### PR TITLE
fix(hicache): emit BlockStored(CPU) event in UnifiedRadixCache insert…

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1967,6 +1967,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         node.children[child_key] = new_node
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(node)
+        self.kv_events.record_store(new_node, medium=StorageMedium.CPU)
         result.inserted_host_node = new_node.id
         return result
 


### PR DESCRIPTION
…_host

The insert_host method in unified_tree_core.py creates a new host-side (L2) node during L3→L2 prefetch but does not emit a BlockStored(CPU) KV event. This causes downstream KV-event consumers (e.g. dynamo local_indexer's lower_tier) to fail with 'Failed to find block' when the prefetched data is later evicted from host — BlockRemoved(CPU) is emitted but no matching BlockStored(CPU) was ever sent.

HiRadixCache's _insert_helper_host (hiradix_cache.py:1854) already emits this event correctly. This was missed during the migration to UnifiedRadixCache.

Fix: add the missing record_store(CPU) call after new_node creation in insert_host, aligning with HiRadixCache's behavior.

Verified on master-1 (sg-glm52-dingo-disagg, UnifiedRadixCache):
- Before fix: 458 insert_host calls, 0 CPU store events from prefetch
- Debug log confirmed: 'record_store_NOT_called_here (bug?)'

Related PR: sgl-project/sglang#22894 (fixes the same issue for HiRadixCache and RadixCache, but does not touch UnifiedRadixCache)

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34193900800](https://github.com/sgl-project/sglang/actions/runs/34193900800)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34193900318](https://github.com/sgl-project/sglang/actions/runs/34193900318)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34193900617](https://github.com/sgl-project/sglang/actions/runs/34193900617)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->