### PR TITLE
[Qwen3-Next] Fix cycling tokens in response for Qwen3-Next-80B-A3B

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -562,6 +562,7 @@ class Qwen3HybridLinearDecoderLayer(nn.Module):
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
             allow_reduce_scatter=True,
+            is_last_layer=(layer_id == config.num_hidden_layers - 1),
         )
 
     def forward(
@@ -734,6 +735,7 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
             allow_reduce_scatter=True,
+            is_last_layer=(layer_id == config.num_hidden_layers - 1),
         )
 
         self.alt_stream = alt_stream


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Implement fix from PR https://github.com/sgl-project/sglang/pull/19411 for Qwen3-Next model

## Modifications

Similarly to the aforementioned fix, `Qwen3HybridLinearDecoderLayer` and `Qwen3HybridAttentionDecoderLayer` did not pass `is_last_layer` parameter when initializing the `LayerCommunicator`

## Accuracy Tests

Launched the engine with tensor parallelism, using the following command

```bash
sglang serve --model "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8" --host 0.0.0.0 --port 17017 --tensor-parallel-size 2
```

Sent input request via OpenAI library for Python:

```python
import json
from openai import OpenAI

req = json.loads("""{
  "model": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
  "stream": false,
  "temperature": 0.3,
  "top_p": 0.9,
  "seed": 0,
  "max_tokens": 4096,
  "extra_body": {
    "return_token_ids": true
  },
  "messages": [
    {
      "role": "system",
      "content": "Audit the fictional records below. Return only JSON matching the schema. Similar-looking records are not necessarily duplicates. Mention each record ID at most once in accepted or rejected."
    },
    {
      "role": "user",
      "content": "R01: sensor A, sample 14, value 81, calibration valid, timestamp valid.\nR02: sensor A, sample 14, value 81, exact retransmission of R01.\nR03: sensor A, sample 15, value 81, calibration valid, timestamp valid.\nR04: sensor B, sample 14, value 18, calibration expired, timestamp valid.\nR05: sensor B, sample 14, value 18, calibration renewed after measurement.\nR06: sensor C, sample 22, value missing, calibration valid, timestamp valid.\nR07: sensor C, sample 23, value 44, calibration valid, timestamp malformed.\nR08: sensor D, sample 31, value 57, calibration valid, timestamp valid.\nR09: sensor D, sample 31, value 57, same payload as R08 but independent device signature.\nR10: sensor E, sample 40, value 102, outside documented range 0 through 100.\nR11: sensor E, sample 41, value 100, calibration valid, timestamp valid.\nR12: sensor F, sample 50, value 62, calibration status unknown, timestamp valid.\nPolicy: reject exact retransmissions, missing values, measurements taken with expired calibration, malformed timestamps, and out-of-range values. Independent signed measurements are retained even when their values match. Unknown calibration status must be reported as ambiguous rather than accepted or rejected."
    }
  ],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "record_audit",
      "strict": true,
      "schema": {
        "type": "object",
        "properties": {
          "overview": {
            "type": "string"
          },
          "accepted": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "record_id": {
                  "type": "string"
                },
                "reason": {
                  "type": "string"
                }
              },
              "required": [
                "record_id",
                "reason"
              ],
              "additionalProperties": false
            }
          },
          "rejected": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "record_id": {
                  "type": "string"
                },
                "reason": {
                  "type": "string"
                }
              },
              "required": [
                "record_id",
                "reason"
              ],
              "additionalProperties": false
            }
          },
          "ambiguous": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "record_id": {
                  "type": "string"
                },
                "reason": {
                  "type": "string"
                }
              },
              "required": [
                "record_id",
                "reason"
              ],
              "additionalProperties": false
            }
          },
          "verification_steps": {
            "type": "array",
            "items": {
              "type": "string"
            }
          },
          "final_note": {
            "type": "string"
          }
        },
        "required": [
          "overview",
          "accepted",
          "rejected",
          "ambiguous",
          "verification_steps",
          "final_note"
        ],
        "additionalProperties": false
      }
    }
  }
}""")

client = OpenAI(base_url="http://0.0.0.0:17017/v1", api_key="dummy-key")
client.chat.completions.create(**req)
```

Output before:

```
ChatCompletion(id='9167914b459e43978cf8334b28bf864c', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content='{\n  "overview": "Audit completed per policy.",\n  "accepted": [\n    {\n      "record_id": "R03"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within range."\n    },\n    {\n      "record_id": "R08"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within range."\n    },\n    {\n      "record_id": "R09"\n    ,\n      "reason": "Independent device signature, even though payload matches R08."\n    },\n    {\n      "record_id": "R11"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within documented range."\n    }\n  ],\n  "rejected": [\n    {\n      "record_id": "R01"\n    ,\n      "reason": "Exact retransmission of R02."\n    },\n    {\n      "record_id": "R02"\n    ,\n      "reason": "Exact retransmission of R01."\n    },\n    {\n      "record_id": "R04"\n    ,\n      "reason": "Calibration expired at time of measurement."\n    },\n    {\n      "record_id": "R06"\n    ,\n      "reason": "Missing value."\n    },\n    {\n      "record_id": "R07"\n    ,\n      "reason": "Malformed timestamp."\n    },\n    {\n      "record_id": "R10"\n    ,\n      "reason": "Value 102 outside documented range 0 through 100."\n    }\n  ],\n  "ambiguous": [\n    {\n      "record_id": "R12"\n    ,\n      "reason": "Calibration status unknown."\n    }\n  ]\n  \n  \n  \n  \n  \n  \n  \n  \n  \n  \n  \n  \n  <...>', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content=None), matched_stop=None, prompt_token_ids=[151644, 8948, 198, 74516, 279, 43582, 7424, 3685, 13, 3411, 1172, 4718, 12579, 279, 10802, 13, 21476, 30248, 7424, 525, 537, 14312, 42328, 13, 85148, 1817, 3255, 3034, 518, 1429, 3055, 304, 11666, 476, 17551, 13, 151645, 198, 151644, 872, 198, 49, 15, 16, 25, 12002, 362, 11, 6077, 220, 16, 19, 11, 897, 220, 23, 16, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 17, 25, 12002, 362, 11, 6077, 220, 16, 19, 11, 897, 220, 23, 16, 11, 4734, 312, 1458, 2728, 315, 431, 15, 16, 624, 49, 15, 18, 25, 12002, 362, 11, 6077, 220, 16, 20, 11, 897, 220, 23, 16, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 19, 25, 12002, 425, 11, 6077, 220, 16, 19, 11, 897, 220, 16, 23, 11, 37611, 26391, 11, 11441, 2697, 624, 49, 15, 20, 25, 12002, 425, 11, 6077, 220, 16, 19, 11, 897, 220, 16, 23, 11, 37611, 35546, 1283, 18662, 624, 49, 15, 21, 25, 12002, 356, 11, 6077, 220, 17, 17, 11, 897, 7402, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 22, 25, 12002, 356, 11, 6077, 220, 17, 18, 11, 897, 220, 19, 19, 11, 37611, 2697, 11, 11441, 79250, 624, 49, 15, 23, 25, 12002, 422, 11, 6077, 220, 18, 16, 11, 897, 220, 20, 22, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 24, 25, 12002, 422, 11, 6077, 220, 18, 16, 11, 897, 220, 20, 22, 11, 1852, 7729, 438, 431, 15, 23, 714, 9489, 3671, 11957, 624, 49, 16, 15, 25, 12002, 468, 11, 6077, 220, 19, 15, 11, 897, 220, 16, 15, 17, 11, 4889, 26372, 2088, 220, 15, 1526, 220, 16, 15, 15, 624, 49, 16, 16, 25, 12002, 468, 11, 6077, 220, 19, 16, 11, 897, 220, 16, 15, 15, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 16, 17, 25, 12002, 434, 11, 6077, 220, 20, 15, 11, 897, 220, 21, 17, 11, 37611, 2639, 9788, 11, 11441, 2697, 624, 13825, 25, 7850, 4734, 312, 1458, 5176, 11, 7402, 2750, 11, 21595, 4429, 448, 26391, 37611, 11, 79250, 48781, 11, 323, 700, 8668, 30508, 2750, 13, 21994, 8499, 21595, 525, 34263, 1496, 979, 862, 2750, 2432, 13, 21693, 37611, 2639, 1969, 387, 4961, 438, 54761, 4751, 1091, 11666, 476, 17551, 13, 151645, 198, 151644, 77091, 198], response_token_ids=[515, 220, 330, 78, 423, 1050, 788, 330, 74516, 8145, 817, 4842, 10346, 220, 330, 54574, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 18, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 2088, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 23, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 2088, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 24, 698, 262, 13493, 414, 330, 19895, 788, 330, 76821, 3671, 11957, 11, 1496, 3498, 7729, 9071, 431, 15, 23, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 16, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 26372, 2088, 10040, 262, 456, 220, 3211, 220, 330, 95353, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 16, 698, 262, 13493, 414, 330, 19895, 788, 330, 57954, 312, 1458, 2728, 315, 431, 15, 17, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 17, 698, 262, 13493, 414, 330, 19895, 788, 330, 57954, 312, 1458, 2728, 315, 431, 15, 16, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 19, 698, 262, 13493, 414, 330, 19895, 788, 330, 8851, 18350, 26391, 518, 882, 315, 18662, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 21, 698, 262, 13493, 414, 330, 19895, 788, 330, 25080, 897, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 22, 698, 262, 13493, 414, 330, 19895, 788, 330, 29600, 10155, 11441, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 15, 698, 262, 13493, 414, 330, 19895, 788, 330, 1130, 220, 16, 15, 17, 4889, 26372, 2088, 220, 15, 1526, 220, 16, 15, 15, 10040, 262, 456, 220, 3211, 220, 330, 90213, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 17, 698, 262, 13493, 414, 330, 19895, 788, 330, 8851, 18350, 2639, 9788, 10040, 262, 456, 220, 5133, 2303, 2303, 2303, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779, 30779,<...>])], created=1788789977, model='Qwen/Qwen3-Next-80B-A3B-Instruct-FP8', object='chat.completion', metadata={'weight_version': 'default', 'weight_versions': [{'version': 'default', 'start': 0, 'end': 4096}]}, moderation=None, service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=4096, prompt_tokens=386, total_tokens=4482, completion_tokens_details=None, prompt_tokens_details=None, reasoning_tokens=0))
```

<img width="1287" height="619" alt="Screenshot 2026-09-07 at 5 22 22 PM" src="https://github.com/user-attachments/assets/16a7f406-406c-421c-88a1-ea5e0fdee523" />

Output after:

```
ChatCompletion(id='8824e3f7bcbe4ef483284471e8831e0e', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='{\n  "overview": "Audit completed per policy.",\n  "accepted": [\n    {\n      "record_id": "R03"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within range."\n    },\n    {\n      "record_id": "R08"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within range."\n    },\n    {\n      "record_id": "R09"\n    ,\n      "reason": "Independent device signature, even though payload matches R08."\n    },\n    {\n      "record_id": "R11"\n    ,\n      "reason": "Valid calibration, valid timestamp, value within documented range."\n    }\n  ],\n  "rejected": [\n    {\n      "record_id": "R01"\n    ,\n      "reason": "Exact retransmission of R02; policy requires rejection of duplicates."\n    },\n    {\n      "record_id": "R02"\n    ,\n      "reason": "Exact retransmission of R01; policy requires rejection of duplicates."\n    },\n    {\n      "record_id": "R04"\n    ,\n      "reason": "Calibration expired at time of measurement."\n    },\n    {\n      "record_id": "R06"\n    ,\n      "reason": "Missing value."\n    },\n    {\n      "record_id": "R07"\n    ,\n      "reason": "Malformed timestamp."\n    },\n    {\n      "record_id": "R10"\n    ,\n      "reason": "Value 102 exceeds documented range (0–100)."\n    }\n  ],\n  "ambiguous": [\n    {\n      "record_id": "R05"\n    ,\n      "reason": "Calibration renewed after measurement — status at time of measurement is unclear."\n    },\n    {\n      "record_id": "R12"\n    ,\n      "reason": "Calibration status unknown — policy requires reporting as ambiguous."\n    }\n  ]\n  \n  ,\n  "verification_steps": [\n    "R01 and R02 identified as exact retransmission pair — both rejected.",\n    "R03: all criteria met — accepted.",\n    "R04: expired calibration — rejected.",\n    "R05: calibration renewed after measurement — ambiguous.",\n    "R06: missing value — rejected.",\n    "R07: malformed timestamp — rejected.",\n    "R08: valid — accepted.",\n    "R09: independent signature — accepted despite matching R08.",\n    "R10: out-of-range — rejected.",\n    "R11: valid — accepted.",\n    "R12: unknown calibration — ambiguous."\n  ]\n  \n  ,\n  "final_note": "All records processed. No record ID appears more than once in accepted or rejected."\n}', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content=None), matched_stop=151645, prompt_token_ids=[151644, 8948, 198, 74516, 279, 43582, 7424, 3685, 13, 3411, 1172, 4718, 12579, 279, 10802, 13, 21476, 30248, 7424, 525, 537, 14312, 42328, 13, 85148, 1817, 3255, 3034, 518, 1429, 3055, 304, 11666, 476, 17551, 13, 151645, 198, 151644, 872, 198, 49, 15, 16, 25, 12002, 362, 11, 6077, 220, 16, 19, 11, 897, 220, 23, 16, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 17, 25, 12002, 362, 11, 6077, 220, 16, 19, 11, 897, 220, 23, 16, 11, 4734, 312, 1458, 2728, 315, 431, 15, 16, 624, 49, 15, 18, 25, 12002, 362, 11, 6077, 220, 16, 20, 11, 897, 220, 23, 16, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 19, 25, 12002, 425, 11, 6077, 220, 16, 19, 11, 897, 220, 16, 23, 11, 37611, 26391, 11, 11441, 2697, 624, 49, 15, 20, 25, 12002, 425, 11, 6077, 220, 16, 19, 11, 897, 220, 16, 23, 11, 37611, 35546, 1283, 18662, 624, 49, 15, 21, 25, 12002, 356, 11, 6077, 220, 17, 17, 11, 897, 7402, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 22, 25, 12002, 356, 11, 6077, 220, 17, 18, 11, 897, 220, 19, 19, 11, 37611, 2697, 11, 11441, 79250, 624, 49, 15, 23, 25, 12002, 422, 11, 6077, 220, 18, 16, 11, 897, 220, 20, 22, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 15, 24, 25, 12002, 422, 11, 6077, 220, 18, 16, 11, 897, 220, 20, 22, 11, 1852, 7729, 438, 431, 15, 23, 714, 9489, 3671, 11957, 624, 49, 16, 15, 25, 12002, 468, 11, 6077, 220, 19, 15, 11, 897, 220, 16, 15, 17, 11, 4889, 26372, 2088, 220, 15, 1526, 220, 16, 15, 15, 624, 49, 16, 16, 25, 12002, 468, 11, 6077, 220, 19, 16, 11, 897, 220, 16, 15, 15, 11, 37611, 2697, 11, 11441, 2697, 624, 49, 16, 17, 25, 12002, 434, 11, 6077, 220, 20, 15, 11, 897, 220, 21, 17, 11, 37611, 2639, 9788, 11, 11441, 2697, 624, 13825, 25, 7850, 4734, 312, 1458, 5176, 11, 7402, 2750, 11, 21595, 4429, 448, 26391, 37611, 11, 79250, 48781, 11, 323, 700, 8668, 30508, 2750, 13, 21994, 8499, 21595, 525, 34263, 1496, 979, 862, 2750, 2432, 13, 21693, 37611, 2639, 1969, 387, 4961, 438, 54761, 4751, 1091, 11666, 476, 17551, 13, 151645, 198, 151644, 77091, 198], response_token_ids=[515, 220, 330, 49278, 788, 330, 74516, 8145, 817, 4842, 10346, 220, 330, 54574, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 18, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 2088, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 23, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 2088, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 24, 698, 262, 13493, 414, 330, 19895, 788, 330, 76821, 3671, 11957, 11, 1496, 3498, 7729, 9071, 431, 15, 23, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 16, 698, 262, 13493, 414, 330, 19895, 788, 330, 4088, 37611, 11, 2697, 11441, 11, 897, 2878, 26372, 2088, 10040, 262, 456, 220, 3211, 220, 330, 95353, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 16, 698, 262, 13493, 414, 330, 19895, 788, 330, 57954, 312, 1458, 2728, 315, 431, 15, 17, 26, 4842, 7460, 36901, 315, 42328, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 17, 698, 262, 13493, 414, 330, 19895, 788, 330, 57954, 312, 1458, 2728, 315, 431, 15, 16, 26, 4842, 7460, 36901, 315, 42328, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 19, 698, 262, 13493, 414, 330, 19895, 788, 330, 8851, 18350, 26391, 518, 882, 315, 18662, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 21, 698, 262, 13493, 414, 330, 19895, 788, 330, 25080, 897, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 22, 698, 262, 13493, 414, 330, 19895, 788, 330, 29600, 10155, 11441, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 15, 698, 262, 13493, 414, 330, 19895, 788, 330, 1130, 220, 16, 15, 17, 35275, 26372, 2088, 320, 15, 4142, 16, 15, 15, 568, 698, 262, 456, 220, 3211, 220, 330, 90213, 788, 2278, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 15, 20, 698, 262, 13493, 414, 330, 19895, 788, 330, 8851, 18350, 35546, 1283, 18662, 1959, 2639, 518, 882, 315, 18662, 374, 24416, 10040, 262, 1153, 262, 341, 414, 330, 8548, 842, 788, 330, 49, 16, 17, 698, 262, 13493, 414, 330, 19895, 788, 330, 8851, 18350, 2639, 9788, 1959, 4842, 7460, 12827, 438, 54761, 10040, 262, 456, 220, 5133, 2303, 220, 13493, 220, 330, 50632, 643, 665, 1690, 788, 2278, 262, 330, 49, 15, 16, 323, 431, 15, 17, 10820, 438, 4734, 312, 1458, 2728, 6716, 1959, 2176, 17551, 10346, 262, 330, 49, 15, 18, 25, 678, 12890, 2270, 1959, 11666, 10346, 262, 330, 49, 15, 19, 25, 26391, 37611, 1959, 17551, 10346, 262, 330, 49, 15, 20, 25, 37611, 35546, 1283, 18662, 1959, 54761, 10346, 262, 330, 49, 15, 21, 25, 7402, 897, 1959, 17551, 10346, 262, 330, 49, 15, 22, 25, 79250, 11441, 1959, 17551, 10346, 262, 330, 49, 15, 23, 25, 2697, 1959, 11666, 10346, 262, 330, 49, 15, 24, 25, 9489, 11957, 1959, 11666, 8818, 12579, 431, 15, 23, 10346, 262, 330, 49, 16, 15, 25, 700, 8668, 30508, 1959, 17551, 10346, 262, 330, 49, 16, 16, 25, 2697, 1959, 11666, 10346, 262, 330, 49, 16, 17, 25, 9788, 37611, 1959, 54761, 10040, 220, 5133, 2303, 220, 13493, 220, 330, 11822, 27207, 788, 330, 2403, 7424, 15233, 13, 2308, 3255, 3034, 7952, 803, 1091, 3055, 304, 11666, 476, 17551, 10040, 92, 151645])], created=1788790243, model='Qwen/Qwen3-Next-80B-A3B-Instruct-FP8', object='chat.completion', metadata={'weight_version': 'default', 'weight_versions': [{'version': 'default', 'start': 0, 'end': 590}]}, moderation=None, service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=590, prompt_tokens=386, total_tokens=976, completion_tokens_details=None, prompt_tokens_details=None, reasoning_tokens=0))
```

<img width="1287" height="692" alt="Screenshot 2026-09-07 at 5 23 45 PM" src="https://github.com/user-attachments/assets/1a7b6391-422b-4137-a955-3364396a4c59" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34134750064](https://github.com/sgl-project/sglang/actions/runs/34134750064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34134749829](https://github.com/sgl-project/sglang/actions/runs/34134749829)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34134750137](https://github.com/sgl-project/sglang/actions/runs/34134750137)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->