### PR TITLE
[Diffusion][CI] Per-case timing tolerance for host-I/O-bound perf guards

### DIFF
--- a/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
@@ -223,7 +223,8 @@
             "runtime_peak_allocated_mb": 11483.0,
             "load_peak_host_anon_mb": 32768.0,
             "runtime_peak_host_anon_mb": 32768.0,
-            "estimated_full_test_time_s": 283.0
+            "estimated_full_test_time_s": 283.0,
+            "timing_tolerance": 0.9
         }
     }
 }

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -700,6 +700,13 @@ class DiffusionServerBase:
         if measured_full_time is not None:
             baseline["estimated_full_test_time_s"] = round(measured_full_time, 1)
 
+        # a per-case timing tolerance is a deliberate property of the case, not a
+        # measurement: carry it into the suggested entry so a baseline refresh
+        # cannot silently drop it
+        existing = BASELINE_CONFIG.scenarios.get(case.id)
+        if existing is not None and existing.timing_tolerance is not None:
+            baseline["timing_tolerance"] = existing.timing_tolerance
+
         # Video-specific metrics
         if case.server_args.modality == "video":
             if "per_frame_generation" not in baseline["stages_ms"]:

--- a/python/sglang/multimodal_gen/test/server/test_server_utils.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_utils.py
@@ -726,6 +726,18 @@ class PerformanceValidator:
     ) -> PerformanceSummary:
         return PerformanceSummary.from_req_perf_record(perf_record, self.step_fractions)
 
+    def _timing_tol(self, profile_tolerance: float) -> float:
+        """Tolerance for a wall-clock check, honoring a per-case override.
+
+        A case whose runtime is dominated by shared-runner host I/O cannot be
+        guarded at the profile tolerance; ``timing_tolerance`` in its baseline
+        entry widens only the wall-clock checks, never the memory ones.
+        """
+        override = self.scenario.timing_tolerance
+        if override is None:
+            return profile_tolerance
+        return max(profile_tolerance, override)
+
     def _validate_e2e(self, summary: PerformanceSummary) -> None:
         """Validate end-to-end performance."""
         assert summary.e2e_ms > 0, "E2E duration missing"
@@ -733,7 +745,7 @@ class PerformanceValidator:
             "E2E Latency",
             summary.e2e_ms,
             self.scenario.expected_e2e_ms,
-            self.tolerances.e2e,
+            self._timing_tol(self.tolerances.e2e),
         )
 
     def _validate_denoise_agg(self, summary: PerformanceSummary) -> None:
@@ -744,13 +756,13 @@ class PerformanceValidator:
             "Average Denoise Step",
             summary.avg_denoise_ms,
             self.scenario.expected_avg_denoise_ms,
-            self.tolerances.denoise_agg,
+            self._timing_tol(self.tolerances.denoise_agg),
         )
         self._assert_le(
             "Median Denoise Step",
             summary.median_denoise_ms,
             self.scenario.expected_median_denoise_ms,
-            self.tolerances.denoise_agg,
+            self._timing_tol(self.tolerances.denoise_agg),
         )
 
     def _validate_denoise_steps(self, summary: PerformanceSummary) -> None:
@@ -766,7 +778,7 @@ class PerformanceValidator:
                     f"Denoise Step {idx}",
                     actual,
                     expected,
-                    FIRST_DENOISE_STEP_TOLERANCE,
+                    self._timing_tol(FIRST_DENOISE_STEP_TOLERANCE),
                     min_abs_tolerance=FIRST_DENOISE_STEP_MIN_ABS_TOLERANCE_MS,
                 )
                 continue
@@ -775,7 +787,7 @@ class PerformanceValidator:
                 f"Denoise Step {idx}",
                 actual,
                 expected,
-                self.tolerances.denoise_step,
+                self._timing_tol(self.tolerances.denoise_step),
             )
 
     def _validate_stages(self, summary: PerformanceSummary) -> None:
@@ -787,7 +799,7 @@ class PerformanceValidator:
                 continue
             actual = summary.stage_metrics.get(stage)
             assert actual is not None, f"Stage {stage} timing missing"
-            tolerance = (
+            tolerance = self._timing_tol(
                 self.tolerances.denoise_stage
                 if stage == "DenoisingStage"
                 else self.tolerances.non_denoise_stage
@@ -822,7 +834,7 @@ class VideoPerformanceValidator(PerformanceValidator):
                     f"Denoise Step {idx}",
                     actual,
                     expected,
-                    FIRST_DENOISE_STEP_TOLERANCE,
+                    self._timing_tol(FIRST_DENOISE_STEP_TOLERANCE),
                     min_abs_tolerance=FIRST_DENOISE_STEP_MIN_ABS_TOLERANCE_MS,
                 )
                 continue
@@ -833,7 +845,7 @@ class VideoPerformanceValidator(PerformanceValidator):
                 f"Denoise Step {idx}",
                 actual,
                 expected,
-                self.tolerances.denoise_step,
+                self._timing_tol(self.tolerances.denoise_step),
                 min_abs_tolerance=VIDEO_DENOISE_STEP_MIN_ABS_TOLERANCE_MS,
             )
 
@@ -863,7 +875,7 @@ class VideoPerformanceValidator(PerformanceValidator):
                 "Average Frame Time",
                 summary.avg_frame_time_ms,
                 expected_frame_time,
-                self.tolerances.denoise_stage,
+                self._timing_tol(self.tolerances.denoise_stage),
             )
 
 

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -127,6 +127,11 @@ class ScenarioConfig:
     # Anonymous-host budget caps; None skips the check (older baselines).
     load_peak_host_anon_mb: float | None = None
     runtime_peak_host_anon_mb: float | None = None
+    # Per-case override for the wall-clock tolerances (e2e, denoise and stage
+    # timings) when a case's runtime is dominated by shared-runner host I/O
+    # rather than by the code under test. Memory guards keep the profile
+    # tolerance -- they are what such a case actually protects.
+    timing_tolerance: float | None = None
 
     @classmethod
     def from_dict(cls, cfg: dict[str, Any]) -> ScenarioConfig:
@@ -148,6 +153,7 @@ class ScenarioConfig:
             runtime_peak_allocated_mb=optional_float("runtime_peak_allocated_mb"),
             load_peak_host_anon_mb=optional_float("load_peak_host_anon_mb"),
             runtime_peak_host_anon_mb=optional_float("runtime_peak_host_anon_mb"),
+            timing_tolerance=optional_float("timing_tolerance"),
         )
 
 

--- a/python/sglang/multimodal_gen/test/unit/test_performance_metrics.py
+++ b/python/sglang/multimodal_gen/test/unit/test_performance_metrics.py
@@ -572,3 +572,65 @@ def test_worker_keeps_the_pool_when_no_probe_ran(monkeypatch):
     worker._release_warmup_pool(_warmup_req())
     worker._release_warmup_pool(SimpleNamespace(is_warmup=False, extra={}))
     assert calls == []
+
+
+def _timing_validator(timing_tolerance: float | None) -> PerformanceValidator:
+    return PerformanceValidator(
+        scenario=ScenarioConfig(
+            stages_ms={"DenoisingStage": 1000.0},
+            denoise_step_ms={1: 100.0},
+            expected_e2e_ms=1000.0,
+            expected_avg_denoise_ms=100.0,
+            expected_median_denoise_ms=100.0,
+            timing_tolerance=timing_tolerance,
+        ),
+        tolerances=ToleranceConfig(0.25, 0.25, 0.25, 0.3, 0.2),
+        step_fractions=(),
+    )
+
+
+def _validate_scaled(validator: PerformanceValidator, scale: float) -> None:
+    summary = PerformanceSummary(
+        1000.0 * scale,
+        100.0 * scale,
+        100.0 * scale,
+        {"DenoisingStage": 1000.0 * scale},
+        [],
+        {1: 100.0 * scale},
+        {1: 100.0 * scale},
+    )
+    validator.collect_metrics = lambda _record: summary
+    validator.validate(None)
+
+
+def test_timing_tolerance_override_widens_wall_clock_checks_only():
+    with patch.object(current_platform, "is_hip", return_value=False):
+        # 1.7x the baseline fails at the profile's 25% e2e tolerance
+        with pytest.raises(AssertionError, match="E2E Latency"):
+            _validate_scaled(_timing_validator(None), 1.7)
+
+        # the same run passes for a case that declares a 90% timing tolerance
+        _validate_scaled(_timing_validator(0.9), 1.7)
+
+        # the override is a ceiling, not a blank cheque
+        with pytest.raises(AssertionError, match="E2E Latency"):
+            _validate_scaled(_timing_validator(0.9), 2.5)
+
+
+def test_timing_tolerance_override_leaves_memory_guards_alone():
+    validator = _timing_validator(0.9)
+    regression = PerformanceSummary(
+        0.0,
+        0.0,
+        0.0,
+        {},
+        [],
+        {},
+        {},
+        load_peak_vram_mb=10_000.0,
+        runtime_peak_vram_mb=10_201.0,
+    )
+
+    with patch.object(current_platform, "is_hip", return_value=False):
+        with pytest.raises(AssertionError, match="Runtime Peak VRAM"):
+            validator.validate_peak_vram(regression, 10_000.0, 10_000.0)


### PR DESCRIPTION
## Motivation

`minimax_h3_t2va_consumer_budget_1gpu_5090` fails the e2e guard on unrelated PRs. The case is not measuring the code under test:

- it streams a 66 GiB model against `SGLANG_DIFFUSION_TEST_CAP_DEVICE_MEMORY_GIB=12` and `SGLANG_DIFFUSION_TEST_FORCE_HOST_AVAILABLE_GIB=32`, so its wall clock is the runner's page cache and disk;
- it runs with `--performance-mode memory`, so `auto_residency_args_skip_reason` short-circuits the whole residency planner — a residency PR cannot change this case's placement at all.

Two jobs on the **same runner** (`5090-e-runner-3`), same config:

| job | samples | e2e (s) |
|---|---|---|
| #37917 (green) | 4 | 33.5, 36.4, 43.8, 52.3 |
| #37918 (red) | 14 | 34.4, 34.4, 37.1, 40.6, 44.4, 46.4, 47.0, 50.5, 51.7, 53.9, 57.0, 60.0, 67.7, 75.2 |

And on another runner (`5090-d-runner-7`), a green job on a PR that touches no residency code:

| job | samples | e2e (s) |
|---|---|---|
| #38441 (green) | 12 | 38.2, 42.6, 43.0, 45.0, 45.8, 46.5, 47.7, 48.4, 49.5, 50.8, 52.3, 57.1 |

Baseline 42763 ms, `pr_test` e2e tolerance 25% → limit 53454 ms. The spread on one runner is 2.2×, so pass/fail is a coin flip. In the same two jobs the other five 5090 cases are flat (17.6 vs 18.5 s, 4.5 vs 4.8 s, 2.2 vs 2.5 s, 1.8 vs 2.1 s, 22.7 vs 22.8 s) — the machine is not globally slower, only the host-I/O-bound case swings.

## Modifications

- `ScenarioConfig.timing_tolerance`: optional per-case override for the wall-clock tolerances only — e2e, avg/median denoise, per-step, stages and frame time. Memory guards (load/runtime peak VRAM, allocated peaks, host anon) keep the profile tolerance; those are what this case actually protects (a 12 GiB device cap and a 32 GiB host cap).
- The override is a ceiling, applied as `max(profile, override)`, so it can only widen, never tighten.
- `_dump_baseline_for_testcase` carries the field into the suggested entry, so refreshing a baseline cannot silently drop it.
- Applied to `minimax_h3_t2va_consumer_budget_1gpu_5090` at `0.9` (limit ≈ 81 s): covers all 18 samples measured so far with headroom, and still fails a ~2× regression.

No other case changes behavior — `timing_tolerance` defaults to `None`.

## Accuracy Tests

Not applicable — CI harness only, no runtime code touched.

## Benchmarking and Profiling

Not applicable — this PR changes no runtime path.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests: `test_timing_tolerance_override_widens_wall_clock_checks_only`, `test_timing_tolerance_override_leaves_memory_guards_alone`.
- [x] `python/sglang/multimodal_gen/test/unit/test_performance_metrics.py` (20 passed), `test_suite_partitioning.py` + `test_sequential_server_requests.py` (56 passed) on an H200 box.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34203969868](https://github.com/sgl-project/sglang/actions/runs/34203969868)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34203985227](https://github.com/sgl-project/sglang/actions/runs/34203985227)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34203969411](https://github.com/sgl-project/sglang/actions/runs/34203969411)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->