### PR TITLE
[CI] Fix the DSpark dp-tier unit test fixture after #34919

### DIFF
--- a/test/registered/spec/dspark/test_dspark_dp_tier.py
+++ b/test/registered/spec/dspark/test_dspark_dp_tier.py
@@ -62,6 +62,7 @@ class TestDraftDpSyncMetadata(CustomTestCase):
             num_tokens_for_logprob_per_req=1,
         )
         proposer.draft_model_runner = SimpleNamespace(device="cpu")
+        proposer._num_token_non_padded = torch.empty((1,), dtype=torch.int32)
 
         forward_batch = SimpleNamespace(input_ids=torch.arange(6))
         batch = SimpleNamespace(
@@ -81,8 +82,13 @@ class TestDraftDpSyncMetadata(CustomTestCase):
             [1, 3, 0, 2],
         )
         self.assertEqual(forward_batch.global_num_tokens_cpu, [6, 18, 0, 12])
-        # Metadata fill sets only the invariant GLOBAL count; the LOCAL
-        # num_token_non_padded is derived later when the draft forward localizes.
+        # The LOCAL count reuses the proposer's persistent buffer; the GLOBAL
+        # count is the invariant every DP rank agrees on.
+        self.assertIs(
+            forward_batch.num_token_non_padded, proposer._num_token_non_padded
+        )
+        self.assertEqual(forward_batch.num_token_non_padded.item(), 6)
+        self.assertEqual(forward_batch.num_token_non_padded_cpu, 6)
         self.assertEqual(forward_batch.global_num_token_non_padded.item(), 6)
         self.assertEqual(forward_batch.global_num_token_non_padded.dtype, torch.int32)
         self.assertEqual(forward_batch.global_num_token_non_padded_cpu, 6)


### PR DESCRIPTION
## Motivation

`base-a-test-cpu (3)` fails on every PR based on today's `main`:

```
test/registered/spec/dspark/test_dspark_dp_tier.py
  TestDraftDpSyncMetadata.test_preserves_unscaled_request_counts_for_cuda_graph_admission
AttributeError: 'DraftBlockProposer' object has no attribute '_num_token_non_padded'
```

#34919 (861d40f3e) gave `DraftBlockProposer.__init__` a persistent
`_num_token_non_padded` buffer and made `_fill_dp_moe_sync_metadata` fill it. The unit
test builds the proposer with `__new__` and hand-sets the fields it needs, so it never
got the new one. Seen on #37584, #38192, #37659, #38159, #37587, #37564.

## Modifications

Test only. The fixture now carries the buffer, and the assertions cover what
`_fill_dp_moe_sync_metadata` writes to the LOCAL count since #34919: it hands the
proposer's buffer to `forward_batch.num_token_non_padded`, filled with the local token
count, next to the GLOBAL count it already checked. The stale comment saying the local
count is derived later is replaced.

## Verification

H200 devbox, `lmsysorg/sglang:dev`, this branch:

| | result |
|---|---|
| `python test/registered/spec/dspark/test_dspark_dp_tier.py` (this fix) | `Ran 5 tests ... OK` |
| same file from `main` 8ae962021 (negative control) | `FAILED (errors=1)`, the `AttributeError` above |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34109807268](https://github.com/sgl-project/sglang/actions/runs/34109807268)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34109807059](https://github.com/sgl-project/sglang/actions/runs/34109807059)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34109807192](https://github.com/sgl-project/sglang/actions/runs/34109807192)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->