### PR TITLE
[DFlash] Add KDA draft attention: block-local and context-scanning modes

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
@@ -115,20 +115,19 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     stride_k = Hg * K
     stride_w = H * K
 
-    # Slot stride comes from the caller (initial_state.stride(0)): the state pool
-    # may be an envelope-strided view (page-major / unified memory), where the
-    # per-slot pitch spans ALL layers' state, not H*V*K. int64: envelope pitches
-    # overflow an int32 index product.
-    index = tl.load(initial_state_indices + i_n).to(tl.int64)
-    # Padded rows carry the -1 sentinel; the decode kernel guards on it
-    # (fused_recurrent.py), the chunked extend path did not.
-    valid_state = index >= 0
-    h0 = initial_state + index * stride_init_state
-    ht = initial_state + index * stride_init_state
-    if USE_INITIAL_STATE:
-        h0 = h0 + i_h * V * K
-    if INPLACE_UPDATE:
-        ht = ht + i_h * V * K
+    if USE_INITIAL_STATE or INPLACE_UPDATE:
+        # Slot stride comes from the caller (initial_state.stride(0)): the state
+        # pool may be an envelope-strided view (page-major / unified memory),
+        # where the per-slot pitch spans all layers' state, not H*V*K. int64:
+        # envelope pitches overflow an int32 index product.
+        index = tl.load(initial_state_indices + i_n).to(tl.int64)
+        # Padded rows carry the -1 sentinel; the decode kernel guards on it
+        # (fused_recurrent.py), the chunked extend path did not.
+        valid_state = index >= 0
+        if USE_INITIAL_STATE:
+            h0 = initial_state + index * stride_init_state + i_h * V * K
+        if INPLACE_UPDATE:
+            ht = initial_state + index * stride_init_state + i_h * V * K
 
     # load initial state
     if USE_INITIAL_STATE and valid_state:
@@ -378,7 +377,7 @@ def chunk_gated_delta_rule_fwd_h(
         USE_G=g is not None,
         USE_GK=gk is not None,
         USE_INITIAL_STATE=initial_state is not None,
-        INPLACE_UPDATE=True,
+        INPLACE_UPDATE=initial_state is not None,
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,
         NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import itertools
 import logging
 from typing import Iterable, Optional, Tuple
 
@@ -38,12 +39,15 @@ from sglang.srt.model_loader.weight_utils import (
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.speculative.dflash_utils import (
+    DFlashKDAConfig,
     can_dflash_slice_qkv_weight,
+    get_dflash_attention_modes,
     get_dflash_attention_sliding_window_size,
     get_dflash_layer_types,
     is_dense_head_weight,
     is_nemotron_35_draft_config,
     parse_dflash_draft_config,
+    parse_dflash_kda_config,
 )
 from sglang.srt.utils import is_npu, set_weight_attrs
 from sglang.srt.utils.common import get_compiler_backend
@@ -353,6 +357,488 @@ class DFlashAttention(nn.Module):
         return k
 
 
+class DFlashKDAShortConvolution(nn.Module):
+    """Checkpoint-compatible causal depthwise convolution for KDA."""
+
+    def __init__(self, channels: int, kernel_size: int) -> None:
+        super().__init__()
+        self.kernel_size = int(kernel_size)
+        self.weight = nn.Parameter(torch.empty(channels, self.kernel_size))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        channels_first = inputs.transpose(1, 2)
+        channels_first = F.pad(channels_first, (self.kernel_size - 1, 0))
+        convolved = F.conv1d(
+            channels_first,
+            self.weight.unsqueeze(1),
+            bias=None,
+            groups=self.weight.shape[0],
+        )
+        return F.silu(convolved.transpose(1, 2))
+
+
+class DFlashKDAGatedRMSNorm(nn.Module):
+    """RMSNorm followed by KDA's sigmoid output gate."""
+
+    def __init__(self, hidden_size: int, eps: float) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = float(eps)
+
+    def forward(self, inputs: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        variance = inputs.float().square().mean(dim=-1, keepdim=True)
+        normalized = inputs * torch.rsqrt(variance + self.eps).to(inputs.dtype)
+        return normalized * self.weight.to(inputs.dtype) * torch.sigmoid(gate)
+
+
+def _kda_kernel_beta(raw_beta: torch.Tensor) -> torch.Tensor:
+    """Beta as the Triton KDA kernels expect it: post-sigmoid, fp32.
+
+    ``chunk_kda`` activates the decay gate in-kernel from the raw gate, A_log,
+    dt_bias and lower_bound, but it does NOT apply sigmoid to beta (the
+    ``beta_is_raw`` keyword is swallowed by ``**kwargs``). Feeding the raw
+    ``b_proj`` output silently changes the delta rule; SpecForge's FLA call
+    uses ``use_beta_sigmoid_in_kernel=True``, so the sigmoid must happen here.
+    """
+    return torch.sigmoid(raw_beta.float())
+
+
+def reference_dflash_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+    *,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+):
+    """Small-sequence KDA oracle and non-CUDA fallback.
+
+    ``initial_state`` (``[B, H, K, V]`` fp32) seeds the recurrence and
+    ``output_final_state`` also returns the state after the last step, the
+    same contract as SpecForge's ``reference_kda``. Note the FLA/Triton pool
+    layout is ``[.., H, V, K]``: transpose the last two dims when crossing.
+    """
+    q = F.normalize(q.float(), dim=-1).to(q.dtype)
+    k = F.normalize(k.float(), dim=-1).to(k.dtype)
+    beta = torch.sigmoid(beta.float()).to(q.dtype)
+
+    gate_input = raw_gate.float() + dt_bias.view(1, 1, *raw_gate.shape[-2:])
+    decay_scale = A_log.float().exp().view(1, 1, -1, 1)
+    if lower_bound is None:
+        log_decay = -decay_scale * F.softplus(gate_input)
+    else:
+        log_decay = float(lower_bound) * torch.sigmoid(decay_scale * gate_input)
+
+    if initial_state is None:
+        state = torch.zeros(
+            q.shape[0],
+            q.shape[2],
+            q.shape[3],
+            v.shape[3],
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        state = initial_state.to(device=q.device, dtype=torch.float32)
+    outputs = []
+    score_scale = q.shape[-1] ** -0.5
+    for step in range(q.shape[1]):
+        state = state * log_decay[:, step].exp().unsqueeze(-1)
+        step_key = k[:, step].float()
+        step_value = v[:, step].float()
+        prediction = torch.einsum("bhd,bhdv->bhv", step_key, state)
+        delta = (step_value - prediction) * beta[:, step].float().unsqueeze(-1)
+        state = state + torch.einsum("bhd,bhv->bhdv", step_key, delta)
+        output = torch.einsum("bhd,bhdv->bhv", q[:, step].float(), state)
+        outputs.append((output * score_scale).to(q.dtype))
+    if outputs:
+        output = torch.stack(outputs, dim=1)
+    else:
+        output = q.new_zeros((q.shape[0], 0, q.shape[2], v.shape[3]))
+    if output_final_state:
+        return output, state
+    return output
+
+
+class DFlashKDAAttention(nn.Module):
+    """KDA recurrent attention over DFlash proposal blocks.
+
+    ``linear_attn_config.context_state`` selects where a block's recurrent
+    state starts (SpecForge PR #836 semantics):
+
+    * ``reset``: every block is an independent sequence starting from a zero
+      state; target context reaches the layer only through the hybrid stack's
+      KV-cache attention layers.
+    * ``scan``: the recurrence first consumes the target context. A per-request
+      running state (and the last ``kernel_size - 1`` context rows for the
+      short convolution) lives in a slot pool indexed by ``req_pool_indices``;
+      the worker advances it with every newly verified context slice
+      (:meth:`advance_context_state`) and each block forward starts from it.
+      The context scan runs through the same raw-gate ``chunk_kda`` kernel as
+      the block, which writes the final state back into the pool slot.
+    """
+
+    is_dflash_kda = True
+
+    def __init__(
+        self, config, layer_id: int, quant_config=None, prefix: str = ""
+    ) -> None:
+        super().__init__()
+        del layer_id, prefix
+        tp_size = int(get_parallel().tp_size)
+        if tp_size != 1:
+            raise ValueError(
+                "DFLASH KDA draft attention currently requires tp_size=1, "
+                f"got tp_size={tp_size}. Run one independent draft server per GPU."
+            )
+        if quant_config is not None:
+            raise ValueError(
+                "DFLASH KDA draft attention currently requires unquantized "
+                "draft weights."
+            )
+
+        spec = parse_dflash_kda_config(config)
+        if spec is None:
+            raise ValueError("DFlashKDAAttention requires a KDA draft config.")
+        self.kda_config: DFlashKDAConfig = spec
+        self.hidden_size = int(config.hidden_size)
+        self.head_dim = spec.head_dim
+        self.num_heads = spec.num_heads
+        self.block_size = parse_dflash_draft_config(
+            draft_hf_config=config
+        ).resolve_block_size(default=16)
+        self.lower_bound = spec.gate_lower_bound
+        projection_size = spec.projection_size
+
+        self.q_proj = nn.Linear(self.hidden_size, projection_size, bias=False)
+        self.k_proj = nn.Linear(self.hidden_size, projection_size, bias=False)
+        self.v_proj = nn.Linear(self.hidden_size, projection_size, bias=False)
+        self.q_conv1d = DFlashKDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+        self.k_conv1d = DFlashKDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+        self.v_conv1d = DFlashKDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+
+        self.A_log = nn.Parameter(
+            torch.log(torch.empty(spec.num_heads, dtype=torch.float32).uniform_(1, 16))
+        )
+        self.f_a_proj = nn.Linear(self.hidden_size, spec.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(spec.head_dim, projection_size, bias=False)
+        self.dt_bias = nn.Parameter(torch.zeros(projection_size, dtype=torch.float32))
+        self.b_proj = nn.Linear(self.hidden_size, spec.num_heads, bias=False)
+        if spec.use_full_rank_gate:
+            self.g_proj = nn.Linear(self.hidden_size, projection_size, bias=False)
+        else:
+            self.g_a_proj = nn.Linear(self.hidden_size, spec.head_dim, bias=False)
+            self.g_b_proj = nn.Linear(spec.head_dim, projection_size, bias=False)
+        self.o_norm = DFlashKDAGatedRMSNorm(
+            spec.head_dim, eps=float(config.rms_norm_eps)
+        )
+        self.o_proj = nn.Linear(projection_size, self.hidden_size, bias=False)
+
+        # Context-scanning policy: per-request running state, allocated by
+        # init_context_state() once the worker knows the request-slot count.
+        self.scans_context = bool(spec.scans_context)
+        self.is_dflash_kda_scan = self.scans_context
+        self.conv_window = int(spec.short_conv_kernel_size) - 1
+        self._ctx_state: Optional[torch.Tensor] = None  # [slots, H, V, K] fp32
+        self._ctx_tail: Optional[torch.Tensor] = None  # [slots, window, hidden]
+
+    def set_block_size(self, block_size: int) -> None:
+        self.block_size = int(block_size)
+
+    def _output_gate(self, blocks: torch.Tensor) -> torch.Tensor:
+        if self.kda_config.use_full_rank_gate:
+            return self.g_proj(blocks)
+        return self.g_b_proj(self.g_a_proj(blocks))
+
+    def _gates(self, rows: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Raw decay gate ``[..., H, D]`` and raw beta ``[..., H]`` for rows."""
+        leading = tuple(rows.shape[:-1])
+        raw_gate = self.f_b_proj(self.f_a_proj(rows)).reshape(
+            *leading, self.num_heads, self.head_dim
+        )
+        beta = self.b_proj(rows).reshape(*leading, self.num_heads)
+        return raw_gate, beta
+
+    @staticmethod
+    def _conv_with_left_rows(
+        conv: DFlashKDAShortConvolution,
+        proj: nn.Linear,
+        left_rows: torch.Tensor,
+        rows: torch.Tensor,
+    ) -> torch.Tensor:
+        """Convolve ``rows`` as if ``left_rows`` immediately preceded them."""
+        joined = torch.cat((proj(left_rows), proj(rows)), dim=1)
+        return conv(joined)[:, left_rows.shape[1] :]
+
+    # -- context-scanning state pool -------------------------------------
+    def init_context_state(
+        self, max_slots: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        """Allocate the per-request running state for ``max_slots`` request slots."""
+        if not self.scans_context:
+            return
+        if max_slots < 1:
+            raise ValueError(f"DFLASH KDA scan needs max_slots >= 1, got {max_slots}.")
+        self._ctx_state = torch.zeros(
+            (int(max_slots), self.num_heads, self.head_dim, self.head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        self._ctx_tail = torch.zeros(
+            (int(max_slots), self.conv_window, self.hidden_size),
+            dtype=dtype,
+            device=device,
+        )
+
+    def _require_context_state(self) -> torch.Tensor:
+        if not self.scans_context:
+            raise RuntimeError("DFLASH KDA layer does not scan context.")
+        if self._ctx_state is None or self._ctx_tail is None:
+            raise RuntimeError(
+                "DFLASH KDA scan state is not allocated; call init_context_state() "
+                "with the request-slot count before serving."
+            )
+        return self._ctx_state
+
+    def reset_context_state(self, slots: torch.Tensor) -> None:
+        """Forget the running context of the given request slots."""
+        state = self._require_context_state()
+        slots = slots.to(device=state.device, dtype=torch.int64)
+        state[slots] = 0
+        self._ctx_tail[slots] = 0
+
+    def advance_context_state(
+        self,
+        slots: torch.Tensor,
+        rows: torch.Tensor,
+        row_lens: torch.Tensor,
+        reset_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Consume newly verified context rows for a batch of request slots.
+
+        ``rows`` is ``[sum(row_lens), hidden_size]``: the rows of slot ``i``
+        are contiguous, in ascending position order, and follow the rows of
+        slot ``i - 1``. Slots flagged in ``reset_mask`` start a new request
+        (their state and conv tail are zeroed first). States are updated in
+        place; nothing is returned.
+        """
+        state = self._require_context_state()
+        device = state.device
+        slots = slots.to(device=device, dtype=torch.int64)
+        lens = [int(n) for n in row_lens.tolist()]
+        if slots.numel() != len(lens):
+            raise ValueError(
+                "DFLASH KDA scan: slots and row_lens disagree: "
+                f"{slots.numel()} vs {len(lens)}."
+            )
+        if reset_mask is not None:
+            reset_mask = reset_mask.to(device=device, dtype=torch.bool)
+            if bool(reset_mask.any()):
+                self.reset_context_state(slots[reset_mask])
+        if rows.device != device:
+            rows = rows.to(device)
+        rows = rows.to(self._ctx_tail.dtype)
+
+        keys, values, gates, betas, seq_slots, seq_lens = [], [], [], [], [], []
+        start = 0
+        for index, length in enumerate(lens):
+            if length == 0:
+                continue
+            slice_rows = rows[start : start + length].unsqueeze(0)  # [1, n, hidden]
+            start += length
+            slot = slots[index]
+            tail = self._ctx_tail[slot].unsqueeze(0)  # [1, window, hidden]
+            shape = (1, length, self.num_heads, self.head_dim)
+            keys.append(
+                self._conv_with_left_rows(
+                    self.k_conv1d, self.k_proj, tail, slice_rows
+                ).reshape(shape)
+            )
+            values.append(
+                self._conv_with_left_rows(
+                    self.v_conv1d, self.v_proj, tail, slice_rows
+                ).reshape(shape)
+            )
+            raw_gate, beta = self._gates(slice_rows)
+            gates.append(raw_gate)
+            betas.append(beta)
+            seq_slots.append(slot)
+            seq_lens.append(length)
+            if self.conv_window:
+                self._ctx_tail[slot] = torch.cat((tail[0], slice_rows[0]), dim=0)[
+                    -self.conv_window :
+                ]
+        if start != int(rows.shape[0]):
+            raise ValueError(
+                f"DFLASH KDA scan: rows has {int(rows.shape[0])} entries but "
+                f"row_lens sum to {start}."
+            )
+        if not seq_lens:
+            return
+
+        k = torch.cat(keys, dim=1)
+        v = torch.cat(values, dim=1)
+        raw_gate = torch.cat(gates, dim=1)
+        beta = torch.cat(betas, dim=1)
+        slot_index = torch.stack(seq_slots)
+        if device.type == "cuda":
+            from sglang.kernels.ops.attention.fla.kda import chunk_kda
+
+            cu_seqlens = torch.tensor(
+                [0, *itertools.accumulate(seq_lens)], device=device, dtype=torch.int64
+            )
+            # The state does not depend on queries; reuse k so the l2norm has
+            # a finite input. With initial_state + initial_state_indices the
+            # kernel reads h0 from, and writes the final state back into, the
+            # addressed pool slots.
+            chunk_kda(
+                q=k,
+                k=k,
+                v=v,
+                g=raw_gate,
+                beta=_kda_kernel_beta(beta),
+                use_qk_l2norm_in_kernel=True,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                lower_bound=self.lower_bound,
+                initial_state=state,
+                initial_state_indices=slot_index,
+                cu_seqlens=cu_seqlens,
+            )
+            return
+        offset = 0
+        for slot, length in zip(seq_slots, seq_lens):
+            sl = slice(offset, offset + length)
+            offset += length
+            # Reference layout is [B, H, K, V]; the pool is [slots, H, V, K].
+            initial = state[slot].transpose(-1, -2).unsqueeze(0)
+            _, final = reference_dflash_kda(
+                k[:, sl],
+                k[:, sl],
+                v[:, sl],
+                raw_gate[:, sl],
+                beta[:, sl],
+                self.A_log,
+                self.dt_bias,
+                self.lower_bound,
+                initial_state=initial,
+                output_final_state=True,
+            )
+            state[slot] = final[0].transpose(-1, -2)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        del positions
+        if hidden_states.ndim != 2:
+            raise ValueError(
+                "DFLASH KDA expects flattened [batch * block_size, hidden_size] "
+                f"states, got shape={tuple(hidden_states.shape)}."
+            )
+        token_count = int(hidden_states.shape[0])
+        if token_count % self.block_size:
+            raise ValueError(
+                "DFLASH KDA token count must be divisible by block_size; "
+                f"got token_count={token_count}, block_size={self.block_size}."
+            )
+
+        blocks = hidden_states.reshape(-1, self.block_size, self.hidden_size)
+        block_count = int(blocks.shape[0])
+        projection_shape = (
+            block_count,
+            self.block_size,
+            self.num_heads,
+            self.head_dim,
+        )
+        initial_state = None
+        if self.scans_context:
+            state = self._require_context_state()
+            slots = forward_batch.req_pool_indices
+            if slots is None:
+                raise RuntimeError(
+                    "DFLASH KDA scan needs forward_batch.req_pool_indices."
+                )
+            slots = slots.to(device=state.device, dtype=torch.int64).reshape(-1)
+            if int(slots.numel()) != block_count:
+                raise ValueError(
+                    "DFLASH KDA scan expects one proposal block per request; got "
+                    f"{block_count} blocks for {int(slots.numel())} requests."
+                )
+            tail = self._ctx_tail[slots]  # [B, window, hidden]
+            q = self._conv_with_left_rows(self.q_conv1d, self.q_proj, tail, blocks)
+            k = self._conv_with_left_rows(self.k_conv1d, self.k_proj, tail, blocks)
+            v = self._conv_with_left_rows(self.v_conv1d, self.v_proj, tail, blocks)
+            # Clone: the kernel writes the post-block state back into whatever
+            # it was handed, and block tokens are speculative.
+            initial_state = state[slots].clone()
+        else:
+            q = self.q_conv1d(self.q_proj(blocks))
+            k = self.k_conv1d(self.k_proj(blocks))
+            v = self.v_conv1d(self.v_proj(blocks))
+        q = q.reshape(projection_shape)
+        k = k.reshape(projection_shape)
+        v = v.reshape(projection_shape)
+        raw_gate, beta = self._gates(blocks)
+
+        if hidden_states.device.type == "cuda":
+            from sglang.kernels.ops.attention.fla.kda import chunk_kda
+
+            state_kwargs = {}
+            if initial_state is not None:
+                state_kwargs = dict(
+                    initial_state=initial_state,
+                    initial_state_indices=torch.arange(
+                        block_count, device=initial_state.device, dtype=torch.int64
+                    ),
+                )
+            attention_output = chunk_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=raw_gate,
+                beta=_kda_kernel_beta(beta),
+                use_qk_l2norm_in_kernel=True,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                lower_bound=self.lower_bound,
+                **state_kwargs,
+            )
+        else:
+            attention_output = reference_dflash_kda(
+                q,
+                k,
+                v,
+                raw_gate,
+                beta,
+                self.A_log,
+                self.dt_bias,
+                self.lower_bound,
+                initial_state=(
+                    None if initial_state is None else initial_state.transpose(-1, -2)
+                ),
+            )
+
+        output_gate = self._output_gate(blocks).reshape(projection_shape)
+        attention_output = self.o_norm(attention_output, output_gate)
+        attention_output = self.o_proj(attention_output.flatten(-2))
+        return attention_output.reshape(token_count, self.hidden_size)
+
+
 class DFlashMLP(nn.Module):
     def __init__(self, config, quant_config=None, prefix: str = "") -> None:
         super().__init__()
@@ -483,7 +969,13 @@ class DFlashDecoderLayer(nn.Module):
 
         self.input_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
         attention_prefix = f"{prefix}.self_attn" if prefix else ""
-        self.self_attn = self.attention_cls(
+        attention_modes = get_dflash_attention_modes(config)
+        layer_mode = attention_modes[layer_id]
+        if layer_mode == "kda":
+            attention_class = DFlashKDAAttention
+        else:
+            attention_class = self.attention_cls
+        self.self_attn = attention_class(
             config=config,
             layer_id=layer_id,
             quant_config=quant_config,
@@ -559,6 +1051,11 @@ class DFlashDraftModel(nn.Module):
 
         hidden_size = int(config.hidden_size)
         num_layers = int(config.num_hidden_layers)
+        self.attention_modes = get_dflash_attention_modes(config)
+        self.supports_fused_context_kv = (
+            bool(type(self).supports_fused_context_kv)
+            and "kda" not in self.attention_modes
+        )
         rms_norm_eps = float(getattr(config, "rms_norm_eps", 1e-6))
         draft_config = self.draft_config = parse_dflash_draft_config(
             draft_hf_config=config
@@ -644,9 +1141,49 @@ class DFlashDraftModel(nn.Module):
         """
         self.block_size = int(block_size)
         for layer in self.layers:
+            set_attention_block_size = getattr(layer.self_attn, "set_block_size", None)
+            if set_attention_block_size is not None:
+                set_attention_block_size(self.block_size)
             for conv in (layer.attention_conv, layer.mlp_conv):
                 if conv is not None:
                     conv.block_size = self.block_size
+
+    def iter_context_attention_layers(self):
+        """Yield only draft layers that own a target-context KV cache."""
+        for layer in self.layers:
+            if not getattr(layer.self_attn, "is_dflash_kda", False):
+                yield layer
+
+    def iter_scan_kda_layers(self):
+        """Yield draft layers whose KDA recurrence scans the target context."""
+        for layer in self.layers:
+            if getattr(layer.self_attn, "is_dflash_kda_scan", False):
+                yield layer
+
+    @property
+    def has_scan_kda_layers(self) -> bool:
+        return any(True for _ in self.iter_scan_kda_layers())
+
+    def init_kda_context_state(
+        self, max_slots: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        """Allocate the per-request running state of context-scanning KDA layers."""
+        for layer in self.iter_scan_kda_layers():
+            layer.self_attn.init_context_state(max_slots, device, dtype)
+
+    def advance_kda_context(
+        self,
+        slots: torch.Tensor,
+        ctx_hidden: torch.Tensor,
+        row_lens: torch.Tensor,
+        reset_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Feed newly verified context rows to every context-scanning KDA layer."""
+        for layer in self.iter_scan_kda_layers():
+            layer_ctx_hidden = self.prepare_context_hidden_for_kv(layer, ctx_hidden)
+            layer.self_attn.advance_context_state(
+                slots, layer_ctx_hidden, row_lens, reset_mask
+            )
 
     def get_attention_sliding_window_size(self) -> Optional[int]:
         return get_dflash_attention_sliding_window_size(self.config)
@@ -751,6 +1288,8 @@ class DFlashDraftModel(nn.Module):
                 return aliased_name
             return None
 
+        loaded_names = set()
+        ignored_names = []
         for name, loaded_weight in weights:
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if f".{weight_name}." not in name:
@@ -762,12 +1301,15 @@ class DFlashDraftModel(nn.Module):
                 param = params_dict[resolved_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight, shard_id)
+                loaded_names.add(resolved_name)
                 break
             else:
                 resolved_name = resolve_param_name(name)
                 if resolved_name is None:
                     # Ignore unexpected weights (e.g., HF rotary caches).
+                    ignored_names.append(name)
                     continue
+                loaded_names.add(resolved_name)
                 param = params_dict[resolved_name]
                 if resolved_name.endswith("fc.weight"):
                     if self.is_nemotron_35_draft:
@@ -798,6 +1340,16 @@ class DFlashDraftModel(nn.Module):
                         )
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+        missing_names = sorted(set(params_dict) - loaded_names)
+        logger.info(
+            "DFLASH draft load_weights: loaded=%d params, ignored=%d checkpoint tensors%s, "
+            "params without checkpoint tensor=%d%s",
+            len(loaded_names),
+            len(ignored_names),
+            f" (e.g. {ignored_names[:6]})" if ignored_names else "",
+            len(missing_names),
+            f" (e.g. {missing_names[:6]})" if missing_names else "",
+        )
 
 
 class DFlashLagunaAttention(DFlashAttention):

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from numbers import Integral
@@ -23,6 +24,7 @@ from sglang.srt.speculative.spec_utils import sample_simulated_acc_len
 from sglang.srt.utils import is_cuda, is_hip, is_musa, is_npu
 
 DEFAULT_DFLASH_MASK_TOKEN = "<|MASK|>"
+_DFLASH_ATTENTION_MODES = frozenset({"gqa", "mha", "kda"})
 
 logger = logging.getLogger(__name__)
 
@@ -522,6 +524,146 @@ def _parse_optional_int(
         comparator = "positive" if int(min_value) == 1 else f">= {int(min_value)}"
         raise ValueError(f"{field_name} must be {comparator}, got {parsed}.")
     return parsed
+
+
+@dataclass(frozen=True)
+class DFlashKDAConfig:
+    head_dim: int
+    num_heads: int
+    short_conv_kernel_size: int
+    use_full_rank_gate: bool
+    gate_lower_bound: Optional[float]
+    #: Where a proposal block's recurrent state starts (SpecForge
+    #: ``linear_attn_config.context_state``): ``reset`` = zero state per block
+    #: (block-local KDA), ``scan`` = the state after the target context strictly
+    #: before the block, kept per request and advanced with every verified slice.
+    context_state: str = "reset"
+
+    @property
+    def projection_size(self) -> int:
+        return self.head_dim * self.num_heads
+
+    @property
+    def scans_context(self) -> bool:
+        return self.context_state == "scan"
+
+
+_DFLASH_KDA_CONTEXT_STATES = ("reset", "scan")
+
+
+def get_dflash_attention_modes(draft_hf_config: Any) -> Tuple[str, ...]:
+    """Return one normalized attention mode for every DFlash draft layer."""
+    dflash_cfg = _get_dflash_config(draft_hf_config)
+    draft_text_config = _get_text_config(draft_hf_config)
+    num_hidden_layers = _parse_optional_int(
+        _cfg_get(draft_text_config, "num_hidden_layers", None),
+        field_name="DFLASH draft num_hidden_layers",
+        min_value=1,
+    )
+    if num_hidden_layers is None:
+        raise ValueError("DFLASH attention modes require num_hidden_layers in config.")
+
+    has_uniform_mode = "attention_mode" in dflash_cfg
+    has_layer_modes = "attention_modes" in dflash_cfg
+    if has_uniform_mode and has_layer_modes:
+        raise ValueError(
+            "DFLASH dflash_config must set only one of attention_mode or "
+            "attention_modes."
+        )
+
+    if has_layer_modes:
+        raw_modes = dflash_cfg["attention_modes"]
+        if not isinstance(raw_modes, (list, tuple)):
+            raise ValueError(
+                "DFLASH dflash_config.attention_modes must be a list with one "
+                f"entry per draft layer, got {raw_modes!r}."
+            )
+        if len(raw_modes) != num_hidden_layers:
+            raise ValueError(
+                "DFLASH dflash_config.attention_modes must contain exactly "
+                f"num_hidden_layers={num_hidden_layers} entries, got "
+                f"{len(raw_modes)}."
+            )
+    else:
+        raw_modes = [dflash_cfg.get("attention_mode", "gqa")] * num_hidden_layers
+
+    modes = tuple(str(mode).lower() for mode in raw_modes)
+    invalid_modes = set(modes) - _DFLASH_ATTENTION_MODES
+    if invalid_modes:
+        raise ValueError(
+            "DFLASH dflash_config attention mode(s) must be selected from "
+            f"{sorted(_DFLASH_ATTENTION_MODES)}, got {sorted(invalid_modes)}."
+        )
+    return modes
+
+
+def parse_dflash_kda_config(draft_hf_config: Any) -> Optional[DFlashKDAConfig]:
+    """Validate KDA dimensions when a DFlash draft contains recurrent layers."""
+    if "kda" not in get_dflash_attention_modes(draft_hf_config):
+        return None
+
+    raw_config = _cfg_get(draft_hf_config, "linear_attn_config", None)
+    if raw_config is None:
+        raise ValueError("DFLASH KDA layers require config.linear_attn_config.")
+    if not isinstance(raw_config, dict):
+        try:
+            raw_config = dict(raw_config)
+        except Exception as exc:
+            raise ValueError(
+                "DFLASH config.linear_attn_config must be a mapping."
+            ) from exc
+
+    required_fields = ("head_dim", "num_heads", "short_conv_kernel_size")
+    missing_fields = [name for name in required_fields if raw_config.get(name) is None]
+    if missing_fields:
+        raise ValueError(
+            "DFLASH KDA linear_attn_config is missing required fields: "
+            f"{missing_fields}."
+        )
+
+    head_dim = _parse_optional_int(
+        raw_config["head_dim"], field_name="DFLASH KDA head_dim", min_value=1
+    )
+    num_heads = _parse_optional_int(
+        raw_config["num_heads"], field_name="DFLASH KDA num_heads", min_value=1
+    )
+    short_conv_kernel_size = _parse_optional_int(
+        raw_config["short_conv_kernel_size"],
+        field_name="DFLASH KDA short_conv_kernel_size",
+        min_value=1,
+    )
+
+    use_full_rank_gate = raw_config.get("use_full_rank_gate", False)
+    if not isinstance(use_full_rank_gate, bool):
+        raise ValueError(
+            "DFLASH KDA linear_attn_config.use_full_rank_gate must be a boolean, "
+            f"got {use_full_rank_gate!r}."
+        )
+
+    gate_lower_bound = raw_config.get("gate_lower_bound")
+    if gate_lower_bound is not None:
+        gate_lower_bound = float(gate_lower_bound)
+        if not math.isfinite(gate_lower_bound) or gate_lower_bound >= 0:
+            raise ValueError(
+                "DFLASH KDA linear_attn_config.gate_lower_bound must be a finite "
+                f"negative number or null, got {gate_lower_bound!r}."
+            )
+
+    context_state = str(raw_config.get("context_state", "reset")).lower()
+    if context_state not in _DFLASH_KDA_CONTEXT_STATES:
+        raise ValueError(
+            "DFLASH KDA linear_attn_config.context_state must be one of "
+            f"{list(_DFLASH_KDA_CONTEXT_STATES)}, got {context_state!r}."
+        )
+
+    return DFlashKDAConfig(
+        head_dim=int(head_dim),
+        num_heads=int(num_heads),
+        short_conv_kernel_size=int(short_conv_kernel_size),
+        use_full_rank_gate=use_full_rank_gate,
+        gate_lower_bound=gate_lower_bound,
+        context_state=context_state,
+    )
 
 
 @dataclass(frozen=True)

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import math
 from dataclasses import replace
@@ -327,6 +328,13 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.draft_model_runner = bundle.draft_model_runner
         self._draft_sampler = None
         self.draft_model = bundle.draft_model
+        # Context-scanning KDA drafts keep one running state per request slot;
+        # the request pools do not exist yet, so the pool is sized lazily on the
+        # first context append (see _advance_kda_context).
+        self._has_scan_kda = bool(
+            getattr(self.draft_model, "has_scan_kda_layers", False)
+        )
+        self._kda_state_ready = False
         self.selector = self.draft_model.candidate_selector
         # Ascend keeps selector proposal aligned with its greedy-only verify path.
         self._selector_sampling_enabled = not _is_npu
@@ -1427,6 +1435,81 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         return out_tokens
 
+    def _init_kda_context_state(self) -> None:
+        """Allocate the per-request running state once the request pools exist."""
+        req_pool = getattr(self.draft_model_runner, "req_to_token_pool", None)
+        if req_pool is None:
+            req_pool = getattr(self.model_runner, "req_to_token_pool", None)
+        if req_pool is None:
+            raise RuntimeError(
+                "DFLASH context-scanning KDA draft needs a request pool to size "
+                "its per-request running state."
+            )
+        max_slots = int(req_pool.size) + 1  # +1 for the padding sentinel slot
+        self.draft_model.init_kda_context_state(
+            max_slots=max_slots,
+            device=self.model_runner.device,
+            dtype=next(self.draft_model.parameters()).dtype,
+        )
+        self._kda_state_ready = True
+        if self.ps.tp_rank == 0:
+            logger.info(
+                "DFLASH context-scanning KDA draft: per-request running state "
+                "allocated for %d slots.",
+                max_slots,
+            )
+
+    def _advance_kda_context(
+        self,
+        *,
+        ctx_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        req_pool_indices: Optional[torch.Tensor],
+        row_lens: Optional[torch.Tensor],
+        row_stride: Optional[int],
+    ) -> None:
+        """Feed newly verified context rows to context-scanning KDA draft layers.
+
+        ``row_lens[i]`` rows belong to request ``req_pool_indices[i]``; they start
+        at ``i * row_stride`` (dense ``[bs, block]`` layouts) or right after the
+        previous request's rows (``row_stride=None``, packed prefill layouts). A
+        request whose first row sits at position 0 starts fresh, so its running
+        state is reset before the rows are consumed.
+        """
+        if not self._has_scan_kda:
+            return
+        if req_pool_indices is None or row_lens is None:
+            raise RuntimeError(
+                "DFLASH context-scanning KDA needs req_pool_indices and row_lens "
+                "for every context append."
+            )
+        if not self._kda_state_ready:
+            self._init_kda_context_state()
+        lens = [int(n) for n in row_lens.to(torch.int64).tolist()]
+        if row_stride is None:
+            starts = [0, *itertools.accumulate(lens)][:-1]
+        else:
+            starts = [i * int(row_stride) for i in range(len(lens))]
+        keep = [i for i, n in enumerate(lens) if n > 0]
+        if not keep:
+            return
+        if row_stride is None and len(keep) == len(lens):
+            rows = ctx_hidden[: starts[-1] + lens[-1]]
+        else:
+            rows = torch.cat(
+                [ctx_hidden[starts[i] : starts[i] + lens[i]] for i in keep]
+            )
+        device = ctx_hidden.device
+        first_rows = torch.tensor(
+            [starts[i] for i in keep], device=device, dtype=torch.int64
+        )
+        reset_mask = positions.to(device)[first_rows] == 0
+        slots = req_pool_indices.to(device=device, dtype=torch.int64).reshape(-1)[
+            torch.tensor(keep, device=device, dtype=torch.int64)
+        ]
+        kept_lens = torch.tensor([lens[i] for i in keep], dtype=torch.int64)
+        self.draft_model.advance_kda_context(slots, rows, kept_lens, reset_mask)
+
     def _append_target_hidden_to_draft_kv_by_loc(
         self,
         *,
@@ -1435,6 +1518,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         positions: torch.Tensor,
         cache_loc_2d: Optional[torch.Tensor] = None,
         commit_lens: Optional[torch.Tensor] = None,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        row_lens: Optional[torch.Tensor] = None,
+        row_stride: Optional[int] = None,
     ) -> None:
         """Materialize target context features into the draft KV cache at explicit slots.
 
@@ -1512,6 +1598,13 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         with torch.inference_mode():
             ctx_hidden = self.draft_model.project_target_hidden(target_hidden)
+            self._advance_kda_context(
+                ctx_hidden=ctx_hidden,
+                positions=positions,
+                req_pool_indices=req_pool_indices,
+                row_lens=row_lens,
+                row_stride=row_stride,
+            )
 
             if cache_loc_2d is not None:
                 bs = int(commit_lens.shape[0])
@@ -1540,7 +1633,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                         self._use_fused_kv_materialize = False
                         self._fused_kv_helper = None
 
-                for layer in self.draft_model.layers:
+                for layer in self.draft_model.iter_context_attention_layers():
                     attn = layer.self_attn
                     layer_ctx_hidden = self.draft_model.prepare_context_hidden_for_kv(
                         layer, ctx_hidden
@@ -1590,7 +1683,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         ctx_positions: torch.Tensor,
         ctx_cache_loc: torch.Tensor,
     ) -> None:
-        for layer in self.draft_model.layers:
+        for layer in self.draft_model.iter_context_attention_layers():
             attn = layer.self_attn
             layer_ctx_hidden = self.draft_model.prepare_context_hidden_for_kv(
                 layer, ctx_hidden
@@ -1947,6 +2040,9 @@ class DFlashWorkerV2(BaseSpecWorker):
                 target_hidden=logits_output.hidden_states,
                 cache_loc=batch.out_cache_loc,
                 positions=positions,
+                req_pool_indices=batch.req_pool_indices,
+                row_lens=ctx_lens,
+                row_stride=None,
             )
 
             # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
@@ -2343,6 +2439,9 @@ class DFlashWorkerV2(BaseSpecWorker):
             cache_loc_2d=verify_out_cache_loc_2d,
             positions=positions,
             commit_lens=commit_lens,
+            req_pool_indices=batch.req_pool_indices,
+            row_lens=commit_lens,
+            row_stride=int(self.block_size),
         )
 
         # Avoid copying large hidden-state buffers to CPU in overlap scheduling.

--- a/test/registered/unit/spec/test_dflash_kda.py
+++ b/test/registered/unit/spec/test_dflash_kda.py
@@ -1,0 +1,331 @@
+"""Tests for context-scanning KDA draft attention (``linear_attn_config.context_state: scan``)."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.models.dflash import (
+    DFlashDraftModel,
+    DFlashKDAAttention,
+    reference_dflash_kda,
+)
+from sglang.srt.speculative.dflash_utils import parse_dflash_kda_config
+from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+HIDDEN, HEADS, HEAD_DIM, BLOCK, CONV = 16, 2, 8, 3, 3
+
+
+def _config(
+    context_state="scan",
+    hidden=HIDDEN,
+    heads=HEADS,
+    head_dim=HEAD_DIM,
+    **dflash_overrides,
+):
+    dflash_config = {
+        "attention_modes": ["kda"],
+        "block_size": BLOCK,
+        **dflash_overrides,
+    }
+    return SimpleNamespace(
+        hidden_size=hidden,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-6,
+        dflash_config=dflash_config,
+        linear_attn_config={
+            "head_dim": head_dim,
+            "num_heads": heads,
+            "short_conv_kernel_size": CONV,
+            "use_full_rank_gate": False,
+            "gate_lower_bound": -5.0,
+            "backend": "fla",
+            "context_state": context_state,
+        },
+    )
+
+
+@pytest.fixture
+def tp1(monkeypatch):
+    monkeypatch.setattr(
+        "sglang.srt.models.dflash.get_parallel", lambda: SimpleNamespace(tp_size=1)
+    )
+
+
+def _attention(
+    context_state="scan", device="cpu", dtype=torch.float32, slots=4, **dims
+):
+    torch.manual_seed(7)
+    attention = DFlashKDAAttention(_config(context_state, **dims), layer_id=0).to(
+        device=device, dtype=dtype
+    )
+    attention.A_log.data = attention.A_log.data.float()
+    attention.dt_bias.data = attention.dt_bias.data.float()
+    attention.init_context_state(slots, torch.device(device), dtype)
+    return attention.eval()
+
+
+def _oracle(attention, context, block):
+    """KDA over the contiguous sequence ``[context ; block]``, block rows only."""
+    sequence = torch.cat((context, block), dim=1)
+    length = sequence.shape[1]
+    heads, head_dim, hidden = (
+        attention.num_heads,
+        attention.head_dim,
+        attention.hidden_size,
+    )
+    shape = (1, length, heads, head_dim)
+    q = attention.q_conv1d(attention.q_proj(sequence)).reshape(shape)
+    k = attention.k_conv1d(attention.k_proj(sequence)).reshape(shape)
+    v = attention.v_conv1d(attention.v_proj(sequence)).reshape(shape)
+    raw_gate, beta = attention._gates(sequence)
+    out = reference_dflash_kda(
+        q,
+        k,
+        v,
+        raw_gate,
+        beta,
+        attention.A_log,
+        attention.dt_bias,
+        attention.lower_bound,
+    )[:, context.shape[1] :]
+    gate = attention._output_gate(block).reshape(1, BLOCK, heads, head_dim)
+    out = attention.o_norm(out, gate)
+    return attention.o_proj(out.flatten(-2)).reshape(BLOCK, hidden)
+
+
+def test_context_state_parses_and_validates():
+    assert parse_dflash_kda_config(_config("reset")).scans_context is False
+    assert parse_dflash_kda_config(_config("scan")).scans_context is True
+    cfg = _config("scan")
+    del cfg.linear_attn_config["context_state"]
+    assert parse_dflash_kda_config(cfg).context_state == "reset"
+    with pytest.raises(ValueError, match="context_state"):
+        parse_dflash_kda_config(_config("sliding"))
+
+
+def test_reset_policy_keeps_block_local_behaviour(tp1):
+    attention = _attention("reset")
+    assert attention.is_dflash_kda_scan is False
+    hidden = torch.randn(2 * BLOCK, HIDDEN)
+    combined = attention(None, hidden, None)
+    separate = torch.cat(
+        [attention(None, hidden[:BLOCK], None), attention(None, hidden[BLOCK:], None)]
+    )
+    torch.testing.assert_close(combined, separate)
+
+
+@torch.no_grad()
+def test_scan_matches_full_sequence_oracle_cpu(tp1):
+    attention = _attention("scan")
+    context = torch.randn(1, 7, HIDDEN)
+    block = torch.randn(1, BLOCK, HIDDEN)
+    slots = torch.tensor([2])
+    # Two verified slices (3 rows, then 4 rows); the first starts the request.
+    attention.advance_context_state(
+        slots, context[0, :3], torch.tensor([3]), torch.tensor([True])
+    )
+    attention.advance_context_state(
+        slots, context[0, 3:], torch.tensor([4]), torch.tensor([False])
+    )
+    out = attention(None, block[0], SimpleNamespace(req_pool_indices=slots))
+    torch.testing.assert_close(
+        out, _oracle(attention, context, block), rtol=1e-4, atol=1e-4
+    )
+    # The block forward must not advance the running state.
+    state_before = attention._ctx_state[2].clone()
+    attention(None, block[0], SimpleNamespace(req_pool_indices=slots))
+    torch.testing.assert_close(attention._ctx_state[2], state_before)
+
+
+@torch.no_grad()
+def test_scan_batches_independent_requests_cpu(tp1):
+    attention = _attention("scan")
+    ctx_a, ctx_b = torch.randn(1, 5, HIDDEN), torch.randn(1, 2, HIDDEN)
+    blocks = torch.randn(2, BLOCK, HIDDEN)
+    slots = torch.tensor([3, 0])
+    rows = torch.cat([ctx_a[0], ctx_b[0]])
+    attention.advance_context_state(
+        slots, rows, torch.tensor([5, 2]), torch.tensor([True, True])
+    )
+    out = attention(
+        None, blocks.reshape(-1, HIDDEN), SimpleNamespace(req_pool_indices=slots)
+    )
+    torch.testing.assert_close(
+        out[:BLOCK], _oracle(attention, ctx_a, blocks[:1]), rtol=1e-4, atol=1e-4
+    )
+    torch.testing.assert_close(
+        out[BLOCK:], _oracle(attention, ctx_b, blocks[1:]), rtol=1e-4, atol=1e-4
+    )
+
+
+@torch.no_grad()
+def test_reset_mask_starts_a_fresh_request(tp1):
+    attention = _attention("scan")
+    stale = torch.randn(1, 6, HIDDEN)
+    context = torch.randn(1, 4, HIDDEN)
+    block = torch.randn(1, BLOCK, HIDDEN)
+    slots = torch.tensor([1])
+    attention.advance_context_state(
+        slots, stale[0], torch.tensor([6]), torch.tensor([True])
+    )
+    attention.advance_context_state(
+        slots, context[0], torch.tensor([4]), torch.tensor([True])
+    )
+    out = attention(None, block[0], SimpleNamespace(req_pool_indices=slots))
+    torch.testing.assert_close(
+        out, _oracle(attention, context, block), rtol=1e-4, atol=1e-4
+    )
+
+
+def test_worker_groups_rows_per_request():
+    calls = []
+    fake = SimpleNamespace(
+        _has_scan_kda=True,
+        _kda_state_ready=True,
+        draft_model=SimpleNamespace(
+            advance_kda_context=lambda slots, rows, lens, reset: calls.append(
+                (slots.tolist(), rows.shape[0], lens.tolist(), reset.tolist())
+            )
+        ),
+    )
+    ctx_hidden = torch.arange(12.0).reshape(12, 1)
+    # Packed prefill layout: request 7 owns rows 0..4 (positions from 0), request 9 owns rows 5..11 (from 3).
+    positions = torch.tensor([0, 1, 2, 3, 4, 3, 4, 5, 6, 7, 8, 9])
+    DFlashWorkerV2._advance_kda_context(
+        fake,
+        ctx_hidden=ctx_hidden,
+        positions=positions,
+        req_pool_indices=torch.tensor([7, 9]),
+        row_lens=torch.tensor([5, 7]),
+        row_stride=None,
+    )
+    assert calls == [([7, 9], 12, [5, 7], [True, False])]
+    calls.clear()
+    # Dense verify layout: block of 4 rows per request, commit 2 / 0 / 4 rows.
+    ctx_hidden = torch.arange(12.0).reshape(12, 1)
+    positions = torch.tensor([10, 11, 12, 13, 0, 1, 2, 3, 0, 1, 2, 3])
+    DFlashWorkerV2._advance_kda_context(
+        fake,
+        ctx_hidden=ctx_hidden,
+        positions=positions,
+        req_pool_indices=torch.tensor([1, 2, 3]),
+        row_lens=torch.tensor([2, 0, 4]),
+        row_stride=4,
+    )
+    assert calls == [([1, 3], 6, [2, 4], [False, True])]
+
+
+def test_draft_model_iterates_scan_layers_only():
+    scan = SimpleNamespace(
+        self_attn=SimpleNamespace(is_dflash_kda=True, is_dflash_kda_scan=True)
+    )
+    local = SimpleNamespace(self_attn=SimpleNamespace(is_dflash_kda=True))
+    gqa = SimpleNamespace(self_attn=SimpleNamespace())
+    model = SimpleNamespace(layers=[scan, local, gqa])
+    assert list(DFlashDraftModel.iter_scan_kda_layers(model)) == [scan]
+    assert list(DFlashDraftModel.iter_context_attention_layers(model)) == [gqa]
+
+
+CUDA_DIMS = dict(
+    hidden=64, heads=2, head_dim=128
+)  # Triton kernels need kernel-sized heads
+
+
+def _reference_state_after(attention, context):
+    """Reference recurrent state ([1, H, K, V]) after scanning ``context`` from zero."""
+    length = context.shape[1]
+    shape = (1, length, attention.num_heads, attention.head_dim)
+    k = attention.k_conv1d(attention.k_proj(context)).reshape(shape)
+    v = attention.v_conv1d(attention.v_proj(context)).reshape(shape)
+    raw_gate, beta = attention._gates(context)
+    _, state = reference_dflash_kda(
+        k,
+        k,
+        v,
+        raw_gate,
+        beta,
+        attention.A_log,
+        attention.dt_bias,
+        attention.lower_bound,
+        output_final_state=True,
+    )
+    return state
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@torch.no_grad()
+def test_reset_policy_cuda_kernel_matches_reference(tp1):
+    attention = _attention("reset", device="cuda", **CUDA_DIMS)
+    hidden = torch.randn(2 * BLOCK, CUDA_DIMS["hidden"], device="cuda")
+    out = attention(None, hidden, None)
+    expected = torch.cat(
+        [
+            _oracle(
+                attention,
+                hidden.new_zeros(1, 0, CUDA_DIMS["hidden"]),
+                hidden[i * BLOCK : (i + 1) * BLOCK].unsqueeze(0),
+            )
+            for i in range(2)
+        ]
+    )
+    torch.testing.assert_close(out, expected, rtol=2e-3, atol=2e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@torch.no_grad()
+def test_scan_cuda_state_matches_reference(tp1):
+    attention = _attention("scan", device="cuda", **CUDA_DIMS)
+    context = torch.randn(1, 70, CUDA_DIMS["hidden"], device="cuda")
+    slots = torch.tensor([1], device="cuda")
+    attention.advance_context_state(
+        slots, context[0, :66], torch.tensor([66]), torch.tensor([True])
+    )
+    attention.advance_context_state(
+        slots, context[0, 66:], torch.tensor([4]), torch.tensor([False])
+    )
+    expected = _reference_state_after(attention, context)[0]  # [H, K, V]
+    kernel_state = attention._ctx_state[1]  # pool layout [H, V, K]
+    torch.testing.assert_close(
+        kernel_state.transpose(-1, -2), expected, rtol=2e-3, atol=2e-3
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@torch.no_grad()
+def test_scan_cuda_kernels_match_cpu_oracle(tp1):
+    attention = _attention("scan", device="cuda", **CUDA_DIMS)
+    hidden = CUDA_DIMS["hidden"]
+    context = torch.randn(1, 70, hidden, device="cuda")
+    block = torch.randn(1, BLOCK, hidden, device="cuda")
+    slots = torch.tensor([1], device="cuda")
+    attention.advance_context_state(
+        slots, context[0, :66], torch.tensor([66]), torch.tensor([True])
+    )
+    attention.advance_context_state(
+        slots, context[0, 66:], torch.tensor([4]), torch.tensor([False])
+    )
+    out = attention(None, block[0], SimpleNamespace(req_pool_indices=slots))
+    expected = _oracle(attention, context, block)
+    torch.testing.assert_close(out, expected, rtol=2e-3, atol=2e-3)
+    # Batched advance with two requests of different lengths.
+    attention.reset_context_state(torch.tensor([1, 2], device="cuda"))
+    ctx_b = torch.randn(1, 9, hidden, device="cuda")
+    attention.advance_context_state(
+        torch.tensor([1, 2], device="cuda"),
+        torch.cat([context[0], ctx_b[0]]),
+        torch.tensor([70, 9]),
+        torch.tensor([True, True]),
+    )
+    out = attention(
+        None,
+        torch.cat([block[0], block[0]]),
+        SimpleNamespace(req_pool_indices=torch.tensor([1, 2], device="cuda")),
+    )
+    torch.testing.assert_close(out[:BLOCK], expected, rtol=2e-3, atol=2e-3)
+    torch.testing.assert_close(
+        out[BLOCK:], _oracle(attention, ctx_b, block), rtol=2e-3, atol=2e-3
+    )


### PR DESCRIPTION
## Summary

- add `DFlashKDAAttention`: Kimi Delta Attention layers for DFlash-family drafts, selected per layer through `dflash_config.attention_modes` (`kda`) with dimensions from `linear_attn_config`
- support both KDA state policies SpecForge trains (`linear_attn_config.context_state`):
  - `reset` (block-local): every proposal block is an independent recurrent sequence from a zero state
  - `scan` (context-scanning): a per-request running state (plus the last `kernel_size - 1` context rows for the short convolution) lives in a slot pool indexed by `req_pool_indices`; the worker advances it with every newly verified context slice, and each block forward starts from it
- reuse `chunk_kda` for the scan: `initial_state` + `initial_state_indices` + `cu_seqlens` make the kernel read each request's state from, and write its final state back into, the addressed pool slot, so serving uses exactly the training kernel math
- fix `chunk_gated_delta_rule_fwd_h` to address/write the state pool only when an initial state is given (the extend path dereferenced `initial_state_indices` unconditionally)
- pass post-sigmoid beta to the KDA kernels: `chunk_kda` activates the decay gate in-kernel (raw gate, `A_log`, `dt_bias`, `lower_bound`) but does not sigmoid beta, and its `beta_is_raw` keyword is swallowed by `**kwargs`
- log loaded / ignored / missing tensor counts in the draft weight loader
- CPU regression coverage: config parsing, block-local behaviour, context-scan equivalence to a full-sequence oracle (single request, batched requests, reset semantics), worker row grouping for packed prefill and dense verify layouts; CUDA tests compare the Triton kernels against the CPU oracle for the block-local path, the in-place state, and the scan block

## Motivation

SpecForge's DFlash2 hybrid drafts can replace GQA layers with KDA (Kimi Delta Attention). The generic `DFlashDraftModel` only builds GQA/MHA attention, so a KDA checkpoint could not be served at all. The block-local variant was straightforward; the context-scanning variant (SpecForge PR #836) needs a recurrent state that follows the request across verify steps, which the DFlash worker did not have.

The beta fix matters on its own: feeding the raw `b_proj` output to `chunk_kda` silently changes the delta rule. The CPU reference used in the tests was checked against `fla.ops.kda.chunk_kda` (`use_beta_sigmoid_in_kernel=True`, `use_gate_in_kernel=True`, `safe_gate`) to 6e-5, and the Triton kernel matches that reference only with pre-sigmoided beta.

## Validation

- `ruff format` / `ruff check` on the touched files, `git diff --check`, Python compilation
- `test/registered/unit/spec/test_dflash_kda.py`: 10 tests pass on GB300 (7 CPU, 3 CUDA)
- Served a Qwen3.8-27B NVFP4 target with SpecForge DFlash2 KDA hybrid drafts (`[kda,kda,gqa,kda,kda]`, block 8, fp8 KV cache, Triton draft backend) on GB300, AIME25/26 acceptance length (60 paired prompts, T=1.0, top-p 0.95, top-k 20):

| draft | AIME25 | AIME26 | mean |
|---|---|---|---|
| GQA reference (same loss) | 3.645 | 3.451 | 3.548 |
| KDA hybrid, `context_state: reset` (block-local) | 3.151 | 2.985 | 3.068 |
| KDA hybrid, `context_state: scan` (context-scanning) | 3.665 | 3.411 | 3.538 |

Paired on the same 60 prompts: scan vs GQA -0.010 [-0.073, +0.053] (a tie), scan vs block-local +0.470 [+0.403, +0.537]. The block-local number moved by only +0.015 with the beta fix (it was 3.053 with raw beta). The context-scanning draft's acceptance no longer decays along the sequence (before the state plumbing it fell to 1.0 after ~100 generated tokens); its within-block conditional acceptance is flat like GQA's (0.77 at position 1 to 0.69 at position 7) where the block-local draft decays to 0.53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34174697527](https://github.com/sgl-project/sglang/actions/runs/34174697527)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34174697296](https://github.com/sgl-project/sglang/actions/runs/34174697296)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34174697366](https://github.com/sgl-project/sglang/actions/runs/34174697366)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->