### PR TITLE
moe: centralize simple combine-input construction

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
@@ -12,6 +12,7 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputChecker,
     DispatchOutputFormat,
+    make_hidden_states_only_combine_input,
 )
 from sglang.srt.layers.moe.token_dispatcher.deepep import (
     DeepEPConfig,
@@ -67,6 +68,7 @@ __all__ = [
     "DispatchOutput",
     "DispatchOutputFormat",
     "DispatchOutputChecker",
+    "make_hidden_states_only_combine_input",
     "FlashinferDispatchOutput",
     "FlashinferDispatcher",
     "MooncakeCombineInput",

--- a/python/sglang/srt/layers/moe/token_dispatcher/base.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/base.py
@@ -279,6 +279,28 @@ class CombineInput(Protocol):
     def format(self) -> CombineInputFormat: ...
 
 
+def make_hidden_states_only_combine_input(
+    dispatch_output: DispatchOutput, hidden_states: torch.Tensor
+) -> CombineInput:
+    """Build a combine input when its only payload is ``hidden_states``."""
+    if dispatch_output.format.is_standard():
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+
+        return StandardCombineInput(hidden_states=hidden_states)
+    if dispatch_output.format.is_flashinfer():
+        from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+            FlashinferCombineInput,
+        )
+
+        return FlashinferCombineInput(hidden_states=hidden_states)
+    raise ValueError(
+        "cannot build a hidden-states-only combine input for "
+        f"dispatch format {dispatch_output.format.value!r}"
+    )
+
+
 # ------------------------------ Base Dispatcher -------------------------------------
 
 

--- a/test/registered/unit/layers/moe/test_moe_runner_extensions.py
+++ b/test/registered/unit/layers/moe/test_moe_runner_extensions.py
@@ -17,6 +17,13 @@ from sglang.srt.layers.moe.moe_runner.base import (
     RunnerInput,
     RunnerOutput,
 )
+from sglang.srt.layers.moe.token_dispatcher import (
+    make_hidden_states_only_combine_input,
+)
+from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+    FlashinferCombineInput,
+    FlashinferDispatchOutput,
+)
 from sglang.srt.layers.moe.token_dispatcher.standard import (
     StandardCombineInput,
     StandardDispatchOutput,
@@ -33,6 +40,35 @@ from sglang.srt.runtime_context import get_context, get_flags, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, suite="stage-b-test-cpu-intel")
+
+
+@pytest.mark.parametrize(
+    ("dispatch_output_type", "combine_input_type"),
+    [
+        (StandardDispatchOutput, StandardCombineInput),
+        (FlashinferDispatchOutput, FlashinferCombineInput),
+    ],
+)
+def test_make_hidden_states_only_combine_input(
+    dispatch_output_type, combine_input_type
+) -> None:
+    hidden_states = torch.zeros(1, 2)
+    dispatch_output = dispatch_output_type(
+        hidden_states=hidden_states,
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=torch.ones(1, 1),
+            topk_ids=torch.zeros(1, 1, dtype=torch.int64),
+            router_logits=torch.zeros(1, 1),
+        ),
+    )
+
+    combine_input = make_hidden_states_only_combine_input(
+        dispatch_output, hidden_states
+    )
+
+    assert isinstance(combine_input, combine_input_type)
+    assert combine_input.hidden_states is hidden_states
 
 
 class _TestDispatchRunnerCore(DispatchMoeRunnerCore):


### PR DESCRIPTION
## Summary

Add a token-dispatcher helper for constructing hidden-states-only combine inputs. This lets external MoE runners preserve dispatcher-specific metadata without duplicating FlashInfer internals.

## Test plan

- `pytest -q test/registered/unit/layers/moe/test_moe_runner_extensions.py -k make_hidden_states_only_combine_input` (2 passed)
- pre-commit hooks on the changed files (passed)

## Original commits

- 1cbdc7c459

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34194518075](https://github.com/sgl-project/sglang/actions/runs/34194518075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34194517958](https://github.com/sgl-project/sglang/actions/runs/34194517958)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34194544418](https://github.com/sgl-project/sglang/actions/runs/34194544418)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->