### PR TITLE
[Docs] Drop ghost prefill-CP and custom-sigquit rows from server arguments

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -781,12 +781,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--custom-sigquit-handler`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Register a custom sigquit handler so you can do additional cleanup after the server is shutdown. This is only available for Engine, not for CLI.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--batch-notify-size`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of streaming notifications to batch before yielding to the event loop. Reduces asyncio wakeup overhead under high concurrency.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`16`</td>
@@ -2882,42 +2876,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable scheduler-side attn_tp_gather (the upstream SP path that pads num_tokens to attn_tp_size and pre-allocates a gathered buffer). Use for models that manage SP scatter/gather at the model level (e.g., perform their own all_gather/reduce_scatter inside attention) and do not consume the upstream gathered_buffer. Without this, the cuda graph runner pads num_tokens to attn_tp_size, which can cause kernel autotuners to select wrong-sized variants at small batches.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-dsa-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-nsa-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsa-prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy &#123;zigzag,interleave&#125; instead. 'in-seq-split' maps to 'zigzag'; 'round-robin-split' maps to 'interleave'.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`round-robin-split`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code>, <code>round-robin-split</code></td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--nsa-prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code>, <code>round-robin-split</code></td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy &#123;zigzag,interleave&#125; instead. 'in-seq-split' maps to 'zigzag'.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`in-seq-split`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-fused-moe-sum-all-reduce`</td>


### PR DESCRIPTION
## Summary
`docs/docs/advanced_features/server_arguments.mdx` still listed several prefill context-parallel CLI spellings that are not live argparse flags, plus a `--custom-sigquit-handler` row for an Engine-only field that has no CLI annotation. Live prefill-CP CLI is only `--enable-prefill-cp` and `--cp-strategy {zigzag,interleave}`.

## Repro
Against current `main`:

```bash
# Docs still list ghost / non-CLI rows
gh api repos/sgl-project/sglang/contents/docs/docs/advanced_features/server_arguments.mdx \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n 'enable-dsa-prefill-context-parallel|enable-nsa-prefill-context-parallel|enable-prefill-context-parallel|dsa-prefill-cp-mode|nsa-prefill-cp-mode|`--prefill-cp-mode`|custom-sigquit-handler'

# Live prefill-CP fields (CLI via A[...]) are only enable_prefill_cp / cp_strategy
gh api repos/sgl-project/sglang/contents/python/sglang/srt/arg_groups/fields/parallel.py \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n -A6 'enable_prefill_cp:|cp_strategy:'

# Ghost spellings are absent from server_args argparse text
gh api repos/sgl-project/sglang/contents/python/sglang/srt/server_args.py \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n 'enable-dsa-prefill-context-parallel|enable-nsa-prefill-context-parallel|enable-prefill-context-parallel|dsa-prefill-cp-mode|nsa-prefill-cp-mode|custom-sigquit' \
  || echo 'no matches'

# custom_sigquit_handler exists without A[...] (not a CLI flag)
gh api repos/sgl-project/sglang/contents/python/sglang/srt/arg_groups/fields/device.py \
  -H 'Accept: application/vnd.github.raw' \
  | rg -n -C1 'custom_sigquit_handler'
```

## Change
In `docs/docs/advanced_features/server_arguments.mdx` only:
- Delete ghost rows: `--enable-dsa-prefill-context-parallel`, `--enable-nsa-prefill-context-parallel`, `--enable-prefill-context-parallel`, `--dsa-prefill-cp-mode`, `--nsa-prefill-cp-mode`, `--prefill-cp-mode`
- Delete `--custom-sigquit-handler` row (Engine-only field, no CLI)
- Keep existing `--enable-prefill-cp` / `--cp-strategy` rows

## Test plan
- [x] Confirmed live fields in `parallel.py` / no ghost strings in `server_args.py`
- [x] Confirmed `custom_sigquit_handler` has no `A[...]` annotation in `device.py`
- [x] Diff limited to `server_arguments.mdx`
- [ ] Docs preview / maintainer glance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34185375960](https://github.com/sgl-project/sglang/actions/runs/34185375960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34185375697](https://github.com/sgl-project/sglang/actions/runs/34185375697)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->