### PR TITLE
[Kimi-Linear] declare packed_modules_mapping and HF-faithful MoE prefixes so compressed-tensors ignore lists apply

### DIFF
--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -142,6 +142,9 @@ class KimiMoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                # Without a prefix the quant loader only sees "gate_up_proj" /
+                # "down_proj" and no `ignore` entry of a checkpoint can match.
+                prefix=add_prefix("shared_experts", prefix),
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -595,7 +598,11 @@ class KimiDecoderLayer(nn.Module):
                 config=config,
                 quant_config=quant_config,
                 layer_idx=layer_idx,
-                prefix=f"{prefix}.mlp",
+                # The checkpoint names this module `block_sparse_moe`; quantization
+                # configs (compressed-tensors `ignore`) match against this prefix.
+                # Weight loading is unaffected (names are remapped in load_weights),
+                # the dense layer 0 keeps the `mlp` prefix.
+                prefix=f"{prefix}.block_sparse_moe",
                 alt_stream=self.alt_stream,
             )
             self.mlp = self.block_sparse_moe
@@ -757,6 +764,13 @@ class KimiLinearModel(nn.Module):
 
 
 class KimiLinearForCausalLM(nn.Module):
+    # Lets compressed-tensors map a checkpoint's `ignore` list (HF names
+    # gate_proj/up_proj, q/k/v_proj) onto the fused modules SGLang builds.
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
     def __init__(
         self,
         config: KimiLinearConfig,


### PR DESCRIPTION
## Motivation

compressed-tensors checkpoints of `Kimi-Linear-48B-A3B-Instruct` that keep the attention projections and the shared experts in bf16 and quantize only the routed experts (e.g. `reinforce20001/Kimi-Linear-48B-A3B-Instruct-NVFP4`, `ignore` list with `gate_proj`/`up_proj`, `q/k/v_proj`, `block_sparse_moe.shared_experts.*`) currently fail to load:

```
KeyError: 'model.layers.0.mlp.gate_up_proj.weight'
KeyError: 'model.layers.1.block_sparse_moe.shared_experts.down_proj.weight'
```

Two causes in `python/sglang/srt/models/kimi_linear.py`:

1. `KimiLinearForCausalLM` declares no `packed_modules_mapping`, so `should_ignore_layer()` cannot map the fused `gate_up_proj` / `qkv_proj` back to the per-shard names in the `ignore` list and builds those layers quantized (`weight_packed` instead of `weight`).
2. `KimiMoE` is constructed with prefix `<layer>.mlp` while the checkpoint names the module `block_sparse_moe`, and its `shared_experts` `KimiMLP` gets no prefix at all — no `ignore` entry can ever match them.

Related: #25331 describes the same failure class (compressed-tensors NVFP4 module without `.weight`) for Kimi-K2.6 in `deepseek_v2.py`. This PR does not address that path.

## Modifications

- Declare `packed_modules_mapping` on `KimiLinearForCausalLM` (same mapping as `qwen3_moe.py`).
- Pass HF-faithful prefixes: `block_sparse_moe` for `KimiMoE`, `shared_experts` for its `KimiMLP`. Weight loading is unaffected (names are remapped in `load_weights`); the dense layer 0 keeps the `mlp` prefix.

One file, 15 insertions, 1 deletion.

## Accuracy Tests

Verified on an NVIDIA GB10 (sm_121) with SGLang 0.5.18: `reinforce20001/Kimi-Linear-48B-A3B-Instruct-NVFP4` now loads and serves (previously the two `KeyError`s above); the FP8-Dynamic sibling of the same quantizer (`…-FP8-Dynamic`, same `ignore` list) loads with and without this change and produces identical outputs at temperature 0. No forward code is touched.

## Speed Tests and Profiling

Not applicable — no runtime code path changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34198050915](https://github.com/sgl-project/sglang/actions/runs/34198050915)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34198050665](https://github.com/sgl-project/sglang/actions/runs/34198050665)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34198050876](https://github.com/sgl-project/sglang/actions/runs/34198050876)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->