### PR TITLE
Fix expert-pack MXFP4 test timeout

### DIFF
--- a/test/registered/expert_pack/test_expert_pack_mxfp4.py
+++ b/test/registered/expert_pack/test_expert_pack_mxfp4.py
@@ -1,5 +1,10 @@
 """CUDA unit tests for the MXFP4 expert-pack kernels."""
 
+import os
+import signal
+import subprocess
+import sys
+import tempfile
 import unittest
 
 import torch
@@ -11,7 +16,12 @@ from sglang.kernels.ops.moe.expert_pack_mxfp4 import (
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=7, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-small")
+
+
+_ISOLATED_WORKER_ENV = "SGLANG_EXPERT_PACK_MXFP4_TEST_WORKER"
+_ISOLATED_ATTEMPTS = 2
+_ISOLATED_TIMEOUT_SECONDS = 240
 
 
 _FP4_VALUES = (
@@ -356,5 +366,43 @@ class TestExpertPackMxfp4(unittest.TestCase):
             )
 
 
+def _run_isolated_tests() -> int:
+    """Bound JIT extension loading and avoid locks shared with prior CI jobs."""
+
+    command = [sys.executable, os.path.abspath(__file__), *sys.argv[1:]]
+    for attempt in range(1, _ISOLATED_ATTEMPTS + 1):
+        with tempfile.TemporaryDirectory(
+            prefix="sglang_expert_pack_mxfp4_test_"
+        ) as extension_dir:
+            env = os.environ.copy()
+            env[_ISOLATED_WORKER_ENV] = "1"
+            env["TORCH_EXTENSIONS_DIR"] = extension_dir
+            process = subprocess.Popen(command, env=env, start_new_session=True)
+            try:
+                return_code = process.wait(timeout=_ISOLATED_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                print(
+                    f"MXFP4 test worker timed out after "
+                    f"{_ISOLATED_TIMEOUT_SECONDS}s (attempt {attempt}/"
+                    f"{_ISOLATED_ATTEMPTS}); terminating its process group.",
+                    flush=True,
+                )
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+                if attempt < _ISOLATED_ATTEMPTS:
+                    print(
+                        "Retrying with a fresh Torch extension build directory.",
+                        flush=True,
+                    )
+                continue
+
+            # Retry only hangs. Preserve genuine test and compilation failures.
+            return return_code
+
+    return 1
+
+
 if __name__ == "__main__":
-    unittest.main()
+    if os.getenv(_ISOLATED_WORKER_ENV) == "1":
+        unittest.main()
+    raise SystemExit(_run_isolated_tests())


### PR DESCRIPTION
[by Codex]

## Summary

- run the MXFP4 expert-pack unittest body in an isolated subprocess group
- use a fresh `TORCH_EXTENSIONS_DIR` for each attempt so stale JIT compilation locks cannot be inherited from prior CI jobs
- terminate the whole process group after 240 seconds and retry a timeout once with another fresh build directory
- preserve genuine test or compilation failures without retrying them
- restore the test estimate to 90 seconds to account for cold extension compilation during partitioning

Closes #38408.

## Motivation

Multiple unrelated H200 CI jobs have hung before the first unittest result while lazily loading `sglang_expert_pack_mxfp4`. The same commit can complete the file in about 6 seconds on rerun. Evidence and the upstream PyTorch stale-lock issue are documented in #38408.

## Validation

- `python3 -m py_compile test/registered/expert_pack/test_expert_pack_mxfp4.py`
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`

The targeted CUDA test was not run locally because the VM host Python does not have PyTorch; GPU validation is left to normal PR CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34812316339](https://github.com/sgl-project/sglang/actions/runs/34812316339)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34824105009](https://github.com/sgl-project/sglang/actions/runs/34824105009)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34812316207](https://github.com/sgl-project/sglang/actions/runs/34812316207)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->