### PR TITLE
[AMD] [Docker] Update MoRI to v1.2.3

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -398,7 +398,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="7c51d18fda59457cc9238ed262bd93c8cad906c9"
+ARG MORI_COMMIT="879983bdbd8c65c52e9f79ad836a61cbffef98b6"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).


### PR DESCRIPTION
## Summary

This PR upgrades the MoRI version used by the ROCm Docker image from `7c51d18fda59457cc9238ed262bd93c8cad906c9` to the exact commit corresponding to the `v1.2.3` tag: `879983bdbd8c65c52e9f79ad836a61cbffef98b6`.

The Dockerfile uses the full commit SHA instead of the tag name to keep the build reproducible.

## Test plan

- Verified `refs/tags/v1.2.3^{}` resolves to `879983bdbd8c65c52e9f79ad836a61cbffef98b6`.
- Verified the previous pin is an ancestor of the new pin.
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34185041586](https://github.com/sgl-project/sglang/actions/runs/34185041586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34185041405](https://github.com/sgl-project/sglang/actions/runs/34185041405)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34185041545](https://github.com/sgl-project/sglang/actions/runs/34185041545)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->