### PR TITLE
[Model] Support pipeline parallelism for Hunyuan V4

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -212,15 +212,21 @@ def is_deepseek_v4(config) -> bool:
     )
 
 
+def is_hunyuan_v4(config) -> bool:
+    return _hf_arch(config) in ("HYV4ForCausalLM", "HYV4ForCausalLMNextN")
+
+
 def resolve_spec_hidden_size(
     hf_config, hidden_size: int, hc_mult: int
 ) -> tuple[int, Optional[int]]:
-    # Only DSV4 carries the hc-flattened stream across the target→draft
-    # boundary; other hc models (hy_v4) collapse to hidden_size first.
-    if hc_mult <= 1 or not is_deepseek_v4(hf_config):
+    if hc_mult <= 1:
         return hidden_size, None
-    hc_hidden_size = hidden_size * hc_mult
-    return hc_hidden_size, hc_hidden_size
+    if is_deepseek_v4(hf_config):
+        hc_hidden_size = hidden_size * hc_mult
+        return hc_hidden_size, hc_hidden_size
+    if is_hunyuan_v4(hf_config):
+        return hidden_size, hidden_size * hc_mult
+    return hidden_size, None
 
 
 def get_dsa_index_head_dim(config: PretrainedConfig) -> int:

--- a/python/sglang/srt/models/hunyuan_v4.py
+++ b/python/sglang/srt/models/hunyuan_v4.py
@@ -6,17 +6,23 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.srt.configs.model_config import (
+    dsa_layer_skips_topk,
+    get_dsa_index_topk,
+)
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.layers.attention.index_topk_share import IndexTopKShareState
 from sglang.srt.layers.communicator import AttentionInputs, get_attn_tp_context
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, ReplicatedLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
     get_embedding_tp_kwargs,
 )
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.models.deepseek_common.attention_forward_methods import (
     AttnForwardMethod,
@@ -30,7 +36,13 @@ from sglang.srt.models.deepseek_v2 import (
     DeepseekV2MoE,
 )
 from sglang.srt.runtime_context import get_parallel, get_stream
-from sglang.srt.utils import BumpAllocator, get_device_capability, is_cuda
+from sglang.srt.utils import (
+    BumpAllocator,
+    add_prefix,
+    get_device_capability,
+    is_cuda,
+    make_layers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -614,45 +626,68 @@ class HYV4DecoderLayer(nn.Module):
 class HYV4Model(nn.Module):
     def __init__(self, config, quant_config=None, prefix=""):
         super().__init__()
-        if get_pp_group().world_size != 1:
-            raise ValueError("HYV4 pipeline parallelism is not supported")
         self.config = config
-        self.start_layer = 0
-        self.end_layer = config.num_hidden_layers
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            prefix=f"{prefix}.embed_tokens",
-            **get_embedding_tp_kwargs(),
-        )
+        self.pp_group = get_pp_group()
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=add_prefix("embed_tokens", prefix),
+                **get_embedding_tp_kwargs(),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
         self.alt_stream = get_stream("alt") if is_cuda() else None
-        self.layers = nn.ModuleList(
-            [
-                HYV4DecoderLayer(
-                    config,
-                    i,
-                    quant_config,
-                    f"{prefix}.layers.{i}",
-                    self.alt_stream,
-                )
-                for i in range(config.num_hidden_layers)
-            ]
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: HYV4DecoderLayer(
+                config,
+                idx,
+                quant_config,
+                prefix,
+                self.alt_stream,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
         )
-        self.hc_head = HYV4HCHeadLayer(config, f"{prefix}.hc_head")
-        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        if self.pp_group.is_last_rank:
+            self.hc_head = HYV4HCHeadLayer(config, add_prefix("hc_head", prefix))
+            self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        else:
+            self.hc_head = PPMissingLayer()
+            self.norm = PPMissingLayer(return_tuple=True)
+            self.send_topk_indices = dsa_layer_skips_topk(config, self.end_layer)
+            self.topk_indices_width = (
+                get_dsa_index_topk(config) if self.send_topk_indices else None
+            )
 
-    def forward(self, input_ids, positions, forward_batch, input_embeds=None):
-        hidden_states = (
-            self.embed_tokens(input_ids) if input_embeds is None else input_embeds
-        )
+    def forward(
+        self,
+        input_ids,
+        positions,
+        forward_batch,
+        input_embeds=None,
+        pp_proxy_tensors=None,
+    ):
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            initial_topk_indices = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            initial_topk_indices = pp_proxy_tensors.tensors.get("topk_indices")
+
         zero_allocator = BumpAllocator(
-            buffer_size=2 * len(self.layers),
+            buffer_size=2 * (self.end_layer - self.start_layer),
             dtype=torch.float32,
             device=hidden_states.device,
         )
-        topk_share = IndexTopKShareState(forward_batch, None)
-        for layer in self.layers:
-            hidden_states, topk_indices = layer(
+        topk_share = IndexTopKShareState(forward_batch, initial_topk_indices)
+        for i in range(self.start_layer, self.end_layer):
+            hidden_states, topk_indices = self.layers[i](
                 positions,
                 hidden_states,
                 forward_batch,
@@ -660,6 +695,18 @@ class HYV4Model(nn.Module):
                 topk_share.topk_indices,
             )
             topk_share.update(topk_indices)
+
+        if not self.pp_group.is_last_rank:
+            proxy_tensors = {"hidden_states": hidden_states.flatten(1)}
+            if self.send_topk_indices:
+                topk_indices = topk_share.topk_indices
+                if topk_indices is None:
+                    topk_indices = hidden_states.new_empty(
+                        (0, self.topk_indices_width), dtype=torch.int32
+                    )
+                proxy_tensors["topk_indices"] = topk_indices
+            return PPProxyTensors(proxy_tensors)
+
         topk_share.publish()
         return self.hc_head(hidden_states, self.norm)
 
@@ -676,34 +723,59 @@ class HYV4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
-        self.model = HYV4Model(config, quant_config, f"{prefix}.model")
+        self.model = HYV4Model(config, quant_config, add_prefix("model", prefix))
         self.num_fused_shared_experts = max(
             (
                 layer.mlp.num_fused_shared_experts
                 for layer in self.model.layers
-                if isinstance(layer.mlp, DeepseekV2MoE)
+                if isinstance(layer, HYV4DecoderLayer)
+                and isinstance(layer.mlp, DeepseekV2MoE)
             ),
             default=0,
         )
-        self.lm_head = ParallelLMHead(
-            config.vocab_size,
-            config.hidden_size,
-            # Keep checkpoint weights in bf16; LogitsProcessor emits fp32
-            # logits when config.enable_lm_head_fp32 is set.
-            quant_config=quant_config,
-            prefix=f"{prefix}.lm_head",
-            use_attn_tp_group=get_parallel().enable_dp_lm_head,
-        )
+        if self.pp_group.is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                # Keep checkpoint weights in bf16; LogitsProcessor emits fp32
+                # logits when config.enable_lm_head_fp32 is set.
+                quant_config=quant_config,
+                prefix=add_prefix("lm_head", prefix),
+                use_attn_tp_group=get_parallel().enable_dp_lm_head,
+            )
+        else:
+            self.lm_head = PPMissingLayer()
         self.logits_processor = LogitsProcessor(config)
 
     @torch.no_grad()
-    def forward(self, input_ids, positions, forward_batch, input_embeds=None):
+    def forward(
+        self,
+        input_ids,
+        positions,
+        forward_batch,
+        input_embeds=None,
+        pp_proxy_tensors=None,
+    ):
         hidden_states = self.model(
-            input_ids, positions, forward_batch, input_embeds=input_embeds
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
+        if not self.pp_group.is_last_rank:
+            return hidden_states
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch
         )
+
+    @property
+    def start_layer(self):
+        return self.model.start_layer
+
+    @property
+    def end_layer(self):
+        return self.model.end_layer
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/hunyuan_v4.py
+++ b/python/sglang/srt/models/hunyuan_v4.py
@@ -56,6 +56,12 @@ def _hpc_ihc_available(op_name: str, hc_mult: int, hidden_size: int) -> bool:
 
 
 def permute_hyv4_indexer_weight(name, loaded_weight, config):
+    # Block-FP8 scales describe complete 128-row blocks. They must stay in
+    # block order and, unlike the corresponding weights, do not contain an
+    # index_head_dim axis to rotate.
+    if name.endswith((".weight_scale", ".weight_scale_inv")):
+        return loaded_weight
+
     if ".self_attn.indexer.wq_b." in name:
         group_count = config.index_n_heads
     elif any(

--- a/test/registered/unit/configs/test_model_config_scaling.py
+++ b/test/registered/unit/configs/test_model_config_scaling.py
@@ -2,7 +2,11 @@ import math
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.configs.model_config import ModelConfig, compute_mla_mscale_scaling
+from sglang.srt.configs.model_config import (
+    ModelConfig,
+    compute_mla_mscale_scaling,
+    resolve_spec_hidden_size,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -88,6 +92,10 @@ class TestInitMlaScaling(CustomTestCase):
     def test_ignores_default_rope_type(self):
         base, scaling = _mla_scaling({"rope_type": "default", "factor": 40})
         self.assertEqual(scaling, base)
+
+    def test_hyv4_keeps_plain_spec_size_and_expands_pp_hidden_size(self):
+        config = {"architectures": ["HYV4ForCausalLM"]}
+        self.assertEqual(resolve_spec_hidden_size(config, 6144, 4), (6144, 24576))
 
     def test_no_rope_scaling_keeps_base(self):
         base, scaling = _mla_scaling(None)

--- a/test/registered/unit/models/test_hunyuan_v4.py
+++ b/test/registered/unit/models/test_hunyuan_v4.py
@@ -115,5 +115,42 @@ def test_hpc_attention_gate_is_bf16_only(monkeypatch):
         supported.cache_clear()
 
 
+class _PPDecoderLayer(nn.Module):
+    def __init__(self, next_hidden, next_topk):
+        super().__init__()
+        self.next_hidden = next_hidden
+        self.next_topk = next_topk
+
+    def forward(self, *args):
+        return self.next_hidden, self.next_topk
+
+
+def test_non_last_pp_stage_forwards_flattened_hidden_and_shared_topk():
+    model = hunyuan_v4.HYV4Model.__new__(hunyuan_v4.HYV4Model)
+    nn.Module.__init__(model)
+    model.pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+    model.start_layer = 1
+    model.end_layer = 2
+    model.send_topk_indices = True
+    model.topk_indices_width = 8
+
+    next_hidden = torch.randn(2, 4, 16)
+    next_topk = torch.ones(2, 8, dtype=torch.int32)
+    model.layers = nn.ModuleList(
+        [nn.Identity(), _PPDecoderLayer(next_hidden, next_topk)]
+    )
+
+    initial_hidden = torch.randn(2, 4, 16)
+    initial_topk = torch.zeros(2, 8, dtype=torch.int32)
+    proxy = hunyuan_v4.PPProxyTensors(
+        {"hidden_states": initial_hidden, "topk_indices": initial_topk}
+    )
+
+    result = model(None, None, object(), pp_proxy_tensors=proxy)
+
+    assert result["hidden_states"].shape == (2, 64)
+    assert result["topk_indices"] is next_topk
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/models/test_hunyuan_v4.py
+++ b/test/registered/unit/models/test_hunyuan_v4.py
@@ -12,6 +12,22 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=9, suite="base-a-test-cpu")
 
 
+def test_indexer_block_fp8_scales_are_not_permuted():
+    config = SimpleNamespace(
+        index_n_heads=32,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+    tensors = {
+        "model.layers.0.self_attn.indexer.wk.weight_scale": torch.empty(1, 48),
+        "model.layers.0.self_attn.indexer.wq_b.weight_scale": torch.empty(32, 16),
+    }
+
+    for name, tensor in tensors.items():
+        result = hunyuan_v4.permute_hyv4_indexer_weight(name, tensor, config)
+        assert result is tensor
+
+
 def test_attention_gate_uses_attention_tp(monkeypatch):
     attn_tp_size = 2
     parallel = SimpleNamespace(
@@ -146,7 +162,8 @@ def test_non_last_pp_stage_forwards_flattened_hidden_and_shared_topk():
         {"hidden_states": initial_hidden, "topk_indices": initial_topk}
     )
 
-    result = model(None, None, object(), pp_proxy_tensors=proxy)
+    forward_batch = SimpleNamespace(reuse_dsa_topk_indices=False, spec_info=None)
+    result = model(None, None, forward_batch, pp_proxy_tensors=proxy)
 
     assert result["hidden_states"].shape == (2, 64)
     assert result["topk_indices"] is next_topk


### PR DESCRIPTION
## Motivation

Add pipeline parallelism (PP) support for Hunyuan V4 to distribute model weights and KV cache across pipeline stages for long-context serving. A PP2/TP8 deployment on two nodes with eight H20 GPUs each successfully served a 1,000,000-token input.

## Modifications

- Partition decoder layers by pipeline rank. Instantiate embeddings only on the first stage and final normalization, the HC head, and the LM head only on the last stage.
- Transfer flattened HC hidden states through `PPProxyTensors`, including shared DSA top-k indices when required across a stage boundary.
- Expose Hy4's HC-expanded intermediate dimension while retaining its original speculative hidden size. Keep the existing dimension-resolution behavior for DeepSeek V4 and other architectures.
- Preserve block FP8 indexer scale tensors during weight loading instead of applying the rotary weight permutation to them.
- Add regression coverage for intermediate dimensions, PP proxy forwarding, and FP8 indexer scale preservation.

The changes are limited to the Hy4 model, model configuration, and their two unit-test files. There are no scheduler, low-level communication, kernel, or deployment-script changes.

## Accuracy Tests

### Unit tests and execution/capacity regression

Both affected unit-test files passed: **16 passed**.

```bash
python -m pytest test/registered/unit/configs/test_model_config_scaling.py test/registered/unit/models/test_hunyuan_v4.py -q
```

Hardware regression tested commit `270dd01895b73dd4f59de7f980287dc77c18370c`:

| Request | Result | Observed end-to-end latency |
| --- | --- | --- |
| 128 input tokens + 32 output tokens | Passed | 3.644 s |
| Four concurrent requests, each with 131,072 input tokens + 16 output tokens | All passed | Approximately 123.2 s per request |
| 1,000,000 input tokens + 8 output tokens after cache flush | Passed; 0 cached tokens | 375.035 s |
| Subsequent `/health_generate` | HTTP 200 | — |

Requests used synthetic token IDs with `ignore_eos=true` and verified the returned input/output token counts.

## Speed Tests and Profiling

The table above records end-to-end latency observations from the execution/capacity regression.

Test configuration:

- Two nodes, each with eight H20-141G GPUs; block FP8 checkpoint.
- TP=8, PP=2; context length 1,048,576; maximum total tokens 1,048,704.
- BF16 KV cache; page size 64; static memory fraction 0.897.
- Chunked prefill size 8,192; maximum prefill tokens 16,384; PP micro-batch size 8.
- DeepGEMM for dense GEMMs and Triton for MoE.
- Decode CUDA Graph enabled up to batch size 8; prefill CUDA Graph disabled; speculative decoding disabled.

## Checklist

- [x] Pass changed-file pre-commit checks and isolated Ruff lint/format checks.
- [x] Add focused regression coverage; both affected unit-test files pass (16 tests).
- [x] Validate PP2/TP8 startup and long-context serving on hardware.
- [x] Record the tested configuration and regression results.
- [x] Reuse existing PP interfaces and limit functional changes to Hy4-specific model/configuration handling and corresponding tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34183980905](https://github.com/sgl-project/sglang/actions/runs/34183980905)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34183980770](https://github.com/sgl-project/sglang/actions/runs/34183980770)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34183980960](https://github.com/sgl-project/sglang/actions/runs/34183980960)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->