### PR TITLE
[CI] Fix request receiver EP scale joiner test patch

### DIFF
--- a/test/registered/unit/managers/test_pp_cp_rank_offsets.py
+++ b/test/registered/unit/managers/test_pp_cp_rank_offsets.py
@@ -128,9 +128,10 @@ class TestRequestReceiverBroadcast(unittest.TestCase):
                 return_value=parallel,
             ),
             patch(
-                "sglang.srt.managers.scheduler_components.request_receiver."
-                "is_ep_scale_joiner",
-                return_value=False,
+                "sglang.srt.managers.scheduler_components.request_receiver.get_exec",
+                return_value=SimpleNamespace(
+                    moe=SimpleNamespace(is_ep_scale_joiner=False)
+                ),
             ),
             patch(
                 "sglang.srt.managers.scheduler_components.request_receiver."


### PR DESCRIPTION
## Summary

- Fix `test_default_control_uses_full_tp_broadcast` to patch the current `request_receiver.get_exec()` read path.
- Provide a fake exec bag with `moe.is_ep_scale_joiner = False`, matching `SchedulerRequestReceiver._broadcast_reqs_across_ranks` after the config bag migration.

## Evidence

- Affected monitor PR: https://github.com/sgl-project/sglang/pull/37058
- Failing job: https://github.com/sgl-project/sglang/actions/runs/34130397012/job/101769089183
- Failure: `AttributeError: request_receiver module does not have the attribute is_ep_scale_joiner` in `test/registered/unit/managers/test_pp_cp_rank_offsets.py::TestRequestReceiverBroadcast::test_default_control_uses_full_tp_broadcast`.
- The `#37058` diff does not touch `request_receiver.py` or `test_pp_cp_rank_offsets.py`.
- Current `main` reads `get_exec().moe.is_ep_scale_joiner` in `request_receiver.py`, while the test was still patching the old module-level symbol after `#38113`.

## Validation

- `python3 -m py_compile test/registered/unit/managers/test_pp_cp_rank_offsets.py`
- `git diff --check`
- Full local test execution was not available in this checkout because the local Python environment is missing repo dependencies such as `numpy`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34132221430](https://github.com/sgl-project/sglang/actions/runs/34132221430)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34132266320](https://github.com/sgl-project/sglang/actions/runs/34132266320)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34132221316](https://github.com/sgl-project/sglang/actions/runs/34132221316)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->