### PR TITLE
[Mooncake] Adapt expert-parallel fault recovery

### DIFF
--- a/python/sglang/srt/elastic_ep/elastic_ep.py
+++ b/python/sglang/srt/elastic_ep/elastic_ep.py
@@ -512,6 +512,14 @@ def maybe_rebalance_after_rank_fault(*, eplb_manager: EPLBManager) -> bool:
     elastic_ep_state = ElasticEPStateManager.instance()
     if elastic_ep_state is None or elastic_ep_state.is_active_equal_last():
         return False
+    group = get_world_group()
+    if torch.distributed.get_backend(group.cpu_group) == "mooncake-cpu":
+        from mooncake import pg
+
+        for backend in (group.device_group, group.cpu_group):
+            response = pg.sync_after_failure(backend)
+            assert response.status != pg.SyncAfterFailureStatus.Rejected
+        group.barrier()
     elastic_ep_state.snapshot_active_to_last()
     elastic_ep_state.sync_active_to_cpu()
     logger.info("EPLB due to rank faults")
@@ -521,4 +529,6 @@ def maybe_rebalance_after_rank_fault(*, eplb_manager: EPLBManager) -> bool:
             next(gen)
         except StopIteration:
             break
+    if torch.distributed.get_backend(group.cpu_group) == "mooncake-cpu":
+        group.barrier()
     return True

--- a/python/sglang/srt/eplb/eplb_algorithms/__init__.py
+++ b/python/sglang/srt/eplb/eplb_algorithms/__init__.py
@@ -63,9 +63,9 @@ def rebalance_experts(
                 algorithm == EplbAlgorithm.elasticity_aware_hierarchical
             ),
             active_ranks=(
-                ElasticEPStateManager.instance().active_ranks
+                ElasticEPStateManager.instance().active_ranks_cpu
                 if ElasticEPStateManager.instance() is not None
-                else ElasticEPStateManager.healthy_rank_state()
+                else ElasticEPStateManager.healthy_rank_state(device=torch.device("cpu"))
             ),
         )
 

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -516,6 +516,7 @@ def broadcast_global_expert_location_metadata(
     metadata = get_global_expert_location_metadata()
     assert metadata is not None
 
+    # Ensure device tensors are contiguous before broadcasting in-place
     metadata.physical_to_logical_map = metadata.physical_to_logical_map.contiguous()
     torch.distributed.broadcast(
         metadata.physical_to_logical_map, src=src_rank, group=group

--- a/python/sglang/srt/eplb/expert_location_updater.py
+++ b/python/sglang/srt/eplb/expert_location_updater.py
@@ -151,7 +151,9 @@ def _update_expert_weights_raw(
 
     world_size = torch.distributed.get_world_size()
     num_local_physical_experts = old_expert_location_metadata.num_local_physical_experts
-    num_gpu_per_node = world_size // nnodes
+    original_world_size = old_expert_location_metadata.ep_size
+    assert original_world_size % nnodes == 0
+    num_gpu_per_node = original_world_size // nnodes
 
     missing_logical_experts_by_layers: Dict[int, List[int]] = {}
 
@@ -421,6 +423,12 @@ def update_expert_weights_single_layer(
                 if old_physical_to_logical_map[x] == logical_expert_id
             ]
         )
+        elastic_ep_state = ElasticEPStateManager.instance()
+        if elastic_ep_state is not None:
+            active_src_ranks = [
+                x for x in all_src_ranks if elastic_ep_state.active_ranks_cpu[x]
+            ]
+            all_src_ranks = active_src_ranks or all_src_ranks
         all_src_nodes = [x // num_gpu_per_node for x in all_src_ranks]
         self_node_src_ranks = [
             x for x in all_src_ranks if x // num_gpu_per_node == self_node_id

--- a/python/sglang/srt/layers/moe/token_dispatcher/mooncake.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/mooncake.py
@@ -19,8 +19,9 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutputFormat,
 )
 from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.utils import DeepEPMode
-from sglang.srt.runtime_context import get_resources
+from sglang.srt.layers.moe.utils import DeepEPMode, get_moe_runner_backend
+from sglang.srt.runtime_context import get_exec, get_resources
+from sglang.srt.environ import envs
 from sglang.srt.utils import get_int_env_var
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ class EPBuffer:
         deepep_mode: DeepEPMode,
         num_max_dispatch_tokens_per_rank: int = -1,
         num_experts: int = -1,
+        connect_on_init: bool = True,
     ):
         state = cls._state()
         if state.buffer is not None:
@@ -118,7 +120,9 @@ class EPBuffer:
                 num_experts,
             )
 
-        state.buffer = Buffer(group, num_ep_buffer_bytes)
+        state.buffer = Buffer(
+            group, num_ep_buffer_bytes, connect_on_init=connect_on_init
+        )
         return state.buffer
 
 
@@ -166,6 +170,9 @@ class _MooncakeEPDispatcherImpl:
 
         self.handle = None
 
+        if get_exec().moe.ep_join_mode == "recover":
+            self._get_buffer(connect_on_init=False)
+
     def dispatch_a(
         self,
         hidden_states: torch.Tensor,
@@ -181,7 +188,7 @@ class _MooncakeEPDispatcherImpl:
         hidden_states, masked_m, event, hook = self._dispatch_core(
             hidden_states,
             topk_ids,
-            use_fp8=True,
+            use_fp8=self._should_use_fp8_dispatch(),
         )
         return (
             hidden_states,
@@ -246,6 +253,12 @@ class _MooncakeEPDispatcherImpl:
         )
         return packed_recv_hidden, packed_recv_count, event, hook
 
+    def _should_use_fp8_dispatch(self) -> bool:
+        backend = get_moe_runner_backend()
+        if envs.SGLANG_DEEPEP_BF16_DISPATCH.get() or backend.is_triton():
+            return False
+        return True
+
     def combine_a(
         self,
         hidden_states: torch.Tensor,
@@ -291,7 +304,7 @@ class _MooncakeEPDispatcherImpl:
             return elastic_state.active_ranks
         return torch.ones(self.group.size(), dtype=torch.int32, device="cuda")
 
-    def _get_buffer(self):
+    def _get_buffer(self, connect_on_init: bool = True):
         return EPBuffer.get_ep_buffer(
             self.group,
             self.hidden_size,
@@ -299,6 +312,7 @@ class _MooncakeEPDispatcherImpl:
             self.deepep_mode,
             self.num_max_dispatch_tokens_per_rank,
             self.num_experts,
+            connect_on_init,
         )
 
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -655,8 +655,8 @@ class DataParallelController:
                     rank_port_args = PortArgs.init_new(
                         server_args, dp_rank, worker_ports
                     )
-                    if get_exec().moe.is_ep_scale_joiner:
-                        # Scale-joiner outputs return through the primary tokenizer.
+                    if get_exec().moe.is_ep_joiner:
+                        # Joiner outputs return through the primary tokenizer.
                         primary_addr = NetworkAddress.parse(
                             get_parallel().dist_init_addr
                         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -53,7 +53,7 @@ from sglang.srt.arg_groups.argparse_actions import (
     DeprecatedStoreConstAction,
     DeprecatedStoreTrueAction,
 )
-from sglang.srt.arg_groups.model_override_base import ep_joiner_of, ep_scale_joiner_of
+from sglang.srt.arg_groups.model_override_base import ep_joiner_of
 from sglang.srt.arg_groups.overrides import (
     remote_instance_transfer_engine_of,
     resolution_projection,
@@ -1012,14 +1012,17 @@ class PortArgs:
             # overflow.
             is_rust_server = envs.SGLANG_RUST_SERVER.get()
             NUM_DERIVED_PORTS = 6 if not is_rust_server else 6 + cfg.dp_size
-            if ep_scale_joiner_of(resolving_view(server_args)):
+            if dist_init_port + NUM_DERIVED_PORTS > 65535:
+                primary_port_base = dist_init_port - NUM_DERIVED_PORTS - 1
+            else:
+                primary_port_base = dist_init_port + 1
+
+            if ep_joiner_of(cfg):
                 port_base = server_args.port + ZMQ_TCP_PORT_DELTA
                 if port_base + NUM_DERIVED_PORTS > 65535:
                     port_base = server_args.port - ZMQ_TCP_PORT_DELTA
-            elif dist_init_port + NUM_DERIVED_PORTS > 65535:
-                port_base = dist_init_port - NUM_DERIVED_PORTS - 1
             else:
-                port_base = dist_init_port + 1
+                port_base = primary_port_base
 
             detokenizer_port = port_base + 1
             rpc_port = port_base + 2
@@ -1037,6 +1040,8 @@ class PortArgs:
                 scheduler_input_port = worker_ports[dp_rank]
 
             is_joiner = ep_joiner_of(resolving_view(server_args))
+            is_recovery_joiner = cfg.ep_join_mode == "recover"
+            tokenizer_port = primary_port_base if is_recovery_joiner else port_base
             # Under SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE, SGLang never binds
             # dist_init_port / nccl_port (rendezvous uses the externally-managed
             # store; see distributed/bootstrap.py:_resolve_dist_init_method), so
@@ -1048,9 +1053,10 @@ class PortArgs:
                 if dp_rank is None:
                     if not (is_joiner or dist_init_overridden):
                         wait_port_available(dist_init_port, "dist_init_port")
-                    wait_port_available(port_base, "port_base")
-                    wait_port_available(detokenizer_port, "detokenizer_port")
-                    if not dist_init_overridden:
+                    if not is_recovery_joiner:
+                        wait_port_available(port_base, "port_base")
+                        wait_port_available(detokenizer_port, "detokenizer_port")
+                    if not (is_recovery_joiner or dist_init_overridden):
                         wait_port_available(nccl_port, "nccl_port")
                     wait_port_available(rpc_port, "rpc_port")
                     wait_port_available(metrics_port, "metrics_port")
@@ -1058,7 +1064,9 @@ class PortArgs:
                         wait_port_available(load_collector_port, "load_collector_port")
                 # Check scheduler_input_port only for dp.
                 # Skip check when using worker_ports since the port is already bound by our ZMQ socket
-                if dp_rank is None or worker_ports is None:
+                if not is_recovery_joiner and (
+                    dp_rank is None or worker_ports is None
+                ):
                     wait_port_available(scheduler_input_port, "scheduler_input_port")
             except ValueError:
                 logger.exception(
@@ -1067,7 +1075,9 @@ class PortArgs:
                 raise
 
             return PortArgs(
-                tokenizer_ipc_name=NetworkAddress(dist_init_host, port_base).to_tcp(),
+                tokenizer_ipc_name=NetworkAddress(
+                    dist_init_host, tokenizer_port
+                ).to_tcp(),
                 scheduler_input_ipc_name=NetworkAddress(
                     dist_init_host, scheduler_input_port
                 ).to_tcp(),

--- a/test/registered/unit/eplb/test_expert_location_updater.py
+++ b/test/registered/unit/eplb/test_expert_location_updater.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.eplb.expert_location_updater import _update_expert_weights_raw
+
+
+def test_gpu_per_node_uses_original_ep_size_after_rank_failure():
+    old_metadata = MagicMock()
+    old_metadata.ep_size = 4
+    old_metadata.num_local_physical_experts = 2
+    old_metadata.physical_to_logical_map_cpu = torch.zeros((1, 8), dtype=torch.int64)
+
+    new_metadata = MagicMock()
+    new_metadata.physical_to_logical_map_cpu = torch.zeros((1, 8), dtype=torch.int64)
+
+    with (
+        patch("torch.distributed.get_world_size", return_value=3),
+        patch(
+            "sglang.srt.eplb.expert_location_updater.create_temp_buffers",
+            return_value=[],
+        ),
+        patch(
+            "sglang.srt.eplb.expert_location_updater.update_expert_weights_single_layer"
+        ) as update_single_layer,
+    ):
+        _update_expert_weights_raw(
+            routed_experts_weights_of_layer={0: [torch.empty(2)]},
+            old_expert_location_metadata=old_metadata,
+            new_expert_location_metadata=new_metadata,
+            update_layer_ids=[0],
+            nnodes=4,
+            rank=0,
+        )
+
+    assert update_single_layer.call_args.kwargs["world_size"] == 3
+    assert update_single_layer.call_args.kwargs["num_gpu_per_node"] == 1

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1323,6 +1323,38 @@ class TestPortArgs(unittest.TestCase):
 
         self.assertIn("Missing port", str(context.exception))
 
+    @patch("sglang.srt.server_args.wait_port_available")
+    def test_recovery_joiner_reports_to_primary_tokenizer(self, _mock_wait_port):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.port = 30000
+        server_args.nccl_port = 25010
+        server_args.enable_dp_attention = True
+        server_args.nnodes = 4
+        server_args.node_rank = 3
+        server_args.dist_init_addr = "192.168.1.1:25000"
+        server_args.ep_join_mode = "recover"
+
+        port_args = PortArgs.init_new(server_args)
+
+        self.assertEqual(port_args.tokenizer_ipc_name, "tcp://192.168.1.1:25001")
+        self.assertEqual(port_args.detokenizer_ipc_name, "tcp://192.168.1.1:30234")
+
+    @patch("sglang.srt.server_args.wait_port_available")
+    def test_scale_joiner_keeps_private_tokenizer_port(self, _mock_wait_port):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.port = 30000
+        server_args.nccl_port = 25010
+        server_args.enable_dp_attention = True
+        server_args.nnodes = 4
+        server_args.node_rank = 3
+        server_args.dist_init_addr = "192.168.1.1:25000"
+        server_args.ep_join_mode = "scale"
+
+        port_args = PortArgs.init_new(server_args)
+
+        self.assertEqual(port_args.tokenizer_ipc_name, "tcp://192.168.1.1:30233")
+        self.assertEqual(port_args.detokenizer_ipc_name, "tcp://192.168.1.1:30234")
+
     def test_init_new_with_malformed_ipv4_address_invalid_port(self):
         server_args = ServerArgs(model_path="dummy")
         server_args.port = 30000


### PR DESCRIPTION
## Motivation

Adapt Mooncake expert-parallel fault recovery so process-group membership, expert placement, buffer initialization, and joiner routing remain consistent after rank loss. This draft isolates the integration changes for review.

## Modifications

- Prepare recovery-joiner EP buffers without connecting during initialization and select BF16 dispatch for the BF16 override or Triton backend.
- Synchronize CPU and device Mooncake process-group membership before fault-triggered EPLB, with entry and exit barriers to keep survivors aligned.
- Use CPU active-rank snapshots for placement, preserve the original expert topology, and prefer surviving expert sources while retaining the missing-expert reload fallback.
- Route recovery-joiner output to primary endpoints and add expert-source and port regression coverage.

This branch contains one cherry-picked commit, `16666b6b8257f5fbd05e099b42e5643b4dd4347f`, from `ff3eb4e991e9c4b017175586b9d8e9a37f531196`, on main baseline `f3ccd1c0e42926e795a4304d50935b8cbd210169`. It excludes the FT control plane, DP-replica status correction, and fixed-topology metadata split. Cherry-picking required no conflict resolution; range-diff changes are surrounding context from removing the other commits.

The deferred buffer connection and membership recovery APIs require the matching Mooncake implementation (developed with mooncake-nohca-ft). Some changes, including expert-source selection and topology handling, apply beyond the noHCA transport. The original Qwen compatibility changes are already upstream and are not part of this diff. End-to-end fixed-topology recovery still requires the separate metadata fix.

## Accuracy Tests

No GPU tests have been run on this isolated branch. Earlier GPU passes exercised the combined stack before its main rebase and do not validate this PR. Commit scope, range-diff, and whitespace checks passed. Included regression tests have not been executed on this isolated branch.

## Speed Tests and Profiling

Not run.

## Checklist

- [ ] Complete formatting and CI checks.
- [ ] Validate against a compatible Mooncake build.
- [ ] Run the included regression tests and recovery integration tests.
- [ ] Complete documentation review and applicable accuracy/performance results.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34184538316](https://github.com/sgl-project/sglang/actions/runs/34184538316)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34184538137](https://github.com/sgl-project/sglang/actions/runs/34184538137)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34184538329](https://github.com/sgl-project/sglang/actions/runs/34184538329)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->