### PR TITLE
fix(hicache): fail-soft Mooncake direct linker loads (resolve transfers in revalidate_load)

### DIFF
--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
@@ -231,16 +231,29 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
         apart; master-side memory-watermark eviction in that window expires
         replicas and would fail the layer-wise load fatally. Re-checking here
         lets the caller degrade the request to a plain cache miss instead.
+
+        Failures inside the revalidation itself never propagate: this hook
+        guards a hot scheduling path, so an unexpected error falls back to
+        "validated" and the async load path retains its own semantics.
         """
-        key_strs: list[str] = []
-        for transfer in transfers:
-            component_keys, _ = self.storage._get_hybrid_page_component_keys(
-                list(transfer.keys), transfer
+        try:
+            resolved = self.pool_group.resolve_transfers(
+                transfers, allow_partial=True, allow_missing_kv=True
             )
-            key_strs.extend(self.storage._tag_keys(component_keys))
-        if not key_strs:
+            if not resolved:
+                return True
+            key_strs: list[str] = []
+            for transfer in resolved:
+                component_keys, _ = self.storage._get_hybrid_page_component_keys(
+                    list(transfer.keys), transfer
+                )
+                key_strs.extend(self.storage._tag_keys(component_keys))
+            if not key_strs:
+                return True
+            exist = self.storage._batch_exist(key_strs)
+        except BaseException:
+            logger.exception("Mooncake direct linker load revalidation error")
             return True
-        exist = self.storage._batch_exist(key_strs)
         missing = [key for key, state in zip(key_strs, exist) if state != 1]
         if missing:
             logger.warning(

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_direct_linker.py
@@ -223,6 +223,39 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
             )
         return restorable
 
+    def revalidate_load(self, transfers: list[PoolTransfer]) -> bool:
+        """Re-check remote existence before the scheduler commits device
+        slots to the async layer-wise load.
+
+        The match-time lookup and ``batch_get_session_start`` can be minutes
+        apart; master-side memory-watermark eviction in that window expires
+        replicas and would fail the layer-wise load fatally. Re-checking here
+        lets the caller degrade the request to a plain cache miss instead.
+        """
+        key_strs: list[str] = []
+        for transfer in transfers:
+            component_keys, _ = self.storage._get_hybrid_page_component_keys(
+                list(transfer.keys), transfer
+            )
+            key_strs.extend(self.storage._tag_keys(component_keys))
+        if not key_strs:
+            return True
+        exist = self.storage._batch_exist(key_strs)
+        missing = [key for key, state in zip(key_strs, exist) if state != 1]
+        if missing:
+            logger.warning(
+                "Mooncake direct linker load revalidation failed: "
+                "missing=%d/%d keys (master eviction race), "
+                "degrading request to cache miss",
+                len(missing),
+                len(key_strs),
+            )
+            failed_get_cache = getattr(self.storage, "failed_get_cache", None)
+            if failed_get_cache is not None:
+                failed_get_cache.update_batch([], missing)
+            return False
+        return True
+
     def load(self, rid: str, transfers: list[PoolTransfer]) -> bool:
         # Query establishes a boundary at which every component is restorable;
         # insert then removes pages already resident in L1. Loading is therefore
@@ -307,10 +340,28 @@ class MooncakeDirectLinker(UnifiedCacheLinker):
                     )
             for keys, _ in batches.values():
                 result = self.storage.store.batch_get_session_start(keys)
-                if list(result) != [0] * len(keys):
+                failed = [key for key, code in zip(keys, result) if code != 0]
+                if failed:
+                    # Master-side eviction (memory watermark) can expire a
+                    # replica between the match-time lookup and this call.
+                    # Session start re-queries the master, so retry the batch
+                    # once before giving up.
+                    logger.warning(
+                        "Mooncake get session start partial failure "
+                        "(keys=%d, failed=%d), retrying once: results=%s",
+                        len(keys),
+                        len(failed),
+                        result,
+                    )
+                    result = self.storage.store.batch_get_session_start(keys)
+                    failed = [key for key, code in zip(keys, result) if code != 0]
+                if failed:
+                    failed_get_cache = getattr(self.storage, "failed_get_cache", None)
+                    if failed_get_cache is not None:
+                        failed_get_cache.update_batch([], failed)
                     raise RuntimeError(
                         f"Mooncake get session start failed: keys={len(keys)}, "
-                        f"results={result}"
+                        f"failed={len(failed)}, results={result}"
                     )
                 started.append(keys)
 

--- a/python/sglang/srt/mem_cache/unified_cache/unified_cache_linker.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_cache_linker.py
@@ -284,6 +284,22 @@ class UnifiedCacheLinkerWrapper:
                 return empty_indices, req.last_node
             component_transfers.append((component, transfer))
 
+        # Keys can be evicted remotely (master memory-watermark eviction)
+        # between the match-time lookup and this load-back; a stale hit would
+        # then fail the async layer-wise session fatally. Re-check existence
+        # here so the request degrades to a plain cache miss instead.
+        revalidate = getattr(self.cache_linker, "revalidate_load", None)
+        if revalidate is not None and not revalidate(
+            [transfer for _, transfer in component_transfers]
+        ):
+            self._update_load(
+                ExternalLinkerLoadPhase.ABORT,
+                req,
+                component_transfers,
+                prefix_len,
+            )
+            return empty_indices, req.last_node
+
         full_transfer = component_transfers[0][1]
         assert full_transfer.name == PoolName.KV
         self._update_load(

--- a/test/registered/unit/mem_cache/test_unified_cache_linker_fail_soft.py
+++ b/test/registered/unit/mem_cache/test_unified_cache_linker_fail_soft.py
@@ -1,0 +1,220 @@
+"""Fail-soft degradation for Mooncake direct linker loads.
+
+Covers the eviction-race window between the match-time L3 lookup and
+load-back: when the linker's revalidation reports keys missing, the
+wrapper must abort the load and degrade the request to a plain cache
+miss (re-prefill) instead of committing device slots to an async
+layer-wise session that would fail fatally.
+"""
+
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    ExternalLinkerLoadPhase,
+    LinkerTransferPhase,
+)
+from sglang.srt.mem_cache.unified_cache.unified_cache_linker import (
+    ExternalCacheHitMarker,
+    UnifiedCacheLinker,
+    UnifiedCacheLinkerWrapper,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class _RevalidatingFakeLinker(UnifiedCacheLinker):
+    """Minimal backend whose revalidate_load verdict is scripted per test."""
+
+    def __init__(self, revalidate_result: bool):
+        self.layer_done_counter = object()
+        self.revalidate_result = revalidate_result
+        self.revalidated_transfers = None
+        self.queued_loads = {}
+        self.completed_loads = []
+        self.completed_offloads = []
+        self.queued_offloads = []
+        self.reset_count = 0
+        self.closed = False
+
+    def lookup(self, rid, transfers):
+        return []
+
+    def load(self, rid, transfers):
+        self.queued_loads[rid] = list(transfers)
+        return True
+
+    def revalidate_load(self, transfers):
+        self.revalidated_transfers = list(transfers)
+        return self.revalidate_result
+
+    def start_layer_wise_loading(self):
+        return 1
+
+    def cancel_queued_load(self, rid):
+        return self.queued_loads.pop(rid, None) is not None
+
+    def num_completed_loads(self):
+        return len(self.completed_loads)
+
+    def pop_completed_load(self):
+        return self.completed_loads.pop(0)
+
+    def num_completed_offloads(self):
+        return len(self.completed_offloads)
+
+    def take_completed_offloads(self, finish_count):
+        return [True] * min(finish_count, len(self.completed_offloads))
+
+    def commit_completed_offloads(self, results):
+        pass
+
+    def offload(self, transfers):
+        self.queued_offloads.append(list(transfers))
+        return True
+
+    def replace_pending_offload_node(self, ack_id, old_node_id, new_node_ids):
+        pass
+
+    def reset(self):
+        self.reset_count += 1
+
+    def close(self):
+        self.closed = True
+
+
+class _LoadBackComponent:
+    """Component handing out a fixed KV transfer and recording load phases."""
+
+    def __init__(self):
+        self.phases = []
+
+    def build_external_linker_transfer(self, phase, node, keys):
+        assert phase == LinkerTransferPhase.LOAD
+        return PoolTransfer(
+            name=PoolName.KV,
+            device_indices=torch.arange(len(keys), dtype=torch.int64),
+            keys=list(keys),
+        )
+
+    def update_external_linker_load(
+        self,
+        phase,
+        req,
+        full_transfer,
+        transfer,
+        prefix_len,
+        *,
+        insert_result=None,
+        canonical_full=None,
+    ):
+        self.phases.append(phase)
+        if phase == ExternalLinkerLoadPhase.ABORT:
+            return None
+        return transfer
+
+
+def _cache_for_load_back(component, empty_indices):
+    lock_params = object()
+    cache = SimpleNamespace(
+        tree_core=SimpleNamespace(
+            enable_external_cache_linker=False,
+            empty_match_result=SimpleNamespace(device_indices=empty_indices),
+        ),
+        write_through_threshold=256,
+        pp_size=1,
+        pp_group=None,
+        page_size=1,
+        _components_tuple=(component,),
+        insert=lambda params: SimpleNamespace(last_device_node=9, mamba_exist=False, adopted_ranges={}),
+        inc_lock_ref=lambda node_id: SimpleNamespace(to_dec_params=lambda: lock_params),
+        dec_lock_ref=lambda node_id, params: None,
+        resolve_node_handle=lambda node_id: SimpleNamespace(id=node_id),
+        req_to_token_pool=SimpleNamespace(mamba_allocator=SimpleNamespace(free=lambda indices: None)),
+    )
+    return cache, lock_params
+
+
+def _hit_marker():
+    return ExternalCacheHitMarker(
+        prefix_key=RadixKey(array("q", range(4))),
+        tail_hashes=["k0", "k1"],
+        device_hit_len=2,
+    )
+
+
+def _load_back(wrapper, component):
+    req = SimpleNamespace(
+        rid="rid",
+        last_node=5,
+        prefix_indices=torch.zeros(2, dtype=torch.int64),
+        kv=None,
+        priority=0,
+    )
+    return wrapper.load_back(req), req, component
+
+
+def test_revalidation_failure_degrades_to_cache_miss():
+    empty_indices = torch.zeros(0, dtype=torch.int64)
+    component = _LoadBackComponent()
+    linker = _RevalidatingFakeLinker(revalidate_result=False)
+    cache, lock_params = _cache_for_load_back(component, empty_indices)
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    wrapper.hit_markers["rid"] = _hit_marker()
+
+    (indices, last_node), _, component = _load_back(wrapper, component)
+
+    # Degrade: the caller sees an empty cache miss on the same node.
+    assert indices is empty_indices
+    assert last_node == 5
+    # The aborted load freed the component slots and never queued a load.
+    assert component.phases == [ExternalLinkerLoadPhase.ABORT]
+    assert linker.queued_loads == {}
+    assert wrapper.hit_markers == {}
+    # Revalidation ran before the abort, with the raw component transfers.
+    assert linker.revalidated_transfers is not None
+    assert linker.revalidated_transfers[0].name == PoolName.KV
+
+
+def test_revalidation_success_proceeds_to_prepare_and_load():
+    empty_indices = torch.zeros(0, dtype=torch.int64)
+    component = _LoadBackComponent()
+    linker = _RevalidatingFakeLinker(revalidate_result=True)
+    cache, lock_params = _cache_for_load_back(component, empty_indices)
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    wrapper.hit_markers["rid"] = _hit_marker()
+
+    (indices, last_node), _, component = _load_back(wrapper, component)
+
+    # The load proceeds: slots committed and the async load queued.
+    assert component.phases == [
+        ExternalLinkerLoadPhase.PREPARE,
+        ExternalLinkerLoadPhase.COMMIT,
+    ]
+    assert "rid" in linker.queued_loads
+    assert len(indices) == 2  # device prefix + loaded tail pages
+    assert last_node == 9
+
+
+def test_backend_without_revalidation_keeps_legacy_path():
+    empty_indices = torch.zeros(0, dtype=torch.int64)
+    component = _LoadBackComponent()
+    linker = _RevalidatingFakeLinker(revalidate_result=True)
+    # Simulate a backend that has not implemented the hook.
+    del linker.revalidate_load
+    cache, lock_params = _cache_for_load_back(component, empty_indices)
+    wrapper = UnifiedCacheLinkerWrapper(cache, linker)
+    wrapper.hit_markers["rid"] = _hit_marker()
+
+    (indices, last_node), _, component = _load_back(wrapper, component)
+
+    assert "rid" in linker.queued_loads
+    assert component.phases == [
+        ExternalLinkerLoadPhase.PREPARE,
+        ExternalLinkerLoadPhase.COMMIT,
+    ]


### PR DESCRIPTION
## Motivation

Follow-up to #37381, picking up the direction discussed there ("Don't treat a partial batch failure as fatal"). We ran the direct linker mode in production (DeepSeek-V4-Flash, TP4, Mooncake L3, ~21M keys / 1.4TB master memory) and hit two crashes:

1. `revalidate_load` fed the adapter's raw component transfers (source pool names) straight into `_get_hybrid_page_component_keys`, which expects physical pool names — the first L3 hit crashed the engine.
2. After master memory crossed the 90% watermark and BatchEvict removed 21k keys in one pass, a layer-wise `batch_get_session_start` returned partial failures; two bad keys out of 32 took down the engine instead of being dropped and re-prefilled.

## Modifications

- resolve transfers via `pool_group.resolve_transfers(allow_partial=True, allow_missing_kv=True)` before the component-key lookup, with a try/except fallback to "validated"
- failed keys are dropped from the load and degraded to cache miss + re-prefill (same policy as the vLLM mooncake connector: vllm-project/vllm#50984, vllm-project/vllm#48216)
- revalidation failure routes through the existing ABORT path instead of raising

## Accuracy Tests

New `test/registered/unit/mem_cache/test_unified_cache_linker_fail_soft.py` (CPU, registered `base-a-test-cpu`): revalidation failure → ABORT + empty indices + no queued load; revalidation success → PREPARE/COMMIT + queued load; backend without the hook keeps the legacy path.

## Known Limitations

- Not yet exercised with decode context parallelism.
- `failed_get_cache` recording is guarded with `getattr` and inert until that infra lands upstream.

## Related

- #37381 (the integration this follows up on; the production incident data in its comments is the motivation here)
- Developed and validated on our internal production branch (DeepSeek-V4-Flash serving, Mooncake L3), rebased onto current main.

## Checklist

- [x] Code is formatted (commits follow the file's existing style; note main tip itself currently fails the pinned ruff-format hook on `mooncake_direct_linker.py` from #38195/#38049 — happy to rebase once a format reconciliation lands)
- [ ] CI passed (will monitor)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34142812459](https://github.com/sgl-project/sglang/actions/runs/34142812459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34142812255](https://github.com/sgl-project/sglang/actions/runs/34142812255)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34142812370](https://github.com/sgl-project/sglang/actions/runs/34142812370)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->