### PR TITLE
[Docs] Drop deprecated --prefill-round-robin-balance from Ascend GLM best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_1.mdx
@@ -312,7 +312,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 16 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -512,7 +511,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -724,7 +722,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 16 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -926,7 +923,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 16 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -1125,7 +1121,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -1335,7 +1330,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 32 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \
@@ -1545,7 +1539,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 4 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_2.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/glm_5_2.mdx
@@ -176,7 +176,6 @@ do
         --watchdog-timeout 9000 \
         --context-length 180000 \
         --tokenizer-worker-num 8 \
-        --prefill-round-robin-balance \
         --disable-shared-experts-fusion \
         --dtype bfloat16 \
         --load-balance-method round_robin \


### PR DESCRIPTION
## Summary
- Remove deprecated `--prefill-round-robin-balance` from Ascend NPU GLM-5.1 and GLM-5.2 best-practice launch snippets.
- The flag is registered with `DeprecatedAction` in `server_args` (`Note: --prefill-round-robin-balance is deprecated now.`).

## Test plan
- [ ] Confirm snippets no longer pass `--prefill-round-robin-balance`
- [ ] Docs preview / lint as applicable

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34182631400](https://github.com/sgl-project/sglang/actions/runs/34182631400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34182631183](https://github.com/sgl-project/sglang/actions/runs/34182631183)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->