### PR TITLE
[CI] test: initialize disable_radix_cache in scheduler stub

### DIFF
--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -1016,6 +1016,7 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
 
         scheduler = object.__new__(scheduler_module.Scheduler)
         scheduler.tokenizer = object()
+        scheduler.disable_radix_cache = False
         scheduler._maybe_namespace_elastic_radix_cache = MagicMock()
         scheduler._add_request_to_queue = MagicMock()
         scheduler._get_multimodal_inputs = MagicMock(


### PR DESCRIPTION
Fixes a CPU unit test that constructs `Scheduler` with `object.__new__` and bypasses `Scheduler.__init__`. Recent scheduler changes pass `self.disable_radix_cache` into embedding `Req` construction, so this test stub must initialize the field explicitly.

Validation:
- `python3 -m py_compile test/registered/unit/multimodal/test_gpu_feature_transport.py`
- pre-commit Python hooks: ast, isort, ruff, ruff format, bare pytest.main checker

Note: local `check-registered-tests` currently fails on unrelated existing taxonomy violations across latest main, so it was skipped for this one-line test stub fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34187835770](https://github.com/sgl-project/sglang/actions/runs/34187835770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34187835647](https://github.com/sgl-project/sglang/actions/runs/34187835647)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34187835783](https://github.com/sgl-project/sglang/actions/runs/34187835783)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->