### PR TITLE
[CI][Intel CPU] Register nightly-intel-cpu-gnr suite and set est_time for registered tests

### DIFF
--- a/test/registered/amd/test_fp8_per_channel_detection.py
+++ b/test/registered/amd/test_fp8_per_channel_detection.py
@@ -13,9 +13,10 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cpu_ci
 
 register_amd_ci(est_time=10, suite="stage-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_proj(weight_dtype, weight_scale_shape=None):

--- a/test/registered/attention/test_torch_native_attention_backend.py
+++ b/test/registered/attention/test_torch_native_attention_backend.py
@@ -7,7 +7,11 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -20,6 +24,7 @@ from sglang.test.test_utils import (
 # Torch native attention backend integration test with MMLU eval
 register_cuda_ci(est_time=310, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=150, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=805, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTorchNativeAttnBackend(CustomTestCase):

--- a/test/registered/attention/unittests/hybrid_linear/test_verify_buffer_fixup_hook.py
+++ b/test/registered/attention/unittests/hybrid_linear/test_verify_buffer_fixup_hook.py
@@ -19,10 +19,11 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     MambaAttnBackendBase,
 )
 from sglang.srt.speculative.eagle_info import EagleVerifyInput
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _STALE = -555
 _MAX_BS = 4

--- a/test/registered/attention/unittests/swa/test_swa_out_cache_loc.py
+++ b/test/registered/attention/unittests/swa/test_swa_out_cache_loc.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSWAKVPoolSetKVBuffer(CustomTestCase):

--- a/test/registered/bench_fn/test_bench_serving_reasoning_stream.py
+++ b/test/registered/bench_fn/test_bench_serving_reasoning_stream.py
@@ -27,6 +27,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=16, suite="base-a-test-cpu")
+register_cpu_ci(est_time=14, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _free_port() -> int:

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -62,6 +62,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=38, suite="base-a-test-cpu")
 register_cpu_ci(est_time=46, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=19, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 _BENCH_SERVING_CLI_CASES = {

--- a/test/registered/bench_fn/test_steady_state_benchmark.py
+++ b/test/registered/bench_fn/test_steady_state_benchmark.py
@@ -14,6 +14,7 @@ from sglang.benchmark.steady_state import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _StringTokenizer:

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -21,6 +21,7 @@ from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.fixture(autouse=True)

--- a/test/registered/core/test_engine_child_pids.py
+++ b/test/registered/core/test_engine_child_pids.py
@@ -14,13 +14,14 @@ import unittest
 import psutil
 
 import sglang as sgl
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     CustomTestCase,
 )
 
 register_cuda_ci(est_time=77, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=180, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestEngineChildPids(CustomTestCase):

--- a/test/registered/core/test_hidden_states.py
+++ b/test/registered/core/test_hidden_states.py
@@ -5,11 +5,16 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import sglang as sgl
 from sglang.srt.utils import get_device, is_hip
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST, CustomTestCase
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=55, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=161, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _is_hip = is_hip()
 if _is_hip:

--- a/test/registered/core/test_srt_empty_deps.py
+++ b/test/registered/core/test_srt_empty_deps.py
@@ -13,6 +13,7 @@ import pytest
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Packages known to transitively depend on torch or triton.
 # If a new package is added to runtime_base and it pulls torch,

--- a/test/registered/cpu/quant/test_autoround.py
+++ b/test/registered/cpu/quant/test_autoround.py
@@ -25,6 +25,7 @@ from sglang.test.test_utils import (
 )
 
 register_cpu_ci(est_time=183, suite="stage-a-tp-test-cpu-intel")
+register_cpu_ci(est_time=391, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestAutoRoundCPUConfig(CustomTestCase):

--- a/test/registered/cpu/test_activation.py
+++ b/test/registered/cpu/test_activation.py
@@ -10,6 +10,7 @@ from sglang.test.cpu_test_utils import GeluAndMul, SiluAndMul, precision
 
 register_cpu_ci(est_time=9, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_binding.py
+++ b/test/registered/cpu/test_binding.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="stage-a-tp-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestBinding(CustomTestCase):

--- a/test/registered/cpu/test_bmm.py
+++ b/test/registered/cpu/test_bmm.py
@@ -12,6 +12,7 @@ from sglang.test.cpu_test_utils import precision
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=13, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=16, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_causal_conv1d.py
+++ b/test/registered/cpu/test_causal_conv1d.py
@@ -10,6 +10,7 @@ from sglang.test.cpu_test_utils import parametrize, precision
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=7, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 causal_conv1d_weight_pack = torch.ops.sgl_kernel.causal_conv1d_weight_pack
 causal_conv1d_fwd = torch.ops.sgl_kernel.causal_conv1d_fwd_cpu

--- a/test/registered/cpu/test_comm.py
+++ b/test/registered/cpu/test_comm.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, find_available_port
 
 register_cpu_ci(est_time=43, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=49, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def run_distributed_test(rank, world_size, master_port, output_writer, fn):

--- a/test/registered/cpu/test_cpu_graph.py
+++ b/test/registered/cpu/test_cpu_graph.py
@@ -22,6 +22,7 @@ from sglang.test.test_utils import (
 )
 
 register_cpu_ci(est_time=315, suite="stage-a-tp-test-cpu-intel")
+register_cpu_ci(est_time=524, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCPUGraph(CustomTestCase):

--- a/test/registered/cpu/test_decode.py
+++ b/test/registered/cpu/test_decode.py
@@ -9,6 +9,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=11, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_extend.py
+++ b/test/registered/cpu/test_extend.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=7, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=12, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_flash_attn.py
+++ b/test/registered/cpu/test_flash_attn.py
@@ -9,6 +9,7 @@ from sglang.test.cpu_test_utils import parametrize, precision
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=54, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=57, suite="nightly-intel-cpu-gnr", nightly=True)
 
 flash_attn_varlen_func = torch.ops.sgl_kernel.flash_attn_varlen_func
 

--- a/test/registered/cpu/test_gemm.py
+++ b/test/registered/cpu/test_gemm.py
@@ -19,6 +19,7 @@ from sglang.test.cpu_test_utils import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=9, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_intel_amx_attention_backend_a.py
+++ b/test/registered/cpu/test_intel_amx_attention_backend_a.py
@@ -22,6 +22,7 @@ from sglang.test.test_utils import (
 )
 
 register_cpu_ci(est_time=685, suite="stage-a-tp-test-cpu-intel")
+register_cpu_ci(est_time=832, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestIntelAMXAttnBackend(CustomTestCase):

--- a/test/registered/cpu/test_intel_amx_attention_backend_b.py
+++ b/test/registered/cpu/test_intel_amx_attention_backend_b.py
@@ -15,6 +15,7 @@ from sglang.test.test_utils import (
 )
 
 register_cpu_ci(est_time=47, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=241, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestIntelAMXAttnBackendQuant(CustomTestCase):

--- a/test/registered/cpu/test_intel_amx_attention_backend_c.py
+++ b/test/registered/cpu/test_intel_amx_attention_backend_c.py
@@ -15,6 +15,7 @@ from sglang.test.test_utils import (
 )
 
 register_cpu_ci(est_time=477, suite="stage-a-tp-test-cpu-intel")
+register_cpu_ci(est_time=280, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestIntelAMXAttnBackendQuant(CustomTestCase):

--- a/test/registered/cpu/test_mamba.py
+++ b/test/registered/cpu/test_mamba.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.cpu_test_utils import precision
 
 register_cpu_ci(est_time=7, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_mla.py
+++ b/test/registered/cpu/test_mla.py
@@ -9,6 +9,7 @@ from sglang.test.cpu_test_utils import precision
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=8, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_moe.py
+++ b/test/registered/cpu/test_moe.py
@@ -35,6 +35,7 @@ from sglang.test.cpu_test_utils import (
 )
 
 register_cpu_ci(est_time=7, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def run_fused_experts(

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -10,6 +10,7 @@ from sglang.test.cpu_test_utils import make_non_contiguous, precision
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_qkv_proj_with_rope.py
+++ b/test/registered/cpu/test_qkv_proj_with_rope.py
@@ -15,6 +15,7 @@ from sglang.test.cpu_test_utils import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=7, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 convert_weight_packed = torch.ops.sgl_kernel.convert_weight_packed
 qkv_proj_with_rope = torch.ops.sgl_kernel.qkv_proj_with_rope

--- a/test/registered/cpu/test_qwen3.py
+++ b/test/registered/cpu/test_qwen3.py
@@ -10,6 +10,7 @@ from sglang.test.cpu_test_utils import precision
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_rank_consensus_checker.py
+++ b/test/registered/cpu/test_rank_consensus_checker.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, find_available_port
 
 register_cpu_ci(est_time=193, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=225, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def run_distributed_test(

--- a/test/registered/cpu/test_request_decompression.py
+++ b/test/registered/cpu/test_request_decompression.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 PAYLOAD = b'{"text":"hello world","n":7}'
 COMPRESSED = zstandard.ZstdCompressor().compress(PAYLOAD)

--- a/test/registered/cpu/test_request_headers.py
+++ b/test/registered/cpu/test_request_headers.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=4, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _obj():

--- a/test/registered/cpu/test_rope.py
+++ b/test/registered/cpu/test_rope.py
@@ -19,6 +19,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=33, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=54, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_shared_expert.py
+++ b/test/registered/cpu/test_shared_expert.py
@@ -21,6 +21,7 @@ from sglang.test.cpu_test_utils import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=8, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(1234)
 

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -10,6 +10,7 @@ from sglang.test.cpu_test_utils import precision
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _topk1_chain_inputs(bs, num_steps):

--- a/test/registered/cpu/test_store_cache.py
+++ b/test/registered/cpu/test_store_cache.py
@@ -12,6 +12,7 @@ from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=14, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=13, suite="nightly-intel-cpu-gnr", nightly=True)
 
 torch.manual_seed(42)
 

--- a/test/registered/cpu/test_subblock_sparse_attention.py
+++ b/test/registered/cpu/test_subblock_sparse_attention.py
@@ -44,6 +44,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=9, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=11, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSubBlockSparseAttentionDispatch(CustomTestCase):

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -17,6 +17,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=30, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=10, suite="base-b-test-cpu-arm64")
+register_cpu_ci(est_time=56, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # This is used by the Deepseek-V2 model

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -34,6 +34,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DCP_SIZES = [1, 2, 3, 4, 8]
 LENS = list(range(0, 41))

--- a/test/registered/debug_utils/comparator/aligner/entrypoint/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/entrypoint/test_executor.py
@@ -34,6 +34,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestExecuteSubPlans:

--- a/test/registered/debug_utils/comparator/aligner/entrypoint/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/entrypoint/test_planner.py
@@ -26,6 +26,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_meta(

--- a/test/registered/debug_utils/comparator/aligner/reorderer/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/reorderer/test_executor.py
@@ -27,6 +27,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _zigzag_order(cp_size: int) -> list[int]:

--- a/test/registered/debug_utils/comparator/aligner/reorderer/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/reorderer/test_planner.py
@@ -27,6 +27,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeReordererPlans:

--- a/test/registered/debug_utils/comparator/aligner/test_axis_aligner.py
+++ b/test/registered/debug_utils/comparator/aligner/test_axis_aligner.py
@@ -18,6 +18,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeAxisAlignerPlan:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_plugins.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_aux_plugins.py
@@ -17,6 +17,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import TokenLayout
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _sglang_plugin = _SGLangPlugin()
 _megatron_plugin = _MegatronPlugin()

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_concat_steps.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_concat_steps.py
@@ -11,6 +11,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestExecuteConcat:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_executor.py
@@ -30,6 +30,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _named(tensor: torch.Tensor, names: list[str]) -> torch.Tensor:

--- a/test/registered/debug_utils/comparator/aligner/token_aligner/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/token_aligner/test_planner.py
@@ -24,6 +24,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestBuildTokenIndexSGLangThd:

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_executor.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_executor.py
@@ -31,6 +31,7 @@ from sglang.srt.debug_utils.comparator.output_types import ReplicatedCheckResult
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _name_tensors(

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_parallel_info.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_parallel_info.py
@@ -10,6 +10,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestNormalizeParallelInfo:

--- a/test/registered/debug_utils/comparator/aligner/unsharder/test_planner.py
+++ b/test/registered/debug_utils/comparator/aligner/unsharder/test_planner.py
@@ -20,6 +20,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import ParallelAxis, parse_dims
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeUnsharderPlan:

--- a/test/registered/debug_utils/comparator/dims_spec/test_dim_parser.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_dim_parser.py
@@ -13,6 +13,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestParseDim:

--- a/test/registered/debug_utils/comparator/dims_spec/test_dims_parser.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_dims_parser.py
@@ -16,6 +16,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSingletonDimUtilFilterOut:

--- a/test/registered/debug_utils/comparator/dims_spec/test_tensor_naming.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_tensor_naming.py
@@ -15,6 +15,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFindDimIndex:

--- a/test/registered/debug_utils/comparator/dims_spec/test_types.py
+++ b/test/registered/debug_utils/comparator/dims_spec/test_types.py
@@ -10,6 +10,7 @@ from sglang.srt.debug_utils.comparator.dims_spec import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDimConstants:

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
@@ -17,6 +17,7 @@ from sglang.srt.debug_utils.comparator.threshold_dsl import DiffThresholdRule
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=20, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeTensorInfo:

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_formatter.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_formatter.py
@@ -64,6 +64,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _DEFAULT_PERCENTILE_LINES: list[str] = [
     "      [blue]p1        [/]    -1.8000      -1.8000   [dim]+0.00e+00[/]",

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_types.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_types.py
@@ -22,6 +22,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.types import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_stats(**overrides) -> TensorStats:

--- a/test/registered/debug_utils/comparator/test_log_sink.py
+++ b/test/registered/debug_utils/comparator/test_log_sink.py
@@ -12,6 +12,7 @@ from sglang.srt.debug_utils.comparator.report_sink import report_sink
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_error_log(**overrides) -> ErrorLog:

--- a/test/registered/debug_utils/comparator/test_manually_verify.py
+++ b/test/registered/debug_utils/comparator/test_manually_verify.py
@@ -24,6 +24,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=24, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _PUBLISH_DIR: Path = Path("/tmp/comparator_manual_verify")
 _PNG_MAGIC: bytes = b"\x89PNG"

--- a/test/registered/debug_utils/comparator/test_meta_overrider.py
+++ b/test/registered/debug_utils/comparator/test_meta_overrider.py
@@ -17,6 +17,7 @@ from sglang.srt.debug_utils.comparator.meta_overrider import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # ───────────────────── Unit: MetaOverrideRule ─────────────────────

--- a/test/registered/debug_utils/comparator/test_model_validation.py
+++ b/test/registered/debug_utils/comparator/test_model_validation.py
@@ -45,6 +45,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair, _check_equal_lengths
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCheckEqualLengths:

--- a/test/registered/debug_utils/comparator/test_output_types.py
+++ b/test/registered/debug_utils/comparator/test_output_types.py
@@ -61,6 +61,7 @@ from sglang.srt.debug_utils.comparator.utils import Pair
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _render_rich(renderable: object) -> str:

--- a/test/registered/debug_utils/comparator/test_per_token_visualizer.py
+++ b/test/registered/debug_utils/comparator/test_per_token_visualizer.py
@@ -16,6 +16,7 @@ from sglang.srt.debug_utils.comparator.tensor_comparator.comparator import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _PNG_MAGIC: bytes = b"\x89PNG"
 

--- a/test/registered/debug_utils/comparator/test_preset.py
+++ b/test/registered/debug_utils/comparator/test_preset.py
@@ -4,6 +4,7 @@ from sglang.srt.debug_utils.comparator.preset import PRESETS, expand_preset
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestExpandPreset:

--- a/test/registered/debug_utils/comparator/test_threshold_dsl.py
+++ b/test/registered/debug_utils/comparator/test_threshold_dsl.py
@@ -12,6 +12,7 @@ from sglang.srt.debug_utils.comparator.threshold_dsl import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _ev(

--- a/test/registered/debug_utils/comparator/test_utils.py
+++ b/test/registered/debug_utils/comparator/test_utils.py
@@ -18,6 +18,7 @@ from sglang.srt.debug_utils.comparator.utils import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCalcRelDiff:

--- a/test/registered/debug_utils/comparator/test_visualizer.py
+++ b/test/registered/debug_utils/comparator/test_visualizer.py
@@ -11,6 +11,7 @@ from sglang.srt.debug_utils.comparator.visualizer.preprocessing import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=2, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPreprocessTensor:

--- a/test/registered/debug_utils/source_patcher/test_code_patcher.py
+++ b/test/registered/debug_utils/source_patcher/test_code_patcher.py
@@ -11,6 +11,7 @@ from sglang.srt.debug_utils.source_patcher.types import EditSpec, PatchSpec
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 SAMPLE_MODULE_NAME = "_source_patcher_test_fixtures.sample_module"
 

--- a/test/registered/debug_utils/source_patcher/test_dumper_integration.py
+++ b/test/registered/debug_utils/source_patcher/test_dumper_integration.py
@@ -9,6 +9,7 @@ from sglang.srt.debug_utils.dumper import DumperConfig, _Dumper
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 SAMPLE_MODULE_NAME = "_source_patcher_test_fixtures.sample_module"
 

--- a/test/registered/debug_utils/source_patcher/test_source_editor.py
+++ b/test/registered/debug_utils/source_patcher/test_source_editor.py
@@ -6,6 +6,7 @@ from sglang.srt.debug_utils.source_patcher.types import EditSpec, PatchApplicati
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestApplyEdits:

--- a/test/registered/debug_utils/test_crash_dump.py
+++ b/test/registered/debug_utils/test_crash_dump.py
@@ -24,6 +24,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=70, stage="nightly", runner_config="1-gpu-large")
 register_amd_ci(est_time=40, suite="nightly-amd-1-gpu", nightly=True)
 register_cpu_ci(est_time=48, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=190, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCrashDump(CustomTestCase):

--- a/test/registered/debug_utils/test_dump_comparator.py
+++ b/test/registered/debug_utils/test_dump_comparator.py
@@ -10,6 +10,7 @@ from sglang.srt.debug_utils.dump_comparator import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # ----------------------------- Unit tests -----------------------------

--- a/test/registered/debug_utils/test_schedule_simulator.py
+++ b/test/registered/debug_utils/test_schedule_simulator.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=357, stage="weekly", runner_config="cpu")
+register_cpu_ci(est_time=347, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # ==================== Non-E2E Tests ====================
 

--- a/test/registered/debug_utils/test_soft_watchdog.py
+++ b/test/registered/debug_utils/test_soft_watchdog.py
@@ -20,6 +20,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=240, stage="nightly", runner_config="1-gpu-large")
 register_amd_ci(est_time=120, suite="nightly-amd-1-gpu", nightly=True)
 register_cpu_ci(est_time=237, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=613, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class BaseTestSoftWatchdog:

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -17,6 +17,7 @@ from sglang.srt.function_call.kimik3_format import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_tool(name: str) -> Tool:

--- a/test/registered/input_embedding/test_input_embeddings.py
+++ b/test/registered/input_embedding/test_input_embeddings.py
@@ -23,6 +23,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=53, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=38, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=58, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=220, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestInputEmbeds(CustomTestCase):

--- a/test/registered/input_embedding/test_input_embeds_chunked.py
+++ b/test/registered/input_embedding/test_input_embeds_chunked.py
@@ -37,6 +37,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=54, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=43, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=54, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=229, suite="nightly-intel-cpu-gnr", nightly=True)
 
 CHUNKED_PREFILL_SIZE = 256
 

--- a/test/registered/kernels/ops/kv_canary/test_utils.py
+++ b/test/registered/kernels/ops/kv_canary/test_utils.py
@@ -9,6 +9,7 @@ from sglang.kernels.jit.benchmark.kv_canary.utils import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, stage="base-a", runner_config="cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_fast_matrix_cases_include_e2e_decode_and_chunked_prefill_scenarios() -> None:

--- a/test/registered/kernels/ops/layernorm/test_fused_op.py
+++ b/test/registered/kernels/ops/layernorm/test_fused_op.py
@@ -17,6 +17,7 @@ from sglang.kernels.spec import KernelBackend, KernelSpec
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _ToyAdd(BaseFusedOp):

--- a/test/registered/kernels/ops/layernorm/test_kernels_namespace.py
+++ b/test/registered/kernels/ops/layernorm/test_kernels_namespace.py
@@ -14,6 +14,7 @@ from sglang.kernels.spec import CapabilityRequirement as Cap
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=24, suite="base-a-test-cpu")
+register_cpu_ci(est_time=25, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _CPU = PlatformInfo(device_type="cpu")
 _SM90 = PlatformInfo(device_type="cuda", cuda_arch_major=9, cuda_arch_minor=0)

--- a/test/registered/kernels/test_fused_op_dispatch.py
+++ b/test/registered/kernels/test_fused_op_dispatch.py
@@ -29,6 +29,7 @@ from sglang.kernels.spec import KernelBackend, PlatformInfo
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _CUDA = PlatformInfo(device_type="cuda", cuda_arch_major=9, cuda_arch_minor=0)
 _HIP = PlatformInfo(device_type="hip")

--- a/test/registered/kernels/test_jit_cache.py
+++ b/test/registered/kernels/test_jit_cache.py
@@ -20,6 +20,7 @@ from sglang.kernels.jit.utils.compile.spec import BuildSpec
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.fixture(autouse=True)

--- a/test/registered/kv_canary/test_e2e_base.py
+++ b/test/registered/kv_canary/test_e2e_base.py
@@ -9,6 +9,7 @@ from sglang.test.kv_canary.e2e_base import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCanaryE2EBase(CustomTestCase):

--- a/test/registered/kv_canary/test_self_unit_buffer_alloc.py
+++ b/test/registered/kv_canary/test_self_unit_buffer_alloc.py
@@ -12,11 +12,16 @@ from sglang.srt.kv_canary.pool_patcher.buffer_alloc import (
     make_row_source,
     resolve_real_kv_read_bytes,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=10, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _config(mode: RealKvHashMode) -> CanaryConfig:

--- a/test/registered/kv_canary/test_self_unit_capacities.py
+++ b/test/registered/kv_canary/test_self_unit_capacities.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeLaunchCapacities(CustomTestCase):

--- a/test/registered/kv_canary/test_self_unit_e2e_base.py
+++ b/test/registered/kv_canary/test_self_unit_e2e_base.py
@@ -9,6 +9,7 @@ from sglang.test.kv_canary.e2e_base import CanaryE2EBase
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 _GOOD_LINE: str = SwaDivergenceLog(

--- a/test/registered/kv_canary/test_self_unit_pool_patcher_utils.py
+++ b/test/registered/kv_canary/test_self_unit_pool_patcher_utils.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import unittest
 
 from sglang.srt.kv_canary.pool_patcher.utils import wrap_method
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=10, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeObj:

--- a/test/registered/kv_canary/test_self_unit_violation.py
+++ b/test/registered/kv_canary/test_self_unit_violation.py
@@ -15,11 +15,16 @@ from sglang.srt.kv_canary.runner.violation_reporter import (
     ViolationReporter,
     _format_violation,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=5, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_row(

--- a/test/registered/lora/test_lora_openai_api.py
+++ b/test/registered/lora/test_lora_openai_api.py
@@ -15,6 +15,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cpu_ci
 
 register_amd_ci(est_time=30, suite="nightly-amd-1-gpu", nightly=True)
 register_cpu_ci(est_time=7, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def publish_config(case):

--- a/test/registered/mock_model/test_self_unit_canary_mock_wiring.py
+++ b/test/registered/mock_model/test_self_unit_canary_mock_wiring.py
@@ -12,12 +12,17 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     _stable_hash_str_to_i64,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.mock_model.utils import mock_model_server_args, mock_model_server_env
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @dataclasses.dataclass

--- a/test/registered/mock_model/test_self_unit_canary_perturb.py
+++ b/test/registered/mock_model/test_self_unit_canary_perturb.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCanaryPerturb(CustomTestCase):

--- a/test/registered/mock_model/test_self_unit_install.py
+++ b/test/registered/mock_model/test_self_unit_install.py
@@ -9,11 +9,16 @@ from sglang.srt.kv_canary.token_oracle.install import install_token_oracle_from_
 from sglang.srt.kv_canary.token_oracle.oracle import HashOracle
 from sglang.srt.layers.sampler import _CUSTOM_SAMPLER_FACTORIES
 from sglang.srt.runtime_context import get_context
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _publish(case, *, sampling_backend: str) -> None:

--- a/test/registered/mock_model/test_self_unit_oracle.py
+++ b/test/registered/mock_model/test_self_unit_oracle.py
@@ -10,11 +10,16 @@ from sglang.srt.kv_canary.token_oracle.oracle import (
     HashOracle,
     _splitmix64_tensor,
 )
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 _U64_MASK: int = (1 << 64) - 1

--- a/test/registered/mock_model/test_self_unit_oracle_torch_vs_ref.py
+++ b/test/registered/mock_model/test_self_unit_oracle_torch_vs_ref.py
@@ -7,11 +7,16 @@ import torch
 
 from sglang.kernels.ops.kv_canary.verify_ref import splitmix64
 from sglang.srt.kv_canary.token_oracle.oracle import HashOracle
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=30, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHashOracleTorchVsRef(CustomTestCase):

--- a/test/registered/mock_model/test_self_unit_sampler_hookpoint.py
+++ b/test/registered/mock_model/test_self_unit_sampler_hookpoint.py
@@ -18,11 +18,16 @@ from sglang.srt.kv_canary.token_oracle.oracle import HashOracle
 from sglang.srt.kv_canary.token_oracle.sampler import install_oracle_sampler
 from sglang.srt.layers.sampler import _CUSTOM_SAMPLER_FACTORIES
 from sglang.srt.server_args import SAMPLING_BACKEND_CHOICES
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="extra-a", runner_config="1-gpu-small")
 register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestInstallOracleSampler(CustomTestCase):

--- a/test/registered/model_loading/test_external_models.py
+++ b/test/registered/model_loading/test_external_models.py
@@ -12,6 +12,7 @@ from sglang.test.test_utils import CustomTestCase
 register_cuda_ci(est_time=34, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=45, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=32, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=143, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestExternalModels(CustomTestCase):

--- a/test/registered/model_loading/test_weight_loader_v2_e2e.py
+++ b/test/registered/model_loading/test_weight_loader_v2_e2e.py
@@ -12,9 +12,10 @@
 # limitations under the License.
 # ==============================================================================
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 
 register_cuda_ci(est_time=62, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=348, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import multiprocessing as mp
 

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -16,6 +16,7 @@ from sglang.srt.server_args import ServerArgs, set_global_server_args_for_schedu
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.fixture(autouse=True)

--- a/test/registered/observability/test_encoder_server_metrics.py
+++ b/test/registered/observability/test_encoder_server_metrics.py
@@ -13,7 +13,11 @@ from prometheus_client.samples import Sample
 from sglang.srt.disaggregation.encoder.http_server import MINIMUM_PNG_PICTURE_BASE64
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.network import get_zmq_socket_on_host
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -24,6 +28,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=180, stage="stage-b", runner_config="1-gpu-small-amd")
+register_cpu_ci(est_time=60, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _MODEL_NAME = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
 

--- a/test/registered/observability/test_priority_metrics.py
+++ b/test/registered/observability/test_priority_metrics.py
@@ -25,6 +25,7 @@ register_cuda_ci(
     runner_config="1-gpu-small",
 )
 register_cpu_ci(est_time=49, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=181, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"
 

--- a/test/registered/openai_server/basic/test_serving_transcription.py
+++ b/test/registered/openai_server/basic/test_serving_transcription.py
@@ -15,7 +15,7 @@ import requests
 import soundfile as sf
 
 from sglang.srt.utils import kill_process_tree, load_audio
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -24,6 +24,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=59, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=243, suite="nightly-intel-cpu-gnr", nightly=True)
 
 WHISPER_MODEL = "openai/whisper-large-v3"
 AUDIO_URL = "https://raw.githubusercontent.com/sgl-project/sgl-test-files/refs/heads/main/audios/Trump_WEF_2018_10s.mp3"

--- a/test/registered/openai_server/features/test_openai_server_hidden_states.py
+++ b/test/registered/openai_server/features/test_openai_server_hidden_states.py
@@ -5,7 +5,11 @@ import openai
 
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE,
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -22,6 +26,7 @@ register_amd_ci(
     suite="stage-b-test-1-gpu-small-amd",
     disabled="see https://github.com/sgl-project/sglang/issues/11127",
 )
+register_cpu_ci(est_time=751, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class BaseTestOpenAIServerWithHiddenStates(ABC):

--- a/test/registered/openai_server/function_call/test_anthropic_tool_use.py
+++ b/test/registered/openai_server/function_call/test_anthropic_tool_use.py
@@ -30,6 +30,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=50, stage="base-b", runner_config="1-gpu-large")
 register_cpu_ci(est_time=54, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=196, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # System message to guide Llama3.2 to produce proper tool call format
 SYSTEM_MESSAGE = (

--- a/test/registered/openai_server/validation/test_large_max_new_tokens.py
+++ b/test/registered/openai_server/validation/test_large_max_new_tokens.py
@@ -27,6 +27,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=58, stage="base-b", runner_config="1-gpu-large")
 register_cpu_ci(est_time=101, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=210, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestLargeMaxNewTokens(CustomTestCase):

--- a/test/registered/openai_server/validation/test_matched_stop.py
+++ b/test/registered/openai_server/validation/test_matched_stop.py
@@ -15,6 +15,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=52, stage="base-b", runner_config="1-gpu-small")
 register_cpu_ci(est_time=83, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=226, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMatchedStop(CustomTestCase, MatchedStopMixin):

--- a/test/registered/openai_server/validation/test_request_length_validation.py
+++ b/test/registered/openai_server/validation/test_request_length_validation.py
@@ -4,7 +4,7 @@ import openai
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -14,6 +14,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=49, stage="base-b", runner_config="1-gpu-large")
+register_cpu_ci(est_time=140, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRequestLengthValidation(CustomTestCase):

--- a/test/registered/perf/test_bench_one_batch_2gpu.py
+++ b/test/registered/perf/test_bench_one_batch_2gpu.py
@@ -1,6 +1,10 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_MOE_MODEL_NAME_FOR_TEST,
@@ -13,6 +17,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=162, stage="extra-a", runner_config="2-gpu-large")
 register_amd_ci(est_time=630, suite="stage-b-test-2-gpu-large-amd")
+register_cpu_ci(est_time=697, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestBenchOneBatch2GPU(CustomTestCase):

--- a/test/registered/prefill_only/test_openai_embedding.py
+++ b/test/registered/prefill_only/test_openai_embedding.py
@@ -20,6 +20,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=94, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=141, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=91, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=371, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestOpenAIEmbedding(CustomTestCase):

--- a/test/registered/prefill_only/test_reward_models.py
+++ b/test/registered/prefill_only/test_reward_models.py
@@ -3,7 +3,11 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.runners import HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase
 
@@ -26,6 +30,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=188, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=132, suite="stage-b-test-1-gpu-small-amd-nondeterministic")
+register_cpu_ci(est_time=568, suite="nightly-intel-cpu-gnr", nightly=True)
 
 MODELS = [
     ("LxzGordon/URM-LLaMa-3.1-8B", 1, 4e-2),

--- a/test/registered/prefill_only/test_serving_rerank.py
+++ b/test/registered/prefill_only/test_serving_rerank.py
@@ -4,11 +4,16 @@ from unittest.mock import Mock
 
 from sglang.srt.entrypoints.openai.protocol import V1RerankReqInput
 from sglang.srt.managers.tokenizer_manager_score_mixin import ScoreResult
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 
 # Keep consistent with other openai_server/basic unit tests.
 register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 try:
     from sglang.srt.entrypoints.openai.serving_rerank import (

--- a/test/registered/quant/test_is_layer_skipped.py
+++ b/test/registered/quant/test_is_layer_skipped.py
@@ -5,6 +5,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Qwen3-Next FP8 actually publishes the equivalent of this in

--- a/test/registered/quant/test_nvfp4_embedding.py
+++ b/test/registered/quant/test_nvfp4_embedding.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 GROUP_SIZE = 16
 

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -7,6 +7,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestQuantLogString(CustomTestCase):

--- a/test/registered/radix_cache/test_radix_attention.py
+++ b/test/registered/radix_cache/test_radix_attention.py
@@ -21,6 +21,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=148, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=100, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=405, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=603, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRadixCacheFCFS(CustomTestCase):

--- a/test/registered/radix_cache/test_radix_cache_hit.py
+++ b/test/registered/radix_cache/test_radix_cache_hit.py
@@ -18,6 +18,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=71, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=55, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=113, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=281, suite="nightly-intel-cpu-gnr", nightly=True)
 
 MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 

--- a/test/registered/radix_cache/test_swa_radix_cache_kl.py
+++ b/test/registered/radix_cache/test_swa_radix_cache_kl.py
@@ -8,6 +8,7 @@ MODEL = "openai/gpt-oss-20b"
 
 register_cuda_ci(est_time=198, stage="base-b", runner_config="1-gpu-large")
 register_cpu_ci(est_time=1602, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=1589, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSWARadixCacheKL(KLDivergenceMixin, DefaultServerBase):

--- a/test/registered/rl/test_pause_generation_tensor_consistency.py
+++ b/test/registered/rl/test_pause_generation_tensor_consistency.py
@@ -11,6 +11,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/rotary/test_rope_cache_invalidation.py
+++ b/test/registered/rotary/test_rope_cache_invalidation.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _ROPE_KWARGS = dict(
     head_size=64,

--- a/test/registered/sampling/test_original_logprobs.py
+++ b/test/registered/sampling/test_original_logprobs.py
@@ -22,11 +22,16 @@ import torch.nn.functional as F
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import sglang as sgl
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=52, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=60, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=292, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # ------------------------- Configurable via env ------------------------- #
 MODEL_ID = DEFAULT_SMALL_MODEL_NAME_FOR_TEST

--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -4,7 +4,11 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -17,6 +21,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=108, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=66, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=789, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPyTorchSamplingBackend(CustomTestCase):

--- a/test/registered/scheduler/test_abort_with_metrics.py
+++ b/test/registered/scheduler/test_abort_with_metrics.py
@@ -20,6 +20,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _HTTP_SCOPE = {
     "type": "http",

--- a/test/registered/scheduler/test_load_snapshot_server.py
+++ b/test/registered/scheduler/test_load_snapshot_server.py
@@ -10,7 +10,11 @@ import unittest
 import urllib.request
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -21,6 +25,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=231, stage="base-b", runner_config="2-gpu-large")
 register_amd_ci(est_time=450, suite="stage-b-test-2-gpu-large-amd")
+register_cpu_ci(est_time=713, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _query_loads(base_url, retries=5, interval=2.0):

--- a/test/registered/scheduler/test_min_free_slots_delayer.py
+++ b/test/registered/scheduler/test_min_free_slots_delayer.py
@@ -7,6 +7,7 @@ from sglang.srt.managers.min_free_slots_delayer import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestResolveMinFreeSlots(unittest.TestCase):

--- a/test/registered/scheduler/test_retract_decode_logprob.py
+++ b/test/registered/scheduler/test_retract_decode_logprob.py
@@ -47,7 +47,11 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -58,6 +62,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=76, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=360, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=396, suite="nightly-intel-cpu-gnr", nightly=True)
 
 N_REQUESTS = 32
 MAX_NEW_TOKENS = 256

--- a/test/registered/scheduler/test_routing_key_scheduling.py
+++ b/test/registered/scheduler/test_routing_key_scheduling.py
@@ -23,6 +23,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=50, stage="weekly", runner_config="1-gpu-large")
 register_amd_ci(est_time=120, suite="nightly-amd-1-gpu", nightly=True)
 register_cpu_ci(est_time=55, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=185, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRoutingKeyScheduling(CustomTestCase):

--- a/test/registered/sessions/test_streaming_session_swa_extra.py
+++ b/test/registered/sessions/test_streaming_session_swa_extra.py
@@ -15,6 +15,7 @@ from sglang.test.server_fixtures.streaming_session_fixture import (
 
 register_cuda_ci(est_time=145, stage="extra-a", runner_config="1-gpu-large")
 register_cpu_ci(est_time=449, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=529, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestStreamingSessionSWARetractMixedChunk(

--- a/test/registered/spec/dspark/test_dspark_block_accept_estimator.py
+++ b/test/registered/spec/dspark/test_dspark_block_accept_estimator.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _GAMMA = 3
 _VOCAB = 8

--- a/test/registered/spec/dspark/test_dspark_confidence_metrics.py
+++ b/test/registered/spec/dspark/test_dspark_confidence_metrics.py
@@ -11,6 +11,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _cpu_metrics(gamma: int) -> PerPositionConfidenceMetrics:

--- a/test/registered/spec/dspark/test_dspark_scheduler.py
+++ b/test/registered/spec/dspark/test_dspark_scheduler.py
@@ -23,6 +23,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _flat_table(

--- a/test/registered/spec/dspark/test_dspark_sps_profiler.py
+++ b/test/registered/spec/dspark/test_dspark_sps_profiler.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def make_load_info() -> LoadInfo:

--- a/test/registered/spec/dspark/test_dspark_sps_table.py
+++ b/test/registered/spec/dspark/test_dspark_sps_table.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_table() -> SpsCostTable:

--- a/test/registered/spec/dspark/test_dspark_sts.py
+++ b/test/registered/spec/dspark/test_dspark_sts.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestApplySts(CustomTestCase):

--- a/test/registered/spec/dspark/test_ragged_verify.py
+++ b/test/registered/spec/dspark/test_ragged_verify.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _DEVICE = torch.device("cpu")
 _GRID = [8, 16, 24, 32, 64]

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -6,10 +6,11 @@ wheels (sgl_kernel) at module scope, which fail to import on CPU runners.
 
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRaggedVerifyGraphCapability(CustomTestCase):

--- a/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
+++ b/test/registered/unit/batch_overlap/test_tbo_cuda_graph_num_token_device.py
@@ -30,6 +30,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTboCudaGraphNumTokenDevice(CustomTestCase):

--- a/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
+++ b/test/registered/unit/batch_overlap/test_tbo_filter_batch_marker.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_target_verify_batch(bs: int) -> ForwardBatch:

--- a/test/registered/unit/bench/test_mixed_prefix_gsm8k.py
+++ b/test/registered/unit/bench/test_mixed_prefix_gsm8k.py
@@ -12,6 +12,7 @@ from sglang.test.simple_eval_mixed_prefix_gsm8k import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _write_synthetic_dataset(path: str, n: int) -> None:

--- a/test/registered/unit/bench/test_mmmu_eval_utils.py
+++ b/test/registered/unit/bench/test_mmmu_eval_utils.py
@@ -16,6 +16,7 @@ except ModuleNotFoundError:
 
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _load_mmmu_eval_utils():

--- a/test/registered/unit/bench/test_simple_eval_gsm8k.py
+++ b/test/registered/unit/bench/test_simple_eval_gsm8k.py
@@ -11,6 +11,7 @@ from sglang.test.run_eval import _run_sgl_eval, run_eval
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _write_fake_metrics(out_parent: Path, eval_name: str, payload: dict) -> None:

--- a/test/registered/unit/cli/test_serve_backends.py
+++ b/test/registered/unit/cli/test_serve_backends.py
@@ -15,6 +15,7 @@ from sglang.cli.serve_backends import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_entry_point(name, factory, distribution=None):

--- a/test/registered/unit/compilation/test_torch_compile_decoration.py
+++ b/test/registered/unit/compilation/test_torch_compile_decoration.py
@@ -7,6 +7,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.compilation.compile import (
     _infer_dynamic_arg_dims_from_annotations,

--- a/test/registered/unit/configs/test_cohere2_moe_config.py
+++ b/test/registered/unit/configs/test_cohere2_moe_config.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCohere2MoeConfig(CustomTestCase):

--- a/test/registered/unit/configs/test_laguna_config.py
+++ b/test/registered/unit/configs/test_laguna_config.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # (factor, attention_factor). S/XS ship attention_factor == the yarn default for
 # their factor; _NON_DEFAULT differs from both 1.0 and the default, so a naive

--- a/test/registered/unit/configs/test_linear_attn_model_registry.py
+++ b/test/registered/unit/configs/test_linear_attn_model_registry.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Dummy config classes for testing

--- a/test/registered/unit/configs/test_locate_anything_config.py
+++ b/test/registered/unit/configs/test_locate_anything_config.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestLocateAnythingConfig(CustomTestCase):

--- a/test/registered/unit/configs/test_minicpm_config.py
+++ b/test/registered/unit/configs/test_minicpm_config.py
@@ -30,6 +30,7 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_minicpm_lightning_config_defaults_are_complete():

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHybridLayerIds(CustomTestCase):

--- a/test/registered/unit/configs/test_model_config_parser_registry.py
+++ b/test/registered/unit/configs/test_model_config_parser_registry.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeParser(ModelConfigParserBase):

--- a/test/registered/unit/configs/test_model_config_scaling.py
+++ b/test/registered/unit/configs/test_model_config_scaling.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _mla_scaling(rope_scaling) -> tuple[float, float]:

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -11,6 +11,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_text_config(**overrides):

--- a/test/registered/unit/configs/test_zaya_config.py
+++ b/test/registered/unit/configs/test_zaya_config.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestZayaConfig(CustomTestCase):

--- a/test/registered/unit/constrained/test_grammar_manager.py
+++ b/test/registered/unit/constrained/test_grammar_manager.py
@@ -38,6 +38,7 @@ register_cpu_ci(2.0, "base-a-test-cpu")
 
 
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_scheduler(grammar_backend_name="none", skip_tokenizer=False):

--- a/test/registered/unit/constrained/test_llguidance_batched_mask.py
+++ b/test/registered/unit/constrained/test_llguidance_batched_mask.py
@@ -12,6 +12,7 @@ from sglang.srt.runtime_context import get_resources
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _REGEX = r"[0-9]{1,8}"
 

--- a/test/registered/unit/constrained/test_mistral_common_xgrammar.py
+++ b/test/registered/unit/constrained/test_mistral_common_xgrammar.py
@@ -8,6 +8,7 @@ from sglang.srt.utils.hf_transformers.mistral_utils import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 VOCAB_SIZE = 300
 NUM_SPECIAL = 8

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(2.0, "base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _DummyTokenizer:

--- a/test/registered/unit/constrained/test_utils.py
+++ b/test/registered/unit/constrained/test_utils.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestIsLegacyStructuralTag(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class FakeReceiver:

--- a/test/registered/unit/disaggregation/test_decode_req_to_token_pool.py
+++ b/test/registered/unit/disaggregation/test_decode_req_to_token_pool.py
@@ -10,6 +10,7 @@ from sglang.srt.disaggregation.decode import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _init_decode_pool(pool):

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_manager():

--- a/test/registered/unit/disaggregation/test_encode_receiver.py
+++ b/test/registered/unit/disaggregation/test_encode_receiver.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_registration_request(request_cls):

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -53,6 +53,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestEncoderDPErrorHandling(CustomTestCase):

--- a/test/registered/unit/disaggregation/test_encoder_health.py
+++ b/test/registered/unit/disaggregation/test_encoder_health.py
@@ -8,6 +8,7 @@ from sglang.srt.managers.schedule_batch import Modality
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=13, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeEncoder:

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -15,6 +15,7 @@ from sglang.srt.managers.schedule_batch import Modality
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _pending(modality: str = "image") -> PendingRequest:

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestResolveLoadPubRange(CustomTestCase):

--- a/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 KV_ITEM_LENS_SUM = 100
 STATE_ITEM_LENS_SUM = 7

--- a/test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py
+++ b/test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py
@@ -8,6 +8,7 @@ from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_k_only_pool(start_layer: int = 0) -> MiniMaxSparseKVPool:

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _prefill_mgr(cls=CommonKVManager, enabled=True):

--- a/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
+++ b/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
@@ -7,6 +7,7 @@ from sglang.srt.disaggregation.nixl.conn import NixlKVSender
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestNixlSenderFailureCleanup(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 import unittest

--- a/test/registered/unit/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/unit/disaggregation/test_specv2_kvcache_offloading.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_mock_req(

--- a/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
+++ b/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeTransferQueue:

--- a/test/registered/unit/distributed/test_cuda_wrapper.py
+++ b/test/registered/unit/distributed/test_cuda_wrapper.py
@@ -5,6 +5,7 @@ import pytest
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.distributed.device_communicators import cuda_wrapper
 

--- a/test/registered/unit/distributed/test_custom_all_reduce_v2_capability.py
+++ b/test/registered/unit/distributed/test_custom_all_reduce_v2_capability.py
@@ -6,6 +6,7 @@ from sglang.srt.distributed.device_communicators import custom_all_reduce_v2
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _patch_group(monkeypatch, *, world_size, same_node):

--- a/test/registered/unit/distributed/test_gated_launch.py
+++ b/test/registered/unit/distributed/test_gated_launch.py
@@ -1,6 +1,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=34, suite="base-a-test-cpu")
+register_cpu_ci(est_time=23, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import multiprocessing
 import threading

--- a/test/registered/unit/distributed/test_get_default_distributed_backend.py
+++ b/test/registered/unit/distributed/test_get_default_distributed_backend.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Worked example: an out-of-tree platform that overrides the torch backend.

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -45,6 +45,7 @@ import pytest
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Import the actual parallel_state module
 parallel_state = pytest.importorskip("sglang.srt.distributed.parallel_state")

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -25,6 +25,7 @@ from sglang.srt.parser.template_detection import (  # noqa: E402
 from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeOpenAIServingChat:

--- a/test/registered/unit/entrypoints/openai/test_audio_chunking.py
+++ b/test/registered/unit/entrypoints/openai/test_audio_chunking.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 SR = 16000
 

--- a/test/registered/unit/entrypoints/openai/test_exa_search.py
+++ b/test/registered/unit/entrypoints/openai/test_exa_search.py
@@ -17,6 +17,7 @@ from sglang.srt.entrypoints.tool import HarmonyBrowserTool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class ExaClientTestCase(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_matched_stop.py
+++ b/test/registered/unit/entrypoints/openai/test_matched_stop.py
@@ -4,6 +4,7 @@ from sglang.srt.sampling.sampling_params import MAX_LEN, get_max_seq_length
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRegexPatternMaxLength(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -36,6 +36,7 @@ from sglang.srt.entrypoints.openai.protocol import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestModelCard(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _in_progress_response(request: ResponsesRequest) -> ResponsesResponse:

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -52,6 +52,7 @@ from sglang.srt.utils import get_or_create_event_loop
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=13, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Every spec resolve_chat_encoding_spec can return; pinned by the guard below.
 _ALL_CHAT_ENCODING_SPECS = ("dsv4", "dsv32", "inkling", "kimi_k3")

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -25,6 +25,7 @@ from sglang.srt.utils import get_or_create_event_loop
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _spec_result(index):

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -60,6 +60,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Mock TokenizerManager for embedding tests

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -32,6 +32,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class InputMessageConstructionTestCase(CustomTestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class NonHarmonyStreamTestCase(CustomTestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_transcription.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_transcription.py
@@ -39,6 +39,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _chunk(text: str, finish: str = None) -> dict:

--- a/test/registered/unit/entrypoints/openai/test_transcription_adapters.py
+++ b/test/registered/unit/entrypoints/openai/test_transcription_adapters.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Per-second scaling rate every speech-LM adapter uses for max_new_tokens.

--- a/test/registered/unit/entrypoints/openai/test_whisper_adapter.py
+++ b/test/registered/unit/entrypoints/openai/test_whisper_adapter.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestWhisperParseFusedOutput(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _ChunkStatus(enum.Enum):

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -36,6 +36,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=13, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _stub_tokenizer_manager(

--- a/test/registered/unit/entrypoints/test_server_warmup.py
+++ b/test/registered/unit/entrypoints/test_server_warmup.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestVlmWarmupImage(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
+++ b/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
@@ -32,6 +32,7 @@ maybe_stub_sgl_kernel()
 
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _temp_path() -> str:

--- a/test/registered/unit/eplb/test_balanced_packing.py
+++ b/test/registered/unit/eplb/test_balanced_packing.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
+++ b/test/registered/unit/eplb/test_compute_logical_to_rank_dispatch_physical_map.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/eplb/test_dispatch_dtype_preservation.py
+++ b/test/registered/unit/eplb/test_dispatch_dtype_preservation.py
@@ -10,6 +10,7 @@ a specific dtype (int32).
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/eplb/test_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_waterfill_eplb.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DSML = "｜DSML｜"
 

--- a/test/registered/unit/function_call/test_dots_detector.py
+++ b/test/registered/unit/function_call/test_dots_detector.py
@@ -8,6 +8,7 @@ from sglang.srt.parser.reasoning_parser import Qwen3Detector, ReasoningParser
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _tool(name: str, properties: dict) -> Tool:

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -38,6 +38,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=70, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=18, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @functools.lru_cache(maxsize=None)

--- a/test/registered/unit/function_call/test_hermes_detector.py
+++ b/test/registered/unit/function_call/test_hermes_detector.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHermesDetector(CustomTestCase):

--- a/test/registered/unit/function_call/test_hunyuan_detector.py
+++ b/test/registered/unit/function_call/test_hunyuan_detector.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_tools():

--- a/test/registered/unit/function_call/test_json_schema_constraint.py
+++ b/test/registered/unit/function_call/test_json_schema_constraint.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(5, "base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestJsonSchemaConstraint(unittest.TestCase):

--- a/test/registered/unit/function_call/test_kimik3_structural_tag.py
+++ b/test/registered/unit/function_call/test_kimik3_structural_tag.py
@@ -29,6 +29,7 @@ from sglang.srt.function_call.kimik3_structural_tag import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _CLOSE_TOKEN = "<|close|>"
 _CLOSE_TOKEN_ID = 256

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestLlama32Detector(CustomTestCase):

--- a/test/registered/unit/function_call/test_minicpm5_detector.py
+++ b/test/registered/unit/function_call/test_minicpm5_detector.py
@@ -9,6 +9,7 @@ from sglang.srt.function_call.minicpm5_detector import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def make_tools_weather():

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 NS = MINIMAX_NS_TOKEN
 

--- a/test/registered/unit/function_call/test_mistral_detector.py
+++ b/test/registered/unit/function_call/test_mistral_detector.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMistralDetector(CustomTestCase):

--- a/test/registered/unit/function_call/test_muse_glimmer_detector.py
+++ b/test/registered/unit/function_call/test_muse_glimmer_detector.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DOUBLED = "get_weather.get_weather"
 

--- a/test/registered/unit/function_call/test_normalize_json_schema_types.py
+++ b/test/registered/unit/function_call/test_normalize_json_schema_types.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestNormalizeJsonSchemaTypes(CustomTestCase):

--- a/test/registered/unit/function_call/test_parallel_tool_calls.py
+++ b/test/registered/unit/function_call/test_parallel_tool_calls.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(5, "base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestParallelToolCalls(unittest.TestCase):

--- a/test/registered/unit/function_call/test_poolside_v1_detector.py
+++ b/test/registered/unit/function_call/test_poolside_v1_detector.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPoolsideV1Detector(CustomTestCase):

--- a/test/registered/unit/function_call/test_unknown_tool_name.py
+++ b/test/registered/unit/function_call/test_unknown_tool_name.py
@@ -11,6 +11,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(5, "base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class DummyDetector(BaseFormatDetector):

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_quantization_override.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_quantization_override.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMlxQuantizationOverride(unittest.TestCase):

--- a/test/registered/unit/layers/attention/linear/kernels/test_kda_nvidia.py
+++ b/test/registered/unit/layers/attention/linear/kernels/test_kda_nvidia.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _RejectTriton:

--- a/test/registered/unit/layers/attention/test_flashattention_graph_metadata.py
+++ b/test/registered/unit/layers/attention/test_flashattention_graph_metadata.py
@@ -6,10 +6,11 @@ import torch
 from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
 from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFlashAttentionGraphMetadata(CustomTestCase):

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -27,6 +27,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _publish(testcase, **fields):

--- a/test/registered/unit/layers/attention/test_index_topk_share.py
+++ b/test/registered/unit/layers/attention/test_index_topk_share.py
@@ -9,6 +9,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _batch(

--- a/test/registered/unit/layers/attention/test_kda_helion_dispatcher.py
+++ b/test/registered/unit/layers/attention/test_kda_helion_dispatcher.py
@@ -13,6 +13,7 @@ from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHelionKDADispatcher(unittest.TestCase):

--- a/test/registered/unit/layers/attention/test_linear_attn_config.py
+++ b/test/registered/unit/layers/attention/test_linear_attn_config.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _Runner:

--- a/test/registered/unit/layers/attention/test_mla_decode_geometry.py
+++ b/test/registered/unit/layers/attention/test_mla_decode_geometry.py
@@ -46,6 +46,7 @@ from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # gfx950 full-GPU. Passed in rather than read from the device so this stays a CPU test.
 CORE_COUNT = 256

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _MAX_BS = 4
 _DRAFT = 3

--- a/test/registered/unit/layers/attention/test_vision_backend_selection.py
+++ b/test/registered/unit/layers/attention/test_vision_backend_selection.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci, register_npu_ci
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
 register_npu_ci(est_time=2, suite="base-b-test-1-npu-a3")
 register_npu_ci(est_time=2, suite="nightly-1-npu-a3", nightly=True)
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.fixture

--- a/test/registered/unit/layers/attention/test_vision_seqlens.py
+++ b/test/registered/unit/layers/attention/test_vision_seqlens.py
@@ -5,6 +5,7 @@ from sglang.srt.layers.attention.vision import SingletonCache, resolve_max_seqle
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_resolve_max_seqlen_accepts_raw_tensor_without_attribute_cache():

--- a/test/registered/unit/layers/attention/test_vision_strided_qkv.py
+++ b/test/registered/unit/layers/attention/test_vision_strided_qkv.py
@@ -18,6 +18,7 @@ from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 EMBED_DIM = 32
 NUM_HEADS = 4

--- a/test/registered/unit/layers/moe/test_aiter_runner.py
+++ b/test/registered/unit/layers/moe/test_aiter_runner.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _runner_input():

--- a/test/registered/unit/layers/moe/test_copy_weight_views_before_h2d.py
+++ b/test/registered/unit/layers/moe/test_copy_weight_views_before_h2d.py
@@ -6,6 +6,7 @@ from sglang.srt.layers.moe.fused_moe_triton.layer import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _assert_independent_copy(source: torch.Tensor, result: torch.Tensor) -> None:

--- a/test/registered/unit/layers/moe/test_fused_moe_common_utils.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_common_utils.py
@@ -8,6 +8,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _load_common_utils():

--- a/test/registered/unit/layers/moe/test_fused_moe_triton_config.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_triton_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=9, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe_triton_config

--- a/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
+++ b/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
@@ -16,6 +16,7 @@ These tests pin the fused shared expert's topk weight contract on three paths:
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/layers/moe/test_hpc_ops_runner_guard.py
+++ b/test/registered/unit/layers/moe/test_hpc_ops_runner_guard.py
@@ -12,6 +12,7 @@ from sglang.srt.runtime_context import get_flags
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.fixture

--- a/test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py
+++ b/test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestW4AFP8DeepEPDispatcherDtype(CustomTestCase):

--- a/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
+++ b/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
@@ -11,6 +11,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # The function under test is a GPU implementation, but this test replaces every
 # launched kernel and only verifies the host-side call contract.  Stub the

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_lm_head.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_lm_head.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import patch

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
@@ -10,6 +10,7 @@ for every group. Both are config-parsing paths, so these tests run on CPU.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest import mock

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_wna16_moe_no_linear.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_wna16_moe_no_linear.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _WNA16_MOE_SCHEMES = (CompressedTensorsWNA16MoE, CompressedTensorsWNA16TritonMoE)
 EXPERTS_LAYER = "model.layers.0.mlp.experts"

--- a/test/registered/unit/layers/quantization/test_deepgemm_ue8m0_requant.py
+++ b/test/registered/unit/layers/quantization/test_deepgemm_ue8m0_requant.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import call, patch

--- a/test/registered/unit/layers/quantization/test_flashinfer_trtllm_fp8_fallback.py
+++ b/test/registered/unit/layers/quantization/test_flashinfer_trtllm_fp8_fallback.py
@@ -21,6 +21,7 @@ backend selector and the two GEMM implementations so they run on CPU CI.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFp8UtilsMxfp4(CustomTestCase):

--- a/test/registered/unit/layers/quantization/test_gptq_scheme_attach.py
+++ b/test/registered/unit/layers/quantization/test_gptq_scheme_attach.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _GPTQ_CHECKPOINT_CONFIG = {
     "bits": 4,

--- a/test/registered/unit/layers/quantization/test_marlin_utils_fp8.py
+++ b/test/registered/unit/layers/quantization/test_marlin_utils_fp8.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFp8MarlinBias(CustomTestCase):

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
@@ -15,6 +15,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestModelOptNvfp4(CustomTestCase):

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
@@ -19,6 +19,7 @@ sizes, so a failure looks like one a real checkpoint would hit.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 per_token_group_quant_module = importlib.import_module(
     "sglang.kernels.ops.quantization.per_token_group_quant"

--- a/test/registered/unit/layers/quantization/test_quark_config.py
+++ b/test/registered/unit/layers/quantization/test_quark_config.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import patch

--- a/test/registered/unit/layers/test_attn_residual.py
+++ b/test/registered/unit/layers/test_attn_residual.py
@@ -4,6 +4,7 @@ from sglang.srt.layers.attn_residual import _supports_attn_res_tma
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestAttnResidual(unittest.TestCase):

--- a/test/registered/unit/layers/test_conv_layer.py
+++ b/test/registered/unit/layers/test_conv_layer.py
@@ -1,6 +1,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _INDEXER = "sglang.srt.layers.attention.dsv4.indexer"
 

--- a/test/registered/unit/layers/test_flashattention_paged_mha.py
+++ b/test/registered/unit/layers/test_flashattention_paged_mha.py
@@ -23,6 +23,7 @@ with patch.dict(
     )
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _backend():

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _simulate_transpose_scale_emit(values: torch.Tensor) -> torch.Tensor:

--- a/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
+++ b/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _fake_communicator(mlp_mode=ScatterMode.TP_ATTN_FULL):

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -17,6 +17,7 @@ from sglang.test.logprob_test_utils import coverage_cases
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 VOCAB = 11
 # Heterogeneous per-sequence parameters; uniform ones hide misalignment.

--- a/test/registered/unit/layers/test_minicpm_attention_adapter.py
+++ b/test/registered/unit/layers/test_minicpm_attention_adapter.py
@@ -25,6 +25,7 @@ with patch.dict(
     )
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _metadata(rows=1):

--- a/test/registered/unit/layers/test_minicpm_sparse_cache.py
+++ b/test/registered/unit/layers/test_minicpm_sparse_cache.py
@@ -22,6 +22,7 @@ from sglang.srt.session.streaming_session import SessionSlot, StreamingSession
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class RecordingAllocator(BaseTokenToKVPoolAllocator):

--- a/test/registered/unit/layers/test_pooler_score_and_pool.py
+++ b/test/registered/unit/layers/test_pooler_score_and_pool.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_forward_batch(

--- a/test/registered/unit/layers/test_radix_attention.py
+++ b/test/registered/unit/layers/test_radix_attention.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _RecordingAttentionBackend:

--- a/test/registered/unit/lora/test_eviction_policy.py
+++ b/test/registered/unit/lora/test_eviction_policy.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestLoRAEvictionPolicy(CustomTestCase):

--- a/test/registered/unit/lora/test_experimental_sgl_marlin_policy.py
+++ b/test/registered/unit/lora/test_experimental_sgl_marlin_policy.py
@@ -12,6 +12,7 @@ from sglang.srt.lora.marlin_lora_temp.policy import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # Both spellings of "this server serves adapters". The validator must apply the

--- a/test/registered/unit/lora/test_experimental_sgl_marlin_runtime_unit.py
+++ b/test/registered/unit/lora/test_experimental_sgl_marlin_runtime_unit.py
@@ -20,6 +20,7 @@ from sglang.srt.lora.trtllm_lora_temp import environ as trtllm_lora_environ
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _SGLANG_ROOT = Path(sglang.__file__).resolve().parent
 

--- a/test/registered/unit/lora/test_inkling_linearized_lora_unit.py
+++ b/test/registered/unit/lora/test_inkling_linearized_lora_unit.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 # Pure layout / bookkeeping math: no CUDA, no distributed groups, no kernels.
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _HIDDEN = 3
 _ADAPTER_RANK = 2

--- a/test/registered/unit/lora/test_laguna_hidden_dim_unit.py
+++ b/test/registered/unit/lora/test_laguna_hidden_dim_unit.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 # CPU-only unit test; no CUDA/distributed dependencies.
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/lora/test_lm_head_pruning.py
+++ b/test/registered/unit/lora/test_lm_head_pruning.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestLMHeadPruning(CustomTestCase):

--- a/test/registered/unit/lora/test_lora_manager_tied_lm_head.py
+++ b/test/registered/unit/lora/test_lora_manager_tied_lm_head.py
@@ -28,6 +28,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _TiedEmbedding(torch.nn.Module):

--- a/test/registered/unit/lora/test_lora_moe_inplace_unit.py
+++ b/test/registered/unit/lora/test_lora_moe_inplace_unit.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 # CPU-only unit test; no CUDA/distributed dependencies.
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import types
 import unittest

--- a/test/registered/unit/lora/test_mem_pool_ep_unit.py
+++ b/test/registered/unit/lora/test_mem_pool_ep_unit.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 # CPU-only unit test; no CUDA/distributed dependencies.
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import ast
 import types

--- a/test/registered/unit/managers/scheduler_components/test_output_sender.py
+++ b/test/registered/unit/managers/scheduler_components/test_output_sender.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.scheduler_components.output_sender import SenderWrapper
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_scheduler_req(http_worker_ipc: str) -> Req:

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -30,6 +30,7 @@ from sglang.srt.managers.data_parallel_controller import (
 from sglang.srt.managers.load_snapshot import LoadSnapshot
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 _BASE_LOAD = msgspec.structs.replace(

--- a/test/registered/unit/managers/test_detailed_annotations.py
+++ b/test/registered/unit/managers/test_detailed_annotations.py
@@ -26,6 +26,7 @@ from sglang.srt.model_executor.step_span_utils import (
 from sglang.srt.utils.profile_utils import build_step_span_name
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _CpuMirror:

--- a/test/registered/unit/managers/test_embed_overrides.py
+++ b/test/registered/unit/managers/test_embed_overrides.py
@@ -27,6 +27,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 HIDDEN_DIM = 4
 

--- a/test/registered/unit/managers/test_fanout_communicator.py
+++ b/test/registered/unit/managers/test_fanout_communicator.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestQueueingCall(CustomTestCase):

--- a/test/registered/unit/managers/test_finish_length_speculative.py
+++ b/test/registered/unit/managers/test_finish_length_speculative.py
@@ -26,6 +26,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 EOS_ID = 2
 STOP_ID = 1

--- a/test/registered/unit/managers/test_generation_auxiliary_output.py
+++ b/test/registered/unit/managers/test_generation_auxiliary_output.py
@@ -21,6 +21,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=14, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @dataclass

--- a/test/registered/unit/managers/test_grammar_stop_speculative.py
+++ b/test/registered/unit/managers/test_grammar_stop_speculative.py
@@ -8,6 +8,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 EOS_TOKEN_ID = 2
 STOP_TOKEN_ID = 17

--- a/test/registered/unit/managers/test_hidden_state_server_mode.py
+++ b/test/registered/unit/managers/test_hidden_state_server_mode.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHiddenStateServerMode(CustomTestCase):

--- a/test/registered/unit/managers/test_kv_page_invariants.py
+++ b/test/registered/unit/managers/test_kv_page_invariants.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _PAGE_SIZE = 256
 

--- a/test/registered/unit/managers/test_load_inquirer.py
+++ b/test/registered/unit/managers/test_load_inquirer.py
@@ -13,6 +13,7 @@ from sglang.srt.managers.scheduler_components.load_inquirer import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSchedulePolicyWaitingQueueMatching(unittest.TestCase):

--- a/test/registered/unit/managers/test_load_snapshot_backends.py
+++ b/test/registered/unit/managers/test_load_snapshot_backends.py
@@ -27,6 +27,7 @@ maybe_stub_sgl_kernel()
 
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _temp_path() -> str:

--- a/test/registered/unit/managers/test_lora_update_result_merge.py
+++ b/test/registered/unit/managers/test_lora_update_result_merge.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _ok(adapters=None) -> LoRAUpdateOutput:

--- a/test/registered/unit/managers/test_mm_embedding_length.py
+++ b/test/registered/unit/managers/test_mm_embedding_length.py
@@ -8,6 +8,7 @@ from sglang.srt.managers import mm_schedule as mm_utils
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="stage-a-test-cpu-intel")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.mark.parametrize(

--- a/test/registered/unit/managers/test_mm_hashes.py
+++ b/test/registered/unit/managers/test_mm_hashes.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMmHashesContract(CustomTestCase):

--- a/test/registered/unit/managers/test_mm_utils_split.py
+++ b/test/registered/unit/managers/test_mm_utils_split.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _bundled_item(grid_key=None, grid=None, feature_len=10, num_images=2):

--- a/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
+++ b/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
@@ -43,6 +43,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _round_trip(obj):

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
 )
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class CustomTokenizerWorker(TokenizerWorker):

--- a/test/registered/unit/managers/test_pp_cp_rank_offsets.py
+++ b/test/registered/unit/managers/test_pp_cp_rank_offsets.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.scheduler_components.request_receiver import (  # noqa:
 from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin  # noqa: E402
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_ps(**overrides) -> ParallelState:

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _RecordingDelayer:

--- a/test/registered/unit/managers/test_prefill_delayer_high_watermark.py
+++ b/test/registered/unit/managers/test_prefill_delayer_high_watermark.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPrefillDelayerHighWatermark(CustomTestCase):

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -24,6 +24,7 @@ from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDisaggregationPriorityQueueing(unittest.TestCase):

--- a/test/registered/unit/managers/test_profile_merger_http_api.py
+++ b/test/registered/unit/managers/test_profile_merger_http_api.py
@@ -5,6 +5,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestProfileMergerHTTPAPI(CustomTestCase):

--- a/test/registered/unit/managers/test_retraction_order.py
+++ b/test/registered/unit/managers/test_retraction_order.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _req(output_len: int, input_len: int = 8, priority=None):

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -20,6 +20,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm  # noqa: E402
 from sglang.srt.utils.common import Range  # noqa: E402
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 AUTO_FILL_EXCLUDED_FIELDS = ["reqs"]
 

--- a/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
+++ b/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode  # noqa: E402
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_req(req_pool_idx, origin_input_ids, output_ids):

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -18,6 +18,7 @@ from sglang.srt.mem_cache.chunk_cache import ChunkCache
 from sglang.srt.utils.common import Range
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_req(

--- a/test/registered/unit/managers/test_scheduler_decision_batch_params.py
+++ b/test/registered/unit/managers/test_scheduler_decision_batch_params.py
@@ -13,6 +13,7 @@ from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixi
 from sglang.srt.managers.scheduler import Scheduler
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 FORBIDDEN_TOKENS = ("self.running_batch", "self.last_batch", "self.cur_batch")
 

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.scheduler_components.flush_wrapper import (
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSchedulerFlushCache(unittest.TestCase):

--- a/test/registered/unit/managers/test_scheduler_hicache_attach.py
+++ b/test/registered/unit/managers/test_scheduler_hicache_attach.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSchedulerHiCacheAttach(CustomTestCase):

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -8,6 +8,7 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -25,6 +25,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSchedulerPauseGeneration(unittest.TestCase):

--- a/test/registered/unit/managers/test_scheduler_prefill_decode_interval.py
+++ b/test/registered/unit/managers/test_scheduler_prefill_decode_interval.py
@@ -11,6 +11,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.managers.scheduler import Scheduler
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_scheduler(*, interval: int, require_mlp_sync: bool) -> Scheduler:

--- a/test/registered/unit/managers/test_scheduler_recv_skipper.py
+++ b/test/registered/unit/managers/test_scheduler_recv_skipper.py
@@ -13,6 +13,7 @@ from sglang.srt.managers.scheduler_components.recv_skipper import (  # noqa: E40
 from sglang.srt.model_executor.forward_batch_info import ForwardMode  # noqa: E402
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _publish(case, interval, enable_dp_attention=False):

--- a/test/registered/unit/managers/test_scheduler_weight_version_tracking.py
+++ b/test/registered/unit/managers/test_scheduler_weight_version_tracking.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _ServingStub:

--- a/test/registered/unit/managers/test_stop_str_speculative.py
+++ b/test/registered/unit/managers/test_stop_str_speculative.py
@@ -13,6 +13,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Token id -> decoded text; decode() concatenates. Distinct symbols so no
 # accidental cross-matches (10-39 are lowercase letters).

--- a/test/registered/unit/managers/test_tokenizer_config_updates.py
+++ b/test/registered/unit/managers/test_tokenizer_config_updates.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _manager(case, **fields):

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -39,6 +39,7 @@ from sglang.srt.observability.req_time_stats import (  # noqa: E402
 from sglang.srt.runtime_context import get_context
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 _NOT_FINISHED = object()  # Sentinel: request has not finished yet

--- a/test/registered/unit/managers/test_trim_matched_stop.py
+++ b/test/registered/unit/managers/test_trim_matched_stop.py
@@ -13,6 +13,7 @@ from sglang.srt.managers.detokenizer_manager import DetokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 GPT_OSS_CALL_TOKEN = 200012
 

--- a/test/registered/unit/managers/test_vocab_boundary_finish.py
+++ b/test/registered/unit/managers/test_vocab_boundary_finish.py
@@ -10,6 +10,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.managers.schedule_batch import FINISH_MATCHED_STR, Req
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 VOCAB_SIZE = 1000
 

--- a/test/registered/unit/mem_cache/test_asymmetric_mha_pool_host_unit.py
+++ b/test/registered/unit/mem_cache/test_asymmetric_mha_pool_host_unit.py
@@ -15,6 +15,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_host(layout: str) -> AsymmetricMHATokenToKVPoolHost:

--- a/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
+++ b/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
@@ -14,6 +14,7 @@ from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeAllocator:

--- a/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
+++ b/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDSALayerShardUtils(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_dsv4_compress_write_pad.py
+++ b/test/registered/unit/mem_cache/test_dsv4_compress_write_pad.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCompressStateWritePad(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_embedding_cache_controller.py
+++ b/test/registered/unit/mem_cache/test_embedding_cache_controller.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.embedding_cache_controller import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_pool(num_pages=16, dim=4, page_size=2, modality="vision"):

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import MagicMock

--- a/test/registered/unit/mem_cache/test_full_loc_fast_path.py
+++ b/test/registered/unit/mem_cache/test_full_loc_fast_path.py
@@ -28,6 +28,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _loc_info(virtual_loc, swa_phys=None, full_phys=None):

--- a/test/registered/unit/mem_cache/test_hicache_dcp_host_pool.py
+++ b/test/registered/unit/mem_cache/test_hicache_dcp_host_pool.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DCP_SIZE = 8
 PHYSICAL_PAGE = 64

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -15,6 +15,7 @@ Run with:
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import os
 import shutil

--- a/test/registered/unit/mem_cache/test_hicache_nixl_cleaner.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_cleaner.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import os
 import shutil

--- a/test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py
+++ b/test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py
@@ -9,6 +9,7 @@ from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeWork:

--- a/test/registered/unit/mem_cache/test_hisparse_allocator.py
+++ b/test/registered/unit/mem_cache/test_hisparse_allocator.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDeepSeekV4HiSparseAllocator(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_hisparse_max_token_pool_size.py
+++ b/test/registered/unit/mem_cache/test_hisparse_max_token_pool_size.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_model_runner(**attrs):

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _Pool:

--- a/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
+++ b/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
@@ -34,6 +34,7 @@ arithmetic execute — no CUDA kernel is launched.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/mem_cache/test_layout_compat.py
+++ b/test/registered/unit/mem_cache/test_layout_compat.py
@@ -22,6 +22,7 @@ envelope formula byte for byte.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=9, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
@@ -6,6 +6,7 @@ from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 NUM_LAYERS = 2
 NUM_SLOTS = 3

--- a/test/registered/unit/mem_cache/test_mem_pool_host.py
+++ b/test/registered/unit/mem_cache/test_mem_pool_host.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHostKVCache(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_minimax_sparse_pool_pd_unit.py
+++ b/test/registered/unit/mem_cache/test_minimax_sparse_pool_pd_unit.py
@@ -6,6 +6,7 @@ from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_k_only_pool(start_layer: int = 0) -> MiniMaxSparseKVPool:

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -1,6 +1,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import sys
 

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class ReplicateConfigWithGroupIds:

--- a/test/registered/unit/mem_cache/test_mooncake_standalone_dummy_mamba.py
+++ b/test/registered/unit/mem_cache/test_mooncake_standalone_dummy_mamba.py
@@ -6,6 +6,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _fake_mooncake_modules(fake_store_cls):

--- a/test/registered/unit/mem_cache/test_mooncake_tenant_config.py
+++ b/test/registered/unit/mem_cache/test_mooncake_tenant_config.py
@@ -13,6 +13,7 @@ from sglang.srt.mem_cache.storage.mooncake_store.mooncake_store import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _fake_mooncake_modules(fake_store_cls):

--- a/test/registered/unit/mem_cache/test_mxfp8_scale_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mxfp8_scale_transfer_buffers.py
@@ -6,6 +6,7 @@ from sglang.srt.mem_cache.memory_pool import MHATokenToKVPoolMXFP8
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 LAYERS = 2
 PAGE_SIZE = 128

--- a/test/registered/unit/mem_cache/test_page_major_layout.py
+++ b/test/registered/unit/mem_cache/test_page_major_layout.py
@@ -13,6 +13,7 @@ Runs on CPU — pure-torch advanced indexing, no Triton.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/mem_cache/test_paged_free_segment.py
+++ b/test/registered/unit/mem_cache/test_paged_free_segment.py
@@ -18,6 +18,7 @@ from sglang.srt.mem_cache.common import _release_overallocated_kv_indices
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 PAGE_SIZE = 4
 NUM_PAGES = 64

--- a/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
+++ b/test/registered/unit/mem_cache/test_pd_envelope_transfer_layout.py
@@ -27,6 +27,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMLAEnvelopeTransferAddressing(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_pure_swa_chunk_cache.py
+++ b/test/registered/unit/mem_cache/test_pure_swa_chunk_cache.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeAllocator:

--- a/test/registered/unit/mem_cache/test_quantized_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_quantized_kv_pool.py
@@ -9,6 +9,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeQuantMethod:

--- a/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRadixCacheCppCacheSalt(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
@@ -15,6 +15,7 @@ from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSLRUAccuracy(unittest.TestCase):

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -8,6 +8,7 @@ RadixCache.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 import unittest.mock

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -4,6 +4,7 @@ from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/test/registered/unit/mem_cache/test_replayssm_ring_accounting.py
+++ b/test/registered/unit/mem_cache/test_replayssm_ring_accounting.py
@@ -24,6 +24,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # temporal = (hv=4, v_dim=8, k_dim=8), num_k_heads_per_tp = 4, record_len = 8,
 # 2 layers. conv bf16 (2B), fp32 gate/beta (4B). Ring tensors (per slot, per

--- a/test/registered/unit/mem_cache/test_retraction_mamba_backup.py
+++ b/test/registered/unit/mem_cache/test_retraction_mamba_backup.py
@@ -7,6 +7,7 @@ from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 MAMBA_STATE = object()
 

--- a/test/registered/unit/mem_cache/test_session_token_share_unit.py
+++ b/test/registered/unit/mem_cache/test_session_token_share_unit.py
@@ -11,6 +11,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from array import array

--- a/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from array import array

--- a/test/registered/unit/mem_cache/test_streaming_session_unit.py
+++ b/test/registered/unit/mem_cache/test_streaming_session_unit.py
@@ -9,6 +9,7 @@ from sglang.srt.session.streaming_session import SessionSlot, StreamingSession
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeAllocator(BaseTokenToKVPoolAllocator):

--- a/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
+++ b/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_self(*, page_size: int, full_available: int, swa_available: int):

--- a/test/registered/unit/mem_cache/test_swa_cpu_copy_filter.py
+++ b/test/registered/unit/mem_cache/test_swa_cpu_copy_filter.py
@@ -7,6 +7,7 @@ from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 ROWS = 4
 

--- a/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
+++ b/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
@@ -26,10 +26,15 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sglang.srt.utils import get_device
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 
 register_cuda_ci(est_time=13, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # ---------------------------------------------------------------------------
 # Infrastructure helpers (shared setup, not logic)

--- a/test/registered/unit/mem_cache/test_swa_lock_release_lifecycle.py
+++ b/test/registered/unit/mem_cache/test_swa_lock_release_lifecycle.py
@@ -29,11 +29,16 @@ from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sglang.srt.utils import get_device
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=12, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _build_tree(

--- a/test/registered/unit/mem_cache/test_tree_core_registry.py
+++ b/test/registered/unit/mem_cache/test_tree_core_registry.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _cache_init_params(**kwargs) -> CacheInitParams:

--- a/test/registered/unit/mem_cache/test_umbp_host_allocator.py
+++ b/test/registered/unit/mem_cache/test_umbp_host_allocator.py
@@ -13,6 +13,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # These tests stub out mori with a fake in-process module, so they need neither
 # a real mori install nor a GPU and run on NVIDIA / CPU CI.

--- a/test/registered/unit/mem_cache/test_unified_mla_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mla_views.py
@@ -24,6 +24,7 @@ GPU parity of the read/write kernels (set_mla_kv_buffer TMA path etc.) lives in
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.unified_cache.components import ComponentType
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _mock_kvcache(cls):

--- a/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.model_runner_components.attention_backend_setup i
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeBackend:

--- a/test/registered/unit/model_executor/model_runner_components/test_cuda_graph_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_cuda_graph_setup.py
@@ -13,6 +13,7 @@ from sglang.srt.model_executor.model_runner_components.cuda_graph_setup import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_standard_gqa_gate_uses_pipeline_local_layer_range():

--- a/test/registered/unit/model_executor/model_runner_components/test_layer_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_layer_setup.py
@@ -9,6 +9,7 @@ from sglang.srt.model_executor.model_runner_components.layer_setup import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestComputeAttentionAndMoeLayers(unittest.TestCase):

--- a/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
@@ -16,6 +16,7 @@ from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager i
 )
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_ngram_info(batch_size: int, skip_token_table_update=None):

--- a/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
@@ -9,6 +9,7 @@ from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state imp
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.mark.parametrize(

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -37,6 +37,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _CAPTURE_TRACE = "SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE"
 _BATCH_CAPTURE = "SGLANG_GRAPH_BATCH_CAPTURE"

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_shared_read_fence.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_shared_read_fence.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DECODE = ForwardMode.DECODE
 

--- a/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
+++ b/test/registered/unit/model_executor/runner/test_hidden_state_graph_recapture.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHiddenStateGraphRecapture(CustomTestCase):

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPrefillCudaGraphPadding(CustomTestCase):

--- a/test/registered/unit/model_executor/runner/test_prefill_shared_read_done.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_shared_read_done.py
@@ -16,6 +16,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _Event:

--- a/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
+++ b/test/registered/unit/model_executor/runner_backend/test_full_cuda_graph_backend.py
@@ -34,6 +34,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Sentinel: distinguishes "runner has no _profiler attribute" from
 # "_profiler is None" in the test fixtures.

--- a/test/registered/unit/model_executor/test_chunked_prefix_cache_gate.py
+++ b/test/registered/unit/model_executor/test_chunked_prefix_cache_gate.py
@@ -8,6 +8,7 @@ saw the flip, so an unsupported backend kept chunked prefix enabled.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
+++ b/test/registered/unit/model_executor/test_cuda_graph_buffer_registry.py
@@ -30,6 +30,7 @@ from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @dataclasses.dataclass

--- a/test/registered/unit/model_executor/test_draft_runner_skips_lora.py
+++ b/test/registered/unit/model_executor/test_draft_runner_skips_lora.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDraftRunnerSkipsLoRA(CustomTestCase):

--- a/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
+++ b/test/registered/unit/model_executor/test_forward_metadata_plan_record.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_batch(bs: int = 2, num_tokens: int = 2) -> ForwardBatch:

--- a/test/registered/unit/model_executor/test_hisparse_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_hisparse_pool_configurator.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHiSparsePoolConfigurator(CustomTestCase):

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @contextlib.contextmanager

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -28,6 +28,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeAttentionBackend:

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _LayerModel:

--- a/test/registered/unit/model_loader/test_prefetch_checkpoints.py
+++ b/test/registered/unit/model_loader/test_prefetch_checkpoints.py
@@ -29,6 +29,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _InlineThread:

--- a/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
@@ -24,6 +24,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeModel:

--- a/test/registered/unit/model_loader/test_weight_cache_protocol.py
+++ b/test/registered/unit/model_loader/test_weight_cache_protocol.py
@@ -51,6 +51,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_cache_config(**overrides) -> CacheConfig:

--- a/test/registered/unit/model_loader/test_weight_utils.py
+++ b/test/registered/unit/model_loader/test_weight_utils.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 INDEX_NAME = "model.safetensors.index.json"
 

--- a/test/registered/unit/models/test_deepseek_mla_dispatch.py
+++ b/test/registered/unit/models/test_deepseek_mla_dispatch.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _fake_forward_batch(is_decode: bool):

--- a/test/registered/unit/models/test_deepseek_v4_rope_policy.py
+++ b/test/registered/unit/models/test_deepseek_v4_rope_policy.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _ModuleStub(nn.Module):

--- a/test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py
+++ b/test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py
@@ -10,6 +10,7 @@ being remapped to a nonexistent decoder parameter and silently dropped.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/models/test_kimi_k3_vision.py
+++ b/test/registered/unit/models/test_kimi_k3_vision.py
@@ -25,6 +25,7 @@ from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @pytest.mark.parametrize(

--- a/test/registered/unit/models/test_kimi_vl.py
+++ b/test/registered/unit/models/test_kimi_vl.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=13, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _VisionTower:

--- a/test/registered/unit/models/test_kimi_vl_moonvit.py
+++ b/test/registered/unit/models/test_kimi_vl_moonvit.py
@@ -4,6 +4,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.models import kimi_vl_moonvit
 from sglang.srt.models.kimi_vl_moonvit import Learnable2DInterpPosEmb

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class PixtralVisionConfig:

--- a/test/registered/unit/models/test_locate_anything.py
+++ b/test/registered/unit/models/test_locate_anything.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _small_config():

--- a/test/registered/unit/models/test_longcat_flash_router_hpc_gemm.py
+++ b/test/registered/unit/models/test_longcat_flash_router_hpc_gemm.py
@@ -14,6 +14,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.models.longcat_flash import LongcatFlashRouter  # noqa: E402
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _longcat_config(hidden_size, n_routed_experts, *, router_bias=False):

--- a/test/registered/unit/models/test_mellum.py
+++ b/test/registered/unit/models/test_mellum.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMellumForCausalLM(CustomTestCase):

--- a/test/registered/unit/models/test_moss_vl_processor.py
+++ b/test/registered/unit/models/test_moss_vl_processor.py
@@ -11,6 +11,7 @@ from sglang.srt.multimodal.processors.moss_vl import MossVLImageProcessor
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _vision_info(frame_count: int):

--- a/test/registered/unit/models/test_nemotron_h_weight_loading.py
+++ b/test/registered/unit/models/test_nemotron_h_weight_loading.py
@@ -8,6 +8,7 @@ parameters absent from the current runtime model.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/models/test_paddleocr_vl_vision.py
+++ b/test/registered/unit/models/test_paddleocr_vl_vision.py
@@ -19,6 +19,7 @@ from sglang.srt.models.paddleocr_vl import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Mixes repeated grids (LFU cache hits), an odd aspect ratio, and t > 1.
 GRIDS = [(1, 4, 6), (1, 8, 10), (2, 2, 4), (1, 8, 10)]

--- a/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
+++ b/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
@@ -22,6 +22,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestModelOptFp4AttentionExclusion(CustomTestCase):

--- a/test/registered/unit/models/test_qwen3_5_packed_weight_loader.py
+++ b/test/registered/unit/models/test_qwen3_5_packed_weight_loader.py
@@ -11,6 +11,7 @@ Regression test for https://github.com/sgl-project/sglang/issues/23051
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
@@ -10,6 +10,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestQwen3_5PipelineParallel(CustomTestCase):

--- a/test/registered/unit/models/test_qwen3_embedding_registration.py
+++ b/test/registered/unit/models/test_qwen3_embedding_registration.py
@@ -9,6 +9,7 @@ and be served as an embedding model, NOT fall back to the Transformers backend.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=17, suite="base-a-test-cpu")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/models/test_qwen3_vl_feature_materialization.py
+++ b/test/registered/unit/models/test_qwen3_vl_feature_materialization.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _RecordingVisual:

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -27,6 +27,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=13, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _quant(name: str):

--- a/test/registered/unit/models/test_vit_pos_embed_interpolate.py
+++ b/test/registered/unit/models/test_vit_pos_embed_interpolate.py
@@ -25,6 +25,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_amd_ci(est_time=20, stage="stage-a", runner_config="1-gpu-small-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 NUM_POS = 2304  # Qwen3-VL num_position_embeddings -> 48x48 grid
 HIDDEN = 64  # small hidden dim keeps the unit test fast

--- a/test/registered/unit/models/test_zaya_cca.py
+++ b/test/registered/unit/models/test_zaya_cca.py
@@ -35,6 +35,7 @@ from sglang.test.layer_ut_utils import init_single_process_dist
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _ensure_dist_initialized(cls) -> None:

--- a/test/registered/unit/models/test_zaya_mod_tp.py
+++ b/test/registered/unit/models/test_zaya_mod_tp.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _reference_blend(

--- a/test/registered/unit/multimodal/rust/shared/test_partition_cores.py
+++ b/test/registered/unit/multimodal/rust/shared/test_partition_cores.py
@@ -15,6 +15,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.rust_server.config import _partition_cores  # noqa: E402
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def partition(node_cores, **kwargs):

--- a/test/registered/unit/multimodal/test_audio_container_decode.py
+++ b/test/registered/unit/multimodal/test_audio_container_decode.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _tone(*, sample_rate: int, channels: int = 1) -> np.ndarray:

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -7,6 +7,7 @@ Media the client supplied but that cannot be fetched or decoded must raise
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import base64
 import binascii

--- a/test/registered/unit/multimodal/test_base_processor_image_decode.py
+++ b/test/registered/unit/multimodal/test_base_processor_image_decode.py
@@ -12,6 +12,7 @@ No server, no model loading — pure CPU.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import asyncio
 import concurrent.futures

--- a/test/registered/unit/multimodal/test_cuda_ipc_pool_budget.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_pool_budget.py
@@ -8,6 +8,7 @@ from sglang.srt.multimodal.transport.cuda_ipc import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCudaIpcPoolBudget(unittest.TestCase):

--- a/test/registered/unit/multimodal/test_dots_note_omni.py
+++ b/test/registered/unit/multimodal/test_dots_note_omni.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _IM_TOKEN_ID = 100
 _AUDIO_TOKEN_ID = 200

--- a/test/registered/unit/multimodal/test_evs.py
+++ b/test/registered/unit/multimodal/test_evs.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import run_doctests
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_resolve_evs_config():

--- a/test/registered/unit/multimodal/test_feature_materialization.py
+++ b/test/registered/unit/multimodal/test_feature_materialization.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFeatureMaterialization(CustomTestCase):

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -11,6 +11,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCudaVmmFeatureTransport(unittest.TestCase):

--- a/test/registered/unit/multimodal/test_kimi_k3_gpu_preprocess.py
+++ b/test/registered/unit/multimodal/test_kimi_k3_gpu_preprocess.py
@@ -12,6 +12,7 @@ from sglang.srt.multimodal.processors.kimi_k25 import _resize_bicubic_if_needed
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _natural_image(height: int, width: int) -> np.ndarray:

--- a/test/registered/unit/multimodal/test_media_artifact_processor.py
+++ b/test/registered/unit/multimodal/test_media_artifact_processor.py
@@ -17,6 +17,7 @@ from sglang.srt.multimodal.media_artifacts import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 @dataclass(frozen=True)

--- a/test/registered/unit/multimodal/test_mrope_encoder_utils.py
+++ b/test/registered/unit/multimodal/test_mrope_encoder_utils.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _RecordingGather:

--- a/test/registered/unit/multimodal/test_pixtral_processor.py
+++ b/test/registered/unit/multimodal/test_pixtral_processor.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPixtralProcessor(CustomTestCase):

--- a/test/registered/unit/multimodal/test_processor_device_selection.py
+++ b/test/registered/unit/multimodal/test_processor_device_selection.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 BASE = "sglang.srt.multimodal.processors.base_processor"
 

--- a/test/registered/unit/multimodal/test_vit_cuda_graph_runner.py
+++ b/test/registered/unit/multimodal/test_vit_cuda_graph_runner.py
@@ -8,6 +8,7 @@ import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.multimodal.internvl_vit_cuda_graph_runner import (
     InternViTCudaGraphRunner,

--- a/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
@@ -10,9 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_npu_ci
 
 register_npu_ci(est_time=4, suite="base-a-test-1-npu-a2")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 for mod in (
     "torch_npu",

--- a/test/registered/unit/npu/attention/test_npu_ascend_torch_native_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_torch_native_backend.py
@@ -11,9 +11,10 @@ from torch.nn.functional import scaled_dot_product_attention
 from sglang.srt.hardware_backend.npu.attention.ascend_torch_native_backend import (
     AscendTorchNativeAttnBackend,
 )
-from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_npu_ci
 
 register_npu_ci(est_time=4, suite="stage-a-unit-test-npu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestInit(unittest.TestCase):

--- a/test/registered/unit/npu/attention/test_npu_mla_preprocess.py
+++ b/test/registered/unit/npu/attention/test_npu_mla_preprocess.py
@@ -8,9 +8,10 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_npu_ci
 
 register_npu_ci(est_time=4, suite="stage-a-unit-test-npu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
     is_fia_nz,

--- a/test/registered/unit/observability/test_cpu_monitor.py
+++ b/test/registered/unit/observability/test_cpu_monitor.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=60, suite="base-a-test-cpu", nightly=True)
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestCpuMonitor(unittest.TestCase):

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -2,6 +2,7 @@ from sglang.srt.runtime_context import get_context, get_observability
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import math
 import types

--- a/test/registered/unit/observability/test_func_timer.py
+++ b/test/registered/unit/observability/test_func_timer.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import asyncio
 import unittest

--- a/test/registered/unit/observability/test_label_transform.py
+++ b/test/registered/unit/observability/test_label_transform.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/observability/test_metrics_utils.py
+++ b/test/registered/unit/observability/test_metrics_utils.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestMetricsUtils(unittest.TestCase):

--- a/test/registered/unit/observability/test_ray_wrappers.py
+++ b/test/registered/unit/observability/test_ray_wrappers.py
@@ -26,6 +26,7 @@ from sglang.test.observability.fake_ray import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/observability/test_req_time_stats.py
+++ b/test/registered/unit/observability/test_req_time_stats.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestSetstatePreservesUnsetTimeSentinels(CustomTestCase):

--- a/test/registered/unit/observability/test_request_metrics_exporter.py
+++ b/test/registered/unit/observability/test_request_metrics_exporter.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import asyncio
 import json

--- a/test/registered/unit/observability/test_startup_func_log_and_timer.py
+++ b/test/registered/unit/observability/test_startup_func_log_and_timer.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import MagicMock, patch

--- a/test/registered/unit/observability/test_stat_loggers_di.py
+++ b/test/registered/unit/observability/test_stat_loggers_di.py
@@ -21,6 +21,7 @@ GPU-backed metrics tests.
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/parser/test_code_completion_parser.py
+++ b/test/registered/unit/parser/test_code_completion_parser.py
@@ -20,6 +20,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRegisterCompletionTemplate(CustomTestCase):

--- a/test/registered/unit/parser/test_conversation.py
+++ b/test/registered/unit/parser/test_conversation.py
@@ -34,6 +34,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestConversationGetPrompt(CustomTestCase):

--- a/test/registered/unit/parser/test_harmony_parser.py
+++ b/test/registered/unit/parser/test_harmony_parser.py
@@ -14,6 +14,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPrefixHold(CustomTestCase):

--- a/test/registered/unit/parser/test_inkling_renderer.py
+++ b/test/registered/unit/parser/test_inkling_renderer.py
@@ -20,6 +20,7 @@ from sglang.srt.parser.inkling_tokenizer import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _text(value: str) -> list[int]:

--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -13,6 +13,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTemplateContentFormatDetection(CustomTestCase):

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -15,6 +15,7 @@ from sglang.srt.parser.reasoning_parser import KimiK3Detector, ReasoningParser
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _stream(detector: KimiK3Detector, chunks: list[str]) -> tuple[str, str]:

--- a/test/registered/unit/parser/test_reasoning_content_without_parser.py
+++ b/test/registered/unit/parser/test_reasoning_content_without_parser.py
@@ -6,6 +6,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Simulated model output that contains think tags (e.g. from DeepSeek-R1)
 THINK_OUTPUT = (

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -23,6 +23,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestBaseReasoningFormatDetector(CustomTestCase):

--- a/test/registered/unit/plugins/test_hook_registry.py
+++ b/test/registered/unit/plugins/test_hook_registry.py
@@ -17,6 +17,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # ---------------------------------------------------------------------------
 # Helpers: synthetic module creation

--- a/test/registered/unit/plugins/test_load_plugins.py
+++ b/test/registered/unit/plugins/test_load_plugins.py
@@ -20,6 +20,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_ep(name, dist_name=None, load_fn=None):

--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import json
 import unittest

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from unittest.mock import MagicMock

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -4,6 +4,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=24, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=53, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -5,6 +5,7 @@ from sglang.test.ci.ci_register import register_cpu_ci, register_xpu_ci
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
 register_xpu_ci(est_time=10, suite="stage-a-test-1-gpu-xpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import copy
 import re

--- a/test/registered/unit/scripted_runtime/test_background_http_poster.py
+++ b/test/registered/unit/scripted_runtime/test_background_http_poster.py
@@ -12,6 +12,7 @@ from sglang.test.scripted_runtime.background_http_poster import BackgroundHttpPo
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _FakeResponse:

--- a/test/registered/unit/scripted_runtime/test_http_server.py
+++ b/test/registered/unit/scripted_runtime/test_http_server.py
@@ -17,6 +17,7 @@ from sglang.test.scripted_runtime.io_struct import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _sample_script(ctx, *args):

--- a/test/registered/unit/scripted_runtime/test_scheduler_hook.py
+++ b/test/registered/unit/scripted_runtime/test_scheduler_hook.py
@@ -8,6 +8,7 @@ from sglang.test.scripted_runtime import scheduler_hook
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _yielding_gen():

--- a/test/registered/unit/scripted_runtime/test_scripted_runtime_utils.py
+++ b/test/registered/unit/scripted_runtime/test_scripted_runtime_utils.py
@@ -10,6 +10,7 @@ from sglang.test.scripted_runtime.utils import ensure_script_importable, resolve
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestResolveFn(CustomTestCase):

--- a/test/registered/unit/scripted_runtime/test_tokenizer_recv_proxy.py
+++ b/test/registered/unit/scripted_runtime/test_tokenizer_recv_proxy.py
@@ -12,6 +12,7 @@ from sglang.test.scripted_runtime.tokenizer_recv_proxy import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/server_args/test_page_major_backend_allowlist.py
+++ b/test/registered/unit/server_args/test_page_major_backend_allowlist.py
@@ -37,6 +37,7 @@ from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _accepts(

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -12,6 +12,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_xpu_ci(est_time=10, suite="stage-a-test-1-gpu-xpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestAdaptiveStepSlot(CustomTestCase):

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -21,6 +21,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=22, suite="base-a-test-cpu")
+register_cpu_ci(est_time=14, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _SRT_DIR = _REPO_ROOT / "python" / "sglang" / "srt"

--- a/test/registered/unit/spec/test_decoupled_spec_io.py
+++ b/test/registered/unit/spec/test_decoupled_spec_io.py
@@ -25,6 +25,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _commit(rid, *, pre, tokens, src_verifier_rank=0, drafter_rank=0) -> VerifyCommit:

--- a/test/registered/unit/spec/test_dflash_extra_buffer_lazy.py
+++ b/test/registered/unit/spec/test_dflash_extra_buffer_lazy.py
@@ -10,10 +10,11 @@ from unittest import mock
 import torch
 
 from sglang.srt.arg_groups.mamba_hook import validate_mamba_extra_buffer
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import override_platform

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -13,6 +13,7 @@ from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=38, suite="base-a-test-cpu")
+register_cpu_ci(est_time=55, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def test_dflash_unary_logit_transform():

--- a/test/registered/unit/spec/test_eagle_draft_cuda_graph_runner.py
+++ b/test/registered/unit/spec/test_eagle_draft_cuda_graph_runner.py
@@ -28,6 +28,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 CAPTURE_BS = 4
 SEQ_LEN_FILL_VALUE = 1

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -25,6 +25,7 @@ register_amd_ci(est_time=20, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _make_corpus(match_type="BFS", **kwargs):

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=23, suite="base-a-test-cpu")
+register_cpu_ci(est_time=14, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestNgramLastCorrectStepIndices(CustomTestCase):

--- a/test/registered/unit/spec/test_plugin_hook_signatures.py
+++ b/test/registered/unit/spec/test_plugin_hook_signatures.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _dispatched_methods():

--- a/test/registered/unit/spec/test_resolve_swa_kv_pool.py
+++ b/test/registered/unit/spec/test_resolve_swa_kv_pool.py
@@ -8,11 +8,16 @@ from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=8, suite="stage-b-test-1-gpu-large-amd")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _RESOLVERS = (
     ("trtllm_mha", TRTLLMHAAttnBackend._resolve_swa_kv_pool, SWAKVPool),

--- a/test/registered/unit/spec/test_spec_utils_traverse_tree.py
+++ b/test/registered/unit/spec/test_spec_utils_traverse_tree.py
@@ -15,6 +15,7 @@ from sglang.srt.speculative.spec_utils import GrammarTree, traverse_tree
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):

--- a/test/registered/unit/test_chain_read_ratchet.py
+++ b/test/registered/unit/test_chain_read_ratchet.py
@@ -26,6 +26,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=28, suite="base-a-test-cpu")
+register_cpu_ci(est_time=14, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _PACKAGE = pathlib.Path(sglang.__file__).resolve().parent
 _SRT = _PACKAGE / "srt"

--- a/test/registered/unit/test_checkpoint_quantization.py
+++ b/test/registered/unit/test_checkpoint_quantization.py
@@ -14,6 +14,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestResolveCheckpointQuantSpec(CustomTestCase):

--- a/test/registered/unit/test_dsa_tilelang_fp8_validation.py
+++ b/test/registered/unit/test_dsa_tilelang_fp8_validation.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDsaTilelangFp8Validation(CustomTestCase):

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -12,6 +12,7 @@ from sglang.srt.environ import _DEPRECATED_ENVS, _DeprecatedEnv, envs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestEnvField(unittest.TestCase):

--- a/test/registered/unit/test_eval_accuracy_kit_sgl_eval.py
+++ b/test/registered/unit/test_eval_accuracy_kit_sgl_eval.py
@@ -25,6 +25,7 @@ from sglang.test.kits.eval_accuracy_kit import GPQAMixin, GSM8KMixin, MMMUProMix
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _fake_get(url, *args, **kwargs):

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -12,6 +12,7 @@ from sglang.kernels.ops.attention.flash_mla_sm120 import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestFlashInferSparseMLAAdapter(unittest.TestCase):

--- a/test/registered/unit/test_precision_baseline_store.py
+++ b/test/registered/unit/test_precision_baseline_store.py
@@ -3,6 +3,7 @@
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import json
 import os

--- a/test/registered/unit/test_runai_utils.py
+++ b/test/registered/unit/test_runai_utils.py
@@ -7,6 +7,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestRunaiUtils(CustomTestCase):

--- a/test/registered/unit/test_server_args_cli_metadata.py
+++ b/test/registered/unit/test_server_args_cli_metadata.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestServerArgsMigratedCliMetadata(CustomTestCase):

--- a/test/registered/unit/tokenizer/test_mistral_empty_assistant.py
+++ b/test/registered/unit/tokenizer/test_mistral_empty_assistant.py
@@ -6,6 +6,7 @@ from sglang.srt.utils.hf_transformers.mistral_utils import (
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _user(text):

--- a/test/registered/unit/tokenizer/test_tekken_tokenizer_routing.py
+++ b/test/registered/unit/tokenizer/test_tekken_tokenizer_routing.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=11, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.utils.hf_transformers.mistral_utils import is_bare_tekken_checkpoint
 from sglang.srt.utils.hf_transformers.tokenizer import get_tokenizer

--- a/test/registered/unit/tokenizer/test_tiktoken_tokenizer.py
+++ b/test/registered/unit/tokenizer/test_tiktoken_tokenizer.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 from sglang.srt.tokenizer.tiktoken_tokenizer import (
     CONTROL_TOKEN_TEXTS,

--- a/test/registered/unit/tools/test_amd_ci_install_dependency.py
+++ b/test/registered/unit/tools/test_amd_ci_install_dependency.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 INSTALL_SCRIPT = (
     Path(__file__).resolve().parents[4] / "scripts/ci/amd/amd_ci_install_dependency.sh"

--- a/test/registered/unit/tools/test_docker_build_metadata_args.py
+++ b/test/registered/unit/tools/test_docker_build_metadata_args.py
@@ -20,6 +20,7 @@ def _load_module(name, path):
 
 register_cpu_ci = _load_module("ci_register", CI_REGISTER_PATH).register_cpu_ci
 register_cpu_ci(est_time=0, suite="base-a-test-cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDockerBuildMetadataArgs(unittest.TestCase):

--- a/test/registered/unit/tools/test_get_version_tag.py
+++ b/test/registered/unit/tools/test_get_version_tag.py
@@ -34,6 +34,7 @@ def _load_module(name, path):
 
 register_cpu_ci = _load_module("ci_register", CI_REGISTER_PATH).register_cpu_ci
 register_cpu_ci(est_time=0, suite="base-a-test-cpu")
+register_cpu_ci(est_time=1, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestGetVersionTag(unittest.TestCase):

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(1.0, "base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestAuthDecision(CustomTestCase):

--- a/test/registered/unit/utils/test_diffusion_torch_fallback.py
+++ b/test/registered/unit/utils/test_diffusion_torch_fallback.py
@@ -17,6 +17,7 @@ register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=1, suite="stage-a-test-cpu-intel")
 register_cpu_ci(est_time=1, suite="base-b-test-cpu-arm64")
 register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestDiffusionTorchFallback(unittest.TestCase):

--- a/test/registered/unit/utils/test_field_validators.py
+++ b/test/registered/unit/utils/test_field_validators.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestValidateListI64_1d(CustomTestCase):

--- a/test/registered/unit/utils/test_gauge_histogram.py
+++ b/test/registered/unit/utils/test_gauge_histogram.py
@@ -2,6 +2,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 import unittest
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -32,6 +32,7 @@ from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_comp
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_hf_transformers_fastokens.py
+++ b/test/registered/unit/utils/test_hf_transformers_fastokens.py
@@ -13,6 +13,7 @@ from sglang.test.test_utils import (
 TOKENIZER_MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN
 
 register_cpu_ci(est_time=14, suite="base-a-test-cpu")
+register_cpu_ci(est_time=18, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 try:

--- a/test/registered/unit/utils/test_http_server_auth.py
+++ b/test/registered/unit/utils/test_http_server_auth.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestHttpServerAdminAuth(unittest.TestCase):

--- a/test/registered/unit/utils/test_invariants.py
+++ b/test/registered/unit/utils/test_invariants.py
@@ -23,6 +23,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 # "test." namespace so the coverage meta-test isolates these from real invariants.

--- a/test/registered/unit/utils/test_json_response.py
+++ b/test/registered/unit/utils/test_json_response.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestJSONResponseUtils(unittest.TestCase):

--- a/test/registered/unit/utils/test_patch_tokenizer.py
+++ b/test/registered/unit/utils/test_patch_tokenizer.py
@@ -13,6 +13,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, suite="base-a-test-cpu", nightly=True)
 register_cpu_ci(est_time=16, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=39, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestPatchTokenizerEndToEndTest(unittest.TestCase):

--- a/test/registered/unit/utils/test_profile_merger.py
+++ b/test/registered/unit/utils/test_profile_merger.py
@@ -19,6 +19,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestProfileMerger(CustomTestCase):

--- a/test/registered/unit/utils/test_subprocess_watchdog.py
+++ b/test/registered/unit/utils/test_subprocess_watchdog.py
@@ -26,6 +26,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=14, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=10, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def healthy_worker():

--- a/test/registered/unit/utils/test_weight_versions.py
+++ b/test/registered/unit/utils/test_weight_versions.py
@@ -18,6 +18,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class _ReqStub:

--- a/test/registered/utils/test_bench_typebaseddispatcher.py
+++ b/test/registered/utils/test_bench_typebaseddispatcher.py
@@ -1,10 +1,11 @@
 import timeit
 from typing import Any, Callable, List, Tuple, Type
 
-from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cpu_ci
 from sglang.utils import TypeBasedDispatcher
 
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TypeBasedDispatcherList:

--- a/test/registered/utils/test_log_utils.py
+++ b/test/registered/utils/test_log_utils.py
@@ -12,6 +12,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=4, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 _LOG_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ")
 

--- a/test/registered/utils/test_network_address.py
+++ b/test/registered/utils/test_network_address.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 # Mock get_device() so ServerArgs tests run on CPU-only CI runners
 _mock_device = patch(

--- a/test/registered/utils/test_socket_utils.py
+++ b/test/registered/utils/test_socket_utils.py
@@ -17,6 +17,7 @@ from sglang.utils import normalize_base_url, release_port, reserve_port
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 register_cpu_ci(est_time=8, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTryBindSocket(CustomTestCase):

--- a/test/registered/utils/test_type_based_dispatcher.py
+++ b/test/registered/utils/test_type_based_dispatcher.py
@@ -13,6 +13,7 @@ from sglang.utils import TypeBasedDispatcher
 
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=6, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=8, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestTypeBasedDispatcher(unittest.TestCase):

--- a/test/registered/vlm/test_token_id_retokenize_e2e.py
+++ b/test/registered/vlm/test_token_id_retokenize_e2e.py
@@ -37,6 +37,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=92, stage="base-b", runner_config="1-gpu-large")
 register_cpu_ci(est_time=123, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=494, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 def _data_uri():

--- a/test/registered/vlm/test_video_utils.py
+++ b/test/registered/vlm/test_video_utils.py
@@ -7,6 +7,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 register_cpu_ci(est_time=5, suite="stage-b-test-cpu-intel")
+register_cpu_ci(est_time=7, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class DummyVideo:

--- a/test/registered/xpu/test_intel_xpu_linear_attn_dispatch.py
+++ b/test/registered/xpu/test_intel_xpu_linear_attn_dispatch.py
@@ -14,10 +14,11 @@ from sglang.srt.layers.attention.linear.kda_backend import KDAKernelDispatcher
 from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
 from sglang.srt.layers.attention.linear.utils import LinearAttnKernelBackend
 from sglang.srt.server_args import LINEAR_ATTN_KERNEL_BACKEND_CHOICES
-from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_xpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_xpu_ci(est_time=5, suite="stage-b-test-1-gpu-xpu")
+register_cpu_ci(est_time=9, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestIntelXpuGDNDispatch(CustomTestCase):

--- a/test/registered/xpu/test_xpu_basic.py
+++ b/test/registered/xpu/test_xpu_basic.py
@@ -10,7 +10,7 @@ python3 -m unittest test_xpu_basic.TestXPUBasic.test_basic_generation
 
 import unittest
 
-from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_xpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
     CustomTestCase,
@@ -19,6 +19,7 @@ from sglang.test.test_utils import (
 )
 
 register_xpu_ci(est_time=300, suite="stage-a-test-1-gpu-xpu")
+register_cpu_ci(est_time=142, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestXPUBasic(CustomTestCase):

--- a/test/registered/xpu/test_xpu_serving_features.py
+++ b/test/registered/xpu/test_xpu_serving_features.py
@@ -14,7 +14,7 @@ import unittest
 import openai
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_xpu_ci
 from sglang.test.kits.cache_hit_kit import run_multiturn_cache_hit_test
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -25,6 +25,7 @@ from sglang.test.test_utils import (
 )
 
 register_xpu_ci(est_time=300, suite="stage-b-test-1-gpu-xpu")
+register_cpu_ci(est_time=208, suite="nightly-intel-cpu-gnr", nightly=True)
 
 
 class TestXPUServingFeatures(CustomTestCase):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -160,7 +160,9 @@ NIGHTLY_SUITES = {
     HWBackend.MUSA: [
         "nightly-musa-1-gpu",
     ],
-    HWBackend.CPU: [],
+    HWBackend.CPU: [
+        "nightly-intel-cpu-gnr",
+    ],
     HWBackend.NPU: [
         "nightly-1-npu-a3",
         "nightly-2-npu-a3",


### PR DESCRIPTION
## Motivation

Enable the Intel CPU nightly suite (`nightly-intel-cpu-gnr`) and give every test that runs in it a proper CPU nightly registration with a measured `est_time`, so the nightly CPU CI can schedule and partition these tests with accurate time estimates.

## Modifications

- `test/run_suite.py`: add `nightly-intel-cpu-gnr` to `NIGHTLY_SUITES[HWBackend.CPU]`.
- 499 registered test files under `test/registered/`: add (or update, where it already existed) the marker
  `register_cpu_ci(est_time=<measured>, suite="nightly-intel-cpu-gnr", nightly=True)`.
  - `est_time` values come from measured nightly Intel CPU runtimes, rounded up to the nearest second.
  - Existing registrations for other suites/backends (`base-a-test-cpu`, `stage-b-test-cpu-intel`, CUDA/AMD/NPU/XPU, etc.) are left unchanged.
  - `register_cpu_ci` is added to the `sglang.test.ci.ci_register` import only where it was not already available.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34194809372](https://github.com/sgl-project/sglang/actions/runs/34194809372)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34194809104](https://github.com/sgl-project/sglang/actions/runs/34194809104)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34194809260](https://github.com/sgl-project/sglang/actions/runs/34194809260)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->