### PR TITLE
[Docs] Prefer --cuda-graph-backend-decode in Hy4-Preview cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Tencent/Hy4-Preview.mdx
+++ b/docs/cookbook/autoregressive/Tencent/Hy4-Preview.mdx
@@ -147,7 +147,7 @@ On H200 (BF16, TP16 → ~95GB of weights per rank) the per-rank pool holds rough
 
 **MXFP8 kernel stack.** The MXFP8 checkpoint self-describes via its ModelOpt `hf_quant_config` (dynamic activations, UE8M0 group-32 weight scales) — no `--quantization` flag needed; the recipes pin `--moe-runner-backend deep_gemm --fp8-gemm-backend deep_gemm`, the validated HYV4 MXFP8 path (the runtime also defaults both to `deep_gemm` for HYV4 when the flags are left unset). The MXFP8 kernel path requires SM100+ (Blackwell); H200 (SM90) cannot serve the MXFP8 checkpoint — use BF16 there.
 
-**CUDA graph decode vs eager.** Decode CUDA-graph capture is on by default; long-duration soak validation of the graph path on Hy4 is still in progress. If you hit instability under long mixed agentic workloads, pass `--disable-cuda-graph` to fall back to eager decode (a restart recovers cleanly either way).
+**CUDA graph decode vs eager.** Decode CUDA-graph capture is on by default; long-duration soak validation of the graph path on Hy4 is still in progress. If you hit instability under long mixed agentic workloads, pass `--cuda-graph-backend-decode=disabled` to fall back to eager decode (a restart recovers cleanly either way).
 
 **MTP (NextN) speculative decoding.** Both checkpoints ship one draft layer; the preset is `--speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-num-draft-tokens 4` (top-k 1). Speculative decoding reserves 4 draft-token slots per request, so the effective request budget is `prompt_tokens + max_tokens + 4 ≤ context length` — requests at the exact context boundary are rejected with the reservation accounted for.
 


### PR DESCRIPTION
## Summary
- In the Hy4-Preview cookbook, replace the deprecated `--disable-cuda-graph` alias with the current `--cuda-graph-backend-decode=disabled` CLI in the eager-decode fallback note.
- `--disable-cuda-graph` is registered as a deprecated alias that redirects to `--cuda-graph-backend-{decode,prefill}=disabled` in `python/sglang/srt/server_args.py`.

## Reproduction / verification
1. On `main` (`91a45ea37e043979731c6725c383fa73759a2aab`), `docs/cookbook/autoregressive/Tencent/Hy4-Preview.mdx` tells readers to pass `--disable-cuda-graph` for eager decode.
2. In `python/sglang/srt/server_args.py`, `--disable-cuda-graph` is a `DeprecatedStoreTrueAction` whose preferred flag is `--cuda-graph-backend-{decode,prefill}=disabled`.
3. Because the Hy4 note is specifically about falling back to eager **decode**, prefer `--cuda-graph-backend-decode=disabled`.
4. After this change, the cookbook no longer recommends the deprecated alias.

## Test plan
- [x] Grep confirms `--disable-cuda-graph` is gone from `Hy4-Preview.mdx`
- [x] Grep confirms `--cuda-graph-backend-decode=disabled` is present
- [x] Cross-checked against `server_args.py` deprecated registrations

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34188645345](https://github.com/sgl-project/sglang/actions/runs/34188645345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34188644894](https://github.com/sgl-project/sglang/actions/runs/34188644894)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->