### PR TITLE
modelopt_fp4: skip the SiLU+FP4 fusion when the runner is marlin

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -179,6 +179,7 @@ def _maybe_enable_silu_fp4_quant_fusion(mlp: nn.Module) -> None:
     """
     if os.environ.get("SGLANG_DISABLE_SILU_FP4_QUANT_FUSION", "0") == "1":
         return
+    from sglang.srt.layers.quantization.fp4_utils import get_fp4_gemm_runner_backend
     from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4LinearMethod
 
     if not (
@@ -186,6 +187,17 @@ def _maybe_enable_silu_fp4_quant_fusion(mlp: nn.Module) -> None:
         and mlp.gate_up_proj.quant_method.quant_mode == "w4a4"
         and isinstance(mlp.down_proj.quant_method, ModelOptFp4LinearMethod)
     ):
+        return
+    if get_fp4_gemm_runner_backend().is_marlin():
+        # Marlin is a weight-only (W4A16) kernel: ModelOptFp4LinearMethod.apply
+        # hands its `x` straight to apply_fp4_marlin_linear, which takes a plain
+        # activation tensor. Feeding it the fused kernel's prequantized
+        # (fp4, scale) tuple raises
+        #   "apply_fp4_marlin_linear() Expected a value of type 'Tensor' for
+        #    argument 'input' but instead found type 'tuple'"
+        # during warmup, so --fp4-gemm-backend marlin cannot start on any model
+        # that takes this path. The fusion is an optimisation for the W4A4
+        # kernels only; skip it and keep act_fn + the linear's own quant.
         return
     try:
         from flashinfer import silu_and_mul_scaled_nvfp4_experts_quantize  # noqa: F401


### PR DESCRIPTION
## Motivation

`--fp4-gemm-backend marlin` cannot start a Qwen3.5 or Qwen3-Next NVFP4 checkpoint. The flag is accepted and the weights are repacked for marlin, then the scheduler dies in `EagerRunner.warmup()` with `sglang::apply_fp4_marlin_linear() Expected a value of type 'Tensor' for argument 'input' but instead found type 'tuple'`, raised out of `ModelOptFp4LinearMethod.apply()` under `qwen2_moe.py`'s `self.down_proj(self._silu_fp4_quant_fused(gate_up))`.

`_maybe_enable_silu_fp4_quant_fusion()` enables a FlashInfer kernel that fuses SiLU+mul with the activation NVFP4 quantization and hands `down_proj` a prequantized `(fp4, scale)` tuple, which is only meaningful for the W4A4 kernels; marlin is weight-only (W4A16) and consumes an unquantized activation, and `apply()` passes its `x` straight to the `apply_fp4_marlin_linear` custom op, whose schema declares `input` as a `Tensor`. The fusion gate checks the layer's quant method and quant mode but never the runner backend, so the two settings can always be selected together, the combination always crashes, and there is no fallback and no diagnostic pointing back at the flag.

## Modifications

Return early from `_maybe_enable_silu_fp4_quant_fusion()` when `get_fp4_gemm_runner_backend().is_marlin()`, in the same predicate that already refuses the fusion for a non-NVFP4 layer and for a missing FlashInfer kernel. `initialize_fp4_gemm_config()` runs in `Scheduler.init_moe_gemm_config()`, before `init_model_worker()` builds the layers, so the backend is known at that point. The W4A4 path is untouched, and `SGLANG_DISABLE_SILU_FP4_QUANT_FUSION=1` keeps working, but a user selecting a documented `--fp4-gemm-backend` value should not have to know that an unrelated environment variable exists. One guard, one file.

## Accuracy Tests

No output change: the guard's body is unreachable unless `--fp4-gemm-backend marlin` is passed, so greedy output is unchanged for every configuration that could run on both sides. On a 27B-class NVFP4 checkpoint (mixed-precision, MLP on NVFP4) on an RTX 5090 (sm_120) with `--fp4-gemm-backend marlin`, the scheduler aborts in warm-up before the change; after it the server starts, captures its graphs and serves.

## Speed Tests and Profiling

No speed change expected: the change only stops an always-crashing flag combination from being selected and adds no work to any serving path.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over python/sglang/srt/models/qwen3_5.py: all hooks pass with no reformatting (single-line config-time guard).)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (n/a: a config-time backend guard; the fused path is unreachable unless --fp4-gemm-backend marlin is selected, so it is covered by byte-identity, and a config-time assertion would need the marlin FP4 backend rather than a CPU stub.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: no documentation surface.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (n/a: no output or speed change; the guard only stops an always-crashing flag combination (before: warm-up abort; after: the server starts, captures graphs and serves). See Accuracy Tests and Speed Tests and Profiling above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit ruff / isort / ruff-format clean on the changed file.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34153583897](https://github.com/sgl-project/sglang/actions/runs/34153583897)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34153583763](https://github.com/sgl-project/sglang/actions/runs/34153583763)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34153583882](https://github.com/sgl-project/sglang/actions/runs/34153583882)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->