### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in Ascend Hy3 tutorial

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/hy3.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/hy3.mdx
@@ -21,7 +21,7 @@ multi-node (Atlas 800I A2) PD mixed mode and speculative decoding.
 | Feature                  | Example usage                                                                                                                          |
 |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | Tensor Parallelism       | `--tp-size 16`                                                                                                                         |
-| NPU Graph                | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs`; e.g. `--cuda-graph-bs 4 8 16 20 24 28 32 36 40` |
+| NPU Graph                | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs-decode`; e.g. `--cuda-graph-bs-decode 4 8 16 20 24 28 32 36 40` |
 | Speculative Decoding     | `--speculative-algorithm EAGLE \`<br/>`--speculative-num-steps 2 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 3` |
 | Overlap Schedule         | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                                                           |
 | Reasoning Mode           | `extra_body={"chat_template_kwargs": {"reasoning_effort": "high"}}` — deep chain-of-thought;<br/>`"reasoning_effort": "low"` — short thinking chain;<br/>`"reasoning_effort": "no_think"` — direct response, no thinking |
@@ -209,7 +209,7 @@ python3 -m sglang.launch_server \
     --base-gpu-id 0 \
     --prefill-max-requests 40 \
     --max-running-requests 40 \
-    --cuda-graph-bs 4 8 16 20 24 28 32 36 40 \
+    --cuda-graph-bs-decode 4 8 16 20 24 28 32 36 40 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 2 \
     --speculative-eagle-topk 1 \
@@ -286,7 +286,7 @@ for i in "${!NODE_IPS[@]}"; do
             --base-gpu-id 0 \
             --prefill-max-requests 40 \
             --max-running-requests 40 \
-            --cuda-graph-bs 4 8 16 20 24 28 32 36 40 \
+            --cuda-graph-bs-decode 4 8 16 20 24 28 32 36 40 \
             --speculative-algorithm EAGLE \
             --speculative-num-steps 2 \
             --speculative-eagle-topk 1 \


### PR DESCRIPTION
## Summary
- Update Ascend Hy3 tutorial to prefer `--cuda-graph-bs-decode` over the deprecated `--cuda-graph-bs` alias (feature table + launch examples).

## Test plan
- [ ] Confirm `python/sglang/srt/server_args.py` still documents `--cuda-graph-bs` as a deprecated alias for `--cuda-graph-bs-decode`
- [ ] Docs preview / visual check of the Hy3 tutorial snippets

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34118688724](https://github.com/sgl-project/sglang/actions/runs/34118688724)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34118688469](https://github.com/sgl-project/sglang/actions/runs/34118688469)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->