### PR TITLE
[Feature] Support pre-sampled video input across native and encoder paths

### DIFF
--- a/docs/docs/advanced_features/epd_disaggregation.mdx
+++ b/docs/docs/advanced_features/epd_disaggregation.mdx
@@ -19,6 +19,20 @@ When launching a language-only model, you must additionally specify the encoder 
 
 We support multiple encoder transfer backends, including zmq_to_scheduler, zmq_to_tokenizer, and mooncake (the default is zmq_to_scheduler). The backend can be selected using `--encoder-transfer-backend`.
 
+### Pre-sampled videos
+
+For Qwen3-VL, Qwen3.5, and GLM video models, the HTTP encoder path accepts
+[pre-sampled RGB frames with timeline metadata](/docs/basic_usage/native_api#pre-sampled-video-input)
+from the native `/generate` API. This lets an upstream service own video decoding
+and frame selection while the encoder runs model-specific spatial preprocessing
+and the vision model. Send the same `video_data` object to a language-only server;
+it forwards the frames and metadata to the encoder. In-process `PreSampledVideo`
+objects are serialized as lossless PNG data URLs for that HTTP transfer.
+
+The supplied frames are not sampled again. For GLM, this path keeps each video's
+frames together instead of using the encoded-video decoder's sharding path.
+The gRPC encoder currently accepts images only.
+
 ### Encoder transfer with Mooncake
 
 `--encoder-transfer-backend mooncake` controls **how encoder outputs are transferred** between encoder and language/prefill services. It is an encoder transfer option and can be used independently of the global multimodal embedding cache.

--- a/docs/docs/basic_usage/native_api.mdx
+++ b/docs/docs/basic_usage/native_api.mdx
@@ -51,6 +51,79 @@ response = requests.post(url, json=data)
 print_highlight(response.json())
 ```
 
+### Pre-sampled video input
+
+You can decode and sample a video in an upstream service, then send its selected
+RGB frames through `video_data`. SGLang preserves their order and original
+constant-frame-rate timeline, skips video codec decoding and temporal sampling,
+and runs the model processor's spatial resizing, normalization, patchification,
+and prompt expansion.
+
+This input is supported by Qwen3-VL, Qwen3.5, and GLM video processors, including
+[HTTP encoder disaggregation](/docs/advanced_features/epd_disaggregation).
+Other processors reject this input. The OpenAI `video_url` interface and the
+gRPC encoder do not accept this representation.
+
+On Linux with one NVIDIA CUDA GPU, start a supported video model:
+
+```bash
+python -m sglang.launch_server --model-path Qwen/Qwen3-VL-2B-Instruct --port 30000
+```
+
+The following example assumes an upstream decoder saved four RGB PNG frames at
+indices 0, 3, 17, and 29 of a 60-frame, 30 FPS video. Select frames according to
+your model's sampling policy and input budget before constructing the request.
+
+```python
+import numpy as np
+import requests
+from PIL import Image
+from transformers import AutoProcessor
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
+
+indices = [0, 3, 17, 29]
+frames = np.stack([
+    np.asarray(Image.open(f"frame_{index:03d}.png").convert("RGB"))
+    for index in indices
+])
+video = PreSampledVideo(
+    frames=frames,
+    source_fps=30.0,
+    total_num_frames=60,
+    frame_indices=indices,
+    do_sample_frames=False,
+)
+processor = AutoProcessor.from_pretrained("Qwen/Qwen3-VL-2B-Instruct")
+prompt = processor.apply_chat_template(
+    [{"role": "user", "content": [
+        {"type": "video"},
+        {"type": "text", "text": "Describe what happens in this video."},
+    ]}],
+    tokenize=False,
+    add_generation_prompt=True,
+)
+response = requests.post("http://localhost:30000/generate", json={
+    "text": prompt,
+    "video_data": video.to_wire(),
+    "sampling_params": {"temperature": 0, "max_new_tokens": 64},
+})
+response.raise_for_status()
+print(response.json()["text"])
+```
+
+`PreSampledVideo` accepts a `uint8` array or CPU tensor in `[frames, height,
+width, 3]` layout, or RGB PIL images with equal dimensions. For `Engine.generate`,
+pass the object directly as `video_data`; for HTTP, `to_wire()` produces a JSON
+object with `format: "pre_sampled_video"` and losslessly encoded PNG data URLs
+in `frames`. Frame URLs and file paths are not accepted inside that JSON object.
+
+`source_fps` must be finite and positive. `total_num_frames` is the original
+video's frame count. `frame_indices` must have one nondecreasing index per supplied
+frame, within the original video; repeated indices are preserved. Optional
+`timestamps` must equal `frame_indices / source_fps`. Variable-frame-rate
+timelines are not supported. `do_sample_frames` must be `false`.
+The model may still pad its last temporal patch as required by its architecture.
+
 ## Get Model Info
 
 Get the information of the model.

--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -54,6 +54,11 @@ from sglang.srt.utils import (
     load_video,
 )
 from sglang.srt.utils.hf_transformers_utils import resolve_image_processor_backend
+from sglang.srt.utils.pre_sampled_video import (
+    PreSampledVideo,
+    is_pre_sampled_video,
+    load_pre_sampled_video,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -310,7 +315,7 @@ class EncoderPreprocessor:
 
         media_metadata = {}
         content_hash = None
-        if isinstance(data, dict):
+        if isinstance(data, dict) and not is_pre_sampled_video(data):
             if "url" not in data:
                 return data
             media_metadata = {key: value for key, value in data.items() if key != "url"}
@@ -349,6 +354,12 @@ class EncoderPreprocessor:
                     }
                 return img
             elif modality == Modality.VIDEO:
+                if is_pre_sampled_video(data):
+                    try:
+                        self._validate_pre_sampled_video_model()
+                        return load_pre_sampled_video(data)
+                    except ValueError as e:
+                        raise BadRequestError(str(e)) from e
                 vid = load_video(data, frame_count_limit)
                 if (
                     media_metadata
@@ -514,6 +525,18 @@ class EncoderPreprocessor:
         }
         return [frames], video_processor_kwargs
 
+    def _validate_pre_sampled_video_model(self):
+        if "glm" not in self.model_type and self.model_type not in (
+            "qwen3_vl",
+            "qwen3_vl_moe",
+            "qwen3_5",
+            "qwen3_5_moe",
+        ):
+            raise ValueError(
+                "Pre-sampled video is supported only for Qwen3-VL, Qwen3.5, "
+                f"and GLM video models; got {self.model_type}"
+            )
+
     async def _flatten_and_load_videos(self, mm_items):
         if not isinstance(mm_items, (list, tuple)):
             mm_items = [mm_items]
@@ -563,8 +586,25 @@ class EncoderPreprocessor:
                     for config in video_configs
                 ]
 
+            pre_sampled = any(
+                isinstance(video, PreSampledVideo) for video in video_items
+            )
             framed = any(isinstance(video, list) for video in video_items)
-            if framed:
+            if pre_sampled:
+                # Supplied frames already have a temporal sampling plan. Keep
+                # each video intact, including mixed encoded/pre-sampled batches.
+                processed = await asyncio.gather(
+                    *[
+                        asyncio.get_running_loop().run_in_executor(
+                            self.io_executor,
+                            glm_sample_and_decode_sync,
+                            video,
+                            video_configs[index],
+                        )
+                        for index, video in enumerate(video_items)
+                    ]
+                )
+            elif framed:
                 processed = await asyncio.gather(
                     *[
                         asyncio.get_running_loop().run_in_executor(

--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -59,6 +59,7 @@ from sglang.srt.utils.network import (
     get_local_ip_auto,
     get_zmq_socket_on_host,
 )
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
 
 logger = logging.getLogger(__name__)
 
@@ -845,6 +846,8 @@ def _encoder_media_item(mm_item: dict):
         for key, value in mm_item.items()
         if key != "modality" and value is not None
     }
+    if isinstance(item.get("url"), PreSampledVideo):
+        item["url"] = item["url"].to_wire()
     return item["url"] if set(item) == {"url"} else item
 
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -69,6 +69,7 @@ from sglang.srt.utils.msgspec_utils import (
     Base64Bytes,
     msgspec_struct_pydantic_core_schema,
 )
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
 from sglang.srt.utils.weight_versions import WeightVersionSpans
 
 # Handle serialization of Image for pydantic
@@ -157,7 +158,7 @@ class SessionParams(msgspec.Struct, kw_only=True, array_like=True):
 # Individual data item types for each modality
 ImageDataInputItem = Union[str, bytes, Dict[str, Any], ImageData, Image]
 AudioDataInputItem = Union[str, bytes, Dict[str, Any]]
-VideoDataInputItem = Union[str, bytes, Dict[str, Any], VideoData]
+VideoDataInputItem = Union[str, bytes, Dict[str, Any], VideoData, PreSampledVideo]
 # Union type for any multimodal data item
 MultimodalDataInputItem = Union[
     ImageDataInputItem, VideoDataInputItem, AudioDataInputItem
@@ -195,7 +196,8 @@ class GenerateReqInput:
     # - List of lists of images (multiple images per request)
     # See also python/sglang/srt/utils.py:load_image for more details.
     image_data: Optional[MultimodalDataInputFormat] = None
-    # The video input. Like image data, it can be a file name, a url, or base64 encoded string.
+    # A video path, URL, base64 video, or PreSampledVideo (wire format:
+    # {"format": "pre_sampled_video", "frames": [...], ...}).
     video_data: Optional[MultimodalDataInputFormat] = None
     # The audio input. Like image data, it can be a file name, a url, or base64 encoded string.
     audio_data: Optional[MultimodalDataInputFormat] = None
@@ -1108,7 +1110,8 @@ class EmbeddingReqInput:
     # - List of lists of images (multiple images per request)
     # See also python/sglang/srt/utils.py:load_image for more details.
     image_data: Optional[MultimodalDataInputFormat] = None
-    # The video input. Like image data, it can be a file name, a url, or base64 encoded string.
+    # A video path, URL, base64 video, or PreSampledVideo (wire format:
+    # {"format": "pre_sampled_video", "frames": [...], ...}).
     video_data: Optional[MultimodalDataInputFormat] = None
     # The audio input. Like image data, it can be a file name, a url, or base64 encoded string.
     audio_data: Optional[MultimodalDataInputFormat] = None

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -60,6 +60,7 @@ from sglang.srt.utils import (
     logger,
     smart_to_rgb,
 )
+from sglang.srt.utils.pre_sampled_video import is_pre_sampled_video
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
@@ -210,6 +211,8 @@ def _tokenizer_of(processor):
 
 
 class BaseMultimodalProcessor(ABC):
+    supports_pre_sampled_video = False
+
     models = []
     gpu_image_decode = True  # Enable GPU decoding by default
     smart_rgb_conversion = False
@@ -1222,6 +1225,12 @@ class BaseMultimodalProcessor(ABC):
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
+        if not self.supports_pre_sampled_video and any(
+            is_pre_sampled_video(video) for video in (video_data or [])
+        ):
+            raise ValueError(
+                f"{type(self).__name__} does not support pre-sampled video input"
+            )
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
 
         input_ids = prompt if isinstance(prompt, list) else None

--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -17,6 +17,7 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 from sglang.srt.utils import GLM_MEDIA_CONFIG_KEYS
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 
 try:
@@ -406,6 +407,11 @@ def glm_decode_frames_at(vr, indices, video_config=None):
 
 
 def glm_sample_and_decode_sync(vr, video_config=None, video_processor=None):
+    if isinstance(vr, PreSampledVideo):
+        return vr.to_processor_inputs()
+    if isinstance(vr, list):
+        frames, metadata = preprocess_video_frames_sync(vr)
+        return np.stack(frames) if isinstance(frames, list) else frames, metadata
     video_config = video_config or {}
     fps = vr.avg_fps
     if not fps or fps <= 0:
@@ -435,6 +441,7 @@ def _passthrough_video_metadata(video, video_config):
 
 
 class Glm4vImageProcessor(SGLangBaseProcessor):
+    supports_pre_sampled_video = True
     smart_rgb_conversion = True
     video_preprocessing_device = "cpu"
     models = [
@@ -557,6 +564,9 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
             multimodal_tokens=self.mm_tokens,
         )
 
+        has_pre_sampled_video = any(
+            isinstance(video, PreSampledVideo) for video in base_output.videos or []
+        )
         video_metadata = None
         videos_kwargs = None
         if base_output.videos and not isinstance(base_output.videos[0], dict):
@@ -574,7 +584,11 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
                     video_configs[index] if index < len(video_configs) else {},
                     effective_max_image_tokens,
                 )
-                if isinstance(video, VideoDecoderWrapper):
+                if isinstance(video, PreSampledVideo):
+                    decode_tasks.append(
+                        asyncio.sleep(0, result=video.to_processor_inputs())
+                    )
+                elif isinstance(video, VideoDecoderWrapper):
                     decode_tasks.append(
                         loop.run_in_executor(
                             self.io_executor,
@@ -626,6 +640,9 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
             }
             if videos_kwargs is not None:
                 processor_video_config.update(videos_kwargs)
+            if has_pre_sampled_video:
+                processor_video_config["do_sample_frames"] = False
+                combine_kwargs.pop("do_sample_frames", None)
             combine_kwargs["processor_video_config"] = processor_video_config
 
         mm_items, input_ids, ret = await self.process_and_combine_mm_data_async(

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -43,6 +43,7 @@ from sglang.srt.multimodal.transport.cuda_ipc import (
 )
 from sglang.srt.runtime_context import get_mm
 from sglang.srt.utils import cpu_has_amx_support, is_cpu
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
@@ -209,6 +210,10 @@ async def preprocess_video(
     image_factor: int = IMAGE_FACTOR,
     video_config: dict = {},
 ) -> torch.Tensor:
+    if isinstance(vr, PreSampledVideo):
+        frames, metadata = vr.to_processor_inputs()
+        return torch.from_numpy(frames).permute(0, 3, 1, 2), metadata
+
     # preprocessed video
     is_video_obj = isinstance(vr, VideoDecoderWrapper)
     if not is_video_obj:
@@ -305,6 +310,12 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         self.model_type = hf_config.model_type
+        self.supports_pre_sampled_video = self.model_type in {
+            "qwen3_vl",
+            "qwen3_vl_moe",
+            "qwen3_5",
+            "qwen3_5_moe",
+        }
         if self.model_type in (
             "qwen2_vl",
             "qwen2_5_vl",
@@ -745,6 +756,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         load_time = time.perf_counter()
         rid = getattr(request_obj, "rid", "anonymous_rid")
 
+        has_pre_sampled_video = any(
+            isinstance(video, PreSampledVideo) for video in base_output.videos or []
+        )
         video_metadata = None
         if base_output.videos and not isinstance(base_output.videos[0], dict):
             videos_processed = [
@@ -776,6 +790,22 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 video_metadata=video_metadata,
                 do_sample_frames=False,
             )
+
+        if has_pre_sampled_video:
+            if not video_metadata or any(item is None for item in video_metadata):
+                raise ValueError(
+                    "Pre-sampled videos cannot be mixed with frame arrays lacking timeline metadata"
+                )
+            # The model processor still owns spatial preprocessing. Only temporal
+            # sampling is disabled for this new input contract.
+            processor_kwargs["processor_video_config"] = {
+                key: value
+                for key, value in self.video_config.items()
+                if key not in {"fps", "nframes", "min_frames", "max_frames"}
+            }
+            processor_kwargs["processor_video_config"]["do_sample_frames"] = False
+            processor_kwargs.pop("do_sample_frames", None)
+            processor_kwargs["video_metadata"] = video_metadata
 
         mm_items, input_ids, ret = await self.process_and_combine_mm_data_async(
             base_output, self.mm_tokens, **processor_kwargs

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2021,6 +2021,14 @@ def get_video_bytes(video_file: Union[str, bytes, VideoData]) -> bytes:
 
 
 def load_video(video_file: Union[str, bytes, VideoData], use_gpu: bool = True):
+    from sglang.srt.utils.pre_sampled_video import (
+        is_pre_sampled_video,
+        load_pre_sampled_video,
+    )
+
+    if is_pre_sampled_video(video_file):
+        return load_pre_sampled_video(video_file)
+
     if isinstance(video_file, VideoData):
         # preprocess_kwargs is consumed by the multimodal processor, not here.
         video_file = video_file.url

--- a/python/sglang/srt/utils/pre_sampled_video.py
+++ b/python/sglang/srt/utils/pre_sampled_video.py
@@ -1,0 +1,241 @@
+"""Video frames sampled upstream, before model-specific spatial preprocessing."""
+
+import base64
+import io
+import math
+from numbers import Integral, Real
+from typing import Any, Optional, Sequence
+
+import msgspec
+import numpy as np
+import torch
+from PIL import Image
+
+
+class PreSampledVideo(msgspec.Struct):
+    """RGB frames with their indices on the original constant-FPS timeline.
+
+    In-process frames may be a uint8 THWC array/tensor or a sequence of RGB PIL
+    images. The JSON representation uses ``format="pre_sampled_video"`` and a
+    list of base64 image data URLs. Loading never invokes a video decoder or
+    selects a subset of the supplied frames.
+    """
+
+    frames: Any
+    source_fps: float
+    total_num_frames: int
+    frame_indices: Sequence[int]
+    timestamps: Optional[Sequence[float]] = None
+    do_sample_frames: bool = False
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        # HTTP inputs use the tagged dictionary; Engine inputs may hold this
+        # in-process object without materializing its frames as JSON arrays.
+        from pydantic_core import core_schema
+
+        return core_schema.is_instance_schema(cls)
+
+    def __post_init__(self):
+        self._validate_metadata()
+
+    def _validate_metadata(self):
+        if self.do_sample_frames is not False:
+            raise ValueError("Pre-sampled video requires do_sample_frames=False")
+        if (
+            isinstance(self.source_fps, bool)
+            or not isinstance(self.source_fps, Real)
+            or not math.isfinite(self.source_fps)
+            or self.source_fps <= 0
+        ):
+            raise ValueError("Pre-sampled video source_fps must be finite and positive")
+        if (
+            isinstance(self.total_num_frames, bool)
+            or not isinstance(self.total_num_frames, Integral)
+            or self.total_num_frames <= 0
+        ):
+            raise ValueError(
+                "Pre-sampled video total_num_frames must be a positive integer"
+            )
+        if not isinstance(self.frames, (list, tuple, np.ndarray, torch.Tensor)):
+            raise ValueError(
+                "Pre-sampled video frames must be a nonempty frame sequence"
+            )
+        if (
+            isinstance(self.frames, (np.ndarray, torch.Tensor))
+            and self.frames.ndim != 4
+        ):
+            raise ValueError("Pre-sampled video arrays must have uint8 THWC RGB layout")
+        count = len(self.frames)
+        if not count:
+            raise ValueError("Pre-sampled video frames must not be empty")
+        if not isinstance(self.frame_indices, (list, tuple, np.ndarray)):
+            raise ValueError("Pre-sampled video frame_indices must be a sequence")
+        if isinstance(self.frame_indices, np.ndarray) and self.frame_indices.ndim != 1:
+            raise ValueError("Pre-sampled video frame_indices must be one-dimensional")
+        if len(self.frame_indices) != count:
+            raise ValueError(
+                "Pre-sampled video frame_indices must match the frame count"
+            )
+        previous = -1
+        for index in self.frame_indices:
+            if (
+                isinstance(index, bool)
+                or not isinstance(index, Integral)
+                or not 0 <= index < self.total_num_frames
+                or index < previous
+            ):
+                raise ValueError(
+                    "Pre-sampled video frame_indices must be nondecreasing integers "
+                    "within the original video"
+                )
+            previous = index
+        if self.timestamps is not None:
+            if not isinstance(self.timestamps, (list, tuple, np.ndarray)):
+                raise ValueError("Pre-sampled video timestamps must be a sequence")
+            if isinstance(self.timestamps, np.ndarray) and self.timestamps.ndim != 1:
+                raise ValueError("Pre-sampled video timestamps must be one-dimensional")
+            if len(self.timestamps) != count:
+                raise ValueError(
+                    "Pre-sampled video timestamps must match the frame count"
+                )
+            for timestamp, index in zip(self.timestamps, self.frame_indices):
+                if (
+                    isinstance(timestamp, bool)
+                    or not isinstance(timestamp, Real)
+                    or not math.isfinite(timestamp)
+                    or not math.isclose(
+                        timestamp, index / self.source_fps, rel_tol=1e-6, abs_tol=1e-6
+                    )
+                ):
+                    raise ValueError(
+                        "Pre-sampled video timestamps must equal frame_indices / source_fps; "
+                        "variable-frame-rate timelines are not supported"
+                    )
+
+    def to_wire(self):
+        """Encode RGB frames losslessly for JSON-based serving and EPD transport."""
+        loaded = load_pre_sampled_video(self)
+        frames = []
+        for frame in loaded.frames:
+            buffer = io.BytesIO()
+            Image.fromarray(frame).save(buffer, format="PNG")
+            frames.append(
+                "data:image/png;base64,"
+                + base64.b64encode(buffer.getvalue()).decode("ascii")
+            )
+        result = {
+            "format": "pre_sampled_video",
+            "frames": frames,
+            "source_fps": float(loaded.source_fps),
+            "total_num_frames": int(loaded.total_num_frames),
+            "frame_indices": [int(index) for index in loaded.frame_indices],
+            "do_sample_frames": False,
+        }
+        if loaded.timestamps is not None:
+            result["timestamps"] = [float(timestamp) for timestamp in loaded.timestamps]
+        return result
+
+    def to_processor_inputs(self):
+        """Return loaded frames and metadata understood by HF video processors."""
+        loaded = load_pre_sampled_video(self)
+        return loaded.frames, {
+            "fps": float(loaded.source_fps),
+            "duration": loaded.total_num_frames / loaded.source_fps,
+            "total_num_frames": int(loaded.total_num_frames),
+            "frames_indices": [int(index) for index in loaded.frame_indices],
+            "video_backend": "sglang",
+        }
+
+
+def is_pre_sampled_video(value):
+    return isinstance(value, PreSampledVideo) or (
+        isinstance(value, dict) and value.get("format") == "pre_sampled_video"
+    )
+
+
+def load_pre_sampled_video(value):
+    """Validate an input and materialize a uint8 THWC RGB array, without sampling."""
+    wire_input = isinstance(value, dict)
+    if wire_input:
+        if value.get("format") != "pre_sampled_video":
+            raise ValueError("Expected format=pre_sampled_video")
+        fields = {key: item for key, item in value.items() if key != "format"}
+        try:
+            value = PreSampledVideo(**fields)
+        except TypeError as exc:
+            raise ValueError("Invalid pre-sampled video fields") from exc
+    if not isinstance(value, PreSampledVideo):
+        raise ValueError("Expected a PreSampledVideo or pre_sampled_video dictionary")
+    value._validate_metadata()
+
+    frames = value.frames
+    if wire_input and not (
+        isinstance(frames, list)
+        and all(
+            isinstance(frame, str)
+            and frame.startswith("data:image/")
+            and ";base64," in frame
+            for frame in frames
+        )
+    ):
+        raise ValueError("Pre-sampled video JSON frames must be base64 image data URLs")
+
+    if isinstance(frames, torch.Tensor):
+        if frames.device.type != "cpu" or frames.dtype != torch.uint8:
+            raise ValueError("Pre-sampled video tensors must be uint8 and on CPU")
+        frames = frames.detach().numpy()
+    if isinstance(frames, np.ndarray):
+        if (
+            frames.dtype != np.uint8
+            or frames.shape[-1] != 3
+            or min(frames.shape[1:3]) <= 0
+        ):
+            raise ValueError("Pre-sampled video arrays must have uint8 THWC RGB layout")
+        return PreSampledVideo(
+            frames=np.ascontiguousarray(frames),
+            source_fps=value.source_fps,
+            total_num_frames=value.total_num_frames,
+            frame_indices=list(value.frame_indices),
+            timestamps=None if value.timestamps is None else list(value.timestamps),
+            do_sample_frames=False,
+        )
+
+    loaded = []
+    for frame in frames:
+        if isinstance(frame, str):
+            if not frame.startswith("data:image/") or ";base64," not in frame:
+                raise ValueError(
+                    "Pre-sampled video frame strings must be base64 image data URLs"
+                )
+            # Reuse normal image validation, without GPU decode or video codecs.
+            from sglang.srt.utils.common import load_image
+
+            frame, _ = load_image(frame, gpu_image_decode=False)
+        if isinstance(frame, Image.Image):
+            if frame.mode != "RGB":
+                raise ValueError("Pre-sampled video images must be RGB")
+            frame = np.asarray(frame)
+        elif isinstance(frame, torch.Tensor):
+            if frame.device.type != "cpu" or frame.dtype != torch.uint8:
+                raise ValueError("Pre-sampled video tensors must be uint8 and on CPU")
+            frame = frame.detach().numpy()
+        if (
+            not isinstance(frame, np.ndarray)
+            or frame.dtype != np.uint8
+            or frame.ndim != 3
+            or frame.shape[-1] != 3
+            or min(frame.shape[:2]) <= 0
+        ):
+            raise ValueError("Pre-sampled video frames must have uint8 HWC RGB layout")
+        if loaded and frame.shape != loaded[0].shape:
+            raise ValueError("Pre-sampled video frames must have identical dimensions")
+        loaded.append(frame)
+    return PreSampledVideo(
+        frames=np.stack(loaded),
+        source_fps=value.source_fps,
+        total_num_frames=value.total_num_frames,
+        frame_indices=list(value.frame_indices),
+        timestamps=None if value.timestamps is None else list(value.timestamps),
+        do_sample_frames=False,
+    )

--- a/test/registered/unit/multimodal/test_pre_sampled_video.py
+++ b/test/registered/unit/multimodal/test_pre_sampled_video.py
@@ -1,0 +1,214 @@
+"""Preserve externally selected video frames across native and encoder inputs."""
+
+import asyncio
+import json
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.encoder.preprocessor import EncoderPreprocessor
+from sglang.srt.disaggregation.encoder.receiver import _encoder_media_item
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.multimodal.processors.glm4v import glm_sample_and_decode_sync
+from sglang.srt.multimodal.processors.qwen_vl import preprocess_video
+from sglang.srt.utils import load_video
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo, load_pre_sampled_video
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+def sample(**overrides):
+    args = dict(
+        frames=np.random.default_rng(7).integers(
+            0, 256, (4, 32, 48, 3), dtype=np.uint8
+        ),
+        source_fps=30.0,
+        total_num_frames=60,
+        frame_indices=[0, 3, 17, 29],
+        timestamps=[0, 3 / 30, 17 / 30, 29 / 30],
+    )
+    args.update(overrides)
+    return PreSampledVideo(**args)
+
+
+class TestPreSampledVideo(CustomTestCase):
+    def test_lossless_json_round_trip_preserves_timeline(self):
+        original = sample()
+        with patch(
+            "sglang.srt.utils.common.VideoDecoderWrapper",
+            side_effect=AssertionError("codec called"),
+        ):
+            loaded = load_video(json.loads(json.dumps(original.to_wire())))
+        np.testing.assert_array_equal(loaded.frames, original.frames)
+        self.assertEqual(loaded.frame_indices, original.frame_indices)
+        self.assertEqual(loaded.timestamps, original.timestamps)
+        _, metadata = loaded.to_processor_inputs()
+        self.assertEqual(metadata["fps"], 30.0)
+        self.assertEqual(metadata["duration"], 2.0)
+        self.assertEqual(metadata["total_num_frames"], 60)
+        self.assertEqual(metadata["frames_indices"], [0, 3, 17, 29])
+
+    def test_in_process_representations(self):
+        original = sample()
+        for frames in (
+            original.frames,
+            torch.from_numpy(original.frames),
+            [Image.fromarray(frame) for frame in original.frames],
+        ):
+            with self.subTest(type=type(frames)):
+                loaded = load_video(sample(frames=frames))
+                np.testing.assert_array_equal(loaded.frames, original.frames)
+
+    def test_repeated_indices_are_not_deduplicated(self):
+        video = sample(frame_indices=[0, 0, 3, 3], timestamps=None)
+        loaded = load_video(video)
+        self.assertEqual(loaded.frame_indices, [0, 0, 3, 3])
+        self.assertEqual(len(loaded.frames), 4)
+
+    def test_invalid_metadata_is_rejected(self):
+        invalid = [
+            {"source_fps": 0},
+            {"source_fps": float("nan")},
+            {"source_fps": True},
+            {"total_num_frames": 1.5},
+            {"total_num_frames": 0},
+            {"frame_indices": [0, 1, 2]},
+            {"frame_indices": [0, 3, 2, 4]},
+            {"frame_indices": [0, 3, 17, 60]},
+            {"frame_indices": [False, 3, 17, 29]},
+            {"frame_indices": np.array(1)},
+            {"frame_indices": np.zeros((4, 1))},
+            {"timestamps": [0, 1, 2, 3]},
+            {"timestamps": [0, float("inf"), 0, 0]},
+            {"do_sample_frames": True},
+            {"do_sample_frames": 0},
+            {"frames": []},
+            {"frames": np.zeros((4, 3))},
+        ]
+        for args in invalid:
+            with self.subTest(args=args), self.assertRaises(ValueError):
+                load_pre_sampled_video(sample(**args))
+
+    def test_invalid_rgb_frames_are_rejected(self):
+        invalid = [
+            np.zeros((4, 32, 48, 3), dtype=np.float32),
+            np.zeros((4, 3, 32, 48), dtype=np.uint8),
+            np.zeros((4, 0, 48, 3), dtype=np.uint8),
+            [Image.new("RGBA", (48, 32))] * 4,
+            [Image.new("RGB", (48, 32)), Image.new("RGB", (49, 32))] * 2,
+        ]
+        for frames in invalid:
+            with (
+                self.subTest(shape=getattr(frames, "shape", None)),
+                self.assertRaises(ValueError),
+            ):
+                load_pre_sampled_video(sample(frames=frames))
+
+    def test_wire_rejects_external_frame_urls_and_unknown_fields(self):
+        for update in (
+            {"frames": ["https://example.com/frame.png"] * 4},
+            {"frames": ["/etc/passwd"] * 4},
+            {"unknown": 1},
+            {"frames": [[0]] * 4},
+        ):
+            wire = sample().to_wire()
+            wire.update(update)
+            with self.subTest(update=update), self.assertRaises(ValueError):
+                load_pre_sampled_video(wire)
+
+    def test_native_request_schema_and_batching(self):
+        app = FastAPI()
+
+        @app.post("/generate")
+        def receive(request: GenerateReqInput):
+            request.normalize_batch_and_arguments()
+            return {"is_single": request.is_single, "video_data": request.video_data}
+
+        wire = sample().to_wire()
+        with TestClient(app) as client:
+            response = client.post(
+                "/generate", json={"text": "video", "video_data": wire}
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+            self.assertEqual(response.json()["video_data"], wire)
+            self.assertEqual(client.get("/openapi.json").status_code, 200)
+        request = GenerateReqInput(text=["first", "second"], video_data=[wire, wire])
+        request.normalize_batch_and_arguments()
+        self.assertEqual(request[0].video_data, wire)
+        self.assertEqual(request[1].video_data, wire)
+
+    def test_unsupported_processor_rejects_before_loading(self):
+        processor = SimpleNamespace(supports_pre_sampled_video=False)
+        with self.assertRaisesRegex(ValueError, "does not support"):
+            asyncio.run(
+                BaseMultimodalProcessor.load_mm_data(
+                    processor,
+                    prompt="video",
+                    multimodal_tokens=None,
+                    video_data=[sample().to_wire()],
+                )
+            )
+
+    def test_qwen_and_glm_skip_temporal_sampling(self):
+        video = load_video(sample())
+        with patch(
+            "sglang.srt.multimodal.processors.qwen_vl.smart_nframes",
+            side_effect=AssertionError("sampled again"),
+        ):
+            frames, metadata = asyncio.run(
+                preprocess_video(video, video_config={"nframes": 2})
+            )
+        torch.testing.assert_close(
+            frames, torch.from_numpy(video.frames).permute(0, 3, 1, 2)
+        )
+        self.assertEqual(metadata["frames_indices"], [0, 3, 17, 29])
+        with patch(
+            "sglang.srt.multimodal.processors.glm4v.glm_sample_frame_indices",
+            side_effect=AssertionError("sampled again"),
+        ):
+            frames, metadata = glm_sample_and_decode_sync(video, {"max_frames": 2})
+        np.testing.assert_array_equal(frames, video.frames)
+        self.assertEqual(metadata["frames_indices"], [0, 3, 17, 29])
+
+    def test_http_encoder_payload_and_preprocessing(self):
+        for model_type in ("qwen3_vl", "glm4v"):
+            with (
+                self.subTest(model_type=model_type),
+                ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                processor = EncoderPreprocessor.__new__(EncoderPreprocessor)
+                processor.model_type = model_type
+                processor.io_executor = executor
+                processor.vision_config = {}
+                processor.video_processor = None
+                processor.server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+                wire = _encoder_media_item(
+                    {"url": sample(), "modality": Modality.VIDEO}
+                )
+                wire = json.loads(json.dumps(wire))
+                videos, kwargs = asyncio.run(processor._flatten_and_load_videos([wire]))
+                self.assertEqual(len(videos[0]), 4)
+                self.assertFalse(kwargs["do_sample_frames"])
+                self.assertEqual(
+                    kwargs["video_metadata"][0]["frames_indices"], [0, 3, 17, 29]
+                )
+                self.assertEqual(kwargs["video_metadata"][0]["fps"], 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/multimodal/test_pre_sampled_video_processors.py
+++ b/test/registered/unit/multimodal/test_pre_sampled_video_processors.py
@@ -1,0 +1,165 @@
+"""Real HF spatial preprocessing must survive the pre-sampled input boundary."""
+
+import asyncio
+import copy
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers.models.glm4v.video_processing_glm4v import Glm4vVideoProcessor
+from transformers.models.qwen3_vl.video_processing_qwen3_vl import Qwen3VLVideoProcessor
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.encoder.preprocessor import EncoderPreprocessor
+from sglang.srt.multimodal.processors.glm4v import glm_sample_and_decode_sync
+from sglang.srt.multimodal.processors.qwen_vl import preprocess_video
+from sglang.srt.utils import load_video
+from sglang.srt.utils.pre_sampled_video import PreSampledVideo
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+class TestPreSampledVideoProcessors(CustomTestCase):
+    def test_spatial_processing_and_encoder_parity(self):
+        for model_type, processor_cls, patch_size in (
+            ("qwen3_vl", Qwen3VLVideoProcessor, 16),
+            ("glm4v", Glm4vVideoProcessor, 14),
+        ):
+            for count in (3, 4):
+                with (
+                    self.subTest(model=model_type, count=count),
+                    ThreadPoolExecutor(max_workers=1) as executor,
+                ):
+                    factor = patch_size * 2
+                    frames = np.random.default_rng(19).integers(
+                        0,
+                        256,
+                        (count, factor * 2 + 5, factor * 3 + 7, 3),
+                        dtype=np.uint8,
+                    )
+                    indices = [0, 3, 17, 29][:count]
+                    video = load_video(PreSampledVideo(frames, 30.0, 60, indices))
+                    hf = processor_cls(
+                        size={
+                            "shortest_edge": factor**2,
+                            "longest_edge": (factor * 4) ** 2,
+                        }
+                    )
+                    _, metadata = video.to_processor_inputs()
+                    # Sampling is forbidden, but actual resize/normalize/patchify runs.
+                    with patch.object(
+                        hf,
+                        "sample_frames",
+                        side_effect=AssertionError("HF sampled supplied frames"),
+                    ):
+                        reference = hf(
+                            videos=[frames],
+                            video_metadata=[copy.deepcopy(metadata)],
+                            do_sample_frames=False,
+                            return_tensors="pt",
+                            device="cpu",
+                        )
+                        if model_type == "qwen3_vl":
+                            data, metadata = asyncio.run(preprocess_video(video))
+                        else:
+                            data, metadata = glm_sample_and_decode_sync(video)
+                        actual = hf(
+                            videos=[data],
+                            video_metadata=[metadata],
+                            do_sample_frames=False,
+                            return_tensors="pt",
+                            device="cpu",
+                        )
+                        for key in ("pixel_values_videos", "video_grid_thw"):
+                            torch.testing.assert_close(
+                                actual[key], reference[key], rtol=0, atol=0
+                            )
+                        self.assertEqual(
+                            int(actual["video_grid_thw"][0, 0]), (count + 1) // 2
+                        )
+                        self.assertTrue(
+                            actual["pixel_values_videos"].is_floating_point()
+                        )
+
+                        encoder = EncoderPreprocessor.__new__(EncoderPreprocessor)
+                        encoder.model_type = model_type
+                        encoder.io_executor = executor
+                        encoder.preproc_executor = executor
+                        encoder.vision_config = {}
+                        encoder.video_processor = hf
+                        encoder.server_args = SimpleNamespace(
+                            mm_enable_dp_encoder=False
+                        )
+                        encoder.model_config = SimpleNamespace(
+                            hf_config=SimpleNamespace(
+                                vision_config=SimpleNamespace(spatial_merge_size=2)
+                            )
+                        )
+                        encoded = asyncio.run(
+                            encoder._process_video_items([video.to_wire()], None)
+                        )
+                        for key in ("pixel_values_videos", "video_grid_thw"):
+                            torch.testing.assert_close(
+                                torch.as_tensor(encoded[key]),
+                                reference[key],
+                                rtol=0,
+                                atol=0,
+                            )
+                        if model_type == "qwen3_vl":
+                            self.assertAlmostEqual(
+                                encoded["video_timestamps"][0][0], 0.05
+                            )
+                            last = (17 + (29 if count == 4 else 17)) / 60
+                            self.assertAlmostEqual(
+                                encoded["video_timestamps"][0][1], last
+                            )
+
+    def test_glm_encoder_mixed_pre_sampled_and_legacy_frames(self):
+        frames = np.random.default_rng(23).integers(
+            0, 256, (4, 56, 84, 3), dtype=np.uint8
+        )
+        video = PreSampledVideo(frames, 30.0, 60, [0, 3, 17, 29])
+        legacy = [
+            {"frame_image": Image.fromarray(frame), "timestamp": index / 30}
+            for frame, index in zip(frames, video.frame_indices)
+        ]
+        hf = Glm4vVideoProcessor()
+        reference_data, reference_metadata = zip(
+            glm_sample_and_decode_sync(video), glm_sample_and_decode_sync(legacy)
+        )
+        reference = hf(
+            videos=list(reference_data),
+            video_metadata=list(reference_metadata),
+            do_sample_frames=False,
+            return_tensors="pt",
+        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            encoder = EncoderPreprocessor.__new__(EncoderPreprocessor)
+            encoder.model_type = "glm4v"
+            encoder.io_executor = encoder.preproc_executor = executor
+            encoder.vision_config = {}
+            encoder.video_processor = hf
+            encoder.server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+            with patch.object(
+                hf, "sample_frames", side_effect=AssertionError("Unexpected sampling")
+            ):
+                actual = asyncio.run(
+                    encoder._process_video_items([video.to_wire(), legacy], None)
+                )
+        for key in ("pixel_values_videos", "video_grid_thw"):
+            torch.testing.assert_close(
+                torch.as_tensor(actual[key]), reference[key], rtol=0, atol=0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

External video services can already decode and select frames, but SGLang does not have a shared input contract for preserving those frames and their original timeline.

Related: #31828.

## Modifications

Add `PreSampledVideo` to the common video loader and native request types, and connect it to Qwen3-VL/Qwen3.5 and GLM video preprocessing and the HTTP encoder path. Supplied frames skip temporal selection and video codec decoding; the model processor still performs spatial preprocessing and prompt expansion.

The in-process form accepts uint8 RGB arrays, CPU tensors, or PIL frames. Its JSON form uses lossless image data URLs, source FPS, original frame count, and selected frame indices. Invalid metadata is rejected, repeated indices are preserved, and unsupported model processors fail explicitly.

Constant-frame-rate timelines are supported. Variable-frame-rate timestamps, the OpenAI `video_url` schema, gRPC video transport, and an upstream sampling-plan API are outside this change.

## Accuracy Tests

Validation on base `792543f98c25bf1ab23c114513a20d44f1d0a6bc`:

- 59 targeted CPU tests and 50 subtests passed, including actual Qwen3-VL and GLM HF spatial processing and video-grid comparisons.
- RTX 4090 / Qwen3-VL-2B-Instruct: native HTTP and HTTP encoder disaggregation returned identical output tokens; repeated JSON requests matched and invalid FPS returned HTTP 400.
- `Engine.generate`: in-process and JSON inputs matched at equal batch size; complete-video path, bytes, and data URL smoke checks passed.
- The unmodified common loader rejects the new tagged dictionary; the patched loader preserves all four frames and the original indices.
- Fixed-version repository pre-commit hooks passed for all changed files. A separate `pre-commit run --all-files` passed every non-Rust hook; four Rust hooks exited 127 because the validation node lacks `cargo`/`rustup`. The full run changed no files.
- Mintlify build validation and internal-link checks passed on a local copy of the complete documentation tree.

These checks establish the input and processing behavior. They do not establish a model-quality score or full GPU coverage of every supported model family.

A single-request and two-request batch differed by one generated token. Comparing the in-process and JSON representations at the same batch size produced identical tokens; this change does not claim batch-invariant generation.

## Speed Tests and Profiling

No throughput improvement is claimed or benchmarked. The validation above checks correctness of the externally sampled input and its processing paths.

## Checklist

- [x] Format changed code with repository pre-commit hooks; whole-repository Rust checks are limited by the missing toolchain noted above.
- [x] Add unit tests.
- [x] Update documentation.
- [ ] Provide model-quality and speed benchmark results (not measured; bounded correctness checks are reported above).
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34208601314](https://github.com/sgl-project/sglang/actions/runs/34208601314)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34208601285](https://github.com/sgl-project/sglang/actions/runs/34208601285)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34208601323](https://github.com/sgl-project/sglang/actions/runs/34208601323)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->