### PR TITLE
speculative: share embed/lm_head before the KV pool is sized

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -199,7 +199,25 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
         self.tree_mask_mode = default_tree_mask_mode()
 
+        # Hand the draft the target's embedding / lm_head HERE, before the KV cache
+        # is sized. A self-draft (NEXTN/MTP) loads its own copy of embed_tokens and
+        # lm_head; init_lm_head() replaces them with the target's tensors and frees
+        # the copies. Doing that inside alloc_memory_pool() -- i.e. after
+        # Scheduler.init_memory_pools() has already profiled free memory -- charges
+        # the KV pool for weights that are about to be released. On a 32 GB card and
+        # Qwen3.5-27B-NVFP4 that is ~4 GB, i.e. most of the KV pool.
+        self._lm_head_initialized = False
+        self._init_token_map_and_lm_head()
+
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+
+    def _init_token_map_and_lm_head(self):
+        """Idempotent: the draft may only share the target's weights once."""
+        if self._lm_head_initialized:
+            return
+        self.init_token_map()
+        self.init_lm_head()
+        self._lm_head_initialized = True
 
     def alloc_memory_pool(
         self,
@@ -215,8 +233,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_token_map()
-        self.init_lm_head()
+        self._init_token_map_and_lm_head()
 
         if get_spec().speculative_use_rejection_sampling:
             target_vocab_size = self.target_worker.model_config.vocab_size


### PR DESCRIPTION
## Motivation

A self-draft speculative head (NEXTN / MTP, and any EAGLE3 draft that sets `load_lm_head_from_target`) constructs and loads its own `embed_tokens` and its own `ParallelLMHead`, and is only afterwards handed the target's tensors by `set_embed_and_head()` / `set_lm_head_from_target()`, which `del` the draft's copies and call `empty_cache()`. That work is done by `EagleDraftWorker.init_lm_head()`, called at the end of `EagleDraftWorker.alloc_memory_pool()`, and `Scheduler.init_model_worker()` runs `init_memory_pools()` before it: `init_target_memory_pool()` profiles free GPU memory and sizes the KV pool before `draft_worker.alloc_memory_pool()` is reached.

The pool is therefore always sized against a reading that is short by one duplicate embedding table plus one duplicate output head. Nothing is leaked, but the memory comes back a few hundred milliseconds after the only consumer that could have used it has already decided how big it is. The shortfall scales with the vocabulary, and on a hybrid (Mamba or linear-attention) model it is charged twice, once to the KV pool and once to the recurrent state cache whose per-slot cost decides `max_running_requests`.

## Modifications

Move `init_token_map()` and `init_lm_head()` into `EagleDraftWorker.__init__`, immediately after the draft's `TpModelWorker` is constructed. Both need only the target model, which is already loaded and is `__init__`'s own `target_worker` argument, and the draft model; neither touches the memory pool, the attention backend or the CUDA graphs. They are wrapped in an idempotent `_init_token_map_and_lm_head()` that `alloc_memory_pool()` still calls, so a caller that reaches `alloc_memory_pool()` by another path behaves exactly as before. One file. A separate change, "speculative: share the target's embedding module with the draft," edits the body of that same call to fix quantized-embedding sharing; the two touch different lines and compose in either order, so this one is raised on its own.

## Accuracy Tests

No output change: this only moves the timing of an existing call and shares the target's tensors earlier. Greedy output, temperature 0, seed 1337, is byte-identical before and after, on both an RTX 5090 (32 GB, sm_120) and an RTX PRO 6000 Blackwell (96 GB), using a 27B-class NVFP4 checkpoint with its own MTP head as the NEXTN draft (`--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`). To benchmark against the unpatched build at matched capacity, pin `--max-total-tokens` to the same value on both sides; greedy output is byte-identical there.

## Speed Tests and Profiling

The change recovers roughly 9 % of the KV pool at identical flags on the target checkpoints, because the pool is no longer sized while a soon-to-be-freed duplicate embedding and head are still charged.

- RTX PRO 6000 Blackwell (96 GB), same checkpoint and flags: `max_total_num_tokens` 817,589 to 890,655 (+8.94 %), throughput unchanged at a mean of -0.42 % over six cells, because on that card the unpatched pool already held about 3.1x the largest workload's demand.
- RTX 5090 (32 GB), identical flags: the recovered capacity is throughput only where the pool was the binding constraint; at matched capacity (`--max-total-tokens` pinned on both sides) greedy output is byte-identical and the patched build is 1.5 % to 5.9 % faster.
- The gain is capacity, not speed: exactly `sizeof(duplicate embed + lm_head) / KV bytes per token` extra KV tokens, so no throughput change is expected above roughly 64 GB of VRAM for a 27B-class model.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over python/sglang/srt/speculative/eagle_worker_v2.py: all hooks pass with no reformatting.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (n/a: a call-ordering move in worker init; it needs a loaded target model on GPU and is verified by byte-identical greedy output and the KV-pool sizing above.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: no documentation surface.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Byte-identical greedy output; recovers ~9 % of the KV pool at identical flags, +8.94 % capacity on a 96 GB card, and 1.5-5.9 % faster at matched capacity on a 32 GB card.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit ruff / isort / ruff-format clean on the changed file.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34153494402](https://github.com/sgl-project/sglang/actions/runs/34153494402)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34153494271](https://github.com/sgl-project/sglang/actions/runs/34153494271)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34153494418](https://github.com/sgl-project/sglang/actions/runs/34153494418)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->