### PR TITLE
Feat/cuda graph tensor dump

### DIFF
--- a/python/sglang/srt/debug_utils/cuda_graph/__init__.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/__init__.py
@@ -1,0 +1,69 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""CUDA-graph-compatible tensor dumping.
+
+`dumper`'s non-intrusive mode registers `nn.Module` forward hooks that call
+`dumper.dump(...)` inline.  That works in eager mode, but a CUDA graph replays
+only *recorded device kernels* -- the Python hook body never runs again, so with
+graphs enabled the hooked modules simply stop producing frames.  Nothing warns;
+the dump directory is just quietly missing every module that lives inside a
+captured region.
+
+This package closes that hole by splitting "take the value" from "write the
+file":
+
+* **take the value** -- during capture the hook issues
+  `buffer.copy_(tensor)`.  That is a real device kernel, so it is *recorded*,
+  with both `data_ptr()`s baked in.  Every later `graph.replay()` re-runs the
+  copy for free, leaving `buffer` holding this replay's value.
+* **write the file** -- after `replay()` returns, host-side code reads the
+  buffers and calls `dumper.dump(...)` outside the graph.
+
+Values therefore come from the capture side and metadata from the replay-side
+`ForwardBatch`; they meet at one collect point per replay.
+
+Three graph backends, three taps:
+
+===============  ==========================================================
+`full`           T1: the existing forward hook, whose `copy_` is recorded.
+`breakable`      T1 inside captured segments; module outputs inside
+                 `eager_on_graph` break bodies fall through to the ordinary
+                 eager `dumper.dump(...)` path, because capture is off there
+                 on both the capture and the replay side.
+`tc_piecewise`   T3: dynamo inlines `Module.__call__`, so the hook's `copy_`
+                 would be traced away.  Instead the hook emits one
+                 dynamo-opaque custom op (`sglang.dumper_tap`) that survives
+                 tracing as an FX node, becomes a piece boundary, and does
+                 the `copy_` from inside the piece's graph.
+===============  ==========================================================
+
+See `sglang.srt.debug_utils.cuda_graph.state` for the dispatch ladder and
+`seams.py` for the two `__init_subclass__` seams that arm it.
+"""
+
+from sglang.srt.debug_utils.cuda_graph.config import CudaGraphDumpConfig
+from sglang.srt.debug_utils.cuda_graph.registry import (
+    BufferKey,
+    BufferRegistry,
+    DumpBudgetExceeded,
+)
+from sglang.srt.debug_utils.cuda_graph.state import cuda_graph_dump
+
+__all__ = [
+    "BufferKey",
+    "BufferRegistry",
+    "CudaGraphDumpConfig",
+    "DumpBudgetExceeded",
+    "cuda_graph_dump",
+]

--- a/python/sglang/srt/debug_utils/cuda_graph/config.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/config.py
@@ -1,0 +1,70 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Configuration for CUDA-graph-compatible dumping.
+
+The knobs live on `DumperConfig` so they inherit its env-var machinery
+(`DUMPER_CUDA_GRAPH_ENABLE`, `..._FILTER`, `..._BUDGET_MB`, `..._STRICT`) and
+its `/dumper/configure` HTTP surface.  This module only projects them into a
+small value object, so the rest of the package needs neither `DumperConfig` nor
+a live dumper to be unit-tested.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+_MB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CudaGraphDumpConfig:
+    """Projection of the `cuda_graph_*` fields of `DumperConfig`."""
+
+    enable: bool = False
+    # Comma-separated *prefixes* of fully-expanded dump names.  Empty means
+    # "every name", which is only sane for small models -- one graph-resident
+    # buffer is allocated per (name, occurrence), so a full leaf sweep over a
+    # large model will hit `budget_mb` and start dropping names.
+    filter: Optional[str] = None
+    budget_mb: int = 4096
+    # Turn the two soft failure modes (budget exhausted, zero taps observed)
+    # into exceptions instead of warnings.  Recommended in CI.
+    strict: bool = False
+
+    @classmethod
+    def from_dumper_config(cls, dumper_config: Any) -> CudaGraphDumpConfig:
+        return cls(
+            enable=bool(getattr(dumper_config, "cuda_graph_enable", False)),
+            filter=getattr(dumper_config, "cuda_graph_filter", None),
+            budget_mb=int(getattr(dumper_config, "cuda_graph_budget_mb", 4096)),
+            strict=bool(getattr(dumper_config, "cuda_graph_strict", False)),
+        )
+
+    @property
+    def prefixes(self) -> tuple[str, ...]:
+        if not self.filter:
+            return ()
+        return tuple(p for p in (s.strip() for s in self.filter.split(",")) if p)
+
+    @property
+    def budget_bytes(self) -> int:
+        """Negative means unbounded."""
+        return -1 if self.budget_mb < 0 else self.budget_mb * _MB
+
+    def accepts(self, name: str) -> bool:
+        prefixes = self.prefixes
+        if not prefixes:
+            return True
+        return any(name.startswith(prefix) for prefix in prefixes)

--- a/python/sglang/srt/debug_utils/cuda_graph/config.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/config.py
@@ -14,10 +14,10 @@
 """Configuration for CUDA-graph-compatible dumping.
 
 The knobs live on `DumperConfig` so they inherit its env-var machinery
-(`DUMPER_CUDA_GRAPH_ENABLE`, `..._FILTER`, `..._BUDGET_MB`, `..._STRICT`) and
-its `/dumper/configure` HTTP surface.  This module only projects them into a
-small value object, so the rest of the package needs neither `DumperConfig` nor
-a live dumper to be unit-tested.
+(`DUMPER_CUDA_GRAPH_ENABLE`, `..._FILTER`, `..._BUDGET_MB`, `..._STRICT`,
+`..._TAPS`) and its `/dumper/configure` HTTP surface.  This module only projects
+them into a small value object, so the rest of the package needs neither
+`DumperConfig` nor a live dumper to be unit-tested.
 """
 
 from __future__ import annotations
@@ -26,6 +26,12 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 _MB = 1024 * 1024
+
+TAP_HOOK = "t1"
+TAP_COMPILED = "t3"
+_ALL_TAPS = (TAP_HOOK, TAP_COMPILED)
+_EVERYTHING = ("all", "*")
+_NOTHING = ("none", "off")
 
 
 @dataclass(frozen=True)
@@ -42,6 +48,8 @@ class CudaGraphDumpConfig:
     # Turn the two soft failure modes (budget exhausted, zero taps observed)
     # into exceptions instead of warnings.  Recommended in CI.
     strict: bool = False
+    # Which channels to arm; None/empty/`all` arms every one.  See `taps`.
+    taps: Optional[str] = None
 
     @classmethod
     def from_dumper_config(cls, dumper_config: Any) -> CudaGraphDumpConfig:
@@ -50,6 +58,7 @@ class CudaGraphDumpConfig:
             filter=getattr(dumper_config, "cuda_graph_filter", None),
             budget_mb=int(getattr(dumper_config, "cuda_graph_budget_mb", 4096)),
             strict=bool(getattr(dumper_config, "cuda_graph_strict", False)),
+            taps=getattr(dumper_config, "cuda_graph_taps", None),
         )
 
     @property
@@ -62,6 +71,27 @@ class CudaGraphDumpConfig:
     def budget_bytes(self) -> int:
         """Negative means unbounded."""
         return -1 if self.budget_mb < 0 else self.budget_mb * _MB
+
+    @property
+    def armed_taps(self) -> frozenset[str]:
+        """The channels the user asked for; every one when unset.
+
+        Unset means "arm everything", not "arm the cheap ones": a debugging tool
+        that quietly under-covers by default is the exact failure this package
+        exists to close.  Narrowing is explicit, and `report()` names what was
+        armed so a narrowed run cannot be mistaken for a complete one.
+        """
+        raw = (self.taps or "").strip().lower()
+        if not raw or raw in _EVERYTHING:
+            return frozenset(_ALL_TAPS)
+        if raw in _NOTHING:
+            return frozenset()
+        return frozenset(
+            t for t in (s.strip() for s in raw.split(",")) if t in _ALL_TAPS
+        )
+
+    def arms(self, tap: str) -> bool:
+        return tap in self.armed_taps
 
     def accepts(self, name: str) -> bool:
         prefixes = self.prefixes

--- a/python/sglang/srt/debug_utils/cuda_graph/registry.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/registry.py
@@ -1,0 +1,209 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Graph-resident dump buffers.
+
+Every buffer here has its `data_ptr()` baked into at least one recorded kernel,
+which drives the whole design:
+
+* a buffer may only be `copy_`-ed into, never reassigned;
+* a buffer can never be grown -- so it is allocated at the largest shape it
+  will ever see, and a later request for more elements is a hard error rather
+  than a silent truncation;
+* the identity of a buffer is `(fully-expanded dump name, occurrence index
+  within one forward)`.  Sharing across shapes and phases is fine (the copy is
+  re-recorded per graph); sharing across *occurrences* is not, because the
+  second `copy_` would overwrite the first before the host ever reads it.
+
+Buffers are flat.  Reconstructing the real shape needs one more piece of
+information -- the shape that was live when the `copy_` was recorded -- which is
+why `record()` takes a `shape_token` and stores a per-token layout.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Callable, Hashable, Iterator, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class DumpBudgetExceeded(RuntimeError):
+    """Raised in strict mode when buffers would exceed `budget_mb`."""
+
+
+class DumpBufferGrowthRejected(RuntimeError):
+    """Raised when a tap needs more elements than its buffer was allocated for.
+
+    Not recoverable: the small allocation's address is already baked into a
+    recorded kernel, so it cannot be replaced.  Both capture loops iterate
+    shapes largest-first (`reversed(capture_bs)` / `reversed(capture_num_tokens)`),
+    so first-sight allocation is normally the max.  Seeing this means that
+    ordering changed, or a shape does not scale monotonically with the bucket.
+    """
+
+
+@dataclass(frozen=True)
+class BufferKey:
+    name: str
+    occurrence: int = 0
+
+    def __str__(self) -> str:
+        return self.name if self.occurrence == 0 else f"{self.name}#{self.occurrence}"
+
+
+class BufferRegistry:
+    """Allocates and hands out the flat graph-resident buffers.
+
+    `accepts` is applied *before* allocation so that a narrow filter costs no
+    device memory at all.
+    """
+
+    def __init__(
+        self,
+        *,
+        budget_bytes: int,
+        accepts: Callable[[str], bool],
+        strict: bool = False,
+    ) -> None:
+        self._budget_bytes = budget_bytes
+        self._accepts = accepts
+        self._strict = strict
+        self._buffers: dict[BufferKey, torch.Tensor] = {}
+        self._addresses: dict[BufferKey, int] = {}
+        self._layouts: dict[BufferKey, dict[Hashable, tuple[int, ...]]] = {}
+        self._tag_of: dict[BufferKey, int] = {}
+        self._key_of_tag: list[BufferKey] = []
+        self._rejected: dict[BufferKey, str] = {}
+        self._used_bytes = 0
+
+    # ------------------------------- introspection --------------------------
+
+    @property
+    def used_bytes(self) -> int:
+        return self._used_bytes
+
+    @property
+    def num_buffers(self) -> int:
+        return len(self._buffers)
+
+    @property
+    def rejected(self) -> dict[BufferKey, str]:
+        return dict(self._rejected)
+
+    def names(self) -> set[str]:
+        return {key.name for key in self._buffers}
+
+    # ------------------------------- tag mapping ----------------------------
+    #
+    # The T3 custom op cannot take a `BufferKey` (dynamo needs plain scalar
+    # arguments), so keys are interned to small ints at trace time and resolved
+    # back inside the op body at run time.
+
+    def tag_for(self, key: BufferKey) -> int:
+        tag = self._tag_of.get(key)
+        if tag is None:
+            tag = len(self._key_of_tag)
+            self._key_of_tag.append(key)
+            self._tag_of[key] = tag
+        return tag
+
+    def key_for_tag(self, tag: int) -> BufferKey:
+        return self._key_of_tag[tag]
+
+    # ------------------------------- recording ------------------------------
+
+    def record(
+        self, key: BufferKey, shape_token: Hashable, tensor: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        """Return the flat slice `tensor` should be copied into, or None.
+
+        None means "this name is not being captured" (filtered out, or the
+        budget ran out in non-strict mode) and the caller should fall through.
+        """
+        if key in self._rejected:
+            return None
+
+        buf = self._buffers.get(key)
+        numel = tensor.numel()
+        if buf is None:
+            if not self._accepts(key.name):
+                self._rejected[key] = "filtered"
+                return None
+            buf = self._allocate(key, tensor)
+            if buf is None:
+                return None
+        elif buf.dtype != tensor.dtype:
+            raise DumpBufferGrowthRejected(
+                f"dtype changed for {key}: buffer is {buf.dtype}, tap is {tensor.dtype}"
+            )
+        elif numel > buf.numel():
+            raise DumpBufferGrowthRejected(
+                f"{key} needs {numel} elements but its buffer holds only "
+                f"{buf.numel()}; a recorded kernel already points at the "
+                f"smaller allocation, so it cannot be replaced"
+            )
+
+        self._layouts.setdefault(key, {})[shape_token] = tuple(tensor.shape)
+        return buf[:numel]
+
+    def _allocate(self, key: BufferKey, tensor: torch.Tensor) -> Optional[torch.Tensor]:
+        nbytes = tensor.numel() * tensor.element_size()
+        if self._budget_bytes >= 0 and self._used_bytes + nbytes > self._budget_bytes:
+            message = (
+                f"dump buffer budget of {self._budget_bytes / (1 << 20):.0f} MiB "
+                f"exhausted at {self.num_buffers} buffers; {key} "
+                f"(+{nbytes / (1 << 20):.1f} MiB) and any later name are dropped. "
+                f"Narrow DUMPER_CUDA_GRAPH_FILTER or raise "
+                f"DUMPER_CUDA_GRAPH_BUDGET_MB."
+            )
+            if self._strict:
+                raise DumpBudgetExceeded(message)
+            logger.warning(message)
+            self._rejected[key] = "budget"
+            return None
+
+        buf = torch.empty(tensor.numel(), dtype=tensor.dtype, device=tensor.device)
+        self._buffers[key] = buf
+        self._addresses[key] = buf.data_ptr()
+        self._used_bytes += nbytes
+        return buf
+
+    # ------------------------------- reading --------------------------------
+
+    def views(self, shape_token: Hashable) -> Iterator[tuple[BufferKey, torch.Tensor]]:
+        """Yield the buffers that were recorded for `shape_token`, reshaped.
+
+        Keys with no layout for this token were never tapped under this shape
+        (a conditionally executed module, or a different graph); they are
+        skipped rather than reported as zeros.
+        """
+        for key, buf in self._buffers.items():
+            shape = self._layouts.get(key, {}).get(shape_token)
+            if shape is None:
+                continue
+            yield key, buf[: math.prod(shape)].view(shape)
+
+    def assert_addresses_stable(self) -> None:
+        """Acceptance check: no buffer was silently reallocated."""
+        for key, buf in self._buffers.items():
+            expected = self._addresses[key]
+            assert buf.data_ptr() == expected, (
+                f"buffer for {key} moved from {expected:#x} to "
+                f"{buf.data_ptr():#x}; every recorded copy_ into it now writes "
+                f"to freed memory"
+            )

--- a/python/sglang/srt/debug_utils/cuda_graph/seams.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/seams.py
@@ -1,0 +1,240 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The two `__init_subclass__` seams that arm the taps.
+
+`cuda_graph_dump` needs four facts that only the graph machinery knows: when a
+backend is being constructed, when a capture session is open, which shape is
+being captured, and when a replay has just finished.  None of that is reachable
+from an `nn.Module` forward hook, and none of it is worth threading through the
+runners by hand.
+
+Both seams are installed from `__init_subclass__` on the two abstract bases, so
+a backend or a phase runner is covered the moment it is *defined* -- including
+the accelerator ports and the speculative-decoding subclasses, in-tree or not.
+Only methods found in `cls.__dict__` are wrapped: an override-free subclass
+inherits its parent's already-wrapped method, so nothing is wrapped twice and
+`super()` chains stay intact.
+"""
+
+from __future__ import annotations
+
+import functools
+from contextlib import contextmanager
+from typing import Any, Callable, Optional
+
+from sglang.srt.debug_utils.cuda_graph.state import cuda_graph_dump
+
+_SEAM_MARK = "__cuda_graph_dump_seam__"
+
+# `type(backend).__name__` -> the `--cuda-graph-backend` value it implements.
+# A backend outside this table is tagged with its class name, which is still
+# unambiguous; the table only exists to make the common frames readable.
+_BACKEND_LABELS = {
+    "FullCudaGraphBackend": "full",
+    "BreakableCudaGraphBackend": "breakable",
+    "TcPiecewiseCudaGraphBackend": "tc_piecewise",
+}
+
+
+def _wrap(cls: type, name: str, factory: Callable[[Callable], Callable]) -> None:
+    """Replace `cls.<name>` with `factory(cls.<name>)`, at most once ever."""
+    fn = cls.__dict__.get(name)
+    if fn is None or getattr(fn, _SEAM_MARK, False):
+        return
+    wrapped = factory(fn)
+    setattr(wrapped, _SEAM_MARK, True)
+    setattr(cls, name, wrapped)
+
+
+def _backend_label(backend: Any) -> str:
+    name = type(backend).__name__
+    return _BACKEND_LABELS.get(name, name)
+
+
+def _first_arg(args: tuple, kwargs: dict, name: str) -> Any:
+    """The value of a leading positional-or-keyword parameter, however passed."""
+    return args[0] if args else kwargs.get(name)
+
+
+# ------------------------------- backend seam -------------------------------
+
+
+def install_backend_seam(cls: type) -> None:
+    """Arm the capture-side scopes and the replay-side collect point."""
+    _wrap(cls, "__init__", _seam_init)
+    _wrap(cls, "capture_session", _seam_capture_session)
+    _wrap(cls, "capture_one", _seam_capture_one)
+    _wrap(cls, "replay", _seam_replay)
+    _wrap(cls, "cleanup", _seam_cleanup)
+
+
+def _seam_init(fn: Callable) -> Callable:
+    """Backend construction: dummy-valued frames seen here are swallowed."""
+
+    @functools.wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        cuda_graph_dump.configure()
+        if not cuda_graph_dump.enabled:
+            return fn(self, *args, **kwargs)
+        with cuda_graph_dump.setup_scope():
+            return fn(self, *args, **kwargs)
+
+    return wrapped
+
+
+def _seam_capture_session(fn: Callable) -> Callable:
+    """Arms the T1 stream-capturing check for the duration of one session.
+
+    All three in-tree backends implement this as a `@contextmanager`, so the
+    wrapper has to be one too and has to re-yield the inner value rather than
+    return the inner context manager.
+    """
+
+    @functools.wraps(fn)
+    @contextmanager
+    def wrapped(self, *args, **kwargs):
+        cuda_graph_dump.configure()
+        if not cuda_graph_dump.enabled:
+            with fn(self, *args, **kwargs) as value:
+                yield value
+            return
+        with cuda_graph_dump.capture_scope():
+            with fn(self, *args, **kwargs) as value:
+                yield value
+
+    return wrapped
+
+
+def _seam_capture_one(fn: Callable) -> Callable:
+    """Publishes the shape being captured, and resets counters per forward.
+
+    `shape_key` doubles as the shape token: it is a frozen dataclass, so it is
+    hashable, and its `.size` is the padded row count `collect` needs.
+    """
+
+    @functools.wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        if not cuda_graph_dump.enabled:
+            return fn(self, *args, **kwargs)
+        shape_key = _first_arg(args, kwargs, "shape_key")
+        args, kwargs = _wrap_forward_fn(args, kwargs)
+        with cuda_graph_dump.shape_scope(shape_key):
+            return fn(self, *args, **kwargs)
+
+    return wrapped
+
+
+def _wrap_forward_fn(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
+    """Substitute `forward_fn` with the occurrence-counter-resetting version.
+
+    `breakable` and `tc_piecewise` both call `forward_fn()` twice per
+    `capture_one`; resetting per `capture_one` instead would make the second
+    pass allocate a second buffer for every name.
+    """
+    if len(args) >= 2:
+        forward_fn = cuda_graph_dump.wrap_forward_fn(args[1])
+        return (args[0], forward_fn) + args[2:], kwargs
+    if "forward_fn" in kwargs:
+        forward_fn = cuda_graph_dump.wrap_forward_fn(kwargs["forward_fn"])
+        return args, {**kwargs, "forward_fn": forward_fn}
+    return args, kwargs
+
+
+def _seam_replay(fn: Callable) -> Callable:
+    """The collect point: after `replay()` returns, outside the graph.
+
+    Every recorded `copy_` has run by now, so the buffers hold *this* replay's
+    values, and `dumper.dump` runs on the host exactly as it does in eager mode.
+    """
+
+    @functools.wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        output = fn(self, *args, **kwargs)
+        if cuda_graph_dump.enabled:
+            shape_key = _first_arg(args, kwargs, "shape_key")
+            cuda_graph_dump.collect(
+                shape_key,
+                graph_backend=_backend_label(self),
+                graph_size=getattr(shape_key, "size", None),
+            )
+        return output
+
+    return wrapped
+
+
+def _seam_cleanup(fn: Callable) -> Callable:
+    """Reports coverage once the backend is torn down.
+
+    Nothing in the tree calls `cleanup()` today; `state` also registers the
+    same one-shot report with `atexit`, which is the path that actually fires.
+    The report runs *after* the inner call and not in a `finally`, so a real
+    teardown exception is never masked by a strict-mode coverage failure.
+    """
+
+    @functools.wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        result = fn(self, *args, **kwargs)
+        cuda_graph_dump.report()
+        return result
+
+    return wrapped
+
+
+# -------------------------------- runner seam -------------------------------
+
+
+def install_runner_seam(cls: type) -> None:
+    """Publish the replay-side runner and batch metadata around `execute`."""
+    _wrap(cls, "execute", _seam_execute)
+
+
+def _seam_execute(fn: Callable) -> Callable:
+    @functools.wraps(fn)
+    def wrapped(self, *args, **kwargs):
+        if not cuda_graph_dump.enabled:
+            return fn(self, *args, **kwargs)
+        forward_batch = _first_arg(args, kwargs, "forward_batch")
+        # Replay-time eager frames (a `breakable` break body, or a module that
+        # was never captured) number their occurrences from the same base as
+        # the capture-side frames only if the counters restart here too.
+        cuda_graph_dump.begin_forward()
+        with cuda_graph_dump.runner_scope(self, **_replay_tags(self, forward_batch)):
+            return fn(self, *args, **kwargs)
+
+    return wrapped
+
+
+def _replay_tags(runner: Any, forward_batch: Any) -> dict:
+    """Metadata that belongs to *this* replay, read from the live batch."""
+    mode = getattr(forward_batch, "forward_mode", None)
+    return {
+        # The class name, not a "prefill"/"decode" guess: it is the one label
+        # that also separates the speculative draft and verify runners.
+        "graph_runner": type(runner).__name__,
+        "forward_mode": getattr(mode, "name", None),
+        "pd_role": _pd_role(),
+    }
+
+
+def _pd_role() -> Optional[str]:
+    """`prefill` / `decode` under PD disaggregation, None when co-located."""
+    try:
+        from sglang.srt.runtime_context import get_disagg
+
+        mode = get_disagg().disaggregation_mode
+    except Exception:  # no published context yet (unit tests, tooling)
+        return None
+    role = getattr(mode, "value", None) or getattr(mode, "name", None)
+    role = str(role if role is not None else mode).lower()
+    return None if role in ("null", "none") else role

--- a/python/sglang/srt/debug_utils/cuda_graph/seams.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/seams.py
@@ -138,9 +138,10 @@ def _seam_capture_one(fn: Callable) -> Callable:
 def _wrap_forward_fn(args: tuple, kwargs: dict) -> tuple[tuple, dict]:
     """Substitute `forward_fn` with the occurrence-counter-resetting version.
 
-    `breakable` and `tc_piecewise` both call `forward_fn()` twice per
-    `capture_one`; resetting per `capture_one` instead would make the second
-    pass allocate a second buffer for every name.
+    `breakable` calls `forward_fn()` three times per `capture_one` (two warmups
+    plus the captured pass) and `tc_piecewise` twice; resetting per `capture_one`
+    instead would make every pass after the first allocate a second buffer for
+    every name.
     """
     if len(args) >= 2:
         forward_fn = cuda_graph_dump.wrap_forward_fn(args[1])

--- a/python/sglang/srt/debug_utils/cuda_graph/split_op.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/split_op.py
@@ -1,0 +1,52 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The T3 tap: one dynamo-opaque custom op, for `tc_piecewise`.
+
+Under `tc_piecewise` the model is `torch.compile`-d with `fullgraph=True`.
+Dynamo inlines `Module.__call__`, so a forward hook's `buffer.copy_` is traced
+away and never becomes a kernel -- and routing to `dumper.dump(...)` instead
+would be a hard trace error.  A custom op is the one construct that survives
+tracing intact: it stays an FX node, `add_split_op` turns it into a piece
+boundary, and its body runs inside the piece's graph where the `copy_` is
+recorded exactly as in the T1 case.
+
+Two declarations carry weight:
+
+* `mutates_args=["x"]` is a deliberate over-statement -- the body only reads
+  `x`.  It is what stops inductor from dead-code-eliminating a call whose
+  return value nobody uses.  Over-constraining inductor costs fusion; under-
+  constraining it costs the whole frame, silently.
+* `eager=True` is required: `register_custom_op`'s own NOTE says lazy
+  registration does not work with `torch.compile`.
+
+This module is imported lazily (from `state._emit_compiled_tap` and from the
+`build_compilation_config` patch) so that `import sglang` does not register a
+torch custom op as a side effect.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.debug_utils.cuda_graph.state import cuda_graph_dump
+from sglang.srt.utils.custom_op import register_custom_op
+
+# Must match the name handed to `CompilationConfig.add_split_op`.
+DUMPER_TAP_OP_NAME = "sglang.dumper_tap"
+
+
+@register_custom_op(op_name="dumper_tap", mutates_args=["x"], eager=True)
+def dumper_tap(x: torch.Tensor, tag_id: int) -> None:
+    """Copy `x` into the graph-resident buffer interned as `tag_id`."""
+    cuda_graph_dump.tap_by_tag(tag_id, x)

--- a/python/sglang/srt/debug_utils/cuda_graph/split_op.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/split_op.py
@@ -13,13 +13,13 @@
 # ==============================================================================
 """The T3 tap: one dynamo-opaque custom op, for `tc_piecewise`.
 
-Under `tc_piecewise` the model is `torch.compile`-d with `fullgraph=True`.
-Dynamo inlines `Module.__call__`, so a forward hook's `buffer.copy_` is traced
-away and never becomes a kernel -- and routing to `dumper.dump(...)` instead
-would be a hard trace error.  A custom op is the one construct that survives
-tracing intact: it stays an FX node, `add_split_op` turns it into a piece
-boundary, and its body runs inside the piece's graph where the `copy_` is
-recorded exactly as in the T1 case.
+Under `tc_piecewise` the model is `torch.compile`-d with `fullgraph=True`, and
+the forward hook cannot reach the eager writer from there: `dumper.dump(...)`
+opens a file, which dynamo refuses to trace, and under `fullgraph=True` a graph
+break is a hard error rather than a fallback.  A custom op is the one construct
+that survives tracing intact: it stays an FX node, `add_split_op` turns it into
+a piece boundary, and its body runs inside the piece's graph where the `copy_`
+is recorded exactly as in the T1 case.
 
 Two declarations carry weight:
 
@@ -30,9 +30,18 @@ Two declarations carry weight:
 * `eager=True` is required: `register_custom_op`'s own NOTE says lazy
   registration does not work with `torch.compile`.
 
+Keeping the Python bookkeeping (name interning, registry lookups, occurrence
+counting) on the near side of the op boundary is the other half of the reason.
+A bare `buffer.copy_(x)` in a hook body does in fact survive dynamo -- measured
+on CPU under both the `eager` and `inductor` backends, the buffer refreshes on
+every call -- but `_record`'s dict mutations and logging would be traced too,
+and whether the resulting copy lands inside a *captured piece* is a property of
+the piecewise splitter, not of dynamo.  The op boundary makes that placement
+explicit instead of incidental.
+
 This module is imported lazily (from `state._emit_compiled_tap` and from the
 `build_compilation_config` patch) so that `import sglang` does not register a
-torch custom op as a side effect.
+torch custom op as a side effect, and only when the T3 tap is armed.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/debug_utils/cuda_graph/state.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/state.py
@@ -313,9 +313,10 @@ class _CudaGraphDumpState:
     def wrap_forward_fn(self, forward_fn):
         """Reset the occurrence counters once per `forward_fn()` invocation.
 
-        `TcPiecewiseCudaGraphBackend.capture_one` calls `forward_fn()` twice, so
-        resetting per capture_one would make the second pass allocate a second
-        buffer for every name.
+        `TcPiecewiseCudaGraphBackend.capture_one` calls `forward_fn()` twice and
+        `BreakableCudaGraphBackend.capture_one` three times (two warmups plus the
+        captured pass), so resetting per capture_one would make every pass after
+        the first allocate a second buffer for every name.
         """
 
         def wrapped(*args, **kwargs):

--- a/python/sglang/srt/debug_utils/cuda_graph/state.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/state.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 _TAP_IN_GRAPH = "t1"
 _TAP_COMPILED = "t3"
+_TAP_EAGER = "eager"
 
 
 def _stream_is_capturing() -> bool:
@@ -226,6 +227,17 @@ class _CudaGraphDumpState:
         if not self.enabled:
             return
         self._record(self._registry.key_for_tag(tag), tensor, _TAP_COMPILED)
+
+    def eager_tags(self) -> dict[str, Any]:
+        """Tags for a frame `tap()` declined, so the eager channel is labelled.
+
+        Empty when the feature is off, so a default run's frames are exactly
+        what they always were.  Enabled, it is what makes the coverage claim
+        checkable: the acceptance gate asserts that the `t1`/`t3` frames plus
+        the `eager` frames equal the pure-eager module set, and "no tap tag"
+        would be indistinguishable from a baseline run's frames.
+        """
+        return {"tap": _TAP_EAGER} if self.enabled else {}
 
     # -------------------------------- scopes --------------------------------
 

--- a/python/sglang/srt/debug_utils/cuda_graph/state.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/state.py
@@ -1,0 +1,368 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Runtime state for CUDA-graph-compatible dumping.
+
+One process-global object, `cuda_graph_dump`, owns the buffer registry and the
+tap/collect dispatch.  It is deliberately a singleton: the taps are reached from
+`nn.Module` forward hooks that have no channel to receive an object, and the
+collect points are backend methods reached through `__init_subclass__` seams.
+
+The dispatch ladder in `tap()` is the whole design in six lines; see the
+docstring there.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+from contextlib import contextmanager
+from typing import Any, Hashable, Iterator, Optional
+
+import torch
+
+from sglang.srt.debug_utils.cuda_graph.config import CudaGraphDumpConfig
+from sglang.srt.debug_utils.cuda_graph.registry import BufferKey, BufferRegistry
+
+logger = logging.getLogger(__name__)
+
+_TAP_IN_GRAPH = "t1"
+_TAP_COMPILED = "t3"
+
+
+def _stream_is_capturing() -> bool:
+    """`torch.cuda.is_current_stream_capturing()` without the CPU-build hazard.
+
+    Only ever reached while a capture session is open, so the import-time cost
+    of `torch.cuda` initialization is not on the normal path.
+    """
+    try:
+        return torch.cuda.is_current_stream_capturing()
+    except Exception:  # no CUDA build, or no current device
+        return False
+
+
+def _row_pairs(runner: Any, shape_token: Hashable) -> list[tuple[int, int]]:
+    """Candidate `(padded_rows, raw_rows)` pairs for this replay.
+
+    A graph is captured at a padded shape and replayed with the tail rows still
+    holding whatever the previous replay left there, so trimming is mandatory.
+    But a dump name may be anything -- token-major, request-major, per-expert,
+    a scalar -- so the axis cannot be assumed.  Both row bases the runners
+    actually pad along are offered here, and `_trim` only fires on an exact
+    match of dim 0; anything else is written at full width, with `graph_size` in
+    the tags so the padding is visible rather than silently believed.
+
+    The raw counters are read here, at collect time, and not captured when the
+    scope opens: `load_batch` (which sets them) runs *inside* `execute`.
+    """
+    raw_tokens = getattr(runner, "raw_num_token", None) or getattr(
+        runner, "raw_num_tokens", None
+    )
+    raw_bs = getattr(runner, "raw_bs", None)
+    size = getattr(shape_token, "size", None)
+    padded_bs = getattr(runner, "bs", None) or size
+    width = getattr(runner, "captured_req_width", None) or 1
+    if getattr(runner, "ragged_verify_mode", False) or hasattr(
+        runner, "raw_num_tokens"
+    ):
+        # ragged decode keys on num_tokens; prefill always does
+        padded_tokens = size
+    else:
+        padded_tokens = padded_bs * width if padded_bs else None
+    pairs = []
+    for padded, raw in ((padded_tokens, raw_tokens), (padded_bs, raw_bs)):
+        if padded and raw and raw < padded and (padded, raw) not in pairs:
+            pairs.append((padded, raw))
+    return pairs
+
+
+def _trim(tensor: torch.Tensor, pairs: list[tuple[int, int]]) -> torch.Tensor:
+    if tensor.dim() == 0:
+        return tensor
+    for padded, raw in pairs:
+        if tensor.shape[0] == padded:
+            return tensor[:raw]
+    return tensor
+
+
+class _CudaGraphDumpState:
+    """Process-global owner of the dump buffers and the tap/collect dispatch."""
+
+    def __init__(self) -> None:
+        self._config = CudaGraphDumpConfig()
+        self._registry: Optional[BufferRegistry] = None
+        # occurrence counter per fully-expanded dump name, reset once per
+        # `forward_fn()` invocation.  Bumped *before* the channel decision so
+        # the eager and graph channels can never disagree about which
+        # occurrence a frame belongs to.
+        self._occurrences: dict[str, int] = {}
+        # non-zero while a backend is being constructed / compiled: frames seen
+        # here carry dummy values and must not reach the eager writer.
+        self._setup_depth = 0
+        self._capture_depth = 0
+        self._shape_token: Hashable = None
+        self._runner_ctx: dict[str, Any] = {}
+        self._channel_of: dict[BufferKey, str] = {}
+        self._tap_hits = 0
+        self._compiled_tap_hits = 0
+        self._collect_calls = 0
+        self._reported = False
+
+    # ------------------------------- lifecycle ------------------------------
+
+    def _ensure_configured(self) -> None:
+        if self._registry is not None:
+            return
+        # Imported here, not at module scope: `dumper` imports *this* module to
+        # reach `tap()`, and its module-level singleton is built at import time.
+        from sglang.srt.debug_utils.dumper import dumper
+
+        self._config = CudaGraphDumpConfig.from_dumper_config(dumper._config)
+        self._registry = BufferRegistry(
+            budget_bytes=self._config.budget_bytes,
+            accepts=self._config.accepts,
+            strict=self._config.strict,
+        )
+        # The only trigger that is guaranteed to run after every capture *and*
+        # every replay.  `BaseCudaGraphBackend.cleanup` would be the natural
+        # lifecycle hook, but nothing in the tree calls it, so a probe hung
+        # there would never fire.  `report()` is one-shot, so an explicit call
+        # from a test or from `cleanup` still wins the race harmlessly.
+        atexit.register(self._report_at_exit)
+
+    @property
+    def enabled(self) -> bool:
+        return self._registry is not None and self._config.enable
+
+    @property
+    def registry(self) -> Optional[BufferRegistry]:
+        return self._registry
+
+    def configure(self) -> None:
+        """Idempotent; safe to call from every seam entry point."""
+        self._ensure_configured()
+
+    def begin_forward(self) -> None:
+        self._occurrences.clear()
+
+    # --------------------------------- taps ---------------------------------
+
+    def tap(self, name: str, value: Any) -> bool:
+        """Take `value` through whichever channel is live.  True = handled.
+
+        The ladder, in priority order:
+
+        1. **not enabled** -> False, the caller writes the file eagerly as it
+           always has.
+        2. **dynamo is tracing** (`tc_piecewise`) -> emit the opaque custom op,
+           which becomes a piece boundary and does the `copy_` from inside the
+           piece's graph.  A `dumper.dump(...)` here would be a hard trace
+           error under `fullgraph=True`.
+        3. **a capture session is open and the stream is capturing**
+           (`full`, and the captured segments of `breakable`) -> `copy_` into
+           the graph-resident buffer, which is recorded.
+        4. **setting up or capturing, but neither channel matched** -> swallow.
+           This is a warmup / compile-pass / break-body forward whose values are
+           dummies; letting it reach the eager writer would publish garbage.
+        5. **otherwise** -> False.  Genuine eager execution: `disabled` mode, or
+           an `eager_on_graph` break body at replay time, where capture is off
+           on both sides and the ordinary eager path is exactly right.
+        """
+        if self._registry is None:
+            if torch.compiler.is_compiling():
+                return False
+            self._ensure_configured()
+        if not self._config.enable or not isinstance(value, torch.Tensor):
+            return False
+
+        key = self._next_key(name)
+        if torch.compiler.is_compiling():
+            return self._emit_compiled_tap(key, value)
+        if self._capture_depth and _stream_is_capturing():
+            self._record(key, value, _TAP_IN_GRAPH)
+            return True
+        return bool(self._setup_depth or self._capture_depth)
+
+    def _next_key(self, name: str) -> BufferKey:
+        occurrence = self._occurrences.get(name, 0)
+        self._occurrences[name] = occurrence + 1
+        return BufferKey(name, occurrence)
+
+    def _record(self, key: BufferKey, tensor: torch.Tensor, channel: str) -> None:
+        slot = self._registry.record(key, self._shape_token, tensor)
+        if slot is None:
+            return  # filtered out, or the budget ran out: drop it
+        slot.copy_(tensor.reshape(-1))
+        self._channel_of[key] = channel
+        self._tap_hits += 1
+
+    def _emit_compiled_tap(self, key: BufferKey, tensor: torch.Tensor) -> bool:
+        # `split_op` is imported lazily so that a plain `import sglang` does not
+        # register a torch custom op as a side effect.
+        from sglang.srt.debug_utils.cuda_graph import split_op
+
+        split_op.dumper_tap(tensor, self._registry.tag_for(key))
+        self._compiled_tap_hits += 1
+        return True
+
+    def tap_by_tag(self, tag: int, tensor: torch.Tensor) -> None:
+        """Body of the T3 custom op; runs at execution time, not at trace time.
+
+        First execution lands in the largest-first compile-warmup loop with real
+        tensors at the maximum shape, which is what makes allocate-on-first-use
+        safe here.
+        """
+        if not self.enabled:
+            return
+        self._record(self._registry.key_for_tag(tag), tensor, _TAP_COMPILED)
+
+    # -------------------------------- scopes --------------------------------
+
+    @contextmanager
+    def setup_scope(self) -> Iterator[None]:
+        """Around backend construction and compilation.  Suppresses dummies."""
+        self._ensure_configured()
+        self._setup_depth += 1
+        try:
+            yield
+        finally:
+            self._setup_depth -= 1
+
+    @contextmanager
+    def capture_scope(self) -> Iterator[None]:
+        """Around one capture session; arms the T1 stream-capturing check."""
+        self._ensure_configured()
+        self._capture_depth += 1
+        try:
+            yield
+        finally:
+            self._capture_depth -= 1
+
+    @contextmanager
+    def shape_scope(self, token: Hashable) -> Iterator[None]:
+        previous = self._shape_token
+        self._shape_token = token
+        try:
+            yield
+        finally:
+            self._shape_token = previous
+
+    @contextmanager
+    def runner_scope(self, runner: Any, **tags: Any) -> Iterator[None]:
+        """Publish the replay-side runner so `collect` can read it lazily."""
+        previous = self._runner_ctx
+        self._runner_ctx = {
+            "runner": runner,
+            "tags": {k: v for k, v in tags.items() if v is not None},
+        }
+        try:
+            yield
+        finally:
+            self._runner_ctx = previous
+
+    def wrap_forward_fn(self, forward_fn):
+        """Reset the occurrence counters once per `forward_fn()` invocation.
+
+        `TcPiecewiseCudaGraphBackend.capture_one` calls `forward_fn()` twice, so
+        resetting per capture_one would make the second pass allocate a second
+        buffer for every name.
+        """
+
+        def wrapped(*args, **kwargs):
+            self.begin_forward()
+            return forward_fn(*args, **kwargs)
+
+        return wrapped
+
+    # -------------------------------- collect -------------------------------
+
+    def collect(self, shape_token: Hashable, **extra_tags: Any) -> int:
+        """Write one frame per buffer recorded under `shape_token`.
+
+        Called from the replay seam, *outside* the graph: the values are this
+        replay's, the metadata is this replay's `ForwardBatch`, and
+        `dumper.dump` runs on the host as it always has.
+        """
+        if not self.enabled:
+            return 0
+        from sglang.srt.debug_utils.dumper import dumper
+
+        ctx = self._runner_ctx
+        runner = ctx.get("runner")
+        pairs = _row_pairs(runner, shape_token) if runner is not None else []
+        tags = {**ctx.get("tags", {}), **extra_tags}
+        written = 0
+        for key, view in self._registry.views(shape_token):
+            frame_tags = {
+                "tap": self._channel_of.get(key),
+                "occurrence": key.occurrence or None,
+                **tags,
+            }
+            dumper.dump(
+                key.name,
+                _trim(view, pairs),
+                **{k: v for k, v in frame_tags.items() if v is not None},
+            )
+            written += 1
+        self._collect_calls += 1
+        return written
+
+    # ------------------------------ diagnostics -----------------------------
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "buffers": 0 if self._registry is None else self._registry.num_buffers,
+            "used_mb": (
+                0.0 if self._registry is None else self._registry.used_bytes / (1 << 20)
+            ),
+            "tap_hits": self._tap_hits,
+            "compiled_tap_hits": self._compiled_tap_hits,
+            "collect_calls": self._collect_calls,
+        }
+
+    def report(self) -> None:
+        """Fails loudly, never silently.  One-shot per process.
+
+        Zero taps with the feature switched on means the capture path did not
+        run at all -- almost always a filter that matches no name.  That is
+        exactly the silent hole this package exists to close, so it is reported
+        rather than ignored, and raised in strict mode.
+        """
+        if not self.enabled or self._reported:
+            return
+        self._reported = True
+        summary = self.summary()
+        if self._tap_hits == 0:
+            message = (
+                "cuda-graph dumping was enabled but no tap fired; no module "
+                "inside a captured region was dumped. Check "
+                "DUMPER_CUDA_GRAPH_FILTER against the dump names, and that the "
+                "non-intrusive dumper is attached."
+            )
+            if self._config.strict:
+                raise RuntimeError(message)
+            logger.warning(message)
+        else:
+            logger.info("cuda-graph dump summary: %s", summary)
+
+    def _report_at_exit(self) -> None:
+        """`report()` for the `atexit` path: never escapes into shutdown noise."""
+        try:
+            self.report()
+        except Exception as error:  # strict mode, or a teardown race
+            logger.error("cuda-graph dump report failed: %s", error)
+
+
+cuda_graph_dump = _CudaGraphDumpState()

--- a/python/sglang/srt/debug_utils/cuda_graph/state.py
+++ b/python/sglang/srt/debug_utils/cuda_graph/state.py
@@ -31,13 +31,17 @@ from typing import Any, Hashable, Iterator, Optional
 
 import torch
 
-from sglang.srt.debug_utils.cuda_graph.config import CudaGraphDumpConfig
+from sglang.srt.debug_utils.cuda_graph.config import (
+    TAP_COMPILED,
+    TAP_HOOK,
+    CudaGraphDumpConfig,
+)
 from sglang.srt.debug_utils.cuda_graph.registry import BufferKey, BufferRegistry
 
 logger = logging.getLogger(__name__)
 
-_TAP_IN_GRAPH = "t1"
-_TAP_COMPILED = "t3"
+_TAP_IN_GRAPH = TAP_HOOK
+_TAP_COMPILED = TAP_COMPILED
 _TAP_EAGER = "eager"
 
 
@@ -117,6 +121,7 @@ class _CudaGraphDumpState:
         self._channel_of: dict[BufferKey, str] = {}
         self._tap_hits = 0
         self._compiled_tap_hits = 0
+        self._disarmed_taps = 0
         self._collect_calls = 0
         self._reported = False
 
@@ -150,6 +155,17 @@ class _CudaGraphDumpState:
     def registry(self) -> Optional[BufferRegistry]:
         return self._registry
 
+    def arms(self, tap: str) -> bool:
+        """Whether `tap` is armed.  False whenever the feature is off at all.
+
+        Read by `tc_piecewise`'s `build_compilation_config` to decide whether to
+        register the T3 split op.  That decision is the only one that cannot be
+        revisited later: `mutates_args` makes each injected op a fusion barrier
+        and `add_split_op` makes it a piece boundary, both at *compile* time,
+        where no runtime filter can reach them.
+        """
+        return self.enabled and self._config.arms(tap)
+
     def configure(self) -> None:
         """Idempotent; safe to call from every seam entry point."""
         self._ensure_configured()
@@ -169,7 +185,9 @@ class _CudaGraphDumpState:
         2. **dynamo is tracing** (`tc_piecewise`) -> emit the opaque custom op,
            which becomes a piece boundary and does the `copy_` from inside the
            piece's graph.  A `dumper.dump(...)` here would be a hard trace
-           error under `fullgraph=True`.
+           error under `fullgraph=True`.  With `t3` disarmed the frame is
+           *swallowed*, not passed through, for exactly that reason: falling
+           through would trade a missing frame for a crashed run.
         3. **a capture session is open and the stream is capturing**
            (`full`, and the captured segments of `breakable`) -> `copy_` into
            the graph-resident buffer, which is recorded.
@@ -187,10 +205,19 @@ class _CudaGraphDumpState:
         if not self._config.enable or not isinstance(value, torch.Tensor):
             return False
 
+        # Bumped for every frame, before any channel decision and regardless of
+        # which taps are armed, so disarming one channel cannot renumber the
+        # other's occurrences.
         key = self._next_key(name)
         if torch.compiler.is_compiling():
+            if not self._config.arms(TAP_COMPILED):
+                self._disarmed_taps += 1
+                return True
             return self._emit_compiled_tap(key, value)
         if self._capture_depth and _stream_is_capturing():
+            if not self._config.arms(TAP_HOOK):
+                self._disarmed_taps += 1
+                return True
             self._record(key, value, _TAP_IN_GRAPH)
             return True
         return bool(self._setup_depth or self._capture_depth)
@@ -335,12 +362,14 @@ class _CudaGraphDumpState:
     def summary(self) -> dict[str, Any]:
         return {
             "enabled": self.enabled,
+            "armed_taps": sorted(self._config.armed_taps),
             "buffers": 0 if self._registry is None else self._registry.num_buffers,
             "used_mb": (
                 0.0 if self._registry is None else self._registry.used_bytes / (1 << 20)
             ),
             "tap_hits": self._tap_hits,
             "compiled_tap_hits": self._compiled_tap_hits,
+            "disarmed_taps": self._disarmed_taps,
             "collect_calls": self._collect_calls,
         }
 
@@ -351,23 +380,36 @@ class _CudaGraphDumpState:
         run at all -- almost always a filter that matches no name.  That is
         exactly the silent hole this package exists to close, so it is reported
         rather than ignored, and raised in strict mode.
+
+        A run that dropped frames because a channel was disarmed is *not* an
+        error -- the user asked for that -- but it is still reported, because
+        "narrowed on purpose" and "broken" produce the same short dump
+        directory and only the summary can tell them apart.
         """
         if not self.enabled or self._reported:
             return
         self._reported = True
         summary = self.summary()
-        if self._tap_hits == 0:
+        if self._tap_hits == 0 and self._compiled_tap_hits == 0:
             message = (
                 "cuda-graph dumping was enabled but no tap fired; no module "
                 "inside a captured region was dumped. Check "
-                "DUMPER_CUDA_GRAPH_FILTER against the dump names, and that the "
-                "non-intrusive dumper is attached."
+                "DUMPER_CUDA_GRAPH_FILTER against the dump names, "
+                "DUMPER_CUDA_GRAPH_TAPS against the graph backend in use, and "
+                "that the non-intrusive dumper is attached."
             )
             if self._config.strict:
                 raise RuntimeError(message)
             logger.warning(message)
         else:
             logger.info("cuda-graph dump summary: %s", summary)
+        if self._disarmed_taps:
+            logger.warning(
+                "cuda-graph dumping dropped %d frame(s) because a tap was "
+                "disarmed (armed: %s); those modules are absent from the dump.",
+                self._disarmed_taps,
+                ",".join(sorted(self._config.armed_taps)) or "none",
+            )
 
     def _report_at_exit(self) -> None:
         """`report()` for the `atexit` path: never escapes into shutdown noise."""

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -22,6 +22,7 @@ import torch
 import torch.distributed as dist
 import zmq
 
+from sglang.srt.debug_utils.cuda_graph import cuda_graph_dump
 from sglang.srt.managers.io_struct import sock_recv, sock_send, wrap_as_pickle
 from sglang.srt.runtime_context import (
     get_parallel,
@@ -166,6 +167,17 @@ class DumperConfig(_BaseConfig):
     # When True, append parallel-rank tags (pp_rank/tp_rank/...) to dump filenames so
     # tensors from different ranks do not collide when dumped into a shared directory.
     include_parallel_rank_in_filename: bool = False
+    # CUDA-graph-compatible dumping. Off by default: it costs one device buffer
+    # per dumped tensor, held for the process lifetime, because a graph-recorded
+    # copy_ bakes in the buffer's address. See sglang.srt.debug_utils.cuda_graph.
+    cuda_graph_enable: bool = False
+    # Comma-separated dump-name prefixes to keep. None/empty means every name,
+    # which is rarely what you want: the buffers are allocated up front.
+    cuda_graph_filter: Optional[str] = None
+    # Device-memory ceiling for those buffers. Negative means unlimited.
+    cuda_graph_budget_mb: int = 4096
+    # Raise instead of warning when the budget is exhausted or no tap fired.
+    cuda_graph_strict: bool = False
 
     @classmethod
     def _env_prefix(cls) -> str:
@@ -744,15 +756,27 @@ class _NonIntrusiveDumper:
     def _dump_value(
         self, module_name: str, value: Any, sub_name: str, *, is_root: bool
     ) -> None:
+        # `cuda_graph_dump.tap` returns True when it has taken the tensor
+        # through a graph-aware channel -- a recorded `copy_` into a
+        # graph-resident buffer, whose contents are written out after the
+        # replay that produced them. False means "nothing captured this", and
+        # the eager path below is exactly right. Inside a captured region a
+        # `self._dumper.dump(...)` here would either be traced away or write
+        # capture-time dummy values, which is the silent hole this guards.
         for key, item in self._convert_value(
             value, skip_forward_batch=(not is_root)
         ).items():
             effective_key = key or sub_name.rsplit(".", 1)[-1]
             if effective_key in self._core_fields:
+                if cuda_graph_dump.tap(effective_key, item):
+                    continue
                 self._dumper.dump(effective_key, item)
             elif self._mode == "all":
                 parts = [p for p in (module_name, sub_name, key) if p]
-                self._dumper.dump(self._NAME_PREFIX + ".".join(parts), item)
+                name = self._NAME_PREFIX + ".".join(parts)
+                if cuda_graph_dump.tap(name, item):
+                    continue
+                self._dumper.dump(name, item)
 
     @staticmethod
     def _convert_value(value, *, skip_forward_batch: bool = False) -> dict[str, Any]:

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -770,13 +770,13 @@ class _NonIntrusiveDumper:
             if effective_key in self._core_fields:
                 if cuda_graph_dump.tap(effective_key, item):
                     continue
-                self._dumper.dump(effective_key, item)
+                self._dumper.dump(effective_key, item, **cuda_graph_dump.eager_tags())
             elif self._mode == "all":
                 parts = [p for p in (module_name, sub_name, key) if p]
                 name = self._NAME_PREFIX + ".".join(parts)
                 if cuda_graph_dump.tap(name, item):
                     continue
-                self._dumper.dump(name, item)
+                self._dumper.dump(name, item, **cuda_graph_dump.eager_tags())
 
     @staticmethod
     def _convert_value(value, *, skip_forward_batch: bool = False) -> dict[str, Any]:

--- a/python/sglang/srt/debug_utils/dumper.py
+++ b/python/sglang/srt/debug_utils/dumper.py
@@ -178,6 +178,13 @@ class DumperConfig(_BaseConfig):
     cuda_graph_budget_mb: int = 4096
     # Raise instead of warning when the budget is exhausted or no tap fired.
     cuda_graph_strict: bool = False
+    # Which taps to arm: comma-separated subset of t1 (forward hook, used by
+    # `full` and `breakable`) and t3 (the `tc_piecewise` custom op); `all` or
+    # empty arms both. Worth narrowing to `t1` unless you need `tc_piecewise`:
+    # t3 costs inductor a fusion barrier and a piece boundary per injection
+    # point, and that cost is paid at compile time, where no runtime filter can
+    # reach it.
+    cuda_graph_taps: Optional[str] = None
 
     @classmethod
     def _env_prefix(cls) -> str:

--- a/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
@@ -132,6 +132,17 @@ class BaseCudaGraphRunner(BaseRunner):
     buffers: ForwardInputBuffers
     backend: BaseCudaGraphBackend
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        # Publishes the replay-side runner and this batch's metadata around
+        # execute(), which is where CUDA-graph-compatible tensor dumping reads
+        # the raw row counts and the forward mode from. See
+        # sglang.srt.debug_utils.cuda_graph. The seam is inert (a few getattrs
+        # per call) unless DUMPER_CUDA_GRAPH_ENABLE is set.
+        super().__init_subclass__(**kwargs)
+        from sglang.srt.debug_utils.cuda_graph.seams import install_runner_seam
+
+        install_runner_seam(cls)
+
     @staticmethod
     def _pad_to_bucket(raw_size: int, buckets: Sequence[int]) -> int:
         """Return the smallest buckets[i] >= raw_size.

--- a/python/sglang/srt/model_executor/runner_backend/base_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/base_cuda_graph_backend.py
@@ -53,6 +53,17 @@ class BaseCudaGraphBackend(ABC):
         backend must retain when its graph records their tensor addresses.
     """
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        # Arms CUDA-graph-compatible tensor dumping: a forward hook's
+        # `buffer.copy_` is only *recorded* if the dumper knows a capture
+        # session is open, and the buffers can only be read back after
+        # `replay()` returns. See sglang.srt.debug_utils.cuda_graph. The seam is
+        # inert (a few getattrs per call) unless DUMPER_CUDA_GRAPH_ENABLE is set.
+        super().__init_subclass__(**kwargs)
+        from sglang.srt.debug_utils.cuda_graph.seams import install_backend_seam
+
+        install_backend_seam(cls)
+
     @abstractmethod
     def capture_session(self, stream: torch.cuda.Stream) -> Iterator[None]: ...
 

--- a/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
@@ -71,6 +71,30 @@ def _suppress_lru_cache_dynamo_warning() -> None:
     warnings.filterwarnings("ignore", message=".*lru_cache.*", module="torch._dynamo")
 
 
+def _may_add_dumper_split_op(config: CompilationConfig) -> None:
+    """Make the tensor-dump tap a piece boundary, when dumping is on.
+
+    Dynamo inlines `Module.__call__`, so a forward hook's `buffer.copy_` is
+    traced away under `fullgraph=True` and never becomes a kernel. The dumper
+    therefore emits an opaque custom op instead; declaring it a split op is what
+    turns that op into a piece boundary, so its body -- and the `copy_` inside
+    it -- runs within a captured piece.
+
+    `SPLIT_OPS` is snapshotted in `CompilationConfig.__init__`, so this has to
+    happen here rather than at import time. Gated on the feature being on: the
+    import registers a torch custom op as a side effect, and each extra split op
+    that actually fires costs inductor a fusion barrier.
+    """
+    from sglang.srt.debug_utils.cuda_graph import cuda_graph_dump
+
+    cuda_graph_dump.configure()
+    if not cuda_graph_dump.enabled:
+        return
+    from sglang.srt.debug_utils.cuda_graph.split_op import DUMPER_TAP_OP_NAME
+
+    config.add_split_op(DUMPER_TAP_OP_NAME)
+
+
 def _toggle_fused_ops(
     model: torch.nn.Module, *, reverse: bool, num_tokens: int
 ) -> None:
@@ -130,6 +154,8 @@ class TcPiecewiseCudaGraphBackend(BaseCudaGraphBackend):
 
         if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
             config.add_split_op("sglang.moe_forward_piecewise_cuda_graph_impl")
+
+        _may_add_dumper_split_op(config)
 
         return config
 

--- a/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
@@ -72,23 +72,26 @@ def _suppress_lru_cache_dynamo_warning() -> None:
 
 
 def _may_add_dumper_split_op(config: CompilationConfig) -> None:
-    """Make the tensor-dump tap a piece boundary, when dumping is on.
+    """Make the tensor-dump tap a piece boundary, when the T3 tap is armed.
 
-    Dynamo inlines `Module.__call__`, so a forward hook's `buffer.copy_` is
-    traced away under `fullgraph=True` and never becomes a kernel. The dumper
-    therefore emits an opaque custom op instead; declaring it a split op is what
-    turns that op into a piece boundary, so its body -- and the `copy_` inside
-    it -- runs within a captured piece.
+    A forward hook cannot serve `tc_piecewise`: reaching the eager writer from
+    inside a `fullgraph=True` trace is a hard dynamo error. The dumper therefore
+    emits an opaque custom op instead; declaring it a split op is what turns that
+    op into a piece boundary, so its body -- and the `copy_` inside it -- runs
+    within a captured piece.
 
     `SPLIT_OPS` is snapshotted in `CompilationConfig.__init__`, so this has to
-    happen here rather than at import time. Gated on the feature being on: the
-    import registers a torch custom op as a side effect, and each extra split op
-    that actually fires costs inductor a fusion barrier.
+    happen here rather than at import time. Gated on the T3 tap specifically,
+    not just on dumping being on: the import registers a torch custom op as a
+    side effect, and every injected op costs inductor a fusion barrier plus a
+    piece boundary. Both are paid at compile time, so `DUMPER_CUDA_GRAPH_TAPS=t1`
+    is the only way to not pay them -- a runtime filter cannot help.
     """
     from sglang.srt.debug_utils.cuda_graph import cuda_graph_dump
+    from sglang.srt.debug_utils.cuda_graph.config import TAP_COMPILED
 
     cuda_graph_dump.configure()
-    if not cuda_graph_dump.enabled:
+    if not cuda_graph_dump.arms(TAP_COMPILED):
         return
     from sglang.srt.debug_utils.cuda_graph.split_op import DUMPER_TAP_OP_NAME
 

--- a/test/registered/debug_utils/test_cuda_graph_dump.py
+++ b/test/registered/debug_utils/test_cuda_graph_dump.py
@@ -90,6 +90,7 @@ class TestCudaGraphDumpConfig:
             cuda_graph_filter="x",
             cuda_graph_budget_mb=7,
             cuda_graph_strict=True,
+            cuda_graph_taps="t1",
         )
         config = CudaGraphDumpConfig.from_dumper_config(dumper_config)
         assert (config.enable, config.filter, config.budget_mb, config.strict) == (
@@ -98,10 +99,13 @@ class TestCudaGraphDumpConfig:
             7,
             True,
         )
+        assert config.armed_taps == {"t1"}
 
     def test_from_dumper_config_tolerates_missing_fields(self):
         config = CudaGraphDumpConfig.from_dumper_config(SimpleNamespace())
         assert not config.enable
+        # A DumperConfig predating the taps field must still arm every channel.
+        assert config.armed_taps == {"t1", "t3"}
 
 
 class TestBufferKey:
@@ -347,6 +351,68 @@ class TestEagerTags:
         # pure-eager baseline frame, and "t1|t3 plus eager equals eager-only"
         # is unverifiable.
         assert _state().eager_tags() == {"tap": "eager"}
+
+
+class TestArmedTaps:
+    def test_unset_arms_everything(self):
+        # A debugging tool that under-covers by default is the failure this
+        # package exists to close, so "unset" must not mean "only the cheap one".
+        assert CudaGraphDumpConfig().armed_taps == {"t1", "t3"}
+        assert CudaGraphDumpConfig(taps="").armed_taps == {"t1", "t3"}
+        assert CudaGraphDumpConfig(taps=" ALL ").armed_taps == {"t1", "t3"}
+
+    def test_narrowing_to_one_channel(self):
+        config = CudaGraphDumpConfig(taps="t1")
+        assert config.arms("t1") and not config.arms("t3")
+
+    def test_whitespace_case_and_unknown_names(self):
+        config = CudaGraphDumpConfig(taps=" T3 , t1 , t9 ")
+        assert config.armed_taps == {"t1", "t3"}
+
+    def test_none_arms_nothing(self):
+        assert CudaGraphDumpConfig(taps="none").armed_taps == frozenset()
+
+    def test_arms_is_false_whenever_the_feature_is_off(self):
+        # `build_compilation_config` asks the state, not the config: a disabled
+        # run must not register the split op no matter what TAPS says.
+        assert _state(enable=False, taps="t1,t3").arms("t3") is False
+        assert _state(enable=True, taps="t1,t3").arms("t3") is True
+
+
+class TestDisarmedTapsSwallow:
+    def test_disarmed_t1_swallows_instead_of_falling_through(self, monkeypatch):
+        state = _state(taps="t3")
+        with _pretend_stream_is_capturing(monkeypatch), state.capture_scope():
+            # True, not False: falling through here would hand a capture-time
+            # dummy to the eager writer and publish garbage.
+            assert state.tap("a", torch.zeros(4)) is True
+        assert state.registry.num_buffers == 0
+        assert state.summary()["disarmed_taps"] == 1
+
+    def test_disarmed_t3_swallows_instead_of_falling_through(self, monkeypatch):
+        state = _state(taps="t1")
+        monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+        # Falling through under `fullgraph=True` would not lose a frame, it
+        # would raise: `dumper.dump` opens a file, which dynamo cannot trace.
+        assert state.tap("a", torch.zeros(4)) is True
+        assert state.summary()["compiled_tap_hits"] == 0
+        assert state.summary()["disarmed_taps"] == 1
+
+    def test_disarming_one_channel_does_not_renumber_the_other(self, monkeypatch):
+        state = _state(taps="t3")
+        with _pretend_stream_is_capturing(monkeypatch), state.capture_scope():
+            state.tap("a", torch.zeros(4))
+            state.tap("a", torch.zeros(4))
+        # The counter is bumped before the channel decision, so an eager frame
+        # for the third occurrence is still numbered 2.
+        assert state._next_key("a").occurrence == 2
+
+    def test_armed_t1_still_records(self, monkeypatch):
+        state = _state(taps="t1")
+        with _pretend_stream_is_capturing(monkeypatch), state.capture_scope():
+            assert state.tap("a", torch.zeros(4)) is True
+        assert state.registry.num_buffers == 1
+        assert state.summary()["disarmed_taps"] == 0
 
 
 class TestOccurrenceCounter:

--- a/test/registered/debug_utils/test_cuda_graph_dump.py
+++ b/test/registered/debug_utils/test_cuda_graph_dump.py
@@ -1,0 +1,630 @@
+"""CPU tests for the CUDA-graph-compatible dumping machinery.
+
+Everything here runs without a GPU. The one thing a CPU cannot exercise is a
+real `torch.cuda.graph()` capture, so the T1 rung of the `tap()` ladder is
+reached by faking `_stream_is_capturing`; the rung *ordering*, the buffer
+bookkeeping, the padding trim and the seam wrappers are all genuinely under
+test. The GPU-only acceptance items (address stability across a real replay,
+set-equality against a pure-eager run) live in the design doc, not here.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import NamedTuple
+
+import pytest
+import torch
+
+from sglang.srt.debug_utils.cuda_graph import (
+    BufferKey,
+    BufferRegistry,
+    CudaGraphDumpConfig,
+    DumpBudgetExceeded,
+)
+from sglang.srt.debug_utils.cuda_graph import seams as seams_module
+from sglang.srt.debug_utils.cuda_graph import state as state_module
+from sglang.srt.debug_utils.cuda_graph.registry import DumpBufferGrowthRejected
+from sglang.srt.debug_utils.cuda_graph.seams import (
+    _backend_label,
+    _first_arg,
+    _pd_role,
+    _wrap,
+    _wrap_forward_fn,
+    install_backend_seam,
+    install_runner_seam,
+)
+from sglang.srt.debug_utils.cuda_graph.state import (
+    _CudaGraphDumpState,
+    _row_pairs,
+    _trim,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, stage="weekly", runner_config="cpu")
+
+
+class _ShapeToken(NamedTuple):
+    """A hashable stand-in for the in-tree `ShapeKey`.
+
+    The registry keys its per-buffer layout table by shape token, so the token
+    has to be hashable — the real `ShapeKey` is a frozen dataclass and hashes by
+    value. `types.SimpleNamespace` defines `__eq__` and therefore has no
+    `__hash__`, which makes it unusable here even though it is fine for the
+    runner / forward-batch stand-ins elsewhere in this file.
+    """
+
+    size: int
+
+
+def _registry(budget_bytes: int = 1 << 30, prefixes=None, strict: bool = False):
+    config = CudaGraphDumpConfig(
+        enable=True,
+        filter=None if prefixes is None else ",".join(prefixes),
+        strict=strict,
+    )
+    return BufferRegistry(
+        budget_bytes=budget_bytes, accepts=config.accepts, strict=strict
+    )
+
+
+class TestCudaGraphDumpConfig:
+    def test_accepts_everything_without_filter(self):
+        config = CudaGraphDumpConfig(enable=True)
+        assert config.prefixes == ()
+        assert config.accepts("anything")
+
+    def test_prefixes_are_split_and_stripped(self):
+        config = CudaGraphDumpConfig(enable=True, filter=" a.b , ,c ")
+        assert config.prefixes == ("a.b", "c")
+        assert config.accepts("a.b.qkv_proj")
+        assert config.accepts("c")
+        assert not config.accepts("b.a")
+
+    def test_budget_bytes(self):
+        assert CudaGraphDumpConfig(budget_mb=2).budget_bytes == 2 * 1024 * 1024
+        assert CudaGraphDumpConfig(budget_mb=-1).budget_bytes == -1
+
+    def test_from_dumper_config_reads_prefixed_fields(self):
+        dumper_config = SimpleNamespace(
+            cuda_graph_enable=True,
+            cuda_graph_filter="x",
+            cuda_graph_budget_mb=7,
+            cuda_graph_strict=True,
+        )
+        config = CudaGraphDumpConfig.from_dumper_config(dumper_config)
+        assert (config.enable, config.filter, config.budget_mb, config.strict) == (
+            True,
+            "x",
+            7,
+            True,
+        )
+
+    def test_from_dumper_config_tolerates_missing_fields(self):
+        config = CudaGraphDumpConfig.from_dumper_config(SimpleNamespace())
+        assert not config.enable
+
+
+class TestBufferKey:
+    def test_str_hides_the_zeroth_occurrence(self):
+        assert str(BufferKey("a.b")) == "a.b"
+        assert str(BufferKey("a.b", 2)) == "a.b#2"
+
+    def test_occurrences_are_distinct_keys(self):
+        assert BufferKey("a", 0) != BufferKey("a", 1)
+        assert len({BufferKey("a", 0), BufferKey("a", 0)}) == 1
+
+
+class TestBufferRegistry:
+    def test_record_returns_a_flat_slice_of_the_right_length(self):
+        registry = _registry()
+        tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        slot = registry.record(BufferKey("a"), "shape0", tensor)
+        assert slot is not None
+        assert slot.shape == (6,)
+        assert registry.num_buffers == 1
+
+    def test_occurrences_get_separate_buffers(self):
+        registry = _registry()
+        tensor = torch.zeros(4)
+        first = registry.record(BufferKey("a", 0), "shape0", tensor)
+        second = registry.record(BufferKey("a", 1), "shape0", tensor)
+        assert first.data_ptr() != second.data_ptr()
+        assert registry.num_buffers == 2
+
+    def test_same_key_reuses_one_buffer_across_shapes(self):
+        registry = _registry()
+        key = BufferKey("a")
+        big = registry.record(key, "big", torch.zeros(8))
+        small = registry.record(key, "small", torch.zeros(4))
+        assert big.data_ptr() == small.data_ptr()
+        assert registry.num_buffers == 1
+
+    def test_filtered_names_cost_no_memory(self):
+        registry = _registry(prefixes=["keep"])
+        assert (
+            registry.record(BufferKey("drop.me"), "shape0", torch.zeros(1024)) is None
+        )
+        assert registry.used_bytes == 0
+        assert registry.rejected[BufferKey("drop.me")] == "filtered"
+        assert (
+            registry.record(BufferKey("keep.me"), "shape0", torch.zeros(4)) is not None
+        )
+
+
+class TestBufferRegistryLimits:
+    def test_budget_rejects_and_warns_by_default(self):
+        registry = _registry(budget_bytes=16)
+        assert registry.record(BufferKey("a"), "s", torch.zeros(4)) is not None
+        assert registry.record(BufferKey("b"), "s", torch.zeros(4)) is None
+        assert registry.rejected[BufferKey("b")] == "budget"
+        # A rejected key stays rejected without re-running the budget check.
+        assert registry.record(BufferKey("b"), "s", torch.zeros(1)) is None
+
+    def test_budget_raises_in_strict_mode(self):
+        registry = _registry(budget_bytes=0, strict=True)
+        with pytest.raises(DumpBudgetExceeded):
+            registry.record(BufferKey("a"), "s", torch.zeros(4))
+
+    def test_unlimited_budget(self):
+        registry = _registry(budget_bytes=-1)
+        assert registry.record(BufferKey("a"), "s", torch.zeros(1024)) is not None
+
+    def test_growth_is_rejected_not_truncated(self):
+        registry = _registry()
+        registry.record(BufferKey("a"), "small", torch.zeros(4))
+        with pytest.raises(DumpBufferGrowthRejected):
+            registry.record(BufferKey("a"), "big", torch.zeros(8))
+
+    def test_dtype_change_is_rejected(self):
+        registry = _registry()
+        registry.record(BufferKey("a"), "s", torch.zeros(4, dtype=torch.float32))
+        with pytest.raises(DumpBufferGrowthRejected):
+            registry.record(BufferKey("a"), "s", torch.zeros(4, dtype=torch.float16))
+
+    def test_addresses_stay_stable(self):
+        registry = _registry()
+        registry.record(BufferKey("a"), "s", torch.zeros(4))
+        registry.assert_addresses_stable()
+
+
+class TestBufferRegistryViews:
+    def test_views_reshape_per_shape_token(self):
+        registry = _registry()
+        key = BufferKey("a")
+        registry.record(key, "big", torch.zeros(2, 4)).copy_(torch.arange(8.0))
+        registry.record(key, "small", torch.zeros(2, 2))
+        big = dict(registry.views("big"))
+        small = dict(registry.views("small"))
+        assert big[key].shape == (2, 4)
+        assert small[key].shape == (2, 2)
+        # The small view aliases the head of the same flat buffer.
+        assert torch.equal(small[key].reshape(-1), torch.arange(4.0))
+
+    def test_views_skip_keys_never_seen_under_that_token(self):
+        registry = _registry()
+        registry.record(BufferKey("a"), "s0", torch.zeros(4))
+        registry.record(BufferKey("b"), "s1", torch.zeros(4))
+        assert [key.name for key, _ in registry.views("s0")] == ["a"]
+        assert [key.name for key, _ in registry.views("s1")] == ["b"]
+        assert list(registry.views("s2")) == []
+
+    def test_names(self):
+        registry = _registry()
+        registry.record(BufferKey("a", 0), "s", torch.zeros(1))
+        registry.record(BufferKey("a", 1), "s", torch.zeros(1))
+        assert registry.names() == {"a"}
+
+
+class TestTagInterning:
+    def test_round_trip_and_stability(self):
+        registry = _registry()
+        key = BufferKey("a", 1)
+        tag = registry.tag_for(key)
+        assert registry.tag_for(key) == tag
+        assert registry.key_for_tag(tag) == key
+
+    def test_distinct_keys_get_distinct_tags(self):
+        registry = _registry()
+        assert registry.tag_for(BufferKey("a")) != registry.tag_for(BufferKey("b"))
+
+
+class TestRowPairs:
+    def test_plain_decode_offers_one_pair(self):
+        runner = SimpleNamespace(raw_num_token=3, raw_bs=3, bs=8)
+        assert _row_pairs(runner, _ShapeToken(size=8)) == [(8, 3)]
+
+    def test_spec_decode_offers_token_and_request_bases(self):
+        # bs=32 padded requests x width=4 -> 128 padded token rows; 4 real
+        # requests -> 16 real token rows. A 32-row per-request tensor must trim
+        # to 4, not to 16, which is what a single (size, raw_num_token) pair
+        # would have done.
+        runner = SimpleNamespace(
+            raw_num_token=16, raw_bs=4, bs=32, captured_req_width=4
+        )
+        pairs = _row_pairs(runner, _ShapeToken(size=128))
+        assert pairs == [(128, 16), (32, 4)]
+        assert _trim(torch.zeros(32, 5), pairs).shape == (4, 5)
+        assert _trim(torch.zeros(128, 5), pairs).shape == (16, 5)
+
+    def test_ragged_verify_keys_on_num_tokens(self):
+        runner = SimpleNamespace(
+            raw_num_token=5,
+            raw_bs=2,
+            bs=4,
+            captured_req_width=4,
+            ragged_verify_mode=True,
+        )
+        assert _row_pairs(runner, _ShapeToken(size=16)) == [(16, 5), (4, 2)]
+
+    def test_prefill_style_runner_keys_on_num_tokens(self):
+        runner = SimpleNamespace(raw_num_tokens=5, bs=None)
+        assert _row_pairs(runner, _ShapeToken(size=16)) == [(16, 5)]
+
+    def test_unpadded_batch_offers_nothing(self):
+        runner = SimpleNamespace(raw_num_token=8, raw_bs=8, bs=8)
+        assert _row_pairs(runner, _ShapeToken(size=8)) == []
+
+
+class TestTrim:
+    def test_only_an_exact_dim0_match_trims(self):
+        pairs = [(8, 3)]
+        assert _trim(torch.zeros(8, 2), pairs).shape == (3, 2)
+        assert _trim(torch.zeros(7, 2), pairs).shape == (7, 2)
+        assert _trim(torch.zeros(2, 8), pairs).shape == (2, 8)
+
+    def test_scalars_pass_through(self):
+        assert _trim(torch.tensor(1.0), [(8, 3)]).dim() == 0
+
+    def test_no_pairs_is_a_no_op(self):
+        assert _trim(torch.zeros(8), []).shape == (8,)
+
+
+def _state(enable: bool = True, **config_kwargs) -> _CudaGraphDumpState:
+    """A state object with the registry injected.
+
+    Bypasses `_ensure_configured`, which would read the real dumper's config and
+    register an `atexit` hook -- neither of which belongs in a unit test.
+    """
+    state = _CudaGraphDumpState()
+    state._config = CudaGraphDumpConfig(enable=enable, **config_kwargs)
+    state._registry = BufferRegistry(
+        budget_bytes=1 << 30,
+        accepts=state._config.accepts,
+        strict=state._config.strict,
+    )
+    return state
+
+
+@contextmanager
+def _pretend_stream_is_capturing(monkeypatch):
+    monkeypatch.setattr(state_module, "_stream_is_capturing", lambda: True)
+    yield
+
+
+class _FakeDumper:
+    """Stands in for the module-level `dumper` singleton at collect time."""
+
+    def __init__(self):
+        self.frames = []
+
+    def dump(self, name, value, **tags):
+        self.frames.append((name, value, tags))
+
+
+class TestTapLadder:
+    def test_disabled_hands_the_tensor_back(self):
+        assert _state(enable=False).tap("a", torch.zeros(4)) is False
+
+    def test_non_tensors_are_never_taken(self):
+        assert _state().tap("a", "not a tensor") is False
+        assert _state().tap("a", 3) is False
+
+    def test_idle_is_the_eager_path(self):
+        # No scope open: genuine eager execution, the caller writes the file.
+        assert _state().tap("a", torch.zeros(4)) is False
+
+    def test_setup_frames_are_swallowed(self):
+        state = _state()
+        with state.setup_scope():
+            # Warmup / compile-pass dummies: taken (True) but not recorded.
+            assert state.tap("a", torch.zeros(4)) is True
+        assert state.registry.num_buffers == 0
+
+    def test_capture_without_a_capturing_stream_is_swallowed(self):
+        state = _state()
+        with state.capture_scope():
+            assert state.tap("a", torch.zeros(4)) is True
+        assert state.registry.num_buffers == 0
+
+
+class TestOccurrenceCounter:
+    def test_repeated_names_get_distinct_occurrences(self):
+        state = _state()
+        assert [state._next_key("a").occurrence for _ in range(3)] == [0, 1, 2]
+        assert state._next_key("b").occurrence == 0
+
+    def test_begin_forward_resets(self):
+        state = _state()
+        state._next_key("a")
+        state.begin_forward()
+        assert state._next_key("a").occurrence == 0
+
+    def test_wrap_forward_fn_resets_per_invocation(self):
+        state = _state()
+        seen = []
+
+        def forward_fn():
+            seen.append(state._next_key("a").occurrence)
+
+        wrapped = state.wrap_forward_fn(forward_fn)
+        # capture_one calls forward_fn twice; the second pass must not allocate a
+        # second buffer for every name.
+        wrapped()
+        wrapped()
+        assert seen == [0, 0]
+
+
+class TestT1EndToEnd:
+    def _record_one_shape(self, state, token, rows):
+        with state.capture_scope(), state.shape_scope(token):
+            assert state.tap(
+                "layer.qkv_proj", torch.arange(rows * 2.0).reshape(rows, 2)
+            )
+            assert state.tap("layer.o_proj", torch.zeros(rows, 2))
+
+    def test_capture_records_and_collect_writes(self, monkeypatch):
+        state = _state()
+        fake = _FakeDumper()
+        monkeypatch.setattr("sglang.srt.debug_utils.dumper.dumper", fake)
+        token = _ShapeToken(size=8)
+        with _pretend_stream_is_capturing(monkeypatch):
+            self._record_one_shape(state, token, rows=8)
+        assert state.registry.num_buffers == 2
+
+        runner = SimpleNamespace(raw_num_token=3, raw_bs=3, bs=8)
+        with state.runner_scope(runner, graph_runner="decode", pd_role=None):
+            written = state.collect(token, graph_backend="full", graph_size=8)
+        assert written == 2
+        assert {name for name, _, _ in fake.frames} == {
+            "layer.qkv_proj",
+            "layer.o_proj",
+        }
+        tags = fake.frames[0][2]
+        assert tags["tap"] == "t1"
+        assert tags["graph_backend"] == "full"
+        assert tags["graph_runner"] == "decode"
+        # pd_role was None, so runner_scope dropped it rather than tagging a None.
+        assert "pd_role" not in tags
+        # 8 padded rows trimmed to the 3 real ones.
+        assert all(value.shape == (3, 2) for _, value, _ in fake.frames)
+
+    def test_second_occurrence_is_tagged_and_kept_apart(self, monkeypatch):
+        state = _state()
+        fake = _FakeDumper()
+        monkeypatch.setattr("sglang.srt.debug_utils.dumper.dumper", fake)
+        token = _ShapeToken(size=4)
+        with _pretend_stream_is_capturing(monkeypatch):
+            with state.capture_scope(), state.shape_scope(token):
+                state.tap("mlp.down_proj", torch.zeros(4, 2))
+                state.tap("mlp.down_proj", torch.ones(4, 2))
+        assert state.registry.num_buffers == 2
+
+        with state.runner_scope(SimpleNamespace(raw_num_token=4, raw_bs=4, bs=4)):
+            assert state.collect(token) == 2
+        occurrences = sorted(
+            (tags.get("occurrence") for _, _, tags in fake.frames),
+            key=lambda occurrence: -1 if occurrence is None else occurrence,
+        )
+        # The zeroth occurrence is left untagged so the common case stays clean.
+        assert occurrences == [None, 1]
+        assert all(name == "mlp.down_proj" for name, _, _ in fake.frames)
+
+    def test_collect_only_sees_the_requested_shape(self, monkeypatch):
+        state = _state()
+        fake = _FakeDumper()
+        monkeypatch.setattr("sglang.srt.debug_utils.dumper.dumper", fake)
+        big, small = _ShapeToken(size=8), _ShapeToken(size=4)
+        with _pretend_stream_is_capturing(monkeypatch):
+            self._record_one_shape(state, big, rows=8)
+            state.begin_forward()
+            self._record_one_shape(state, small, rows=4)
+        # One buffer per name, shared across both shapes.
+        assert state.registry.num_buffers == 2
+        with state.runner_scope(SimpleNamespace(bs=4)):
+            assert state.collect(small) == 2
+        assert all(value.shape == (4, 2) for _, value, _ in fake.frames)
+
+    def test_disabled_collect_writes_nothing(self):
+        assert _state(enable=False).collect(_ShapeToken(size=8)) == 0
+
+
+class TestReport:
+    def test_zero_taps_warns_once(self, caplog):
+        state = _state()
+        state.report()
+        state.report()
+        assert sum("no tap fired" in r.getMessage() for r in caplog.records) == 1
+
+    def test_zero_taps_raises_in_strict_mode(self):
+        with pytest.raises(RuntimeError, match="no tap fired"):
+            _state(strict=True).report()
+
+    def test_at_exit_swallows_the_strict_failure(self, caplog):
+        # atexit must not turn a diagnostic into interpreter shutdown noise.
+        _state(strict=True)._report_at_exit()
+        assert any("report failed" in r.getMessage() for r in caplog.records)
+
+
+class TestSeamHelpers:
+    def test_first_arg_reads_positional_and_keyword_forms(self):
+        assert _first_arg(("a",), {}, "shape_key") == "a"
+        assert _first_arg((), {"shape_key": "a"}, "shape_key") == "a"
+        assert _first_arg((), {}, "shape_key") is None
+
+    def test_backend_label_falls_back_to_the_class_name(self):
+        assert _backend_label(type("FullCudaGraphBackend", (), {})()) == "full"
+        assert (
+            _backend_label(type("TcPiecewiseCudaGraphBackend", (), {})())
+            == "tc_piecewise"
+        )
+        assert _backend_label(type("NpuFooBackend", (), {})()) == "NpuFooBackend"
+
+    def test_pd_role_is_none_without_a_published_context(self):
+        # Co-located, or a unit test with no runtime context: must not raise.
+        assert _pd_role() in (None, "prefill", "decode")
+
+    def test_wrap_forward_fn_handles_both_call_shapes(self, monkeypatch):
+        state = _state()
+        monkeypatch.setattr(seams_module, "cuda_graph_dump", state)
+        calls = []
+        args, kwargs = _wrap_forward_fn(("key", lambda: calls.append("pos")), {})
+        args[1]()
+        args, kwargs = _wrap_forward_fn(
+            ("key",), {"forward_fn": lambda: calls.append("kw")}
+        )
+        kwargs["forward_fn"]()
+        assert calls == ["pos", "kw"]
+        # Nothing to substitute: passed through untouched.
+        assert _wrap_forward_fn(("key",), {}) == (("key",), {})
+
+    def test_wrap_is_idempotent_and_dict_local(self):
+        class Base:
+            def execute(self):
+                return "base"
+
+        class Child(Base):
+            pass
+
+        seen = []
+
+        def factory(fn):
+            def wrapped(self):
+                seen.append(1)
+                return fn(self)
+
+            return wrapped
+
+        _wrap(Base, "execute", factory)
+        _wrap(Base, "execute", factory)  # _SEAM_MARK short-circuits the second
+        _wrap(Child, "execute", factory)  # no override in __dict__: nothing to wrap
+        assert "execute" not in Child.__dict__
+        Child().execute()
+        assert seen == [1]
+
+
+class _DummyBackend:
+    """The shape of a BaseCudaGraphBackend subclass, without the import weight.
+
+    `runner_backend/__init__.py` eagerly imports all three real backends, which
+    would drag the whole model executor into a CPU test. The seam only ever
+    touches these five methods, so a stand-in exercises it faithfully.
+    """
+
+    def __init__(self):
+        self.replayed = []
+
+    @contextmanager
+    def capture_session(self, stream):
+        yield "session"
+
+    def capture_one(self, shape_key, forward_fn, **kwargs):
+        forward_fn()
+        forward_fn()
+
+    def replay(self, shape_key, static_forward_batch, **kwargs):
+        self.replayed.append(shape_key)
+        return "logits"
+
+    def cleanup(self):
+        return None
+
+
+def _fresh_backend() -> type:
+    """A new class whose *own* `__dict__` holds every seam target.
+
+    `_wrap` only ever replaces entries in `cls.__dict__`, which mirrors the real
+    backends: each one is a concrete override of the ABC. A plain subclass of
+    `_DummyBackend` would inherit the methods and get nothing wrapped.
+    """
+    body = {
+        k: v
+        for k, v in _DummyBackend.__dict__.items()
+        if k not in ("__dict__", "__weakref__")
+    }
+    return type("Backend", (), body)
+
+
+class TestSeamIntegration:
+    def _armed(self, monkeypatch):
+        state = _state()
+        monkeypatch.setattr(seams_module, "cuda_graph_dump", state)
+        cls = _fresh_backend()
+        install_backend_seam(cls)
+        install_backend_seam(cls)  # idempotent
+        return state, cls
+
+    def test_capture_then_replay_writes_one_frame_per_buffer(self, monkeypatch):
+        state, Backend = self._armed(monkeypatch)
+        fake = _FakeDumper()
+        monkeypatch.setattr("sglang.srt.debug_utils.dumper.dumper", fake)
+        token = _ShapeToken(size=4)
+
+        backend = Backend()
+        with _pretend_stream_is_capturing(monkeypatch):
+            with backend.capture_session(stream=None) as session:
+                assert session == "session"
+                backend.capture_one(token, lambda: state.tap("a.b", torch.zeros(4, 2)))
+        # forward_fn ran twice; wrap_forward_fn reset the counter, so one buffer.
+        assert state.registry.num_buffers == 1
+
+        runner = SimpleNamespace(raw_num_token=2, raw_bs=2, bs=4)
+        with state.runner_scope(runner):
+            assert backend.replay(token, None) == "logits"
+        assert [name for name, _, _ in fake.frames] == ["a.b"]
+        tags = fake.frames[0][2]
+        assert tags["tap"] == "t1"
+        assert tags["graph_backend"] == "Backend"
+        assert tags["graph_size"] == 4
+        assert fake.frames[0][1].shape == (2, 2)
+
+    def test_capture_outside_a_session_records_nothing(self, monkeypatch):
+        state, Backend = self._armed(monkeypatch)
+        with _pretend_stream_is_capturing(monkeypatch):
+            # No capture_session open: the ladder must not reach the T1 rung.
+            Backend().capture_one(
+                _ShapeToken(size=4), lambda: state.tap("a.b", torch.zeros(4))
+            )
+        assert state.registry.num_buffers == 0
+
+    def test_cleanup_reports(self, monkeypatch):
+        state, Backend = self._armed(monkeypatch)
+        state._config = CudaGraphDumpConfig(enable=True, strict=True)
+        with pytest.raises(RuntimeError, match="no tap fired"):
+            Backend().cleanup()
+
+    def test_runner_seam_publishes_the_runner_and_resets_occurrences(self, monkeypatch):
+        state = _state()
+        monkeypatch.setattr(seams_module, "cuda_graph_dump", state)
+        seen = []
+
+        class Runner:
+            bs = 8
+
+            def execute(self, forward_batch):
+                seen.append(
+                    (
+                        state._runner_ctx.get("runner") is self,
+                        state._next_key("a").occurrence,
+                    )
+                )
+                return "out"
+
+        install_runner_seam(Runner)
+        runner = Runner()
+        batch = SimpleNamespace(forward_mode=SimpleNamespace(name="DECODE"))
+        assert runner.execute(batch) == "out"
+        assert runner.execute(batch) == "out"
+        # Published both times, and begin_forward() zeroed the counter each time.
+        assert seen == [(True, 0), (True, 0)]
+        # The scope closed: nothing leaks into the next eager forward.
+        assert state._runner_ctx == {}

--- a/test/registered/debug_utils/test_cuda_graph_dump.py
+++ b/test/registered/debug_utils/test_cuda_graph_dump.py
@@ -337,6 +337,18 @@ class TestTapLadder:
         assert state.registry.num_buffers == 0
 
 
+class TestEagerTags:
+    def test_disabled_adds_nothing(self):
+        # A default run's frames must be byte-for-byte what they always were.
+        assert _state(enable=False).eager_tags() == {}
+
+    def test_enabled_labels_the_eager_channel(self):
+        # Without this the acceptance gate cannot tell a declined frame from a
+        # pure-eager baseline frame, and "t1|t3 plus eager equals eager-only"
+        # is unverifiable.
+        assert _state().eager_tags() == {"tap": "eager"}
+
+
 class TestOccurrenceCounter:
     def test_repeated_names_get_distinct_occurrences(self):
         state = _state()


### PR DESCRIPTION
<!-- Title: [debug_utils] Dump module tensors under CUDA graph in the non-intrusive dumper -->
<!-- base: sgl-project/sglang:main  <-  compare: ShawnZL/sglang:feat/cuda-graph-tensor-dump-v2 -->

## Motivation

The non-intrusive dumper (`DUMPER_ENABLE=1 DUMPER_TARGET_MODULES=...`) registers
`nn.Module` forward hooks that call `dumper.dump(...)` inline. That works in eager mode.
Under CUDA graph it does not: a replay re-runs only the *recorded device kernels*, so the
Python hook body never executes again. **Every module that lives inside a captured region
silently stops producing frames** — nothing warns, no error is raised, the dump directory
is simply missing them. A user comparing a graph-mode run against a reference sees a
partial dump and no indication that it is partial.

The existing escape hatch makes the gap worse rather than better:
`--debug-tensor-dump-output-folder` force-disables CUDA graph
(`ServingArgs`/`CudaGraphArgs` hook). So today you can dump tensors, or you can reproduce
graph-mode numerics — never both. That is precisely the configuration where graph-specific
numeric bugs live: capture-time address baking, padding tails that survive from the
previous replay, piecewise recompilation boundaries.

This PR makes the **existing** `DUMPER_*` path produce correct data with graphs enabled,
for all three graph backends, without changing any model or kernel code and without adding
a single server arg.

## Modifications

### Idea: split "take the value" from "write the file"

* **take the value** — during capture the hook issues `buffer.copy_(tensor)`. That is a
  real device kernel, so it *is recorded*, with both `data_ptr()`s baked in. Every later
  `graph.replay()` re-runs the copy for free, leaving `buffer` holding *this* replay's
  value.
* **write the file** — after `replay()` returns, host-side code reads the buffers and
  calls `dumper.dump(...)` outside the graph, exactly as in eager mode.

Values therefore come from the capture side and metadata from the replay-side
`ForwardBatch`; they meet at one collect point per replay. The existing dump-file format,
`dump_loader`, and `dump_comparator` need zero changes — everything new is carried as tags.

### Three backends, three channels

| backend | channel |
|---|---|
| `full` | **T1**: the existing forward hook, whose `copy_` is recorded |
| `breakable` (BCG) | **T1** inside captured segments; modules inside `eager_on_graph` break bodies fall through to the ordinary eager writer, because capture is off there on *both* the capture and the replay side |
| `tc_piecewise` | **T3**: dynamo inlines `Module.__call__`, so the hook's `copy_` would be traced away and reaching the eager writer is a hard error under `fullgraph=True`. The hook instead emits one dynamo-opaque custom op (`sglang.dumper_tap`) that survives tracing as an FX node, is declared a split op so it becomes a piece boundary, and does the `copy_` from inside the piece's graph |
| `disabled` | unchanged eager path, byte-for-byte |

Which channel is live is decided by one predicate ladder in `state.tap()`, keyed on
`torch.compiler.is_compiling()` and `torch.cuda.is_current_stream_capturing()` — not on a
self-maintained flag. Warmup/compile-pass forwards carry dummy values and are swallowed
rather than written.

### New subpackage `python/sglang/srt/debug_utils/cuda_graph/` (~1.1k lines)

| file | lines | role |
|---|---|---|
| `registry.py` | 209 | Buffer registry. One graph-resident buffer per `(dump name, occurrence)`, allocated at the largest shape and reused across shapes (a prerequisite for BCG's graph dedup), with a device-memory budget guard and stable `data_ptr()`s |
| `state.py` | 423 | Process-global singleton: the tap dispatch ladder, the scopes, and the single `collect()` (read buffers → assemble meta → trim padding → `dumper.dump`) |
| `seams.py` | 241 | The two `__init_subclass__` seams (below) |
| `split_op.py` | 61 | T3: the `sglang.dumper_tap` custom op plus its tag interning |
| `config.py` | 100 | Projection of the five new `DumperConfig` fields into a value object, so the package is unit-testable without a live dumper |
| `__init__.py` | 69 | Package docstring documenting the three-backend/three-channel matrix, plus exports |

### Two `__init_subclass__` seams instead of per-file patches

Four facts are needed that only the graph machinery knows: when a backend is being
constructed, when a capture session is open, which shape is being captured, and when a
replay has just finished. None is reachable from a forward hook.

| seam | location | covers |
|---|---|---|
| A | `runner_backend/base_cuda_graph_backend.py` | all backends — `full` / `breakable` / `tc_piecewise`, the XPU and NPU ports, and every speculative path, since they all route through this ABC |
| B | `runner/base_cuda_graph_runner.py` | `DecodeCudaGraphRunner` / `PrefillCudaGraphRunner` and the speculative runners, which deliberately skip the parent `__init__` but do inherit the class |

Because `__init_subclass__` fires at *class-creation* time, a backend is armed the moment
it is **defined** — including out-of-tree and accelerator-port backends, with no
registration and no cooperation from the subclass. `seams._wrap` only touches
`cls.__dict__` and marks what it wraps, so an override-free subclass inherits its parent's
already-wrapped method: nothing is wrapped twice and `super()` chains stay intact.

### In-tree changes: 4 files, ~86 lines

| file | change |
|---|---|
| `debug_utils/dumper.py` | 5 new `DumperConfig` fields (all defaulted off) + route each dumped item through `cuda_graph_dump.tap()` in `_NonIntrusiveDumper._dump_value`; `False` means "nothing captured this" and the pre-existing eager `dump()` runs, now labelled `tap=eager` |
| `runner_backend/base_cuda_graph_backend.py` | `__init_subclass__` → seam A (11 lines) |
| `runner/base_cuda_graph_runner.py` | `__init_subclass__` → seam B (11 lines) |
| `runner_backend/tc_piecewise_cuda_graph_backend.py` | `build_compilation_config` declares `sglang.dumper_tap` a split op, via the public `add_split_op` — gated on the T3 tap being armed, so with the feature off the op is never even imported |

Not touched: any `models/*.py`, any `speculative/*worker*.py`, any concrete runner
subclass, `hook_manager.py`, `compilation/*` globals, and the `breakable_cuda_graph`
internals.

### Correctness details worth a reviewer's attention

* **Padding is trimmed.** A graph is captured at a padded shape and replayed with the tail
  rows still holding the previous replay's values, so trimming is mandatory. But a dump
  name may be token-major, request-major, per-expert, or scalar, so the axis cannot be
  assumed: both row bases the runners actually pad along are offered, trimming fires only
  on an exact dim-0 match, and `graph_size` is tagged on every frame so residual padding
  is visible rather than silently believed.
* **One graph, N steps.** `EAGLEDraftCudaGraphRunner` records `speculative_num_steps`
  steps into a single graph. Buffer identity is `(name, occurrence index within this
  forward)`, and the counters reset per `forward_fn()` invocation — not per `capture_one`,
  because `tc_piecewise` calls `forward_fn()` twice per `capture_one` (warm FX state, then
  capture). This removes the need to inject step counters into any worker file.
* **Fails loudly, never silently.** Zero taps with the feature on is reported (and raised
  under `DUMPER_CUDA_GRAPH_STRICT=1`), because "the filter matched no name" and "it worked"
  otherwise look identical from the dump directory. Frames dropped because a channel was
  deliberately disarmed are reported separately, so a narrowed run cannot be mistaken for
  a complete one.
* **Off by default and cheap when off.** With `DUMPER_CUDA_GRAPH_ENABLE` unset, `tap()`
  returns on its first rung, the seams are a few `getattr`s per capture/replay call, and no
  custom op is registered or injected.

### Usage

```bash
export DUMPER_ENABLE=1
export DUMPER_DIR=/tmp/dump_graph
export DUMPER_TARGET_MODULES=all              # or a module list
export DUMPER_CUDA_GRAPH_ENABLE=1             # arm the graph-aware channels
export DUMPER_CUDA_GRAPH_FILTER=model.layers.0,model.layers.1   # strongly recommended
export DUMPER_CUDA_GRAPH_BUDGET_MB=4096       # negative = unlimited
export DUMPER_CUDA_GRAPH_TAPS=t1              # t1 / t3 / all (default: all)
export DUMPER_CUDA_GRAPH_STRICT=1             # recommended in CI
```

`DUMPER_CUDA_GRAPH_FILTER` matters more than it looks: one device buffer is allocated per
`(name, occurrence)` and held for the process lifetime, because a recorded `copy_` bakes in
the address. `DUMPER_CUDA_GRAPH_TAPS=t1` is the way to avoid the `tc_piecewise` compile-time
cost when you do not need that backend — a runtime filter cannot reach it.

## Accuracy Tests

No model or kernel forward code is touched, and with `DUMPER_CUDA_GRAPH_ENABLE` unset the
new code paths return before doing anything, so serving output is unchanged by construction.

65 unit tests in 17 classes (`test/registered/debug_utils/test_cuda_graph_dump.py`, 708
lines), CPU-only, no GPU required:

* registry: buffer reuse across shapes, separate buffers per occurrence, stable addresses,
  budget rejection (warn) vs `strict` (raise), rejection of shape/dtype growth, filtered
  names costing no memory
* padding: both row bases, exact-match-only trimming, scalars and unpadded batches
* tap ladder: every rung — disabled, non-tensor, idle-eager, setup-swallow,
  capture-without-a-capturing-stream, disarmed channels swallowing instead of falling
  through, and disarming one channel not renumbering the other
* occurrence counters, including the two-`forward_fn`-calls-per-`capture_one` shape that
  `tc_piecewise` really has
* seams: `_wrap` idempotency and `__dict__`-locality, capture→replay writing one frame per
  buffer, capture outside a session recording nothing, the runner seam publishing the
  runner and resetting counters
* the fail-loud report: warn once, raise under strict, and never escape from `atexit`

End-to-end validation intended for this PR (numbers to be filled in on a GPU host):

1. **eager ↔ graph bitwise comparison** — same requests, once with graphs off and once with
   each backend; `dump_comparator` must report an identical frame set and bitwise-equal
   tensors.
2. **frame-set equality per backend** — the set of dumped names under
   `full` / `breakable` / `tc_piecewise` equals the set from the eager run. This is the
   claim the PR is making, expressed as an assertion rather than prose.
3. **break-body modules** — under `breakable`, modules inside `eager_on_graph` bodies must
   appear with `tap=eager`, on every replay, with contents that change between batches.
4. **speculative decoding** — `spec_step` completeness across `speculative_num_steps`, and
   `TARGET_VERIFY` frames tagged from `forward_batch.forward_mode` rather than inferred
   from which runner captured the graph.

## Speed Tests and Profiling

* Feature off (the default): no custom op registered, no split op injected, no buffers
  allocated; the seams add a handful of attribute reads per capture/replay call. Expected
  to be inside run-to-run noise — to be confirmed with a throughput A/B.
* Feature on, `t1` only (`full` / `breakable`): one extra device-to-device `copy_` per
  dumped tensor per replay, plus the host-side write that eager mode already pays.
* Feature on, `t3` (`tc_piecewise`): each injection point is an inductor fusion barrier and
  a piece boundary, both paid at compile time. Based on the equivalent mechanism in vLLM,
  expect compile time +~19% and throughput −~27% with unrestricted injection; narrowing via
  `DUMPER_CUDA_GRAPH_FILTER` reduces it roughly linearly in the number of injection points.
  This is documented as "not for performance-sensitive traffic", which is appropriate for a
  debugging tool.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34347573203](https://github.com/sgl-project/sglang/actions/runs/34347573203)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34347573283](https://github.com/sgl-project/sglang/actions/runs/34347573283)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34347572814](https://github.com/sgl-project/sglang/actions/runs/34347572814)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->