### PR TITLE
Fix DeepGEMM import for independently enabled MHC prenorm

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -286,6 +286,9 @@ def tf32_hc_prenorm_gemm(
 ):
     if x.shape[0] == 0:
         return
+    # HC prenorm has an independent gate and can run with JIT DeepGEMM disabled.
+    import deep_gemm
+
     deep_gemm.tf32_hc_prenorm_gemm(x, fn, out, sqrsum, num_splits=num_splits)
 
 

--- a/test/registered/unit/layers/test_deep_gemm_hc_prenorm_import.py
+++ b/test/registered/unit/layers/test_deep_gemm_hc_prenorm_import.py
@@ -1,0 +1,85 @@
+"""Exercise the real wrapper's imports without a CUDA or DeepGEMM installation."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SGLANG_ROOT = REPO_ROOT / "python" / "sglang"
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+register_cpu_ci = _load_module(
+    "ci_register", SGLANG_ROOT / "test" / "ci" / "ci_register.py"
+).register_cpu_ci
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDeepGemmHcPrenormImport(unittest.TestCase):
+    def setUp(self):
+        wrapper = "sglang.srt.layers.deep_gemm_wrapper"
+        configurer = types.ModuleType(f"{wrapper}.configurer")
+        for name in (
+            "ENABLE_JIT_DEEPGEMM",
+            "DEEPGEMM_BLACKWELL",
+            "DEEPGEMM_NEED_TMA_ALIGNED_SCALES",
+            "DEEPGEMM_SCALE_UE8M0",
+        ):
+            setattr(configurer, name, False)
+        package = types.ModuleType(wrapper)
+        package.compile_utils = types.ModuleType(f"{wrapper}.compile_utils")
+        environ = types.ModuleType("sglang.srt.environ")
+        environ.envs = mock.Mock()
+        environ.envs.SGLANG_DEEPGEMM_SANITY_CHECK.get.return_value = False
+        torch = types.ModuleType("torch")
+        torch.Tensor = object
+        self.modules = {
+            wrapper: package,
+            f"{wrapper}.configurer": configurer,
+            "sglang.srt.environ": environ,
+            "torch": torch,
+            "deep_gemm": None,
+        }
+        with mock.patch.dict(sys.modules, self.modules):
+            self.entrypoint = _load_module(
+                "hc_prenorm_entrypoint",
+                SGLANG_ROOT / "srt/layers/deep_gemm_wrapper/entrypoint.py",
+            )
+        self.assertFalse(self.entrypoint.ENABLE_JIT_DEEPGEMM)
+        self.assertNotIn("deep_gemm", vars(self.entrypoint))
+
+    def test_nonempty_input_imports_deep_gemm_when_jit_disabled(self):
+        kernel = mock.Mock()
+        deep_gemm = types.ModuleType("deep_gemm")
+        deep_gemm.tf32_hc_prenorm_gemm = kernel
+        x = types.SimpleNamespace(shape=(1, 4))
+        fn, out, sqrsum = object(), object(), object()
+        with mock.patch.dict(sys.modules, {"deep_gemm": deep_gemm}):
+            self.entrypoint.tf32_hc_prenorm_gemm(x, fn, out, sqrsum, 2)
+        kernel.assert_called_once_with(x, fn, out, sqrsum, num_splits=2)
+
+    def test_empty_input_does_not_require_deep_gemm(self):
+        with mock.patch.dict(sys.modules, {"deep_gemm": None}):
+            self.entrypoint.tf32_hc_prenorm_gemm(
+                types.SimpleNamespace(shape=(0, 4)), None, None, None, 1
+            )
+
+    def test_missing_dependency_reports_import_error(self):
+        with mock.patch.dict(sys.modules, {"deep_gemm": None}):
+            with self.assertRaises(ImportError):
+                self.entrypoint.tf32_hc_prenorm_gemm(
+                    types.SimpleNamespace(shape=(1, 4)), None, None, None, 1
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek V4 can reach `tf32_hc_prenorm_gemm` through `SGLANG_OPT_DEEPGEMM_HC_PRENORM` even when `SGLANG_ENABLE_JIT_DEEPGEMM=0`. In that configuration, the module-level import is skipped and nonempty inputs fail with `NameError: name 'deep_gemm' is not defined`, despite DeepGEMM being installed. This can also surface during MHC prewarming at model load time.

Fixes #29738. This uses the same local-import approach proposed in #29740 and adds CPU regression coverage against the current main branch.

## Modifications

Import `deep_gemm` inside `tf32_hc_prenorm_gemm`, after the existing empty-input return. The independently enabled HC-prenorm path now loads its own dependency instead of relying on the JIT gate's module-level import. Empty inputs still return without requiring DeepGEMM, and a missing dependency raises its actual import error.

Add three registered CPU tests that execute the real entrypoint module with the JIT gate disabled and stubbed external dependencies. They check kernel argument forwarding, the empty-input fast path, and missing-dependency error propagation. Before the fix, the two nonempty-input tests reproduce the NameError; after the fix, all three pass.

## Accuracy Tests

- `python3 test/registered/unit/layers/test_deep_gemm_hc_prenorm_import.py`: 3 passed.
- `uvx pre-commit run --files python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py test/registered/unit/layers/test_deep_gemm_hc_prenorm_import.py`: all applicable hooks passed, including CI registry validation.
- No CUDA kernel implementation or tensor arithmetic changed. GPU numerical accuracy and full-model startup were not tested for this patch.

## Speed Tests and Profiling

Not run. The change adds a function-local Python import (cached by Python after the first import); no measured throughput or latency claim is made.

## Checklist

- [x] Add unit tests according to the contribution guide.
- [x] Follow the SGLang code style guidance.
- [x] Format your code with pre-commit (all applicable hooks passed).
- [ ] Update documentation (no public API or configuration change).
- [ ] Provide accuracy and speed benchmark results (not run; scope described above).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34197052129](https://github.com/sgl-project/sglang/actions/runs/34197052129)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34197051961](https://github.com/sgl-project/sglang/actions/runs/34197051961)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34197051914](https://github.com/sgl-project/sglang/actions/runs/34197051914)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->