### PR TITLE
gguf: load Qwen3.5 / Qwen3-Next checkpoints correctly

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -600,6 +600,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         is_gguf_weight = getattr(param, "is_gguf_weight", False)
         is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
         if is_gguf_weight_type:
+            # param.data[loaded_shard_id] is a 0-dim slot.  A checkpoint whose
+            # fused shards are split by a packed weight loader hands one
+            # 1-element (not 0-dim) chunk per shard, which copy_ rejects with
+            # "output with shape [] doesn't match the broadcast shape [1]".
+            # The next line already treats the value as a scalar.
+            if loaded_weight.numel() == 1:
+                loaded_weight = loaded_weight.reshape(())
             param.data[loaded_shard_id].copy_(loaded_weight)
             param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
             return

--- a/python/sglang/srt/model_loader/gguf_name_maps.py
+++ b/python/sglang/srt/model_loader/gguf_name_maps.py
@@ -24,9 +24,12 @@ GGUF tensor left out of the map is skipped by ``gguf_quant_weights_iterator``,
 which is how dummy tensors are dropped.
 """
 
-from typing import Callable, Dict
+from typing import TYPE_CHECKING, Callable, Dict, Sequence
 
 from transformers import PretrainedConfig
+
+if TYPE_CHECKING:
+    import torch
 
 # Sandwich naming: ffn_norm is the pre-FFN norm.
 _MUSE_GLIMMER_LAYER_TENSORS = {
@@ -70,3 +73,333 @@ def build_muse_glimmer_name_map(config: PretrainedConfig) -> Dict[str, str]:
 GGUF_HF_NAME_MAP_BUILDERS: Dict[str, Callable[[PretrainedConfig], Dict[str, str]]] = {
     "muse_glimmer": build_muse_glimmer_name_map,
 }
+
+
+# =============================================================================
+# Qwen3.5 / Qwen3-Next (Gated DeltaNet) GGUF support
+# =============================================================================
+#
+# Three things stop a llama.cpp-produced Qwen3.5 GGUF from loading correctly and
+# none of them can be expressed as a name map alone:
+#
+#  1. gguf-py spells the architecture "qwen35" while transformers spells the
+#     model_type "qwen3_5" / "qwen3_5_text", and gguf-py's name map cannot
+#     resolve ``linear_attn.A_log`` / ``linear_attn.dt_bias`` because
+#     ``_get_gguf_weights_map`` splits an HF name on its LAST dot and asks the
+#     map about the remainder ("....linear_attn").  Fixed by the builder below.
+#
+#  2. llama.cpp orders the Gated-DeltaNet VALUE heads differently from HF.  The
+#     GDN kernels pair value head ``i`` with key head ``i // (n_v / n_k)``
+#     (k-group-major) in SGLang and in transformers, but llama.cpp broadcasts
+#     the key/query heads with a plain ``ggml_repeat`` (see
+#     ``llama_model_qwen35::graph::build_layer_attn_linear``), which pairs value
+#     head ``p`` with key head ``p % n_k``.  llama.cpp's converter therefore
+#     stores the value-head-indexed tensors transposed:
+#         GGUF value head p  ==  HF value head (p % n_k) * (n_v / n_k) + p // n_k
+#     Loading those rows verbatim silently mis-pairs every value head with a
+#     key head, which does not crash and does not look wrong in a checksum --
+#     it just produces incoherent text.
+#
+#  3. llama.cpp stores ``blk.N.ssm_a`` already exponentiated and negated,
+#     ``-exp(A_log)``, because its graph multiplies the gate by it directly
+#     ("-A_log.exp() * softplus" in build_layer_attn_linear).  SGLang's
+#     ``fused_gdn_gating`` kernel computes ``-exp(A_log) * softplus`` itself,
+#     so the tensor must be turned back into ``A_log = log(-ssm_a)``.
+#
+# Plus one shape convention: the depthwise causal conv weight is [conv_dim, 1,
+# kernel] in HF and [conv_dim, kernel] in GGUF (llama.cpp drops the singleton).
+#
+# 2 and 3 and the conv rank are weight *values*, not names, so they are applied
+# by a weight transform (GGUF_WEIGHT_TRANSFORMS) that GGUFModelLoader runs over
+# the weight iterator.
+
+_QWEN3_5_MODEL_TYPES = ("qwen3_5", "qwen3_5_text", "qwen3_next", "qwen3_next_text")
+
+# Qwen3.5 uses a zero-centred RMSNorm everywhere except the Gated-DeltaNet's own
+# gated norm: transformers' Qwen3_5RMSNorm.forward is
+#     output = _norm(x) * (1.0 + self.weight)
+# (modeling_qwen3_5.py:736) and SGLang matches it by building these five norms
+# with GemmaRMSNorm (qwen3_5.py:939, 1179-1185, 1652).  llama.cpp has only a
+# plain RMS norm, so its converter folds the +1 into the stored weight.  The
+# GDN norm (Qwen3_5RMSNormGated / RMSNormGated, plain `self.weight * x`) is
+# stored raw and must NOT be touched -- it is the exception that makes this
+# defect easy to miss.
+_QWEN3_5_GEMMA_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+_QWEN3_5_GEMMA_NORM_EXACT = ("model.norm.weight",)
+
+# gguf tensor suffix -> HF parameter suffix, for the two parameters gguf-py's
+# name map cannot resolve.
+_QWEN3_5_GDN_EXTRA = {
+    "ssm_a": "linear_attn.A_log",
+    "ssm_dt.bias": "linear_attn.dt_bias",
+}
+
+
+def build_qwen3_5_name_map(config: PretrainedConfig) -> Dict[str, str]:
+    """{gguf_tensor_name: hf_param_name} for qwen3_5 / qwen3_5_text."""
+    import gguf
+    import torch
+    from transformers import AutoModelForCausalLM
+
+    text_config = getattr(config, "text_config", None) or config
+    num_layers = text_config.num_hidden_layers
+
+    # transformers' Qwen3_5DecoderLayer reads config.layer_types[layer_idx].  A
+    # Qwen3_5TextConfig rebuilt from GGUF metadata (or narrowed from a VL
+    # config) can arrive without it; the schedule is fully determined by
+    # full_attention_interval.
+    if getattr(text_config, "layer_types", None) is None:
+        interval = getattr(text_config, "full_attention_interval", 4)
+        text_config.layer_types = [
+            "full_attention" if (i + 1) % interval == 0 else "linear_attention"
+            for i in range(num_layers)
+        ]
+
+    arch = None
+    for key, value in gguf.MODEL_ARCH_NAMES.items():
+        if value == "qwen35":
+            arch = key
+            break
+    if arch is None:
+        raise RuntimeError(
+            "gguf-py does not know the 'qwen35' architecture; a newer gguf "
+            f"package is required (have {getattr(gguf, '__version__', 'unknown')})"
+        )
+    name_map = gguf.get_tensor_name_map(arch, num_layers)
+
+    with torch.device("meta"):
+        dummy_model = AutoModelForCausalLM.from_config(text_config)
+    state_dict = dummy_model.state_dict()
+
+    gguf_to_hf_name_map: Dict[str, str] = {}
+    unresolved = []
+    for hf_name in state_dict:
+        stem, _, suffix = hf_name.rpartition(".")
+        gguf_name = name_map.get_name(stem)
+        if gguf_name is None:
+            unresolved.append(hf_name)
+            continue
+        gguf_to_hf_name_map[f"{gguf_name}.{suffix}"] = hf_name
+
+    for layer in range(num_layers):
+        for gguf_suffix, hf_suffix in _QWEN3_5_GDN_EXTRA.items():
+            hf_name = f"model.layers.{layer}.{hf_suffix}"
+            if hf_name in state_dict:
+                gguf_to_hf_name_map[f"blk.{layer}.{gguf_suffix}"] = hf_name
+                if hf_name in unresolved:
+                    unresolved.remove(hf_name)
+
+    if unresolved:
+        raise RuntimeError(
+            f"{len(unresolved)} Qwen3.5 parameters have no GGUF tensor name, "
+            f"e.g. {unresolved[:4]}"
+        )
+    return gguf_to_hf_name_map
+
+
+def _permute_head_blocks(
+    tensor: "torch.Tensor", index: Sequence[int], block: int, offset: int = 0
+):
+    """Reorder ``len(index)`` groups of ``block`` consecutive rows.
+
+    Row ``offset + i * block + j`` of the result is row
+    ``offset + index[i] * block + j`` of the input.  Rows before ``offset`` are
+    left alone.  For a GGUF-quantised tensor the rows are packed bytes and each
+    row is self-contained, so this is an exact byte move for every quant type.
+    """
+    import torch
+
+    body = tensor[offset:]
+    n = len(index)
+    if body.shape[0] != n * block:
+        raise ValueError(
+            f"cannot split {body.shape[0]} rows into {n} groups of {block}"
+        )
+    rest = tuple(body.shape[1:])
+    body = body.reshape(n, block, *rest)[list(index)].reshape(n * block, *rest)
+    if offset == 0:
+        return body
+    return torch.cat([tensor[:offset], body], dim=0)
+
+
+class Qwen3_5GGUFWeightTransform:
+    """Turn llama.cpp's Gated-DeltaNet weight conventions into HF's.
+
+    Called with the HF parameter name, the tensor as it comes out of
+    ``gguf_quant_weights_iterator`` (packed uint8 rows for a quantised tensor,
+    real values for F32) and the GGML type id the loader announced for it.
+    """
+
+    def __init__(self, config: PretrainedConfig):
+        text_config = getattr(config, "text_config", None) or config
+        self.num_k_heads = int(text_config.linear_num_key_heads)
+        self.num_v_heads = int(text_config.linear_num_value_heads)
+        self.head_k_dim = int(text_config.linear_key_head_dim)
+        self.head_v_dim = int(text_config.linear_value_head_dim)
+        self.key_dim = self.num_k_heads * self.head_k_dim
+        self.value_dim = self.num_v_heads * self.head_v_dim
+        if self.num_v_heads % self.num_k_heads:
+            raise ValueError(
+                f"linear_num_value_heads {self.num_v_heads} is not a multiple "
+                f"of linear_num_key_heads {self.num_k_heads}"
+            )
+        group = self.num_v_heads // self.num_k_heads
+        # HF value head h is stored by llama.cpp at GGUF value head
+        # (h % group) * num_k_heads + h // group  -- the inverse of
+        # perm[p] = (p % num_k_heads) * group + p // num_k_heads.
+        self.gguf_index_of_hf_head = [
+            (h % group) * self.num_k_heads + h // group for h in range(self.num_v_heads)
+        ]
+        self.counts = {}
+
+    def _count(self, what: str):
+        self.counts[what] = self.counts.get(what, 0) + 1
+
+    def _permute_columns(self, name: str, tensor, weight_type):
+        """Permute value-head groups along the INPUT dim of out_proj."""
+        import torch
+
+        index = self.gguf_index_of_hf_head
+        if tensor.dtype != torch.uint8:
+            # unquantised: columns are real values
+            if tensor.shape[1] != self.value_dim:
+                raise ValueError(f"{name}: expected {self.value_dim} columns")
+            return (
+                _permute_head_blocks(
+                    tensor.transpose(0, 1).contiguous(), index, self.head_v_dim
+                )
+                .transpose(0, 1)
+                .contiguous()
+            )
+
+        import gguf
+
+        quant = gguf.GGMLQuantizationType(int(weight_type))
+        block_size, type_size = gguf.GGML_QUANT_SIZES[quant]
+        if self.head_v_dim % block_size:
+            raise NotImplementedError(
+                f"{name}: value head dim {self.head_v_dim} is not a multiple of "
+                f"the {quant.name} block size {block_size}, so llama.cpp's "
+                "value-head order cannot be undone without requantising. "
+                "Re-quantise this tensor with a type whose block size divides "
+                f"{self.head_v_dim} (e.g. Q8_0)."
+            )
+        group_bytes = (self.head_v_dim // block_size) * type_size
+        if tensor.shape[1] != self.num_v_heads * group_bytes:
+            raise ValueError(
+                f"{name}: {tensor.shape[1]} bytes per row, expected "
+                f"{self.num_v_heads * group_bytes} for {quant.name}"
+            )
+        out = tensor.reshape(tensor.shape[0], self.num_v_heads, group_bytes)
+        return out[:, list(index), :].reshape(tensor.shape[0], -1).contiguous()
+
+    def __call__(self, name: str, tensor, weight_type):
+        import torch
+
+        index = self.gguf_index_of_hf_head
+
+        if name in _QWEN3_5_GEMMA_NORM_EXACT or (
+            name.endswith(_QWEN3_5_GEMMA_NORM_SUFFIXES)
+            and ".linear_attn.norm." not in name
+        ):
+            if tensor.dtype == torch.uint8:
+                raise NotImplementedError(
+                    f"{name}: a zero-centred RMSNorm weight must be loaded "
+                    "unquantised so the folded +1 can be removed"
+                )
+            self._count("gemma_norm")
+            return tensor - 1.0
+
+        if ".linear_attn." not in name:
+            return tensor
+
+        if name.endswith(".linear_attn.A_log"):
+            # llama.cpp stores -exp(A_log); SGLang's gating kernel exponentiates
+            # A_log itself.
+            tensor = _permute_head_blocks(tensor, index, 1)
+            if not bool((tensor < 0).all()):
+                raise ValueError(
+                    f"{name}: expected every ssm_a entry to be negative "
+                    "(-exp(A_log)); this GGUF does not follow llama.cpp's "
+                    "qwen35 convention"
+                )
+            self._count("A_log")
+            return torch.log(-tensor.to(torch.float32)).to(tensor.dtype)
+
+        if name.endswith(".linear_attn.dt_bias"):
+            self._count("dt_bias")
+            return _permute_head_blocks(tensor, index, 1)
+
+        if ".linear_attn.conv1d." in name:
+            # rows are [key_dim (q), key_dim (k), value_dim (v)] channels
+            tensor = _permute_head_blocks(
+                tensor, index, self.head_v_dim, offset=2 * self.key_dim
+            )
+            if tensor.dim() == 2:
+                # HF keeps the depthwise singleton channel dim that llama.cpp drops
+                tensor = tensor.unsqueeze(1)
+            self._count("conv1d")
+            return tensor
+
+        if ".linear_attn.in_proj_qkv." in name:
+            self._count("in_proj_qkv")
+            return _permute_head_blocks(
+                tensor, index, self.head_v_dim, offset=2 * self.key_dim
+            )
+
+        if ".linear_attn.in_proj_z." in name:
+            self._count("in_proj_z")
+            return _permute_head_blocks(tensor, index, self.head_v_dim)
+
+        if ".linear_attn.in_proj_b." in name or ".linear_attn.in_proj_a." in name:
+            self._count("in_proj_ba")
+            return _permute_head_blocks(tensor, index, 1)
+
+        if ".linear_attn.out_proj." in name:
+            self._count("out_proj")
+            return self._permute_columns(name, tensor, weight_type)
+
+        return tensor
+
+
+def build_qwen3_5_weight_transform(config: PretrainedConfig):
+    return Qwen3_5GGUFWeightTransform(config)
+
+
+GGUF_HF_NAME_MAP_BUILDERS.update(
+    {model_type: build_qwen3_5_name_map for model_type in _QWEN3_5_MODEL_TYPES}
+)
+
+# Keyed like GGUF_HF_NAME_MAP_BUILDERS, by HF ``config.model_type``.  A builder
+# returns ``f(hf_param_name, tensor, ggml_type_id) -> tensor``; ``ggml_type_id``
+# is None for a tensor the GGUF stores unquantised.
+GGUF_WEIGHT_TRANSFORMS: Dict[str, Callable[[PretrainedConfig], Callable]] = {
+    model_type: build_qwen3_5_weight_transform for model_type in _QWEN3_5_MODEL_TYPES
+}
+
+
+def get_gguf_weight_transform(config: PretrainedConfig):
+    builder = GGUF_WEIGHT_TRANSFORMS.get(config.model_type)
+    return None if builder is None else builder(config)
+
+
+def apply_gguf_weight_transform(weights_iterator, transform):
+    """Run ``transform`` over a GGUF weight iterator.
+
+    ``gguf_quant_weights_iterator`` yields every ``*.qweight_type`` first and
+    the tensors afterwards, so the GGML type of each quantised tensor is known
+    by the time its data arrives.
+    """
+    weight_types = {}
+    for name, tensor in weights_iterator:
+        if name.endswith(".qweight_type"):
+            weight_types[name[: -len(".qweight_type")]] = int(tensor.reshape(-1)[0])
+            yield name, tensor
+            continue
+        stem, _, suffix = name.rpartition(".")
+        yield name, transform(name, tensor, weight_types.get(stem))

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -3218,9 +3218,28 @@ class GGUFModelLoader(BaseModelLoader):
         return gguf_to_hf_name_map
 
     def _get_weights_iterator(
-        self, model_name_or_path: str, gguf_to_hf_name_map: Dict[str, str]
+        self,
+        model_name_or_path: str,
+        gguf_to_hf_name_map: Dict[str, str],
+        model_config: Optional[ModelConfig] = None,
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
-        return gguf_quant_weights_iterator(model_name_or_path, gguf_to_hf_name_map)
+        from sglang.srt.model_loader.gguf_name_maps import (
+            apply_gguf_weight_transform,
+            get_gguf_weight_transform,
+        )
+
+        weights = gguf_quant_weights_iterator(model_name_or_path, gguf_to_hf_name_map)
+        # Some architectures need the *values* converted, not just renamed:
+        # llama.cpp may store a tensor in a different head order or a different
+        # value domain from the HF checkpoint it was converted from.
+        transform = (
+            None
+            if model_config is None
+            else get_gguf_weight_transform(model_config.hf_config)
+        )
+        if transform is None:
+            return weights
+        return apply_gguf_weight_transform(weights, transform)
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config.model_path)
@@ -3246,7 +3265,9 @@ class GGUFModelLoader(BaseModelLoader):
             with target_device:
                 model = _initialize_model(model_config, self.load_config, quant_config)
             model.load_weights(
-                self._get_weights_iterator(local_model_path, gguf_weights_map)
+                self._get_weights_iterator(
+                    local_model_path, gguf_weights_map, model_config
+                )
             )
 
             for _, module in model.named_modules():

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -501,7 +501,18 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
     def _bind_packed_weight_loaders(self, module):
         """Bind packed-checkpoint-aware loaders to all relevant params of a merged module."""
-        for attr_name in ("weight", "weight_scale_inv", "weight_scale", "input_scale"):
+        for attr_name in (
+            "weight",
+            "weight_scale_inv",
+            "weight_scale",
+            "input_scale",
+            # GGUF spells the packed weight "qweight" and carries an accompanying
+            # "qweight_type"; without them the tuple shard id (0, 1, 2) that
+            # in_proj_qkv needs never reaches _make_packed_weight_loader and
+            # MergedColumnParallelLinear.weight_loader dies on param.data[(0,1,2)].
+            "qweight",
+            "qweight_type",
+        ):
             param = getattr(module, attr_name, None)
             if param is None:
                 continue
@@ -1577,6 +1588,8 @@ class Qwen3_5ForCausalLM(nn.Module):
                 config.hidden_size,
                 org_num_embeddings=config.vocab_size,
                 enable_tp=not is_dp_attention_enabled(),
+                quant_config=quant_config,
+                prefix=add_prefix("embed_tokens", prefix),
             )
         else:
             self.embed_tokens = PPMissingLayer()

--- a/python/sglang/srt/models/qwen3_5_text.py
+++ b/python/sglang/srt/models/qwen3_5_text.py
@@ -199,17 +199,23 @@ class Qwen3_5ForCausalLM(nn.Module):
             for name, loaded_weight in weights:
                 if name.startswith(_MODEL_PREFIX):
                     yield name[len(_MODEL_PREFIX) :], loaded_weight
-                elif name == "lm_head.weight":
+                elif name.startswith("lm_head."):
+                    # A GGUF checkpoint spells the quantised head
+                    # "lm_head.qweight" / "lm_head.qweight_type", so matching
+                    # "lm_head.weight" exactly would silently drop the head and
+                    # leave it uninitialised.  Accept any lm_head parameter the
+                    # model actually declares, which is what the generic
+                    # per-model loading loops already do.
                     if self.config.tie_word_embeddings:
                         continue
-                    if "lm_head.weight" not in params_dict:
+                    if name not in params_dict:
                         continue
-                    param = params_dict["lm_head.weight"]
+                    param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
-                    loaded_params.add("lm_head.weight")
+                    loaded_params.add(name)
 
         body_loaded = self.model.load_weights(body_weights())
         loaded_params.update(f"{_MODEL_PREFIX}{n}" for n in body_loaded)


### PR DESCRIPTION
## Motivation

A llama.cpp-produced Qwen3.5 / Qwen3-Next GGUF loads, serves, and then answers every prompt with a run of `!`: all five top logprobs sit at -12.4226 = -ln(vocab_size) at every step, independent of the prompt, while llama.cpp b11654 serves the same file correctly. Anyone serving a llama.cpp GGUF of these architectures with a quantized token embedding hits this, and nothing raises or logs the root cause. `Qwen3_5ForCausalLM.__init__` and `Qwen3NextForCausalLM.__init__` build `embed_tokens` without `quant_config`, so `VocabParallelEmbedding` falls back to `UnquantizedEmbeddingMethod` and registers a plain bf16 `weight`, while `gguf_quant_weights_iterator` delivers `model.embed_tokens.qweight` and `.qweight_type`; neither name is in `params_dict`, both are dropped with one "not found in params_dict" line each, and the table keeps its `torch.empty()` contents.

Three value conversions are also missing underneath that, none of which raises or logs. llama.cpp has only a plain RMS norm, so its converter folds the `+1` of Qwen3.5's `x_normed * (1 + w)` into every `input_layernorm`, `post_attention_layernorm`, `q_norm`, `k_norm` and `model.norm`; it broadcasts q/k with a plain `ggml_repeat` and so pairs value head `p` with key head `p % n_k`, where SGLang's GDN kernels and transformers pair value head `i` with key head `i // (n_v/n_k)`; and it stores `blk.N.ssm_a` as `-exp(A_log)` because its graph multiplies the gate by it directly, while `fused_gdn_gating` exponentiates `A_log` itself. Two further defects stop the load outright: `qwen3_5_text.py` routes the head with `elif name == "lm_head.weight"` and so drops a quantized `lm_head.qweight`, and `Qwen3_5GatedDeltaNet._bind_packed_weight_loaders` binds its tuple-aware loader only to the safetensors parameter names, so the `(0, 1, 2)` shard id that `in_proj_qkv` needs reaches `MergedColumnParallelLinear.weight_loader` unwrapped.

## Modifications

Pass `quant_config` and `prefix` to the embedding, as `llama.py`, `qwen2.py` and `qwen2_moe.py` already do; it is a no-op for FP8 and BF16, where `get_quant_method()` returns `None` for a `VocabParallelEmbedding`. Register a `qwen3_5` GGUF name-map builder, and add `GGUF_WEIGHT_TRANSFORMS`, a per-architecture weight transform alongside the existing `GGUF_HF_NAME_MAP_BUILDERS` extension point that `GGUFModelLoader` runs over the weight iterator: it removes the folded `+1` from the five `GemmaRMSNorm` weights, leaves the Gated-DeltaNet gated norm (plain `w * x`, stored raw) alone, undoes the value-head order, converts `ssm_a` back to `A_log`, and restores the depthwise `conv1d` singleton dim llama.cpp drops. Accept any `lm_head.*` parameter, bind the packed loader to the GGUF parameter names, and reshape a 1-element weight-type chunk to 0-dim. The head permutation is applied to the packed bytes: GGUF rows are self-contained, so an output-dim permutation is an exact byte move for any quantization type, and the input-dim permutation of `out_proj` is exact whenever the quant block size divides the value head dim (Q8_0: 32 divides 128); where it does not (Q6_K and Q5_K, super-block 256 against head dim 128) the loader raises `NotImplementedError` naming the tensor and the type rather than serving a silently wrong model. Scope: the embedding `quant_config` hunk is small and stands on its own; many `VocabParallelEmbedding(...)` constructions under `python/sglang/srt/models/` omit `quant_config` and share the same latent defect, so that hunk can be taken separately from the rest of the GGUF support if preferred.

## Accuracy Tests

This changes model outputs (it fixes them), so the evidence is direct, measured on a 27B-class model, Q8_0 GGUF (26.63 GiB), one RTX 5090, `--tp-size 1`.

- All 851 mapped tensors match the FP8 checkpoint the GGUF was converted from after the transform: worst relative error 0.0271, the Q8_0 noise floor, and exactly 0.0 for every F32 tensor. Without the transform there are 7 mismatches per layer pair, up to 18.66.
- Greedy completions, temperature 0, 64 new tokens, 5 prompts: token-for-token identical to llama.cpp b11654 serving the same file, 320/320 tokens.
- Perplexity on wikitext, `n_ctx` 512, 100 chunks, the same scored window `llama-perplexity` uses: 6.7497 against `llama-perplexity`'s 6.7514 +/- 0.10331.
- Load log: 0 "not found in params_dict" warnings, down from 2.

## Speed Tests and Profiling

No speed change expected: the transform runs once at load over the weight iterator, and the served forward is unchanged.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over the changed files: isort, ruff, ruff-format and codespell all pass. ruff-format reflowed two of our added lines in gguf_name_maps.py, and we added a TYPE_CHECKING-guarded torch import so the string annotation on _permute_head_blocks resolves (ruff F821).)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (n/a: loader correctness needs a llama.cpp GGUF and a GPU; it is covered by 851/851 tensor match, 320/320 greedy identity vs llama.cpp and wikitext perplexity on GPU. No CPU-only test is meaningful without a GGUF checkpoint.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: bug fix, no user-facing documentation surface.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy: 851/851 tensors match the source FP8 checkpoint at the Q8_0 noise floor, greedy 320/320 identical to llama.cpp, wikitext perplexity 6.7497 vs 6.7514. Load-time fix, serving speed unchanged.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit isort / ruff / ruff-format report no further changes on the changed files.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34153357024](https://github.com/sgl-project/sglang/actions/runs/34153357024)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34153356878](https://github.com/sgl-project/sglang/actions/runs/34153356878)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34153357015](https://github.com/sgl-project/sglang/actions/runs/34153357015)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->