### PR TITLE
glm5_next: do not require a residual in the PP proxy tensors

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -980,7 +980,9 @@ class Glm5NextModel(nn.Module):
         else:
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
-            residual = pp_proxy_tensors["residual"]
+            # mHC folds the residual into the widened hidden state, so the
+            # previous stage sends none (sglang#36906): absent means None.
+            residual = pp_proxy_tensors.tensors.get("residual")
         device = hidden_states.device
         zero_allocator = BumpAllocator(
             buffer_size=total_num_layers * 2 * (2 if forward_batch.can_run_tbo else 1),
@@ -1058,12 +1060,11 @@ class Glm5NextModel(nn.Module):
             )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            # A None residual cannot travel over PP IPC; send only what exists.
+            proxy = {"hidden_states": hidden_states}
+            if residual is not None:
+                proxy["residual"] = residual
+            return PPProxyTensors(proxy)
         else:
             if not forward_batch.forward_mode.is_idle():
                 if residual is None:

--- a/test/registered/unit/model_executor/test_pp_proxy_missing_residual.py
+++ b/test/registered/unit/model_executor/test_pp_proxy_missing_residual.py
@@ -1,0 +1,79 @@
+"""PPProxyTensors tolerates a pipeline stage that sends no residual — CPU-only.
+
+Regression guard for sglang#36906. An mHC model (``hc_hidden_size is not None``,
+e.g. GLM-5.3-Flash / DeepSeek-V4) folds the residual into the widened hidden
+state, so a non-first pipeline stage receives a proxy that carries only
+``hidden_states``. ``Glm5NextModel.forward`` previously read
+``pp_proxy_tensors["residual"]`` unconditionally and died with
+``KeyError: residual`` on every non-first stage; it now reads
+``pp_proxy_tensors.tensors.get("residual")`` and re-inserts the key on the send
+side only when a residual actually exists (a ``None`` cannot travel over PP
+IPC).
+
+These tests pin the container contract that fix relies on. They need no GPU and
+no model weights.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _forward_pp_residual(pp_proxy_tensors):
+    """The residual read/re-send pattern of ``Glm5NextModel.forward``, isolated
+    from the (GPU-only) model body.
+
+    Returns the residual read from the incoming proxy (``None`` when the stage
+    sent none) and the proxy this stage would forward on.
+    """
+    hidden_states = pp_proxy_tensors["hidden_states"]
+    residual = pp_proxy_tensors.tensors.get("residual")
+
+    proxy = {"hidden_states": hidden_states}
+    if residual is not None:
+        proxy["residual"] = residual
+    return residual, PPProxyTensors(proxy)
+
+
+class TestPPProxyMissingResidual(CustomTestCase):
+    def test_absent_residual_reads_as_none(self):
+        """The read path the fix uses: no residual key -> None, not KeyError."""
+        pp = PPProxyTensors({"hidden_states": torch.zeros(3, 2)})
+        self.assertIsNone(pp.tensors.get("residual"))
+
+    def test_indexing_absent_residual_raises(self):
+        """Documents the pre-fix crash: __getitem__ still raises KeyError, so
+        the fix had to stop indexing the key unconditionally."""
+        pp = PPProxyTensors({"hidden_states": torch.zeros(3, 2)})
+        with self.assertRaises(KeyError):
+            pp["residual"]
+
+    def test_absent_residual_forward_omits_key(self):
+        """An mHC-style stage (hidden_states only) does not KeyError and does
+        not put a None residual back on the wire."""
+        hidden = torch.arange(6.0).reshape(3, 2)
+        residual, out = _forward_pp_residual(PPProxyTensors({"hidden_states": hidden}))
+        self.assertIsNone(residual)
+        self.assertNotIn("residual", out.tensors)
+        self.assertIs(out.tensors["hidden_states"], hidden)
+
+    def test_present_residual_passes_through_unchanged(self):
+        """A non-mHC stage still forwards the residual it received, by identity,
+        so every pp_size > 1, non-mHC run is unaffected."""
+        hidden = torch.arange(6.0).reshape(3, 2)
+        res = torch.ones(3, 2)
+        residual, out = _forward_pp_residual(
+            PPProxyTensors({"hidden_states": hidden, "residual": res})
+        )
+        self.assertIs(residual, res)
+        self.assertIs(out.tensors["residual"], res)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Any `--pp-size > 1` worker running GLM-5.3-Flash dies at the first forward with `KeyError: 'residual'` on every non-first pipeline stage. `Glm5NextModel.forward` reads `pp_proxy_tensors["residual"]` unconditionally and returns both keys when it is not the last rank, but with mHC the previous stage never sends a residual, because mHC folds it into the widened hidden state.

The two sides disagree by construction. The checkpoint's config sets `hc_mult = 4` and `mhc = true`, so `hc_hidden_size` is 16384 rather than `None`; `model_executor/runner_utils/buffers.py` and `runner/base_runner.py` both compute `is_mhc = hc_hidden_size is not None`, allocate only `hidden_states` at the widened size, and guard the residual buffer behind `if not is_mhc:` with the comment "mHC (e.g. DSV4) flattens residual into hidden_states". The reference mHC model does the matching thing on the send side: `deepseek_v4.py` returns only `{"hidden_states": hidden_states.flatten(1)}`. `glm5_next` is the odd one out. Fixes #36906.

## Modifications

Read the proxy with `.tensors.get("residual")`, so an absent key means `None` rather than a `KeyError`, and put the key back into the outgoing `PPProxyTensors` only when it exists, because a `None` cannot travel over PP IPC. Two hunks, one file. When the key is present `.tensors.get()` returns exactly what indexing returned, so a non-mHC configuration and every `pp_size == 1` run are unaffected. #37375 proposed the same one-line idea first; it was stacked on the GLM-5.3-Flash support branch and was auto-closed unmerged when that branch merged, but the bug survived the merge (`main` still reads the key unconditionally). Credit for the diagnosis belongs to that author; this is the same fix re-targeted at `main`.

## Accuracy Tests

Output-preserving: a present residual is passed through unchanged, so this only lets `--pp-size > 1` start rather than altering any computed value. Without the change, `KeyError: 'residual'` fires at the first forward on the non-first stages, and there is no working three-GPU shape to fall back to (tp=3 is impossible at 64 heads and tp2 x pp2 hits the same line). With it, the worker starts and serves, and its log carries zero residual `KeyError`s. Served a GLM-5.3-Flash NVFP4 build on 3 x RTX PRO 6000 Blackwell (96 GB) as pp=3 x tp=1, DSA + TileLang, bf16 KV, 262,144-token context, in production since 2026-09-02: 9/9 quality gates, including needle recall 1.0 at 32k, 64k and 128k, GSM8K 0.946, tool calls 10/10, vision 3/3 and HumanEval 20/20.

## Speed Tests and Profiling

No speed change expected: the change is a dict-access guard (indexing to `.tensors.get()`, plus a conditional re-insert on the send side), and the forward is otherwise unchanged. On the served configuration the KV pool is 2,684,288 tokens per stage with `max_running_requests` 29.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over the changed file and the new test: all hooks pass with no reformatting.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Adds test/registered/unit/model_executor/test_pp_proxy_missing_residual.py, four CPU tests under register_cpu_ci (no GPU, no weights) pinning that an absent 'residual' key reads as None rather than KeyError and is not re-sent over PP IPC.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: bug fix, no documentation surface.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (n/a: output-preserving fix that only lets --pp-size > 1 start; correctness shown by 9/9 production quality gates. No before/after benchmark, since the unpatched build cannot start on this shape, and no speed change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit ruff / isort / ruff-format clean on the changed files.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34153705918](https://github.com/sgl-project/sglang/actions/runs/34153705918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34153705618](https://github.com/sgl-project/sglang/actions/runs/34153705618)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34153705909](https://github.com/sgl-project/sglang/actions/runs/34153705909)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->