### PR TITLE
[AMD] Fix EAGLE crash when no kv_index_translator is bound on the DSA fp8 read door

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -656,9 +656,14 @@ class DeepseekMHAForwardMixin:
             # reads cached prefix KV crashes with "576 != 656".
             kv_indices = filter_dcp_local_kv_indices(kv_indices=kv_indices)
             # Read door: the pool never translates, so the production site does.
-            kv_indices = get_attn_backend().kv_index_translator.translate_dcp_read_ids(
-                kv_indices
-            )
+            # Only the FlashAttention/FlashInfer backends bind a translator; the
+            # base class documents its None default as "no translate", and the DSA
+            # backend the EAGLE draft model runs on keeps that default. With no
+            # translator the ids never went VIRTUAL, so there is nothing to
+            # collapse.
+            translator = get_attn_backend().kv_index_translator
+            if translator is not None:
+                kv_indices = translator.translate_dcp_read_ids(kv_indices)
             kv_a, k_pe = get_token_to_kv_pool().get_mla_kv_buffer(
                 self.attn_mha, kv_indices, torch.bfloat16
             )


### PR DESCRIPTION
## Motivation

`_get_mla_kv_buffer_from_fp8_for_dsa` translates its read ids through the attention backend's `kv_index_translator` unconditionally:

https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py#L659

But only the FlashAttention and FlashInfer backends bind a translator. `BaseAttentionBackend` documents its `None` default as meaning "no translate":

```python
# The runner's KVIndexTranslator; backends that read through it set the
# instance attribute in __init__. None means "no translate" -- a backend
# that never set it cannot serve the unified pool, which the server-args
# allow-list enforces.
kv_index_translator = None
```

The DSA backend keeps that default. Under EAGLE the draft model runs on the DSA backend and reaches this door, so on gfx950 with `--kv-cache-dtype fp8_e4m3` every TP rank dies on the first request:

```
  File "python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py", line 211, in forward_normal_rocm_prepare
    kv_a, k_pe = self._get_mla_kv_buffer_from_fp8_for_dsa(forward_batch)
  File "python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py", line 659, in _get_mla_kv_buffer_from_fp8_for_dsa
    kv_indices = get_attn_backend().kv_index_translator.translate_dcp_read_ids(
AttributeError: 'NoneType' object has no attribute 'translate_dcp_read_ids'
```

The server comes up fine and dies the moment the first request arrives, taking down all four ranks. A target-only (non-speculative) run has no draft model and never reaches this door, which is why the crash is specific to speculative decoding.

Repro (crashes on current `main`, serves normally with this PR):

```
python3 -m sglang.launch_server --model amd/GLM-5.2-MXFP4 --tp 4 --trust-remote-code \
  --kv-cache-dtype fp8_e4m3 --disable-radix-cache --chunked-prefill-size 16384 \
  --dsa-prefill-backend triton --dsa-decode-backend triton \
  --speculative-algorithm EAGLE --speculative-num-draft-tokens 4 \
  --speculative-num-steps 3 --speculative-eagle-topk 1
```

## Modifications

Honor the documented contract at the read door: skip the translation when no translator is bound. With no translator the ids were never widened to VIRTUAL, so there is nothing to collapse. Behavior for the backends that do bind a translator is unchanged.

```python
translator = get_attn_backend().kv_index_translator
if translator is not None:
    kv_indices = translator.translate_dcp_read_ids(kv_indices)
```

One file, guard only, no functional change on any path that previously worked.

## Accuracy Tests

GLM-5.2-MXFP4, MI355X (gfx950), TP4, GSM8K, three runs. Before the fix the speculative server could not serve a single request, so there was no MTP result to compare against.

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| EAGLE (this PR) | 0.941 | 0.932 | 0.927 |
| target-only, same build | 0.929 | 0.932 | 0.932 |

Speculative decoding lands in the same band as the target-only reference, as expected.

## Speed Tests and Profiling

Not applicable: the change adds a single `None` check and leaves every previously working path byte-for-byte identical.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34112612224](https://github.com/sgl-project/sglang/actions/runs/34112612224)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34113804718](https://github.com/sgl-project/sglang/actions/runs/34113804718)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34112612204](https://github.com/sgl-project/sglang/actions/runs/34112612204)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->