### PR TITLE
[AMD] Skip AITER FP8 ASM prefill when GQA is unsupported

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -154,6 +154,18 @@ class ForwardMetadata:
 _AITER_PARTITION_SIZE_ROCM = 256
 
 
+# AITER's gfx950 FP8 FMHA ASM kernels only cover these GQA ratios. Other
+# ratios (e.g. Qwen3.8-27B 24Q/4KV = 6) must not take the pertensor shortcut.
+_AITER_FP8_ASM_GQA_RATIOS = frozenset({1, 2, 4, 8, 16})
+
+
+def _aiter_fp8_asm_supports_gqa(num_q_heads: int, num_kv_heads: int) -> bool:
+    """Whether AITER's FP8 FMHA ASM kernel supports this GQA ratio."""
+    if num_kv_heads <= 0 or num_q_heads % num_kv_heads != 0:
+        return False
+    return (num_q_heads // num_kv_heads) in _AITER_FP8_ASM_GQA_RATIOS
+
+
 def _asm_context_prefill_gather_indices(
     kv_indptr: torch.Tensor,
     kv_indices: torch.Tensor,
@@ -2871,6 +2883,9 @@ class AiterAttnBackend(AttentionBackend):
                 and layer.qk_head_dim == 256
                 and layer.v_head_dim == 256
                 and self.kv_cache_dtype == fp8_dtype
+                and _aiter_fp8_asm_supports_gqa(
+                    layer.tp_q_head_num, layer.tp_k_head_num
+                )
                 and not self.kv_cache_is_vectorized_5d
                 and self.forward_metadata.max_kv_len is not None
             ):
@@ -2936,6 +2951,9 @@ class AiterAttnBackend(AttentionBackend):
                 and layer.qk_head_dim == 256
                 and layer.v_head_dim == 256
                 and self.kv_cache_dtype == fp8_dtype
+                and _aiter_fp8_asm_supports_gqa(
+                    layer.tp_q_head_num, layer.tp_k_head_num
+                )
             ):
                 q_c = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
                 k_c = k.contiguous().view(-1, layer.tp_k_head_num, layer.head_dim)

--- a/test/registered/unit/layers/attention/test_aiter_fp8_asm_gqa.py
+++ b/test/registered/unit/layers/attention/test_aiter_fp8_asm_gqa.py
@@ -1,0 +1,27 @@
+"""Tests for the AITER FP8 FMHA ASM GQA routing guard."""
+
+import unittest
+
+from sglang.srt.layers.attention.aiter_backend import _aiter_fp8_asm_supports_gqa
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestAiterFp8AsmSupportsGqa(unittest.TestCase):
+    def test_supported_asm_gqa_ratios(self):
+        for ratio in (1, 2, 4, 8, 16):
+            with self.subTest(ratio=ratio):
+                self.assertTrue(_aiter_fp8_asm_supports_gqa(ratio * 4, 4))
+
+    def test_rejects_qwen38_27b_gqa6(self):
+        self.assertFalse(_aiter_fp8_asm_supports_gqa(24, 4))
+
+    def test_rejects_other_unsupported_ratios(self):
+        for num_q_heads, num_kv_heads in ((12, 4), (32, 1), (24, 0), (23, 4), (0, 4)):
+            with self.subTest(num_q_heads=num_q_heads, num_kv_heads=num_kv_heads):
+                self.assertFalse(_aiter_fp8_asm_supports_gqa(num_q_heads, num_kv_heads))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On gfx950, AiterAttnBackend routes FP8 KV `hd=256` extend through `flash_attn_varlen_fp8_pertensor_func` whenever `qk_head_dim == 256`. That shortcut is only valid for AITER's FP8 FMHA ASM GQA ratios `{1, 2, 4, 8, 16}`.

Qwen3.8-27B is 24 Q / 4 KV heads (GQA 6). ASM has no kernel of that shape, the CK pertensor JIT still runs, and 8K prefill crashes:

```
RuntimeError: invalid argument for fmha_fwd
```

`SGLANG_USE_AITER_UNIFIED_ATTN=1` does not avoid this: unified attention is used on decode, while the crash is in `forward_extend`. TP cannot change the ratio either (GQA stays 6 at TP1/2/4; TP8 does not divide 4 KV heads).

## Modifications

- Gate both pertensor branches (prefix-gather and no-prefix first chunk) on `_aiter_fp8_asm_supports_gqa()`.
- Unsupported ratios fall through to `mha_batch_prefill_func`.
- Add a registered AMD unit test for the GQA allowlist, including the 24/4 Qwen3.8-27B case.

## Accuracy Tests

Not a kernel change. Overlay of this routing guard on `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907` served `amd/Qwen3.8-27B-Quark-AWQ-MXFP4` with `--kv-cache-dtype fp8_e4m3` on MI355 TP1. 8K/1K `sglang.benchmark.serving` completed 32/32 (conc=4) and 64/64 (conc=32) with no `fmha_fwd` errors. Stock image without the guard dies in warmup on the same workload.

## Speed Tests and Profiling

Same image/model/FP8 KV, 8K ISL / 1K OSL, MI355 TP1:

| Config | Conc | In tok/s | Out tok/s | Median TTFT | Median TPOT |
| --- | --- | --- | --- | --- | --- |
| Guard only | 4 | 3150 | 396 | 257 ms | 9.63 ms |
| Guard only | 32 | 12337 | 1526 | 598 ms | 17.65 ms |

Power-of-two GQA models keep the ASM shortcut.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34210690558](https://github.com/sgl-project/sglang/actions/runs/34210690558)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #34212140693](https://github.com/sgl-project/sglang/actions/runs/34212140693)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34210690276](https://github.com/sgl-project/sglang/actions/runs/34210690276)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->