### PR TITLE
Enable compact GLM NoPE KV storage with native FlashInfer

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -718,13 +718,42 @@ def _validate_flashinfer_sparse_mla_backend(
     return uses_flashinfer_sparse_mla
 
 
+def create_flashinfer_sparse_mla_runner(
+    *,
+    qk_rope_head_dim: int,
+    kv_lora_rank: int,
+    max_num_tokens: int,
+    max_num_heads: int,
+    device: str,
+) -> object | None:
+    """Use native NoPE kernels when available; preserve the existing RoPE API."""
+    if qk_rope_head_dim != 0 or kv_lora_rank != 512:
+        return None
+    from flashinfer import mla
+
+    wrapper = getattr(mla, "SparseMLASm120Wrapper", None)
+    configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
+    if wrapper is None or configs is None or "glm53_nope" not in configs():
+        raise RuntimeError(
+            "GLM NoPE sparse MLA requires FlashInfer native SM120 support "
+            "with the glm53_nope configuration."
+        )
+    return wrapper(
+        max_num_tokens=max_num_tokens,
+        max_num_heads=max_num_heads,
+        d_v=kv_lora_rank,
+        kv_scale_format="arbitrary_fp32",
+        device=device,
+    )
+
+
 def flashinfer_sparse_mla_forward(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
     indices: torch.Tensor,
     seq_lens: torch.Tensor,
     workspace_buffer: torch.Tensor,
-    runner: object,
+    runner: object | None = None,
     *,
     page_size: int,
     kv_cache_dim: int,
@@ -742,6 +771,35 @@ def flashinfer_sparse_mla_forward(
     rows contain 512 FP8 latent values and four inline FP32 scales. Both
     compact 528-byte rows and the padded 656-byte fp8_ds_mla ABI are supported.
     """
+    if runner is None:
+        if qk_rope_head_dim == 0 and kv_lora_rank == 512:
+            raise RuntimeError(
+                "GLM NoPE sparse MLA requires FlashInfer native SM120 support "
+                "with the glm53_nope configuration."
+            )
+        from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+
+        topk = indices.shape[1]
+        result = trtllm_batch_decode_with_kv_cache_mla(
+            query=q.unsqueeze(1),
+            kv_cache=kv_cache.view(torch.uint8)
+            .view(-1, page_size, kv_cache_dim)
+            .unsqueeze(1),
+            workspace_buffer=workspace_buffer,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=indices.unsqueeze(1),
+            seq_lens=seq_lens,
+            max_seq_len=topk,
+            sparse_mla_top_k=topk,
+            bmm1_scale=float(sm_scale),
+            bmm2_scale=1.0,
+            kv_scale_format="arbitrary_fp32",
+            skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+        )
+        return result.squeeze(1)
+
     if skip_softmax_threshold_scale_factor is not None:
         raise ValueError(
             "flashinfer_sparse_mla does not support skip-softmax thresholds"
@@ -779,9 +837,7 @@ def flashinfer_sparse_mla_forward(
                 value=-1,
             )
 
-    kv_cache_u8 = kv_cache.view(torch.uint8).view(
-        -1, page_size, kv_cache_dim
-    )
+    kv_cache_u8 = kv_cache.view(torch.uint8).view(-1, page_size, kv_cache_dim)
     output = torch.empty(
         q.shape[0], q.shape[1], kv_lora_rank, dtype=torch.bfloat16, device=q.device
     )
@@ -803,12 +859,16 @@ def flashinfer_sparse_mla_forward(
                 f"need {required_bytes} bytes, have {available_bytes}"
             )
         workspace_u8 = workspace_buffer.view(torch.uint8)
-        mid_out = workspace_u8[:mid_out_bytes].view(torch.bfloat16).view(
-            q.shape[0], scratch_heads, num_splits, kv_lora_rank
+        mid_out = (
+            workspace_u8[:mid_out_bytes]
+            .view(torch.bfloat16)
+            .view(q.shape[0], scratch_heads, num_splits, kv_lora_rank)
         )
-        mid_lse = workspace_u8[
-            mid_out_bytes : mid_out_bytes + mid_lse_bytes
-        ].view(torch.float32).view(q.shape[0], scratch_heads, num_splits)
+        mid_lse = (
+            workspace_u8[mid_out_bytes : mid_out_bytes + mid_lse_bytes]
+            .view(torch.float32)
+            .view(q.shape[0], scratch_heads, num_splits)
+        )
 
     runner.run(
         q,

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -754,10 +754,16 @@ def create_flashinfer_sparse_mla_runner(
 
     wrapper = getattr(mla, "SparseMLASm120Wrapper", None)
     configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
-    if wrapper is None or configs is None or "glm53_nope" not in configs():
+    config = configs().get("glm53_nope") if configs is not None else None
+    # The initial NoPE API advertises the family but still reads mutable slot
+    # zero for masked candidates and uses incompatible eight-head scratch.
+    # Row-width support alone does not establish either correctness contract.
+    if wrapper is None or getattr(config, "glm53_nope_contract_version", 0) < 1:
         raise RuntimeError(
             "GLM NoPE sparse MLA requires FlashInfer native SM120 support "
-            "with the glm53_nope configuration."
+            "with glm53_nope contract version 1 or later "
+            "(masked candidate reads and eight-head decode scratch). "
+            "Upgrade FlashInfer to a build advertising this contract."
         )
     return wrapper(
         max_num_tokens=max_num_tokens,

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -29,7 +29,12 @@ _is_hip = is_hip()
 _GLM_DSA_MODEL_ARCHS = (
     "GlmMoeDsaForCausalLM",
     "GlmMoeDsaForCausalLMNextN",
+    "Glm5NextForConditionalGeneration",
+    "Glm5NextForConditionalGenerationNextN",
 )
+
+_GLM53_NOPE_FLASHINFER_TOPK = 2176
+_GLM53_NOPE_FLASHINFER_KV_DIMS = (528, 656)
 
 # Page layout constants for DSv4-Flash (MODEL1):
 #   nope_dim = 448, rope_dim = 64, quantize_block_size = 64
@@ -699,7 +704,10 @@ def _validate_flashinfer_sparse_mla_backend(
             f"kv_cache_dtype={kv_cache_dtype}, prefill_impl={prefill_impl!r}, "
             f"decode_impl={decode_impl!r}."
         )
-    if is_glm_sm12_fp8:
+    # This validator owns only configurations that actually select the native
+    # FlashInfer backend.  Other GLM SM12 FP8 backend pairs (notably the raw
+    # TileLang path) have their own layout validation and must pass through.
+    if uses_flashinfer_sparse_mla and is_glm_sm12_fp8:
         unsupported = selected - {"flashinfer_sparse_mla"}
         if unsupported:
             raise ValueError(
@@ -716,6 +724,7 @@ def flashinfer_sparse_mla_forward(
     indices: torch.Tensor,
     seq_lens: torch.Tensor,
     workspace_buffer: torch.Tensor,
+    runner: object,
     *,
     page_size: int,
     kv_cache_dim: int,
@@ -725,26 +734,90 @@ def flashinfer_sparse_mla_forward(
     sm_scale: float,
     skip_softmax_threshold_scale_factor: float | None,
 ) -> torch.Tensor:
-    """Run FlashInfer's SM120 sparse MLA kernel on SGLang's packed DSA cache."""
-    from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+    """Run FlashInfer's persistent native SM120 sparse-MLA wrapper.
 
-    topk = indices.shape[1]
-    result = trtllm_batch_decode_with_kv_cache_mla(
-        query=q.unsqueeze(1),
-        kv_cache=kv_cache.view(torch.uint8)
-        .view(-1, page_size, kv_cache_dim)
-        .unsqueeze(1),
-        workspace_buffer=workspace_buffer,
-        qk_nope_head_dim=qk_nope_head_dim,
-        kv_lora_rank=kv_lora_rank,
-        qk_rope_head_dim=qk_rope_head_dim,
-        block_tables=indices.unsqueeze(1),
-        seq_lens=seq_lens,
-        max_seq_len=topk,
-        sparse_mla_top_k=topk,
-        bmm1_scale=float(sm_scale),
-        bmm2_scale=1.0,
-        kv_scale_format="arbitrary_fp32",
-        skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+    GLM-5.3 emits 2,051 candidates (2,048 selected plus its three-token KPool
+    tail).  FlashInfer's native NoPE kernels use the 2,176-wide physical
+    contract, so the unused right edge is padded with ``-1`` sentinels.  KV
+    rows contain 512 FP8 latent values and four inline FP32 scales. Both
+    compact 528-byte rows and the padded 656-byte fp8_ds_mla ABI are supported.
+    """
+    if skip_softmax_threshold_scale_factor is not None:
+        raise ValueError(
+            "flashinfer_sparse_mla does not support skip-softmax thresholds"
+        )
+
+    # GLM-5.3's configured qk_nope_head_dim is 256, while the absorbed query
+    # presented to sparse MLA is 512 wide. Detect the native kernel contract
+    # from that actual tensor/layout geometry; checking the pre-absorption
+    # config dimension silently skipped the required 2051 -> 2176 padding.
+    is_glm53_nope = (
+        q.shape[-1] == 512
+        and kv_lora_rank == 512
+        and qk_rope_head_dim == 0
+        and kv_cache_dim in _GLM53_NOPE_FLASHINFER_KV_DIMS
     )
-    return result.squeeze(1)
+    if is_glm53_nope:
+        topk = indices.shape[-1]
+        if topk > _GLM53_NOPE_FLASHINFER_TOPK:
+            raise ValueError(
+                "GLM-5.3 native NoPE sparse MLA supports at most "
+                f"{_GLM53_NOPE_FLASHINFER_TOPK} candidates, got {topk}"
+            )
+        # Pass the EXACT per-row valid candidate count, not seq_lens. Raw
+        # seq_lens exceeds the index width for long rows, which turns -1
+        # pad columns into "active" candidates: their logits are masked,
+        # but the slot-0-clamped gathered rows still feed the value MMA,
+        # so one NaN-decoding byte in that row poisons the whole output
+        # row (0 * NaN). Valid entries are a contiguous prefix by the
+        # top-k transform's construction, so the count bounds them all.
+        seq_lens = (indices >= 0).sum(dim=-1, dtype=seq_lens.dtype)
+        if topk < _GLM53_NOPE_FLASHINFER_TOPK:
+            indices = torch.nn.functional.pad(
+                indices,
+                (0, _GLM53_NOPE_FLASHINFER_TOPK - topk),
+                value=-1,
+            )
+
+    kv_cache_u8 = kv_cache.view(torch.uint8).view(
+        -1, page_size, kv_cache_dim
+    )
+    output = torch.empty(
+        q.shape[0], q.shape[1], kv_lora_rank, dtype=torch.bfloat16, device=q.device
+    )
+
+    mid_out = None
+    mid_lse = None
+    if q.shape[0] <= 64:
+        scratch_heads = 8 if q.shape[1] == 8 else math.ceil(q.shape[1] / 16) * 16
+        num_splits = math.ceil(indices.shape[-1] / 64)
+        mid_out_numel = q.shape[0] * scratch_heads * num_splits * kv_lora_rank
+        mid_out_bytes = mid_out_numel * torch.bfloat16.itemsize
+        mid_lse_numel = q.shape[0] * scratch_heads * num_splits
+        mid_lse_bytes = mid_lse_numel * torch.float32.itemsize
+        required_bytes = mid_out_bytes + mid_lse_bytes
+        available_bytes = workspace_buffer.numel() * workspace_buffer.element_size()
+        if required_bytes > available_bytes:
+            raise ValueError(
+                "FlashInfer sparse-MLA decode workspace is too small: "
+                f"need {required_bytes} bytes, have {available_bytes}"
+            )
+        workspace_u8 = workspace_buffer.view(torch.uint8)
+        mid_out = workspace_u8[:mid_out_bytes].view(torch.bfloat16).view(
+            q.shape[0], scratch_heads, num_splits, kv_lora_rank
+        )
+        mid_lse = workspace_u8[
+            mid_out_bytes : mid_out_bytes + mid_lse_bytes
+        ].view(torch.float32).view(q.shape[0], scratch_heads, num_splits)
+
+    runner.run(
+        q,
+        kv_cache_u8,
+        indices,
+        output,
+        float(sm_scale),
+        topk_length=seq_lens,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+    return output

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -755,9 +755,9 @@ def create_flashinfer_sparse_mla_runner(
     wrapper = getattr(mla, "SparseMLASm120Wrapper", None)
     configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
     config = configs().get("glm53_nope") if configs is not None else None
-    # Require the compact-capable native API. The FlashInfer dependency must
-    # include its masked-read and eight-head fixes as well as the row layout.
-    if wrapper is None or getattr(config, "compact_bytes_per_token", None) != 528:
+    # Require the canonical GLM NoPE payload. The FlashInfer dependency must
+    # also include the masked-read and eight-head fixes.
+    if wrapper is None or getattr(config, "bytes_per_token", None) != 528:
         raise RuntimeError(
             "GLM NoPE sparse MLA requires FlashInfer native SM120 support "
             "with compact GLM NoPE rows (glm53_nope). "

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -680,6 +680,26 @@ def _flash_mla_flashinfer(
     return (output.unsqueeze(1), None)
 
 
+def _flashinfer_sparse_mla_max_tokens(
+    *,
+    chunked_prefill_size: Optional[int],
+    max_prefill_tokens: int,
+    context_len: int,
+    max_running_requests: int,
+    speculative_num_draft_tokens: Optional[int],
+) -> int:
+    chunk_size = int(chunked_prefill_size or 0)
+    prefill_tokens = max(64, chunk_size, max_prefill_tokens)
+    if chunk_size <= 0:
+        # Unchunked admission allows the first prompt to exceed the prefill
+        # budget. The configured model context still bounds that request.
+        prefill_tokens = max(prefill_tokens, context_len)
+    # Mixed batches can add decode or verify tokens to the prefill budget.
+    return prefill_tokens + max_running_requests * max(
+        1, speculative_num_draft_tokens or 1
+    )
+
+
 def _validate_flashinfer_sparse_mla_backend(
     *,
     model_arch: str,

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -691,9 +691,10 @@ def _flashinfer_sparse_mla_max_tokens(
     chunk_size = int(chunked_prefill_size or 0)
     prefill_tokens = max(64, chunk_size, max_prefill_tokens)
     if chunk_size <= 0:
-        # Unchunked admission allows the first prompt to exceed the prefill
-        # budget. The configured model context still bounds that request.
-        prefill_tokens = max(prefill_tokens, context_len)
+        # Unchunked admission can add one whole prompt before observing that
+        # the budget is exhausted (including ignore_eos without a radix cache).
+        # Reserve the budget plus one context-sized prompt for that overshoot.
+        prefill_tokens += context_len
     # Mixed batches can add decode or verify tokens to the prefill budget.
     return prefill_tokens + max_running_requests * max(
         1, speculative_num_draft_tokens or 1

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -822,14 +822,16 @@ def flashinfer_sparse_mla_forward(
                 "GLM-5.3 native NoPE sparse MLA supports at most "
                 f"{_GLM53_NOPE_FLASHINFER_TOPK} candidates, got {topk}"
             )
-        # Pass the EXACT per-row valid candidate count, not seq_lens. Raw
-        # seq_lens exceeds the index width for long rows, which turns -1
-        # pad columns into "active" candidates: their logits are masked,
-        # but the slot-0-clamped gathered rows still feed the value MMA,
-        # so one NaN-decoding byte in that row poisons the whole output
-        # row (0 * NaN). Valid entries are a contiguous prefix by the
-        # top-k transform's construction, so the count bounds them all.
-        seq_lens = (indices >= 0).sum(dim=-1, dtype=seq_lens.dtype)
+        # A valid tail can follow -1 holes from defensive top-k selection.
+        # Bound by the last valid column, not the number of valid columns.
+        # FlashInfer must mask the invalid KV payload as well as its logit.
+        if topk:
+            columns = torch.arange(
+                1, topk + 1, device=indices.device, dtype=seq_lens.dtype
+            )
+            seq_lens = torch.where(indices >= 0, columns, 0).amax(dim=-1)
+        else:
+            seq_lens = torch.zeros_like(seq_lens)
         if topk < _GLM53_NOPE_FLASHINFER_TOPK:
             indices = torch.nn.functional.pad(
                 indices,

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -755,15 +755,14 @@ def create_flashinfer_sparse_mla_runner(
     wrapper = getattr(mla, "SparseMLASm120Wrapper", None)
     configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
     config = configs().get("glm53_nope") if configs is not None else None
-    # The initial NoPE API advertises the family but still reads mutable slot
-    # zero for masked candidates and uses incompatible eight-head scratch.
-    # Row-width support alone does not establish either correctness contract.
-    if wrapper is None or getattr(config, "glm53_nope_contract_version", 0) < 1:
+    # Require the compact-capable native API. The FlashInfer dependency must
+    # include its masked-read and eight-head fixes as well as the row layout.
+    if wrapper is None or getattr(config, "compact_bytes_per_token", None) != 528:
         raise RuntimeError(
             "GLM NoPE sparse MLA requires FlashInfer native SM120 support "
-            "with glm53_nope contract version 1 or later "
-            "(masked candidate reads and eight-head decode scratch). "
-            "Upgrade FlashInfer to a build advertising this contract."
+            "with compact GLM NoPE rows (glm53_nope). "
+            "Upgrade FlashInfer to a build including compact rows, "
+            "masked candidate reads, and eight-head decode support."
         )
     return wrapper(
         max_num_tokens=max_num_tokens,

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_kpool.py
@@ -41,12 +41,12 @@ class DeepseekSparseAttnBackendKPoolMixin:
         if (
             topk_indices is None
             or self.dsa_index_kpool <= 1
-            or dsa_impl in ("fa3", "tilelang", "trtllm")
+            or dsa_impl in ("fa3", "tilelang", "trtllm", "flashinfer_sparse_mla")
         ):
             return
         raise NotImplementedError(
             "index_kpool > 1 appends tail tokens to topk_indices and is "
-            f"currently only supported by the FA3/TileLang/TRTLLM DSA {phase} "
+            f"currently only supported by the FA3/TileLang/TRTLLM/FlashInfer sparse-MLA DSA {phase} "
             "backend."
         )
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -50,8 +50,6 @@ from sglang.kernels.ops.attention.utils import (
 from sglang.kernels.ops.kvcache.cache_ops import concat_and_cast_q_fp8_pad
 from sglang.srt.configs.model_config import (
     get_dsa_index_kpool,
-    get_dsa_index_topk,
-    is_deepseek_dsa,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -88,7 +86,6 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
 from sglang.srt.layers.cp.base import get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_active
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_buffer, get_exec, get_parallel, get_spec
 from sglang.srt.utils import (
     is_cuda,
     is_gfx95_supported,
@@ -514,6 +511,7 @@ class DeepseekSparseAttnBackend(
 
         from sglang.kernels.ops.attention.flash_mla_sm120 import (
             _validate_flashinfer_sparse_mla_backend,
+            create_flashinfer_sparse_mla_runner,
         )
 
         uses_flashinfer_sparse_mla = _validate_flashinfer_sparse_mla_backend(
@@ -532,6 +530,20 @@ class DeepseekSparseAttnBackend(
                     dtype=torch.uint8,
                     device=model_runner.device,
                 ),
+            )
+            max_runner_tokens = max(
+                64,
+                int(getattr(model_runner.server_args, "chunked_prefill_size", 0) or 0),
+                int(getattr(model_runner.server_args, "max_prefill_tokens", 0) or 0),
+                model_runner.max_running_requests
+                * max(1, self.speculative_num_draft_tokens or 1),
+            )
+            self.flashinfer_sparse_mla_runner = create_flashinfer_sparse_mla_runner(
+                qk_rope_head_dim=self.qk_rope_head_dim,
+                kv_lora_rank=self.kv_lora_rank,
+                max_num_tokens=max_runner_tokens,
+                max_num_heads=self.num_q_heads,
+                device=model_runner.device,
             )
         # Allocate global workspace buffer for TRT-LLM kernels (ragged attention on SM100/B200, or trtllm decode)
         elif self.device_sm_major >= 10 or self.dsa_decode_impl == "trtllm":
@@ -2936,6 +2948,7 @@ class DeepseekSparseAttnBackend(
             indices=page_table_1,
             seq_lens=seq_lens,
             workspace_buffer=self.workspace_buffer,
+            runner=self.flashinfer_sparse_mla_runner,
             page_size=self.real_page_size,
             kv_cache_dim=self.kv_cache_dim,
             qk_nope_head_dim=self.qk_nope_head_dim,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -510,6 +510,7 @@ class DeepseekSparseAttnBackend(
         self._q8kv8_born_q_tbo = get_exec().overlap.enable_two_batch_overlap
 
         from sglang.kernels.ops.attention.flash_mla_sm120 import (
+            _flashinfer_sparse_mla_max_tokens,
             _validate_flashinfer_sparse_mla_backend,
             create_flashinfer_sparse_mla_runner,
         )
@@ -531,14 +532,12 @@ class DeepseekSparseAttnBackend(
                     device=model_runner.device,
                 ),
             )
-            # Mixed chunks can include decode or verify tokens in addition
-            # to the prefill token budget.
-            max_runner_tokens = max(
-                64,
-                int(getattr(model_runner.server_args, "chunked_prefill_size", 0) or 0),
-                int(getattr(model_runner.server_args, "max_prefill_tokens", 0) or 0),
-            ) + model_runner.max_running_requests * max(
-                1, self.speculative_num_draft_tokens or 1
+            max_runner_tokens = _flashinfer_sparse_mla_max_tokens(
+                chunked_prefill_size=model_runner.server_args.chunked_prefill_size,
+                max_prefill_tokens=model_runner.server_args.max_prefill_tokens,
+                context_len=model_runner.model_config.context_len,
+                max_running_requests=model_runner.max_running_requests,
+                speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             )
             self.flashinfer_sparse_mla_runner = create_flashinfer_sparse_mla_runner(
                 qk_rope_head_dim=self.qk_rope_head_dim,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -531,12 +531,14 @@ class DeepseekSparseAttnBackend(
                     device=model_runner.device,
                 ),
             )
+            # Mixed chunks can include decode or verify tokens in addition
+            # to the prefill token budget.
             max_runner_tokens = max(
                 64,
                 int(getattr(model_runner.server_args, "chunked_prefill_size", 0) or 0),
                 int(getattr(model_runner.server_args, "max_prefill_tokens", 0) or 0),
-                model_runner.max_running_requests
-                * max(1, self.speculative_num_draft_tokens or 1),
+            ) + model_runner.max_running_requests * max(
+                1, self.speculative_num_draft_tokens or 1
             )
             self.flashinfer_sparse_mla_runner = create_flashinfer_sparse_mla_runner(
                 qk_rope_head_dim=self.qk_rope_head_dim,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -2580,6 +2580,24 @@ def calculate_mla_kv_cache_dim(
     if uses_trtllm_kv_layout:
         return kv_cache_dim
 
+    # NoPE needs 512 FP8 values and four FP32 scales. Use compact rows when
+    # FlashInfer advertises them; older kernels require 128 padding bytes.
+    uses_flashinfer_sparse_mla = (
+        get_exec().kernel.dsa_prefill_backend == "flashinfer_sparse_mla"
+        or get_exec().kernel.dsa_decode_backend == "flashinfer_sparse_mla"
+    )
+    if (
+        not _is_hip
+        and kv_cache_dtype == torch.float8_e4m3fn
+        and qk_rope_head_dim == 0
+        and kv_lora_rank == 512
+        and uses_flashinfer_sparse_mla
+    ):
+        from flashinfer.mla import supported_sparse_mla_sm120_configs
+
+        config = supported_sparse_mla_sm120_configs()["glm53_nope"]
+        return getattr(config, "compact_bytes_per_token", None) or 656
+
     # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
     # nope(512 fp8) + rope(64 fp8), without extra per-block scales.
     if _is_hip and (

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -2597,7 +2597,7 @@ def calculate_mla_kv_cache_dim(
 
         supported_configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
         config = supported_configs().get("glm53_nope") if supported_configs else None
-        return getattr(config, "compact_bytes_per_token", None) or 656
+        return getattr(config, "bytes_per_token", None) or 656
 
     # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
     # nope(512 fp8) + rope(64 fp8), without extra per-block scales.

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -2593,9 +2593,10 @@ def calculate_mla_kv_cache_dim(
         and kv_lora_rank == 512
         and uses_flashinfer_sparse_mla
     ):
-        from flashinfer.mla import supported_sparse_mla_sm120_configs
+        from flashinfer import mla
 
-        config = supported_sparse_mla_sm120_configs()["glm53_nope"]
+        supported_configs = getattr(mla, "supported_sparse_mla_sm120_configs", None)
+        config = supported_configs().get("glm53_nope") if supported_configs else None
         return getattr(config, "compact_bytes_per_token", None) or 656
 
     # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -6,9 +6,14 @@ import torch
 
 from sglang.kernels.ops.attention.flash_mla_sm120 import (
     _validate_flashinfer_sparse_mla_backend,
+    create_flashinfer_sparse_mla_runner,
     flashinfer_sparse_mla_forward,
 )
 from sglang.srt.mem_cache import kv_cache_configurator
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.layers.attention.dsa.dsa_backend_kpool import (
+    DeepseekSparseAttnBackendKPoolMixin,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
@@ -33,20 +38,25 @@ class TestFlashInferSparseMLAAdapter(unittest.TestCase):
         indices = torch.full((2, 2051), -1, dtype=torch.int32)
         indices[0, :2] = torch.tensor([7, 9], dtype=torch.int32)
         indices[1, :3] = torch.tensor([4, 6, 8], dtype=torch.int32)
-        output = flashinfer_sparse_mla_forward(
-            q=torch.zeros((2, 8, 512), dtype=torch.bfloat16),
-            kv_cache=torch.zeros((128, 1, 528), dtype=torch.uint8),
-            indices=indices,
-            seq_lens=torch.tensor([2, 3], dtype=torch.int32),
+        backend = SimpleNamespace(
             workspace_buffer=torch.zeros(2 * 1024 * 1024, dtype=torch.uint8),
-            runner=FakeRunner(),
-            page_size=64,
+            flashinfer_sparse_mla_runner=FakeRunner(),
+            real_page_size=64,
             kv_cache_dim=528,
-            # This is the checkpoint's pre-absorption dimension. The query
-            # reaching the native sparse-MLA kernel is 512 wide.
             qk_nope_head_dim=256,
             kv_lora_rank=512,
             qk_rope_head_dim=0,
+            dsa_index_kpool=4,
+        )
+        DeepseekSparseAttnBackendKPoolMixin._check_kpool_tail_backend(
+            backend, indices, "flashinfer_sparse_mla", "prefill"
+        )
+        output = DeepseekSparseAttnBackend._forward_flashinfer_sparse_mla(
+            backend,
+            q_all=torch.zeros((2, 8, 512), dtype=torch.bfloat16),
+            kv_cache=torch.zeros((128, 1, 528), dtype=torch.uint8),
+            page_table_1=indices,
+            seq_lens=torch.tensor([4096, 8192], dtype=torch.int32),
             sm_scale=0.125,
             skip_softmax_threshold_scale_factor=None,
         )
@@ -62,6 +72,71 @@ class TestFlashInferSparseMLAAdapter(unittest.TestCase):
         self.assertEqual(tuple(captured["mid_lse"].shape), (2, 8, 34))
         self.assertEqual(tuple(output.shape), (2, 8, 512))
         self.assertTrue(torch.all(output == 2))
+
+
+class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
+    def _create(self, rope=0):
+        return create_flashinfer_sparse_mla_runner(
+            qk_rope_head_dim=rope,
+            kv_lora_rank=512,
+            max_num_tokens=4096,
+            max_num_heads=32,
+            device="cpu",
+        )
+
+    def test_existing_rope_path_does_not_require_native_api(self):
+        with patch("flashinfer.mla.SparseMLASm120Wrapper", None, create=True):
+            self.assertIsNone(self._create(rope=64))
+
+    def test_nope_requires_advertised_native_support(self):
+        with patch("flashinfer.mla.SparseMLASm120Wrapper", None, create=True):
+            with self.assertRaisesRegex(RuntimeError, "glm53_nope"):
+                self._create()
+
+    def test_native_wrapper_is_sized_before_capture(self):
+        marker = object()
+        with (
+            patch(
+                "flashinfer.mla.SparseMLASm120Wrapper", return_value=marker, create=True
+            ) as wrapper,
+            patch(
+                "flashinfer.mla.supported_sparse_mla_sm120_configs",
+                return_value={"glm53_nope": object()},
+                create=True,
+            ),
+        ):
+            self.assertIs(self._create(), marker)
+            wrapper.assert_called_once_with(
+                max_num_tokens=4096,
+                max_num_heads=32,
+                d_v=512,
+                kv_scale_format="arbitrary_fp32",
+                device="cpu",
+            )
+
+    def test_legacy_rope_call_keeps_pinned_flashinfer_api(self):
+        expected = torch.ones(2, 1, 8, 512, dtype=torch.bfloat16)
+        with patch(
+            "flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla",
+            return_value=expected,
+        ) as legacy:
+            output = flashinfer_sparse_mla_forward(
+                q=torch.zeros(2, 8, 576, dtype=torch.bfloat16),
+                kv_cache=torch.zeros(128, 1, 656, dtype=torch.uint8),
+                indices=torch.zeros(2, 2048, dtype=torch.int32),
+                seq_lens=torch.tensor([2, 3], dtype=torch.int32),
+                workspace_buffer=torch.zeros(1, dtype=torch.uint8),
+                page_size=64,
+                kv_cache_dim=656,
+                qk_nope_head_dim=512,
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+                sm_scale=0.125,
+                skip_softmax_threshold_scale_factor=None,
+            )
+        torch.testing.assert_close(output, expected.squeeze(1))
+        self.assertEqual(legacy.call_args.kwargs["query"].shape, (2, 1, 8, 576))
+        self.assertEqual(legacy.call_args.kwargs["kv_cache"].shape, (2, 1, 64, 656))
 
 
 class TestFlashInferSparseMLABackendGate(unittest.TestCase):
@@ -116,28 +191,52 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
 class TestFlashInferSparseMLAKVLayout(unittest.TestCase):
     def test_glm53_nope_layout_follows_kernel_capability(self):
         model_config = SimpleNamespace(
-            hf_config=SimpleNamespace(), kv_lora_rank=512, qk_rope_head_dim=0,
+            hf_config=SimpleNamespace(),
+            kv_lora_rank=512,
+            qk_rope_head_dim=0,
         )
-        execution = SimpleNamespace(kernel=SimpleNamespace(
-            dsa_prefill_backend="flashinfer_sparse_mla",
-            dsa_decode_backend="flashinfer_sparse_mla",
-        ))
+        execution = SimpleNamespace(
+            kernel=SimpleNamespace(
+                dsa_prefill_backend="flashinfer_sparse_mla",
+                dsa_decode_backend="flashinfer_sparse_mla",
+            )
+        )
         for capability, expected in [
+            ("missing_api", 656),
+            (None, 656),
             (SimpleNamespace(), 656),
             (SimpleNamespace(compact_bytes_per_token=None), 656),
             (SimpleNamespace(compact_bytes_per_token=528), 528),
         ]:
             with (
                 self.subTest(expected=expected),
-                patch.object(kv_cache_configurator, "is_deepseek_dsa", return_value=True),
+                patch.object(
+                    kv_cache_configurator, "is_deepseek_dsa", return_value=True
+                ),
                 patch.object(kv_cache_configurator, "get_exec", return_value=execution),
-                patch.object(kv_cache_configurator, "get_disagg", return_value=SimpleNamespace(disaggregation_mode="null")),
+                patch.object(
+                    kv_cache_configurator,
+                    "get_disagg",
+                    return_value=SimpleNamespace(disaggregation_mode="null"),
+                ),
                 patch.object(kv_cache_configurator, "_is_hip", False),
-                patch("flashinfer.mla.supported_sparse_mla_sm120_configs", return_value={"glm53_nope": capability}),
+                patch(
+                    "flashinfer.mla.supported_sparse_mla_sm120_configs",
+                    new=(
+                        None
+                        if capability == "missing_api"
+                        else lambda: {"glm53_nope": capability}
+                    ),
+                    create=True,
+                ),
             ):
-                self.assertEqual(kv_cache_configurator.calculate_mla_kv_cache_dim(
-                    model_config=model_config, kv_cache_dtype=torch.float8_e4m3fn,
-                ), expected)
+                self.assertEqual(
+                    kv_cache_configurator.calculate_mla_kv_cache_dim(
+                        model_config=model_config,
+                        kv_cache_dtype=torch.float8_e4m3fn,
+                    ),
+                    expected,
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -1,6 +1,5 @@
-import sys
 import unittest
-from types import ModuleType
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -9,65 +8,58 @@ from sglang.kernels.ops.attention.flash_mla_sm120 import (
     _validate_flashinfer_sparse_mla_backend,
     flashinfer_sparse_mla_forward,
 )
+from sglang.srt.mem_cache import kv_cache_configurator
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 
 class TestFlashInferSparseMLAAdapter(unittest.TestCase):
-    def _mock_flashinfer(self, op):
-        flashinfer = ModuleType("flashinfer")
-        flashinfer.__path__ = []
-        mla = ModuleType("flashinfer.mla")
-        mla.trtllm_batch_decode_with_kv_cache_mla = op
-        flashinfer.mla = mla
-        return patch.dict(
-            sys.modules,
-            {"flashinfer": flashinfer, "flashinfer.mla": mla},
-        )
-
-    def test_maps_sglang_layout_to_public_flashinfer_api(self):
+    def test_maps_glm53_nope_layout_to_persistent_flashinfer_runner(self):
         captured = {}
 
-        def fake_op(**kwargs):
-            captured.update(kwargs)
-            query = kwargs["query"]
-            return query.new_full((*query.shape[:-1], kwargs["kv_lora_rank"]), 2)
+        class FakeRunner:
+            def run(self, q, kv_cache, indices, output, sm_scale, **kwargs):
+                captured.update(
+                    q=q,
+                    kv_cache=kv_cache,
+                    indices=indices,
+                    output=output,
+                    sm_scale=sm_scale,
+                    **kwargs,
+                )
+                output.fill_(2)
 
-        with self._mock_flashinfer(fake_op):
-            output = flashinfer_sparse_mla_forward(
-                q=torch.zeros((2, 8, 576), dtype=torch.bfloat16),
-                kv_cache=torch.zeros((128, 1, 656), dtype=torch.uint8),
-                indices=torch.tensor(
-                    [[7, 9, -1, -1], [4, 6, 8, -1]], dtype=torch.int32
-                ),
-                seq_lens=torch.tensor([2, 3], dtype=torch.int32),
-                workspace_buffer=torch.zeros(1024, dtype=torch.uint8),
-                page_size=64,
-                kv_cache_dim=656,
-                qk_nope_head_dim=192,
-                kv_lora_rank=512,
-                qk_rope_head_dim=64,
-                sm_scale=0.125,
-                skip_softmax_threshold_scale_factor=0.25,
-            )
-
-        self.assertEqual(tuple(captured["query"].shape), (2, 1, 8, 576))
-        self.assertEqual(tuple(captured["kv_cache"].shape), (2, 1, 64, 656))
-        self.assertEqual(tuple(captured["block_tables"].shape), (2, 1, 4))
-        self.assertEqual(
-            captured["block_tables"].tolist(),
-            [[[7, 9, -1, -1]], [[4, 6, 8, -1]]],
+        indices = torch.full((2, 2051), -1, dtype=torch.int32)
+        indices[0, :2] = torch.tensor([7, 9], dtype=torch.int32)
+        indices[1, :3] = torch.tensor([4, 6, 8], dtype=torch.int32)
+        output = flashinfer_sparse_mla_forward(
+            q=torch.zeros((2, 8, 512), dtype=torch.bfloat16),
+            kv_cache=torch.zeros((128, 1, 528), dtype=torch.uint8),
+            indices=indices,
+            seq_lens=torch.tensor([2, 3], dtype=torch.int32),
+            workspace_buffer=torch.zeros(2 * 1024 * 1024, dtype=torch.uint8),
+            runner=FakeRunner(),
+            page_size=64,
+            kv_cache_dim=528,
+            # This is the checkpoint's pre-absorption dimension. The query
+            # reaching the native sparse-MLA kernel is 512 wide.
+            qk_nope_head_dim=256,
+            kv_lora_rank=512,
+            qk_rope_head_dim=0,
+            sm_scale=0.125,
+            skip_softmax_threshold_scale_factor=None,
         )
-        self.assertEqual(captured["seq_lens"].tolist(), [2, 3])
-        self.assertEqual(captured["max_seq_len"], 4)
-        self.assertEqual(captured["sparse_mla_top_k"], 4)
-        self.assertEqual(captured["qk_nope_head_dim"], 192)
-        self.assertEqual(captured["bmm1_scale"], 0.125)
-        self.assertEqual(captured["bmm2_scale"], 1.0)
-        self.assertEqual(captured["kv_scale_format"], "arbitrary_fp32")
-        self.assertEqual(captured["skip_softmax_threshold_scale_factor"], 0.25)
-        self.assertNotIn("backend", captured)
+
+        self.assertEqual(tuple(captured["q"].shape), (2, 8, 512))
+        self.assertEqual(tuple(captured["kv_cache"].shape), (2, 64, 528))
+        self.assertEqual(tuple(captured["indices"].shape), (2, 2176))
+        self.assertEqual(captured["indices"][0, :4].tolist(), [7, 9, -1, -1])
+        self.assertTrue(torch.all(captured["indices"][:, 2051:] == -1))
+        self.assertEqual(captured["topk_length"].tolist(), [2, 3])
+        self.assertEqual(captured["sm_scale"], 0.125)
+        self.assertEqual(tuple(captured["mid_out"].shape), (2, 8, 34, 512))
+        self.assertEqual(tuple(captured["mid_lse"].shape), (2, 8, 34))
         self.assertEqual(tuple(output.shape), (2, 8, 512))
         self.assertTrue(torch.all(output == 2))
 
@@ -86,6 +78,8 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
         for model_arch in (
             "GlmMoeDsaForCausalLM",
             "GlmMoeDsaForCausalLMNextN",
+            "Glm5NextForConditionalGeneration",
+            "Glm5NextForConditionalGenerationNextN",
         ):
             with self.subTest(model_arch=model_arch):
                 self.assertTrue(
@@ -96,14 +90,14 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
                     )
                 )
 
-    def test_rejects_other_or_mixed_backends(self):
-        for prefill, decode in (
-            ("trtllm", "trtllm"),
-            ("flashinfer_sparse_mla", "trtllm"),
-        ):
+    def test_ignores_other_backends_when_flashinfer_is_not_selected(self):
+        for prefill, decode in (("tilelang", "tilelang"), ("trtllm", "trtllm")):
             with self.subTest(prefill=prefill, decode=decode):
-                with self.assertRaisesRegex(ValueError, "only flashinfer_sparse_mla"):
-                    self._validate(prefill, decode)
+                self.assertFalse(self._validate(prefill, decode))
+
+    def test_rejects_mixed_flashinfer_backend(self):
+        with self.assertRaisesRegex(ValueError, "only flashinfer_sparse_mla"):
+            self._validate("flashinfer_sparse_mla", "trtllm")
 
     def test_reports_unsupported_configuration(self):
         with self.assertRaises(ValueError) as error:
@@ -117,6 +111,33 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
         self.assertIn("model_arch='DeepseekV3ForCausalLM'", message)
         self.assertIn("sm_major=12", message)
         self.assertIn("kv_cache_dtype=torch.float8_e4m3fn", message)
+
+
+class TestFlashInferSparseMLAKVLayout(unittest.TestCase):
+    def test_glm53_nope_layout_follows_kernel_capability(self):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(), kv_lora_rank=512, qk_rope_head_dim=0,
+        )
+        execution = SimpleNamespace(kernel=SimpleNamespace(
+            dsa_prefill_backend="flashinfer_sparse_mla",
+            dsa_decode_backend="flashinfer_sparse_mla",
+        ))
+        for capability, expected in [
+            (SimpleNamespace(), 656),
+            (SimpleNamespace(compact_bytes_per_token=None), 656),
+            (SimpleNamespace(compact_bytes_per_token=528), 528),
+        ]:
+            with (
+                self.subTest(expected=expected),
+                patch.object(kv_cache_configurator, "is_deepseek_dsa", return_value=True),
+                patch.object(kv_cache_configurator, "get_exec", return_value=execution),
+                patch.object(kv_cache_configurator, "get_disagg", return_value=SimpleNamespace(disaggregation_mode="null")),
+                patch.object(kv_cache_configurator, "_is_hip", False),
+                patch("flashinfer.mla.supported_sparse_mla_sm120_configs", return_value={"glm53_nope": capability}),
+            ):
+                self.assertEqual(kv_cache_configurator.calculate_mla_kv_cache_dim(
+                    model_config=model_config, kv_cache_dtype=torch.float8_e4m3fn,
+                ), expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import torch
 
 from sglang.kernels.ops.attention.flash_mla_sm120 import (
+    _flashinfer_sparse_mla_max_tokens,
     _validate_flashinfer_sparse_mla_backend,
     create_flashinfer_sparse_mla_runner,
     flashinfer_sparse_mla_forward,
@@ -237,6 +238,40 @@ class TestFlashInferSparseMLAKVLayout(unittest.TestCase):
                     ),
                     expected,
                 )
+
+
+class TestFlashInferSparseMLARunnerCapacity(unittest.TestCase):
+    def test_unchunked_first_prompt_can_exceed_prefill_budget(self):
+        for chunk in (None, 0, -1):
+            with self.subTest(chunk=chunk):
+                capacity = _flashinfer_sparse_mla_max_tokens(
+                    chunked_prefill_size=chunk,
+                    max_prefill_tokens=16384,
+                    context_len=32768,
+                    max_running_requests=4,
+                    speculative_num_draft_tokens=6,
+                )
+                self.assertGreaterEqual(capacity, 32768 + 4 * 6)
+
+    def test_chunked_mixed_batch_does_not_reserve_entire_context(self):
+        capacity = _flashinfer_sparse_mla_max_tokens(
+            chunked_prefill_size=4096,
+            max_prefill_tokens=4096,
+            context_len=524288,
+            max_running_requests=4,
+            speculative_num_draft_tokens=6,
+        )
+        self.assertEqual(capacity, 4120)
+
+    def test_unchunked_batch_budget_can_exceed_one_context(self):
+        capacity = _flashinfer_sparse_mla_max_tokens(
+            chunked_prefill_size=None,
+            max_prefill_tokens=65536,
+            context_len=32768,
+            max_running_requests=4,
+            speculative_num_draft_tokens=None,
+        )
+        self.assertGreaterEqual(capacity, 65536 + 4)
 
 
 class TestFlashInferSparseMLAIndexAndWorkspaceBounds(unittest.TestCase):

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -9,11 +9,11 @@ from sglang.kernels.ops.attention.flash_mla_sm120 import (
     create_flashinfer_sparse_mla_runner,
     flashinfer_sparse_mla_forward,
 )
-from sglang.srt.mem_cache import kv_cache_configurator
-from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
 from sglang.srt.layers.attention.dsa.dsa_backend_kpool import (
     DeepseekSparseAttnBackendKPoolMixin,
 )
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.mem_cache import kv_cache_configurator
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -14,6 +14,7 @@ from sglang.srt.layers.attention.dsa.dsa_backend_kpool import (
     DeepseekSparseAttnBackendKPoolMixin,
 )
 from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache import kv_cache_configurator
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -252,6 +253,48 @@ class TestFlashInferSparseMLARunnerCapacity(unittest.TestCase):
                     speculative_num_draft_tokens=6,
                 )
                 self.assertGreaterEqual(capacity, 32768 + 4 * 6)
+
+    def test_ignore_eos_last_prompt_can_overshoot_prefill_budget(self):
+        adder = PrefillAdder(
+            page_size=64,
+            tree_cache=SimpleNamespace(
+                disable=True, supports_mamba=lambda: False, evictable_size=lambda: 0
+            ),
+            token_to_kv_pool_allocator=SimpleNamespace(available_size=lambda: 450560),
+            running_batch=None,
+            new_token_ratio=1.0,
+            rem_input_tokens=16384,
+            rem_chunk_tokens=None,
+        )
+
+        class Request(SimpleNamespace):
+            def set_extend_range(self, start, end):
+                self.extend_range = SimpleNamespace(length=end - start)
+
+        for length, result in (
+            (8192, AddReqResult.CONTINUE),
+            (30000, AddReqResult.OTHER),
+        ):
+            req = Request(
+                full_untruncated_fill_ids=range(length),
+                origin_input_ids=range(length),
+                prefix_indices=[],
+                output_ids=[],
+                sampling_params=SimpleNamespace(ignore_eos=True, max_new_tokens=8),
+                retracted_stain=False,
+            )
+            self.assertIs(adder.add_one_req(req, False, None), result)
+        self.assertEqual(len(adder.can_run_list), 2)
+        admitted = sum(req.extend_range.length for req in adder.can_run_list)
+        self.assertEqual(admitted, 38192)
+        capacity = _flashinfer_sparse_mla_max_tokens(
+            chunked_prefill_size=None,
+            max_prefill_tokens=16384,
+            context_len=32768,
+            max_running_requests=4,
+            speculative_num_draft_tokens=6,
+        )
+        self.assertGreaterEqual(capacity, admitted + 4 * 6)
 
     def test_chunked_mixed_batch_does_not_reserve_entire_context(self):
         capacity = _flashinfer_sparse_mla_max_tokens(

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -99,8 +99,8 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
         for config in (
             None,
             SimpleNamespace(),
-            SimpleNamespace(compact_bytes_per_token=None),
-            SimpleNamespace(compact_bytes_per_token=656),
+            SimpleNamespace(bytes_per_token=None),
+            SimpleNamespace(bytes_per_token=656),
         ):
             with (
                 self.subTest(config=config),
@@ -123,9 +123,7 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
             ) as wrapper,
             patch(
                 "flashinfer.mla.supported_sparse_mla_sm120_configs",
-                return_value={
-                    "glm53_nope": SimpleNamespace(compact_bytes_per_token=528)
-                },
+                return_value={"glm53_nope": SimpleNamespace(bytes_per_token=528)},
                 create=True,
             ),
         ):
@@ -229,8 +227,8 @@ class TestFlashInferSparseMLAKVLayout(unittest.TestCase):
             ("missing_api", 656),
             (None, 656),
             (SimpleNamespace(), 656),
-            (SimpleNamespace(compact_bytes_per_token=None), 656),
-            (SimpleNamespace(compact_bytes_per_token=528), 528),
+            (SimpleNamespace(bytes_per_token=None), 656),
+            (SimpleNamespace(bytes_per_token=528), 528),
         ]:
             with (
                 self.subTest(expected=expected),

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -239,5 +239,64 @@ class TestFlashInferSparseMLAKVLayout(unittest.TestCase):
                 )
 
 
+class TestFlashInferSparseMLAIndexAndWorkspaceBounds(unittest.TestCase):
+    def _run(self, indices, heads=32, workspace_bytes=None):
+        captured = {}
+
+        class FakeRunner:
+            def run(self, q, kv_cache, indices, output, sm_scale, **kwargs):
+                captured.update(indices=indices, **kwargs)
+                output.zero_()
+
+        tokens = indices.shape[0]
+        scratch_heads = 8 if heads == 8 else ((heads + 15) // 16) * 16
+        required = tokens * scratch_heads * 34 * (512 * 2 + 4)
+        flashinfer_sparse_mla_forward(
+            q=torch.zeros(tokens, heads, 512, dtype=torch.bfloat16),
+            kv_cache=torch.zeros(1, 64, 528, dtype=torch.uint8),
+            indices=indices,
+            seq_lens=torch.full((tokens,), 8192, dtype=torch.int32),
+            workspace_buffer=torch.zeros(
+                required if workspace_bytes is None else workspace_bytes,
+                dtype=torch.uint8,
+            ),
+            runner=FakeRunner(),
+            page_size=64,
+            kv_cache_dim=528,
+            qk_nope_head_dim=256,
+            kv_lora_rank=512,
+            qk_rope_head_dim=0,
+            sm_scale=0.125,
+            skip_softmax_threshold_scale_factor=None,
+        )
+        return captured, required
+
+    def test_holes_do_not_exclude_kpool_tail(self):
+        indices = torch.full((1, 2051), -1, dtype=torch.int32)
+        indices[0, :2044] = torch.arange(1, 2045, dtype=torch.int32)
+        indices[0, 2048:] = torch.tensor([9000, 9001, 9002], dtype=torch.int32)
+        captured, _ = self._run(indices)
+        self.assertEqual(captured["topk_length"].tolist(), [2051])
+        torch.testing.assert_close(captured["indices"][:, :2051], indices)
+
+    def test_leading_holes_and_empty_rows(self):
+        indices = torch.tensor([[-1, 2, 3, -1], [-1, -1, -1, -1]], dtype=torch.int32)
+        captured, _ = self._run(indices)
+        self.assertEqual(captured["topk_length"].tolist(), [3, 0])
+
+    def test_exact_and_one_byte_short_workspace(self):
+        indices = torch.tensor([[2, -1]], dtype=torch.int32)
+        for heads in (8, 24, 32):
+            with self.subTest(heads=heads):
+                captured, required = self._run(indices, heads=heads)
+                expected_heads = 8 if heads == 8 else 32
+                self.assertEqual(
+                    captured["mid_out"].shape, (1, expected_heads, 34, 512)
+                )
+                self.assertEqual(captured["mid_lse"].shape, (1, expected_heads, 34))
+                with self.assertRaisesRegex(ValueError, "workspace is too small"):
+                    self._run(indices, heads=heads, workspace_bytes=required - 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -95,6 +95,26 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "glm53_nope"):
                 self._create()
 
+    def test_nope_rejects_legacy_and_compact_only_capabilities(self):
+        for config in (
+            None,
+            SimpleNamespace(),
+            SimpleNamespace(compact_bytes_per_token=528),
+            SimpleNamespace(glm53_nope_contract_version=0),
+        ):
+            with (
+                self.subTest(config=config),
+                patch("flashinfer.mla.SparseMLASm120Wrapper", create=True) as wrapper,
+                patch(
+                    "flashinfer.mla.supported_sparse_mla_sm120_configs",
+                    return_value={"glm53_nope": config},
+                    create=True,
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "contract version 1"):
+                    self._create()
+                wrapper.assert_not_called()
+
     def test_native_wrapper_is_sized_before_capture(self):
         marker = object()
         with (
@@ -103,7 +123,11 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
             ) as wrapper,
             patch(
                 "flashinfer.mla.supported_sparse_mla_sm120_configs",
-                return_value={"glm53_nope": object()},
+                # Corrected 656-byte implementations need not advertise compact
+                # rows. The execution contract is independent of row capacity.
+                return_value={
+                    "glm53_nope": SimpleNamespace(glm53_nope_contract_version=1)
+                },
                 create=True,
             ),
         ):

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -95,12 +95,12 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "glm53_nope"):
                 self._create()
 
-    def test_nope_rejects_legacy_and_compact_only_capabilities(self):
+    def test_nope_requires_compact_capable_native_backend(self):
         for config in (
             None,
             SimpleNamespace(),
-            SimpleNamespace(compact_bytes_per_token=528),
-            SimpleNamespace(glm53_nope_contract_version=0),
+            SimpleNamespace(compact_bytes_per_token=None),
+            SimpleNamespace(compact_bytes_per_token=656),
         ):
             with (
                 self.subTest(config=config),
@@ -111,7 +111,7 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
                     create=True,
                 ),
             ):
-                with self.assertRaisesRegex(RuntimeError, "contract version 1"):
+                with self.assertRaisesRegex(RuntimeError, "compact GLM NoPE rows"):
                     self._create()
                 wrapper.assert_not_called()
 
@@ -123,10 +123,8 @@ class TestFlashInferSparseMLARunnerCompatibility(unittest.TestCase):
             ) as wrapper,
             patch(
                 "flashinfer.mla.supported_sparse_mla_sm120_configs",
-                # Corrected 656-byte implementations need not advertise compact
-                # rows. The execution contract is independent of row capacity.
                 return_value={
-                    "glm53_nope": SimpleNamespace(glm53_nope_contract_version=1)
+                    "glm53_nope": SimpleNamespace(compact_bytes_per_token=528)
                 },
                 create=True,
             ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

With compact-aware FlashInfer kernels, the same memory budget for GLM NoPE KV rows can hold 24.2% more token slots: each row uses 528 rather than 656 bytes, with the same FP8 values and FP32 scales. That provides more room for long prompts or cached request context without reducing precision. This is the row-capacity gain before allocator padding; other memory pools and configured context limits still apply.

This PR makes that capacity available to SGLang by integrating FlashInfer's native GLM NoPE attention backend on SM120 and selecting compact rows when supported. The existing RoPE entry point cannot serve GLM's NoPE query and sparse-candidate geometry. The required [FlashInfer #5075](https://github.com/flashinfer-ai/flashinfer/pull/5075) provides Gabriel Wu’s canonical compact payload, runtime row strides and masked-read correction; [David Orman’s follow-up](https://github.com/lucifer1004/flashinfer/pull/3) supplies the eight-head decode fix and additional validation. No isolated serving speedup is claimed.

Related to #36830 for the SM120 native-backend path; this PR does not add SM90 support.

## Modifications

Use a persistent native FlashInfer wrapper for GLM NoPE and recognize the Glm5Next architectures. Pad 2,051 candidates to 2,176 columns and bound each row by its last valid column, preserving valid tail entries after missing groups. Size the runner buffers for mixed prefill/decode/verify batches and the scheduler's final whole-prompt admission when chunking is disabled. Allow this backend with multiple KPool index groups. When either attention phase selects the native backend, require both phases to select it; preserve other backend pairs for their existing validation paths.

Select compact 528-byte FP8 KV rows from FlashInfer’s model-specific canonical payload metadata. Native GLM NoPE runner construction requires this capability; the earlier padded-only native API is rejected. Both layouts contain the same 512 FP8 values and four FP32 scales. Compact rows remove 128 unused RoPE bytes per cached token per affected layer without requantization. This applies to GLM NoPE, not models that store RoPE values in those bytes.

This backend requires the complete changes in [FlashInfer #5075](https://github.com/flashinfer-ai/flashinfer/pull/5075) and [lucifer1004/flashinfer#3](https://github.com/lucifer1004/flashinfer/pull/3), including the masked-read correction and compatible eight-head decode scratch. Until these changes land upstream, the complete FlashInfer dependency is available at `ormandj/flashinfer` commit `e7cad40ef1c1c279186c92a22656cdf42325d31c`. Runner construction requires `supported_sparse_mla_sm120_configs()["glm53_nope"].bytes_per_token == 528`. That check excludes older payload metadata, but does not independently verify correctness fixes; partial cherry-picks of compact-row support are unsupported. The compact-capable kernels accept both 528- and 656-byte inputs. The separate open PR #37625 addresses finite top-k selection; this adapter also handles `-1` holes without dropping subsequent valid candidates. The existing RoPE API remains available. The native GLM NoPE path does not support skip-softmax thresholds: leave `SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR` and `SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR` unset.

## Accuracy Tests

Author CPU validation at `28379a7c55`, based on SGLang main `dc5f59c3a2`: 18 tests and 21 subtests passed with CUDA hidden, using FlashInfer with [#5075](https://github.com/flashinfer-ai/flashinfer/pull/5075) and [lucifer1004/flashinfer#3](https://github.com/lucifer1004/flashinfer/pull/3). The tests cover canonical model-specific payload metadata, rejecting older or incompatible APIs, preserving legacy RoPE entry points, and the layout/capacity cases below. Configured hooks passed on the changed files. Earlier GPU and sanitizer results retain their original source scope.

Earlier author-run GPU and sanitizer results used SGLang source `6ccd5e37e4` with FlashInfer source `c35c4d12a6`. These are separate from the current CPU validation above.

| Test scope | Result |
|---|---|
| Adapter with the companion FlashInfer changes, RTX PRO 6000 Blackwell SM120 | 6 GPU cases passed |
| Compute Sanitizer on those 6 adapter cases and 64 FlashInfer masked-entry cases | 70 cases passed; 0 errors |

The CPU tests cover backend selection, layout capability, unchunked scheduler overshoot, mixed-batch capacity, holes and empty rows, and exact versus one-byte-short workspace at 8/24/32 heads. The GPU cases use `(tokens, heads)` of `(1, 32)`, `(4, 8)` and `(65, 32)` with both 528- and 656-byte rows. They check finite, expected outputs with NaNs planted in unused cache slot 0, missing candidates and valid tail entries. These adapter/kernel checks do not establish whole-model accuracy.

```bash
python -m pytest -q test/registered/unit/test_flashinfer_sparse_mla.py
```

## Speed Tests and Profiling

Per-row storage decreases from 656 to 528 bytes, a 128-byte reduction (19.5%). Total storage saved is `128 bytes × cached token slots × affected layers`, before allocator padding. The FP8 values and FP32 scales are unchanged. No isolated serving throughput result is available for this adapter; smaller cache rows do not by themselves establish faster attention.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34542801921](https://github.com/sgl-project/sglang/actions/runs/34542801921)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34542801577](https://github.com/sgl-project/sglang/actions/runs/34542801577)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34542801955](https://github.com/sgl-project/sglang/actions/runs/34542801955)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
