### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3.6 / Qwen3-8-Max guides

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx
@@ -96,7 +96,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 60 \
     --max-mamba-cache-size 60 \
     --mem-fraction-static 0.74 \
-    --cuda-graph-bs 2 4 8 14 16 24 26 32 36 37 40 42 44 45 46 50 52 60 \
+    --cuda-graph-bs-decode 2 4 8 14 16 24 26 32 36 37 40 42 44 45 46 50 52 60 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -194,7 +194,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 38 \
     --max-mamba-cache-size 38 \
     --mem-fraction-static 0.7 \
-    --cuda-graph-bs 1 2 4 8 10 12 16 20 24 28 30 32 35 38 \
+    --cuda-graph-bs-decode 1 2 4 8 10 12 16 20 24 28 30 32 35 38 \
     --enable-prefill-delayer \
     --prefill-delayer-queue-min-ratio 0.45 \
     --prefill-delayer-max-delay-ms 5500 \
@@ -297,7 +297,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 20 \
     --max-mamba-cache-size 160 \
     --mem-fraction-static 0.82 \
-    --cuda-graph-bs 1 2 5 10 15 17 19 20 \
+    --cuda-graph-bs-decode 1 2 5 10 15 17 19 20 \
     --dtype bfloat16 \
     --mamba-ssm-dtype bfloat16 \
     --speculative-algorithm NEXTN \
@@ -397,7 +397,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 64 \
     --max-mamba-cache-size 74 \
     --mem-fraction-static 0.7 \
-    --cuda-graph-bs 2 8 16 32 40 45 50 54 \
+    --cuda-graph-bs-decode 2 8 16 32 40 45 50 54 \
     --enable-multimodal \
     --quantization modelslim \
     --mm-attention-backend ascend_attn \
@@ -491,7 +491,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 6 \
     --max-mamba-cache-size 16 \
     --mem-fraction-static 0.6 \
-    --cuda-graph-bs 1 2 4 5 6 \
+    --cuda-graph-bs-decode 1 2 4 5 6 \
     --quantization modelslim \
     --dtype bfloat16 \
     --mamba-ssm-dtype bfloat16 \
@@ -587,7 +587,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 6 \
     --max-mamba-cache-size 7 \
     --mem-fraction-static 0.63 \
-    --cuda-graph-bs 1 2 4 5 6 \
+    --cuda-graph-bs-decode 1 2 4 5 6 \
     --enable-multimodal \
     --quantization modelslim \
     --mm-attention-backend ascend_attn \
@@ -682,7 +682,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 37 \
     --max-mamba-cache-size 74 \
     --mem-fraction-static 0.7 \
-    --cuda-graph-bs 1 2 3 4 6 8 10 12 14 16 18 20 21 23 24 25 26 27 28 29 30 31 33 35 37 \
+    --cuda-graph-bs-decode 1 2 3 4 6 8 10 12 14 16 18 20 21 23 24 25 26 27 28 29 30 31 33 35 37 \
     --quantization modelslim \
     --dtype bfloat16 \
     --mamba-ssm-dtype bfloat16 \
@@ -779,7 +779,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 28 \
     --max-mamba-cache-size 50 \
     --mem-fraction-static 0.7 \
-    --cuda-graph-bs 2 4 6 \
+    --cuda-graph-bs-decode 2 4 6 \
     --enable-multimodal \
     --quantization modelslim \
     --mm-attention-backend ascend_attn \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx
@@ -103,7 +103,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 120 \
     --max-mamba-cache-size 120 \
     --mem-fraction-static 0.85 \
-    --cuda-graph-bs 4 16 32 48 64 110 165 \
+    --cuda-graph-bs-decode 4 16 32 48 64 110 165 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -205,7 +205,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 42 \
     --max-mamba-cache-size 42 \
     --mem-fraction-static 0.75 \
-    --cuda-graph-bs 4 8 16 24 48 64 80 \
+    --cuda-graph-bs-decode 4 8 16 24 48 64 80 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -308,7 +308,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 3 \
     --max-mamba-cache-size 3 \
     --mem-fraction-static 0.9 \
-    --cuda-graph-bs 1 2 3 \
+    --cuda-graph-bs-decode 1 2 3 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -406,7 +406,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 103 \
     --max-mamba-cache-size 85 \
     --mem-fraction-static 0.85 \
-    --cuda-graph-bs 2 4 8 16 32 48 64 80 96 103 \
+    --cuda-graph-bs-decode 2 4 8 16 32 48 64 80 96 103 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -507,7 +507,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 1 \
     --max-mamba-cache-size 6 \
     --mem-fraction-static 0.65 \
-    --cuda-graph-bs 1 \
+    --cuda-graph-bs-decode 1 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -606,7 +606,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 122 \
     --max-mamba-cache-size 122 \
     --mem-fraction-static 0.9 \
-    --cuda-graph-bs 4 16 32 64 96 116 120 122 \
+    --cuda-graph-bs-decode 4 16 32 64 96 116 120 122 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -705,7 +705,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 10 \
     --max-mamba-cache-size 20 \
     --mem-fraction-static 0.65 \
-    --cuda-graph-bs 2 4 8 12 14 16 \
+    --cuda-graph-bs-decode 2 4 8 12 14 16 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -804,7 +804,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 40 \
     --max-mamba-cache-size 200 \
     --mem-fraction-static 0.9 \
-    --cuda-graph-bs 2 8 16 24 32 36 40 \
+    --cuda-graph-bs-decode 2 8 16 24 32 36 40 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \
@@ -906,7 +906,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 1 \
     --max-mamba-cache-size 6 \
     --mem-fraction-static 0.68 \
-    --cuda-graph-bs 1 \
+    --cuda-graph-bs-decode 1 \
     --enable-multimodal \
     --mm-attention-backend ascend_attn \
     --dtype bfloat16 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_27b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_27b.mdx
@@ -26,7 +26,7 @@ v0.5.16 or a later version.
 | Tensor Parallelism            | `--tp-size 2`                                                                                 |
 | Quantization                  | `--quantization modelslim`                                                                    |
 | Chunked Prefill               | auto based on device memory, or set explicit value;<br/>disable with `--chunked-prefill-size -1`; e.g., `--chunked-prefill-size 32768` |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 2 8 16 32 48` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 2 8 16 32 48` |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_8_max.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_8_max.mdx
@@ -28,7 +28,7 @@ source.
 | Expert Parallelism            | `--moe-a2a-backend deepep \`<br/>`--deepep-mode auto`                                    |
 | Quantization                  | `--quantization modelslim`                                                                    |
 | Chunked Prefill               | auto based on device memory, or set explicit value;<br/>disable with `--chunked-prefill-size -1`; e.g., `--chunked-prefill-size 8192` |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 16` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 16` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |
 
@@ -215,7 +215,7 @@ do
             --enable-dp-attention --dp-size 4 --enable-dp-lm-head \
             --mem-fraction-static 0.8 \
             --chunked-prefill-size 8192 \
-            --cuda-graph-bs 16 \
+            --cuda-graph-bs-decode 16 \
             --disable-radix-cache \
             --max-running-requests 64 \
             --host 0.0.0.0 \


### PR DESCRIPTION
### What

In Ascend Qwen3.6 / Qwen3-8-Max best-practices and tutorials, prefer current CUDA graph CLIs:

- `--cuda-graph-bs` → `--cuda-graph-bs-decode`
- `--disable-cuda-graph` → `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled`

Files:
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_27b.mdx`
- `docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_8_max.mdx`

### Why

Those flags are deprecated aliases in `python/sglang/srt/server_args.py`.

### How I checked

```bash
SHA=80e9a4ec742669d01e3a82dbc06b84b272f678d6
for f in \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b.mdx \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b.mdx \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_27b.mdx \
  docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_8_max.mdx; do
  echo "== $f =="; curl -fsSL "https://raw.githubusercontent.com/sgl-project/sglang/$SHA/$f" | rg -n -- '--cuda-graph-bs|--disable-cuda-graph' || true
done
```

Base tip at open: `80e9a4ec742669d01e3a82dbc06b84b272f678d6`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34187211300](https://github.com/sgl-project/sglang/actions/runs/34187211300)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34187211208](https://github.com/sgl-project/sglang/actions/runs/34187211208)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->