### PR TITLE
feat(flexkv): integrate chunked prefetch policies and hybrid restore lifecycle

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1095,6 +1095,12 @@ class Req(ReqDllmMixin):
         # Prefix info
         # The indices to kv cache for the shared prefix.
         self.prefix_indices: torch.Tensor = torch.empty((0,), dtype=torch.int64)
+        # A storage load-back remains request-owned until cache_finished_req or
+        # cache_unfinished_req transfers those slots into the prefix cache.
+        # Keep that ownership separate from prefix_indices: the latter is
+        # rebuilt on every prefix match and cannot identify an in-flight restore.
+        self.pending_restore_generation: Optional[int] = None
+        self.pending_restore_slots: Optional[torch.Tensor] = None
         # TODO(ispobock): rename to last_device_node
         self.last_node: Any = None
         self.last_host_node: Any = None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -816,6 +816,42 @@ class PrefillAdder:
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
 
+    def _get_chunked_prefill_len(
+        self, prefix_len: int, chunk_limit: int, alignment: Optional[int]
+    ) -> int:
+        """Calculate admission before a storage restore can allocate GPU slots."""
+        length = chunk_limit // self.page_size * self.page_size
+        if alignment is not None:
+            length = length // alignment * alignment
+        end = (prefix_len + length) // self.page_size * self.page_size
+        return max(0, end - prefix_len)
+
+    def _check_prefill_shape(
+        self,
+        prefix_len: int,
+        total_len: int,
+        chunk_limit: Optional[int],
+        alignment: Optional[int],
+    ) -> Optional[AddReqResult]:
+        input_tokens = self.ceil_paged_tokens(total_len - prefix_len)
+        if (
+            self.rem_chunk_tokens is None
+            and self.can_run_list
+            and input_tokens >= self.rem_input_tokens
+        ):
+            return AddReqResult.OTHER
+        if self.dllm_config is not None:
+            if self.rem_dllm_tokens <= 0:
+                return AddReqResult.OTHER
+            assert alignment is None, "truncation alignment is not supported for dllm"
+        elif chunk_limit is not None and input_tokens > chunk_limit:
+            input_tokens = self._get_chunked_prefill_len(
+                prefix_len, chunk_limit, alignment
+            )
+            if input_tokens <= 0:
+                return AddReqResult.OTHER
+        return self._check_prefill_tile_budget(input_tokens)
+
     def budget_state(self):
         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
         if not no_token and self.is_hybrid_swa:
@@ -1330,6 +1366,19 @@ class PrefillAdder:
             ):
                 return AddReqResult.OTHER
 
+            # Check all remaining admission gates before a request-owned H2D.
+            # A rejected request must not leave detached GPU slots in waiting_queue.
+            projected_prefix_len = prefix_len + req.host_hit_length
+            if (
+                shape_stop := self._check_prefill_shape(
+                    projected_prefix_len,
+                    len(req.full_untruncated_fill_ids),
+                    chunk_tokens_limit,
+                    truncation_align_size,
+                )
+            ) is not None:
+                return shape_stop
+
             if req.needs_host_load_back():
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
@@ -1341,43 +1390,29 @@ class PrefillAdder:
                 req.host_loaded_length = len(new_indices)
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 prefix_len = len(req.prefix_indices)
-                req.kv.cache_protected_len = prefix_len
+                if req.pending_restore_slots is None:
+                    req.kv.cache_protected_len = prefix_len
 
             input_tokens = self.ceil_paged_tokens(
                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
             )
 
-            if (
-                self.rem_chunk_tokens is None
-                and len(self.can_run_list) != 0
-                and input_tokens >= self.rem_input_tokens
-            ):
-                # If without chunked prefill:
-                # - if the can_run_list is not empty, we satisfy the constraint of (max_prefill_tokens)
-                # - if the can_run_list is empty, always accept the first prefill request
-                return AddReqResult.OTHER
+            # A failed restore returns zero; recheck the now-larger prefill.
+            if prefix_len != projected_prefix_len:
+                if (
+                    shape_stop := self._check_prefill_shape(
+                        prefix_len,
+                        len(req.full_untruncated_fill_ids),
+                        chunk_tokens_limit,
+                        truncation_align_size,
+                    )
+                ) is not None:
+                    return shape_stop
 
             if self.dllm_config is not None:
-                if self.rem_dllm_tokens <= 0:
-                    return AddReqResult.OTHER
-
-                assert truncation_align_size is None, (
-                    "truncation_align_size is not supported for dllm prefill"
-                )
-
-                if (
-                    tile_stop := self._check_prefill_tile_budget(input_tokens)
-                ) is not None:
-                    return tile_stop
-
                 self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
             elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
-                if (
-                    tile_stop := self._check_prefill_tile_budget(input_tokens)
-                ) is not None:
-                    return tile_stop
-
                 # Non-chunked prefill — the whole sequence is committed this iter.
                 req.set_extend_range(
                     len(req.prefix_indices), len(req.full_untruncated_fill_ids)
@@ -1397,34 +1432,9 @@ class PrefillAdder:
                 )
                 self._account_prefill_cache_admission(req, prefix_len)
             else:
-                # Make sure at least one page is available
-                trunc_len = chunk_tokens_limit // self.page_size * self.page_size
-
-                if trunc_len <= 0:
-                    return AddReqResult.OTHER
-
-                # When truncation align size is set, we want to assert that the prefill prefix length is multiple of truncation align size
-                # A typical use case is when deterministic inference is enabled with flashinfer attention backend,
-                # we need the prefill prefix length to be multiple of attention split size
-                if truncation_align_size is not None:
-                    if trunc_len < truncation_align_size:
-                        return AddReqResult.OTHER
-                    else:
-                        trunc_len = truncation_align_size * (
-                            trunc_len // truncation_align_size
-                        )
-
-                now_input_len = trunc_len + len(req.prefix_indices)
-                now_input_len = now_input_len // self.page_size * self.page_size
-                trunc_len = now_input_len - len(req.prefix_indices)
-
-                if trunc_len <= 0:
-                    return AddReqResult.OTHER
-
-                if (
-                    tile_stop := self._check_prefill_tile_budget(trunc_len)
-                ) is not None:
-                    return tile_stop
+                trunc_len = self._get_chunked_prefill_len(
+                    prefix_len, chunk_tokens_limit, truncation_align_size
+                )
 
                 # Chunked prefill
                 req.set_extend_range(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -609,6 +609,10 @@ class Scheduler(
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
+        self.enable_flexkv_prefetch = bool(
+            get_memory().enable_flexkv
+            and getattr(self.tree_cache, "supports_storage_prefetch", False)
+        )
         if self.enable_hierarchical_cache:
             cache_controller = self.tree_cache.cache_controller
             if cache_controller is not None:
@@ -3066,6 +3070,21 @@ class Scheduler(
             self.handle_generate_request(tokenized_req)
 
     def _prefetch_kvcache(self, req: Req):
+        if self.enable_flexkv_prefetch:
+            req.init_next_round_input(self.tree_cache, cow_mamba=False)
+            matched_len = len(req.prefix_indices) + req.host_hit_length
+            match_end = req._compute_max_prefix_len(len(req.full_untruncated_fill_ids))
+            if matched_len >= match_end:
+                return
+            self.tree_cache.prefetch_from_storage(
+                req.rid,
+                req.last_host_node,
+                req.full_untruncated_fill_ids[matched_len:match_end],
+                matched_prefix_tokens=req.full_untruncated_fill_ids[:matched_len],
+                extra_key=req.extra_key,
+                cache_salt=req.cache_salt,
+            )
+            return
         if self.enable_hicache_storage:
             req.init_next_round_input(self.tree_cache, cow_mamba=False)
             tree_cache = self.tree_cache
@@ -3197,6 +3216,7 @@ class Scheduler(
         if (
             self.enable_hierarchical_cache
             or self.enable_hicache_storage
+            or self.enable_flexkv_prefetch
             or self.enable_unified_cache_external_linker
         ):
             self.tree_cache.release_aborted_request(rid)
@@ -3788,7 +3808,12 @@ class Scheduler(
             prefill_tile_block_m=prefill_tile_block_m,
         )
 
-        if self.chunked_req is not None:
+        has_uncommitted_restore = getattr(
+            self.tree_cache, "has_uncommitted_restore", None
+        )
+        if self.chunked_req is not None and not (
+            has_uncommitted_restore and has_uncommitted_restore(self.chunked_req)
+        ):
             self.chunked_req.init_next_round_input()
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
 
@@ -3810,6 +3835,10 @@ class Scheduler(
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
+            # Preserve the request's detached slots until cache completion publishes them.
+            if has_uncommitted_restore and has_uncommitted_restore(req):
+                continue
+
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
 
@@ -3835,7 +3864,7 @@ class Scheduler(
                 ):
                     break
 
-            if self.enable_hicache_storage:
+            if self.enable_hicache_storage or self.enable_flexkv_prefetch:
                 prefetch_done = self.tree_cache.check_prefetch_progress(req.rid)
                 if not prefetch_done:
                     # skip staging requests that are ongoing prefetch
@@ -3892,9 +3921,11 @@ class Scheduler(
                 if res == AddReqResult.NO_TOKEN:
                     if (
                         self.enable_hierarchical_cache
+                        or get_memory().enable_flexkv
                         or self.enable_unified_cache_external_linker
                     ):
-                        # Set batch_is_full after making sure there are requests that can be served
+                        # An empty batch must retry after host-cache admission
+                        # pressure clears; no running decode can clear this flag.
                         running_batch.batch_is_full = len(adder.can_run_list) > 0 or (
                             not running_batch.is_empty()
                         )
@@ -3906,6 +3937,11 @@ class Scheduler(
                 # lifecycle and freeing them here causes double-free.
                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
                 if not added:
+                    if has_uncommitted_restore and has_uncommitted_restore(req):
+                        raise RuntimeError(
+                            f"Request rejected after FlexKV restore: {req.rid}"
+                        )
+
                     # init_next_round_input() may stage deferred Mamba COW/clear
                     # metadata before add_one_req() rejects the request.
                     req.kv.mamba_cow_src_index = None

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -149,7 +149,12 @@ def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
     tree_cache.cache_unfinished_req(req, **kwargs)
 
 
-def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
+def evict_from_tree_cache(
+    tree_cache: BasePrefixCache | None,
+    num_tokens: int,
+    *,
+    swa_num_tokens: int | None = None,
+):
     if tree_cache is None:
         return
 
@@ -163,9 +168,10 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
         full_available_size = allocator.full_available_size()
         swa_available_size = allocator.swa_available_size()
 
-        if full_available_size < num_tokens or swa_available_size < num_tokens:
+        swa_need = num_tokens if swa_num_tokens is None else swa_num_tokens
+        if full_available_size < num_tokens or swa_available_size < swa_need:
             full_num_tokens = max(0, num_tokens - full_available_size)
-            swa_num_tokens = max(0, num_tokens - swa_available_size)
+            swa_num_tokens = max(0, swa_need - swa_available_size)
             tree_cache.evict_for_alloc(
                 EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
             )

--- a/python/sglang/srt/mem_cache/storage/flexkv/__init__.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/__init__.py
@@ -27,6 +27,20 @@ def _flexkv_factory(ctx):
     needs them to fan out lookup/store decisions across the full TP × CP
     × PP topology.
     """
+    try:
+        from flexkv.integration.sglang.connector import FlexKVConnector  # noqa: F401
+    except ImportError as exc:
+        try:
+            import flexkv  # noqa: F401
+        except ImportError:
+            raise RuntimeError(
+                "FlexKV is not installed. Please install the FlexKV package "
+                "to use --enable-flexkv."
+            ) from exc
+        raise RuntimeError(
+            f"FlexKV is installed but incompatible version: {exc}."
+        ) from exc
+
     from sglang.srt.distributed.parallel_state import (
         get_attn_cp_group,
         get_attn_tp_group,
@@ -58,23 +72,48 @@ def _flexkv_factory(ctx):
     # fall back to 0 for single-rank dims.
     pp_rank = pp_group.rank_in_group if pp_group is not None else 0
     attn_cp_rank = attn_cp_group.rank_in_group if attn_cp_group is not None else 0
+    parallel_state = getattr(ctx.tp_worker, "ps", None)
+    from sglang.srt.runtime_context import get_parallel
 
-    return FlexKVRadixCache(
+    if get_parallel().enable_dp_attention:
+        dp_rank = getattr(parallel_state, "attn_dp_rank", 0)
+    else:
+        dp_rank = getattr(parallel_state, "dp_rank", 0) or 0
+
+    common_kwargs = dict(
         params=ctx.params,
         model_config=ctx.model_config,
         server_args=server_args,
         tp_rank=ctx.tp_rank,
-        tp_size=ctx.tp_size,
-        # ``dp_rank`` isn't carried on TreeCacheBuildContext or ServerArgs
-        # at construction time; the connector normalizes ``None`` to 0
-        # for the single-DP-rank case that this factory targets.
-        dp_rank=None,
+        dp_rank=dp_rank,
         pp_rank=pp_rank,
         attn_cp_rank=attn_cp_rank,
         tp_group=ctx.tp_group,
         pp_group=pp_group,
         attn_tp_group=attn_tp_group,
         attn_cp_group=attn_cp_group,
+    )
+
+    if ctx.is_hybrid_ssm:
+        raise NotImplementedError("FlexKV does not support Mamba/SSM pools yet")
+
+    if ctx.is_hybrid_swa:
+        from sglang.srt.mem_cache.storage.flexkv.flexkv_hybrid_radix_cache import (
+            FlexKVHybridRadixCache,
+        )
+        from sglang.srt.mem_cache.unified_cache.components import ComponentType
+        from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+        ctx.params.tree_components = (ComponentType.FULL, ComponentType.SWA)
+        inner_cache = UnifiedRadixCache(ctx.params)
+        return FlexKVHybridRadixCache(
+            inner_cache=inner_cache,
+            **common_kwargs,
+        )
+
+    return FlexKVRadixCache(
+        tp_size=ctx.tp_size,
+        **common_kwargs,
     )
 
 

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_hybrid_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_hybrid_radix_cache.py
@@ -1,0 +1,604 @@
+"""FlexKV adapter for SGLang's component-based hybrid radix cache."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from array import array
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+import torch
+from flexkv.integration.sglang.connector import (
+    FlexKVConnector,
+    FlexKVHostReleaseShim,
+)
+
+from sglang.srt.mem_cache.allocator.hisparse import (
+    DeepSeekV4HiSparseTokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    DecLockRefParams,
+    EvictParams,
+    EvictResult,
+    IncLockRefResult,
+    InitLoadBackParams,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sglang.srt.mem_cache.radix_cache import RadixKey
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _LoadMarker:
+    key: RadixKey
+    device_length: int
+
+
+@dataclass
+class _RestoreLease:
+    generation: int
+    req: Req
+    device_indices: torch.Tensor
+
+
+class FlexKVHybridRadixCache(BasePrefixCache):
+    """Compose FlexKV I/O with an existing hybrid radix implementation.
+
+    The inner cache remains the sole owner of radix/SWA bookkeeping. FlexKV
+    only restores request-owned slots; the normal cache_finished_req path then
+    inserts those slots with the same component semantics as fresh prefill.
+    """
+
+    def __init__(
+        self,
+        *,
+        params: CacheInitParams,
+        inner_cache: BasePrefixCache,
+        model_config: Optional[ModelConfig],
+        server_args: ServerArgs,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        pp_rank: int,
+        attn_cp_rank: int,
+        tp_group: Any = None,
+        pp_group: Any = None,
+        attn_tp_group: Any = None,
+        attn_cp_group: Any = None,
+    ) -> None:
+        self._inner_cache = inner_cache
+        self.req_to_token_pool = inner_cache.req_to_token_pool
+        self.token_to_kv_pool_allocator = inner_cache.token_to_kv_pool_allocator
+        self.page_size = inner_cache.page_size
+        self.disable = inner_cache.disable
+        self.device = inner_cache.device
+
+        kvcache = self.token_to_kv_pool_allocator.get_kvcache()
+        if isinstance(
+            self.token_to_kv_pool_allocator,
+            DeepSeekV4HiSparseTokenToKVPoolAllocator,
+        ):
+            raise NotImplementedError(
+                "FlexKV does not support the independent DSv4 HiSparse "
+                "device-page mapping yet"
+            )
+        self.flexkv_connector = FlexKVConnector(
+            sgl_model_config=model_config,
+            server_args=server_args,
+            page_size=self.page_size,
+            kvcache=kvcache,
+            tp_rank=tp_rank,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
+            attn_cp_rank=attn_cp_rank,
+            pp_group=pp_group,
+            attn_tp_group=attn_tp_group if attn_tp_group is not None else tp_group,
+            attn_cp_group=attn_cp_group,
+        )
+        if self.flexkv_connector.enable_layerwise:
+            self.flexkv_connector.register_layer_transfer_counter(kvcache)
+
+        # Same hook HiCache uses: scheduler.release_host_resources → destroy().
+        self.token_to_kv_pool_host = FlexKVHostReleaseShim(self.flexkv_connector)
+
+        self._load_markers: dict[str, _LoadMarker] = {}
+        self._restore_leases: dict[str, _RestoreLease] = {}
+        self._restore_generation = 0
+        self._inflight_store_nodes: dict[str, tuple[Any, DecLockRefParams]] = {}
+        self._store_generation = 0
+        self._node_lock = threading.Lock()
+
+    def reset(self) -> None:
+        # FlexKV still owns references to GPU source/destination slots while an
+        # asynchronous store or layerwise load is in flight. Drain those tasks
+        # before the inner cache releases the slots.
+        self.flexkv_connector.reset()
+        self._free_uncommitted_restores()
+        self._inner_cache.reset()
+        self._load_markers.clear()
+        with self._node_lock:
+            self._inflight_store_nodes.clear()
+
+    def shutdown(self) -> None:
+        # Prefer token_to_kv_pool_host.destroy() (HiCache path); keep this alias.
+        self.token_to_kv_pool_host.destroy()
+
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
+        result = self._inner_cache.match_prefix(params)
+        if self.disable or params.req is None:
+            return result
+
+        # A live restore still owns request-local slots. Rematching would
+        # overwrite the request's only reference before cache insertion.
+        if params.req.rid in self._restore_leases:
+            logger.warning(
+                "Skipping duplicate FlexKV lookup for uncommitted restore rid=%s",
+                params.req.rid,
+            )
+            return result
+
+        key = params.key.page_aligned(self.page_size)
+        token_ids = key.raw_token_ids()
+        device_length = int(result.device_indices.numel())
+        if not token_ids or device_length >= len(token_ids):
+            return result
+
+        token_mask = torch.zeros(len(token_ids), dtype=torch.bool)
+        token_mask[device_length:] = True
+        _, hit_length = self.flexkv_connector.lookup_kv(
+            token_ids,
+            token_mask,
+            rid=params.req.rid,
+            sglang_req_id=params.req.rid,
+        )
+        if hit_length <= 0:
+            return result
+
+        snapshot = token_ids[:] if token_ids is key.token_ids else token_ids
+        self._load_markers[params.req.rid] = _LoadMarker(
+            key=RadixKey(snapshot, key.extra_key, key.is_bigram),
+            device_length=device_length,
+        )
+        return result._replace(
+            last_host_node=result.last_device_node,
+            best_match_node=result.last_device_node,
+            host_hit_length=hit_length,
+            swa_host_hit_length=min(self.page_size, hit_length),
+            cache_protected_len=device_length,
+        )
+
+    def init_load_back(self, params: InitLoadBackParams) -> tuple[torch.Tensor, Any]:
+        req = params.req
+        if req.rid in self._restore_leases:
+            self._load_markers.pop(req.rid, None)
+            self.flexkv_connector.release_pending(req.rid)
+            logger.warning(
+                "Skipping duplicate FlexKV load-back for uncommitted restore rid=%s",
+                req.rid,
+            )
+            return self._empty_indices(), req.last_node
+
+        marker = self._load_markers.pop(req.rid, None)
+        if marker is None or params.host_hit_length <= 0:
+            self.flexkv_connector.release_pending(req.rid)
+            return self._empty_indices(), req.last_node
+
+        device_indices = self._alloc_restore_slots(req, params.host_hit_length)
+        if device_indices is None:
+            self.flexkv_connector.release_pending(req.rid)
+            return self._empty_indices(), req.last_node
+
+        # Register ownership before launching the connector. If launch raises,
+        # its write status may be unknown; reset must drain the connector before
+        # these slots can be freed safely.
+        generation = self._restore_generation
+        self._restore_generation += 1
+        lease = _RestoreLease(
+            generation=generation,
+            req=req,
+            device_indices=device_indices,
+        )
+        self._restore_leases[req.rid] = lease
+        req.pending_restore_generation = generation
+        req.pending_restore_slots = device_indices
+
+        if self.flexkv_connector.enable_layerwise:
+            loaded, _ = self.flexkv_connector.start_load_kv_layerwise(
+                req.rid, device_indices
+            )
+        else:
+            loaded = self.flexkv_connector.retrieve_kv(req.rid, device_indices)
+
+        # Admission planning uses the lookup hit length. Keep load-back
+        # all-or-nothing so a successful restore cannot invalidate the checks
+        # that deliberately ran before this allocation. Both connector paths
+        # normally return either the entire mapping or zero.
+        if loaded != device_indices.numel():
+            self._free_restore_lease(lease)
+            return self._empty_indices(), req.last_node
+
+        if (
+            self.supports_swa()
+            and self.page_size > 1
+            and hasattr(self.token_to_kv_pool_allocator, "alloc_extend_swa_tail")
+            and device_indices.numel() > 0
+        ):
+            restored_end = int(req.prefix_indices.numel() + device_indices.numel())
+            swa_tail_length = min(self.page_size, int(device_indices.numel()))
+            req._flexkv_swa_evicted_seqlen = restored_end - swa_tail_length
+
+        # The restored tail is request-owned until the normal cache completion
+        # path inserts it. Preserve the pre-restore protection boundary so the
+        # inner cache can deduplicate or free every restored slot correctly.
+        req.kv.cache_protected_len = marker.device_length
+        return device_indices, req.last_node
+
+    def has_uncommitted_restore(self, req: Req) -> bool:
+        return req.rid in self._restore_leases
+
+    def _commit_restore(self, req: Req) -> None:
+        lease = self._restore_leases.get(req.rid)
+        if lease is None:
+            return
+
+        generation = req.pending_restore_generation
+        slots = req.pending_restore_slots
+        if (
+            lease.req is not req
+            or generation != lease.generation
+            or slots is not lease.device_indices
+        ):
+            raise RuntimeError(
+                f"FlexKV restore lease mismatch: rid={req.rid} "
+                f"expected_generation={lease.generation} actual_generation={generation}"
+            )
+
+        self._restore_leases.pop(req.rid, None)
+        req.pending_restore_generation = None
+        req.pending_restore_slots = None
+
+    def _free_restore_lease(self, lease: _RestoreLease) -> None:
+        tracked = self._restore_leases.get(lease.req.rid)
+        if tracked is not lease:
+            raise RuntimeError(
+                "FlexKV restore lease changed before free: "
+                f"rid={lease.req.rid} generation={lease.generation}"
+            )
+        self.token_to_kv_pool_allocator.free(lease.device_indices)
+        self._restore_leases.pop(lease.req.rid)
+        lease.req.pending_restore_generation = None
+        lease.req.pending_restore_slots = None
+
+    def _free_uncommitted_restores(self) -> None:
+        for lease in list(self._restore_leases.values()):
+            self._free_restore_lease(lease)
+
+    def _alloc_restore_slots(
+        self, req: Req, host_hit_length: int
+    ) -> Optional[torch.Tensor]:
+        slots = self._alloc_restore_slots_once(req, host_hit_length)
+        if slots is not None:
+            return slots
+
+        from sglang.srt.mem_cache.common import evict_from_tree_cache
+
+        swa_need = None
+        if self.supports_swa():
+            swa_need = (
+                host_hit_length
+                if self.page_size == 1
+                else min(self.page_size, host_hit_length)
+            )
+        evict_from_tree_cache(self, host_hit_length, swa_num_tokens=swa_need)
+        return self._alloc_restore_slots_once(req, host_hit_length)
+
+    def _alloc_restore_slots_once(
+        self, req: Req, host_hit_length: int
+    ) -> Optional[torch.Tensor]:
+        """Allocate full KV plus the one-page SWA/state tail for this boundary."""
+        allocator = self.token_to_kv_pool_allocator
+        if self.page_size == 1:
+            return allocator.alloc(host_hit_length)
+        prefix_length = int(req.prefix_indices.numel())
+        sequence_length = prefix_length + host_hit_length
+        prefix_lengths = torch.tensor(
+            [prefix_length], dtype=torch.int64, device=self.device
+        )
+        prefix_lengths_cpu = torch.tensor([prefix_length], dtype=torch.int64)
+        sequence_lengths = torch.tensor(
+            [sequence_length], dtype=torch.int64, device=self.device
+        )
+        sequence_lengths_cpu = torch.tensor([sequence_length], dtype=torch.int64)
+        last_location = (
+            req.prefix_indices[-1:].to(device=self.device, dtype=torch.int64)
+            if prefix_length > 0
+            else torch.tensor([-1], dtype=torch.int64, device=self.device)
+        )
+        if hasattr(allocator, "alloc_extend_swa_tail") and self.supports_swa():
+            return allocator.alloc_extend_swa_tail(
+                prefix_lengths,
+                prefix_lengths_cpu,
+                sequence_lengths,
+                sequence_lengths_cpu,
+                last_location,
+                host_hit_length,
+                min(self.page_size, host_hit_length),
+            )
+        return allocator.alloc_extend(
+            prefix_lengths,
+            prefix_lengths_cpu,
+            sequence_lengths,
+            sequence_lengths_cpu,
+            last_location,
+            host_hit_length,
+        )
+
+    def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs) -> None:
+        self._apply_restore_swa_boundary(req)
+        kv_length = int(kwargs.get("kv_len_to_handle", req.kv.kv_committed_len))
+        token_ids = (req.origin_input_ids + req.output_ids)[:kv_length]
+        self._inner_cache.cache_finished_req(req, is_insert=is_insert, **kwargs)
+        self._commit_restore(req)
+        if not is_insert:
+            return
+
+        self._store_prefix(req, token_ids)
+
+    def cache_unfinished_req(self, req: Req, **kwargs) -> None:
+        self._apply_restore_swa_boundary(req)
+        self._inner_cache.cache_unfinished_req(req, **kwargs)
+        self._commit_restore(req)
+
+        # A chunk boundary is not a reusable request boundary and its state may
+        # still be changing. The non-chunked call marks prefill completion, when
+        # DSv4's SWA/compress state exactly describes the prompt prefix.
+        if kwargs.get("chunked", False):
+            return
+        self._store_prefix(req, list(req.get_fill_ids()))
+
+    def _store_prefix(self, req: Req, token_ids: Sequence[int]) -> None:
+        """Store a page-aligned prefix and its exact SWA/state snapshot."""
+
+        aligned_length = len(token_ids) // self.page_size * self.page_size
+        if aligned_length <= 0:
+            return
+        token_ids = list(token_ids[:aligned_length])
+        key = RadixKey(
+            array("q", token_ids),
+            req.extra_key,
+            is_bigram=bool(getattr(self._inner_cache, "is_eagle", False)),
+        )
+        match = self._inner_cache.match_prefix(MatchPrefixParams(key=key))
+        node = match.last_device_node
+        indices = match.device_indices
+        if node is self._inner_cache.root_node or indices.numel() == 0:
+            return
+        if indices.numel() < len(token_ids):
+            token_ids = token_ids[: indices.numel()]
+        if not token_ids or len(token_ids) != indices.numel():
+            return
+
+        lock_result = self._inner_cache.inc_lock_ref(node)
+        with self._node_lock:
+            store_key = f"{req.rid}:flexkv-store:{self._store_generation}"
+            self._store_generation += 1
+        try:
+            task_id = self.flexkv_connector.store_kv(
+                store_key,
+                token_ids,
+                indices,
+                sglang_req_id=req.rid,
+            )
+        except Exception:
+            self._inner_cache.dec_lock_ref(node, lock_result.to_dec_params())
+            raise
+        if task_id < 0:
+            self._inner_cache.dec_lock_ref(node, lock_result.to_dec_params())
+            return
+        with self._node_lock:
+            self._inflight_store_nodes[store_key] = (
+                node,
+                lock_result.to_dec_params(),
+            )
+
+    @staticmethod
+    def _apply_restore_swa_boundary(req: Req) -> None:
+        boundary = getattr(req, "_flexkv_swa_evicted_seqlen", None)
+        if boundary is None or req.kv is None:
+            return
+        req.kv.swa_evicted_seqlen = max(req.kv.swa_evicted_seqlen, boundary)
+        del req._flexkv_swa_evicted_seqlen
+
+    def evict(self, params: EvictParams) -> EvictResult:
+        self._drain_completed_stores()
+        return self._inner_cache.evict(params)
+
+    def evict_for_alloc(self, params: EvictParams) -> EvictResult:
+        self._drain_completed_stores()
+        return self._inner_cache.evict_for_alloc(params)
+
+    def check_hicache_events(self) -> None:
+        self._drain_completed_stores()
+        self.flexkv_connector.drain_launched_loads()
+
+    def _drain_completed_stores(self) -> None:
+        completed = self.flexkv_connector.check_completed_stores()
+        if not completed:
+            return
+        with self._node_lock:
+            for rid in completed:
+                tracked = self._inflight_store_nodes.pop(rid, None)
+                if tracked is not None:
+                    node, dec_params = tracked
+                    self._inner_cache.dec_lock_ref(node, dec_params)
+
+    def release_aborted_request(self, rid: str) -> None:
+        self._load_markers.pop(rid, None)
+        self.flexkv_connector.release_pending(rid)
+        self.flexkv_connector.cancel_prefetch(rid)
+        # Do not free an active restore here. Scheduled aborts immediately flow
+        # through cache_finished_req(is_insert=False), which transfers/frees the
+        # request slots before committing the lease. A direct free here could
+        # race the layerwise H2D writer. Waiting requests cannot own a lease
+        # because every admission rejection runs before init_load_back.
+
+    @property
+    def supports_storage_prefetch(self) -> bool:
+        return bool(getattr(self.flexkv_connector, "_chunked_prefetch", False))
+
+    def prefetch_from_storage(
+        self,
+        rid: str,
+        last_host_node: Any,
+        token_ids,
+        last_hash=None,
+        prefix_keys=None,
+        *,
+        matched_prefix_tokens=None,
+        extra_key=None,
+        cache_salt=None,
+    ) -> None:
+        """Pass the full hash-chain input, including the scheduler's prefix."""
+        # FlexKV's foreground adapter does not yet propagate namespace/salt.
+        # Do not prefetch cross-namespace data through this optional path.
+        if extra_key is not None or cache_salt is not None:
+            return
+        if matched_prefix_tokens is not None:
+            full_tokens = list(matched_prefix_tokens) + list(token_ids)
+            candidate_start = len(matched_prefix_tokens)
+        else:
+            marker = self._load_markers.get(rid)
+            full_tokens = (
+                list(marker.key.raw_token_ids()) if marker else list(token_ids)
+            )
+            candidate_start = max(0, len(full_tokens) - len(token_ids))
+        if getattr(self.flexkv_connector, "_chunked_prefetch", False):
+            self.flexkv_connector.prefetch_async(
+                rid, full_tokens, candidate_start_token=candidate_start
+            )
+        else:
+            self.flexkv_connector.prefetch_async(rid, full_tokens)
+
+    def check_prefetch_progress(self, rid: str) -> bool:
+        return self.flexkv_connector.check_prefetch_progress(rid)
+
+    def terminate_prefetch(self, rid: str) -> None:
+        self.flexkv_connector.cancel_prefetch(rid)
+
+    def pop_prefetch_loaded_tokens(self, rid: str) -> int:
+        return self.flexkv_connector.pop_prefetch_loaded_tokens(rid)
+
+    def pop_prefetch_loaded_span(self, rid: str):
+        return self.flexkv_connector.pop_prefetch_loaded_span(rid)
+
+    def inc_lock_ref(self, node: Any) -> IncLockRefResult:
+        return self._inner_cache.inc_lock_ref(node)
+
+    def dec_lock_ref(self, node: Any, params: Optional[DecLockRefParams] = None) -> Any:
+        return self._inner_cache.dec_lock_ref(node, params)
+
+    def supports_swa(self) -> bool:
+        return self._inner_cache.supports_swa()
+
+    def supports_mamba(self) -> bool:
+        return self._inner_cache.supports_mamba()
+
+    def supports_fast_match_prefix(self) -> bool:
+        return self._inner_cache.supports_fast_match_prefix()
+
+    # BasePrefixCache provides default implementations for these methods, so
+    # __getattr__ cannot forward them. Delegate them explicitly; otherwise the
+    # scheduler sees zero evictable/protected tokens and reports the inner
+    # UnifiedRadixCache's live pages as a pool leak.
+    def evictable_size(self) -> int:
+        return self._inner_cache.evictable_size()
+
+    def full_evictable_size(self) -> int:
+        return self._inner_cache.full_evictable_size()
+
+    def swa_evictable_size(self) -> int:
+        return self._inner_cache.swa_evictable_size()
+
+    def protected_size(self) -> int:
+        return self._inner_cache.protected_size()
+
+    def full_protected_size(self) -> int:
+        return self._inner_cache.full_protected_size()
+
+    def swa_protected_size(self) -> int:
+        return self._inner_cache.swa_protected_size()
+
+    def total_size(self) -> int:
+        return self._inner_cache.total_size()
+
+    def pretty_print(self) -> None:
+        return self._inner_cache.pretty_print()
+
+    def ready_to_load_host_cache(self) -> Any:
+        return self._inner_cache.ready_to_load_host_cache()
+
+    def flush_write_through_acks(self) -> None:
+        self._drain_completed_stores()
+        self._inner_cache.flush_write_through_acks()
+
+    def take_events(self) -> list[Any]:
+        return self._inner_cache.take_events()
+
+    def swa_reprefill_tail_tokens(self) -> int:
+        return self._inner_cache.swa_reprefill_tail_tokens()
+
+    def supports_streaming_session(self) -> bool:
+        return self._inner_cache.supports_streaming_session()
+
+    def release_session(self, session_id: str) -> None:
+        self._inner_cache.release_session(session_id)
+
+    def release_radix_session(self, session_id: str) -> None:
+        self._inner_cache.release_radix_session(session_id)
+
+    def session_held_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
+        return self._inner_cache.session_held_tokens(active_pool_idxs)
+
+    def session_held_full_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
+        return self._inner_cache.session_held_full_tokens(active_pool_idxs)
+
+    def session_held_swa_tokens(self, active_pool_idxs: Optional[set] = None) -> int:
+        return self._inner_cache.session_held_swa_tokens(active_pool_idxs)
+
+    def session_held_req_count(self, active_pool_idxs: Optional[set] = None) -> int:
+        return self._inner_cache.session_held_req_count(active_pool_idxs)
+
+    def session_held_mamba_slots(self, active_pool_idxs: Optional[set] = None) -> int:
+        return self._inner_cache.session_held_mamba_slots(active_pool_idxs)
+
+    def is_chunk_cache(self) -> bool:
+        return self._inner_cache.is_chunk_cache()
+
+    def is_tree_cache(self) -> bool:
+        return self._inner_cache.is_tree_cache()
+
+    def available_and_evictable_str(self) -> str:
+        return self._inner_cache.available_and_evictable_str()
+
+    def init_metrics_collector(self) -> None:
+        self._inner_cache.init_metrics_collector()
+
+    def _empty_indices(self) -> torch.Tensor:
+        return torch.empty((0,), dtype=torch.int64, device=self.device)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        inner = self.__dict__.get("_inner_cache")
+        if inner is None:
+            raise AttributeError(name)
+        return getattr(inner, name)

--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
+from flexkv.integration.sglang.connector import FlexKVConnector
 
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
@@ -41,7 +42,6 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchResult,
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
-from sglang.srt.mem_cache.storage.flexkv.flexkv_connector import FlexKVConnector
 from sglang.srt.runtime_context import get_spec
 
 if TYPE_CHECKING:
@@ -496,14 +496,42 @@ class FlexKVRadixCache(RadixCache):
         self.flexkv_connector.release_pending(rid)
         self.flexkv_connector.cancel_prefetch(rid)
 
+    @property
+    def supports_storage_prefetch(self) -> bool:
+        return bool(getattr(self.flexkv_connector, "_chunked_prefetch", False))
+
     def prefetch_from_storage(
-        self, rid: str, last_host_node: TreeNode, token_ids
+        self,
+        rid: str,
+        last_host_node: TreeNode,
+        token_ids,
+        last_hash=None,
+        prefix_keys=None,
+        *,
+        matched_prefix_tokens=None,
+        extra_key=None,
+        cache_salt=None,
     ) -> None:
-        """Kick off an opportunistic prefetch (SSD/Remote → CPU)."""
-        try:
-            self.flexkv_connector.prefetch_async(rid, list(token_ids))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("[FlexKV] prefetch_from_storage: %s", exc)
+        """Pass the full hash-chain input, including the scheduler's prefix."""
+        # FlexKV's foreground adapter does not yet propagate namespace/salt.
+        # Do not prefetch cross-namespace data through this optional path.
+        if extra_key is not None or cache_salt is not None:
+            return
+        if matched_prefix_tokens is not None:
+            full_tokens = list(matched_prefix_tokens) + list(token_ids)
+            candidate_start = len(matched_prefix_tokens)
+        else:
+            marker = self._load_markers.get(rid)
+            full_tokens = (
+                list(marker.key.raw_token_ids()) if marker else list(token_ids)
+            )
+            candidate_start = max(0, len(full_tokens) - len(token_ids))
+        if getattr(self.flexkv_connector, "_chunked_prefetch", False):
+            self.flexkv_connector.prefetch_async(
+                rid, full_tokens, candidate_start_token=candidate_start
+            )
+        else:
+            self.flexkv_connector.prefetch_async(rid, full_tokens)
 
     def check_prefetch_progress(self, rid: str) -> bool:
         return self.flexkv_connector.check_prefetch_progress(rid)
@@ -512,8 +540,10 @@ class FlexKVRadixCache(RadixCache):
         self.flexkv_connector.cancel_prefetch(rid)
 
     def pop_prefetch_loaded_tokens(self, rid: str) -> int:
-        # FlexKV doesn't expose per-rid prefetched token counts yet.
-        return 0
+        return self.flexkv_connector.pop_prefetch_loaded_tokens(rid)
+
+    def pop_prefetch_loaded_span(self, rid: str):
+        return self.flexkv_connector.pop_prefetch_loaded_span(rid)
 
     @property
     def hicache_storage_pass_prefix_keys(self) -> bool:

--- a/test/registered/unit/mem_cache/test_flexkv_prefetch.py
+++ b/test/registered/unit/mem_cache/test_flexkv_prefetch.py
@@ -1,0 +1,345 @@
+"""CPU contract tests execute wrapper bodies without importing model kernels."""
+
+import ast
+import logging
+from pathlib import Path
+from types import MethodType
+from types import SimpleNamespace as NS
+from typing import Any, Optional
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+ROOT = Path(__file__).resolve().parents[4]
+SOURCE = ROOT / "python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py"
+HYBRID = SOURCE.with_name("flexkv_hybrid_radix_cache.py")
+POLICY = ROOT / "python/sglang/srt/managers/schedule_policy.py"
+SCHEDULER = ROOT / "python/sglang/srt/managers/scheduler.py"
+
+
+def method(path, cls, name):
+    tree = ast.parse(path.read_text())
+    class_node = next(
+        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == cls
+    )
+    body = next(
+        n for n in class_node.body if isinstance(n, ast.FunctionDef) and n.name == name
+    )
+    body.decorator_list = []
+    namespace = {
+        "TreeNode": object,
+        "Req": object,
+        "Any": Any,
+        "Optional": Optional,
+        "AddReqResult": NS(OTHER="other"),
+        "torch": torch,
+        "InitLoadBackParams": object,
+        "_RestoreLease": NS,
+        "logger": logging.getLogger(__name__),
+    }
+    exec(
+        compile(ast.Module(body=[body], type_ignores=[]), str(path), "exec"), namespace
+    )
+    return namespace[name]
+
+
+@pytest.mark.parametrize("matched", [[], [10, 11, 12, 13]])
+def test_full_chain_and_candidate_offset(matched):
+    connector = Mock(_chunked_prefetch=True)
+    cache = NS(flexkv_connector=connector)
+    method(SOURCE, "FlexKVRadixCache", "prefetch_from_storage")(
+        cache, "r", None, [20, 21], None, None, matched_prefix_tokens=matched
+    )
+    connector.prefetch_async.assert_called_once_with(
+        "r", matched + [20, 21], candidate_start_token=len(matched)
+    )
+
+
+def test_scheduler_starts_flexkv_without_hicache_storage_backend():
+    cache = Mock()
+    scheduler = NS(
+        enable_flexkv_prefetch=True, enable_hicache_storage=False, tree_cache=cache
+    )
+    req = NS(
+        rid="r",
+        prefix_indices=[0, 1],
+        host_hit_length=2,
+        full_untruncated_fill_ids=list(range(10)),
+        last_host_node=None,
+        extra_key=None,
+        cache_salt=None,
+        init_next_round_input=Mock(),
+        _compute_max_prefix_len=lambda n: n - 1,
+    )
+    method(SCHEDULER, "Scheduler", "_prefetch_kvcache")(scheduler, req)
+    args = cache.prefetch_from_storage.call_args
+    assert args.args[2] == [4, 5, 6, 7, 8]
+    assert args.kwargs["matched_prefix_tokens"] == [0, 1, 2, 3]
+
+
+def test_abort_releases_flexkv_without_hicache_enabled():
+    cache = Mock()
+    scheduler = NS(
+        enable_flexkv_prefetch=True,
+        enable_hicache_storage=False,
+        enable_hierarchical_cache=False,
+        enable_unified_cache_external_linker=False,
+        tree_cache=cache,
+    )
+    method(SCHEDULER, "Scheduler", "_release_aborted_request")(scheduler, "r")
+    cache.release_aborted_request.assert_called_once_with("r")
+
+
+def test_prefetch_stats_pass_through():
+    connector = Mock()
+    connector.pop_prefetch_loaded_span.return_value = (16, 32)
+    cache = NS(flexkv_connector=connector)
+    assert method(SOURCE, "FlexKVRadixCache", "pop_prefetch_loaded_span")(
+        cache, "r"
+    ) == (16, 32)
+
+
+@pytest.mark.parametrize("key,salt", [("adapter", None), (None, "salt")])
+def test_unsupported_namespace_does_not_use_unscoped_prefetch(key, salt):
+    connector = Mock()
+    cache = NS(flexkv_connector=connector)
+    method(SOURCE, "FlexKVRadixCache", "prefetch_from_storage")(
+        cache, "r", None, [1], extra_key=key, cache_salt=salt
+    )
+    connector.prefetch_async.assert_not_called()
+
+
+def test_scheduler_does_not_prefetch_already_matched_request():
+    cache = Mock()
+    scheduler = NS(
+        enable_flexkv_prefetch=True, enable_hicache_storage=False, tree_cache=cache
+    )
+    req = NS(
+        prefix_indices=list(range(8)),
+        host_hit_length=0,
+        full_untruncated_fill_ids=list(range(8)),
+        init_next_round_input=Mock(),
+        _compute_max_prefix_len=lambda n: n - 1,
+    )
+    method(SCHEDULER, "Scheduler", "_prefetch_kvcache")(scheduler, req)
+    cache.prefetch_from_storage.assert_not_called()
+
+
+@pytest.mark.parametrize("matched", [[], [1, 2, 3, 4]])
+def test_hybrid_preserves_hash_chain_and_candidate(matched):
+    connector = Mock(_chunked_prefetch=True)
+    cache = NS(flexkv_connector=connector)
+    method(HYBRID, "FlexKVHybridRadixCache", "prefetch_from_storage")(
+        cache, "swa", None, [5, 6], matched_prefix_tokens=matched
+    )
+    connector.prefetch_async.assert_called_once_with(
+        "swa", matched + [5, 6], candidate_start_token=len(matched)
+    )
+
+
+@pytest.mark.parametrize(
+    "prefix,limit,alignment,expected",
+    [
+        (0, 63, None, 0),
+        (64, 256, 512, 0),
+        (64, 512, 512, 512),
+        (0, 260, None, 256),
+        (65, 256, None, 255),
+    ],
+)
+def test_admission_chunk_boundary(prefix, limit, alignment, expected):
+    assert (
+        method(POLICY, "PrefillAdder", "_get_chunked_prefill_len")(
+            NS(page_size=64), prefix, limit, alignment
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "chunk_limit,remaining,align,dllm,tile,expected",
+    [
+        (32, 4096, None, None, None, "other"),
+        (256, 4096, 512, None, None, "other"),
+        (None, 1024, None, None, None, "other"),
+        (None, 4096, None, True, None, "other"),
+        (256, 4096, None, None, "other", "other"),
+        (256, 4096, None, None, None, None),
+    ],
+)
+def test_remaining_admission_gates_are_side_effect_free(
+    chunk_limit, remaining, align, dllm, tile, expected
+):
+    cache = NS(
+        page_size=64,
+        rem_chunk_tokens=chunk_limit,
+        can_run_list=[object()],
+        rem_input_tokens=remaining,
+        dllm_config=dllm,
+        rem_dllm_tokens=0,
+        ceil_paged_tokens=lambda n: (n + 63) // 64 * 64,
+        _check_prefill_tile_budget=Mock(return_value=tile),
+    )
+    calculate = method(POLICY, "PrefillAdder", "_get_chunked_prefill_len")
+    cache._get_chunked_prefill_len = lambda *args: calculate(cache, *args)
+    assert (
+        method(POLICY, "PrefillAdder", "_check_prefill_shape")(
+            cache, 1024, 3072, chunk_limit, align
+        )
+        == expected
+    )
+    assert len(cache.can_run_list) == 1
+
+
+@pytest.fixture
+def hybrid_restore():
+    req = NS(
+        rid="restore",
+        prefix_indices=torch.arange(256),
+        last_node=object(),
+        kv=NS(cache_protected_len=128),
+    )
+    slots = torch.arange(256, 768)
+    connector = Mock(enable_layerwise=False)
+    allocator = NS(free=Mock(), alloc_extend_swa_tail=Mock())
+    cache = NS(
+        flexkv_connector=connector,
+        page_size=256,
+        token_to_kv_pool_allocator=allocator,
+        _restore_generation=7,
+        _restore_leases={},
+        _load_markers={req.rid: NS(device_length=256)},
+        _alloc_restore_slots=Mock(return_value=slots),
+        supports_swa=lambda: True,
+        _empty_indices=lambda: torch.empty(0, dtype=torch.int64),
+    )
+    for name in ("_commit_restore", "_free_restore_lease", "init_load_back"):
+        setattr(
+            cache,
+            name,
+            MethodType(method(HYBRID, "FlexKVHybridRadixCache", name), cache),
+        )
+
+    def retrieve(rid, actual_slots):
+        lease = cache._restore_leases[rid]
+        assert lease.device_indices is actual_slots
+        assert req.pending_restore_slots is actual_slots
+        return actual_slots.numel()
+
+    connector.retrieve_kv.side_effect = retrieve
+    return cache, req, slots
+
+
+def test_hybrid_restore_owns_slots_before_h2d_and_preserves_tree_boundary(
+    hybrid_restore,
+):
+    cache, req, slots = hybrid_restore
+    restored, node = cache.init_load_back(NS(req=req, host_hit_length=512))
+    assert restored is slots and node is req.last_node
+    assert req.kv.cache_protected_len == 256
+    assert req._flexkv_swa_evicted_seqlen == 512
+    assert req.pending_restore_slots is slots
+    cache._commit_restore(req)
+    assert not cache._restore_leases and req.pending_restore_slots is None
+    cache.token_to_kv_pool_allocator.free.assert_not_called()
+
+
+def test_hybrid_failed_restore_frees_once(hybrid_restore):
+    cache, req, slots = hybrid_restore
+    cache.flexkv_connector.retrieve_kv.side_effect = None
+    cache.flexkv_connector.retrieve_kv.return_value = 0
+    restored, _ = cache.init_load_back(NS(req=req, host_hit_length=512))
+    assert restored.numel() == 0 and not cache._restore_leases
+    cache.token_to_kv_pool_allocator.free.assert_called_once_with(slots)
+    assert req.pending_restore_slots is None
+
+
+def test_hybrid_duplicate_restore_does_not_allocate_again(hybrid_restore):
+    cache, req, _ = hybrid_restore
+    cache.init_load_back(NS(req=req, host_hit_length=512))
+    restored, _ = cache.init_load_back(NS(req=req, host_hit_length=512))
+    assert restored.numel() == 0
+    assert cache._alloc_restore_slots.call_count == 1
+    assert req.rid in cache._restore_leases
+    cache.token_to_kv_pool_allocator.free.assert_not_called()
+
+
+def test_hybrid_stale_generation_cannot_free_current_slots(hybrid_restore):
+    cache, req, _ = hybrid_restore
+    cache.init_load_back(NS(req=req, host_hit_length=512))
+    req.pending_restore_generation -= 1
+    with pytest.raises(RuntimeError, match="lease mismatch"):
+        cache._commit_restore(req)
+    assert req.rid in cache._restore_leases
+    cache.token_to_kv_pool_allocator.free.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "flexkv,admitted,running,expected_full",
+    [
+        (True, False, False, False),
+        (True, True, False, True),
+        (True, False, True, True),
+        (False, False, False, True),
+    ],
+)
+def test_capacity_rejection_keeps_idle_flexkv_schedulable(
+    flexkv, admitted, running, expected_full
+):
+    """Execute the scheduler's NO_TOKEN handling, including rejected-req cleanup."""
+    tree = ast.parse(SCHEDULER.read_text())
+    cls = next(
+        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Scheduler"
+    )
+    method_node = next(
+        n
+        for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_get_new_batch_prefill_raw"
+    )
+    stop_branch = next(
+        n
+        for n in ast.walk(method_node)
+        if isinstance(n, ast.If)
+        and ast.unparse(n.test) == "res != AddReqResult.CONTINUE"
+    )
+    module = ast.fix_missing_locations(
+        ast.Module(
+            body=[
+                ast.For(
+                    target=ast.Name(id="_", ctx=ast.Store()),
+                    iter=ast.Tuple(elts=[ast.Constant(0)], ctx=ast.Load()),
+                    body=[stop_branch],
+                    orelse=[],
+                )
+            ],
+            type_ignores=[],
+        )
+    )
+    req = NS(kv=NS(holds_mamba=False))
+    batch = NS(batch_is_full=False, is_empty=lambda: not running)
+    namespace = dict(
+        self=NS(
+            enable_hierarchical_cache=False, enable_unified_cache_external_linker=False
+        ),
+        get_memory=lambda: NS(enable_flexkv=flexkv),
+        AddReqResult=NS(CONTINUE="continue", NO_TOKEN="no_token"),
+        res="no_token",
+        running_batch=batch,
+        adder=NS(can_run_list=[req] if admitted else []),
+        req=req,
+        has_uncommitted_restore=None,
+    )
+    exec(compile(module, str(SCHEDULER), "exec"), namespace)
+    assert batch.batch_is_full is expected_full
+    if not admitted:
+        assert req.kv.mamba_cow_src_index is None
+        assert req.kv.mamba_needs_clear is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
**Superseded by [XingLiu1/sglang#6](https://github.com/XingLiu1/sglang/pull/6).** The change is now a review PR targeting `agent/flexkv-dsv4-main`, the branch behind upstream #31781. The mistaken direct push to that branch was reverted; prefetch is not yet incorporated. The review head `2f91f9f5f0` has the same source tree as the version that passed 167 CPU tests and 12 subtests. Companion: [FlexKV #291](https://github.com/taco-project/FlexKV/pull/291).

## Motivation

FlexKV's whole-prefix prefetch cannot stop issuing remote work when a queued request becomes a scheduling candidate or exhausts its prefetch budget. Integrate the optional chunked API from https://github.com/taco-project/FlexKV/pull/291 so SGLang can consume a safely drained partial prefix and compute the remainder.

## Modifications

- Start prefetch on queue entry using the full hash-chain token input; issue demand at scheduling candidacy and propagate abort independently of HiCache backend configuration.
- Consume terminal, leased CPU prefixes through CPU-only LOOKUP and held GET. Synchronize leader decisions across TP ranks and account only actually published L3 spans.
- Compose FlexKV I/O with the existing hybrid radix implementation. Request-owned restore slots and SWA/state checkpoints retain one ownership path until normal cache insertion or rollback.
- Check admission shape/capacity before H2D, retain pending restore slots across scheduler iterations, and let an empty batch retry after host-cache pressure clears.
- Add CPU adapter/admission contract tests. No model kernels or underlying transfer protocol changes.

Depends on the companion FlexKV PR. Rebased on SGLang `5aab054ec8`; the default remains unchanged unless FlexKV chunked prefetch is enabled. Configuration, interfaces, sequence diagrams and monitoring boundaries are documented in the companion PR's `docs/design/chunked_prefetch_reference.md` and review document. `chunk_max_blocks` is the single chunk-size option; remove the former experimental `chunk_target_bytes` field.

## Accuracy Tests

- Rebased revisions: **57 SGLang tests passed plus 12 subtests**: 29 FlexKV adapter/admission cases and 28 existing PrefillAdder cases.
- Companion FlexKV: **456 passed, 9 Python-radix SWA skips**; C++ SWA cases executed. Tests used an isolated CPU/native container, not a GPU serving run.
- Ruff/isort/formatting, registered-test validation, patch applicability and diff whitespace checks passed.

Earlier implementation snapshots passed 25 real H20/Mooncake tests, a Full+SWA byte round trip, and 210/210 formal requests each for GLM-5.2 and V4 Flash (TP8/DP1). Full generated-token comparisons were used. Those results predate this rebase and chunk-size simplification; repeat GPU/model checks on the paired PR revisions before marking ready.

## Speed Tests and Profiling

No throughput or latency improvement is claimed. Earlier C1/C8/C32 workloads included shared prefixes, queueing and CPU/GPU cache hits. Same-cache-state repeated A/B, IPC/forward timeline alignment, longer load/fault/resource checks, and DP/layerwise coverage remain outstanding. Dedicated chunked-prefetch Prometheus instrumentation is follow-up work and is explicitly separated from existing metrics in the design.

## Checklist

- [x] Format changed code and check imports/lint with repository-pinned tools.
- [x] Add and register unit tests; run existing PrefillAdder regressions.
- [x] Document paired configuration, API/lifecycle, diagrams and monitoring boundaries in the FlexKV dependency.
- [ ] Repeat model accuracy and speed benchmarks on the rebased revisions.
- [ ] Complete GPU/runtime and broader topology acceptance before marking ready.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34200927062](https://github.com/sgl-project/sglang/actions/runs/34200927062)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34200926458](https://github.com/sgl-project/sglang/actions/runs/34200926458)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34200926774](https://github.com/sgl-project/sglang/actions/runs/34200926774)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->