### PR TITLE
Stop --default-chat-template-kwargs from outranking a request's reasoning_effort

### DIFF
--- a/docs/docs/basic_usage/openai_api_completions.mdx
+++ b/docs/docs/basic_usage/openai_api_completions.mdx
@@ -196,7 +196,7 @@ python -m sglang.launch_server \
 2. The value in `--default-chat-template-kwargs`
 3. The model's chat-template default
 
-`reasoning_effort` follows a separate normalization path, so the precedence list above does not apply to it. Configure `reasoning_effort` in either the server defaults or individual requests, not both.
+A `reasoning_effort` sent inside the request's `chat_template_kwargs` follows the same precedence as any other key. The top-level OpenAI `reasoning_effort` field is different: it never passes through `chat_template_kwargs`, so `--default-chat-template-kwargs` still outranks it. Send the effort in `chat_template_kwargs` when you need a per-request value to win over the server default.
 
 The accepted keys are model-specific. For example, Qwen3 uses `enable_thinking`, while other model families may use `thinking` or may not expose a reasoning toggle. The reasoning parser controls how reasoning tokens are separated from the response; it does not by itself enable reasoning in the chat template.
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1097,7 +1097,11 @@ class OpenAIServingChat(OpenAIServingBase):
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
 
         # Process messages and apply chat template
-        processed_messages = self._process_messages(request, is_multimodal)
+        processed_messages = self._process_messages(
+            request,
+            is_multimodal,
+            effort_from_template_kwargs=reasoning_effort is not None,
+        )
         # Build sampling parameters
         sampling_params = request.to_sampling_params(
             stop=processed_messages.stop,
@@ -1199,12 +1203,28 @@ class OpenAIServingChat(OpenAIServingBase):
         return adapted_request, request
 
     def _process_messages(
-        self, request: ChatCompletionRequest, is_multimodal: bool
+        self,
+        request: ChatCompletionRequest,
+        is_multimodal: bool,
+        effort_from_template_kwargs: bool = False,
     ) -> MessageProcessingResult:
-        """Process chat messages and apply chat template"""
+        """Process chat messages and apply chat template.
+
+        ``effort_from_template_kwargs`` says the request itself sent
+        ``chat_template_kwargs["reasoning_effort"]``, which
+        ``_convert_to_internal_request`` has already popped onto
+        ``request.reasoning_effort``. Without it the ``setdefault`` below cannot
+        tell a request that chose an effort from one that did not, inserts the
+        server default, and ``_apply_jinja_template``'s
+        ``extra_template_kwargs.update(request.chat_template_kwargs)`` then
+        renders with the default -- the one ``chat_template_kwargs`` key where
+        the server would outrank the request.
+        """
         if self.default_chat_template_kwargs:
             ctk = dict(request.chat_template_kwargs or {})
             for k, v in self.default_chat_template_kwargs.items():
+                if k == "reasoning_effort" and effort_from_template_kwargs:
+                    continue
                 ctk.setdefault(k, v)
             request.chat_template_kwargs = ctk
             effort = ctk.get("reasoning_effort")

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -700,6 +700,83 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.assertTrue(adapted.require_reasoning)
 
+    def _render_template_kwargs(self, request) -> dict:
+        """Drive the real request path and return the kwargs the template got."""
+        self.template_manager.chat_template_name = None
+        captured = {}
+
+        def fake_apply(messages, **kwargs):
+            captured.update(kwargs)
+            return "PROMPT"
+
+        self.chat.tokenizer_manager.tokenizer.apply_chat_template = fake_apply
+        self.chat.tokenizer_manager.tokenizer.encode = lambda text, **kw: [1, 2, 3]
+        self.chat._convert_to_internal_request(request, None)
+        return captured
+
+    # `_convert_to_internal_request` pops `reasoning_effort` out of
+    # `chat_template_kwargs` and onto `request.reasoning_effort`, so the
+    # `--default-chat-template-kwargs` merge cannot otherwise tell a request that
+    # chose an effort from one that did not. These pin the value that actually
+    # reaches `apply_chat_template`.
+    def test_request_chat_template_kwargs_effort_beats_the_server_default(self):
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "medium"}
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            chat_template_kwargs={"reasoning_effort": "xhigh"},
+        )
+
+        captured = self._render_template_kwargs(request)
+
+        self.assertEqual(captured.get("reasoning_effort"), "xhigh")
+        self.assertEqual(request.reasoning_effort, "xhigh")
+
+    def test_other_defaults_still_merge_when_the_request_pins_the_effort(self):
+        self.chat.default_chat_template_kwargs = {
+            "reasoning_effort": "medium",
+            "thinking": True,
+        }
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            chat_template_kwargs={"reasoning_effort": "xhigh"},
+        )
+
+        captured = self._render_template_kwargs(request)
+
+        self.assertEqual(captured.get("reasoning_effort"), "xhigh")
+        self.assertIs(captured.get("thinking"), True)
+
+    def test_default_reasoning_effort_applies_when_the_request_is_silent(self):
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "medium"}
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+        )
+
+        captured = self._render_template_kwargs(request)
+
+        self.assertEqual(captured.get("reasoning_effort"), "medium")
+        self.assertEqual(request.reasoning_effort, "medium")
+
+    def test_top_level_reasoning_effort_still_loses_to_the_server_default(self):
+        # Characterization, not an endorsement. The OpenAI top-level field never
+        # passes through `chat_template_kwargs`, so the server default still wins
+        # for it -- the same precedence
+        # `test_k2_output_parser_reuses_effective_template_default` pins for the
+        # Responses API's `reasoning.effort`. Flipping it is a separate decision.
+        self.chat.default_chat_template_kwargs = {"reasoning_effort": "medium"}
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            reasoning_effort="xhigh",
+        )
+
+        captured = self._render_template_kwargs(request)
+
+        self.assertEqual(captured.get("reasoning_effort"), "medium")
+
     def test_process_messages_records_template_reasoning_state(self):
         self.chat.default_chat_template_kwargs = {"thinking": True}
         self.template_manager.reasoning_config = ReasoningToggleConfig(


### PR DESCRIPTION
## Motivation

Fixes #38104.

> **Measured on a real server, both halves.** @pinkgom ran this on production (2 × H200 NVL, `Qwen/Qwen3.8-Flash-Next-FP8`, TP2+EP2, image `593134d`, model's own chat template), server started with `--default-chat-template-kwargs '{"reasoning_effort": "medium"}'`, effort sent per request in `chat_template_kwargs`. Only `serving_chat.py` differs between the two columns.
>
> Two-step arithmetic prompt, "show your reasoning":
>
> | request asks for | stock: reasoning chars / completion tokens | with this PR |
> | --- | ---: | ---: |
> | `low` | 1089 / 1053 | 1627 / 1006 |
> | `medium` | 1145 / 1057 | 1771 / 1171 |
> | `xhigh` | 1300 / 1060 | **13926 / 4893** |
>
> On stock the three are 1053 / 1057 / 1060 — the server default renders whatever the request asked for. On this branch `xhigh` is ~8× the reasoning and ~4.5× the completion tokens, and `medium` reproduces the stock number exactly, which is the sanity check that the server default still applies when the request agrees with it.
>
> They also closed their own #38105 in favour of this PR, having confirmed the trap described below breaks `test_serving_responses.py`.

`_convert_to_internal_request` pops `reasoning_effort` out of the request's `chat_template_kwargs` and stores it on `request.reasoning_effort`:

```python
reasoning_effort = (
    request.chat_template_kwargs.pop("reasoning_effort", None)
    if request.chat_template_kwargs
    else None
)
```

By the time `_process_messages` merges `--default-chat-template-kwargs`, the dict no longer records that the request chose one, so `setdefault` inserts the server default. `_apply_jinja_template` then does:

```python
if request.reasoning_effort is not None:
    extra_template_kwargs["reasoning_effort"] = request.reasoning_effort
if request.chat_template_kwargs:
    extra_template_kwargs.update(request.chat_template_kwargs)   # default wins
```

so the default overwrites the request's own value. `reasoning_effort` is the only `chat_template_kwargs` key where the server outranks the request.

Observed by driving the real request path with `apply_chat_template` captured — server default `medium`, request asking for `xhigh`:

```
after _convert_to_internal_request:
    request.reasoning_effort   = xhigh
    request.chat_template_kwargs = {'reasoning_effort': 'medium', 'thinking': True}
apply_chat_template got reasoning_effort = medium      # on main
apply_chat_template got reasoning_effort = xhigh       # this branch
```

## Modifications

Carry the fact that the request supplied one from the pop site to the merge, as an explicit `effort_from_template_kwargs` argument on `_process_messages`, and skip the default for that key when it is set. Both are in `_convert_to_internal_request`, so nothing new is stashed on the request object.

The argument defaults to `False`, so the two other callers of `_process_messages` — `serving_tokenize.py:102` and `serving_responses.py:602` — keep today's precedence.

**That last part is deliberate, and it is the one thing worth a maintainer's eye.** My first attempt keyed the guard off `request.reasoning_effort is not None`, which also flipped the Responses API and broke `test_k2_output_parser_reuses_effective_template_default`:

```python
# Template kwargs are the final render inputs, so the server default
# below takes precedence over this API convenience field.
reasoning={"effort": "medium"},
...
self.assertEqual(render_call.kwargs["reasoning_effort"], "low")
```

That reads as an intentional decision, so I scoped the fix instead of reversing it. The consequence is that #38104 is half-fixed on purpose: a `reasoning_effort` inside `chat_template_kwargs` now wins, and the **top-level OpenAI `reasoning_effort` field still loses** to the server default, matching the Responses API. `test_top_level_reasoning_effort_still_loses_to_the_server_default` records that rather than leaving it untested.

If you would rather the top-level field win too, that is a two-line follow-up here plus a decision about the K2 Responses test, and I am happy to do it either way — I did not want to reverse a documented behaviour on my own reading.

The docs paragraph that carried the workaround ("Configure `reasoning_effort` in either the server defaults or individual requests, not both") is replaced with the actual precedence.

## Accuracy Test

Four cases in `test_serving_chat.py`, all asserting on the kwargs that reach `apply_chat_template`, not on intermediate state:

| test | on `main` | here |
| --- | --- | --- |
| request's `chat_template_kwargs` effort beats the server default | ❌ `'medium' != 'xhigh'` | ✅ |
| other defaults still merge when the request pins the effort | ❌ | ✅ |
| server default applies when the request is silent | ✅ | ✅ |
| top-level field still loses to the server default | ✅ | ✅ |

```bash
pytest -q test/registered/unit/entrypoints/openai/
# 8 failed, 344 passed        (this branch)
# 8 failed, 340 passed        (pristine main)
```

The 8 are identical in both runs — `test_serving_transcription.py` and `test_audio_chunking.py`, from optional audio deps missing in my environment. I diffed the two `FAILED` lists: no test changes state except the four added here.

`pre-commit run --files ...` passes on all three files.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34128631349](https://github.com/sgl-project/sglang/actions/runs/34128631349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34128631110](https://github.com/sgl-project/sglang/actions/runs/34128631110)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34128631283](https://github.com/sgl-project/sglang/actions/runs/34128631283)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

