### PR TITLE
[CI] Cut Lark CI card noise: daily queue digest, tighter slow bar, extra-test aggregator filter

### DIFF
--- a/.github/workflows/ci-lark-notify.yml
+++ b/.github/workflows/ci-lark-notify.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
   schedule:
     - cron: '*/15 * * * *'   # runner-health
-    - cron: '30 */8 * * *'   # queue-digest
+    - cron: '30 16 * * *'    # queue-digest
   workflow_dispatch:
     inputs:
       task:
@@ -94,7 +94,8 @@ jobs:
           LARK_WEBHOOK: ${{ secrets.LARK_WEBHOOK }}
         run: |
           python scripts/ci_monitor/lark_notify.py $DRY_RUN_FLAG runner-health \
-            --state-file runner-health-state.json
+            --state-file runner-health-state.json \
+            --remind-hours 6
       - name: Save runner-health state
         if: ${{ !inputs.dry_run }}
         uses: actions/cache/save@v4
@@ -105,7 +106,7 @@ jobs:
   queue-digest:
     if: >-
       github.repository == 'sgl-project/sglang' && (
-        (github.event_name == 'schedule' && github.event.schedule == '30 */8 * * *') ||
+        (github.event_name == 'schedule' && github.event.schedule == '30 16 * * *') ||
         (github.event_name == 'workflow_dispatch' && inputs.task == 'queue-digest')
       )
     runs-on: ubuntu-latest
@@ -119,8 +120,10 @@ jobs:
           python-version: '3.12'
       - name: Post queue digest
         env:
-          # PAT: an 8h window is ~400-500 API calls, too close to GITHUB_TOKEN's 1000/h
+          # PAT: an 8h window is ~400-500 API calls, too close to GITHUB_TOKEN's 1000/h.
+          # Do not widen the window: 24h exhausts even a PAT's 5000/h.
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
           LARK_WEBHOOK: ${{ secrets.LARK_WEBHOOK }}
         run: |
-          python scripts/ci_monitor/lark_notify.py $DRY_RUN_FLAG queue-digest --hours 8 --only-if-slow
+          python scripts/ci_monitor/lark_notify.py $DRY_RUN_FLAG queue-digest \
+            --hours 8 --slow-minutes 120 --only-if-slow

--- a/scripts/ci_monitor/README.md
+++ b/scripts/ci_monitor/README.md
@@ -7,8 +7,8 @@ Scripts used by [.github/workflows/ci-failure-monitor.yml](../../.github/workflo
 1. **Failures Analyzer** (`ci_failures_analysis.py`): Tracks consecutive failures, identifies flaky jobs, and monitors runner health across PR Test / Nightly workflows (Nvidia, AMD, Intel, XPU, NPU).
 2. **Lark Notifier** (`lark_notify.py`): Posts CUDA CI health cards to a Lark group through an incoming webhook (`LARK_WEBHOOK` secret). Stdlib only. Three subcommands:
    - `ci-status --run-id N`: one card per finished scheduled run of the Nvidia nightly / weekly / scheduled pr-test. The first attempt lists its failed jobs; a rerun (attempt N > 1) is compared with attempt N-1 of the same run (fixed by rerun / still failing). Triggered by `workflow_run`.
-   - `runner-health --state-file F`: per-pool online / offline counts for the primary CUDA labels (`N-gpu-h100|h200|h20|5090|b200|b300|gb200|gb300|a10`). Posts only on degraded / recovered transitions plus an hourly reminder while degraded; state is carried between runs via `actions/cache`. Needs an admin PAT to list runners.
-   - `queue-digest --hours 8 --only-if-slow`: per-pool queue time p50 / p90 / max over the window plus currently queued jobs, posted only when some pool's p90 exceeds `--slow-minutes` (default 30). Links to the latest Runner Utilization Report run.
+   - `runner-health --state-file F`: per-pool online / offline counts for the primary CUDA labels (`N-gpu-h100|h200|h20|5090|b200|b300|gb200|gb300`). Posts only on degraded / recovered transitions plus a reminder every `--remind-hours` (6h in CI) while degraded; state is carried between runs via `actions/cache`. Needs an admin PAT to list runners.
+   - `queue-digest --hours 8 --only-if-slow`: per-pool queue time p50 / p90 / max over the window plus currently queued jobs, posted only when some pool's p90 exceeds `--slow-minutes` (120 in CI; the pools sit above 30m most of the day, so a low bar fires every run). Runs once a day. Links to the latest Runner Utilization Report run.
 
    All subcommands accept `--dry-run` to print the card JSON instead of posting.
 

--- a/scripts/ci_monitor/lark_notify.py
+++ b/scripts/ci_monitor/lark_notify.py
@@ -27,8 +27,9 @@ GITHUB_API = "https://api.github.com"
 UTILIZATION_WORKFLOW = "runner-utilization.yml"
 
 # Primary pool labels only; aliases (1-gpu-runner, 8-gpu-h200-deepep, ...) are
-# excluded so every runner is counted under exactly one label.
-CUDA_LABEL_RE = re.compile(r"^\d+-gpu-(h100|h200|h20|5090|b200|b300|gb200|gb300|a10)$")
+# excluded so every runner is counted under exactly one label. a10 is left out
+# as well: it serves no per-commit test, so its transitions are noise.
+CUDA_LABEL_RE = re.compile(r"^\d+-gpu-(h100|h200|h20|5090|b200|b300|gb200|gb300)$")
 
 # Workflows whose jobs run on the CUDA pools; used for queue-digest.
 CUDA_WORKFLOW_FILES = [
@@ -40,7 +41,11 @@ CUDA_WORKFLOW_FILES = [
 
 FAILED_CONCLUSIONS = {"failure", "timed_out", "startup_failure", "action_required"}
 # Aggregator jobs fail whenever any other job fails; listing them is noise.
-AGGREGATOR_JOB_RE = re.compile(r"^(check-all-jobs|pr-test-finish)$")
+# Jobs from a called workflow arrive prefixed ("call-pr-test-extra / <name>"),
+# so the aggregator name is matched on the last segment.
+AGGREGATOR_JOB_RE = re.compile(
+    r"^(?:.+ / )?(check-all-jobs|pr-test-finish|pr-test-extra-finish)$"
+)
 MAX_LISTED_JOBS = 15
 
 


### PR DESCRIPTION
Reduces the Lark CI card volume: queue-digest runs daily with a p90 bar of 2h, runner-health reminds every 6h, the a10 pool is dropped, and the reusable-workflow aggregator job `call-pr-test-extra / pr-test-extra-finish` no longer shows up as a failed job.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34170883665](https://github.com/sgl-project/sglang/actions/runs/34170883665)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34170883492](https://github.com/sgl-project/sglang/actions/runs/34170883492)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->