### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3-235B guides

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_235b_a22b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_235b_a22b.mdx
@@ -101,7 +101,7 @@ python3 -m sglang.launch_server \
     --enable-dp-lm-head \
     --tp 16 \
     --mem-fraction-static 0.78 \
-    --cuda-graph-bs 1 \
+    --cuda-graph-bs-decode 1 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen25
 ```
@@ -210,7 +210,7 @@ python3 -m sglang.launch_server \
     --enable-dp-attention \
     --enable-dp-lm-head \
     --mem-fraction-static 0.8 \
-    --cuda-graph-bs 1 2 4 8 16 20 24 26 27 \
+    --cuda-graph-bs-decode 1 2 4 8 16 20 24 26 27 \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen25
 ```

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_235b_a22b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_235b_a22b.mdx
@@ -30,7 +30,7 @@ v0.5.16 or a later version.
 | PD Disaggregation             | `--disaggregation-mode prefill \`<br/>`--disaggregation-transfer-backend ascend`              |
 | Quantization                  | `--quantization modelslim`                                                                    |
 | Chunked Prefill               | auto based on device memory, or set explicit value;<br/>disable with `--chunked-prefill-size -1`; e.g., `--chunked-prefill-size 94208` |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 1 2 4 8 16 20 24 26 27` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 1 2 4 8 16 20 24 26 27` |
 | Speculative Decoding          | `--speculative-algorithm EAGLE3 \`<br/>`--speculative-draft-model-path /path/to/draft-model-weights \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4 \`<br/>`--speculative-draft-model-quantization unquant` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |
@@ -256,7 +256,8 @@ python3 -m sglang.launch_server \
     --disaggregation-transfer-backend ascend \
     --attention-backend ascend \
     --mem-fraction-static 0.8 \
-    --disable-cuda-graph \
+    --cuda-graph-backend-decode=disabled \
+    --cuda-graph-backend-prefill=disabled \
     --device npu \
     --quantization modelslim \
     --disable-radix-cache \
@@ -371,7 +372,8 @@ python3 -m sglang.launch_server \
     --quantization modelslim \
     --attention-backend ascend \
     --disable-radix-cache \
-    --disable-cuda-graph \
+    --cuda-graph-backend-decode=disabled \
+    --cuda-graph-backend-prefill=disabled \
     --mem-fraction-static 0.7 \
     --chunked-prefill-size 32768 \
     --skip-server-warmup \


### PR DESCRIPTION
## Summary
- Prefer `--cuda-graph-bs-decode` over deprecated `--cuda-graph-bs` in Ascend Qwen3-235B-A22B best practices.
- Prefer `--cuda-graph-backend-{decode,prefill}=disabled` and `--cuda-graph-bs-decode` over deprecated `--disable-cuda-graph` / `--cuda-graph-bs` in the matching tutorial (NPU Graph table + decode examples).

Verified against live `python/sglang/srt/server_args.py` deprecated aliases on `main`.

## Test plan
- [ ] Confirm docs snippets match current CLI names
- [ ] No behavior change intended (docs-only)

Signed-off-by: ADou <ikun3.1415927@gmail.com>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34199987384](https://github.com/sgl-project/sglang/actions/runs/34199987384)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34199987115](https://github.com/sgl-project/sglang/actions/runs/34199987115)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->