### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3-30B-A3B guides

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_30b_a3b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_30b_a3b.mdx
@@ -109,7 +109,7 @@ python3 -m sglang.launch_server \
     --enable-dp-attention \
     --dp-size 2 \
     --mem-fraction-static 0.85 \
-    --cuda-graph-bs 1 2 4 8 16 20 24 28 32 36 40 44 48 52 56 60 64 68 72 76 80 84 \
+    --cuda-graph-bs-decode 1 2 4 8 16 20 24 28 32 36 40 44 48 52 56 60 64 68 72 76 80 84 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen
@@ -211,7 +211,7 @@ python3 -m sglang.launch_server \
     --speculative-num-draft-tokens 4 \
     --tp-size 2 \
     --mem-fraction-static 0.87 \
-    --cuda-graph-bs 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162 \
+    --cuda-graph-bs-decode 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen
@@ -311,7 +311,7 @@ python3 -m sglang.launch_server \
     --speculative-num-draft-tokens 4 \
     --tp-size 2 \
     --mem-fraction-static 0.87 \
-    --cuda-graph-bs 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162 \
+    --cuda-graph-bs-decode 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen
@@ -411,7 +411,7 @@ python3 -m sglang.launch_server \
     --max-prefill-tokens 35000 \
     --tp-size 2 \
     --mem-fraction-static 0.6 \
-    --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 \
+    --cuda-graph-bs-decode 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 \
     --dtype bfloat16 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_30b_a3b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_30b_a3b.mdx
@@ -26,7 +26,7 @@ v0.5.16 or a later version.
 | Tensor Parallelism            | `--tp-size 2`                                                                                 |
 | Data Parallelism              | `--dp-size 2`                                                                                 |
 | Quantization                  | `--quantization modelslim`                                                                    |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 1 5 15 40 70 100 120 130 140 146 150 154 156 158 160 162` |
 | Speculative Decoding          | `--speculative-algorithm EAGLE3 \`<br/>`--speculative-draft-model-path /path/to/draft-model-weights \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4 \`<br/>`--speculative-draft-model-quantization unquant` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 


### PR DESCRIPTION
## Summary
- Ascend Qwen3-30B-A3B **best practices**: replace deprecated `--cuda-graph-bs` with `--cuda-graph-bs-decode` (4 call sites).
- Ascend Qwen3-30B-A3B **tutorial**: update the NPU Graph feature row to prefer `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled` and `--cuda-graph-bs-decode`.

Verified against `python/sglang/srt/server_args.py` at tip `5aab054ec8ce`: `--cuda-graph-bs` / `--disable-cuda-graph` are deprecated aliases.

## Test plan
- [x] Raw tip repro of deprecated flags in the two docs
- [x] Confirm new flag names in server_args DeprecatedAlias / DeprecatedStoreTrue registrations
- [ ] Docs render / maintainer glance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34195691591](https://github.com/sgl-project/sglang/actions/runs/34195691591)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34195691365](https://github.com/sgl-project/sglang/actions/runs/34195691365)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->