### PR TITLE
[Core] Load plugins before ServerArgs resolves the model, and in every spawned process

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -51,6 +51,7 @@ from sglang.srt.observability.trace import (
     process_tracing_init,
     trace_set_thread_info,
 )
+from sglang.srt.plugins import load_plugins
 from sglang.srt.runtime_context import (
     get_device,
     get_observability,
@@ -1719,6 +1720,9 @@ def launch_dp_worker(
     release_path: str,
     result_path: str,
 ):
+    # Load plugins so hooks can override the model config and weight loaders
+    # used by MMEncoder below.
+    load_plugins()
     publish(server_args, role="encoder")
     try:
         configure_logger(server_args, prefix=f" encode_dp_worker[{dp_rank}]")

--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -57,6 +57,7 @@ from sglang.srt.multimodal.encoder_preprocessing import (
     resolve_encoder_media_processor_config,
 )
 from sglang.srt.observability.metrics_collector import EncoderMetricsCollector
+from sglang.srt.plugins import load_plugins
 from sglang.srt.runtime_context import (
     assert_published,
     get_device,
@@ -2470,6 +2471,9 @@ async def _handle_encoder_worker_request(encoder: MMEncoder, request):
 
 
 def launch_encoder(server_args, schedule_path, dist_init_method, rank):
+    # Load plugins so hooks can override the model config and weight loaders
+    # used by MMEncoder below.
+    load_plugins()
     publish(server_args, role="encoder")
     try:
         asyncio.run(run_encoder(server_args, schedule_path, dist_init_method, rank))

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1071,13 +1071,14 @@ class Engine(EngineScoreMixin, EngineBase):
 
         # Configure global environment
         configure_logger(server_args)
+
+        # Defensive: ensure plugins loaded before resolution builds the model
+        # config (may already be loaded by Engine.__init__ or CLI entry; a
+        # record that arrived by pickle never ran __post_init__ here).
+        load_plugins()
         server_args.resolve_once()
 
         _set_envs_and_config(server_args)
-
-        # Defensive: ensure plugins loaded (may already be loaded by
-        # Engine.__init__ or CLI entry).
-        load_plugins()
 
         # Not read-only: the LoRA checks normalize adapter paths through late
         # resolution, which a published config refuses. Hence before publish --

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -165,6 +165,7 @@ from sglang.srt.observability.trace import (
 )
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.parser.template_manager import TemplateManager
+from sglang.srt.plugins import load_plugins
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import (
     add_prometheus_middleware,
@@ -228,6 +229,10 @@ async def init_multi_tokenizer() -> ServerArgs:
     server_args: ServerArgs
     port_args: PortArgs
 
+    # This is a fresh worker process and the record arrived by pickle, so
+    # nothing has loaded plugins here yet. Load them before the tokenizer
+    # worker resolves the model and tokenizer.
+    load_plugins()
     publish(server_args, role="tokenizer")
 
     # API key authentication is not supported in multi-tokenizer mode

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -43,6 +43,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.multi_tokenizer_mixin import MultiHttpWorkerDetokenizerMixin
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
+from sglang.srt.plugins import load_plugins
 from sglang.srt.runtime_context import (
     get_device,
     get_model,
@@ -544,6 +545,8 @@ def run_detokenizer_process(
     kill_itself_when_parent_died()
     setproctitle.setproctitle("sglang::detokenizer")
     configure_logger(server_args)
+    # Load plugins so hooks can override the tokenizer loaders used below.
+    load_plugins()
     publish(server_args, role="detokenizer")
     parent_process = psutil.Process().parent()
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -234,6 +234,20 @@ class ServerArgs:
         config being inspected, one being handed to a subprocess that will
         resolve it itself -- stays raw.
         """
+        # Loading plugins is a process-level side effect that does not touch
+        # the record. It happens here because construction is the earliest
+        # point every path shares: an embedder that builds ServerArgs and
+        # resolves the model config before Engine.__init__ would otherwise
+        # run the resolution path (ModelConfig, config/tokenizer loaders)
+        # with no hooks applied. load_plugins() is idempotent: whichever of
+        # this call and the pre-construction one in Engine.__init__ runs
+        # first does the work. The latter stays because a hook on
+        # __post_init__ itself can only fire on the first record if plugins
+        # were loaded before construction. This mirrors vLLM, which loads
+        # plugins in EngineArgs.__post_init__.
+        from sglang.srt.plugins import load_plugins
+
+        load_plugins()
 
     def resolve_once(self) -> None:
         """Run the resolution pipeline, unless this record has been through it.

--- a/test/registered/unit/plugins/test_model_config_loads_plugins.py
+++ b/test/registered/unit/plugins/test_model_config_loads_plugins.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for plugin loading ahead of model resolution.
+
+``ServerArgs.__post_init__`` loads plugins, so an embedder that builds
+``ServerArgs`` and resolves the model config before ``Engine.__init__`` still
+gets its hooks applied. A hook on ``ModelConfig.__init__`` is only installed by
+``HookRegistry.apply_hooks()``; if ``load_plugins()`` has not run by the time
+the constructor is called, the hook is silently skipped.
+
+Spawned processes receive ``ServerArgs`` by pickle, which bypasses
+``__post_init__``, so their entry functions have to load plugins themselves.
+
+Run:  python -m pytest test/registered/unit/plugins/test_model_config_loads_plugins.py -v
+"""
+
+from unittest.mock import MagicMock, patch
+
+import sglang.srt.plugins as plugins_mod
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.managers import detokenizer_manager
+from sglang.srt.plugins.hook_registry import HookRegistry, HookType
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_TARGET = "sglang.srt.configs.model_config.ModelConfig.__init__"
+_MODEL_PATH = "org/not-a-real-model"
+
+
+class _HookFired(Exception):
+    """Raised by the fake hook so ModelConfig.__init__ never runs."""
+
+
+class TestServerArgsLoadsPlugins(CustomTestCase):
+    def setUp(self):
+        self._saved_loaded = plugins_mod._plugins_loaded
+        self._saved_hooks = {k: list(v) for k, v in HookRegistry._hooks.items()}
+        self._saved_patched = set(HookRegistry._patched)
+        # HookRegistry.reset() clears bookkeeping but does not un-patch, so
+        # the original constructor is restored by hand in tearDown.
+        self._saved_init = ModelConfig.__dict__["__init__"]
+
+        plugins_mod._plugins_loaded = False
+        HookRegistry.reset()
+        self.seen_model_paths = []
+
+    def tearDown(self):
+        setattr(ModelConfig, "__init__", self._saved_init)
+        HookRegistry.reset()
+        HookRegistry._hooks.update(self._saved_hooks)
+        HookRegistry._patched.update(self._saved_patched)
+        plugins_mod._plugins_loaded = self._saved_loaded
+
+    def _fake_plugin(self):
+        def before_init(*args, **kwargs):
+            self.seen_model_paths.append(kwargs.get("model_path"))
+            raise _HookFired()
+
+        HookRegistry.register(_TARGET, before_init, HookType.BEFORE)
+
+    def test_server_args_construction_loads_plugins(self):
+        """Constructing ServerArgs loads plugins and applies hooks, so a
+        BEFORE hook on ModelConfig.__init__ fires on the first model config
+        build even though nobody called load_plugins()."""
+        with patch.object(
+            plugins_mod,
+            "load_plugins_by_group",
+            return_value={"fake": (self._fake_plugin, "fake-dist")},
+        ) as mock_group:
+            self.assertFalse(plugins_mod._plugins_loaded)
+            self.assertNotIn(_TARGET, HookRegistry._patched)
+
+            server_args = ServerArgs(model_path=_MODEL_PATH)
+
+            self.assertTrue(plugins_mod._plugins_loaded)
+            self.assertIn(_TARGET, HookRegistry._patched)
+            self.assertEqual(mock_group.call_count, 1)
+            self.assertEqual(self.seen_model_paths, [])
+
+            with self.assertRaises(_HookFired):
+                ModelConfig.from_server_args(server_args)
+            self.assertEqual(self.seen_model_paths, [_MODEL_PATH])
+
+            # A second record reuses the already-loaded plugins; discovery
+            # is not repeated and the hook stays installed.
+            ServerArgs(model_path=_MODEL_PATH)
+            self.assertEqual(mock_group.call_count, 1)
+            with self.assertRaises(_HookFired):
+                ModelConfig.from_server_args(server_args)
+            self.assertEqual(self.seen_model_paths, [_MODEL_PATH, _MODEL_PATH])
+
+
+class TestDetokenizerProcessLoadsPlugins(CustomTestCase):
+    def test_run_detokenizer_process_loads_plugins_before_manager(self):
+        """run_detokenizer_process loads plugins before the manager (and its
+        tokenizer) is constructed, without touching the parent process."""
+        calls = []
+
+        def fake_load_plugins():
+            calls.append("load_plugins")
+
+        def fake_manager_class(server_args, port_args):
+            calls.append("manager")
+            manager = MagicMock()
+            manager.event_loop.side_effect = lambda: calls.append("event_loop")
+            return manager
+
+        serving = MagicMock()
+        serving.tokenizer_worker_num = 1
+
+        with (
+            patch.object(detokenizer_manager, "load_plugins", fake_load_plugins),
+            patch.object(detokenizer_manager, "kill_itself_when_parent_died"),
+            patch.object(detokenizer_manager, "setproctitle"),
+            patch.object(detokenizer_manager, "configure_logger"),
+            patch.object(detokenizer_manager, "publish"),
+            patch.object(detokenizer_manager, "psutil"),
+            patch.object(detokenizer_manager, "get_serving", return_value=serving),
+        ):
+            detokenizer_manager.run_detokenizer_process(
+                server_args=MagicMock(),
+                port_args=MagicMock(),
+                detokenizer_manager_class=fake_manager_class,
+            )
+
+        self.assertEqual(calls, ["load_plugins", "manager", "event_loop"])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

`load_plugins()` is only called from SGLang's own entry points: `launch_server.py`, `sglang serve`, `Engine.__init__`, and `run_scheduler_process`. Two gaps follow:

1. An embedder that builds `ServerArgs` itself and reads the model config before creating `Engine` (for example `ServerArgs.from_cli_args(...)` followed by `model_config_of(server_args)` / `get_model_config()`, and only later `sgl.Engine(server_args=...)`) never reaches any of those entry points. The first `ModelConfig` is constructed before `HookRegistry.apply_hooks()` has run, so any plugin hook on the model-resolution path (`ModelConfig.__init__`, `ModelConfig.from_server_args`, `model_config_of`, the config/tokenizer loaders) is silently skipped.
2. The `load_plugins()` docstring says it "should be called early in every process (main, engine core, workers)", but only the scheduler process does. `run_detokenizer_process` and the multi-tokenizer worker entry (`init_multi_tokenizer` in `http_server.py`) never call it, so `DetokenizerManager.init_tokenizer -> get_tokenizer(...)` and `TokenizerWorker` resolve the tokenizer with no hooks applied. Spawned processes receive `ServerArgs` by pickle, which bypasses `__post_init__`, so fixing (1) alone does not cover them.

vLLM handles (1) in the engine itself: `EngineArgs.__post_init__` calls `load_general_plugins()` immediately before resolving the model path, so plugins are loaded no matter who constructs `EngineArgs` (vllm-project/vllm#8717, v0.6.3). SGLang's `ServerArgs` has no equivalent.

## Modifications

- `ServerArgs.__post_init__` now calls `load_plugins()` (local import) as its first statement. Construction is the earliest point every path shares. Loading plugins is a process-level side effect that does not touch the record, so construction still leaves the record raw as the docstring promises. `load_plugins()` is idempotent, so the existing pre-construction call in `Engine.__init__` stays a no-op.
- `run_detokenizer_process` and `init_multi_tokenizer` call `load_plugins()` at the start, mirroring `run_scheduler_process`.
- In `Engine._launch_subprocesses`, the existing defensive `load_plugins()` moves ahead of `server_args.resolve_once()`, which builds the model config. This only matters when the record arrived by pickle (`HttpServerEngineAdapter` spawns `launch_server` with a pickled `ServerArgs`).

`run_multi_detokenizer_router_process` and `run_data_parallel_controller_process` do not read model files (the DP controller spawns schedulers, which load plugins themselves) and are left unchanged.

Why `__post_init__` rather than `ModelConfig.from_server_args`: a call inside `from_server_args` covers hooks on `ModelConfig.__init__` and the loaders, but hooks that target `from_server_args` itself or `model_config_of` would still miss an embedder's first call, because the wrapper is installed only after that call has started. `ServerArgs` construction precedes all of them. If maintainers prefer to keep `__post_init__` free of side effects, `from_server_args` is the alternative placement, with that narrower coverage.

Limitation: hooks that target `ServerArgs.__post_init__` itself still require plugins to be loaded before `ServerArgs` is constructed; SGLang's own entry points keep doing that.

Compatibility: no behaviour change for deployments without installed `sglang.srt.plugins` entry points beyond one `entry_points()` lookup at the first `ServerArgs` construction.

Tests: `test/registered/unit/plugins/test_model_config_loads_plugins.py` (CPU CI, `base-a-test-cpu`).

- Patches `load_plugins_by_group` to return a fake plugin that registers a `BEFORE` hook on `ModelConfig.__init__` (records `model_path`, raises a sentinel so the real constructor and any Hugging Face access never run). Constructs `ServerArgs(model_path="org/not-a-real-model")` without calling `load_plugins()`, asserts `_plugins_loaded` is set and the target is in `HookRegistry._patched`, then asserts the hook fires on `ModelConfig.from_server_args` and that a second record does not re-run discovery. With the `server_args.py` change reverted, the test fails at the `_plugins_loaded` assertion.
- Stubs the collaborators of `run_detokenizer_process` (no real process, no parent signal) and asserts `load_plugins()` runs before the manager is constructed.

Existing plugin tests and `test/registered/unit/server_args` pass with the same result set as `main`.

## Accuracy Tests

Not applicable: no change to model forward or kernel code.

## Speed Tests and Profiling

Not applicable: one idempotent `entry_points()` lookup at first `ServerArgs` construction; no change on the request path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34301245335](https://github.com/sgl-project/sglang/actions/runs/34301245335)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34301244836](https://github.com/sgl-project/sglang/actions/runs/34301244836)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34301244985](https://github.com/sgl-project/sglang/actions/runs/34301244985)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->