### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend DeepSeek-V3.2 best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_v3_2.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_v3_2.mdx
@@ -118,7 +118,8 @@ do
         --deepep-mode normal \
         --quantization modelslim \
         --disaggregation-transfer-backend ascend \
-        --disable-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --moe-dense-tp-size 1 \
         --enable-prefill-cp \
         --cp-strategy zigzag \
@@ -316,7 +317,8 @@ do
         --deepep-mode normal \
         --quantization modelslim \
         --disaggregation-transfer-backend ascend \
-        --disable-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --moe-dense-tp-size 1 \
         --enable-prefill-cp \
         --cp-strategy zigzag \
@@ -513,7 +515,8 @@ do
         --deepep-mode normal \
         --quantization modelslim \
         --disaggregation-transfer-backend ascend \
-        --disable-cuda-graph \
+        --cuda-graph-backend-decode=disabled \
+        --cuda-graph-backend-prefill=disabled \
         --moe-dense-tp-size 1 \
         --enable-prefill-cp \
         --cp-strategy zigzag \


### PR DESCRIPTION
## Summary
- In Ascend DeepSeek-V3.2 best practices, replace deprecated `--disable-cuda-graph` with `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` in the PD launch snippets.
- `--disable-cuda-graph` is registered as a deprecated alias that redirects to `--cuda-graph-backend-{decode,prefill}=disabled` in `python/sglang/srt/server_args.py`.

## Reproduction / verification
1. On `main` (`5aab054ec8ce`), `docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_v3_2.mdx` passes `--disable-cuda-graph` in three PD launch examples.
2. In `python/sglang/srt/server_args.py`, `--disable-cuda-graph` is a `DeprecatedStoreTrueAction` whose preferred flag is `--cuda-graph-backend-{decode,prefill}=disabled`.
3. After this change, those launch snippets recommend the current CUDA graph backend CLIs.

## Test plan
- [x] Grep confirms `--disable-cuda-graph` is gone from the DeepSeek-V3.2 best-practices doc
- [x] Grep confirms `--cuda-graph-backend-decode=disabled` and `--cuda-graph-backend-prefill=disabled` are present (3× each)
- [x] Cross-checked against `server_args.py` deprecated registrations

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34190677898](https://github.com/sgl-project/sglang/actions/runs/34190677898)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34190677750](https://github.com/sgl-project/sglang/actions/runs/34190677750)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->