### PR TITLE
[HiCache] Keep the backup worker alive on storage backend failures

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -229,6 +229,14 @@ class StorageOperation:
         self.completed_tokens = 0
         self.hash_value = hash_value if hash_value is not None else []
         self.prefix_keys = prefix_keys
+        # Backup outcome, filled in by the backup worker so the ack consumer
+        # can tell a partial or failed write from a complete one.
+        self.failed: bool = False
+        # "backend_false" | "exception" | "sidecar_backend_false"
+        self.failure_kind: Optional[str] = None
+        self.unwritten_pages: int = 0
+        # pool name -> number of pages the sidecar backend did not write
+        self.sidecar_unwritten_by_pool: dict = {}
         # Full queried page-hash chain, set by _storage_hit_query before
         # hash_value is truncated to the hit boundary; the tail is the
         # absence signal that invalidates buffer-mode existence beliefs.
@@ -1266,8 +1274,13 @@ class HiCacheController:
             extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
             success = self.page_set_func(batch_hashes, batch_host_indices, extra_info)
             if not success:
+                operation.failed = True
+                operation.failure_kind = "backend_false"
+                remaining = len(operation.hash_value) - i
+                operation.unwritten_pages = remaining
                 logger.warning(
-                    f"Write page to storage: {len(batch_hashes)} pages failed."
+                    f"Write page to storage: {len(batch_hashes)} pages failed, "
+                    f"{remaining} pages unwritten."
                 )
                 break
 
@@ -1286,7 +1299,23 @@ class HiCacheController:
                     continue
 
                 if not self.backup_skip:
-                    self._page_backup(operation)
+                    try:
+                        self._page_backup(operation)
+                    except Exception:
+                        # A backend error must not kill the worker: every
+                        # operation is still acked so the tree cache releases
+                        # its host memory and the queue keeps draining.
+                        operation.failed = True
+                        operation.failure_kind = "exception"
+                        operation.unwritten_pages = max(
+                            0,
+                            len(operation.hash_value)
+                            - operation.completed_tokens // self.page_size,
+                        )
+                        logger.exception(
+                            "Backup operation %s raised an exception.",
+                            operation.id,
+                        )
                 self.ack_backup_queue.put(operation)
 
             except Empty:

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -684,6 +684,7 @@ class HybridCacheController(BaseHiCacheController):
             if self.should_backup(transfer)
         ]
 
+        sidecar_unwritten_by_pool = {}
         if backup_transfers:
             self._resolve_sidecar_kv_derived_pool_transfers(operation)
             self._resolve_sidecar_nonkv_derived_pool_transfers(operation)
@@ -691,25 +692,36 @@ class HybridCacheController(BaseHiCacheController):
             pool_hits = count_pool_hits(results)
             operation.pool_storage_result.update_extra_pool_hit_pages(pool_hits)
 
+            for transfer in backup_transfers:
+                success_list = results.get(transfer.name)
+                if success_list is None:
+                    success_list = results.get(transfer.name.value)
+                expected = len(transfer.keys or [])
+                if expected == 0 and transfer.host_indices is not None:
+                    expected = int(transfer.host_indices.numel())
+                if not isinstance(success_list, (list, tuple)):
+                    failed_in_pool = expected
+                else:
+                    failed_in_pool = sum(
+                        1 for success in success_list[:expected] if not success
+                    ) + max(0, expected - len(success_list))
+                if failed_in_pool:
+                    sidecar_unwritten_by_pool[transfer.name] = failed_in_pool
+            if sidecar_unwritten_by_pool:
+                operation.failed = True
+                if operation.failure_kind is None:
+                    operation.failure_kind = "sidecar_backend_false"
+                operation.sidecar_unwritten_by_pool = sidecar_unwritten_by_pool
+                logger.warning(
+                    "Sidecar pool write failed for operation %s: %s",
+                    operation.id,
+                    sidecar_unwritten_by_pool,
+                )
+
         if not self.backup_skip:
             super()._page_backup(operation)
         else:
-            sidecar_ok = bool(backup_transfers)
-            if sidecar_ok:
-                for transfer in backup_transfers:
-                    result = results.get(transfer.name)
-                    if result is None:
-                        result = results.get(transfer.name.value)
-                    expected = len(transfer.keys or [])
-                    if expected == 0 and transfer.host_indices is not None:
-                        expected = int(transfer.host_indices.numel())
-                    if (
-                        not isinstance(result, (list, tuple))
-                        or len(result) != expected
-                        or not all(bool(ok) for ok in result)
-                    ):
-                        sidecar_ok = False
-                        break
+            sidecar_ok = bool(backup_transfers) and not sidecar_unwritten_by_pool
             operation.completed_tokens = (
                 len(operation.hash_value) * self.page_size if sidecar_ok else 0
             )
@@ -748,7 +760,23 @@ class HybridCacheController(BaseHiCacheController):
                 operation = self.backup_queue.get(block=True, timeout=1)
                 if operation is None:
                     continue
-                self._page_backup(operation)
+                try:
+                    self._page_backup(operation)
+                except Exception:
+                    operation.failed = True
+                    operation.failure_kind = "exception"
+                    operation.unwritten_pages = (
+                        0
+                        if self.backup_skip
+                        else max(
+                            0,
+                            len(operation.hash_value)
+                            - operation.completed_tokens // self.page_size,
+                        )
+                    )
+                    logger.exception(
+                        "Backup operation %s raised an exception.", operation.id
+                    )
                 self.ack_backup_queue.put(operation)
             except Empty:
                 continue

--- a/test/registered/unit/mem_cache/test_hicache_backup_resilience.py
+++ b/test/registered/unit/mem_cache/test_hicache_backup_resilience.py
@@ -1,0 +1,274 @@
+"""HiCache backup worker resilience.
+
+The backup thread only caught ``queue.Empty``; any exception raised by the
+storage backend (I/O error, timeout, malformed response) escaped the loop and
+killed the daemon thread. Every subsequent backup operation then stayed in the
+queue forever, its host memory was never released, and the failure was only
+visible as host-pool exhaustion much later. These tests exercise the production
+``backup_thread_func`` / ``_page_backup`` and assert that failed operations are
+still acked and annotated with what went wrong.
+
+Usage:
+    python -m pytest test/registered/unit/mem_cache/test_hicache_backup_resilience.py -v
+"""
+
+import threading
+import unittest
+from queue import Queue
+from unittest import mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+from sglang.srt.managers.cache_controller import HiCacheController, StorageOperation
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+)
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    StorageOperation as HybridStorageOperation,
+)
+
+
+def _make_op(num_pages: int, page_size: int = 16) -> StorageOperation:
+    return StorageOperation(
+        host_indices=torch.zeros(num_pages * page_size),
+        token_ids=list(range(num_pages * page_size)),
+        hash_value=[f"h{i}" for i in range(num_pages)],
+    )
+
+
+def _run_worker(cls, controller) -> threading.Thread:
+    thread = threading.Thread(
+        target=cls.backup_thread_func, args=(controller,), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+def _stop_worker(controller, thread: threading.Thread) -> None:
+    controller.storage_stop_event.set()
+    controller.backup_queue.put(None)
+    thread.join(timeout=5)
+
+
+class TestStorageOperationFailureFields(CustomTestCase):
+    def test_default_values(self):
+        op = _make_op(2)
+        self.assertFalse(op.failed)
+        self.assertIsNone(op.failure_kind)
+        self.assertEqual(op.unwritten_pages, 0)
+        self.assertEqual(op.sidecar_unwritten_by_pool, {})
+
+
+class TestBackupThreadExceptionHandling(CustomTestCase):
+    """backup_thread_func survives exceptions and still acks the operation."""
+
+    def _make_controller(self, page_backup_impl, backup_skip=False):
+        controller = mock.MagicMock()
+        controller.storage_stop_event = threading.Event()
+        controller.backup_skip = backup_skip
+        controller.page_size = 16
+        controller.backup_queue = Queue()
+        controller.ack_backup_queue = Queue()
+        controller._page_backup = page_backup_impl
+        return controller
+
+    def test_exception_does_not_kill_thread(self):
+        def failing_page_backup(operation):
+            raise RuntimeError("storage IO error")
+
+        controller = self._make_controller(failing_page_backup)
+        op = _make_op(4)
+        controller.backup_queue.put(op)
+
+        thread = _run_worker(HiCacheController, controller)
+        acked_op = controller.ack_backup_queue.get(timeout=5)
+        _stop_worker(controller, thread)
+
+        self.assertFalse(thread.is_alive())
+        self.assertIs(acked_op, op)
+        self.assertTrue(acked_op.failed)
+        self.assertEqual(acked_op.failure_kind, "exception")
+        self.assertEqual(acked_op.unwritten_pages, 4)
+
+    def test_exception_after_partial_progress_counts_remaining_pages(self):
+        def partial_then_raise(operation):
+            operation.completed_tokens = 16 * 3
+            raise RuntimeError("storage IO error")
+
+        controller = self._make_controller(partial_then_raise)
+        op = _make_op(4)
+        controller.backup_queue.put(op)
+
+        thread = _run_worker(HiCacheController, controller)
+        acked_op = controller.ack_backup_queue.get(timeout=5)
+        _stop_worker(controller, thread)
+
+        self.assertTrue(acked_op.failed)
+        self.assertEqual(acked_op.unwritten_pages, 1)
+
+    def test_backend_false_marks_failure(self):
+        controller = mock.MagicMock()
+        controller.page_size = 16
+        controller.backup_skip = False
+        controller.page_set_func = mock.MagicMock(return_value=False)
+        op = _make_op(4)
+
+        HiCacheController._page_backup(controller, op)
+
+        self.assertTrue(op.failed)
+        self.assertEqual(op.failure_kind, "backend_false")
+        self.assertEqual(op.unwritten_pages, 4)
+        self.assertEqual(op.completed_tokens, 0)
+
+    def test_backend_success_leaves_operation_clean(self):
+        controller = mock.MagicMock()
+        controller.page_size = 16
+        controller.backup_skip = False
+        controller.page_set_func = mock.MagicMock(return_value=True)
+        op = _make_op(4)
+
+        HiCacheController._page_backup(controller, op)
+
+        self.assertFalse(op.failed)
+        self.assertIsNone(op.failure_kind)
+        self.assertEqual(op.unwritten_pages, 0)
+        self.assertEqual(op.completed_tokens, 64)
+
+    def test_thread_continues_after_exception(self):
+        first_call = [True]
+
+        def fail_on_first_then_succeed(operation):
+            if first_call[0]:
+                first_call[0] = False
+                raise RuntimeError("transient error")
+            operation.completed_tokens = 16 * len(operation.hash_value)
+
+        controller = self._make_controller(fail_on_first_then_succeed)
+        op1 = _make_op(2)
+        op2 = _make_op(2)
+        controller.backup_queue.put(op1)
+        controller.backup_queue.put(op2)
+
+        thread = _run_worker(HiCacheController, controller)
+        ack1 = controller.ack_backup_queue.get(timeout=5)
+        ack2 = controller.ack_backup_queue.get(timeout=5)
+        _stop_worker(controller, thread)
+
+        self.assertIs(ack1, op1)
+        self.assertTrue(ack1.failed)
+        self.assertEqual(ack1.failure_kind, "exception")
+        self.assertIs(ack2, op2)
+        self.assertFalse(ack2.failed)
+        self.assertEqual(ack2.completed_tokens, 32)
+
+    def test_backup_skip_does_not_call_page_backup(self):
+        controller = self._make_controller(
+            mock.MagicMock(side_effect=AssertionError("should not be called")),
+            backup_skip=True,
+        )
+        op = _make_op(2)
+        controller.backup_queue.put(op)
+
+        thread = _run_worker(HiCacheController, controller)
+        acked_op = controller.ack_backup_queue.get(timeout=5)
+        _stop_worker(controller, thread)
+
+        self.assertFalse(acked_op.failed)
+        self.assertIs(acked_op, op)
+
+
+class TestHybridBackupResilience(CustomTestCase):
+    """HybridCacheController: worker survives, sidecar failures are recorded."""
+
+    def _make_hybrid_op(self, num_pages: int, pool_transfers=None):
+        return HybridStorageOperation(
+            host_indices=torch.zeros(num_pages * 16),
+            token_ids=list(range(num_pages * 16)),
+            hash_value=[f"h{i}" for i in range(num_pages)],
+            pool_transfers=pool_transfers,
+        )
+
+    def test_hybrid_backup_worker_survives_exception(self):
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.storage_stop_event = threading.Event()
+        controller.backup_skip = False
+        controller.page_size = 16
+        controller.backup_queue = Queue()
+        controller.ack_backup_queue = Queue()
+        controller._page_backup = mock.MagicMock(
+            side_effect=RuntimeError("sidecar IO error")
+        )
+        op = self._make_hybrid_op(2)
+        controller.backup_queue.put(op)
+
+        thread = _run_worker(HybridCacheController, controller)
+        acked_op = controller.ack_backup_queue.get(timeout=5)
+        _stop_worker(controller, thread)
+
+        self.assertFalse(thread.is_alive())
+        self.assertIs(acked_op, op)
+        self.assertTrue(op.failed)
+        self.assertEqual(op.failure_kind, "exception")
+        self.assertEqual(op.unwritten_pages, 2)
+
+    def _make_sidecar_controller(self, sidecar_results):
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.page_size = 16
+        controller.backup_skip = False
+        controller.storage_backend_type = "test"
+        controller.storage_backend = mock.MagicMock()
+        controller.storage_backend.batch_set_v2 = mock.MagicMock(
+            return_value=sidecar_results
+        )
+        controller._resolve_sidecar_kv_derived_pool_transfers = lambda op: None
+        controller._resolve_sidecar_nonkv_derived_pool_transfers = lambda op: None
+        return controller
+
+    def _indexer_transfer(self, num_pages: int) -> PoolTransfer:
+        return PoolTransfer(
+            name=PoolName.INDEXER,
+            host_indices=torch.zeros(num_pages),
+            keys=[f"i{i}" for i in range(num_pages)],
+        )
+
+    def test_sidecar_failure_marks_operation(self):
+        # 2 failures out of 3 indexer pages; primary KV write succeeds.
+        controller = self._make_sidecar_controller(
+            {PoolName.INDEXER: [True, False, False]}
+        )
+        op = self._make_hybrid_op(3, pool_transfers=[self._indexer_transfer(3)])
+
+        with mock.patch.object(
+            HiCacheController, "_page_backup", autospec=True, return_value=None
+        ):
+            HybridCacheController._page_backup(controller, op)
+
+        self.assertTrue(op.failed)
+        self.assertEqual(op.failure_kind, "sidecar_backend_false")
+        self.assertEqual(op.sidecar_unwritten_by_pool, {PoolName.INDEXER: 2})
+        self.assertEqual(op.unwritten_pages, 0)
+
+    def test_sidecar_success_leaves_operation_clean(self):
+        controller = self._make_sidecar_controller(
+            {PoolName.INDEXER: [True, True, True]}
+        )
+        op = self._make_hybrid_op(3, pool_transfers=[self._indexer_transfer(3)])
+
+        with mock.patch.object(
+            HiCacheController, "_page_backup", autospec=True, return_value=None
+        ):
+            HybridCacheController._page_backup(controller, op)
+
+        self.assertFalse(op.failed)
+        self.assertIsNone(op.failure_kind)
+        self.assertEqual(op.sidecar_unwritten_by_pool, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #38428.

`HiCacheController.backup_thread_func` (and the `HybridCacheController` override) only catches `queue.Empty`. Any exception raised by the storage backend while writing a page (I/O error, timeout, malformed response from a remote store) escapes the loop and silently kills the daemon thread. After that every backup operation stays in `backup_queue` forever, `ack_backup_queue` never drains, and the host memory held by those operations is never released. The only visible symptom is host pool exhaustion much later, with no log line pointing at the backup thread.

A backend returning `False` already stops the current operation, but the ack consumer cannot tell a partial or failed write from a complete one.

## Modifications

- Wrap `_page_backup` in `try/except Exception` in both backup loops. A failing operation is logged with `logger.exception` and still acked, so the tree cache releases its host memory and the worker keeps draining the queue.
- `StorageOperation` gains `failed`, `failure_kind` (`"backend_false" | "exception" | "sidecar_backend_false"`), `unwritten_pages` and `sidecar_unwritten_by_pool`.
- `HybridCacheController._page_backup` derives the sidecar outcome from per-pool failure counts instead of the previous all-or-nothing check, so a partial sidecar failure is reported rather than folded into `completed_tokens = 0`.
- New CPU unit test `test/registered/unit/mem_cache/test_hicache_backup_resilience.py` that drives the production `backup_thread_func` / `_page_backup` with a raising or refusing backend and checks that the thread survives, the operation is acked and the failure fields are set. The test fails on `main` and passes with this change.

No behavior change on the success path. The new fields are not yet consumed by metrics; a follow-up can export failed-operation counters if maintainers want them.

## Accuracy Tests

N/A (error path only, no change to model forward).

## Speed Tests and Profiling

N/A (error path only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (not needed)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
