### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend DeepSeek-R1 guides

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_r1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/deepseek_r1.mdx
@@ -169,7 +169,7 @@ do
         --enable-dp-attention \
         --deepep-mode low_latency \
         --enable-dp-lm-head \
-        --cuda-graph-bs 2 4 6 8 10 12 14 16 18 20 22 24 26 \
+        --cuda-graph-bs-decode 2 4 6 8 10 12 14 16 18 20 22 24 26 \
         --watchdog-timeout 9000 \
         --context-length 8192 \
         --speculative-algorithm NEXTN \
@@ -296,7 +296,7 @@ python3 -m sglang.launch_server \
     --device npu \
     --quantization modelslim \
     --watchdog-timeout 9000 \
-    --cuda-graph-bs 4 8 12 14 \
+    --cuda-graph-bs-decode 4 8 12 14 \
     --mem-fraction-static 0.9 \
     --max-running-requests 224 \
     --context-length 8188 \
@@ -481,7 +481,7 @@ do
         --deepep-mode low_latency \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \
-        --cuda-graph-bs 2 4 6 \
+        --cuda-graph-bs-decode 2 4 6 \
         --watchdog-timeout 9000 \
         --context-length 8192 \
         --speculative-algorithm NEXTN \
@@ -689,7 +689,7 @@ do
         --enable-dp-attention \
         --deepep-mode low_latency \
         --moe-dense-tp 1 \
-        --cuda-graph-bs 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32 \
+        --cuda-graph-bs-decode 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30 32 \
         --watchdog-timeout 9000 \
         --context-length 8192 \
         --speculative-algorithm NEXTN \
@@ -893,7 +893,7 @@ do
         --deepep-mode low_latency \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \
-        --cuda-graph-bs 2 4 6 \
+        --cuda-graph-bs-decode 2 4 6 \
         --watchdog-timeout 9000 \
         --context-length 8192 \
         --speculative-algorithm NEXTN \
@@ -1097,7 +1097,7 @@ do
         --deepep-mode low_latency \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \
-        --cuda-graph-bs 2 4 6 \
+        --cuda-graph-bs-decode 2 4 6 \
         --watchdog-timeout 9000 \
         --context-length 8192 \
         --speculative-algorithm NEXTN \
@@ -1300,7 +1300,7 @@ do
         --deepep-mode low_latency \
         --enable-dp-lm-head \
         --moe-dense-tp 1 \
-        --cuda-graph-bs 2 4 6 \
+        --cuda-graph-bs-decode 2 4 6 \
         --watchdog-timeout 9000 \
         --speculative-algorithm NEXTN \
         --speculative-num-steps 3 \

--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/deepseek_r1.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/deepseek_r1.mdx
@@ -27,7 +27,7 @@ v0.5.16 or a later version.
 | Expert Parallelism            | `--ep-size 16 \`<br/>`--moe-a2a-backend deepep \`<br/>`--deepep-mode auto`                     |
 | PD Disaggregation             | `--disaggregation-mode prefill \`<br/>`--disaggregation-transfer-backend ascend`              |
 | Quantization                  | `--quantization modelslim`                                                                    |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 4 8 20 21 22` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 4 8 20 21 22` |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 2 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 3` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |


### PR DESCRIPTION
## Summary
- Ascend DeepSeek-R1 **best practices**: replace deprecated `--cuda-graph-bs` with `--cuda-graph-bs-decode` (7 call sites).
- Ascend DeepSeek-R1 **tutorial**: update the NPU Graph feature row to prefer `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled` and `--cuda-graph-bs-decode`.

Verified against `python/sglang/srt/server_args.py` at tip `4c3d47f1df9dee2d77794f6fc5ef11c64817e4fc`: `--cuda-graph-bs` / `--disable-cuda-graph` are deprecated aliases.

## Test plan
- [x] Raw tip repro of deprecated flags in the two docs
- [x] Confirm new flag names in server_args DeprecatedAlias / DeprecatedStoreTrue registrations
- [ ] Docs render / maintainer glance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34205150993](https://github.com/sgl-project/sglang/actions/runs/34205150993)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34205150691](https://github.com/sgl-project/sglang/actions/runs/34205150691)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->