### PR TITLE
fix(hicache): fix MTP layer addressing under CP layer split

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -230,9 +230,16 @@ class DSAIndexerPoolHost(HostKVCache):
     ):
         if not is_draft and not self._is_device_layer_owned(device_pool, layer_id):
             return
-        # MTP draft layers do not participate in CP layer sharding.
-        host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
-        device_layer_id = 0 if is_draft else layer_id
+        if is_draft:
+            # MTP draft layers do not participate in CP layer sharding.
+            # Place the draft offset after the padded local target layers.
+            host_layer_id = self.target_layer_num + (
+                layer_id - self.device_pool.layer_num
+            )
+            device_layer_id = 0
+        else:
+            host_layer_id = self._host_layer_index(layer_id)
+            device_layer_id = layer_id
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
@@ -292,9 +299,16 @@ class DSAIndexerPoolHost(HostKVCache):
         *,
         is_draft: bool = False,
     ):
-        # MTP draft layers do not participate in CP layer sharding.
-        host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
-        device_layer_id = 0 if is_draft else layer_id
+        if is_draft:
+            # MTP draft layers do not participate in CP layer sharding.
+            # Place the draft offset after the padded local target layers.
+            host_layer_id = self.target_layer_num + (
+                layer_id - self.device_pool.layer_num
+            )
+            device_layer_id = 0
+        else:
+            host_layer_id = self._host_layer_index(layer_id)
+            device_layer_id = layer_id
 
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -259,9 +259,16 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             return
         host_indices = self.maybe_dcp_kernel_indices(host_indices)
         device_indices = self.maybe_dcp_kernel_indices(device_indices)
-        # MTP draft layers do not participate in CP layer sharding.
-        host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
-        device_layer_id = 0 if is_draft else layer_id
+        if is_draft:
+            # MTP draft layers do not participate in CP layer sharding.
+            # Place the draft offset after the padded local target layers.
+            host_layer_id = self.target_layer_num + (
+                layer_id - self.device_pool.layer_num
+            )
+            device_layer_id = 0
+        else:
+            host_layer_id = self._host_layer_index(layer_id)
+            device_layer_id = layer_id
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
@@ -354,9 +361,16 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         is_draft: bool = False,
     ):
         # Indices arrive already translated by backup_from_device_all_layer.
-        # MTP draft layers do not participate in CP layer sharding.
-        host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
-        device_layer_id = 0 if is_draft else layer_id
+        if is_draft:
+            # MTP draft layers do not participate in CP layer sharding.
+            # Place the draft offset after the padded local target layers.
+            host_layer_id = self.target_layer_num + (
+                layer_id - self.device_pool.layer_num
+            )
+            device_layer_id = 0
+        else:
+            host_layer_id = self._host_layer_index(layer_id)
+            device_layer_id = layer_id
 
         if io_backend == "kernel":
             if self.layout == "layer_first":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix incorrect MTP draft layer addressing when HiCache uses CP layer split

## Modifications

Map packed MTP draft layers after the local padded target layer region in the MLA and DSA host caches

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34119028210](https://github.com/sgl-project/sglang/actions/runs/34119028210)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34119027860](https://github.com/sgl-project/sglang/actions/runs/34119027860)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34119028368](https://github.com/sgl-project/sglang/actions/runs/34119028368)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->