### PR TITLE
tilelang: make the DSA v1 head tile a parameter

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -271,6 +271,7 @@ def sparse_attention_fwd_kernel_v1(
     block_I=64,
     num_stages=2,
     threads=256,
+    heads_per_block=64,
 ):
     assert dim == tilelang.math.next_power_of_2(dim) or dim % 64 == 0, (
         f"dim={dim} must be a power of 2 or a multiple of 64"
@@ -310,13 +311,17 @@ def sparse_attention_fwd_kernel_v1(
     D = dim
     D_tail = tail_dim
 
-    if head_kv > 64:
-        assert head_kv % 64 == 0, "head_kv should be a multiple of 64"
-        REPLICATE_H = head_kv // 64
+    # heads_per_block bounds the Q/O tiles held in shared memory; a rank with more
+    # heads runs several blocks per query position (REPLICATE_H) instead.
+    if head_kv > heads_per_block:
+        assert head_kv % heads_per_block == 0, (
+            f"head_kv should be a multiple of {heads_per_block}"
+        )
+        REPLICATE_H = head_kv // heads_per_block
     else:
         REPLICATE_H = 1
 
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    H_per_block = padded_H if REPLICATE_H == 1 else heads_per_block
 
     @T.prim_func
     def main(
@@ -357,7 +362,9 @@ def sparse_attention_fwd_kernel_v1(
             q_i = s_i
             max_kv_i = q_i
 
-            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+            H0 = g_i * padded_H + (
+                0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * heads_per_block
+            )
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)


### PR DESCRIPTION
## Motivation

`sparse_attention_fwd_kernel_v1` takes `block_I`, `num_stages` and `threads` as parameters, but the number of query heads a block holds is the literal `64`, written three times: `if head_kv > 64`, `H_per_block = padded_H if REPLICATE_H == 1 else 64`, and `(bx % REPLICATE_H) * 64`. That literal is what sets the kernel's shared-memory footprint, since `Q_shared` and `O_shared` are `[H_per_block, 512]` and `S_shared` is `[H_per_block, block_I]`, all bf16.

A device whose per-block dynamic shared-memory ceiling is below what the tile asks cannot launch the kernel at all, and nothing at the call site can lower it: `tilelang_sparse_fwd()` calls `kernel_factory(num_heads, d_v, tail_dim, topk, sm_scale=sm_scale)` and passes no tile, there is no environment variable and there is no autotune. On consumer Blackwell (SM120/121) the ceiling is 101,376 B against roughly 169,984 B at 32 heads per rank and 206,848 B at 64, so the launch fails with `tvm.error.InternalError: Failed to set the allowed dynamic shared memory size to 206848`. That is #37105, and today the only way out of it is to edit the kernel.

## Modifications

Add `heads_per_block=64` next to the other three tile parameters and use it in place of the three literals. `REPLICATE_H` already exists to run several blocks per query position when a rank has more heads than one block holds; this only lets a caller decide where that threshold sits. One file, three hunks, no call site changed. It makes the tile selectable but does not select one: choosing a tile per device is a separate change, and deriving it from the device's own dynamic shared-memory ceiling would be better than a capability-major branch. `sparse_attention_fwd_kernel_v2` is untouched; it has no `num_stages`/`threads` parameters either, so the same generalisation there would be a larger change and is not attempted here.

## Accuracy Tests

No output change at the default, checked mechanically rather than argued: substituting `heads_per_block` back to `64` in the patched file recovers the original file except for one comment, the wording of the `assert` message and one line wrap. Every executable expression is character-identical (`head_kv > 64`, `head_kv % 64 == 0`, `head_kv // 64`, `else 64`, `(bx % REPLICATE_H) * 64`), and no existing caller passes the parameter, so every current build takes the default and generates the same kernel. With a non-default tile (`block_I=32, num_stages=1, threads=128, heads_per_block=32`) on an RTX 5090 (SM120), the kernel matches a float32 gathered-attention reference to a relative error of about 2.0e-3 at both 32 and 64 heads, which is bf16 rounding noise; the comparable public figure is LibertAI's GB10 retune at 2.4e-3. That tile has served a GLM-5.3-Flash NVFP4 build on 3 x RTX PRO 6000 Blackwell as pp=3 x tp=1 (64 heads per rank, DSA tilelang backend) in production since 2026-09-02: 9/9 quality gates, needle recall 1.0 at 32k, 64k and 128k, GSM8K 0.946, decode ITL unchanged.

## Speed Tests and Profiling

No speed change at the default, which generates a byte-identical kernel. Where a smaller tile is chosen so the kernel can launch on a shared-memory-constrained device, it trades tile size for launchability, and decode ITL was unchanged in the served pp=3 x tp=1 configuration.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (pre-commit run over python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py: all hooks pass with no reformatting.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (n/a: the new heads_per_block parameter defaults to the previous literal 64, a no-op checked by kernel byte-identity; a real unit test would need TileLang/CUDA compilation and is not CPU-testable, and the numerical match is shown against a float32 reference.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a: heads_per_block is an internal kernel-factory parameter, not a server flag or environment variable, so there is no user-facing doc surface (the change adds no call site, env var or autotune).)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Byte-identical kernel at the default; a non-default tile matches a float32 reference to about 2.0e-3 at 32 and 64 heads, decode ITL unchanged.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (pre-commit ruff / isort / ruff-format clean on the changed file.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34154568128](https://github.com/sgl-project/sglang/actions/runs/34154568128)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34154567909](https://github.com/sgl-project/sglang/actions/runs/34154567909)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34154568066](https://github.com/sgl-project/sglang/actions/runs/34154568066)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->