### PR TITLE
Support namespaced function tools in the Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1586,10 +1586,27 @@ class ResponseTool(BaseModel):
     def validate_function_tool(self) -> ResponseTool:
         if self.type == "function" and not self.name:
             raise ValueError("Function tools must include a name.")
+        if self.type == "namespace":
+            if not self.name or self.tools is None:
+                raise ValueError("Namespace tools must include a name and tools.")
+            for tool in self.tools:
+                if tool.get("type") not in ("function", "custom"):
+                    raise ValueError(
+                        "Namespaces can contain only function or custom tools."
+                    )
+                if not tool.get("name"):
+                    raise ValueError("Tools in a namespace must include a name.")
         return self
 
 
+class ResponseNamespacedFunctionToolCall(ResponseFunctionToolCall):
+    # Older SDK input TypedDicts silently discard this field. Give it an
+    # explicit model arm so stateless replay preserves the tool identity.
+    namespace: str
+
+
 ResponseInputOutputItem: TypeAlias = Union[
+    ResponseNamespacedFunctionToolCall,
     ResponseInputItemParam,
     "ResponseReasoningItem",
     ResponseFunctionToolCall,
@@ -1779,6 +1796,8 @@ class ResponsesRequest(BaseModel):
             "name"
         )
         if tool_choice.get("type") == "function" and name:
+            if namespace := tool_choice.get("namespace"):
+                name = f"{namespace}.{name}"
             return {"type": "function", "name": name}
         return "auto"
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -247,10 +247,13 @@ class OpenAIServingResponses(OpenAIServingChat):
         # FIXME: If the engine is dead, raise an error
         # This is required for the streaming case
 
-        # ``tool_choice="required"`` only works with ``function`` tools.
-        if request.tool_choice == "required" and not any(
-            tool.type == "function" for tool in (request.tools or [])
-        ):
+        try:
+            chat_tools = self._response_tools_to_chat_tools(request)
+        except ValueError as exc:
+            return self.create_error_response(str(exc), param="tools")
+
+        # Namespaced functions are client-executed functions too.
+        if request.tool_choice == "required" and not chat_tools:
             return self.create_error_response(
                 'tool_choice="required" requires at least one tool with '
                 'type="function"; other built-in tool types cannot be forced.'
@@ -902,7 +905,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 arguments=call_info.parameters or "",
                                 call_id=f"call_{random_uuid()[:24]}",
                                 type="function_call",
-                                name=call_info.name,
+                                **self._response_function_identity(
+                                    request, call_info.name
+                                ),
                                 id=f"fc_{random_uuid()[:8]}",
                                 status="completed",
                             )
@@ -934,7 +939,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 arguments=arguments,
                                 call_id=f"call_{random_uuid()[:24]}",
                                 type="function_call",
-                                name=tool["name"],
+                                **self._response_function_identity(
+                                    request, tool["name"]
+                                ),
                                 id=f"fc_{random_uuid()[:8]}",
                                 status="completed",
                             )
@@ -986,23 +993,47 @@ class OpenAIServingResponses(OpenAIServingChat):
 
     @staticmethod
     def _response_tools_to_chat_tools(request: ResponsesRequest) -> list[Tool]:
-        # Only ``function`` tools flow to chat; built-ins go through harmony.
+        # Chat templates have a flat function list. Qualify namespace members
+        # here, and restore their separate name/namespace fields on output.
         chat_tools = []
+        names = set()
         for tool in request.tools:
-            if tool.type != "function":
-                continue
-            chat_tools.append(
-                Tool(
-                    type="function",
-                    function=Function(
-                        name=tool.name,
-                        description=tool.description,
-                        parameters=tool.parameters,
-                        strict=tool.strict,
-                    ),
+            members = tool.tools if tool.type == "namespace" else [tool.model_dump()]
+            for member in members:
+                if member["type"] != "function":
+                    continue
+                name = member["name"]
+                if tool.type == "namespace":
+                    name = f"{tool.name}.{name}"
+                if name in names:
+                    raise ValueError(f"Ambiguous function tool name: {name!r}")
+                names.add(name)
+                chat_tools.append(
+                    Tool(
+                        type="function",
+                        function=Function(
+                            name=name,
+                            description=member.get("description"),
+                            parameters=member.get("parameters"),
+                            strict=member.get("strict", False),
+                        ),
+                    )
                 )
-            )
         return chat_tools
+
+    @staticmethod
+    def _response_function_identity(request: ResponsesRequest, name: str) -> dict:
+        # Match declared members rather than splitting on dots: top-level
+        # function names can themselves contain dots.
+        for tool in request.tools:
+            if tool.type == "namespace":
+                for member in tool.tools:
+                    if (
+                        member["type"] == "function"
+                        and name == f"{tool.name}.{member['name']}"
+                    ):
+                        return {"name": member["name"], "namespace": tool.name}
+        return {"name": name}
 
     @staticmethod
     def _normalize_response_content_part_for_chat(content_part: Any) -> Any:
@@ -1085,7 +1116,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                         "id": message.get("call_id") or message.get("id"),
                         "type": "function",
                         "function": {
-                            "name": message.get("name"),
+                            "name": (
+                                f"{message['namespace']}.{message.get('name')}"
+                                if message.get("namespace")
+                                else message.get("name")
+                            ),
                             "arguments": raw,
                         },
                     }
@@ -2183,7 +2218,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             completed_item = ResponseFunctionToolCall(
                 arguments=arguments,
                 call_id=state["call_id"],
-                name=state["name"] or "",
+                **self._response_function_identity(request, state["name"] or ""),
                 type="function_call",
                 id=state["item_id"],
                 status="completed",
@@ -2196,7 +2231,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         item_id=state["item_id"],
                         output_index=state["output_index"],
                         arguments=arguments,
-                        name=state["name"] or "",
+                        **self._response_function_identity(
+                            request, state["name"] or ""
+                        ),
                     )
                 ),
                 _send_event(
@@ -2379,7 +2416,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     item=ResponseFunctionToolCall(
                                         arguments="",
                                         call_id=state["call_id"],
-                                        name=state["name"],
+                                        **self._response_function_identity(
+                                            request, state["name"]
+                                        ),
                                         type="function_call",
                                         id=state["item_id"],
                                         status="in_progress",

--- a/test/registered/unit/entrypoints/openai/test_response_namespace_tools.py
+++ b/test/registered/unit/entrypoints/openai/test_response_namespace_tools.py
@@ -1,0 +1,170 @@
+import unittest
+from unittest.mock import Mock
+
+from utils import StreamFixture, engine_chunk, make_serving
+
+from sglang.srt.entrypoints.openai.protocol import ResponsesRequest
+from sglang.srt.runtime_context import reset_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def namespace(name):
+    return {
+        "type": "namespace",
+        "name": name,
+        "description": "Weather tools",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup",
+                "description": "Look up the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "strict": True,
+            }
+        ],
+    }
+
+
+class ResponseNamespaceToolsTest(CustomTestCase):
+    def setUp(self):
+        reset_context()
+        self.addCleanup(reset_context)
+        self.serving = make_serving()
+        self.request = ResponsesRequest(
+            model="test-model",
+            input="weather",
+            tools=[namespace("weather")],
+            store=False,
+        )
+
+    def test_flattening_preserves_schemas_and_distinguishes_namespaces(self):
+        self.request = ResponsesRequest(
+            model="test-model",
+            input="weather",
+            tools=[namespace("weather"), namespace("travel")],
+        )
+        tools = self.serving._response_tools_to_chat_tools(self.request)
+        self.assertEqual(
+            [t.function.name for t in tools], ["weather.lookup", "travel.lookup"]
+        )
+        self.assertEqual(
+            tools[0].function.parameters, namespace("weather")["tools"][0]["parameters"]
+        )
+        self.assertEqual(tools[0].function.description, "Look up the weather")
+        self.assertTrue(tools[0].function.strict)
+
+    def test_qualified_name_collision_is_rejected(self):
+        request = ResponsesRequest(
+            model="test-model",
+            input="weather",
+            tools=[
+                namespace("weather"),
+                {"type": "function", "name": "weather.lookup"},
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "Ambiguous function tool name"):
+            self.serving._response_tools_to_chat_tools(request)
+
+    def test_dotted_top_level_function_is_not_reinterpreted(self):
+        request = ResponsesRequest(
+            model="test-model",
+            input="hi",
+            tools=[{"type": "function", "name": "weather.lookup"}],
+        )
+        self.assertEqual(
+            self.serving._response_function_identity(request, "weather.lookup"),
+            {"name": "weather.lookup"},
+        )
+
+    def test_forced_namespace_tool_choice_is_qualified(self):
+        self.request.tool_choice = {
+            "type": "function",
+            "name": "lookup",
+            "namespace": "weather",
+        }
+        self.assertEqual(
+            self.request.effective_tool_choice(),
+            {"type": "function", "name": "weather.lookup"},
+        )
+
+    def test_nonstreaming_call_and_stateless_replay_preserve_namespace(self):
+        self.request.tool_choice = "required"
+        self.serving.tool_call_parser = None
+        output = self.serving._make_response_output_items(
+            self.request,
+            '[{"name":"weather.lookup","parameters":{"city":"Paris"}}]',
+            tokenizer=Mock(),
+            require_reasoning=False,
+        )
+        call = output[0].model_dump(exclude_none=True)
+        self.assertEqual(call["name"], "lookup")
+        self.assertEqual(call["namespace"], "weather")
+        for tool_output in ("sunny", [{"type": "input_text", "text": "sunny"}]):
+            with self.subTest(tool_output=tool_output):
+                replay = ResponsesRequest(
+                    model="test-model",
+                    store=False,
+                    tools=[namespace("weather")],
+                    input=[
+                        {"role": "user", "content": "weather"},
+                        call,
+                        {
+                            "type": "function_call_output",
+                            "call_id": call["call_id"],
+                            "output": tool_output,
+                        },
+                    ],
+                )
+                messages = self.serving._construct_input_messages(replay)
+                self.assertEqual(
+                    messages[1]["tool_calls"][0]["function"]["name"], "weather.lookup"
+                )
+                self.assertEqual(messages[2]["tool_call_id"], call["call_id"])
+        self.assertFalse(self.serving.response_store)
+        self.assertFalse(self.serving.msg_store)
+
+    def test_streaming_call_preserves_namespace_in_all_item_events(self):
+        from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+
+        self.serving.tool_call_parser = "qwen3_coder"
+        detector = Qwen3CoderDetector()
+        text = (
+            f"{detector.tool_call_start_token}{detector.tool_call_prefix}weather.lookup>"
+            f"{detector.parameter_prefix}city>Paris{detector.parameter_end_token}"
+            f"{detector.function_end_token}{detector.tool_call_end_token}"
+        )
+        events = StreamFixture(self.serving, self.request).run_seq(
+            [engine_chunk(text), engine_chunk(text, finish=True)]
+        )
+        items = [
+            p["item"]
+            for t, p in events
+            if t in ("response.output_item.added", "response.output_item.done")
+            and p["item"]["type"] == "function_call"
+        ]
+        self.assertEqual(len(items), 2)
+        for item in items:
+            self.assertEqual((item["namespace"], item["name"]), ("weather", "lookup"))
+        final = next(p["response"] for t, p in events if t == "response.completed")
+        self.assertEqual(final["output"][-1]["namespace"], "weather")
+        self.assertFalse(self.serving.response_store)
+
+    def test_nested_namespaces_and_missing_member_names_are_rejected(self):
+        for member in (namespace("nested"), {"type": "function"}):
+            with self.subTest(member=member), self.assertRaises(ValueError):
+                ResponsesRequest(
+                    model="test-model",
+                    input="hi",
+                    tools=[{"type": "namespace", "name": "weather", "tools": [member]}],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -820,7 +820,7 @@ class HarmonyResponsesTestCase(CustomTestCase):
                 parameters={"type": "object"},
             ),
             ResponseTool(type="web_search"),
-            ResponseTool(type="namespace", name="codex"),
+            ResponseTool(type="namespace", name="codex", tools=[]),
             ResponseTool(type="mcp"),
         ]
         msg = get_developer_message(instructions="be helpful", tools=tools)


### PR DESCRIPTION
## Motivation

Responses clients such as Codex group client-executed functions under `type="namespace"`. SGLang accepts these declarations but omits their functions from the chat template, and replay can discard the namespace. This prevents a stateless tool-call loop.

Related gateway protocol fixes: https://github.com/smg-project/smg/pull/2451

## Modifications

- Flatten namespace members into qualified model-facing names while preserving each function's schema, description, and strictness.
- Restore separate `name` and `namespace` fields in non-streaming calls and streaming item events, and preserve them on stateless replay.
- Support named namespace tool selection, reject ambiguous qualified names, and validate namespace membership shape. Custom tools and hosted tools retain their existing behavior.
- Add regression coverage for duplicate member names in different namespaces, dotted top-level names, collisions, forced selection, streaming, and string/content-array tool results.

## Accuracy Tests

No kernel or model-forward changes. Responses unit tests on the patched serving runtime: **50 passed, 4 subtests passed**.

```bash
cd test/registered/unit/entrypoints/openai
python3 -m pytest -q test_response_namespace_tools.py test_serving_responses.py test_serving_responses_stream.py
```

Live GLM-5.3-Flash checks passed in both streaming and non-streaming modes: force `weather.lookup`, verify `namespace="weather"` and the JSON arguments, then replay the returned call with a content-array tool result and `store=false` (no `previous_response_id`). The next response correctly uses the supplied result. Codex CLI 0.153.0 also completed a namespaced MCP call, replayed its result, inspected and edited a Python file through the shell, passed all three fixture tests, and returned the exact synthetic marker from the MCP result.

## Speed Tests and Profiling

No inference kernel changes; no throughput claim. The change adds function declaration/name translation at the API boundary.

## Checklist

- [x] Ruff lint/format, isort, codespell, and `git diff --check` pass for changed files.
- [x] Added CPU unit tests registered with CI.
- [x] Followed existing Responses serving/test conventions.
- Documentation and model accuracy/speed benchmarks: not applicable to the protocol translation tested here.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34147251332](https://github.com/sgl-project/sglang/actions/runs/34147251332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34147251186](https://github.com/sgl-project/sglang/actions/runs/34147251186)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34147251277](https://github.com/sgl-project/sglang/actions/runs/34147251277)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->