### PR TITLE
[Docs] Prefer --cuda-graph-backend-*=disabled in benchmark profiling guide

### DIFF
--- a/docs/docs/developer_guide/benchmark_and_profiling.mdx
+++ b/docs/docs/developer_guide/benchmark_and_profiling.mdx
@@ -396,7 +396,7 @@ python -m sglang.bench_serving --backend sglang --model meta-llama/Llama-3.1-8B-
 
 This command sets the number of prompts to 2 with `--num-prompts` argument and limits the length of output sequences to 100 with `--sharegpt-output-len` argument, which can generate a small trace file for browser to open smoothly.
 
-Additionally, if you want to locate the SGLang Python source code through the cuda kernel in Trace, you need to disable CUDA Graph when starting the service. This can be done by using the `--disable-cuda-graph` parameter in the command to start the service.
+Additionally, if you want to locate the SGLang Python source code through the cuda kernel in Trace, you need to disable CUDA Graph when starting the service. This can be done by using `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` when starting the service.
 
 ## Profile with Nsight
 
@@ -487,10 +487,11 @@ This method allows you to control exactly when profiling starts/stops via HTTP A
      python -m sglang.launch_server \
        --model-path meta-llama/Llama-3.1-8B-Instruct \
        --enable-layerwise-nvtx-marker \
-       --disable-cuda-graph
+       --cuda-graph-backend-decode=disabled \
+       --cuda-graph-backend-prefill=disabled
    ```
 
-   Note: NVTX markers are not emitted for kernel launches captured by CUDA graphs. Use `--disable-cuda-graph` to ensure all layerwise NVTX markers are emitted in the trace.
+   Note: NVTX markers are not emitted for kernel launches captured by CUDA graphs. Use `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` to ensure all layerwise NVTX markers are emitted in the trace.
 
 2. In another terminal, control profiling via `/start_profile` with `CUDA_PROFILER` activity:
 
@@ -528,11 +529,12 @@ For simpler use cases where you don't need fine-grained control over profiling s
 
 ```bash Command
 # Terminal 1: Start server with layerwise NVTX
-# Note: --disable-cuda-graph ensures all NVTX markers are emitted
+# Note: disable CUDA graph backends so all NVTX markers are emitted
 python -m sglang.launch_server \
   --model-path meta-llama/Llama-3.1-8B-Instruct \
   --enable-layerwise-nvtx-marker \
-  --disable-cuda-graph
+  --cuda-graph-backend-decode=disabled \
+  --cuda-graph-backend-prefill=disabled
 
 # Terminal 2: Profile the benchmarking client
 nsys profile --trace-fork-before-exec=true \


### PR DESCRIPTION
## Summary
- Replace deprecated `--disable-cuda-graph` in the developer profiling guide with `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled`.
- Keeps NVTX / Nsight Systems snippets aligned with the current CUDA graph CLI.

## Test plan
- [x] Confirmed `--disable-cuda-graph` is a deprecated alias in `python/sglang/srt/server_args.py` (`DeprecatedStoreTrueAction`, new_flag `--cuda-graph-backend-{decode,prefill}=disabled`).
- [x] Grepped the updated doc for remaining `--disable-cuda-graph` usages.
- [ ] Docs preview / maintainer check of the profiling section.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34175550656](https://github.com/sgl-project/sglang/actions/runs/34175550656)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34175550437](https://github.com/sgl-project/sglang/actions/runs/34175550437)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->