### PR TITLE
[NPU] Integrate Kimi-K3 DSPARK, MXFP4 MoE and distributed inference support

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/cumsum.py
+++ b/python/sglang/kernels/ops/attention/fla/cumsum.py
@@ -10,6 +10,9 @@ import triton.language as tl
 
 from sglang.kernels.ops.attention.fla.index import prepare_chunk_indices
 from sglang.kernels.ops.attention.fla.utils import check_shared_mem, input_guard
+from sglang.srt.utils import is_npu
+
+_is_npu = is_npu()
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -70,16 +73,8 @@ def chunk_local_cumsum_scalar_kernel(
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BS": BS}, num_warps=num_warps)
-        for BS in BS_LIST
-        for num_warps in [2, 4, 8]
-    ],
-    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE", "HAS_SCALE"],
-)
 @triton.jit(do_not_specialize=["T"])
-def chunk_local_cumsum_vector_kernel(
+def _chunk_local_cumsum_vector_kernel(
     s,
     o,
     scale,
@@ -159,6 +154,16 @@ def chunk_local_cumsum_vector_kernel(
     tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
+chunk_local_cumsum_vector_kernel = triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in BS_LIST
+        for num_warps in [2, 4, 8]
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE", "HAS_SCALE"],
+)(_chunk_local_cumsum_vector_kernel)
+
+
 def chunk_local_cumsum_scalar(
     g: torch.Tensor,
     chunk_size: int,
@@ -226,13 +231,24 @@ def chunk_local_cumsum_vector(
 
     g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
 
-    def grid(meta):
-        return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+    if not _is_npu:
+        kernel = chunk_local_cumsum_vector_kernel
+
+        def grid(meta):
+            return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+
+        static_config = {}
+    else:
+        # Ascend's autotuner benchmarks every CUDA-oriented candidate during
+        # the first request. Use the stable A3 configuration directly.
+        kernel = _chunk_local_cumsum_vector_kernel
+        grid = (triton.cdiv(S, 64), NT, B * H)
+        static_config = {"BS": 64, "num_warps": 4, "num_stages": 3}
 
     # keep cumulative normalizer in fp32
     # this kernel is equivalent to
     # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
-    chunk_local_cumsum_vector_kernel[grid](
+    kernel[grid](
         s=g_org,
         o=g,
         scale=scale,
@@ -247,6 +263,7 @@ def chunk_local_cumsum_vector(
         REVERSE=reverse,
         HAS_SCALE=scale is not None,
         IS_VARLEN=cu_seqlens is not None,
+        **static_config,
     )
     return g
 

--- a/python/sglang/kernels/ops/attention/fla/kda.py
+++ b/python/sglang/kernels/ops/attention/fla/kda.py
@@ -30,6 +30,9 @@ from sglang.kernels.ops.attention.fla.utils import (
     is_intel,
     is_nvidia,
 )
+from sglang.srt.utils import is_npu
+
+_is_npu = is_npu()
 
 if is_intel:
     from sglang.srt.hardware_backend.xpu.kernels.fla.chunk_delta_h import (
@@ -211,17 +214,8 @@ def rms_norm_gated(
     return y if not prenorm else (y, residual_out.reshape(x_shape_og))
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64]
-        for num_warps in [1, 2, 4, 8]
-        for num_stages in [2, 3, 4]
-    ],
-    key=["BC", "IS_VARLEN"],
-)
 @triton.jit(do_not_specialize=["T"])
-def chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
+def _chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
     q,
     k,
     g,
@@ -325,12 +319,19 @@ def chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
     tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.autotune(
-    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
-    key=["BK", "BT", "IS_VARLEN"],
-)
+chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter = triton.autotune(
+    configs=[
+        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BC", "IS_VARLEN"],
+)(_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter)
+
+
 @triton.jit(do_not_specialize=["T"])
-def chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
+def _chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
     q,
     k,
     g,
@@ -421,6 +422,12 @@ def chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
         p_gk += H * K
 
 
+chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra = triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    key=["BK", "BT", "IS_VARLEN"],
+)(_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra)
+
+
 def chunk_kda_scaled_dot_kkt_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -472,8 +479,21 @@ def chunk_kda_scaled_dot_kkt_fwd(
     BK = max(next_power_of_2(K), 16)
     A = torch.zeros(B, T, H, BT, device=k.device, dtype=output_dtype)
     Aqk = torch.zeros(B, T, H, BT, device=k.device, dtype=output_dtype)
+    if not _is_npu:
+        inter_kernel = chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter
+        inter_config = {}
+        intra_kernel = chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra
+        intra_config = {}
+    else:
+        # Ascend's autotuner benchmarks CUDA-oriented candidates during the
+        # first request. Launch the stable A3 configurations directly.
+        inter_kernel = _chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter
+        inter_config = {"BK": 64, "num_warps": 4, "num_stages": 3}
+        intra_kernel = _chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra
+        intra_config = {"num_warps": 4, "num_stages": 3}
+
     grid = (NT, NC * NC, B * H)
-    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter[grid](
+    inter_kernel[grid](
         q=q,
         k=k,
         g=gk,
@@ -491,10 +511,11 @@ def chunk_kda_scaled_dot_kkt_fwd(
         BC=BC,
         NC=NC,
         IS_VARLEN=cu_seqlens is not None,
+        **inter_config,
     )
 
     grid = (NT, NC, B * H)
-    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra[grid](
+    intra_kernel[grid](
         q=q,
         k=k,
         g=gk,
@@ -512,6 +533,7 @@ def chunk_kda_scaled_dot_kkt_fwd(
         BC=BC,
         BK=BK,
         IS_VARLEN=cu_seqlens is not None,
+        **intra_config,
     )
     return A, Aqk
 

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -8,15 +8,22 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.ops.speculative.dspark.dispatch import inputs_on_cuda
-from sglang.kernels.ops.speculative.reject_sampling import (
-    chain_speculative_sampling_triton,
-)
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import (
     _get_or_create_chain_verify_buffers,
     build_dflash_verify_target_probs,
     compute_dflash_correct_drafts_and_bonus,
 )
+from sglang.srt.utils import is_npu
+
+_is_npu = is_npu()
+
+if _is_npu:
+    from sgl_kernel_npu.sample import chain_speculative_sampling_triton
+else:
+    from sglang.kernels.ops.speculative.reject_sampling import (
+        chain_speculative_sampling_triton,
+    )
 
 
 class AcceptSampling:
@@ -117,7 +124,12 @@ def _accept_sampling_core(
         draft_token_num=verify_num_draft_tokens,
         device=device,
     )
-    uniform_samples = torch.rand((bs, gamma), dtype=torch.float32, device=device)
+    # The NPU implementation uses the candidate width as its row stride.  The
+    # last value is intentionally unused because candidate slot 0 is the root.
+    uniform_width = candidates.shape[1] if _is_npu else gamma
+    uniform_samples = torch.rand(
+        (bs, uniform_width), dtype=torch.float32, device=device
+    )
     uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
     chain_speculative_sampling_triton(
         predicts=predicts,

--- a/python/sglang/srt/arg_groups/fields/disagg.py
+++ b/python/sglang/srt/arg_groups/fields/disagg.py
@@ -79,7 +79,7 @@ class Disagg:
     ] = None
     disaggregation_decode_enable_radix_cache: A[
         bool,
-        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse, speculative decoding, and --disaggregation-transfer-backend fake.",
+        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Speculative decoding is supported only for Kimi-K3 with DSPARK. Incompatible with --enable-hisparse and --disaggregation-transfer-backend fake.",
     ] = False
     disaggregation_decode_enable_offload_kvcache: A[
         bool, "Enable async KV cache offloading on decode server (PD mode)."

--- a/python/sglang/srt/arg_groups/fields/parallel.py
+++ b/python/sglang/srt/arg_groups/fields/parallel.py
@@ -207,6 +207,12 @@ class Parallel:
         bool,
         "Shard shared expert weights across the attention TP group when using an expert-parallel all-to-all backend.",
     ] = False
+    shared_experts_tp_size: A[
+        Optional[int],
+        "Shared-expert TP size for Kimi-K3 with an expert-parallel all-to-all "
+        "backend. Must divide attention TP size. Overrides "
+        "--enable-shared-experts-attn-tp when set; 1 replicates the weights.",
+    ] = None
     enable_dense_mlp_attn_tp: A[
         bool,
         "Shard dense MLP weights across the attention TP group under DP attention.",

--- a/python/sglang/srt/arg_groups/kimi_k3_hook.py
+++ b/python/sglang/srt/arg_groups/kimi_k3_hook.py
@@ -22,10 +22,14 @@ def apply_kimi_k3_spec_backend_defaults(server_args: ServerArgs) -> None:
     if cfg.speculative_algorithm is None:
         return
 
-    # Use the fused Kimi-K3/DSPARK CuTeDSL kernel for KDA target verification.
+    # Use the fused Kimi-K3/DSPARK CuTeDSL kernel for KDA target verification
+    # only on CUDA. Ascend/NPU uses its existing verify implementation; the
+    # CUDA-only backend otherwise gets selected before the NPU workers start.
     # Decode is left free (its bf16-ssm SM100+ flashinfer default is fine -- the
-    # target only verifies under spec); the verify backend is pinned directly.
-    if cfg.linear_attn_verify_backend is None:
+    # target only verifies under spec); the CUDA verify backend is pinned
+    # directly. Use the requested runtime device instead of probing torch.cuda:
+    # torch_npu may redirect torch.cuda APIs and initialize device state early.
+    if cfg.linear_attn_verify_backend is None and cfg.device == "cuda":
         declare_resolution(
             server_args,
             "apply_kimi_k3_spec_backend_defaults",

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -114,6 +114,46 @@ def handle_context_parallelism(server_args: Any):
     )
 
 
+def handle_shared_experts_tp(server_args: Any):
+    cfg = resolving_view(server_args)
+    size = cfg.shared_experts_tp_size
+    if size is None:
+        return
+
+    from sglang.srt.runtime_context import derive_attention_widths
+
+    view = resolved_view(server_args)
+    _, attn_tp_size = derive_attention_widths(
+        tp_size=cfg.tp_size,
+        attn_cp_size=view.attn_cp_size,
+        dp_size=cfg.dp_size,
+        enable_dp_attention=view.enable_dp_attention,
+    )
+    if size < 1 or attn_tp_size % size != 0:
+        raise ValueError(
+            f"--shared-experts-tp-size ({size}) must be a positive divisor "
+            f"of attention TP size ({attn_tp_size})."
+        )
+    if parse_connector_type(cfg.model_path) == ConnectorType.INSTANCE:
+        raise ValueError(
+            "--shared-experts-tp-size requires a Kimi-K3 model configuration."
+        )
+    model_arch = model_config_of(server_args).hf_config.architectures[0]
+    if model_arch != "KimiK3ForConditionalGeneration":
+        raise ValueError("--shared-experts-tp-size is only supported for Kimi-K3.")
+    if cfg.moe_a2a_backend not in (
+        "deepep",
+        "megamoe",
+        "mooncake",
+        "ascend_fuseep",
+        "mori",
+    ):
+        raise ValueError(
+            "--shared-experts-tp-size requires an expert-parallel all-to-all "
+            "backend (deepep, megamoe, mooncake, ascend_fuseep or mori)."
+        )
+
+
 def handle_dcp_validation(server_args: Any):
     cfg = resolving_view(server_args)
     if cfg.dcp_size < 1:

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -86,11 +86,21 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
                     "--disaggregation-decode-enable-radix-cache is incompatible "
                     "with --disaggregation-transfer-backend fake"
                 )
-            if cfg.speculative_algorithm is not None:
+            if (
+                cfg.speculative_algorithm is not None
+                and cfg.speculative_algorithm != "DSPARK"
+            ):
                 raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache is incompatible "
-                    "with speculative decoding "
-                    f"(--speculative-algorithm {cfg.speculative_algorithm})"
+                    "--disaggregation-decode-enable-radix-cache supports "
+                    "speculative decoding only with --speculative-algorithm "
+                    "DSPARK; got "
+                    f"{cfg.speculative_algorithm!r}."
+                )
+            if cfg.speculative_algorithm == "DSPARK":
+                logger.warning(
+                    "EXPERIMENTAL: PD decode radix cache with DSPARK requires "
+                    "Kimi-K3; the model-specific memory-pool validation runs "
+                    "after model loading."
                 )
 
             if resolved_view(server_args).enable_dp_attention:

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -168,6 +168,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_elastic_ep,
         handle_eplb_and_dispatch,
         handle_expert_distribution_metrics,
+        handle_shared_experts_tp,
     )
 
     validate_prefill_only_disable_kv_cache_args(server_args)
@@ -308,6 +309,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
 
     handle_moe_kernel_config(server_args)
     handle_a2a_moe(server_args)
+    handle_shared_experts_tp(server_args)
     handle_eplb_and_dispatch(server_args)
     handle_expert_distribution_metrics(server_args)
     handle_elastic_ep(server_args)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -406,6 +406,24 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 "(e.g. GQA, MHA). MLA models should not set this flag."
             )
         self.kv_manager = self._init_kv_manager()
+        if (
+            get_disagg().disaggregation_decode_enable_radix_cache
+            and self.scheduler.spec_algorithm.is_dspark()
+        ):
+            if self.tree_cache.supports_mamba():
+                raise RuntimeError(
+                    "Kimi-K3 DSPARK PD decode radix cache must not index "
+                    "Mamba/KDA checkpoints; prefill's prompt-end state is "
+                    "authoritative."
+                )
+            if (
+                hasattr(self.req_to_token_pool, "mamba_allocator")
+                and StateType.MAMBA not in self.kv_manager.kv_args.state_types
+            ):
+                raise RuntimeError(
+                    "Kimi-K3 DSPARK PD decode radix cache requires the PD "
+                    "connector to register the Mamba/KDA/conv state channel."
+                )
         if self.enable_staging:
             self.transfer_queue._init_staging_handler(self.kv_manager)
 
@@ -2159,6 +2177,17 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             return
 
         self._commit_hicache_local_restore_to_req(decode_req)
+
+        # In the Kimi-K3 decode-radix layout the tree owns only per-token
+        # MLA/draft KV. The final PD transfer overwrites the request's freshly
+        # allocated recurrent slot with the prompt-end KDA/conv state, so it is
+        # initialized even when the MLA prefix was a full local hit.
+        if (
+            get_disagg().disaggregation_decode_enable_radix_cache
+            and self.spec_algorithm.is_dspark()
+            and decode_req.req.kv.holds_mamba
+        ):
+            decode_req.req.kv.mamba_needs_clear = False
 
         # Case 3: Success - commit the transfer
         # PD true-retraction rebootstrap: the prefill recomputed the prefix KV

--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -291,6 +291,7 @@ def _init_parallel_groups(
         attention_context_model_parallel_size=attn_cp_size,
         moe_data_model_parallel_size=moe_dp_size,
         decode_context_parallel_size=dcp_size,
+        shared_experts_tensor_parallel_size=get_parallel().shared_experts_tp_size,
         duplicate_tp_group=get_disagg().enable_pdmux,
         enable_symm_mem=get_exec().comm.enable_symm_mem,
         recovered_rank=is_ep_joiner,

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1937,6 +1937,7 @@ def init_model_parallel_group(
 
 _TP: Optional[GroupCoordinator] = None
 _ATTN_TP: Optional[GroupCoordinator] = None
+_SHARED_EXPERTS_TP: Optional[GroupCoordinator] = None
 _ATTN_CP: Optional[GroupCoordinator] = None
 _DCP: Optional[GroupCoordinator] = None
 
@@ -1966,6 +1967,13 @@ def get_attn_tp_group() -> GroupCoordinator:
         "attention tensor model parallel group is not initialized"
     )
     return _ATTN_TP
+
+
+def get_shared_experts_tp_group() -> GroupCoordinator:
+    assert _SHARED_EXPERTS_TP is not None, (
+        "shared-expert tensor model parallel group is not initialized"
+    )
+    return _SHARED_EXPERTS_TP
 
 
 def get_attn_cp_group() -> GroupCoordinator:
@@ -2058,7 +2066,7 @@ def graph_capture(stream=None):
     ):
         with contextlib.ExitStack() as stack:
             seen = {id(_TP), id(_PP)}
-            for group in (_DCP, _ATTN_TP, _MOE_EP, _MOE_TP):
+            for group in (_DCP, _ATTN_TP, _SHARED_EXPERTS_TP, _MOE_EP, _MOE_TP):
                 if group is not None and id(group) not in seen:
                     seen.add(id(group))
                     stack.enter_context(group.graph_capture(context))
@@ -2309,6 +2317,7 @@ def initialize_model_parallel(
     recovered_rank: bool = False,
     rank_offset: int = 0,
     max_world_size: Optional[int] = None,
+    shared_experts_tensor_parallel_size: Optional[int] = None,
 ) -> None:
     """
     Initialize model parallel groups.
@@ -2331,6 +2340,8 @@ def initialize_model_parallel(
             tensor-parallel group during decoding. Must be a divisor of
             tensor_model_parallel_size and is currently only supported on the
             AMD HIP platform.
+        shared_experts_tensor_parallel_size: optional shared-expert TP width.
+            Must divide attention TP; subgroups never cross attention replicas.
 
     Let's say we have a total of 8 GPUs denoted by g0 ... g7 and we
     use 2 GPUs to parallelize the model tensor, and 4 GPUs to parallelize
@@ -2396,6 +2407,21 @@ def initialize_model_parallel(
             f"tensor_model_parallel_size ({tensor_model_parallel_size}) must be divisible by "
             f"decode_context_parallel_size ({decode_context_parallel_size})"
         )
+
+    if shared_experts_tensor_parallel_size is not None:
+        attn_width = (
+            tensor_model_parallel_size
+            // attention_data_parallel_size
+            // attention_context_model_parallel_size
+        )
+        if (
+            shared_experts_tensor_parallel_size < 1
+            or attn_width % shared_experts_tensor_parallel_size != 0
+        ):
+            raise ValueError(
+                "Shared-expert TP size must be a positive divisor of "
+                f"attention TP size ({attn_width})."
+            )
 
     # Build the tensor model-parallel groups.
     num_tensor_model_parallel_groups: int = world_size // tensor_model_parallel_size
@@ -2550,6 +2576,34 @@ def initialize_model_parallel(
             rank_offset=rank_offset,
             max_world_size=max_world_size,
         )
+
+    global _SHARED_EXPERTS_TP
+    assert _SHARED_EXPERTS_TP is None, "shared-expert TP group already initialized"
+    if (
+        shared_experts_tensor_parallel_size is not None
+        and shared_experts_tensor_parallel_size > 1
+    ):
+        if shared_experts_tensor_parallel_size == attn_tp_size:
+            _SHARED_EXPERTS_TP = _ATTN_TP
+        else:
+            # Attention TP groups are contiguous, and the requested width
+            # divides each one. These groups also stay inside their PP stage.
+            shared_size = shared_experts_tensor_parallel_size
+            shared_group_ranks = [
+                list(range(start, start + shared_size))
+                for start in range(0, world_size, shared_size)
+            ]
+            _SHARED_EXPERTS_TP = init_model_parallel_group(
+                shared_group_ranks,
+                get_world_group().local_rank,
+                backend,
+                use_custom_allreduce=False,
+                use_torch_symm_mem_allreduce=False,
+                group_name="shared_experts_tp",
+                recovered_rank=recovered_rank,
+                rank_offset=rank_offset,
+                max_world_size=max_world_size,
+            )
 
     moe_ep_size = expert_model_parallel_size
     moe_dp_size = moe_data_model_parallel_size
@@ -2934,7 +2988,17 @@ def destroy_model_parallel():
         dwdp_mgr.cleanup()
         set_global_dwdp_manager(None)
 
+    global _SHARED_EXPERTS_TP
+    global _ATTN_TP
     global _TP
+    if (
+        _SHARED_EXPERTS_TP is not None
+        and _SHARED_EXPERTS_TP is not _ATTN_TP
+        and _SHARED_EXPERTS_TP is not _TP
+    ):
+        _SHARED_EXPERTS_TP.destroy()
+    _SHARED_EXPERTS_TP = None
+
     if _TP:
         _TP.destroy()
     _TP = None
@@ -2970,7 +3034,6 @@ def destroy_model_parallel():
         _ATTN_CP.destroy()
     _ATTN_CP = None
 
-    global _ATTN_TP
     if _ATTN_TP:
         _ATTN_TP.destroy()
     _ATTN_TP = None

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -923,6 +923,9 @@ class Envs:
     # ===================================================================
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
+    # Kimi-K3 attention-TP shared experts: overlap AG / MLP / RS with the
+    # routed front / DeepEP dispatch / routed GEMMs, respectively.
+    SGLANG_NPU_FINE_GRAINED_MOE_DUAL_STREAM = EnvBool(False)
     SGLANG_NPU_USE_MLAPO = EnvBool(False)
     SGLANG_NPU_ENABLE_SPARSE_KV_OFFLOAD = EnvBool(False)
     # Fuse grouped Kimi-K3 SiTU with valid-row MXFP8 quantization before GMM2.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -925,6 +925,9 @@ class Envs:
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
     SGLANG_NPU_USE_MLAPO = EnvBool(False)
     SGLANG_NPU_ENABLE_SPARSE_KV_OFFLOAD = EnvBool(False)
+    # Fuse grouped Kimi-K3 SiTU with valid-row MXFP8 quantization before GMM2.
+    # Set to 0 to restore the separate SiTU + npu_dynamic_mx_quant path.
+    SGLANG_NPU_MOE_SITU_MXFP8_FUSED = EnvBool(True)
     # Forward native implementation for activation gelu tanh for model Skywork-Reward-Gemma-2-27B-v0.2
     SGLANG_NPU_FORWARD_NATIVE_GELUTANH = EnvBool(False)
     # Forward native implementation for gemma rms norm for model Skywork-Reward-Gemma-2-27B-v0.2

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -936,6 +936,9 @@ class Envs:
     SGLANG_USE_AG_AFTER_QLORA = EnvBool(False)
     # Enable int4x2 weights loading
     SGLANG_NPU_W4A4_NEW_PACKING = EnvBool(False)
+    # Use FIAS V2 for DSpark MLA target verify and MHA draft paths. Graph
+    # replay requires torch_npu's V2 handler to update actual_seq_kvlen.
+    SGLANG_NPU_USE_FIAS_V2_BSND = EnvBool(False)
     # Use the graph-safe Triton-Ascend kernel for masked speculative KV commits.
     SGLANG_NPU_USE_TRITON_PREFIX_KV_CACHE_STORE = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_NPU_USE_TRITON_KV_CACHE_STORE"

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -39,6 +39,7 @@ import torch
 import torch.distributed
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import get_is_extend_in_batch
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.observability.metrics_collector import (
     STAT_LOGGER_ROLE_EXPERT_DISPATCH,
@@ -348,6 +349,12 @@ class _SinglePassGatherer(ABC):
                     rank,
                     elastic_ep_enabled=get_exec().moe.elastic_ep_backend is not None,
                 )
+            elif get_exec().moe.deepep_mode == "auto":
+                return _DeepepAutoSinglePassGatherer(
+                    expert_location_metadata,
+                    rank,
+                    elastic_ep_enabled=get_exec().moe.elastic_ep_backend is not None,
+                )
             else:
                 raise NotImplementedError
 
@@ -609,6 +616,48 @@ class _DeepepLowLatencySinglePassGatherer(_LayerBasedGpuSinglePassGatherer):
                     (0, n - local_physical_count_of_layer.shape[0]),
                 )
         self._data[layer_idx, :] += local_physical_count_of_layer
+
+
+class _DeepepAutoSinglePassGatherer(_SinglePassGatherer):
+    """Use the gatherer matching DeepEP AUTO's per-forward dispatch mode."""
+
+    def __init__(
+        self,
+        expert_location_metadata: ExpertLocationMetadata,
+        rank: int,
+        elastic_ep_enabled: bool = False,
+    ):
+        super().__init__(expert_location_metadata, rank)
+        self._normal = _SelectExpertsSinglePassGatherer(expert_location_metadata, rank)
+        self._low_latency = _DeepepLowLatencySinglePassGatherer(
+            expert_location_metadata,
+            rank,
+            elastic_ep_enabled=elastic_ep_enabled,
+        )
+
+    def on_select_experts(self, layer_idx: int, topk_ids: torch.Tensor):
+        # DeepEP AUTO resolves extend/prefill to NORMAL and decode to
+        # LOW_LATENCY using this same forward-local flag. For NORMAL, count
+        # the mapped physical TopK ids. For LOW_LATENCY, wait for the dispatch
+        # hook so padding/filtering is reflected by the actual receive counts.
+        if get_is_extend_in_batch():
+            self._normal.on_select_experts(layer_idx, topk_ids)
+
+    def on_deepep_dispatch_low_latency(
+        self, layer_idx: int, local_physical_count_of_layer: torch.Tensor
+    ):
+        self._low_latency.on_deepep_dispatch_low_latency(
+            layer_idx, local_physical_count_of_layer
+        )
+
+    def reset(self):
+        self._normal.reset()
+        self._low_latency.reset()
+
+    def collect(self) -> Dict:
+        normal_count = self._normal.collect()["global_physical_count"]
+        low_latency_count = self._low_latency.collect()["global_physical_count"]
+        return dict(global_physical_count=normal_count + low_latency_count)
 
 
 def _convert_per_token_to_global_physical_count(

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -12,6 +12,7 @@ from sgl_kernel_npu.attention.sinks_attention import (
 
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.ascend_torch_native_backend import (
     AscendTorchNativeAttnBackend,
 )
@@ -370,6 +371,10 @@ class AscendAttnBackend(AttentionBackend):
                 self.sparse_kv_manager,
             )
         self.use_fia = get_bool_env_var("ASCEND_USE_FIA", "False")
+        self.use_fias_v2_bsnd = (
+            envs.SGLANG_NPU_USE_FIAS_V2_BSND.get()
+            and model_runner.spec_algorithm.is_dspark()
+        )
         self.enable_torch_compile = get_flags().capture.enable_torch_compile
         self.speculative_num_draft_tokens = get_spec().speculative_num_draft_tokens
         if (
@@ -474,22 +479,23 @@ class AscendAttnBackend(AttentionBackend):
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
         self.forward_metadata = ForwardMetadata()
-        seq_lens_max = forward_batch.seq_lens.max()
+        # Empty attention-DP ranks still participate in the target forward.
+        seq_lens_max = forward_batch.seq_lens.max() if forward_batch.batch_size else 0
         if forward_batch.forward_mode.is_target_verify():
             spec_tokens_per_req = int(forward_batch.spec_info.draft_token_num)
             # Overlap scheduling can publish the CPU sequence length one step
             # ahead of the device tensor. FIA consumes seq_lens_cpu below, so
             # derive the block-table width from the same source. Otherwise a
             # page-aligned request can expose KV_S=N while asking FIA for N+1.
-            seq_lens_max = forward_batch.seq_lens_cpu.max().item() + spec_tokens_per_req
+            if forward_batch.batch_size:
+                seq_lens_max = (
+                    forward_batch.seq_lens_cpu.max().item() + spec_tokens_per_req
+                )
         elif (
             forward_batch.forward_mode.is_decode_or_idle()
             and forward_batch.spec_info is not None
         ):
-            seq_lens_max = forward_batch.seq_lens.max()
             seq_lens_max += self.speculative_step_id + 1
-        else:
-            seq_lens_max = forward_batch.seq_lens.max()
         self.forward_metadata.block_tables = (
             self.req_to_token_pool.req_to_token[
                 forward_batch.req_pool_indices, :seq_lens_max
@@ -1728,176 +1734,66 @@ class AscendAttnBackend(AttentionBackend):
             # This branch adds support for prefix cache for GLM-4.7-Flash.
             # When using the MLA architecture, if qk head dim equals v head dim and the head count is not a power of 2,
             # we use the FIA kernel for computation.
-            if layer.qk_head_dim == layer.v_head_dim:
-                q = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+            q = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
 
-                k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-                v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
-                kv_cached = torch.index_select(
-                    k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
-                )
-                k_rope_cached = torch.index_select(
-                    v_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
-                ).flatten(0, 1)
+            k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+            v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+            kv_cached = torch.index_select(
+                k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
+            )
+            k_rope_cached = torch.index_select(
+                v_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
+            ).flatten(0, 1)
 
-                assert layer.kv_b_proj is not None
-                kv = layer.kv_b_proj(kv_cached)[0].view(
-                    -1, layer.tp_k_head_num, self.qk_nope_head_dim + layer.v_head_dim
-                )
-                k_nope, v_pre = kv.split(
-                    [self.qk_nope_head_dim, layer.v_head_dim], dim=-1
-                )
+            assert layer.kv_b_proj is not None
+            kv = layer.kv_b_proj(kv_cached)[0].view(
+                -1, layer.tp_k_head_num, self.qk_nope_head_dim + layer.v_head_dim
+            )
+            k_nope, v_pre = kv.split([self.qk_nope_head_dim, layer.v_head_dim], dim=-1)
 
-                k_rope = k_rope_cached.expand(-1, layer.tp_k_head_num, -1)
-                k_pre = torch.cat([k_nope, k_rope], dim=-1)
+            k_rope = k_rope_cached.expand(-1, layer.tp_k_head_num, -1)
+            k_pre = torch.cat([k_nope, k_rope], dim=-1)
 
-                attn_output = torch.empty(
-                    (q.size(0), layer.tp_q_head_num, layer.v_head_dim),
-                    device=q.device,
-                    dtype=q.dtype,
-                )
-                q_len_offset = 0
-                prefix_len_offset = 0
-                for q_len, prefix_len in zip(
-                    self.forward_metadata.extend_seq_lens_cpu_int,
-                    self.forward_metadata.prefix_lens,
-                ):
-                    k_cur_slice = k[None, q_len_offset : q_len_offset + q_len]
-                    v_cur_slice = v[None, q_len_offset : q_len_offset + q_len]
-                    k_pre_slice = k_pre[
-                        None, prefix_len_offset : prefix_len_offset + prefix_len
-                    ]
-                    v_pre_slice = v_pre[
-                        None, prefix_len_offset : prefix_len_offset + prefix_len
-                    ]
-
-                    k_full = torch.cat([k_pre_slice, k_cur_slice], dim=1)
-                    v_full = torch.cat([v_pre_slice, v_cur_slice], dim=1)
-
-                    attn_output[q_len_offset : q_len_offset + q_len] = (
-                        torch.ops.npu.npu_fused_infer_attention_score(
-                            q[None, q_len_offset : q_len_offset + q_len],
-                            k_full,
-                            v_full,
-                            num_heads=layer.tp_q_head_num,
-                            num_key_value_heads=layer.tp_k_head_num,
-                            input_layout="BSND",  # todo, TND not supports q_heads!=k_heads
-                            atten_mask=self.fia_mask,
-                            sparse_mode=3,
-                            scale=layer.scaling,
-                            next_tokens=0,
-                        )[0]
-                    )
-                    q_len_offset += q_len
-                    prefix_len_offset += prefix_len
-                attn_output = attn_output.view(
-                    -1, layer.tp_q_head_num * layer.v_head_dim
-                )
-            else:
-                num_token_padding = q.shape[0]
-                q, k, v = [
-                    data[: forward_batch.global_num_token_non_padded_cpu]
-                    for data in [q, k, v]
+            attn_output = torch.empty(
+                (q.size(0), layer.tp_q_head_num, layer.v_head_dim),
+                device=q.device,
+                dtype=q.dtype,
+            )
+            q_len_offset = 0
+            prefix_len_offset = 0
+            for q_len, prefix_len in zip(
+                self.forward_metadata.extend_seq_lens_cpu_int,
+                self.forward_metadata.prefix_lens,
+            ):
+                k_cur_slice = k[None, q_len_offset : q_len_offset + q_len]
+                v_cur_slice = v[None, q_len_offset : q_len_offset + q_len]
+                k_pre_slice = k_pre[
+                    None, prefix_len_offset : prefix_len_offset + prefix_len
                 ]
-                q_nope, q_rope = q.split(
-                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                )
-                k_nope, k_rope = k.split(
-                    [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
-                )
+                v_pre_slice = v_pre[
+                    None, prefix_len_offset : prefix_len_offset + prefix_len
+                ]
 
-                # 1st, compute extend tokens to get attn_output and attn_lse
-                num_tokens = q_nope.size(0)
-                attn_output = torch.zeros(
-                    num_tokens,
-                    layer.tp_q_head_num,
-                    layer.v_head_dim,
-                    dtype=q_nope.dtype,
-                    device=q_nope.device,
-                )
-                attn_lse = torch.zeros(
-                    layer.tp_q_head_num,
-                    num_tokens,
-                    dtype=torch.float32,
-                    device=q_nope.device,
-                )
-                torch_npu.atb.npu_ring_mla(
-                    q_nope=q_nope,
-                    q_rope=q_rope,
-                    k_nope=k_nope,
-                    k_rope=k_rope,
-                    value=v,
-                    mask=self.ringmla_mask,
-                    seqlen=self.forward_metadata.extend_seq_lens_cpu_int,
-                    head_num=layer.tp_q_head_num,
-                    kv_head_num=layer.tp_k_head_num,
-                    pre_out=None,
-                    prev_lse=None,
-                    qk_scale=layer.scaling,
-                    kernel_type="kernel_type_high_precision",
-                    mask_type="mask_type_triu",
-                    calc_type="calc_type_first_ring",
-                    output=attn_output,
-                    softmax_lse=attn_lse,
-                )
+                k_full = torch.cat([k_pre_slice, k_cur_slice], dim=1)
+                v_full = torch.cat([v_pre_slice, v_cur_slice], dim=1)
 
-                # 2nd, load history kvcache(kv_a and k_pe) and calculate k_nope
-                k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-                v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
-                kv_cached = torch.index_select(
-                    k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
+                attn_output[q_len_offset : q_len_offset + q_len] = (
+                    torch.ops.npu.npu_fused_infer_attention_score(
+                        q[None, q_len_offset : q_len_offset + q_len],
+                        k_full,
+                        v_full,
+                        num_heads=layer.tp_q_head_num,
+                        num_key_value_heads=layer.tp_k_head_num,
+                        input_layout="BSND",  # todo, TND not supports q_heads!=k_heads
+                        atten_mask=self.fia_mask,
+                        sparse_mode=3,
+                        scale=layer.scaling,
+                        next_tokens=0,
+                    )[0]
                 )
-                k_rope_cached = torch.index_select(
-                    v_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
-                ).flatten(0, 1)
-
-                assert layer.kv_b_proj is not None
-                kv = layer.kv_b_proj(kv_cached)[0].view(
-                    -1, layer.tp_k_head_num, self.qk_nope_head_dim + layer.v_head_dim
-                )
-                k_nope, v = kv.split([self.qk_nope_head_dim, layer.v_head_dim], dim=-1)
-
-                # 3rd, compute history kv to attn_out
-                k_rope = k_rope_cached.expand(-1, layer.tp_k_head_num, -1)
-                seq_len = torch.stack(
-                    [
-                        self.forward_metadata.extend_seq_lens_cpu_int,
-                        self.forward_metadata.prefix_lens,
-                    ]
-                )
-                torch_npu.atb.npu_ring_mla(
-                    q_nope=q_nope,
-                    q_rope=q_rope,
-                    k_nope=k_nope,
-                    k_rope=k_rope,
-                    value=v,
-                    mask=self.ringmla_mask,
-                    seqlen=seq_len,
-                    head_num=layer.tp_q_head_num,
-                    kv_head_num=layer.tp_k_head_num,
-                    pre_out=attn_output,
-                    prev_lse=attn_lse,
-                    qk_scale=layer.scaling,
-                    kernel_type="kernel_type_high_precision",
-                    mask_type="no_mask",
-                    calc_type="calc_type_default",
-                    output=attn_output,
-                    softmax_lse=attn_lse,
-                )
-                attn_output = attn_output.reshape(
-                    [-1, layer.tp_q_head_num, layer.v_head_dim]
-                )
-                if num_token_padding != forward_batch.global_num_token_non_padded_cpu:
-                    attn_output = torch.cat(
-                        [
-                            attn_output,
-                            attn_output.new_zeros(
-                                num_token_padding - attn_output.shape[0],
-                                *attn_output.shape[1:],
-                            ),
-                        ],
-                        dim=0,
-                    )
+                q_len_offset += q_len
+                prefix_len_offset += prefix_len
+            attn_output = attn_output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
         else:
             if layer.qk_head_dim == layer.v_head_dim:
                 """FIA will support multi-bs in the later version of CANN"""
@@ -2154,7 +2050,7 @@ class AscendAttnBackend(AttentionBackend):
                 mask = self.mtp_mask
                 sparse_mode = 4 if is_swa_layer else 3
 
-            if self.is_hybrid_swa:
+            if self.is_hybrid_swa or self.use_fias_v2_bsnd:
                 attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
                     query,
                     k_cache,
@@ -2289,48 +2185,107 @@ class AscendAttnBackend(AttentionBackend):
                 q_nope = torch.cat([q_nope, nope_padding], dim=1).contiguous()
                 q_rope = torch.cat([q_rope, rope_padding], dim=1).contiguous()
 
-            workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                q_nope,
-                c_kv_cache,
-                c_kv_cache,
-                query_rope=q_rope,
-                key_rope=k_rope_cache,
-                num_heads=self.q_head_num_padding,
-                num_key_value_heads=layer.tp_k_head_num,
-                input_layout="TND",
-                scale=layer.scaling,
-                antiquant_mode=0,
-                antiquant_scale=None,
-                block_table=block_table,
-                block_size=self.page_size,
-                sparse_mode=3,
-                atten_mask=self.mtp_mask,
-                actual_seq_lengths=actual_seq_lengths,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-            )
-            attn_output = torch.empty_like(q_nope, dtype=q.dtype, device=q.device)
-            softmax_lse = torch.empty(1, dtype=q.dtype, device=q.device)
-            torch_npu.npu_fused_infer_attention_score.out(
-                q_nope,
-                c_kv_cache,
-                c_kv_cache,
-                query_rope=q_rope,
-                key_rope=k_rope_cache,
-                num_heads=self.q_head_num_padding,
-                num_key_value_heads=layer.tp_k_head_num,
-                input_layout="TND",
-                scale=layer.scaling,
-                antiquant_mode=0,
-                antiquant_scale=None,
-                block_table=block_table,
-                block_size=self.page_size,
-                sparse_mode=3,
-                atten_mask=self.mtp_mask,
-                actual_seq_lengths=actual_seq_lengths,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                workspace=workspace,
-                out=[attn_output, softmax_lse],
-            )
+            num_query_heads = q_nope.shape[1]
+            if self.use_fias_v2_bsnd:
+                # The existing paged MLA cache is [block, KV_N, page, D].
+                # V2 consumes it with BNSD queries; keep the cache unchanged.
+                batch_size = len(actual_seq_lengths_kv)
+                query_seq_len = self.speculative_num_draft_tokens
+                assert q_nope.shape[0] == batch_size * query_seq_len, (
+                    "FIAS V2 target verify requires one fixed draft block per request"
+                )
+                if batch_size == 0:
+                    attn_output = torch.empty_like(q_nope)
+                else:
+                    q_nope_bnsd = (
+                        q_nope.view(
+                            batch_size,
+                            query_seq_len,
+                            num_query_heads,
+                            self.kv_lora_rank,
+                        )
+                        .transpose(1, 2)
+                        .contiguous()
+                    )
+                    q_rope_bnsd = (
+                        q_rope.view(
+                            batch_size,
+                            query_seq_len,
+                            num_query_heads,
+                            self.qk_rope_head_dim,
+                        )
+                        .transpose(1, 2)
+                        .contiguous()
+                    )
+                    attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
+                        q_nope_bnsd,
+                        c_kv_cache,
+                        c_kv_cache,
+                        query_rope=q_rope_bnsd,
+                        key_rope=k_rope_cache,
+                        num_query_heads=num_query_heads,
+                        num_key_value_heads=layer.tp_k_head_num,
+                        input_layout="BNSD",
+                        softmax_scale=layer.scaling,
+                        block_table=block_table,
+                        block_size=self.page_size,
+                        sparse_mode=3,
+                        atten_mask=self.mtp_mask,
+                        actual_seq_qlen=[query_seq_len] * batch_size,
+                        actual_seq_kvlen=actual_seq_lengths_kv,
+                        pre_tokens=FULL_ATTENTION_WINDOW,
+                        next_tokens=0,
+                    )
+                    attn_output = (
+                        attn_output.transpose(1, 2)
+                        .contiguous()
+                        .reshape(-1, num_query_heads, self.kv_lora_rank)
+                    )
+            else:
+                workspace = (
+                    torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+                        q_nope,
+                        c_kv_cache,
+                        c_kv_cache,
+                        query_rope=q_rope,
+                        key_rope=k_rope_cache,
+                        num_heads=num_query_heads,
+                        num_key_value_heads=layer.tp_k_head_num,
+                        input_layout="TND",
+                        scale=layer.scaling,
+                        antiquant_mode=0,
+                        antiquant_scale=None,
+                        block_table=block_table,
+                        block_size=self.page_size,
+                        sparse_mode=3,
+                        atten_mask=self.mtp_mask,
+                        actual_seq_lengths=actual_seq_lengths,
+                        actual_seq_lengths_kv=actual_seq_lengths_kv,
+                    )
+                )
+                attn_output = torch.empty_like(q_nope, dtype=q.dtype, device=q.device)
+                softmax_lse = torch.empty(1, dtype=q.dtype, device=q.device)
+                torch_npu.npu_fused_infer_attention_score.out(
+                    q_nope,
+                    c_kv_cache,
+                    c_kv_cache,
+                    query_rope=q_rope,
+                    key_rope=k_rope_cache,
+                    num_heads=num_query_heads,
+                    num_key_value_heads=layer.tp_k_head_num,
+                    input_layout="TND",
+                    scale=layer.scaling,
+                    antiquant_mode=0,
+                    antiquant_scale=None,
+                    block_table=block_table,
+                    block_size=self.page_size,
+                    sparse_mode=3,
+                    atten_mask=self.mtp_mask,
+                    actual_seq_lengths=actual_seq_lengths,
+                    actual_seq_lengths_kv=actual_seq_lengths_kv,
+                    workspace=workspace,
+                    out=[attn_output, softmax_lse],
+                )
             attn_output = attn_output[:, : layer.tp_q_head_num, :]
             attn_output = attn_output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
             if (

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -16,6 +16,7 @@ from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.ascend_torch_native_backend import (
     AscendTorchNativeAttnBackend,
 )
+from sglang.srt.hardware_backend.npu.attention.mla_cache import gather_mla_cache_pages
 from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
     is_fia_nz,
     is_mla_preprocess_enabled,
@@ -1738,11 +1739,15 @@ class AscendAttnBackend(AttentionBackend):
 
             k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
             v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
-            kv_cached = torch.index_select(
-                k_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
+            kv_cached = gather_mla_cache_pages(
+                k_buffer,
+                self.forward_metadata.flatten_prefix_block_tables,
+                is_nz=is_fia_nz(),
             )
-            k_rope_cached = torch.index_select(
-                v_buffer, 0, self.forward_metadata.flatten_prefix_block_tables
+            k_rope_cached = gather_mla_cache_pages(
+                v_buffer,
+                self.forward_metadata.flatten_prefix_block_tables,
+                is_nz=is_fia_nz(),
             ).flatten(0, 1)
 
             assert layer.kv_b_proj is not None

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -458,7 +458,6 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             intermediate_states_buffer=intermediate_state,
             intermediate_state_indices=intermediate_indices,
             cache_steps=draft_token_num,
-            lower_bound=None,
             gates_are_preactivated=True,
         )
         if dense_token_indices is None:

--- a/python/sglang/srt/hardware_backend/npu/attention/mla_cache.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/mla_cache.py
@@ -1,0 +1,23 @@
+"""Read logical pages from the explicit PA-NZ storage of the NPU MLA cache."""
+
+import torch
+
+
+def gather_mla_cache_pages(
+    cache: torch.Tensor, block_ids: torch.Tensor, *, is_nz: bool
+) -> torch.Tensor:
+    """Return selected pages in logical [blocks, page_size, 1, head_dim] order.
+
+    NZ buffers retain that public shape, but their physical contents are
+    [blocks, head_dim // 16, page_size, 16]. Restore token-major order before
+    projecting cached latent vectors or concatenating their RoPE features.
+    """
+    pages = torch.index_select(cache, 0, block_ids)
+    if not is_nz:
+        return pages
+    page_size, head_dim = cache.shape[1], cache.shape[-1]
+    return (
+        pages.view(block_ids.numel(), head_dim // 16, page_size, 16)
+        .permute(0, 2, 1, 3)
+        .reshape(block_ids.numel(), page_size, 1, head_dim)
+    )

--- a/python/sglang/srt/hardware_backend/npu/attention/mla_preprocess.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/mla_preprocess.py
@@ -23,12 +23,14 @@ def is_mla_preprocess_enabled() -> bool:
 
 @lru_cache(maxsize=1)
 def is_fia_nz() -> bool:
-    is_fia_nz_ = get_bool_env_var("SGLANG_USE_FIA_NZ")
-    if is_fia_nz_:
-        assert is_mla_preprocess_enabled(), (
-            "SGLANG_USE_FIA_NZ must be enable with SGLANG_NPU_USE_MLAPO"
-        )
-    return is_fia_nz_
+    """Whether MLA KV cache uses the FIA NZ physical layout.
+
+    This is a cache-layout choice, not an MLAPO-only optimization. MLAPO can
+    write NZ cache directly, while the ordinary MLA path writes the same
+    layout through ``NPUMLATokenToKVPool``. Keeping the switch independent
+    lets models such as Kimi-K3 use FIA NZ without selecting MLAPO.
+    """
+    return get_bool_env_var("SGLANG_USE_FIA_NZ")
 
 
 def round_up(val: int, align: int) -> int:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_cudagraph_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_cudagraph_backend.py
@@ -12,7 +12,7 @@ non-NPU hosts.
 
 from __future__ import annotations
 
-import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
@@ -62,6 +62,13 @@ class NPUCudaGraphBackend(BaseCudaGraphBackend):
         )
         self._enable_torch_compile = getattr(
             cuda_graph_runner, "enable_torch_compile", False
+        )
+        # Reuse one device-bound worker for graph input updates.
+        self._update_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="npu-graph-update",
+            initializer=self._device_module.set_device,
+            initargs=(self._device_id,),
         )
 
     @contextmanager
@@ -150,8 +157,10 @@ class NPUCudaGraphBackend(BaseCudaGraphBackend):
         attr_type: Any = None,
         cpu_update_input: list = None,
     ) -> Any:
-        """Rebind seq_lens on the recorded NPU graph in a background
-        thread, then replay. Used when the model is not deepseek-nsa.
+        """Rebind seq_lens on the recorded NPU graph, then replay.
+
+        NPUGraph.update must complete before replay can consume the updated
+        KV lengths. Used when the model is not deepseek-nsa.
 
         Two calling conventions:
         1. (legacy) seq_lens + attr_name + attr_type:
@@ -166,17 +175,15 @@ class NPUCudaGraphBackend(BaseCudaGraphBackend):
 
         graph = self._graphs[shape_key]
 
-        def _update():
-            self._device_module.set_device(self._device_id)
-            graph.update(cpu_update_input=cpu_update_input)
-
-        thread = threading.Thread(target=_update)
-        thread.start()
+        update_future = self._update_executor.submit(
+            graph.update, cpu_update_input=cpu_update_input
+        )
+        update_future.result()
         graph.replay()
-        thread.join()
         return self._outputs[shape_key]
 
     def cleanup(self) -> None:
+        self._update_executor.shutdown(wait=True, cancel_futures=True)
         self._graphs.clear()
         self._outputs.clear()
         self._pool = None

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -19,8 +19,8 @@ capture/replay mechanics live in the backend. This class adds:
   - NPU-specific patch_model monkey-patch for the decode-Full +
     torch.compile path.
   - Profile context override (NPU profiler emits to disk, not in-mem).
-  - Replay override that issues an async NPUGraph.update for
-    seq_lens before replay (skipped for deepseek-nsa).
+  - Replay override that updates dynamic seq_lens before NPUGraph replay
+    (skipped for deepseek-nsa).
   - Smaller cache_loc dtype (int32 instead of int64).
 """
 

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -116,6 +116,10 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM", "Step3p5ForCausalLM")
             for arch in (model_runner.model_config.hf_config.architectures or [])
         )
+        self.use_fias_v2_bsnd = (
+            envs.SGLANG_NPU_USE_FIAS_V2_BSND.get()
+            and model_runner.spec_algorithm.is_dspark()
+        )
 
     def _init_arch_map(self):
         if self.is_dllm:
@@ -157,13 +161,21 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             out = run_once_fn()
         return out
 
+    def _uses_v2_seq_len_update(self):
+        # IDLE DP ranks replay the same target-verify graph as active ranks.
+        # Select the handler from the captured graph, not the runtime mode;
+        # a V1 update key is ignored by V2 and leaves stale KV lengths behind.
+        return self.if_use_v2 or (
+            self.use_fias_v2_bsnd and self.capture_forward_mode.is_target_verify()
+        )
+
     def _get_update_attr_name(self):
-        if self.if_use_v2:
+        if self._uses_v2_seq_len_update():
             return self.attr_name["TARGET_VERIFY"]
         return self.attr_name[AttentionArch.MLA]
 
     def _get_update_attr_type(self):
-        if self.if_use_v2:
+        if self._uses_v2_seq_len_update():
             return self.attr_type["TARGET_VERIFY"]
         return self.attr_type[AttentionArch.MLA]
 
@@ -240,7 +252,15 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             or is_deepseek_v4(self.model_runner.model_config.hf_config)
         ):
             if forward_batch.forward_mode.is_target_verify():
-                seq_lens_cpu = forward_batch.seq_lens.cpu() + self.captured_req_width
+                if self.model_runner.spec_algorithm.is_dspark():
+                    # DSpark publishes the final verify KV boundary on CPU.
+                    # Do not add the speculative width a second time.
+                    assert forward_batch.seq_lens_cpu is not None
+                    seq_lens_cpu = forward_batch.seq_lens_cpu[: self.raw_bs]
+                else:
+                    seq_lens_cpu = (
+                        forward_batch.seq_lens.cpu() + self.captured_req_width
+                    )
                 seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)
             else:
                 seq_lens = forward_batch.seq_lens.cpu().tolist() + [0] * (

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -22,6 +22,34 @@ if is_npu():
     import torch_npu
 
 
+def _mla_fia_nz_scatter_indices(
+    loc: torch.Tensor, head_dim: int, page_size: int
+) -> torch.Tensor:
+    """Return physical rows for token-wise writes into an MLA NZ cache.
+
+    The storage allocation remains page-major ``[page, slot, 1, D]`` for
+    transfer and bookkeeping compatibility. FIA reads that storage as
+    ``[page, 1, D / 16, page_size, 16]``. A token-major scatter would therefore
+    write the wrong physical rows, so every logical token expands to its
+    ``D / 16`` NZ tiles.
+    """
+    if head_dim % 16:
+        raise ValueError(
+            "FIA NZ MLA cache requires a head dimension divisible by 16, "
+            f"got {head_dim}."
+        )
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}.")
+
+    num_tiles = head_dim // 16
+    page = torch.div(loc, page_size, rounding_mode="floor")
+    slot = torch.remainder(loc, page_size)
+    tiles = torch.arange(num_tiles, dtype=loc.dtype, device=loc.device)
+    # Flatten [token, tile] in the same order as source.view(T, tiles, 16).
+    rows = ((page[:, None] * num_tiles + tiles) * page_size) + slot[:, None]
+    return rows.reshape(-1, 1)
+
+
 def _init_npu_conv_state(
     conv_state_in,
     conv_state_shape,
@@ -540,6 +568,10 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
         indexer_layer_ids: Optional[Sequence[int]] = None,
         kv_cache_dim: Optional[int] = None,
     ):
+        # MLAPO historically owned NZ writes. Keep the allocation unchanged and
+        # write into the NZ-addressed view below so ordinary MLA (including
+        # Kimi-K3 MTP) can use FIA NZ without MLAPO.
+        self.use_fia_nz = get_bool_env_var("SGLANG_USE_FIA_NZ")
         super(MLATokenToKVPool, self).__init__(
             size=size,
             page_size=page_size,
@@ -829,6 +861,12 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
                 packed.view(-1, 1, self.kv_cache_dim),
             )
             return
+
+        if cache_v is None:
+            cache_k, cache_v = cache_k.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+
         if cache_k.dtype != self.dtype:
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
@@ -837,10 +875,9 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
             cache_k = cache_k.view(self.store_dtype)
             cache_v = cache_v.view(self.store_dtype)
 
-        if cache_v is None:
-            cache_k, cache_v = cache_k.split(
-                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
-            )
+        if self.use_fia_nz:
+            self._set_fia_nz_kv_buffer(layer_id, loc, cache_k, cache_v)
+            return
 
         torch_npu.npu_scatter_nd_update_(
             self.k_buffer[layer_id - self.start_layer].view(-1, 1, self.kv_lora_rank),
@@ -854,6 +891,28 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
             loc.view(-1, 1),
             cache_v.view(-1, 1, self.qk_rope_head_dim),
         )
+
+    def _set_fia_nz_kv_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+    ) -> None:
+        """Store MLA latent and RoPE KV tensors in FIA's NZ tile order."""
+
+        def scatter(cache: torch.Tensor, values: torch.Tensor, head_dim: int):
+            num_tiles = head_dim // 16
+            indices = _mla_fia_nz_scatter_indices(loc, head_dim, self.page_size)
+            # Destination rows are ordered [page, tile, slot]. Source rows use
+            # the matching [token, tile] order after this reshape.
+            dst = cache.view(-1, 1, num_tiles, self.page_size, 16).view(-1, 16)
+            src = values.contiguous().view(-1, num_tiles, 16).view(-1, 16)
+            torch_npu.npu_scatter_nd_update_(dst, indices, src)
+
+        offset = layer_id - self.start_layer
+        scatter(self.k_buffer[offset], cache_k, self.kv_lora_rank)
+        scatter(self.v_buffer[offset], cache_v, self.qk_rope_head_dim)
 
     def set_index_k_buffer(
         self,

--- a/python/sglang/srt/hardware_backend/npu/moe/activation.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/activation.py
@@ -148,6 +148,31 @@ class NPUSitu(BaseActivation):
         )
 
 
+class NPUSituMXFP8Quant(BaseActivation):
+    """A5 AscendC grouped SiTU with valid-row MXFP8 quantization."""
+
+    def __init__(self, *, beta: float = 4.0, linear_beta: float = 25.0):
+        from sgl_kernel_npu.activation.situ_mxfp8_quant import situ_mxfp8_quant
+
+        self.situ_mxfp8_quant = situ_mxfp8_quant
+        self.beta = float(beta)
+        self.linear_beta = float(linear_beta)
+
+    def _apply_activation(
+        self,
+        hidden_states: torch.Tensor,
+        group_list: torch.Tensor,
+        group_list_type: int,
+    ):
+        return self.situ_mxfp8_quant(
+            hidden_states,
+            group_list,
+            group_list_type,
+            beta=self.beta,
+            linear_beta=self.linear_beta,
+        )
+
+
 class NPUGeluAndMul(BaseActivation):
     def __init__(self):
         self._gelu = GeluAndMul()

--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -223,10 +223,17 @@ class NPUW4A8MXFP4MoEMethod(_NPUMoEMethodBase):
         ).transpose(1, 2)
         weight_scale.data = scale
 
-        # The refactored NPU dispatchers currently support BF16 and INT8.
-        # Keep dispatch in BF16 and quantize to MXFP8 immediately before GMM.
-        if weight_prefix == "w13":
-            self._set_dispatcher_output_dtype(layer, "bf16")
+        # A5 DeepEP low-latency dispatch quantizes the valid received rows to
+        # MXFP8 and returns the matching E8M0 block scales.  Keep normal mode
+        # in BF16 because A5 MXFP8 normal dispatch is intranode-only; this also
+        # preserves multi-node prefill when ``deepep-mode=auto``.
+        if weight_prefix == "w13" and hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config(
+                {
+                    "normal_dispatcher_output_dtype": "bf16",
+                    "low_latency_dispatcher_output_dtype": "mxfp8",
+                }
+            )
 
     def apply(
         self,

--- a/python/sglang/srt/layers/moe/moe_runner/ascend.py
+++ b/python/sglang/srt/layers/moe/moe_runner/ascend.py
@@ -7,10 +7,12 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.moe.activation import (
     AllGatherActivationWrapper,
     NPUGeluAndMul,
     NPUSitu,
+    NPUSituMXFP8Quant,
     NPUSwiglu,
     NPUSwigluDeepEPKernel,
     NPUSwigluOAI,
@@ -20,6 +22,7 @@ from sglang.srt.hardware_backend.npu.moe.activation import (
 from sglang.srt.hardware_backend.npu.quantization.moe_methods import (
     NPUMXFP8MoEMethod,
     NPUW4A8Int8MoEMethod,
+    NPUW4A8MXFP4MoEMethod,
     NPUW8A8Int8MoEMethod,
 )
 from sglang.srt.layers.moe.moe_runner.base import (
@@ -33,15 +36,15 @@ from sglang.srt.layers.moe.moe_runner.base import (
 )
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.ascend_tp import (
+        AscendTPCombineInput,
+        AscendTPDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.deepep import (
         DeepEPLLCombineInput,
         DeepEPLLDispatchOutput,
         DeepEPNormalCombineInput,
         DeepEPNormalDispatchOutput,
-    )
-    from sglang.srt.layers.moe.token_dispatcher.ascend_tp import (
-        AscendTPDispatchOutput,
-        AscendTPCombineInput,
     )
 
 from sglang.srt.layers.moe.utils import (
@@ -103,13 +106,25 @@ class AscendRunnerCore(MoeRunnerCore):
                 kernel, (NPUW4A8Int8MoEMethod, NPUW8A8Int8MoEMethod)
             )
             if config.activation == "situ":
-                self.activation = NPUSitu(
-                    need_quant=is_quant_kernel,
-                    beta=(
-                        config.gemm1_alpha if config.gemm1_alpha is not None else 4.0
-                    ),
-                    linear_beta=config.gemm1_clamp_limit,
-                )
+                beta = config.gemm1_alpha if config.gemm1_alpha is not None else 4.0
+                if (
+                    isinstance(kernel, NPUW4A8MXFP4MoEMethod)
+                    and envs.SGLANG_NPU_MOE_SITU_MXFP8_FUSED.get()
+                ):
+                    if config.gemm1_clamp_limit is None:
+                        raise ValueError(
+                            "fused SiTU MXFP8 quantization requires gemm1_clamp_limit"
+                        )
+                    self.activation = NPUSituMXFP8Quant(
+                        beta=beta,
+                        linear_beta=config.gemm1_clamp_limit,
+                    )
+                else:
+                    self.activation = NPUSitu(
+                        need_quant=is_quant_kernel,
+                        beta=beta,
+                        linear_beta=config.gemm1_clamp_limit,
+                    )
             else:
                 self.activation = NPUSwigluDeepEPKernel(
                     need_quant=is_quant_kernel,
@@ -121,6 +136,15 @@ class AscendRunnerCore(MoeRunnerCore):
             # 1. Choose the base activation according to the quant method
             if isinstance(kernel, (NPUW4A8Int8MoEMethod, NPUW8A8Int8MoEMethod)):
                 inner = NPUSwigluQuant()
+            elif config.activation == "situ":
+                # Grouped SiTU (Kimi-K3). need_quant=False: the MXFP4 / BF16
+                # gmm2 requantizes the activations itself, so no quant is
+                # fused here. Matches the DeepEP branch below.
+                inner = NPUSitu(
+                    need_quant=False,
+                    beta=config.gemm1_alpha if config.gemm1_alpha is not None else 4.0,
+                    linear_beta=config.gemm1_clamp_limit,
+                )
             else:
                 if config.activation == "npu_swiglu_oai":
                     # NPUSwigluOAI requires the runner config to pass
@@ -186,7 +210,7 @@ class AscendRunnerCore(MoeRunnerCore):
             # Grouped-row activations require dispatch metadata.
             if isinstance(
                 self.activation,
-                (NPUSwigluDeepEPKernel, NPUSitu),
+                (NPUSwigluDeepEPKernel, NPUSitu, NPUSituMXFP8Quant),
             ):
                 hidden_states, pertoken_scale = self.activation._apply_activation(
                     hidden_states,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -53,6 +53,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsWNA16MoE,
     CompressedTensorsWNA16TritonMoE,
     NPUCompressedTensorsW4A8Int8DynamicMoE,
+    NPUCompressedTensorsW4A8mxfp4MoE,
     NPUCompressedTensorsW4A16Int4DynamicMoE,
     NPUCompressedTensorsW8A8Int8,
     NPUCompressedTensorsW8A8Int8DynamicMoE,
@@ -225,7 +226,10 @@ class CompressedTensorsConfig(QuantizationConfig):
             # Detect MXFP4 before the scheme-based path: MXFP4 uses a
             # dedicated FusedMoEMethodBase (Mxfp4MoEMethod) that already
             # handles all MoE backends, bypassing the scheme abstraction.
-            if self._is_mxfp4_moe(layer_name=prefix):
+            # On NPU the dedicated Mxfp4MoEMethod does not apply, so fall
+            # through to the scheme-based path and let get_moe_scheme select
+            # NPUCompressedTensorsW4A8mxfp4MoE.
+            if self._is_mxfp4_moe(layer_name=prefix) and not _is_npu:
                 from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
 
                 logger.info_once(
@@ -818,6 +822,14 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         weight_quant = scheme_dict.get("weights")
         input_quant = scheme_dict.get("input_activations")
+
+        # MXFP4 MoE on NPU is served by NPUCompressedTensorsW4A8mxfp4MoE. Detect
+        # it before the WNA16 branch: MXFP4 weights are FP4 (float) group-32 so
+        # `_is_wNa16_group_channel` / `_is_dynamic_token_w4a8` would otherwise
+        # misroute them to the INT4 WNA16 or W4A8-int8 schemes.
+        if _is_npu and self._is_mxfp4_moe(layer_name=layer_name):
+            logger.info_once("Using NPUCompressedTensorsW4A8mxfp4MoE")
+            return NPUCompressedTensorsW4A8mxfp4MoE()
 
         if self._is_wNa16_group_channel(weight_quant, input_quant):
             if not _is_npu:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -9,6 +9,7 @@ from .compressed_tensors_w4a4_nvfp4 import CompressedTensorsW4A4Fp4
 from .compressed_tensors_w4a4_nvfp4_moe import CompressedTensorsW4A4Nvfp4MoE
 from .compressed_tensors_w4a8_fp8_moe import CompressedTensorsW4AFP8MoE
 from .compressed_tensors_w4a8_int8_moe import NPUCompressedTensorsW4A8Int8DynamicMoE
+from .compressed_tensors_w4a8_mxfp4_moe import NPUCompressedTensorsW4A8mxfp4MoE
 from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
 from .compressed_tensors_w8a8_fp8_moe import CompressedTensorsW8A8Fp8MoE
 from .compressed_tensors_w8a8_int8 import (
@@ -43,4 +44,5 @@ __all__ = [
     "NPUCompressedTensorsW4A8Int8DynamicMoE",
     "CompressedTensorsMxInt4MoE",
     "CompressedTensorsW4AFP8MoE",
+    "NPUCompressedTensorsW4A8mxfp4MoE",
 ]

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_mxfp4_moe.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.hardware_backend.npu.quantization.moe_methods import (
+    NPUW4A8MXFP4MoEMethod,
+)
+from sglang.srt.layers.moe.moe_runner import MoeRunner, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.ascend import AscendQuantInfo
+from sglang.srt.layers.moe.utils import MoeRunnerBackend, get_moe_runner_backend
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsMoEScheme,
+)
+from sglang.srt.utils import set_weight_attrs
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        CombineInput,
+        StandardDispatchOutput,
+    )
+
+__all__ = ["NPUCompressedTensorsW4A8mxfp4MoE"]
+
+logger = logging.getLogger(__name__)
+
+
+class NPUCompressedTensorsW4A8mxfp4MoE(CompressedTensorsMoEScheme):
+    """Compressed-tensors MXFP4 MoE scheme for Ascend NPU.
+
+    Follows the same structure as the other NPU MoE schemes: the MXFP4
+    payload / scale layout transforms live in ``NPUW4A8MXFP4MoEMethod``
+    (shared with the ModelSlim path), and the runner drives w13 -> activation
+    -> w2 through the Ascend ``MoeRunner``.
+    """
+
+    def __init__(self):
+        self.group_size = 32
+        self.w13_kernel = NPUW4A8MXFP4MoEMethod()
+        self.w2_kernel = NPUW4A8MXFP4MoEMethod()
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
+
+        layer.params_dtype = params_dtype
+
+        # Weights are stored as packed FP4 (two FP4 items per byte), so the
+        # K dimension is halved. The compressed-tensors loader writes the
+        # payload under the `_packed` suffix; process_weights_after_loading
+        # renames it to the kernel's `w{13,2}_weight`.
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // 2,
+                requires_grad=False,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_packed", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // 2,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_packed", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        # Weight scales: one e8m0 block scale per 32-value group.
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.GROUP.value}
+        )
+        w13_weight_scale = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // self.group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight_scale", w13_weight_scale)
+        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+
+        w2_weight_scale = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // self.group_size,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w2_weight_scale", w2_weight_scale)
+        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # The compressed-tensors MXFP4 loader stores the packed FP4 payloads
+        # under the `_packed` suffix; rename them to the kernel's expected
+        # names before delegating the NZ layout / scale transform.
+        layer.w13_weight = torch.nn.Parameter(
+            layer.w13_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w13_weight_packed")
+
+        layer.w2_weight = torch.nn.Parameter(
+            layer.w2_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w2_weight_packed")
+
+        self.w13_kernel.process_weights_after_loading(layer, "w13")
+        self.w2_kernel.process_weights_after_loading(layer, "w2")
+
+    def create_moe_runner(
+        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
+    ):
+        layer.w13_kernel = self.w13_kernel
+        layer.w2_kernel = self.w2_kernel
+        moe_runner_config.layer = layer
+        self.moe_runner_config = moe_runner_config
+        backend = get_moe_runner_backend()
+        if backend.is_auto():
+            backend = MoeRunnerBackend.ASCEND
+        self.runner = MoeRunner(backend, moe_runner_config)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        dispatch_output: StandardDispatchOutput,
+    ) -> CombineInput:
+        quant_info = AscendQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_weight_scale=layer.w13_weight_scale,
+            w2_weight_scale=layer.w2_weight_scale,
+        )
+        return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
+++ b/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
@@ -244,12 +244,11 @@ class SchedulerPoolStatsObserver:
         return pool_stats
 
     def _get_mamba_token_info(self):
-        is_mamba_radix_cache = (
-            self.tree_cache.supports_mamba() and self.tree_cache.is_tree_cache()
-        )
+        is_tree_cache = self.tree_cache.is_tree_cache()
+        is_mamba_radix_cache = self.tree_cache.supports_mamba() and is_tree_cache
         full_available_size = self.token_to_kv_pool_allocator.available_size()
         full_evictable_size = (
-            self.tree_cache.full_evictable_size() if is_mamba_radix_cache else 0
+            self.tree_cache.full_evictable_size() if is_tree_cache else 0
         )
         mamba_available_size = self.req_to_token_pool.mamba_allocator.available_size()
         # `mamba_usage`/`mamba_num_used` track the ACTIVE bf16 pool occupancy (running

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -80,9 +80,40 @@ class SchedulerProfilerManager:
         self.profile_in_progress: bool = False
         self.merge_profiles = False
         self.detailed_annotations: bool = False
+        self.profile_ranks = self._parse_profile_ranks(
+            os.getenv("SGLANG_PROFILE_RANKS")
+        )
+        if self.profile_ranks is not None:
+            invalid_ranks = sorted(
+                rank for rank in self.profile_ranks if rank >= self.ps.tp_size
+            )
+            if invalid_ranks:
+                raise ValueError(
+                    "SGLANG_PROFILE_RANKS contains ranks outside the TP world "
+                    f"size {self.ps.tp_size}: {invalid_ranks}."
+                )
+        self.profile_this_rank = (
+            self.profile_ranks is None or self.ps.tp_rank in self.profile_ranks
+        )
 
         # For ROCM
         self.rpd_profiler = None
+
+    @staticmethod
+    def _parse_profile_ranks(raw: Optional[str]) -> Optional[set[int]]:
+        if raw is None or not raw.strip():
+            return None
+
+        ranks: set[int] = set()
+        for item in raw.split(","):
+            item = item.strip()
+            if not item or not item.isdigit():
+                raise ValueError(
+                    "SGLANG_PROFILE_RANKS must be a comma-separated list of "
+                    f"non-negative TP ranks, got {raw!r}."
+                )
+            ranks.add(int(item))
+        return ranks
 
     def _init_profile(
         self,
@@ -200,6 +231,17 @@ class SchedulerProfilerManager:
             activity_map[a] for a in activities if a in activity_map
         ]
 
+        if not self.profile_this_rank:
+            logger.info(
+                "Profiling collection skipped on TP rank %s; selected ranks: %s",
+                self.ps.tp_rank,
+                sorted(self.profile_ranks),
+            )
+            # Keep control state aligned across ranks so explicit and automatic
+            # stop requests succeed without constructing a profiler here.
+            self.profile_in_progress = True
+            return ProfileReqOutput(success=True, message="Succeeded")
+
         if "RPD" in activities:  # for ROCM
             from rpdTracerControl import rpdTracerControl
 
@@ -222,7 +264,8 @@ class SchedulerProfilerManager:
                 schema.writeSchema(connection)
                 connection.commit()
                 del connection
-            torch.distributed.barrier(self.dp_tp_cpu_group)
+            if self.profile_ranks is None:
+                torch.distributed.barrier(self.dp_tp_cpu_group)
 
             self.rpd_profiler = rpdTracerControl()
             self.rpd_profiler.setPythonTrace(True)
@@ -323,6 +366,12 @@ class SchedulerProfilerManager:
                 message="Profiling is not in progress. Call /start_profile first.",
             )
 
+        if not self.profile_this_rank:
+            self.profile_in_progress = False
+            self.profiler_start_forward_ct = None
+            self._apply_detailed_annotations(False)
+            return ProfileReqOutput(success=True, message="Succeeded.")
+
         self.torch_profiler_output_dir.mkdir(parents=True, exist_ok=True)
 
         if self.profile_prefix:
@@ -356,14 +405,16 @@ class SchedulerProfilerManager:
                 self.torch_profiler.export_chrome_trace(
                     os.path.join(self.torch_profiler_output_dir, filename)
                 )
-            torch.distributed.barrier(self.dp_tp_cpu_group)
+            if self.profile_ranks is None:
+                torch.distributed.barrier(self.dp_tp_cpu_group)
 
         if self.rpd_profiler is not None:
             self.rpd_profiler.rangePop()
             self.rpd_profiler.stop()
             self.rpd_profiler.flush()
 
-            torch.distributed.barrier(self.dp_tp_cpu_group)
+            if self.profile_ranks is None:
+                torch.distributed.barrier(self.dp_tp_cpu_group)
             if self.ps.tp_rank == 0:
                 from sglang.srt.utils.rpd_utils import rpd_to_chrome_trace
 

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -34,7 +34,7 @@ from sglang.srt.configs.hybrid_arch import (
     linear_attn_model_spec,
     mamba2_config,
 )
-from sglang.srt.configs.model_config import ModelImpl, is_deepseek_dsa
+from sglang.srt.configs.model_config import ModelImpl, is_deepseek_dsa, is_kimi_k3
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.managers.mm_schedule import init_mm_embedding_cache
@@ -132,6 +132,42 @@ def uses_ssm_state(model_config) -> bool:
         or glm5_next_config(model_config) is not None
         or hybrid_lightning_config(model_config) is not None
     )
+
+
+def resolve_pd_decode_remote_mamba_state(
+    *,
+    model_config: ModelConfig,
+    spec_algorithm: SpeculativeAlgorithm,
+    is_hybrid_ssm: bool,
+    enable_hierarchical_cache: bool,
+) -> bool:
+    """Validate the narrow hybrid-SSM decode-radix mode.
+
+    Kimi-K3 + DSPARK can reuse decode-local per-token MLA/draft KV while
+    receiving the prompt-end KDA/conv state from prefill. Other recurrent
+    models remain rejected until their state protocol has the same contract.
+    """
+    disagg = get_disagg()
+    if not (
+        is_hybrid_ssm
+        and disagg.disaggregation_mode == "decode"
+        and disagg.disaggregation_decode_enable_radix_cache
+    ):
+        return False
+
+    if not (is_kimi_k3(model_config.hf_config) and spec_algorithm.is_dspark()):
+        raise ValueError(
+            "--disaggregation-decode-enable-radix-cache with Mamba/SSM is "
+            "currently supported only for Kimi-K3 with "
+            "--speculative-algorithm DSPARK."
+        )
+    if enable_hierarchical_cache:
+        raise ValueError(
+            "Kimi-K3 DSPARK PD decode radix cache currently supports only "
+            "device-resident prefix KV and is incompatible with "
+            "--enable-hierarchical-cache."
+        )
+    return True
 
 
 def resolve_decode_retraction_backup(*, tp_worker: BaseTpWorker) -> str:
@@ -248,6 +284,13 @@ def build_kv_cache(
             "Transformers backend to avoid multimodal prefix-cache mismatches."
         )
 
+    remote_mamba_state_authoritative = resolve_pd_decode_remote_mamba_state(
+        model_config=model_config,
+        spec_algorithm=spec_algorithm,
+        is_hybrid_ssm=is_hybrid_ssm,
+        enable_hierarchical_cache=enable_hierarchical_cache,
+    )
+
     # Decode-side radix cache supports SWA only through the unified tree, whose
     # component pools preserve the full-attention prefix while transferring the
     # SWA window fresh. The legacy SWA cache and hybrid SSM pools remain
@@ -280,11 +323,6 @@ def build_kv_cache(
                     "--disaggregation-decode-enable-radix-cache does not support "
                     "SWA-compress models (e.g. Gemma4 / MiMo-V2) yet."
                 )
-        if is_hybrid_ssm:
-            raise ValueError(
-                "--disaggregation-decode-enable-radix-cache is incompatible "
-                "with Mamba/SSM models"
-            )
 
     effective_chunked_prefill_size = get_schedule().chunked_prefill_size
     if model_config.is_multimodal and uses_transformers_backend:
@@ -332,6 +370,7 @@ def build_kv_cache(
             is_hybrid_swa=is_hybrid_swa,
             full_tokens_per_layer=full_tokens_per_layer,
             is_hybrid_ssm=is_hybrid_ssm,
+            remote_mamba_state_authoritative=remote_mamba_state_authoritative,
             is_dsa=is_dsa,
             enable_hierarchical_cache=enable_hierarchical_cache,
             disable_radix_cache=disable_radix_cache,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1132,12 +1132,10 @@ class KVCacheConfigurator:
             enable_mamba_extra_buffer=get_exec().mamba.enable_mamba_extra_buffer,
             enable_mamba_extra_buffer_lazy=get_exec().mamba.enable_mamba_extra_buffer_lazy,
             **ple_kwargs,
-            # A PD prefill server never runs TARGET_VERIFY, so skip the
-            # verify-only per-draft-token state snapshots (see the draft-head
-            # case above: None => the pool skips SpeculativeState).
+            # NPU keeps speculative buffers in both PD pools.
             speculative_num_draft_tokens=(
                 None
-                if get_disagg().disaggregation_mode == "prefill"
+                if get_disagg().disaggregation_mode == "prefill" and not _is_npu
                 else max_speculative_num_draft_tokens()
             ),
             speculative_eagle_topk=get_spec().speculative_eagle_topk,

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -45,6 +45,10 @@ class TreeCacheBuildContext:
     tp_group: Any
     full_tokens_per_layer: Optional[int] = None
     is_dsa: bool = False
+    # PD decode receives the prompt-end recurrent state from prefill. In that
+    # mode the radix tree must not constrain an independently reusable token-KV
+    # prefix to the last locally cached Mamba/KDA checkpoint.
+    remote_mamba_state_authoritative: bool = False
 
 
 RadixCacheFactory = Callable[[TreeCacheBuildContext], BasePrefixCache]
@@ -164,8 +168,15 @@ def _create_unified_radix_cache(
     tree_components = [ComponentType.FULL]
     if ctx.is_hybrid_swa:
         tree_components.append(ComponentType.SWA)
-    if ctx.is_hybrid_ssm:
+    if ctx.is_hybrid_ssm and not ctx.remote_mamba_state_authoritative:
         tree_components.append(ComponentType.MAMBA)
+
+    if ctx.remote_mamba_state_authoritative:
+        logger.info(
+            "PD decode radix cache uses per-token FULL/MLA KV only; the "
+            "prompt-end Mamba/KDA/conv state received from prefill is "
+            "authoritative."
+        )
 
     if hasattr(params.req_to_token_pool, "req_to_c128_sidecar"):
         from sglang.srt.hardware_backend.npu.dsv4.c128_sidecar_component import (
@@ -179,7 +190,7 @@ def _create_unified_radix_cache(
         }
 
     params.tree_components = tuple(tree_components)
-    if use_mlx() and ctx.is_hybrid_ssm:
+    if use_mlx() and ctx.is_hybrid_ssm and not ctx.remote_mamba_state_authoritative:
         from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
             MlxAuxiliaryStateComponent,
         )

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -76,6 +76,7 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import (
@@ -453,14 +454,20 @@ class KimiK3MoE(nn.Module):
         # full precision (matches GateLinear in mke). codespell:ignore mke
         self.gate = MoEGate(config, quant_config=None, prefix=f"{prefix}.gate")
 
-        # For MXFP4 compressed-tensors, replace quant_config with Mxfp4Config
-        # so FusedMoE's weight_loader uses the MXFP4 fast path
+        # For MXFP4 compressed-tensors on non-NPU, replace quant_config with
+        # Mxfp4Config so FusedMoE's weight_loader uses the MXFP4 fast path. On
+        # NPU the compressed-tensors config is kept so the scheme-based path
+        # selects NPUCompressedTensorsW4A8mxfp4MoE (see get_moe_scheme).
         moe_quant_config = quant_config
-        if quant_config is not None and getattr(quant_config, "quant_format", None):
-            if "mxfp4" in quant_config.quant_format:
-                from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
+        if (
+            quant_config is not None
+            and getattr(quant_config, "quant_format", None)
+            and "mxfp4" in quant_config.quant_format
+            and not _is_npu
+        ):
+            from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
 
-                moe_quant_config = Mxfp4Config(is_checkpoint_mxfp4_serialized=True)
+            moe_quant_config = Mxfp4Config(is_checkpoint_mxfp4_serialized=True)
 
         # Routed experts (operate in moe_hidden_size space)
         # gate_up_interleaved=False: K3 loads per-expert w1/w3 into non-interleaved layout
@@ -1442,13 +1449,15 @@ class KimiK3DeltaAttention(nn.Module):
             quant_config, f"{prefix}.b_proj"
         )
 
-        # The fused path hardcodes tp_size sharding, so require attn_tp == tp.
-        # Full-rank K3 also fuses mixed block-FP8 attention projections.
+        # Preserve the CUDA/ROCm fusion condition, including quantized K3.
         self.do_fuse_qkvbfg = self.attn_tp_size == self.tp_size and (
-            quant_config is None or self.use_full_rank_gate
+            quant_config is None or (self.use_full_rank_gate and not _is_npu)
         )
+        # NPU's full-rank [q, k, v, g] projection is explicitly sharded by
+        # attention TP and also supports DP attention and ModelSlim configs.
+        self.do_fuse_qkvg = self.use_full_rank_gate and (_is_npu or self.do_fuse_qkvbfg)
 
-        if self.do_fuse_qkvbfg and self.use_full_rank_gate:
+        if self.do_fuse_qkvg:
             # Fuse only the alignment-friendly wide projections [q, k, v, g]
             # (6144/rank at TP8). Folding b (12/rank) and f_a (128, replicated)
             # in as well skews the output dim to 6284 and measurably degrades
@@ -1470,8 +1479,8 @@ class KimiK3DeltaAttention(nn.Module):
                 prefix=f"{prefix}.fused_qkvg_proj",
             )
             self.split_sizes = [
-                3 * projection_size // self.tp_size,
-                projection_size // self.tp_size,
+                3 * projection_size // self.attn_tp_size,
+                projection_size // self.attn_tp_size,
             ]
             self.b_proj = ColumnParallelLinear(
                 self.hidden_size,
@@ -1999,7 +2008,7 @@ class KimiK3DeltaAttention(nn.Module):
         defer_f_b = (
             self._kda_hip_fused_decode_ready and forward_batch.forward_mode.is_decode()
         )
-        if self.do_fuse_qkvbfg:
+        if self.do_fuse_qkvbfg or self.do_fuse_qkvg:
             mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg_fused(
                 hidden_states, defer_f_b=defer_f_b
             )
@@ -3023,6 +3032,13 @@ class KimiK3LinearModel(nn.Module):
 class KimiK3LinearForCausalLM(nn.Module):
     """Text-only K3 causal LM."""
 
+    # ModelSlim describes quantization with the original checkpoint module
+    # names. Register the runtime fused QKVG module so it can resolve the
+    # q_proj scheme while the weight loader packs q/k/v/g into its shards.
+    packed_modules_mapping = {
+        "fused_qkvg_proj": ["q_proj", "k_proj", "v_proj", "g_proj"],
+    }
+
     def __init__(
         self,
         config: KimiLinearConfig,
@@ -3032,6 +3048,15 @@ class KimiK3LinearForCausalLM(nn.Module):
         super().__init__()
         self.config = config
         self.quant_config = quant_config
+        if quant_config is not None:
+            if isinstance(quant_config, ModelSlimConfig):
+                model_mapping = {
+                    **quant_config.packed_modules_mapping.get("model", {}),
+                    **self.packed_modules_mapping,
+                }
+                quant_config.update_packed_modules_mapping({"model": model_mapping})
+            else:
+                quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
         self.model = KimiK3LinearModel(
             config, quant_config, prefix=maybe_prefix(prefix, "model")
         )
@@ -3197,7 +3222,8 @@ class KimiK3LinearForCausalLM(nn.Module):
                     continue
 
             # compressed-tensors MXFP4 stores as weight_packed; Mxfp4MoEMethod uses weight
-            if "weight_packed" in name:
+            # (NPU keeps weight_packed for NPUCompressedTensorsW4A8mxfp4MoE).
+            if "weight_packed" in name and not _is_npu:
                 name = name.replace("weight_packed", "weight")
 
             # MLA: fuse q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa
@@ -3243,7 +3269,11 @@ class KimiK3LinearForCausalLM(nn.Module):
                     if not self.config.is_kda_layer(layer_id):
                         continue
                     layer = self.model.layers[layer_id].self_attn
-                    if not getattr(layer, "do_fuse_qkvbfg", False):
+                    # Match the projection selected during layer construction.
+                    if param_name == ".fused_qkvg_proj":
+                        if not getattr(layer, "do_fuse_qkvg", False):
+                            continue
+                    elif not getattr(layer, "do_fuse_qkvbfg", False):
                         continue
                 if weight_name in {".q_proj", ".k_proj", ".v_proj"}:
                     layer_id = int(name.split(".")[2])

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -582,7 +582,6 @@ class KimiK3MoE(nn.Module):
         self._shared_experts_attn_tp_comm = (
             get_parallel().enable_shared_experts_attn_tp
             and self._ep_a2a
-            and self._dp_attention
             and get_parallel().attn_tp_size > 1
         )
         shared_experts_tp_kwargs = {}
@@ -619,12 +618,12 @@ class KimiK3MoE(nn.Module):
         # (TP8/EP8 MegaMoE + SP-MoE): +4~5% output tok/s and −5% ITL over
         # bs 1–32, GSM8K unchanged — so it is on whenever the shape allows,
         # no flag.
-        # EP a2a only: with plain-TP experts the fused front already lands both
-        # partial sums in one collective (_forward_fused), a strictly better
-        # overlap than two streams.
+        # NPU attention-TP compatibility mode can also overlap the shared
+        # collectives using SGLANG_NPU_FINE_GRAINED_MOE_DUAL_STREAM. Otherwise
+        # the collectives stay on the current stream.
         self._sbo_shared_overlap = (
             self._ep_a2a
-            and not self._shared_experts_attn_tp_comm
+            and (not self._shared_experts_attn_tp_comm or _is_npu)
             and self.shared_experts is not None
             and self.alt_stream is not None
         )
@@ -1018,10 +1017,41 @@ class KimiK3MoE(nn.Module):
         # the DP local buffer is the full reassembled per-replica batch.
         gathered_hidden_states = get_local_dp_buffer(group)
         attn_tp_all_gather_into_tensor(gathered_hidden_states, hidden_states)
+
         gathered_shared_output = self.shared_experts(gathered_hidden_states)
         shared_output = torch.empty_like(hidden_states)
         attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
         return shared_output
+
+    def _can_overlap_shared_experts_npu(self, hidden_states: torch.Tensor) -> bool:
+        if not (
+            _is_npu
+            and envs.SGLANG_NPU_FINE_GRAINED_MOE_DUAL_STREAM.get()
+            and self._sbo_shared_overlap
+            and self._shared_experts_attn_tp_comm
+            and self.use_latent_moe
+            and hidden_states.shape[0] > 0
+            and get_moe_a2a_backend().is_deepep()
+            # Per-forward hook registration is not traceable by Dynamo.
+            and not torch.compiler.is_compiling()
+        ):
+            return False
+
+        from sglang.srt.batch_overlap.two_batch_overlap import (
+            MaybeTboDeepEPDispatcher,
+        )
+        from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+            is_in_tc_piecewise_cuda_graph,
+        )
+
+        # The hooks must surround the complete dispatch, including its receive
+        # wait. Fused EP bypasses these hooks. An eager/piecewise graph break
+        # must not split the side-stream event record from its wait.
+        return (
+            isinstance(self.experts.dispatcher, MaybeTboDeepEPDispatcher)
+            and not is_in_breakable_cuda_graph()
+            and not is_in_tc_piecewise_cuda_graph()
+        )
 
     def _forward_unfused(
         self,
@@ -1034,33 +1064,120 @@ class KimiK3MoE(nn.Module):
         # Shared experts on original hidden_states. Under SBO they go to the
         # side stream and are joined at the tail (see _sbo_shared_overlap).
         #
-        # Issued *after* the front, deliberately: alt_stream.wait_stream() makes
-        # the side stream wait for whatever the main stream has enqueued so far,
-        # so issuing here means the shared experts overlap the routed a2a rather
-        # than the front GEMMs. The shared branch is the shorter of the two and
-        # does not need a head start; running it against the front only takes
-        # bandwidth away from the critical path.
+        # CUDA issues this after the front so the shared experts overlap the
+        # routed a2a rather than the front GEMMs. NPU starts the shared branch
+        # before the front. Fine-grained NPU overlap splits it at the complete
+        # dispatch boundaries:
+        #   current: front ---------- dispatch ---------- routed GEMMs -- tail
+        #   alt:     all-gather ----- shared MLP -------- reduce-scatter
+        # Shared and routed GEMMs wait for each other at phase boundaries;
+        # each can run beside the other branch's communication.
+        fine_grained_overlap = self._can_overlap_shared_experts_npu(hidden_states)
+        shared_input = None
         shared_output = None
         shared_event = None
+        shared_compute_event = None
 
         def issue_shared():
-            nonlocal shared_output, shared_event
+            nonlocal shared_input, shared_output, shared_event
             if self.shared_experts is None or hidden_states.shape[0] == 0:
                 return
-            if self._sbo_shared_overlap:
+            if fine_grained_overlap:
+                # Fork before the routed front so HCCL's completion wait is
+                # queued on the side stream, leaving the front free to run.
                 self.alt_stream.wait_stream(torch.cuda.current_stream())
+                hidden_states.record_stream(self.alt_stream)
                 with torch.cuda.stream(self.alt_stream):
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    shared_input = get_local_dp_buffer(get_parallel().attn_tp_group)
+                    shared_input.record_stream(self.alt_stream)
+                    attn_tp_all_gather_into_tensor(shared_input, hidden_states)
+                return
+            if self._sbo_shared_overlap:
+                current_stream = torch.cuda.current_stream()
+                # Keep HCCL collectives on the current stream. The alternate
+                # stream only executes the shared-expert MLP.
+                shared_input = hidden_states
+                if self._shared_experts_attn_tp_comm:
+                    group = get_parallel().attn_tp_group
+                    shared_input = get_local_dp_buffer(group)
+                    attn_tp_all_gather_into_tensor(shared_input, hidden_states)
+                shared_input.record_stream(self.alt_stream)
+                self.alt_stream.wait_stream(current_stream)
+                with torch.cuda.stream(self.alt_stream):
+                    shared_output = self.shared_experts(shared_input)
                     shared_event = self.alt_stream.record_event()
             else:
                 shared_output = self._forward_shared_experts(hidden_states)
+
+        def run_experts(expert_input, topk_output):
+            if not fine_grained_overlap:
+                return (
+                    self._forward_mega_experts(expert_input, topk_output)
+                    if self._use_mega_moe
+                    else self.experts(expert_input, topk_output)
+                )
+
+            def pre_dispatch(dispatcher, dispatch_input, dispatch_topk):
+                nonlocal shared_output, shared_compute_event
+                # AllGather is already queued. Delay shared GEMMs until the
+                # gate, TopK and latent down projection finish on current.
+                self.alt_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(self.alt_stream):
+                    shared_output = self.shared_experts(shared_input)
+                    shared_compute_event = self.alt_stream.record_event()
+
+            def post_dispatch(dispatcher, dispatch_output):
+                nonlocal shared_output, shared_event
+                current_stream = torch.cuda.current_stream()
+                # Dispatch has queued its receive wait. RS waits for that
+                # communication and the shared MLP, while routed GEMMs wait
+                # only for the MLP (not for RS).
+                self.alt_stream.wait_stream(current_stream)
+                with torch.cuda.stream(self.alt_stream):
+                    gathered_shared_output = shared_output
+                    shared_output = torch.empty_like(hidden_states)
+                    attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
+                    shared_event = self.alt_stream.record_event()
+                current_stream.wait_event(shared_compute_event)
+
+            dispatcher = self.experts.dispatcher
+            pre_handle = dispatcher.register_pre_dispatch_hook(pre_dispatch)
+            try:
+                post_handle = dispatcher.register_post_dispatch_hook(post_dispatch)
+                try:
+                    return self.experts(expert_input, topk_output)
+                finally:
+                    post_handle.remove()
+            finally:
+                # Remove outside hook iteration, including on dispatch/GEMM
+                # failures, so closures cannot leak into the next forward.
+                pre_handle.remove()
+
+        def wait_and_finalize_shared_experts():
+            nonlocal shared_output
+            if shared_event is None:
+                return
+            # Join just before consuming the shared result. The legacy path
+            # still needs to reduce-scatter its TP-partial MLP output here.
+            current_stream = torch.cuda.current_stream()
+            current_stream.wait_event(shared_event)
+            shared_output.record_stream(current_stream)
+            if self._shared_experts_attn_tp_comm and not fine_grained_overlap:
+                gathered_shared_output = shared_output
+                shared_output = torch.empty_like(hidden_states)
+                attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
+
+        # Give the NPU shared-expert branch a head start. At this point
+        # hidden_states is the decoder layer's post-attention RMSNorm output.
+        if _is_npu and self._sbo_shared_overlap:
+            issue_shared()
 
         # Front: gate + TopK (+ latent down-proj when the merged front covers it).
         # The gate and the latent down-proj read the same hidden_states, so the
         # merged-weight strategies compute both in one GEMM; see
         # kernels/ops/moe/moe_front.py for the strategy table.
         routed_input = self._ep_front(hidden_states)
-        if routed_input is None:
+        if routed_input is None and not fine_grained_overlap:
             routed_input = self._ep_front_overlap(hidden_states)
         topk_output = None
         if routed_input is not None:
@@ -1071,12 +1188,12 @@ class KimiK3MoE(nn.Module):
             # fp32 logits reach the radix router from moe_fused_gate.
             router_logits = self.gate(hidden_states)
             topk_output = self.topk(hidden_states, router_logits)
-        issue_shared()
+        if not (_is_npu and self._sbo_shared_overlap):
+            issue_shared()
 
         if not self.use_latent_moe:
             expert_output = self.experts(hidden_states, topk_output)
-            if shared_event is not None:
-                torch.cuda.current_stream().wait_event(shared_event)
+            wait_and_finalize_shared_experts()
             if shared_output is not None:
                 expert_output = expert_output + shared_output
             if self.tp_size > 1:
@@ -1101,11 +1218,7 @@ class KimiK3MoE(nn.Module):
                 routed_input = hidden_states.new_empty((0, self.moe_hidden_size))
             else:
                 routed_input, _ = self.routed_expert_down_proj(hidden_states)
-        expert_output = (
-            self._forward_mega_experts(routed_input, topk_output)
-            if self._use_mega_moe
-            else self.experts(routed_input, topk_output)
-        )
+        expert_output = run_experts(routed_input, topk_output)
         if expert_output.shape[0] == 0:
             # The EP combine returns one row per source token.  Keep the
             # source-side empty result while avoiding empty RMSNorm/up-proj
@@ -1115,10 +1228,7 @@ class KimiK3MoE(nn.Module):
             latent = self._reduce_latent(expert_output)
             # up_proj is replicated, so the routed output is now fully reduced.
             out, _ = self.routed_expert_up_proj(latent)
-        if shared_event is not None:
-            # SBO join: as late as possible, so the side-stream shared experts
-            # get the whole routed a2a + latent tail to hide under.
-            torch.cuda.current_stream().wait_event(shared_event)
+        wait_and_finalize_shared_experts()
         if shared_output is not None:
             # tp1 shared experts (SP-MoE) are complete per-rank; TP-sharded
             # ones need the partial-sum reduction.

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -31,6 +31,8 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
+from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers import (
     k3_ar_fusion,
     k3_gemm_ar,
@@ -415,6 +417,18 @@ def _k3_symm_o_proj_out(o_proj: RowParallelLinear, x: torch.Tensor) -> torch.Ten
     )
 
 
+def _get_num_physical_routed_experts(config: KimiLinearConfig) -> int:
+    """Return the routed-expert slots allocated by FusedMoE/DeepEP.
+
+    Routing still selects among the checkpoint's logical experts. EPLB maps
+    those logical ids to this larger physical space when replicas are enabled.
+    """
+    num_logical_experts = getattr(config, "n_routed_experts", None)
+    if num_logical_experts is None:
+        num_logical_experts = config.num_experts
+    return num_logical_experts + get_exec().moe.ep_num_redundant_experts
+
+
 class KimiK3MoE(nn.Module):
     """K3 MoE with Latent MoE (experts run in moe_hidden_size space)."""
 
@@ -471,7 +485,7 @@ class KimiK3MoE(nn.Module):
         # Routed experts (operate in moe_hidden_size space)
         # gate_up_interleaved=False: K3 loads per-expert w1/w3 into non-interleaved layout
         self.experts = get_moe_impl_class(moe_quant_config)(
-            num_experts=getattr(config, "n_routed_experts", config.num_experts),
+            num_experts=_get_num_physical_routed_experts(config),
             top_k=config.num_experts_per_token,
             hidden_size=self.moe_hidden_size,
             intermediate_size=config.moe_intermediate_size,
@@ -904,11 +918,15 @@ class KimiK3MoE(nn.Module):
             return False
         if self.gate.e_score_correction_bias is None:
             return False
-        # K3 calls self.topk() without a padding mask or EPLB dispatch info, so
-        # select_experts' post-processing collapses to the capture hook and the
-        # recorder -- both of which build_precomputed_topk_output runs. Bail out
-        # if that ever stops holding rather than silently dropping the remap.
-        if not precomputed_topk_postprocess_is_noop(cfg):
+        # A non-trivial expert placement requires select_experts to translate
+        # logical expert ids to the physical slots whose weights were populated
+        # by FusedMoE.weight_loader. The precomputed fused-front path cannot do
+        # that post-processing, so keep it disabled whenever dispatch metadata
+        # is active.
+        if not precomputed_topk_postprocess_is_noop(
+            cfg,
+            expert_location_dispatch_info=self._expert_location_dispatch_info(),
+        ):
             return False
         if get_exec().deterministic.enable_deterministic_inference:
             return False
@@ -917,6 +935,17 @@ class KimiK3MoE(nn.Module):
         except Exception:
             return False
         return moe_front.available()
+
+    def _expert_location_dispatch_info(self):
+        return ExpertLocationDispatchInfo.init_new(layer_id=self.layer_idx)
+
+    def _select_experts(self, hidden_states: torch.Tensor, router_logits: torch.Tensor):
+        """Select logical experts and remap them to their loaded physical slots."""
+        return self.topk(
+            hidden_states,
+            router_logits,
+            expert_location_dispatch_info=self._expert_location_dispatch_info(),
+        )
 
     @cached_property
     def _ep_front_eligible(self) -> bool:
@@ -997,7 +1026,7 @@ class KimiK3MoE(nn.Module):
         self.alt_stream.wait_stream(current_stream)
         with torch.cuda.stream(self.alt_stream):
             router_logits = self.gate(hidden_states)
-            topk_output = self.topk(hidden_states, router_logits)
+            topk_output = self._select_experts(hidden_states, router_logits)
 
         routed_input, _ = self.routed_expert_down_proj(hidden_states)
         current_stream.wait_stream(self.alt_stream)
@@ -1206,7 +1235,7 @@ class KimiK3MoE(nn.Module):
             # or tiny_gemm_bf16); non-CUDA falls back to F.linear (bf16). The
             # fp32 logits reach the radix router from moe_fused_gate.
             router_logits = self.gate(hidden_states)
-            topk_output = self.topk(hidden_states, router_logits)
+            topk_output = self._select_experts(hidden_states, router_logits)
         if not (_is_npu and self._sbo_shared_overlap):
             issue_shared()
 
@@ -1306,7 +1335,7 @@ class KimiK3MoE(nn.Module):
         if self._route_quant_fuse_eligible:
             route_quant_handoff.stage(routed_input)
         try:
-            topk_output = self.topk(hidden_states, router_logits)
+            topk_output = self._select_experts(hidden_states, router_logits)
             with zero_copy_context.set_moe_output(latent):
                 expert_output = self.experts(routed_input, topk_output)
         finally:
@@ -1322,7 +1351,7 @@ class KimiK3MoE(nn.Module):
         if self._route_quant_fuse_eligible:
             route_quant_handoff.stage(routed_input)
         try:
-            topk_output = self.topk(hidden_states, router_logits)
+            topk_output = self._select_experts(hidden_states, router_logits)
             return self.experts.forward_deferred_finalize(routed_input, topk_output)
         finally:
             route_quant_handoff.clear()
@@ -3209,6 +3238,16 @@ class KimiK3LinearForCausalLM(nn.Module):
     def get_input_embeddings(self):
         return self.model.embed_tokens
 
+    @classmethod
+    def get_model_config_for_expert_location(cls, config: KimiLinearConfig):
+        if config.num_experts is None:
+            return None
+        return ModelConfigForExpertLocation(
+            num_layers=config.num_hidden_layers,
+            num_logical_experts=config.num_experts,
+            num_groups=config.num_expert_group,
+        )
+
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
         if self.pp_group.world_size > 1:
             # Capture layers living on non-last PP ranks would be silently
@@ -3648,6 +3687,12 @@ class KimiK3ForConditionalGeneration(nn.Module):
         # Delegate so DummyModelLoader's post-load hook reaches the LM tower.
         if self.language_model is not None:
             self.language_model.post_load_weights()
+
+    @classmethod
+    def get_model_config_for_expert_location(cls, config: KimiK3Config):
+        return KimiK3LinearForCausalLM.get_model_config_for_expert_location(
+            config.text_config
+        )
 
     def precompile_kernels_after_loading(self) -> None:
         if self.config.language_only:

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -22,6 +22,7 @@ from sglang.srt.configs.kimi_linear import KimiLinearConfig
 from sglang.srt.distributed import (
     divide,
     get_pp_group,
+    get_shared_experts_tp_group,
     get_tp_group,
     tensor_model_parallel_all_reduce,
 )
@@ -40,8 +41,6 @@ from sglang.srt.layers.activation import SiluAndMul, SituAndMul
 from sglang.srt.layers.attn_residual import AttnResidual, aggregate_stream, get_cw
 from sglang.srt.layers.dcp.planner import prepare_decode_context_parallel_metadata
 from sglang.srt.layers.dp_attention import (
-    attn_tp_all_gather_into_tensor,
-    attn_tp_reduce_scatter_tensor,
     dp_gather_replicate,
     dp_scatter,
     get_global_dp_buffer,
@@ -568,32 +567,42 @@ class KimiK3MoE(nn.Module):
             and config.hidden_act == "situ"
         )
 
-        # Shared experts (operate in original hidden_size space).
-        # Replicate the shared-expert weights (tp1, DSv2 convention) under EP
-        # a2a: the block runs on partial batches (shard / DP-local rows), and
-        # a TP-sharded partial sum could never be reduced across ranks that
-        # hold different tokens.
-        self._shared_experts_tp1 = (
-            self._ep_a2a and not get_parallel().enable_shared_experts_attn_tp
+        # Shared experts operate on original hidden states. EP a2a gives each
+        # rank a token shard: either replicate the weights, or gather within
+        # the shared-expert TP subgroup and reduce-scatter back to those rows.
+        parallel = get_parallel()
+        requested_shared_tp = parallel.shared_experts_tp_size
+        shared_tp = requested_shared_tp
+        if shared_tp is None and parallel.enable_shared_experts_attn_tp:
+            shared_tp = parallel.attn_tp_size
+        if requested_shared_tp is not None and not self._ep_a2a:
+            raise ValueError("Independent shared-expert TP requires an EP a2a backend.")
+        self._shared_experts_tp1 = self._ep_a2a and shared_tp in (None, 1)
+        self._shared_experts_tp_comm = (
+            self._ep_a2a and shared_tp is not None and shared_tp > 1
         )
-        # NPU compatibility mode keeps DeepEP's DP-local token dispatch but
-        # uses the original TP-sharded shared MLP. Gather only that branch's
-        # inputs, then reduce-scatter its output back to the DP-local rows.
-        self._shared_experts_attn_tp_comm = (
-            get_parallel().enable_shared_experts_attn_tp
-            and self._ep_a2a
-            and get_parallel().attn_tp_size > 1
-        )
+        self._shared_experts_tp_group = None
         shared_experts_tp_kwargs = {}
         if self._shared_experts_tp1:
             shared_experts_tp_kwargs = dict(tp_rank=0, tp_size=1)
-        elif self._shared_experts_attn_tp_comm:
+        elif self._shared_experts_tp_comm:
+            group = (
+                get_shared_experts_tp_group()
+                if requested_shared_tp is not None
+                else parallel.attn_tp_group
+            )
+            assert group.world_size == shared_tp
+            self._shared_experts_tp_group = group
             shared_experts_tp_kwargs = dict(
-                tp_rank=get_parallel().attn_tp_rank,
-                tp_size=get_parallel().attn_tp_size,
+                tp_rank=group.rank_in_group, tp_size=group.world_size
             )
         if self.num_shared_experts is not None and self.num_shared_experts > 0:
             shared_intermediate_size = moe_intermediate_size * self.num_shared_experts
+            if shared_tp is not None and shared_intermediate_size % shared_tp != 0:
+                raise ValueError(
+                    f"Shared-expert intermediate size ({shared_intermediate_size}) "
+                    f"must be divisible by shared-expert TP size ({shared_tp})."
+                )
             self.shared_experts = KimiK3MLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=shared_intermediate_size,
@@ -618,12 +627,12 @@ class KimiK3MoE(nn.Module):
         # (TP8/EP8 MegaMoE + SP-MoE): +4~5% output tok/s and −5% ITL over
         # bs 1–32, GSM8K unchanged — so it is on whenever the shape allows,
         # no flag.
-        # NPU attention-TP compatibility mode can also overlap the shared
+        # NPU shared-expert TP can also overlap the shared
         # collectives using SGLANG_NPU_FINE_GRAINED_MOE_DUAL_STREAM. Otherwise
         # the collectives stay on the current stream.
         self._sbo_shared_overlap = (
             self._ep_a2a
-            and (not self._shared_experts_attn_tp_comm or _is_npu)
+            and (not self._shared_experts_tp_comm or _is_npu)
             and self.shared_experts is not None
             and self.alt_stream is not None
         )
@@ -1007,28 +1016,41 @@ class KimiK3MoE(nn.Module):
             return self._latent_norm(latent)
         return self._latent_norm(tensor_model_parallel_all_reduce(latent))
 
+    def _gather_shared_expert_inputs(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        group = self._shared_experts_tp_group
+        # The attention DP buffer spans the entire attention-TP replica.
+        # Size this buffer from the subgroup's actual token shards instead.
+        with use_symmetric_memory(group, disabled=not is_allocation_symmetric()):
+            gathered = hidden_states.new_empty(
+                (hidden_states.shape[0] * group.world_size, *hidden_states.shape[1:])
+            )
+        group.all_gather_into_tensor(gathered, hidden_states)
+        return gathered
+
+    def _reduce_scatter_shared_experts(
+        self, shared_output: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        output = torch.empty_like(hidden_states)
+        self._shared_experts_tp_group.reduce_scatter_tensor(output, shared_output)
+        return output
+
     def _forward_shared_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Run TP-sharded shared experts while DeepEP tokens stay scattered."""
-        if not self._shared_experts_attn_tp_comm:
+        if not self._shared_experts_tp_comm:
             return self.shared_experts(hidden_states)
 
-        group = get_parallel().attn_tp_group
-        # SP-MoE presents one contiguous token shard per attention-TP rank;
-        # the DP local buffer is the full reassembled per-replica batch.
-        gathered_hidden_states = get_local_dp_buffer(group)
-        attn_tp_all_gather_into_tensor(gathered_hidden_states, hidden_states)
-
+        gathered_hidden_states = self._gather_shared_expert_inputs(hidden_states)
         gathered_shared_output = self.shared_experts(gathered_hidden_states)
-        shared_output = torch.empty_like(hidden_states)
-        attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
-        return shared_output
+        return self._reduce_scatter_shared_experts(
+            gathered_shared_output, hidden_states
+        )
 
     def _can_overlap_shared_experts_npu(self, hidden_states: torch.Tensor) -> bool:
         if not (
             _is_npu
             and envs.SGLANG_NPU_FINE_GRAINED_MOE_DUAL_STREAM.get()
             and self._sbo_shared_overlap
-            and self._shared_experts_attn_tp_comm
+            and self._shared_experts_tp_comm
             and self.use_latent_moe
             and hidden_states.shape[0] > 0
             and get_moe_a2a_backend().is_deepep()
@@ -1088,19 +1110,16 @@ class KimiK3MoE(nn.Module):
                 self.alt_stream.wait_stream(torch.cuda.current_stream())
                 hidden_states.record_stream(self.alt_stream)
                 with torch.cuda.stream(self.alt_stream):
-                    shared_input = get_local_dp_buffer(get_parallel().attn_tp_group)
+                    shared_input = self._gather_shared_expert_inputs(hidden_states)
                     shared_input.record_stream(self.alt_stream)
-                    attn_tp_all_gather_into_tensor(shared_input, hidden_states)
                 return
             if self._sbo_shared_overlap:
                 current_stream = torch.cuda.current_stream()
                 # Keep HCCL collectives on the current stream. The alternate
                 # stream only executes the shared-expert MLP.
                 shared_input = hidden_states
-                if self._shared_experts_attn_tp_comm:
-                    group = get_parallel().attn_tp_group
-                    shared_input = get_local_dp_buffer(group)
-                    attn_tp_all_gather_into_tensor(shared_input, hidden_states)
+                if self._shared_experts_tp_comm:
+                    shared_input = self._gather_shared_expert_inputs(hidden_states)
                 shared_input.record_stream(self.alt_stream)
                 self.alt_stream.wait_stream(current_stream)
                 with torch.cuda.stream(self.alt_stream):
@@ -1134,9 +1153,9 @@ class KimiK3MoE(nn.Module):
                 # only for the MLP (not for RS).
                 self.alt_stream.wait_stream(current_stream)
                 with torch.cuda.stream(self.alt_stream):
-                    gathered_shared_output = shared_output
-                    shared_output = torch.empty_like(hidden_states)
-                    attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
+                    shared_output = self._reduce_scatter_shared_experts(
+                        shared_output, hidden_states
+                    )
                     shared_event = self.alt_stream.record_event()
                 current_stream.wait_event(shared_compute_event)
 
@@ -1162,10 +1181,10 @@ class KimiK3MoE(nn.Module):
             current_stream = torch.cuda.current_stream()
             current_stream.wait_event(shared_event)
             shared_output.record_stream(current_stream)
-            if self._shared_experts_attn_tp_comm and not fine_grained_overlap:
-                gathered_shared_output = shared_output
-                shared_output = torch.empty_like(hidden_states)
-                attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
+            if self._shared_experts_tp_comm and not fine_grained_overlap:
+                shared_output = self._reduce_scatter_shared_experts(
+                    shared_output, hidden_states
+                )
 
         # Give the NPU shared-expert branch a head start. At this point
         # hidden_states is the decoder layer's post-attention RMSNorm output.
@@ -1196,7 +1215,9 @@ class KimiK3MoE(nn.Module):
             wait_and_finalize_shared_experts()
             if shared_output is not None:
                 expert_output = expert_output + shared_output
-            if self.tp_size > 1:
+            # EP combine and the shared-expert subgroup have already completed
+            # each source token. A global TP reduction would mix token shards.
+            if self.tp_size > 1 and not self._ep_a2a:
                 expert_output = tensor_model_parallel_all_reduce(expert_output)
             if prefix_sum is not None:
                 expert_output = expert_output + prefix_sum
@@ -1235,7 +1256,7 @@ class KimiK3MoE(nn.Module):
             if (
                 self.tp_size > 1
                 and not self._shared_experts_tp1
-                and not self._shared_experts_attn_tp_comm
+                and not self._shared_experts_tp_comm
             ):
                 shared_output = tensor_model_parallel_all_reduce(shared_output)
             out = _add3(out, shared_output, prefix_sum)

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -913,9 +913,32 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         last_correct_step_indices = commit_lens.to(torch.int64) - 1
         mamba_steps_to_track = None
+        mamba_track_indices = batch.mamba_track_indices
 
-        if batch.mamba_track_indices is not None:
+        if mamba_track_indices is not None:
             mamba_track_interval = mamba_track_grid(batch.tree_cache.page_size)
+            seq_lens_cpu = batch.seq_lens_cpu
+            if (
+                _is_npu
+                and seq_lens_cpu is not None
+                and seq_lens_cpu.device.type == "cpu"
+                and seq_lens_cpu.ndim == 1
+                and seq_lens_cpu.numel() == seq_lens_pre_verify.numel()
+                and seq_lens_cpu.dtype in (torch.int32, torch.int64)
+            ):
+                # Verify restores the CPU prefix lengths before the forward.
+                # Acceptance can commit at most this many tokens, so this
+                # check needs no device readback. Passing None also avoids
+                # the NPU backend's conv-state self-copy for untracked rows.
+                if all(
+                    seq_len >= 0
+                    and seq_len // mamba_track_interval
+                    == (seq_len + self.verify_num_draft_tokens) // mamba_track_interval
+                    for seq_len in seq_lens_cpu.tolist()
+                ):
+                    mamba_track_indices = None
+
+        if mamba_track_indices is not None:
             to_track_mask = (
                 seq_lens_pre_verify // mamba_track_interval
                 != seq_lens_post_verify // mamba_track_interval
@@ -935,7 +958,7 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         attn_backend.update_mamba_state_after_mtp_verify(
             last_correct_step_indices=last_correct_step_indices,
-            mamba_track_indices=batch.mamba_track_indices,
+            mamba_track_indices=mamba_track_indices,
             mamba_steps_to_track=mamba_steps_to_track,
             model=self.target_worker.model_runner.model,
             req_pool_indices=batch.req_pool_indices,

--- a/test/registered/unit/eplb/test_expert_distribution_deepep_auto.py
+++ b/test/registered/unit/eplb/test_expert_distribution_deepep_auto.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.eplb.expert_distribution as expert_distribution
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _metadata():
+    return SimpleNamespace(
+        num_layers=2,
+        num_physical_experts=4,
+        num_local_physical_experts=2,
+    )
+
+
+def _make_auto_gatherer():
+    with (
+        get_context().override_server_args(
+            expert_distribution_recorder_mode="stat",
+            moe_a2a_backend="deepep",
+            deepep_mode="auto",
+            elastic_ep_backend=None,
+        ),
+        patch.object(expert_distribution, "get_device", return_value="cpu"),
+    ):
+        return expert_distribution._SinglePassGatherer.init_new(_metadata(), rank=1)
+
+
+def test_deepep_auto_counts_selected_experts_for_extend():
+    gatherer = _make_auto_gatherer()
+
+    gatherer.reset()
+    with patch.object(expert_distribution, "get_is_extend_in_batch", return_value=True):
+        gatherer.on_select_experts(0, torch.tensor([[0, 3], [3, -1]]))
+    result = gatherer.collect()["global_physical_count"]
+
+    assert torch.equal(result, torch.tensor([[1, 0, 0, 2], [0, 0, 0, 0]]))
+
+
+def test_deepep_auto_counts_selected_experts_for_decode():
+    gatherer = _make_auto_gatherer()
+
+    gatherer.reset()
+    with patch.object(
+        expert_distribution, "get_is_extend_in_batch", return_value=False
+    ):
+        gatherer.on_select_experts(0, torch.tensor([[0, 3]]))
+    gatherer.on_deepep_dispatch_low_latency(0, torch.tensor([2, 4]))
+    result = gatherer.collect()["global_physical_count"]
+
+    # rank=1 owns physical experts 2 and 3. The selected TopK ids above must
+    # not be counted again for a low-latency pass.
+    assert torch.equal(result, torch.tensor([[0, 0, 2, 4], [0, 0, 0, 0]]))
+
+
+def test_deepep_auto_keeps_normal_and_low_latency_paths_separate():
+    gatherer = _make_auto_gatherer()
+
+    gatherer.reset()
+    with patch.object(expert_distribution, "get_is_extend_in_batch", return_value=True):
+        gatherer.on_select_experts(0, torch.tensor([[0, 3]]))
+    with patch.object(
+        expert_distribution, "get_is_extend_in_batch", return_value=False
+    ):
+        gatherer.on_select_experts(1, torch.tensor([[0, 3]]))
+    gatherer.on_deepep_dispatch_low_latency(1, torch.tensor([5, 7]))
+
+    result = gatherer.collect()["global_physical_count"]
+    assert torch.equal(result, torch.tensor([[1, 0, 0, 1], [0, 0, 5, 7]]))

--- a/test/registered/unit/layers/moe/test_npu_mxfp8_deepep_dispatch.py
+++ b/test/registered/unit/layers/moe/test_npu_mxfp8_deepep_dispatch.py
@@ -1,0 +1,44 @@
+"""CPU regressions for A5 MXFP8 DeepEP low-latency dispatch wiring."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.moe import utils as moe_utils
+from sglang.srt.layers.moe.utils import DeepEPMode, DispatcherOutputDtype
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestNPUMXFP8DeepEPDispatch(CustomTestCase):
+    def test_mode_specific_dtype_selection(self):
+        quant_config = {
+            "normal_dispatcher_output_dtype": "bf16",
+            "low_latency_dispatcher_output_dtype": "mxfp8",
+        }
+        common = dict(
+            quant_config=quant_config,
+        )
+        with (
+            patch.object(moe_utils, "get_server_args", return_value=None),
+            patch.object(
+                moe_utils.envs.SGLANG_DEEPEP_BF16_DISPATCH,
+                "get",
+                return_value=False,
+            ),
+        ):
+            normal = moe_utils.get_deepep_output_dtype(
+                SimpleNamespace(**common, dispatch_mode=DeepEPMode.NORMAL)
+            )
+            low_latency = moe_utils.get_deepep_output_dtype(
+                SimpleNamespace(**common, dispatch_mode=DeepEPMode.LOW_LATENCY)
+            )
+
+        self.assertEqual(normal, DispatcherOutputDtype.BF16)
+        self.assertEqual(low_latency, DispatcherOutputDtype.MXFP8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_profiler_rank_filter.py
+++ b/test/registered/unit/managers/test_profiler_rank_filter.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sglang.srt.managers.scheduler_components.profiler_manager import (
+    SchedulerProfilerManager,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+
+def make_manager(*, tp_rank: int = 0, profile_ranks: str = "0"):
+    with patch.dict(
+        "os.environ",
+        {"SGLANG_PROFILE_RANKS": profile_ranks, "SGLANG_PROFILE_V2": "0"},
+    ):
+        return SchedulerProfilerManager(
+            ps=SimpleNamespace(tp_size=8, tp_rank=tp_rank),
+            dp_tp_cpu_group=None,
+            get_forward_ct=lambda: 0,
+        )
+
+
+def configure_profile(manager):
+    result = manager._init_profile(
+        output_dir="/tmp/sglang-test-profile",
+        start_step=None,
+        num_steps=None,
+        activities=["CPU", "GPU"],
+        with_stack=False,
+        record_shapes=False,
+        profile_by_stage=False,
+        profile_id="test-profile",
+    )
+    assert result.success
+
+
+def test_parse_profile_ranks():
+    assert SchedulerProfilerManager._parse_profile_ranks(None) is None
+    assert SchedulerProfilerManager._parse_profile_ranks("") is None
+    assert SchedulerProfilerManager._parse_profile_ranks("0, 2,2") == {0, 2}
+    with pytest.raises(ValueError):
+        SchedulerProfilerManager._parse_profile_ranks("0,-1")
+
+
+def test_reject_profile_rank_outside_tp_world():
+    with pytest.raises(ValueError, match="outside the TP world"):
+        make_manager(profile_ranks="8")
+
+
+def test_non_selected_rank_never_constructs_profiler():
+    manager = make_manager(tp_rank=1)
+    configure_profile(manager)
+
+    result = manager._start_profile(ForwardMode.DECODE)
+
+    assert result.success
+    assert manager.profile_in_progress
+    assert manager.torch_profiler is None
+
+    result = manager._stop_profile(ForwardMode.DECODE)
+    assert result.success
+    assert not manager.profile_in_progress
+
+
+def test_selected_rank_stop_has_no_cross_rank_barrier(tmp_path):
+    manager = make_manager()
+    manager.profile_in_progress = True
+    manager.torch_profiler = Mock()
+    manager.torch_profiler_output_dir = Path(tmp_path)
+    manager.profile_prefix = ""
+    manager.profile_id = "test-profile"
+    manager.profiler_activities = ["CPU", "GPU"]
+    manager.merge_profiles = False
+    manager.ps.dp_size = 1
+    manager.ps.pp_size = 1
+    manager.ps.moe_ep_size = 1
+
+    module = "sglang.srt.managers.scheduler_components.profiler_manager"
+    with (
+        patch(f"{module}._is_npu", True),
+        patch(f"{module}.torch.distributed.barrier") as barrier,
+    ):
+        result = manager._stop_profile(ForwardMode.DECODE)
+
+    assert result.success
+    barrier.assert_not_called()

--- a/test/registered/unit/models/test_kimi_k3_expert_location.py
+++ b/test/registered/unit/models/test_kimi_k3_expert_location.py
@@ -1,0 +1,115 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+import sglang.srt.models.kimi_k3 as kimi_k3
+from sglang.srt.configs.kimi_k3 import KimiK3Config
+from sglang.srt.configs.kimi_linear import KimiLinearConfig
+from sglang.srt.models.kimi_k3 import (
+    KimiK3ForConditionalGeneration,
+    KimiK3LinearForCausalLM,
+    KimiK3MoE,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_kimi_k3_text_exposes_expert_location_config():
+    config = KimiLinearConfig(
+        num_hidden_layers=61,
+        num_experts=384,
+        num_expert_group=8,
+    )
+
+    expert_config = KimiK3LinearForCausalLM.get_model_config_for_expert_location(config)
+
+    assert expert_config.num_layers == 61
+    assert expert_config.num_logical_experts == 384
+    assert expert_config.num_groups == 8
+
+
+def test_kimi_k3_multimodal_exposes_text_expert_location_config():
+    config = KimiK3Config(
+        text_config={
+            "num_hidden_layers": 61,
+            "num_experts": 384,
+            "num_expert_group": 8,
+        }
+    )
+
+    expert_config = KimiK3ForConditionalGeneration.get_model_config_for_expert_location(
+        config
+    )
+
+    assert expert_config.num_layers == 61
+    assert expert_config.num_logical_experts == 384
+    assert expert_config.num_groups == 8
+
+
+def test_kimi_k3_dense_config_has_no_expert_location_config():
+    config = KimiLinearConfig(num_experts=None)
+
+    assert KimiK3LinearForCausalLM.get_model_config_for_expert_location(config) is None
+
+
+def test_kimi_k3_allocates_redundant_physical_expert_slots():
+    config = SimpleNamespace(num_experts=896)
+
+    for redundant_experts, expected_physical_experts in [
+        (0, 896),
+        (32, 928),
+        (64, 960),
+    ]:
+        with patch.object(
+            kimi_k3,
+            "get_exec",
+            return_value=SimpleNamespace(
+                moe=SimpleNamespace(ep_num_redundant_experts=redundant_experts)
+            ),
+        ):
+            assert (
+                kimi_k3._get_num_physical_routed_experts(config)
+                == expected_physical_experts
+            )
+
+
+def test_kimi_k3_prefers_n_routed_experts_for_physical_slots():
+    config = SimpleNamespace(num_experts=896, n_routed_experts=384)
+
+    with patch.object(
+        kimi_k3,
+        "get_exec",
+        return_value=SimpleNamespace(moe=SimpleNamespace(ep_num_redundant_experts=32)),
+    ):
+        assert kimi_k3._get_num_physical_routed_experts(config) == 416
+
+
+def test_kimi_k3_topk_receives_expert_location_dispatch_info():
+    expected_output = object()
+    dispatch_info = object()
+    owner = SimpleNamespace(
+        layer_idx=17,
+        topk=Mock(return_value=expected_output),
+    )
+    owner._expert_location_dispatch_info = lambda: (
+        KimiK3MoE._expert_location_dispatch_info(owner)
+    )
+    hidden_states = torch.empty(2, 4)
+    router_logits = torch.empty(2, 8)
+
+    with patch.object(
+        kimi_k3.ExpertLocationDispatchInfo,
+        "init_new",
+        return_value=dispatch_info,
+    ) as init_new:
+        actual = KimiK3MoE._select_experts(owner, hidden_states, router_logits)
+
+    assert actual is expected_output
+    init_new.assert_called_once_with(layer_id=17)
+    owner.topk.assert_called_once_with(
+        hidden_states,
+        router_logits,
+        expert_location_dispatch_info=dispatch_info,
+    )

--- a/test/registered/unit/npu/attention/test_npu_mla_cache.py
+++ b/test/registered/unit/npu/attention/test_npu_mla_cache.py
@@ -1,0 +1,70 @@
+"""CPU checks for logical prefix reads from ND and PA-NZ MLA cache pages."""
+
+import unittest
+
+import torch
+
+from sglang.srt.hardware_backend.npu.attention.mla_cache import gather_mla_cache_pages
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMLACachePrefixRead(CustomTestCase):
+    def test_page_order_and_layout(self):
+        # Both latent and RoPE buffers must preserve every token's features.
+        for page_size in (16, 128):
+            for head_dim in (64, 512):
+                logical = torch.arange(4 * page_size * head_dim).reshape(
+                    4, page_size, 1, head_dim
+                )
+                packed = (
+                    logical.reshape(4, page_size, head_dim // 16, 16)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                    .reshape_as(logical)
+                )
+                for is_nz, cache in ((False, logical), (True, packed)):
+                    for selected in ([3, 1, 3, 0], [], [2]):
+                        with self.subTest(
+                            page_size=page_size,
+                            head_dim=head_dim,
+                            is_nz=is_nz,
+                            selected=selected,
+                        ):
+                            ids = torch.tensor(selected, dtype=torch.int32)
+                            actual = gather_mla_cache_pages(cache, ids, is_nz=is_nz)
+                            expected = logical[selected]
+                            self.assertEqual(actual.shape, expected.shape)
+                            self.assertTrue(torch.equal(actual, expected))
+
+    def test_partial_page_writes_preserve_prefix_features(self):
+        # Populate NZ storage by scalar coordinates, independently of the
+        # reshape/permute used by the reader. Leave unwritten slots sentinel-filled.
+        page_size = 128
+        slots = (128, 129, 255, 256, 383, 511)
+        for head_dim in (64, 512):
+            with self.subTest(head_dim=head_dim):
+                tiles = head_dim // 16
+                cache = torch.full((4, page_size, 1, head_dim), -1, dtype=torch.int64)
+                logical = torch.full_like(cache, -1)
+                flat = cache.view(-1)
+                for slot in slots:
+                    for dim in range(head_dim):
+                        value = slot * 1000 + dim
+                        logical[slot // page_size, slot % page_size, 0, dim] = value
+                        offset = (
+                            ((slot // page_size) * tiles + dim // 16) * page_size
+                            + slot % page_size
+                        ) * 16 + dim % 16
+                        flat[offset] = value
+                ids = torch.tensor([3, 1, 2, 1], dtype=torch.int64)
+                actual = gather_mla_cache_pages(cache, ids, is_nz=True)
+                self.assertTrue(torch.equal(actual, logical[[3, 1, 2, 1]]))
+                # The former raw page gather must fail for this regression case.
+                self.assertFalse(torch.equal(cache[ids], actual))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Enable Kimi-K3 inference on Ascend with MXFP4 experts, DSPARK attention and state handling, and communication overlap. Support reusable PD decode prefixes and configurable shared-expert TP while preserving the decomposed KDA prefill implementation.

## Modifications

- Stabilize NPU KDA launch settings and retain speculative scratch in both PD pools. Preserve the existing NPU speculative temporal-state transpose.
- Wire compressed-tensors/ModelSlim K3 projections and MXFP4 MoE to Ascend, use MXFP8 low-latency dispatch, and fuse SiTU with MXFP8 requantization.
- Reuse the graph-update worker, update inputs before replay, and select the matching FIA v2 sequence-length handler for DSPARK.
- Use NPU chain rejection sampling and skip checkpoint tracking when no verify request can cross a checkpoint boundary.
- Support K3 DSPARK PD decode radix caching with prefill-provided recurrent state.
- Overlap shared-expert communication and computation with routed MoE; allow shared-expert TP subgroups within attention TP.
- Support ordinary MLA writes to FIA NZ cache and restore logical prefix pages before projection.
- Add K3 EPLB placement metadata, redundant physical expert slots, and actual DeepEP AUTO decode accounting.
- Allow selecting profiler TP ranks with `SGLANG_PROFILE_RANKS`.

The branch contains 12 feature commits. Contributor identities are retained, and `--shared-experts-tp-size` is declared in the current parallel configuration schema.

## Validation

- Ruff 0.15.1 lint (`F401,F821,UP037`) and format checks passed.
- isort 7.0.0 and codespell 2.4.1 passed for all 39 changed Python files.
- Python AST parsing and `git diff --check` passed.
- Verified the KDA extend implementation matches the upstream decomposed path and contains no `torch.ops.npu.chunk_kda_fwd` call. The temporal-state pool layout is unchanged from the upstream base.
- Included the source CPU regression coverage for MXFP8 dispatch, NZ prefix reads, EPLB, and profiler rank selection. Runtime tests and NPU benchmarks were not rerun during integration.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34426362052](https://github.com/sgl-project/sglang/actions/runs/34426362052)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34426361825](https://github.com/sgl-project/sglang/actions/runs/34426361825)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34426361854](https://github.com/sgl-project/sglang/actions/runs/34426361854)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
