### PR TITLE
fix(hicache): fail-soft SWA prefetch degrade with Mamba guard, prefetch last_hash recompute

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -319,6 +319,14 @@ class SWAComponent(TreeComponent):
                 state["len"] = 0
                 if swa_device_only_hicache and (node.backuped or not node.evicted):
                     return True
+                # Fail-soft: a backuped node whose SWA is absent on *both*
+                # layers (device tombstone plus no L3 backup — the hole a
+                # degraded prefetch can graft) still has Full KV on host.
+                # Treat only that case as a valid match boundary — SWA will
+                # be rebuilt from Full KV at load-back via
+                # SWARebuild/RecoverSWAWithLockedFull.
+                if cd.host_value is None and node.backuped:
+                    return True
                 return False
             state["len"] += len(node.key)
             return state["len"] >= sliding_window_size
@@ -1051,7 +1059,12 @@ class SWAComponent(TreeComponent):
                 cur is not self.tree_core.root_node and n_swa < self.sliding_window_size
             ):
                 cd = cur.component_data[ct]
-                assert cd.host_value is not None or cd.value is not None
+                # Fail-soft: a degraded prefetch may insert a backuped node
+                # whose SWA was never backed up (tombstoned before backup).
+                # Stop collecting — SWA will be rebuilt from Full KV at
+                # load-back via SWARebuild/RecoverSWAWithLockedFull.
+                if cd.host_value is None and cd.value is None:
+                    break
                 if cd.value is not None:
                     # device exists, skip it
                     n_swa += len(cd.value)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -45,6 +45,7 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.mem_cache.unified_cache.cache_action import (
     BackupKV,
     CacheAction,
@@ -1766,6 +1767,15 @@ class UnifiedRadixCache(BasePrefixCache):
             # A fetch (or an unconsumed hold) already exists for this rid;
             # overwriting would leak its staging slots.
             return
+
+        # Recompute last_hash from the full matched prefix so the hash chain
+        # is correct regardless of which node was selected as anchor.  The
+        # anchor's hash_value may be at a different position than matched_len
+        # when the anchor has no host_value (async backup not yet complete).
+        if matched_prefix_tokens and len(matched_prefix_tokens) >= self.page_size:
+            prefix_hashes = get_hash_str(matched_prefix_tokens, None, self.page_size)
+            if prefix_hashes:
+                last_hash = prefix_hashes[-1]
 
         # Buffer mode holds no tree state during the fetch: buffers are
         # operation-owned, so the anchor needs no pin.

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1960,6 +1960,10 @@ class UnifiedRadixCache(BasePrefixCache):
         ):
             # Hybrid all-or-nothing check failed; result already discarded.
             return
+        # The check may have degraded the result (fail-soft): re-read the
+        # retained KV prefix length and hash chain off the operation.
+        completed_tokens = operation.completed_tokens
+        hash_value = operation.hash_value
 
         allocated_tokens = len(host_indices)
         if completed_tokens < allocated_tokens:
@@ -2096,50 +2100,106 @@ class UnifiedRadixCache(BasePrefixCache):
             for transfer, count in zip(pool_transfers, pool_hit_pages)
         )
         if pool_transfers and not all_succeeded:
-            # Drop the KV beliefs from the first page any pool failed to serve;
-            # the next insert then re-writes that span through one FULL check,
-            # restoring the missing aux pages.
-            keep_pages = completed_tokens // self.page_size
-            for transfer, count in zip(pool_transfers, pool_hit_pages):
-                if transfer.keys is None:
-                    keep_pages = 0
-                elif count < len(transfer.keys):
-                    # Aux transfers key the chain's trailing pages.
-                    keep_pages = min(
-                        keep_pages, max(0, len(hash_value) - len(transfer.keys))
-                    )
+            # Identify which non-KV components fell short.  KV-derived
+            # sidecars (indices_from_pool == KV) are excluded — they share
+            # the KV hit length and are always covered when KV succeeds.
+            comp_xfers = self.ongoing_prefetch[req_id].comp_xfers
+            failed_components = [
+                ct
+                for ct, xfers in comp_xfers.items()
+                if any(x.indices_from_pool != PoolName.KV for x in xfers)
+            ]
+            # Only SWA has a cheap rebuild path (_translate_full_to_swa);
+            # the missing window is rebuilt at load-back via
+            # SWARebuild/RecoverSWAWithLockedFull.  Mamba SSM states require
+            # O(seq_len) recompute — not degradable.
+            rebuildable = all(ct != ComponentType.MAMBA for ct in failed_components)
+
+            if completed_tokens == 0 or not rebuildable:
+                # Full discard — nothing usable from any pool, or a
+                # non-rebuildable pool (Mamba) fell short so the whole
+                # result is unusable.
+                # Drop the KV beliefs from the first page any pool failed to serve;
+                # the next insert then re-writes that span through one FULL check,
+                # restoring the missing aux pages.
+                keep_pages = completed_tokens // self.page_size
+                for transfer, count in zip(pool_transfers, pool_hit_pages):
+                    if transfer.keys is None:
+                        keep_pages = 0
+                    elif count < len(transfer.keys):
+                        # Aux transfers key the chain's trailing pages.
+                        keep_pages = min(
+                            keep_pages, max(0, len(hash_value) - len(transfer.keys))
+                        )
+                self.storage_existence_cache.invalidate_beyond(
+                    PoolName.KV, hash_value, keep_pages=keep_pages
+                )
+                # The controller's prefetch IO thread already releases the untransferred
+                # tail (host_indices[completed_tokens:])
+                self.cache_controller.append_host_mem_release(
+                    host_indices=host_indices[:completed_tokens],
+                    extra_pools=pool_transfers if operation.pool_transfers_done else None,
+                )
+                self._finish_storage_prefetch(
+                    req_id, fulfilled_tokens=0, reason="storage_transfer"
+                )
+                if anchor_lock_params is not None:
+                    self.dec_host_lock_ref(last_host_node_id, anchor_lock_params)
+                if self.buffer_pipeline is not None:
+                    self.buffer_pipeline.pop_prefix_ctx(req_id)
+                    self.buffer_pipeline.release_anchor_lock(req_id)
+                del self.ongoing_prefetch[req_id]
+                self.cache_controller.prefetch_tokens_occupied -= (
+                    self._prefetch_occupied_span(prefetch_key, host_indices)
+                )
+                self.prefetch_loaded_tokens_by_reqid[req_id] = 0
+                self.prefetch_loaded_storage_start_by_reqid.pop(req_id, None)
+                logger.warning(
+                    "HiCache hybrid prefetch discarded req=%s completed=%d requested=%d "
+                    "kv_beliefs_kept_pages=%d",
+                    req_id,
+                    completed_tokens,
+                    expected_tokens,
+                    keep_pages,
+                )
+                return False
+
+            # Fail-soft degrade: retain the Full KV (+ KV-derived sidecar)
+            # result and discard **only** the failed non-KV independent
+            # pools (SWA) whose storage fetch fell short.  Their host
+            # buffers are released here and their component entries are
+            # removed from comp_xfers so the caller's normal commit /
+            # staging path never touches the freed memory.  At load-back
+            # time the missing SWA window is rebuilt via the existing
+            # RecoverSWAWithLockedFull / SWARebuild path in swa_component.py.
+            # Belief self-heal is scoped to the retained KV prefix.
             self.storage_existence_cache.invalidate_beyond(
-                PoolName.KV, hash_value, keep_pages=keep_pages
+                PoolName.KV,
+                hash_value,
+                keep_pages=completed_tokens // self.page_size,
             )
-            # The controller's prefetch IO thread already releases the untransferred
-            # tail (host_indices[completed_tokens:])
             self.cache_controller.append_host_mem_release(
-                host_indices=host_indices[:completed_tokens],
                 extra_pools=pool_transfers if operation.pool_transfers_done else None,
             )
-            self._finish_storage_prefetch(
-                req_id, fulfilled_tokens=0, reason="storage_transfer"
-            )
-            if anchor_lock_params is not None:
-                self.dec_host_lock_ref(last_host_node_id, anchor_lock_params)
-            if self.buffer_pipeline is not None:
-                self.buffer_pipeline.pop_prefix_ctx(req_id)
-                self.buffer_pipeline.release_anchor_lock(req_id)
-            del self.ongoing_prefetch[req_id]
-            self.cache_controller.prefetch_tokens_occupied -= (
-                self._prefetch_occupied_span(prefetch_key, host_indices)
-            )
-            self.prefetch_loaded_tokens_by_reqid[req_id] = 0
-            self.prefetch_loaded_storage_start_by_reqid.pop(req_id, None)
+            # Remove failed non-KV components from comp_xfers (same dict as
+            # the caller's) so the commit / staging path won't touch freed
+            # host buffers.
+            for ct in failed_components:
+                del comp_xfers[ct]
+            # Retain only the KV-fetched prefix; the caller re-reads these
+            # off the operation after the check passes.
+            operation.completed_tokens = completed_tokens
+            operation.hash_value = hash_value[: completed_tokens // self.page_size]
             logger.warning(
-                "HiCache hybrid prefetch discarded req=%s completed=%d requested=%d "
-                "kv_beliefs_kept_pages=%d",
+                "HiCache hybrid prefetch degraded req=%s completed=%d "
+                "requested=%d retained_kv=%d discarded_components=%s",
                 req_id,
                 completed_tokens,
                 expected_tokens,
-                keep_pages,
+                completed_tokens,
+                [ct.value for ct in failed_components],
             )
-            return False
+            return True
         return True
 
     def _record_storage_prefetch_hit(self, req_id: str, num_tokens: int) -> None:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -4598,7 +4598,7 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(self._host_avail_sizes(cons3), avail3)
         cons3.sanity_check()
 
-    # ---------- TP consistency for SWA prefetch (all-or-nothing) ----------
+    # ---------- TP consistency for SWA prefetch (fail-soft degrade) ----------
 
     def _patch_tp_prefetch_sync(self, cache, drop_swa: bool):
         """Fake all_reduce so _reduce_prefetch_ack runs the tp>1 path."""
@@ -4685,9 +4685,11 @@ class UnifiedRadixCacheSuite:
             self.skipTest("fixture does not exercise SWA L3 prefetch")
         return storage_dir, seq
 
-    def test_tp_swa_prefetch_dropped_when_peer_misses(self):
-        """A peer rank missing the SWA window drops the whole prefetch result
-        on every rank (TP-consistent all-or-nothing)."""
+    def test_tp_swa_prefetch_degrades_to_kv_only_when_peer_misses(self):
+        """A peer rank missing the SWA window degrades the prefetch to KV-only
+        on every rank (TP-consistent fail-soft: the fetched KV prefix is
+        retained, only the failed SWA pool is discarded and rebuilt at
+        load-back)."""
         setup = self._setup_swa_tp_prefetch()
         if setup is None:
             return
@@ -4699,7 +4701,10 @@ class UnifiedRadixCacheSuite:
         self._consume_prefetch(cons, seq, "drop")
 
         m = cons.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
-        self.assertEqual(m.host_hit_length, 0)
+        # Fail-soft: the KV pool fetched a usable prefix and it is retained.
+        self.assertEqual(m.host_hit_length, len(seq))
+        # TP consistency: every rank agrees SWA itself is missing — the
+        # degraded span carries no SWA host mirror (rebuilt from Full KV).
         self.assertFalse(
             self._swa_host_on_path(cons, seq), "SWA must be dropped when a peer misses"
         )
@@ -4726,9 +4731,11 @@ class UnifiedRadixCacheSuite:
         )
         cons.sanity_check()
 
-    def test_tp_swa_prefetch_drop_frees_host_pool(self):
-        """A dropped SWA prefetch must return its whole host buffer to the pool
-        (no leak, no over-free)."""
+    def test_tp_swa_prefetch_degrade_frees_failed_swa_host_pool(self):
+        """A degraded prefetch (peer missing SWA) must return the failed SWA
+        pool's host buffer to the pool (no leak, no over-free) while the
+        retained KV span stays occupied — the fail-soft degrade never
+        double-frees the kept side (TP-consistent on every rank)."""
         setup = self._setup_swa_tp_prefetch()
         if setup is None:
             return
@@ -4737,18 +4744,25 @@ class UnifiedRadixCacheSuite:
         cons = self._l3_consumer(storage_dir)
         cons.tp_world_size = 2
         self._patch_tp_prefetch_sync(cons, drop_swa=True)
-        avail_before = cons.swa_kv_pool_host.available_size()
+        avail_before = self._host_avail_sizes(cons)
         self._consume_prefetch(cons, seq, "drop")
 
         self.assertEqual(
             cons.match_prefix(
                 MatchPrefixParams(key=RadixKey(array("q", seq)))
             ).host_hit_length,
-            0,
+            len(seq),
         )
-        # Whole window dropped -> its host buffer is fully released back.
         cons.drain_storage_control_queues()  # Drain the release queue.
-        self.assertEqual(cons.swa_kv_pool_host.available_size(), avail_before)
+        avail_after = self._host_avail_sizes(cons)
+        # Failed pool: its whole SWA window is released back (no leak).
+        self.assertEqual(
+            cons.swa_kv_pool_host.available_size(), avail_before[PoolName.SWA]
+        )
+        # Retained side: the KV graft keeps its host buffer occupied — the
+        # degrade must not release the KV it just decided to keep.
+        self.assertLess(avail_after[PoolName.KV], avail_before[PoolName.KV])
+        cons.sanity_check()
 
     def test_hicache_write_back_evict_drops_unbacked_leaf_when_host_full(self):
         """Write-back eviction will keep freeing device KV when the host pool
@@ -6997,10 +7011,17 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(xfer.nodes_to_load, [y])
         self.assertEqual(int(xfer.host_indices.numel()), ps)
 
-        with self.assertRaises(AssertionError):
-            cache.tree_core.build_hicache_transfers(
-                ComponentType.SWA, y, CacheTransferPhase.LOAD_BACK
-            )
+        # Anchored on Y, the walk reaches N's both-layers-absent SWA hole:
+        # the fail-soft LOAD_BACK builder stops collecting there instead of
+        # asserting — the missing SWA window is rebuilt from Full KV at
+        # load-back via SWARebuild/RecoverSWAWithLockedFull.
+        transfers = cache.tree_core.build_hicache_transfers(
+            ComponentType.SWA, y, CacheTransferPhase.LOAD_BACK
+        )
+        self.assertEqual(len(transfers), 1)
+        xfer = transfers[0]
+        self.assertEqual(xfer.nodes_to_load, [y])
+        self.assertEqual(int(xfer.host_indices.numel()), ps)
 
     def test_hicache_swa_finalize_anchored_on_best_match_node(self):
         cache, _, _, y, x, _ = self._swa_anchor_setup()


### PR DESCRIPTION
## Motivation

When a non-KV pool (SWA) falls short during L3 prefetch but KV succeeds, the whole batch was discarded. SWA is rebuildable from Full KV, so throwing away a successful KV fetch wastes the round trip. Separately, `prefetch_from_storage` anchored `last_hash` at the requested prefix rather than the actually matched one, misaligning the hash chain and causing batch_exists to miss on the first page.

## Modifications

- `prefetch_from_storage` recomputes `last_hash` from `matched_prefix_tokens` (`get_hash_str(tokens, None, page_size)`) so the hash chain is anchored at matched_len
- shortfall handling is split: full-discard only when `completed_tokens == 0` or a Mamba-component shortfall; otherwise degrade — release failed pools via `append_host_mem_release(extra_pools=...)`, drop their entries from `ongoing_prefetch[req_id].comp_xfers`, truncate `operation.hash_value` to the retained KV prefix, and scope the belief self-heal from #36386 via `invalidate_beyond(..., keep_pages=completed_tokens // page_size)` so the heal covers only the retained length
- Mamba guard (`rebuildable = all(ct != ComponentType.MAMBA for ct in failed_components)`) keeps linear-attention slot pools on the all-or-nothing path — relevant for hybrid models with KDA layers (e.g. GLM-5.3-Flash) that use MambaSlotAllocator
- SWA match validator tombstone branch admits only both-layers-absent backuped nodes; ordinary host tombstones keep the original verdict
- LOAD_BACK builder `break`s instead of asserting when both SWA host_value and value are None

## Accuracy Tests

`test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py`: SWA degrade retains the KV span (host_hit_length == len(seq)), failed SWA pool fully released while retained KV stays occupied; load_back takes the break path with a single transfer.

## Known Limitations

- The Mamba guard does not change mamba/slot allocation logic; it only opts mamba components out of the degrade path.

## Related

- #36386 (its belief self-heal is kept and scoped to the retained prefix in the degrade branch)
- #30106 (adjacent prefetch host-insert assert crash, different bug)
- Developed and validated on our internal production branch (DeepSeek-V4-Flash serving, Mooncake L3), rebased onto current main.

## Checklist

- [x] Code is formatted (follows existing expanded style; main tip itself fails the pinned ruff-format hook on `unified_radix_cache.py` — see the note on #38347)
- [ ] CI passed (will monitor)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34142813426](https://github.com/sgl-project/sglang/actions/runs/34142813426)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34142813035](https://github.com/sgl-project/sglang/actions/runs/34142813035)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34142813242](https://github.com/sgl-project/sglang/actions/runs/34142813242)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->