### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend DeepSeek-V4-Flash best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_v4_flash.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_v4_flash.mdx
@@ -139,7 +139,8 @@ do
         --quantization modelslim \
         --enable-dp-lm-head \
         --kv-cache-dtype bfloat16 \
-        --disable-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --disable-radix-cache \
         --load-balance-method round_robin \
         --ep-dispatch-algorithm static
@@ -185,7 +186,7 @@ do
         --quantization modelslim \
         --enable-dp-lm-head \
         --kv-cache-dtype bfloat16 \
-        --cuda-graph-bs 1 2 4 8 16 24 36 40 48 56 \
+        --cuda-graph-bs-decode 1 2 4 8 16 24 36 40 48 56 \
         --speculative-algorithm EAGLE \
         --speculative-num-steps 2 \
         --speculative-eagle-topk 1 \
@@ -329,7 +330,7 @@ python3 -m sglang.launch_server \
     --enable-dp-lm-head \
     --kv-cache-dtype auto \
     --skip-server-warmup \
-    --cuda-graph-bs 1 2 4 8 \
+    --cuda-graph-bs-decode 1 2 4 8 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 2 \
     --speculative-eagle-topk 1 \
@@ -455,7 +456,7 @@ python3 -m sglang.launch_server \
     --enable-dp-lm-head \
     --kv-cache-dtype auto \
     --skip-server-warmup \
-    --cuda-graph-bs 1 2 4 8 10 \
+    --cuda-graph-bs-decode 1 2 4 8 10 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 2 \
     --speculative-eagle-topk 1 \


### PR DESCRIPTION
## Summary
Ascend DeepSeek-V4-Flash best practices still document deprecated CUDA-graph CLIs (`--disable-cuda-graph`, `--cuda-graph-bs`). Prefer the current flags from `server_args` deprecations: `--cuda-graph-backend-{decode,prefill}=disabled` and `--cuda-graph-bs-decode`.

## Test plan
- [ ] Confirm replacements match `python/sglang/srt/server_args.py` DeprecatedAlias / DeprecatedStoreTrueAction mappings
- [ ] Spot-check launch command snippets still render correctly in the docs site

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34179937734](https://github.com/sgl-project/sglang/actions/runs/34179937734)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34179937647](https://github.com/sgl-project/sglang/actions/runs/34179937647)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->