### PR TITLE
[Docs] Prefer --mem-fraction-static in Ling/Ring 2.5-1T guides

### DIFF
--- a/docs/cookbook/autoregressive/InclusionAI/Ling-2.5-1T.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-2.5-1T.mdx
@@ -48,7 +48,7 @@ import { Ling251TDeployment } from '/src/snippets/autoregressive/ling-25-1t-depl
 - The `--trust-remote-code` flag is required for this model due to custom modeling code.
 - `--tp-size` can be set to a maximum of 8 for this model. If you have more GPUs available, increase `--pp-size` to scale across additional nodes.
 - Adding `--model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}'` enables faster model loading.
-- On H200/GB200/GB300 with 2-node deployment, `--mem-frac 0.95` is required to avoid OOM since the model occupies most of the GPU memory. For better throughput, consider 4-node deployment (ref [model card](https://huggingface.co/inclusionAI/Ling-2.5-1T#run-inference) for more details).
+- On H200/GB200/GB300 with 2-node deployment, `--mem-fraction-static 0.95` is required to avoid OOM since the model occupies most of the GPU memory. For better throughput, consider 4-node deployment (ref [model card](https://huggingface.co/inclusionAI/Ling-2.5-1T#run-inference) for more details).
 
 ## 4. Model Invocation
 
@@ -74,7 +74,7 @@ python3 -m sglang.launch_server \
 --dist-init-addr ${MASTER_IP}:${DIST_PORT} \
 --tool-call-parser qwen \
 --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' \
---mem-frac 0.95
+--mem-fraction-static 0.95
 
 
 # Node 1:
@@ -88,7 +88,7 @@ python3 -m sglang.launch_server \
 --dist-init-addr ${MASTER_IP}:${DIST_PORT} \
 --tool-call-parser qwen \
 --model-loader-extra-config '{"enable_multithread_load": "true","num_threads": 64}' \
---mem-frac 0.95
+--mem-fraction-static 0.95
 ```
 
 Once the server is running, send requests to the master node:

--- a/docs/src/snippets/autoregressive/ling-25-1t-deployment.jsx
+++ b/docs/src/snippets/autoregressive/ling-25-1t-deployment.jsx
@@ -116,7 +116,7 @@ export const Ling251TDeployment = () => {
         cmd += ` \\\n  --tool-call-parser qwen`;
       }
       if (needMemFrac) {
-        cmd += ` \\\n  --mem-frac 0.95`;
+        cmd += ` \\\n  --mem-fraction-static 0.95`;
       }
       return cmd;
     };

--- a/docs/src/snippets/autoregressive/ring-25-1t-deployment.jsx
+++ b/docs/src/snippets/autoregressive/ring-25-1t-deployment.jsx
@@ -124,7 +124,7 @@ export const Ring251TDeployment = () => {
         cmd += '--dist-init-addr ${MASTER_IP}:${DIST_PORT} \\\n';
         cmd += '--attention-backend triton \\\n';
         cmd += '--model-loader-extra-config \'{"enable_multithread_load": "true","num_threads": 64}\' \\\n';
-        cmd += '--mem-frac 0.95';
+        cmd += '--mem-fraction-static 0.95';
         extraFlags.forEach((flag) => {
           cmd += ` \\\n${flag}`;
         });


### PR DESCRIPTION
## Summary
Ling/Ring 2.5-1T cookbook + playground snippets teach `--mem-frac`, but the live ServerArgs field is `mem_fraction_static` in `python/sglang/srt/arg_groups/fields/schedule.py`, which registers only `--mem-fraction-static` (no `aliases=`). Prefer the canonical full flag for consistency with sibling guides such as `Ring-2.6-1T.mdx`.

## Files
- `docs/cookbook/autoregressive/InclusionAI/Ling-2.5-1T.mdx`
- `docs/src/snippets/autoregressive/ling-25-1t-deployment.jsx`
- `docs/src/snippets/autoregressive/ring-25-1t-deployment.jsx`

## Repro (against main @ `ccfa120daecabab4b9b4d7e89ec82f41e071a7e9`)
1. Docs still use the short form:
   ```bash
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/ccfa120daecabab4b9b4d7e89ec82f41e071a7e9/docs/cookbook/autoregressive/InclusionAI/Ling-2.5-1T.mdx | rg -n -- '--mem-frac\b'
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/ccfa120daecabab4b9b4d7e89ec82f41e071a7e9/docs/src/snippets/autoregressive/ling-25-1t-deployment.jsx | rg -n -- '--mem-frac\b'
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/ccfa120daecabab4b9b4d7e89ec82f41e071a7e9/docs/src/snippets/autoregressive/ring-25-1t-deployment.jsx | rg -n -- '--mem-frac\b'
   ```
2. Live field / CLI name (no aliases):
   ```bash
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/ccfa120daecabab4b9b4d7e89ec82f41e071a7e9/python/sglang/srt/arg_groups/fields/schedule.py | rg -n -A6 'mem_fraction_static'
   ```
   → `mem_fraction_static` → CLI `--mem-fraction-static` via `_field_to_cli_name`; no `Arg(aliases=...)`.
3. Sibling already uses the full flag:
   ```bash
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/ccfa120daecabab4b9b4d7e89ec82f41e071a7e9/docs/cookbook/autoregressive/InclusionAI/Ring-2.6-1T.mdx | rg -n -- '--mem-fraction-static'
   ```

## Notes
- Left `docs/docs/developer_guide/benchmark_and_profiling.mdx` alone (same short form residual; owned by another open docs PR).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34207254033](https://github.com/sgl-project/sglang/actions/runs/34207254033)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34207253907](https://github.com/sgl-project/sglang/actions/runs/34207253907)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->