### PR TITLE
[HiCache] Order D2H completion before subsequent forward work

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -811,7 +811,7 @@ class HiCacheController:
             self._l2_transfers(host_indices, device_indices, pool_transfers)
         )
         # Rejoin the D2H stream onto the current scheduler stream so subsequent
-        # forward work cannot overtake the backup. Event waits are host-asynchronous.
+        # forward work starts only after this KV cache transfer completes.
         completion.finish_event.wait()
 
         self.ack_write_queue.append(

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -810,6 +810,9 @@ class HiCacheController:
         completion = self.l2_transfer_engine.submit_device_to_host(
             self._l2_transfers(host_indices, device_indices, pool_transfers)
         )
+        # Rejoin the D2H stream onto the current scheduler stream so subsequent
+        # forward work cannot overtake the backup. Event waits are host-asynchronous.
+        completion.finish_event.wait()
 
         self.ack_write_queue.append(
             HiCacheAck(

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -170,12 +170,13 @@ def _cpu_per_layer_pf_lf_copy(
 class _FakeEvent:
     def __init__(self, enable_timing=False):
         self.enable_timing = enable_timing
+        self.waited_streams = []
 
     def record(self):
         pass
 
-    def wait(self, stream):
-        pass
+    def wait(self, stream=None):
+        self.waited_streams.append(stream)
 
 
 class _FakeDeviceModule:
@@ -1044,6 +1045,9 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         controller.move_indices.assert_not_called()
         self.assertEqual(captured["host_indices"].device.type, "cpu")
+        self.assertEqual(
+            controller.ack_write_queue[0].finish_event.waited_streams, [None]
+        )
 
     def test_cache_controller_moves_indices_without_write_back_jit(self):
         captured = {}


### PR DESCRIPTION
[by Codex]

## Summary

- Rejoin each HiCache device-to-host write onto the caller's current scheduler stream through its existing completion event.
- Prevent subsequent forward/CUDA-graph work from overtaking the asynchronous KV-cache backup.
- Keep the wait device-side and host-asynchronous.
- Add unit coverage that verifies the completion event is waited on by the caller's current stream.

## Motivation

This is a correctness-first fix candidate for #38300.

With overlap scheduling, HiCache currently forks work from the scheduler stream onto its private D2H stream, while later forward work can proceed independently:

```text
schedule_stream --start_event--> D2H stream
       |
       +------------------------> forward stream / CUDA graph
```

Waiting on the existing finish event closes that fork without synchronizing the host:

```text
schedule --start--> D2H --finish--> schedule --> forward graph
```

Under the issue reproducer's secondary CUDA-context churn, the unfenced path can stop one TP rank before a collective while its peer enters MNNVL/NCCL and waits indefinitely.

## Validation

- The fence-only variant completed two independent 720-second, 2,927-request stress runs on 2x B300, with context churn applied to GPU 0 and GPU 1 respectively.
- Full CUDA graphs for decode and breakable piecewise CUDA graphs for prefill remained enabled.
- The original HiCache event lifecycle and allocator free path remained enabled.
- Comparable unfenced runs repeatedly wedged.
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`

The focused CPU test was not run locally because the available Python environment does not include PyTorch. This PR is left as a draft while performance impact and broader CI coverage are evaluated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34210050838](https://github.com/sgl-project/sglang/actions/runs/34210050838)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34210050648](https://github.com/sgl-project/sglang/actions/runs/34210050648)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34210050800](https://github.com/sgl-project/sglang/actions/runs/34210050800)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->