### PR TITLE
[Feature] Support EAGLE3 chain decoding for MiniCPM-SALA

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -405,6 +405,34 @@ print(response.choices[0].message.content)
 
 ---
 
+### MiniCPM-SALA
+
+MiniCPM-SALA provides speculative target interfaces and EAGLE-3 chain
+verification (`--speculative-eagle-topk 1`). Use a draft checkpoint trained
+for the target model; this support does not imply that every speculative
+algorithm can use the target.
+
+Add the following options to your MiniCPM-SALA launch command, preserving
+its model, quantization, and memory settings:
+
+```bash
+--attention-backend minicpm_flashinfer \
+--speculative-algorithm EAGLE3 \
+--speculative-draft-model-path /path/to/matching-eagle3-draft \
+--speculative-draft-attention-backend flashinfer \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+--disable-radix-cache \
+--disable-prefill-cuda-graph \
+--disable-flashinfer-autotune
+```
+
+Decode CUDA graphs remain enabled. The compressed-key cache is request-local,
+so prefix-cache reuse must remain disabled. Prefill graphs are outside this
+configuration. Set `SGLANG_MINICPM_DENSE_AS_SPARSE=1` to use sparse rows for
+short queries as well; otherwise short queries retain dense attention.
+
 ## Multi Token Prediction
 
 We support [MTP (Multi-Token Prediction)](https://arxiv.org/pdf/2404.19737) in SGLang by using speculative decoding. We use `XiaomiMiMo/MiMo-7B-RL` as an example here (for DeepSeek MTP usage, refer to [DeepSeek-V3.2 cookbook §4.2.3](/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2#4-2-3-multi-token-prediction-eagle-speculative-decoding)).

--- a/python/sglang/srt/layers/attention/minicpm/attention_adapter.py
+++ b/python/sglang/srt/layers/attention/minicpm/attention_adapter.py
@@ -86,6 +86,7 @@ class MiniCPMFlashInferAdapter:
         head_dim: int,
         page_size: int,
         max_kv_tokens_per_row: int,
+        rows_per_req: int,
     ):
         if not is_flashinfer_available():
             raise RuntimeError("minicpm_flashinfer requires the flashinfer package.")
@@ -104,7 +105,9 @@ class MiniCPMFlashInferAdapter:
         self.q_dtype = model_runner.dtype
         self.kv_dtype = model_runner.kv_cache_dtype
 
-        max_sparse_bs = model_runner.req_to_token_pool.size * head_group_num
+        max_sparse_bs = model_runner.req_to_token_pool.size * rows_per_req
+        # The wrapped backend sizes its own kv_indptr per request; sparse plans one
+        # row per (token, head group), so it must borrow this row-sized buffer.
         self.kv_indptr = torch.zeros(
             max_sparse_bs + 1,
             dtype=torch.int32,

--- a/python/sglang/srt/layers/attention/minicpm/backend.py
+++ b/python/sglang/srt/layers/attention/minicpm/backend.py
@@ -19,10 +19,16 @@ from sglang.srt.layers.attention.minicpm.cache import attach_compressed_cache
 from sglang.srt.layers.attention.minicpm.sparse_utils import (
     CompressionLevelMetadata,
     MiniCPMSparseMetadata,
+    RepeatedSegmentLayout,
+    _assign_row_metadata,
+    _build_dense_verify_overwrite,
     _build_k1_k2_compression_metadata,
     _build_sparse_decode_metadata,
+    _build_sparse_verify_rows,
+    _plan_repeated_segments,
     _plan_sparse_decode,
     _plan_sparse_prefill,
+    _plan_sparse_verify,
     allocate_and_compress_keys,
     batched_gather,
     compressed_attention,
@@ -35,6 +41,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_platform,
     get_schedule,
+    get_spec,
 )
 from sglang.srt.utils import next_power_of_2
 
@@ -197,6 +204,8 @@ class MiniCPMSparseBackend(AttentionBackend):
         self.dense_len = (
             0 if self.minicpm_dense_as_sparse else sparse_config["dense_len"]
         )
+        # Seeds graph captures' history length and bounds the startup context check;
+        # unlike dense_len, the dense-as-sparse env does not zero it.
         self.config_dense_len = sparse_config["dense_len"]
         topk = sparse_config["topk"]
         self.local_blocks = self.window_size // self.block_size
@@ -223,9 +232,16 @@ class MiniCPMSparseBackend(AttentionBackend):
         self.k2_kernel_size = self.kernel_size * 4
         self.k2_kernel_stride = self.kernel_stride * 4
 
+        self._init_spec_decode_config()
+
         self.minicpm_fuse_topk = (
             use_blackwell and use_flashinfer
         ) or envs.SGLANG_MINICPM_FUSE_TOPK.get()
+        # The fused top-k scores on the k1 level alone,
+        # so the k2 repeat layout has no readers under minicpm_fuse_topk.
+        self.verify_repeat_levels = frozenset(
+            name for name in ("k1", "k2") if name != "k2" or not self.minicpm_fuse_topk
+        )
         dtype_str = str(self.model_dtype).removeprefix("torch.")
         if self.minicpm_fuse_topk and dtype_str not in ("bfloat16", "float16"):
             raise ValueError(
@@ -296,10 +312,23 @@ class MiniCPMSparseBackend(AttentionBackend):
                     self.dense_len,
                     self.num_sparse_topk_tokens,
                 ),
+                rows_per_req=self.head_group_num
+                * (self.speculative_num_draft_tokens or 1),
             )
             if use_flashinfer
             else MiniCPMFlashAttentionAdapter(self.flash_attn_backend)
         )
+
+    def _init_spec_decode_config(self):
+        spec = get_spec()
+        self.speculative_num_draft_tokens = spec.speculative_num_draft_tokens
+        # A target-only server carries no speculative args (eagle_topk is
+        # None); treat that as chain drafts.
+        if (spec.speculative_eagle_topk or 1) > 1:
+            raise NotImplementedError(
+                "MiniCPM backend target verify supports chain drafts only "
+                "(speculative_eagle_topk == 1)"
+            )
 
     def _get_fused_topk_kernel(self, batch_size: int, *, is_prefill: bool):
         if not self.minicpm_fuse_topk:
@@ -323,6 +352,10 @@ class MiniCPMSparseBackend(AttentionBackend):
     def update_batch_for_sparse(
         self, forward_batch: ForwardBatch, metadata: MiniCPMSparseMetadata
     ):
+        if forward_batch.forward_mode.is_target_verify():
+            self._update_batch_for_verify(forward_batch, metadata)
+            return
+
         metadata.k1, metadata.k2 = _build_k1_k2_compression_metadata(
             req_pool_indices=forward_batch.req_pool_indices,
             base_metadata=metadata.base,
@@ -369,11 +402,51 @@ class MiniCPMSparseBackend(AttentionBackend):
                 head_group_num=self.head_group_num,
             )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        if forward_batch.forward_mode.is_target_verify():
-            raise NotImplementedError(
-                "MiniCPM backend does not support speculative decoding (target verify)"
+    def _update_batch_for_verify(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: MiniCPMSparseMetadata,
+    ):
+        # seq_lens + num_draft_tokens: compression must cover the draft keys
+        # too, or block scoring never sees the proposed tokens.
+        metadata.k1, metadata.k2 = _build_k1_k2_compression_metadata(
+            req_pool_indices=forward_batch.req_pool_indices,
+            base_metadata=metadata.base,
+            req_to_sparse_k1_token=self.req_to_sparse_k1_token,
+            req_to_sparse_k2_token=self.req_to_sparse_k2_token,
+            k1_kernel_size=self.k1_kernel_size,
+            k1_kernel_stride=self.k1_kernel_stride,
+            k2_kernel_size=self.k2_kernel_size,
+            k2_kernel_stride=self.k2_kernel_stride,
+            cu_seqlens_q=metadata.base.cu_seqlens_q,
+            seq_lens_cpu=(
+                forward_batch.seq_lens_cpu + self.speculative_num_draft_tokens
+            ),
+        )
+        _plan_sparse_verify(
+            forward_batch,
+            metadata,
+            head_group_num=self.head_group_num,
+            heads_per_group=self.heads_per_group,
+            dense_len=self.dense_len,
+            sparse_topk=self.sparse_topk,
+            block_size=self.block_size,
+            num_draft_tokens=self.speculative_num_draft_tokens,
+        )
+        # Varlen segments cannot be shared across verify rows.
+        metadata.k1_repeat = _plan_repeated_segments(
+            metadata.k1.cu_seqlens,
+            total_tokens=metadata.k1.cu_seqlens_cpu[-1],
+            repeats=self.speculative_num_draft_tokens,
+        )
+        if "k2" in self.verify_repeat_levels:
+            metadata.k2_repeat = _plan_repeated_segments(
+                metadata.k2.cu_seqlens,
+                total_tokens=metadata.k2.cu_seqlens_cpu[-1],
+                repeats=self.speculative_num_draft_tokens,
             )
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_draft_extend_v2():
             raise NotImplementedError(
                 "MiniCPM backend does not support draft extend mode"
@@ -385,10 +458,15 @@ class MiniCPMSparseBackend(AttentionBackend):
         if forward_batch.forward_mode.is_idle():
             self.forward_metadata = metadata
             return
+        is_target_verify = forward_batch.forward_mode.is_target_verify()
         self.update_batch_for_sparse(forward_batch, metadata)
         self.attention_adapter.prepare_forward(
             metadata,
-            is_prefill=not forward_batch.forward_mode.is_decode_or_idle(),
+            # Verify rows are single-query paged-decode rows,
+            # so they plan on the decode wrapper; verify dispatches as an extend.
+            is_prefill=not (
+                forward_batch.forward_mode.is_decode_or_idle() or is_target_verify
+            ),
             graph=False,
         )
         self.forward_metadata = metadata
@@ -509,6 +587,14 @@ class MiniCPMSparseBackend(AttentionBackend):
             )
             compressed_cu_seqlens = metadata.k1.cu_seqlens
             compressed_cu_seqlens2 = metadata.k2.cu_seqlens
+            if metadata.k1_repeat is not None:
+                compressed_k = compressed_k.index_select(0, metadata.k1_repeat.index)
+                compressed_cu_seqlens = metadata.k1_repeat.cu_seqlens
+                if metadata.k2_repeat is not None:
+                    compressed_k2 = compressed_k2.index_select(
+                        0, metadata.k2_repeat.index
+                    )
+                    compressed_cu_seqlens2 = metadata.k2_repeat.cu_seqlens
 
             ret = self.sparse_get_topk_impl(
                 query_states,
@@ -544,9 +630,8 @@ class MiniCPMSparseBackend(AttentionBackend):
         cache_lens = None
         if max_seqlen_in_batch_k > max_seqlen_in_batch_q:
             if max_seqlen_in_batch_q == 1:
-                # One query token per row.
-                # Decode rows: the staged stage-1 lens equals seq_lens_k - seq_lens_q,
-                # the kv length excluding the current token.
+                # Single-query rows: decode stages kv_len - 1 (seq_lens_k - seq_lens_q),
+                # verify stages each draft row's causal prefix (token position - 1).
                 cache_lens = self.forward_metadata.cache_seqlens_int32_stage1
             else:
                 seq_lens_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
@@ -617,6 +702,18 @@ class MiniCPMSparseBackend(AttentionBackend):
         if forward_batch.forward_mode.is_draft_extend_v2():
             raise NotImplementedError(
                 "MiniCPM backend does not support draft extend mode"
+            )
+        if forward_batch.forward_mode.is_target_verify():
+            return self._forward_paged_rows(
+                q=q,
+                k=k,
+                v=v,
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                q_rope=q_rope,
+                k_rope=k_rope,
+                sinks=sinks,
             )
 
         if k is not None:
@@ -848,6 +945,16 @@ class MiniCPMSparseBackend(AttentionBackend):
         ).reshape(-1, self.num_sparse_topk_tokens)
         destination = metadata.sparse_page_table[:, : self.num_sparse_topk_tokens]
         torch.where(metadata.sparse_row_mask, topk_rows, destination, out=destination)
+        if metadata.verify_dense_rows is not None:
+            self._overwrite_dense_verify_rows(metadata)
+
+    def _overwrite_dense_verify_rows(self, metadata: MiniCPMSparseMetadata):
+        # Rows read the prefix pages exactly as _copy_dense_page_table writes them.
+        src = metadata.verify_dense_rows
+        rows = metadata.sparse_page_table.view(src.shape[0], self.head_group_num, -1)
+        rows[:, :, : src.shape[2]] = torch.where(
+            metadata.verify_dense_mask, src, rows[:, :, : src.shape[2]]
+        )
 
     def forward_decode(
         self,
@@ -885,29 +992,42 @@ class MiniCPMSparseBackend(AttentionBackend):
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.flash_attn_backend.init_cuda_graph_state(max_bs, max_num_tokens)
-        self.attention_adapter.init_cuda_graph_state(max_bs * self.head_group_num)
-        buffers = self.flash_attn_backend.decode_cuda_graph_metadata
-        self.decode_cuda_graph_metadata = buffers
+        # max_num_tokens (= max_bs * draft width) already covers the verify rows.
+        # The flashinfer adapter sizes its cuda_graph_custom_mask from this row
+        # count; the sparse path never reads it, so the over-allocation is accepted.
+        self.attention_adapter.init_cuda_graph_state(
+            max_num_tokens * self.head_group_num,
+        )
+        self.decode_cuda_graph_metadata = (
+            self.flash_attn_backend.decode_cuda_graph_metadata
+        )
+        self._init_sparse_row_graph_buffers(max_bs, max_num_tokens)
+        self._init_verify_graph_buffers(max_bs, max_num_tokens)
+        self._init_compression_graph_buffers(max_bs)
+
+    def _init_sparse_row_graph_buffers(self, max_bs: int, max_num_tokens: int):
+        buffers = self.decode_cuda_graph_metadata
         sparse_max_num_pages = (
             max(self.dense_len, self.num_sparse_topk_tokens) + self.page_size - 1
         ) // self.page_size
+        max_rows = max_num_tokens * self.head_group_num
         buffers.update(
             {
                 "sparse_cache_seqlens": torch.full(
-                    (max_bs * self.head_group_num,),
+                    (max_rows,),
                     self.num_sparse_topk_tokens,
                     dtype=torch.int32,
                     device=self.device,
                 ),
                 "sparse_cu_seqlens_q": torch.arange(
                     0,
-                    max_bs * self.head_group_num + 1,
+                    max_rows + 1,
                     dtype=torch.int32,
                     device=self.device,
                 ),
                 "sparse_cu_seqlens_k": torch.arange(
                     0,
-                    (max_bs * self.head_group_num + 1) * self.num_sparse_topk_tokens,
+                    (max_rows + 1) * self.num_sparse_topk_tokens,
                     self.num_sparse_topk_tokens,
                     dtype=torch.int32,
                     device=self.device,
@@ -916,27 +1036,65 @@ class MiniCPMSparseBackend(AttentionBackend):
                     0, max_bs, dtype=torch.int32, device=self.device
                 ),
                 "sparse_page_table": torch.zeros(
-                    max_bs * self.head_group_num,
+                    max_rows,
                     sparse_max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
                 "sparse_row_mask": torch.zeros(
-                    max_bs * self.head_group_num,
-                    1,
-                    dtype=torch.bool,
-                    device=self.device,
+                    max_rows, 1, dtype=torch.bool, device=self.device
                 ),
                 "cu_seqlens_q_adjusted": torch.arange(
-                    0, max_bs + 1, dtype=torch.int32, device=self.device
+                    0, max_num_tokens + 1, dtype=torch.int32, device=self.device
                 )
                 * self.heads_per_group,
                 "cache_seqlens_int32_stage1": torch.zeros(
-                    max_bs, dtype=torch.int32, device=self.device
+                    max_num_tokens, dtype=torch.int32, device=self.device
                 ),
             }
         )
 
+    def _init_verify_graph_buffers(self, max_bs: int, max_num_tokens: int):
+        if self.speculative_num_draft_tokens is None:
+            return
+        buffers = self.decode_cuda_graph_metadata
+        draft_width = self.speculative_num_draft_tokens
+        assert max_bs * draft_width <= max_num_tokens, (
+            f"verify tokens {max_bs * draft_width} exceed the graph runner's "
+            f"token budget {max_num_tokens}"
+        )
+        buffers["verify_token_to_bs"] = torch.arange(
+            0, max_bs, dtype=torch.int32, device=self.device
+        ).repeat_interleave(draft_width)
+        buffers["token_pos_in_bs"] = torch.zeros(
+            max_num_tokens, dtype=torch.int32, device=self.device
+        )
+        # Verify rows never share sparse_row_mask with decode replays, which
+        # rewrite that buffer; every verify row takes the selection output.
+        buffers["verify_row_mask"] = torch.ones(
+            max_num_tokens * self.head_group_num,
+            1,
+            dtype=torch.bool,
+            device=self.device,
+        )
+        if self.dense_len > 0:
+            buffers["verify_dense_rows"] = torch.zeros(
+                max_num_tokens,
+                self.head_group_num,
+                self.dense_len,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            buffers["verify_dense_mask"] = torch.zeros(
+                max_num_tokens,
+                1,
+                self.dense_len,
+                dtype=torch.bool,
+                device=self.device,
+            )
+
+    def _init_compression_graph_buffers(self, max_bs: int):
+        buffers = self.decode_cuda_graph_metadata
         for name, kernel_size, kernel_stride in (
             ("k1", self.k1_kernel_size, self.k1_kernel_stride),
             ("k2", self.k2_kernel_size, self.k2_kernel_stride),
@@ -964,6 +1122,22 @@ class MiniCPMSparseBackend(AttentionBackend):
             buffers[f"{name}.history_compress_token_nums"] = torch.zeros(
                 max_bs, dtype=torch.int32, device=self.device
             )
+            if self.speculative_num_draft_tokens is not None and (
+                name in self.verify_repeat_levels
+            ):
+                # The captured gather records this index's address; it must
+                # outlive the graphs, and every round rewrites its packed layout.
+                max_verify_tokens = max_bs * self.speculative_num_draft_tokens
+                buffers[f"{name}_repeat"] = RepeatedSegmentLayout(
+                    index=torch.zeros(
+                        max_verify_tokens * (self.max_context_len // kernel_stride),
+                        dtype=torch.int64,
+                        device=self.device,
+                    ),
+                    cu_seqlens=torch.zeros(
+                        max_verify_tokens + 1, dtype=torch.int32, device=self.device
+                    ),
+                )
             for field in (
                 "cu_seqlens",
                 "cu_new_token_nums",
@@ -978,28 +1152,41 @@ class MiniCPMSparseBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
-        if not forward_batch.forward_mode.is_decode_or_idle():
+        is_target_verify = forward_batch.forward_mode.is_target_verify()
+        if not (forward_batch.forward_mode.is_decode_or_idle() or is_target_verify):
             raise NotImplementedError(
-                "MiniCPM backend CUDA graph only supports decode/idle mode, "
-                f"got {forward_batch.forward_mode}"
+                "MiniCPM backend CUDA graph only supports decode/idle and "
+                f"target verify modes, got {forward_batch.forward_mode}"
             )
 
         self._use_cuda_graph_buffers = True
+        num_selection_rows = forward_batch.batch_size
+        if is_target_verify:
+            num_selection_rows *= self.speculative_num_draft_tokens
         self._get_fused_topk_kernel(
-            forward_batch.batch_size,
+            num_selection_rows,
             is_prefill=False,
         )
         self.flash_attn_backend.init_forward_metadata_out_graph(
             forward_batch, in_capture
         )
         metadata = MiniCPMSparseMetadata(base=self.flash_attn_backend.forward_metadata)
-        self._bind_sparse_graph_metadata(
-            forward_batch,
-            metadata,
-            in_capture=in_capture,
-        )
-        if not in_capture:
-            self._replay_sparse_graph_metadata(forward_batch, metadata)
+        if is_target_verify:
+            self._bind_sparse_verify_graph_metadata(
+                forward_batch,
+                metadata,
+                in_capture=in_capture,
+            )
+            if not in_capture:
+                self._replay_sparse_verify_graph_metadata(forward_batch, metadata)
+        else:
+            self._bind_sparse_graph_metadata(
+                forward_batch,
+                metadata,
+                in_capture=in_capture,
+            )
+            if not in_capture:
+                self._replay_sparse_graph_metadata(forward_batch, metadata)
         self.attention_adapter.prepare_forward(
             metadata,
             is_prefill=False,
@@ -1045,13 +1232,6 @@ class MiniCPMSparseBackend(AttentionBackend):
         bs = forward_batch.batch_size
         buffers = self.decode_cuda_graph_metadata
         sparse_rows = self.head_group_num * bs
-        metadata.sparse_cache_seqlens_int32 = buffers["sparse_cache_seqlens"][
-            :sparse_rows
-        ]
-        metadata.sparse_cu_seqlens_q = buffers["sparse_cu_seqlens_q"][: sparse_rows + 1]
-        metadata.sparse_cu_seqlens_k = buffers["sparse_cu_seqlens_k"][: sparse_rows + 1]
-        metadata.token_to_bs = buffers["token_to_bs"][:bs]
-        metadata.sparse_page_table = buffers["sparse_page_table"][:sparse_rows]
 
         assume_kv_len = self.config_dense_len
         if in_capture:
@@ -1061,42 +1241,81 @@ class MiniCPMSparseBackend(AttentionBackend):
             )
             metadata.base.max_seq_len_k = assume_kv_len
 
-        for name, kernel_size, kernel_stride in (
-            ("k1", self.k1_kernel_size, self.k1_kernel_stride),
-            ("k2", self.k2_kernel_size, self.k2_kernel_stride),
-        ):
-            level = CompressionLevelMetadata()
-            setattr(metadata, name, level)
-            level_len = max(0, (assume_kv_len - kernel_size) // kernel_stride + 1)
-            level.cu_seqlens_cpu = [index * level_len for index in range(bs + 1)]
-            level.cu_seqlens = buffers[f"{name}.cu_seqlens"][: bs + 1]
-            if in_capture:
-                level.cu_seqlens.copy_(
-                    torch.arange(bs + 1, device=self.device, dtype=torch.int32)
-                    * level_len
-                )
-            level.table = buffers[f"{name}.table"][:bs]
-            level.history_compress_token_nums = buffers[
-                f"{name}.history_compress_token_nums"
-            ][:bs]
-            for field in (
-                "cu_new_token_nums",
-                "cu_total_compress_token_nums",
-            ):
-                setattr(level, field, buffers[f"{name}.{field}"][: bs + 1])
-
-        metadata.cu_seqlens_q_adjusted = buffers["cu_seqlens_q_adjusted"][: bs + 1]
-        metadata.cache_seqlens_int32_stage1 = buffers["cache_seqlens_int32_stage1"][:bs]
-        metadata.max_seqlen_q_adjusted = (
-            metadata.base.max_seq_len_q * self.heads_per_group
+        self._bind_compression_graph_metadata(
+            bs=bs, metadata=metadata, in_capture=in_capture, assume_kv_len=assume_kv_len
         )
-        metadata.token_pos_in_bs = metadata.base.cache_seqlens_int32
-        metadata.seqlen_k_sparse_bs_tensor = metadata.base.cache_seqlens_int32
-        metadata.topk_cu_seqlens_q = metadata.base.cu_seqlens_q
-        metadata.topk_cu_seqlens_k = metadata.base.cu_seqlens_k
-        metadata.topk_max_seqlen_q = 1
-        metadata.topk_max_seqlen_k = metadata.base.max_seq_len_k
+
         metadata.sparse_row_mask = buffers["sparse_row_mask"][:sparse_rows]
+        _assign_row_metadata(
+            metadata,
+            sparse_cache_seqlens_int32=buffers["sparse_cache_seqlens"][:sparse_rows],
+            sparse_cu_seqlens_q=buffers["sparse_cu_seqlens_q"][: sparse_rows + 1],
+            sparse_cu_seqlens_k=buffers["sparse_cu_seqlens_k"][: sparse_rows + 1],
+            sparse_page_table=buffers["sparse_page_table"][:sparse_rows],
+            token_to_bs=buffers["token_to_bs"][:bs],
+            token_pos_in_bs=metadata.base.cache_seqlens_int32,
+            cache_seqlens_int32_stage1=buffers["cache_seqlens_int32_stage1"][:bs],
+            cu_seqlens_q_adjusted=buffers["cu_seqlens_q_adjusted"][: bs + 1],
+            max_seqlen_q_adjusted=metadata.base.max_seq_len_q * self.heads_per_group,
+            topk_cu_seqlens_q=metadata.base.cu_seqlens_q,
+            topk_cu_seqlens_k=metadata.base.cu_seqlens_k,
+            topk_max_seqlen_q=1,
+            topk_max_seqlen_k=metadata.base.max_seq_len_k,
+        )
+
+    def _bind_compression_graph_metadata(
+        self,
+        bs: int,
+        metadata: MiniCPMSparseMetadata,
+        *,
+        in_capture: bool,
+        assume_kv_len: int,
+    ):
+        metadata.k1 = self._bind_compression_level(
+            "k1",
+            kernel_size=self.k1_kernel_size,
+            kernel_stride=self.k1_kernel_stride,
+            bs=bs,
+            in_capture=in_capture,
+            assume_kv_len=assume_kv_len,
+        )
+        metadata.k2 = self._bind_compression_level(
+            "k2",
+            kernel_size=self.k2_kernel_size,
+            kernel_stride=self.k2_kernel_stride,
+            bs=bs,
+            in_capture=in_capture,
+            assume_kv_len=assume_kv_len,
+        )
+
+    def _bind_compression_level(
+        self,
+        name: str,
+        *,
+        kernel_size: int,
+        kernel_stride: int,
+        bs: int,
+        in_capture: bool,
+        assume_kv_len: int,
+    ) -> CompressionLevelMetadata:
+        buffers = self.decode_cuda_graph_metadata
+        level = CompressionLevelMetadata()
+        level_len = max(0, (assume_kv_len - kernel_size) // kernel_stride + 1)
+        level.cu_seqlens_cpu = [index * level_len for index in range(bs + 1)]
+        level.cu_seqlens = buffers[f"{name}.cu_seqlens"][: bs + 1]
+        if in_capture:
+            level.cu_seqlens.copy_(
+                torch.arange(bs + 1, device=self.device, dtype=torch.int32) * level_len
+            )
+        level.table = buffers[f"{name}.table"][:bs]
+        level.history_compress_token_nums = buffers[
+            f"{name}.history_compress_token_nums"
+        ][:bs]
+        level.cu_new_token_nums = buffers[f"{name}.cu_new_token_nums"][: bs + 1]
+        level.cu_total_compress_token_nums = buffers[
+            f"{name}.cu_total_compress_token_nums"
+        ][: bs + 1]
+        return level
 
     def _replay_sparse_graph_metadata(
         self,
@@ -1106,6 +1325,8 @@ class MiniCPMSparseBackend(AttentionBackend):
         bs = forward_batch.batch_size
         real_bs = bs - forward_batch.num_padding
         if real_bs == 0:
+            # All-padding replay: stale row tables feed only discarded padding rows,
+            # and the zeroed lengths keep the captured gathers in bounds.
             metadata.sparse_cache_seqlens_int32.zero_()
             metadata.sparse_cu_seqlens_k.zero_()
             metadata.cache_seqlens_int32_stage1.zero_()
@@ -1144,6 +1365,36 @@ class MiniCPMSparseBackend(AttentionBackend):
             head_group_num=self.head_group_num,
         )
 
+        self._replay_compression_graph_metadata(
+            forward_batch=forward_batch,
+            metadata=metadata,
+            compression_metadata=compression_metadata,
+            real_bs=real_bs,
+            cu_fields=(
+                "cu_seqlens",
+                "cu_new_token_nums",
+                "cu_total_compress_token_nums",
+            ),
+        )
+
+        if real_bs < bs:
+            metadata.sparse_cache_seqlens_int32[real_sparse_rows:].zero_()
+            metadata.sparse_cu_seqlens_k[real_sparse_rows + 1 :].fill_(
+                decode_metadata.sparse_cu_seqlens_k[-1]
+            )
+            metadata.cache_seqlens_int32_stage1[real_bs:].zero_()
+            metadata.sparse_row_mask[real_sparse_rows:].zero_()
+
+    def _replay_compression_graph_metadata(
+        self,
+        *,
+        forward_batch: ForwardBatch,
+        metadata: MiniCPMSparseMetadata,
+        compression_metadata,
+        real_bs: int,
+        cu_fields: tuple[str, ...],
+    ):
+        bs = forward_batch.batch_size
         for (name, req_to_sparse), src in zip(
             (
                 ("k1", self.req_to_sparse_k1_token),
@@ -1157,25 +1408,279 @@ class MiniCPMSparseBackend(AttentionBackend):
             )
             if real_bs < bs:
                 dst.history_compress_token_nums[real_bs:].zero_()
-            for field in (
-                "cu_seqlens",
-                "cu_new_token_nums",
-                "cu_total_compress_token_nums",
-            ):
+            for field in cu_fields:
                 dst_field = getattr(dst, field)
                 src_field = getattr(src, field)
                 dst_field[: real_bs + 1].copy_(src_field)
                 if real_bs < bs:
+                    # Padded rows get zero-length tails
+                    # so the captured gathers stay in bounds.
                     dst_field[real_bs + 1 :].fill_(src_field[-1])
             dst.table.copy_(req_to_sparse[forward_batch.req_pool_indices])
 
-        if real_bs < bs:
-            metadata.sparse_cache_seqlens_int32[real_sparse_rows:].zero_()
-            metadata.sparse_cu_seqlens_k[real_sparse_rows + 1 :].fill_(
-                decode_metadata.sparse_cu_seqlens_k[-1]
+    def _bind_sparse_verify_graph_metadata(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: MiniCPMSparseMetadata,
+        *,
+        in_capture: bool,
+    ):
+        bs = forward_batch.batch_size
+        num_draft_tokens = self.speculative_num_draft_tokens
+        num_verify_tokens = bs * num_draft_tokens
+        sparse_rows = num_verify_tokens * self.head_group_num
+        buffers = self.decode_cuda_graph_metadata
+        metadata.sparse_row_mask = buffers["verify_row_mask"][:sparse_rows]
+        if self.dense_len > 0:
+            num_cols = min(self.dense_len, metadata.base.page_table.shape[1])
+            metadata.verify_dense_rows = buffers["verify_dense_rows"][
+                :num_verify_tokens, :, :num_cols
+            ]
+            metadata.verify_dense_mask = buffers["verify_dense_mask"][
+                :num_verify_tokens, :, :num_cols
+            ]
+        _assign_row_metadata(
+            metadata,
+            sparse_cache_seqlens_int32=buffers["sparse_cache_seqlens"][:sparse_rows],
+            sparse_cu_seqlens_q=buffers["sparse_cu_seqlens_q"][: sparse_rows + 1],
+            sparse_cu_seqlens_k=buffers["sparse_cu_seqlens_k"][: sparse_rows + 1],
+            sparse_page_table=buffers["sparse_page_table"][:sparse_rows],
+            token_to_bs=buffers["verify_token_to_bs"][:num_verify_tokens],
+            token_pos_in_bs=buffers["token_pos_in_bs"][:num_verify_tokens],
+            # These buffers are prefix-stable (arange / zeros),
+            # so the decode ones serve verify's row count too.
+            cache_seqlens_int32_stage1=buffers["cache_seqlens_int32_stage1"][
+                :num_verify_tokens
+            ],
+            cu_seqlens_q_adjusted=buffers["cu_seqlens_q_adjusted"][
+                : num_verify_tokens + 1
+            ],
+            max_seqlen_q_adjusted=self.heads_per_group,
+            topk_cu_seqlens_q=buffers["sparse_cu_seqlens_q"][: num_verify_tokens + 1],
+            topk_cu_seqlens_k=metadata.base.cu_seqlens_k,
+            topk_max_seqlen_q=1,
+            # Static across capture and replay: the captured selection froze its
+            # cache_lens branch here, and replays do not refresh base.max_seq_len_k.
+            topk_max_seqlen_k=self.max_context_len,
+        )
+
+        assume_kv_len = min(
+            self.config_dense_len + num_draft_tokens, self.max_context_len
+        )
+        if in_capture:
+            metadata.base.cu_seqlens_k.copy_(
+                torch.arange(bs + 1, device=self.device, dtype=torch.int32)
+                * assume_kv_len
             )
-            metadata.cache_seqlens_int32_stage1[real_bs:].zero_()
-            metadata.sparse_row_mask[real_sparse_rows:].zero_()
+            metadata.base.cache_seqlens_int32.fill_(assume_kv_len)
+            seed_seq_lens = torch.full(
+                (bs,),
+                assume_kv_len - num_draft_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._write_verify_graph_rows(
+                metadata, seed_seq_lens, real_rows=sparse_rows
+            )
+        self._bind_compression_graph_metadata(
+            bs=bs, metadata=metadata, in_capture=in_capture, assume_kv_len=assume_kv_len
+        )
+        if in_capture:
+            self._bind_verify_repeat_layouts(
+                metadata, bs=bs, num_verify_tokens=num_verify_tokens
+            )
+
+    def _bind_verify_repeat_layouts(
+        self,
+        metadata: MiniCPMSparseMetadata,
+        *,
+        bs: int,
+        num_verify_tokens: int,
+    ):
+        metadata.k1_repeat = self._bind_verify_repeat_level(
+            metadata.k1,
+            name="k1",
+            kernel_stride=self.k1_kernel_stride,
+            bs=bs,
+            num_verify_tokens=num_verify_tokens,
+        )
+        metadata.k2_repeat = self._bind_verify_repeat_level(
+            metadata.k2,
+            name="k2",
+            kernel_stride=self.k2_kernel_stride,
+            bs=bs,
+            num_verify_tokens=num_verify_tokens,
+        )
+
+    def _bind_verify_repeat_level(
+        self,
+        level_metadata: CompressionLevelMetadata,
+        *,
+        name: str,
+        kernel_stride: int,
+        bs: int,
+        num_verify_tokens: int,
+    ) -> Optional[RepeatedSegmentLayout]:
+        segment_rows = self.max_context_len // kernel_stride
+        packed_total = level_metadata.cu_seqlens_cpu[-1]
+        level_metadata.cu_total_compress_token_nums.copy_(
+            torch.arange(bs + 1, device=self.device, dtype=torch.int32) * segment_rows
+        )
+        # _compress_decode_keys sizes the compression view from cu_seqlens_cpu,
+        # so seed it to the slab extent the compression kernel writes into.
+        level_metadata.cu_seqlens_cpu = [row * segment_rows for row in range(bs + 1)]
+        # Mirror the eager planner: under minicpm_fuse_topk the k2 repeat is unset,
+        # and the captured gather records the plain level cu_seqlens.
+        if name not in self.verify_repeat_levels:
+            return None
+        repeat = self._verify_repeat_layout_views(
+            name, bs=bs, num_verify_tokens=num_verify_tokens, segment_rows=segment_rows
+        )
+        self._write_verify_repeat_layout(
+            level_metadata, repeat, packed_total=packed_total
+        )
+        return repeat
+
+    def _verify_repeat_layout_views(
+        self, name: str, *, bs: int, num_verify_tokens: int, segment_rows: int
+    ) -> RepeatedSegmentLayout:
+        # The captured gather recorded the retained buffers' addresses,
+        # so capture and replay both work through prefix views of them.
+        retained = self.decode_cuda_graph_metadata[f"{name}_repeat"]
+        return RepeatedSegmentLayout(
+            index=retained.index[: num_verify_tokens * segment_rows],
+            cu_seqlens=retained.cu_seqlens[: num_verify_tokens + 1],
+        )
+
+    def _write_verify_repeat_layout(
+        self,
+        level_metadata: CompressionLevelMetadata,
+        repeat: RepeatedSegmentLayout,
+        *,
+        packed_total: int,
+    ) -> None:
+        # The compression kernel writes request b's chunks at slab offset
+        # cu_total[b], so the packed rows gather from there.
+        layout = _plan_repeated_segments(
+            level_metadata.cu_seqlens,
+            total_tokens=packed_total,
+            repeats=self.speculative_num_draft_tokens,
+            segment_starts=level_metadata.cu_total_compress_token_nums[:-1],
+        )
+        packed = layout.index.numel()
+        repeat.index[:packed].copy_(layout.index)
+        # The captured gather reads the whole view, so the unreferenced tail
+        # must stay inside the smallest compression view: point it at row 0.
+        repeat.index[packed:].zero_()
+        repeat.cu_seqlens.copy_(layout.cu_seqlens)
+
+    def _write_verify_graph_rows(
+        self,
+        metadata: MiniCPMSparseMetadata,
+        seq_lens: torch.Tensor,
+        *,
+        real_rows: int,
+    ):
+        """Refresh the static verify row buffers; the row-length outputs past
+        real_rows (CUDA-graph padding) are zeroed."""
+        num_draft_tokens = self.speculative_num_draft_tokens
+        token_pos, row_lens = _build_sparse_verify_rows(
+            seq_lens,
+            head_group_num=self.head_group_num,
+            dense_len=self.dense_len,
+            sparse_topk=self.sparse_topk,
+            block_size=self.block_size,
+            num_draft_tokens=num_draft_tokens,
+        )
+        row_lens[real_rows:] = 0
+        metadata.token_pos_in_bs.copy_(token_pos)
+        metadata.sparse_cache_seqlens_int32.copy_(row_lens)
+        torch.cumsum(
+            row_lens, dim=0, dtype=torch.int32, out=metadata.sparse_cu_seqlens_k[1:]
+        )
+        # Per-row decode-form cache length for the block selection.
+        metadata.cache_seqlens_int32_stage1.copy_(token_pos - 1)
+        if self.dense_len > 0:
+            _build_dense_verify_overwrite(
+                token_pos=token_pos,
+                token_to_bs=metadata.token_to_bs,
+                page_table=metadata.base.page_table,
+                dense_len=self.dense_len,
+                head_group_num=self.head_group_num,
+                out_rows=metadata.verify_dense_rows,
+                out_mask=metadata.verify_dense_mask,
+            )
+
+    def _replay_sparse_verify_graph_metadata(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: MiniCPMSparseMetadata,
+    ):
+        bs = forward_batch.batch_size
+        num_draft_tokens = self.speculative_num_draft_tokens
+        # num_padding comes only from the graph runner's synthetic replay batch;
+        # it is not a ForwardBatch contract member.
+        real_bs = bs - forward_batch.num_padding
+        if real_bs == 0:
+            # All-padding replay: zero this round's lengths so the captured
+            # compression and gathers see empty segments, not the previous round's.
+            metadata.sparse_cache_seqlens_int32.zero_()
+            metadata.sparse_cu_seqlens_k.zero_()
+            metadata.cache_seqlens_int32_stage1.zero_()
+            for level in (metadata.k1, metadata.k2):
+                level.history_compress_token_nums.zero_()
+                level.cu_seqlens.zero_()
+                level.cu_new_token_nums.zero_()
+            for name in self.verify_repeat_levels:
+                self.decode_cuda_graph_metadata[f"{name}_repeat"].cu_seqlens[
+                    : bs * num_draft_tokens + 1
+                ].zero_()
+            return
+
+        # Padding slots keep the runner's seq-len fill value,
+        # so their token positions stay in range.
+        self._write_verify_graph_rows(
+            metadata,
+            forward_batch.seq_lens,
+            real_rows=real_bs * num_draft_tokens * self.head_group_num,
+        )
+
+        compression_metadata = _build_k1_k2_compression_metadata(
+            req_pool_indices=forward_batch.req_pool_indices[:real_bs],
+            base_metadata=metadata.base,
+            req_to_sparse_k1_token=self.req_to_sparse_k1_token,
+            req_to_sparse_k2_token=self.req_to_sparse_k2_token,
+            k1_kernel_size=self.k1_kernel_size,
+            k1_kernel_stride=self.k1_kernel_stride,
+            k2_kernel_size=self.k2_kernel_size,
+            k2_kernel_stride=self.k2_kernel_stride,
+            cu_seqlens_q=metadata.base.cu_seqlens_q,
+            seq_lens_cpu=forward_batch.seq_lens_cpu[:real_bs] + num_draft_tokens,
+        )
+        # cu_total_compress_token_nums keeps the capture-time slab offsets the
+        # compression kernel writes at; only the packed lengths are refreshed.
+        self._replay_compression_graph_metadata(
+            forward_batch=forward_batch,
+            metadata=metadata,
+            compression_metadata=compression_metadata,
+            real_bs=real_bs,
+            cu_fields=("cu_seqlens", "cu_new_token_nums"),
+        )
+        for name, kernel_stride, level_metadata, src in (
+            ("k1", self.k1_kernel_stride, metadata.k1, compression_metadata[0]),
+            ("k2", self.k2_kernel_stride, metadata.k2, compression_metadata[1]),
+        ):
+            if name in self.verify_repeat_levels:
+                self._write_verify_repeat_layout(
+                    level_metadata,
+                    self._verify_repeat_layout_views(
+                        name,
+                        bs=bs,
+                        num_verify_tokens=bs * num_draft_tokens,
+                        segment_rows=self.max_context_len // kernel_stride,
+                    ),
+                    packed_total=src.cu_seqlens_cpu[-1],
+                )
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.flash_attn_backend.get_cuda_graph_seq_len_fill_value()

--- a/python/sglang/srt/layers/attention/minicpm/backend.py
+++ b/python/sglang/srt/layers/attention/minicpm/backend.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from sglang.kernels.ops.minicpm_sala import get_block_table
 from sglang.srt.configs.minicpm import MiniCPMHybridConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -16,6 +16,19 @@ from sglang.srt.layers.attention.minicpm.attention_adapter import (
     MiniCPMFlashInferAdapter,
 )
 from sglang.srt.layers.attention.minicpm.cache import attach_compressed_cache
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    CompressionLevelMetadata,
+    MiniCPMSparseMetadata,
+    _build_k1_k2_compression_metadata,
+    _build_sparse_decode_metadata,
+    _plan_sparse_decode,
+    _plan_sparse_prefill,
+    allocate_and_compress_keys,
+    batched_gather,
+    compressed_attention,
+    compressed_attention_tilelang,
+    get_compress_k_v2,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
     get_exec,
@@ -28,21 +41,6 @@ from sglang.srt.utils import next_power_of_2
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-
-
-from sglang.kernels.ops.minicpm_sala import get_block_table
-from sglang.srt.layers.attention.minicpm.sparse_utils import (
-    CompressionLevelMetadata,
-    MiniCPMSparseMetadata,
-    _build_k1_k2_compression_metadata,
-    _plan_sparse_decode,
-    _plan_sparse_prefill,
-    allocate_and_compress_keys,
-    batched_gather,
-    compressed_attention,
-    compressed_attention_tilelang,
-    get_compress_k_v2,
-)
 
 
 def _transpose_head_group_layout(
@@ -105,18 +103,20 @@ def _gather_compressed_keys(
 
 
 def _copy_dense_page_tables(
-    metadata: MiniCPMSparseMetadata,
-    seq_lens_cpu,
+    sparse_page_table: torch.Tensor,
+    page_table: torch.Tensor,
+    *,
+    dense_rows: list[tuple[int, int, int]],
     head_group_num: int,
 ) -> None:
-    for dense_bs, row_start, _, _ in metadata.dense_layout:
+    for row_start, batch_idx, kv_len in dense_rows:
         _copy_dense_page_table(
-            metadata.sparse_page_table,
-            row_start,
-            metadata.base.page_table,
-            dense_bs,
-            int(seq_lens_cpu[dense_bs]),
-            head_group_num,
+            destination=sparse_page_table,
+            destination_row=row_start,
+            source=page_table,
+            source_row=batch_idx,
+            kv_len=kv_len,
+            head_group_num=head_group_num,
         )
 
 
@@ -158,7 +158,6 @@ class MiniCPMSparseBackend(AttentionBackend):
         # Sparse attention configuration (required for MiniCPM)
         hf_config = model_runner.model_config.hf_config
 
-        # MiniCPM must have sparse attention enabled
         if not isinstance(hf_config, MiniCPMHybridConfig) or not (
             hf_config.has_minicpm_sparse_attention
         ):
@@ -200,7 +199,7 @@ class MiniCPMSparseBackend(AttentionBackend):
         )
         self.config_dense_len = sparse_config["dense_len"]
         topk = sparse_config["topk"]
-        self.local_blocks = self.window_size // self.block_size  # local_blocks
+        self.local_blocks = self.window_size // self.block_size
         self.sparse_topk = topk + (self.window_size // self.block_size)
         self.num_sparse_topk_tokens = self.block_size * self.sparse_topk
         required_context_len = max(self.config_dense_len, self.num_sparse_topk_tokens)
@@ -251,10 +250,8 @@ class MiniCPMSparseBackend(AttentionBackend):
         self.prefill_fused_kernels = {}
         bucketed_pooled_k_len = next_power_of_2(pooled_k_len)
 
-        pooling_block_stride = self.block_size // self.kernel_stride  # = 64 // 16 = 4
-        pooling_pad_len = (
-            self.kernel_size // self.kernel_stride - 1
-        )  # = 32 // 16 - 1 = 1
+        pooling_block_stride = self.block_size // self.kernel_stride
+        pooling_pad_len = self.kernel_size // self.kernel_stride - 1
         pooling_num_offs = (
             self.kernel_size // self.kernel_stride
             + self.block_size // self.kernel_stride
@@ -326,10 +323,8 @@ class MiniCPMSparseBackend(AttentionBackend):
     def update_batch_for_sparse(
         self, forward_batch: ForwardBatch, metadata: MiniCPMSparseMetadata
     ):
-        cu_seqlens_q = metadata.base.cu_seqlens_q
-
         metadata.k1, metadata.k2 = _build_k1_k2_compression_metadata(
-            forward_batch=forward_batch,
+            req_pool_indices=forward_batch.req_pool_indices,
             base_metadata=metadata.base,
             req_to_sparse_k1_token=self.req_to_sparse_k1_token,
             req_to_sparse_k2_token=self.req_to_sparse_k2_token,
@@ -337,7 +332,8 @@ class MiniCPMSparseBackend(AttentionBackend):
             k1_kernel_stride=self.k1_kernel_stride,
             k2_kernel_size=self.k2_kernel_size,
             k2_kernel_stride=self.k2_kernel_stride,
-            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_q=metadata.base.cu_seqlens_q,
+            seq_lens_cpu=forward_batch.seq_lens_cpu,
         )
 
         if forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed():
@@ -351,30 +347,27 @@ class MiniCPMSparseBackend(AttentionBackend):
                 block_size=self.block_size,
             )
             _copy_dense_page_tables(
-                metadata, forward_batch.seq_lens_cpu, self.head_group_num
+                metadata.sparse_page_table,
+                metadata.base.page_table,
+                dense_rows=metadata.dense_rows,
+                head_group_num=self.head_group_num,
             )
         else:
             _plan_sparse_decode(
-                forward_batch=forward_batch,
-                metadata=metadata,
+                forward_batch,
+                metadata,
                 head_group_num=self.head_group_num,
+                heads_per_group=self.heads_per_group,
                 dense_len=self.dense_len,
                 sparse_topk=self.sparse_topk,
                 block_size=self.block_size,
             )
-
             _copy_dense_page_tables(
-                metadata, forward_batch.seq_lens_cpu, self.head_group_num
+                metadata.sparse_page_table,
+                metadata.base.page_table,
+                dense_rows=metadata.dense_rows,
+                head_group_num=self.head_group_num,
             )
-
-            # Stage1 optimization metadata for decode mode
-            metadata.cache_seqlens_int32_stage1 = (
-                metadata.base.cache_seqlens_int32[metadata.sparse_bs_list] - 1
-            )
-            metadata.cu_seqlens_q_adjusted = (
-                metadata.topk_cu_seqlens_q * self.heads_per_group
-            )
-            metadata.max_seqlen_q_adjusted = self.heads_per_group
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_target_verify():
@@ -383,7 +376,7 @@ class MiniCPMSparseBackend(AttentionBackend):
             )
         if forward_batch.forward_mode.is_draft_extend_v2():
             raise NotImplementedError(
-                "MiniCPM backend does not support speculative decoding (draft extend)"
+                "MiniCPM backend does not support draft extend mode"
             )
 
         self._use_cuda_graph_buffers = False
@@ -443,6 +436,8 @@ class MiniCPMSparseBackend(AttentionBackend):
         forward_batch,
         is_prefill=True,
     ):
+        """Select this layer's top-k blocks for every planned row
+        (prefill: the sparse sub-batch), with layout [head_group, token, topk]."""
         if is_prefill:
             metadata = self.forward_metadata
             sparse_bs = metadata.sparse_bs_list
@@ -512,36 +507,21 @@ class MiniCPMSparseBackend(AttentionBackend):
                 layer,
                 forward_batch,
             )
-
-            sparse_bs = metadata.sparse_bs_list
-            if not sparse_bs:
-                return None
-
-            cu_seqlens_q = metadata.base.cu_seqlens_q
             compressed_cu_seqlens = metadata.k1.cu_seqlens
             compressed_cu_seqlens2 = metadata.k2.cu_seqlens
-            if len(sparse_bs) < forward_batch.batch_size:
-                query_states = query_states[sparse_bs]
-                compressed_k, compressed_cu_seqlens = _gather_compressed_keys(
-                    compressed_k, metadata.k1, sparse_bs
-                )
-                compressed_k2, compressed_cu_seqlens2 = _gather_compressed_keys(
-                    compressed_k2, metadata.k2, sparse_bs
-                )
-                cu_seqlens_q = metadata.topk_cu_seqlens_q
 
             ret = self.sparse_get_topk_impl(
                 query_states,
-                cu_seqlens_q,
-                metadata.base.cu_seqlens_k,
-                1,
-                metadata.base.max_seq_len_k,
+                metadata.topk_cu_seqlens_q,
+                metadata.topk_cu_seqlens_k,
+                metadata.topk_max_seqlen_q,
+                metadata.topk_max_seqlen_k,
                 compressed_k=compressed_k,
                 compressed_cu_seqlens=compressed_cu_seqlens,
                 compressed_k2=compressed_k2,
                 compressed_cu_seqlens2=compressed_cu_seqlens2,
                 fused_kernel=self._get_fused_topk_kernel(
-                    len(sparse_bs),
+                    metadata.topk_cu_seqlens_q.shape[0] - 1,
                     is_prefill=False,
                 ),
             )
@@ -564,6 +544,9 @@ class MiniCPMSparseBackend(AttentionBackend):
         cache_lens = None
         if max_seqlen_in_batch_k > max_seqlen_in_batch_q:
             if max_seqlen_in_batch_q == 1:
+                # One query token per row.
+                # Decode rows: the staged stage-1 lens equals seq_lens_k - seq_lens_q,
+                # the kv length excluding the current token.
                 cache_lens = self.forward_metadata.cache_seqlens_int32_stage1
             else:
                 seq_lens_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
@@ -705,6 +688,25 @@ class MiniCPMSparseBackend(AttentionBackend):
                 max_context_length=self.max_context_len,
             )
 
+        return self._forward_grouped_heads(
+            q,
+            layer,
+            metadata,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            sinks=sinks,
+        )
+
+    def _forward_grouped_heads(
+        self,
+        q: torch.Tensor,
+        layer: RadixAttention,
+        metadata: MiniCPMSparseMetadata,
+        *,
+        k_descale: Optional[torch.Tensor],
+        v_descale: Optional[torch.Tensor],
+        sinks: Optional[torch.Tensor],
+    ) -> torch.Tensor:
         dense_layout_spans = [
             (query_start, query_len)
             for _, _, query_start, query_len in metadata.dense_layout
@@ -746,28 +748,19 @@ class MiniCPMSparseBackend(AttentionBackend):
 
         return result.view(-1, layer.tp_q_head_num * layer.head_dim)
 
-    def forward_decode(
+    def _forward_paged_rows(
         self,
+        *,
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
         layer: RadixAttention,
         forward_batch: ForwardBatch,
-        save_kv_cache=True,
-        # For multi-head latent attention
-        q_rope: Optional[torch.Tensor] = None,
-        k_rope: Optional[torch.Tensor] = None,
-        sinks: Optional[torch.Tensor] = None,
+        save_kv_cache: bool,
+        q_rope: Optional[torch.Tensor],
+        k_rope: Optional[torch.Tensor],
+        sinks: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        if layer.is_cross_attention:
-            raise NotImplementedError(
-                "MiniCPM backend does not support cross attention"
-            )
-        if layer.sliding_window_size not in (None, -1):
-            raise NotImplementedError(
-                "MiniCPM backend does not support sliding-window attention"
-            )
-
         bs = forward_batch.batch_size
         if k is not None:
             assert v is not None
@@ -793,58 +786,31 @@ class MiniCPMSparseBackend(AttentionBackend):
                 is_prefill=False,
             )
         )
+        q_reshaped = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+
+        if self._rows_need_block_selection(bs=bs, metadata=metadata):
+            topk_idx = self.get_topk_for_sparse(
+                query_states=q_reshaped,
+                key_states=k,
+                layer=layer,
+                forward_batch=forward_batch,
+                is_prefill=False,
+            )
+            self._plan_paged_sparse_page_table(topk_idx=topk_idx, metadata=metadata)
+        else:
+            # Dense rows still extend the persistent chunk table,
+            # which the first sparse round past dense_len reads as history.
+            self._compress_decode_keys(
+                query_states=q_reshaped, layer=layer, forward_batch=forward_batch
+            )
+
         key_cache, value_cache = self.flash_attn_backend.get_paged_mha_kv_cache(
             layer,
             head_group_num=self.head_group_num,
         )
-
-        page_table = metadata.base.page_table
-        cache_seqlens = metadata.base.cache_seqlens_int32
-        q_reshaped = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
-
-        topk_idx = self.get_topk_for_sparse(
-            query_states=q_reshaped,
-            key_states=k,
-            layer=layer,
-            forward_batch=forward_batch,
-            is_prefill=False,
-        )
-        if topk_idx is not None:
-            topk_page_table = page_table
-            topk_cache_seqlens = cache_seqlens
-            if not self._use_cuda_graph_buffers:
-                topk_page_table = page_table[metadata.sparse_bs_list]
-                topk_cache_seqlens = cache_seqlens[metadata.sparse_bs_list]
-            sparse_page_table = get_block_table(
-                topk_idx,
-                topk_page_table,
-                metadata.token_to_bs,
-                topk_cache_seqlens,
-                topk_cache_seqlens,
-                head_group_num=self.head_group_num,
-                block_size=self.block_size,
-                elementwise=True,
-            ).reshape(-1, self.num_sparse_topk_tokens)
-            destination = metadata.sparse_page_table[:, : self.num_sparse_topk_tokens]
-            if self._use_cuda_graph_buffers:
-                destination.copy_(
-                    torch.where(
-                        (cache_seqlens >= self.dense_len).repeat_interleave(
-                            self.head_group_num
-                        )[:, None],
-                        sparse_page_table,
-                        destination,
-                    )
-                )
-            else:
-                destination[metadata.sparse_idx] = sparse_page_table
-
-        q_reshaped_by_head_group = q_reshaped.reshape(
-            -1, self.heads_per_group, layer.head_dim
-        )
-        assert self.page_size == 1
         result = self.attention_adapter.forward(
-            q_reshaped_by_head_group,
+            # One row per (token, head group).
+            q_reshaped.reshape(-1, self.heads_per_group, layer.head_dim),
             key_cache,
             value_cache,
             metadata,
@@ -856,6 +822,66 @@ class MiniCPMSparseBackend(AttentionBackend):
         )
 
         return result.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+    def _rows_need_block_selection(
+        self, *, bs: int, metadata: MiniCPMSparseMetadata
+    ) -> bool:
+        # Selection output is fully masked out when every decode row is dense.
+        # The graph binds leave dense_rows unset, so captured shapes stay static.
+        return metadata.dense_rows is None or len(metadata.dense_rows) < bs
+
+    def _plan_paged_sparse_page_table(
+        self,
+        *,
+        topk_idx: torch.Tensor,
+        metadata: MiniCPMSparseMetadata,
+    ) -> None:
+        topk_rows = get_block_table(
+            topk_idx=topk_idx,
+            block_table=metadata.base.page_table,
+            token_to_bs=metadata.token_to_bs,
+            token_pos_in_bs=metadata.token_pos_in_bs,
+            seqlen_q=metadata.seqlen_k_sparse_bs_tensor,
+            head_group_num=self.head_group_num,
+            block_size=self.block_size,
+            elementwise=True,
+        ).reshape(-1, self.num_sparse_topk_tokens)
+        destination = metadata.sparse_page_table[:, : self.num_sparse_topk_tokens]
+        torch.where(metadata.sparse_row_mask, topk_rows, destination, out=destination)
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+        # For multi-head latent attention
+        q_rope: Optional[torch.Tensor] = None,
+        k_rope: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if layer.is_cross_attention:
+            raise NotImplementedError(
+                "MiniCPM backend does not support cross attention"
+            )
+        if layer.sliding_window_size not in (None, -1):
+            raise NotImplementedError(
+                "MiniCPM backend does not support sliding-window attention"
+            )
+
+        return self._forward_paged_rows(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            q_rope=q_rope,
+            k_rope=k_rope,
+            sinks=sinks,
+        )
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.flash_attn_backend.init_cuda_graph_state(max_bs, max_num_tokens)
@@ -893,6 +919,12 @@ class MiniCPMSparseBackend(AttentionBackend):
                     max_bs * self.head_group_num,
                     sparse_max_num_pages,
                     dtype=torch.int32,
+                    device=self.device,
+                ),
+                "sparse_row_mask": torch.zeros(
+                    max_bs * self.head_group_num,
+                    1,
+                    dtype=torch.bool,
                     device=self.device,
                 ),
                 "cu_seqlens_q_adjusted": torch.arange(
@@ -977,20 +1009,20 @@ class MiniCPMSparseBackend(AttentionBackend):
 
     def _build_sparse_decode_replay_metadata(
         self,
-        forward_batch: ForwardBatch,
         metadata: MiniCPMSparseMetadata,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
     ):
-        decode_metadata = MiniCPMSparseMetadata(base=metadata.base)
-        _plan_sparse_decode(
-            forward_batch=forward_batch,
-            metadata=decode_metadata,
+        decode_metadata = _build_sparse_decode_metadata(
+            seq_lens_cpu=seq_lens_cpu,
+            base_metadata=metadata.base,
             head_group_num=self.head_group_num,
             dense_len=self.dense_len,
             sparse_topk=self.sparse_topk,
             block_size=self.block_size,
         )
         compression_metadata = _build_k1_k2_compression_metadata(
-            forward_batch=forward_batch,
+            req_pool_indices=req_pool_indices,
             base_metadata=metadata.base,
             req_to_sparse_k1_token=self.req_to_sparse_k1_token,
             req_to_sparse_k2_token=self.req_to_sparse_k2_token,
@@ -999,6 +1031,7 @@ class MiniCPMSparseBackend(AttentionBackend):
             k2_kernel_size=self.k2_kernel_size,
             k2_kernel_stride=self.k2_kernel_stride,
             cu_seqlens_q=metadata.base.cu_seqlens_q,
+            seq_lens_cpu=seq_lens_cpu,
         )
         return decode_metadata, compression_metadata
 
@@ -1019,7 +1052,6 @@ class MiniCPMSparseBackend(AttentionBackend):
         metadata.sparse_cu_seqlens_k = buffers["sparse_cu_seqlens_k"][: sparse_rows + 1]
         metadata.token_to_bs = buffers["token_to_bs"][:bs]
         metadata.sparse_page_table = buffers["sparse_page_table"][:sparse_rows]
-        metadata.sparse_bs_list = list(range(bs))
 
         assume_kv_len = self.config_dense_len
         if in_capture:
@@ -1058,6 +1090,13 @@ class MiniCPMSparseBackend(AttentionBackend):
         metadata.max_seqlen_q_adjusted = (
             metadata.base.max_seq_len_q * self.heads_per_group
         )
+        metadata.token_pos_in_bs = metadata.base.cache_seqlens_int32
+        metadata.seqlen_k_sparse_bs_tensor = metadata.base.cache_seqlens_int32
+        metadata.topk_cu_seqlens_q = metadata.base.cu_seqlens_q
+        metadata.topk_cu_seqlens_k = metadata.base.cu_seqlens_k
+        metadata.topk_max_seqlen_q = 1
+        metadata.topk_max_seqlen_k = metadata.base.max_seq_len_k
+        metadata.sparse_row_mask = buffers["sparse_row_mask"][:sparse_rows]
 
     def _replay_sparse_graph_metadata(
         self,
@@ -1070,6 +1109,7 @@ class MiniCPMSparseBackend(AttentionBackend):
             metadata.sparse_cache_seqlens_int32.zero_()
             metadata.sparse_cu_seqlens_k.zero_()
             metadata.cache_seqlens_int32_stage1.zero_()
+            metadata.sparse_row_mask.zero_()
             for level in (metadata.k1, metadata.k2):
                 level.history_compress_token_nums.zero_()
                 level.cu_seqlens.zero_()
@@ -1077,13 +1117,12 @@ class MiniCPMSparseBackend(AttentionBackend):
                 level.cu_total_compress_token_nums.zero_()
             return
 
-        sparse_forward_batch = SimpleNamespace(
-            batch_size=real_bs,
-            req_pool_indices=forward_batch.req_pool_indices[:real_bs],
-            seq_lens_cpu=forward_batch.seq_lens_cpu[:real_bs],
-        )
         decode_metadata, compression_metadata = (
-            self._build_sparse_decode_replay_metadata(sparse_forward_batch, metadata)
+            self._build_sparse_decode_replay_metadata(
+                metadata,
+                req_pool_indices=forward_batch.req_pool_indices[:real_bs],
+                seq_lens_cpu=forward_batch.seq_lens_cpu[:real_bs],
+            )
         )
         real_sparse_rows = self.head_group_num * real_bs
         metadata.sparse_cache_seqlens_int32[:real_sparse_rows].copy_(
@@ -1095,9 +1134,14 @@ class MiniCPMSparseBackend(AttentionBackend):
         metadata.cache_seqlens_int32_stage1[:real_bs].copy_(
             metadata.base.cache_seqlens_int32[:real_bs] - 1
         )
-        metadata.dense_layout = decode_metadata.dense_layout
+        metadata.sparse_row_mask[:real_sparse_rows].copy_(
+            decode_metadata.sparse_row_mask
+        )
         _copy_dense_page_tables(
-            metadata, forward_batch.seq_lens_cpu, self.head_group_num
+            metadata.sparse_page_table,
+            metadata.base.page_table,
+            dense_rows=decode_metadata.dense_rows,
+            head_group_num=self.head_group_num,
         )
 
         for (name, req_to_sparse), src in zip(
@@ -1131,6 +1175,7 @@ class MiniCPMSparseBackend(AttentionBackend):
                 decode_metadata.sparse_cu_seqlens_k[-1]
             )
             metadata.cache_seqlens_int32_stage1[real_bs:].zero_()
+            metadata.sparse_row_mask[real_sparse_rows:].zero_()
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.flash_attn_backend.get_cuda_graph_seq_len_fill_value()

--- a/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
+++ b/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
@@ -406,27 +406,83 @@ class CompressionLevelMetadata(msgspec.Struct):
 
 
 class MiniCPMSparseMetadata(msgspec.Struct):
+    """Per-forward sparse-attention metadata: the FlashAttention base geometry
+    plus the row, selection and compression fields the MiniCPM backend plans
+    around it."""
+
     base: FlashAttentionMetadata
+    # Per-request compressed-level metadata (cu_seqlens, token tables).
     k1: Optional[CompressionLevelMetadata] = None
     k2: Optional[CompressionLevelMetadata] = None
+    # Requests taking the sparse path this prefill,
+    # and the sparse_page_table rows they occupy.
     sparse_bs_list: Optional[list[int]] = None
     sparse_idx: Optional[list[int]] = None
+    # Dense prefill spans as (batch_idx, sparse_page_table row_start,
+    # query_group_start, query_len).
     dense_layout: Optional[list[tuple[int, int, int, int]]] = None
+    # Dense rows as (sparse_page_table row_start, batch_idx, kv_len);
+    # the row_start heads a head_group_num-long run of rows.
+    dense_rows: Optional[list[tuple[int, int, int]]] = None
+    # [rows, 1] bool, True on the decode rows the per-layer sparse gather
+    # may overwrite (kv >= dense_len); dense rows keep their planned pages.
+    sparse_row_mask: Optional[torch.Tensor] = None
+    # Per-sparse-request kv lengths: the base cache lengths for
+    # decode, the sparse sub-batch lengths for prefill.
     seqlen_k_sparse_bs_tensor: Optional[torch.Tensor] = None
+    # Token row -> request index, and the row's 1-based causal position
+    # (the attention gate is key_pos < token_pos_in_bs).
     token_to_bs: Optional[torch.Tensor] = None
     token_pos_in_bs: Optional[torch.Tensor] = None
+    # Head-group-interleaved block table for the sparse rows.
     sparse_page_table: Optional[torch.Tensor] = None
+    # Varlen geometry of the sparse row attention (decode rows).
     sparse_cache_seqlens_int32: Optional[torch.Tensor] = None
     sparse_cu_seqlens_q: Optional[torch.Tensor] = None
     sparse_cu_seqlens_k: Optional[torch.Tensor] = None
     sparse_max_seq_len_q: int = 1
+    # Stage-1 cache lengths excluding the current token (decode topk gate).
     cache_seqlens_int32_stage1: Optional[torch.Tensor] = None
+    # Stage-1 query geometry expanded to one row per (token, head group).
     cu_seqlens_q_adjusted: Optional[torch.Tensor] = None
     max_seqlen_q_adjusted: int = 1
     topk_cu_seqlens_q: Optional[torch.Tensor] = None
     topk_cu_seqlens_k: Optional[torch.Tensor] = None
     topk_max_seqlen_q: int = 1
     topk_max_seqlen_k: int = 1
+
+
+def _assign_row_metadata(
+    metadata: MiniCPMSparseMetadata,
+    *,
+    sparse_cache_seqlens_int32: torch.Tensor,
+    sparse_cu_seqlens_q: torch.Tensor,
+    sparse_cu_seqlens_k: torch.Tensor,
+    sparse_page_table: torch.Tensor,
+    token_to_bs: torch.Tensor,
+    token_pos_in_bs: torch.Tensor,
+    cache_seqlens_int32_stage1: torch.Tensor,
+    cu_seqlens_q_adjusted: torch.Tensor,
+    max_seqlen_q_adjusted: int,
+    topk_cu_seqlens_q: torch.Tensor,
+    topk_cu_seqlens_k: torch.Tensor,
+    topk_max_seqlen_q: int,
+    topk_max_seqlen_k: int,
+) -> None:
+    metadata.sparse_cache_seqlens_int32 = sparse_cache_seqlens_int32
+    metadata.sparse_cu_seqlens_q = sparse_cu_seqlens_q
+    metadata.sparse_cu_seqlens_k = sparse_cu_seqlens_k
+    metadata.sparse_page_table = sparse_page_table
+    metadata.token_to_bs = token_to_bs
+    metadata.token_pos_in_bs = token_pos_in_bs
+    metadata.seqlen_k_sparse_bs_tensor = metadata.base.cache_seqlens_int32
+    metadata.cache_seqlens_int32_stage1 = cache_seqlens_int32_stage1
+    metadata.cu_seqlens_q_adjusted = cu_seqlens_q_adjusted
+    metadata.max_seqlen_q_adjusted = max_seqlen_q_adjusted
+    metadata.topk_cu_seqlens_q = topk_cu_seqlens_q
+    metadata.topk_cu_seqlens_k = topk_cu_seqlens_k
+    metadata.topk_max_seqlen_q = topk_max_seqlen_q
+    metadata.topk_max_seqlen_k = topk_max_seqlen_k
 
 
 def _compute_single_compression_metadata(
@@ -479,7 +535,7 @@ def _compute_single_compression_metadata(
 
 
 def _build_k1_k2_compression_metadata(
-    forward_batch: ForwardBatch,
+    req_pool_indices: torch.Tensor,
     base_metadata: FlashAttentionMetadata,
     req_to_sparse_k1_token: torch.Tensor,
     req_to_sparse_k2_token: torch.Tensor,
@@ -488,13 +544,14 @@ def _build_k1_k2_compression_metadata(
     k2_kernel_size: int,
     k2_kernel_stride: int,
     cu_seqlens_q: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
 ) -> tuple[CompressionLevelMetadata, CompressionLevelMetadata]:
-    bs = forward_batch.batch_size
     seq_lens_cpu = torch.as_tensor(
-        forward_batch.seq_lens_cpu,
+        seq_lens_cpu,
         dtype=base_metadata.cu_seqlens_q.dtype,
         device="cpu",
     )
+    bs = seq_lens_cpu.numel()
     token_nums = (
         base_metadata.cu_seqlens_k[1 : bs + 1] - base_metadata.cu_seqlens_k[:bs]
     )
@@ -506,7 +563,7 @@ def _build_k1_k2_compression_metadata(
             seq_lens_cpu,
             token_nums,
             history_lens,
-            forward_batch.req_pool_indices,
+            req_pool_indices,
             req_to_sparse_token,
             kernel_size,
             kernel_stride,
@@ -532,6 +589,19 @@ def _get_sparse_cache_lens(
     return torch.where(seq_lens <= sparse_capacity, seq_lens, sparse_lens)
 
 
+def _plan_dense_rows(
+    seq_lens_cpu: torch.Tensor,
+    *,
+    dense_len: int,
+    head_group_num: int,
+) -> list[tuple[int, int, int]]:
+    return [
+        (batch_idx * head_group_num, batch_idx, kv_len)
+        for batch_idx, kv_len in enumerate(seq_lens_cpu.tolist())
+        if kv_len < dense_len
+    ]
+
+
 def _plan_sparse_prefill(
     forward_batch: ForwardBatch,
     metadata: MiniCPMSparseMetadata,
@@ -546,6 +616,7 @@ def _plan_sparse_prefill(
     sparse_bs_list = []
     sparse_idx = []
     dense_layout = []
+    dense_rows = []
     row_q_lens = []
     sparse_cache_seqlens = []
     token_to_bs = []
@@ -583,6 +654,7 @@ def _plan_sparse_prefill(
             max_sparse_cache_len = max(max_sparse_cache_len, sparse_capacity)
         else:
             dense_layout.append((batch_idx, row_start, query_group_start, query_len))
+            dense_rows.append((row_start, batch_idx, seq_len))
             dense_q_lens.append(query_len)
             row_q_lens.extend([query_len] * head_group_num)
             sparse_cache_seqlens.extend([seq_len] * head_group_num)
@@ -592,6 +664,7 @@ def _plan_sparse_prefill(
     metadata.sparse_bs_list = sparse_bs_list
     metadata.sparse_idx = sparse_idx
     metadata.dense_layout = dense_layout
+    metadata.dense_rows = dense_rows
     metadata.token_to_bs = torch.tensor(token_to_bs, dtype=torch.int32, device=device)
     metadata.token_pos_in_bs = torch.tensor(
         token_pos_in_bs, dtype=torch.int32, device=device
@@ -644,76 +717,107 @@ def _plan_sparse_prefill(
         metadata.max_seqlen_q_adjusted = metadata.base.max_seq_len_q * heads_per_group
 
 
-def _plan_sparse_decode(
-    forward_batch: ForwardBatch,
-    metadata: MiniCPMSparseMetadata,
+class SparseDecodeMetadata(msgspec.Struct):
+    dense_rows: list[tuple[int, int, int]]
+    sparse_row_mask: torch.Tensor
+    sparse_cache_seqlens_int32: torch.Tensor
+    sparse_cu_seqlens_k: torch.Tensor
+
+
+def _build_sparse_decode_metadata(
+    seq_lens_cpu: torch.Tensor,
+    base_metadata: FlashAttentionMetadata,
+    *,
     head_group_num: int,
     dense_len: int,
     sparse_topk: int,
     block_size: int,
-) -> None:
-    base_metadata = metadata.base
-    bs = forward_batch.batch_size
+) -> SparseDecodeMetadata:
     cache_seqlens = base_metadata.cache_seqlens_int32
-    page_table = base_metadata.page_table
+
     seq_lens_cpu = torch.as_tensor(
-        forward_batch.seq_lens_cpu, dtype=cache_seqlens.dtype, device="cpu"
+        seq_lens_cpu, dtype=cache_seqlens.dtype, device="cpu"
     )
-    sparse_capacity = sparse_topk * block_size
-    cache_lens_cpu = torch.where(
-        seq_lens_cpu >= dense_len,
-        _get_sparse_cache_lens(seq_lens_cpu, sparse_capacity, block_size),
+    is_sparse = seq_lens_cpu >= dense_len
+    sparse_cache_seqlens_cpu = torch.where(
+        is_sparse,
+        _get_sparse_cache_lens(seq_lens_cpu, sparse_topk * block_size, block_size),
         seq_lens_cpu,
-    )
-    sparse_mask_cpu = seq_lens_cpu >= dense_len
-    sparse_bs_list = sparse_mask_cpu.nonzero().flatten().tolist()
-    dense_bs_list = (~sparse_mask_cpu).nonzero().flatten().tolist()
-    sparse_idx = [
-        row
-        for batch_idx in sparse_bs_list
-        for row in range(batch_idx * head_group_num, (batch_idx + 1) * head_group_num)
-    ]
-    max_sparse_cache_len = max(
-        int(cache_lens_cpu.max()),
-        sparse_capacity if sparse_bs_list else 0,
-    )
-    sparse_cache_seqlens_cpu = cache_lens_cpu.repeat_interleave(head_group_num)
+    ).repeat_interleave(head_group_num)
 
     sparse_cache_seqlens_int32 = sparse_cache_seqlens_cpu.to(
+        device=cache_seqlens.device
+    )
+    sparse_row_mask = is_sparse.repeat_interleave(head_group_num)[:, None].to(
         device=cache_seqlens.device
     )
     sparse_cu_seqlens_k = F.pad(
         torch.cumsum(sparse_cache_seqlens_int32, dim=0, dtype=torch.int32), (1, 0)
     )
-    sparse_cu_seqlens_q = torch.arange(
-        0,
-        bs * head_group_num + 1,
-        dtype=torch.int32,
-        device=base_metadata.cu_seqlens_q.device,
-    )
-    token_to_bs = torch.arange(
-        0, len(sparse_bs_list), dtype=torch.int32, device=page_table.device
-    )
-    sparse_page_table = torch.zeros(
-        (head_group_num * bs, max_sparse_cache_len),
-        dtype=page_table.dtype,
-        device=page_table.device,
+    return SparseDecodeMetadata(
+        dense_rows=_plan_dense_rows(
+            seq_lens_cpu, dense_len=dense_len, head_group_num=head_group_num
+        ),
+        sparse_row_mask=sparse_row_mask,
+        sparse_cache_seqlens_int32=sparse_cache_seqlens_int32,
+        sparse_cu_seqlens_k=sparse_cu_seqlens_k,
     )
 
-    metadata.sparse_cache_seqlens_int32 = sparse_cache_seqlens_int32
-    metadata.sparse_cu_seqlens_k = sparse_cu_seqlens_k
-    metadata.sparse_cu_seqlens_q = sparse_cu_seqlens_q
-    metadata.sparse_page_table = sparse_page_table
-    metadata.sparse_bs_list = sparse_bs_list
-    metadata.sparse_idx = sparse_idx
-    metadata.dense_layout = [
-        (batch_idx, batch_idx * head_group_num, batch_idx * head_group_num, 1)
-        for batch_idx in dense_bs_list
-    ]
-    metadata.token_to_bs = token_to_bs
-    metadata.topk_cu_seqlens_q = torch.arange(
-        0,
-        len(sparse_bs_list) + 1,
-        dtype=torch.int32,
-        device=base_metadata.cu_seqlens_q.device,
+
+def _plan_sparse_decode(
+    forward_batch: ForwardBatch,
+    metadata: MiniCPMSparseMetadata,
+    *,
+    head_group_num: int,
+    heads_per_group: int,
+    dense_len: int,
+    sparse_topk: int,
+    block_size: int,
+) -> None:
+    base_metadata = metadata.base
+    sparse_capacity = sparse_topk * block_size
+    decode_metadata = _build_sparse_decode_metadata(
+        seq_lens_cpu=forward_batch.seq_lens_cpu,
+        base_metadata=base_metadata,
+        head_group_num=head_group_num,
+        dense_len=dense_len,
+        sparse_topk=sparse_topk,
+        block_size=block_size,
+    )
+
+    sparse_rows = head_group_num * forward_batch.batch_size
+    metadata.dense_rows = decode_metadata.dense_rows
+    metadata.sparse_row_mask = decode_metadata.sparse_row_mask
+    _assign_row_metadata(
+        metadata,
+        sparse_cache_seqlens_int32=decode_metadata.sparse_cache_seqlens_int32,
+        sparse_cu_seqlens_q=torch.arange(
+            0,
+            sparse_rows + 1,
+            dtype=torch.int32,
+            device=base_metadata.cu_seqlens_q.device,
+        ),
+        sparse_cu_seqlens_k=decode_metadata.sparse_cu_seqlens_k,
+        sparse_page_table=torch.zeros(
+            (
+                sparse_rows,
+                max(dense_len, sparse_capacity),
+            ),
+            dtype=base_metadata.page_table.dtype,
+            device=base_metadata.page_table.device,
+        ),
+        token_to_bs=torch.arange(
+            0,
+            forward_batch.batch_size,
+            dtype=torch.int32,
+            device=base_metadata.page_table.device,
+        ),
+        token_pos_in_bs=base_metadata.cache_seqlens_int32,
+        cache_seqlens_int32_stage1=base_metadata.cache_seqlens_int32 - 1,
+        cu_seqlens_q_adjusted=base_metadata.cu_seqlens_q * heads_per_group,
+        max_seqlen_q_adjusted=base_metadata.max_seq_len_q * heads_per_group,
+        topk_cu_seqlens_q=base_metadata.cu_seqlens_q,
+        topk_cu_seqlens_k=base_metadata.cu_seqlens_k,
+        topk_max_seqlen_q=1,
+        topk_max_seqlen_k=base_metadata.max_seq_len_k,
     )

--- a/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
+++ b/python/sglang/srt/layers/attention/minicpm/sparse_utils.py
@@ -405,6 +405,15 @@ class CompressionLevelMetadata(msgspec.Struct):
     cu_total_compress_token_nums: Optional[torch.Tensor] = None
 
 
+class RepeatedSegmentLayout(msgspec.Struct):
+    """Per-row gather of each request's compressed segment:
+    ``index`` gathers the repeated segments from a flat compressed cache;
+    ``cu_seqlens`` bounds them per row."""
+
+    index: torch.Tensor
+    cu_seqlens: torch.Tensor
+
+
 class MiniCPMSparseMetadata(msgspec.Struct):
     """Per-forward sparse-attention metadata: the FlashAttention base geometry
     plus the row, selection and compression fields the MiniCPM backend plans
@@ -414,6 +423,9 @@ class MiniCPMSparseMetadata(msgspec.Struct):
     # Per-request compressed-level metadata (cu_seqlens, token tables).
     k1: Optional[CompressionLevelMetadata] = None
     k2: Optional[CompressionLevelMetadata] = None
+    # Verify-round expansion of the levels: one segment copy per draft token.
+    k1_repeat: Optional[RepeatedSegmentLayout] = None
+    k2_repeat: Optional[RepeatedSegmentLayout] = None
     # Requests taking the sparse path this prefill,
     # and the sparse_page_table rows they occupy.
     sparse_bs_list: Optional[list[int]] = None
@@ -427,8 +439,8 @@ class MiniCPMSparseMetadata(msgspec.Struct):
     # [rows, 1] bool, True on the decode rows the per-layer sparse gather
     # may overwrite (kv >= dense_len); dense rows keep their planned pages.
     sparse_row_mask: Optional[torch.Tensor] = None
-    # Per-sparse-request kv lengths: the base cache lengths for
-    # decode, the sparse sub-batch lengths for prefill.
+    # Per-sparse-request kv lengths: the base cache lengths for decode/verify,
+    # the sparse sub-batch lengths for prefill.
     seqlen_k_sparse_bs_tensor: Optional[torch.Tensor] = None
     # Token row -> request index, and the row's 1-based causal position
     # (the attention gate is key_pos < token_pos_in_bs).
@@ -436,12 +448,16 @@ class MiniCPMSparseMetadata(msgspec.Struct):
     token_pos_in_bs: Optional[torch.Tensor] = None
     # Head-group-interleaved block table for the sparse rows.
     sparse_page_table: Optional[torch.Tensor] = None
-    # Varlen geometry of the sparse row attention (decode rows).
+    # Chain-verify dense-row overwrite (_build_dense_verify_overwrite): prefix pages
+    # and the sparse_page_table entries they replace; the verify graphs bind it static.
+    verify_dense_rows: Optional[torch.Tensor] = None
+    verify_dense_mask: Optional[torch.Tensor] = None
+    # Varlen geometry of the sparse row attention (decode or verify rows).
     sparse_cache_seqlens_int32: Optional[torch.Tensor] = None
     sparse_cu_seqlens_q: Optional[torch.Tensor] = None
     sparse_cu_seqlens_k: Optional[torch.Tensor] = None
     sparse_max_seq_len_q: int = 1
-    # Stage-1 cache lengths excluding the current token (decode topk gate).
+    # Stage-1 cache lengths excluding the current token (decode/verify topk gate).
     cache_seqlens_int32_stage1: Optional[torch.Tensor] = None
     # Stage-1 query geometry expanded to one row per (token, head group).
     cu_seqlens_q_adjusted: Optional[torch.Tensor] = None
@@ -602,6 +618,65 @@ def _plan_dense_rows(
     ]
 
 
+def _build_sparse_verify_rows(
+    seq_lens: torch.Tensor,
+    *,
+    head_group_num: int,
+    dense_len: int,
+    sparse_topk: int,
+    block_size: int,
+    num_draft_tokens: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = seq_lens.device
+    sparse_capacity = sparse_topk * block_size
+    offsets = torch.arange(1, num_draft_tokens + 1, dtype=torch.int32, device=device)
+    token_pos = seq_lens.to(torch.int32).repeat_interleave(
+        num_draft_tokens
+    ) + offsets.repeat(seq_lens.numel())
+    row_lens = torch.where(
+        token_pos < dense_len,
+        token_pos,
+        _get_sparse_cache_lens(
+            token_pos, sparse_capacity=sparse_capacity, block_size=block_size
+        ),
+    )
+    # token_pos: (bs * num_draft_tokens,) causal positions;
+    # row_lens: one entry per (token, head group), dense rows keep token_pos, others clamp.
+    return token_pos, row_lens.repeat_interleave(head_group_num)
+
+
+def _build_dense_verify_overwrite(
+    token_pos: torch.Tensor,
+    token_to_bs: torch.Tensor,
+    page_table: torch.Tensor,
+    *,
+    dense_len: int,
+    head_group_num: int,
+    out_rows: Optional[torch.Tensor] = None,
+    out_mask: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # The page table can be narrower than the configured dense window.
+    num_cols = min(dense_len, page_table.shape[1])
+    dense_src = torch.index_select(page_table[:, :num_cols], 0, token_to_bs)
+    group_offsets = torch.arange(
+        head_group_num, dtype=dense_src.dtype, device=page_table.device
+    )
+    cols = torch.arange(num_cols, device=page_table.device)
+    # Rows at token positions past dense_len get a zero column limit,
+    # folding the row gate into the column comparison.
+    col_limits = torch.where(token_pos < dense_len, token_pos, 0)
+    # Group-interleaved prefix pages plus the mask of entries they replace,
+    # in the layout _copy_dense_page_table writes.
+    rows = torch.add(
+        group_offsets[None, :, None],
+        dense_src[:, None, :],
+        alpha=head_group_num,
+        out=out_rows,
+    )
+    mask = torch.lt(cols[None, None, :], col_limits[:, None, None], out=out_mask)
+    return rows, mask
+
+
 def _plan_sparse_prefill(
     forward_batch: ForwardBatch,
     metadata: MiniCPMSparseMetadata,
@@ -715,6 +790,106 @@ def _plan_sparse_prefill(
     else:
         metadata.cu_seqlens_q_adjusted = metadata.base.cu_seqlens_q * heads_per_group
         metadata.max_seqlen_q_adjusted = metadata.base.max_seq_len_q * heads_per_group
+
+
+def _plan_repeated_segments(
+    cu_seqlens: torch.Tensor,
+    *,
+    total_tokens: int,
+    repeats: int,
+    segment_starts: Optional[torch.Tensor] = None,
+) -> RepeatedSegmentLayout:
+    lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).repeat_interleave(repeats)
+    out_cu_seqlens = F.pad(torch.cumsum(lengths, dim=0, dtype=torch.int32), (1, 0))
+    # segment_starts locates each request's chunks in the source buffer
+    # when it is not packed (the CUDA graph slab); the output stays packed.
+    if segment_starts is None:
+        segment_starts = cu_seqlens[:-1]
+    # index[i] = segment_start + (i - output_row_start),
+    # so each output row adds (segment_start - output_row_start) to a flat arange.
+    row_delta = (segment_starts.repeat_interleave(repeats) - out_cu_seqlens[:-1]).to(
+        torch.int64
+    )
+    # total_tokens as output_size keeps repeat_interleave sync-free.
+    index = row_delta.repeat_interleave(
+        lengths.to(torch.int64), output_size=repeats * total_tokens
+    ) + torch.arange(
+        repeats * total_tokens, dtype=torch.int64, device=cu_seqlens.device
+    )
+    return RepeatedSegmentLayout(index=index, cu_seqlens=out_cu_seqlens)
+
+
+def _plan_sparse_verify(
+    forward_batch: ForwardBatch,
+    metadata: MiniCPMSparseMetadata,
+    *,
+    head_group_num: int,
+    heads_per_group: int,
+    dense_len: int,
+    sparse_topk: int,
+    block_size: int,
+    num_draft_tokens: int,
+) -> None:
+    base_metadata = metadata.base
+    bs = forward_batch.batch_size
+    device = base_metadata.cu_seqlens_q.device
+    sparse_capacity = sparse_topk * block_size
+
+    token_to_bs = torch.repeat_interleave(
+        torch.arange(bs, dtype=torch.int32, device=device), num_draft_tokens
+    )
+    rows = bs * num_draft_tokens * head_group_num
+    sparse_cu_seqlens_q = torch.arange(rows + 1, dtype=torch.int32, device=device)
+    verify_cu_seqlens_q = torch.arange(
+        bs * num_draft_tokens + 1, dtype=torch.int32, device=device
+    )
+
+    token_pos_in_bs, sparse_cache_seqlens_int32 = _build_sparse_verify_rows(
+        forward_batch.seq_lens,
+        head_group_num=head_group_num,
+        dense_len=dense_len,
+        sparse_topk=sparse_topk,
+        block_size=block_size,
+        num_draft_tokens=num_draft_tokens,
+    )
+    # Every verify row takes the selection output; the dense rows are then
+    # overwritten from the prefix pages, so the mask is uniformly True.
+    metadata.sparse_row_mask = torch.ones((rows, 1), dtype=torch.bool, device=device)
+    if dense_len > 0:
+        metadata.verify_dense_rows, metadata.verify_dense_mask = (
+            _build_dense_verify_overwrite(
+                token_pos_in_bs,
+                token_to_bs,
+                base_metadata.page_table,
+                dense_len=dense_len,
+                head_group_num=head_group_num,
+            )
+        )
+    # The selection fill must write exactly these row lengths, row for row;
+    # the FlashInfer plan consumes them.
+    _assign_row_metadata(
+        metadata,
+        sparse_cache_seqlens_int32=sparse_cache_seqlens_int32,
+        sparse_cu_seqlens_q=sparse_cu_seqlens_q,
+        sparse_cu_seqlens_k=F.pad(
+            torch.cumsum(sparse_cache_seqlens_int32, dim=0, dtype=torch.int32),
+            (1, 0),
+        ),
+        sparse_page_table=torch.zeros(
+            (rows, max(dense_len, sparse_capacity)),
+            dtype=base_metadata.page_table.dtype,
+            device=base_metadata.page_table.device,
+        ),
+        token_to_bs=token_to_bs,
+        token_pos_in_bs=token_pos_in_bs,
+        cache_seqlens_int32_stage1=token_pos_in_bs - 1,
+        cu_seqlens_q_adjusted=verify_cu_seqlens_q * heads_per_group,
+        max_seqlen_q_adjusted=heads_per_group,
+        topk_cu_seqlens_q=verify_cu_seqlens_q,
+        topk_cu_seqlens_k=base_metadata.cu_seqlens_k,
+        topk_max_seqlen_q=1,
+        topk_max_seqlen_k=base_metadata.max_seq_len_k,
+    )
 
 
 class SparseDecodeMetadata(msgspec.Struct):

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -673,7 +673,7 @@ def alloc_for_spec_decode(
     nxt_kv_lens: torch.Tensor,
     nxt_kv_lens_cpu: torch.Tensor,
     num_needed_tokens: int,
-    batch: Optional[ScheduleBatch] = None,
+    batch: ScheduleBatch,
 ) -> None:
     if num_needed_tokens > 0:
         if tree_cache.token_to_kv_pool_allocator.page_size == 1:
@@ -706,6 +706,18 @@ def alloc_for_spec_decode(
             out_cache_loc,
             len(reqs),
         )
+
+    # A failed aux grow leaves freed slot ids in req_to_token; nothing reads them:
+    # the raise precedes any forward, and teardown stops at kv_allocated_len.
+    try:
+        req_to_token_pool.alloc_aux_to_lengths(
+            req_pool_indices_cpu=batch.req_pool_indices_cpu,
+            target_seq_lens_cpu=nxt_kv_lens_cpu,
+        )
+    except Exception:
+        if num_needed_tokens > 0:
+            tree_cache.token_to_kv_pool_allocator.free(out_cache_loc)
+        raise
 
     nxt_kv_lens_list = nxt_kv_lens_cpu.tolist()
     for req, nxt_kv_len in zip(reqs, nxt_kv_lens_list, strict=True):

--- a/python/sglang/srt/models/minicpm.py
+++ b/python/sglang/srt/models/minicpm.py
@@ -14,7 +14,7 @@
 """Inference-only MiniCPM model compatible with HuggingFace weights."""
 
 import math
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -487,6 +487,7 @@ class MiniCPMModel(nn.Module):
             ]
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers_to_capture: List[int] = []
 
     def forward(
         self,
@@ -494,23 +495,29 @@ class MiniCPMModel(nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor = None,
-    ) -> torch.Tensor:
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, List[torch.Tensor]]]:
         if input_embeds is None:
             hidden_states = self.embed_tokens(input_ids) * self.config.scale_emb
         else:
             hidden_states = input_embeds
         residual = None
 
-        for i in range(len(self.layers)):
-            layer = self.layers[i]
+        aux_hidden_states = []
+        for i, layer in enumerate(self.layers):
+            if i in self.layers_to_capture:
+                aux_hidden_states.append(hidden_states)
             hidden_states, residual = layer(
                 positions,
                 hidden_states,
                 forward_batch,
                 residual,
             )
+        if len(self.layers) in self.layers_to_capture:
+            aux_hidden_states.append(hidden_states)
         hidden_states = self.norm(hidden_states)
-        return hidden_states
+        if not aux_hidden_states:
+            return hidden_states
+        return hidden_states, aux_hidden_states
 
 
 class MiniCPMSALAForCausalLM(nn.Module):
@@ -540,6 +547,7 @@ class MiniCPMSALAForCausalLM(nn.Module):
         self.scale_width = self.config.hidden_size / self.config.dim_model_base
 
         self.logits_processor = LogitsProcessor(config)
+        self.capture_aux_hidden_states = False
 
     @torch.no_grad()
     def forward(
@@ -552,12 +560,37 @@ class MiniCPMSALAForCausalLM(nn.Module):
         if input_embeds is not None:
             input_embeds = input_embeds * self.config.scale_emb
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
         hidden_states = hidden_states / self.scale_width
-        if self.config.tie_word_embeddings:
-            lm_head = self.model.embed_tokens
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self._lm_head_module(),
+            forward_batch,
+            aux_hidden_states,
+        )
+
+    def _lm_head_module(self):
+        return (
+            self.model.embed_tokens if self.config.tie_word_embeddings else self.lm_head
+        )
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self._lm_head_module().weight
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        self.capture_aux_hidden_states = True
+        if layer_ids is None:
+            num_layers = self.config.num_hidden_layers
+            self.model.layers_to_capture = [2, num_layers // 2, num_layers - 3]
         else:
-            lm_head = self.lm_head
-        return self.logits_processor(input_ids, hidden_states, lm_head, forward_batch)
+            # The draft checkpoint indexes target layers by their output hidden state;
+            # capturing before layer i+1 reads layer i's output.
+            self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/test/minicpm_fixtures.py
+++ b/python/sglang/test/minicpm_fixtures.py
@@ -1,0 +1,121 @@
+"""Shared construction scaffold for MiniCPMSparseBackend unit tests."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.srt.runtime_context import get_schedule, override_platform
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import torch
+
+from sglang.srt.layers.attention.minicpm import backend as backend_module
+from sglang.srt.layers.attention.minicpm.backend import MiniCPMSparseBackend
+
+POOL_SIZE = 8
+
+
+def _sparse_token_table(*, pages, device):
+    """One compression level's request-to-chunk table, distinct value per slot."""
+    return torch.arange(POOL_SIZE * pages, dtype=torch.int32, device=device).view(
+        POOL_SIZE, pages
+    )
+
+
+def make_runner_scaffold(
+    *,
+    max_context_len=1024,
+    max_running_requests=1,
+):
+    """Build the (model_runner, flash_attn_backend) SimpleNamespace pair
+    that MiniCPMSparseBackend construction reads;
+    callers add the fields only their tests consume
+    before patching in the backend."""
+    kernel_size, kernel_stride = 32, 16
+    # attach_compressed_cache is stubbed out here, so the scaffold sizes the K1/K2
+    # tables the way cache.py does.
+    req_pool = SimpleNamespace(
+        req_to_sparse_k1_token=_sparse_token_table(
+            pages=(max_context_len - kernel_size) // kernel_stride + 1, device="cpu"
+        ),
+        req_to_sparse_k2_token=_sparse_token_table(
+            pages=(max_context_len - kernel_size * 4) // (kernel_stride * 4) + 1,
+            device="cpu",
+        ),
+    )
+    flash_attn_backend = SimpleNamespace(
+        max_context_len=max_context_len,
+        device="cpu",
+        decode_cuda_graph_metadata={},
+        req_to_token_pool=req_pool,
+        token_to_kv_pool=SimpleNamespace(),
+        page_size=1,
+    )
+    server_args = SimpleNamespace(enable_memory_saver=False)
+    model_runner = SimpleNamespace(
+        dtype=torch.float16,
+        max_running_requests=max_running_requests,
+        token_to_kv_pool_allocator=SimpleNamespace(),
+        server_args=server_args,
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                has_minicpm_sparse_attention=True,
+                sparse_config={
+                    "kernel_size": kernel_size,
+                    "kernel_stride": kernel_stride,
+                    "init_blocks": 1,
+                    "block_size": 64,
+                    "window_size": 64,
+                    "dense_len": 128,
+                    "topk": 1,
+                },
+            ),
+            num_attention_heads=16,
+            head_dim=128,
+            get_num_kv_heads=lambda _tp: 1,
+        ),
+    )
+    return model_runner, flash_attn_backend
+
+
+class FakeFlashInferAdapter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def make_sparse_backend(
+    *,
+    max_context_len=256,
+    chunked_prefill_size=64,
+    max_running_requests=1,
+    use_flashinfer=False,
+    blackwell=False,
+    kv_cache_dtype_str="bfloat16",
+):
+    """A CPU MiniCPMSparseBackend over the mocked runner scaffold; returns
+    (backend, model_runner, flash_attn_backend, flash_attention_ctor)."""
+    model_runner, flash_attn_backend = make_runner_scaffold(
+        max_context_len=max_context_len,
+        max_running_requests=max_running_requests,
+    )
+    flash_attn_backend.kv_cache_dtype_str = kv_cache_dtype_str
+    flash_attn_backend.init_forward_metadata = Mock()
+    flash_attn_backend.forward_metadata = None
+    with (
+        get_schedule().override(chunked_prefill_size=chunked_prefill_size),
+        patch.object(backend_module, "MiniCPMHybridConfig", SimpleNamespace),
+        override_platform(is_blackwell=blackwell),
+        patch.object(
+            backend_module, "FlashAttentionBackend", return_value=flash_attn_backend
+        ) as flash_attention,
+        patch.object(backend_module, "MiniCPMFlashInferAdapter", FakeFlashInferAdapter),
+        patch.object(
+            backend_module,
+            "get_parallel",
+            return_value=SimpleNamespace(attn_tp_size=1),
+        ),
+        patch.object(backend_module, "attach_compressed_cache"),
+    ):
+        backend = MiniCPMSparseBackend(model_runner, use_flashinfer=use_flashinfer)
+    return backend, model_runner, flash_attn_backend, flash_attention

--- a/python/sglang/test/minicpm_fixtures.py
+++ b/python/sglang/test/minicpm_fixtures.py
@@ -3,15 +3,20 @@
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from sglang.srt.runtime_context import get_schedule, override_platform
+from sglang.srt.runtime_context import get_context, override_platform
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
 import torch
+import torch.nn.functional as F
 
 from sglang.srt.layers.attention.minicpm import backend as backend_module
 from sglang.srt.layers.attention.minicpm.backend import MiniCPMSparseBackend
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    MiniCPMSparseMetadata,
+    _plan_sparse_verify,
+)
 
 POOL_SIZE = 8
 
@@ -27,6 +32,7 @@ def make_runner_scaffold(
     *,
     max_context_len=1024,
     max_running_requests=1,
+    num_kv_heads=1,
 ):
     """Build the (model_runner, flash_attn_backend) SimpleNamespace pair
     that MiniCPMSparseBackend construction reads;
@@ -71,9 +77,9 @@ def make_runner_scaffold(
                     "topk": 1,
                 },
             ),
-            num_attention_heads=16,
+            num_attention_heads=16 * num_kv_heads,
             head_dim=128,
-            get_num_kv_heads=lambda _tp: 1,
+            get_num_kv_heads=lambda _tp: num_kv_heads,
         ),
     )
     return model_runner, flash_attn_backend
@@ -92,30 +98,151 @@ def make_sparse_backend(
     use_flashinfer=False,
     blackwell=False,
     kv_cache_dtype_str="bfloat16",
+    server_args_overrides=None,
+    num_kv_heads=1,
 ):
     """A CPU MiniCPMSparseBackend over the mocked runner scaffold; returns
     (backend, model_runner, flash_attn_backend, flash_attention_ctor)."""
     model_runner, flash_attn_backend = make_runner_scaffold(
         max_context_len=max_context_len,
         max_running_requests=max_running_requests,
+        num_kv_heads=num_kv_heads,
     )
     flash_attn_backend.kv_cache_dtype_str = kv_cache_dtype_str
     flash_attn_backend.init_forward_metadata = Mock()
+    flash_attn_backend.init_cuda_graph_state = Mock()
     flash_attn_backend.forward_metadata = None
-    with (
-        get_schedule().override(chunked_prefill_size=chunked_prefill_size),
-        patch.object(backend_module, "MiniCPMHybridConfig", SimpleNamespace),
-        override_platform(is_blackwell=blackwell),
-        patch.object(
-            backend_module, "FlashAttentionBackend", return_value=flash_attn_backend
-        ) as flash_attention,
-        patch.object(backend_module, "MiniCPMFlashInferAdapter", FakeFlashInferAdapter),
-        patch.object(
-            backend_module,
-            "get_parallel",
-            return_value=SimpleNamespace(attn_tp_size=1),
-        ),
-        patch.object(backend_module, "attach_compressed_cache"),
-    ):
-        backend = MiniCPMSparseBackend(model_runner, use_flashinfer=use_flashinfer)
+    # The constructor reads chunked_prefill_size and the draft shape off the
+    # published context; publish them for the build.
+    override = get_context().override_server_args(
+        chunked_prefill_size=chunked_prefill_size, **(server_args_overrides or {})
+    )
+    override.install()
+    try:
+        with (
+            patch.object(backend_module, "MiniCPMHybridConfig", SimpleNamespace),
+            override_platform(is_blackwell=blackwell),
+            patch.object(
+                backend_module, "FlashAttentionBackend", return_value=flash_attn_backend
+            ) as flash_attention,
+            patch.object(
+                backend_module, "MiniCPMFlashInferAdapter", FakeFlashInferAdapter
+            ),
+            patch.object(
+                backend_module,
+                "get_parallel",
+                return_value=SimpleNamespace(attn_tp_size=1),
+            ),
+            patch.object(backend_module, "attach_compressed_cache"),
+        ):
+            backend = MiniCPMSparseBackend(model_runner, use_flashinfer=use_flashinfer)
+    finally:
+        override.restore()
     return backend, model_runner, flash_attn_backend, flash_attention
+
+
+def make_spec_backend(*, num_draft_tokens, eagle_topk, num_kv_heads=1):
+    """Build a MiniCPMSparseBackend configured for one draft shape,
+    with a mocked adapter. Returns (backend, flash_attn_backend)."""
+    backend, _, flash_attn_backend, _ = make_sparse_backend(
+        server_args_overrides={
+            "speculative_num_draft_tokens": num_draft_tokens,
+            "speculative_eagle_topk": eagle_topk,
+        },
+        num_kv_heads=num_kv_heads,
+    )
+    backend.attention_adapter = Mock()
+    return backend, flash_attn_backend
+
+
+def _verify_round_layout(*, seq_lens, num_draft_tokens):
+    """The seq/cu_seqlens layout shared by the eager and replay builders."""
+    bs = len(seq_lens)
+    seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int32)
+    cache_seqlens = seq_lens_cpu + num_draft_tokens
+    cu_seqlens_q = torch.arange(
+        0, bs * num_draft_tokens + 1, num_draft_tokens, dtype=torch.int32
+    )
+    cu_seqlens_k = F.pad(torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32), (1, 0))
+    return cache_seqlens, cu_seqlens_q, cu_seqlens_k
+
+
+def make_verify_batch(seq_lens, num_draft_tokens):
+    """Build one verify round's eager inputs: (forward_batch, base)."""
+    bs = len(seq_lens)
+    seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int32)
+    cache_seqlens, cu_seqlens_q, cu_seqlens_k = _verify_round_layout(
+        seq_lens=seq_lens, num_draft_tokens=num_draft_tokens
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=bs,
+        seq_lens=seq_lens_cpu.clone(),
+        seq_lens_cpu=seq_lens_cpu,
+        req_pool_indices=torch.arange(bs, dtype=torch.int64),
+    )
+    base = SimpleNamespace(
+        cache_seqlens_int32=cache_seqlens,
+        max_seq_len_k=int(cache_seqlens.max()),
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        page_table=torch.zeros((bs, int(cache_seqlens.max())), dtype=torch.int32),
+    )
+    return forward_batch, base
+
+
+def plan_verify(
+    seq_lens,
+    num_draft_tokens,
+    *,
+    head_group_num,
+    heads_per_group,
+    dense_len,
+    sparse_topk,
+    block_size,
+):
+    """Plan one eager verify round; returns (forward_batch, base, metadata)."""
+    forward_batch, base = make_verify_batch(seq_lens, num_draft_tokens)
+    metadata = MiniCPMSparseMetadata(base=base)
+    _plan_sparse_verify(
+        forward_batch=forward_batch,
+        metadata=metadata,
+        head_group_num=head_group_num,
+        heads_per_group=heads_per_group,
+        dense_len=dense_len,
+        sparse_topk=sparse_topk,
+        block_size=block_size,
+        num_draft_tokens=num_draft_tokens,
+    )
+    return forward_batch, base, metadata
+
+
+def make_replay_backend(
+    seq_lens,
+    num_draft_tokens,
+    *,
+    eagle_topk=1,
+    num_kv_heads=1,
+    max_bs,
+):
+    """Size a backend's CUDA-graph buffers for max_bs verify requests;
+    return (backend, base) with the static base buffers the replay leaves."""
+    bs = len(seq_lens)
+    cache_seqlens, cu_seqlens_q, cu_seqlens_k = _verify_round_layout(
+        seq_lens=seq_lens, num_draft_tokens=num_draft_tokens
+    )
+    backend, _ = make_spec_backend(
+        num_draft_tokens=num_draft_tokens,
+        eagle_topk=eagle_topk,
+        num_kv_heads=num_kv_heads,
+    )
+    backend.init_cuda_graph_state(max_bs, max_bs * num_draft_tokens)
+    base = SimpleNamespace(
+        cache_seqlens_int32=cache_seqlens,
+        max_seq_len_q=num_draft_tokens,
+        max_seq_len_k=int(cache_seqlens.max()),
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        # The graph page table spans the context; page_size is 1 in the scaffold.
+        page_table=torch.zeros((bs, backend.max_context_len), dtype=torch.int32),
+    )
+    return backend, base

--- a/test/registered/unit/layers/test_minicpm_attention_adapter.py
+++ b/test/registered/unit/layers/test_minicpm_attention_adapter.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 with patch.dict(
     sys.modules,
@@ -47,7 +48,7 @@ def _metadata(rows=1):
     )
 
 
-class TestMiniCPMAttentionAdapter(unittest.TestCase):
+class TestMiniCPMAttentionAdapter(CustomTestCase):
     def test_flashattention_adapter_owns_kernel_arguments(self):
         expected = torch.ones(1, 1, 1)
         flash_attn_backend = SimpleNamespace(
@@ -196,6 +197,7 @@ class TestMiniCPMAttentionAdapter(unittest.TestCase):
                 head_dim=128,
                 page_size=1,
                 max_kv_tokens_per_row=7,
+                rows_per_req=2,
             )
 
         metadata = _metadata(rows=2)

--- a/test/registered/unit/layers/test_minicpm_sparse_cache.py
+++ b/test/registered/unit/layers/test_minicpm_sparse_cache.py
@@ -1,5 +1,6 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -14,6 +15,8 @@ from sglang.srt.managers.scheduler_components.invariant_checker import (
 from sglang.srt.managers.scheduler_components.pool_stats_observer import (
     SchedulerPoolStatsObserver,
 )
+from sglang.srt.mem_cache import allocation
+from sglang.srt.mem_cache.allocation import alloc_for_spec_decode
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.runtime_context import publish, reset_context
@@ -330,6 +333,60 @@ def test_allocator_reset_rebuilds_reserve():
     pool.reset_aux_cache_allocator()
     assert allocator.available_size() == 39
     assert len(pool._aux_cache.free_slots) == 25
+
+
+def _spec_decode_to_len(pool, req, req_pool_idx, allocator, *, cur_len, nxt_len):
+    """Run alloc_for_spec_decode on CPU;
+    the triton req_to_token writer is patched out since it cannot run on CPU tensors."""
+    tree_cache = SimpleNamespace(
+        token_to_kv_pool_allocator=allocator,
+        is_chunk_cache=lambda: True,
+    )
+    with patch.object(allocation, "assign_req_to_token_pool_func"):
+        alloc_for_spec_decode(
+            tree_cache,
+            pool,
+            reqs=[req],
+            req_pool_indices=torch.tensor([req_pool_idx], dtype=torch.int64),
+            cur_kv_lens=torch.tensor([cur_len], dtype=torch.int64),
+            cur_kv_lens_cpu=torch.tensor([cur_len], dtype=torch.int64),
+            nxt_kv_lens=torch.tensor([nxt_len], dtype=torch.int64),
+            nxt_kv_lens_cpu=torch.tensor([nxt_len], dtype=torch.int64),
+            num_needed_tokens=nxt_len - cur_len,
+            batch=SimpleNamespace(
+                req_pool_indices_cpu=torch.tensor([req_pool_idx], dtype=torch.int64)
+            ),
+        )
+
+
+def test_spec_decode_grows_compressed_tables_to_target_lens():
+    """alloc_for_spec_decode must grow the compressed tables to the target kv lens,
+    or the sparse kernels read aux slots past the last allocation."""
+    pool, req, req_pool_idx, allocator = make_pool_and_req()
+    cache = pool._aux_cache
+    alloc_extend(pool, req_pool_idx, seq_len=8)
+    assert len(cache.free_slots) == 22
+
+    req.kv.kv_allocated_len = 8
+    _spec_decode_to_len(pool, req, req_pool_idx, allocator, cur_len=8, nxt_len=12)
+
+    # Aux growth for seq 12 (kernel_size=4, stride=2) matches the decode path.
+    assert len(cache.free_slots) == 20
+    assert req.kv.kv_allocated_len == 12
+
+
+def test_spec_decode_aux_failure_frees_draft_kv_slots():
+    """A failed aux allocation must free the draft-token KV slots;
+    those were allocated just before it."""
+    pool, req, req_pool_idx, allocator = make_pool_and_req(capacity=18)
+    req.kv.kv_allocated_len = 8
+    available_before = allocator.available_size()
+
+    with pytest.raises(RuntimeError, match="out of reserved slots"):
+        _spec_decode_to_len(pool, req, req_pool_idx, allocator, cur_len=8, nxt_len=16)
+
+    assert allocator.available_size() == available_before
+    assert req.kv.kv_allocated_len == 8
 
 
 def test_attach_compressed_cache_is_idempotent():

--- a/test/registered/unit/layers/test_minicpm_sparse_metadata.py
+++ b/test/registered/unit/layers/test_minicpm_sparse_metadata.py
@@ -332,6 +332,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             extend_seq_lens_cpu=[1],
             extend_prefix_lens_cpu=[0],
             forward_mode=SimpleNamespace(
+                is_target_verify=lambda: False,
                 is_extend_or_draft_extend_or_mixed=lambda: True,
             ),
         )
@@ -483,6 +484,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             extend_prefix_lens_cpu=[49, 199],
             req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
             forward_mode=SimpleNamespace(
+                is_target_verify=lambda: False,
                 is_extend_or_draft_extend_or_mixed=lambda: True,
             ),
         )
@@ -571,6 +573,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             out_cache_loc=torch.tensor([0, 1], dtype=torch.int64),
             forward_mode=SimpleNamespace(
                 is_draft_extend_v2=lambda: False,
+                is_target_verify=lambda: False,
             ),
         )
 
@@ -674,6 +677,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
         forward_batch = SimpleNamespace(
             batch_size=2,
             out_cache_loc=torch.tensor([1, 2], dtype=torch.int64),
+            forward_mode=SimpleNamespace(is_target_verify=lambda: False),
         )
 
         with patch.object(
@@ -810,6 +814,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
         backend.k1_kernel_stride = 16
         backend.k2_kernel_size = 128
         backend.k2_kernel_stride = 64
+        backend.speculative_num_draft_tokens = None
 
         backend.init_cuda_graph_state(max_bs=1, max_num_tokens=1)
 
@@ -1083,6 +1088,7 @@ import sglang.srt.layers.attention.minicpm.backend
     def test_mixed_prefill_compiles_fused_topk_for_sparse_batch_only(self):
         """A mixed batch must compile fused top-k for its sparse sub-batch only."""
         backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
+        backend._use_cuda_graph_buffers = False
         backend.forward_metadata = SimpleNamespace(
             sparse_bs_list=[1],
             base=SimpleNamespace(

--- a/test/registered/unit/layers/test_minicpm_sparse_metadata.py
+++ b/test/registered/unit/layers/test_minicpm_sparse_metadata.py
@@ -2,40 +2,31 @@ import subprocess
 import sys
 import unittest
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import torch
 
-from sglang.srt.runtime_context import override_platform
+from sglang.srt.runtime_context import get_context, override_platform
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import CustomTestCase
+from sglang.test.minicpm_fixtures import FakeFlashInferAdapter, make_sparse_backend
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
-with patch.dict(
-    sys.modules,
-    {
-        module: MagicMock()
-        for module in (
-            "sgl_kernel",
-            "sgl_kernel.quantization",
-            "sgl_kernel.scalar_type",
-        )
-    },
-):
-    from sglang.srt.layers.attention import attention_registry
-    from sglang.srt.layers.attention.minicpm import backend as backend_module
-    from sglang.srt.layers.attention.minicpm import sparse_utils
-    from sglang.srt.layers.attention.minicpm.attention_adapter import (
-        MiniCPMFlashAttentionAdapter,
-    )
-    from sglang.srt.layers.attention.minicpm.backend import (
-        MiniCPMSparseBackend,
-        _gather_compressed_keys,
-        _transpose_head_group_layout,
-    )
-    from sglang.srt.layers.attention.minicpm.sparse_utils import (
-        CompressionLevelMetadata,
-    )
-    from sglang.srt.runtime_context import get_context, get_schedule
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention import attention_registry
+from sglang.srt.layers.attention.minicpm import backend as backend_module
+from sglang.srt.layers.attention.minicpm import sparse_utils
+from sglang.srt.layers.attention.minicpm.attention_adapter import (
+    MiniCPMFlashAttentionAdapter,
+)
+from sglang.srt.layers.attention.minicpm.backend import (
+    MiniCPMSparseBackend,
+    _gather_compressed_keys,
+    _transpose_head_group_layout,
+)
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    CompressionLevelMetadata,
+)
 
 register_cpu_ci(est_time=22, suite="base-a-test-cpu")
 
@@ -49,89 +40,45 @@ def _compression_layout():
     )
 
 
-def _construct_sparse_backend(
-    *,
-    max_context_len=256,
-    chunked_prefill_size=64,
-    max_running_requests=1,
-    use_flashinfer=False,
-    blackwell=False,
-):
-    req_pool = SimpleNamespace(
-        req_to_sparse_k1_token=torch.empty(0),
-        req_to_sparse_k2_token=torch.empty(0),
+def _dense_decode_scaffold(dense_len, seq_len):
+    config = _compression_layout()
+    backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
+    backend.head_group_num = 2
+    backend.heads_per_group = 16
+    backend.dense_len = dense_len
+    backend.sparse_topk = 96
+    backend.block_size = 64
+    backend.k1_kernel_size = config.k1_kernel_size
+    backend.k1_kernel_stride = config.k1_kernel_stride
+    backend.k2_kernel_size = config.k2_kernel_size
+    backend.k2_kernel_stride = config.k2_kernel_stride
+    backend.req_to_sparse_k1_token = torch.zeros((1, 512), dtype=torch.int32)
+    backend.req_to_sparse_k2_token = torch.zeros((1, 512), dtype=torch.int32)
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(
+            is_target_verify=lambda: False,
+            is_extend_or_draft_extend_or_mixed=lambda: False,
+        ),
+        batch_size=1,
+        seq_lens_cpu=torch.tensor([seq_len], dtype=torch.int32),
+        req_pool_indices=torch.tensor([0], dtype=torch.int64),
     )
-    flash_attn_backend = SimpleNamespace(
-        max_context_len=max_context_len,
-        device="cpu",
-        decode_cuda_graph_metadata={},
-        req_to_token_pool=req_pool,
-        token_to_kv_pool=SimpleNamespace(),
-        page_size=1,
+    metadata = sparse_utils.MiniCPMSparseMetadata(
+        base=SimpleNamespace(
+            cache_seqlens_int32=torch.tensor([seq_len], dtype=torch.int32),
+            page_table=torch.empty((1, seq_len), dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, seq_len], dtype=torch.int32),
+            max_seq_len_q=1,
+            max_seq_len_k=seq_len,
+        )
     )
-    model_runner = SimpleNamespace(
-        dtype=torch.float16,
-        max_running_requests=max_running_requests,
-        token_to_kv_pool_allocator=SimpleNamespace(),
-        server_args=SimpleNamespace(
-            enable_memory_saver=False,
-        ),
-        model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(
-                has_minicpm_sparse_attention=True,
-                sparse_config={
-                    "kernel_size": 32,
-                    "kernel_stride": 16,
-                    "init_blocks": 1,
-                    "block_size": 64,
-                    "window_size": 64,
-                    "dense_len": 128,
-                    "topk": 1,
-                },
-            ),
-            num_attention_heads=16,
-            head_dim=128,
-            get_num_kv_heads=lambda _tp: 1,
-        ),
-    )
-    with (
-        get_schedule().override(chunked_prefill_size=chunked_prefill_size),
-        patch.object(backend_module, "MiniCPMHybridConfig", SimpleNamespace),
-        override_platform(is_blackwell=blackwell),
-        patch.object(
-            backend_module,
-            "FlashAttentionBackend",
-            return_value=flash_attn_backend,
-        ) as flash_attention,
-        patch.object(
-            backend_module,
-            "MiniCPMFlashInferAdapter",
-            return_value=object(),
-        ),
-        patch.object(
-            backend_module,
-            "get_parallel",
-            return_value=SimpleNamespace(attn_tp_size=1),
-        ),
-        patch.object(backend_module, "attach_compressed_cache"),
-    ):
-        backend = MiniCPMSparseBackend(model_runner, use_flashinfer=use_flashinfer)
-    return backend, model_runner, flash_attn_backend, flash_attention
+    return backend, forward_batch, metadata
 
 
 class _DeviceOffsetsMustNotBeRead:
     def __getitem__(self, _index):
         raise AssertionError("prefill layers must use scheduler-derived CPU offsets")
-
-
-class _GraphTensorMustNotUseHostListIndex:
-    def __init__(self, tensor):
-        self.tensor = tensor
-
-    def __getitem__(self, index):
-        if isinstance(index, list):
-            raise AssertionError("CUDA graph tensors must not use host list indices")
-        return self.tensor[index]
 
 
 class _SingleTensorConversion:
@@ -152,6 +99,25 @@ class _SingleTensorConversion:
         return self.values[index]
 
 
+def _graph_replay_level(history, cumulative):
+    return CompressionLevelMetadata(
+        history_compress_token_nums=torch.tensor(history),
+        cu_seqlens=torch.tensor(cumulative),
+        cu_new_token_nums=torch.tensor(cumulative),
+        cu_total_compress_token_nums=torch.tensor(cumulative),
+    )
+
+
+def _graph_replay_graph_level():
+    return CompressionLevelMetadata(
+        table=torch.full((4, 2), -1),
+        history_compress_token_nums=torch.full((4,), -1),
+        cu_seqlens=torch.full((5,), -1),
+        cu_new_token_nums=torch.full((5,), -1),
+        cu_total_compress_token_nums=torch.full((5,), -1),
+    )
+
+
 class TestMiniCPMSparseMetadata(CustomTestCase):
     def setUp(self):
         super().setUp()
@@ -167,14 +133,14 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             ValueError,
             "requires context_length >= 128, got 64",
         ):
-            _construct_sparse_backend(max_context_len=64)
+            make_sparse_backend(max_context_len=64)
 
     def test_fused_topk_rejects_disabled_chunked_prefill(self):
         with self.assertRaisesRegex(
             ValueError,
             "requires a positive --chunked-prefill-size",
         ):
-            _construct_sparse_backend(
+            make_sparse_backend(
                 chunked_prefill_size=-1,
                 use_flashinfer=True,
                 blackwell=True,
@@ -257,7 +223,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
     def test_flashattn_variant_uses_fa4_on_blackwell(self):
         """Blackwell must select FA4 because FA3 binaries cannot execute there."""
         backend, model_runner, flash_attn_backend, flash_attention = (
-            _construct_sparse_backend(blackwell=True)
+            make_sparse_backend(blackwell=True)
         )
         model_config = model_runner.model_config
 
@@ -279,7 +245,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
         self.assertEqual(backend.fused_kernel_kwargs["kernel_stride"], 16)
 
         model_runner.server_args.attention_backend = "minicpm_flashinfer"
-        flashinfer_adapter = object()
+
         fake_fuse_kernel = ModuleType("sglang.srt.layers.attention.minicpm.fuse_kernel")
         fake_fuse_kernel.fused_attn_pooling_online_topk_prefill = Mock(
             return_value="prefill"
@@ -302,7 +268,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             patch.object(
                 backend_module,
                 "MiniCPMFlashInferAdapter",
-                return_value=flashinfer_adapter,
+                FakeFlashInferAdapter,
             ),
             patch.object(
                 backend_module,
@@ -314,7 +280,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             backend = MiniCPMSparseBackend(model_runner, use_flashinfer=True)
 
         self.assertIs(backend.flash_attn_backend, flash_attn_backend)
-        self.assertIs(backend.attention_adapter, flashinfer_adapter)
+        self.assertIsInstance(backend.attention_adapter, FakeFlashInferAdapter)
 
         model_config.num_attention_heads = 8
         with (
@@ -355,72 +321,18 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             MiniCPMSparseBackend(model_runner, use_flashinfer=False)
 
     def test_dense_as_sparse_routes_short_prefill(self):
-        req_pool = SimpleNamespace(
-            req_to_sparse_k1_token=torch.empty(0),
-            req_to_sparse_k2_token=torch.empty(0),
-        )
-        flash_attn_backend = SimpleNamespace(
-            max_context_len=256,
-            device="cpu",
-            decode_cuda_graph_metadata={},
-            req_to_token_pool=req_pool,
-            token_to_kv_pool=SimpleNamespace(),
-            page_size=1,
-        )
-        hf_config = SimpleNamespace(
-            has_minicpm_sparse_attention=True,
-            sparse_config={
-                "kernel_size": 32,
-                "kernel_stride": 16,
-                "init_blocks": 1,
-                "block_size": 64,
-                "window_size": 64,
-                "dense_len": 128,
-                "topk": 1,
-            },
-        )
-        model_runner = SimpleNamespace(
-            dtype=torch.float16,
-            token_to_kv_pool_allocator=SimpleNamespace(),
-            server_args=SimpleNamespace(
-                attention_backend="minicpm_flashattn",
-                disable_cuda_graph=False,
-                enable_memory_saver=False,
-            ),
-            model_config=SimpleNamespace(
-                hf_config=hf_config,
-                num_attention_heads=16,
-                head_dim=128,
-                get_num_kv_heads=lambda _tp: 1,
-            ),
-        )
-
-        with (
-            backend_module.envs.SGLANG_MINICPM_DENSE_AS_SPARSE.override(True),
-            patch.object(backend_module, "MiniCPMHybridConfig", SimpleNamespace),
-            override_platform(is_blackwell=False),
-            patch.object(
-                backend_module,
-                "FlashAttentionBackend",
-                return_value=flash_attn_backend,
-            ),
-            patch.object(
-                backend_module,
-                "get_parallel",
-                return_value=SimpleNamespace(attn_tp_size=1),
-            ),
-            patch.object(backend_module, "attach_compressed_cache"),
-        ):
-            backend = MiniCPMSparseBackend(model_runner, use_flashinfer=False)
+        with backend_module.envs.SGLANG_MINICPM_DENSE_AS_SPARSE.override(True):
+            backend, *_ = make_sparse_backend()
 
         forward_batch = SimpleNamespace(
             batch_size=1,
             seq_lens_cpu=torch.tensor([1], dtype=torch.int32),
             seq_lens=torch.tensor([1], dtype=torch.int32),
+            req_pool_indices=torch.tensor([0], dtype=torch.int64),
             extend_seq_lens_cpu=[1],
             extend_prefix_lens_cpu=[0],
             forward_mode=SimpleNamespace(
-                is_extend_or_draft_extend_or_mixed=lambda: True
+                is_extend_or_draft_extend_or_mixed=lambda: True,
             ),
         )
         metadata = sparse_utils.MiniCPMSparseMetadata(
@@ -571,7 +483,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             extend_prefix_lens_cpu=[49, 199],
             req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
             forward_mode=SimpleNamespace(
-                is_extend_or_draft_extend_or_mixed=lambda: True
+                is_extend_or_draft_extend_or_mixed=lambda: True,
             ),
         )
         metadata = sparse_utils.MiniCPMSparseMetadata(
@@ -598,28 +510,16 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             metadata.base.page_table[0, :50].tolist(),
         )
 
-    def test_dense_decode_page_table_matches_batch_length(self):
-        forward_batch = SimpleNamespace(
-            batch_size=1,
-            seq_lens_cpu=torch.tensor([7000], dtype=torch.int32),
-        )
-        base_metadata = SimpleNamespace(
-            cache_seqlens_int32=torch.tensor([7000], dtype=torch.int32),
-            page_table=torch.empty((1, 7000), dtype=torch.int32),
-            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
-        )
-
-        metadata = sparse_utils.MiniCPMSparseMetadata(base=base_metadata)
-        sparse_utils._plan_sparse_decode(
-            forward_batch=forward_batch,
-            metadata=metadata,
-            head_group_num=2,
-            dense_len=8192,
-            sparse_topk=96,
-            block_size=64,
-        )
-
-        self.assertEqual(metadata.sparse_page_table.shape, (2, 7000))
+    def test_dense_decode_page_table_width_covers_both_operands(self):
+        """The dense decode page table is max(dense_len, sparse capacity) wide;
+        a width taken from either operand alone fails one arm."""
+        for dense_len, seq_len, width in ((8192, 7000, 8192), (2048, 1500, 6144)):
+            with self.subTest(dense_len=dense_len):
+                backend, forward_batch, metadata = _dense_decode_scaffold(
+                    dense_len, seq_len
+                )
+                backend.update_batch_for_sparse(forward_batch, metadata)
+                self.assertEqual(metadata.sparse_page_table.shape, (2, width))
 
     def test_mixed_prefill_uses_compact_sparse_page_table(self):
         backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
@@ -669,7 +569,9 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             seq_lens_cpu=torch.tensor([1, 2], dtype=torch.int32),
             extend_seq_lens_cpu=[1, 1],
             out_cache_loc=torch.tensor([0, 1], dtype=torch.int64),
-            forward_mode=SimpleNamespace(is_draft_extend_v2=lambda: False),
+            forward_mode=SimpleNamespace(
+                is_draft_extend_v2=lambda: False,
+            ),
         )
 
         def get_sparse_page_table(_topk, page_table, *_args, **_kwargs):
@@ -689,83 +591,39 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             [[10, 0], [21, 0]],
         )
 
-    def test_dense_decode_copies_full_page_table(self):
-        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
-        q = torch.ones(1, 1)
-        k = torch.ones(1, 1, 1)
-        v = torch.ones(1, 1, 1)
-        key_cache = torch.ones(4, 1, 1, 1)
-        value_cache = torch.ones(4, 1, 1, 1)
-        backend.flash_attn_backend = SimpleNamespace(
-            prepare_paged_mha_query=Mock(return_value=(q, None, None, None, None)),
-            get_paged_mha_kv_cache=Mock(return_value=(key_cache, value_cache)),
-            forward_decode=Mock(),
-        )
-        backend.token_to_kv_pool = SimpleNamespace(set_kv_buffer=Mock())
-        backend.attention_adapter = SimpleNamespace(
-            forward=Mock(return_value=torch.ones(1, 1, 1))
-        )
-        backend.forward_metadata = sparse_utils.MiniCPMSparseMetadata(
-            base=SimpleNamespace(
-                page_table=torch.tensor([[5, 6, 7, 0]], dtype=torch.int32),
-                cache_seqlens_int32=torch.tensor([3], dtype=torch.int32),
-                max_seq_len_q=1,
-            ),
-            sparse_bs_list=[],
-            sparse_idx=[],
-            sparse_page_table=torch.tensor([[5, 6, 7, 0]], dtype=torch.int32),
-            sparse_cache_seqlens_int32=torch.tensor([3], dtype=torch.int32),
-            sparse_cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
-            sparse_cu_seqlens_k=torch.tensor([0, 3], dtype=torch.int32),
-            token_to_bs=torch.tensor([0], dtype=torch.int32),
-        )
-        backend.head_group_num = 1
-        backend.heads_per_group = 1
-        backend.page_size = 1
-        backend.block_size = 1
-        backend.num_sparse_topk_tokens = 2
-        backend.dense_len = 4
-        backend._use_cuda_graph_buffers = False
-        backend._compress_decode_keys = Mock()
-        backend.get_topk_for_sparse = Mock(return_value=None)
-        layer = SimpleNamespace(
-            is_cross_attention=False,
-            sliding_window_size=-1,
-            tp_q_head_num=1,
-            tp_k_head_num=1,
-            tp_v_head_num=1,
-            head_dim=1,
-            v_head_dim=1,
-            k_scale=None,
-            v_scale=None,
-        )
-        forward_batch = SimpleNamespace(
-            batch_size=1,
-            seq_lens_cpu=torch.tensor([3], dtype=torch.int32),
-            out_cache_loc=torch.tensor([1], dtype=torch.int64),
-        )
+    def test_dense_decode_plans_full_page_table_rows(self):
+        """Eager decode planning must write a dense request's prefix pages
+        (group-interleaved) into its sparse_page_table rows and mask those rows
+        out of the per-layer sparse gather; a sparse request gets the inverse."""
+        backend, forward_batch, metadata = _dense_decode_scaffold(8192, 7000)
+        pages = torch.arange(7000, dtype=torch.int32)
+        metadata.base.page_table.copy_(pages[None, :])
+        backend.update_batch_for_sparse(forward_batch, metadata)
 
-        with patch.object(
-            backend_module,
-            "get_block_table",
-        ) as get_block_table:
-            backend.forward_decode(q, k, v, layer, forward_batch)
+        self.assertEqual(metadata.dense_rows, [(0, 0, 7000)])
+        self.assertEqual(metadata.sparse_row_mask.tolist(), [[False], [False]])
+        for group in range(2):
+            self.assertTrue(
+                torch.equal(metadata.sparse_page_table[group, :7000], pages * 2 + group)
+            )
+        self.assertEqual(int(metadata.sparse_page_table[:, 7000:].abs().sum()), 0)
 
-        backend.get_topk_for_sparse.assert_called_once()
-        get_block_table.assert_not_called()
-        backend._compress_decode_keys.assert_not_called()
-        backend.attention_adapter.forward.assert_called_once()
-        backend.flash_attn_backend.forward_decode.assert_not_called()
-        self.assertEqual(
-            backend.forward_metadata.sparse_page_table[0, :3].tolist(),
-            [5, 6, 7],
-        )
+        backend, forward_batch, metadata = _dense_decode_scaffold(2048, 3000)
+        backend.update_batch_for_sparse(forward_batch, metadata)
 
-    def test_graph_decode_preserves_dense_rows_from_sparse_topk(self):
+        self.assertEqual(metadata.dense_rows, [])
+        self.assertEqual(metadata.sparse_row_mask.tolist(), [[True], [True]])
+        self.assertEqual(int(metadata.sparse_page_table.abs().sum()), 0)
+
+    def test_decode_sparse_gather_preserves_dense_rows(self):
+        """The decode sparse gather must not touch rows sparse_row_mask clears;
+        the planning-time dense-prefix copy owns those rows."""
         backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
         q = torch.ones(2, 1)
-        key_cache = torch.ones(8, 1, 1, 1)
-        value_cache = torch.ones(8, 1, 1, 1)
+        k = torch.ones(2, 1, 1)
+        v = torch.ones(2, 1, 1)
+        key_cache = torch.ones(4, 1, 1, 1)
+        value_cache = torch.ones(4, 1, 1, 1)
         backend.flash_attn_backend = SimpleNamespace(
             prepare_paged_mha_query=Mock(return_value=(q, None, None, None, None)),
             get_paged_mha_kv_cache=Mock(return_value=(key_cache, value_cache)),
@@ -774,27 +632,33 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
         backend.attention_adapter = SimpleNamespace(
             forward=Mock(return_value=torch.ones(2, 1, 1))
         )
+        # Batch 0 is dense (kv 2 < dense_len 4), batch 1 is sparse (kv 10 >= 4),
+        # so the planner masks row 0 out of the gather.
         backend.forward_metadata = sparse_utils.MiniCPMSparseMetadata(
             base=SimpleNamespace(
-                page_table=_GraphTensorMustNotUseHostListIndex(
-                    torch.tensor([[5, 6, 7, 0, 0], [8, 9, 10, 11, 12]])
+                page_table=torch.tensor(
+                    [[10, 11, 12, 13], [20, 21, 22, 23]], dtype=torch.int32
                 ),
-                cache_seqlens_int32=torch.tensor([3, 5], dtype=torch.int32),
+                cache_seqlens_int32=torch.tensor([2, 10], dtype=torch.int32),
             ),
-            sparse_bs_list=[0, 1],
-            sparse_idx=[0, 1],
+            # Non-zero sentinel baseline: instead of the sentinel,
+            # a gather leak into the dense row shows up.
+            sparse_page_table=torch.tensor(
+                [[701, 702, 703, 704], [901, 902, 903, 904]], dtype=torch.int32
+            ),
             token_to_bs=torch.tensor([0, 1], dtype=torch.int32),
-            sparse_page_table=torch.tensor([[5, 6, 7, 0, 0], [0, 0, 0, 0, 0]]),
+            token_pos_in_bs=torch.tensor([2, 10], dtype=torch.int32),
+            seqlen_k_sparse_bs_tensor=torch.tensor([2, 10], dtype=torch.int32),
+            sparse_row_mask=torch.tensor([[False], [True]]),
+            dense_rows=[],
         )
         backend.head_group_num = 1
         backend.heads_per_group = 1
-        backend.page_size = 1
         backend.block_size = 1
-        backend.num_sparse_topk_tokens = 2
         backend.dense_len = 4
-        backend._use_cuda_graph_buffers = True
+        backend.num_sparse_topk_tokens = 3
         backend.get_topk_for_sparse = Mock(
-            return_value=torch.tensor([[[0, 1], [0, 1]]], dtype=torch.int32)
+            return_value=torch.tensor([[[0, 1]]], dtype=torch.int32)
         )
         layer = SimpleNamespace(
             is_cross_attention=False,
@@ -815,27 +679,90 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
         with patch.object(
             backend_module,
             "get_block_table",
-            return_value=torch.tensor([[30, 31], [40, 41]], dtype=torch.int32),
-        ):
-            backend.forward_decode(
-                q,
-                torch.ones(2, 1, 1),
-                torch.ones(2, 1, 1),
-                layer,
-                forward_batch,
-            )
+            return_value=torch.tensor([[30, 31, 32], [40, 41, 42]], dtype=torch.int32),
+        ) as get_block_table:
+            backend.forward_decode(q, k, v, layer, forward_batch)
 
+        self.assertTrue(get_block_table.call_args.kwargs["elementwise"])
         self.assertEqual(
-            backend.forward_metadata.sparse_page_table[:, :3].tolist(),
-            [[5, 6, 7], [40, 41, 0]],
+            backend.forward_metadata.sparse_page_table.tolist(),
+            [
+                # Dense row 0 keeps every sentinel: the gathered [30, 31, 32]
+                # must not land on a masked row.
+                [701, 702, 703, 704],
+                # Sparse row 1: [0:topk) takes the gathered row;
+                # beyond-topk keeps sentinel 904.
+                [40, 41, 42, 904],
+            ],
+        )
+
+    def test_all_dense_decode_compresses_keys_without_block_selection(self):
+        """An all-dense eager decode batch scores no blocks,
+        every row keeping the prefix pages the planner copied,
+        but still writes its compressed chunks:
+        the first sparse round past dense_len reads them as history."""
+        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
+        q = torch.ones(1, 1)
+        backend.flash_attn_backend = SimpleNamespace(
+            prepare_paged_mha_query=Mock(return_value=(q, None, None, None, None)),
+            get_paged_mha_kv_cache=Mock(
+                return_value=(torch.ones(4, 1, 1, 1), torch.ones(4, 1, 1, 1))
+            ),
+        )
+        backend.token_to_kv_pool = SimpleNamespace(set_kv_buffer=Mock())
+        backend.attention_adapter = SimpleNamespace(
+            forward=Mock(return_value=torch.ones(1, 1, 1))
+        )
+        page_rows = torch.tensor([[701, 702, 703, 704]], dtype=torch.int32)
+        backend.forward_metadata = sparse_utils.MiniCPMSparseMetadata(
+            base=SimpleNamespace(
+                page_table=torch.tensor([[10, 11, 12, 13]], dtype=torch.int32),
+                cache_seqlens_int32=torch.tensor([2], dtype=torch.int32),
+            ),
+            sparse_page_table=page_rows.clone(),
+            dense_rows=[(0, 0, 2)],
+            sparse_row_mask=torch.tensor([[False]]),
+        )
+        backend.head_group_num = 1
+        backend.heads_per_group = 1
+        backend.block_size = 1
+        backend.num_sparse_topk_tokens = 3
+        backend.get_topk_for_sparse = Mock(
+            return_value=torch.tensor([[[0]]], dtype=torch.int32)
+        )
+        backend._compress_decode_keys = Mock(return_value=(None, None))
+        layer = SimpleNamespace(
+            is_cross_attention=False,
+            sliding_window_size=-1,
+            tp_q_head_num=1,
+            tp_k_head_num=1,
+            tp_v_head_num=1,
+            head_dim=1,
+            v_head_dim=1,
+            k_scale=None,
+            v_scale=None,
+        )
+        forward_batch = SimpleNamespace(
+            batch_size=1,
+            out_cache_loc=torch.tensor([1], dtype=torch.int64),
+            forward_mode=SimpleNamespace(is_target_verify=lambda: False),
+        )
+
+        with patch.object(
+            backend_module,
+            "get_block_table",
+            return_value=torch.tensor([[30, 31, 32]], dtype=torch.int32),
+        ):
+            backend.forward_decode(q, None, None, layer, forward_batch)
+
+        backend.get_topk_for_sparse.assert_not_called()
+        backend._compress_decode_keys.assert_called_once()
+        self.assertEqual(
+            backend.forward_metadata.sparse_page_table.tolist(), page_rows.tolist()
         )
 
     def test_decode_metadata_uses_scheduler_cpu_lengths(self):
         """Decode metadata must not synchronize device offsets to recover lengths."""
-        forward_batch = SimpleNamespace(
-            batch_size=2,
-            seq_lens_cpu=torch.tensor([64, 200], dtype=torch.int32),
-        )
         base_metadata = SimpleNamespace(
             cache_seqlens_int32=SimpleNamespace(
                 dtype=torch.int32,
@@ -845,10 +772,9 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             cu_seqlens_q=torch.tensor([0, 1, 2], dtype=torch.int32),
         )
 
-        metadata = sparse_utils.MiniCPMSparseMetadata(base=base_metadata)
-        sparse_utils._plan_sparse_decode(
-            forward_batch=forward_batch,
-            metadata=metadata,
+        metadata = sparse_utils._build_sparse_decode_metadata(
+            seq_lens_cpu=torch.tensor([64, 200], dtype=torch.int32),
+            base_metadata=base_metadata,
             head_group_num=2,
             dense_len=100,
             sparse_topk=2,
@@ -859,12 +785,6 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             metadata.sparse_cache_seqlens_int32.tolist(),
             [64, 64, 72, 72],
         )
-        self.assertEqual(metadata.sparse_bs_list, [1])
-        self.assertEqual(metadata.sparse_idx, [2, 3])
-        self.assertEqual(metadata.dense_layout, [(0, 0, 0, 1)])
-        self.assertEqual(metadata.token_to_bs.tolist(), [0])
-        self.assertEqual(metadata.topk_cu_seqlens_q.tolist(), [0, 1])
-        self.assertEqual(metadata.sparse_page_table.shape, (4, 128))
 
     def test_cuda_graph_page_table_covers_dense_decode(self):
         """Captured dense decode must reserve a threshold-sized page table."""
@@ -914,12 +834,16 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
                 )
 
         base_metadata = SimpleNamespace(
+            cache_seqlens_int32=torch.zeros(1, dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
             cu_seqlens_k=torch.zeros(2, dtype=torch.int32),
             max_seq_len_k=0,
             max_seq_len_q=1,
         )
         capture_metadata = sparse_utils.MiniCPMSparseMetadata(base=base_metadata)
-        forward_batch = SimpleNamespace(batch_size=1)
+        forward_batch = SimpleNamespace(
+            batch_size=1, seq_lens_cpu=torch.zeros(1, dtype=torch.int32)
+        )
         backend._bind_sparse_graph_metadata(
             forward_batch,
             capture_metadata,
@@ -1012,79 +936,6 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
                 compress.assert_called_once()
                 self.assertNotIn("padded", compress.call_args.kwargs)
 
-    def test_dense_decode_maintains_compressed_cache_without_topk(self):
-        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
-        backend.forward_metadata = SimpleNamespace(sparse_bs_list=[])
-        backend._compress_decode_keys = Mock(
-            return_value=(torch.empty(0), torch.empty(0))
-        )
-        backend.sparse_get_topk_impl = Mock()
-        layer = SimpleNamespace()
-        forward_batch = SimpleNamespace(batch_size=1)
-
-        result = backend.get_topk_for_sparse(
-            query_states=torch.empty(1, 1, 1),
-            key_states=torch.empty(1, 1, 1),
-            layer=layer,
-            forward_batch=forward_batch,
-            is_prefill=False,
-        )
-
-        self.assertIsNone(result)
-        backend._compress_decode_keys.assert_called_once()
-        backend.sparse_get_topk_impl.assert_not_called()
-
-    def test_mixed_decode_runs_topk_for_sparse_requests_only(self):
-        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
-        backend.forward_metadata = SimpleNamespace(
-            sparse_bs_list=[1],
-            base=SimpleNamespace(
-                cu_seqlens_q=torch.tensor([0, 1, 2], dtype=torch.int32),
-                cu_seqlens_k=torch.tensor([0, 3, 8], dtype=torch.int32),
-                max_seq_len_k=5,
-            ),
-            topk_cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
-            topk_cu_seqlens_k=torch.tensor([0, 5], dtype=torch.int32),
-            topk_max_seqlen_k=5,
-            k1=SimpleNamespace(
-                cu_seqlens=torch.tensor([0, 1, 3], dtype=torch.int32),
-                cu_seqlens_cpu=[0, 1, 3],
-            ),
-            k2=SimpleNamespace(
-                cu_seqlens=torch.tensor([0, 1, 2], dtype=torch.int32),
-                cu_seqlens_cpu=[0, 1, 2],
-            ),
-        )
-        backend._compress_decode_keys = Mock(
-            return_value=(
-                torch.tensor([[[10.0]], [[20.0]], [[21.0]]]),
-                torch.tensor([[[30.0]], [[31.0]]]),
-            )
-        )
-        backend._get_fused_topk_kernel = Mock(return_value="kernel")
-        backend.sparse_get_topk_impl = Mock(return_value="topk")
-        forward_batch = SimpleNamespace(batch_size=2)
-
-        result = backend.get_topk_for_sparse(
-            query_states=torch.tensor([[[1.0]], [[2.0]]]),
-            key_states=torch.empty(2, 1, 1),
-            layer=SimpleNamespace(),
-            forward_batch=forward_batch,
-            is_prefill=False,
-        )
-
-        self.assertEqual(result, "topk")
-        args = backend.sparse_get_topk_impl.call_args.args
-        kwargs = backend.sparse_get_topk_impl.call_args.kwargs
-        self.assertEqual(args[0].flatten().tolist(), [2.0])
-        self.assertEqual(args[1].tolist(), [0, 1])
-        self.assertEqual(args[2].tolist(), [0, 3, 8])
-        self.assertEqual(kwargs["compressed_k"].flatten().tolist(), [20.0, 21.0])
-        self.assertEqual(kwargs["compressed_cu_seqlens"].tolist(), [0, 2])
-        self.assertEqual(kwargs["compressed_k2"].flatten().tolist(), [31.0])
-        self.assertEqual(kwargs["compressed_cu_seqlens2"].tolist(), [0, 1])
-        backend._get_fused_topk_kernel.assert_called_once_with(1, is_prefill=False)
-
     def test_fused_topk_prefill_kernels_compile_for_all_batches_at_startup(self):
         fake_fuse_kernel = ModuleType("sglang.srt.layers.attention.minicpm.fuse_kernel")
         fake_fuse_kernel.fused_attn_pooling_online_topk_prefill = Mock(
@@ -1097,7 +948,7 @@ class TestMiniCPMSparseMetadata(CustomTestCase):
             sys.modules,
             {"sglang.srt.layers.attention.minicpm.fuse_kernel": fake_fuse_kernel},
         ):
-            backend, *_ = _construct_sparse_backend(
+            backend, *_ = make_sparse_backend(
                 max_running_requests=3,
                 use_flashinfer=True,
                 blackwell=True,
@@ -1286,17 +1137,49 @@ import sglang.srt.layers.attention.minicpm.backend
         self.assertEqual(result, "sparse-kernel")
         get_kernel.assert_called_once_with(1, is_prefill=True)
 
+    def test_decode_recompresses_keys_and_compiles_decode_fused_topk(self):
+        """Decode rows must re-compress staged keys, feed the plain level offsets
+        to selection, and pick the decode kernel sized by the row count."""
+        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
+        cu = torch.tensor([0, 1, 2], dtype=torch.int32)
+        k1_cu = torch.tensor([0, 3, 5], dtype=torch.int32)
+        k2_cu = torch.tensor([0, 1, 2], dtype=torch.int32)
+        compressed_k = torch.ones(5, 1, 1)
+        compressed_k2 = torch.ones(2, 1, 1)
+        backend.forward_metadata = SimpleNamespace(
+            k1_repeat=None,
+            k1=SimpleNamespace(cu_seqlens=k1_cu),
+            k2=SimpleNamespace(cu_seqlens=k2_cu),
+            topk_cu_seqlens_q=cu,
+            topk_cu_seqlens_k=cu,
+            topk_max_seqlen_q=1,
+            topk_max_seqlen_k=1,
+        )
+        backend._compress_decode_keys = Mock(return_value=(compressed_k, compressed_k2))
+        backend._get_fused_topk_kernel = Mock(return_value="decode-kernel")
+        backend.sparse_get_topk_impl = Mock(return_value="topk")
+
+        result = backend.get_topk_for_sparse(
+            cu, cu, SimpleNamespace(), SimpleNamespace(), is_prefill=False
+        )
+
+        self.assertEqual(result, "topk")
+        backend._compress_decode_keys.assert_called_once()
+        backend._get_fused_topk_kernel.assert_called_once_with(2, is_prefill=False)
+        kwargs = backend.sparse_get_topk_impl.call_args.kwargs
+        self.assertIs(kwargs["compressed_k"], compressed_k)
+        self.assertIs(kwargs["compressed_cu_seqlens"], k1_cu)
+        self.assertIs(kwargs["compressed_k2"], compressed_k2)
+        self.assertIs(kwargs["compressed_cu_seqlens2"], k2_cu)
+        self.assertIs(kwargs["fused_kernel"], "decode-kernel")
+
     def test_compression_metadata_ignores_cuda_graph_padding(self):
         """CUDA graph padding rows must not alter offsets for real requests."""
         config = _compression_layout()
 
         # The graph was captured for batch size 4, but only the first three
         # requests are real during this replay.
-        forward_batch = SimpleNamespace(
-            batch_size=3,
-            seq_lens_cpu=_SingleTensorConversion([100, 200, 300]),
-            req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int64),
-        )
+        real_bs = 3
         base_metadata = SimpleNamespace(
             cu_seqlens_q=torch.arange(5, dtype=torch.int32),
             cu_seqlens_k=torch.tensor([0, 100, 200, 300, 400], dtype=torch.int32),
@@ -1304,7 +1187,7 @@ import sglang.srt.layers.attention.minicpm.backend
         req_to_sparse_token = torch.arange(4 * 32, dtype=torch.int32).reshape(4, 32)
 
         k1, k2 = sparse_utils._build_k1_k2_compression_metadata(
-            forward_batch=forward_batch,
+            req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int64),
             base_metadata=base_metadata,
             req_to_sparse_k1_token=req_to_sparse_token,
             req_to_sparse_k2_token=req_to_sparse_token,
@@ -1313,24 +1196,23 @@ import sglang.srt.layers.attention.minicpm.backend
             k2_kernel_size=config.k2_kernel_size,
             k2_kernel_stride=config.k2_kernel_stride,
             cu_seqlens_q=base_metadata.cu_seqlens_q,
+            seq_lens_cpu=_SingleTensorConversion([100, 200, 300]),
         )
 
         self.assertEqual(k1.cu_seqlens_cpu, [0, 5, 16, 33])
         self.assertEqual(k2.cu_seqlens_cpu, [0, 0, 2, 5])
         for level in (k1, k2):
-            self.assertEqual(level.table.shape[0], forward_batch.batch_size)
-            self.assertEqual(
-                level.history_compress_token_nums.numel(), forward_batch.batch_size
-            )
+            self.assertEqual(level.table.shape[0], real_bs)
+            self.assertEqual(level.history_compress_token_nums.numel(), real_bs)
             self.assertEqual(level.cu_new_token_nums.numel(), 4)
             self.assertEqual(level.cu_total_compress_token_nums.numel(), 4)
 
     def test_sparse_graph_replay_pads_metadata_for_missing_request(self):
         backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
         backend.head_group_num = 2
+        backend.max_context_len = 8
         backend.k1_kernel_stride = 2
         backend.k2_kernel_stride = 4
-        backend.max_context_len = 8
         backend.req_to_sparse_k1_token = torch.arange(8).reshape(4, 2)
         backend.req_to_sparse_k2_token = torch.arange(8).reshape(4, 2)
         backend.decode_cuda_graph_metadata = {
@@ -1348,8 +1230,8 @@ import sglang.srt.layers.attention.minicpm.backend
 
         decode_metadata = sparse_utils.MiniCPMSparseMetadata(
             base=SimpleNamespace(),
-            sparse_idx=[2, 3, 4, 5],
-            dense_layout=[(0, 0, 0, 1)],
+            dense_rows=[],
+            sparse_row_mask=torch.ones((6, 1), dtype=torch.bool),
             sparse_cache_seqlens_int32=torch.tensor([1, 1, 2, 2, 3, 3]),
             sparse_cu_seqlens_k=torch.tensor([0, 1, 2, 4, 6, 9, 12]),
         )
@@ -1373,16 +1255,14 @@ import sglang.srt.layers.attention.minicpm.backend
         metadata = sparse_utils.MiniCPMSparseMetadata(
             base=SimpleNamespace(
                 cache_seqlens_int32=torch.tensor([2, 3, 4, 0]),
-                page_table=torch.tensor(
-                    [[5, 6, 0, 0], [7, 8, 9, 0], [10, 11, 12, 13], [0, 0, 0, 0]]
-                ),
+                page_table=torch.zeros((4, 8), dtype=torch.int32),
             ),
             k1=graph_level(),
             k2=graph_level(),
-            sparse_page_table=torch.full((8, 4), -1, dtype=torch.int32),
             sparse_cache_seqlens_int32=torch.full((8,), -1),
             sparse_cu_seqlens_k=torch.full((9,), -1),
             cache_seqlens_int32_stage1=torch.full((4,), -1),
+            sparse_row_mask=torch.zeros((8, 1), dtype=torch.bool),
         )
         forward_batch = SimpleNamespace(
             batch_size=4,
@@ -1400,8 +1280,6 @@ import sglang.srt.layers.attention.minicpm.backend
             metadata.sparse_cu_seqlens_k.tolist(), [0, 1, 2, 4, 6, 9, 12, 12, 12]
         )
         self.assertEqual(metadata.cache_seqlens_int32_stage1.tolist(), [1, 2, 3, 0])
-        self.assertEqual(metadata.sparse_page_table[0, :2].tolist(), [10, 12])
-        self.assertEqual(metadata.sparse_page_table[1, :2].tolist(), [11, 13])
         for compression, expected_history, expected_cumulative in (
             (metadata.k1, [1, 2, 3, 0], [0, 1, 3, 6, 6]),
             (metadata.k2, [4, 5, 6, 0], [0, 4, 9, 15, 15]),
@@ -1416,6 +1294,87 @@ import sglang.srt.layers.attention.minicpm.backend
             self.assertEqual(
                 compression.cu_total_compress_token_nums.tolist(), expected_cumulative
             )
+
+    def test_sparse_graph_replay_refreshes_dense_rows_and_mask(self):
+        """Decode replay must refresh the graph buffers from the live lengths:
+        the dense rows' page-table entries, which the captured gather never
+        writes, and sparse_row_mask with its padding rows cleared; a stale
+        True on a dense row lets the captured gather overwrite those pages."""
+        backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
+        backend.head_group_num = 2
+        backend.dense_len = 5
+        backend.sparse_topk = 2
+        backend.block_size = 4
+        backend.k1_kernel_size = 4
+        backend.k1_kernel_stride = 2
+        backend.k2_kernel_size = 8
+        backend.k2_kernel_stride = 4
+        backend.req_to_sparse_k1_token = torch.arange(8).reshape(4, 2)
+        backend.req_to_sparse_k2_token = torch.arange(8).reshape(4, 2)
+        # Live lens [3, 9, 1] plus one padded request: with dense_len 5 and
+        # capacity 8 (sparse_topk 2 * block_size 4) only request 1 is sparse.
+        # Request b's page for token t is 100 * (b + 1) + t; the graph buffer
+        # is hg 2 * bs 4 rows by 8 columns, all holding the stale -1 marker.
+        metadata = sparse_utils.MiniCPMSparseMetadata(
+            base=SimpleNamespace(
+                cache_seqlens_int32=torch.tensor([3, 9, 1, 0], dtype=torch.int32),
+                cu_seqlens_q=torch.arange(5, dtype=torch.int32),
+                page_table=torch.tensor(
+                    [
+                        [100, 101, 102, 103, 104, 105, 106, 107],
+                        [200, 201, 202, 203, 204, 205, 206, 207],
+                        [300, 301, 302, 303, 304, 305, 306, 307],
+                        [400, 401, 402, 403, 404, 405, 406, 407],
+                    ],
+                    dtype=torch.int32,
+                ),
+            ),
+            k1=_graph_replay_graph_level(),
+            k2=_graph_replay_graph_level(),
+            sparse_cache_seqlens_int32=torch.full((8,), -1, dtype=torch.int32),
+            sparse_cu_seqlens_k=torch.full((9,), -1, dtype=torch.int32),
+            cache_seqlens_int32_stage1=torch.full((4,), -1, dtype=torch.int32),
+            sparse_page_table=torch.full((8, 8), -1, dtype=torch.int32),
+            sparse_row_mask=torch.ones((8, 1), dtype=torch.bool),
+        )
+        forward_batch = SimpleNamespace(
+            batch_size=4,
+            num_padding=1,
+            req_pool_indices=torch.arange(4),
+            seq_lens_cpu=torch.tensor([3, 9, 1, 0]),
+        )
+
+        with patch.object(
+            backend_module,
+            "_build_k1_k2_compression_metadata",
+            return_value=(
+                _graph_replay_level([1, 2, 3], [0, 1, 3, 6]),
+                _graph_replay_level([4, 5, 6], [0, 4, 9, 15]),
+            ),
+        ):
+            backend._replay_sparse_graph_metadata(forward_batch, metadata)
+
+        self.assertEqual(metadata.cache_seqlens_int32_stage1.tolist(), [2, 8, 0, 0])
+        self.assertEqual(
+            metadata.sparse_page_table.tolist(),
+            [
+                # Dense request 0, groups 0/1: page_table[0][:3] * 2 + group.
+                [200, 202, 204, -1, -1, -1, -1, -1],
+                [201, 203, 205, -1, -1, -1, -1, -1],
+                # Sparse request 1 and the padded request 3 stay untouched.
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+                # Dense request 2: page_table[2][:1] * 2 + group.
+                [600, -1, -1, -1, -1, -1, -1, -1],
+                [601, -1, -1, -1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+                [-1, -1, -1, -1, -1, -1, -1, -1],
+            ],
+        )
+        self.assertEqual(
+            metadata.sparse_row_mask[:, 0].tolist(),
+            [False, False, True, True, False, False, False, False],
+        )
 
     def test_idle_sparse_graph_replay_clears_compression_lengths(self):
         backend = MiniCPMSparseBackend.__new__(MiniCPMSparseBackend)
@@ -1435,6 +1394,7 @@ import sglang.srt.layers.attention.minicpm.backend
             sparse_cache_seqlens_int32=torch.ones(2, dtype=torch.int32),
             sparse_cu_seqlens_k=torch.ones(3, dtype=torch.int32),
             cache_seqlens_int32_stage1=torch.ones(2, dtype=torch.int32),
+            sparse_row_mask=torch.ones((2, 1), dtype=torch.bool),
         )
 
         backend._replay_sparse_graph_metadata(
@@ -1445,6 +1405,7 @@ import sglang.srt.layers.attention.minicpm.backend
             metadata.sparse_cache_seqlens_int32,
             metadata.sparse_cu_seqlens_k,
             metadata.cache_seqlens_int32_stage1,
+            metadata.sparse_row_mask,
             metadata.k1.history_compress_token_nums,
             metadata.k1.cu_seqlens,
             metadata.k1.cu_new_token_nums,

--- a/test/registered/unit/models/test_minicpm_eagle3_capture.py
+++ b/test/registered/unit/models/test_minicpm_eagle3_capture.py
@@ -1,0 +1,144 @@
+"""EAGLE3 aux hidden-state capture through the MiniCPM target forward."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sglang.srt.models.minicpm import MiniCPMModel, MiniCPMSALAForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_NUM_LAYERS = 8
+_HIDDEN = 4
+
+
+def _bare_causal_lm(*, capture: bool) -> MiniCPMSALAForCausalLM:
+    lm = MiniCPMSALAForCausalLM.__new__(MiniCPMSALAForCausalLM)
+    lm.config = SimpleNamespace(
+        scale_emb=1.0,
+        tie_word_embeddings=True,
+        num_hidden_layers=_NUM_LAYERS,
+    )
+    lm.model = Mock()
+    lm.scale_width = 4.0
+    lm.logits_processor = Mock(return_value="logits")
+    lm.capture_aux_hidden_states = capture
+    return lm
+
+
+class _RecordingLayer:
+    def __init__(self, delta: float):
+        self.delta = delta
+
+    def __call__(self, positions, hidden_states, forward_batch, residual):
+        return hidden_states + 2 * self.delta, None
+
+
+def _bare_model(layers_to_capture) -> MiniCPMModel:
+    model = MiniCPMModel.__new__(MiniCPMModel)
+    model.config = SimpleNamespace(scale_emb=1.0)
+    model.embed_tokens = lambda input_ids: torch.zeros(
+        input_ids.shape[0], _HIDDEN, dtype=torch.float32
+    )
+    model.layers = [_RecordingLayer(delta=float(i + 1)) for i in range(_NUM_LAYERS)]
+    model.norm = lambda hidden_states: hidden_states
+    model.layers_to_capture = layers_to_capture
+    return model
+
+
+class TestEagle3LayerMapping(CustomTestCase):
+    def test_draft_layer_ids_shift_by_one(self):
+        lm = _bare_causal_lm(capture=False)
+        lm.set_eagle3_layers_to_capture([1, _NUM_LAYERS // 2, _NUM_LAYERS - 4])
+
+        self.assertTrue(lm.capture_aux_hidden_states)
+        self.assertEqual(
+            lm.model.layers_to_capture,
+            [2, _NUM_LAYERS // 2 + 1, _NUM_LAYERS - 3],
+        )
+
+    def test_default_layers_follow_eagle3_convention(self):
+        lm = _bare_causal_lm(capture=False)
+        lm.set_eagle3_layers_to_capture(None)
+
+        self.assertEqual(
+            lm.model.layers_to_capture,
+            [2, _NUM_LAYERS // 2, _NUM_LAYERS - 3],
+        )
+
+
+class TestAuxCaptureForward(CustomTestCase):
+    def test_capture_records_complete_layer_outputs(self):
+        model = _bare_model(layers_to_capture=[1, 2])
+        input_ids = torch.zeros(3, dtype=torch.int64)
+
+        hidden_states, aux = model.forward(
+            input_ids, positions=None, forward_batch=None
+        )
+
+        # Each layer adds two branches, so layer i's input is 2 * sum(1..i).
+        self.assertEqual(len(aux), 2)
+        self.assertTrue(torch.equal(aux[0], torch.full((3, _HIDDEN), 2.0)))
+        self.assertTrue(torch.equal(aux[1], torch.full((3, _HIDDEN), 6.0)))
+        # The final layer output is 2 * sum(1..8) = 72.
+        self.assertTrue(torch.equal(hidden_states, torch.full((3, _HIDDEN), 72.0)))
+
+    def test_no_capture_returns_plain_tensor(self):
+        # Runners unpack a tuple only when capture_aux_hidden_states is set.
+        model = _bare_model(layers_to_capture=[])
+
+        result = model.forward(
+            torch.zeros(3, dtype=torch.int64), positions=None, forward_batch=None
+        )
+
+        self.assertIsInstance(result, torch.Tensor)
+
+    def test_last_layer_capture_precedes_final_normalization(self):
+        """Selecting the last target layer must retain its full residual output."""
+        for layer_ids, expected in (([7], [72.0]), ([0, 7], [2.0, 72.0])):
+            with self.subTest(layer_ids=layer_ids):
+                lm = _bare_causal_lm(capture=False)
+                torch.nn.Module.__init__(lm)
+                lm.model = _bare_model(layers_to_capture=[])
+                lm.model.norm = lambda hidden_states: hidden_states / 2
+                lm.set_eagle3_layers_to_capture(layer_ids)
+
+                hidden_states, aux = lm.model.forward(
+                    torch.zeros(3, dtype=torch.int64),
+                    positions=None,
+                    forward_batch=None,
+                )
+
+                self.assertEqual(len(aux), len(expected))
+                for actual, value in zip(aux, expected, strict=True):
+                    self.assertTrue(
+                        torch.equal(actual, torch.full((3, _HIDDEN), value))
+                    )
+                self.assertTrue(
+                    torch.equal(hidden_states, torch.full((3, _HIDDEN), 36.0))
+                )
+
+    def test_aux_reaches_logits_processor_unscaled(self):
+        # scale_width divides only the logits input, not the aux hidden states.
+        lm = _bare_causal_lm(capture=True)
+        hidden = torch.full((3, _HIDDEN), 8.0)
+        aux = [torch.full((3, _HIDDEN), 5.0)]
+        lm.model.return_value = (hidden, aux)
+        input_ids = torch.zeros(3, dtype=torch.int64)
+
+        lm.forward(input_ids, positions=None, forward_batch="batch")
+
+        ids, scaled_hidden, lm_head, batch, passed_aux = (
+            lm.logits_processor.call_args.args
+        )
+        self.assertTrue(torch.equal(scaled_hidden, torch.full((3, _HIDDEN), 2.0)))
+        self.assertIs(passed_aux, aux)
+        self.assertIs(lm_head, lm.model.embed_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_minicpm_target_verify.py
+++ b/test/registered/unit/spec/test_minicpm_target_verify.py
@@ -1,0 +1,372 @@
+"""MiniCPM sparse target-verify: row planning, segment layouts,
+verify metadata construction, and graph buffers."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.minicpm_fixtures import (
+    make_spec_backend,
+    make_verify_batch,
+    plan_verify,
+)
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention.minicpm import backend as backend_module
+from sglang.srt.layers.attention.minicpm.backend import _copy_dense_page_table
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    _build_dense_verify_overwrite,
+    _build_sparse_decode_metadata,
+    _plan_repeated_segments,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+HEAD_GROUP = 2
+HEADS_PER_GROUP = 16
+BLOCK_SIZE = 64
+SPARSE_TOPK = 96
+CAPACITY = SPARSE_TOPK * BLOCK_SIZE
+
+
+def _plan(seq_lens, num_draft_tokens, dense_len):
+    return plan_verify(
+        seq_lens,
+        num_draft_tokens,
+        head_group_num=HEAD_GROUP,
+        heads_per_group=HEADS_PER_GROUP,
+        dense_len=dense_len,
+        sparse_topk=SPARSE_TOPK,
+        block_size=BLOCK_SIZE,
+    )
+
+
+class TestVerifyMetadataClosedForm(CustomTestCase):
+    def test_rows_match_decode_metadata_at_each_draft_position(self):
+        """Verify row (b, i) must plan exactly like a decode step:
+        seq_len = prefix + i + 1 -- draft tokens see the same key set."""
+        seq_lens = [100, 6142, 8190, 8192]
+        num_draft_tokens = 4
+        for dense_len in (8192, 0):
+            _, _, metadata = _plan(seq_lens, num_draft_tokens, dense_len)
+            row_lens = metadata.sparse_cache_seqlens_int32
+            for batch_idx, seq_len in enumerate(seq_lens):
+                for draft_idx in range(num_draft_tokens):
+                    token_pos = seq_len + draft_idx + 1
+                    decode = _build_sparse_decode_metadata(
+                        seq_lens_cpu=torch.tensor([token_pos]),
+                        base_metadata=SimpleNamespace(
+                            cache_seqlens_int32=torch.tensor(
+                                [token_pos], dtype=torch.int32
+                            ),
+                            page_table=torch.zeros((1, token_pos), dtype=torch.int32),
+                            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+                        ),
+                        head_group_num=HEAD_GROUP,
+                        dense_len=dense_len,
+                        sparse_topk=SPARSE_TOPK,
+                        block_size=BLOCK_SIZE,
+                    )
+                    row_start = (batch_idx * num_draft_tokens + draft_idx) * HEAD_GROUP
+                    self.assertTrue(
+                        torch.equal(
+                            row_lens[row_start : row_start + HEAD_GROUP],
+                            decode.sparse_cache_seqlens_int32,
+                        ),
+                        f"seq_len={seq_len} draft_idx={draft_idx} "
+                        f"dense_len={dense_len}",
+                    )
+
+    def test_row_lengths_match_selection_fill(self):
+        """Planned sparse row length equals the page-table entries;
+        the block selection fills them."""
+        num_draft_tokens = 3
+        seq_lens = [6141, 6144, 6205, 8189]
+        _, _, metadata = _plan(seq_lens, num_draft_tokens, dense_len=0)
+        row_lens = metadata.sparse_cache_seqlens_int32
+        for batch_idx, seq_len in enumerate(seq_lens):
+            for draft_idx in range(num_draft_tokens):
+                token_pos = seq_len + draft_idx + 1
+                num_blocks = -(-token_pos // BLOCK_SIZE)
+                if num_blocks <= SPARSE_TOPK:
+                    selected = range(num_blocks)
+                else:
+                    # Only the forced last block can be partial;
+                    # which others score in is irrelevant.
+                    selected = [*range(SPARSE_TOPK - 1), num_blocks - 1]
+                fill = sum(
+                    min(BLOCK_SIZE, token_pos - block * BLOCK_SIZE)
+                    for block in selected
+                )
+                row = (batch_idx * num_draft_tokens + draft_idx) * HEAD_GROUP
+                self.assertEqual(int(row_lens[row]), fill)
+
+    def test_topk_selection_uses_decode_form(self):
+        """Regression: selection must run the decode form (one row per draft token,
+        cache len token_pos - 1);
+        the prefill form stops at the last complete block and drops the draft slots."""
+        seq_lens = [50, 9000]
+        num_draft_tokens = 4
+        _, _, metadata = _plan(seq_lens, num_draft_tokens, dense_len=8192)
+
+        num_tokens = len(seq_lens) * num_draft_tokens
+        self.assertTrue(
+            torch.equal(
+                metadata.topk_cu_seqlens_q,
+                torch.arange(num_tokens + 1, dtype=torch.int32),
+            )
+        )
+        self.assertEqual(metadata.topk_max_seqlen_q, 1)
+        # The decode form stages each verify row's cache at its own causal prefix:
+        # seq_len + draft_idx keys.
+        self.assertTrue(
+            torch.equal(
+                metadata.cache_seqlens_int32_stage1,
+                torch.tensor(
+                    [s + d for s in seq_lens for d in range(num_draft_tokens)],
+                    dtype=torch.int32,
+                ),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                metadata.cu_seqlens_q_adjusted,
+                torch.arange(num_tokens + 1, dtype=torch.int32) * HEADS_PER_GROUP,
+            )
+        )
+
+
+class TestPlanRepeatedSegments(CustomTestCase):
+    def test_segments_repeat_per_draft_token(self):
+        flat = torch.arange(5, dtype=torch.float32).view(5, 1, 1)
+        layout = _plan_repeated_segments(
+            torch.tensor([0, 2, 5], dtype=torch.int32), total_tokens=5, repeats=3
+        )
+        self.assertEqual(layout.cu_seqlens.tolist(), [0, 2, 4, 6, 9, 12, 15])
+        want = torch.cat([flat[0:2]] * 3 + [flat[2:5]] * 3)
+        self.assertTrue(torch.equal(flat.index_select(0, layout.index), want))
+
+    def test_slab_segment_starts_gather_packed_rows(self):
+        """A layout planned over slab offsets must gather, from a slab-laid buffer,
+        what the packed layout gathers from a packed one, with equal row bounds."""
+        segment_rows, num_draft_tokens = 8, 3
+        chunk_lens = torch.tensor([3, 8, 0, 5], dtype=torch.int32)
+        packed_cu = F.pad(torch.cumsum(chunk_lens, dim=0, dtype=torch.int32), (1, 0))
+        total = int(packed_cu[-1])
+        packed = torch.arange(total, dtype=torch.float32)
+        slab = torch.full((len(chunk_lens) * segment_rows,), float("nan"))
+        slab_starts = torch.arange(len(chunk_lens), dtype=torch.int32) * segment_rows
+        for batch_idx, n in enumerate(chunk_lens.tolist()):
+            start = batch_idx * segment_rows
+            slab[start : start + n] = packed[
+                packed_cu[batch_idx] : packed_cu[batch_idx + 1]
+            ]
+
+        packed_layout = _plan_repeated_segments(
+            packed_cu, total_tokens=total, repeats=num_draft_tokens
+        )
+        slab_layout = _plan_repeated_segments(
+            packed_cu,
+            total_tokens=total,
+            repeats=num_draft_tokens,
+            segment_starts=slab_starts,
+        )
+
+        self.assertTrue(torch.equal(slab_layout.cu_seqlens, packed_layout.cu_seqlens))
+        self.assertTrue(
+            torch.equal(slab[slab_layout.index], packed[packed_layout.index])
+        )
+
+
+def _verify_forward_batch(seq_lens, num_draft_tokens, spec_info=None):
+    forward_batch, base_metadata = make_verify_batch(seq_lens, num_draft_tokens)
+    forward_batch.spec_info = spec_info
+    forward_batch.req_pool_indices = torch.arange(len(seq_lens), dtype=torch.int64)
+    forward_batch.forward_mode = SimpleNamespace(
+        is_draft_extend_v2=lambda: False,
+        is_idle=lambda: False,
+        is_target_verify=lambda: True,
+        is_decode_or_idle=lambda: False,
+    )
+    return forward_batch, base_metadata
+
+
+def _k1_k2_stub() -> tuple[SimpleNamespace, SimpleNamespace]:
+    """The k1/k2 compression stubs shared by the verify tests."""
+    k1 = SimpleNamespace(
+        cu_seqlens=torch.tensor([0, 1, 3], dtype=torch.int32),
+        cu_seqlens_cpu=[0, 1, 3],
+    )
+    k2 = SimpleNamespace(
+        cu_seqlens=torch.tensor([0, 0, 1], dtype=torch.int32),
+        cu_seqlens_cpu=[0, 0, 1],
+    )
+    return k1, k2
+
+
+class TestBackendVerifyMetadata(CustomTestCase):
+    def test_init_forward_metadata_builds_verify_metadata(self):
+        num_draft_tokens = 2
+        backend, flash_attn_backend = make_spec_backend(
+            num_draft_tokens=num_draft_tokens, eagle_topk=1
+        )
+        forward_batch, base_metadata = _verify_forward_batch([3, 200], num_draft_tokens)
+        flash_attn_backend.forward_metadata = base_metadata
+        k1, k2 = _k1_k2_stub()
+
+        with patch.object(
+            backend_module,
+            "_build_k1_k2_compression_metadata",
+            return_value=(k1, k2),
+        ) as build_k1_k2:
+            backend.init_forward_metadata(forward_batch)
+
+        metadata = backend.forward_metadata
+        # K1/K2 tables cover prefix + draft tokens.
+        kwargs = build_k1_k2.call_args.kwargs
+        self.assertTrue(
+            torch.equal(
+                kwargs["seq_lens_cpu"], forward_batch.seq_lens_cpu + num_draft_tokens
+            )
+        )
+        self.assertIs(kwargs["cu_seqlens_q"], base_metadata.cu_seqlens_q)
+
+        self.assertEqual(metadata.k1_repeat.index.tolist(), [0, 0, 1, 2, 1, 2])
+        self.assertEqual(metadata.k1_repeat.cu_seqlens.tolist(), [0, 1, 2, 4, 6])
+        self.assertEqual(metadata.k2_repeat.index.tolist(), [0, 0])
+        self.assertEqual(metadata.k2_repeat.cu_seqlens.tolist(), [0, 0, 0, 1, 2])
+
+        # dense_len=128: request 0 rows are dense, request 1 rows sparse.
+        self.assertEqual(
+            metadata.sparse_cache_seqlens_int32.tolist(),
+            # Sparse rows clamp to capacity 128 - block 64 + token_pos % 64.
+            [4, 5, 73, 74],
+        )
+        self.assertEqual(
+            metadata.verify_dense_mask[:, 0, :].sum(dim=1).tolist(), [4, 5, 0, 0]
+        )
+        self.assertEqual(metadata.max_seqlen_q_adjusted, backend.heads_per_group)
+
+        prepare_kwargs = backend.attention_adapter.prepare_forward.call_args.kwargs
+        self.assertFalse(prepare_kwargs["is_prefill"])
+
+    def test_tree_drafts_raise(self):
+        with self.assertRaisesRegex(NotImplementedError, "chain drafts only"):
+            make_spec_backend(num_draft_tokens=4, eagle_topk=2)
+
+    def test_draft_extend_raises(self):
+        backend, _ = make_spec_backend(num_draft_tokens=4, eagle_topk=1)
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(is_draft_extend_v2=lambda: True)
+        )
+        with self.assertRaisesRegex(NotImplementedError, "draft extend"):
+            backend.init_forward_metadata(forward_batch)
+
+
+class TestVerifyGraphBuffers(CustomTestCase):
+    def test_dense_overwrite_matches_python_loop(self):
+        """The masked overwrite must write, exactly,
+        what the eager _copy_dense_page_table loop writes and nothing else."""
+        num_draft_tokens = 3
+        backend, _ = make_spec_backend(
+            num_draft_tokens=num_draft_tokens, eagle_topk=1, num_kv_heads=2
+        )
+        hg = backend.head_group_num
+        seq_lens = [60, 126, 500]
+        bs = len(seq_lens)
+        width = max(backend.dense_len, backend.num_sparse_topk_tokens)
+        generator = torch.Generator().manual_seed(0)
+        page_table = torch.randint(
+            0, 500, (bs, 1024), dtype=torch.int32, generator=generator
+        )
+        original = torch.randint(
+            0,
+            500,
+            (bs * num_draft_tokens * hg, width),
+            dtype=torch.int32,
+            generator=generator,
+        )
+        token_pos_in_bs = torch.tensor(
+            [s + d + 1 for s in seq_lens for d in range(num_draft_tokens)],
+            dtype=torch.int32,
+        )
+        token_to_bs = torch.repeat_interleave(
+            torch.arange(bs, dtype=torch.int32), num_draft_tokens
+        )
+        dense_rows, dense_mask = _build_dense_verify_overwrite(
+            token_pos_in_bs,
+            token_to_bs,
+            page_table,
+            dense_len=backend.dense_len,
+            head_group_num=hg,
+        )
+        metadata = SimpleNamespace(
+            sparse_page_table=original.clone(),
+            verify_dense_rows=dense_rows,
+            verify_dense_mask=dense_mask,
+        )
+        reference = original.clone()
+        for batch_idx, seq_len in enumerate(seq_lens):
+            for draft_idx in range(num_draft_tokens):
+                kv_len = seq_len + draft_idx + 1
+                if kv_len < backend.dense_len:
+                    _copy_dense_page_table(
+                        reference,
+                        (batch_idx * num_draft_tokens + draft_idx) * hg,
+                        page_table,
+                        batch_idx,
+                        kv_len,
+                        hg,
+                    )
+
+        backend._overwrite_dense_verify_rows(metadata)
+
+        self.assertTrue(torch.equal(metadata.sparse_page_table, reference))
+        # The batch spans both regimes, so some rows must actually change.
+        self.assertFalse(torch.equal(reference, original))
+
+
+class TestFusedTopkRepeatGate(CustomTestCase):
+    """Regression: the fused top-k scores the k1 level alone,
+    so under minicpm_fuse_topk the verify plan leaves the k2 repeat layout unset
+    while k1 keeps its per-draft repeats."""
+
+    def test_eager_verify_plan_leaves_k2_repeat_unset(self):
+        num_draft_tokens = 2
+        with (
+            backend_module.envs.SGLANG_MINICPM_FUSE_TOPK.override(True),
+            patch.object(
+                backend_module.MiniCPMSparseBackend,
+                "_get_fused_topk_kernel",
+                return_value=None,
+            ),
+        ):
+            backend, flash_attn_backend = make_spec_backend(
+                num_draft_tokens=num_draft_tokens, eagle_topk=1
+            )
+            self.assertTrue(backend.minicpm_fuse_topk)
+            forward_batch, base_metadata = _verify_forward_batch(
+                [3, 200], num_draft_tokens
+            )
+            flash_attn_backend.forward_metadata = base_metadata
+            k1, k2 = _k1_k2_stub()
+            with patch.object(
+                backend_module,
+                "_build_k1_k2_compression_metadata",
+                return_value=(k1, k2),
+            ):
+                backend.init_forward_metadata(forward_batch)
+            metadata = backend.forward_metadata
+            self.assertEqual(metadata.k1_repeat.index.tolist(), [0, 0, 1, 2, 1, 2])
+            self.assertEqual(metadata.k1_repeat.cu_seqlens.tolist(), [0, 1, 2, 4, 6])
+            self.assertIsNone(metadata.k2_repeat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_minicpm_verify_replay.py
+++ b/test/registered/unit/spec/test_minicpm_verify_replay.py
@@ -1,0 +1,604 @@
+"""Pin the MiniCPM verify CUDA-graph capture seed and replay refresh bitwise;
+the eager sparse-verify builders are the reference."""
+
+import unittest
+import warnings
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.minicpm_fixtures import (
+    make_replay_backend,
+    make_sparse_backend,
+    make_verify_batch,
+)
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.minicpm.backend import MiniCPMSparseBackend
+from sglang.srt.layers.attention.minicpm.sparse_utils import (
+    MiniCPMSparseMetadata,
+    _build_k1_k2_compression_metadata,
+    _build_sparse_verify_rows,
+    _plan_repeated_segments,
+    _plan_sparse_verify,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _eager_verify(backend, seq_lens, num_draft_tokens):
+    """Eager-builder oracle for the real (unpadded) batch."""
+    forward_batch, base_metadata = make_verify_batch(seq_lens, num_draft_tokens)
+    metadata = MiniCPMSparseMetadata(base=base_metadata)
+    _plan_sparse_verify(
+        forward_batch=forward_batch,
+        metadata=metadata,
+        head_group_num=backend.head_group_num,
+        heads_per_group=backend.heads_per_group,
+        dense_len=backend.dense_len,
+        sparse_topk=backend.sparse_topk,
+        block_size=backend.block_size,
+        num_draft_tokens=num_draft_tokens,
+    )
+    return metadata
+
+
+def _replay_verify_graph(
+    backend,
+    base,
+    *,
+    bs,
+    real_bs,
+    padded_seq_lens,
+    req_pool_indices,
+    spec_info,
+):
+    """Bind the replay metadata and run the verify replay for the padded batch;
+    the caller controls what the base buffers hold in between."""
+    forward_batch = SimpleNamespace(
+        batch_size=bs,
+        num_padding=bs - real_bs,
+        seq_lens=torch.tensor(padded_seq_lens, dtype=torch.int32),
+        seq_lens_cpu=torch.tensor(padded_seq_lens, dtype=torch.int32),
+        req_pool_indices=req_pool_indices,
+        spec_info=spec_info,
+    )
+    metadata = MiniCPMSparseMetadata(base=base)
+    backend._bind_sparse_verify_graph_metadata(
+        forward_batch, metadata, in_capture=False
+    )
+    backend._replay_sparse_verify_graph_metadata(forward_batch, metadata)
+    return forward_batch, metadata
+
+
+def _capture_seed(backend, base, *, bs):
+    """Bind a capture-seed metadata for a spec_info=None batch of bs rows;
+    returns (metadata, forward_batch)."""
+    forward_batch = SimpleNamespace(batch_size=bs, spec_info=None)
+    metadata = MiniCPMSparseMetadata(base=base)
+    backend._bind_sparse_verify_graph_metadata(forward_batch, metadata, in_capture=True)
+    return metadata, forward_batch
+
+
+def _capture_seed_chain_rows(backend, num_draft_tokens):
+    """The chain closed-form row lengths at the capture seed geometry."""
+    _, chain_rows = _build_sparse_verify_rows(
+        torch.full((2,), backend.config_dense_len, dtype=torch.int32),
+        head_group_num=backend.head_group_num,
+        dense_len=backend.dense_len,
+        sparse_topk=backend.sparse_topk,
+        block_size=backend.block_size,
+        num_draft_tokens=num_draft_tokens,
+    )
+    return chain_rows
+
+
+class TestVerifyGraphReplay(CustomTestCase):
+    def test_capture_seed_fits_minimum_context_capacity(self):
+        """A context ending at the dense threshold must still fit the capture
+        seed and repeated compression rows for the full draft width."""
+        for num_draft_tokens in (2, 64):
+            with self.subTest(num_draft_tokens=num_draft_tokens):
+                backend, _, _, _ = make_sparse_backend(
+                    max_context_len=128,
+                    server_args_overrides={
+                        "speculative_num_draft_tokens": num_draft_tokens,
+                        "speculative_eagle_topk": 1,
+                    },
+                )
+                backend.attention_adapter = Mock()
+                backend.init_cuda_graph_state(1, num_draft_tokens)
+                _, base = make_verify_batch([1], num_draft_tokens)
+                base.max_seq_len_q = num_draft_tokens
+                base.page_table = torch.zeros((1, 128), dtype=torch.int32)
+                metadata, _ = _capture_seed(backend, base, bs=1)
+                self.assertLessEqual(
+                    int(metadata.token_pos_in_bs.max()), base.page_table.shape[1]
+                )
+                for name in ("k1", "k2"):
+                    repeat = getattr(metadata, f"{name}_repeat")
+                    if repeat is not None:
+                        level = getattr(metadata, name)
+                        self.assertLess(
+                            int(repeat.index.max()), level.cu_seqlens_cpu[-1]
+                        )
+
+    def _assert_level_buffers_match_eager_builder(
+        self, backend, metadata, forward_batch, real_seq_lens, num_draft_tokens
+    ):
+        """K1/K2 level buffers hold the eager compression builder's output for the
+        real batch, with flat cumsum tails and zero history on the padded rows."""
+        real_bs = len(real_seq_lens)
+        _, eager_base = make_verify_batch(real_seq_lens, num_draft_tokens)
+        expected = _build_k1_k2_compression_metadata(
+            req_pool_indices=forward_batch.req_pool_indices[:real_bs],
+            base_metadata=eager_base,
+            req_to_sparse_k1_token=backend.req_to_sparse_k1_token,
+            req_to_sparse_k2_token=backend.req_to_sparse_k2_token,
+            k1_kernel_size=backend.k1_kernel_size,
+            k1_kernel_stride=backend.k1_kernel_stride,
+            k2_kernel_size=backend.k2_kernel_size,
+            k2_kernel_stride=backend.k2_kernel_stride,
+            cu_seqlens_q=eager_base.cu_seqlens_q,
+            seq_lens_cpu=torch.tensor(real_seq_lens, dtype=torch.int32)
+            + num_draft_tokens,
+        )
+        for name, want in zip(("k1", "k2"), expected):
+            level = getattr(metadata, name)
+            for field in ("cu_seqlens", "cu_new_token_nums"):
+                got, exp = getattr(level, field), getattr(want, field)
+                self.assertTrue(torch.equal(got[: real_bs + 1], exp), f"{name}.{field}")
+                self.assertTrue(
+                    (got[real_bs + 1 :] == exp[-1]).all(), f"{name}.{field}"
+                )
+            self.assertTrue(
+                torch.equal(
+                    level.history_compress_token_nums[:real_bs],
+                    want.history_compress_token_nums,
+                ),
+                name,
+            )
+            self.assertTrue(
+                (level.history_compress_token_nums[real_bs:] == 0).all(), name
+            )
+            self.assertTrue(torch.equal(level.table[:real_bs], want.table), name)
+        return expected
+
+    def _assert_repeat_layouts_match_eager(
+        self, backend, metadata, eager_levels, real_bs, num_draft_tokens
+    ):
+        """The retained repeat layouts gather, from the slab-laid compression
+        buffers, the chunk rows the eager planner gathers from packed ones;
+        the row bounds are equal and the padded tokens have empty rows."""
+        num_real_tokens = real_bs * num_draft_tokens
+        for name, eager_level in zip(("k1", "k2"), eager_levels):
+            if name not in backend.verify_repeat_levels:
+                continue
+            level = getattr(metadata, name)
+            eager_layout = _plan_repeated_segments(
+                eager_level.cu_seqlens,
+                total_tokens=eager_level.cu_seqlens_cpu[-1],
+                repeats=num_draft_tokens,
+            )
+            retained = backend.decode_cuda_graph_metadata[f"{name}_repeat"]
+            padded_tokens = level.cu_seqlens.numel() - 1
+            padded_tokens *= num_draft_tokens
+            cu_seqlens = retained.cu_seqlens[: padded_tokens + 1]
+            self.assertTrue(
+                torch.equal(cu_seqlens[: num_real_tokens + 1], eager_layout.cu_seqlens),
+                name,
+            )
+            self.assertTrue(
+                (
+                    cu_seqlens[num_real_tokens + 1 :] == eager_layout.cu_seqlens[-1]
+                ).all(),
+                name,
+            )
+            # Lay the packed chunk rows out at the slab offsets the compression
+            # kernel writes to, then gather both ways.
+            packed_cu = eager_level.cu_seqlens
+            packed = torch.arange(int(packed_cu[-1]), dtype=torch.float32)
+            slab = torch.full((int(level.cu_total_compress_token_nums[-1]),), -1.0)
+            for batch_idx in range(real_bs):
+                start = int(level.cu_total_compress_token_nums[batch_idx])
+                rows = packed[packed_cu[batch_idx] : packed_cu[batch_idx + 1]]
+                slab[start : start + rows.numel()] = rows
+            gathered = slab[retained.index[: eager_layout.index.numel()]]
+            self.assertTrue(torch.equal(gathered, packed[eager_layout.index]), name)
+
+    def _assert_capture_frozen_aranges_intact(
+        self, backend, metadata, bs, num_draft_tokens
+    ):
+        """Replay refreshes the row buffers;
+        the capture-frozen selection arange tensors must stay intact."""
+        self.assertTrue(
+            torch.equal(
+                metadata.topk_cu_seqlens_q,
+                torch.arange(bs * num_draft_tokens + 1, dtype=torch.int32),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                metadata.cu_seqlens_q_adjusted,
+                torch.arange(bs * num_draft_tokens + 1, dtype=torch.int32)
+                * backend.heads_per_group,
+            )
+        )
+
+    def _assert_uniform_slab_offsets_survive_replay(self, backend, metadata, bs):
+        """Capture-seeded uniform slab offsets must survive replay;
+        the static repeat index depends on them."""
+        for name, kernel_stride in (
+            ("k1", backend.k1_kernel_stride),
+            ("k2", backend.k2_kernel_stride),
+        ):
+            self._assert_slab_offsets(
+                level=getattr(metadata, name),
+                backend=backend,
+                bs=bs,
+                name=name,
+                kernel_stride=kernel_stride,
+            )
+
+    def _assert_slab_offsets(self, level, backend, bs, name, kernel_stride):
+        """cu_total_compress_token_nums keeps the capture-seeded,
+        uniform slab offsets."""
+        self.assertTrue(
+            torch.equal(
+                level.cu_total_compress_token_nums,
+                torch.arange(bs + 1, dtype=torch.int32)
+                * (backend.max_context_len // kernel_stride),
+            ),
+            name,
+        )
+
+    def _assert_replay_rows(
+        self, metadata, eager, real_bs, num_draft_tokens, head_group_num
+    ):
+        """Replay row lengths match the eager builder, padded rows zeroed;
+        returns (real_rows, row_lens) for the follow-up assertions."""
+        real_rows = real_bs * num_draft_tokens * head_group_num
+        row_lens = metadata.sparse_cache_seqlens_int32
+        self.assertTrue(
+            torch.equal(row_lens[:real_rows], eager.sparse_cache_seqlens_int32)
+        )
+        self.assertTrue((row_lens[real_rows:] == 0).all())
+        return real_rows, row_lens
+
+    def _assert_row_lens_cumsum(self, metadata, row_lens):
+        """The replayed sparse cu_seqlens_k is the cumsum of the row lengths."""
+        self.assertTrue(
+            torch.equal(
+                metadata.sparse_cu_seqlens_k,
+                F.pad(torch.cumsum(row_lens, dim=0, dtype=torch.int32), (1, 0)),
+            )
+        )
+
+    def test_capture_seeds_consistent_plan(self):
+        """Capture seed must be self-consistent (cu_seqlens_k == cumsum of row lengths,
+        all rows live); otherwise the captured fill disagrees with the capture plan."""
+        num_draft_tokens = 2
+        # num_kv_heads=2 makes sparse_rows outnumber the verify tokens, so
+        # the row-width and token-width binds below cannot swap silently.
+        backend, base = make_replay_backend(
+            [1, 1], num_draft_tokens, num_kv_heads=2, max_bs=2
+        )
+        metadata, forward_batch = _capture_seed(backend, base, bs=2)
+        self.assertTrue((metadata.sparse_cache_seqlens_int32 > 0).all())
+        self.assertTrue(
+            torch.equal(
+                metadata.sparse_cu_seqlens_k,
+                F.pad(
+                    torch.cumsum(
+                        metadata.sparse_cache_seqlens_int32, dim=0, dtype=torch.int32
+                    ),
+                    (1, 0),
+                ),
+            )
+        )
+        assume_kv_len = backend.config_dense_len + num_draft_tokens
+        self.assertTrue(
+            torch.equal(
+                base.cu_seqlens_k,
+                torch.arange(3, dtype=torch.int32) * assume_kv_len,
+            )
+        )
+        # Magnitude pin:
+        # the seeded rows must equal the chain closed form at the capture seed geometry
+        # -- a constant seed would pass every check above.
+        chain_rows = _capture_seed_chain_rows(backend, num_draft_tokens)
+        self.assertTrue(torch.equal(metadata.sparse_cache_seqlens_int32, chain_rows))
+        # The decode-form selection geometry the captured plan freezes:
+        # prefix-stable arange buffers bound at their verify-width slice,
+        # with the head-group expansion applied to the adjusted one.
+        arange = torch.arange(2 * num_draft_tokens + 1, dtype=torch.int32)
+        self.assertTrue(torch.equal(metadata.topk_cu_seqlens_q, arange))
+        self.assertTrue(
+            torch.equal(
+                metadata.cu_seqlens_q_adjusted, arange * backend.heads_per_group
+            )
+        )
+        # Frozen across capture and replay: the captured selection recorded its
+        # cache_lens branch from this bound, not from a per-batch maximum.
+        self.assertEqual(metadata.topk_max_seqlen_k, backend.max_context_len)
+        self.assertEqual(metadata.max_seqlen_q_adjusted, backend.heads_per_group)
+        # Row width: the row-count prefix sum is the full sparse-row arange,
+        # not the token-width slice.
+        sparse_rows = (
+            forward_batch.batch_size * num_draft_tokens * backend.head_group_num
+        )
+        self.assertTrue(
+            torch.equal(
+                metadata.sparse_cu_seqlens_q,
+                torch.arange(sparse_rows + 1, dtype=torch.int32),
+            )
+        )
+
+    def test_capture_binds_retained_repeat_layouts(self):
+        """Regression: the captured gather records the repeat index's address,
+        so binding must hand out prefix views of buffers init_cuda_graph_state retains,
+        never per-capture allocations."""
+        num_draft_tokens = 2
+        bs = 2
+        backend, base = make_replay_backend([1] * bs, num_draft_tokens, max_bs=4)
+        metadata, _ = _capture_seed(backend, base, bs=bs)
+        for name in ("k1", "k2"):
+            layout = getattr(metadata, f"{name}_repeat")
+            retained = backend.decode_cuda_graph_metadata[f"{name}_repeat"]
+            self.assertEqual(layout.index.data_ptr(), retained.index.data_ptr())
+            self.assertEqual(
+                layout.cu_seqlens.data_ptr(), retained.cu_seqlens.data_ptr()
+            )
+
+    def test_capture_skips_k2_repeat_binding_under_fused_topk(self):
+        """Regression:
+        under minicpm_fuse_topk the captured gather reads no k2 repeat layout,
+        so capture must skip the k2 binding;
+        k1 still binds prefix views of the retained layout."""
+        num_draft_tokens = 2
+        with (
+            envs.SGLANG_MINICPM_FUSE_TOPK.override(True),
+            patch.object(
+                MiniCPMSparseBackend,
+                "_get_fused_topk_kernel",
+                return_value=None,
+            ),
+        ):
+            backend, base = make_replay_backend([1, 1], num_draft_tokens, max_bs=4)
+            metadata = MiniCPMSparseMetadata(base=base)
+            backend._bind_sparse_verify_graph_metadata(
+                SimpleNamespace(batch_size=2, spec_info=None),
+                metadata,
+                in_capture=True,
+            )
+            retained = backend.decode_cuda_graph_metadata["k1_repeat"]
+            self.assertEqual(
+                metadata.k1_repeat.index.data_ptr(), retained.index.data_ptr()
+            )
+            self.assertIsNone(metadata.k2_repeat)
+            self.assertNotIn("k2_repeat", backend.decode_cuda_graph_metadata)
+
+    def test_capture_compression_view_covers_retained_slab(self):
+        """Regression: the captured gather reads the repeat layout's index,
+        which addresses the slab offsets the compression kernel writes at,
+        so the compression view sized from cu_seqlens_cpu must cover the slab
+        -- a dense-window seed lets the captured index_select read past the view."""
+        num_draft_tokens = 2
+        backend, base = make_replay_backend([1] * 4, num_draft_tokens, max_bs=4)
+        _capture_seed(backend, base, bs=4)
+        # A smaller capture reuses the retained index after a larger one wrote
+        # it; the gather reads the whole smaller view, tail included.
+        _, small_base = make_verify_batch([1, 1], num_draft_tokens)
+        small_base.max_seq_len_q = num_draft_tokens
+        metadata, _ = _capture_seed(backend, small_base, bs=2)
+        for name in ("k1", "k2"):
+            level = getattr(metadata, name)
+            self.assertLess(
+                int(getattr(metadata, f"{name}_repeat").index.max()),
+                level.cu_seqlens_cpu[-1],
+            )
+
+    def test_capture_dense_views_preserve_retained_buffers(self):
+        """Narrow page tables must not resize retained graph views during capture
+        or change their storage across row refreshes."""
+        backend, base = make_replay_backend([1, 1], 2, max_bs=4)
+        buffers = backend.decode_cuda_graph_metadata
+        retained = buffers["verify_dense_rows"]
+        shape, stride, pointer = retained.shape, retained.stride(), retained.data_ptr()
+        for width in (3, backend.dense_len, backend.max_context_len):
+            with self.subTest(width=width):
+                base.page_table = torch.arange(width, dtype=torch.int32).repeat(2, 1)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "error",
+                        message="An output with one or more elements was resized",
+                    )
+                    metadata, _ = _capture_seed(backend, base, bs=2)
+                    num_cols = min(width, backend.dense_len)
+                    self.assertEqual(metadata.verify_dense_rows.shape, (4, 1, num_cols))
+                    self.assertEqual(metadata.verify_dense_mask.shape, (4, 1, num_cols))
+                    views = (metadata.verify_dense_rows, metadata.verify_dense_mask)
+                    identities = [(v.shape, v.stride(), v.data_ptr()) for v in views]
+                    for length in (1, 2):
+                        backend._write_verify_graph_rows(
+                            metadata,
+                            torch.tensor([length, length], dtype=torch.int32),
+                            real_rows=4,
+                        )
+                        cols = torch.arange(num_cols, dtype=torch.int32)
+                        positions = torch.tensor([length + 1, length + 2] * 2)
+                        torch.testing.assert_close(views[0], cols.expand(4, 1, -1))
+                        torch.testing.assert_close(
+                            views[1], cols[None, None, :] < positions[:, None, None]
+                        )
+                        self.assertEqual(
+                            [(v.shape, v.stride(), v.data_ptr()) for v in views],
+                            identities,
+                        )
+                self.assertEqual(
+                    (retained.shape, retained.stride(), retained.data_ptr()),
+                    (shape, stride, pointer),
+                )
+
+    def test_replay_refreshes_static_buffers_to_eager_geometry(self):
+        """Replay must leave the static buffers,
+        holding the eager builder's geometry for the real batch, padded rows zeroed,
+        and cu_seqlens_k == cumsum(row lengths)."""
+        num_draft_tokens = 2
+        # 190 puts a token position on a block multiple past the sparse capacity,
+        # the clamp's mod == 0 arm; the others cover identity, dense and remainder.
+        real_seq_lens = [100, 130, 126, 190]
+        padded_seq_lens = [*real_seq_lens, 1]
+        bs, real_bs = len(padded_seq_lens), len(real_seq_lens)
+        backend, base = make_replay_backend(padded_seq_lens, num_draft_tokens, max_bs=5)
+        head_group_num = backend.head_group_num
+
+        capture_batch = SimpleNamespace(batch_size=bs, spec_info=None)
+        backend._bind_sparse_verify_graph_metadata(
+            capture_batch, MiniCPMSparseMetadata(base=base), in_capture=True
+        )
+        # The FlashAttention replay refreshes the base buffers;
+        # the capture seeding overwrote them.
+        base.cache_seqlens_int32.copy_(
+            torch.tensor(padded_seq_lens, dtype=torch.int32) + num_draft_tokens
+        )
+        base.cu_seqlens_k.copy_(
+            F.pad(
+                torch.cumsum(base.cache_seqlens_int32, dim=0, dtype=torch.int32),
+                (1, 0),
+            )
+        )
+
+        forward_batch, metadata = _replay_verify_graph(
+            backend,
+            base,
+            bs=bs,
+            real_bs=real_bs,
+            padded_seq_lens=padded_seq_lens,
+            req_pool_indices=torch.tensor([2, 5, 1, 4, 0]),
+            spec_info=None,
+        )
+
+        eager = _eager_verify(
+            backend, seq_lens=real_seq_lens, num_draft_tokens=num_draft_tokens
+        )
+        _, row_lens = self._assert_replay_rows(
+            metadata=metadata,
+            eager=eager,
+            real_bs=real_bs,
+            num_draft_tokens=num_draft_tokens,
+            head_group_num=head_group_num,
+        )
+        self._assert_row_lens_cumsum(metadata, row_lens)
+        self.assertTrue(
+            torch.equal(
+                metadata.token_pos_in_bs[: real_bs * num_draft_tokens],
+                eager.token_pos_in_bs,
+            )
+        )
+        num_real_tokens = real_bs * num_draft_tokens
+        self.assertTrue(
+            torch.equal(
+                metadata.cache_seqlens_int32_stage1[:num_real_tokens],
+                eager.cache_seqlens_int32_stage1,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                metadata.verify_dense_mask[:num_real_tokens], eager.verify_dense_mask
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                metadata.verify_dense_rows[:num_real_tokens], eager.verify_dense_rows
+            )
+        )
+        self._assert_capture_frozen_aranges_intact(
+            backend=backend, metadata=metadata, bs=bs, num_draft_tokens=num_draft_tokens
+        )
+        self.assertEqual(metadata.topk_max_seqlen_k, backend.max_context_len)
+
+        self._assert_uniform_slab_offsets_survive_replay(
+            backend=backend, metadata=metadata, bs=bs
+        )
+        eager_levels = self._assert_level_buffers_match_eager_builder(
+            backend, metadata, forward_batch, real_seq_lens, num_draft_tokens
+        )
+        self._assert_repeat_layouts_match_eager(
+            backend, metadata, eager_levels, real_bs, num_draft_tokens
+        )
+
+    def test_all_padding_replay_zeroes_compression_buffers(self):
+        """Bug regression:
+        an all-padding verify replay must zero the k1/k2 per-round compression lengths
+        and the repeat row bounds -- stale counts otherwise feed the captured
+        compression and selection kernels -- while cu_total_compress_token_nums
+        keeps the capture-time slab offsets the compression kernel writes at."""
+        num_draft_tokens = 2
+        bs = 2
+        backend, base = make_replay_backend([1] * bs, num_draft_tokens, max_bs=bs)
+        backend._bind_sparse_verify_graph_metadata(
+            SimpleNamespace(batch_size=bs, spec_info=None),
+            MiniCPMSparseMetadata(base=base),
+            in_capture=True,
+        )
+        forward_batch = SimpleNamespace(
+            batch_size=bs,
+            num_padding=bs,
+            seq_lens=torch.ones(bs, dtype=torch.int32),
+            seq_lens_cpu=torch.ones(bs, dtype=torch.int32),
+            req_pool_indices=torch.arange(bs, dtype=torch.int64),
+            spec_info=None,
+        )
+        metadata = MiniCPMSparseMetadata(base=base)
+        backend._bind_sparse_verify_graph_metadata(
+            forward_batch, metadata, in_capture=False
+        )
+        refreshed_fields = (
+            "history_compress_token_nums",
+            "cu_seqlens",
+            "cu_new_token_nums",
+        )
+        # Dirty the refreshed fields as a previous non-padded replay would.
+        for name in ("k1", "k2"):
+            level = getattr(metadata, name)
+            for field in refreshed_fields:
+                getattr(level, field).fill_(7)
+            backend.decode_cuda_graph_metadata[f"{name}_repeat"].cu_seqlens.fill_(7)
+
+        backend._replay_sparse_verify_graph_metadata(forward_batch, metadata)
+
+        self.assertTrue((metadata.sparse_cache_seqlens_int32 == 0).all())
+        self.assertTrue((metadata.sparse_cu_seqlens_k == 0).all())
+        self.assertTrue((metadata.cache_seqlens_int32_stage1 == 0).all())
+        for name, kernel_stride in (
+            ("k1", backend.k1_kernel_stride),
+            ("k2", backend.k2_kernel_stride),
+        ):
+            level = getattr(metadata, name)
+            for field in refreshed_fields:
+                buf = getattr(level, field)
+                self.assertTrue(
+                    (buf == 0).all(), f"{name}.{field} stale: {buf.tolist()}"
+                )
+            self._assert_slab_offsets(
+                level=level,
+                backend=backend,
+                bs=bs,
+                name=name,
+                kernel_stride=kernel_stride,
+            )
+            repeat = backend.decode_cuda_graph_metadata[f"{name}_repeat"]
+            self.assertTrue(
+                (repeat.cu_seqlens[: bs * num_draft_tokens + 1] == 0).all(), name
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Enable EAGLE3 chain decoding for MiniCPM-SALA in eager and CUDA graph execution. The draft generates a single candidate chain for the target to verify as a block. SALA combines eight sparse attention layers with 24 recurrent Lightning layers. Verifying a draft block requires a causal attention view for each token and a recurrent state that retains only the accepted prefix.

Supports chain decoding (`--speculative-eagle-topk 1`). Tree decoding is outside this PR.

Related MiniCPM-SALA fixes are tracked separately in #38230, #38231, and #38232. The serving checks and benchmarks below were run with those fixes applied.

## Modifications

Each verify token selects blocks from its preceding history and attends to that history plus the current token. For committed length `L` and zero-based token index `i`, the selector prefix length is `L + i` and the attention length is `L + i + 1`. Map each token and KV head group to a row in the existing paged-decode wrapper. K1/K2 compression covers the draft window while each row remains causally bounded; dense rows retain their full causal page tables.

Reuse Lightning's chain verifier to snapshot recurrent state at each candidate position without changing persistent state. After acceptance, commit the snapshot at the last retained position, discarding the rejected suffix from subsequent state evolution.

Expose the embedding, output head, and complete layer outputs needed by the draft, before final normalization and width scaling.

Grow compressed-key tables with speculative KV allocation and release the new KV slots if growth fails. Update preallocated row and compression buffers in place during CUDA graph replay.

## Accuracy Tests

Per-token selector and attention lengths matched decode planning, including dense causal page tables. CUDA capture/replay tests checked dense-row values, masks, shapes, strides, and stable buffer addresses; boundary tests compared replay metadata with eager planning.

Cache-allocation failure cleanup and serving checks for mixed dense/sparse requests, EOS, cancellation followed by another request, and TP2 also passed.

## Speed Tests and Profiling

The table was measured at commit [73f5934a4f](https://github.com/zywang-hust/sglang-upstream/commit/73f5934a4f36549db5ecee749ad72bfd8c3f7890), which includes both EAGLE3 chain support and the follow-up DSpark adapter.

Measured on the first 100 GSM8K test questions with chat + thinking, greedy decoding, and a 2048-token output cap. Both modes used the same RTX 5090 at each concurrency, TP1, and CUDA graphs.

| Concurrency | Mode | Mean acceptance length | Output tokens/s | Speedup | Correct |
|---|---|---|---|---|---|
| 1 | Target-only | — | 113.34 | 1.000× | 89/100 |
| 1 | EAGLE3 chain | 2.484 | 223.50 | **1.972×** | 87/100 |
| 8 | Target-only | — | 773.21 | 1.000× | 89/100 |
| 8 | EAGLE3 chain | 2.512 | 1408.28 | **1.821×** | 90/100 |

Throughput includes prefill and excludes warmup. All requests completed; capped outputs remain in the accuracy score. Mean acceptance length is the average number of tokens emitted per verification, including the guaranteed target token.

<details>
<summary>Models and benchmark configuration</summary>

The target-only baseline is shared with the DSpark comparison. Output-cap counts come from the same requests used for throughput and accuracy: at concurrency 1, 17 target and 17 EAGLE3 requests reached 2048 tokens; at concurrency 8, the counts were 18 and 20, respectively.

Both modes use a 16384-token context, 4096-token prefill chunks, server capacity of 17 requests, and seed 1234. The backend is `minicpm_flashinfer` with adaptive split scheduling and `dense_as_sparse` enabled; radix cache, prefill graphs, fused top-k, and FlashInfer autotuning are disabled. PyTorch 2.11.0+cu130; CUDA 13.0 runtime and 13.1 compiler.

The target and draft are NVFP4. EAGLE3 uses three draft steps and verify width 4: one guaranteed target token plus three draft tokens per target verification.

- Target: [zhiyaowang/MiniCPM-SALA-NVFP4-GPTQ](https://huggingface.co/zhiyaowang/MiniCPM-SALA-NVFP4-GPTQ/tree/5797ba95c7c54aa23d5f80c99582e41245649b87).
- Draft: [zhiyaowang/MiniCPM-SALA-EAGLE3-Draft-NVFP4](https://huggingface.co/zhiyaowang/MiniCPM-SALA-EAGLE3-Draft-NVFP4/tree/8583cf6a8cd887ce03af47ae1680cfc67a5b8a2a).

Add these options to the MiniCPM-SALA server command to enable EAGLE3:

```bash
--speculative-algorithm EAGLE3 \
--speculative-draft-model-path zhiyaowang/MiniCPM-SALA-EAGLE3-Draft-NVFP4 \
--speculative-draft-attention-backend flashinfer \
--speculative-num-steps 3 --speculative-eagle-topk 1 \
--speculative-num-draft-tokens 4
```

</details>

## Checklist

- [x] Run pre-commit.
- [x] Add unit tests.
- [x] Update speculative-decoding documentation.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34122075031](https://github.com/sgl-project/sglang/actions/runs/34122075031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34122074889](https://github.com/sgl-project/sglang/actions/runs/34122074889)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34122074832](https://github.com/sgl-project/sglang/actions/runs/34122074832)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->