### PR TITLE
[qwen4-main-squashed] Cherry-pick #36811: avoid zero-bias allocation in fused softmax routing (fixes GB10 NEXTN collapse)

### DIFF
--- a/python/sglang/kernels/ops/moe/moe_fused_gate.py
+++ b/python/sglang/kernels/ops/moe/moe_fused_gate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 import triton
@@ -109,6 +109,7 @@ def _router_triton_kernel(
     HAS_SOFTCAP: tl.constexpr,  # tanh softcapping (softmax only)
     RENORMALIZE: tl.constexpr,
     APPLY_SCALE: tl.constexpr,  # apply_routed_scaling_factor_on_output
+    HAS_BIAS: tl.constexpr,
     USE_PDL: tl.constexpr,
     stride_sm,
     stride_sn,
@@ -126,10 +127,13 @@ def _router_triton_kernel(
     mask_m = offs_m < M
     mask_n = offs_n < N
 
-    # prefetch bias before PDL wait
-    bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0).to(
-        tl.float32
-    )  # [BLOCK_N]
+    # Prefetch a real bias before the PDL wait. Plain softmax routing has no
+    # bias, so keep the zero value in registers rather than materializing and
+    # clearing a device tensor for every routing call.
+    if HAS_BIAS:
+        bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0).to(tl.float32)
+    else:
+        bias = tl.zeros([BLOCK_N], dtype=tl.float32)
 
     if USE_PDL:
         tl.extra.cuda.gdc_wait()
@@ -254,7 +258,7 @@ def _router_triton_kernel(
 @debug_kernel_api
 def moe_fused_gate(
     scores: torch.Tensor,
-    bias: torch.Tensor,
+    bias: Optional[torch.Tensor],
     topk: int,
     scoring_func: str = "sigmoid",
     num_fused_shared_experts: int = 0,
@@ -282,10 +286,24 @@ def moe_fused_gate(
         torch.float16,
         torch.bfloat16,
     ), "scores must be float32/float16/bfloat16"
-    assert bias.dtype == torch.float32, "bias must be float32"
     assert scores.ndim == 2, "scores must be 2D"
-    assert bias.ndim == 1, "bias must be 1D"
-    assert scores.size(1) == bias.size(0), "scores and bias must have same num_experts"
+    if bias is None:
+        assert (
+            scoring_func.lower() == "softmax"
+        ), "bias is required for non-softmax routing"
+    else:
+        # The kernel loads the bias and upcasts it to fp32 in-register (see
+        # _router_triton_kernel), so a non-fp32 bias (DeepSeek-V4 stores the
+        # correction bias in bf16) needs no host-side cast/copy.
+        assert bias.dtype in (
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+        ), "bias must be float32/float16/bfloat16"
+        assert bias.ndim == 1, "bias must be 1D"
+        assert scores.size(1) == bias.size(
+            0
+        ), "scores and bias must have same num_experts"
     assert topk > num_fused_shared_experts, "topk must be > num_fused_shared_experts"
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
@@ -342,7 +360,7 @@ def moe_fused_gate(
     extra = {"launch_pdl": True} if use_pdl else {}
     _router_triton_kernel[grid](
         scores,
-        bias,
+        bias if bias is not None else scores,
         weights,
         indices,
         M,
@@ -362,6 +380,7 @@ def moe_fused_gate(
         HAS_SOFTCAP=bool(moe_softcapping != 0.0),
         RENORMALIZE=bool(renormalize),
         APPLY_SCALE=bool(apply_routed_scaling_factor_on_output),
+        HAS_BIAS=bias is not None,
         USE_PDL=use_pdl,
         stride_sm=scores.stride(0),
         stride_sn=scores.stride(1),

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -881,14 +881,9 @@ def fused_topk(
                 moe_fused_gate as _jit_moe_fused_gate,
             )
 
-            zero_bias = torch.zeros(
-                gating_output.shape[1],
-                dtype=torch.float32,
-                device=gating_output.device,
-            )
             topk_weights, topk_ids = _jit_moe_fused_gate(
                 gating_output,
-                zero_bias,
+                None,
                 topk,
                 scoring_func="softmax",
                 renormalize=renormalize,

--- a/test/registered/kernels/ops/moe/test_moe_fused_gate.py
+++ b/test/registered/kernels/ops/moe/test_moe_fused_gate.py
@@ -343,6 +343,23 @@ def test_moe_fused_gate_softmax_matches_aot(
     )
 
 
+@pytest.mark.parametrize("M", [1, 8, 32])
+def test_moe_fused_gate_softmax_none_bias_matches_zero_bias(M: int) -> None:
+    torch.manual_seed(M)
+    scores = torch.randn(M, 256, dtype=torch.float32, device=DEVICE)
+    zero_bias = torch.zeros(256, dtype=torch.float32, device=DEVICE)
+
+    none_w, none_i = moe_fused_gate(
+        scores, None, topk=8, scoring_func="softmax", renormalize=True
+    )
+    zero_w, zero_i = moe_fused_gate(
+        scores, zero_bias, topk=8, scoring_func="softmax", renormalize=True
+    )
+
+    torch.testing.assert_close(none_w, zero_w, rtol=0, atol=0)
+    torch.testing.assert_close(none_i, zero_i, rtol=0, atol=0)
+
+
 _SIGMOID_AOT_CASES = get_ci_test_range(
     [
         (1, 128, 4, True, True, torch.float32),


### PR DESCRIPTION
Cherry-pick of #36811 (main commit 221a6273ce) onto `qwen4-main-squashed`. One trivial conflict resolved: this branch still had the `assert bias.dtype == torch.float32` line that #36811 deletes.

## Why

On DGX Spark (GB10) every NEXTN cell of Qwen3.8-Flash-Next-NVFP4 built from this branch sporadically collapses to repeated `!` (NaN logits, #37111). Root cause: `fused_topk` passes a fresh `torch.zeros` bias to the Triton router kernel, which loads it before its PDL wait, so under programmatic dependent launch it can read the buffer's previous bytes; on GB10 the MTP draft leaves NaN there. An instrumented run captured the kernel consuming NaN bias before the wait, zeros after it, with correct logits. #36811 removes the zero-bias allocation for softmax routing, so there is no buffer left to read early.

## Validation (1x DGX Spark, RadixArk/Qwen3.8-Flash-Next-NVFP4, NEXTN 3/1/4, radix cache off, 8 running requests, GSM8K 1319 + churn client, the shape that collapsed within 2 to 25 min in most runs on this branch tip)

With only this cherry-pick applied: 0.971 accuracy, 0 invalid, 1319/1319 stopped normally, 0 NaN events, 0 routing mismatches against a settled reference recomputed after the kernel. The unpatched branch collapsed twice in the same hours on the same shape.

The kernel-side hardening (wait before the bias load, Triton + radix) is proposed separately against main in #38290 and is not required for this branch's cells.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34104919156](https://github.com/sgl-project/sglang/actions/runs/34104919156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34104918908](https://github.com/sgl-project/sglang/actions/runs/34104918908)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34104919185](https://github.com/sgl-project/sglang/actions/runs/34104919185)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->