### PR TITLE
[Bugfix] Handle empty DFlash2 proposals with a one-token verify window

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -1012,6 +1012,11 @@ class CandidateSelector(nn.Module):
         """Walk one path, with q over the K candidates for the verify. greedy_mask
         rows take the argmax, selected rather than branched, so one captured graph
         serves greedy and sampling batches alike."""
+        if candidate_ids.shape[1] == 0:
+            return (
+                candidate_ids.new_empty(candidate_ids.shape[:2]),
+                scores.new_empty(candidate_ids.shape, dtype=torch.float32),
+            )
         if scores.is_cuda:
             return selector_walk_triton(
                 candidate_ids=candidate_ids,

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -204,6 +204,14 @@ def _is_all_greedy(sampling_info) -> bool:
 def _selector_lattice(draft_model, pred_hidden, anchor_token_ids):
     # Flattened to [N, H] and viewed back because the radix top-k kernel is 2D.
     bs, num_pred = pred_hidden.shape[0], pred_hidden.shape[1]
+    if num_pred == 0:
+        # A one-token verify window contains only the anchor. FlashInfer top-k
+        # cannot process the resulting zero-row logits tensor.
+        k = draft_model.candidate_selector.top_k
+        return (
+            torch.empty((bs, 0, k), dtype=torch.int64, device=pred_hidden.device),
+            torch.empty((bs, 0, k, k), dtype=torch.float32, device=pred_hidden.device),
+        )
     candidate_ids, unary_logits = draft_model.compute_candidates(
         pred_hidden.reshape(-1, pred_hidden.shape[-1])
     )

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -1,5 +1,6 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -401,6 +402,32 @@ def test_selector_accept_uses_greedy_fallback_without_staged_sample(monkeypatch)
     assert out_tokens.tolist() == [[7, 0]]
     assert target_predict.tolist() == [[1, 0]]
     assert sync_sites == [worker_mod.SpecTpSyncSite.DFLASH_ACCEPT_GREEDY]
+
+
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_selector_empty_proposals(batch_size):
+    from sglang.srt.speculative.dflash_worker_v2 import _selector_lattice
+
+    selector = CandidateSelector(hidden_size=4, vocab_size=16, state_rank=2, top_k=4)
+    draft = SimpleNamespace(candidate_selector=selector, compute_candidates=Mock())
+    candidates, scores = _selector_lattice(
+        draft, torch.empty(batch_size, 0, 4), torch.zeros(batch_size, dtype=torch.int64)
+    )
+    # There is no draft distribution to compute for an anchor-only window.
+    draft.compute_candidates.assert_not_called()
+    assert candidates.shape == (batch_size, 0, 4)
+    assert scores.shape == (batch_size, 0, 4, 4)
+    tokens, q_rows = selector.sample_path(
+        candidate_ids=candidates,
+        scores=scores,
+        uniforms=torch.empty(batch_size, 0),
+        temperatures=torch.ones(batch_size),
+        greedy_mask=torch.arange(batch_size) % 2 == 0,
+    )
+    assert tokens.shape == (batch_size, 0)
+    assert tokens.dtype == torch.int64
+    assert q_rows.shape == (batch_size, 0, 4)
+    assert q_rows.dtype == torch.float32
 
 
 def test_grouped_conv_supports_runtime_block_sizes():


### PR DESCRIPTION
## Motivation

`--speculative-dflash-block-size 1` is accepted, but Qwen3.8-27B with a DFlash2 draft crashes on its first generation request: `TopK failed with error code invalid argument`. The verify window contains only the anchor, so the selector receives zero proposal rows and launches FlashInfer top-k on an empty logits tensor.

## Modifications

Return an empty candidate lattice when there are no proposal slots, and return an empty path/distribution from the selector. Both the eager draft path and the sampler inside the draft CUDA graph use these helpers. Target verification and acceptance remain unchanged.

Add a regression test for batches of 1 and 3, checking empty output shapes/dtypes and that the candidate projection is skipped.

## Accuracy Tests

Base: `b5c9b68f03c0552c94b717e200e7c2e6166c6741`. Hardware: 4× RTX 5090, TP=4. Models: local BF16 Qwen3.8-27B and Qwen3.8-27B-DFlash2. Runtime: PyTorch 2.13.0+cu130, FlashInfer 0.6.18, driver 595.58.03.

- Unpatched main: reproduced the FlashInfer top-k crash on the first request with block size 1. Both new regression cases fail on unpatched code.
- Patched: all 12 tests in `test/registered/unit/spec/test_dflash_logits.py` pass.
- Patched eager generation: block sizes 1, 2, and 8 each completed 8 requests × 64 tokens, covering three prompts with thinking enabled/disabled and repeats. All returned token log-probabilities were finite.
- At block size 8, all 8 token sequences and returned log-probabilities exactly match unpatched main.
- Block size 1 also completed 2 requests × 32 tokens per configuration for eager sampling (`temperature=0.7`), CUDA Graph greedy, and CUDA Graph sampling (`temperature=0.7`). Both graph runs captured the draft verify graph and logged `cuda graph: True` during decode. Graph runs removed `--disable-cuda-graph` and set `--cuda-graph-max-bs 1`.

This fixes the empty-proposal crash. It does not establish greedy parity between TARGET_VERIFY and ordinary decode: one of six distinct block-size-1 cases still differs from target-only decode, outside the selector computation changed here.

Reproduction uses the following server settings, followed by a chat completion requesting more than one generated token:

```bash
python -m sglang.launch_server \
  --model-path /path/to/Qwen3.8-27B \
  --speculative-draft-model-path /path/to/Qwen3.8-27B-DFlash2 \
  --speculative-algorithm DFLASH --speculative-dflash-block-size 1 \
  --tp-size 4 --context-length 32768 --mem-fraction-static 0.75 \
  --max-running-requests 1 --disable-radix-cache \
  --disable-overlap-schedule --disable-cuda-graph \
  --reasoning-parser qwen3 --tool-call-parser qwen3_coder
```

## Speed Tests and Profiling

No speedup claim. The added branches only short-circuit empty proposal slots; nonempty lattice construction and sampling are unchanged.

## Checklist

- [x] Add and run regression tests, including the unpatched negative control.
- [x] Validate with the actual target and draft models on GPU.
- [x] Run repository-configured Ruff lint/format, isort, codespell, and whitespace checks.
- Documentation: no CLI or default changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34141586066](https://github.com/sgl-project/sglang/actions/runs/34141586066)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34141585845](https://github.com/sgl-project/sglang/actions/runs/34141585845)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34141586032](https://github.com/sgl-project/sglang/actions/runs/34141586032)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->