### PR TITLE
[HiCache] Issue round-head H2D copies before the load burst hand-over

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -13,6 +13,7 @@ from sglang.srt.runtime_context import (
     get_spec,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_npu
+from sglang.srt.utils.common import is_pin_memory_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -82,6 +83,94 @@ def _assert_nonneg_and_invalidate(
     Compiled so the reduction + assert + scatter run as one kernel launch."""
     torch._assert_async((values >= 0).all())
     buf[indices] = -1
+
+
+@dataclass
+class StagedDeviceTensor:
+    """One-shot device copy of a host value, uploaded on the schedule stream
+    ahead of the HiCache load burst hand-over (see pre_upload_forward_inputs).
+
+    ``take(source)`` hands the tensor out exactly once, and only while
+    ``source`` is still the host object the copy was made from. A later
+    re-assignment of the host value (draft-extend rewrites extend_lens, a DP
+    step re-gathers global_num_tokens) therefore falls back to a fresh upload
+    instead of reading a stale copy. Consuming mutates this object rather than
+    the ScheduleBatch, so it also survives the spec forward-isolation snapshot
+    and restore.
+    """
+
+    source: Any
+    tensor: Optional[torch.Tensor]
+
+    def take(self, source: Any) -> Optional[torch.Tensor]:
+        if self.tensor is None or source is not self.source:
+            return None
+        tensor, self.tensor = self.tensor, None
+        return tensor
+
+
+def _stage(values: Any, dtype: torch.dtype, device) -> StagedDeviceTensor:
+    tensor = torch.tensor(
+        values, dtype=dtype, pin_memory=is_pin_memory_available(device)
+    ).to(device, non_blocking=True)
+    return StagedDeviceTensor(source=values, tensor=tensor)
+
+
+def pre_upload_forward_inputs(batch: ScheduleBatch) -> None:
+    """Issue the round-head H2D uploads on the current (schedule) stream,
+    BEFORE the HiCache load burst is handed over.
+
+    The first ops a prefill forward enqueues are small H2D copies: the deferred
+    input_ids upload in resolve_forward_inputs and the extend / DP-sync
+    metadata tensors built by ForwardBatch.init_new. When an asynchronous
+    HiCache load burst is already queued on the load stream, the copy engine
+    can serve those head copies only after the whole burst, and the entire
+    forward waits behind them. HiCacheController.start_loading records its
+    start_event on the schedule stream and makes the load stream wait on it,
+    so every copy issued here before that record is ordered ahead of the
+    burst by stream contract.
+
+    Only prefill batches reach this point (see Scheduler._handover_hicache_load)
+    and the batch is final: mixing with running decodes and the DP mlp-sync
+    gather have already happened.
+
+    * Pure prefill: input_ids goes straight to the device; the pinned staging
+      is released and resolve_forward_inputs becomes a no-op for it (the same
+      pattern the dynamic chunk sizer uses). A mixed prefill+decode batch keeps
+      the deferred path because its input_ids needs the forward-time FutureMap
+      gather.
+    * extend_lens / prefix_lens (host lists on the main path) and the
+      mlp-sync global token counts are staged as StagedDeviceTensor and
+      consumed once by ForwardBatch.init_new. Speculative batches skip the
+      global counts: init_new rescales them, so the staged values would be
+      wrong.
+    """
+    if batch.prefill_input_ids_cpu is not None and batch.mix_running_indices is None:
+        batch.input_ids = batch.prefill_input_ids_cpu.to(
+            batch.device, non_blocking=True
+        )
+        batch.prefill_input_ids_cpu = None
+
+    device = batch.device
+    if isinstance(batch.extend_lens, list) and batch.extend_lens:
+        batch.head_staged_extend_seq_lens = _stage(
+            batch.extend_lens, torch.int32, device
+        )
+    if isinstance(batch.prefix_lens, list) and batch.prefix_lens:
+        batch.head_staged_extend_prefix_lens = _stage(
+            batch.prefix_lens, torch.int32, device
+        )
+
+    if batch.spec_info is not None:
+        return
+    if batch.global_num_tokens is not None:
+        batch.head_staged_global_num_tokens = _stage(
+            batch.global_num_tokens, torch.int64, device
+        )
+    if batch.global_num_tokens_for_logprob is not None:
+        batch.head_staged_global_num_tokens_for_logprob = _stage(
+            batch.global_num_tokens_for_logprob, torch.int64, device
+        )
 
 
 def resolve_forward_inputs(batch: ScheduleBatch, future_map: FutureMap) -> None:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -147,6 +147,7 @@ if TYPE_CHECKING:
 
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.overlap_utils import StagedDeviceTensor
     from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
     from sglang.srt.session.session_controller import Session
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
@@ -2251,6 +2252,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # CPU twin of mix_running_indices; lets the overlap tail resolve gather
     # pinned mirrors without a device sync.
     mix_running_indices_cpu: Optional[torch.Tensor] = None
+    # Round-head metadata pre-uploaded on the schedule stream before the
+    # HiCache load burst hand-over (overlap_utils.pre_upload_forward_inputs).
+    # ForwardBatch.init_new takes each one at most once, and only while the
+    # host list it was built from is still the batch's current value.
+    head_staged_extend_seq_lens: Optional[StagedDeviceTensor] = None
+    head_staged_extend_prefix_lens: Optional[StagedDeviceTensor] = None
+    head_staged_global_num_tokens: Optional[StagedDeviceTensor] = None
+    head_staged_global_num_tokens_for_logprob: Optional[StagedDeviceTensor] = None
     input_embeds: torch.Tensor = None  # shape: [b, hidden_size], float32
 
     # Token replacement embeddings and absolute positions (optional).
@@ -3551,6 +3560,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.input_ids = torch.cat([self.input_ids, other.input_ids])
         else:
             self.input_ids = None
+        # Round-head staging belongs to one formation; a merged batch must not
+        # consume either side's tensors.
+        self.head_staged_extend_seq_lens = None
+        self.head_staged_extend_prefix_lens = None
+        self.head_staged_global_num_tokens = None
+        self.head_staged_global_num_tokens_for_logprob = None
         # Optional under no-verify-sync; drop the mirror if either side absent.
         if self.seq_lens_cpu is None or other.seq_lens_cpu is None:
             self.seq_lens_cpu = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -193,6 +193,7 @@ from sglang.srt.managers.overlap_utils import (
     RelayPayload,
     decide_needs_confidence_relay,
     decide_needs_cpu_seq_lens,
+    pre_upload_forward_inputs,
     resolve_forward_inputs,
 )
 from sglang.srt.managers.prefill_delayer import (
@@ -3944,12 +3945,9 @@ class Scheduler(
             self.chunked_req is None or len(can_run_list) != 1
         )
 
-        if self.enable_hierarchical_cache or self.enable_unified_cache_external_linker:
-            # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
-            new_batch.hicache_consumer_index = (
-                self.tree_cache.ready_to_load_host_cache()
-            )
-
+        # The HiCache load burst is handed over later, in run_batch
+        # (_handover_hicache_load), so that every round-head H2D copy is
+        # enqueued on the schedule stream before the burst starts.
         new_batch.prepare_for_extend()
 
         if self.tp_worker.model_runner.prefill_aware_swa:
@@ -4176,6 +4174,35 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
+    def _handover_hicache_load(self, batch: ScheduleBatch) -> None:
+        """Pre-upload the round-head forward inputs, then start the HiCache
+        load burst queued for this prefill batch.
+
+        This runs in run_batch rather than at batch formation because the
+        batch is only final here: mix_with_running and the DP mlp-sync gather
+        (which assigns global_num_tokens) happen in between. start_loading
+        records its start_event on the schedule stream and makes the load
+        stream wait on it, so the copies issued by pre_upload_forward_inputs
+        are ordered ahead of the burst. Issued the other way round, the
+        forward's first H2D copy can queue behind the entire burst on the copy
+        engine and stall the whole round.
+
+        Only new prefill batches own queued loads. The consumer-index check
+        keeps the hand-over idempotent for batches that re-enter run_batch
+        (pd-multiplexing runs a split prefill batch once per slice).
+        """
+        if not (
+            self.enable_hierarchical_cache or self.enable_unified_cache_external_linker
+        ):
+            return
+        if not batch.forward_mode.is_extend_without_speculative():
+            return
+        if batch.hicache_consumer_index != -1:
+            return
+        pre_upload_forward_inputs(batch)
+        # todo (zhiqiang): disable cuda graph execution if hicache loading triggered
+        batch.hicache_consumer_index = self.tree_cache.ready_to_load_host_cache()
+
     @scheduler_stage_method(SCHEDULER_STAGE_RUN_BATCH)
     def run_batch(
         self,
@@ -4202,6 +4229,8 @@ class Scheduler(
         # Place holder handling for pd-disagg decode event loop
         if batch.forward_mode.is_prebuilt():
             return self._run_batch_prebuilt(batch)
+
+        self._handover_hicache_load(batch)
 
         # PD prefill: early-send cached prefix KV, overlapping the suffix forward.
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -32,7 +32,7 @@ import warnings
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import total_ordering
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from sglang.srt.layers.cp.base import BaseContextParallelMetadata
     from sglang.srt.layers.dcp.metadata import DecodeContextParallelMetadata
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang.srt.managers.overlap_utils import StagedDeviceTensor
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -78,6 +79,21 @@ if TYPE_CHECKING:
 # Warn-once flag for the deprecated skip_attn_backend_init kwarg; see
 # ForwardBatch.apply_deprecated_skip_attn_backend_init.
 _skip_attn_backend_init_warned = False
+
+
+def _take_staged(
+    staged: Optional[StagedDeviceTensor], source: Any
+) -> Optional[torch.Tensor]:
+    """Consume a scheduler pre-uploaded device tensor built from ``source``.
+
+    Returns None when nothing was staged, when the staging was already taken
+    by an earlier init_new on the same batch, or when ``source`` is no longer
+    the host object it was uploaded from; the caller then uploads afresh.
+    """
+    if staged is None:
+        return None
+    return staged.take(source)
+
 
 _is_npu = is_npu()
 _is_cpu = is_cpu()
@@ -735,16 +751,35 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         self.original_global_num_tokens_cpu = batch.global_num_tokens
         self.global_num_tokens_cpu = global_num_tokens
+        # Prefer the copies the scheduler uploaded ahead of the HiCache load
+        # burst; they were built from the unscaled lists, so only a batch
+        # without spec scaling can use them (the staging itself skips spec
+        # batches, and take() guards against a re-gathered list).
+        staged_gpu = staged_logprob_gpu = None
+        if self.spec_info is None:
+            staged_gpu = _take_staged(
+                batch.head_staged_global_num_tokens, global_num_tokens
+            )
+            staged_logprob_gpu = _take_staged(
+                batch.head_staged_global_num_tokens_for_logprob,
+                global_num_tokens_for_logprob,
+            )
         pin_memory = is_pin_memory_available(device)
-        self.global_num_tokens_gpu = torch.tensor(
-            global_num_tokens, dtype=torch.int64, pin_memory=pin_memory
-        ).to(device, non_blocking=True)
+        if staged_gpu is not None:
+            self.global_num_tokens_gpu = staged_gpu
+        else:
+            self.global_num_tokens_gpu = torch.tensor(
+                global_num_tokens, dtype=torch.int64, pin_memory=pin_memory
+            ).to(device, non_blocking=True)
         self.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
-        self.global_num_tokens_for_logprob_gpu = torch.tensor(
-            global_num_tokens_for_logprob,
-            dtype=torch.int64,
-            pin_memory=pin_memory,
-        ).to(device, non_blocking=True)
+        if staged_logprob_gpu is not None:
+            self.global_num_tokens_for_logprob_gpu = staged_logprob_gpu
+        else:
+            self.global_num_tokens_for_logprob_gpu = torch.tensor(
+                global_num_tokens_for_logprob,
+                dtype=torch.int64,
+                pin_memory=pin_memory,
+            ).to(device, non_blocking=True)
         self.can_run_decode_cuda_graph = batch.can_run_decode_cuda_graph
 
     @classmethod
@@ -925,14 +960,30 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         else:
             if isinstance(extend_seq_lens, list):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
+                # The scheduler may already have uploaded these lists ahead of
+                # the HiCache load burst (head_staged_*); take() returns None
+                # once consumed or if the list was re-assigned since (e.g. a
+                # draft-extend re-running init_new on the same batch).
                 assert isinstance(extend_prefix_lens, list)
                 pin_memory = is_pin_memory_available(device)
-                ret.extend_seq_lens = torch.tensor(
-                    extend_seq_lens, dtype=torch.int32, pin_memory=pin_memory
-                ).to(device, non_blocking=True)
-                ret.extend_prefix_lens = torch.tensor(
-                    extend_prefix_lens, dtype=torch.int32, pin_memory=pin_memory
-                ).to(device, non_blocking=True)
+                staged_seq_lens = _take_staged(
+                    batch.head_staged_extend_seq_lens, extend_seq_lens
+                )
+                staged_prefix_lens = _take_staged(
+                    batch.head_staged_extend_prefix_lens, extend_prefix_lens
+                )
+                if staged_seq_lens is not None:
+                    ret.extend_seq_lens = staged_seq_lens
+                else:
+                    ret.extend_seq_lens = torch.tensor(
+                        extend_seq_lens, dtype=torch.int32, pin_memory=pin_memory
+                    ).to(device, non_blocking=True)
+                if staged_prefix_lens is not None:
+                    ret.extend_prefix_lens = staged_prefix_lens
+                else:
+                    ret.extend_prefix_lens = torch.tensor(
+                        extend_prefix_lens, dtype=torch.int32, pin_memory=pin_memory
+                    ).to(device, non_blocking=True)
                 ret.extend_prefix_lens_cpu = extend_prefix_lens
                 ret.extend_seq_lens_cpu = extend_seq_lens
             else:

--- a/test/registered/unit/managers/test_generation_auxiliary_output.py
+++ b/test/registered/unit/managers/test_generation_auxiliary_output.py
@@ -415,6 +415,8 @@ def test_pdmux_split_prefill_schedules_auxiliary_output_copy():
     scheduler.is_generation = True
     scheduler.enable_overlap = False
     scheduler.enable_pdmux = True
+    scheduler.enable_hierarchical_cache = False
+    scheduler.enable_unified_cache_external_linker = False
     scheduler.ps = SimpleNamespace(pp_size=1)
     scheduler.tp_worker = SimpleNamespace(
         forward_batch_split_prefill=Mock(return_value=result)

--- a/test/registered/unit/managers/test_head_upload_ordering.py
+++ b/test/registered/unit/managers/test_head_upload_ordering.py
@@ -1,0 +1,306 @@
+"""Unit tests for the HiCache load-burst ordering fix (round-head H2D pre-upload).
+
+The first ops a prefill forward enqueues are small H2D copies (the deferred
+input_ids upload plus init_new's extend / DP-sync metadata). With an
+asynchronous HiCache load burst already queued on the load stream, the copy
+engine can serve those head copies only after the whole burst, and the entire
+forward waits behind them. The fix issues those copies on the schedule stream
+BEFORE start_loading() records the burst's start_event, so they are ordered
+ahead of the burst by stream contract.
+
+Properties pinned here:
+* pre_upload_forward_inputs consumes the prefill staging into device-resident
+  input_ids for pure-prefill batches, leaves mixed batches on the deferred
+  path, and stages the extend / global metadata as one-shot device tensors;
+* StagedDeviceTensor hands its tensor out once, and only while the host list
+  it was built from is still the batch's current value;
+* resolve_forward_inputs on a pre-uploaded batch touches nothing, and keeps
+  its behaviour for batches that were NOT pre-uploaded;
+* ForwardBatch.init_mlp_sync_metadata consumes the staged global counts for
+  non-spec batches and falls back to a fresh upload otherwise;
+* Scheduler._handover_hicache_load pre-uploads and then hands the burst over
+  only for new prefill batches, exactly once per batch.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.overlap_utils import (
+    StagedDeviceTensor,
+    pre_upload_forward_inputs,
+    resolve_forward_inputs,
+)
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+def _batch(**over):
+    base = dict(
+        device="cpu",
+        prefill_input_ids_cpu=torch.tensor([1, 2, 3, 4], dtype=torch.int64),
+        mix_running_indices=None,
+        input_ids=None,
+        extend_lens=[3, 1],
+        prefix_lens=[10, 20],
+        global_num_tokens=[4, 4, 4, 4],
+        global_num_tokens_for_logprob=[4, 4, 4, 4],
+        spec_info=None,
+        head_staged_extend_seq_lens=None,
+        head_staged_extend_prefix_lens=None,
+        head_staged_global_num_tokens=None,
+        head_staged_global_num_tokens_for_logprob=None,
+        hicache_consumer_index=-1,
+        forward_mode=ForwardMode.EXTEND,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+class TestStagedDeviceTensor(CustomTestCase):
+    def test_take_is_one_shot(self):
+        src = [1, 2]
+        staged = StagedDeviceTensor(source=src, tensor=torch.tensor(src))
+        first = staged.take(src)
+        self.assertIsNotNone(first)
+        self.assertIsNone(staged.take(src))
+
+    def test_take_rejects_reassigned_source(self):
+        src = [1, 2]
+        staged = StagedDeviceTensor(source=src, tensor=torch.tensor(src))
+        # Same values, different object: the host list was rebuilt (draft
+        # extend, DP re-gather), so the staged copy must not be used.
+        self.assertIsNone(staged.take([1, 2]))
+        # The original source still takes.
+        self.assertIsNotNone(staged.take(src))
+
+
+class TestPreUpload(CustomTestCase):
+    def test_pure_prefill_consumes_staging_into_input_ids(self):
+        b = _batch()
+        pre_upload_forward_inputs(b)
+        self.assertIsNone(b.prefill_input_ids_cpu)
+        self.assertEqual(b.input_ids.tolist(), [1, 2, 3, 4])
+
+    def test_mixed_batch_keeps_the_deferred_path(self):
+        b = _batch(mix_running_indices=torch.tensor([0, 1]))
+        pre_upload_forward_inputs(b)
+        # input_ids needs a forward-time FutureMap gather; staging must survive.
+        self.assertIsNotNone(b.prefill_input_ids_cpu)
+        self.assertIsNone(b.input_ids)
+        # Metadata staging is still safe for a mixed batch.
+        self.assertIsNotNone(b.head_staged_extend_seq_lens)
+
+    def test_metadata_is_staged_as_device_tensors(self):
+        b = _batch()
+        pre_upload_forward_inputs(b)
+        seq = b.head_staged_extend_seq_lens
+        self.assertIs(seq.source, b.extend_lens)
+        self.assertEqual(seq.tensor.tolist(), [3, 1])
+        self.assertEqual(seq.tensor.dtype, torch.int32)
+        pre = b.head_staged_extend_prefix_lens
+        self.assertIs(pre.source, b.prefix_lens)
+        self.assertEqual(pre.tensor.tolist(), [10, 20])
+        glob = b.head_staged_global_num_tokens
+        self.assertIs(glob.source, b.global_num_tokens)
+        self.assertEqual(glob.tensor.tolist(), [4, 4, 4, 4])
+        self.assertEqual(glob.tensor.dtype, torch.int64)
+        self.assertEqual(
+            b.head_staged_global_num_tokens_for_logprob.tensor.tolist(), [4, 4, 4, 4]
+        )
+
+    def test_spec_batch_skips_global_counts(self):
+        b = _batch(spec_info=object())  # init_new rescales the counts
+        pre_upload_forward_inputs(b)
+        self.assertIsNotNone(b.head_staged_extend_seq_lens)
+        self.assertIsNone(b.head_staged_global_num_tokens)
+        self.assertIsNone(b.head_staged_global_num_tokens_for_logprob)
+
+    def test_no_dp_attention_stages_no_globals(self):
+        b = _batch(global_num_tokens=None, global_num_tokens_for_logprob=None)
+        pre_upload_forward_inputs(b)
+        self.assertIsNone(b.head_staged_global_num_tokens)
+        self.assertIsNone(b.head_staged_global_num_tokens_for_logprob)
+
+    def test_tensor_form_extend_lens_not_restaged(self):
+        # gpu_only deployments hand device tensors in directly; staging must
+        # not clobber them with a second copy.
+        t = torch.tensor([3, 1], dtype=torch.int32)
+        b = _batch(extend_lens=t, prefix_lens=t)
+        pre_upload_forward_inputs(b)
+        self.assertIsNone(b.head_staged_extend_seq_lens)
+        self.assertIsNone(b.head_staged_extend_prefix_lens)
+
+
+class _FakeFutureMap:
+    def __init__(self):
+        self.output_tokens_buf = torch.arange(100, dtype=torch.int64)
+        self.spec_algo = SimpleNamespace(is_none=lambda: True)
+
+
+class TestResolveInterplay(CustomTestCase):
+    def _resolve_batch(self, **over):
+        b = _batch(**over)
+        b.req_pool_indices = torch.tensor([5, 6])
+        b.enable_overlap = True
+        b.spec_algorithm = SimpleNamespace(is_none=lambda: True)
+        return b
+
+    def test_resolve_is_a_noop_after_pre_upload(self):
+        b = self._resolve_batch()
+        pre_upload_forward_inputs(b)
+        uploaded = b.input_ids
+        resolve_forward_inputs(b, _FakeFutureMap())
+        self.assertIs(b.input_ids, uploaded)
+
+    def test_resolve_unchanged_without_pre_upload(self):
+        b = self._resolve_batch()
+        resolve_forward_inputs(b, _FakeFutureMap())
+        self.assertEqual(b.input_ids.tolist(), [1, 2, 3, 4])
+        self.assertIsNone(b.prefill_input_ids_cpu)
+
+    def test_resolve_decode_gather_untouched(self):
+        b = self._resolve_batch(prefill_input_ids_cpu=None)
+        pre_upload_forward_inputs(b)
+        resolve_forward_inputs(b, _FakeFutureMap())
+        self.assertEqual(b.input_ids.tolist(), [5, 6])
+
+
+class TestInitNewConsumesStagedGlobals(CustomTestCase):
+    def _forward_batch(self, spec_info=None):
+        fb = ForwardBatch.__new__(ForwardBatch)
+        fb.spec_info = spec_info
+        return fb
+
+    def test_non_spec_takes_staged_tensors_once(self):
+        b = _batch(can_run_decode_cuda_graph=False)
+        pre_upload_forward_inputs(b)
+        staged = b.head_staged_global_num_tokens.tensor
+        staged_logprob = b.head_staged_global_num_tokens_for_logprob.tensor
+
+        fb = self._forward_batch()
+        fb.init_mlp_sync_metadata(b, "cpu")
+        self.assertIs(fb.global_num_tokens_gpu, staged)
+        self.assertIs(fb.global_num_tokens_for_logprob_gpu, staged_logprob)
+        self.assertEqual(fb.global_num_tokens_cpu, [4, 4, 4, 4])
+
+        # A second init_new on the same batch gets a fresh upload, never the
+        # tensor the first forward already owns.
+        fb2 = self._forward_batch()
+        fb2.init_mlp_sync_metadata(b, "cpu")
+        self.assertIsNot(fb2.global_num_tokens_gpu, staged)
+        self.assertEqual(fb2.global_num_tokens_gpu.tolist(), [4, 4, 4, 4])
+
+    def test_regathered_counts_fall_back(self):
+        b = _batch(can_run_decode_cuda_graph=False)
+        pre_upload_forward_inputs(b)
+        staged = b.head_staged_global_num_tokens.tensor
+        b.global_num_tokens = [8, 8, 8, 8]  # DP step re-gathered the counts
+        fb = self._forward_batch()
+        fb.init_mlp_sync_metadata(b, "cpu")
+        self.assertIsNot(fb.global_num_tokens_gpu, staged)
+        self.assertEqual(fb.global_num_tokens_gpu.tolist(), [8, 8, 8, 8])
+
+    def test_without_staging_uploads_as_before(self):
+        b = _batch(can_run_decode_cuda_graph=False)
+        fb = self._forward_batch()
+        fb.init_mlp_sync_metadata(b, "cpu")
+        self.assertEqual(fb.global_num_tokens_gpu.tolist(), [4, 4, 4, 4])
+        self.assertEqual(fb.global_num_tokens_for_logprob_gpu.dtype, torch.int64)
+
+
+class TestHandover(CustomTestCase):
+    def _scheduler(self, calls, hicache=True, linker=False):
+        return SimpleNamespace(
+            enable_hierarchical_cache=hicache,
+            enable_unified_cache_external_linker=linker,
+            tree_cache=SimpleNamespace(
+                ready_to_load_host_cache=lambda: calls.append("ready") or 7
+            ),
+        )
+
+    def test_prefill_batch_pre_uploads_then_hands_over(self):
+        calls = []
+        b = _batch()
+        Scheduler._handover_hicache_load(self._scheduler(calls), b)
+        self.assertEqual(calls, ["ready"])
+        self.assertEqual(b.hicache_consumer_index, 7)
+        # Every round-head copy was issued before the hand-over.
+        self.assertIsNone(b.prefill_input_ids_cpu)
+        self.assertEqual(b.input_ids.tolist(), [1, 2, 3, 4])
+        self.assertIsNotNone(b.head_staged_extend_seq_lens)
+        self.assertIsNotNone(b.head_staged_global_num_tokens)
+
+    def test_hand_over_order_is_upload_then_record(self):
+        order = []
+        b = _batch()
+        b.prefill_input_ids_cpu = SimpleNamespace(
+            to=lambda *a, **k: order.append("upload") or torch.tensor([1, 2, 3, 4])
+        )
+        sched = SimpleNamespace(
+            enable_hierarchical_cache=True,
+            enable_unified_cache_external_linker=False,
+            tree_cache=SimpleNamespace(
+                ready_to_load_host_cache=lambda: order.append("record") or 0
+            ),
+        )
+        Scheduler._handover_hicache_load(sched, b)
+        self.assertEqual(order, ["upload", "record"])
+
+    def test_external_linker_alone_hands_over(self):
+        calls = []
+        b = _batch()
+        Scheduler._handover_hicache_load(
+            self._scheduler(calls, hicache=False, linker=True), b
+        )
+        self.assertEqual(calls, ["ready"])
+
+    def test_disabled_hicache_is_a_noop(self):
+        calls = []
+        b = _batch()
+        Scheduler._handover_hicache_load(self._scheduler(calls, hicache=False), b)
+        self.assertEqual(calls, [])
+        self.assertEqual(b.hicache_consumer_index, -1)
+        # Nothing is pre-uploaded either: no burst, no ordering to enforce.
+        self.assertIsNotNone(b.prefill_input_ids_cpu)
+        self.assertIsNone(b.head_staged_extend_seq_lens)
+
+    def test_non_prefill_batches_do_not_hand_over(self):
+        for mode in (ForwardMode.DECODE, ForwardMode.IDLE, ForwardMode.TARGET_VERIFY):
+            calls = []
+            b = _batch(forward_mode=mode)
+            Scheduler._handover_hicache_load(self._scheduler(calls), b)
+            self.assertEqual(calls, [], mode)
+            self.assertEqual(b.hicache_consumer_index, -1, mode)
+
+    def test_all_prefill_modes_hand_over(self):
+        for mode in (
+            ForwardMode.EXTEND,
+            ForwardMode.MIXED,
+            ForwardMode.SPLIT_PREFILL,
+            ForwardMode.DLLM_EXTEND,
+        ):
+            calls = []
+            b = _batch(forward_mode=mode)
+            Scheduler._handover_hicache_load(self._scheduler(calls), b)
+            self.assertEqual(calls, ["ready"], mode)
+
+    def test_already_handed_over_is_idempotent(self):
+        calls = []
+        b = _batch(hicache_consumer_index=3)
+        Scheduler._handover_hicache_load(self._scheduler(calls), b)
+        self.assertEqual(calls, [])
+        self.assertEqual(b.hicache_consumer_index, 3)
+        self.assertIsNotNone(b.prefill_input_ids_cpu)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #38448.

With hierarchical cache enabled, `get_new_batch_prefill` calls `ready_to_load_host_cache()` *before* `prepare_for_extend()`. `start_loading` records its `start_event` on the schedule stream and the load stream waits on it, then submits the whole burst. Every H2D copy the scheduler issues after that record (`seq_lens` in `prepare_for_extend`, the deferred `input_ids` upload in `resolve_forward_inputs`, the extend / mlp-sync metadata tensors in `ForwardBatch.init_new`) is queued behind the burst on the copy engine, and the forward's first kernels depend on them. Depending on copy-engine arbitration, a round then waits for the *entire* burst instead of overlapping the loads layer by layer.

On an 8 x H100 TP=8 deployment with multi-GiB bursts, 27 of 80 profiled prefill rounds were stalled this way (~42-49 ms direct cost per gated round and rank, first head copy delayed up to 374 ms). With this change, 0 of 98 rounds were stalled, the head-copy launch-to-execution p99 dropped below 2 ms, and the per-layer load ordering checks stayed at zero violations.

## Modifications

The fix makes the round-head copies win by stream contract instead of arbitration: they are issued on the schedule stream before `start_loading` records its event.

- **Hand-over moves from batch formation to `run_batch`** (`Scheduler._handover_hicache_load`). The batch is only final there: `mix_with_running` and the DP mlp-sync gather (which assigns `global_num_tokens`) happen in between. The hand-over is limited to new prefill batches (`forward_mode.is_extend_without_speculative()`) and is idempotent for batches that re-enter `run_batch` (pd-multiplexing runs a split prefill batch once per slice). Same `enable_hierarchical_cache or enable_unified_cache_external_linker` condition as before.
- **`overlap_utils.pre_upload_forward_inputs`** runs right before the hand-over: uploads `input_ids` for pure-prefill batches (`resolve_forward_inputs` then short-circuits, the same pattern `dynamic_chunk_sizer` already uses) and stages `extend_lens` / `prefix_lens` / `global_num_tokens` / `global_num_tokens_for_logprob` as `StagedDeviceTensor`. Mixed batches keep the deferred `input_ids` path (they need the forward-time FutureMap gather); spec batches skip the global counts (`init_new` rescales them).
- **`ForwardBatch.init_new` consumes the staged tensors** via `StagedDeviceTensor.take(source)`: at most once, and only while the host list it was built from is still the batch's current value. A draft-extend re-running `init_new` on the same batch, or a DP step re-gathering the counts, therefore falls back to the existing upload. Consuming mutates the staging object, not the `ScheduleBatch`, so it respects the "init_new must not mutate the batch" contract and survives the spec forward-isolation snapshot/restore.
- `merge_batch` drops any staging.
- `test_generation_auxiliary_output.py` builds a bare `Scheduler` for `run_batch`; it now sets the two flags the hand-over reads.

Deployments without hierarchical cache / the external linker are unaffected: the pre-upload only runs when a burst can exist, and `init_new` takes the unchanged path when nothing is staged.

Trade-off worth noting: the burst now starts at `run_batch` instead of at batch formation, i.e. after `PrefillStats`, the mixed-chunk logic and the mlp-sync gather. In the profiled deployment this did not show up; the loads are still issued before the forward stream waits on the schedule stream.

## Accuracy Tests

N/A. No change to model inputs: the same tensors are uploaded, only earlier and on the schedule stream. New CPU unit test `test/registered/unit/managers/test_head_upload_ordering.py` (21 cases) pins the ordering (`pre_upload_forward_inputs` before `ready_to_load_host_cache`), the one-shot / identity-guarded consumption in `init_mlp_sync_metadata`, the mode gating and the idempotency. `test_schedule_batch_*`, `test_mlp_sync_pad_unpad`, `test_generation_auxiliary_output` and the other unit tests touching these modules were run before and after the change with identical results.

## Speed Tests and Profiling

Internal deployment, 8 x H100, TP=8, hierarchical cache, long shared-prefix prefill workload, nsys traces:

| | before | after |
| --- | --- | --- |
| prefill rounds stalled behind the whole burst | 27 / 80 | 0 / 98 |
| first head H2D copy of a round, launch-to-execution | max 373.8 ms | p99 < 2 ms |
| NCCL kernel time per attention round, mean | 373.9 ms | 233.8 ms |
| end-to-end wall time of the workload | baseline | −4.0 % |

Per-layer load ordering violations (`layer_done_counter` waits) were 0 before and after.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (not needed)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34200895946](https://github.com/sgl-project/sglang/actions/runs/34200895946)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34200895523](https://github.com/sgl-project/sglang/actions/runs/34200895523)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34200895767](https://github.com/sgl-project/sglang/actions/runs/34200895767)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->