### PR TITLE
[diffusion] Test grouped QKV shard ownership and rejection boundaries

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_qkv_loading.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_qkv_loading.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU contracts for dense grouped-QKV loading; no communication runtime."""
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
+    _copy_grouped_qkv_tp_shard,
+    _reorder_grouped_qkv_to_qkv,
+)
+
+
+@pytest.mark.parametrize("tp_size,ulysses_size", [(1, 2), (2, 2), (2, 4)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_composed_rank_shards_reconstruct_grouped_qkv(tp_size, ulysses_size, dtype):
+    heads, head_dim, hidden = 56, 2, 3
+    dense = ((torch.arange(heads * 3 * head_dim * hidden) % 127 - 63) / 4).to(dtype)
+    dense = dense.reshape(heads * 3 * head_dim, hidden)
+    local_heads = heads // (tp_size * ulysses_size)
+    shards = []
+    x = torch.tensor([[0.25, -0.5, 0.75], [1.0, 0.5, -0.25]])
+    projected = []
+    for tp_rank in range(tp_size):
+        for ulysses_rank in range(ulysses_size):
+            rank = tp_rank * ulysses_size + ulysses_rank
+            shard = torch.empty(3 * local_heads * head_dim, hidden, dtype=dtype)
+            shard.output_dim = 0
+            assert _copy_grouped_qkv_tp_shard(
+                shard,
+                dense,
+                num_query_groups=heads,
+                head_dim=head_dim,
+                tp_rank=rank,
+                tp_size=tp_size * ulysses_size,
+            )
+            # Independent native [head, Q/K/V, dim, hidden] ownership oracle.
+            start = rank * local_heads
+            expected = dense.view(heads, 3, head_dim, hidden)[
+                start : start + local_heads
+            ]
+            expected = expected.permute(1, 0, 2, 3).reshape_as(shard)
+            assert torch.equal(shard.view(torch.uint8), expected.view(torch.uint8))
+            shards.append(shard.reshape(3, local_heads, head_dim, hidden))
+            projected.append(torch.einsum("si,qhdi->sqhd", x, shards[-1].float()))
+
+    full = _reorder_grouped_qkv_to_qkv(
+        dense,
+        num_query_groups=heads,
+        heads_per_group=1,
+        head_dim=head_dim,
+    ).reshape(3, heads, head_dim, hidden)
+    reconstructed = torch.cat(shards, dim=1)
+    assert torch.equal(reconstructed.view(torch.uint8), full.view(torch.uint8))
+    torch.testing.assert_close(
+        torch.cat(projected, dim=2),
+        torch.einsum("si,qhdi->sqhd", x, full.float()),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "output_dim",
+        "sharded",
+        "packed",
+        "negative_rank",
+        "rank_outside",
+        "zero_size",
+        "nondivisible_size",
+        "source_shape",
+        "target_shape",
+        "source_stride",
+        "target_stride",
+        "unsupported_dtype",
+        "dtype_mismatch",
+    ],
+)
+def test_unsupported_direct_copy_leaves_source_and_destination_unchanged(boundary):
+    source = torch.arange(144, dtype=torch.float32).reshape(48, 3).to(torch.bfloat16)
+    target = torch.full((12, 3), -7, dtype=torch.bfloat16)
+    rank, size = 0, 4
+    if boundary == "negative_rank":
+        rank = -1
+    elif boundary == "rank_outside":
+        rank = size
+    elif boundary == "zero_size":
+        size = 0
+    elif boundary == "nondivisible_size":
+        size = 3
+    elif boundary == "source_shape":
+        source = source[:-1]
+    elif boundary == "target_shape":
+        target = target[:-1]
+    elif boundary == "source_stride":
+        source = source.t().contiguous().t()
+    elif boundary == "target_stride":
+        target = target.t().contiguous().t()
+    elif boundary == "unsupported_dtype":
+        source, target = source.float(), target.float()
+    elif boundary == "dtype_mismatch":
+        target = target.to(torch.float8_e4m3fn)
+    target.output_dim = 1 if boundary == "output_dim" else 0
+    if boundary == "sharded":
+        target.is_sharded_weight = True
+    if boundary == "packed":
+        target.packed_dim = 0
+    source_before, target_before = source.clone(), target.clone()
+    assert not _copy_grouped_qkv_tp_shard(
+        target,
+        source,
+        num_query_groups=8,
+        head_dim=2,
+        tp_rank=rank,
+        tp_size=size,
+    )
+    assert torch.equal(source.float(), source_before.float())
+    assert torch.equal(target.float(), target_before.float())


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/sgl-project/sglang/pull/38382/files) against `main`.

## Motivation

Extract the reusable grouped-QKV loading contracts from #36244 into an independent, test-only change. This can be reviewed and merged without the opt-in H3 TP/Ulysses execution path.

## Modifications

- Exercise the existing `_copy_grouped_qkv_tp_shard` helper with composed rank ownership, `rank = tp_rank * ulysses_size + ulysses_rank`.
- Verify per-rank bytes against an independent native-head oracle, reconstruct the full reordered QKV weight, and compare FP32 projections exactly.
- Cover BF16 and FP8 helper inputs for algebraic partitions 1×2, 2×2, and 2×4.
- Cover 13 rejection boundaries: rank/size, shape, stride, metadata, and dtype; assert that rejection leaves both tensors unchanged.

Only one 119-line test file is added. There are no production changes, collectives, checkpoint downloads, new supported runtime configurations, or dependency on #36244. In particular, these algebraic partitions and FP8 helper inputs are not claims of supported H3 runtime deployments.

## Accuracy Tests

On `a3dfd01cce4a3778d8a8380aa8d491def63d594a`, based on main `20ca564bf77518604b89dc9f7fdba640daabd88b`:

```bash
SGLANG_DIFFUSION_PLATFORM_OVERRIDE=cpu PYTHONPATH=python python -m pytest -q \
  python/sglang/multimodal_gen/test/unit/test_minimax_h3_qkv_loading.py
```

- **19 passed** on macOS arm64, Python 3.12.13, PyTorch 2.13.0.
- All applicable pre-commit hooks and `git diff --check`: passed.
- Imports resolve to the real source checkout; no source-extraction harness or import stubs.
- The initial validation above was CPU-only; the separately completed native E2E is documented below.

### Independent native-checkpoint E2E — 2026-09-08

**PASS for output non-regression, with CUDA allocation warnings noted below.**
This validation was run specifically on this PR's exact head `a3dfd01cce4a3778d8a8380aa8d491def63d594a` and its parent `20ca564bf77518604b89dc9f7fdba640daabd88b`; it does not reuse #36244's E2E as evidence for this PR.

- Source manifests were checked before and after execution: 8,941 parent files and 8,942 candidate files, with identical production contents and symlinks. The only added file is this PR's 119-line test.
- The candidate's focused CPU suite was rerun through real Linux checkout imports: **19 passed, 0 failed, 0 errors, 0 skipped** (Python 3.12, PyTorch 2.13.0+cu130). No source extraction or import stubs.
- Hardware: **4 × RTX PRO 4000 Blackwell**. Native MiniMax-H3 FL2VA checkpoint revision `42ed227ee7df40d41602854ae760620d6eb651fe`; all 83 cached files / 144,051,223,967 bytes freshly hashed before use.
- Separate fresh native servers for parent and candidate, with identical launch arguments/environment except the source `PYTHONPATH`. BF16/native loader, TP=2, SP/Ulysses=2, ring=1, `torch_sdpa`, folded encoder parallelism, resident text encoder, memory-mode offload, prefetch=1, CPU pinning/FSDP/compilation disabled, online AdaLN with nine GPU plans and zero host cache. `SGLANG_MINIMAX_H3_ULYSSES_GATHER_QKV` was **unset**.
- Each server completed two 2-step warmups followed by one 10-step formal `t2va` request. Same prompt/seed 20260824, short edge 768, aspect 16:9, target duration 4 s, flow shift 12, audio flow shift 3.

| Request | Parent client elapsed | Candidate client elapsed | Output comparison |
| --- | ---: | ---: | --- |
| First warmup, 2 steps | 65.272 s | 64.899 s | Byte-identical MP4 |
| Second warmup, 2 steps | 40.157 s | 40.168 s | Byte-identical MP4 |
| Formal, 10 steps | 135.433 s | 136.418 s | Byte-identical MP4 |

All **six** artifacts decoded successfully on the test host and independently after retrieval: **107 frames, 1344×768, 24 fps, stereo 32 kHz audio**. The native output duration is 4.458333 s for the requested 4 s target. Decoded RGB/audio match between parent and candidate in each paired decoder environment. Both formal MP4s are 535,407 bytes with SHA256 `f8692468033486f3c4c600914d445bc599a2b6ca0ebeea0659ba8cf11bd437db`.

Resource qualification is deliberately limited: all requests returned `completed` with no request errors or uncaught OutOfMemoryError, but the CUDA allocator logged `memory allocation failed with OOM` warnings on **both** sides (34 parent / 33 candidate). Sampled GPU memory peaked at 24,025 / 24,023 MiB. This is **not a zero-GPU-OOM or ample-GPU-headroom claim**. Both controlled server shutdowns also logged a four-semaphore resource-tracker cleanup warning.

The host/cgroup guard did not abort; all sampled `oom`, `oom_kill`, `failcnt` and `under_oom` values were zero. Peak estimated non-reclaimable usage was 102.471 / 102.380 GiB under a 144 GiB limit, with the unchanged 16 GiB reserve applied to that estimate (not total usage including reclaimable cache). The original model service and configuration hashes were restored and its model endpoint verified.

Attempt 1 completed only the parent requests and then stopped at the harness port probe before candidate launch; its evidence is preserved. A server-compatible TIME_WAIT port probe, tested for both reuse and active-listener rejection on Linux, fixed the harness-only issue. Attempt 2 reran the **complete fresh pair**, with no source/model/configuration changes, relaxed numerical assertions or reduced resource guard. The completed-run evidence archive SHA256 is `7013b483fea975b081e322f981e4536e66caa10ed41441125195eb16870e50ef` (raw attempts, source manifests, harness, requests, logs, JUnit and media retained locally).

These single-pair timings are completion evidence, **not a performance claim**. The E2E checks the existing native BF16 execution path; it does not establish FP8 runtime support or deployability of every algebraic partition in the CPU tests. This manual validation is separate from the bot-maintained GitHub CI results below.

## Speed Tests and Profiling

Not applicable: no production changes and no performance claim.

## Checklist

- [x] Focused tests pass.
- [x] Pre-commit and diff checks pass.
- [x] No production behavior or runtime configuration changes.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34174586082](https://github.com/sgl-project/sglang/actions/runs/34174586082)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34174585954](https://github.com/sgl-project/sglang/actions/runs/34174585954)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34174586063](https://github.com/sgl-project/sglang/actions/runs/34174586063)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->