### PR TITLE
fix(moss-vl): preserve multimodal state across retraction

### DIFF
--- a/python/sglang/srt/models/moss_vl.py
+++ b/python/sglang/srt/models/moss_vl.py
@@ -1288,6 +1288,7 @@ class MossVLForConditionalGeneration(nn.Module):
         pixel_values_list = []
         grid_thw_list = []
         vision_pos_ids_list = []
+        device = forward_batch.seq_lens.device
 
         for i, mm_input in enumerate(forward_batch.mm_inputs):
             if forward_batch.encoder_cached[i] or mm_input is None:
@@ -1296,7 +1297,13 @@ class MossVLForConditionalGeneration(nn.Module):
                 continue
 
             item = mm_input.mm_items[0]
-            pixel_values_list.append(item.feature)
+            feature = item.feature
+            if feature is None:
+                raise RuntimeError(
+                    "MossVL cannot re-encode an uncached request without its "
+                    "vision features. Keep them until the request finishes."
+                )
+            pixel_values_list.append(feature.to(device, non_blocking=True))
             grid_thw = getattr(item, "grid_thw", None)
             if grid_thw is not None:
                 grid_thw_list.append(torch.as_tensor(grid_thw, dtype=torch.long))
@@ -1304,7 +1311,9 @@ class MossVLForConditionalGeneration(nn.Module):
 
             vp = mm_input.vision_position_ids
             if vp is not None:
-                vision_pos_ids_list.append(vp[:, :encoder_len])
+                vision_pos_ids_list.append(
+                    vp[:, :encoder_len].to(device, non_blocking=True)
+                )
 
         if not pixel_values_list:
             return None, None, None
@@ -1383,6 +1392,18 @@ class MossVLForConditionalGeneration(nn.Module):
         custom_mask = self._build_cross_attention_custom_mask(forward_batch)
         if custom_mask is not None:
             forward_batch.cross_attention_custom_mask = custom_mask
+
+    @staticmethod
+    def _slice_vis_counts_with_pad(
+        visible_frame_counts, offset: int, length: int, device
+    ) -> torch.Tensor:
+        """Preserve prompt visibility and repeat its last row for generated tokens."""
+        counts = torch.as_tensor(visible_frame_counts)
+        vis_counts = counts[offset : offset + length].to(device)
+        if vis_counts.numel() < length:
+            pad = counts[-1:].to(device).expand(length - vis_counts.numel())
+            vis_counts = torch.cat([vis_counts, pad])
+        return vis_counts
 
     def _build_cross_attention_custom_mask(
         self, forward_batch: ForwardBatch
@@ -1466,8 +1487,8 @@ class MossVLForConditionalGeneration(nn.Module):
             # is the cached-text offset into the full text sequence.
             text_offset = extend_prefix_len
 
-            vis_counts = visible_frame_counts[text_offset : text_offset + q_len].to(
-                device
+            vis_counts = self._slice_vis_counts_with_pad(
+                visible_frame_counts, text_offset, q_len, device
             )
 
             mask = torch.zeros(q_len, kv_len, dtype=torch.uint8, device=device)
@@ -1571,23 +1592,70 @@ class MossVLForConditionalGeneration(nn.Module):
                 # cached-text offset into the full text sequence.
                 text_offset = extend_prefix_len
 
-                vis_counts = visible_frame_counts[
-                    text_offset : text_offset + extend_seq_len
-                ].to(device)
+                vis_counts = self._slice_vis_counts_with_pad(
+                    visible_frame_counts, text_offset, extend_seq_len, device
+                )
                 full_text_row_masked_out_mask[offset : offset + extend_seq_len] = (
                     vis_counts > 0
                 )
 
-                # Last prefill chunk for this request: decode will only need
-                # visible_frame_counts[-1], so shrink the tensor to that single
-                # element and drop the rest. .clone() detaches the view from
-                # the original storage so the large tensor can be freed.
-                if text_offset + extend_seq_len >= visible_frame_counts.shape[0]:
-                    mm_input.visible_frame_counts = visible_frame_counts[-1:].clone()
-
                 offset += extend_seq_len
 
         return full_text_row_masked_out_mask.reshape(-1, 1)
+
+    def _repair_mrope_positions(self, forward_batch: ForwardBatch) -> torch.Tensor:
+        """Fill generated-token positions missing from a re-prefill's prompt table."""
+        if (
+            not forward_batch.forward_mode.is_extend()
+            or forward_batch.extend_seq_lens_cpu is None
+        ):
+            return forward_batch.mrope_positions
+
+        mm_inputs = forward_batch.mm_inputs or [None] * forward_batch.batch_size
+        lengths = forward_batch.extend_seq_lens_cpu
+        prefixes = forward_batch.extend_prefix_lens_cpu
+        if not any(
+            length > 0
+            and mm_input is not None
+            and mm_input.mrope_positions is not None
+            and mm_input.mrope_positions.shape[1] < prefix + length
+            for mm_input, prefix, length in zip(mm_inputs, prefixes, lengths)
+        ):
+            return forward_batch.mrope_positions
+
+        device = forward_batch.mrope_positions.device
+        positions_list = []
+        for mm_input, prefix, length in zip(mm_inputs, prefixes, lengths):
+            if length == 0:
+                continue
+            if mm_input is None or mm_input.mrope_positions is None:
+                text_positions = torch.arange(
+                    prefix, prefix + length, dtype=torch.int64, device=device
+                )
+                positions_list.append(text_positions.unsqueeze(0).repeat(3, 1))
+                continue
+
+            head = mm_input.mrope_positions[:, prefix : prefix + length].to(
+                device=device, dtype=torch.int64
+            )
+            if head.shape[1] < length:
+                if mm_input.mrope_position_delta is None:
+                    raise ValueError(
+                        "MossVL needs mrope_position_delta to rebuild generated-token positions"
+                    )
+                # Match decode: all three axes use delta + absolute text position.
+                tail = mm_input.mrope_position_delta.flatten().to(
+                    device
+                ) + torch.arange(
+                    prefix + head.shape[1],
+                    prefix + length,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                head = torch.cat([head, tail.unsqueeze(0).repeat(3, 1)], dim=1)
+            positions_list.append(head)
+
+        return torch.cat(positions_list, dim=1)
 
     # ---- Forward ----
 
@@ -1600,7 +1668,7 @@ class MossVLForConditionalGeneration(nn.Module):
         pp_proxy_tensors=None,
     ):
         if self.is_mrope_enabled:
-            positions = forward_batch.mrope_positions
+            positions = self._repair_mrope_positions(forward_batch)
 
         # 1. Collect vision inputs for uncached requests
         pixel_values, grid_thw, vision_position_ids = self._collect_mm_data(
@@ -1634,21 +1702,18 @@ class MossVLForConditionalGeneration(nn.Module):
             cross_attention_states = self._insert_separator_tokens(
                 vision_hidden_states, grid_thw
             )
-            # Drop heavy per-request vision tensors now that the encoder KV
-            # has been produced and will be cached. Otherwise pixel_values and
-            # vision_position_ids stay pinned on req.multimodal_inputs across
-            # the entire decode phase. (visible_frame_counts is shrunk to a
-            # single scalar element at the end of the last prefill chunk in
-            # get_full_text_row_masked_out_mask, so decode still works.)
-            # Note: the local `vision_position_ids` is still needed by the LM
-            # cross-attention below, so we keep it; but we drop the per-request
-            # copy on mm_input, which we won't read again.
+            # Release device memory, but keep CPU inputs for re-encoding after
+            # retraction. The local vision_position_ids still serves this forward.
             del pixel_values, vision_hidden_states
             for i, mm_input in enumerate(forward_batch.mm_inputs):
                 if forward_batch.encoder_cached[i] or mm_input is None:
                     continue
-                mm_input.release_features()
-                mm_input.vision_position_ids = None
+                for item in mm_input.mm_items:
+                    if item.feature is not None:
+                        item.feature = item.feature.to("cpu")
+                vpid = mm_input.vision_position_ids
+                if vpid is not None:
+                    mm_input.vision_position_ids = vpid.cpu()
 
         # 4. Run language model with cross attention
         hidden_states = self.language_model(

--- a/test/registered/unit/models/test_moss_vl_retraction.py
+++ b/test/registered/unit/models/test_moss_vl_retraction.py
@@ -1,0 +1,170 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.srt.models import moss_vl
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _model():
+    model = object.__new__(moss_vl.MossVLForConditionalGeneration)
+    torch.nn.Module.__init__(model)
+    model.spatial_merge_size = 1
+    model.is_mrope_enabled = True
+    model._get_vision_features = Mock(side_effect=lambda pixels, grid: pixels)
+    model._insert_separator_tokens = Mock(side_effect=lambda features, grid: features)
+    model.language_model = Mock(side_effect=lambda **kwargs: kwargs["positions"])
+    model.logits_processor = Mock(side_effect=lambda ids, hidden, *args: hidden)
+    return model
+
+
+def _mm_input(device="cpu"):
+    item = SimpleNamespace(
+        feature=torch.arange(8, dtype=torch.float32, device=device).reshape(4, 2),
+        grid_thw=torch.tensor([[2, 1, 1]]),
+        acknowledge_deferred_cuda_ipc_feature=lambda: None,
+    )
+    return moss_vl.MultimodalInputs(
+        mm_items=[item],
+        vision_position_ids=torch.arange(4, device=device).repeat(3, 1),
+        visible_frame_counts=torch.tensor([0, 1, 2]),
+        mrope_positions=torch.tensor([[4, 5, 6]]).repeat(3, 1),
+        mrope_position_delta=torch.tensor([4]),
+    )
+
+
+def _batch(mm, length=3, prefix=0, device="cpu"):
+    return SimpleNamespace(
+        batch_size=1,
+        forward_mode=SimpleNamespace(is_decode=lambda: False, is_extend=lambda: True),
+        encoder_cached=[False],
+        encoder_lens=torch.tensor([4], device=device),
+        encoder_lens_cpu=[4],
+        seq_lens=torch.tensor([prefix + length], device=device),
+        extend_seq_lens=torch.tensor([length], device=device),
+        extend_seq_lens_cpu=[length],
+        extend_prefix_lens_cpu=[prefix],
+        mm_inputs=[mm],
+        mrope_positions=mm.mrope_positions[:, prefix : prefix + length].to(device),
+    )
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA unavailable"
+            ),
+        ),
+    ],
+)
+def test_repeated_prefill_preserves_vision_inputs_and_prompt_visibility(
+    monkeypatch, device
+):
+    monkeypatch.setattr(moss_vl, "get_is_capture_mode", lambda: False)
+    model, mm = _model(), _mm_input(device)
+    original_feature = mm.mm_items[0].feature.cpu().clone()
+    original_positions = mm.vision_position_ids.cpu().clone()
+
+    # Repeat encoder computation as a retracted request accumulates output tokens.
+    for length in (3, 5, 7):
+        batch = _batch(mm, length=length, device=device)
+        model.prepare_forward_batch(batch)
+        expected = torch.ones(length, 4, dtype=torch.uint8, device=device)
+        expected[0] = 0
+        expected[1, 2:] = 0
+        torch.testing.assert_close(
+            batch.cross_attention_custom_mask.reshape(length, 4), expected
+        )
+
+        result = model.forward(
+            torch.arange(length, device=device), batch.mrope_positions, batch
+        )
+        torch.testing.assert_close(
+            result.cpu(), torch.arange(4, 4 + length).repeat(3, 1)
+        )
+        assert mm.mm_items[0].feature.device.type == "cpu"
+        torch.testing.assert_close(mm.mm_items[0].feature, original_feature)
+        torch.testing.assert_close(mm.vision_position_ids, original_positions)
+        torch.testing.assert_close(mm.visible_frame_counts, torch.tensor([0, 1, 2]))
+        assert model._get_vision_features.call_args.args[0].device.type == device
+
+    # Normal request cleanup must still be able to release the retained inputs.
+    mm.release_features()
+    assert mm.mm_items[0].feature is None
+
+
+@pytest.mark.parametrize("prefix,length", [(0, 5), (1, 4), (3, 2), (5, 2)])
+def test_reprefill_mask_and_positions_with_cached_text_prefix(prefix, length):
+    model, mm = _model(), _mm_input()
+    batch = _batch(mm, length=length, prefix=prefix)
+    model.prepare_forward_batch(batch)
+    expected_counts = torch.tensor([0, 1, 2, 2, 2, 2, 2])[prefix : prefix + length]
+    expected = torch.arange(4)[None, :] // 2 < expected_counts[:, None]
+    torch.testing.assert_close(
+        batch.cross_attention_custom_mask.reshape(length, 4).bool(), expected
+    )
+    row_mask = model.get_full_text_row_masked_out_mask(batch)
+    torch.testing.assert_close(row_mask[:, 0], expected_counts > 0)
+    positions = model._repair_mrope_positions(batch)
+    torch.testing.assert_close(
+        positions, torch.arange(4 + prefix, 4 + prefix + length).repeat(3, 1)
+    )
+
+
+def test_mixed_reprefill_preserves_per_request_mask_offsets():
+    model = _model()
+    first, second = _mm_input(), _mm_input()
+    batch = _batch(first, length=2, prefix=3)
+    batch.batch_size = 3
+    batch.mm_inputs = [first, None, second]
+    batch.encoder_lens_cpu = [4, 0, 4]
+    batch.extend_seq_lens_cpu = [2, 2, 2]
+    batch.extend_prefix_lens_cpu = [3, 5, 1]
+    mask = model._build_cross_attention_custom_mask(batch)
+    expected = torch.tensor(
+        [[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 0, 0], [1, 1, 1, 1]], dtype=torch.uint8
+    )
+    torch.testing.assert_close(mask, expected.flatten())
+    positions = model._repair_mrope_positions(batch)
+    torch.testing.assert_close(
+        positions, torch.tensor([[7, 8, 5, 6, 5, 6]]).repeat(3, 1)
+    )
+
+
+def test_cached_encoder_does_not_require_released_features():
+    model, mm = _model(), _mm_input()
+    mm.release_features()
+    batch = _batch(mm)
+    batch.encoder_cached = [True]
+    assert model._collect_mm_data(batch) == (None, None, None)
+    batch.encoder_cached = [False]
+    with pytest.raises(RuntimeError, match="without its vision features"):
+        model._collect_mm_data(batch)
+
+
+@pytest.mark.parametrize("is_extend,lengths", [(False, [3]), (True, None), (True, [3])])
+def test_mrope_fast_path_preserves_existing_tensor(is_extend, lengths):
+    model, mm = _model(), _mm_input()
+    batch = _batch(mm)
+    batch.forward_mode.is_extend = lambda: is_extend
+    batch.extend_seq_lens_cpu = lengths
+    assert model._repair_mrope_positions(batch) is batch.mrope_positions
+
+
+def test_short_mrope_table_requires_position_delta():
+    model, mm = _model(), _mm_input()
+    mm.mrope_position_delta = None
+    with pytest.raises(ValueError, match="mrope_position_delta"):
+        model._repair_mrope_positions(_batch(mm, length=5))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

MossVL drops request-local visual features and vision positions after the first encoder forward, and reduces `visible_frame_counts` to its final entry. A decode request retracted and requeued for prefill still needs those inputs: re-encoding receives `None` features, while rebuilding the cross-attention mask can fail with a shape mismatch or produce an all-zero mask for a cached text prefix.

Re-prefill may also extend beyond a request's available MRoPE table. The model needs a complete position column for every query token, including a prefix that already extends past the original prompt.

## Modifications

- Retain visual features and vision positions on CPU until normal request cleanup; transfer them to the active device when encoder KV must be recomputed.
- Preserve the prompt's complete frame-visibility table. For generated tokens, repeat its final visibility row instead of truncating the table or reading an undersized slice.
- Add a MossVL-local fallback that preserves existing prompt positions and fills missing generated-token positions using the decode delta convention. Decode, speculative modes without extend lengths, and already complete tables keep their existing positions.
- Register CPU regressions for repeated prefill, cached prefixes, per-request mask offsets, cached encoders, and MRoPE edge cases. An optional CUDA case verifies device-to-host retention and restoration.

This is limited to the MossVL model and its tests; it does not include the separate Ascend backend adaptations.

## Accuracy Tests

```bash
PYTHONPATH=python PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -B -m pytest -q -p no:cacheprovider \
  test/registered/unit/models/test_moss_vl_retraction.py \
  test/registered/unit/models/test_moss_vl_processor.py
```

- **19 passed**, including CPU and CUDA cases, on an H200 node with Python 3.12, PyTorch 2.11 and Transformers 5.12.1.
- Loading the unmodified upstream model in memory makes the repeated-prefill regression fail on both CPU and CUDA because retained features are `None`.
- The lifecycle tests use the real model orchestration and metadata methods with mocked vision/language computations; they are not full-model accuracy benchmarks.
- A full-server smoke test with `SGLANG_TEST_RETRACT=1`, interval 8 and radix cache disabled was attempted, but startup stopped at the dependency check: the available environment has FlashInfer 0.6.14, while current main requires >=0.6.18. No end-to-end or fully pinned current-main validation is claimed; upstream CI is still needed.

## Speed Tests and Profiling

Not benchmarked. Keeping CPU copies adds device-to-host transfers after an uncached encoder forward and retains host memory until request completion. Re-encoding restores those inputs to the device; cached-encoder and ordinary decode requests do not repeat the transfer.

## Checklist

- [x] Format and selected static checks passed with the repository's isort 7.0.0 and Ruff 0.15.1 versions.
- [x] Add registered CPU tests with optional CUDA coverage.
- [ ] Run full-model accuracy and speed validation in a current-main dependency environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34123907100](https://github.com/sgl-project/sglang/actions/runs/34123907100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34123906517](https://github.com/sgl-project/sglang/actions/runs/34123906517)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34123907021](https://github.com/sgl-project/sglang/actions/runs/34123907021)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->