### PR TITLE
[HiCache] Feed existence beliefs only for the storage-written prefix

### DIFF
--- a/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
+++ b/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
@@ -704,18 +704,33 @@ class BufferModePipeline:
         )
         self.ongoing_backup[operation_id] = entry
 
-    def finish_storage_write_ack(self, operation_id: int) -> None:
+    def finish_storage_write_ack(
+        self, operation_id: int, successful_tokens: Optional[int] = None
+    ) -> None:
         """Storage write acked (rank-synced drain): free the entry's staging
-        outright. Existence entries are added unconditionally
-        (completed_tokens can diverge across ranks under backend failure) to
-        keep admission decisions TP-deterministic. No-op for operations this
+        outright. Existence beliefs are added only for the prefix the storage
+        write actually persisted; marking the unwritten tail as stored would
+        make ``covers_all`` skip its re-write forever, and unlike a normal
+        stale positive the data never reached L3 so the belief never
+        self-heals (recompute re-stages the same content hashes).
+
+        ``successful_tokens`` is the cross-rank-aligned minimum successful
+        prefix (caller all-reduces ``operation.completed_tokens``); ``None``
+        means the caller cannot supply it (detach/shutdown local drain, where
+        beliefs are cleared on the same path). No-op for operations this
         pipeline does not own (e.g. acks for already-reset state)."""
         entry = self.ongoing_backup.pop(operation_id, None)
         if entry is None:
             return
         intent = entry.intent
         snapshot = intent.snapshot
-        self._cache.storage_existence_cache.add(PoolName.KV, snapshot.hash_values)
+        if successful_tokens is None:
+            successful_pages = snapshot.hash_values
+        else:
+            successful_pages = snapshot.hash_values[
+                : max(0, successful_tokens) // self._cache.page_size
+            ]
+        self._cache.storage_existence_cache.add(PoolName.KV, successful_pages)
         self._free_staging_now(entry.host_indices, entry.aux_xfers)
         self.write_staged_tokens_ -= len(entry.host_indices)
         self.inflight_backup_node_ids.discard(snapshot.node_id)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2568,11 +2568,29 @@ class UnifiedRadixCache(BasePrefixCache):
 
         def _drain_backup():
             drained = 0
+            # On the rank-synced path, all-reduce completed_tokens to the
+            # minimum successful prefix so every rank feeds identical
+            # (pessimistic) existence beliefs, keeping covers_all admission
+            # TP-deterministic when the backend failed partway on a subset.
+            # The detach/shutdown local drain (n_backup is None) skips sync;
+            # it passes None and beliefs are cleared on the same path.
+            local_drain = n_backup is None
             for operation in _drain_queue(cc.ack_backup_queue, n_backup):
                 drained += 1
                 if buffer_mode:
                     # Storage write acked: free the staging.
-                    self.buffer_pipeline.finish_storage_write_ack(operation.id)
+                    successful_tokens = None
+                    if not local_drain:
+                        ct = torch.tensor(
+                            operation.completed_tokens,
+                            dtype=torch.int,
+                            device="cpu",
+                        )
+                        self._all_reduce(ct, torch.distributed.ReduceOp.MIN)
+                        successful_tokens = int(ct.item())
+                    self.buffer_pipeline.finish_storage_write_ack(
+                        operation.id, successful_tokens=successful_tokens
+                    )
                 else:
                     entry = self.ongoing_backup.pop(operation.id, None)
                     if entry is not None:


### PR DESCRIPTION
## Motivation

When a buffer-mode storage backup fails partway (`_page_backup` hits a
`batch_set` failure and `break`s), `finish_storage_write_ack` still marks the
**entire** snapshot as present in L3 — including pages the backend never wrote.
Those pages get a stale-positive existence belief with no self-heal: `covers_all`
skips their re-write forever, and recompute re-stages the same content hashes
the belief already covers, so they are recomputed on every access.

Unlike a normal stale positive (bounded to "one cold recompute" per the
`StorageExistenceCache` docstring), the data never reached L3, so the belief
never heals. Trigger is production-common (connection blip, disk full, network
error) and silent (warning only).

Affects the buffer-mode backup ack path that the sidecar-borrow paths from
#37424 flow through.

## Modifications

- `pipeline.py` `finish_storage_write_ack`: add a `successful_tokens` param
  and feed beliefs only for `hash_values[:successful_tokens // page_size]` —
  the prefix the write actually persisted. `None` keeps full-span behavior.
- `unified_radix_cache.py` `_drain_backup`: all-reduce `completed_tokens`
  (`MIN`) on the rank-synced drain so every rank feeds identical (pessimistic)
  beliefs — preserving the original TP-determinism intent. Mirrors the existing
  `_reduce_prefetch_ack` pattern. The detach/shutdown local drain (`n_backup
  is None`) passes `None` (beliefs cleared on that path).

No change on the happy path (all pages written → full span).

## Accuracy Tests

N/A — cache bookkeeping change, does not affect model outputs.

## Speed Tests and Profiling

N/A — one all-reduce per backup ack on the rank-synced drain (same pattern as
the existing prefetch-ack sync; backup acks are low-volume). No forward-path
impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — cache bookkeeping only)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34111841695](https://github.com/sgl-project/sglang/actions/runs/34111841695)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34915129902](https://github.com/sgl-project/sglang/actions/runs/34915129902)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34111841652](https://github.com/sgl-project/sglang/actions/runs/34111841652)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->