### PR TITLE
models: register external architecture capabilities

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -20,7 +20,7 @@ import os
 from enum import Enum, IntEnum, auto
 from functools import cached_property
 from pathlib import Path
-from typing import Any, List, Optional, Set, Union
+from typing import Any, Iterable, List, Optional, Set, Union
 
 import torch
 from transformers import PretrainedConfig
@@ -2123,8 +2123,44 @@ multimodal_breakable_cuda_graph_supported_model_archs = [
     "KimiK25ForConditionalGeneration",
 ]
 
+
+def register_external_model_architectures(
+    model_architectures: str | Iterable[str],
+    *,
+    multimodal: bool = False,
+    multimodal_piecewise_cuda_graph: bool = False,
+    multimodal_breakable_cuda_graph: bool = False,
+) -> None:
+    """Register capabilities for architectures supplied by an external package."""
+    if isinstance(model_architectures, str):
+        model_architectures = (model_architectures,)
+    else:
+        model_architectures = tuple(model_architectures)
+    if not model_architectures or any(
+        not isinstance(name, str) or not name for name in model_architectures
+    ):
+        raise ValueError("external model architecture names must be non-empty")
+    capabilities = (
+        (multimodal, multimodal_model_archs),
+        (
+            multimodal_piecewise_cuda_graph,
+            multimodal_piecewise_cuda_graph_supported_model_archs,
+        ),
+        (
+            multimodal_breakable_cuda_graph,
+            multimodal_breakable_cuda_graph_supported_model_archs,
+        ),
+    )
+    if not any(enabled for enabled, _ in capabilities):
+        raise ValueError("at least one external model capability must be enabled")
+    for architecture in model_architectures:
+        for enabled, registry in capabilities:
+            if enabled and architecture not in registry:
+                registry.append(architecture)
+
+
 if external_mm_model_arch := envs.SGLANG_EXTERNAL_MM_MODEL_ARCH.get():
-    multimodal_model_archs.append(external_mm_model_arch)
+    register_external_model_architectures(external_mm_model_arch, multimodal=True)
 
 
 def is_multimodal_model(model_architectures: List[str]):

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -7,11 +7,29 @@ from sglang.srt.configs.model_config import (
     ModelConfig,
     get_hybrid_layer_ids,
     is_embedding_gemma,
+    is_multimodal_breakable_cuda_graph_supported,
+    is_multimodal_model,
+    is_multimodal_piecewise_cuda_graph_supported,
+    register_external_model_architectures,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def test_register_external_model_architectures():
+    architecture = "TestExternalMultimodalForConditionalGeneration"
+
+    register_external_model_architectures(
+        architecture,
+        multimodal=True,
+        multimodal_breakable_cuda_graph=True,
+    )
+
+    assert is_multimodal_model([architecture])
+    assert is_multimodal_breakable_cuda_graph_supported([architecture])
+    assert not is_multimodal_piecewise_cuda_graph_supported([architecture])
 
 
 class TestHybridLayerIds(CustomTestCase):


### PR DESCRIPTION
## Summary

Add one idempotent registration API for model architectures implemented by external packages. Callers can declare multimodal, piecewise-CUDA-graph, and breakable-CUDA-graph capabilities without mutating SGLang registry lists directly.

## Test plan

- `pytest -q test/registered/unit/configs/test_model_config.py -k register_external_model_architectures` (1 passed)
- pre-commit hooks on the changed files (passed)

## Original commits

- eed6878d99

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34212930997](https://github.com/sgl-project/sglang/actions/runs/34212930997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34212930612](https://github.com/sgl-project/sglang/actions/runs/34212930612)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34212931137](https://github.com/sgl-project/sglang/actions/runs/34212931137)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->