### PR TITLE
[Perf][DSA] Skip absorb-q concat when nope/rope already abut

### DIFF
--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -231,7 +231,8 @@ def concat_mla_absorb_q_general(q_nope, q_rope):
         )
     if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
         return concat_mla_absorb_q(q_nope, q_rope)
-    return torch.cat([q_nope, q_rope], dim=-1)
+    else:
+        return torch.cat([q_nope, q_rope], dim=-1)
 
 
 @triton.jit

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -216,18 +216,14 @@ def mla_quantize_without_rope_for_fp8(
 def concat_mla_absorb_q_general(q_nope, q_rope):
     # Adjacent slices of one fused [T, H, d_nope + d_rope] tensor: return the
     # parent instead of allocating a copy. DSA splits then re-concats this way.
-    if (
-        q_nope.dim() == 3
-        and q_rope.dim() == 3
-        and q_nope.dtype == q_rope.dtype
-        and q_nope.shape[:2] == q_rope.shape[:2]
-    ):
+    if q_nope.dim() == 3 and q_rope.dim() == 3:
         tokens, heads, d_nope = q_nope.shape
         width = d_nope + q_rope.shape[2]
         fused_stride = (heads * width, width, 1)
         if (
             q_nope.stride() == fused_stride
             and q_rope.stride() == fused_stride
+            and q_nope.shape[:2] == q_rope.shape[:2]
             and q_rope.storage_offset() == q_nope.storage_offset() + d_nope
             and q_nope.untyped_storage().data_ptr()
             == q_rope.untyped_storage().data_ptr()

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -214,10 +214,30 @@ def mla_quantize_without_rope_for_fp8(
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):
+    # Adjacent slices of one fused [T, H, d_nope + d_rope] tensor: return the
+    # parent instead of allocating a copy. DSA splits then re-concats this way.
+    if (
+        q_nope.dim() == 3
+        and q_rope.dim() == 3
+        and q_nope.dtype == q_rope.dtype
+        and q_nope.shape[:2] == q_rope.shape[:2]
+    ):
+        tokens, heads, d_nope = q_nope.shape
+        width = d_nope + q_rope.shape[2]
+        fused_stride = (heads * width, width, 1)
+        if (
+            q_nope.stride() == fused_stride
+            and q_rope.stride() == fused_stride
+            and q_rope.storage_offset() == q_nope.storage_offset() + d_nope
+            and q_nope.untyped_storage().data_ptr()
+            == q_rope.untyped_storage().data_ptr()
+        ):
+            return q_nope.as_strided(
+                (tokens, heads, width), fused_stride, q_nope.storage_offset()
+            )
     if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
         return concat_mla_absorb_q(q_nope, q_rope)
-    else:
-        return torch.cat([q_nope, q_rope], dim=-1)
+    return torch.cat([q_nope, q_rope], dim=-1)
 
 
 @triton.jit

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -216,21 +216,19 @@ def mla_quantize_without_rope_for_fp8(
 def concat_mla_absorb_q_general(q_nope, q_rope):
     # Adjacent slices of one fused [T, H, d_nope + d_rope] tensor: return the
     # parent instead of allocating a copy. DSA splits then re-concats this way.
-    if q_nope.dim() == 3 and q_rope.dim() == 3:
-        tokens, heads, d_nope = q_nope.shape
-        width = d_nope + q_rope.shape[2]
-        fused_stride = (heads * width, width, 1)
-        if (
-            q_nope.stride() == fused_stride
-            and q_rope.stride() == fused_stride
-            and q_nope.shape[:2] == q_rope.shape[:2]
-            and q_rope.storage_offset() == q_nope.storage_offset() + d_nope
-            and q_nope.untyped_storage().data_ptr()
-            == q_rope.untyped_storage().data_ptr()
-        ):
-            return q_nope.as_strided(
-                (tokens, heads, width), fused_stride, q_nope.storage_offset()
-            )
+    tokens, heads, d_nope = q_nope.shape
+    width = d_nope + q_rope.shape[2]
+    fused_stride = (heads * width, width, 1)
+    if (
+        q_nope.stride() == fused_stride
+        and q_rope.stride() == fused_stride
+        and q_nope.shape[:2] == q_rope.shape[:2]
+        and q_rope.storage_offset() == q_nope.storage_offset() + d_nope
+        and q_nope.untyped_storage().data_ptr() == q_rope.untyped_storage().data_ptr()
+    ):
+        return q_nope.as_strided(
+            (tokens, heads, width), fused_stride, q_nope.storage_offset()
+        )
     if _is_cuda and q_nope.shape[-1] == 512 and q_rope.shape[-1] == 64:
         return concat_mla_absorb_q(q_nope, q_rope)
     return torch.cat([q_nope, q_rope], dim=-1)

--- a/test/registered/kernels/ops/attention/test_concat_mla_absorb_q_view.py
+++ b/test/registered/kernels/ops/attention/test_concat_mla_absorb_q_view.py
@@ -1,0 +1,98 @@
+"""Skip absorb-q concat when nope/rope already abut in one fused tensor."""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.utils import concat_mla_absorb_q_general
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+HEADS = 64
+
+
+def _split_fused(tokens: int, d_nope: int, d_rope: int):
+    fused = torch.randn(tokens, HEADS, d_nope + d_rope, device=DEVICE, dtype=DTYPE)
+    return fused, fused[..., :d_nope], fused[..., d_nope:]
+
+
+@pytest.mark.parametrize("d_nope,d_rope", [(512, 64), (128, 64)])
+def test_abutting_halves_alias_the_parent(d_nope: int, d_rope: int) -> None:
+    fused, q_nope, q_rope = _split_fused(8, d_nope, d_rope)
+    copied = torch.cat([q_nope, q_rope], dim=-1)
+    aliased = concat_mla_absorb_q_general(q_nope, q_rope)
+
+    assert torch.equal(aliased, copied)
+    assert aliased.shape == copied.shape
+    assert aliased.stride() == copied.stride()
+    assert aliased.dtype == copied.dtype
+    assert aliased.is_contiguous()
+    assert aliased.data_ptr() == fused.data_ptr()
+    assert aliased.untyped_storage().data_ptr() == fused.untyped_storage().data_ptr()
+
+
+def test_separate_allocations_still_concat() -> None:
+    q_nope = torch.randn(8, HEADS, 512, device=DEVICE, dtype=DTYPE)
+    q_pe = torch.randn(8, HEADS, 64, device=DEVICE, dtype=DTYPE)
+    result = concat_mla_absorb_q_general(q_nope, q_pe)
+    assert torch.equal(result, torch.cat([q_nope, q_pe], dim=-1))
+    assert result.data_ptr() != q_nope.data_ptr()
+
+
+def test_non_adjacent_halves_still_concat() -> None:
+    fused, nope, rope = _split_fused(8, 512, 64)
+    reversed_cat = concat_mla_absorb_q_general(rope, nope)
+    assert torch.equal(reversed_cat, torch.cat([rope, nope], dim=-1))
+    assert reversed_cat.data_ptr() != fused.data_ptr()
+
+    gapped = torch.randn(8, HEADS, 512 + 64 + 8, device=DEVICE, dtype=DTYPE)
+    gapped_nope = gapped[..., :512]
+    gapped_rope = gapped[..., 512 + 8 :]
+    gapped_cat = concat_mla_absorb_q_general(gapped_nope, gapped_rope)
+    assert torch.equal(gapped_cat, torch.cat([gapped_nope, gapped_rope], dim=-1))
+
+    rope_from_start = fused[..., :64]
+    start_cat = concat_mla_absorb_q_general(nope, rope_from_start)
+    assert torch.equal(start_cat, torch.cat([nope, rope_from_start], dim=-1))
+    assert start_cat.data_ptr() != fused.data_ptr()
+
+
+def test_halves_from_different_parents_still_concat() -> None:
+    fused_a, q_nope, _ = _split_fused(8, 512, 64)
+    fused_b, _, q_rope = _split_fused(8, 512, 64)
+    result = concat_mla_absorb_q_general(q_nope, q_rope)
+    assert torch.equal(result, torch.cat([q_nope, q_rope], dim=-1))
+    assert result.data_ptr() != fused_a.data_ptr()
+    assert result.data_ptr() != fused_b.data_ptr()
+
+
+def test_sparse_mla_output_is_bit_identical_with_the_view() -> None:
+    pytest.importorskip("sgl_kernel")
+    from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+    tokens, kv_len, topk = 64, 256, 64
+    _fused, q_nope, q_rope = _split_fused(tokens, 512, 64)
+    kv = torch.randn(kv_len, 1, 576, device=DEVICE, dtype=DTYPE)
+    indices = torch.randint(
+        0, kv_len, (tokens, 1, topk), dtype=torch.int32, device=DEVICE
+    )
+
+    copied = torch.cat([q_nope, q_rope], dim=-1)
+    aliased = concat_mla_absorb_q_general(q_nope, q_rope)
+    assert copied.data_ptr() != aliased.data_ptr()
+
+    out_copied, _, _ = flash_mla_sparse_fwd(
+        q=copied, kv=kv, indices=indices, sm_scale=0.1, d_v=512
+    )
+    out_alias, _, _ = flash_mla_sparse_fwd(
+        q=aliased, kv=kv, indices=indices, sm_scale=0.1, d_v=512
+    )
+    assert torch.equal(out_copied, out_alias)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`concat_mla_absorb_q_general` always allocated a copy, even when `q_nope` and `q_rope` were already adjacent views of one fused `[T, H, d_nope + d_rope]` tensor.

DSA commonly splits that fused query and concatenates it again (`forward_extend` / `forward_decode` when `q_rope is not None`). CUDA also re-cats when the caller already passed the fused form (`q_rope is None`) to keep the pre-patch path byte-identical. Both cases are a memcpy of the parent.

On the production absorb-q shape `[4096, 64, 576]` bf16 this is 288 MiB read + 288 MiB write per concat.

## Modifications

- In `concat_mla_absorb_q_general`, return an `as_strided` view of the parent when both halves already have fused stride `(H*W, W, 1)` and `q_rope` starts exactly `d_nope` into `q_nope` on the same storage.
- Keep the existing CUDA kernel (`512+64`) and `torch.cat` fallbacks when the halves are separate allocations, gapped, reversed, or from different parents.
- Add unit tests covering the alias, fallbacks, and bit-identical `flash_mla_sparse_fwd` output.

This is a zero-copy skip of a redundant concat. It does not change the kernel, the DSA calling convention, or the values consumed by sparse MLA.

## Accuracy Tests

```bash
PYTHONPATH=python python -m pytest -v \
  test/registered/kernels/ops/attention/test_concat_mla_absorb_q_view.py
```

Result: `6 passed` (including `flash_mla_sparse_fwd` bit-identity of the aliased view vs a real concat).

## Speed Tests and Profiling

Not re-measured on this checkout. The skipped work is a memcpy of the fused query. On `[4096, 64, 576]` bf16 that is 288 MiB each way per call. DSA full-MLA layers that split then re-concat pay this once per layer.

## Checklist

- [x] Format code according to the pre-commit configuration (`ruff check`/`ruff format`/`isort` on the changed files).
- [x] Add unit tests.
- [x] Documentation is not required; behavior is unchanged for non-abutting inputs.
- [x] Accuracy covered by the new unit tests; end-to-end speed benchmark not run in this environment.
- [x] Follow the SGLang code style guidance.

The in-tree `pre-commit` config requires a newer pre-commit than the one installed here (`default_stages: pre-commit` vs `commit`). Equivalent ruff/isort hooks were run on the changed files. Rust hooks were not run; this PR does not modify Rust files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34122457204](https://github.com/sgl-project/sglang/actions/runs/34122457204)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34122456952](https://github.com/sgl-project/sglang/actions/runs/34122456952)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34122457116](https://github.com/sgl-project/sglang/actions/runs/34122457116)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->