### PR TITLE
test: stop TestPortArgs from asking the host whether its ports are free

### DIFF
--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1098,6 +1098,30 @@ class TestContextParallelServerArgs(CustomTestCase):
 
 
 class TestPortArgs(unittest.TestCase):
+    # These cases are about how names and ports are *derived*. Two things in
+    # `init_new` reach the host's port table instead, and neither is what is
+    # under test:
+    #
+    # * `nccl_port=None` sends it to `get_free_port()`, which binds an
+    #   ephemeral socket;
+    # * the DP-attention path calls `wait_port_available()` on each derived
+    #   port -- fixed numbers like 30000 + ZMQ_TCP_PORT_DELTA -- and that binds
+    #   to check and waits up to SGLANG_WAIT_PORT_TIMEOUT (30s) before raising.
+    #
+    # So anything holding one of those ports, a leftover server from another
+    # test run included, fails a test that never meant to ask. Both are pinned
+    # here; `network.py` is where their real behaviour is covered.
+    FREE_PORT = 41234
+
+    def setUp(self):
+        for target, kwargs in (
+            ("sglang.srt.server_args.get_free_port", {"return_value": self.FREE_PORT}),
+            ("sglang.srt.server_args.wait_port_available", {"return_value": True}),
+        ):
+            patcher = patch(target, **kwargs)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
     @patch("sglang.srt.server_args.tempfile.NamedTemporaryFile")
     def test_init_new_standard_case(self, mock_temp_file):
         mock_temp_file.return_value.name = "temp_file"
@@ -1176,7 +1200,7 @@ class TestPortArgs(unittest.TestCase):
             port_args.scheduler_input_ipc_name.startswith("tcp://127.0.0.1:")
         )
         self.assertTrue(port_args.detokenizer_ipc_name.startswith("tcp://127.0.0.1:"))
-        self.assertIsInstance(port_args.nccl_port, int)
+        self.assertEqual(port_args.nccl_port, self.FREE_PORT)
 
     def test_init_new_with_dp_rank(self):
         server_args = ServerArgs(model_path="dummy")


### PR DESCRIPTION
`TestPortArgs` asks the host whether six fixed port numbers are free, and fails
when the answer is no. Nine tests about *how ports are derived* are decided by
what else is running on the machine.

## What happens

`PortArgs.init_new` calls `wait_port_available()` on each port it derives. For
the single-node cases those are fixed: `30000 + ZMQ_TCP_PORT_DELTA` and five
neighbours, 30233-30238. The helper binds to check, and on failure waits up to
`SGLANG_WAIT_PORT_TIMEOUT` (30s) before raising. So anything holding one of
those ports -- another test run, a leftover server -- turns the test red after a
30-second stall.

All nine cases in the class also pass `nccl_port=None`, which sends `init_new`
to `get_free_port()` and binds an ephemeral socket. That is 31 binds for a class
whose subject is name and port *arithmetic*.

It bit a batch run of mine, and passed on every solo re-run, which is the shape
that gets a test written off as flaky. It is not flaky; it is asking a question
it does not need the answer to.

## The change

A `setUp` pinning `get_free_port` and `wait_port_available`, and one assertion
tightened from `assertIsInstance(nccl_port, int)` to the value it should be.

`get_free_port` and `wait_port_available` keep their own coverage in the
`network.py` tests -- what this removes is nine derivation tests depending on
the host's port table.

## Evidence

Holding all six derived ports, same command both sides:

| | result |
|---|---|
| before | `1 failed, 8 passed` |
| after | `9 passed` |

The one that fails is `test_init_new_with_single_node_dp_attention`, the one
that flaked. Instrumenting `socket.bind` shows the class going from 31 binds to
one import-time `('::1', 0)` probe.

This reproduces identically on `main` (`20ca564bf7`), so it is a pre-existing
fault, not a regression from anything in flight.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34171384033](https://github.com/sgl-project/sglang/actions/runs/34171384033)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34171383977](https://github.com/sgl-project/sglang/actions/runs/34171383977)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34171384072](https://github.com/sgl-project/sglang/actions/runs/34171384072)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->