### PR TITLE
[Bugfix] MoE runtime LoRA: nondeterministic logprobs and greedy flips on identical inputs (temperature=0, small-batch decode)

### DIFF
--- a/python/sglang/kernels/ops/moe/virtual_experts.py
+++ b/python/sglang/kernels/ops/moe/virtual_experts.py
@@ -270,7 +270,15 @@ def _invoke_moe_lora_shrink_splitk(
     num_n_blocks = triton.cdiv(N, BLOCK_SIZE_N)
     base_grid = num_m_blocks * num_n_blocks
     max_split_k = max(1, K // BLOCK_SIZE_K)
-    SPLIT_K = min(max_split_k, max(1, 128 // base_grid)) if base_grid < 128 else 1
+    # Force SPLIT_K=1: the split-K path accumulates partial sums with
+    # tl.atomic_add(sem="relaxed"), whose accumulation order is nondeterministic
+    # run-to-run. This produces measurable logprob drift (up to ~0.7 nats at
+    # near-tied tokens) and greedy argmax flips on identical inputs for small
+    # decode batches (base_grid < 128, e.g. single-request decode with
+    # num_m_blocks x num_n_blocks = 1x2 previously picked SPLIT_K up to 64).
+    # Batches with base_grid >= 128 already used SPLIT_K=1, so
+    # high-concurrency serving throughput is unaffected.
+    SPLIT_K = 1
 
     grid = (SPLIT_K * base_grid,)
 


### PR DESCRIPTION
## Problem

The virtual-experts LoRA shrink kernel (`_invoke_moe_lora_shrink_splitk`) uses split-K with relaxed atomic accumulation for small batches:

```python
SPLIT_K = min(max_split_k, max(1, 128 // base_grid)) if base_grid < 128 else 1
```

For small decode batches (base_grid < 128 — e.g. a single request decoding with
num_m_blocks x num_n_blocks = 1x2) SPLIT_K can reach 64. The partial sums are
accumulated with `tl.atomic_add(sem="relaxed")`; floating-point addition order
across CTAs is nondeterministic run-to-run, which after many layers produces
measurable logprob drift and greedy argmax flips **on identical inputs with
temperature=0**.

## Change

Force `SPLIT_K = 1` in `_invoke_moe_lora_shrink_splitk`. With SPLIT_K=1 each
output element is written exactly once via `tl.store`, making the kernel
deterministic for a given input. Batches with base_grid >= 128 already used
SPLIT_K=1, so high-concurrency serving throughput is unaffected; only
small-batch LoRA latency changes.

This is the MoE counterpart of the dense attention LoRA shrink kernel
(`chunked_sgmv_shrink`), which avoids split-K entirely.

## Test results (GLM-5.3 MoE + shared-outer LoRA, B300 1P1D, temperature=0)

Test setup: identical 2-message prompt, `max_tokens=8`, `logprobs=true`,
`top_logprobs=5`. Each run records the full sequence of
(token id, logprob) pairs; "identical" = same token ids **and** same logprob
values to 1e-6 across runs.

### Before the fix (unpatched)

Sequential single requests, 8 runs:

| run | top-1 token | logprob |
|---|---|---|
| 0 | `</think>` | -0.350815 |
| 1 | `</think>` | -0.071657 |
| 2 | `</think>` | -0.004741 |
| 3 | `</think>` | -0.038808 |
| 4 | `</think>` | -0.252851 |
| 5 | `</think>` | -0.633645 |
| 6 | `</think>` | -0.089512 |
| 7 | `</think>` | -0.161512 |

**8/8 runs unique** — logprob swings ~0.6 nats on identical inputs. In another
6-run series the argmax itself flipped between `</think>` and `Let`
(logprob -0.01 .. -0.66). Control: the same prompt **without** LoRA
(base model) was stable, isolating the drift to the runtime-LoRA path.

### After the fix (patched)

| test | result |
|---|---|
| warm prefix (cached), same request ×4 | **4/4 identical** (token ids + logprobs to 1e-6) |
| fixed nonce (cold prefix) ×6 | runs 2-6 **bit-identical**; run 1 differs only in the last logprob decimals (fresh-compute vs cache-reuse path, argmax unchanged) |
| base / LoRA alternating ×6 | each adapter state returns to the exact same (token, logprob) on every revisit |
| long generation (max_tokens=64) ×8 | **7/8 outputs byte-identical** (the 1/8 diverged only at ~token 20; remaining rare source is a separate dense-kernel split-K pattern already absent upstream) |

Note: on our fork stack the dense attention LoRA shrink kernel
(`chunked_sgmv_shrink`) carried the same split-K-atomic pattern and was fixed
with an equivalent change; upstream already avoids it there, so this PR only
ports the virtual-experts (MoE) half.