### PR TITLE
[MoE] Add FlashInfer SM120 W4A8 MegaMoE backend for DeepSeek-V4-Flash

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -80,13 +80,18 @@ def validate_deepseek_v4_mega_moe_token_budget(
         // token_alignment
         * token_alignment
     )
-    max_tokens_per_rank = (
-        envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
-    )
+    if cfg.moe_runner_backend == "flashinfer_megamoe":
+        max_tokens_per_rank = cfg.flashinfer_megamoe_max_num_tokens
+        capacity_name = "--flashinfer-megamoe-max-num-tokens"
+    else:
+        max_tokens_per_rank = (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
+        )
+        capacity_name = "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK"
     if max_tokens_per_rank < required_tokens_per_rank:
         raise ValueError(
             "DeepSeekV4 with MegaMoE requires "
-            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK to "
+            f"{capacity_name} to "
             "cover each rank's effective prefill token budget. "
             f"Current values: chunked_prefill_size="
             f"{cfg.chunked_prefill_size}, "
@@ -94,12 +99,10 @@ def validate_deepseek_v4_mega_moe_token_budget(
             f"token_partition_size={token_partition_size}, "
             f"token_alignment={token_alignment}, "
             f"required_per_rank={required_tokens_per_rank}, "
-            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK="
-            f"{max_tokens_per_rank}. Set "
-            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK to at "
+            f"{capacity_name}={max_tokens_per_rank}. Set {capacity_name} to at "
             f"least {required_tokens_per_rank}, or lower "
             "--chunked-prefill-size until the effective per-rank budget fits. "
-            "Otherwise MegaMoE falls back to the fused MoE path at runtime."
+            "Otherwise MegaMoE cannot execute that batch."
         )
 
 

--- a/python/sglang/srt/arg_groups/mega_moe_hook.py
+++ b/python/sglang/srt/arg_groups/mega_moe_hook.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 def handle_mega_moe(server_args: ServerArgs) -> None:
     handle_moe_runner_backend_alias(server_args)
+    handle_flashinfer_megamoe(server_args)
 
 
 def handle_moe_runner_backend_alias(server_args: ServerArgs) -> None:
@@ -35,4 +36,37 @@ def handle_moe_runner_backend_alias(server_args: ServerArgs) -> None:
         "handle_moe_runner_backend_alias",
         moe_runner_backend="auto",
         moe_a2a_backend="megamoe",
+    )
+
+
+def handle_flashinfer_megamoe(server_args: ServerArgs) -> None:
+    """Bind the FlashInfer MegaMoE runner to SGLang's fused MegaMoE path."""
+    cfg = resolving_view(server_args)
+    if cfg.moe_runner_backend != "flashinfer_megamoe":
+        return
+
+    if cfg.moe_a2a_backend not in ("none", "megamoe"):
+        raise ValueError(
+            "--moe-runner-backend flashinfer_megamoe owns dispatch and combine; "
+            "it cannot be combined with --moe-a2a-backend "
+            f"{cfg.moe_a2a_backend!r}."
+        )
+    if cfg.enable_eplb or cfg.ep_num_redundant_experts != 0:
+        raise ValueError(
+            "FlashInfer MegaMoE currently requires an even, non-replicated "
+            "expert placement; disable EPLB and redundant experts."
+        )
+    if cfg.flashinfer_megamoe_max_num_tokens <= 0:
+        raise ValueError("--flashinfer-megamoe-max-num-tokens must be positive")
+
+    if not cfg.disable_shared_experts_fusion:
+        logger.warning(
+            "FlashInfer MegaMoE computes the shared expert separately from the "
+            "routed MegaMoE kernel; enabling --disable-shared-experts-fusion."
+        )
+    declare_resolution(
+        server_args,
+        "handle_flashinfer_megamoe",
+        moe_a2a_backend="megamoe",
+        disable_shared_experts_fusion=True,
     )

--- a/python/sglang/srt/arg_groups/mega_moe_hook.py
+++ b/python/sglang/srt/arg_groups/mega_moe_hook.py
@@ -45,6 +45,11 @@ def handle_flashinfer_megamoe(server_args: ServerArgs) -> None:
     if cfg.moe_runner_backend != "flashinfer_megamoe":
         return
 
+    if cfg.enable_two_batch_overlap:
+        raise ValueError(
+            "--moe-runner-backend flashinfer_megamoe does not support "
+            "--enable-two-batch-overlap yet; disable TBO for this backend."
+        )
     if cfg.moe_a2a_backend not in ("none", "megamoe"):
         raise ValueError(
             "--moe-runner-backend flashinfer_megamoe owns dispatch and combine; "

--- a/python/sglang/srt/layers/moe/flashinfer_mega_moe.py
+++ b/python/sglang/srt/layers/moe/flashinfer_mega_moe.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import weakref
 from typing import Any, Optional
 
@@ -13,9 +12,9 @@ from sglang.srt.distributed.parallel_state import get_moe_ep_group
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.custom_op import register_custom_op
 
-logger = logging.getLogger(__name__)
-
-_ADAPTERS: dict[int, weakref.ReferenceType["FlashInferMegaMoEAdapter"]] = {}
+_ADAPTERS: weakref.WeakValueDictionary[int, FlashInferMegaMoEAdapter] = (
+    weakref.WeakValueDictionary()
+)
 
 
 def _view_byte_dtype(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
@@ -27,8 +26,7 @@ def _view_byte_dtype(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
 
 
 def _lookup_adapter(handle: int) -> FlashInferMegaMoEAdapter:
-    ref = _ADAPTERS.get(handle)
-    adapter = ref() if ref is not None else None
+    adapter = _ADAPTERS.get(handle)
     if adapter is None:
         raise RuntimeError(f"stale FlashInfer MegaMoE adapter handle {handle}")
     return adapter
@@ -59,55 +57,26 @@ class FlashInferMegaMoEAdapter(nn.Module):
         self.layer: Any = None
         self._tensors_cls: Any = None
         self._fast_tensors: Any = None
-        self._output: Optional[torch.Tensor] = None
         self.handle = id(self)
-        _ADAPTERS[self.handle] = weakref.ref(self)
+        _ADAPTERS[self.handle] = self
 
     @staticmethod
-    def _api() -> dict[str, Any]:
+    def _api() -> Any:
         try:
-            from flashinfer.moe_ep import (
-                BootstrapConfig,
-                FleetParams,
-                MegaConfig,
-                MoEEpLayer,
-                MoEEpTensors,
-                PrequantizedMoEWeights,
-                Sm120_Mxfp4_Mxfp8_Bf16_Cutedsl_MegaMoeConfig,
-            )
+            import flashinfer.moe_ep as moe_ep
         except ImportError as exc:
             raise ImportError(
-                "flashinfer_megamoe requires the FlashInfer "
-                "sm120-w4a8-megamoe branch with flashinfer.moe_ep support"
+                "flashinfer_megamoe requires FlashInfer with flashinfer.moe_ep support"
             ) from exc
-        return {
-            "BootstrapConfig": BootstrapConfig,
-            "FleetParams": FleetParams,
-            "MegaConfig": MegaConfig,
-            "MoEEpLayer": MoEEpLayer,
-            "MoEEpTensors": MoEEpTensors,
-            "PrequantizedMoEWeights": PrequantizedMoEWeights,
-            "KernelConfig": Sm120_Mxfp4_Mxfp8_Bf16_Cutedsl_MegaMoeConfig,
-        }
+        return moe_ep
 
-    def _validate_runtime(self, device: torch.device) -> None:
-        capability = torch.cuda.get_device_capability(device)
-        if capability[0] != 12:
-            raise NotImplementedError(
-                "FlashInfer MXFP4 x MXFP8 MegaMoE requires SM120; got "
-                f"SM{capability[0]}{capability[1]}."
-            )
+    def _validate_parallel(self) -> None:
         parallel = get_parallel()
         if parallel.attn_tp_size != 1 or parallel.moe_tp_size != 1:
             raise ValueError(
                 "FlashInfer MegaMoE requires attention TP1 and MoE TP1. "
                 f"Derived widths are attn_tp={parallel.attn_tp_size}, "
                 f"moe_tp={parallel.moe_tp_size}."
-            )
-        if self.hidden_size % 128 or self.intermediate_size % 128:
-            raise ValueError(
-                "FlashInfer MegaMoE requires hidden and intermediate sizes "
-                "to be multiples of 128."
             )
 
     def finalize_weights(
@@ -117,9 +86,7 @@ class FlashInferMegaMoEAdapter(nn.Module):
         w13_scale: torch.Tensor,
         w2_scale: torch.Tensor,
     ) -> None:
-        if self.layer is not None:
-            return
-        self._validate_runtime(w13.device)
+        self._validate_parallel()
         api = self._api()
         ep_group = get_moe_ep_group()
         if ep_group.world_size * self.num_local_experts != self.num_experts:
@@ -128,56 +95,46 @@ class FlashInferMegaMoEAdapter(nn.Module):
                 "expert partition."
             )
 
-        weights = api["PrequantizedMoEWeights"](
+        weights = api.PrequantizedMoEWeights(
             w13=_view_byte_dtype(w13, torch.float4_e2m1fn_x2),
             w2=_view_byte_dtype(w2, torch.float4_e2m1fn_x2),
             w13_scale=_view_byte_dtype(w13_scale, torch.float8_e8m0fnu),
             w2_scale=_view_byte_dtype(w2_scale, torch.float8_e8m0fnu),
         )
-        bootstrap = api["BootstrapConfig"](
+        bootstrap = api.BootstrapConfig(
             world_size=ep_group.world_size,
             rank=ep_group.rank_in_group,
             device=torch.cuda.current_device(),
             process_group=ep_group.device_group,
         )
-        fleet = api["FleetParams"](
+        fleet = api.FleetParams(
             num_experts=self.num_experts,
             max_tokens_per_rank=self.max_num_tokens,
             token_hidden_size=self.hidden_size,
         )
-        kernel_config = api["KernelConfig"](
+        kernel_cls = api.Sm120_Mxfp4_Mxfp8_Bf16_Cutedsl_MegaMoeConfig
+        kernel_config = kernel_cls(
             intermediate_size=self.intermediate_size,
             top_k=self.top_k,
             gate_up_clamp=self.activation_clamp,
         )
-        self.layer = api["MoEEpLayer"](
+        self.layer = api.MoEEpLayer(
             bootstrap=bootstrap,
             fleet_params=fleet,
             weights=weights,
-            backend=api["MegaConfig"](
+            backend=api.MegaConfig(
                 megakernel=kernel_config,
                 quantize_input=True,
                 preprocess_weights=True,
             ),
         )
-        self._tensors_cls = api["MoEEpTensors"]
-        self._output = self.layer.output_buffer
-        logger.info(
-            "Initialized FlashInfer MegaMoE: experts=%d local_experts=%d "
-            "top_k=%d hidden=%d intermediate=%d capacity=%d",
-            self.num_experts,
-            self.num_local_experts,
-            self.top_k,
-            self.hidden_size,
-            self.intermediate_size,
-            self.max_num_tokens,
-        )
+        self._tensors_cls = api.MoEEpTensors
 
     @property
     def output_buffer(self) -> torch.Tensor:
-        if self._output is None:
+        if self.layer is None:
             raise RuntimeError("FlashInfer MegaMoE weights are not finalized")
-        return self._output
+        return self.layer.output_buffer
 
     def stage_into(
         self,
@@ -187,29 +144,9 @@ class FlashInferMegaMoEAdapter(nn.Module):
         output: torch.Tensor,
         *,
         compile_tokens_per_rank: int,
-        activation_clamp: Optional[float],
     ) -> None:
         if self.layer is None or self._tensors_cls is None:
             raise RuntimeError("FlashInfer MegaMoE weights are not finalized")
-        if hidden_states.shape[0] > self.max_num_tokens:
-            raise ValueError(
-                f"local token count {hidden_states.shape[0]} exceeds FlashInfer "
-                f"MegaMoE capacity {self.max_num_tokens}"
-            )
-        if compile_tokens_per_rank < hidden_states.shape[0]:
-            raise ValueError(
-                "compile_tokens_per_rank cannot be smaller than the local rows"
-            )
-        if activation_clamp != self.activation_clamp:
-            raise ValueError(
-                "FlashInfer MegaMoE activation clamp changed after construction: "
-                f"{self.activation_clamp} -> {activation_clamp}"
-            )
-        if topk_ids.dtype != torch.int64 or topk_weights.dtype != torch.float32:
-            raise TypeError(
-                "FlashInfer MegaMoE requires int64 topk_ids and fp32 topk_weights; "
-                f"got {topk_ids.dtype} and {topk_weights.dtype}."
-            )
 
         if self._fast_tensors is None:
             self._fast_tensors = self._tensors_cls(
@@ -242,7 +179,6 @@ def flashinfer_megamoe_stage(
     output: torch.Tensor,
     handle: int,
     compile_tokens_per_rank: int,
-    activation_clamp: Optional[float],
 ) -> None:
     _lookup_adapter(handle).stage_into(
         hidden_states,
@@ -250,7 +186,6 @@ def flashinfer_megamoe_stage(
         topk_ids,
         output,
         compile_tokens_per_rank=compile_tokens_per_rank,
-        activation_clamp=activation_clamp,
     )
 
 
@@ -276,29 +211,19 @@ def finalize_flashinfer_megamoe_weights(layer, *, max_num_tokens: int) -> None:
         max_num_tokens=max_num_tokens,
         activation_clamp=layer.moe_runner_config.swiglu_limit,
     )
-    w13_scale_name = (
-        "w13_weight_scale_inv"
-        if hasattr(layer, "w13_weight_scale_inv")
-        else "w13_weight_scale"
-    )
-    w2_scale_name = (
-        "w2_weight_scale_inv"
-        if hasattr(layer, "w2_weight_scale_inv")
-        else "w2_weight_scale"
-    )
     adapter.finalize_weights(
         layer.w13_weight.data,
         layer.w2_weight.data,
-        getattr(layer, w13_scale_name).data,
-        getattr(layer, w2_scale_name).data,
+        layer.w13_weight_scale_inv.data,
+        layer.w2_weight_scale_inv.data,
     )
     layer.flashinfer_megamoe_adapter = adapter
     # FlashInfer owns the preprocessed weight pack after construction. Drop the
     # loader-side Parameters to avoid retaining a second full expert copy.
     layer.w13_weight = None
     layer.w2_weight = None
-    setattr(layer, w13_scale_name, None)
-    setattr(layer, w2_scale_name, None)
+    layer.w13_weight_scale_inv = None
+    layer.w2_weight_scale_inv = None
     layer._mega_moe_weights_built = True
 
 
@@ -309,7 +234,6 @@ def run_flashinfer_megamoe(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     compile_tokens_per_rank: int,
-    activation_clamp: Optional[float],
 ) -> torch.Tensor:
     adapter = getattr(layer, "flashinfer_megamoe_adapter", None)
     if adapter is None:
@@ -322,7 +246,6 @@ def run_flashinfer_megamoe(
         output,
         adapter.handle,
         compile_tokens_per_rank,
-        activation_clamp,
     )
     flashinfer_megamoe_compute(output, adapter.handle)
     return output[: hidden_states.shape[0]]

--- a/python/sglang/srt/layers/moe/flashinfer_mega_moe.py
+++ b/python/sglang/srt/layers/moe/flashinfer_mega_moe.py
@@ -1,0 +1,328 @@
+"""SGLang adapter for FlashInfer's SM120 MXFP4 x MXFP8 MegaMoE backend."""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.distributed.parallel_state import get_moe_ep_group
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils.custom_op import register_custom_op
+
+logger = logging.getLogger(__name__)
+
+_ADAPTERS: dict[int, weakref.ReferenceType["FlashInferMegaMoEAdapter"]] = {}
+
+
+def _view_byte_dtype(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    if tensor.dtype == dtype:
+        return tensor
+    if tensor.dtype not in (torch.uint8, torch.int8):
+        raise TypeError(f"expected byte storage or {dtype}, got {tensor.dtype}")
+    return tensor.view(dtype)
+
+
+def _lookup_adapter(handle: int) -> FlashInferMegaMoEAdapter:
+    ref = _ADAPTERS.get(handle)
+    adapter = ref() if ref is not None else None
+    if adapter is None:
+        raise RuntimeError(f"stale FlashInfer MegaMoE adapter handle {handle}")
+    return adapter
+
+
+class FlashInferMegaMoEAdapter(nn.Module):
+    """Own one FlashInfer ``MoEEpLayer`` and its stable output buffer."""
+
+    def __init__(
+        self,
+        *,
+        num_experts: int,
+        num_local_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        max_num_tokens: int,
+        activation_clamp: Optional[float],
+    ) -> None:
+        super().__init__()
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.max_num_tokens = max_num_tokens
+        self.activation_clamp = activation_clamp
+        self.layer: Any = None
+        self._tensors_cls: Any = None
+        self._fast_tensors: Any = None
+        self._output: Optional[torch.Tensor] = None
+        self.handle = id(self)
+        _ADAPTERS[self.handle] = weakref.ref(self)
+
+    @staticmethod
+    def _api() -> dict[str, Any]:
+        try:
+            from flashinfer.moe_ep import (
+                BootstrapConfig,
+                FleetParams,
+                MegaConfig,
+                MoEEpLayer,
+                MoEEpTensors,
+                PrequantizedMoEWeights,
+                Sm120_Mxfp4_Mxfp8_Bf16_Cutedsl_MegaMoeConfig,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "flashinfer_megamoe requires the FlashInfer "
+                "sm120-w4a8-megamoe branch with flashinfer.moe_ep support"
+            ) from exc
+        return {
+            "BootstrapConfig": BootstrapConfig,
+            "FleetParams": FleetParams,
+            "MegaConfig": MegaConfig,
+            "MoEEpLayer": MoEEpLayer,
+            "MoEEpTensors": MoEEpTensors,
+            "PrequantizedMoEWeights": PrequantizedMoEWeights,
+            "KernelConfig": Sm120_Mxfp4_Mxfp8_Bf16_Cutedsl_MegaMoeConfig,
+        }
+
+    def _validate_runtime(self, device: torch.device) -> None:
+        capability = torch.cuda.get_device_capability(device)
+        if capability[0] != 12:
+            raise NotImplementedError(
+                "FlashInfer MXFP4 x MXFP8 MegaMoE requires SM120; got "
+                f"SM{capability[0]}{capability[1]}."
+            )
+        parallel = get_parallel()
+        if parallel.attn_tp_size != 1 or parallel.moe_tp_size != 1:
+            raise ValueError(
+                "FlashInfer MegaMoE requires attention TP1 and MoE TP1. "
+                f"Derived widths are attn_tp={parallel.attn_tp_size}, "
+                f"moe_tp={parallel.moe_tp_size}."
+            )
+        if self.hidden_size % 128 or self.intermediate_size % 128:
+            raise ValueError(
+                "FlashInfer MegaMoE requires hidden and intermediate sizes "
+                "to be multiples of 128."
+            )
+
+    def finalize_weights(
+        self,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+    ) -> None:
+        if self.layer is not None:
+            return
+        self._validate_runtime(w13.device)
+        api = self._api()
+        ep_group = get_moe_ep_group()
+        if ep_group.world_size * self.num_local_experts != self.num_experts:
+            raise ValueError(
+                "FlashInfer MegaMoE requires an even, non-replicated EP "
+                "expert partition."
+            )
+
+        weights = api["PrequantizedMoEWeights"](
+            w13=_view_byte_dtype(w13, torch.float4_e2m1fn_x2),
+            w2=_view_byte_dtype(w2, torch.float4_e2m1fn_x2),
+            w13_scale=_view_byte_dtype(w13_scale, torch.float8_e8m0fnu),
+            w2_scale=_view_byte_dtype(w2_scale, torch.float8_e8m0fnu),
+        )
+        bootstrap = api["BootstrapConfig"](
+            world_size=ep_group.world_size,
+            rank=ep_group.rank_in_group,
+            device=torch.cuda.current_device(),
+            process_group=ep_group.device_group,
+        )
+        fleet = api["FleetParams"](
+            num_experts=self.num_experts,
+            max_tokens_per_rank=self.max_num_tokens,
+            token_hidden_size=self.hidden_size,
+        )
+        kernel_config = api["KernelConfig"](
+            intermediate_size=self.intermediate_size,
+            top_k=self.top_k,
+            gate_up_clamp=self.activation_clamp,
+        )
+        self.layer = api["MoEEpLayer"](
+            bootstrap=bootstrap,
+            fleet_params=fleet,
+            weights=weights,
+            backend=api["MegaConfig"](
+                megakernel=kernel_config,
+                quantize_input=True,
+                preprocess_weights=True,
+            ),
+        )
+        self._tensors_cls = api["MoEEpTensors"]
+        self._output = self.layer.output_buffer
+        logger.info(
+            "Initialized FlashInfer MegaMoE: experts=%d local_experts=%d "
+            "top_k=%d hidden=%d intermediate=%d capacity=%d",
+            self.num_experts,
+            self.num_local_experts,
+            self.top_k,
+            self.hidden_size,
+            self.intermediate_size,
+            self.max_num_tokens,
+        )
+
+    @property
+    def output_buffer(self) -> torch.Tensor:
+        if self._output is None:
+            raise RuntimeError("FlashInfer MegaMoE weights are not finalized")
+        return self._output
+
+    def stage_into(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        output: torch.Tensor,
+        *,
+        compile_tokens_per_rank: int,
+        activation_clamp: Optional[float],
+    ) -> None:
+        if self.layer is None or self._tensors_cls is None:
+            raise RuntimeError("FlashInfer MegaMoE weights are not finalized")
+        if hidden_states.shape[0] > self.max_num_tokens:
+            raise ValueError(
+                f"local token count {hidden_states.shape[0]} exceeds FlashInfer "
+                f"MegaMoE capacity {self.max_num_tokens}"
+            )
+        if compile_tokens_per_rank < hidden_states.shape[0]:
+            raise ValueError(
+                "compile_tokens_per_rank cannot be smaller than the local rows"
+            )
+        if activation_clamp != self.activation_clamp:
+            raise ValueError(
+                "FlashInfer MegaMoE activation clamp changed after construction: "
+                f"{self.activation_clamp} -> {activation_clamp}"
+            )
+        if topk_ids.dtype != torch.int64 or topk_weights.dtype != torch.float32:
+            raise TypeError(
+                "FlashInfer MegaMoE requires int64 topk_ids and fp32 topk_weights; "
+                f"got {topk_ids.dtype} and {topk_weights.dtype}."
+            )
+
+        if self._fast_tensors is None:
+            self._fast_tensors = self._tensors_cls(
+                hidden_states=hidden_states,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+                output=output,
+            )
+        else:
+            self._fast_tensors.hidden_states = hidden_states
+            self._fast_tensors.topk_ids = topk_ids
+            self._fast_tensors.topk_weights = topk_weights
+            self._fast_tensors.output = output
+        self.layer.stage_inputs(
+            self._fast_tensors,
+            compile_tokens_per_rank=compile_tokens_per_rank,
+        )
+
+    def compute_staged_into(self, output: torch.Tensor) -> None:
+        if self.layer is None:
+            raise RuntimeError("FlashInfer MegaMoE weights are not finalized")
+        self.layer.compute_staged(output=output)
+
+
+@register_custom_op(mutates_args=["output"])
+def flashinfer_megamoe_stage(
+    hidden_states: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    output: torch.Tensor,
+    handle: int,
+    compile_tokens_per_rank: int,
+    activation_clamp: Optional[float],
+) -> None:
+    _lookup_adapter(handle).stage_into(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        output,
+        compile_tokens_per_rank=compile_tokens_per_rank,
+        activation_clamp=activation_clamp,
+    )
+
+
+@register_custom_op(mutates_args=["output"])
+def flashinfer_megamoe_compute(output: torch.Tensor, handle: int) -> None:
+    _lookup_adapter(handle).compute_staged_into(output)
+
+
+def finalize_flashinfer_megamoe_weights(layer, *, max_num_tokens: int) -> None:
+    if getattr(layer, "flashinfer_megamoe_adapter", None) is not None:
+        return
+    if layer.num_fused_shared_experts != 0:
+        raise ValueError(
+            "FlashInfer MegaMoE requires --disable-shared-experts-fusion; "
+            "the shared expert is computed separately."
+        )
+    adapter = FlashInferMegaMoEAdapter(
+        num_experts=layer.num_experts,
+        num_local_experts=layer.num_local_experts,
+        top_k=layer.moe_runner_config.top_k,
+        hidden_size=layer.moe_runner_config.hidden_size,
+        intermediate_size=layer.intermediate_size_per_partition,
+        max_num_tokens=max_num_tokens,
+        activation_clamp=layer.moe_runner_config.swiglu_limit,
+    )
+    w13_scale_name = (
+        "w13_weight_scale_inv"
+        if hasattr(layer, "w13_weight_scale_inv")
+        else "w13_weight_scale"
+    )
+    w2_scale_name = (
+        "w2_weight_scale_inv"
+        if hasattr(layer, "w2_weight_scale_inv")
+        else "w2_weight_scale"
+    )
+    adapter.finalize_weights(
+        layer.w13_weight.data,
+        layer.w2_weight.data,
+        getattr(layer, w13_scale_name).data,
+        getattr(layer, w2_scale_name).data,
+    )
+    layer.flashinfer_megamoe_adapter = adapter
+    # FlashInfer owns the preprocessed weight pack after construction. Drop the
+    # loader-side Parameters to avoid retaining a second full expert copy.
+    layer.w13_weight = None
+    layer.w2_weight = None
+    setattr(layer, w13_scale_name, None)
+    setattr(layer, w2_scale_name, None)
+    layer._mega_moe_weights_built = True
+
+
+def run_flashinfer_megamoe(
+    layer,
+    hidden_states: torch.Tensor,
+    *,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    compile_tokens_per_rank: int,
+    activation_clamp: Optional[float],
+) -> torch.Tensor:
+    adapter = getattr(layer, "flashinfer_megamoe_adapter", None)
+    if adapter is None:
+        raise RuntimeError("FlashInfer MegaMoE adapter is not initialized")
+    output = adapter.output_buffer
+    flashinfer_megamoe_stage(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        output,
+        adapter.handle,
+        compile_tokens_per_rank,
+        activation_clamp,
+    )
+    flashinfer_megamoe_compute(output, adapter.handle)
+    return output[: hidden_states.shape[0]]

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 _MEGA_MOE_SYMM_BUFFER: dict = {}
 
 
-def get_mega_moe_max_tokens_per_rank() -> int:
+def _get_mega_moe_max_tokens_per_rank() -> int:
     if get_moe_runner_backend().is_flashinfer_megamoe():
         return get_exec().moe.flashinfer_megamoe_max_num_tokens
     return envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
@@ -134,24 +134,8 @@ def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
         return False
 
-    # FlashInfer takes ownership of the checkpoint-format expert parameters in
-    # post-load processing, so there is intentionally no ordinary FusedMoE
-    # fallback. Fail explicitly on a capacity violation instead of falling
-    # through to a runner whose source weights have already been released.
+    # FlashInfer owns the source weights, so it has no ordinary FusedMoE fallback.
     if get_moe_runner_backend().is_flashinfer_megamoe():
-        global_num_tokens = get_dp_global_num_tokens()
-        if global_num_tokens and not is_dsa_enable_prefill_cp():
-            max_tokens_per_rank = max(global_num_tokens)
-        else:
-            max_tokens_per_rank = hidden_states.shape[0]
-        cap = get_mega_moe_max_tokens_per_rank()
-        if max_tokens_per_rank > cap:
-            raise ValueError(
-                "FlashInfer MegaMoE token capacity exceeded: "
-                f"required={max_tokens_per_rank}, capacity={cap}. Raise "
-                "--flashinfer-megamoe-max-num-tokens or reduce the per-rank "
-                "prefill/decode admission limit."
-            )
         return True
 
     if _device_sm == 90:
@@ -165,7 +149,7 @@ def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool
         max_tokens_per_rank = max(global_num_tokens)
     else:
         max_tokens_per_rank = hidden_states.shape[0]
-    cap = get_mega_moe_max_tokens_per_rank()
+    cap = _get_mega_moe_max_tokens_per_rank()
     return max_tokens_per_rank <= cap
 
 
@@ -194,9 +178,7 @@ def forward_mega_moe(
         mega_stream_ctx = nullcontext()
 
     with mega_stream_ctx:
-        y = _run_mega_routed(
-            moe, hidden_states, forward_batch, input_ids_global, num_tokens
-        )
+        y = _run_mega_routed(moe, hidden_states, forward_batch, input_ids_global)
 
     if sbo_overlap_flag:
         current_stream.wait_stream(moe.alt_stream)
@@ -211,11 +193,8 @@ def _run_mega_routed(
     hidden_states: torch.Tensor,
     forward_batch: Optional[ForwardBatch],
     input_ids_global: Optional[torch.Tensor],
-    num_tokens: int,
 ) -> torch.Tensor:
-    from sglang.srt.distributed.parallel_state import get_moe_ep_group
-
-    hidden_size = moe.config.hidden_size
+    num_tokens = hidden_states.shape[0]
 
     if num_tokens > 0:
         router_logits = moe.gate(hidden_states, forward_batch=forward_batch)
@@ -239,17 +218,7 @@ def _run_mega_routed(
         topk_ids = None
         topk_weights = None
 
-    ep_group = get_moe_ep_group().device_group
-    num_experts = moe.experts.num_experts
     top_k = moe.config.num_experts_per_tok + moe.num_fused_shared_experts
-    intermediate_size = moe.config.moe_intermediate_size
-    num_max_tokens_per_rank = get_mega_moe_max_tokens_per_rank()
-    assert num_tokens <= num_max_tokens_per_rank, (
-        f"mega MoE: num_tokens={num_tokens} exceeds cap "
-        f"MegaMoE max tokens per rank="
-        f"{num_max_tokens_per_rank}; raise the configured capacity or shrink "
-        f"cuda_graph_max_bs / chunked_prefill_size accordingly"
-    )
 
     if get_moe_runner_backend().is_flashinfer_megamoe():
         from sglang.srt.layers.moe.flashinfer_mega_moe import (
@@ -257,9 +226,15 @@ def _run_mega_routed(
         )
 
         global_num_tokens = get_dp_global_num_tokens()
-        compile_tokens_per_rank = (
-            max(global_num_tokens) if global_num_tokens else num_tokens
-        )
+        compile_tokens_per_rank = max([num_tokens, *(global_num_tokens or [])])
+        capacity = _get_mega_moe_max_tokens_per_rank()
+        if compile_tokens_per_rank > capacity:
+            raise ValueError(
+                "FlashInfer MegaMoE token capacity exceeded: "
+                f"required={compile_tokens_per_rank}, capacity={capacity}. Raise "
+                "--flashinfer-megamoe-max-num-tokens or reduce the per-rank "
+                "prefill/decode admission limit."
+            )
         y = run_flashinfer_megamoe(
             moe.experts,
             hidden_states,
@@ -273,14 +248,26 @@ def _run_mega_routed(
                 if topk_weights is not None
                 else hidden_states.new_empty((0, top_k), dtype=torch.float32)
             ),
-            compile_tokens_per_rank=max(compile_tokens_per_rank, num_tokens),
-            activation_clamp=getattr(moe.config, "swiglu_limit", None),
+            compile_tokens_per_rank=compile_tokens_per_rank,
         )
         if not moe.experts.should_fuse_routed_scaling_factor_in_topk:
             y.mul_(moe.routed_scaling_factor)
         return y
 
     import deep_gemm
+    from sglang.srt.distributed.parallel_state import get_moe_ep_group
+
+    ep_group = get_moe_ep_group().device_group
+    num_experts = moe.experts.num_experts
+    hidden_size = moe.config.hidden_size
+    intermediate_size = moe.config.moe_intermediate_size
+    num_max_tokens_per_rank = _get_mega_moe_max_tokens_per_rank()
+    assert num_tokens <= num_max_tokens_per_rank, (
+        f"mega MoE: num_tokens={num_tokens} exceeds cap "
+        f"MegaMoE max tokens per rank="
+        f"{num_max_tokens_per_rank}; raise the configured capacity or shrink "
+        f"cuda_graph_max_bs / chunked_prefill_size accordingly"
+    )
 
     buf = _get_mega_moe_symm_buffer(
         ep_group,

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -30,7 +30,7 @@ from sglang.srt.layers.moe.mega_moe_sm90 import (
     is_sm90_fp8_mega_moe_available,
     run_sm90_mega_routed,
 )
-from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.models.deepseek_common.utils import _device_sm
 from sglang.srt.runtime_context import get_exec
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
 
 
 _MEGA_MOE_SYMM_BUFFER: dict = {}
+
+
+def get_mega_moe_max_tokens_per_rank() -> int:
+    if get_moe_runner_backend().is_flashinfer_megamoe():
+        return get_exec().moe.flashinfer_megamoe_max_num_tokens
+    return envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
 
 
 def _mega_moe_mma_type() -> str:
@@ -127,6 +133,27 @@ def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
         return False
+
+    # FlashInfer takes ownership of the checkpoint-format expert parameters in
+    # post-load processing, so there is intentionally no ordinary FusedMoE
+    # fallback. Fail explicitly on a capacity violation instead of falling
+    # through to a runner whose source weights have already been released.
+    if get_moe_runner_backend().is_flashinfer_megamoe():
+        global_num_tokens = get_dp_global_num_tokens()
+        if global_num_tokens and not is_dsa_enable_prefill_cp():
+            max_tokens_per_rank = max(global_num_tokens)
+        else:
+            max_tokens_per_rank = hidden_states.shape[0]
+        cap = get_mega_moe_max_tokens_per_rank()
+        if max_tokens_per_rank > cap:
+            raise ValueError(
+                "FlashInfer MegaMoE token capacity exceeded: "
+                f"required={max_tokens_per_rank}, capacity={cap}. Raise "
+                "--flashinfer-megamoe-max-num-tokens or reduce the per-rank "
+                "prefill/decode admission limit."
+            )
+        return True
+
     if _device_sm == 90:
         if not is_sm90_fp8_mega_moe_available(moe.experts):
             return False
@@ -138,7 +165,7 @@ def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool
         max_tokens_per_rank = max(global_num_tokens)
     else:
         max_tokens_per_rank = hidden_states.shape[0]
-    cap = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
+    cap = get_mega_moe_max_tokens_per_rank()
     return max_tokens_per_rank <= cap
 
 
@@ -186,8 +213,6 @@ def _run_mega_routed(
     input_ids_global: Optional[torch.Tensor],
     num_tokens: int,
 ) -> torch.Tensor:
-    import deep_gemm
-
     from sglang.srt.distributed.parallel_state import get_moe_ep_group
 
     hidden_size = moe.config.hidden_size
@@ -218,15 +243,44 @@ def _run_mega_routed(
     num_experts = moe.experts.num_experts
     top_k = moe.config.num_experts_per_tok + moe.num_fused_shared_experts
     intermediate_size = moe.config.moe_intermediate_size
-    num_max_tokens_per_rank = (
-        envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
-    )
+    num_max_tokens_per_rank = get_mega_moe_max_tokens_per_rank()
     assert num_tokens <= num_max_tokens_per_rank, (
         f"mega MoE: num_tokens={num_tokens} exceeds cap "
-        f"SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK="
-        f"{num_max_tokens_per_rank}; raise the env var or shrink "
+        f"MegaMoE max tokens per rank="
+        f"{num_max_tokens_per_rank}; raise the configured capacity or shrink "
         f"cuda_graph_max_bs / chunked_prefill_size accordingly"
     )
+
+    if get_moe_runner_backend().is_flashinfer_megamoe():
+        from sglang.srt.layers.moe.flashinfer_mega_moe import (
+            run_flashinfer_megamoe,
+        )
+
+        global_num_tokens = get_dp_global_num_tokens()
+        compile_tokens_per_rank = (
+            max(global_num_tokens) if global_num_tokens else num_tokens
+        )
+        y = run_flashinfer_megamoe(
+            moe.experts,
+            hidden_states,
+            topk_ids=(
+                topk_ids.to(torch.int64)
+                if topk_ids is not None
+                else hidden_states.new_empty((0, top_k), dtype=torch.int64)
+            ),
+            topk_weights=(
+                topk_weights.to(torch.float32)
+                if topk_weights is not None
+                else hidden_states.new_empty((0, top_k), dtype=torch.float32)
+            ),
+            compile_tokens_per_rank=max(compile_tokens_per_rank, num_tokens),
+            activation_clamp=getattr(moe.config, "swiglu_limit", None),
+        )
+        if not moe.experts.should_fuse_routed_scaling_factor_in_topk:
+            y.mul_(moe.routed_scaling_factor)
+        return y
+
+    import deep_gemm
 
     buf = _get_mega_moe_symm_buffer(
         ep_group,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -144,6 +144,9 @@ class _MoeRunnerBackendPredicates:
     def is_flashinfer_mxfp4(self):
         return self.value == MoeRunnerBackend.FLASHINFER_MXFP4.value
 
+    def is_flashinfer_megamoe(self):
+        return self.value == MoeRunnerBackend.FLASHINFER_MEGAMOE.value
+
     def is_cutlass(self):
         return self.value == MoeRunnerBackend.CUTLASS.value
 
@@ -177,6 +180,7 @@ class MoeRunnerBackend(_MoeRunnerBackendPredicates, Enum):
     FLASHINFER_TRTLLM_ROUTED = "flashinfer_trtllm_routed"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_MXFP4 = "flashinfer_mxfp4"
+    FLASHINFER_MEGAMOE = "flashinfer_megamoe"
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
     CUTLASS = "cutlass"
     MARLIN = "marlin"

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -409,8 +409,22 @@ class Fp8Config(QuantizationConfig):
 
                 return Mxfp4HummingMoEMethod(fp8_method, prefix=prefix)
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_flashinfer_mxfp4():
+            if self.is_fp4_experts and (
+                get_moe_runner_backend().is_flashinfer_mxfp4()
+                or get_moe_runner_backend().is_flashinfer_megamoe()
+            ):
                 # SM100 uses TRT-LLM; SM90 uses W4A16 and SM120 uses MXFP8xMXFP4.
+                if get_moe_runner_backend().is_flashinfer_megamoe():
+                    if not get_platform().is_sm120:
+                        raise NotImplementedError(
+                            "flashinfer_megamoe currently requires SM120."
+                        )
+                    from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
+                        Mxfp4FlashinferCutlassMoEMethod,
+                    )
+
+                    return Mxfp4FlashinferCutlassMoEMethod(fp8_method, prefix=prefix)
+
                 if get_platform().is_sm90 or get_platform().is_sm120:
                     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
                         Mxfp4FlashinferCutlassMoEMethod,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -388,21 +388,22 @@ class Fp8Config(QuantizationConfig):
                 return NPUMXFP8OnlineMoEMethod(self)
 
             fp8_method = Fp8MoEMethod(self)
+            moe_runner_backend = get_moe_runner_backend()
 
             if self.is_fp4_experts and self.dequant_fp4_to_fp8:
-                assert get_moe_runner_backend().is_auto(), (
-                    f"{get_moe_runner_backend()} is not compatible with SGLANG_DSV4_FP4_DEQUANT=1"
+                assert moe_runner_backend.is_auto(), (
+                    f"{moe_runner_backend} is not compatible with SGLANG_DSV4_FP4_DEQUANT=1"
                 )
                 return fp8_method
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_marlin():
+            if self.is_fp4_experts and moe_runner_backend.is_marlin():
                 from sglang.srt.layers.quantization.mxfp4_marlin_moe import (
                     Mxfp4MarlinMoEMethod,
                 )
 
                 return Mxfp4MarlinMoEMethod(fp8_method, prefix=prefix)
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_humming():
+            if self.is_fp4_experts and moe_runner_backend.is_humming():
                 from sglang.srt.layers.quantization.mxfp4_humming_moe import (
                     Mxfp4HummingMoEMethod,
                 )
@@ -410,22 +411,17 @@ class Fp8Config(QuantizationConfig):
                 return Mxfp4HummingMoEMethod(fp8_method, prefix=prefix)
 
             if self.is_fp4_experts and (
-                get_moe_runner_backend().is_flashinfer_mxfp4()
-                or get_moe_runner_backend().is_flashinfer_megamoe()
+                moe_runner_backend.is_flashinfer_mxfp4()
+                or moe_runner_backend.is_flashinfer_megamoe()
             ):
+                platform = get_platform()
                 # SM100 uses TRT-LLM; SM90 uses W4A16 and SM120 uses MXFP8xMXFP4.
-                if get_moe_runner_backend().is_flashinfer_megamoe():
-                    if not get_platform().is_sm120:
-                        raise NotImplementedError(
-                            "flashinfer_megamoe currently requires SM120."
-                        )
-                    from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
-                        Mxfp4FlashinferCutlassMoEMethod,
+                if moe_runner_backend.is_flashinfer_megamoe() and not platform.is_sm120:
+                    raise NotImplementedError(
+                        "flashinfer_megamoe currently requires SM120."
                     )
 
-                    return Mxfp4FlashinferCutlassMoEMethod(fp8_method, prefix=prefix)
-
-                if get_platform().is_sm90 or get_platform().is_sm120:
+                if platform.is_sm90 or platform.is_sm120:
                     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
                         Mxfp4FlashinferCutlassMoEMethod,
                     )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -388,7 +388,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
-        self.use_flashinfer_megamoe = get_moe_runner_backend().is_flashinfer_megamoe()
         self.use_marlin = get_moe_runner_backend().is_marlin()
         # True W4A8: DeepGEMM fp8_fp4 grouped GEMM (SM100 MXF8F6F4 UMMA).
         # Weights stay MXFP4 (e2m1 + ue8m0 g32, zero requantization);
@@ -652,18 +651,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 deinterleave_moe_mxfp4_w13_for_marlin(layer)
             prepare_moe_mxfp4_layer_for_marlin(layer)
             layer._mxfp4_backend = "marlin"
-            return
-
-        if self.use_flashinfer_megamoe:
-            from sglang.srt.layers.moe.flashinfer_mega_moe import (
-                finalize_flashinfer_megamoe_weights,
-            )
-
-            finalize_flashinfer_megamoe_weights(
-                layer,
-                max_num_tokens=get_exec().moe.flashinfer_megamoe_max_num_tokens,
-            )
-            layer._mxfp4_backend = "flashinfer_megamoe"
             return
 
         if self.use_deep_gemm or self.use_mega_moe:
@@ -1461,10 +1448,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass  # noqa: F401
 
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
-        elif moe_runner_backend.is_flashinfer_megamoe():
-            # FlashInfer MegaMoE owns dispatch, both GEMMs and combine, so it
-            # bypasses the ordinary per-expert MoeRunner.
-            self.runner = None
         else:
             # Legacy bypass path (e.g. SM100 trtllm-gen under flashinfer_mxfp4)
             # routes through `apply` without a MoeRunner. TODO(cwan): migrate.

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -388,6 +388,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
+        self.use_flashinfer_megamoe = get_moe_runner_backend().is_flashinfer_megamoe()
         self.use_marlin = get_moe_runner_backend().is_marlin()
         # True W4A8: DeepGEMM fp8_fp4 grouped GEMM (SM100 MXF8F6F4 UMMA).
         # Weights stay MXFP4 (e2m1 + ue8m0 g32, zero requantization);
@@ -651,6 +652,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 deinterleave_moe_mxfp4_w13_for_marlin(layer)
             prepare_moe_mxfp4_layer_for_marlin(layer)
             layer._mxfp4_backend = "marlin"
+            return
+
+        if self.use_flashinfer_megamoe:
+            from sglang.srt.layers.moe.flashinfer_mega_moe import (
+                finalize_flashinfer_megamoe_weights,
+            )
+
+            finalize_flashinfer_megamoe_weights(
+                layer,
+                max_num_tokens=get_exec().moe.flashinfer_megamoe_max_num_tokens,
+            )
+            layer._mxfp4_backend = "flashinfer_megamoe"
             return
 
         if self.use_deep_gemm or self.use_mega_moe:
@@ -1448,6 +1461,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass  # noqa: F401
 
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+        elif moe_runner_backend.is_flashinfer_megamoe():
+            # FlashInfer MegaMoE owns dispatch, both GEMMs and combine, so it
+            # bypasses the ordinary per-expert MoeRunner.
+            self.runner = None
         else:
             # Legacy bypass path (e.g. SM100 trtllm-gen under flashinfer_mxfp4)
             # routes through `apply` without a MoeRunner. TODO(cwan): migrate.

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_cutlass_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_cutlass_moe.py
@@ -1,7 +1,8 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by FlashInfer CUTLASS MoE.
+"""DeepSeek-V4 MXFP4 expert backends backed by FlashInfer.
 
 ``Fp8Config`` selects this backend for SM90 and SM120; SM100 uses the
-TRT-LLM implementation.
+TRT-LLM implementation. On SM120 it also supplies the native checkpoint
+loader/finalizer for FlashInfer MegaMoE.
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ import torch
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.runtime_context import get_exec, get_platform
 from sglang.srt.utils import is_flashinfer_available, log_info_on_rank0
 
@@ -37,6 +39,7 @@ class Mxfp4FlashinferCutlassMoEMethod:
     def __init__(self, fp8_method, prefix: str):
         if not is_flashinfer_available():
             raise RuntimeError("Mxfp4FlashinferCutlassMoEMethod requires FlashInfer.")
+        self._use_flashinfer_megamoe = get_moe_runner_backend().is_flashinfer_megamoe()
         self._use_mxfp8_act_scaling = get_platform().is_sm120
         precision = get_exec().moe.flashinfer_mxfp4_moe_precision
         # precision=fp8 is an SM90 knob (Humming W4A8); on SM120 the MXFP8
@@ -51,8 +54,11 @@ class Mxfp4FlashinferCutlassMoEMethod:
 
     @property
     def load_up_proj_weight_first(self) -> bool:
-        """Load W13 directly as ``[up; gate]`` for FlashInfer CUTLASS."""
-        return True
+        """Select the canonical W13 order expected by the chosen backend."""
+        # FlashInfer CUTLASS consumes [up; gate]. MegaMoE's public weight
+        # preprocessor consumes canonical [gate; up] and performs its own
+        # granularity-8 interleave.
+        return not self._use_flashinfer_megamoe
 
     def create_weights(
         self,
@@ -88,6 +94,12 @@ class Mxfp4FlashinferCutlassMoEMethod:
 
         self.moe_runner_config = moe_runner_config
 
+        if self._use_flashinfer_megamoe:
+            # The public FlashInfer MoEEpLayer owns dispatch, FC1, FC2 and
+            # combine, bypassing SGLang's ordinary per-expert MoeRunner.
+            self.runner = None
+            return
+
         E = layer.num_local_experts
         device = layer.w13_weight.device
         if self._use_mxfp8_act_scaling:
@@ -122,6 +134,30 @@ class Mxfp4FlashinferCutlassMoEMethod:
         self.runner = MoeRunner(MoeRunnerBackend.FLASHINFER_MXFP4, moe_runner_config)
 
     def process_weights_after_loading(self, layer: Module) -> None:
+        if self._use_flashinfer_megamoe:
+            # create_weights() deliberately kept checkpoint E8M0 scales in
+            # their native dtype. Do not call the borrowed Fp8 method here:
+            # SGLang's existing DeepGEMM MegaMoE branch would transform both
+            # weights and scales before the FlashInfer adapter can take them.
+            for name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+                scale = getattr(layer, name)
+                if scale.dtype != torch.float8_e8m0fnu:
+                    raise TypeError(
+                        f"{name} must remain native E8M0 for FlashInfer MegaMoE, "
+                        f"got {scale.dtype}."
+                    )
+
+            from sglang.srt.layers.moe.flashinfer_mega_moe import (
+                finalize_flashinfer_megamoe_weights,
+            )
+
+            finalize_flashinfer_megamoe_weights(
+                layer,
+                max_num_tokens=get_exec().moe.flashinfer_megamoe_max_num_tokens,
+            )
+            layer._dsv4_mxfp4_backend = "flashinfer_megamoe_sm120"
+            return
+
         # Preserve the base FP4 post-load handling.
         self._fp8.process_weights_after_loading(layer)
 

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_cutlass_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_cutlass_moe.py
@@ -135,18 +135,7 @@ class Mxfp4FlashinferCutlassMoEMethod:
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if self._use_flashinfer_megamoe:
-            # create_weights() deliberately kept checkpoint E8M0 scales in
-            # their native dtype. Do not call the borrowed Fp8 method here:
-            # SGLang's existing DeepGEMM MegaMoE branch would transform both
-            # weights and scales before the FlashInfer adapter can take them.
-            for name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
-                scale = getattr(layer, name)
-                if scale.dtype != torch.float8_e8m0fnu:
-                    raise TypeError(
-                        f"{name} must remain native E8M0 for FlashInfer MegaMoE, "
-                        f"got {scale.dtype}."
-                    )
-
+            # Leave checkpoint weights and scales to FlashInfer's preprocessor.
             from sglang.srt.layers.moe.flashinfer_mega_moe import (
                 finalize_flashinfer_megamoe_weights,
             )
@@ -155,7 +144,6 @@ class Mxfp4FlashinferCutlassMoEMethod:
                 layer,
                 max_num_tokens=get_exec().moe.flashinfer_megamoe_max_num_tokens,
             )
-            layer._dsv4_mxfp4_backend = "flashinfer_megamoe_sm120"
             return
 
         # Preserve the base FP4 post-load handling.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -278,6 +278,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "flashinfer_trtllm_routed",
     "flashinfer_cutlass",
     "flashinfer_mxfp4",
+    "flashinfer_megamoe",
     "flashinfer_cutedsl",
     "cutlass",
     "aiter",
@@ -2430,6 +2431,12 @@ class ServerArgs:
         "path introduced by FlashInfer #3738 and requires FlashInfer >= 0.6.18.",
         NS("exec.moe"),
     ] = "default"
+    flashinfer_megamoe_max_num_tokens: A[
+        int,
+        "Maximum number of input tokens per EP rank in the FlashInfer "
+        "MXFP4-weight x MXFP8-activation MegaMoE symmetric workspace.",
+        NS("exec.moe"),
+    ] = 8192
     deepep_mode: A[
         Literal["auto", "normal", "low_latency"],
         "Select the mode when enable DeepEP or MoriEP MoE, could be `normal`, `low_latency` or `auto`. Default is `auto`, which means `low_latency` for decode batch and `normal` for prefill batch.",

--- a/test/registered/unit/layers/moe/test_flashinfer_megamoe_adapter.py
+++ b/test/registered/unit/layers/moe/test_flashinfer_megamoe_adapter.py
@@ -38,6 +38,11 @@ def test_flashinfer_megamoe_rejects_eplb():
         _resolve_dummy(enable_eplb=True)
 
 
+def test_flashinfer_megamoe_rejects_tbo():
+    with pytest.raises(ValueError, match="does not support.*two-batch-overlap"):
+        _resolve_dummy(enable_two_batch_overlap=True)
+
+
 def test_mxfp4_weight_view_is_zero_copy():
     storage = torch.arange(16, dtype=torch.uint8)
     viewed = _view_byte_dtype(storage, torch.float4_e2m1fn_x2)

--- a/test/registered/unit/layers/moe/test_flashinfer_megamoe_adapter.py
+++ b/test/registered/unit/layers/moe/test_flashinfer_megamoe_adapter.py
@@ -1,0 +1,45 @@
+import pytest
+import torch
+
+from sglang.srt.arg_groups.model_override_base import resolved_view
+from sglang.srt.layers.moe.flashinfer_mega_moe import _view_byte_dtype
+from sglang.srt.server_args import ServerArgs
+
+
+def _resolve_dummy(**kwargs):
+    args = ServerArgs(
+        model_path="dummy",
+        tp_size=4,
+        dp_size=4,
+        enable_dp_attention=True,
+        ep_size=4,
+        moe_runner_backend="flashinfer_megamoe",
+        **kwargs,
+    )
+    args.resolve_once()
+    return resolved_view(args)
+
+
+def test_flashinfer_megamoe_resolution_contract():
+    cfg = _resolve_dummy()
+    assert cfg.moe_a2a_backend == "megamoe"
+    assert cfg.disable_shared_experts_fusion
+    assert cfg.flashinfer_megamoe_max_num_tokens == 8192
+
+
+@pytest.mark.parametrize("moe_a2a_backend", ["deepep", "mori"])
+def test_flashinfer_megamoe_rejects_external_dispatch(moe_a2a_backend):
+    with pytest.raises(ValueError, match="owns dispatch and combine"):
+        _resolve_dummy(moe_a2a_backend=moe_a2a_backend)
+
+
+def test_flashinfer_megamoe_rejects_eplb():
+    with pytest.raises(ValueError, match="disable EPLB"):
+        _resolve_dummy(enable_eplb=True)
+
+
+def test_mxfp4_weight_view_is_zero_copy():
+    storage = torch.arange(16, dtype=torch.uint8)
+    viewed = _view_byte_dtype(storage, torch.float4_e2m1fn_x2)
+    assert viewed.dtype == torch.float4_e2m1fn_x2
+    assert viewed.data_ptr() == storage.data_ptr()


### PR DESCRIPTION
## Summary

This PR adds an opt-in `flashinfer_megamoe` runner backend for DeepSeek-V4-Flash with MXFP4 expert weights and MXFP8 activations on SM120 GPUs.

The backend calls FlashInfer's public `flashinfer.moe_ep` interface and replaces the routed MoE sequence

`dispatch -> FC1 -> FC2 -> combine`

with a FlashInfer `MoEEpLayer`.

The initial supported configuration is:

```bash
--tp-size 4 \
--dp-size 4 \
--enable-dp-attention \
--ep-size 4 \
--moe-runner-backend flashinfer_megamoe \
--flashinfer-megamoe-max-num-tokens 8192
```

<p>With DP attention enabled, each rank owns a different DP token stream when entering the MoE layers. The adapter communicates the maximum active token count across ranks to FlashInfer and supports ranks with zero local tokens.</p><p>Existing MoE backends are unchanged unless <code dir="ltr">flashinfer_megamoe</code> is selected explicitly.</p><h2>Implementation</h2><p>This PR:</p><ul><li>Adds <code dir="ltr">flashinfer_megamoe</code> to the MoE runner backend choices.</li><li>Adds <code dir="ltr">--flashinfer-megamoe-max-num-tokens</code> for the symmetric workspace capacity.</li><li>Constructs FlashInfer <code dir="ltr">PrequantizedMoEWeights</code>, <code dir="ltr">BootstrapConfig</code>, <code dir="ltr">FleetParams</code>, and <code dir="ltr">MoEEpLayer</code> objects from SGLang-loaded checkpoint weights.</li><li>Preserves the canonical <code dir="ltr">[gate; up]</code> W13 layout expected by the MegaMoE preprocessor.</li><li>Uses zero-copy byte dtype views for MXFP4 weights and UE8M0 scales.</li><li>Registers CUDA Graph-compatible staging and compute custom operations.</li><li>Reuses FlashInfer's stable output buffer.</li><li>Drops loader-side expert tensors after FlashInfer has created its preprocessed weight pack, avoiding retention of a second expert-weight copy.</li><li>Handles different DP token counts and empty ranks.</li><li>Computes the shared expert separately and disables shared-expert fusion for this backend.</li><li>Applies the routed scaling factor consistently with SGLang's existing MoE path.</li><li>Validates the per-rank token capacity before execution.</li></ul><h2>Validation and unsupported combinations</h2><p>The argument resolver rejects configurations that are not currently supported:</p><ul><li><code dir="ltr">--enable-two-batch-overlap</code></li><li>External MoE dispatch backends such as DeepEP or MORI</li><li>EPLB</li><li>Redundant or replicated experts</li><li>Attention TP or MoE TP greater than 1 after parallelism groups are derived</li><li>Uneven expert placement</li></ul><p>The token capacity must be large enough for the maximum number of active tokens on any EP rank. The backend reports an explicit error when the configured capacity is exceeded.</p>

</div></div></div><p>All benchmark requests completed without crashes, OOMs, watchdog failures, CUDA/NCCL errors, or HTTP 5xx responses.</p><h2>Tests</h2><pre dir="ltr"><code>python3 -m pytest -q \
  test/registered/unit/layers/moe/test_flashinfer_megamoe_adapter.py

pre-commit run ruff --files &lt;changed-files&gt;
pre-commit run ruff-format --files &lt;changed-files&gt;</code></pre><p>Result:</p><pre dir="ltr"><code>6 passed
ruff passed
ruff-format passed</code></pre><p>The unit tests cover:</p><ul><li>Argument-resolution defaults</li><li>External dispatch rejection</li><li>EPLB rejection</li><li>TBO rejection</li><li>Zero-copy MXFP4 dtype views</li></ul><h2>FlashInfer dependency</h2><p>This PR requires a FlashInfer version that provides the SM120 MXFP4-weight × MXFP8-activation <code dir="ltr">flashinfer.moe_ep</code> backend.</p><p>The prerequisite FlashInfer infrastructure PR has been merged:</p><ul><li><a href="https://github.com/flashinfer-ai/flashinfer/pull/4387"><span><span>https://github.com/flashinfer-ai/flashinfer/pull/4387</span></span></a></li></ul><p>We're working on the CI of MXFP4 x MXFP8 MegaMoE in FlashInfer. Will be merged soon:</p><ul><li><a href="https://github.com/flashinfer-ai/flashinfer/pull/4632"><span><span>https://github.com/flashinfer-ai/flashinfer/pull/4632</span></span></a></li></ul>

<h2>Current limitations</h2><ul><li>SM120 only</li><li>MXFP4 expert weights with MXFP8 activations</li><li>Even, non-replicated expert placement</li><li>No TBO</li><li>No EPLB</li><li>No external MoE A2A backend</li><li>Shared-expert fusion is disabled</li><li>The configured per-rank token capacity is fixed when the FlashInfer layer is constructed</li></ul>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35589409572](https://github.com/sgl-project/sglang/actions/runs/35589409572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35589409400](https://github.com/sgl-project/sglang/actions/runs/35589409400)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35589409423](https://github.com/sgl-project/sglang/actions/runs/35589409423)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->