### PR TITLE
fix: wrap scalar cross-encoder scores into per-item rows for `/v1/score`

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
@@ -240,6 +240,15 @@ class TokenizerManagerScoreMixin:
 
                 prompt_tokens += result.get("meta_info", {}).get("prompt_tokens", 0)
 
+                # Single-label cross-encoder heads (e.g. bge-reranker-v2-m3)
+                # produce a scalar per item: CrossEncodingPooler squeezes the
+                # [num_labels] classification logits down to a 0-d value.
+                # ScoreResult.scores declares one row per item, so wrap
+                # scalars into a row here. This also keeps apply_softmax
+                # well-defined (a 0-d tensor has no trailing dim to reduce).
+                if not isinstance(embedding, list):
+                    embedding = [embedding]
+
                 if apply_softmax:
                     embedding = torch.softmax(
                         torch.as_tensor(embedding), dim=-1

--- a/test/registered/prefill_only/test_score_engine.py
+++ b/test/registered/prefill_only/test_score_engine.py
@@ -6,6 +6,7 @@ Two model types, two scoring modes:
   TestSeqClsScoring          — SequenceClassification, single-item mode
   TestSeqClsMISScoring       — SequenceClassification, MIS mode (--enable-mis)
   TestSeqClsMISAdvancedScoring — SeqCls MIS with 12 labels (tensor shape stress)
+  TestSingleItemScoreShape   — unit: scalar/vector embedding row coercion
 
 The Engine (Python API) is the right layer for correctness testing: it
 exercises tokenization, forward pass, pooling, and score extraction without
@@ -23,6 +24,9 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from sglang.srt.entrypoints.engine import Engine
+from sglang.srt.managers.tokenizer_manager_score_mixin import (
+    TokenizerManagerScoreMixin,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST, CustomTestCase
 
@@ -485,6 +489,53 @@ class TestSeqClsMISAdvancedScoring(CustomTestCase):
         for row in scores:
             self.assertEqual(len(row), self.NUM_LABELS)
             self.assertAlmostEqual(sum(row), 1.0, places=5)
+
+
+# ---------------------------------------------------------------------------
+# Unit: single-item result shape (no Engine required)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleItemScoreShape(CustomTestCase):
+    """Unit tests for _process_single_item_scoring_results row handling.
+
+    Single-label cross-encoder heads (BERT / XLM-RoBERTa rerankers such as
+    BAAI/bge-reranker-v2-m3) emit a scalar per item: CrossEncodingPooler
+    squeezes the [num_labels] classification logits with squeeze(-1).
+    ScoreResult.scores declares one row per item, so scalars must be
+    wrapped into a row before being appended.
+    """
+
+    class _Manager(TokenizerManagerScoreMixin):
+        is_generation = False
+
+    def _run(self, results, apply_softmax=False):
+        return self._Manager()._process_single_item_scoring_results(
+            results, label_token_ids=None, apply_softmax=apply_softmax
+        )
+
+    def test_scalar_embedding_becomes_single_element_row(self):
+        results = [
+            {"embedding": 5.875, "meta_info": {"prompt_tokens": 10}},
+            {"embedding": -10.109375, "meta_info": {"prompt_tokens": 17}},
+        ]
+        out = self._run(results)
+        self.assertEqual(out.scores, [[5.875], [-10.109375]])
+        self.assertEqual(out.prompt_tokens, 27)
+
+    def test_vector_embedding_keeps_row_shape(self):
+        results = [
+            {"embedding": [0.25, 0.75], "meta_info": {"prompt_tokens": 5}},
+        ]
+        out = self._run(results)
+        self.assertEqual(out.scores, [[0.25, 0.75]])
+
+    def test_scalar_with_softmax_stays_well_defined(self):
+        # A single-label softmax is degenerate (always 1.0), but it must not
+        # crash on a 0-d tensor and must still yield one row per item.
+        results = [{"embedding": 5.875, "meta_info": {"prompt_tokens": 3}}]
+        out = self._run(results, apply_softmax=True)
+        self.assertEqual(out.scores, [[1.0]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`/v1/score` fails with a validation error for single-label cross-encoder rerankers (e.g. `BAAI/bge-reranker-v2-m3`) — see #38360 for the full report:

```
2 validation errors for ScoringResponse scores.0 Input should be a valid list [type=list_type, input_value=5.875, input_type=float] scores.1 Input should be a valid list [type=list_type, input_value=-10.109375, input_type=float]
```

Root cause: `CrossEncodingPooler` applies `squeeze(-1)` to the `[num_labels]` classification logits, so single-label heads emit a **scalar** per item. `_process_single_item_scoring_results` appended it directly, producing a flat `scores` list although `ScoreResult.scores` declares `List[List[float]]` (one row per item). `serving_score` then fails `ScoringResponse` construction, which is caught by `except ValueError` and returned as an error response.

## Modification

Wrap scalar embeddings into a one-element row before appending. This mirrors the coercion the rerank path already has in `_build_rerank_response` (#16403), and additionally makes `apply_softmax` well-defined for scalars (a 0-d tensor has no trailing dimension to reduce — previously a RuntimeError).

Notes for reviewers:

- The fix is at result assembly rather than in `CrossEncodingPooler` because the pooler's `embeddings` output is consumed by several paths (rerank, embedding, MIS); removing `squeeze(-1)` there has a much wider blast radius. This matches the precedent set by #16403.
- Behavior change: Engine-API consumers using single-label cross-encoders previously received flat lists, which already violated the declared `ScoreResult.scores` type; the HTTP path was entirely broken. This PR aligns both with the declared contract.

## Test Plan

- New unit test `TestSingleItemScoreShape` in `test/registered/prefill_only/test_score_engine.py`: scalar → single-element row, vector passthrough, softmax scalar (no GPU/model required).
- Verified end-to-end on `BAAI/bge-reranker-v2-m3`: `POST /v1/score` with one query + two items now returns `{"scores": [[5.875], [-10.109375]], ...}` instead of the validation error above.

Fixes #38360

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34148031345](https://github.com/sgl-project/sglang/actions/runs/34148031345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34148031111](https://github.com/sgl-project/sglang/actions/runs/34148031111)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34148031266](https://github.com/sgl-project/sglang/actions/runs/34148031266)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->