### PR TITLE
[cuda-graph] Do not let an explicit prefill backend override hard incompatibilities

### DIFF
--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -113,6 +113,15 @@ def apply_cuda_graph_compatibility(server_args: Any):
 
     cfg = resolving_view(server_args)
     if (Phase.PREFILL, "backend") in server_args._cuda_graph_config_locked:
+        # An explicit --cuda-graph-backend-prefill overrides the auto-selection
+        # policy below -- that is the point of the flag, and the ROCm enablement
+        # relies on it. It must not, however, silently override the rules that
+        # are not conservatism but hard incompatibility: there, capture succeeds
+        # and every captured graph is discarded on its first serving step.
+        if cfg.cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE:
+            disable_tc_piecewise_cudagraph_if_incompatible(
+                server_args, explicitly_requested=True
+            )
         return
 
     # PP prefill graph replay is opt-in. It is most useful for small
@@ -166,9 +175,22 @@ def apply_cuda_graph_compatibility(server_args: Any):
         disable_full_prefill_cudagraph_if_incompatible(server_args)
 
 
-def disable_tc_piecewise_cudagraph_if_incompatible(server_args: Any):
+# Rules an explicit --cuda-graph-backend-prefill=tc_piecewise must NOT override.
+# Everything else in the list below is conservatism: the backend may be
+# unvalidated there, but it still runs. These are configurations where it
+# provably does not, so honouring the flag would only make the engine slower.
+_TC_PIECEWISE_HARD_INCOMPATIBLE = frozenset({"hierarchical cache"})
+
+
+def disable_tc_piecewise_cudagraph_if_incompatible(
+    server_args: Any, *, explicitly_requested: bool = False
+):
     """TcPiecewise (torch.compile + piecewise) is incompatible with
     these configurations. Most are torch.compile / dynamo limitations.
+
+    ``explicitly_requested`` means the user set the prefill backend by hand.
+    Then only :data:`_TC_PIECEWISE_HARD_INCOMPATIBLE` rules still disable it;
+    the rest merely warn.
     """
 
     cfg = resolving_view(server_args)
@@ -223,9 +245,18 @@ def disable_tc_piecewise_cudagraph_if_incompatible(server_args: Any):
             ),
         ),
         ("DLLM (diffusion LLM)", lambda: cfg.dllm_algorithm is not None),
+        ("CPU offload", lambda: cfg.cpu_offload_gb > 0),
+        # HARD: hierarchical cache attaches its LayerDoneCounter to the device
+        # KV pool only after the prefill graphs are captured, so capture traces
+        # `layer_transfer_counter is None` in wait_layer_transfer while serving
+        # sees a real counter. Dynamo guards on that identity, so every captured
+        # shape misses its guard the first time it is served and is replaced by
+        # a fresh CUDAPiecewiseBackend with no graphs -- capture_session is never
+        # re-entered, so the loss is permanent. Registering it earlier would not
+        # help: the wait is a cross-stream wait_event, which cannot be captured.
         (
-            "CPU offload / hierarchical cache",
-            lambda: cfg.cpu_offload_gb > 0 or cfg.enable_hierarchical_cache,
+            "hierarchical cache",
+            lambda: cfg.enable_hierarchical_cache,
         ),
         (
             "deterministic inference",
@@ -254,18 +285,38 @@ def disable_tc_piecewise_cudagraph_if_incompatible(server_args: Any):
             lambda: cfg.dcp_size > 1,
         ),
     ]
-    for _name, predicate in rules:
-        if predicate():
-            declare_resolution(
-                server_args,
-                "_disable_tc_piecewise_cudagraph_if_incompatible",
-                cuda_graph_config=with_phase(
-                    cfg.cuda_graph_config, Phase.PREFILL, backend=Backend.DISABLED
-                ),
+    for name, predicate in rules:
+        if not predicate():
+            continue
+        if explicitly_requested and name not in _TC_PIECEWISE_HARD_INCOMPATIBLE:
+            # The user asked for this backend on purpose; the rule is policy,
+            # not a hard block. Say so once instead of silently overriding.
+            logger.warning(
+                "tc_piecewise prefill CUDA graph is not validated with %s, but "
+                "--cuda-graph-backend-prefill was set explicitly. Keeping it.",
+                name,
             )
-            # One decision, one declaration: every rule declares the same
-            # value, so a later match would only append a duplicate entry.
-            break
+            continue
+        if explicitly_requested:
+            logger.error(
+                "Disabling the prefill CUDA graph: tc_piecewise cannot work with "
+                "%s, and --cuda-graph-backend-prefill=tc_piecewise does not "
+                "override that. Capture would succeed and then every captured "
+                "graph would be discarded on its first serving step, leaving the "
+                "engine slower than with the graph off while still paying the "
+                "full capture time and graph memory. Drop one of the two flags.",
+                name,
+            )
+        declare_resolution(
+            server_args,
+            "_disable_tc_piecewise_cudagraph_if_incompatible",
+            cuda_graph_config=with_phase(
+                cfg.cuda_graph_config, Phase.PREFILL, backend=Backend.DISABLED
+            ),
+        )
+        # One decision, one declaration: every rule declares the same
+        # value, so a later match would only append a duplicate entry.
+        break
 
 
 def disable_breakable_cudagraph_if_incompatible(server_args: Any):


### PR DESCRIPTION
`--cuda-graph-backend-prefill` locks the phase, and `apply_cuda_graph_compatibility`
returns before evaluating a single rule when it is locked. That is correct for the
rules that are conservatism — `non-CUDA hardware (HIP/NPU/CPU/MPS/XPU)` is exactly
the one the ROCm enablement opts out of — but it also discards, in silence, the
rules where the backend provably cannot work.

## What goes wrong

`hierarchical cache` was already on the incompatibility list, so an implicit run
does the right thing. An explicit `--cuda-graph-backend-prefill=tc_piecewise`
skips the check, and then:

1. The engine captures every prefill bucket (~23 min, 18.3 GB/rank here).
2. The cache controller registers its `LayerDoneCounter` on the device KV pool
   **after** capture. Startup log, same run:
   ```
   14:08:29  Capture target prefill CUDA graph begin
   14:31:10  Capture target prefill CUDA graph end. elapsed=1360.78 s
   14:33:24  Tree cache initialized: ... hicache_attached=True
   ```
3. Capture therefore traced `layer_transfer_counter is None` inside
   `wait_layer_transfer`; serving sees a real counter. Dynamo guards on that
   identity — `TORCH_LOGS=recompiles`:
   ```
   Recompiling function forward in .../models/deepseek_v4.py:3233
     triggered by the following guard failure(s):
     - 0/18: G[...forward_context]._current.attn_backend.token_to_kv_pool
             .layer_transfer_counter is None
             # if self.layer_transfer_counter is not None:
             # .../mem_cache/deepseek_v4_memory_pool.py:1023 in wait_layer_transfer
   ```
4. Every captured shape misses its guard the first time it is served and is
   replaced by a fresh `CUDAPiecewiseBackend` whose `cudagraph` entries are all
   `None`. `capture_session` is only entered at startup, so the loss is permanent.
5. `is_in_tc_piecewise_cuda_graph()` stays true through the eager fallback, so the
   model keeps taking the capture-friendly variants — outplace pynccl all-reduce,
   unregistered reduce-scatter/all-gather, `moe_forward_piecewise_cuda_graph_impl`.
   Full cost of the piecewise path, none of its benefit. That is why the result is
   worse than `disabled`, not merely no better.

The number of recompiles equals the number of distinct prefill shapes actually
served, so it scales with workload variety. Every one of those shapes *was*
captured — the graph exists, the guard is what fails.

Registering the counter before capture would not fix it: the wait is
`current_stream().wait_event(load_event)` on an event recorded by the controller
stream, which cannot be captured into a graph.

## Fix

Evaluate the rules even when the backend is locked. Policy rules now log a warning
naming themselves and keep the user's choice; only rules in
`_TC_PIECEWISE_HARD_INCOMPATIBLE` still force `DISABLED`, with an error that says
what would otherwise happen. `hierarchical cache` is split out of the combined
`CPU offload / hierarchical cache` entry so that CPU offload keeps its current
(soft) treatment — I have no measurement for that one.

The implicit path is unchanged: with `explicitly_requested=False` neither new
branch is reachable.

## Measurements

MI355X, DeepSeek-V4-Pro, `--tp 8 --dp 8 --enable-dp-attention` + EAGLE(3/1/4) +
FP4 indexer + `--enable-hierarchical-cache`, GSM8K 200 questions 5-shot. All three
runs use the same image and the same server command, differing only in
`--cuda-graph-backend-prefill` and this patch.

| run | latency | accuracy | runtime recompiles | prefill capture |
|---|---|---|---|---|
| `tc_piecewise`, before | 88.115 s | 0.950 | 4 | 1360.78 s |
| `disabled` (baseline)  | 14.196 s | 0.965 | 0 | none |
| `tc_piecewise`, after  | 14.671 s | 0.970 | 0 | none |

**6.0x**, landing within 3% of the baseline, and the capture time and graph memory
are no longer spent on graphs that will be discarded.

An agentic workload on the same build recompiled 43 times per rank and lost 31.9%
of end-to-end output throughput (ITL mean +67%, TTFT mean +78%), which is the shape
this fix is really aimed at; GSM8K is more prefill-heavy and so shows a larger
factor.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34142598871](https://github.com/sgl-project/sglang/actions/runs/34142598871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34142598639](https://github.com/sgl-project/sglang/actions/runs/34142598639)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34142598885](https://github.com/sgl-project/sglang/actions/runs/34142598885)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->