### PR TITLE
Reuse host lengths to avoid KDA prefill synchronization

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -817,7 +817,14 @@ class KDAAttnBackend(MambaAttnBackendBase):
         has_initial_state = forward_batch.extend_prefix_lens > 0
 
         physical_num_tokens = mixed_qkv.shape[0]
-        logical_num_tokens = int(query_start_loc[-1])
+        # These host lengths also build query_start_loc. Reading its final
+        # device element synchronizes every KDA layer with the GPU. Keep the
+        # fallback for batches whose extend metadata exists only on device.
+        logical_num_tokens = (
+            sum(forward_batch.extend_seq_lens_cpu)
+            if forward_batch.extend_seq_lens_cpu is not None
+            else int(query_start_loc[-1])
+        )
         if logical_num_tokens < physical_num_tokens:
             mixed_qkv = mixed_qkv[:logical_num_tokens]
             a = a[:, :logical_num_tokens]

--- a/test/registered/unit/layers/attention/test_kda_extend_host_lengths.py
+++ b/test/registered/unit/layers/attention/test_kda_extend_host_lengths.py
@@ -1,0 +1,115 @@
+"""KDA extend must trim padding without reading device lengths when host metadata exists."""
+
+from types import SimpleNamespace as NS
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.linear import kda_backend
+from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class DeviceOffsets:
+    """A stand-in that rejects any host read of GPU sequence boundaries."""
+
+    def __getitem__(self, index):
+        raise AssertionError("Host metadata path read device query_start_loc")
+
+
+def run(lengths, padding, prefix, host_metadata, track=False):
+    n = sum(lengths)
+    seen = []
+    offsets = (
+        DeviceOffsets()
+        if host_metadata
+        else torch.tensor([0, *torch.tensor(lengths).cumsum(0).tolist()])
+    )
+
+    def conv(x, *args, **kw):
+        assert x.shape == (6, n)
+        assert kw["query_start_loc"] is offsets
+        assert kw["seq_lens_cpu"] == (lengths if host_metadata else None)
+        torch.testing.assert_close(kw["has_initial_state"], torch.tensor(prefix) > 0)
+        seen.append("conv")
+        return x
+
+    def extend(**kw):
+        assert kw["q"].shape == (1, n, 1, 2)
+        assert kw["g"].shape == (1, n, 1, 2)
+        assert kw["beta"].shape == (1, n, 1)
+        assert kw["query_start_loc"] is offsets
+        out = kw["q"] + kw["k"] + kw["v"] + kw["g"] + kw["beta"].unsqueeze(-1)
+        seen.append("extend")
+        return (out, torch.ones(1)) if track else out
+
+    states = NS(conv=[torch.zeros(3, 2, 6)], temporal=torch.zeros(3, 1, 2, 2))
+    meta = NS(
+        query_start_loc=offsets,
+        mamba_cache_indices=torch.tensor([2, 0, 1][: len(lengths)]),
+        has_mamba_track_mask=track,
+        conv_states_mask_indices=torch.tensor([1]),
+        track_conv_indices=torch.tensor([[0, 1]]),
+        track_ssm_h_src=torch.tensor([0]),
+    )
+
+    def track_state(*args):
+        seen.append("track")
+
+    backend = NS(
+        forward_metadata=meta,
+        req_to_token_pool=NS(mamba2_layer_cache=lambda _: states),
+        kernel_dispatcher=NS(extend=extend),
+        accept_lens_pool=None,
+        _track_mamba_state_extend=track_state,
+    )
+    mode = NS(is_target_verify=lambda: False, is_draft_extend_v2=lambda: False)
+    batch = NS(
+        forward_mode=mode,
+        extend_prefix_lens=torch.tensor(prefix),
+        extend_seq_lens_cpu=list(lengths) if host_metadata else None,
+    )
+    layer = NS(
+        layer_id=0,
+        conv_weights=None,
+        bias=None,
+        q_dim=2,
+        k_dim=2,
+        v_dim=2,
+        head_q_dim=2,
+        head_k_dim=2,
+        head_v_dim=2,
+        A_log=None,
+        dt_bias=None,
+        lower_bound=None,
+    )
+    x = torch.arange((n + padding) * 6, dtype=torch.float32).reshape(n + padding, 6)
+    a = torch.ones(1, n + padding, 2)
+    b = torch.ones(1, n + padding, 1)
+    x[n:] = float("nan")
+    a[:, n:] = float("nan")
+    b[:, n:] = float("nan")
+    with patch.object(kda_backend, "causal_conv1d_fn", conv, create=True):
+        out = KDAAttnBackend.forward_extend(backend, layer, batch, x, a, b)
+    expected = x[:n, :2] + x[:n, 2:4] + x[:n, 4:] + 2
+    torch.testing.assert_close(out[0, :n, 0], expected, rtol=0, atol=0)
+    assert out.shape == (1, n + padding, 1, 2)
+    assert torch.isfinite(out).all()
+    assert torch.count_nonzero(out[:, n:]) == 0
+    assert seen == ["conv", "extend"] + (["track"] if track else [])
+    return out, states.conv[0]
+
+
+@pytest.mark.parametrize(
+    "lengths,prefix", [([5], [0]), ([3, 2], [4096, 0]), ([3, 2, 0], [8192, 7, 0])]
+)
+@pytest.mark.parametrize("padding", [0, 11])
+@pytest.mark.parametrize("host_metadata", [False, True])
+@pytest.mark.parametrize("track", [False, True])
+def test_kda_extend_host_lengths_preserve_layout_and_tracking(
+    lengths, prefix, padding, host_metadata, track
+):
+    run(lengths, padding, prefix, host_metadata, track=track)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This change targets a shorter wait for the first response token, especially for long prompts. KDA prefill currently waits for a sequence-length read from the GPU in every layer of every chunk, even though the scheduler already has that length on the CPU.

Reusing the host lengths removes those repeated waits without changing the attention computation or generation settings. The profile below shows 1,122 device scalar reads eliminated for a 131,158-token prompt. That establishes reduced synchronization work; an isolated time-to-first-token improvement has not yet been measured.



## Modifications

Use the sum of `extend_seq_lens_cpu` when available. Keep the device-offset fallback when host lengths are absent, and preserve input trimming, output padding, cached-state handling and target verification.

## Accuracy Tests

Author CPU validation at `c0a43f8c19`: 24 tests passed, with CUDA hidden. Its Python runtime and test trees are unchanged at refreshed head `eb71d35924` on main `afe90a8bc9`. Earlier GPU and serving results retain their stated source scope.

Author-run result: 24 CPU cases pass in `test/registered/unit/layers/attention/test_kda_extend_host_lengths.py`. They cover host lengths and the device fallback, padding and state tracking. The host-metadata cases raise if the code reads device offsets, and check exact output values, shape and padding with stubbed numerical kernels. These tests validate the metadata change, not GPU kernel numerics.

```bash
python -m pytest -q test/registered/unit/layers/attention/test_kda_extend_host_lengths.py
```

## Speed Tests and Profiling

Author-reported CPU/CUDA profiling of GLM-5.3-Flash W4A16 with FP8 KV on two RTX PRO 6000 Blackwell Max-Q 96 GB GPUs at 300 W, TP2 over PCIe. One cold 131,158-token prompt was traced for each path, using 4,096-token prefill chunks and stopping after one generated token. The table counts KDA sequence-length scalar reads on rank 0 across the 33 target prefill chunks.

| KDA sequence-length reads from device | Device-offset path | Host-length path |
|---|---:|---:|
| Per target prefill chunk | 34 | 0 |
| Full prompt | 1,122 | 0 |

These are operation counts from the profiled paths. The surrounding builds also differed in KV layout, so they do not establish an isolated serving speedup for this PR. The device-offset fallback still synchronizes when host lengths are absent.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34282262308](https://github.com/sgl-project/sglang/actions/runs/34282262308)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34282261977](https://github.com/sgl-project/sglang/actions/runs/34282261977)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34282262293](https://github.com/sgl-project/sglang/actions/runs/34282262293)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->