### PR TITLE
[Perf] Persistent lazy eviction heaps for the unified radix cache full component

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -53,6 +53,14 @@ class FullComponent(TreeComponent):
             if cache.enable_session_radix_cache
             else None
         )
+        # Persistent lazy min-heaps over the leaf sets, entries (key, seq, node).
+        # Exact because a stored key is a lower bound on the node's current key:
+        # strategy keys never decrease, and session_ref decrements re-push.
+        self._device_leaf_heap: list = []
+        self._host_leaf_heap: list = []
+        self._leaf_heap_seq = 0
+        self._evict_device_last_node = None
+        self._evict_device_declined: list = []
 
     def _ensure_eviction_strategy(self) -> None:
         if self.session_ref_eviction_strategy is None:
@@ -60,12 +68,59 @@ class FullComponent(TreeComponent):
                 self.tree_core.eviction_strategy.get_priority
             )
 
+    def on_evictable_leaf_added(self, node: UnifiedTreeNode, layer: EvictLayer) -> None:
+        """Push a fresh heap entry for a node just added to a leaf set."""
+        self._ensure_eviction_strategy()
+        self._leaf_heap_seq += 1
+        heap = (
+            self._device_leaf_heap
+            if layer is EvictLayer.DEVICE
+            else self._host_leaf_heap
+        )
+        heapq.heappush(
+            heap,
+            (self.session_ref_eviction_strategy(node), self._leaf_heap_seq, node),
+        )
+
+    def _repush_if_evictable(self, node: UnifiedTreeNode) -> None:
+        """A session_ref decrement lowers a node's eviction key; re-push so the
+        heaps keep a lower-bound entry for every evictable leaf."""
+        if node in self.tree_core.evictable_device_leaves:
+            self.on_evictable_leaf_added(node, EvictLayer.DEVICE)
+        if node in self.tree_core.evictable_host_leaves:
+            self.on_evictable_leaf_added(node, EvictLayer.HOST)
+
+    def _refresh_leaf_heap(self, layer: EvictLayer) -> None:
+        """Rebuild a leaf heap when stale entries dominate (amortized O(1))."""
+        leaves = (
+            self.tree_core.evictable_device_leaves
+            if layer is EvictLayer.DEVICE
+            else self.tree_core.evictable_host_leaves
+        )
+        heap = (
+            self._device_leaf_heap
+            if layer is EvictLayer.DEVICE
+            else self._host_leaf_heap
+        )
+        if len(heap) > max(1024, 4 * len(leaves)):
+            heap = [
+                (self.session_ref_eviction_strategy(n), i, n)
+                for i, n in enumerate(leaves)
+            ]
+            heapq.heapify(heap)
+            self._leaf_heap_seq = max(self._leaf_heap_seq, len(heap))
+            if layer is EvictLayer.DEVICE:
+                self._device_leaf_heap = heap
+            else:
+                self._host_leaf_heap = heap
+
     def _dec_session_coverage(self, session_id: str, leaf: UnifiedTreeNode) -> None:
         node = leaf
         while node is not None and node is not self.tree_core.root_node:
             cd = node.component_data[self.component_type]
             assert cd.session_ref > 0
             cd.session_ref -= 1
+            self._repush_if_evictable(node)
             node = node.parent
 
     def _advance_session_coverage(
@@ -100,6 +155,7 @@ class FullComponent(TreeComponent):
             cd = node.component_data[self.component_type]
             assert cd.session_ref > 0
             cd.session_ref -= 1
+            self._repush_if_evictable(node)
             node = node.parent
 
     def create_match_validator(
@@ -195,11 +251,8 @@ class FullComponent(TreeComponent):
         self._ensure_eviction_strategy()
         self._evict_device_request_cnt = request_cnt
         self._evict_device_last_node = None
-        self._evict_device_heap = [
-            (self.session_ref_eviction_strategy(n), n)
-            for n in self.tree_core.evictable_device_leaves
-        ]
-        heapq.heapify(self._evict_device_heap)
+        self._evict_device_declined = []
+        self._refresh_leaf_heap(EvictLayer.DEVICE)
 
     def _evict_device_next_node(
         self,
@@ -209,27 +262,37 @@ class FullComponent(TreeComponent):
     ) -> Optional[NodeId]:
         ct = self.component_type
         lv = self._evict_device_last_node
-        if (
-            lv is not None
-            and lv.parent is not None
-            and lv.parent in self.tree_core.evictable_device_leaves
-        ):
-            heapq.heappush(
-                self._evict_device_heap,
-                (self.session_ref_eviction_strategy(lv.parent), lv.parent),
-            )
+        if lv is not None and lv in self.tree_core.evictable_device_leaves:
+            # The driver declined to evict the node we returned (write-back
+            # fallback refused). Keep it out of this walk so the driver makes
+            # progress; _evict_device_end re-pushes it.
+            self._evict_device_declined.append(lv)
         self._evict_device_last_node = None
-        while tracker[ct] < self._evict_device_request_cnt and self._evict_device_heap:
-            _, x = heapq.heappop(self._evict_device_heap)
+        while tracker[ct] < self._evict_device_request_cnt and self._device_leaf_heap:
+            key, _seq, x = heapq.heappop(self._device_leaf_heap)
             if x not in self.tree_core.evictable_device_leaves:
+                continue
+            current_key = self.session_ref_eviction_strategy(x)
+            if current_key != key:
+                # Refreshed since push: re-insert at the current key.
+                self._leaf_heap_seq += 1
+                heapq.heappush(
+                    self._device_leaf_heap, (current_key, self._leaf_heap_seq, x)
+                )
                 continue
             self._evict_device_last_node = x
             return x.id
         return None
 
     def _evict_device_end(self) -> None:
-        self._evict_device_heap = []
+        # Restore the heap invariant for nodes handed to the driver but still
+        # in the leaf set: the last returned node (walk stopped before its
+        # eviction) and any declined ones skipped during this walk.
+        for node in (self._evict_device_last_node, *self._evict_device_declined):
+            if node is not None and node in self.tree_core.evictable_device_leaves:
+                self.on_evictable_leaf_added(node, EvictLayer.DEVICE)
         self._evict_device_last_node = None
+        self._evict_device_declined = []
 
     def drive_host_eviction(
         self,
@@ -240,25 +303,22 @@ class FullComponent(TreeComponent):
     ) -> None:
         """Evict host leaves to free KV host pool space."""
         self._ensure_eviction_strategy()
-        heap = [
-            (self.session_ref_eviction_strategy(n), n)
-            for n in self.tree_core.evictable_host_leaves
-        ]
-        heapq.heapify(heap)
+        self._refresh_leaf_heap(EvictLayer.HOST)
         ct = self.component_type
-        while tracker[ct] < num_tokens and heap:
-            _, x = heapq.heappop(heap)
+        while tracker[ct] < num_tokens and self._host_leaf_heap:
+            key, _seq, x = heapq.heappop(self._host_leaf_heap)
             if x not in self.tree_core.evictable_host_leaves:
                 continue
-            self.tree_core._evict_host_leaf(x, tracker, device_frees, host_frees)
-            if (
-                x.parent is not None
-                and x.parent in self.tree_core.evictable_host_leaves
-            ):
+            current_key = self.session_ref_eviction_strategy(x)
+            if current_key != key:
+                self._leaf_heap_seq += 1
                 heapq.heappush(
-                    heap,
-                    (self.session_ref_eviction_strategy(x.parent), x.parent),
+                    self._host_leaf_heap, (current_key, self._leaf_heap_seq, x)
                 )
+                continue
+            # x leaves the set here; a parent that becomes a host leaf
+            # re-enters through the leaf-set hook.
+            self.tree_core._evict_host_leaf(x, tracker, device_frees, host_frees)
 
     def acquire_component_lock(
         self,

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1268,14 +1268,21 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.kv_events.record_store(node, medium=StorageMedium.GPU)
 
     def _update_evictable_leaf_sets(self, node: UnifiedTreeNode) -> None:
-        """Update both device and host leaf sets for a node."""
+        """Update both device and host leaf sets for a node. Additions also
+        feed the full component's persistent eviction heaps; removals are
+        handled lazily at pop time."""
+        full = self.components_by_type[BASE_COMPONENT_TYPE]
         if self._is_device_leaf(node):
-            self.evictable_device_leaves.add(node)
+            if node not in self.evictable_device_leaves:
+                self.evictable_device_leaves.add(node)
+                full.on_evictable_leaf_added(node, EvictLayer.DEVICE)
         else:
             self.evictable_device_leaves.discard(node)
 
         if self._is_host_leaf(node):
-            self.evictable_host_leaves.add(node)
+            if node not in self.evictable_host_leaves:
+                self.evictable_host_leaves.add(node)
+                full.on_evictable_leaf_added(node, EvictLayer.HOST)
         else:
             self.evictable_host_leaves.discard(node)
 

--- a/test/registered/unit/mem_cache/test_unified_evict_heap.py
+++ b/test/registered/unit/mem_cache/test_unified_evict_heap.py
@@ -1,0 +1,171 @@
+"""Eviction-order equivalence of the persistent lazy leaf heaps in FullComponent."""
+
+import heapq
+import os
+import random
+import sys
+import types
+import unittest
+from typing import Optional
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_cache.components.full_component import EvictLayer
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from test_unified_radix_cache_unittest import CacheConfig, build_fixture  # noqa: E402
+
+
+# Reference: the per-walk rebuild these heaps replace.
+def _ref_evict_device_start(self, request_cnt: int) -> None:
+    self._ensure_eviction_strategy()
+    self._evict_device_request_cnt = request_cnt
+    self._ref_last_node = None
+    self._ref_heap = [
+        (self.session_ref_eviction_strategy(n), n)
+        for n in self.tree_core.evictable_device_leaves
+    ]
+    heapq.heapify(self._ref_heap)
+
+
+def _ref_evict_device_next_node(
+    self, tracker, device_frees, host_frees
+) -> Optional[int]:
+    ct = self.component_type
+    lv = self._ref_last_node
+    if (
+        lv is not None
+        and lv.parent is not None
+        and lv.parent in self.tree_core.evictable_device_leaves
+    ):
+        heapq.heappush(
+            self._ref_heap, (self.session_ref_eviction_strategy(lv.parent), lv.parent)
+        )
+    self._ref_last_node = None
+    while tracker[ct] < self._evict_device_request_cnt and self._ref_heap:
+        _, x = heapq.heappop(self._ref_heap)
+        if x not in self.tree_core.evictable_device_leaves:
+            continue
+        self._ref_last_node = x
+        return x.id
+    return None
+
+
+def _ref_evict_device_end(self) -> None:
+    self._ref_heap = []
+    self._ref_last_node = None
+
+
+def _full_component(cache):
+    for comp in cache.tree_core.components:
+        if comp.component_type == ComponentType.FULL:
+            return comp
+    raise AssertionError("no FULL component")
+
+
+def _make(reference: bool):
+    cache, allocator, _ = build_fixture(CacheConfig(kv_size=4096, max_context_len=8192))
+    if reference:
+        comp = _full_component(cache)
+        comp._evict_device_start = types.MethodType(_ref_evict_device_start, comp)
+        comp._evict_device_next_node = types.MethodType(
+            _ref_evict_device_next_node, comp
+        )
+        comp._evict_device_end = types.MethodType(_ref_evict_device_end, comp)
+    return cache, allocator
+
+
+def _run_trace(cache, allocator, seed: int, steps: int = 3000):
+    order = []
+    core = cache.tree_core
+    orig = core.evict_device_leaf
+
+    def spy(node_id, *args, **kwargs):
+        order.append(tuple(core.node_by_id(node_id).key.token_ids))
+        return orig(node_id, *args, **kwargs)
+
+    core.evict_device_leaf = spy
+    rng = random.Random(seed)
+    tok = 0
+    locked = []
+    for _ in range(steps):
+        op = rng.random()
+        if op < 0.55:
+            length = rng.randint(1, 12)
+            key = RadixKey(
+                token_ids=[rng.randint(0, 30) for _ in range(length)],
+                extra_key=str(rng.randint(0, 40)),
+            )
+            value = torch.arange(
+                tok, tok + length, dtype=torch.int64, device=allocator.device
+            )
+            tok += length
+            cache.insert(InsertParams(key=key, value=value))
+        elif op < 0.68:
+            length = rng.randint(1, 12)
+            key = RadixKey(
+                token_ids=[rng.randint(0, 30) for _ in range(length)],
+                extra_key=str(rng.randint(0, 40)),
+            )
+            cache.match_prefix(MatchPrefixParams(key=key))
+        elif op < 0.76 and core.evictable_device_leaves:
+            node = rng.choice(sorted(core.evictable_device_leaves, key=lambda n: n.id))
+            cache.inc_lock_ref(node.id)
+            locked.append(node.id)
+        elif op < 0.84 and locked:
+            cache.dec_lock_ref(locked.pop(rng.randrange(len(locked))))
+        else:
+            cache.evict(EvictParams(num_tokens=rng.randint(1, 40)))
+    cache.evict(EvictParams(num_tokens=1 << 20))
+    return order
+
+
+class TestUnifiedEvictHeap(unittest.TestCase):
+    def test_eviction_order_matches_reference(self):
+        for seed in (1, 2, 3):
+            with self.subTest(seed=seed):
+                ref = _run_trace(*_make(reference=True), seed)
+                got = _run_trace(*_make(reference=False), seed)
+                self.assertGreater(len(ref), 0)
+                self.assertEqual(ref, got)
+
+    def test_heap_bounded_and_drained(self):
+        cache, allocator = _make(reference=False)
+        comp = _full_component(cache)
+        core = cache.tree_core
+        rng = random.Random(0)
+        for i in range(3000):
+            key = RadixKey(
+                token_ids=[rng.randint(0, 50) for _ in range(8)], extra_key=str(i)
+            )
+            cache.insert(
+                InsertParams(
+                    key=key,
+                    value=torch.arange(8, dtype=torch.int64, device=allocator.device),
+                )
+            )
+            if i % 3 == 0:
+                cache.evict(EvictParams(num_tokens=8))
+            self.assertLessEqual(
+                len(comp._device_leaf_heap),
+                max(1024, 4 * len(core.evictable_device_leaves)),
+            )
+        cache.evict(EvictParams(num_tokens=1 << 30))
+        self.assertEqual(len(core.evictable_device_leaves), 0)
+        comp._refresh_leaf_heap(EvictLayer.DEVICE)
+        self.assertEqual(len(comp._device_leaf_heap), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`FullComponent._evict_device_start` rebuilds the eviction heap from every evictable leaf on each walk (`list` + `heapify`, O(L)), and the host walk does the same. Once the KV pool is full, that runs on every scheduler step: at ~41k leaves it costs 70-77 ms per evict and takes 95% of the scheduler thread, and throughput drops 87-92%. This PR keeps one lazy heap per leaf set across walks instead, with eviction order unchanged. 

SGLang-Omni hit the same rebuild first and harder (short zero-hit audio requests keep the pool saturated on a host-bound scheduler; ASR throughput fell 92%) and carries the same construction on the classic tree in sgl-project/sglang-omni#1724; this PR moves it to where every dense model runs.

## Modifications

- **Persistent leaf heaps** (`unified_cache/components/full_component.py`): one lazy min-heap each for the device and host leaf sets, entries `(key, seq, node)`. A pop drops entries whose node left the set and re-pushes entries whose key moved; a heap is rebuilt only when stale entries exceed `max(1024, 4 x leaves)`.
- **Push hook** (`unified_cache/unified_tree_core.py`): `_update_evictable_leaf_sets` calls `on_evictable_leaf_added` when a node enters a leaf set. That is the single add site, so every evictable leaf always has a live entry.
- **Tests** (`test/registered/unit/mem_cache/test_unified_evict_heap.py`, `1-gpu-small`): eviction order equals the previous per-walk rebuild on randomized insert / match / lock / evict traces (3 seeds); heap size stays within the compaction bound and drains after a full evict.

Design notes:

- Lazy, not decrease-key: a pushed key is a lower bound on the node's current key for every built-in strategy (LRU / LFU / FIFO / priority / SLRU keys never decrease per node), so the heap top is the true minimum and a mismatched entry can simply be re-pushed. `session_ref` decrements are the one input that lowers a key; those re-push explicitly.
- Nodes the driver declines inside a walk (write-back backup failed, node locked) are skipped for that walk and restored at walk end, so the walk cannot spin on them.

## Accuracy Tests

Eviction order is unchanged (trace test above). Upstream suites `test_unified_radix_cache_unittest.py`, `test_unified_radix_allocation_eviction.py`, `test_session_unified_radix_cache.py`: 1201 passed / 1345 skipped, same as main (c5367fa964).

## Speed Tests and Profiling

Qwen2.5-0.5B-Instruct, one H200 per arm, `--max-total-tokens 4000000`, `sglang.benchmark.serving --dataset-name random-ids --random-input-len 64 --random-output-len 32 --max-concurrency 64`, 20k unique prompts per loop (~96-token leaves, ~41k leaves at saturation), baseline -> this PR:

| loop | qps | e2e p99 (ms) | eviction time per loop | per evict |
|---|---:|---:|---:|---:|
| 1 | 274 -> 299 | 792 -> 531 | 0 | - |
| 2 | 292 -> 296 | 531 -> 702 | 0 | - |
| 3 (pool saturates) | **35.8 -> 297.8** | 2889 -> 587 | 501 s -> 1.5 s | 70.7 ms -> 0.18 ms |
| 4 | **22.9 -> 296.9** | 3360 -> 666 | 819 s -> 2.4 s | 77.3 ms -> 0.19 ms |
| 5, 6 (this PR only) | 292.9, 288.5 | 794, 788 | 2.5 s | 0.20 ms |

Before saturation the arms are within noise. After it the baseline keeps degrading as leaves accumulate; this PR holds the pre-saturation level for six loops. Eviction time is upstream's own `sglang:eviction_duration_seconds`.

Mechanism-level confirmation (py-spy on the scheduler process, 30 s at 200 Hz, loop 3):

```text
baseline  5871 samples  eviction frames 95.3%  hottest: full_component.py:199-202 (list + heapify)
this PR   0.18-0.21 ms per evict, 11k evictions in 2.1 s over the whole saturated window
```

Microbenchmark on the same tree (50k thin leaves, 1000 x `evict(16)`): 70.4 ms -> 0.066 ms per call. Measured on 07c8f7294 with this change applied; the eviction code is identical to the current base.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34202996391](https://github.com/sgl-project/sglang/actions/runs/34202996391)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34202996103](https://github.com/sgl-project/sglang/actions/runs/34202996103)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34202996161](https://github.com/sgl-project/sglang/actions/runs/34202996161)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->