### PR TITLE
[Bench] Amortize the GDN ReplaySSM decode latency over the flush cycle

### DIFF
--- a/benchmark/kernels/attention/bench_gdn_replayssm_decode.py
+++ b/benchmark/kernels/attention/bench_gdn_replayssm_decode.py
@@ -13,6 +13,13 @@ ReplaySSM kernel reads S every step but writes it only 1-in-L steps, plus a
 small ring append (d:[HV,V], k:[H,K], g:[HV] per step). The amortized state
 traffic ratio is reported per L.
 
+Because the write happens only 1-in-L steps, the latency has to be amortized the
+same way. The kernel branches on the caller's `write_pos` cursor and folds the
+ring into the checkpoint only at `write_pos == L-1`, so both phases are timed and
+combined: a cycle is L-1 non-flush steps and one flush step, and the flush step
+costs roughly 2.3x a non-flush one. Timing a single pinned cursor position would
+report whichever phase was pinned as if it were the per-step cost.
+
 Run::
 
     python benchmark/kernels/attention/bench_gdn_replayssm_decode.py
@@ -62,7 +69,24 @@ def _state_bytes_per_step(B, HV, K, V, L, dtype):
     return packed, replay
 
 
-def _bench_cfg(B, H, HV, K, V, Ls, dtype, device, num_slots=None, warmup=25, rep=100):
+def _amortize(t_nonflush, t_flush, L):
+    """Mean per-step latency over one full L-phase cycle.
+
+    `write_pos` walks 0, 1, ... L-1 and wraps, so a steady-state cycle is L-1
+    non-flush steps and one flush step. The non-flush steps are not identical --
+    each replays one more ring entry than the last -- so the midpoint phase is
+    sampled as their representative rather than phase 0, which replays nothing
+    and is the cheapest step in the cycle. Against a full per-phase sweep this
+    is accurate to <1%, where using phase 0 understates the mean by ~3%.
+    """
+    if L == 1:
+        return t_flush
+    return ((L - 1) * t_nonflush + t_flush) / L
+
+
+def _bench_cfg(
+    B, H, HV, K, V, Ls, dtype, device, nk=2, num_slots=None, warmup=25, rep=100
+):
     num_slots = num_slots or B
     mixed_qkv, a, b, A_log, dt_bias = _make_static(B, H, HV, K, V, dtype, device)
     scale = K**-0.5
@@ -94,9 +118,8 @@ def _bench_cfg(B, H, HV, K, V, Ls, dtype, device, num_slots=None, warmup=25, rep
         d_cache = torch.zeros(num_slots, HV, L, V, device=device, dtype=dtype)
         k_cache = torch.zeros(num_slots, H, L, K, device=device, dtype=dtype)
         g_cache = torch.zeros(num_slots, HV, L, device=device, dtype=torch.float32)
-        write_pos = torch.zeros(B, device=device, dtype=torch.int32)
+        write_pos = torch.empty(B, device=device, dtype=torch.int32)
         rout = mixed_qkv.new_empty(B, 1, HV, V)
-        nk = 1 if L == 1 else 2
 
         def run_replay():
             fused_recurrent_gdn_replayssm_decode(
@@ -117,9 +140,29 @@ def _bench_cfg(B, H, HV, K, V, Ls, dtype, device, num_slots=None, warmup=25, rep
                 nk=nk,
             )
 
-        t_replay = triton.testing.do_bench(run_replay, warmup=warmup, rep=rep)
+        def time_at(pos):
+            write_pos.fill_(pos)
+            return triton.testing.do_bench(run_replay, warmup=warmup, rep=rep)
+
+        # The kernel branches on write_pos: it appends to the ring on every step
+        # but folds the ring into the checkpoint only when write_pos == L-1. Both
+        # phases have to be timed, or the reported cost is the cheap one repeated
+        # (see `_amortize`). L == 1 is all flush, so it has no non-flush phase.
+        t_flush = time_at(L - 1)
+        t_nonflush = time_at((L - 1) // 2) if L > 1 else None
+        t_replay = _amortize(t_nonflush, t_flush, L)
+
         packed_bytes, replay_bytes = _state_bytes_per_step(B, HV, K, V, L, dtype)
-        rows.append((L, t_replay, t_packed / t_replay, replay_bytes / packed_bytes))
+        rows.append(
+            (
+                L,
+                t_replay,
+                t_nonflush,
+                t_flush,
+                t_packed / t_replay,
+                replay_bytes / packed_bytes,
+            )
+        )
     return t_packed, rows
 
 
@@ -132,6 +175,9 @@ def main():
     parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1, 16, 64, 256])
     parser.add_argument("--ls", type=int, nargs="+", default=[1, 8, 16])
     parser.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
+    parser.add_argument(
+        "--nk", type=int, default=2, help="K-chunks the reconstruction walks"
+    )
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -145,20 +191,26 @@ def main():
 
     print(
         f"GDN ReplaySSM decode microbench  HV={args.hv} H={args.h} "
-        f"K={args.k} V={args.v} dtype={args.dtype}\n"
-        "per-step latency (ms); speedup = packed/replay; "
-        "state-traffic = replay/packed (lower is better)"
+        f"K={args.k} V={args.v} dtype={args.dtype} nk={args.nk}\n"
+        "replay = mean per-step latency over one L-phase cycle (ms), split into "
+        "its\nnon-flush and flush steps; speedup = packed/replay; "
+        "state-traffic = replay/packed\n(lower is better)"
     )
     for B in args.batch_sizes:
         t_packed, rows = _bench_cfg(
-            B, args.h, args.hv, args.k, args.v, args.ls, dtype, device
+            B, args.h, args.hv, args.k, args.v, args.ls, dtype, device, nk=args.nk
         )
         print(f"\nB={B:<4d}  packed={t_packed:.4f} ms")
-        for L, t_replay, speedup, traffic_ratio in rows:
+        for L, t_replay, t_nonflush, t_flush, speedup, traffic_ratio in rows:
+            split = (
+                f"(flush only)"
+                if t_nonflush is None
+                else f"(non-flush {t_nonflush:.4f}, flush {t_flush:.4f})"
+            )
             print(
                 f"    L={L:<3d} replay={t_replay:.4f} ms  "
                 f"speedup={speedup:5.2f}x  "
-                f"state-traffic={traffic_ratio:5.2f}x"
+                f"state-traffic={traffic_ratio:5.2f}x  {split}"
             )
 
 


### PR DESCRIPTION
# [Bench] Amortize the GDN ReplaySSM decode latency over the flush cycle

Fixes #38398

## Motivation

`bench_gdn_replayssm_decode.py` creates `write_pos = torch.zeros(B)` and never
advances it, though the kernel wrapper's docstring says the caller must. The
kernel folds the ring into the checkpoint only when `write_pos == L - 1`, so with
the cursor pinned at 0 and `L >= 2` the timed step never flushes and never
replays: every iteration re-measures the cheapest phase of the L-phase cycle.

The two reported columns therefore disagree. `state-traffic` is computed from a
model that assumes one checkpoint write per L steps:

```python
replay = (state_elems * fp32) * (1 + 1.0 / L)   # read every step + write 1/L
```

while `speedup` is measured on a path that performs that write zero times per L
steps. Both labels claim the amortized quantity.

## Modifications

**Time both phases and combine them.** A steady-state cycle is `L-1` non-flush
steps and one flush step, so the benchmark now times one of each and reports

```
((L - 1) * t_nonflush + t_flush) / L
```

The non-flush steps are not identical (each replays one more ring entry than the
last), so the *midpoint* phase is sampled as their representative. Phase 0
replays nothing and is the cheapest step in the cycle, which is exactly what made
the old number wrong.

Sweeping every phase and comparing (see the table below) puts this estimator
within **0.5%** of the exact mean, at two timings per L instead of L. A full
sweep would make the benchmark 8-16x slower to run for a sub-percent gain.

**Report the split.** The flush step costs ~2.3x a non-flush one, so the per-step
mean alone still hides that the cost is bursty by construction. Each row now
prints both components.

**Drop the `nk = 1 if L == 1 else 2` special case**, and expose `--nk` instead.
`nk` is the number of K-chunks the reconstruction walks (`BKT = BK // nk`,
validated by `BK % nk == 0` and `BKT >= 16`); at `K=128` both values are legal at
every L, so the special case was not structural, and `nk=1` is the slower of the
two by 2x. It was what produced the old 0.38x column at L=1.

## Results

H200 NVL, the benchmark's own defaults (`HV=32, H=16, K=V=128`, bf16 I/O, fp32
state).

| B | L | packed | before | after | speedup before | speedup after |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 0.0088 | 0.0106 | 0.0113 | 0.83x | 0.78x |
| 1 | 16 | 0.0088 | 0.0102 | 0.0110 | 0.86x | 0.80x |
| 16 | 8 | 0.0277 | 0.0199 | 0.0218 | 1.40x | 1.27x |
| 16 | 16 | 0.0277 | 0.0199 | 0.0213 | 1.40x | 1.30x |
| 64 | 8 | 0.0775 | 0.0535 | 0.0610 | 1.46x | 1.27x |
| 64 | 16 | 0.0775 | 0.0528 | 0.0589 | 1.48x | 1.32x |
| 256 | 8 | 0.2808 | 0.1612 | 0.1955 | **1.75x** | **1.44x** |
| 256 | 16 | 0.2808 | 0.1608 | 0.1847 | **1.75x** | **1.52x** |

Latencies in ms. The old column overstated the speedup by 6-21% depending on
batch size.

`L=8` and `L=16` were indistinguishable before (1.40/1.40, 1.46/1.48, 1.75/1.75)
because the non-flush step costs the same for both: `BC = max(16,
next_power_of_2(max_cache_len))` is 16 for every `L <= 16`. Only including the
flush phase shows that a larger L amortizes it over more steps.

## Validation of the estimator

Every phase timed for each (B, L) the benchmark reports, exact mean against the
shipped two-point estimate and against the two obvious wrong choices:

| B | L | exact mean | 2pt (mid) | err | 2pt (phase 0) | err | old 1pt | err |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 0.0112 | 0.0111 | -0.5% | 0.0111 | -0.8% | 0.0106 | -5.6% |
| 1 | 16 | 0.0110 | 0.0110 | -0.0% | 0.0105 | -4.8% | 0.0102 | -7.5% |
| 16 | 8 | 0.0218 | 0.0218 | +0.0% | 0.0216 | -1.0% | 0.0201 | -8.0% |
| 16 | 16 | 0.0212 | 0.0213 | +0.2% | 0.0207 | -2.4% | 0.0200 | -6.1% |
| 64 | 8 | 0.0611 | 0.0612 | +0.2% | 0.0602 | -1.4% | 0.0534 | -12.6% |
| 64 | 16 | 0.0588 | 0.0591 | +0.5% | 0.0564 | -4.0% | 0.0528 | -10.1% |
| 256 | 8 | 0.1939 | 0.1947 | +0.4% | 0.1879 | -3.1% | 0.1611 | -17.0% |
| 256 | 16 | 0.1838 | 0.1843 | +0.3% | 0.1746 | -5.0% | 0.1606 | -12.6% |

Worst error of the shipped estimator: **0.5%**. Using phase 0 as the non-flush
representative instead would cost up to 5.0%, which is why the midpoint is
sampled.

Independently, a loop that really advances `write_pos` every step costs **0.1935
ms/step** at `B=256, L=8`, against a phase-pinned mean of **0.1946 ms/step**, a
0.6% difference. Pinning the cursor and averaging measures the same thing as
cycling it, without folding a per-step cursor-update launch into the timing.

## Sample output

```
GDN ReplaySSM decode microbench  HV=32 H=16 K=128 V=128 dtype=bf16 nk=2
replay = mean per-step latency over one L-phase cycle (ms), split into its
non-flush and flush steps; speedup = packed/replay; state-traffic = replay/packed
(lower is better)

B=256   packed=0.2806 ms
    L=1   replay=0.3667 ms  speedup= 0.77x  state-traffic= 1.00x  (flush only)
    L=8   replay=0.1955 ms  speedup= 1.44x  state-traffic= 0.56x  (non-flush 0.1693, flush 0.3791)
    L=16  replay=0.1848 ms  speedup= 1.52x  state-traffic= 0.53x  (non-flush 0.1713, flush 0.3873)
```

## Checklist

- [x] Format the code and run the linters
- [x] Add unit tests / benchmarks where applicable — this is a benchmark-only
      change; the estimator it introduces is validated against a full per-phase
      sweep in the table above
- [x] Update documentation — the module docstring now describes what is timed and
      why

## Scope

- Benchmark script only. No runtime code is touched, so there is no correctness
  or performance impact on serving.
- Measured on a single H200 NVL at the benchmark's own defaults, kernels from
  `main`. Not swept over head counts or state dtype.
- Runtime cost of the change: two timings per L instead of one, so the benchmark
  takes about twice as long to run.

## One observation, not addressed here

The flush step costs **1.31x** packed decode at `L=1`, where the ring is empty
and the kernel header states it "reduces *algebraically* to the corresponding
packed-decode kernel". Holding `nk=2` and timing only the flush phase:

| L | real ring entries | flush step | vs packed |
|---:|---:|---:|---:|
| 1 | 0 | 0.3672 ms | 1.31x |
| 2 | 1 | 0.3681 ms | 1.31x |
| 8 | 7 | 0.3763 ms | 1.34x |
| 16 | 15 | 0.3874 ms | 1.38x |
| 32 | 31 | 0.4271 ms | 1.52x |

The cost does scale with the number of real ring entries, so the 1.31x at zero
entries is a fixed floor rather than fold work, and it is not explained by the BC
padding. I did not chase the cause; it is out of scope for a benchmark fix and
may well be expected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34182194168](https://github.com/sgl-project/sglang/actions/runs/34182194168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34200835081](https://github.com/sgl-project/sglang/actions/runs/34200835081)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->