### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in Ascend Qwen3-32B best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_32b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_32b.mdx
@@ -100,7 +100,7 @@ python3 -m sglang.launch_server \
     --speculative-num-draft-tokens 5 \
     --tp-size 16 \
     --mem-fraction-static 0.72 \
-    --cuda-graph-bs 1 \
+    --cuda-graph-bs-decode 1 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen
@@ -199,7 +199,7 @@ python3 -m sglang.launch_server \
     --speculative-num-draft-tokens 4 \
     --tp-size 4 \
     --mem-fraction-static 0.845 \
-    --cuda-graph-bs 16 32 64 72 88 90 92 94 96 97 98 99 100 101 \
+    --cuda-graph-bs-decode 16 32 64 72 88 90 92 94 96 97 98 99 100 101 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen
@@ -298,7 +298,7 @@ python3 -m sglang.launch_server \
     --speculative-num-draft-tokens 4 \
     --tp-size 4 \
     --mem-fraction-static 0.845 \
-    --cuda-graph-bs 16 32 64 72 88 90 92 94 96 97 98 99 100 101 \
+    --cuda-graph-bs-decode 16 32 64 72 88 90 92 94 96 97 98 99 100 101 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen


### PR DESCRIPTION
## Summary
- Prefer `--cuda-graph-bs-decode` over deprecated `--cuda-graph-bs` in Ascend Qwen3-32B best-practices launch examples.

## Verification
- `python/sglang/srt/server_args.py` registers `--cuda-graph-bs` as `DeprecatedAliasStoreAction` with `new_flag="--cuda-graph-bs-decode"`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34177373274](https://github.com/sgl-project/sglang/actions/runs/34177373274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34177373179](https://github.com/sgl-project/sglang/actions/runs/34177373179)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->