### PR TITLE
[ROCm][DSV4] Add FP4 LiteTopK indexer path

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/fp4_litetopk_hip.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_litetopk_hip.py
@@ -1,0 +1,468 @@
+"""Fail-closed adapter for AITER's gfx950 FP4 LiteTopK prefill operator."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import lru_cache
+from inspect import signature
+from typing import TYPE_CHECKING, NamedTuple
+
+import torch
+
+if TYPE_CHECKING:
+    from aiter.ops.flydsl import FP4LiteTopKWorkspace
+
+
+_HEADS = 64
+_PACKED_HEAD_DIM = 64
+_SUPPORTED_TOPKS = (512, 1024)
+_PAGE_SIZE = 64
+_MIN_CONTEXT = 65_536
+_MAX_CONTEXT = 196_608
+_MAX_WORKSPACE_ROWS = 1024
+_ALLOCATION_HEADROOM_BYTES = 256 * 1024 * 1024
+
+
+class FP4LiteTopKScratch(NamedTuple):
+    workspace: FP4LiteTopKWorkspace
+    rows: int
+    topk: int
+    device_index: int
+    stream_id: int
+
+
+def _is_status_aware_aiter_api(run_litetopk, workspace_type: type) -> bool:
+    try:
+        parameters = signature(run_litetopk).parameters
+    except (TypeError, ValueError):
+        return False
+    return "status_ok" in getattr(workspace_type, "_fields", ()) and (
+        "enforce_status" in parameters
+    )
+
+
+@lru_cache(maxsize=1)
+def get_aiter_fp4_litetopk():
+    """Resolve the complete optional AITER API, or return ``None``."""
+    try:
+        from aiter.ops.flydsl import (
+            FP4_LITETOPK_SUPPORTED_TOPKS,
+            FP4LiteTopKResult,
+            FP4LiteTopKWorkspace,
+            allocate_fp4_litetopk_workspace,
+            flydsl_pa_mqa_litetopk_fp4_prefill,
+            fp4_litetopk_workspace_size,
+        )
+    except (ImportError, AttributeError):
+        return None
+    if not _is_status_aware_aiter_api(
+        flydsl_pa_mqa_litetopk_fp4_prefill, FP4LiteTopKWorkspace
+    ):
+        return None
+    try:
+        supported_topks = frozenset(int(topk) for topk in FP4_LITETOPK_SUPPORTED_TOPKS)
+    except (TypeError, ValueError):
+        return None
+    return (
+        flydsl_pa_mqa_litetopk_fp4_prefill,
+        allocate_fp4_litetopk_workspace,
+        fp4_litetopk_workspace_size,
+        FP4LiteTopKWorkspace,
+        FP4LiteTopKResult,
+        supported_topks,
+    )
+
+
+def aiter_fp4_litetopk_supports_topk(topk: int) -> bool:
+    api = get_aiter_fp4_litetopk()
+    return topk in _SUPPORTED_TOPKS and api is not None and topk in api[-1]
+
+
+def can_use_fp4_litetopk(
+    *,
+    enabled: bool,
+    is_hip: bool,
+    arch: str,
+    is_extend: bool,
+    batch_size: int,
+    query_rows: int,
+    heads: int,
+    packed_head_dim: int,
+    topk: int,
+    page_size: int,
+    max_context: int,
+    attn_cp_size: int,
+    use_sgl_topk: bool,
+    use_prefill_graph: bool,
+    capturing: bool,
+    in_piecewise_graph: bool,
+    in_breakable_graph: bool,
+    has_tbo_parent: bool,
+    has_tbo_children: bool,
+    has_spec_info: bool,
+    has_spec_algorithm: bool,
+    enable_multi_stream: bool,
+    skip_compressor: bool,
+    has_hisparse: bool,
+    has_prefill_workspace: bool,
+    aiter_available: bool,
+) -> bool:
+    """Return whether a call matches the deliberately narrow v1 contract."""
+    return fp4_litetopk_ineligible_reason(**locals()) is None
+
+
+def fp4_litetopk_ineligible_reason(**kwargs) -> str | None:
+    """Return the first failed v1 requirement, or ``None`` when eligible."""
+    checks = (
+        (kwargs["enabled"], "feature flag is disabled"),
+        (kwargs["is_hip"], "platform is not HIP"),
+        (kwargs["arch"] == "gfx950", f"architecture is {kwargs['arch']!r}"),
+        (kwargs["is_extend"], "forward mode is not plain EXTEND"),
+        (kwargs["batch_size"] == 1, "batch size is not one"),
+        (kwargs["query_rows"] > 0, "query row count is zero"),
+        (kwargs["heads"] == _HEADS, "query head count is not 64"),
+        (
+            kwargs["packed_head_dim"] == _PACKED_HEAD_DIM,
+            "packed query head dimension is not 64",
+        ),
+        (
+            kwargs["topk"] in _SUPPORTED_TOPKS,
+            f"top-k is not one of {_SUPPORTED_TOPKS}",
+        ),
+        (kwargs["page_size"] == _PAGE_SIZE, "C4 page size is not 64"),
+        (
+            _MIN_CONTEXT <= kwargs["max_context"] <= _MAX_CONTEXT,
+            "C4 context is outside [65536, 196608]",
+        ),
+        (kwargs["attn_cp_size"] == 1, "attention context parallelism is active"),
+        (kwargs["use_sgl_topk"], "SGL top-k backend is not selected"),
+        (not kwargs["use_prefill_graph"], "prefill graph metadata is active"),
+        (not kwargs["capturing"], "stream capture is active"),
+        (not kwargs["in_piecewise_graph"], "piecewise graph is active"),
+        (not kwargs["in_breakable_graph"], "breakable graph is active"),
+        (not kwargs["has_tbo_parent"], "TBO parent range is active"),
+        (not kwargs["has_tbo_children"], "TBO child batches are active"),
+        (not kwargs["has_spec_info"], "speculative metadata is active"),
+        (not kwargs["has_spec_algorithm"], "speculative decoding is configured"),
+        (not kwargs["enable_multi_stream"], "multi-stream indexer is active"),
+        (not kwargs["skip_compressor"], "compressor execution is skipped"),
+        (not kwargs["has_hisparse"], "HiSparse is active"),
+        (
+            kwargs["has_prefill_workspace"],
+            "prefill workspace is missing or incompatible",
+        ),
+        (kwargs["aiter_available"], "AITER LiteTopK API is unavailable"),
+    )
+    return next((reason for passed, reason in checks if not passed), None)
+
+
+def is_fp4_litetopk_prefill_workspace_compatible(
+    workspace: object | None,
+    *,
+    rows: int,
+    max_seq_len: int,
+    device: torch.device,
+) -> bool:
+    """Return whether cached prefill metadata can serve this LiteTopK call."""
+    if workspace is None or rows <= 0 or max_seq_len <= 0:
+        return False
+    try:
+        guarded_page_table = workspace.guarded_page_table
+        row_to_batch = workspace.row_to_batch
+        local_starts = workspace.local_starts
+        workspace_max_seq_len = int(workspace.max_seq_len)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    device = torch.device(device)
+    return (
+        isinstance(guarded_page_table, torch.Tensor)
+        and guarded_page_table.dtype == torch.int32
+        and guarded_page_table.device == device
+        and guarded_page_table.ndim == 2
+        and guarded_page_table.shape[0] >= rows
+        and guarded_page_table.is_contiguous()
+        and isinstance(row_to_batch, torch.Tensor)
+        and row_to_batch.dtype == torch.int32
+        and row_to_batch.device == device
+        and row_to_batch.ndim == 1
+        and row_to_batch.shape[0] >= rows
+        and row_to_batch.is_contiguous()
+        and isinstance(local_starts, torch.Tensor)
+        and local_starts.dtype == torch.int32
+        and local_starts.device == device
+        and local_starts.ndim == 1
+        and local_starts.shape[0] >= rows
+        and local_starts.is_contiguous()
+        and workspace_max_seq_len >= max_seq_len
+        and guarded_page_table.shape[1] * _PAGE_SIZE >= max_seq_len
+    )
+
+
+def validate_fp4_litetopk_static_configuration(
+    *,
+    required: bool,
+    is_hip_platform: bool,
+    use_fp4_indexer: bool,
+    arch: str = "gfx950",
+    heads: int = _HEADS,
+    packed_head_dim: int = _PACKED_HEAD_DIM,
+    topk: int = _SUPPORTED_TOPKS[0],
+    use_sgl_topk: bool = True,
+    aiter_available: bool = True,
+) -> None:
+    """Fail early when REQUIRED cannot be served by this model runner."""
+    if not required:
+        return
+    if not is_hip_platform:
+        raise RuntimeError(
+            "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires a HIP platform"
+        )
+    if not use_fp4_indexer:
+        raise RuntimeError(
+            "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires the AITER FP4 indexer"
+        )
+    if arch != "gfx950":
+        raise RuntimeError(
+            f"SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires gfx950, got {arch!r}"
+        )
+    if (
+        heads != _HEADS
+        or packed_head_dim != _PACKED_HEAD_DIM
+        or topk not in _SUPPORTED_TOPKS
+    ):
+        raise RuntimeError(
+            "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires H=64, packed D=64, "
+            f"and K in {_SUPPORTED_TOPKS}; got H={heads}, "
+            f"packed D={packed_head_dim}, K={topk}"
+        )
+    if not use_sgl_topk:
+        raise RuntimeError(
+            "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires the SGL top-k backend"
+        )
+    if not aiter_available:
+        raise RuntimeError(
+            "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires the complete AITER "
+            "LiteTopK API"
+        )
+
+
+def max_c4_context_from_seq_lens(
+    seq_lens_cpu: Sequence[int] | torch.Tensor | None,
+) -> int:
+    """Return the largest compressed C4 length using metadata's floor rule."""
+    if seq_lens_cpu is None:
+        return 0
+    values = (
+        seq_lens_cpu.tolist()
+        if isinstance(seq_lens_cpu, torch.Tensor)
+        else list(seq_lens_cpu)
+    )
+    return max((int(length) for length in values), default=0) // 4
+
+
+def fp4_litetopk_must_dispatch(
+    *, required: bool, is_plain_extend: bool, max_context: int
+) -> bool:
+    """Return whether REQUIRED applies to this forward phase.
+
+    Early prefill chunks below the crossover and decode are deliberate legacy
+    fallbacks. Once a plain EXTEND reaches the crossover, REQUIRED makes every
+    other eligibility failure fatal, including contexts above the supported cap.
+    """
+    return required and is_plain_extend and max_context >= _MIN_CONTEXT
+
+
+def prepare_fp4_litetopk_scratch(
+    *,
+    rows: int,
+    topk: int,
+    device: torch.device,
+    scratch: FP4LiteTopKScratch | None = None,
+) -> FP4LiteTopKScratch:
+    if rows <= 0 or rows > _MAX_WORKSPACE_ROWS:
+        raise ValueError(
+            f"LiteTopK workspace rows must be in [1, {_MAX_WORKSPACE_ROWS}], got {rows}"
+        )
+    if topk not in _SUPPORTED_TOPKS:
+        raise ValueError(
+            f"FP4 LiteTopK top-k must be one of {_SUPPORTED_TOPKS}, got {topk}"
+        )
+    device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"FP4 LiteTopK scratch requires a GPU device, got {device}")
+    if device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    device_index = device.index
+    assert device_index is not None
+
+    api = get_aiter_fp4_litetopk()
+    if api is None:
+        raise RuntimeError("The installed AITER does not expose FP4 LiteTopK")
+    _, allocate_workspace, workspace_size, _, _, supported_topks = api
+    if topk not in supported_topks:
+        raise RuntimeError(
+            f"The installed AITER does not support FP4 LiteTopK K={topk}"
+        )
+    stream = torch.cuda.current_stream(device)
+    if (
+        scratch is not None
+        and scratch.rows >= rows
+        and scratch.topk == topk
+        and scratch.device_index == device_index
+        and scratch.stream_id == stream.cuda_stream
+    ):
+        return scratch
+    required_bytes = workspace_size(rows, topk=topk)
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    cached_bytes = max(
+        0,
+        torch.cuda.memory_reserved(device) - torch.cuda.memory_allocated(device),
+    )
+    available_bytes = free_bytes + cached_bytes
+    if required_bytes + _ALLOCATION_HEADROOM_BYTES > available_bytes:
+        raise torch.OutOfMemoryError(
+            "insufficient free memory for FP4 LiteTopK workspace: "
+            f"required={required_bytes}, driver_free={free_bytes}, "
+            f"allocator_cached={cached_bytes}, "
+            f"reserved_headroom={_ALLOCATION_HEADROOM_BYTES}"
+        )
+    return FP4LiteTopKScratch(
+        workspace=allocate_workspace(rows, device, topk=topk, stream=stream),
+        rows=rows,
+        topk=topk,
+        device_index=device_index,
+        stream_id=stream.cuda_stream,
+    )
+
+
+def prepare_fp4_litetopk_scratch_for_dispatch(
+    *,
+    rows: int,
+    topk: int,
+    device: torch.device,
+    scratch: FP4LiteTopKScratch | None,
+    required: bool,
+) -> FP4LiteTopKScratch | None:
+    try:
+        return prepare_fp4_litetopk_scratch(
+            rows=rows,
+            topk=topk,
+            device=device,
+            scratch=scratch,
+        )
+    except RuntimeError as exc:
+        if required:
+            raise RuntimeError(
+                "FP4 LiteTopK workspace setup failed in required mode"
+            ) from exc
+        return None
+
+
+def aiter_fp4_litetopk(
+    *,
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_payload: torch.Tensor,
+    k_scale: torch.Tensor,
+    weights: torch.Tensor,
+    guarded_page_table: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    row_starts: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    max_seq_len: int,
+    topk: int,
+    weight_scale: float,
+    out_page_indices: torch.Tensor,
+    out_raw_indices: torch.Tensor,
+    scratch: FP4LiteTopKScratch | None = None,
+) -> FP4LiteTopKScratch:
+    """Run AITER LiteTopK and write SGLang's logical and physical outputs."""
+    api = get_aiter_fp4_litetopk()
+    if api is None:
+        raise RuntimeError("The installed AITER does not expose FP4 LiteTopK")
+    run_litetopk, _, _, _, result_type, supported_topks = api
+    if topk not in supported_topks:
+        raise RuntimeError(
+            f"The installed AITER does not support FP4 LiteTopK K={topk}"
+        )
+    rows = q_fp4.shape[0]
+    scratch = prepare_fp4_litetopk_scratch(
+        rows=rows,
+        topk=topk,
+        device=q_fp4.device,
+        scratch=scratch,
+    )
+    result = result_type(
+        values=scratch.workspace.selected_values[:rows],
+        raw_indices=out_raw_indices,
+        physical_indices=out_page_indices,
+        counts=scratch.workspace.output_counts[:rows],
+        candidate_counts=scratch.workspace.candidate_counts[:rows],
+        status=scratch.workspace.status[:rows],
+    )
+    run_litetopk(
+        q_fp4.view(torch.uint8),
+        q_scale,
+        k_payload.view(torch.uint8),
+        k_scale,
+        guarded_page_table,
+        weights,
+        row_to_batch,
+        row_starts,
+        c4_seq_lens.reshape(-1).to(torch.int32).contiguous(),
+        max_seq_len,
+        topk=topk,
+        weight_scale=weight_scale,
+        workspace=scratch.workspace,
+        out=result,
+        enforce_status=True,
+    )
+    return scratch
+
+
+def run_aiter_fp4_litetopk_chunks(
+    *,
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_payload: torch.Tensor,
+    k_scale: torch.Tensor,
+    weights: torch.Tensor,
+    guarded_page_table: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    row_starts: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    max_seq_len: int,
+    topk: int,
+    weight_scale: float,
+    out_page_indices: torch.Tensor,
+    out_raw_indices: torch.Tensor,
+    rows_per_chunk: int,
+    scratch: FP4LiteTopKScratch,
+) -> FP4LiteTopKScratch:
+    if rows_per_chunk <= 0:
+        raise ValueError("rows_per_chunk must be positive")
+    query_rows = q_fp4.shape[0]
+    for start in range(0, query_rows, rows_per_chunk):
+        rows = slice(start, min(start + rows_per_chunk, query_rows))
+        scratch = aiter_fp4_litetopk(
+            q_fp4=q_fp4[rows],
+            q_scale=q_scale[rows],
+            k_payload=k_payload,
+            k_scale=k_scale,
+            weights=weights[rows],
+            guarded_page_table=guarded_page_table,
+            row_to_batch=row_to_batch[rows],
+            row_starts=row_starts[rows],
+            c4_seq_lens=c4_seq_lens[rows],
+            max_seq_len=max_seq_len,
+            topk=topk,
+            weight_scale=weight_scale,
+            out_page_indices=out_page_indices[rows, :topk],
+            out_raw_indices=out_raw_indices[rows, :topk],
+            scratch=scratch,
+        )
+    return scratch
+
+
+def fp4_litetopk_rows_per_chunk() -> int:
+    return _MAX_WORKSPACE_ROWS

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1415,6 +1415,9 @@ class Envs:
     # Quantize the SWA fp8 KV cache from bf16-rounded values (matches
     # trainer-side QAT and the DSA-CP path) instead of fp32 registers.
     SGLANG_DSV4_USE_BF16_KV_QUANT_SOURCE = EnvBool(False)
+    # Experimental gfx950 FP4 indexer path using bounded-prefix LiteTopK.
+    SGLANG_DSV4_FP4_LITETOPK = EnvBool(False)
+    SGLANG_DSV4_FP4_LITETOPK_REQUIRED = EnvBool(False)
 
     # Kernels and indexer
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -477,6 +477,8 @@ class DeepseekV4HipRadixBackend(
         self.enable_deepseek_v4_fp4_indexer: bool = (
             get_exec().kernel.enable_deepseek_v4_fp4_indexer
         )
+        self.fp4_litetopk_scratch = None
+        self.spec_algorithm = model_runner.spec_algorithm
         self.topk = get_spec().speculative_eagle_topk or 0
         assert self.topk in [0, 1], "MTP Topk > 1 not supported for DeepSeek V4"
         self.mtp_enabled = self.topk > 0
@@ -505,12 +507,18 @@ class DeepseekV4HipRadixBackend(
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
 
-    def init_forward_metadata_indexer(self, core_attn_metadata: DSV4AttnMetadata):
+    def init_forward_metadata_indexer(
+        self,
+        core_attn_metadata: DSV4AttnMetadata,
+        *,
+        use_prefill_cuda_graph: bool = False,
+    ):
         return PagedIndexerMetadata(
             page_size=self.page_size,
             page_table=core_attn_metadata.page_table,
             c4_seq_lens=core_attn_metadata.c4_topk_lengths_raw,
             use_topk_v2=self.dsa_topk_backend.should_use_topk_v2(),
+            use_prefill_cuda_graph=use_prefill_cuda_graph,
         )
 
     def init_forward_metadata_decode(
@@ -597,7 +605,10 @@ class DeepseekV4HipRadixBackend(
                 core_attn_metadata, req_pool_indices_repeated
             )
         indexer_metadata = (
-            self.init_forward_metadata_indexer(core_attn_metadata)
+            self.init_forward_metadata_indexer(
+                core_attn_metadata,
+                use_prefill_cuda_graph=use_prefill_cuda_graph,
+            )
             if need_compress
             else None
         )
@@ -753,7 +764,10 @@ class DeepseekV4HipRadixBackend(
             out_loc=out_cache_loc,
             need_compress=True,
         )
-        indexer_metadata = self.init_forward_metadata_indexer(core_attn_metadata)
+        indexer_metadata = self.init_forward_metadata_indexer(
+            core_attn_metadata,
+            use_prefill_cuda_graph=True,
+        )
         create = functools.partial(
             create_paged_compressor_data,
             is_prefill=True,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -28,6 +28,17 @@ from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
     aiter_q_indexer_fp4,
     logits_rows_per_chunk,
 )
+from sglang.kernels.ops.attention.dsv4.fp4_litetopk_hip import (
+    aiter_fp4_litetopk_supports_topk,
+    fp4_litetopk_ineligible_reason,
+    fp4_litetopk_must_dispatch,
+    fp4_litetopk_rows_per_chunk,
+    is_fp4_litetopk_prefill_workspace_compatible,
+    max_c4_context_from_seq_lens,
+    prepare_fp4_litetopk_scratch_for_dispatch,
+    run_aiter_fp4_litetopk_chunks,
+    validate_fp4_litetopk_static_configuration,
+)
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
@@ -688,7 +699,10 @@ class C4IndexerBackendMixin:
         q_lora_ready: Optional[torch.cuda.Event] = None,
         skip_compressor: bool = False,
     ) -> None:
+        litetopk_required = envs.SGLANG_DSV4_FP4_LITETOPK_REQUIRED.get()
         if forward_batch.forward_mode.is_idle():
+            if not litetopk_required:
+                self.fp4_litetopk_scratch = None
             return
         token_to_kv_pool = self.token_to_kv_pool
 
@@ -702,6 +716,12 @@ class C4IndexerBackendMixin:
 
         assert isinstance(indexer_metadata, PagedIndexerMetadata)
         use_aiter_fp4 = c4_indexer.use_fp4_indexer and is_hip()
+        if litetopk_required and not use_aiter_fp4:
+            raise RuntimeError(
+                "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 requires the HIP AITER FP4 indexer"
+            )
+        if not use_aiter_fp4:
+            self.fp4_litetopk_scratch = None
 
         positions = core_metadata.positions
         if use_aiter_fp4:
@@ -826,6 +846,11 @@ class C4IndexerBackendMixin:
                 query_rows=query_rows,
             )
         if self.debug_use_external_c4_sparse_indices:
+            if litetopk_required:
+                raise RuntimeError(
+                    "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 is incompatible with "
+                    "external C4 sparse indices"
+                )
             return
 
         indexer_capturer = get_global_indexer_capturer()
@@ -912,6 +937,134 @@ class C4IndexerBackendMixin:
                 c4_indexer.layer_id
             )
             k_scale = token_to_kv_pool.get_index_k_fp4_scale_buffer(c4_indexer.layer_id)
+
+            litetopk_enabled = envs.SGLANG_DSV4_FP4_LITETOPK.get()
+            use_litetopk = False
+            litetopk_capturing = False
+            prefill_workspace = metadata.fp4_prefill_workspace
+            if litetopk_enabled or litetopk_required:
+                max_c4_context = max_c4_context_from_seq_lens(
+                    forward_batch.seq_lens_cpu
+                )
+                device_properties = torch.cuda.get_device_properties(q_fp4.device)
+                arch = str(getattr(device_properties, "gcnArchName", "")).split(":")[0]
+                spec_algorithm = getattr(self, "spec_algorithm", None)
+                litetopk_capturing = torch.cuda.is_current_stream_capturing()
+                is_plain_extend = (
+                    forward_batch.forward_mode == ForwardMode.EXTEND
+                    and forward_batch._original_forward_mode is None
+                )
+                eligibility = {
+                    "enabled": litetopk_enabled or litetopk_required,
+                    "is_hip": is_hip(),
+                    "arch": arch,
+                    "is_extend": is_plain_extend,
+                    "batch_size": forward_batch.batch_size,
+                    "query_rows": query_rows,
+                    "heads": q_fp4.shape[1],
+                    "packed_head_dim": q_fp4.shape[2],
+                    "topk": c4_indexer.index_topk,
+                    "page_size": indexer_metadata.c4_page_size,
+                    "max_context": max_c4_context,
+                    "attn_cp_size": get_parallel().attn_cp_size,
+                    "use_sgl_topk": self.dsa_topk_backend.is_sgl_kernel(),
+                    "use_prefill_graph": indexer_metadata.use_prefill_cuda_graph,
+                    "capturing": litetopk_capturing,
+                    "in_piecewise_graph": is_in_tc_piecewise_cuda_graph(),
+                    "in_breakable_graph": is_in_breakable_cuda_graph(),
+                    "has_tbo_parent": forward_batch.tbo_parent_token_range is not None,
+                    "has_tbo_children": bool(
+                        getattr(forward_batch, "tbo_children", None)
+                    ),
+                    "has_spec_info": forward_batch.spec_info is not None,
+                    "has_spec_algorithm": spec_algorithm is not None
+                    and not spec_algorithm.is_none(),
+                    "enable_multi_stream": enable_multi_stream,
+                    "skip_compressor": skip_compressor,
+                    "has_hisparse": hisparse_coordinator is not None,
+                    "has_prefill_workspace": (
+                        is_fp4_litetopk_prefill_workspace_compatible(
+                            prefill_workspace,
+                            rows=query_rows,
+                            max_seq_len=max_c4_context,
+                            device=q_fp4.device,
+                        )
+                    ),
+                    "aiter_available": aiter_fp4_litetopk_supports_topk(
+                        c4_indexer.index_topk
+                    ),
+                }
+                reason = fp4_litetopk_ineligible_reason(**eligibility)
+                use_litetopk = reason is None
+                litetopk_must_dispatch = fp4_litetopk_must_dispatch(
+                    required=litetopk_required,
+                    is_plain_extend=is_plain_extend,
+                    max_context=max_c4_context,
+                )
+                if litetopk_must_dispatch and not use_litetopk:
+                    raise RuntimeError(
+                        "SGLANG_DSV4_FP4_LITETOPK_REQUIRED=1 rejected this "
+                        f"forward: {reason}"
+                    )
+            if use_litetopk:
+                rows_per_chunk = fp4_litetopk_rows_per_chunk()
+                existing_scratch = getattr(self, "fp4_litetopk_scratch", None)
+                device_index = q_fp4.device.index
+                if device_index is None:
+                    device_index = torch.cuda.current_device()
+                if existing_scratch is not None and (
+                    existing_scratch.rows < min(query_rows, rows_per_chunk)
+                    or existing_scratch.topk != c4_indexer.index_topk
+                    or existing_scratch.device_index != device_index
+                    or existing_scratch.stream_id
+                    != torch.cuda.current_stream(q_fp4.device).cuda_stream
+                ):
+                    self.fp4_litetopk_scratch = None
+                    existing_scratch = None
+                self.fp4_litetopk_scratch = prepare_fp4_litetopk_scratch_for_dispatch(
+                    rows=min(query_rows, rows_per_chunk),
+                    topk=c4_indexer.index_topk,
+                    device=q_fp4.device,
+                    scratch=existing_scratch,
+                    required=litetopk_must_dispatch,
+                )
+                use_litetopk = self.fp4_litetopk_scratch is not None
+            if (
+                not use_litetopk
+                and not litetopk_required
+                and getattr(self, "fp4_litetopk_scratch", None) is not None
+                and not litetopk_capturing
+            ):
+                self.fp4_litetopk_scratch = None
+            if use_litetopk:
+                assert prefill_workspace is not None
+                if raw_indices is None:
+                    raw_indices = torch.empty_like(c4_sparse_page_indices)
+                self.fp4_litetopk_scratch = run_aiter_fp4_litetopk_chunks(
+                    q_fp4=q_fp4,
+                    q_scale=q_scale,
+                    k_payload=k_payload,
+                    k_scale=k_scale,
+                    weights=weights,
+                    guarded_page_table=prefill_workspace.guarded_page_table,
+                    row_to_batch=prefill_workspace.row_to_batch,
+                    row_starts=prefill_workspace.local_starts,
+                    c4_seq_lens=c4_seq_lens,
+                    max_seq_len=max_c4_context,
+                    topk=c4_indexer.index_topk,
+                    weight_scale=c4_indexer.weight_scale,
+                    out_page_indices=c4_sparse_page_indices,
+                    out_raw_indices=raw_indices,
+                    rows_per_chunk=rows_per_chunk,
+                    scratch=self.fp4_litetopk_scratch,
+                )
+                core_metadata.c4_sparse_raw_indices = raw_indices
+                if capture_enabled:
+                    compress_layer_id = token_to_kv_pool.layer_mapping[
+                        c4_indexer.layer_id
+                    ].compress_layer_id
+                    indexer_capturer.capture(compress_layer_id, raw_indices)
+                return
 
             def run_fp4_indexer(rows: slice) -> None:
                 logits = aiter_fp4_paged_mqa_logits(
@@ -1034,6 +1187,27 @@ class C4Indexer(nn.Module):
         self.softmax_scale = self.head_dim**-0.5
         self.n_local_heads = self.n_heads
         self.use_fp4_indexer = get_exec().kernel.enable_deepseek_v4_fp4_indexer
+        litetopk_required = envs.SGLANG_DSV4_FP4_LITETOPK_REQUIRED.get()
+        litetopk_arch = ""
+        if litetopk_required and is_hip():
+            litetopk_arch = str(
+                torch.cuda.get_device_properties(
+                    torch.cuda.current_device()
+                ).gcnArchName
+            ).split(":")[0]
+        validate_fp4_litetopk_static_configuration(
+            required=litetopk_required,
+            is_hip_platform=is_hip(),
+            use_fp4_indexer=self.use_fp4_indexer,
+            arch=litetopk_arch,
+            heads=self.n_heads,
+            packed_head_dim=self.head_dim // 2,
+            topk=self.index_topk,
+            use_sgl_topk=DSATopKBackend(
+                get_exec().kernel.dsa_topk_backend
+            ).is_sgl_kernel(),
+            aiter_available=aiter_fp4_litetopk_supports_topk(self.index_topk),
+        )
         self.wq_b = ReplicatedLinear(
             self.q_lora_rank,
             self.n_heads * self.head_dim,

--- a/test/registered/kernels/ops/attention/test_fp4_indexer_hip.py
+++ b/test/registered/kernels/ops/attention/test_fp4_indexer_hip.py
@@ -37,6 +37,10 @@ from sglang.kernels.ops.attention.dsv4.fp4_indexer_hip import (
     prepare_fp4_k_write_metadata,
     prepare_fp4_prefill_workspace,
 )
+from sglang.kernels.ops.attention.dsv4.fp4_litetopk_hip import (
+    aiter_fp4_litetopk,
+    get_aiter_fp4_litetopk,
+)
 from sglang.srt.utils import get_device, is_gfx95_supported, is_hip
 from sglang.test.ci.ci_register import register_amd_ci
 
@@ -694,6 +698,73 @@ def test_prefill_paged_mqa_logits(batch: int, seq_len: int) -> None:
     logits = _run_logits(case, is_decode=False, prefill_ws=workspace)
 
     _assert_logits_agree(logits, case)
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_fp4_litetopk_adapter_maps_pages_and_reuses_scratch(topk: int) -> None:
+    if get_aiter_fp4_litetopk() is None:
+        pytest.skip("installed AITER does not expose status-aware FP4 LiteTopK")
+    torch.manual_seed(42)
+    seq_len = 65_536
+    case = _build_logits_case(1, seq_len, shuffle_pages=True)
+    prefill = prepare_fp4_prefill_workspace(case["page_table"], case["c4_seq_lens"])
+    rows = case["q_fp4"].shape[0]
+    dense_logits = _run_logits(case, is_decode=False, prefill_ws=prefill)
+    expected_raw_indices = dense_logits.topk(topk, dim=-1).indices.to(torch.int32)
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device=get_device())
+    row_starts = torch.zeros(rows, dtype=torch.int32, device=get_device())
+    out_page_indices = torch.empty((rows, topk), dtype=torch.int32, device=get_device())
+    out_raw_indices = torch.empty_like(out_page_indices)
+
+    scratch = aiter_fp4_litetopk(
+        q_fp4=case["q_fp4"],
+        q_scale=case["q_scale"],
+        k_payload=case["payload"],
+        k_scale=case["scale"],
+        weights=case["weights"],
+        guarded_page_table=prefill.guarded_page_table,
+        row_to_batch=row_to_batch,
+        row_starts=row_starts,
+        c4_seq_lens=case["c4_seq_lens"],
+        max_seq_len=prefill.max_seq_len,
+        topk=topk,
+        weight_scale=case["weight_scale"],
+        out_page_indices=out_page_indices,
+        out_raw_indices=out_raw_indices,
+    )
+    candidate_ptr = scratch.workspace.candidate_values.data_ptr()
+    scratch = aiter_fp4_litetopk(
+        q_fp4=case["q_fp4"],
+        q_scale=case["q_scale"],
+        k_payload=case["payload"],
+        k_scale=case["scale"],
+        weights=case["weights"],
+        guarded_page_table=prefill.guarded_page_table,
+        row_to_batch=row_to_batch,
+        row_starts=row_starts,
+        c4_seq_lens=case["c4_seq_lens"],
+        max_seq_len=prefill.max_seq_len,
+        topk=topk,
+        weight_scale=case["weight_scale"],
+        out_page_indices=out_page_indices,
+        out_raw_indices=out_raw_indices,
+        scratch=scratch,
+    )
+    torch.cuda.synchronize()
+
+    assert scratch.workspace.candidate_values.data_ptr() == candidate_ptr
+    assert scratch.workspace.status_ok.item() == 1
+    assert torch.all((out_raw_indices >= 0) & (out_raw_indices < seq_len))
+    torch.testing.assert_close(
+        out_raw_indices.sort(dim=-1).values,
+        expected_raw_indices.sort(dim=-1).values,
+    )
+    assert torch.any(out_raw_indices >= 8192)
+    expected = (
+        case["page_table"][0, out_raw_indices.long() // PAGE_SIZE] * PAGE_SIZE
+        + out_raw_indices % PAGE_SIZE
+    )
+    torch.testing.assert_close(out_page_indices, expected)
 
 
 @pytest.mark.parametrize("is_decode", [True, False])

--- a/test/registered/unit/layers/test_dsv4_fp4_litetopk.py
+++ b/test/registered/unit/layers/test_dsv4_fp4_litetopk.py
@@ -1,0 +1,722 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import fp4_litetopk_hip
+from sglang.kernels.ops.attention.dsv4.fp4_litetopk_hip import (
+    FP4LiteTopKScratch,
+    aiter_fp4_litetopk,
+    aiter_fp4_litetopk_supports_topk,
+    can_use_fp4_litetopk,
+    fp4_litetopk_ineligible_reason,
+    fp4_litetopk_must_dispatch,
+    is_fp4_litetopk_prefill_workspace_compatible,
+    max_c4_context_from_seq_lens,
+    prepare_fp4_litetopk_scratch,
+    prepare_fp4_litetopk_scratch_for_dispatch,
+    run_aiter_fp4_litetopk_chunks,
+    validate_fp4_litetopk_static_configuration,
+)
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
+from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
+from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_INDEXER = "sglang.srt.layers.attention.dsv4.indexer"
+_METADATA = "sglang.srt.layers.attention.dsv4.metadata"
+
+
+class TestDSV4FP4LiteTopK(CustomTestCase):
+    def _eligible(self, **overrides):
+        values = {
+            "enabled": True,
+            "is_hip": True,
+            "arch": "gfx950",
+            "is_extend": True,
+            "batch_size": 1,
+            "query_rows": 64,
+            "heads": 64,
+            "packed_head_dim": 64,
+            "topk": 512,
+            "page_size": 64,
+            "max_context": 65_536,
+            "attn_cp_size": 1,
+            "use_sgl_topk": True,
+            "use_prefill_graph": False,
+            "capturing": False,
+            "in_piecewise_graph": False,
+            "in_breakable_graph": False,
+            "has_tbo_parent": False,
+            "has_tbo_children": False,
+            "has_spec_info": False,
+            "has_spec_algorithm": False,
+            "enable_multi_stream": False,
+            "skip_compressor": False,
+            "has_hisparse": False,
+            "has_prefill_workspace": True,
+            "aiter_available": True,
+        }
+        values.update(overrides)
+        return can_use_fp4_litetopk(**values)
+
+    def test_feature_is_default_off(self):
+        self.assertFalse(envs.SGLANG_DSV4_FP4_LITETOPK.default)
+        self.assertFalse(envs.SGLANG_DSV4_FP4_LITETOPK_REQUIRED.default)
+
+    def test_v4_flash_and_pro_topk_are_supported(self):
+        self.assertTrue(self._eligible(topk=512))
+        self.assertTrue(self._eligible(topk=1024))
+        self.assertTrue(self._eligible(max_context=196_608))
+
+    def test_c4_context_boundaries_use_floor_division(self):
+        self.assertFalse(self._eligible(max_context=65_535))
+        self.assertTrue(self._eligible(max_context=65_536))
+        self.assertTrue(self._eligible(max_context=196_608))
+        self.assertFalse(self._eligible(max_context=196_609))
+        self.assertEqual(max_c4_context_from_seq_lens([262_143]), 65_535)
+        self.assertEqual(max_c4_context_from_seq_lens([262_144]), 65_536)
+        self.assertEqual(max_c4_context_from_seq_lens([786_435]), 196_608)
+        self.assertEqual(max_c4_context_from_seq_lens([786_436]), 196_609)
+
+    def test_ineligible_configurations_fail_closed(self):
+        cases = (
+            {"enabled": False},
+            {"is_hip": False},
+            {"arch": "gfx942"},
+            {"is_extend": False},
+            {"batch_size": 2},
+            {"query_rows": 0},
+            {"heads": 32},
+            {"packed_head_dim": 128},
+            {"topk": 2048},
+            {"page_size": 1},
+            {"max_context": 65_535},
+            {"max_context": 196_609},
+            {"attn_cp_size": 2},
+            {"use_sgl_topk": False},
+            {"use_prefill_graph": True},
+            {"capturing": True},
+            {"in_piecewise_graph": True},
+            {"in_breakable_graph": True},
+            {"has_tbo_parent": True},
+            {"has_tbo_children": True},
+            {"has_spec_info": True},
+            {"has_spec_algorithm": True},
+            {"enable_multi_stream": True},
+            {"skip_compressor": True},
+            {"has_hisparse": True},
+            {"has_prefill_workspace": False},
+            {"aiter_available": False},
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertFalse(self._eligible(**case))
+
+    def test_ineligible_reason_names_the_failed_requirement(self):
+        values = {
+            "enabled": True,
+            "is_hip": True,
+            "arch": "gfx950",
+            "is_extend": True,
+            "batch_size": 1,
+            "query_rows": 64,
+            "heads": 64,
+            "packed_head_dim": 64,
+            "topk": 512,
+            "page_size": 64,
+            "max_context": 65_536,
+            "attn_cp_size": 1,
+            "use_sgl_topk": True,
+            "use_prefill_graph": False,
+            "capturing": False,
+            "in_piecewise_graph": False,
+            "in_breakable_graph": False,
+            "has_tbo_parent": False,
+            "has_tbo_children": False,
+            "has_spec_info": False,
+            "has_spec_algorithm": False,
+            "enable_multi_stream": False,
+            "skip_compressor": False,
+            "has_hisparse": False,
+            "has_prefill_workspace": True,
+            "aiter_available": True,
+        }
+        self.assertIsNone(fp4_litetopk_ineligible_reason(**values))
+        values["attn_cp_size"] = 2
+        self.assertEqual(
+            fp4_litetopk_ineligible_reason(**values),
+            "attention context parallelism is active",
+        )
+
+    def test_required_static_configuration_fails_early(self):
+        validate_fp4_litetopk_static_configuration(
+            required=False,
+            is_hip_platform=False,
+            use_fp4_indexer=False,
+        )
+        with self.assertRaisesRegex(RuntimeError, "requires a HIP platform"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=False,
+                use_fp4_indexer=True,
+            )
+        with self.assertRaisesRegex(RuntimeError, "requires the AITER FP4 indexer"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=True,
+                use_fp4_indexer=False,
+            )
+        with self.assertRaisesRegex(RuntimeError, "requires gfx950"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=True,
+                use_fp4_indexer=True,
+                arch="gfx942",
+            )
+        with self.assertRaisesRegex(RuntimeError, "requires H=64"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=True,
+                use_fp4_indexer=True,
+                heads=32,
+            )
+        validate_fp4_litetopk_static_configuration(
+            required=True,
+            is_hip_platform=True,
+            use_fp4_indexer=True,
+            topk=1024,
+        )
+        with self.assertRaisesRegex(RuntimeError, "requires the SGL top-k"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=True,
+                use_fp4_indexer=True,
+                use_sgl_topk=False,
+            )
+        with self.assertRaisesRegex(RuntimeError, "complete AITER LiteTopK API"):
+            validate_fp4_litetopk_static_configuration(
+                required=True,
+                is_hip_platform=True,
+                use_fp4_indexer=True,
+                aiter_available=False,
+            )
+
+    def test_required_applies_only_to_qualified_prefill_phase(self):
+        self.assertFalse(
+            fp4_litetopk_must_dispatch(
+                required=True,
+                is_plain_extend=True,
+                max_context=65_535,
+            )
+        )
+        self.assertFalse(
+            fp4_litetopk_must_dispatch(
+                required=True,
+                is_plain_extend=False,
+                max_context=65_536,
+            )
+        )
+        self.assertTrue(
+            fp4_litetopk_must_dispatch(
+                required=True,
+                is_plain_extend=True,
+                max_context=65_536,
+            )
+        )
+        self.assertTrue(
+            fp4_litetopk_must_dispatch(
+                required=True,
+                is_plain_extend=True,
+                max_context=196_609,
+            )
+        )
+
+    def test_aiter_api_requires_status_aware_contract(self):
+        class LegacyWorkspace:
+            _fields = ("status",)
+
+        class CurrentWorkspace:
+            _fields = ("status", "status_ok")
+
+        def legacy_run():
+            pass
+
+        def current_run(*, enforce_status=True):
+            pass
+
+        self.assertFalse(
+            fp4_litetopk_hip._is_status_aware_aiter_api(current_run, LegacyWorkspace)
+        )
+        self.assertFalse(
+            fp4_litetopk_hip._is_status_aware_aiter_api(legacy_run, CurrentWorkspace)
+        )
+        self.assertTrue(
+            fp4_litetopk_hip._is_status_aware_aiter_api(current_run, CurrentWorkspace)
+        )
+
+    def test_aiter_topk_capability_is_explicit(self):
+        api = (MagicMock(), MagicMock(), MagicMock(), object, object, {512, 1024})
+        with patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api):
+            self.assertTrue(aiter_fp4_litetopk_supports_topk(512))
+            self.assertTrue(aiter_fp4_litetopk_supports_topk(1024))
+            self.assertFalse(aiter_fp4_litetopk_supports_topk(2048))
+        with patch.object(
+            fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=None
+        ):
+            self.assertFalse(aiter_fp4_litetopk_supports_topk(1024))
+
+    def test_prefill_workspace_compatibility(self):
+        workspace = SimpleNamespace(
+            guarded_page_table=torch.empty((4, 1028), dtype=torch.int32),
+            row_to_batch=torch.empty(4, dtype=torch.int32),
+            local_starts=torch.empty(4, dtype=torch.int32),
+            max_seq_len=65_536,
+        )
+        kwargs = {
+            "rows": 4,
+            "max_seq_len": 65_536,
+            "device": torch.device("cpu"),
+        }
+        self.assertTrue(
+            is_fp4_litetopk_prefill_workspace_compatible(workspace, **kwargs)
+        )
+        self.assertFalse(
+            is_fp4_litetopk_prefill_workspace_compatible(
+                SimpleNamespace(
+                    **{
+                        **vars(workspace),
+                        "guarded_page_table": workspace.guarded_page_table[:3],
+                    }
+                ),
+                **kwargs,
+            )
+        )
+        self.assertFalse(
+            is_fp4_litetopk_prefill_workspace_compatible(
+                workspace, **{**kwargs, "rows": 5}
+            )
+        )
+        self.assertFalse(
+            is_fp4_litetopk_prefill_workspace_compatible(
+                SimpleNamespace(**{**vars(workspace), "max_seq_len": 65_535}),
+                **kwargs,
+            )
+        )
+        self.assertFalse(is_fp4_litetopk_prefill_workspace_compatible(None, **kwargs))
+
+    def test_workspace_preflight_rejects_before_allocation(self):
+        allocator = MagicMock()
+        api = (
+            MagicMock(),
+            allocator,
+            MagicMock(return_value=1024),
+            object,
+            object,
+            {512, 1024},
+        )
+        stream = SimpleNamespace(cuda_stream=17)
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch("torch.cuda.current_stream", return_value=stream),
+            patch("torch.cuda.mem_get_info", return_value=(1024, 4096)),
+            patch("torch.cuda.memory_reserved", return_value=0),
+            patch("torch.cuda.memory_allocated", return_value=0),
+            self.assertRaises(torch.OutOfMemoryError),
+        ):
+            prepare_fp4_litetopk_scratch(
+                rows=1, topk=1024, device=torch.device("cuda:0")
+            )
+        allocator.assert_not_called()
+
+    def test_compatible_workspace_is_reused_without_preflight(self):
+        workspace = object()
+        scratch = FP4LiteTopKScratch(
+            workspace=workspace, rows=4, topk=1024, device_index=0, stream_id=17
+        )
+        api = (MagicMock(), MagicMock(), MagicMock(), object, object, {512, 1024})
+        stream = SimpleNamespace(cuda_stream=17)
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch("torch.cuda.current_stream", return_value=stream),
+            patch("torch.cuda.mem_get_info") as mem_get_info,
+        ):
+            actual = prepare_fp4_litetopk_scratch(
+                rows=3,
+                topk=1024,
+                device=torch.device("cuda:0"),
+                scratch=scratch,
+            )
+        self.assertIs(actual, scratch)
+        mem_get_info.assert_not_called()
+
+    def test_workspace_on_another_device_is_not_reused(self):
+        workspace = object()
+        scratch = FP4LiteTopKScratch(
+            workspace=workspace, rows=4, topk=1024, device_index=1, stream_id=17
+        )
+        allocated = object()
+        allocator = MagicMock(return_value=allocated)
+        api = (
+            MagicMock(),
+            allocator,
+            MagicMock(return_value=1024),
+            object,
+            object,
+            {512, 1024},
+        )
+        stream = SimpleNamespace(cuda_stream=17)
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch("torch.cuda.current_stream", return_value=stream),
+            patch("torch.cuda.mem_get_info", return_value=(1 << 30, 1 << 30)),
+            patch("torch.cuda.memory_reserved", return_value=0),
+            patch("torch.cuda.memory_allocated", return_value=0),
+        ):
+            actual = prepare_fp4_litetopk_scratch(
+                rows=3,
+                topk=1024,
+                device=torch.device("cuda:0"),
+                scratch=scratch,
+            )
+        self.assertEqual(actual.device_index, 0)
+        self.assertEqual(actual.topk, 1024)
+        self.assertIs(actual.workspace, allocated)
+        allocator.assert_called_once_with(
+            3, torch.device("cuda:0"), topk=1024, stream=stream
+        )
+
+    def test_workspace_with_another_topk_is_not_reused(self):
+        scratch = FP4LiteTopKScratch(object(), 4, 512, 0, 17)
+        allocated = object()
+        allocator = MagicMock(return_value=allocated)
+        workspace_size = MagicMock(return_value=1024)
+        api = (MagicMock(), allocator, workspace_size, object, object, {512, 1024})
+        stream = SimpleNamespace(cuda_stream=17)
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch("torch.cuda.current_stream", return_value=stream),
+            patch("torch.cuda.mem_get_info", return_value=(1 << 30, 1 << 30)),
+            patch("torch.cuda.memory_reserved", return_value=0),
+            patch("torch.cuda.memory_allocated", return_value=0),
+        ):
+            actual = prepare_fp4_litetopk_scratch(
+                rows=3,
+                topk=1024,
+                device=torch.device("cuda:0"),
+                scratch=scratch,
+            )
+        self.assertEqual(actual.topk, 1024)
+        workspace_size.assert_called_once_with(3, topk=1024)
+        allocator.assert_called_once_with(
+            3, torch.device("cuda:0"), topk=1024, stream=stream
+        )
+
+    def test_workspace_preflight_counts_allocator_cache(self):
+        allocated = object()
+        allocator = MagicMock(return_value=allocated)
+        required_bytes = 1024
+        cached_bytes = fp4_litetopk_hip._ALLOCATION_HEADROOM_BYTES + required_bytes
+        api = (
+            MagicMock(),
+            allocator,
+            MagicMock(return_value=required_bytes),
+            object,
+            object,
+            {512, 1024},
+        )
+        stream = SimpleNamespace(cuda_stream=17)
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch("torch.cuda.current_stream", return_value=stream),
+            patch("torch.cuda.mem_get_info", return_value=(0, 1 << 30)),
+            patch("torch.cuda.memory_reserved", return_value=cached_bytes),
+            patch("torch.cuda.memory_allocated", return_value=0),
+        ):
+            actual = prepare_fp4_litetopk_scratch(
+                rows=1,
+                topk=1024,
+                device=torch.device("cuda:0"),
+            )
+
+        self.assertIs(actual.workspace, allocated)
+        allocator.assert_called_once()
+
+    def test_dispatch_workspace_failure_policy(self):
+        failures = (
+            torch.OutOfMemoryError("test allocation failure"),
+            RuntimeError("test workspace setup failure"),
+        )
+        for setup_error in failures:
+            with (
+                self.subTest(error=type(setup_error).__name__),
+                patch.object(
+                    fp4_litetopk_hip,
+                    "prepare_fp4_litetopk_scratch",
+                    side_effect=setup_error,
+                ),
+            ):
+                self.assertIsNone(
+                    prepare_fp4_litetopk_scratch_for_dispatch(
+                        rows=1,
+                        topk=1024,
+                        device=torch.device("cuda:0"),
+                        scratch=None,
+                        required=False,
+                    )
+                )
+                with self.assertRaisesRegex(
+                    RuntimeError, "workspace setup failed in required mode"
+                ) as error:
+                    prepare_fp4_litetopk_scratch_for_dispatch(
+                        rows=1,
+                        topk=1024,
+                        device=torch.device("cuda:0"),
+                        scratch=None,
+                        required=True,
+                    )
+                self.assertIs(error.exception.__cause__, setup_error)
+
+    def test_adapter_explicitly_enforces_status(self):
+        rows, topk = 2, 1024
+        workspace = SimpleNamespace(
+            selected_values=torch.empty((rows, topk), dtype=torch.float32),
+            output_counts=torch.empty(rows, dtype=torch.int32),
+            candidate_counts=torch.empty(rows, dtype=torch.int32),
+            status=torch.empty(rows, dtype=torch.int32),
+        )
+        scratch = FP4LiteTopKScratch(workspace, rows, topk, 0, 17)
+        run_litetopk = MagicMock()
+        result_type = MagicMock(return_value=object())
+        api = (
+            run_litetopk,
+            MagicMock(),
+            MagicMock(),
+            object,
+            result_type,
+            {512, 1024},
+        )
+        with (
+            patch.object(fp4_litetopk_hip, "get_aiter_fp4_litetopk", return_value=api),
+            patch.object(
+                fp4_litetopk_hip,
+                "prepare_fp4_litetopk_scratch",
+                return_value=scratch,
+            ),
+        ):
+            actual = aiter_fp4_litetopk(
+                q_fp4=torch.empty((rows, 1, 1), dtype=torch.uint8),
+                q_scale=torch.empty((rows, 1), dtype=torch.uint8),
+                k_payload=torch.empty(1, dtype=torch.uint8),
+                k_scale=torch.empty(1, dtype=torch.uint8),
+                weights=torch.empty((rows, 1)),
+                guarded_page_table=torch.empty((1, 1), dtype=torch.int32),
+                row_to_batch=torch.zeros(rows, dtype=torch.int32),
+                row_starts=torch.zeros(rows, dtype=torch.int32),
+                c4_seq_lens=torch.ones(rows, dtype=torch.int32),
+                max_seq_len=1,
+                topk=topk,
+                weight_scale=1.0,
+                out_page_indices=torch.empty((rows, topk), dtype=torch.int32),
+                out_raw_indices=torch.empty((rows, topk), dtype=torch.int32),
+                scratch=scratch,
+            )
+
+        self.assertIs(actual, scratch)
+        self.assertTrue(run_litetopk.call_args.kwargs["enforce_status"])
+        self.assertEqual(run_litetopk.call_args.kwargs["topk"], topk)
+
+    def test_chunk_boundary_preserves_global_row_metadata(self):
+        query_rows, topk = 1025, 1024
+        scratch = FP4LiteTopKScratch(
+            workspace=object(), rows=1024, topk=topk, device_index=0, stream_id=17
+        )
+        final_scratch = FP4LiteTopKScratch(
+            workspace=object(), rows=1024, topk=topk, device_index=0, stream_id=17
+        )
+        row_ids = torch.arange(query_rows, dtype=torch.int32)
+        out_page_indices = torch.empty(query_rows, topk, dtype=torch.int32)
+        out_raw_indices = torch.empty_like(out_page_indices)
+        run = MagicMock(side_effect=(scratch, final_scratch))
+        with patch.object(fp4_litetopk_hip, "aiter_fp4_litetopk", run):
+            actual = run_aiter_fp4_litetopk_chunks(
+                q_fp4=row_ids.reshape(-1, 1, 1),
+                q_scale=row_ids.reshape(-1, 1),
+                k_payload=torch.empty(1),
+                k_scale=torch.empty(1),
+                weights=row_ids.reshape(-1, 1),
+                guarded_page_table=torch.empty(1),
+                row_to_batch=row_ids,
+                row_starts=row_ids + 10_000,
+                c4_seq_lens=row_ids + 65_536,
+                max_seq_len=196_608,
+                topk=topk,
+                weight_scale=1.0,
+                out_page_indices=out_page_indices,
+                out_raw_indices=out_raw_indices,
+                rows_per_chunk=1024,
+                scratch=scratch,
+            )
+
+        self.assertIs(actual, final_scratch)
+        self.assertEqual(run.call_count, 2)
+        first = run.call_args_list[0].kwargs
+        second = run.call_args_list[1].kwargs
+        self.assertEqual(first["row_to_batch"].tolist(), list(range(1024)))
+        self.assertEqual(second["row_to_batch"].tolist(), [1024])
+        self.assertEqual(second["row_starts"].tolist(), [11_024])
+        self.assertEqual(second["c4_seq_lens"].tolist(), [66_560])
+        self.assertEqual(second["q_fp4"].reshape(-1).tolist(), [1024])
+        self.assertEqual(second["out_page_indices"].shape, (1, topk))
+        self.assertEqual(second["out_raw_indices"].shape, (1, topk))
+        self.assertEqual(second["topk"], topk)
+        self.assertIs(second["scratch"], scratch)
+
+    def test_forward_dispatches_litetopk_publishes_and_captures(self):
+        rows, topk, c4_len, layer_id = 1, 1024, 65_536, 7
+        page_table = torch.arange(c4_len // 64, dtype=torch.int32).reshape(1, -1)
+        c4_seq_lens = torch.tensor([c4_len], dtype=torch.int32)
+        with patch(f"{_METADATA}.is_hip", return_value=True):
+            indexer_metadata = PagedIndexerMetadata(
+                page_size=256,
+                page_table=page_table,
+                c4_seq_lens=c4_seq_lens,
+                use_topk_v2=False,
+                use_prefill_cuda_graph=False,
+            )
+
+        physical = torch.full((rows, topk), -1, dtype=torch.int32)
+        core = SimpleNamespace(
+            positions=torch.zeros(rows, dtype=torch.int32),
+            c4_sparse_page_indices=physical,
+            c4_sparse_raw_indices=None,
+        )
+        prefill = SimpleNamespace(
+            guarded_page_table=page_table,
+            row_to_batch=torch.zeros(rows, dtype=torch.int32),
+            local_starts=torch.zeros(rows, dtype=torch.int32),
+            max_seq_len=c4_len,
+        )
+        metadata = SimpleNamespace(
+            indexer_metadata=indexer_metadata,
+            core_metadata=core,
+            fp4_prefill_workspace=prefill,
+            fp4_decode_workspace=None,
+            fp4_q_positions=None,
+        )
+        payload = torch.empty(1, dtype=torch.uint8)
+        scale = torch.empty(1)
+        pool = SimpleNamespace(
+            get_index_k_fp4_payload_buffer=MagicMock(return_value=payload),
+            get_index_k_fp4_scale_buffer=MagicMock(return_value=scale),
+            layer_mapping={layer_id: SimpleNamespace(compress_layer_id=3)},
+        )
+        backend = C4IndexerBackendMixin()
+        backend.token_to_kv_pool = pool
+        backend.forward_metadata = metadata
+        backend.hisparse_coordinator = None
+        backend.spec_algorithm = None
+        backend.fp4_litetopk_scratch = None
+        backend.dsa_topk_backend = DSATopKBackend.SGL_KERNEL
+
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            _original_forward_mode=None,
+            batch_size=1,
+            seq_lens_cpu=[4 * c4_len],
+            tbo_parent_token_range=None,
+            tbo_children=None,
+            spec_info=None,
+        )
+        c4_indexer = SimpleNamespace(
+            use_fp4_indexer=True,
+            layer_id=layer_id,
+            index_topk=topk,
+            weight_scale=0.125,
+        )
+        q_fp4 = torch.empty((rows, 64, 64), dtype=torch.uint8)
+        q_scale = torch.empty((rows, 1, 4, 16, 4), dtype=torch.uint8)
+        weights = torch.empty((rows, 64), dtype=torch.float32)
+        prepared = FP4LiteTopKScratch(object(), rows, topk, 0, 17)
+        retained = FP4LiteTopKScratch(object(), rows, topk, 0, 17)
+        expected_raw = torch.arange(topk, dtype=torch.int32).reshape(rows, topk)
+        expected_physical = expected_raw + 4096
+        events = []
+
+        def fake_run(**kwargs):
+            events.append("run")
+            kwargs["out_raw_indices"].copy_(expected_raw)
+            kwargs["out_page_indices"].copy_(expected_physical)
+            return retained
+
+        def fake_capture(compress_layer_id, raw):
+            events.append("capture")
+            self.assertEqual(compress_layer_id, 3)
+            self.assertIs(backend.fp4_litetopk_scratch, retained)
+            self.assertIs(core.c4_sparse_raw_indices, raw)
+
+        run = MagicMock(side_effect=fake_run)
+        dense = MagicMock(side_effect=AssertionError("dense scorer was reached"))
+        capturer = SimpleNamespace(capture=MagicMock(side_effect=fake_capture))
+        with (
+            envs.SGLANG_DSV4_FP4_LITETOPK.override(True),
+            envs.SGLANG_DSV4_FP4_LITETOPK_REQUIRED.override(False),
+            get_parallel().override(attn_cp_size=1),
+            patch(f"{_INDEXER}.is_hip", return_value=True),
+            patch(f"{_INDEXER}.aiter_fp4_litetopk_supports_topk", return_value=True),
+            patch(f"{_INDEXER}.get_global_indexer_capturer", return_value=capturer),
+            patch(f"{_INDEXER}.is_in_tc_piecewise_cuda_graph", return_value=False),
+            patch(f"{_INDEXER}.is_in_breakable_cuda_graph", return_value=False),
+            patch(
+                f"{_INDEXER}.torch.cuda.is_current_stream_capturing",
+                return_value=False,
+            ),
+            patch(
+                f"{_INDEXER}.torch.cuda.get_device_properties",
+                return_value=SimpleNamespace(gcnArchName="gfx950:sramecc+"),
+            ),
+            patch(f"{_INDEXER}.torch.cuda.current_device", return_value=0),
+            patch(
+                f"{_INDEXER}.prepare_fp4_litetopk_scratch_for_dispatch",
+                return_value=prepared,
+            ),
+            patch(f"{_INDEXER}.run_aiter_fp4_litetopk_chunks", run),
+            patch(f"{_INDEXER}.aiter_fp4_paged_mqa_logits", dense),
+            patch.object(
+                C4IndexerBackendMixin,
+                "_forward_prepare_normal",
+                return_value=((q_fp4, q_scale), weights),
+            ),
+        ):
+            result = backend.forward_c4_indexer(
+                torch.empty((rows, 1)),
+                torch.empty((rows, 1)),
+                c4_indexer,
+                batch,
+            )
+            events.append("return")
+
+        self.assertIsNone(result)
+        run.assert_called_once()
+        dense.assert_not_called()
+        self.assertIs(backend.fp4_litetopk_scratch, retained)
+        self.assertEqual(run.call_args.kwargs["topk"], topk)
+        self.assertIs(run.call_args.kwargs["out_page_indices"], physical)
+        self.assertIs(
+            run.call_args.kwargs["out_raw_indices"], core.c4_sparse_raw_indices
+        )
+        torch.testing.assert_close(physical, expected_physical)
+        torch.testing.assert_close(core.c4_sparse_raw_indices, expected_raw)
+        capturer.capture.assert_called_once_with(3, core.c4_sparse_raw_indices)
+        self.assertEqual(events, ["run", "capture", "return"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Enable the ROCm FP4 LiteTopK indexer for both released DeepSeek-V4 contracts: Flash `H64/D128/K512` and Pro `H64/D128/K1024`.

## Modifications

- Propagate the model's `index_topk` through eligibility, workspace sizing, scratch reuse, AITER dispatch, and output publication.
- Handshake against AITER's explicit `(512, 1024)` capability and fail closed in required mode.
- Keep the feature off by default and preserve legacy fallback outside the qualified eager single-request C4 range.

## Accuracy Tests

- AITER FP4: `29 passed, 1 skipped`; K512/K1024 exact-set, ties, short rows, and max C4 context covered.
- SGLang CPU: `19 passed` with `29` subtests.
- SGLang MI355X adapter: `45 passed`; real adapter K512/K1024: `2 passed`.
- The aligned operator benchmark checks exact TopK sets for both released model shapes.

## Speed Tests and Profiling

Real DeepSeek-V4-Pro checkpoint, native `H64/D128/K1024`, 8x MI355X, TP8/DP8, one request per DP rank, one warmup plus three scored rounds. Required mode prevents silent fallback. All 72 requests per arm returned HTTP 200 with zero cache hits and zero retractions.

| Raw context | Baseline TTFT p50 | LiteTopK TTFT p50 | Change |
|---:|---:|---:|---:|
| 262,144 | 52.7516 s | 52.7523 s | +0.0013% |
| 524,288 | 113.5007 s | 113.5192 s | +0.0163% |
| 774,144 | 178.8446 s | 178.1876 s | -0.3674% |

Service TTFT is neutral at 256K/512K and improves 0.37% at the longest point. Flash K512 and GLM K2048 results are kept in their owning AITER PRs rather than mixed into this K1024 E2E table.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34357449647](https://github.com/sgl-project/sglang/actions/runs/34357449647)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34357449431](https://github.com/sgl-project/sglang/actions/runs/34357449431)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34357449674](https://github.com/sgl-project/sglang/actions/runs/34357449674)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
