### PR TITLE
fix(mem_cache): eliminate chunked-prefill radix-insert race corrupting QSA KV pages (#38319)

### DIFF
--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -36,6 +36,13 @@ class CacheInitParams:
     enable_mamba_extra_buffer: bool = False
     enable_mamba_extra_buffer_lazy: bool = False
 
+    # When True, MambaRadixCache skips the radix insert during chunked
+    # prefill (cache_unfinished_req with chunked=True) and defers it to
+    # cache_finished_req.  This eliminates the race where a retracted
+    # request frees KV pages that the radix tree already references,
+    # which corrupts QSA compressed-KV slots (full_slot // ratio).
+    disable_chunked_radix_insert: bool = False
+
     pp_rank: int = 0
     pp_size: int = 1
 

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -228,6 +228,32 @@ def build_kv_cache(
     )
     is_dsa = is_deepseek_dsa(model_config.hf_config)
 
+    # QSA compressed-attention models (e.g. Qwen3.8-Flash-Next) are
+    # susceptible to the chunked-prefill radix-insert race: a retracted
+    # request frees KV pages that the radix tree already references, and
+    # the QSA compressed-KV slot (full_slot // ratio) then reads data from
+    # a different request.  Auto-enable the guard unless the user
+    # explicitly overrides it.
+    from sglang.srt.layers.attention.qsa.config import (
+        QSA_VARIANT_COMPRESSED,
+        parse_qsa_profile,
+    )
+
+    _qsa_profile = parse_qsa_profile(model_config.hf_text_config)
+    _is_qsa_compressed = (
+        _qsa_profile is not None and _qsa_profile.variant == QSA_VARIANT_COMPRESSED
+    )
+    if server_args.disable_chunked_radix_insert is None:
+        disable_chunked_radix_insert = _is_qsa_compressed
+        if _is_qsa_compressed:
+            logger.info(
+                "Auto-enabled --disable-chunked-radix-insert for QSA "
+                "compressed-attention model (prevents chunked-prefill "
+                "radix-insert race, see issue #38319)."
+            )
+    else:
+        disable_chunked_radix_insert = server_args.disable_chunked_radix_insert
+
     sliding_window_size = None
     if is_hybrid_swa:
         sliding_window_size = tp_worker.sliding_window_size
@@ -296,6 +322,7 @@ def build_kv_cache(
         enable_session_radix_cache=server_args.enable_session_radix_cache,
         enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),
         enable_mamba_extra_buffer_lazy=server_args.enable_mamba_extra_buffer_lazy(),
+        disable_chunked_radix_insert=disable_chunked_radix_insert,
         pp_rank=ps.pp_rank,
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -463,6 +463,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.enable_kv_cache_events = params.enable_kv_cache_events
         self.enable_mamba_extra_buffer = params.enable_mamba_extra_buffer
         self.enable_mamba_extra_buffer_lazy = params.enable_mamba_extra_buffer_lazy
+        self.disable_chunked_radix_insert = params.disable_chunked_radix_insert
         self.kv_event_queue = []
 
         if not self.enable_mamba_extra_buffer:
@@ -692,6 +693,15 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             else len(token_ids)
         )
         if self.disable or cache_len is None:
+            return _skip_cache_unfinished_req(req)
+
+        # Skip the radix insert during chunked prefill when the flag is set.
+        # This eliminates the race where a retracted request frees KV pages
+        # that the radix tree already references (dangling node → QSA
+        # compressed-KV corruption via full_slot // ratio).  The insert is
+        # deferred to cache_finished_req, which runs after the request is
+        # fully committed and no longer subject to retraction.
+        if self.disable_chunked_radix_insert and chunked:
             return _skip_cache_unfinished_req(req)
 
         kv_indices_orig = self.req_to_token_pool.req_to_token[

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -961,6 +961,15 @@ class ServerArgs:
         "Disable chunked prefix cache feature for deepseek, which should save overhead for short sequences.",
         NS("schedule"),
     ] = False
+    disable_chunked_radix_insert: A[
+        Optional[bool],
+        "Skip the radix-cache insert during chunked prefill and defer it to "
+        "request completion. Prevents the race where a retracted request frees "
+        "KV pages that the radix tree already references, which corrupts QSA "
+        "compressed-KV slots (full_slot // ratio). None (default) auto-enables "
+        "for QSA compressed-attention hybrid models; set True/False to override.",
+        NS("schedule"),
+    ] = None
     disable_overlap_schedule: A[
         bool,
         Arg(


### PR DESCRIPTION
## Summary

Fixes #38319 — a race between chunked-prefill KV-page insertion into the Radix Cache and pool page deallocation (retract/abort) that silently corrupts KV pages on QSA compressed-attention models (e.g. Qwen3.8-Flash-Next).

## The bug

Once a corrupt prefix is cached in the radix tree, every subsequent request matching the same prefix reads garbage attention data on its **very first decode step**, producing an impossible-token loop (token `248319` = an untrained `lm_head` padding row).

Observed symptoms (from the issue's forensic dumps):
- First decode token after prefill is always the impossible token `248319`
- `num_correct_drafts = 0`, `accept_len = 1` — the target model independently produces the bad token
- The corrupted KV slot range is **identical** across repeated requests with the same prefix
- `flush_cache` resolves it temporarily (evicts the corrupt radix prefix)

## Root cause

During chunked prefill, `MambaRadixCache.cache_unfinished_req()` inserts each chunk's KV pages into the radix tree **mid-prefill**. The radix node then holds references to KV pages that still belong to the in-flight request.

If the request is retracted (decode OOM) or aborted before prefill completes, `release_kv_cache()` → `cache_finished_req(is_insert=False)` frees those pages back to the allocator. The radix node survives with **dangling references**: the pages are re-allocated to a different request (or hold uninitialized data), but the tree still points at them.

For QSA the corruption is amplified: the compressed-KV slot is addressed as `full_slot // compress_ratio`, so a single freed full-KV page maps to a compressed slot that now contains another request's data. This explains why the corruption is:
- **stochastic** (depends on chunk-insert vs retract timing),
- **persistent** (the radix cache keeps the bad prefix),
- **prefix-specific** (same slot range across repeated requests),
- **resolved temporarily by `flush_cache`**.

## The fix

Add a `disable_chunked_radix_insert` guard to `MambaRadixCache`. When set, `cache_unfinished_req()` skips the radix insert for chunked prefill (`chunked=True`) and only updates `req.prefix_indices` (the existing `_skip_cache_unfinished_req` path). The insert is **deferred to `cache_finished_req()`**, which runs after the request is fully committed and no longer subject to retraction.

This closes the race window: the radix tree never references a request's KV pages while those pages can still be freed by a retract.

The guard is **auto-enabled for QSA compressed-attention models** (`parse_qsa_profile` variant == `"compressed"`) and exposed as the tri-state server arg `--disable-chunked-radix-insert` (`None`=auto, `True`/`False`=override). Non-QSA models are unaffected (flag defaults to `False`).

## Why it is safe

- The skip path (`_skip_cache_unfinished_req`) already exists and is used when the cache is disabled or `cache_len is None`; it correctly maintains `req.prefix_indices` for chunk continuation via `add_chunked_req`.
- `req.last_node` is only assigned by the initial `match_prefix` and by the normal `cache_unfinished_req` path; the skip path leaves it unchanged, so `cache_finished_req`'s `dec_lock_ref(req.last_node)` balances the initial `inc_lock_ref` from `_req_inc_lock_ref`.
- `cache_finished_req` calls the same `insert(prev_prefix_len=req.cache_protected_len)`. `insert()` is idempotent: it matches what is already in the tree and inserts only the new tokens. The KV pages are the same (allocated by `alloc_for_extend`); only the timing of tree-node creation differs.
- On retraction, `cache_finished_req(is_insert=False)` frees `kv_indices[cache_protected_len:]`; with no intermediate inserts the tree holds no nodes for that range, so the free is correct and the shared prefix (`0..cache_protected_len`) is untouched.
- `mamba_last_track_seqlen` is set by the last prefill chunk's forward pass in both paths, so `cache_finished_req` reads the same value.

## Files changed

| File | Change |
|---|---|
| `python/sglang/srt/server_args.py` | new `--disable-chunked-radix-insert` arg (tri-state) |
| `python/sglang/srt/mem_cache/cache_init_params.py` | new `disable_chunked_radix_insert` field |
| `python/sglang/srt/mem_cache/kv_cache_builder.py` | QSA auto-detect + wiring into `CacheInitParams` |
| `python/sglang/srt/mem_cache/mamba_radix_cache.py` | the guard in `cache_unfinished_req` |

## Testing

Verified by static analysis and full code-path trace (lock-ref balance, `req_to_token` prefix mapping via `write_cache_indices`, `insert` idempotency, retraction free range, mamba track-seqlen handling). Runtime verification on a DGX Spark (GB10) with the Qwen3.8-Flash-Next checkpoint is the remaining step — the corruption is silent, so a clean boot is not sufficient; Needle@240k + GSM8K under chunked prefill + retraction pressure is the real check.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829698030](https://github.com/sgl-project/sglang/actions/runs/34829698030)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829697659](https://github.com/sgl-project/sglang/actions/runs/34829697659)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829698084](https://github.com/sgl-project/sglang/actions/runs/34829698084)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->