### PR TITLE
fix(server_args): resolve --speculative-algorithm before DeepSeek-V4 matches it

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -145,14 +145,28 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
 
     if cfg.speculative_algorithm is not None:
-        assert cfg.speculative_algorithm in (
-            "EAGLE",
-            "DSPARK",
+        # Resolve before comparing. This handler runs from
+        # handle_model_specific_adjustments, well before handle_speculative_decoding
+        # case-folds the field and collapses the NEXTN alias, so the raw CLI string
+        # arrives here unnormalized: "NEXTN" and "eagle" would both fail the membership
+        # test even though both mean EAGLE. SpeculativeAlgorithm.from_string is the
+        # same resolution the speculative hook eventually applies.
+        # Lazy import to avoid a circular import at module scope.
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        algorithm = SpeculativeAlgorithm.from_string(cfg.speculative_algorithm)
+        assert algorithm in (
+            SpeculativeAlgorithm.EAGLE,
+            SpeculativeAlgorithm.DSPARK,
         ), (
             f"Only EAGLE and DSPARK speculative algorithms are supported for {model_arch}"
         )
-        if cfg.speculative_algorithm == "EAGLE":
-            assert cfg.speculative_eagle_topk == 1, (
+        if algorithm is SpeculativeAlgorithm.EAGLE:
+            # None is the unset default; handle_speculative_decoding fills it with 1
+            # later (speculative_hook.py, `if cfg.speculative_eagle_topk is None`), so
+            # rejecting None here would reject a valid command line that simply omits
+            # --speculative-eagle-topk.
+            assert cfg.speculative_eagle_topk in (None, 1), (
                 f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
             )
 

--- a/test/registered/unit/spec/test_deepseek_v4_spec_algorithm_alias.py
+++ b/test/registered/unit/spec/test_deepseek_v4_spec_algorithm_alias.py
@@ -1,0 +1,84 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.arg_groups.deepseek_v4_hook import apply_deepseek_v4_defaults
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_MODEL_ARCH = "DeepseekV4ForCausalLM"
+
+
+def _make_v4_args(algorithm, **overrides) -> ServerArgs:
+    # model_path="dummy" short-circuits ServerArgs.__post_init__; invoke the model
+    # hook directly (same pattern as test_spec_cpu_overlap_constraint.py). The
+    # injected _model_config carries no _model_config_built_from key, so
+    # model_config_of hands it back instead of loading a checkpoint.
+    args = ServerArgs(model_path="dummy")
+    args.speculative_algorithm = algorithm
+    args.speculative_num_steps = 2
+    args.speculative_eagle_topk = 1
+    args.speculative_num_draft_tokens = 3
+    args._model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=[_MODEL_ARCH],
+            get_text_config=lambda: SimpleNamespace(),
+        )
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class TestDeepseekV4SpeculativeAlgorithmAlias(CustomTestCase):
+    """apply_deepseek_v4_defaults must resolve the algorithm name before matching it.
+
+    It runs from handle_model_specific_adjustments, well before
+    handle_speculative_decoding case-folds --speculative-algorithm and collapses the
+    NEXTN alias, so the raw CLI string reaches it. Matching that string literally
+    rejected three valid command lines (issue #38236).
+    """
+
+    def test_nextn_alias_is_accepted(self):
+        # The reported bug: NEXTN is a documented EAGLE alias.
+        apply_deepseek_v4_defaults(_make_v4_args("NEXTN"), _MODEL_ARCH)
+
+    def test_lowercase_algorithm_is_accepted(self):
+        # The same root cause: .upper() also happens in the later hook.
+        apply_deepseek_v4_defaults(_make_v4_args("eagle"), _MODEL_ARCH)
+        apply_deepseek_v4_defaults(_make_v4_args("nextn"), _MODEL_ARCH)
+
+    def test_unset_eagle_topk_is_accepted(self):
+        # None is the unset default; the later hook fills it with 1, so rejecting it
+        # here rejects a command line that simply omits --speculative-eagle-topk.
+        apply_deepseek_v4_defaults(
+            _make_v4_args("EAGLE", speculative_eagle_topk=None), _MODEL_ARCH
+        )
+
+    def test_supported_algorithms_still_pass(self):
+        apply_deepseek_v4_defaults(_make_v4_args("EAGLE"), _MODEL_ARCH)
+        apply_deepseek_v4_defaults(
+            _make_v4_args("DSPARK", speculative_eagle_topk=None), _MODEL_ARCH
+        )
+
+    def test_topk_guard_stays_live_through_the_alias(self):
+        # Resolving the name must not silence the topk check: accepting "NEXTN"
+        # without resolving it would let a bad topk through unnoticed.
+        for algorithm in ("EAGLE", "NEXTN", "nextn"):
+            with self.subTest(algorithm=algorithm):
+                args = _make_v4_args(algorithm, speculative_eagle_topk=2)
+                with self.assertRaisesRegex(AssertionError, "topk == 1"):
+                    apply_deepseek_v4_defaults(args, _MODEL_ARCH)
+
+    def test_unsupported_algorithms_are_still_rejected(self):
+        for algorithm in ("EAGLE3", "DFLASH"):
+            with self.subTest(algorithm=algorithm):
+                args = _make_v4_args(algorithm)
+                with self.assertRaisesRegex(AssertionError, "EAGLE and DSPARK"):
+                    apply_deepseek_v4_defaults(args, _MODEL_ARCH)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #38236, and two further failures with the same root cause that the issue did not cover.

`apply_deepseek_v4_defaults` runs from `handle_model_specific_adjustments` (pipeline.py:233). The
`--speculative-algorithm` string is case-folded and the `NEXTN` alias collapsed in
`handle_speculative_decoding` (pipeline.py:312), and `--speculative-eagle-topk` gets its default of 1
there too. So this handler matches the raw CLI string against `("EAGLE", "DSPARK")` and compares an
option that has not been defaulted yet.

Probed on `main` at 20ca564 by calling the handler directly — no GPU, no weights:

| `--speculative-algorithm` | `--speculative-eagle-topk` | before | after |
|---|---|---|---|
| `NEXTN` | 1 | `AssertionError: Only EAGLE and DSPARK ... supported` | ok |
| `eagle` | 1 | `AssertionError: Only EAGLE and DSPARK ... supported` | ok |
| `EAGLE` | unset | `AssertionError: Only EAGLE ... with topk == 1 ...` | ok |
| `EAGLE` | 1 | ok | ok |
| `DSPARK` | unset | ok | ok |

Row 1 is the reported bug: `NEXTN` is a documented EAGLE alias
(`SpeculativeAlgorithm.from_string` collapses it via `_RESERVED_ALIASES`), so the value is valid and
resolves to `EAGLE` seventy-odd pipeline lines later.

Row 3 is worth calling out because it makes the reported bug harder to work around than it looks:
`--speculative-algorithm EAGLE` with no `--speculative-eagle-topk` is a valid command line — the
later hook fills the field with 1 (`if cfg.speculative_eagle_topk is None`) — but this handler
rejects `None`. Since `EAGLE` is the natural workaround for #38236, a user who hits the alias bug and
switches to `EAGLE` lands on this one unless they also pass `--speculative-eagle-topk 1`.

## Modifications

Resolve at the point of use instead of matching the raw string, using the project's own
`SpeculativeAlgorithm.from_string` — the same resolution the speculative hook eventually applies, so
there is one definition of what a name means:

- compare `SpeculativeAlgorithm.from_string(cfg.speculative_algorithm)` against
  `SpeculativeAlgorithm.EAGLE` / `SpeculativeAlgorithm.DSPARK`;
- keep the `topk` guard on the *resolved* value, and accept the unset default with
  `in (None, 1)`.

Imported lazily inside the function to avoid a circular import at module scope, matching the pattern
already used for `ModelConfig` in `model_config_of`.

Adds `test/registered/unit/spec/test_deepseek_v4_spec_algorithm_alias.py`, following
`test_spec_cpu_overlap_constraint.py`: `ServerArgs(model_path="dummy")` with an injected
`_model_config`, calling the handler directly. CPU CI, no GPU, no weights.

**Considered and not done:** hoisting the whole alias resolution ahead of the model hooks. Two
reasons. `_resolve_speculative_algorithm_alias` is not a string map — when
`speculative_draft_model_path` is set it calls `get_config(...)`, which reads GGUF files, can pull a
remote directory, and ends in `AutoConfig.from_pretrained(..., trust_remote_code=...)`; moving that
earlier moves disk/network I/O and a remote-code-execution surface toward the dummy-model boundary
that pipeline.py's principle 2 protects. And normalizing the field before
`handle_model_specific_adjustments` would silently change three other readers inside it —
`model_overrides/mimo_v2.py` and `overrides.py::_step3p_overrides` gate
`enable_multi_layer_eagle=True` on `== "EAGLE"`, which selects a different speculative worker class
— so `NEXTN` on those families would flip from single-layer to multi-layer EAGLE with no diagnostic.
Fixing at the point of use keeps the blast radius equal to the bug.

**One behaviour change to flag:** an unrecognised name now surfaces as
`ValueError: Unknown speculative algorithm name: <x>` from `from_string`, rather than the
`Only EAGLE and DSPARK ...` assertion. More accurate for a name that is not an algorithm at all, but
it is a different error message.

## Accuracy Tests

Not applicable — argument resolution only, no kernel or forward-pass change. Every accepted
configuration resolves to the same algorithm the speculative hook would have produced anyway.

Test evidence, `test/registered/unit/spec/test_deepseek_v4_spec_algorithm_alias.py` on 20ca564:

```
without the fix:  5 failed, 3 passed, 3 subtests passed
with the fix:     6 passed, 5 subtests passed in 69.51s
```

The failures without the fix are exactly `test_nextn_alias_is_accepted`,
`test_lowercase_algorithm_is_accepted`, `test_unset_eagle_topk_is_accepted`, and the `NEXTN` /
`nextn` subtests of `test_topk_guard_stays_live_through_the_alias` (which raise the *wrong*
assertion before the fix). Negative controls are part of the test: `topk=2` must still be rejected
for `EAGLE`, `NEXTN` and `nextn`, and `EAGLE3` / `DFLASH` must still be rejected for this
architecture. The `nextn` + `topk=2` case is the one that would regress if the alias were simply
added to the accepted tuple without resolving it — the topk guard would stop firing.

## Speed Tests and Profiling

Not applicable — startup-time argument resolution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- no user-facing behaviour to document: this makes a documented alias work as documented -->
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- not applicable, see the two sections above -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34185180815](https://github.com/sgl-project/sglang/actions/runs/34185180815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34185180793](https://github.com/sgl-project/sglang/actions/runs/34185180793)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34185180871](https://github.com/sgl-project/sglang/actions/runs/34185180871)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->