### PR TITLE
[Multimodal] Limit encoder batch input tokens

### DIFF
--- a/python/sglang/srt/arg_groups/field_order.py
+++ b/python/sglang/srt/arg_groups/field_order.py
@@ -381,6 +381,7 @@ POSITIONAL_FIELD_ORDER = (
     "enable_broadcast_mm_inputs_process",
     "enable_prefix_mm_cache",
     "mm_enable_dp_encoder",
+    "mm_max_encoder_input_tokens_per_batch",
     "mm_process_config",
     "mm_processor_worker_num",
     "mm_io_worker_num",

--- a/python/sglang/srt/arg_groups/fields/mm.py
+++ b/python/sglang/srt/arg_groups/fields/mm.py
@@ -67,6 +67,12 @@ class Mm:
         bool,
         "Enabling data parallelism for mm encoder. The dp size will be set to the tp size automatically.",
     ] = False
+    mm_max_encoder_input_tokens_per_batch: A[
+        Optional[int],
+        "Maximum number of encoder input tokens in one multimodal encoder "
+        "batch. Larger cross-request batches are split into multiple encoder "
+        "calls. A single item larger than the limit is encoded alone.",
+    ] = None
     mm_process_config: A[
         Optional[Dict[str, Any]],
         Arg(

--- a/python/sglang/srt/arg_groups/serving_hook.py
+++ b/python/sglang/srt/arg_groups/serving_hook.py
@@ -118,6 +118,11 @@ def handle_multimodal(server_args: Any):
     """Validate mm_process_config structure before model loading."""
     cfg = resolving_view(server_args)
     if (
+        cfg.mm_max_encoder_input_tokens_per_batch is not None
+        and cfg.mm_max_encoder_input_tokens_per_batch <= 0
+    ):
+        raise ValueError("--mm-max-encoder-input-tokens-per-batch must be positive")
+    if (
         cfg.mm_preprocess_cache_size_mb is not None
         and cfg.mm_preprocess_cache_size_mb < 0
     ):

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -3,13 +3,15 @@
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
+import numpy as np
 import torch
 
 from sglang.srt.managers.schedule_batch import MultimodalDataItem
 from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalStaticCache
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
-from sglang.srt.runtime_context import get_parallel, get_schedule
-from sglang.srt.utils import is_hip, is_npu, is_xpu
+from sglang.srt.multimodal.transport.cuda_ipc import CudaIpcTensorTransportProxy
+from sglang.srt.runtime_context import get_mm, get_parallel, get_schedule
+from sglang.srt.utils import is_hip, is_npu, is_xpu, print_warning_once
 from sglang.srt.utils.async_probe import maybe_assert_sum
 from sglang.utils import logger
 
@@ -320,14 +322,91 @@ class PerImageRequestInfo:
     )
 
 
+def _get_encoder_input_token_count(item: MultimodalDataItem) -> Optional[int]:
+    """Return the number of patch rows consumed by the multimodal encoder."""
+    feature = item.feature
+    if isinstance(feature, (torch.Tensor, np.ndarray)) and feature.ndim == 2:
+        return int(feature.shape[0])
+    if isinstance(feature, CudaIpcTensorTransportProxy):
+        shape = feature.proxy_state.get("ipc_extra", {}).get("recons_shape")
+        if shape is not None and len(shape) == 2:
+            return int(shape[0])
+
+    for key in ("image_grid_thw", "video_grid_thw", "image_grid_hws"):
+        grid = item.model_specific_data.get(key)
+        if grid is None:
+            continue
+        if isinstance(grid, torch.Tensor):
+            grid = grid.detach().cpu().numpy()
+        else:
+            grid = np.asarray(grid)
+        if grid.ndim == 1:
+            return int(np.prod(grid))
+        if grid.ndim == 2:
+            return int(np.prod(grid, axis=-1).sum())
+
+    return None
+
+
+def _split_items_by_encoder_token_budget(
+    items: List[MultimodalDataItem], max_tokens: Optional[int]
+) -> List[List[MultimodalDataItem]]:
+    """Split items into stable microbatches bounded by encoder input tokens."""
+    if not items:
+        return []
+    if max_tokens is None:
+        return [items]
+
+    batches = []
+    current_batch = []
+    current_tokens = 0
+
+    def flush_current_batch():
+        nonlocal current_batch, current_tokens
+        if current_batch:
+            batches.append(current_batch)
+            current_batch = []
+            current_tokens = 0
+
+    for item in items:
+        item_tokens = _get_encoder_input_token_count(item)
+        if item_tokens is None:
+            flush_current_batch()
+            batches.append([item])
+            print_warning_once(
+                "Cannot determine multimodal encoder input token count; "
+                "encoding the item in its own batch."
+            )
+            continue
+
+        if item_tokens > max_tokens:
+            flush_current_batch()
+            batches.append([item])
+            print_warning_once(
+                f"A multimodal item has {item_tokens} encoder input tokens, "
+                f"exceeding the configured batch limit {max_tokens}; "
+                "encoding the item alone."
+            )
+            continue
+
+        if current_batch and current_tokens + item_tokens > max_tokens:
+            flush_current_batch()
+        current_batch.append(item)
+        current_tokens += item_tokens
+
+    flush_current_batch()
+    return batches
+
+
 def _batch_encode_per_image_misses(
     data_embedding_func: DataEmbeddingFunc,
     per_image_requests: List[PerImageRequestInfo],
     device: torch.device,
 ) -> Dict[Tuple[Optional[int], int], torch.Tensor]:
     """
-    Collect cache misses across ALL per-image requests, deduplicate by hash and
-    expected token count, encode in a single ViT call, and populate the cache.
+    Collect cache misses across all per-image requests, deduplicate by hash and
+    expected token count, encode in token-bounded ViT batches, and populate the
+    cache.
 
     Returns:
         hash_to_embedding: mapping from (item.hash, token_count) to its full
@@ -370,37 +449,41 @@ def _batch_encode_per_image_misses(
             elif cache_key not in unique_misses:
                 unique_misses[cache_key] = (item, expected_token_count)
 
-    # Phase 1b: single ViT call for all unique cache misses
+    # Phase 1b: encode unique cache misses in bounded ViT microbatches
     if unique_misses:
         ordered_cache_keys = list(unique_misses.keys())
         miss_items = [unique_misses[key][0] for key in ordered_cache_keys]
-        token_counts = [unique_misses[key][1] for key in ordered_cache_keys]
+        max_tokens = get_mm().mm_max_encoder_input_tokens_per_batch
+        item_batches = _split_items_by_encoder_token_budget(miss_items, max_tokens)
 
-        if not _can_skip_pre_embed_feature_move(data_embedding_func):
-            _move_items_to_device(miss_items, device)
-        all_miss_embedding = data_embedding_func(miss_items)
-
-        if isinstance(all_miss_embedding, list):
-            # Per-item embeddings: no split needed, and each cache entry owns
-            # its storage (a torch.split view would pin the whole concatenated
-            # buffer for as long as any single item stays cached). Mirrors
-            # _get_chunked_embedding_by_item.
-            assert len(all_miss_embedding) == len(miss_items), (
-                f"per-item embedding count {len(all_miss_embedding)} != "
-                f"cache-miss item count {len(miss_items)}"
-            )
-            split_embeddings = [
-                emb.reshape(-1, emb.shape[-1]) for emb in all_miss_embedding
+        item_offset = 0
+        for item_batch in item_batches:
+            batch_cache_keys = ordered_cache_keys[
+                item_offset : item_offset + len(item_batch)
             ]
-        else:
-            all_miss_embedding = all_miss_embedding.reshape(
-                -1, all_miss_embedding.shape[-1]
-            )
-            split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
-        for cache_key, emb in zip(ordered_cache_keys, split_embeddings):
-            embedding_cache.set(cache_key[0], EmbeddingResult(embedding=emb))
-            # Keep a local ref (no extra GPU memory) so assembly never fails due to LRU eviction.
-            hash_to_embedding[cache_key] = emb
+            item_offset += len(item_batch)
+            token_counts = [unique_misses[key][1] for key in batch_cache_keys]
+
+            if not _can_skip_pre_embed_feature_move(data_embedding_func):
+                _move_items_to_device(item_batch, device)
+            batch_embedding = data_embedding_func(item_batch)
+
+            if isinstance(batch_embedding, list):
+                assert len(batch_embedding) == len(item_batch), (
+                    f"per-item embedding count {len(batch_embedding)} != "
+                    f"cache-miss item count {len(item_batch)}"
+                )
+                split_embeddings = [
+                    emb.reshape(-1, emb.shape[-1]) for emb in batch_embedding
+                ]
+            else:
+                batch_embedding = batch_embedding.reshape(-1, batch_embedding.shape[-1])
+                split_embeddings = torch.split(batch_embedding, token_counts, dim=0)
+
+            for cache_key, emb in zip(batch_cache_keys, split_embeddings):
+                embedding_cache.set(cache_key[0], EmbeddingResult(embedding=emb))
+                # Keep a local ref so assembly cannot fail after LRU eviction.
+                hash_to_embedding[cache_key] = emb
 
     return hash_to_embedding
 
@@ -589,7 +672,7 @@ def _get_chunked_prefill_embedding(
         else:
             full_path_requests.append(req_info)
 
-    # Phase 1: batch encode all per-image cache misses in ONE ViT call
+    # Phase 1: batch encode per-image cache misses under the encoder token budget
     hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor] = {}
     if per_image_requests:
         hash_to_embedding = _batch_encode_per_image_misses(

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -17,7 +17,7 @@ import torch
 
 from sglang.srt.managers import mm_schedule
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
-from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.srt.runtime_context import get_context, get_mm, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
@@ -107,6 +107,18 @@ def _make_items():
     ]
 
 
+def _make_items_with_encoder_tokens(token_counts):
+    return [
+        MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=2000 + i,
+            feature=torch.zeros(token_count, 4),
+            offsets=[(0, 1)],
+        )
+        for i, token_count in enumerate(token_counts)
+    ]
+
+
 def _run_by_item_chunks(encoder):
     mm_schedule.init_mm_embedding_cache(1 << 30)
     items = _make_items()
@@ -186,6 +198,55 @@ def test_tensor_cache_entries_share_storage():
         assert (
             emb.untyped_storage().nbytes() == total_tokens * HIDDEN * emb.element_size()
         )
+
+
+def test_encoder_token_budget_splits_items_in_stable_order():
+    items = _make_items_with_encoder_tokens([6, 5, 7])
+
+    batches = mm_schedule._split_items_by_encoder_token_budget(items, max_tokens=12)
+
+    assert [[item.hash for item in batch] for batch in batches] == [
+        [2000, 2001],
+        [2002],
+    ]
+
+
+def test_oversized_encoder_item_runs_alone():
+    items = _make_items_with_encoder_tokens([5, 13, 6])
+
+    batches = mm_schedule._split_items_by_encoder_token_budget(items, max_tokens=12)
+
+    assert [[item.hash for item in batch] for batch in batches] == [
+        [2000],
+        [2001],
+        [2002],
+    ]
+
+
+def test_cross_request_encoder_batch_respects_token_budget():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    items = _make_items_with_encoder_tokens([6, 5, 7])
+    requests = [
+        mm_schedule.PerImageRequestInfo(
+            req_idx=i,
+            items=[item],
+            items_offset=[(0, 1)],
+            extend_prefix_len=0,
+            extend_seq_len=2,
+        )
+        for i, item in enumerate(items)
+    ]
+    calls = []
+
+    def encoder(item_batch):
+        calls.append([item.hash for item in item_batch])
+        return torch.zeros(len(item_batch) * 2, HIDDEN)
+
+    with get_mm().override(mm_max_encoder_input_tokens_per_batch=12):
+        embeddings = mm_schedule._batch_encode_per_image_misses(encoder, requests, _CPU)
+
+    assert calls == [[2000, 2001], [2002]]
+    assert list(embeddings) == [(2000, 2), (2001, 2), (2002, 2)]
 
 
 def test_by_item_mismatched_cache_entry_is_reencoded():

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -280,6 +280,23 @@ class TestPrepareServerArgs(CustomTestCase):
 
 
 class TestMmEncoderDataParallelLogging(CustomTestCase):
+    def test_encoder_input_token_batch_limit(self):
+        parser = server_args_module.argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        parsed = parser.parse_args(
+            [
+                "--model-path",
+                "dummy",
+                "--mm-max-encoder-input-tokens-per-batch",
+                "16384",
+            ]
+        )
+        self.assertEqual(parsed.mm_max_encoder_input_tokens_per_batch, 16384)
+
+        args = ServerArgs(model_path="dummy", mm_max_encoder_input_tokens_per_batch=0)
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            serving_hook.handle_multimodal(args)
+
     def test_logs_when_encoder_dp_has_no_parallelism(self):
         server_args = ServerArgs(
             model_path="dummy", mm_enable_dp_encoder=True, tp_size=1


### PR DESCRIPTION
## Motivation

Cross-request multimodal batching can combine an unbounded number of image or video patches into one encoder call. The resulting activation peak can OOM the vision encoder even when each request is individually valid.

## Modifications

- Add `--mm-max-encoder-input-tokens-per-batch`.
- Count encoder input rows from materialized features, CUDA IPC metadata, or multimodal grid metadata.
- Split cache-miss items into stable ViT microbatches whose total encoder input tokens stay within the configured budget.
- Preserve the existing unlimited batching behavior when the option is unset.
- Encode an individually oversized or unknown-size item alone rather than rejecting the request.
- Add CLI validation and CPU unit coverage.

## Accuracy Tests

The change only partitions one encoder batch into ordered microbatches. Embeddings are reassembled and cached under the existing keys in the same request order.

Targeted CPU tests in Canoe job `j-ujn7palhtm`:

```
4 passed, 132 deselected in 25.98s
```

## Speed Tests and Profiling

No benchmark was run. The default remains unchanged. Setting the limit can add encoder calls in exchange for bounding peak vision-encoder memory.

## Checklist

- [x] Format code with pre-commit (AST, isort, ruff, ruff-format, and codespell pass).
- [x] Add unit tests.
- [x] CLI help documents the new option; no separate user guide is required.
- [x] Accuracy behavior is unchanged because batching order and cache keys are preserved.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34154329167](https://github.com/sgl-project/sglang/actions/runs/34154329167)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34154328893](https://github.com/sgl-project/sglang/actions/runs/34154328893)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34154329104](https://github.com/sgl-project/sglang/actions/runs/34154329104)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->