### PR TITLE
[Test] Remove obsolete CP mocks from NextN MM embedding tests

### DIFF
--- a/test/registered/unit/models/test_deepseek_nextn_mm_embed.py
+++ b/test/registered/unit/models/test_deepseek_nextn_mm_embed.py
@@ -93,14 +93,6 @@ class TestDeepseekNextNMmEmbed(CustomTestCase):
 
         with (
             patch(
-                "sglang.srt.models.deepseek_nextn.dsa_use_prefill_cp",
-                return_value=False,
-            ),
-            patch(
-                "sglang.srt.models.deepseek_nextn.mla_use_prefill_cp",
-                return_value=False,
-            ),
-            patch(
                 "sglang.srt.models.deepseek_nextn.fused_eh_norm",
                 side_effect=lambda h, p, ew, hw, eps: torch.cat(
                     [model.enorm(h), model.hnorm(p)], dim=-1
@@ -157,14 +149,6 @@ class TestDeepseekNextNMmEmbed(CustomTestCase):
         embed_calls = mock_embed.call_args_list
 
         with (
-            patch(
-                "sglang.srt.models.deepseek_nextn.dsa_use_prefill_cp",
-                return_value=False,
-            ),
-            patch(
-                "sglang.srt.models.deepseek_nextn.mla_use_prefill_cp",
-                return_value=False,
-            ),
             patch(
                 "sglang.srt.models.deepseek_nextn.fused_eh_norm",
                 side_effect=lambda h, p, ew, hw, eps: torch.cat(


### PR DESCRIPTION
## Summary
Stacked on #38293 (base commit adb9fdc1951bc83e7849ad4a77510bbbbdf5658b).

Remove the obsolete dsa_use_prefill_cp and mla_use_prefill_cp patches from both NextN multimodal embedding regression tests. #38293 removes these symbols from deepseek_nextn.py, so unittest.mock.patch raises AttributeError before either test can exercise the embedding logic.

Only the four stale patch blocks are removed (one test file, 16 deleted lines). Existing test inputs, assertions, and production code are unchanged; no AMD/NPU logic is changed.

## Validation
- Baseline failure: https://github.com/sgl-project/sglang/actions/runs/34093542682/job/101652182591
- pre-commit checks: passed with Python 3.12.
- Local full test execution is blocked by a missing requests dependency.
- Requested `/rerun-test test/registered/unit/models/test_deepseek_nextn_mm_embed.py` on this PR.
- Targeted CPU CI passed on commit 8cef199bd548a6f266bab995b104924d7d241b33: **2 tests, OK** (1.079s unittest runtime; 30s including imports).
- CI result: https://github.com/sgl-project/sglang/actions/runs/34159882867/job/101859265597