### PR TITLE
[Multimodal] Materialize split views before caching embeddings

### DIFF
--- a/python/sglang/srt/mem_cache/multimodal_cache.py
+++ b/python/sglang/srt/mem_cache/multimodal_cache.py
@@ -1,6 +1,6 @@
 import abc
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List, Optional
 
 import torch
@@ -115,6 +115,13 @@ class MultiModalStaticCache(MultimodalCache):
                 return False
             lru_hash, lru_embedding = self.mm_cache.popitem(last=False)
             self.current_size -= _get_tensor_size(lru_embedding.embedding)
+
+        tensor = embedding.embedding
+        if tensor.untyped_storage().nbytes() > data_size:
+            # torch.split/slicing returns views. Caching a view would retain the
+            # whole batched encoder output while current_size accounts for only
+            # this item's bytes. replace() preserves subclass metadata.
+            embedding = replace(embedding, embedding=tensor.clone())
 
         self.mm_cache[mm_hash] = embedding
         self.current_size += data_size

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -2,9 +2,9 @@
 
 A DataEmbeddingFunc may return either one combined [tokens, hidden] tensor or
 one tensor per item (see mm_schedule.DataEmbeddingFunc). These tests assert the
-two forms produce bitwise-identical chunked-prefill embeddings, and that the
-per-item form yields cache entries that own their storage (a torch.split view
-of the combined tensor pins the whole concatenated buffer).
+two forms produce bitwise-identical chunked-prefill embeddings and that cached
+embeddings own their storage (a torch.split view of the combined tensor would
+otherwise pin the whole concatenated buffer).
 
 CPU-only: exercises mm_schedule internals directly, no engine or GPU.
 """
@@ -172,20 +172,16 @@ def test_list_cache_entries_own_storage():
         assert emb.untyped_storage().nbytes() == own_bytes
 
 
-def test_tensor_cache_entries_share_storage():
-    # Documents the motivation for the per-item form: split views of the
-    # combined tensor keep the whole concatenated buffer alive.
+def test_tensor_cache_entries_own_storage():
     mm_schedule.init_mm_embedding_cache(1 << 30)
     items = _make_items()
     mm_schedule._get_chunked_embedding_by_item(
         _encoder_tensor, items, ITEM_OFFSETS, 0, TOTAL_LEN, _CPU
     )
-    total_tokens = sum(_num_tokens(item) for item in items)
     for item in items:
         emb = mm_schedule.embedding_cache.get_single(item.hash).embedding
-        assert (
-            emb.untyped_storage().nbytes() == total_tokens * HIDDEN * emb.element_size()
-        )
+        own_bytes = emb.numel() * emb.element_size()
+        assert emb.untyped_storage().nbytes() == own_bytes
 
 
 def test_by_item_mismatched_cache_entry_is_reencoded():


### PR DESCRIPTION
## Motivation

When a multimodal encoder returns one combined tensor, `torch.split` produces
per-item views that share the combined tensor's backing storage. Caching any
one of those views retains the whole batched encoder output, while the LRU's
`current_size` accounts for only the view's logical bytes. Actual GPU memory
can therefore significantly exceed the configured multimodal cache budget and
eventually cause OOMs as entries are replaced.

## Modifications

- Materialize an embedding before insertion only when its backing storage is
  larger than its logical tensor size.
- Use `dataclasses.replace` so `EmbeddingResult` subclasses retain their
  metadata.
- Turn the existing combined-tensor storage behavior test into a regression
  test that requires each cached embedding to own its storage.

## Accuracy Tests

Not applicable. Cloning preserves the embedding values. A PyTorch 2.14 CPU
regression check verified value equality, independent storage, and preservation
of dataclass subclass metadata.

## Speed Tests and Profiling

Not run. Embeddings that already own appropriately sized storage stay on the
existing zero-copy path. Split views incur one copy when they are admitted to
the cache; this is required to make physical memory follow the cache budget.

## Validation

- Ruff lint and format checks
- isort and codespell checks
- registered-test and pytest-main repository lint checks
- `git diff --check`
- focused PyTorch CPU storage regression check

## Checklist

- [x] Format the code according to the contribution guide.
- [x] Add focused regression coverage.
- [x] Documentation changes are not needed for this internal cache invariant.
- [x] Accuracy and speed implications are described above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34142491048](https://github.com/sgl-project/sglang/actions/runs/34142491048)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34142490924](https://github.com/sgl-project/sglang/actions/runs/34142490924)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34142491067](https://github.com/sgl-project/sglang/actions/runs/34142491067)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->