### PR TITLE
[mem_cache] skip duplicates host evict via environ

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -722,6 +722,7 @@ class Envs:
     SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB = EnvInt(256)
     SGLANG_HICACHE_HF3FS_CONFIG_PATH = EnvStr(None)
     SGLANG_HICACHE_DECODE_OFFLOAD_STRIDE = EnvInt(None)
+    SGLANG_HICACHE_SKIP_HOST_DUPLICATE_RECLAIM = EnvBool(False)
     SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR = EnvStr(None)
     # File-backend LRU eviction (opt-in; sizes accept SI/IEC suffixes, "0" disables).
     SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE = EnvStr(None)

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -27,6 +27,7 @@ import msgspec
 import torch
 
 from sglang.srt.disaggregation.kv_events import StorageMedium
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefParams,
     DecLockRefResult,
@@ -1490,11 +1491,16 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self, component_type: ComponentType, num_tokens: int
     ) -> DriveHostEvictionResult:
         """Evict a component's host-side resources; no-op if absent. Under
-        write_back, FULL pressure reclaims redundant Full host copies first."""
+        write_back, FULL pressure reclaims redundant Full host copies first
+        (skipped if SGLANG_HICACHE_SKIP_HOST_DUPLICATE_RECLAIM=1)."""
         result = DriveHostEvictionResult()
         comp = self.components_by_type.get(component_type)
         if comp is not None:
-            if self.is_write_back and component_type == BASE_COMPONENT_TYPE:
+            if (
+                not envs.SGLANG_HICACHE_SKIP_HOST_DUPLICATE_RECLAIM.get()
+                and self.is_write_back
+                and component_type == BASE_COMPONENT_TYPE
+            ):
                 self._reclaim_full_host_duplicates(
                     num_tokens,
                     result.tracker,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When device-side memory is constrained, evicted cache lines are continuously offloaded to host memory. Once host memory reaches capacity, a host-side eviction policy must be enforced. Under a write-back strategy, cache lines that are redundantly held on both device and host are preferentially selected for eviction. Consequently, prefix cache lines that were previously offloaded from device to host may be re-transmitted, thereby degrading overall throughput during benchmarking.

## Modifications

To mitigate the throughput degradation caused by redundant re-transmission of prefix cache lines, we introduce an environment variable SGLANG_HICACHE_SKIP_HOST_DUPLICATE_RECLAIM that bypasses the _reclaim_full_host_duplicates eviction path. When set to 1, the system skips the preferential eviction of device–host duplicate cache lines and proceeds directly to the general host eviction routine (drive_host_eviction), thereby preserving previously offloaded prefix entries on the host side and avoiding unnecessary re-offloading overhead.

## Accuracy Tests

None

## Speed Tests and Profiling
140k + 95%cache

Before:
<img width="1592" height="811" alt="image" src="https://github.com/user-attachments/assets/e176f307-6b86-4fb7-bcb3-464d5056d641" />

<img width="580" height="532" alt="image" src="https://github.com/user-attachments/assets/db01d13b-c24d-486a-bd5b-f80376c14751" />


After:
<img width="1343" height="778" alt="image" src="https://github.com/user-attachments/assets/f34753e1-d99c-4619-a259-94c3c45ee4a3" />


<img width="522" height="547" alt="image" src="https://github.com/user-attachments/assets/5687a069-a952-44e2-aa26-b4a6ca70e60b" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34211872549](https://github.com/sgl-project/sglang/actions/runs/34211872549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34211872289](https://github.com/sgl-project/sglang/actions/runs/34211872289)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34211872520](https://github.com/sgl-project/sglang/actions/runs/34211872520)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->