### PR TITLE
speculative: share the target's embedding module with the draft

### DIFF
--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -580,6 +580,48 @@ class VocabParallelEmbedding(torch.nn.Module):
                 output_parallel = tensor_model_parallel_all_reduce(output_parallel)
         return output_parallel
 
+    def share_table_from(self, source: "VocabParallelEmbedding") -> None:
+        """Take over ``source``'s table, quantization state included.
+
+        EAGLE / NextN drafts build their own input embedding and are then handed
+        the target's by ``set_embed_and_head()`` / ``set_embed()``, which moves
+        ``weight`` alone. That is the whole table only while it is a dense
+        ``[vocab, hidden]`` tensor. A quantized table stores packed rows whose
+        dequantization state -- the scales, the LUT, and the ``quant_method``
+        that reads them -- lives on the *module*, so a receiver that keeps its
+        own unquantized method gathers packed bytes and returns rows of the
+        wrong width and dtype. Adopt the source's method and every tensor it
+        owns instead; nothing is copied, so both modules share one table.
+        """
+        if source is self:
+            return
+        if (
+            self.num_embeddings_padded != source.num_embeddings_padded
+            or self.embedding_dim != source.embedding_dim
+            or self.tp_size != source.tp_size
+            or self.shard_indices != source.shard_indices
+        ):
+            raise ValueError(
+                "Cannot share an embedding table across different vocab-parallel "
+                f"layouts: {self.extra_repr()} vs {source.extra_repr()}."
+            )
+        for name in list(self._parameters) + list(self._buffers):
+            delattr(self, name)
+        self.quant_config = source.quant_config
+        self.quant_method = source.quant_method
+        self.scheme = source.scheme
+        for name, param in source.named_parameters(recurse=False):
+            # A previous handover may have left a plain attribute behind.
+            self.__dict__.pop(name, None)
+            self.register_parameter(name, param)
+        for name, buffer in source.named_buffers(recurse=False):
+            self.__dict__.pop(name, None)
+            self.register_buffer(
+                name,
+                buffer,
+                persistent=name not in source._non_persistent_buffers_set,
+            )
+
     def extra_repr(self) -> str:
         s = f"num_embeddings={self.num_embeddings_per_partition}"
         s += f", embedding_dim={self.embedding_dim}"
@@ -669,3 +711,22 @@ class ParallelLMHead(VocabParallelEmbedding):
     def forward(self, input_):
         del input_
         raise RuntimeError("LMHead's weights should be used in the sampler.")
+
+
+def find_embedding_module(
+    model: torch.nn.Module, weight: torch.Tensor
+) -> Optional[VocabParallelEmbedding]:
+    """The ``VocabParallelEmbedding`` in ``model`` whose table is ``weight``.
+
+    Identity, not name: the speculative handover is defined in terms of the
+    tensor a model hands over (``get_embed_and_head()``), and every model
+    spells the module that holds it differently. ``Module.modules()``
+    deduplicates by identity, so a tied lm_head is visited once.
+    """
+    for module in model.modules():
+        if (
+            isinstance(module, VocabParallelEmbedding)
+            and getattr(module, "weight", None) is weight
+        ):
+            return module
+    return None

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -333,6 +333,22 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                 param_name = "model.embed_tokens.weight"
                 if param_name in params_dict:
                     param = params_dict[param_name]
+                    if param.shape[1:] != loaded_weight.shape[1:]:
+                        # The checkpoint's embedding is quantized -- packed rows,
+                        # narrower than the hidden size -- while the MTP branch is
+                        # built unquantized, because these checkpoints exclude
+                        # `mtp*` from quantization. The local copy cannot hold it,
+                        # and it does not have to: a self-draft is handed the
+                        # target's embedding, and the speculative worker shares the
+                        # quantized module along with it.
+                        logger.warning_once(
+                            f"MTP: not loading {name} into the draft's unquantized "
+                            f"embedding (checkpoint rows are "
+                            f"{tuple(loaded_weight.shape[1:])}, the draft's are "
+                            f"{tuple(param.shape[1:])}); the draft shares the "
+                            f"target's embedding module instead."
+                        )
+                        continue
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -98,6 +98,7 @@ from sglang.srt.speculative.spec_utils import (
     renorm_draft_probs,
     sample_draft_proposal,
     select_top_k_tokens,
+    share_target_embedding,
     spec_stage_span,
 )
 from sglang.srt.utils.async_probe import (
@@ -336,6 +337,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             # Share the embedding and lm_head
             self.draft_runner.model.set_embed_and_head(embed, head)
             maybe_share_target_lm_head()
+
+        # Both branches above move the target's embedding *tensor* onto the
+        # draft. When that table is quantized the tensor is only the packed
+        # rows; the draft also needs the module state that dequantizes them.
+        share_target_embedding(
+            self.target_worker.model_runner.model, self.draft_runner.model, embed
+        )
 
     def init_attention_backend(self):
         # Create multi-step attn backends and cuda graph runners

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -77,6 +77,7 @@ from sglang.srt.speculative.spec_utils import (
     fast_topk,
     get_plan_stream,
     select_top_k_tokens,
+    share_target_embedding,
     spec_stage_span,
 )
 from sglang.srt.utils import empty_context, get_available_gpu_memory
@@ -156,6 +157,11 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
         if hasattr(self.draft_model_runner.model, "set_embed_and_head"):
             self.draft_model_runner.model.set_embed_and_head(embed, head)
+            share_target_embedding(
+                self.target_worker.model_runner.model,
+                self.draft_model_runner.model,
+                embed,
+            )
         else:
             logger.debug(
                 "Draft model %s does not implement set_embed_and_head; "

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -85,6 +85,7 @@ from sglang.srt.speculative.spec_utils import (
     get_plan_stream,
     sample_draft_proposal,
     select_top_k_tokens,
+    share_target_embedding,
 )
 from sglang.srt.utils import (
     get_available_gpu_memory,
@@ -366,6 +367,11 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         # Share the embedding and lm_head
         for i in range(self.speculative_num_steps):
             self.draft_runner_list[i].model.set_embed_and_head(embed, head)
+            share_target_embedding(
+                self.target_worker.model_runner.model,
+                self.draft_runner_list[i].model,
+                embed,
+            )
 
     def init_attention_backend(self):
         # Create attn backends

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -1095,3 +1095,57 @@ def get_plan_stream(
         return plan_stream, plan_stream_ctx
     else:
         return None, contextlib.nullcontext()
+
+
+def share_target_embedding(
+    target_model: torch.nn.Module,
+    draft_model: torch.nn.Module,
+    embed: Optional[torch.Tensor],
+) -> None:
+    """Finish a quantized embedding handover the draft cannot finish itself.
+
+    ``set_embed_and_head()`` / ``set_embed()`` move the target's embedding
+    ``weight`` onto the draft. For an unquantized table that is the whole
+    table and there is nothing more to do -- the common case, and the early
+    return below. A quantized table is not self-contained: its rows are packed
+    and the scales, the lookup table and the ``quant_method`` that turn them
+    back into hidden states live on the target's *module*. The draft, built
+    unquantized (these checkpoints exclude the draft branch from
+    quantization), would gather packed bytes with its own unquantized method
+    and hand its first norm rows of half the width. Give it the target's
+    module state as well; the tensors are shared, not copied.
+    """
+    from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
+    from sglang.srt.layers.vocab_parallel_embedding import find_embedding_module
+
+    if embed is None:
+        return
+    target_embed = find_embedding_module(target_model, embed)
+    if target_embed is None or isinstance(
+        target_embed.quant_method, UnquantizedEmbeddingMethod
+    ):
+        return
+    draft_embed = find_embedding_module(draft_model, embed)
+    if draft_embed is None:
+        # Not an error: several EAGLE3 drafts deliberately keep their own table
+        # -- their set_embed() returns early when target_hidden_size differs
+        # from the draft's hidden_size, and one converts the tensor rather than
+        # adopting it. Those drafts never gather from the target's packed rows,
+        # so there is nothing to finish here; leave them as they are.
+        logger.warning(
+            "The draft model did not adopt the target's embedding tensor "
+            "(set_embed_and_head()/set_embed() kept the draft's own table, as "
+            "EAGLE3 drafts do when target_hidden_size != hidden_size), so the "
+            "target's %s table is not shared. The draft embeds tokens with its "
+            "own table.",
+            type(target_embed.quant_method).__name__,
+        )
+        return
+    if draft_embed is target_embed:
+        return
+    draft_embed.share_table_from(target_embed)
+    logger.info(
+        "Draft model shares the target's %s embedding table (module state, not "
+        "just the packed weight).",
+        type(target_embed.quant_method).__name__,
+    )

--- a/test/registered/quant/test_nvfp4_embedding.py
+++ b/test/registered/quant/test_nvfp4_embedding.py
@@ -6,7 +6,13 @@ import torch
 
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
+    ModelOptMixedPrecisionConfig,
     ModelOptNvFp4EmbeddingMethod,
+)
+from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
+from sglang.srt.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+    find_embedding_module,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -118,6 +124,161 @@ class TestNvFp4Embedding(CustomTestCase):
                 output_size=8,
                 params_dtype=torch.bfloat16,
             )
+
+
+VOCAB_SIZE, HIDDEN_SIZE = 128, 64
+EMBED_PREFIX = "model.embed_tokens"
+
+
+def mixed_precision_config(embedding_quant_algo: str) -> ModelOptMixedPrecisionConfig:
+    """A MIXED_PRECISION config shaped like the Tool-Suite recipes: the token
+    embedding is NVFP4, and the draft branch is excluded from quantization."""
+    return ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quant_algo": "MIXED_PRECISION",
+            "ignore": ["mtp*", "mtp.layers.0*"],
+            "packed_modules_mapping": {},
+            "quantized_layers": {
+                EMBED_PREFIX: {
+                    "quant_algo": embedding_quant_algo,
+                    "group_size": GROUP_SIZE,
+                },
+                "lm_head": {"quant_algo": "FP8"},
+            },
+        }
+    )
+
+
+def build_embedding(quant_config, prefix: str) -> VocabParallelEmbedding:
+    """A real VocabParallelEmbedding, off the TP path (no process group here)."""
+    return VocabParallelEmbedding(
+        VOCAB_SIZE,
+        HIDDEN_SIZE,
+        params_dtype=torch.bfloat16,
+        quant_config=quant_config,
+        prefix=prefix,
+        enable_tp=False,
+    )
+
+
+def fill_nvfp4_table(layer: VocabParallelEmbedding) -> None:
+    generator = torch.Generator().manual_seed(1)
+    layer.weight.data.copy_(
+        torch.randint(
+            0,
+            256,
+            layer.weight.shape,
+            dtype=torch.uint8,
+            generator=generator,
+        )
+    )
+    layer.weight_scale.data.copy_(
+        torch.randint(
+            1, 8, layer.weight_scale.shape, dtype=torch.int32, generator=generator
+        ).to(torch.float8_e4m3fn)
+    )
+    layer.weight_scale_2.data.fill_(0.125)
+
+
+def gather(layer: VocabParallelEmbedding, ids: torch.Tensor) -> torch.Tensor:
+    """forward() needs the TP group; the gather itself does not."""
+    return layer.quant_method.embedding(layer, ids.long())
+
+
+class TestQuantizedEmbeddingSharing(CustomTestCase):
+    """The speculative handover moves `weight`; a quantized table is a module."""
+
+    def _target_and_draft(self):
+        config = mixed_precision_config("NVFP4")
+        target = build_embedding(config, EMBED_PREFIX)
+        self.assertIsInstance(target.quant_method, ModelOptNvFp4EmbeddingMethod)
+        fill_nvfp4_table(target)
+        # The draft branch is excluded from quantization by the checkpoint, so
+        # it builds a dense bf16 table of the full hidden size.
+        draft = build_embedding(config, "mtp.embed_tokens")
+        self.assertIsInstance(draft.quant_method, UnquantizedEmbeddingMethod)
+        return target, draft
+
+    def test_tensor_only_handover_returns_packed_rows(self):
+        """The defect this fixes, stated as a test."""
+        target, draft = self._target_and_draft()
+        ids = torch.tensor([0, 5, 63, 127])
+
+        del draft.weight
+        draft.weight = target.weight  # what set_embed_and_head() does
+
+        got = gather(draft, ids)
+        self.assertEqual(got.shape[-1], HIDDEN_SIZE // 2)  # packed, half width
+        self.assertEqual(got.dtype, torch.uint8)
+
+    def test_share_table_from_matches_the_target_gather(self):
+        target, draft = self._target_and_draft()
+        ids = torch.tensor([[0, 5, 63], [127, 5, 0]])
+        expected = gather(target, ids)
+
+        del draft.weight
+        draft.weight = target.weight
+        draft.share_table_from(target)
+
+        got = gather(draft, ids)
+        self.assertEqual(got.shape, expected.shape)
+        self.assertEqual(got.dtype, torch.bfloat16)
+        self.assertTrue(torch.equal(got, expected))
+
+    def test_sharing_copies_nothing(self):
+        target, draft = self._target_and_draft()
+        del draft.weight
+        draft.weight = target.weight
+        draft.share_table_from(target)
+
+        self.assertIs(draft.quant_method, target.quant_method)
+        for name, param in target.named_parameters(recurse=False):
+            self.assertIs(dict(draft.named_parameters(recurse=False))[name], param)
+        for name, buffer in target.named_buffers(recurse=False):
+            self.assertIs(dict(draft.named_buffers(recurse=False))[name], buffer)
+        # No leftover bf16 table of its own.
+        self.assertEqual(draft.weight.dtype, torch.uint8)
+
+    def test_layout_mismatch_raises(self):
+        target, _ = self._target_and_draft()
+        other = VocabParallelEmbedding(
+            VOCAB_SIZE * 2,
+            HIDDEN_SIZE,
+            params_dtype=torch.bfloat16,
+            enable_tp=False,
+        )
+        with self.assertRaisesRegex(ValueError, "vocab-parallel"):
+            other.share_table_from(target)
+
+    def test_find_embedding_module_by_identity(self):
+        target, draft = self._target_and_draft()
+        model = torch.nn.Module()
+        model.embed_tokens = target
+        model.other = draft
+
+        self.assertIs(find_embedding_module(model, target.weight), target)
+        self.assertIsNone(
+            find_embedding_module(model, torch.zeros(VOCAB_SIZE, HIDDEN_SIZE))
+        )
+
+    def test_unquantized_target_is_untouched(self):
+        """The gate: an unquantized embedding keeps the plain tensor handover."""
+        from sglang.srt.speculative.spec_utils import share_target_embedding
+
+        target = build_embedding(None, EMBED_PREFIX)
+        draft = build_embedding(None, "mtp.embed_tokens")
+        self.assertIsInstance(target.quant_method, UnquantizedEmbeddingMethod)
+
+        del draft.weight
+        draft.weight = target.weight
+        draft_method = draft.quant_method
+
+        target_model, draft_model = torch.nn.Module(), torch.nn.Module()
+        target_model.embed_tokens = target
+        draft_model.embed_tokens = draft
+        share_target_embedding(target_model, draft_model, target.weight)
+
+        self.assertIs(draft.quant_method, draft_method)  # untouched
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

EAGLE / NextN self-draft speculative decoding cannot start on a ModelOpt `MIXED_PRECISION` checkpoint whose token embedding is NVFP4, although the same checkpoint serves correctly without speculation. Adding `--speculative-algorithm NEXTN --speculative-draft-model-path <the same checkpoint>` kills the scheduler either at weight load, with `The size of tensor a (5120) must match the size of tensor b (2560) at non-singleton dimension 1` from `qwen3_5_mtp.py` into `vocab_parallel_embedding.py`, or, for a draft that skips the key at load (`glm5_next.py`), at the first draft forward inside CUDA-graph capture, with `CHECK_EQ(input.size(1), weight.size(0)) failed. 2560 vs 5120`.

Both are the same fact: 5120 is the hidden size and 2560 the same row after NVFP4 packs two 4-bit codes into each byte. `EagleDraftWorker.init_lm_head()` hands the draft a bare `weight` tensor from the target's `get_embed_and_head()`, which is the whole table only while it is dense; an NVFP4 table is `weight` plus `weight_scale`, `weight_scale_2` and an `e2m1_lut` buffer, and the dequantizing gather reads all four off the module, so the draft gathers packed bytes with its own `UnquantizedEmbeddingMethod`. Quantizing the embedding is worth doing and is therefore a common recipe: on a 27B-class model with a 248,320-token vocabulary it is 12.11 % of a bf16 build and 3.73 % as NVFP4, saving 1.70 GiB, about 8.7 % of the checkpoint, at close to no quality cost.

## Modifications

`VocabParallelEmbedding.share_table_from(source)` checks that both sides have the same vocab-parallel layout (`num_embeddings_padded`, `embedding_dim`, `tp_size`, `shard_indices`) and then adopts the source's `quant_config`, `quant_method`, `scheme` and every parameter and buffer by reference, so nothing is copied and the draft costs no extra memory. `find_embedding_module(model, weight)` returns the `VocabParallelEmbedding` whose `.weight` is that tensor, by identity rather than by name, which keeps the change model-agnostic: no per-model accessor, no Qwen branch, and the many `get_embed_and_head()` implementations untouched. `share_target_embedding()` in `spec_utils` ties the two together at the end of `EagleDraftWorker.init_lm_head()` and in the multi-layer and frozen-KV workers; it returns immediately when the target's embedding is `UnquantizedEmbeddingMethod`, the gate that keeps every checkpoint working today on exactly the path it takes today, and it warns rather than raises when the draft never adopted the tensor, as the EAGLE3 drafts deliberately do not when `target_hidden_size != hidden_size`.

One model-side hunk: `qwen3_5_mtp.load_weights()` loads its local embedding copy only when the local parameter can hold the checkpoint table, and otherwise skips it with a `warning_once` naming the reason. That copy exists for PP-split targets, where the draft's rank receives `embed=None` and genuinely needs one. `qwen3_5_mtp` is the only MTP class that force-loads a local embedding; `glm5_next`, `qwen3_next`, `qwen3_moe_mtp`, `mimo*_nextn`, `hunyuan_v3_nextn` and `step3p5_mtp` use the same tensor-only handover and are fixed by the worker call alone. A pipeline-parallel target stays out of scope: the draft's rank receives `embed=None`, keeps its own unloaded table, and the skip warns with the exact condition; verification is output-preserving, so this costs acceptance rate rather than token correctness. The test file is a second commit, separated only so the code change reads on its own.

## Accuracy Tests

Measured on an RTX 5090 (32 GB, sm_120) with a 27B-class model quantized to `MIXED_PRECISION` (NVFP4 token embedding at `group_size` 16, FP8 `lm_head`, `mtp*` excluded from quantization), NEXTN self-draft (`--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`). Both arms ran on one interpreter, differing only by `PYTHONPATH`.

- Without the change the server dies at weight load. With it, it loads, captures every CUDA graph including the draft-decode graph that used to raise `2560 vs 5120`, and serves 8/8 greedy prompts.
- Target forward unmoved: teacher-forced over 2,550 positions with the full 248,320-wide distribution stored, every stored array byte-for-byte equal, max abs delta log q 0.0, top-1 agreement 100 %, both for no speculation patched against unpatched and for NEXTN-on patched against no speculation unpatched. These dumps request `max_new_tokens: 0`, so they pin the target's forward and nothing else.
- Inert on a bf16 embedding, read from the server's own log rather than asserted: the sharing line is present on both NVFP4 cells and absent on both bf16 cells; greedy output 8/8 identical patched against unpatched, acceptance 2.7044 on both.
- Draft acceptance length 2.58 to 2.89 of a maximum 4 on the NVFP4-embedding checkpoint, against 2.70 to 2.95 on a bf16-embedding one at the same flags. Every paired comparison sized an identical KV pool, from the engine's own `KV Cache is allocated` line.
- Six CPU tests in `test/registered/quant/test_nvfp4_embedding.py`, an existing `register_cpu_ci` suite, running in about 0.4 s with no GPU and no checkpoint: they pin the defect, the post-share gather equality against the target's, sharing by identity, the layout-mismatch error, the identity lookup, and the unquantized-target gate.

## Speed Tests and Profiling

Once the change lets speculation run at all, NEXTN decode roughly doubles versus no speculation on the same checkpoint; prefill pays a few percent at low concurrency and gains at higher concurrency. Mean of two passes: decode +75.1 % chat c1, +70.7 % chat c8, +104.9 % coding c1, +49.8 % coding c8; prefill +77.9 % and +40.0 % at c8, -10.0 % and -6.5 % at c1. Every paired comparison sized an identical KV pool, so the gain is speculation, not capacity.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over the changed files: all hooks pass; ruff-format added one blank line before the __main__ block in the test file, which is kept.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Ships test/registered/quant/test_nvfp4_embedding.py, six CPU tests under register_cpu_ci, about 0.4 s, no GPU.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: no documentation surface.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy: target forward byte-identical over 2,550 positions, 8/8 greedy prompts served. Speed: NEXTN decode gains roughly +50 % to +105 % over no speculation once speculation can run.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit ruff / isort / ruff-format clean on the changed files.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34153649827](https://github.com/sgl-project/sglang/actions/runs/34153649827)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34153649655](https://github.com/sgl-project/sglang/actions/runs/34153649655)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34153649973](https://github.com/sgl-project/sglang/actions/runs/34153649973)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->