### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in Ascend Qwen3-8B best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_8b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_8b.mdx
@@ -95,7 +95,7 @@ python3 -m sglang.launch_server \
     --chunked-prefill-size 16384 \
     --tp-size 1 \
     --mem-fraction-static 0.85 \
-    --cuda-graph-bs 8 12 24 36 48 51 55 60 63 64 66 68 70 \
+    --cuda-graph-bs-decode 8 12 24 36 48 51 55 60 63 64 66 68 70 \
     --dtype bfloat16 \
     --speculative-draft-model-quantization unquant \
     --speculative-algorithm EAGLE3 \
@@ -192,7 +192,7 @@ python3 -m sglang.launch_server \
     --chunked-prefill-size -1 \
     --tp-size 2 \
     --mem-fraction-static 0.894 \
-    --cuda-graph-bs 1 \
+    --cuda-graph-bs-decode 1 \
     --dtype bfloat16 \
     --speculative-draft-model-quantization unquant \
     --speculative-algorithm EAGLE3 \
@@ -289,7 +289,7 @@ python3 -m sglang.launch_server \
     --chunked-prefill-size -1 \
     --tp-size 2 \
     --mem-fraction-static 0.894 \
-    --cuda-graph-bs 1 5 15 16 \
+    --cuda-graph-bs-decode 1 5 15 16 \
     --dtype bfloat16 \
     --speculative-draft-model-quantization unquant \
     --speculative-algorithm EAGLE3 \


### PR DESCRIPTION
## Summary
- Update Ascend Qwen3-8B best practices to prefer `--cuda-graph-bs-decode` over the deprecated `--cuda-graph-bs` alias in launch examples.

## Test plan
- [ ] Confirm `python/sglang/srt/server_args.py` still documents `--cuda-graph-bs` as a deprecated alias for `--cuda-graph-bs-decode`
- [ ] Docs preview / visual check of the Qwen3-8B best practices snippets

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34175600580](https://github.com/sgl-project/sglang/actions/runs/34175600580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34175600517](https://github.com/sgl-project/sglang/actions/runs/34175600517)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->