### PR TITLE
[FT] Add DP-only fault tolerance

### DIFF
--- a/python/sglang/srt/arg_groups/fields/parallel.py
+++ b/python/sglang/srt/arg_groups/fields/parallel.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-from typing import Optional
+from typing import Literal, Optional
 
 from sglang.srt.arg_groups.arg_utils import (
     A,
@@ -97,6 +97,22 @@ class Parallel:
             ],
         ),
     ] = "auto"
+    enable_fault_tolerance: A[
+        bool,
+        "Enable the DP-only fault-tolerance control plane.",
+    ] = False
+    fault_tolerance_on_error_strategy: A[
+        Literal["pause", "continue"],
+        "Fault-tolerance strategy for scheduler exceptions.",
+    ] = "pause"
+    fault_tolerance_timeout: A[
+        int,
+        "Timeout in seconds for each fault-tolerance control phase.",
+    ] = 60
+    fault_tolerance_pause_timeout: A[
+        float,
+        "Fail-stop timeout in seconds for an unattended fault-tolerance pause.",
+    ] = 300
     attn_cp_size: A[
         int,
         Arg(

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -683,3 +683,16 @@ def handle_expert_distribution_metrics(server_args: Any):
                 "_handle_expert_distribution_metrics",
                 expert_distribution_recorder_buffer_size=1000,
             )
+
+
+def handle_fault_tolerance(server_args: Any):
+    cfg = resolving_view(server_args)
+    if not cfg.enable_fault_tolerance:
+        return
+    assert cfg.dp_size > 1, "Fault tolerance requires --dp-size greater than 1."
+    assert cfg.enable_dp_attention, "Fault tolerance requires --enable-dp-attention."
+    assert cfg.disaggregation_mode == "null", (
+        "Fault tolerance does not support disaggregation."
+    )
+    assert cfg.fault_tolerance_on_error_strategy in ("pause", "continue")
+    assert cfg.fault_tolerance_timeout > 0 and cfg.fault_tolerance_pause_timeout > 0

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -367,4 +367,9 @@ def run_resolution_pipeline(server_args: Any) -> None:
     validate_deepep_v2_speculative_draft(server_args)
     validate_deepep_v2_dispatch_token_budget(server_args)
 
+    # Validate FT after topology, MoE, and Elastic EP resolution.
+    from sglang.srt.arg_groups.parallel_hook import handle_fault_tolerance
+
+    handle_fault_tolerance(server_args)
+
     server_args._resolution_finished = True

--- a/python/sglang/srt/elastic_ep/elastic_ep.py
+++ b/python/sglang/srt/elastic_ep/elastic_ep.py
@@ -508,14 +508,18 @@ def maybe_recover_ep_ranks(
     return False
 
 
-def maybe_rebalance_after_rank_fault(*, eplb_manager: EPLBManager) -> bool:
+def maybe_rebalance_after_rank_fault(
+    *, eplb_manager: EPLBManager, force: bool = False
+) -> bool:
     elastic_ep_state = ElasticEPStateManager.instance()
-    if elastic_ep_state is None or elastic_ep_state.is_active_equal_last():
+    if elastic_ep_state is None or (
+        not force and elastic_ep_state.is_active_equal_last()
+    ):
         return False
     elastic_ep_state.snapshot_active_to_last()
     elastic_ep_state.sync_active_to_cpu()
     logger.info("EPLB due to rank faults")
-    gen = eplb_manager.rebalance()
+    gen = eplb_manager.rebalance(force=force)
     while True:
         try:
             next(gen)

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -113,6 +113,7 @@ from sglang.srt.entrypoints.openai.serving_transcription import (
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
 from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
+from sglang.srt.fault_tolerance.protocol import parse_apply_request
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.managers.io_struct import (
     AbortReq,
@@ -301,6 +302,11 @@ async def lifespan(fast_api_app: FastAPI):
         elif get_disagg().disaggregation_mode == "decode":
             thread_label = "Decode" + thread_label
         trace_set_thread_info(thread_label)
+
+    if get_parallel().enable_fault_tolerance and hasattr(
+        _global_state.tokenizer_manager, "auto_create_handle_loop"
+    ):
+        _global_state.tokenizer_manager.auto_create_handle_loop()
 
     # Initialize OpenAI serving handlers
     fast_api_app.state.openai_serving_completion = OpenAIServingCompletion(
@@ -1724,6 +1730,49 @@ async def continue_generation(
         content={"message": "Generation continued successfully.", "status": "ok"},
         status_code=200,
     )
+
+
+@app.get("/fault_tolerance/status")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def fault_tolerance_status(request: Request):
+    status_code, body = _global_state.tokenizer_manager.fault_tolerance_status()
+    if status_code != HTTPStatus.OK:
+        return _fault_tolerance_error_response(status_code, body["message"])
+    return ORJSONResponse(content=body, status_code=status_code)
+
+
+def _fault_tolerance_error_response(status_code: int, message: str):
+    return ORJSONResponse(
+        content={
+            "error": {
+                "message": message,
+                "type": HTTPStatus(status_code).phrase,
+                "param": None,
+                "code": status_code,
+            }
+        },
+        status_code=status_code,
+    )
+
+
+@app.post("/fault_tolerance/apply")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def fault_tolerance_apply(request: Request):
+    content_type = request.headers.get("content-type", "").lower()
+    if content_type.split(";", maxsplit=1)[0] != "application/json":
+        return _fault_tolerance_error_response(
+            HTTPStatus.BAD_REQUEST,
+            "Unsupported Media Type: Only 'application/json' is allowed",
+        )
+    try:
+        obj = parse_apply_request(await request.body())
+    except ValueError as exc:
+        return _fault_tolerance_error_response(HTTPStatus.BAD_REQUEST, str(exc))
+
+    status_code, body = _global_state.tokenizer_manager.fault_tolerance_apply(obj)
+    if status_code != HTTPStatus.ACCEPTED:
+        return _fault_tolerance_error_response(status_code, body["message"])
+    return ORJSONResponse(content=body, status_code=status_code)
 
 
 ##### OpenAI-compatible API endpoints #####

--- a/python/sglang/srt/eplb/eplb_manager.py
+++ b/python/sglang/srt/eplb/eplb_manager.py
@@ -95,7 +95,7 @@ class EPLBManager:
 
             yield from self.rebalance()
 
-    def rebalance(self):
+    def rebalance(self, *, force: bool = False):
         if self._rebalance_disabled_reason is not None:
             if not self._rebalance_disabled_logged:
                 logger.debug(
@@ -131,7 +131,9 @@ class EPLBManager:
         ]
 
         # Check whether rebalancing is needed
-        if not self._check_rebalance_needed(average_utilization_rate_over_window):
+        if not force and not self._check_rebalance_needed(
+            average_utilization_rate_over_window
+        ):
             return
 
         expert_location_metadata = self._compute_expert_location_metadata(

--- a/python/sglang/srt/fault_tolerance/constants.py
+++ b/python/sglang/srt/fault_tolerance/constants.py
@@ -1,0 +1,2 @@
+FT_OPERATION_RETRY = "retry"
+FT_OPERATION_SCALE_DOWN = "scale_down"

--- a/python/sglang/srt/fault_tolerance/dpc_watchdog.py
+++ b/python/sglang/srt/fault_tolerance/dpc_watchdog.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+import threading
+from multiprocessing import Process
+
+import zmq
+from sglang.srt.managers.io_struct import (
+    FaultToleranceDPCShutdownReqInput,
+    ProcessActiveRanksOutput,
+    WatchdogHeartbeatOutput,
+    sock_recv,
+    sock_send,
+)
+from sglang.srt.utils.network import (
+    NetworkAddress,
+    get_local_ip_auto,
+    get_zmq_socket_on_host,
+)
+from sglang.srt.utils.watchdog import SubprocessWatchdog
+
+logger = logging.getLogger(__name__)
+
+FT_WATCHDOG_POLL_INTERVAL = 3.0
+FT_WATCHDOG_SEND_TIMEOUT_MS = 60_000
+
+
+class DPCFaultToleranceWatchdog(SubprocessWatchdog):
+    """Own DPC fault-tolerance control sockets in the watchdog thread."""
+
+    def __init__(
+        self,
+        *,
+        context: zmq.Context,
+        tokenizer_endpoint: str,
+        node_rank: int,
+        processes: list[Process],
+        process_dp_ranks: list[int],
+        process_global_ranks: list[int],
+    ) -> None:
+        self._context = context
+        self._tokenizer_endpoint = tokenizer_endpoint
+        self._node_rank = node_rank
+        self._process_dp_ranks = process_dp_ranks
+        self._process_global_ranks = process_global_ranks
+        self._shutdown_receiver = None
+        self._heartbeat_sender = None
+        self._ready = threading.Event()
+        self._start_error: Exception | None = None
+        self.control_endpoint: str | None = None
+        super().__init__(
+            processes=processes,
+            process_names=[f"scheduler_rank_{rank}" for rank in process_global_ranks],
+            on_exit=self._report_process_exit,
+            on_poll=self._poll_control,
+            on_thread_stop=self._close_sockets,
+            interval=FT_WATCHDOG_POLL_INTERVAL,
+            fail_stop_on_exit=False,
+            report_clean_exit=True,
+        )
+
+    def start(self) -> None:
+        super().start()
+        self._ready.wait()
+        if self._start_error is not None:
+            raise self._start_error
+
+    def _on_thread_start(self) -> None:
+        try:
+            host = get_local_ip_auto(fallback="127.0.0.1")
+            port, self._shutdown_receiver = get_zmq_socket_on_host(
+                self._context, zmq.PULL, host=host
+            )
+            self.control_endpoint = NetworkAddress(host, port).to_tcp()
+
+            self._heartbeat_sender = self._context.socket(zmq.PUSH)
+            self._heartbeat_sender.setsockopt(zmq.LINGER, 0)
+            self._heartbeat_sender.setsockopt(zmq.SNDHWM, 1)
+            self._heartbeat_sender.setsockopt(zmq.IMMEDIATE, 1)
+            self._heartbeat_sender.setsockopt(
+                zmq.SNDTIMEO, FT_WATCHDOG_SEND_TIMEOUT_MS
+            )
+            if "[" in self._tokenizer_endpoint:
+                self._heartbeat_sender.setsockopt(zmq.IPV6, 1)
+            self._heartbeat_sender.connect(self._tokenizer_endpoint)
+        except Exception as error:
+            self._start_error = error
+            raise
+        finally:
+            self._ready.set()
+
+    def heartbeat(self) -> WatchdogHeartbeatOutput:
+        return WatchdogHeartbeatOutput(
+            node_rank=self._node_rank,
+            ranks=sorted(self._process_global_ranks),
+            control_endpoint=self.control_endpoint,
+        )
+
+    def _report_process_exit(self, index, proc, name) -> None:
+        dp_rank = self._process_dp_ranks[index]
+        global_rank = self._process_global_ranks[index]
+        logger.warning(
+            "Scheduler global rank %s for DP rank %s exited (pid=%s)",
+            global_rank,
+            dp_rank,
+            proc.pid,
+        )
+        sock_send(
+            self._heartbeat_sender,
+            ProcessActiveRanksOutput(ranks=[global_rank], active=False),
+        )
+
+    def _poll_control(self) -> None:
+        try:
+            request = sock_recv(self._shutdown_receiver, flags=zmq.NOBLOCK)
+        except zmq.Again:
+            pass
+        else:
+            self._shutdown_dp(request)
+
+        try:
+            sock_send(self._heartbeat_sender, self.heartbeat(), flags=zmq.NOBLOCK)
+        except zmq.Again:
+            logger.debug("Dropping watchdog heartbeat because tokenizer is unavailable")
+
+    def _shutdown_dp(self, request: FaultToleranceDPCShutdownReqInput) -> None:
+        targets = set(request.target_dp_ranks)
+        for proc, dp_rank in zip(self._processes, self._process_dp_ranks):
+            if dp_rank in targets and proc.is_alive():
+                proc.kill()
+
+    def _close_sockets(self) -> None:
+        if self._heartbeat_sender is not None:
+            self._heartbeat_sender.close(linger=0)
+        if self._shutdown_receiver is not None:
+            self._shutdown_receiver.close(linger=0)

--- a/python/sglang/srt/fault_tolerance/ft_state.py
+++ b/python/sglang/srt/fault_tolerance/ft_state.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Iterable, List
+
+
+class RankState(str, Enum):
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    DEAD = "dead"
+
+
+class FaultToleranceState:
+    def __init__(self, *, dp_size: int, strategy: str, global_rank_count: int):
+        self.dp_size = dp_size
+        self.strategy = strategy
+        self.global_rank_count = global_rank_count
+        self.global_ranks_per_dp = global_rank_count // dp_size
+        self.expected_dp_mask = [True] * dp_size
+        self.runtime_active_dp_mask = [True] * dp_size
+        self.process_alive_global_rank_mask = [True] * global_rank_count
+        self.pending_recovery_global_ranks: set[int] = set()
+        self.unhealthy_dp_ranks: set[int] = set()
+        self.ft_operation_in_progress = False
+        self.cluster_paused = False
+
+    def global_ranks_for_dp(self, dp_rank: int) -> range:
+        start = dp_rank * self.global_ranks_per_dp
+        return range(start, start + self.global_ranks_per_dp)
+
+    def global_ranks_for_dps(self, dp_ranks: Iterable[int]) -> List[int]:
+        return [
+            rank
+            for dp in sorted(set(dp_ranks))
+            for rank in self.global_ranks_for_dp(dp)
+        ]
+
+    def expand_dp_mask_to_global_rank_mask(self, dp_mask: List[bool]) -> List[bool]:
+        return [
+            dp_mask[rank // self.global_ranks_per_dp]
+            for rank in range(self.global_rank_count)
+        ]
+
+    def project_global_rank_mask_to_dp_mask(
+        self, global_rank_mask: List[bool]
+    ) -> List[bool]:
+        return [
+            all(global_rank_mask[rank] for rank in self.global_ranks_for_dp(dp))
+            for dp in range(self.dp_size)
+        ]
+
+    def process_alive_dp_mask(self) -> List[bool]:
+        return self.project_global_rank_mask_to_dp_mask(
+            self.process_alive_global_rank_mask
+        )
+
+    def expected_dp_ranks(self) -> List[int]:
+        return [rank for rank, expected in enumerate(self.expected_dp_mask) if expected]
+
+    def _rank_state(self, rank: int) -> RankState:
+        if not self.expected_dp_mask[rank] or not self.process_alive_dp_mask()[rank]:
+            return RankState.DEAD
+        if rank in self.unhealthy_dp_ranks:
+            return RankState.UNHEALTHY
+        return RankState.HEALTHY
+
+    def status_response(self) -> Dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "total_engines": self.dp_size,
+            "engines": [
+                {"id": rank, "status": self._rank_state(rank).value}
+                for rank in range(self.dp_size)
+            ],
+        }
+
+    def has_unresolved_expected_dp_fault(self) -> bool:
+        """Return whether an expected DP is unhealthy or has lost a process."""
+        process_alive_dp_mask = self.process_alive_dp_mask()
+        return bool(self.unhealthy_dp_ranks) or any(
+            expected and not process_alive_dp_mask[rank]
+            for rank, expected in enumerate(self.expected_dp_mask)
+        )
+
+    def is_global_admission_blocked(self, route_dp_mask: List[bool]) -> bool:
+        return (
+            not any(route_dp_mask)
+            or self.ft_operation_in_progress
+            or (self.strategy == "pause" and self.cluster_paused)
+        )
+
+    def observe_process_active_ranks(self, ranks: List[int], *, active: bool) -> None:
+        for rank in ranks:
+            self.process_alive_global_rank_mask[rank] = active
+        if not active:
+            self.pending_recovery_global_ranks.update(ranks)
+            self.cluster_paused = True
+
+    def observe_runtime_active_dp_mask(self, active_dp_mask: List[bool]) -> None:
+        self.runtime_active_dp_mask = active_dp_mask
+        self.pending_recovery_global_ranks = {
+            rank
+            for rank in self.pending_recovery_global_ranks
+            if not active_dp_mask[rank // self.global_ranks_per_dp]
+        }
+
+    def observe_rank_fault(self, rank: int) -> None:
+        if self.strategy == "pause":
+            self.unhealthy_dp_ranks.add(rank)
+            self.cluster_paused = True

--- a/python/sglang/srt/fault_tolerance/manager.py
+++ b/python/sglang/srt/fault_tolerance/manager.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+import os
+import time
+import uuid
+from typing import Dict, List, Optional, Tuple
+
+import zmq
+import zmq.asyncio
+
+from sglang.srt.fault_tolerance.constants import (
+    FT_OPERATION_RETRY,
+    FT_OPERATION_SCALE_DOWN,
+)
+from sglang.srt.fault_tolerance.ft_state import FaultToleranceState
+from sglang.srt.fault_tolerance.protocol import FaultToleranceApplyRequest
+from sglang.srt.managers.io_struct import (
+    ActiveRanksOutput,
+    FaultToleranceCommandReqInput,
+    FaultToleranceCommandReqOutput,
+    FaultToleranceDPCShutdownReqInput,
+    FaultToleranceRankFaultOutput,
+    ProcessActiveRanksOutput,
+    RouteUpdateAckOutput,
+    WatchdogHeartbeatOutput,
+    async_sock_send,
+)
+from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils.network import get_zmq_socket
+from sglang.utils import TypeBasedDispatcher, get_exception_traceback
+
+logger = logging.getLogger(__name__)
+
+WATCHDOG_LEASE_SWEEP_INTERVAL_SEC = 1
+WATCHDOG_LEASE_TIMEOUT_SEC = 60
+FT_REQUEST_ACCEPTED_MESSAGE = (
+    "Request accepted; poll /fault_tolerance/status for updates."
+)
+
+
+@dataclasses.dataclass
+class PendingFTCommand:
+    remaining_ranks: set[int]
+    future: asyncio.Future
+
+    def acknowledge(self, rank: int) -> None:
+        self.remaining_ranks.discard(rank)
+        if not self.remaining_ranks:
+            self.future.set_result(None)
+
+
+class FaultToleranceManager:
+    def __init__(self, *, server_args, zmq_context, send_to_scheduler):
+        self.server_args = server_args
+        self._zmq_context = zmq_context
+        self.send_to_scheduler = send_to_scheduler
+        self.send_to_watchdog: Dict[int, zmq.asyncio.Socket] = {}
+        self._watchdog_endpoints: Dict[int, str] = {}
+        self.state = FaultToleranceState(
+            dp_size=server_args.dp_size,
+            strategy=server_args.fault_tolerance_on_error_strategy,
+            global_rank_count=server_args.tp_size,
+        )
+        self.event_loop = None
+        self.asyncio_tasks = None
+        self._pending_commands: Dict[str, PendingFTCommand] = {}
+        self._pending_active_rank_updates: Dict[str, asyncio.Future] = {}
+        self._shutdown_waiter: Optional[Tuple[set[int], asyncio.Future]] = None
+        self._watchdog_leases: Dict[int, Tuple[float, Tuple[int, ...]]] = {}
+        self._watchdog_lease_task: Optional[asyncio.Task] = None
+        self._route_dp_mask = [True] * server_args.dp_size
+        self._last_ft_request_id: Optional[str] = None
+        self._ft_error: Optional[str] = None
+
+    def bind_event_loop(self, loop) -> None:
+        if self.event_loop is loop:
+            return
+        if self.event_loop is not None:
+            raise RuntimeError(
+                "fault tolerance manager is already bound to an event loop"
+            )
+        self.event_loop = loop
+        self.asyncio_tasks = set()
+
+    def init_request_dispatcher(self) -> TypeBasedDispatcher:
+        return TypeBasedDispatcher(
+            [
+                (RouteUpdateAckOutput, self.handle_route_update_ack),
+                (FaultToleranceCommandReqOutput, self.handle_command_output),
+                (FaultToleranceRankFaultOutput, self.handle_rank_fault),
+                (WatchdogHeartbeatOutput, self.observe_watchdog_heartbeat),
+            ]
+        )
+
+    def status(self) -> tuple[int, dict]:
+        body = self.state.status_response()
+        if self._last_ft_request_id is not None:
+            body["last_ft_request_id"] = self._last_ft_request_id
+            if self._ft_error is not None:
+                body["ft_error"] = self._ft_error
+        return 200, body
+
+    def submit(self, request: FaultToleranceApplyRequest) -> tuple[int, dict]:
+        if request.instruction == FT_OPERATION_SCALE_DOWN and any(
+            rank >= self.state.dp_size for rank in request.params.removed_dp_ranks
+        ):
+            return 400, {"message": "'removed_dp_ranks' contains a rank out of range."}
+        # One centralized SGLang request controls all DP engines atomically.
+        if self.state.ft_operation_in_progress:
+            return 409, {"message": "ft_operation_in_progress"}
+
+        self.state.ft_operation_in_progress = True
+        try:
+            self._create_task(self._run_submitted_apply(request))
+        except Exception:
+            self.state.ft_operation_in_progress = False
+            raise
+        return 202, {
+            "message": FT_REQUEST_ACCEPTED_MESSAGE,
+            "request_id": request.request_id,
+        }
+
+    async def _run_submitted_apply(self, request: FaultToleranceApplyRequest) -> None:
+        timeout = self.server_args.fault_tolerance_timeout
+
+        if not self.state.has_unresolved_expected_dp_fault():
+            self._finish_submitted_apply(
+                request.request_id,
+                f"{request.instruction}_requires_unresolved_expected_dp_fault",
+            )
+            return
+
+        if request.instruction == FT_OPERATION_RETRY:
+            error = await self._apply_retry(timeout)
+        elif request.instruction == FT_OPERATION_SCALE_DOWN:
+            error = await self._apply_scale_down(
+                request.params.removed_dp_ranks, timeout
+            )
+
+        if error is None:
+            self.state.unhealthy_dp_ranks.clear()
+            self.state.cluster_paused = False
+        self._finish_submitted_apply(request.request_id, error)
+
+    def _finish_submitted_apply(self, request_id: str, error: Optional[str]) -> None:
+        self._last_ft_request_id = request_id
+        self._ft_error = error
+        self.state.ft_operation_in_progress = False
+
+    async def _apply_retry(self, timeout: int) -> Optional[str]:
+        st = self.state
+        process_alive_dp_mask = st.process_alive_dp_mask()
+        if any(
+            expected and not process_alive_dp_mask[rank]
+            for rank, expected in enumerate(st.expected_dp_mask)
+        ):
+            return "retry_requires_all_expected_processes_alive"
+
+        await self._send_command_collect(
+            command=FT_OPERATION_RETRY,
+            target_ranks=st.expected_dp_ranks(),
+            timeout_sec=timeout,
+        )
+        await self._publish_route_dp_mask(st.expected_dp_mask, timeout)
+        return None
+
+    async def _apply_scale_down(self, ranks: List[int], timeout: int) -> Optional[str]:
+        st = self.state
+        requested = set(ranks)
+        if not requested:
+            return "scale_down_requires_ranks"
+        if any(not st.expected_dp_mask[rank] for rank in requested):
+            return "scale_down_requires_expected_ranks"
+
+        # DP ranks that remain active after the scale-down.
+        candidate_dp_mask = [
+            expected and rank not in requested
+            for rank, expected in enumerate(st.expected_dp_mask)
+        ]
+        if not any(candidate_dp_mask):
+            return "cannot_scale_down_all_expected_ranks"
+
+        await self._shutdown_dp_processes(requested, timeout)
+        await self._send_command_collect(
+            command=FT_OPERATION_SCALE_DOWN,
+            target_ranks=[
+                rank for rank, active in enumerate(candidate_dp_mask) if active
+            ],
+            timeout_sec=timeout,
+            active_global_rank_mask=st.expand_dp_mask_to_global_rank_mask(
+                candidate_dp_mask
+            ),
+        )
+        await self._publish_route_dp_mask(candidate_dp_mask, timeout)
+        for rank in requested:
+            st.expected_dp_mask[rank] = False
+        return None
+
+    def admission_error(self, routed_dp_rank: Optional[int]) -> Optional[str]:
+        if routed_dp_rank is not None and not self._route_dp_mask[routed_dp_rank]:
+            return f"routed_dp_rank={routed_dp_rank} is not active"
+        if self.state.is_global_admission_blocked(self._route_dp_mask):
+            return "fault_tolerance_paused"
+        return None
+
+    def _route_dp_update(
+        self, route_dp_mask: List[bool]
+    ) -> Optional[ActiveRanksOutput]:
+        # Cache a changed route mask and return the update for TokenizerManager.
+        if route_dp_mask == self._route_dp_mask:
+            return None
+        self._route_dp_mask = list(route_dp_mask)
+        return ActiveRanksOutput(status=route_dp_mask)
+
+    def _auto_recover_ready_dps(self) -> List[int]:
+        # Re-add removed DPs only after process and runtime recovery complete.
+        st = self.state
+        if st.ft_operation_in_progress:
+            return []
+
+        process_alive_dp_mask = st.process_alive_dp_mask()
+        recovered_dp_ranks = []
+        for dp_rank in range(st.dp_size):
+            if st.expected_dp_mask[dp_rank]:
+                continue
+            if (
+                process_alive_dp_mask[dp_rank]
+                and st.runtime_active_dp_mask[dp_rank]
+                and not any(
+                    member in st.pending_recovery_global_ranks
+                    for member in st.global_ranks_for_dp(dp_rank)
+                )
+            ):
+                st.expected_dp_mask[dp_rank] = True
+                recovered_dp_ranks.append(dp_rank)
+        return recovered_dp_ranks
+
+    def _update_route_after_observation(
+        self, recovered_dp_ranks: List[int]
+    ) -> Optional[ActiveRanksOutput]:
+        # Apply observed process/runtime availability to the admission route.
+        st = self.state
+        if st.strategy == "continue":
+            process_alive_dp_mask = st.process_alive_dp_mask()
+            return self._route_dp_update(
+                [
+                    expected
+                    and process_alive_dp_mask[dp_rank]
+                    and st.runtime_active_dp_mask[dp_rank]
+                    for dp_rank, expected in enumerate(st.expected_dp_mask)
+                ]
+            )
+
+        if not recovered_dp_ranks:
+            return None
+        route_dp_mask = list(self._route_dp_mask)
+        for dp_rank in recovered_dp_ranks:
+            route_dp_mask[dp_rank] = True
+        return self._route_dp_update(route_dp_mask)
+
+    def observe_active_ranks(
+        self, ranks: ActiveRanksOutput
+    ) -> Optional[ActiveRanksOutput]:
+        # This Scheduler report is runtime/backend readiness, not the route mask.
+        self.state.observe_runtime_active_dp_mask(list(ranks.status))
+        return self._update_route_after_observation(self._auto_recover_ready_dps())
+
+    def observe_process_active_ranks(
+        self, ranks: ProcessActiveRanksOutput
+    ) -> Optional[ActiveRanksOutput]:
+        self.state.observe_process_active_ranks(ranks.ranks, active=ranks.active)
+        self._finish_shutdown_if_ready()
+        return self._update_route_after_observation(self._auto_recover_ready_dps())
+
+    def observe_watchdog_heartbeat(self, heartbeat: WatchdogHeartbeatOutput) -> None:
+        existing = self._watchdog_leases.get(heartbeat.node_rank)
+        ranks = tuple(sorted(set(heartbeat.ranks))) if existing is None else existing[1]
+        self._watchdog_leases[heartbeat.node_rank] = (time.monotonic(), ranks)
+        if self._watchdog_lease_task is None or self._watchdog_lease_task.done():
+            self._watchdog_lease_task = self._create_task(
+                self._watchdog_lease_sweep_loop()
+            )
+
+        endpoint = heartbeat.control_endpoint
+        if (
+            not endpoint
+            or self._watchdog_endpoints.get(heartbeat.node_rank) == endpoint
+        ):
+            return
+
+        new = get_zmq_socket(self._zmq_context, zmq.PUSH, endpoint, False)
+        old = self.send_to_watchdog.get(heartbeat.node_rank)
+        self.send_to_watchdog[heartbeat.node_rank] = new
+        self._watchdog_endpoints[heartbeat.node_rank] = endpoint
+        if old is not None:
+            old.close(linger=0)
+
+    async def _send_watchdog_command(
+        self, nodes: List[int], request: FaultToleranceDPCShutdownReqInput
+    ) -> None:
+        for node in nodes:
+            await async_sock_send(self.send_to_watchdog[node], request)
+
+    async def _watchdog_lease_sweep_loop(self) -> None:
+        try:
+            while self._watchdog_leases:
+                await asyncio.sleep(WATCHDOG_LEASE_SWEEP_INTERVAL_SEC)
+                await self._sweep_expired_watchdog_leases()
+        finally:
+            self._watchdog_lease_task = None
+
+    async def _sweep_expired_watchdog_leases(self, now: Optional[float] = None) -> None:
+        now = time.monotonic() if now is None else now
+        expired = [
+            node
+            for node, (last_seen, _) in self._watchdog_leases.items()
+            if now - last_seen >= WATCHDOG_LEASE_TIMEOUT_SEC
+        ]
+        inactive = set()
+        for node in expired:
+            _, ranks = self._watchdog_leases.pop(node)
+            inactive.update(ranks)
+        if not inactive:
+            return
+        logger.warning(
+            "FT watchdog lease expired: nodes=%s global_ranks=%s",
+            sorted(expired),
+            sorted(inactive),
+        )
+        update = self.observe_process_active_ranks(
+            ProcessActiveRanksOutput(ranks=sorted(inactive), active=False)
+        )
+        if update is not None:
+            await self.send_to_scheduler(update)
+
+    def handle_command_output(self, output: FaultToleranceCommandReqOutput) -> None:
+        pending = self._pending_commands.get(output.request_id)
+        if pending is None:
+            logger.warning("Unknown fault tolerance command ack: rank=%s", output.rank)
+            return
+        pending.acknowledge(output.rank)
+
+    def handle_route_update_ack(self, output: RouteUpdateAckOutput) -> None:
+        future = self._pending_active_rank_updates.get(output.request_id)
+        if future is None or future.done():
+            return
+        future.set_result(None)
+
+    def handle_rank_fault(self, event: FaultToleranceRankFaultOutput) -> None:
+        self.state.observe_rank_fault(event.rank)
+        logger.warning(
+            "FT observed scheduler exception on rank %s: %s", event.rank, event.message
+        )
+
+    def _create_task(self, coro):
+        if self.event_loop is None:
+            coro.close()
+            raise RuntimeError("fault tolerance manager has no bound event loop")
+        task = self.event_loop.create_task(self._fatal_task_wrapper(coro))
+        self.asyncio_tasks.add(task)
+        task.add_done_callback(self.asyncio_tasks.discard)
+        return task
+
+    async def _fatal_task_wrapper(self, coro):
+        try:
+            await coro
+        except Exception:
+            self._failstop(
+                f"FaultToleranceManager hit an exception: {get_exception_traceback()}"
+            )
+
+    async def _publish_route_dp_mask(
+        self, route_dp_mask: List[bool], timeout_sec: int
+    ) -> None:
+        request_id = uuid.uuid4().hex
+        future = self.event_loop.create_future()
+        self._pending_active_rank_updates[request_id] = future
+        try:
+            await self.send_to_scheduler(
+                ActiveRanksOutput(status=list(route_dp_mask), request_id=request_id)
+            )
+            await asyncio.wait_for(future, timeout=timeout_sec)
+            self._route_dp_mask = list(route_dp_mask)
+        finally:
+            self._pending_active_rank_updates.pop(request_id, None)
+
+    async def _send_command_collect(
+        self,
+        *,
+        command: str,
+        target_ranks: List[int],
+        timeout_sec: int,
+        active_global_rank_mask: Optional[List[bool]] = None,
+    ) -> None:
+        targets = set(target_ranks)
+        if not targets:
+            return
+        request_id = uuid.uuid4().hex
+        pending = PendingFTCommand(
+            remaining_ranks=targets, future=self.event_loop.create_future()
+        )
+        self._pending_commands[request_id] = pending
+        req = FaultToleranceCommandReqInput(
+            request_id=request_id,
+            command=command,
+            target_ranks=sorted(targets),
+            # This command is consumed by per-scheduler Elastic EP control, so
+            # its active_mask remains a physical scheduler/global-rank mask.
+            active_mask=active_global_rank_mask,
+        )
+        await self.send_to_scheduler(req)
+        try:
+            await asyncio.wait_for(pending.future, timeout=timeout_sec)
+        finally:
+            self._pending_commands.pop(request_id, None)
+
+    def _finish_shutdown_if_ready(self) -> None:
+        if self._shutdown_waiter is None:
+            return
+        targets, future = self._shutdown_waiter
+        if not future.done() and not any(
+            self.state.process_alive_global_rank_mask[rank] for rank in targets
+        ):
+            future.set_result(None)
+
+    async def _shutdown_dp_processes(
+        self, target_dp_ranks: set[int], timeout_sec: int
+    ) -> None:
+        targets = set(self.state.global_ranks_for_dps(target_dp_ranks))
+        live_targets = {
+            rank for rank in targets if self.state.process_alive_global_rank_mask[rank]
+        }
+        if not live_targets:
+            return
+        nodes = [
+            node
+            for node, (_, owned) in self._watchdog_leases.items()
+            if live_targets.intersection(owned)
+        ]
+        future = self.event_loop.create_future()
+        self._shutdown_waiter = (targets, future)
+        try:
+            await self._send_watchdog_command(
+                nodes,
+                FaultToleranceDPCShutdownReqInput(
+                    target_dp_ranks=sorted(target_dp_ranks)
+                ),
+            )
+            await asyncio.wait_for(future, timeout=timeout_sec)
+        finally:
+            self._shutdown_waiter = None
+
+    @staticmethod
+    def _failstop(message: str) -> None:
+        logger.error(message)
+        kill_process_tree(os.getpid(), include_parent=True)
+        raise RuntimeError(message)

--- a/python/sglang/srt/fault_tolerance/protocol.py
+++ b/python/sglang/srt/fault_tolerance/protocol.py
@@ -1,0 +1,46 @@
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+DPRank = Annotated[int, Field(strict=True, ge=0)]
+RequestId = Annotated[str, Field(strict=True)]
+
+
+class RetryParams(BaseModel):
+    pass
+
+
+class ScaleDownParams(BaseModel):
+    removed_dp_ranks: list[DPRank]
+
+
+class RetryRequest(BaseModel):
+    instruction: Literal["retry"]
+    params: RetryParams = Field(default_factory=RetryParams)
+    request_id: RequestId = ""
+
+
+class ScaleDownRequest(BaseModel):
+    instruction: Literal["scale_down"]
+    params: ScaleDownParams
+    request_id: RequestId = ""
+
+
+FaultToleranceApplyRequest = Annotated[
+    Union[RetryRequest, ScaleDownRequest],
+    Field(discriminator="instruction"),
+]
+
+_APPLY_REQUEST_ADAPTER = TypeAdapter(FaultToleranceApplyRequest)
+
+
+def parse_apply_request(body: bytes) -> FaultToleranceApplyRequest:
+    try:
+        return _APPLY_REQUEST_ADAPTER.validate_json(body)
+    except ValidationError as exc:
+        error = exc.errors()[0]
+        if error["type"] == "union_tag_invalid":
+            message = f"Invalid instruction: '{error['ctx']['tag']}'."
+        else:
+            message = error["msg"]
+        raise ValueError(message) from None

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -27,14 +27,19 @@ import setproctitle
 import zmq
 
 from sglang.srt.environ import envs
+from sglang.srt.fault_tolerance.dpc_watchdog import DPCFaultToleranceWatchdog
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.managers.io_struct import (
+    AbortReq,
     ActiveRanksOutput,
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
     BlockReqInput,
     ElasticScaleUpdateReq,
+    FaultToleranceCommandReqInput,
+    ProcessActiveRanksOutput,
     ProfileReq,
+    RouteUpdateAckOutput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     sock_recv,
@@ -160,6 +165,11 @@ class DataParallelController:
             self.recv_from_tokenizer = get_zmq_socket(
                 self.context, zmq.PULL, port_args.scheduler_input_ipc_name, False
             )
+        self.send_to_tokenizer = None
+        if get_parallel().enable_fault_tolerance:
+            self.send_to_tokenizer = get_zmq_socket(
+                self.context, zmq.PUSH, port_args.tokenizer_ipc_name, False
+            )
 
         # Dispatch method
         self.round_robin_counter = 0
@@ -198,6 +208,8 @@ class DataParallelController:
 
         # Launch data parallel workers
         self.scheduler_procs = []
+        self.scheduler_process_dp_ranks: list[int] = []
+        self.scheduler_process_global_ranks: list[int] = []
         self.workers: list[zmq.Socket | None] = [None] * self.max_dp_size
         self.status: list[bool] = list(self.dp_active)
         self._active_workers: list[int] = list(range(self.launch_dp_size))
@@ -215,6 +227,21 @@ class DataParallelController:
         else:
             self.launch_dp_schedulers(server_args, port_args)
             self.control_message_step = 1
+
+        self._scheduler_watchdog = None
+        if get_parallel().enable_fault_tolerance and self.scheduler_procs:
+            self._scheduler_watchdog = DPCFaultToleranceWatchdog(
+                context=self.context,
+                tokenizer_endpoint=port_args.tokenizer_ipc_name,
+                node_rank=get_parallel().node_rank,
+                processes=self.scheduler_procs,
+                process_dp_ranks=self.scheduler_process_dp_ranks,
+                process_global_ranks=self.scheduler_process_global_ranks,
+            )
+            self._scheduler_watchdog.start()
+            sock_send(self.send_to_tokenizer, self._scheduler_watchdog.heartbeat())
+            if get_exec().moe.ep_join_mode == "recover":
+                self._report_process_active_ranks(active=True)
 
         self.init_dispatcher()
 
@@ -239,6 +266,25 @@ class DataParallelController:
             if worker is not None:
                 sock_send(worker, obj)
 
+    def send_fault_tolerance_command(self, obj: FaultToleranceCommandReqInput):
+        for rank in obj.target_ranks:
+            worker = self.workers[rank]
+            if worker is None:
+                raise ValueError(f"DP rank {rank} has no scheduler socket")
+            sock_send(worker, obj)
+
+    def _report_process_active_ranks(self, *, active: bool) -> None:
+        sock_send(
+            self.send_to_tokenizer,
+            ProcessActiveRanksOutput(
+                ranks=sorted(self.scheduler_process_global_ranks),
+                active=active,
+            ),
+        )
+
+    def handle_load_update_req(self, obj):
+        self.dp_budget.update_budget(obj)
+
     def update_active_ranks(self, ranks: ActiveRanksOutput):
         if get_exec().moe.elastic_ep_backend is not None:
             if len(ranks.status) != self.max_dp_size:
@@ -254,6 +300,9 @@ class DataParallelController:
                 for i in range(self.max_dp_size)
             ]
             self._refresh_active_workers()
+            if get_parallel().enable_fault_tolerance and ranks.request_id is not None:
+                ack = RouteUpdateAckOutput(request_id=ranks.request_id)
+                sock_send(self.send_to_tokenizer, ack)
             return
         if len(ranks.status) != self.max_dp_size:
             logger.warning(
@@ -332,7 +381,10 @@ class DataParallelController:
 
         time_stats.set_dp_dispatch_time()
         req.time_stats = wrap_as_pickle(time_stats)
-        self.dispatching(req)
+        if get_parallel().enable_fault_tolerance and not self._active_workers:
+            self._reject_req(req, "no active DP rank")
+        else:
+            self.dispatching(req)
         req.time_stats = time_stats
         req.time_stats.set_dp_dispatch_finish_time()
 
@@ -364,6 +416,7 @@ class DataParallelController:
                         msg.slot_offset, msg.slot_count
                     ),
                 ),
+                (FaultToleranceCommandReqInput, self.send_fault_tolerance_command),
             ]
         )
         self._request_dispatcher.add_fallback_fn(self.send_control_message)
@@ -736,6 +789,16 @@ class DataParallelController:
                     ):
                         proc.start()
                 self.scheduler_procs.append(proc)
+                if get_parallel().enable_fault_tolerance:
+                    self.scheduler_process_dp_ranks.append(dp_rank)
+                    rank_offset = (
+                        get_parallel().ep_join_rank_offset
+                        if get_exec().moe.is_ep_scale_joiner
+                        else 0
+                    )
+                    self.scheduler_process_global_ranks.append(
+                        rank_offset + get_parallel().tp_size * pp_rank + tp_rank
+                    )
                 scheduler_pipe_readers.append(reader)
 
         # Wait for model to finish loading
@@ -758,11 +821,22 @@ class DataParallelController:
                 or rank not in self._active_workers
                 or self.workers[rank] is None
             ):
+                if get_parallel().enable_fault_tolerance:
+                    self._reject_req(req, f"routed_dp_rank={rank} is inactive")
+                    return True
                 raise ValueError(f"DP rank {rank} is not active.")
             logger.debug(f"Direct routing to DP rank {rank}")
             sock_send(self.workers[rank], req)
             return True
         return False
+
+    def _reject_req(self, req: Req, message: str):
+        logger.warning("Rejecting DP request %s: %s", getattr(req, "rid", ""), message)
+        if self.send_to_tokenizer is not None:
+            sock_send(
+                self.send_to_tokenizer,
+                AbortReq(rid=req.rid, abort_message=message)
+            )
 
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
@@ -820,7 +894,6 @@ class DataParallelController:
                 except zmq.ZMQError:
                     break
                 self._request_dispatcher(recv_req)
-
 
 def run_data_parallel_controller_process(
     server_args: ServerArgs,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1761,6 +1761,23 @@ class ContinueGenerationReqInput(BaseReq, kw_only=True):
     torch_empty_cache: bool = True
 
 
+class FaultToleranceCommandReqInput(BaseReq, kw_only=True):
+    request_id: str
+    command: Literal["retry", "scale_down"]
+    target_ranks: List[int]
+    active_mask: Optional[List[bool]] = None
+
+
+class FaultToleranceCommandReqOutput(BaseReq, kw_only=True):
+    request_id: str
+    rank: int
+
+
+class FaultToleranceRankFaultOutput(BaseReq, kw_only=True):
+    rank: int
+    message: str = ""
+
+
 class TokenizerWorkerRegistrationReq(BaseReq, kw_only=True):
     """Sent by each TokenizerWorker on startup to register its IPC name with the router."""
 
@@ -2062,6 +2079,26 @@ class EncoderDispatchErrorReq(BaseReq, kw_only=True):
 
 class ActiveRanksOutput(BaseReq, kw_only=True):
     status: List[bool]
+    request_id: Optional[str] = None
+
+
+class ProcessActiveRanksOutput(BaseReq, kw_only=True):
+    ranks: List[int]
+    active: bool
+
+
+class WatchdogHeartbeatOutput(BaseReq, kw_only=True):
+    node_rank: int
+    ranks: List[int]
+    control_endpoint: Optional[str] = None
+
+
+class FaultToleranceDPCShutdownReqInput(BaseReq, kw_only=True):
+    target_dp_ranks: List[int]
+
+
+class RouteUpdateAckOutput(BaseReq, kw_only=True):
+    request_id: str
 
 
 class ElasticScaleUpdateReq(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -103,6 +103,10 @@ from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
 from sglang.srt.environ import envs, exportable_env_vars
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
+from sglang.srt.fault_tolerance.constants import (
+    FT_OPERATION_RETRY,
+    FT_OPERATION_SCALE_DOWN,
+)
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
@@ -136,6 +140,9 @@ from sglang.srt.managers.io_struct import (
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
+    FaultToleranceCommandReqInput,
+    FaultToleranceCommandReqOutput,
+    FaultToleranceRankFaultOutput,
     FinishReasonDict,
     FlushCacheReqInput,
     FreezeGCReq,
@@ -333,6 +340,7 @@ from sglang.srt.utils import (
     is_hip,
     is_mps,
     kill_itself_when_parent_died,
+    notify_node_main_process_failure,
     rank_consensus_checker,
     require_mlp_sync,
     set_gpu_proc_affinity,
@@ -1272,6 +1280,8 @@ class Scheduler(
         self.session_controller = SessionController(self.tree_cache)
         self.forward_sleep_time = None
         self._engine_paused = False
+        self._ft_pause_deadline: Optional[float] = None
+        self._ft_result_queue: Optional[Deque] = None
 
     def init_chunked_prefill(self):
         self.chunked_prefill_size = get_schedule().chunked_prefill_size
@@ -1791,6 +1801,7 @@ class Scheduler(
                 (UnloadLoRAAdapterReqInput, self.unload_lora_adapter),
                 (PauseGenerationReqInput, self.pause_generation),
                 (ContinueGenerationReqInput, self.continue_generation),
+                (FaultToleranceCommandReqInput, self.handle_fault_tolerance_command),
                 (ConfigureLoggingReq, self.configure_logging),
                 (ScaleElasticEPReqInput, self.handle_scale_elastic_ep),
                 (DumperControlReqInput, self.handle_dumper_control),
@@ -1887,7 +1898,119 @@ class Scheduler(
         self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
         with self.device_module.StreamContext(self.schedule_stream):
             self.metrics_reporter.start_scheduler_time_accounting()
-            dispatch_event_loop(self)
+            if get_parallel().enable_fault_tolerance:
+                self._run_event_loop_fault_tolerance()
+            else:
+                dispatch_event_loop(self)
+
+    def _run_event_loop_fault_tolerance(self) -> None:
+        while True:
+            try:
+                dispatch_event_loop(self)
+                return
+            except Exception as exc:
+                if self._ft_result_queue is None:
+                    self._ft_result_queue = getattr(self, "result_queue", None)
+                abort_succeeded = self._ft_abort_inflight_window()
+                if get_parallel().fault_tolerance_on_error_strategy == "continue":
+                    discard_succeeded = self._ft_discard_inflight_window()
+                    should_continue = abort_succeeded and discard_succeeded
+                else:
+                    should_continue = False
+                if not should_continue:
+                    self._engine_paused = True
+                    self._ft_pause_deadline = (
+                        time.monotonic()
+                        + get_parallel().fault_tolerance_pause_timeout
+                    )
+                self.ipc_channels.send_to_tokenizer.send_output(
+                    FaultToleranceRankFaultOutput(
+                        rank=self.ps.dp_rank,
+                        message=str(exc),
+                    )
+                )
+
+    def _ft_inflight_reqs(self) -> Dict[str, Req]:
+        window_batches = [
+            self.cur_batch_for_debug,
+            self.last_batch,
+            self.running_batch,
+        ]
+        if self._ft_result_queue is not None:
+            window_batches.extend(batch for batch, _ in self._ft_result_queue)
+
+        def should_discard(req):
+            owns_state = req.kv.holds_kv or req.kv.holds_mamba
+            return not req.finished() or owns_state
+
+        discarded_by_rid = {}
+        for batch in window_batches:
+            if batch is None:
+                continue
+            for req in batch.reqs:
+                if should_discard(req):
+                    discarded_by_rid.setdefault(req.rid, req)
+        if self.chunked_req is not None and should_discard(self.chunked_req):
+            discarded_by_rid.setdefault(self.chunked_req.rid, self.chunked_req)
+        return discarded_by_rid
+
+    def _ft_abort_inflight_window(self) -> bool:
+        success = True
+        for req in self._ft_inflight_reqs().values():
+            try:
+                abort_reason = FINISH_ABORT(
+                    message="Request discarded during fault tolerance recovery.",
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                    err_type="SchedulerFault",
+                )
+                req.finished_reason = abort_reason
+                self.ipc_channels.send_to_tokenizer.send_output(
+                    AbortReq(
+                        finished_reason=abort_reason.to_json(),
+                        rid=req.rid,
+                    ),
+                    req,
+                )
+            except Exception:
+                logger.exception("FT failed to abort in-flight request")
+                success = False
+        return success
+
+    def _ft_discard_inflight_window(self) -> bool:
+        discarded_reqs = self._ft_inflight_reqs()
+        success = True
+        for req in discarded_reqs.values():
+            try:
+                req.kv.kv_committed_len = min(
+                    req.kv.kv_committed_len,
+                    len(req.origin_input_ids) + len(req.output_ids),
+                )
+                # A failed forward may leave allocated but uncommitted KV slots.
+                release_kv_cache(
+                    req,
+                    self.tree_cache,
+                    is_insert=False,
+                    allow_non_spec_overallocated=True,
+                )
+            except Exception:
+                logger.exception("FT failed to discard request state")
+                success = False
+
+        self.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
+        if self.chunked_req is not None and self.chunked_req.rid in discarded_reqs:
+            self.chunked_req = None
+        if self._ft_result_queue is not None:
+            self._ft_result_queue.clear()
+        self._ft_result_queue = None
+        self.cur_batch_for_debug = None
+        self.last_batch = None
+        logger.warning("FT discarded %d in-flight request(s)", len(discarded_reqs))
+        return success
+
+    def _process_next_overlap_result(self) -> None:
+        batch, result = self.result_queue[0]
+        self.process_batch_result(batch, result)
+        self.result_queue.popleft()
 
     def _apply_war_barrier(self):
         # WAR: keep later schedule_stream writes behind this forward's shared reads.
@@ -1914,6 +2037,7 @@ class Scheduler(
             if recv_reqs:
                 self.metrics_reporter.record_scheduler_active()
             self.process_input_requests(recv_reqs)
+            self._check_ft_pause_deadline()
             if self._engine_paused:
                 self._record_scheduler_state_for_paused_engine()
                 continue
@@ -1949,8 +2073,7 @@ class Scheduler(
 
         def pop_and_process():
             # Process the results of the last batch
-            tmp_batch, tmp_result = self.result_queue.popleft()
-            self.process_batch_result(tmp_batch, tmp_result)
+            self._process_next_overlap_result()
 
         while True:
             if self.gracefully_exit:
@@ -1961,6 +2084,7 @@ class Scheduler(
             if recv_reqs:
                 self.metrics_reporter.record_scheduler_active()
             self.process_input_requests(recv_reqs)
+            self._check_ft_pause_deadline()
             if self._engine_paused:
                 self._record_scheduler_state_for_paused_engine()
                 continue
@@ -5394,6 +5518,46 @@ class Scheduler(
         ):
             self.disagg_decode_prealloc_queue.enqueue_held_rebootstrap()
         self._engine_paused = False
+
+    def handle_fault_tolerance_command(
+        self, recv_req: FaultToleranceCommandReqInput
+    ) -> Optional[FaultToleranceCommandReqOutput]:
+        rank = self.ps.dp_rank
+        if rank not in recv_req.target_ranks:
+            return None
+
+        if recv_req.command == FT_OPERATION_RETRY:
+            active_mask = None
+        elif recv_req.command == FT_OPERATION_SCALE_DOWN:
+            active_mask = recv_req.active_mask
+        else:
+            logger.warning("FT unknown command: %s", recv_req.command)
+            return None
+
+        self.tp_worker.model_runner.update_fault_tolerance_active_ranks(active_mask)
+        if not self._ft_discard_inflight_window():
+            raise RuntimeError("FT failed to discard in-flight request state")
+        self._engine_paused = False
+        self._ft_pause_deadline = None
+
+        if self.ps.attn_tp_rank != 0 or self.ps.attn_cp_rank != 0:
+            return None
+        return FaultToleranceCommandReqOutput(
+            request_id=recv_req.request_id,
+            rank=rank,
+        )
+
+    def _check_ft_pause_deadline(self) -> None:
+        deadline = self._ft_pause_deadline
+        if deadline is None or time.monotonic() < deadline:
+            return
+        self._ft_pause_deadline = None
+        logger.error(
+            "Fault tolerance pause unattended: timeout_sec=%s dp_rank=%s",
+            get_parallel().fault_tolerance_pause_timeout,
+            self.ps.dp_rank,
+        )
+        notify_node_main_process_failure()
 
     def handle_scale_elastic_ep(
         self, recv_req: ScaleElasticEPReqInput

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -180,6 +180,7 @@ class SchedulerRequestReceiver:
             _local_ctrl = (
                 get_parallel().enable_dp_attention_local_control_broadcast
                 or get_exec().moe.is_ep_scale_joiner
+                or get_parallel().enable_fault_tolerance
             )
             if _local_ctrl:
                 control_reqs = attn_cp_tp_broadcast_pyobj(control_reqs)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -34,7 +34,17 @@ from datetime import datetime
 from enum import Enum
 from functools import lru_cache
 from http import HTTPStatus
-from typing import Any, Awaitable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import fastapi
 import numpy as np
@@ -54,6 +64,8 @@ from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.disaggregation.encoder.receiver import create_mm_receiver
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
+from sglang.srt.fault_tolerance.manager import FaultToleranceManager
+from sglang.srt.fault_tolerance.protocol import FaultToleranceApplyRequest
 from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
 from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
 from sglang.srt.managers.disagg_service import start_disagg_service
@@ -79,6 +91,7 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     OpenSessionReqOutput,
     PauseGenerationReqInput,
+    ProcessActiveRanksOutput,
     ScaleElasticEPReqInput,
     ScaleElasticEPReqOutput,
     SessionParams,
@@ -446,6 +459,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Init running status
         self.init_running_status()
 
+        # Init fault tolerance state. Disabled FT keeps this as None.
+        self.init_fault_tolerance()
+
         # Init logging and dumping
         self.init_request_logging_and_dumping()
 
@@ -557,6 +573,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     def init_ipc_channels(self, port_args: PortArgs):
         context = zmq.asyncio.Context(2)
+        self._zmq_context = context
         self.recv_from_detokenizer = get_zmq_socket(
             context, zmq.PULL, port_args.tokenizer_ipc_name, True
         )
@@ -604,6 +621,19 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Subprocess liveness watchdog — set by Engine or http_server after construction
         self._subprocess_watchdog = None
+
+    def init_fault_tolerance(self):
+        self.fault_tolerance: Optional[FaultToleranceManager] = None
+        if not get_parallel().enable_fault_tolerance:
+            return
+
+        # Scheduler commands reuse the primary DPC and its scheduler connections.
+        # Per-node DPC control only stops locally owned scheduler processes.
+        self.fault_tolerance = FaultToleranceManager(
+            server_args=get_parallel(),
+            zmq_context=self._zmq_context,
+            send_to_scheduler=self._async_dispatch_to_scheduler,
+        )
 
     def init_request_logging_and_dumping(self):
         # TODO: Refactor and organize the log export code.
@@ -751,23 +781,25 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.metrics_collector.emit_startup_time(startup_time)
 
     def init_request_dispatcher(self):
-        self._result_dispatcher = TypeBasedDispatcher(
-            [
-                (AbortReq, self._handle_abort_req),
-                (OpenSessionReqOutput, self._handle_open_session_req_output),
-                (
-                    UpdateWeightFromDiskReqOutput,
-                    self._handle_update_weights_from_disk_req_output,
-                ),
-                (FreezeGCReq, lambda x: None),
-                # For handling case when scheduler skips detokenizer and forwards back to the tokenizer manager, we ignore it.
-                (HealthCheckOutput, lambda x: None),
-                # Same skip-detokenizer forwarding case as above.
-                (ConfigureLoggingReq, lambda x: None),
-                (ActiveRanksOutput, self.update_active_ranks),
-                (ElasticScaleUpdateReq, self.forward_elastic_scale_update),
-            ]
-        )
+        handlers: list[tuple[type[BaseReq], Callable[[Any], Any]]] = [
+            (AbortReq, self._handle_abort_req),
+            (OpenSessionReqOutput, self._handle_open_session_req_output),
+            (
+                UpdateWeightFromDiskReqOutput,
+                self._handle_update_weights_from_disk_req_output,
+            ),
+            (FreezeGCReq, lambda x: None),
+            # For handling case when scheduler skips detokenizer and forwards back to the tokenizer manager, we ignore it.
+            (HealthCheckOutput, lambda x: None),
+            # Same skip-detokenizer forwarding case as above.
+            (ConfigureLoggingReq, lambda x: None),
+            (ActiveRanksOutput, self.update_active_ranks),
+            (ProcessActiveRanksOutput, self.update_process_active_ranks),
+            (ElasticScaleUpdateReq, self.forward_elastic_scale_update),
+        ]
+        self._result_dispatcher = TypeBasedDispatcher(handlers)
+        if self.fault_tolerance is not None:
+            self._result_dispatcher += self.fault_tolerance.init_request_dispatcher()
         self.init_communicators()
 
         self.sampling_params_class = SamplingParams
@@ -803,6 +835,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 raise ValueError(
                     f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
                 )
+        if self.fault_tolerance is not None:
+            routed_dp_rank = (
+                obj.routed_dp_rank if isinstance(obj, GenerateReqInput) else None
+            )
+            if error := self.fault_tolerance.admission_error(routed_dp_rank):
+                raise fastapi.HTTPException(status_code=503, detail=error)
 
         self._init_req_state(obj, request)
         request_rids = {obj.rid} if obj.is_single else set(obj.rid)
@@ -2053,6 +2091,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             await self._async_dispatch_to_scheduler(obj)
             self.is_pause_cond.notify_all()
 
+    def fault_tolerance_status(self):
+        if self.fault_tolerance is None:
+            return 503, {"message": "fault_tolerance_disabled"}
+        return self.fault_tolerance.status()
+
+    def fault_tolerance_apply(self, obj: FaultToleranceApplyRequest):
+        if self.fault_tolerance is None:
+            return 503, {"message": "fault_tolerance_disabled"}
+        return self.fault_tolerance.submit(obj)
+
     async def update_weights_from_disk(
         self,
         obj: UpdateWeightFromDiskReqInput,
@@ -2207,6 +2255,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             loop.create_task(print_exception_wrapper(self.handle_loop))
         )
         self.event_loop = loop
+        if self.fault_tolerance is not None:
+            self.fault_tolerance.bind_event_loop(loop)
 
         # We only add signal handler when the tokenizer manager is in the main thread
         # due to the CPython limitation.
@@ -3309,6 +3359,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         state.event.set()
 
     def update_active_ranks(self, ranks: ActiveRanksOutput):
+        if self.fault_tolerance is not None:
+            ranks = self.fault_tolerance.observe_active_ranks(ranks)
+            if ranks is None:
+                return
         self._dispatch_to_scheduler(ranks)
 
     def forward_elastic_scale_update(self, msg: ElasticScaleUpdateReq):
@@ -3364,6 +3418,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.elastic_scale_phase = responses[0].scale_phase
         self.elastic_last_error = None
         return responses[0]
+
+    def update_process_active_ranks(self, ranks: ProcessActiveRanksOutput):
+        if self.fault_tolerance is not None:
+            active_ranks = self.fault_tolerance.observe_process_active_ranks(ranks)
+            if active_ranks is not None:
+                self._dispatch_to_scheduler(active_ranks)
 
     def _handle_open_session_req_output(self, recv_obj):
         future = self.session_futures.get(recv_obj.session_id)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -247,7 +247,12 @@ def retraction_discard(req: Req, tree_cache: BasePrefixCache, backend: str) -> N
     req.kv.retraction_backup = None
 
 
-def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = True):
+def release_kv_cache(
+    req: Req,
+    tree_cache: BasePrefixCache,
+    is_insert: bool = True,
+    allow_non_spec_overallocated: bool = False,
+):
     assert (not req.kv.holds_kv) == req.kv.is_kv_released
     # MambaRadixCache may alloc mamba state before alloc KV cache
     if not req.kv.holds_kv:
@@ -276,7 +281,13 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
         return
 
     start_p, end_p = effective_kv_committed_len, req.kv.kv_allocated_len
-    _release_overallocated_kv_indices(req, start_p, end_p, tree_cache)
+    _release_overallocated_kv_indices(
+        req,
+        start_p,
+        end_p,
+        tree_cache,
+        allow_non_spec_overallocated=allow_non_spec_overallocated,
+    )
 
     # If the prefix cache doesn't manage mamba states, we must free them here.
     if isinstance(tree_cache.req_to_token_pool, HybridReqToTokenPool) and (
@@ -293,7 +304,12 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
 
 
 def _release_overallocated_kv_indices(
-    req: Req, start_p: int, end_p: int, tree_cache: BasePrefixCache
+    req: Req,
+    start_p: int,
+    end_p: int,
+    tree_cache: BasePrefixCache,
+    *,
+    allow_non_spec_overallocated: bool = False,
 ) -> None:
     allocator = tree_cache.token_to_kv_pool_allocator
     page_size = allocator.page_size
@@ -301,7 +317,11 @@ def _release_overallocated_kv_indices(
 
     # strip_thinking_cache intentionally reports output tokens as overallocated
     # so they fall into the free path below (#22373).
-    if spec_algo is None and not get_serving().strip_thinking_cache:
+    if (
+        spec_algo is None
+        and not get_serving().strip_thinking_cache
+        and not allow_non_spec_overallocated
+    ):
         assert start_p == end_p, (
             f"Unexpected overallocated KV cache, {req.kv.kv_committed_len=}, {req.kv.kv_allocated_len=}"
         )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -989,7 +989,9 @@ class ModelRunner:
                 )
 
     def post_capture_elastic_ep_recover(self):
+        logger.info("Elastic EP recovery join process groups begin")
         join_process_groups()
+        logger.info("Elastic EP recovery join process groups done")
 
         global_ep_rank = self.ps.tp_rank + get_parallel().ep_join_rank_offset
         broadcast_global_expert_location_metadata(
@@ -2210,6 +2212,16 @@ class ModelRunner:
         reinit_attn_backend: bool,
         split_forward_count: int,
     ) -> ModelRunnerOutput:
+        state = ElasticEPStateManager.instance()
+        if (
+            get_parallel().enable_fault_tolerance
+            and get_parallel().fault_tolerance_on_error_strategy == "pause"
+            and state is not None
+            and bool(
+                (state.last_active_ranks.bool() & ~state.active_ranks.bool()).any()
+            )
+        ):
+            raise RuntimeError("Elastic EP membership loss detected before EPLB")
         if maybe_rebalance_after_rank_fault(eplb_manager=self.eplb_manager):
             output = self._forward_raw(
                 forward_batch,
@@ -2218,6 +2230,26 @@ class ModelRunner:
                 split_forward_count,
             )
         return output
+
+    def update_fault_tolerance_active_ranks(
+        self, active_mask: Optional[list[bool]] = None
+    ) -> None:
+        """Restore the last rank mask, or apply a new one and rebalance."""
+        state = ElasticEPStateManager.instance()
+        active_ranks = state.last_active_ranks
+        if active_mask is not None:
+            active_ranks = torch.as_tensor(
+                active_mask,
+                dtype=state.active_ranks.dtype,
+                device=state.active_ranks.device,
+            )
+        state.active_ranks.copy_(active_ranks)
+        state.active_ranks_cpu.copy_(active_ranks.detach().cpu())
+        if active_mask is not None:
+            maybe_rebalance_after_rank_fault(
+                eplb_manager=self.eplb_manager,
+                force=True,
+            )
 
     def update_model_fields(
         self,

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2334,6 +2334,15 @@ def kill_process_tree(
         _wait_for_reap_or_raise(killed, wait_timeout)
 
 
+def notify_node_main_process_failure() -> None:
+    """Notify the current Scheduler's node main process to clean up locally."""
+    dpc_process = psutil.Process().parent()
+    node_main_process = dpc_process.parent() if dpc_process is not None else None
+    if node_main_process is None:
+        raise RuntimeError("Node main process not found")
+    node_main_process.send_signal(signal.SIGQUIT)
+
+
 def monkey_patch_p2p_access_check():
     """
     Monkey patch the slow p2p access check.

--- a/python/sglang/srt/utils/watchdog.py
+++ b/python/sglang/srt/utils/watchdog.py
@@ -172,18 +172,33 @@ class SubprocessWatchdog:
     sends SIGQUIT to trigger proper cleanup.
 
     See: https://github.com/sgl-project/sglang/issues/18421
+
+    An optional ``on_exit`` callback is invoked before the default SIGQUIT path.
+    Callers that can isolate one failed subprocess may disable that fail-stop
+    while retaining polling for the remaining subprocesses.
     """
 
     def __init__(
         self,
         processes: List[Process],
         process_names: Optional[List[str]] = None,
+        on_exit: Optional[Callable[[int, Process, str], None]] = None,
+        fail_stop_on_exit: bool = True,
         interval: float = 1.0,
+        on_poll: Optional[Callable[[], None]] = None,
+        on_thread_stop: Optional[Callable[[], None]] = None,
+        report_clean_exit: bool = False,
     ):
         self._processes = processes
         self._names = process_names or [f"process_{i}" for i in range(len(processes))]
         self._interval = interval
+        self._on_exit = on_exit
+        self._fail_stop_on_exit = fail_stop_on_exit
+        self._on_poll = on_poll
+        self._on_thread_stop = on_thread_stop
+        self._report_clean_exit = report_clean_exit
         self._stop_event = threading.Event()
+        self._reported = set()
         self._thread: Optional[threading.Thread] = None
 
     def start(self) -> None:
@@ -195,29 +210,58 @@ class SubprocessWatchdog:
         self._thread.start()
 
     def stop(self) -> None:
-        self._stop_event.set()
         if self._thread is not None:
+            self._stop_event.set()
             self._thread.join(timeout=self._interval * 2)
             self._thread = None
 
+    def _on_thread_start(self) -> None:
+        pass
+
     def _monitor_loop(self) -> None:
         try:
+            self._on_thread_start()
             while not self._stop_event.wait(self._interval):
                 if self._check_processes():
                     return
+                if self._on_poll is None and len(self._reported) == len(
+                    self._processes
+                ):
+                    return
+                if self._on_poll is not None:
+                    self._on_poll()
         except Exception as e:
             logger.error(f"SubprocessWatchdog thread crashed: {e}", exc_info=True)
+        finally:
+            if self._on_thread_stop is not None:
+                self._on_thread_stop()
 
     def _check_processes(self) -> bool:
-        for proc, name in zip(self._processes, self._names):
-            if proc.is_alive() or proc.exitcode == 0:
+        for index, (proc, name) in enumerate(zip(self._processes, self._names)):
+            if index in self._reported or proc.is_alive() or proc.exitcode is None:
                 continue
-
-            logger.error(
-                f"Subprocess {name} (pid={proc.pid}) crashed "
-                f"with exit code {proc.exitcode}. "
-                f"Triggering SIGQUIT for cleanup..."
-            )
-            os.kill(os.getpid(), signal.SIGQUIT)
-            return True
+            self._reported.add(index)
+            if proc.exitcode == 0 and not self._report_clean_exit:
+                continue
+            if self._handle_process_exit(index, proc, name):
+                return True
         return False
+
+    def _handle_process_exit(self, index: int, proc: Process, name: str) -> bool:
+        if self._on_exit is not None:
+            self._on_exit(index, proc, name)
+
+        if proc.exitcode == 0:
+            return False
+
+        if not self._fail_stop_on_exit:
+            logger.warning(f"Subprocess {name} (pid={proc.pid}) crashed with exit code {proc.exitcode}.")
+            return False
+
+        logger.error(
+            f"Subprocess {name} (pid={proc.pid}) crashed "
+            f"with exit code {proc.exitcode}. "
+            f"Triggering SIGQUIT for cleanup..."
+        )
+        os.kill(os.getpid(), signal.SIGQUIT)
+        return True

--- a/test/registered/unit/fault_tolerance/test_manager.py
+++ b/test/registered/unit/fault_tolerance/test_manager.py
@@ -1,0 +1,198 @@
+import unittest
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from sglang.srt.fault_tolerance.ft_state import FaultToleranceState
+from sglang.srt.fault_tolerance.manager import FaultToleranceManager
+from sglang.srt.fault_tolerance.protocol import parse_apply_request
+from sglang.srt.managers.io_struct import ActiveRanksOutput, ProcessActiveRanksOutput
+from sglang.srt.managers.scheduler import Scheduler
+
+
+def make_manager(*, dp_size=2, ranks_per_dp=1, strategy="pause"):
+    return FaultToleranceManager(
+        server_args=SimpleNamespace(
+            dp_size=dp_size,
+            tp_size=dp_size * ranks_per_dp,
+            fault_tolerance_on_error_strategy=strategy,
+            fault_tolerance_timeout=1,
+        ),
+        zmq_context=Mock(),
+        send_to_scheduler=AsyncMock(),
+    )
+
+
+class TestFaultTolerance(unittest.IsolatedAsyncioTestCase):
+    def test_protocol_and_state_contract(self):
+        request = parse_apply_request(
+            b'{"instruction":"scale_down","params":{"removed_dp_ranks":[1]}}'
+        )
+        self.assertEqual(request.params.removed_dp_ranks, [1])
+        with self.assertRaisesRegex(ValueError, "Invalid instruction"):
+            parse_apply_request(b'{"instruction":"recover"}')
+
+        state = FaultToleranceState(dp_size=2, strategy="pause", global_rank_count=4)
+        state.observe_process_active_ranks([2], active=False)
+        self.assertEqual(state.process_alive_dp_mask(), [True, False])
+        self.assertEqual(state.status_response()["engines"][1]["status"], "dead")
+        self.assertEqual(
+            state.expand_dp_mask_to_global_rank_mask([True, False]),
+            [True, True, False, False],
+        )
+
+        manager = make_manager()
+        manager._finish_submitted_apply("request-1", None)
+        status = manager.status()[1]
+        self.assertEqual(status["last_ft_request_id"], "request-1")
+        self.assertNotIn("ft_error", status)
+        self.assertNotIn("last_ft_request_id", status["engines"][0])
+        manager._finish_submitted_apply("request-2", "failed")
+        self.assertEqual(manager.status()[1]["ft_error"], "failed")
+
+    async def test_retry_uses_expected_topology(self):
+        manager = make_manager(dp_size=4)
+        manager.state.expected_dp_mask = [True, True, False, True]
+        manager._send_command_collect = AsyncMock()
+        manager._publish_route_dp_mask = AsyncMock()
+
+        self.assertIsNone(await manager._apply_retry(1))
+        manager._send_command_collect.assert_awaited_once_with(
+            command="retry", target_ranks=[0, 1, 3], timeout_sec=1
+        )
+        manager._publish_route_dp_mask.assert_awaited_once_with(
+            [True, True, False, True], 1
+        )
+
+    async def test_scale_down_orders_shutdown_command_and_route(self):
+        manager = make_manager(dp_size=4, ranks_per_dp=2)
+        events = []
+        manager._shutdown_dp_processes = AsyncMock(
+            side_effect=lambda *_: events.append("shutdown")
+        )
+        manager._send_command_collect = AsyncMock(
+            side_effect=lambda **_: events.append("command")
+        )
+        manager._publish_route_dp_mask = AsyncMock(
+            side_effect=lambda *_: events.append("route")
+        )
+
+        self.assertIsNone(await manager._apply_scale_down([2], 1))
+        self.assertEqual(events, ["shutdown", "command", "route"])
+        manager._send_command_collect.assert_awaited_once_with(
+            command="scale_down",
+            target_ranks=[0, 1, 3],
+            timeout_sec=1,
+            active_global_rank_mask=[
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+            ],
+        )
+        self.assertEqual(manager.state.expected_dp_mask, [True, True, False, True])
+
+    async def test_continue_routes_only_ready_processes(self):
+        manager = make_manager(dp_size=2, ranks_per_dp=2, strategy="continue")
+
+        down = manager.observe_process_active_ranks(
+            ProcessActiveRanksOutput(ranks=[2, 3], active=False)
+        )
+        self.assertEqual(down.status, [True, False])
+        self.assertEqual(manager.state.expected_dp_mask, [True, True])
+
+        manager.observe_process_active_ranks(
+            ProcessActiveRanksOutput(ranks=[2, 3], active=True)
+        )
+        up = manager.observe_active_ranks(ActiveRanksOutput(status=[True, True]))
+        self.assertEqual(up.status, [True, True])
+        manager.send_to_scheduler.assert_not_awaited()
+
+    def test_abort_precedes_resource_cleanup(self):
+        req = Mock(
+            rid="request-1",
+            kv=SimpleNamespace(holds_kv=True, holds_mamba=False, kv_committed_len=3),
+            origin_input_ids=[1, 2],
+            output_ids=[3],
+            finished_reason=None,
+        )
+        req.finished.side_effect = lambda: req.finished_reason is not None
+        batch = SimpleNamespace(reqs=[req])
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.cur_batch_for_debug = batch
+        scheduler.last_batch = batch
+        scheduler.running_batch = batch
+        scheduler.chunked_req = req
+        failed_result_queue = deque([(batch, object())])
+        scheduler._ft_result_queue = failed_result_queue
+        scheduler.result_queue = deque()
+        scheduler.tree_cache = Mock()
+        scheduler.ipc_channels = SimpleNamespace(send_to_tokenizer=Mock())
+
+        with patch(
+            "sglang.srt.managers.scheduler.release_kv_cache"
+        ) as release_kv_cache:
+            self.assertTrue(scheduler._ft_abort_inflight_window())
+            release_kv_cache.assert_not_called()
+            self.assertIs(scheduler.running_batch, batch)
+            self.assertTrue(failed_result_queue)
+
+            self.assertTrue(scheduler._ft_discard_inflight_window())
+            release_kv_cache.assert_called_once_with(
+                req,
+                scheduler.tree_cache,
+                is_insert=False,
+                allow_non_spec_overallocated=True,
+            )
+
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_called_once()
+        self.assertFalse(scheduler.running_batch.reqs)
+        self.assertFalse(failed_result_queue)
+        self.assertIsNone(scheduler._ft_result_queue)
+        self.assertIsNone(scheduler.chunked_req)
+
+    def test_finished_requests_without_resources_are_not_discarded(self):
+        req = SimpleNamespace(
+            rid="finished",
+            kv=SimpleNamespace(holds_kv=False, holds_mamba=False),
+            finished=lambda: True,
+        )
+        batch = SimpleNamespace(reqs=[req])
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.cur_batch_for_debug = batch
+        scheduler.last_batch = batch
+        scheduler.running_batch = batch
+        scheduler.chunked_req = None
+        scheduler._ft_result_queue = None
+
+        self.assertEqual(scheduler._ft_inflight_reqs(), {})
+        req.kv.holds_mamba = True
+        self.assertEqual(scheduler._ft_inflight_reqs(), {req.rid: req})
+
+    def test_recovery_precedes_discard(self):
+        events = []
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.ps = SimpleNamespace(dp_rank=0, attn_tp_rank=0, attn_cp_rank=0)
+        scheduler.tp_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                update_fault_tolerance_active_ranks=lambda _: events.append("recover")
+            )
+        )
+        scheduler._ft_discard_inflight_window = lambda: events.append("discard") or True
+        scheduler._engine_paused = True
+        scheduler._ft_pause_deadline = 1
+
+        scheduler.handle_fault_tolerance_command(
+            SimpleNamespace(command="retry", target_ranks=[0], request_id="retry-1")
+        )
+
+        self.assertEqual(events, ["recover", "discard"])
+        self.assertFalse(scheduler._engine_paused)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_subprocess_watchdog.py
+++ b/test/registered/unit/utils/test_subprocess_watchdog.py
@@ -134,6 +134,20 @@ class TestSubprocessWatchdog(CustomTestCase):
             "SIGQUIT should not be triggered for normal exit (exitcode=0)",
         )
 
+    def test_callback_can_isolate_crash(self):
+        exit_seen = threading.Event()
+        process = self._spawn(slow_crash_worker, args=(0.1,))
+        self._monitor = SubprocessWatchdog(
+            processes=[process],
+            on_exit=lambda *_: exit_seen.set(),
+            fail_stop_on_exit=False,
+            interval=0.01,
+        )
+        self._monitor.start()
+
+        self.assertTrue(exit_seen.wait(timeout=5.0))
+        self.assertFalse(self.sigquit_triggered.is_set())
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## Motivation

Add a DP-only fault-tolerance control plane that lets operators inspect rank health and request retry or scale-down after worker failures. This draft isolates the FT implementation for review.

## Modifications

- Add asynchronous recovery operations, process/engine health tracking, route acknowledgements, and bounded pause/watchdog handling.
- Abort and discard affected in-flight requests during recovery and expose operation results through the status API.
- Integrate scheduler, tokenizer, and DP-controller handling with the current runtime configuration model.

This branch contains only commit `6d07cd2eb884f841d5de3b728c1b38645b963039` on main baseline `f3ccd1c0e42926e795a4304d50935b8cbd210169`. The DP-replica status correction, fixed-topology metadata fix, and Mooncake integration are excluded. In particular, TP > 1 health-mask handling needs the separate DP-replica correction; this draft is not a complete end-to-end recovery stack.

Known review follow-up: the FT abort path constructs AbortReq directly and does not yet use the upstream helper that attaches per-token weight-version spans.

## Accuracy Tests

No GPU tests have been run on this isolated branch. Earlier GPU passes exercised the combined stack before its main rebase and do not validate this PR. Commit scope and whitespace checks passed.

## Speed Tests and Profiling

Not run.

## Checklist

- [ ] Complete formatting and CI checks.
- [ ] Validate this isolated branch with unit and integration tests.
- [ ] Complete documentation review.
- [ ] Provide accuracy and performance results where applicable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->