### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3.5-397B guides

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_5_397b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_5_397b.mdx
@@ -111,7 +111,7 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --max-running-requests 16 \
     --mem-fraction-static 0.6 \
-    --cuda-graph-bs 2 3 4 5 6 8 10 12 14 16 \
+    --cuda-graph-bs-decode 2 3 4 5 6 8 10 12 14 16 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -451,7 +451,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 48 \
     --mem-fraction-static 0.8 \
     --max-total-tokens 210000 \
-    --cuda-graph-bs 2 4 6 8 10 12 \
+    --cuda-graph-bs-decode 2 4 6 8 10 12 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -569,7 +569,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 144 \
     --mem-fraction-static 0.8 \
     --max-total-tokens 635000 \
-    --cuda-graph-bs 2 4 6 8 12 14 16 18 20 24 26 28 30 32 34 36 \
+    --cuda-graph-bs-decode 2 4 6 8 12 14 16 18 20 24 26 28 30 32 34 36 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -686,7 +686,7 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --max-running-requests 160 \
     --mem-fraction-static 0.8 \
-    --cuda-graph-bs 2 4 6 8 10 12 14 16 18 20 \
+    --cuda-graph-bs-decode 2 4 6 8 10 12 14 16 18 20 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -803,7 +803,7 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --max-running-requests 432 \
     --mem-fraction-static 0.8 \
-    --cuda-graph-bs 2 4 6 8 12 16 20 24 28 32 36 40 44 48 50 52 54 \
+    --cuda-graph-bs-decode 2 4 6 8 12 16 20 24 28 32 36 40 44 48 50 52 54 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -921,7 +921,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 16 \
     --mem-fraction-static 0.6 \
     --max-total-tokens 1065000 \
-    --cuda-graph-bs 2 4 6 8 10 12 14 16 \
+    --cuda-graph-bs-decode 2 4 6 8 10 12 14 16 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \
@@ -1039,7 +1039,7 @@ python3 -m sglang.launch_server \
     --max-running-requests 32 \
     --mem-fraction-static 0.6 \
     --max-total-tokens 1065000 \
-    --cuda-graph-bs 2 4 6 8 12 14 16 \
+    --cuda-graph-bs-decode 2 4 6 8 12 14 16 \
     --quantization modelslim \
     --enable-multimodal \
     --moe-a2a-backend deepep \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_5_397b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_5_397b.mdx
@@ -28,7 +28,7 @@ use v0.5.16 or a later version.
 | Data Parallelism              | `--dp-size 8`                                                                                 |
 | Expert Parallelism            | `--ep-size 16 \`<br/>`--moe-a2a-backend deepep \`<br/>`--deepep-mode auto`                     |
 | Quantization                  | `--quantization modelslim`                                                                    |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 2 4 6 8 10 12 14 16 18 20` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 2 4 6 8 10 12 14 16 18 20` |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4 \`<br/>`--speculative-draft-model-quantization unquant` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |


### PR DESCRIPTION
## Summary
Prefer current CUDA graph CLIs in Ascend Qwen3.5-397B best practices and tutorial:

- `--cuda-graph-bs` → `--cuda-graph-bs-decode`
- `--disable-cuda-graph` → `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`

These match the current server argument names; the old flags remain deprecated aliases.

## Test plan
- [ ] Confirm snippets use `--cuda-graph-bs-decode` / `--cuda-graph-backend-*=disabled`
- [ ] Confirm no remaining bare `--cuda-graph-bs` / `--disable-cuda-graph` in the touched files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34188380675](https://github.com/sgl-project/sglang/actions/runs/34188380675)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34188380378](https://github.com/sgl-project/sglang/actions/runs/34188380378)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->