### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Kimi K2.6 best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/kimi_k2_6.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/kimi_k2_6.mdx
@@ -123,7 +123,7 @@ do
         --dp-size 32 \
         --moe-a2a-backend deepep \
         --deepep-mode auto \
-        --cuda-graph-bs 1 \
+        --cuda-graph-bs-decode 1 \
         --disable-radix-cache \
         --speculative-algorithm EAGLE3 \
         --speculative-draft-model-path $DRAFT_MODEL_PATH \
@@ -305,7 +305,7 @@ do
         --sampling-backend ascend \
         --moe-a2a-backend deepep \
         --deepep-mode auto \
-        --cuda-graph-bs 1 2 4 6 8 16 \
+        --cuda-graph-bs-decode 1 2 4 6 8 16 \
         --speculative-algorithm EAGLE3 \
         --speculative-draft-model-path $DRAFT_MODEL_PATH \
         --speculative-num-steps 3 \
@@ -504,7 +504,7 @@ do
         --sampling-backend ascend \
         --moe-a2a-backend deepep \
         --deepep-mode auto \
-        --cuda-graph-bs 1 2 4 6 8 16 \
+        --cuda-graph-bs-decode 1 2 4 6 8 16 \
         --speculative-algorithm EAGLE3 \
         --speculative-draft-model-path $DRAFT_MODEL_PATH \
         --speculative-num-steps 3 \
@@ -646,7 +646,8 @@ do
         --device npu \
         --tp-size 16 \
         --disable-radix-cache \
-        --disable-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --mem-fraction-static 0.78 \
         --max-running-requests 1 \
         --moe-a2a-backend deepep \
@@ -702,7 +703,7 @@ do
         --sampling-backend ascend \
         --moe-a2a-backend deepep \
         --deepep-mode auto \
-        --cuda-graph-bs 16 \
+        --cuda-graph-bs-decode 16 \
         --reasoning-parser kimi_k2 \
         --tool-call-parser kimi_k2 \
         --speculative-algorithm EAGLE3 \
@@ -896,7 +897,7 @@ do
         --sampling-backend ascend \
         --moe-a2a-backend deepep \
         --deepep-mode auto \
-        --cuda-graph-bs 1 2 4 6 8 \
+        --cuda-graph-bs-decode 1 2 4 6 8 \
         --reasoning-parser kimi_k2 \
         --tool-call-parser kimi_k2 \
         --speculative-algorithm EAGLE3 \


### PR DESCRIPTION
## Summary
Align Ascend Kimi K2.6 best-practice launch recipes with the current CUDA graph CLIs in `python/sglang/srt/server_args.py`.

- Prefer `--cuda-graph-bs-decode` over the deprecated alias `--cuda-graph-bs` (5 remaining recipes; several snippets in this file already used the decode form).
- Prefer `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` over the deprecated `--disable-cuda-graph` (1 recipe).

## Repro
On current `main`, `ServerArgs` still registers:

- `--cuda-graph-bs` as `DeprecatedAliasStoreAction` → `--cuda-graph-bs-decode`
- `--disable-cuda-graph` as `DeprecatedStoreTrueAction` → `--cuda-graph-backend-{decode,prefill}=disabled`

```bash
# Deprecated aliases still accepted, but docs should show the current names:
rg -n 'DeprecatedAliasStoreAction|DeprecatedStoreTrueAction|--cuda-graph-bs"|--disable-cuda-graph' \
  python/sglang/srt/server_args.py

# Docs leftovers before this PR:
rg -n -- '--cuda-graph-bs |--disable-cuda-graph' \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/kimi_k2_6.mdx
```

Batch-size argument lists are unchanged; only the flag names are updated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34102110164](https://github.com/sgl-project/sglang/actions/runs/34102110164)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34102109913](https://github.com/sgl-project/sglang/actions/runs/34102109913)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->