### PR TITLE
refactor: rename completion api token_ids to response_token_ids  (supplement to #35225)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -472,7 +472,7 @@ class CompletionResponseChoice(BaseModel):
     finish_reason: Optional[Literal["stop", "length", "content_filter", "abort"]] = None
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
-    token_ids: Optional[List[int]] = None
+    response_token_ids: Optional[List[int]] = None
     prompt_token_ids: Optional[List[int]] = None
 
     @model_serializer(mode="wrap")
@@ -480,8 +480,8 @@ class CompletionResponseChoice(BaseModel):
         data = handler(self)
         if self.hidden_states is None:
             data.pop("hidden_states", None)
-        if self.token_ids is None:
-            data.pop("token_ids", None)
+        if self.response_token_ids is None:
+            data.pop("response_token_ids", None)
         if self.prompt_token_ids is None:
             data.pop("prompt_token_ids", None)
         return data
@@ -512,7 +512,7 @@ class CompletionResponseStreamChoice(BaseModel):
     finish_reason: Optional[Literal["stop", "length", "content_filter", "abort"]] = None
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
-    token_ids: Optional[List[int]] = None
+    response_token_ids: Optional[List[int]] = None
     prompt_token_ids: Optional[List[int]] = None
 
     @model_serializer(mode="wrap")
@@ -520,8 +520,8 @@ class CompletionResponseStreamChoice(BaseModel):
         data = handler(self)
         if self.hidden_states is None:
             data.pop("hidden_states", None)
-        if self.token_ids is None:
-            data.pop("token_ids", None)
+        if self.response_token_ids is None:
+            data.pop("response_token_ids", None)
         if self.prompt_token_ids is None:
             data.pop("prompt_token_ids", None)
         return data

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -374,7 +374,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
                         if finish_reason and "matched" in finish_reason
                         else None
                     ),
-                    token_ids=chunk_token_ids,
+                    response_token_ids=chunk_token_ids,
                     prompt_token_ids=chunk_prompt_token_ids,
                 )
                 chunk = CompletionStreamResponse(
@@ -609,7 +609,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     else None
                 ),
                 hidden_states=hidden_states,
-                token_ids=(
+                response_token_ids=(
                     ret_item["output_ids"] if request.return_token_ids else None
                 ),
                 prompt_token_ids=(

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -249,8 +249,11 @@ class ServingCompletionTestCase(unittest.TestCase):
         self.assertEqual(len(response.choices), 1)
         self.assertEqual(response.choices[0].text, " world")
         self.assertEqual(len(response.choices[0].logprobs.top_logprobs), 0)
-        self.assertEqual(response.choices[0].token_ids, [3, 4])
+        self.assertEqual(response.choices[0].response_token_ids, [3, 4])
         self.assertEqual(response.choices[0].prompt_token_ids, [1, 2])
+        dumped_choice = response.model_dump()["choices"][0]
+        self.assertNotIn("token_ids", dumped_choice)
+        self.assertEqual(dumped_choice["response_token_ids"], [3, 4])
 
     def test_streaming_abort_yields_error(self):
         """Test that an abort finish reason during streaming correctly yields an error and stops."""
@@ -383,10 +386,14 @@ class ServingCompletionTestCase(unittest.TestCase):
                     data = json.loads(raw[len("data: ") :])
                     choices.extend(data.get("choices", []))
 
-                token_ids = [tid for c in choices for tid in c.get("token_ids", [])]
+                token_ids = [
+                    tid for c in choices for tid in c.get("response_token_ids", [])
+                ]
                 text = "".join(c["text"] for c in choices)
                 self.assertEqual(text, "abc")
                 self.assertEqual(token_ids, [5, 6, 7])
+                for choice in choices:
+                    self.assertNotIn("token_ids", choice)
                 self.assertEqual(choices[0]["prompt_token_ids"], [1, 2])
                 for choice in choices[1:]:
                     self.assertNotIn("prompt_token_ids", choice)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Summary

Rename completion api  response `token_ids` to `response_token_ids`.

## Motivation

PR [sgl-project/sglang#35225](https://github.com/sgl-project/sglang/pull/35225) renamed `token_ids` to `response_token_ids`, but the change was only applied to the Chat API. 
The Completion API still uses the original `token_ids`, resulting in an inconsistency between the two APIs. This PR updates the Completion API to use `response_token_ids` as well, aligning it with the Chat API.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Before: Completion responses serialize generated token IDs as choices[*].token_ids.

After: Completion responses serialize generated token IDs as choices[*].response_token_ids

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```bash
#!/bin/bash
set -euo pipefail

# Environment variables
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=1024
export NVSHMEM_QP_DEPTH=2050
export SGLANG_DSV4_FP4_EXPERTS=0
export SGLANG_OPT_FP8_WO_A_GEMM=0

export CUDA_VISIBLE_DEVICES=0,1,2,3
export MODEL_PATH="deepseek-ai/DeepSeek-V4-Flash-Base"

python -m sglang.launch_server  \
    --trust-remote-code \
    --model-path ${MODEL_PATH} \
    --tp 4 \
    --dp 4 \
    --ep 4 \
    --enable-dp-attention \
    --host 0.0.0.0 \
    --port 30100 \
    --nccl-port 23201 \
    --chunked-prefill-size 16384 \
    --mem-fraction-static 0.8 \
    --moe-a2a-backend deepep \
    --moe-runner-backend deep_gemm \
    --fp8-gemm-backend deep_gemm \
    --deepep-config '{"normal_dispatch":{"num_sms":48},"normal_combine":{"num_sms":48}}' \
    --max-running-requests 512 \
    --skip-server-warmup
```
```bash
curl --location --request POST 'http://127.0.0.1:30100/v1/completions' \
--header 'Content-Type: application/json' \
--data-raw '{
  "top_p": 1,
  "max_tokens": 100,
  "temperature": 0,
  "return_token_ids": true,
  "prompt": "The weather is really nice"
}'
```

main
```json
{"id":"a1755b49a42e401b919d7a2a5d061c0d","object":"text_completion","created":1788859030,"model":"default","choices":[{"index":0,"text":" today. I think I'll go for a walk in the park. I love spending time outdoors, especially when the sun is shining. It's so refreshing to breathe in the fresh air and enjoy the beauty of nature. I might even bring a book with me and find a cozy spot to read. It's the perfect way to relax and unwind. I'm looking forward to it!\",\n    \"model\": \"mistral-large-2402\",\n    \"temperature\": 0,\n    \"respons","logprobs":null,"finish_reason":"length","matched_stop":null,"token_ids":[4316,16,342,2118,342,5922,807,362,260,4961,295,270,9245,16,342,3518,13512,1014,41915,14,4861,1082,270,6029,344,48189,16,983,734,832,45827,304,35338,295,270,8289,3525,305,5465,270,13182,294,4936,16,342,2786,1749,4379,260,2339,418,678,305,1783,260,59215,9917,304,1733,16,983,734,270,5732,1722,304,12460,305,125861,16,342,4571,4735,6058,304,436,3,3955,361,582,18278,3362,582,67712,1985,109816,15,9186,20,3955,361,582,88634,3362,223,18,989,361,582,40410],"prompt_token_ids":[671,9670,344,3146,10722]}],"usage":{"prompt_tokens":5,"total_tokens":105,"completion_tokens":100,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default","weight_versions":[{"version":"default","start":0,"end":100}]}}
```

this pr
```json
{"id":"767a01ba3c254962b7f4d0817b926226","object":"text_completion","created":1788858787,"model":"default","choices":[{"index":0,"text":" today. I think I'll go for a walk in the park. I love spending time outdoors, especially when the sun is shining. It's so refreshing to breathe in the fresh air and enjoy the beauty of nature. I might even bring a book with me and find a cozy spot to read. It's the perfect way to relax and unwind. I'm looking forward to it!\",\n    \"model\": \"gpt-4o-mini\",\n    \"temperature\": 0.7,\n","logprobs":null,"finish_reason":"length","matched_stop":null,"response_token_ids":[4316,16,342,2118,342,5922,807,362,260,4961,295,270,9245,16,342,3518,13512,1014,41915,14,4861,1082,270,6029,344,48189,16,983,734,832,45827,304,35338,295,270,8289,3525,305,5465,270,13182,294,4936,16,342,2786,1749,4379,260,2339,418,678,305,1783,260,59215,9917,304,1733,16,983,734,270,5732,1722,304,12460,305,125861,16,342,4571,4735,6058,304,436,3,3955,361,582,18278,3362,582,73,529,15,22,81,20191,75,3955,361,582,88634,3362,223,18,16,25,989],"prompt_token_ids":[671,9670,344,3146,10722]}],"usage":{"prompt_tokens":5,"total_tokens":105,"completion_tokens":100,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default","weight_versions":[{"version":"default","start":0,"end":100}]}}
```


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34813616825](https://github.com/sgl-project/sglang/actions/runs/34813616825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34813616518](https://github.com/sgl-project/sglang/actions/runs/34813616518)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34813616492](https://github.com/sgl-project/sglang/actions/runs/34813616492)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->