### PR TITLE
[AMD][Fix] Fix regression in jit build error with FLUX.2-dev on gfx1250

### DIFF
--- a/python/sglang/kernels/ops/diffusion/norm/flux2_gated_resnorm_jit.py
+++ b/python/sglang/kernels/ops/diffusion/norm/flux2_gated_resnorm_jit.py
@@ -15,8 +15,13 @@ _ALIGNMENT = 32
 
 
 def _blackwell_or_newer(device: torch.device) -> bool:
+    # ROCm reports a capability derived from the gfx number, so gfx1250 comes
+    # back as (12, 5) and clears a bare major >= 10 test. The kernel is PTX, so
+    # require a CUDA build like rope/qwen_qkv_epilogue_jit.py does.
     return (
-        torch.cuda.is_available() and torch.cuda.get_device_capability(device)[0] >= 10
+        torch.version.cuda is not None
+        and torch.cuda.is_available()
+        and torch.cuda.get_device_capability(device)[0] >= 10
     )
 
 


### PR DESCRIPTION
## Motivation
FLUX.2-dev fails on gfx1250 as soon as denoising starts:
```
Failed to build JIT module sgl_kernel_jit_flux2_gated_resnorm
flux2_gated_resnorm.cuh:57:9: error: invalid output constraint '=&f' in asm
flux2_gated_resnorm.cuh:64:43: error: invalid output constraint '=f' in asm
amd_warp_sync_functions.h:297:62: error: static assertion failed due to requirement
    'sizeof(unsigned int) == 8': The mask must be a 64-bit integer.
3 errors generated when compiling for gfx1250.
```
The kernel added in #37112 is CUDA-only — it uses PTX inline asm with
float-register operand constraints and `__shfl_down_sync` with a 32-bit mask,
and AMDGPU has neither.
It gets selected because `_blackwell_or_newer()` only tests the device
capability. On ROCm that capability is derived from the gfx number, so gfx1250
reports `(12, 5)` and clears the `major >= 10` test, with
`torch.cuda.is_available()` already true under HIP.
Same class of issue as #34481, for a kernel added after it.
## Modifications
Require a CUDA build in `_blackwell_or_newer()`, matching the guard
`rope/qwen_qkv_epilogue_jit.py` already applies to the same capability test:
```python
 def _blackwell_or_newer(device: torch.device) -> bool:
     return (
-        torch.cuda.is_available() and torch.cuda.get_device_capability(device)[0] >= 10
+        torch.version.cuda is not None
+        and torch.cuda.is_available()
+        and torch.cuda.get_device_capability(device)[0] >= 10
     )
```
Both entry points, `can_defer_flux2_gated_residual()` and
`can_use_flux2_gated_resnorm()`, route through the guard, so ROCm now takes the
`residual_gate_add` + eager norm path for both. CUDA is unaffected.
## Accuracy Tests
ROCm falls back to the same unfused path it used before #37112, so there is no
new numerical behavior to validate on either platform.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34122415409](https://github.com/sgl-project/sglang/actions/runs/34122415409)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34308873698](https://github.com/sgl-project/sglang/actions/runs/34308873698)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34122415417](https://github.com/sgl-project/sglang/actions/runs/34122415417)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->