### PR TITLE
[Docs] Prefer --mm-feature-transport for multimodal CUDA IPC

### DIFF
--- a/docs/cookbook/autoregressive/GLM/GLM-4.5V.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.5V.mdx
@@ -39,7 +39,7 @@ import { GLM45VDeployment } from "/src/snippets/autoregressive/glm-45v-deploymen
 <GLM45VDeployment />
 
 ### 3.2 Configuration Tips
-- **TTFT Optimization** : Set `SGLANG_USE_CUDA_IPC_TRANSPORT=1` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
+- **TTFT Optimization** : Pass `--mm-feature-transport cuda_ipc` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
 - **TP=8 Configuration**: When using Tensor Parallelism (TP) of 8, the vision attention's 12 heads cannot be evenly divided. You can resolve this by adding `--mm-enable-dp-encoder`.
 - **Fast Model Loading**: For large models (like the 106B version), you can speed up model loading by using `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'`.
 - **Hardware Notes:**
@@ -48,12 +48,10 @@ import { GLM45VDeployment } from "/src/snippets/autoregressive/glm-45v-deploymen
   - **H200 / B200:** Runs out of the box, supporting full context length plus concurrent image + video processing.
 - **Additional Multimodal Parameters:**
   - `--mm-attention-backend fa3`: Specify multimodal attention backend (Flash Attention 3).
-  - `--keep-mm-feature-on-device`: Retain multimodal feature tensors on GPU after processing to avoid D2H memory copies.
-  - `SGLANG_USE_CUDA_IPC_TRANSPORT=1`: Use CUDA IPC shared memory for multimodal data transport to significantly improve E2E latency.
+  - `--mm-feature-transport cuda_ipc`: Keep multimodal feature tensors on a bounded CUDA IPC pool to avoid D2H copies and improve E2E latency (replaces deprecated `--keep-mm-feature-on-device` / `SGLANG_USE_CUDA_IPC_TRANSPORT`).
 
 **Example with full multimodal optimizations:**
 ```bash Command
-SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
 SGLANG_VLM_CACHE_SIZE_MB=0 \
 python -m sglang.launch_server \
   --model-path zai-org/GLM-4.5V \
@@ -69,6 +67,7 @@ python -m sglang.launch_server \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
   --mm-enable-dp-encoder \
+  --mm-feature-transport cuda_ipc \
   --enable-metrics
 ```
 

--- a/docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx
@@ -67,7 +67,7 @@ import { GLM46VDeployment } from "/src/snippets/autoregressive/glm-46v-deploymen
 <GLM46VDeployment />
 
 ### 3.2 Configuration Tips
-- **TTFT Optimization** : Set `SGLANG_USE_CUDA_IPC_TRANSPORT=1` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
+- **TTFT Optimization** : Pass `--mm-feature-transport cuda_ipc` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
 - **TP=8 Configuration**: When using Tensor Parallelism (TP) of 8, the vision attention's 12 heads cannot be evenly divided. You can resolve this by adding `--mm-enable-dp-encoder` (which the generator above handles automatically).
 - **Fast Model Loading**: For large models (like the 106B version), you can speed up model loading by using `--model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'`.
 - **Hardware Notes:**
@@ -76,12 +76,10 @@ import { GLM46VDeployment } from "/src/snippets/autoregressive/glm-46v-deploymen
   - **H200 / B200:** Runs out of the box, supporting full context length plus concurrent image + video processing.
 - **Additional Multimodal Parameters:**
   - `--mm-attention-backend fa3`: Specify multimodal attention backend (Flash Attention 3).
-  - `--keep-mm-feature-on-device`: Retain multimodal feature tensors on GPU after processing to avoid D2H memory copies.
-  - `SGLANG_USE_CUDA_IPC_TRANSPORT=1`: Use CUDA IPC shared memory for multimodal data transport to significantly improve E2E latency.
+  - `--mm-feature-transport cuda_ipc`: Keep multimodal feature tensors on a bounded CUDA IPC pool to avoid D2H copies and improve E2E latency (replaces deprecated `--keep-mm-feature-on-device` / `SGLANG_USE_CUDA_IPC_TRANSPORT`).
 
 **Example with full multimodal optimizations:**
 ```bash Command
-SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
 SGLANG_VLM_CACHE_SIZE_MB=0 \
 python -m sglang.launch_server \
   --model-path zai-org/GLM-4.6V \
@@ -97,6 +95,7 @@ python -m sglang.launch_server \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
   --mm-enable-dp-encoder \
+  --mm-feature-transport cuda_ipc \
   --enable-metrics
 ```
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3-VL.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-VL.mdx
@@ -45,7 +45,7 @@ import { Qwen3VLDeployment } from "/src/snippets/autoregressive/qwen3-vl-deploym
 ### 3.2 Configuration Tips
 
 * **Multimodal attention backend** : Usually, `--mm-attention-backend` is default to `fa3` on H100/H200/A100 for better performance, but it is default to `triton_attn` on B200 for compatibility.
-* **TTFT Optimization** : Set `SGLANG_USE_CUDA_IPC_TRANSPORT=1` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
+* **TTFT Optimization** : Pass `--mm-feature-transport cuda_ipc` to use CUDA IPC for transferring multimodal features, which significantly improves TTFT. This consumes additional memory and may require adjusting `--mem-fraction-static` and/or `--max-running-requests`. (additional memory is proportional to image size * number of images in current running requests.)
 * **Memory Management** : Set lower `--context-length` to conserve memory. A value of `128000` is sufficient for most scenarios, down from the default 262K.
 * **Expert Parallelism** : SGLang supports Expert Parallelism (EP) via `--ep`, allowing experts in MoE models to be deployed on separate GPUs for better throughput. One thing to note is that, for quantized models, you need to set `--ep` to a value that satisfies the requirement: `(moe_intermediate_size / moe_tp_size) % weight_block_size_n == 0, where moe_tp_size is equal to tp_size divided by ep_size.` Note that EP may perform worse in low concurrency scenarios due to additional communication overhead. Check out [Expert Parallelism Deployment](../../../docs/advanced_features/expert_parallelism) for more details.
 * **Kernel Tuning** : For MoE Triton kernel tuning on your specific hardware, refer to [fused_moe_triton](https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton).
@@ -56,11 +56,10 @@ import { Qwen3VLDeployment } from "/src/snippets/autoregressive/qwen3-vl-deploym
 - **H200 / B200:** Runs out of the box, supporting full context length plus concurrent image + video processing.
 
 **Additional multimodal server parameters:**
-- `--keep-mm-feature-on-device`: Retain multimodal feature tensors on GPU after processing to avoid device-to-host memory copies, improving performance for high-frequency inference.
+- `--mm-feature-transport cuda_ipc`: Keep multimodal feature tensors on a bounded CUDA IPC pool to avoid device-to-host memory copies, improving performance for high-frequency inference.
 
 **Example with full multimodal optimizations:**
 ```bash Command
-SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
 SGLANG_VLM_CACHE_SIZE_MB=0 \
 python -m sglang.launch_server \
   --model-path Qwen/Qwen3-VL-235B-A22B-Instruct \
@@ -75,6 +74,7 @@ python -m sglang.launch_server \
   --chunked-prefill-size 8192 \
   --attention-backend fa3 \
   --mm-attention-backend fa3 \
+  --mm-feature-transport cuda_ipc \
   --enable-metrics
 ```
 
@@ -600,16 +600,17 @@ Max ITL (ms):                            31.92
 
 **Optimized Results (with CUDA IPC Transport):**
 
-For further TTFT optimization, enable CUDA IPC Transport for multimodal features by setting `SGLANG_USE_CUDA_IPC_TRANSPORT=1`. This significantly reduces TTFT by using CUDA IPC for transferring multimodal features.
+For further TTFT optimization, enable CUDA IPC transport for multimodal features with `--mm-feature-transport cuda_ipc`. This significantly reduces TTFT by using CUDA IPC for transferring multimodal features.
 
 - Model Deployment Command:
 
 ```shell Command
-SGLANG_USE_CUDA_IPC_TRANSPORT=1 python -m sglang.launch_server \
+python -m sglang.launch_server \
   --model Qwen/Qwen3-VL-235B-A22B-Instruct \
   --tp 8 \
   --host 0.0.0.0 \
-  --port 30000
+  --port 30000 \
+  --mm-feature-transport cuda_ipc
 ```
 
 - Benchmark Command:
@@ -631,7 +632,7 @@ python3 -m sglang.bench_serving \
 
 - **Test Results:**
 
-  With `SGLANG_USE_CUDA_IPC_TRANSPORT=1`, TTFT improves significantly:
+  With `--mm-feature-transport cuda_ipc`, TTFT improves significantly:
 
 ```text Output
 ============ Serving Benchmark Result ============

--- a/docs/docs/sglang-diffusion/disaggregation.mdx
+++ b/docs/docs/sglang-diffusion/disaggregation.mdx
@@ -226,7 +226,7 @@ sglang serve \
   --cuda-graph-max-bs 28 \
   --device npu \
   --attention-backend ascend \
-  --disable-fast-image-processor \
+  --image-processor-backend pil \
   --tp-size 2 \
   --host 0.0.0.0 \
   --port 30020 \

--- a/docs/docs/supported-models/multimodal_language_models.mdx
+++ b/docs/docs/supported-models/multimodal_language_models.mdx
@@ -404,10 +404,12 @@ sglang serve \
 
 ### Performance Optimization
 
-For multimodal models, you can use the `--keep-mm-feature-on-device` flag to optimize for latency at the cost of increased GPU memory usage:
+For multimodal models, prefer `--mm-feature-transport cuda_ipc` to optimize for latency at the cost of increased GPU memory usage:
 
-- **Default behavior**: Multimodal feature tensors are moved to CPU after processing to save GPU memory
-- **With `--keep-mm-feature-on-device`**: Feature tensors remain on GPU, reducing device-to-host copy overhead and improving latency, but consuming more GPU memory
+- **Default / auto behavior**: Multimodal feature tensors typically use CPU transport to save GPU memory
+- **With `--mm-feature-transport cuda_ipc`**: Feature tensors stay on a bounded CUDA IPC pool, reducing device-to-host copy overhead and improving latency, but reserving GPU memory for the pool
+
+(`--keep-mm-feature-on-device` and `SGLANG_USE_CUDA_IPC_TRANSPORT` remain deprecated aliases for the same cuda_ipc policy.)
 
 Use this flag when you have sufficient GPU memory and want to minimize latency for multimodal inference.
 


### PR DESCRIPTION
## Summary
Docs still recommend deprecated multimodal CUDA IPC knobs (`--keep-mm-feature-on-device`, `SGLANG_USE_CUDA_IPC_TRANSPORT`) and one `--disable-fast-image-processor` example. Current SGLang maps the IPC aliases to `--mm-feature-transport=cuda_ipc` and the image-processor alias to `--image-processor-backend=pil`.

This change-set updates user-facing multimodal docs/cookbooks to prefer the current CLIs (leaves `server_arguments.mdx` / Ascend support tables that intentionally list deprecated flags alone).

## Repro
```bash
# Source: deprecated keep_mm_feature_on_device maps to cuda_ipc
rg -n 'keep_mm_feature_on_device|mm-feature-transport=cuda_ipc' \
  python/sglang/srt/arg_groups/serving_hook.py

# Source: disable_fast_image_processor maps to image-processor-backend=pil
rg -n 'disable_fast_image_processor|image-processor-backend=pil' \
  python/sglang/srt/arg_groups/serving_hook.py python/sglang/srt/arg_groups/fields/mm.py

# Docs still recommended the old knobs on main before this PR:
rg -n 'keep-mm-feature-on-device|SGLANG_USE_CUDA_IPC_TRANSPORT' \
  docs/docs/supported-models/multimodal_language_models.mdx \
  docs/cookbook/autoregressive/Qwen/Qwen3-VL.mdx \
  docs/cookbook/autoregressive/GLM/GLM-4.5V.mdx \
  docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx
rg -n 'disable-fast-image-processor' docs/docs/sglang-diffusion/disaggregation.mdx
```

## Files
- `docs/docs/supported-models/multimodal_language_models.mdx`
- `docs/cookbook/autoregressive/Qwen/Qwen3-VL.mdx`
- `docs/cookbook/autoregressive/GLM/GLM-4.5V.mdx`
- `docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx`
- `docs/docs/sglang-diffusion/disaggregation.mdx`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34184771788](https://github.com/sgl-project/sglang/actions/runs/34184771788)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34184771614](https://github.com/sgl-project/sglang/actions/runs/34184771614)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->