### PR TITLE
[Docs] Prefer --cuda-graph-bs-decode in Ascend Qwen3-Next best practices

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_next_80b_a3b_instruct.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_next_80b_a3b_instruct.mdx
@@ -116,7 +116,7 @@ python3 -m sglang.launch_server \
     --speculative-draft-model-quantization unquant \
     --chunked-prefill-size -1 \
     --max-running-requests 2 \
-    --cuda-graph-bs 2 \
+    --cuda-graph-bs-decode 2 \
     --mamba-ssm-dtype bfloat16 \
     --speculative-draft-model-path $DRAFT_MODEL_PATH \
     --reasoning-parser qwen3 \
@@ -235,7 +235,7 @@ python3 -m sglang.launch_server \
     --enable-dp-lm-head \
     --moe-a2a-backend deepep \
     --deepep-mode auto \
-    --cuda-graph-bs 1 2 3 4 5 6 7 8 10 12 14 16 18 20 22 24 26 28 30 32 40 44 48 52 56 60 64 72 80 88 96 104 112 120 128 136 144 150 \
+    --cuda-graph-bs-decode 1 2 3 4 5 6 7 8 10 12 14 16 18 20 22 24 26 28 30 32 40 44 48 52 56 60 64 72 80 88 96 104 112 120 128 136 144 150 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_coder
 ```
@@ -349,7 +349,7 @@ python3 -m sglang.launch_server \
     --speculative-draft-model-quantization unquant \
     --chunked-prefill-size -1 \
     --max-running-requests 16 \
-    --cuda-graph-bs 2 4 8 \
+    --cuda-graph-bs-decode 2 4 8 \
     --mamba-ssm-dtype bfloat16 \
     --speculative-draft-model-path $DRAFT_MODEL_PATH \
     --reasoning-parser qwen3 \


### PR DESCRIPTION
## Summary
- Replace deprecated `--cuda-graph-bs` with `--cuda-graph-bs-decode` in Ascend Qwen3-Next-80B-A3B instruct best-practice launch snippets.
- Matches the current `ServerArgs` preferred CUDA-graph decode CLI (`--cuda-graph-bs` is a deprecated alias).

## Test plan
- [x] Confirmed `--cuda-graph-bs` → `--cuda-graph-bs-decode` in `python/sglang/srt/server_args.py` (`DeprecatedAliasStoreAction`)
- [x] Grepped the touched file for remaining bare `--cuda-graph-bs` (none left)
- [ ] Docs render / maintainer review

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34196077956](https://github.com/sgl-project/sglang/actions/runs/34196077956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34196077802](https://github.com/sgl-project/sglang/actions/runs/34196077802)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->