### PR TITLE
[HiCache] Run the host->device load-back enqueue on a loader thread (opt-in)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -720,6 +720,13 @@ class Envs:
     # ===================================================================
     # Per-call cudaHostRegister limit in GB.
     SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB = EnvInt(256)
+    # Run the host->device load-back *enqueue* on a dedicated loader thread
+    # instead of inline on the scheduler thread. With io_backend='direct' every
+    # layer's submission builds a batched-copy descriptor on the CPU (hundreds
+    # of milliseconds per burst on deep models), so by the time the forward
+    # launches every copy has already landed and the layer-wise pipeline
+    # overlaps nothing. Off keeps the synchronous path unchanged.
+    SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE = EnvBool(False)
     SGLANG_HICACHE_HF3FS_CONFIG_PATH = EnvStr(None)
     SGLANG_HICACHE_DECODE_OFFLOAD_STRIDE = EnvInt(None)
     SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR = EnvStr(None)

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -36,11 +36,16 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.mem_cache.pool_host import HostKVCache
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
     get_attention_dp_rank,
     is_dp_attention_enabled,
 )
-from sglang.srt.mem_cache.l2_transfer import L2Transfer, L2TransferEngine
+from sglang.srt.mem_cache.l2_transfer import (
+    L2Transfer,
+    L2TransferEngine,
+    make_timing_event_pair,
+)
 from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import get_device_module
@@ -50,18 +55,93 @@ logger = logging.getLogger(__name__)
 device_module = get_device_module()
 
 
+# How long a consumer may wait for a layer's device event to be recorded before
+# the wait is reported. Only reachable with async load enqueue on; a burst that
+# takes this long has gone wrong somewhere the loader thread could not report.
+_ASYNC_RECORD_WAIT_WARN_S = 30.0
+
+
 class LayerLoadingEvent:
-    def __init__(self, num_layers: int):
+    def __init__(self, num_layers: int, async_enqueue: bool = False):
         self._num_layers = num_layers
         self.load_events = [device_module.Event() for _ in range(num_layers)]
         self.start_event = device_module.Event()  # start event on controller stream
+        # Async load enqueue only. The per-layer events are recorded by the
+        # loader thread, which runs *behind* the consumer instead of ahead of
+        # it, and waiting on a device event that has not been recorded yet is a
+        # no-op -- the consumer would sail past a copy that has not even been
+        # submitted. These flags are the CPU-side half of the handshake. They
+        # are None (and every method below a no-op) with the gate off, where the
+        # record always happens before the wait because both run on one thread.
+        self._recorded = (
+            [threading.Event() for _ in range(num_layers)] if async_enqueue else None
+        )
+        # Set once the burst holding this slot has been fully enqueued.
+        # update_producer needs it because finish_event alone cannot distinguish
+        # a slot whose burst is still sitting in the loader queue (its
+        # finish_event is the *previous* rotation's, long since ready) from a
+        # free one.
+        self._enqueue_done = threading.Event() if async_enqueue else None
+        if self._enqueue_done is not None:
+            self._enqueue_done.set()
 
     def complete(self, layer_index: int):
         assert 0 <= layer_index < self._num_layers
         self.load_events[layer_index].record()
+        # Read once: disable_async_handshake may drop the list concurrently.
+        recorded = self._recorded
+        if recorded is not None:
+            recorded[layer_index].set()
 
     def wait(self, layer_index: int):
+        recorded = self._recorded
+        if recorded is not None:
+            while not recorded[layer_index].wait(_ASYNC_RECORD_WAIT_WARN_S):
+                logger.error(
+                    "HiCache async load enqueue: layer %d has not been submitted "
+                    "after %.0fs; the forward is still blocked waiting for it.",
+                    layer_index,
+                    _ASYNC_RECORD_WAIT_WARN_S,
+                )
         device_module.current_stream().wait_event(self.load_events[layer_index])
+
+    def rearm(self):
+        """Scheduler thread, right before the slot is handed to a new burst."""
+        if self._recorded is None:
+            return
+        for recorded in self._recorded:
+            recorded.clear()
+        self._enqueue_done.clear()
+
+    def is_enqueue_done(self) -> bool:
+        enqueue_done = self._enqueue_done
+        return enqueue_done is None or enqueue_done.is_set()
+
+    def wait_enqueue_done(self):
+        enqueue_done = self._enqueue_done
+        if enqueue_done is not None:
+            enqueue_done.wait()
+
+    def mark_enqueue_done(self):
+        enqueue_done = self._enqueue_done
+        if enqueue_done is not None:
+            enqueue_done.set()
+
+    def disable_async_handshake(self):
+        """Drop back to the synchronous contract (record always precedes wait).
+
+        Callers that stop the loader thread must call this: nothing on the
+        synchronous path hands _enqueue_done back, so leaving it armed would
+        park the next rotation of this slot forever. Any current waiter is
+        released before the flags go away.
+        """
+        if self._recorded is None:
+            return
+        for recorded in self._recorded:
+            recorded.set()
+        self._enqueue_done.set()
+        self._recorded = None
+        self._enqueue_done = None
 
     @property
     def finish_event(self):
@@ -69,20 +149,34 @@ class LayerLoadingEvent:
 
 
 class LayerDoneCounter:
-    def __init__(self, num_layers: int):
+    def __init__(self, num_layers: int, async_enqueue: bool = False):
         self.num_layers = num_layers
         # extra producer and consumer counters for overlap mode
         self.num_counters = 3
-        self.events = [LayerLoadingEvent(num_layers) for _ in range(self.num_counters)]
+        self.events = [
+            LayerLoadingEvent(num_layers, async_enqueue=async_enqueue)
+            for _ in range(self.num_counters)
+        ]
         self.producer_index = -1
         self.consumer_index = -1
 
     def update_producer(self):
         self.producer_index = (self.producer_index + 1) % self.num_counters
-        assert self.events[self.producer_index].finish_event.query(), (
+        producer_event = self.events[self.producer_index]
+        # No-op with async load enqueue off. With it on, this is the rotation's
+        # backpressure: block until the burst that last held this slot has been
+        # enqueued, so the assert below inspects that burst's finish_event and
+        # not a stale one.
+        producer_event.wait_enqueue_done()
+        assert producer_event.finish_event.query(), (
             "Producer finish event should be ready before being reused."
         )
+        producer_event.rearm()
         return self.producer_index
+
+    def disable_async_handshake(self):
+        for event in self.events:
+            event.disable_async_handshake()
 
     def set_consumer(self, index: int):
         self.consumer_index = index
@@ -344,7 +438,12 @@ class HiCacheController:
 
         self.device = self.mem_pool_device.device
         self.layer_num = self.mem_pool_device.layer_num
-        self.layer_done_counter = LayerDoneCounter(self.layer_num)
+        # Read once here: the loader thread and the per-layer event handshake
+        # are wired at construction and never switched at runtime.
+        self.async_load_enqueue = envs.SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE.get()
+        self.layer_done_counter = LayerDoneCounter(
+            self.layer_num, async_enqueue=self.async_load_enqueue
+        )
         self.mem_pool_device.register_layer_transfer_counter(self.layer_done_counter)
 
         if write_policy not in [
@@ -364,6 +463,18 @@ class HiCacheController:
         self.ack_write_queue: List[HiCacheAck] = []
 
         self.l2_transfer_engine = L2TransferEngine(io_backend)
+
+        self._init_load_enqueue_thread(self.async_load_enqueue)
+        # Positive activation signature: without this line there is no way to
+        # tell from the logs whether SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE reached
+        # the scheduler process (an unset env silently runs the inline path).
+        # The concrete class is named because subclasses inherit this path, and
+        # stop_load_enqueue_thread logs the matching downgrade line.
+        logger.info(
+            "HiCache async load enqueue: %s (%s)",
+            "enabled" if self.async_load_enqueue else "disabled",
+            type(self).__name__,
+        )
 
         # If a storage backend is provided at startup, treat it as an implicit attach,
         # so init/runtime share the same lifecycle semantics and code paths.
@@ -432,6 +543,179 @@ class HiCacheController:
     ) -> None:
         for group in groups:
             torch.distributed.all_reduce(tensor, op=op, group=group)
+
+    def _init_load_enqueue_thread(self, enabled: bool) -> None:
+        """Wire the async load-enqueue worker (SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE).
+
+        Nothing is created when the gate is off, so start_loading takes the
+        original inline path and no thread exists to reason about.
+        """
+        # Guards the ack append against reset()'s clear(); see _append_load_ack.
+        self._ack_load_lock = threading.Lock()
+        self.load_enqueue_stop_event = threading.Event()
+        self.load_enqueue_queue: Optional[Queue] = None
+        self.load_enqueue_thread: Optional[threading.Thread] = None
+        # Latched last loader-thread failure, for diagnostics; see _abort_load_burst.
+        self.load_enqueue_error: Optional[BaseException] = None
+        # A fresh thread starts on device 0, not on this rank's device, so
+        # capture the scheduler thread's device index here and re-apply it on
+        # the worker.
+        self.load_enqueue_device_index = None
+        if not enabled:
+            return
+
+        try:
+            self.load_enqueue_device_index = device_module.current_device()
+        except Exception:
+            logger.warning(
+                "Could not read the current device index for the HiCache load "
+                "enqueue thread; it will inherit the process default.",
+                exc_info=True,
+            )
+        self.load_enqueue_queue = Queue()
+        self.load_enqueue_thread = threading.Thread(
+            target=self._load_enqueue_thread_func,
+            name="hicache-load-enqueue",
+            daemon=True,
+        )
+        self.load_enqueue_thread.start()
+
+    def _load_enqueue_thread_func(self):
+        """Drain load bursts, submitting each layer-wise onto the H2D stream.
+
+        Deliberately a single consumer: the H2D stream ordering, the 3-slot
+        producer rotation and the ack queue the scheduler pops in order are all
+        FIFO, so a second worker would reorder all three.
+        """
+        if self.load_enqueue_device_index is not None:
+            try:
+                device_module.set_device(self.load_enqueue_device_index)
+            except Exception:
+                logger.warning(
+                    "Could not bind the HiCache load enqueue thread to device %s.",
+                    self.load_enqueue_device_index,
+                    exc_info=True,
+                )
+
+        while (
+            not self.load_enqueue_stop_event.is_set()
+        ) or not self.load_enqueue_queue.empty():
+            try:
+                job = self.load_enqueue_queue.get(block=True, timeout=1)
+            except Empty:
+                continue
+            try:
+                if job is not None:
+                    op, producer_event, fence_event = job
+                    self._enqueue_load_burst(
+                        op,
+                        producer_event,
+                        start_event_recorded=True,
+                        fence_event=fence_event,
+                    )
+            except Exception as e:
+                self._abort_load_burst(job[0], job[1], e)
+            finally:
+                if job is not None:
+                    # After the abort path, so a slot is never handed back out
+                    # while its release is still being recorded.
+                    job[1].mark_enqueue_done()
+                self.load_enqueue_queue.task_done()
+
+    def _abort_load_burst(
+        self,
+        op: CacheOperation,
+        producer_event: LayerLoadingEvent,
+        exc: BaseException,
+    ) -> None:
+        """Release everything a failed burst would otherwise leave waiting.
+
+        A forward that has already issued wait_until() for this producer is
+        parked on a per-layer event that will never be recorded, and there is
+        no way to interrupt it from here -- releasing it is the only outcome
+        that cannot deadlock. So every layer is marked complete and the ack is
+        published with a recorded finish event; withholding the ack instead
+        would strand this burst's node locks and, because loading_check pops in
+        order, every later burst's too. The events are recorded on the H2D
+        stream so the layers that did get submitted keep their real ordering.
+
+        The KV those layers point at is stale, hence the error log with the
+        node ids and the latched load_enqueue_error. The exception is not
+        re-raised: killing the loader thread would deadlock the next burst, and
+        a traceback raised here reaches nobody -- the scheduler thread is
+        elsewhere.
+        """
+        node_ids = getattr(op, "node_ids", None)
+        self.load_enqueue_error = exc
+        logger.error(
+            "HiCache async load enqueue failed for node_ids=%s; releasing %d layer "
+            "events and publishing the ack so no forward stays blocked. The KV for "
+            "these nodes is NOT valid.",
+            node_ids,
+            self.layer_num,
+            exc_info=exc,
+        )
+        try:
+            ack_start_event, ack_finish_event, timing_enabled = make_timing_event_pair()
+            stream = self.l2_transfer_engine.host_to_device_stream
+            with device_module.stream(stream):
+                for i in range(self.layer_num):
+                    producer_event.complete(i)
+                ack_start_event.record()
+                ack_finish_event.record()
+            self._append_load_ack(
+                HiCacheAck(
+                    start_event=ack_start_event,
+                    finish_event=ack_finish_event,
+                    node_ids=node_ids or [],
+                    num_tokens=0,
+                    timing_enabled=timing_enabled,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "HiCache async load abort path failed for node_ids=%s; a forward "
+                "waiting on this producer may now hang.",
+                node_ids,
+            )
+
+    def _drain_load_enqueue(self) -> None:
+        """Block until the loader thread holds no queued or in-flight burst."""
+        if self.load_enqueue_queue is not None:
+            # task_done() runs in the worker's finally, including on failure, so
+            # this cannot hang on a burst the loader already gave up on.
+            self.load_enqueue_queue.join()
+
+    def stop_load_enqueue_thread(self) -> None:
+        """Stop the load-enqueue worker and fall back to the inline path."""
+        if self.load_enqueue_thread is None:
+            return
+
+        # The __init__ line already claimed "enabled"; without this the process
+        # would run inline for the rest of its life behind a log that says
+        # otherwise.
+        logger.info(
+            "HiCache async load enqueue: downgraded to inline (%s)",
+            type(self).__name__,
+        )
+        self.load_enqueue_stop_event.set()
+        # Wake the worker if it is blocked on the queue's 1s get().
+        try:
+            self.load_enqueue_queue.put_nowait(None)
+        except Exception:
+            pass
+
+        self.load_enqueue_thread.join(timeout=10)
+        if self.load_enqueue_thread.is_alive():
+            logger.error("Failed to stop the HiCache load enqueue thread cleanly.")
+            return
+        self.load_enqueue_thread = None
+        # Falls start_loading back to the inline path rather than queueing onto
+        # a thread that is gone; the handshake has to go with it, since only the
+        # loader thread ever hands _enqueue_done back.
+        self.load_enqueue_queue = None
+        self.async_load_enqueue = False
+        self.layer_done_counter.disable_async_handshake()
 
     def _start_storage_threads(self):
         """Start storage prefetch/backup threads and their queues.
@@ -742,10 +1026,16 @@ class HiCacheController:
     def reset(self):
         self.storage_stop_event.set()
 
+        # Let the loader thread finish what it already holds first: an append
+        # that lands after the clear below would resurrect an ack for nodes
+        # this reset has dropped.
+        self._drain_load_enqueue()
+
         self.write_queue.clear()
         self.load_queue.clear()
         self.ack_write_queue.clear()
-        self.ack_load_queue.clear()
+        with self._ack_load_lock:
+            self.ack_load_queue.clear()
         if self.enable_storage:
             self.prefetch_thread.join()
             self.prefetch_io_aux_thread.join()
@@ -912,23 +1202,85 @@ class HiCacheController:
         return self._l2_transfers(host_indices, device_indices, pool_transfers)
 
     def start_loading(self) -> int:
+        # Only the producer slot has to be settled before this returns: the
+        # batch is created with it as hicache_consumer_index. Everything else
+        # -- the index move and the per-layer enqueue -- is scheduler-thread CPU
+        # that the async gate hands to the loader thread.
         if len(self.load_queue) == 0:
             return -1
 
         producer_id = self.layer_done_counter.update_producer()
         op = CacheOperation.merge_ops(self.load_queue)
-        host_indices, device_indices, pool_transfers = self._move_op_indices(op)
         self.load_queue.clear()
         producer_event = self.layer_done_counter.events[producer_id]
-        producer_event.start_event.record()
 
-        if self.load_fence_stream is not None:
+        load_enqueue_queue = self.load_enqueue_queue
+        if load_enqueue_queue is None:
+            self._enqueue_load_burst(op, producer_event, start_event_recorded=False)
+        else:
+            # start_event orders the loads behind this point of the *compute*
+            # stream, and Event.record() takes the calling thread's current
+            # stream -- so it can only be recorded here, before the hand-over.
+            producer_event.start_event.record()
+            # Same for the fence: the point of the forward stream it captures
+            # has to be the one at hand-over, not wherever that stream is by
+            # the time the loader thread gets to the burst.
+            fence_event = None
+            if self.load_fence_stream is not None:
+                fence_event = device_module.Event()
+                fence_event.record(self.load_fence_stream)
+            load_enqueue_queue.put((op, producer_event, fence_event))
+        return producer_id
+
+    def _enqueue_load_burst(
+        self,
+        op: CacheOperation,
+        producer_event: LayerLoadingEvent,
+        start_event_recorded: bool,
+        fence_event=None,
+    ) -> None:
+        """Submit one load burst layer by layer onto the H2D stream.
+
+        This is the CPU cost the async gate exists to move: with io_backend
+        'direct' every layer builds a batched-copy descriptor, so the loop runs
+        for hundreds of milliseconds without touching the GPU. Runs inline on
+        the scheduler thread with the gate off, on the loader thread with it on.
+
+        ``start_event_recorded`` False means this body records
+        producer_event.start_event itself, after the index move, exactly as the
+        inline path always did. True means the caller recorded it before the
+        hand-over, and any read of an allocator-produced device tensor -- the
+        index move included -- must happen under the H2D stream after waiting
+        on it: that record point is the only ordering this body has against
+        the compute stream that wrote those values, and off the scheduler
+        thread there is no implicit one.
+        """
+        h2d_stream = self.l2_transfer_engine.host_to_device_stream
+        if start_event_recorded:
+            # Loader thread: op.device_indices' *values* are written by
+            # allocator kernels on the compute stream, and the current stream
+            # here is not that one. The D2H copy inside move_indices ('direct'
+            # backends) must therefore be ordered behind the hand-over point,
+            # or it reads unsettled memory and the copies built from it target
+            # wild device addresses.
+            with device_module.stream(h2d_stream):
+                producer_event.start_event.wait(h2d_stream)
+                host_indices, device_indices, pool_transfers = self._move_op_indices(op)
+        else:
+            host_indices, device_indices, pool_transfers = self._move_op_indices(op)
+            # Recorded after the index move: for the 'direct' backends
+            # move_indices ends in a blocking D2H copy, so the point of the
+            # current stream this captures depends on the order.
+            producer_event.start_event.record()
+
+        if fence_event is not None:
+            # Recorded on load_fence_stream by start_loading at hand-over time.
+            fence_event.wait(h2d_stream)
+        elif self.load_fence_stream is not None:
             # in overlap scheduling, reclaimed pages might still be written by the forward thread
             # therefore a fence is needed for loading thread to prevent memory corruption
             # todo: it's possible to use a finer-grained fence
-            self.l2_transfer_engine.host_to_device_stream.wait_stream(
-                self.load_fence_stream
-            )
+            h2d_stream.wait_stream(self.load_fence_stream)
 
         completion = self.l2_transfer_engine.submit_host_to_device(
             self._l2_load_transfers(host_indices, device_indices, pool_transfers),
@@ -937,7 +1289,7 @@ class HiCacheController:
             layer_num=self.layer_num,
         )
 
-        self.ack_load_queue.append(
+        self._append_load_ack(
             HiCacheAck(
                 start_event=completion.start_event,
                 finish_event=completion.finish_event,
@@ -948,7 +1300,16 @@ class HiCacheController:
                 num_bytes=self._transfer_num_bytes(op),
             )
         )
-        return producer_id
+
+    def _append_load_ack(self, ack: HiCacheAck) -> None:
+        # The scheduler still scans and pops ack_load_queue unlocked, which
+        # stays correct: list append/pop are atomic under the GIL and the ack
+        # is fully built before the append, so it becomes visible only
+        # complete. The lock is what keeps a loader-thread append from landing
+        # *after* reset()'s clear() and resurrecting an ack whose nodes the
+        # scheduler already dropped.
+        with self._ack_load_lock:
+            self.ack_load_queue.append(ack)
 
     def evict_device(self, device_indices: torch.Tensor) -> int:
         self.mem_pool_device_allocator.free(device_indices)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1137,10 +1137,12 @@ class HiRadixCache(RadixCache):
         if consumer_index < 0:
             return True
 
-        finish_event = self.cache_controller.layer_done_counter.events[
-            consumer_index
-        ].finish_event
-        if not finish_event.query():
+        event = self.cache_controller.layer_done_counter.events[consumer_index]
+        # With async load enqueue the slot's finish_event is still the previous
+        # rotation's until the loader thread has submitted this burst.
+        if not getattr(event, "is_enqueue_done", lambda: True)():
+            return False
+        if not event.finish_event.query():
             return False
 
         self.loading_check()

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -134,7 +134,13 @@ class HybridCacheController(BaseHiCacheController):
         # not just the full attention layers reported by full_kv_pool.
         if transfer_layer_num is not None and transfer_layer_num != self.layer_num:
             self.layer_num = transfer_layer_num
-            self.layer_done_counter = LayerDoneCounter(self.layer_num)
+            # async_enqueue has to be carried over: the replacement counter is
+            # the one the load path uses, and without the flag its per-layer
+            # handshake is absent, so a forward would sail past copies the
+            # loader thread has not submitted yet.
+            self.layer_done_counter = LayerDoneCounter(
+                self.layer_num, async_enqueue=self.async_load_enqueue
+            )
 
         self.storage_host_pool = mem_pool_host.anchor_entry.host_pool
         if startup_storage_backend is not None:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -3033,10 +3033,12 @@ class UnifiedRadixCache(BasePrefixCache):
         if consumer_index < 0 or self.cache_controller is None:
             return True
 
-        finish_event = self.cache_controller.layer_done_counter.events[
-            consumer_index
-        ].finish_event
-        if not finish_event.query():
+        event = self.cache_controller.layer_done_counter.events[consumer_index]
+        # With async load enqueue the slot's finish_event is still the previous
+        # rotation's until the loader thread has submitted this burst.
+        if not getattr(event, "is_enqueue_done", lambda: True)():
+            return False
+        if not event.finish_event.query():
             return False
 
         self.loading_check()

--- a/test/registered/unit/mem_cache/test_hicache_async_load_enqueue.py
+++ b/test/registered/unit/mem_cache/test_hicache_async_load_enqueue.py
@@ -1,0 +1,1057 @@
+"""Unit tests for the async HiCache load-enqueue split.
+
+``start_loading`` used to submit every layer's host->device copy inline on the
+scheduler thread, which is hundreds of milliseconds of descriptor construction
+with io_backend='direct' -- long enough that the copies were finished before
+the forward ever launched, so the layer-wise pipeline overlapped nothing.
+``SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE`` keeps the producer-slot hand-out on the
+scheduler thread and moves the enqueue loop to a dedicated worker.
+
+There is no device here, so the ``device_module`` globals of the controller and
+of the transfer engine are swapped for a fake that records the exact
+stream/event call sequence together with the thread that made each call; the
+KV pools are duck-typed for the same reason. The index tensors are real CPU
+tensors, because ``move_indices`` and ``merge_ops`` are the production ones.
+"""
+
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers import cache_controller
+from sglang.srt.managers.cache_controller import (
+    CacheOperation,
+    HiCacheController,
+    LayerDoneCounter,
+)
+from sglang.srt.mem_cache import l2_transfer
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+)
+from sglang.srt.mem_cache.l2_transfer import L2TransferEngine
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+LOADER_THREAD_NAME = "hicache-load-enqueue"
+JOIN_TIMEOUT = 10.0
+
+
+def _thread() -> str:
+    return threading.current_thread().name
+
+
+class FakeEvent:
+    def __init__(self, log, enable_timing=False):
+        self._log = log
+        self.enable_timing = enable_timing
+        self.recorded_on = None
+        self.recorded_stream = None
+
+    def record(self, stream=None):
+        self.recorded_on = _thread()
+        self.recorded_stream = stream
+        self._log.append(("record", self, _thread()))
+
+    def wait(self, stream=None):
+        self._log.append(("event_wait", self, stream, _thread()))
+
+    def query(self):
+        return True
+
+    def synchronize(self):
+        pass
+
+    def elapsed_time(self, other):
+        return 0.0
+
+
+class FakeStream:
+    def __init__(self, name, log=None):
+        self.name = name
+        self._log = log if log is not None else []
+
+    def wait_event(self, event):
+        self._log.append(("stream_wait_event", self, event, _thread()))
+
+    def wait_stream(self, stream):
+        self._log.append(("stream_wait_stream", self, stream, _thread()))
+
+    def __repr__(self):
+        return f"<FakeStream {self.name}>"
+
+
+class _StreamContext:
+    def __init__(self, module, stream):
+        self._module = module
+        self._stream = stream
+
+    def __enter__(self):
+        self._module.log.append(("stream_enter", self._stream, _thread()))
+        self._previous = self._module.current_stream()
+        self._module._local.stream = self._stream
+        return self._stream
+
+    def __exit__(self, *exc):
+        self._module._local.stream = self._previous
+        self._module.log.append(("stream_exit", self._stream, _thread()))
+        return False
+
+
+class FakeDeviceModule:
+    """Enough of torch.cuda for the load path, with an ordered call log."""
+
+    __name__ = "fake_device_module"
+
+    def __init__(self):
+        self.log = []
+        self.set_device_calls = []
+        self.device_index = 7
+        self._local = threading.local()
+        self._default_stream = FakeStream("default", self.log)
+        self._stream_count = 0
+
+    def Event(self, enable_timing=False):
+        return FakeEvent(self.log, enable_timing)
+
+    def Stream(self):
+        self._stream_count += 1
+        return FakeStream(f"stream{self._stream_count}", self.log)
+
+    def stream(self, stream):
+        return _StreamContext(self, stream)
+
+    def current_stream(self):
+        return getattr(self._local, "stream", self._default_stream)
+
+    def current_device(self):
+        return self.device_index
+
+    def set_device(self, index):
+        self.set_device_calls.append((index, _thread()))
+
+
+class FakeHostPool:
+    """Duck-typed host pool: records each per-layer submission, and can be told
+    to block or to fail so a test can observe a burst mid-flight."""
+
+    layout = "page_first_direct"
+    size_per_token = 16
+
+    def __init__(self, layer_num, log, name="kv"):
+        self.layer_num = layer_num
+        self.name = name
+        self._log = log
+        self.gate = None
+        self.fail_at_layer = None
+        self.failure = RuntimeError("injected load_to_device_per_layer failure")
+
+    def load_to_device_per_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        layer_id,
+        io_backend,
+        is_draft=False,
+    ):
+        if self.gate is not None:
+            self.gate.wait()
+        if self.fail_at_layer == layer_id:
+            raise self.failure
+        self._log.append(("load_layer", layer_id, _thread(), self.name))
+
+
+class AsyncLoadEnqueueTestBase(CustomTestCase):
+    layer_num = 3
+
+    def setUp(self):
+        super().setUp()
+        self.device_module = FakeDeviceModule()
+        for module in (cache_controller, l2_transfer):
+            patcher = mock.patch.object(module, "device_module", self.device_module)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        # The support probe is process-cached and would otherwise carry a
+        # verdict taken against the real device module.
+        l2_transfer._timing_events_supported.cache_clear()
+        self.addCleanup(l2_transfer._timing_events_supported.cache_clear)
+
+    @property
+    def log(self):
+        return self.device_module.log
+
+    def _wire(self, controller, async_enabled: bool, mem_pool_host):
+        controller.layer_num = self.layer_num
+        controller.io_backend = "direct"
+        controller.device = "cpu"
+        controller.mem_pool_device = object()
+        controller.mem_pool_host = mem_pool_host
+        controller.load_queue = []
+        controller.ack_load_queue = []
+        controller.load_fence_stream = None
+        controller.l2_transfer_engine = L2TransferEngine("direct")
+        controller.async_load_enqueue = async_enabled
+        controller.layer_done_counter = LayerDoneCounter(
+            self.layer_num, async_enqueue=async_enabled
+        )
+        controller._init_load_enqueue_thread(async_enabled)
+        self.addCleanup(self._shutdown, controller)
+
+        real_move_indices = controller.move_indices
+
+        def logging_move_indices(host_indices, device_indices):
+            self.log.append(("move_indices", _thread()))
+            return real_move_indices(host_indices, device_indices)
+
+        controller.move_indices = logging_move_indices
+        return controller
+
+    def make_controller(self, async_enabled: bool) -> HiCacheController:
+        """A controller carrying only what the load path touches.
+
+        __init__ wants a real allocator, host pool and process group; the load
+        path wants none of that, so the fields are set directly and the one
+        initializer under test is called explicitly.
+        """
+        controller = HiCacheController.__new__(HiCacheController)
+        return self._wire(
+            controller, async_enabled, FakeHostPool(self.layer_num, self.log)
+        )
+
+    def _shutdown(self, controller):
+        gate = getattr(controller.mem_pool_host, "gate", None)
+        if gate is not None:
+            gate.set()
+        controller.stop_load_enqueue_thread()
+
+    @staticmethod
+    def h2d(controller):
+        return controller.l2_transfer_engine.host_to_device_stream
+
+    def queue_burst(self, controller, node_id, num_tokens=2):
+        controller.load_queue.append(
+            CacheOperation(
+                torch.arange(num_tokens, dtype=torch.int64),
+                torch.arange(num_tokens, dtype=torch.int64),
+                node_id,
+            )
+        )
+
+    def loader_threads(self):
+        return [t for t in threading.enumerate() if t.name == LOADER_THREAD_NAME]
+
+    def entries(self, kind):
+        return [entry for entry in self.log if entry[0] == kind]
+
+    def _wait_for(self, predicate, timeout=JOIN_TIMEOUT):
+        tick = threading.Event()
+        waited = 0.0
+        while waited < timeout:
+            if predicate():
+                return
+            tick.wait(0.01)
+            waited += 0.01
+        self.fail("timed out waiting for the loader thread to make progress")
+
+    def _run_with_timeout(self, fn, message, timeout=JOIN_TIMEOUT):
+        done = threading.Event()
+        failure = []
+
+        def runner():
+            try:
+                fn()
+            except BaseException as e:  # surfaced below; a dead thread reads as a hang
+                failure.append(e)
+            else:
+                done.set()
+
+        worker = threading.Thread(target=runner, daemon=True)
+        worker.start()
+        worker.join(timeout=timeout)
+        if failure:
+            raise failure[0]
+        self.assertTrue(done.is_set(), message)
+
+
+class TestSyncPathUnchanged(AsyncLoadEnqueueTestBase):
+    def test_gate_off_creates_no_thread(self):
+        controller = self.make_controller(async_enabled=False)
+        self.assertIsNone(controller.load_enqueue_queue)
+        self.assertIsNone(controller.load_enqueue_thread)
+        self.assertEqual(self.loader_threads(), [])
+        self.assertEqual(self.device_module.set_device_calls, [])
+
+    def test_gate_off_call_sequence_is_the_pre_split_one(self):
+        controller = self.make_controller(async_enabled=False)
+        self.queue_burst(controller, node_id=11)
+
+        producer_id = controller.start_loading()
+
+        self.assertEqual(producer_id, 0)
+        self.assertEqual(len(controller.ack_load_queue), 1)
+        ack = controller.ack_load_queue[0]
+        producer_event = controller.layer_done_counter.events[producer_id]
+        h2d = self.h2d(controller)
+        me = threading.current_thread().name
+
+        expected = [
+            ("move_indices", me),
+            ("record", producer_event.start_event, me),
+            ("stream_enter", h2d, me),
+            ("event_wait", producer_event.start_event, h2d, me),
+            ("record", ack.start_event, me),
+        ]
+        for layer in range(self.layer_num):
+            expected.append(("load_layer", layer, me, "kv"))
+            expected.append(("record", producer_event.load_events[layer], me))
+        expected.append(("record", ack.finish_event, me))
+        expected.append(("stream_exit", h2d, me))
+
+        self.assertEqual(self.log, expected)
+        self.assertEqual(ack.node_ids, [11])
+        self.assertEqual(ack.num_tokens, 2)
+        self.assertEqual(ack.num_tokens_by_pool, {PoolName.KV.value: 2})
+        self.assertEqual(ack.num_bytes, 2 * FakeHostPool.size_per_token)
+        self.assertEqual(controller.load_queue, [])
+
+    def test_gate_off_empty_queue_returns_minus_one(self):
+        controller = self.make_controller(async_enabled=False)
+        self.assertEqual(controller.start_loading(), -1)
+        self.assertEqual(self.log, [])
+
+    def test_gate_off_fence_still_waits_on_the_forward_stream_inline(self):
+        controller = self.make_controller(async_enabled=False)
+        fence = FakeStream("forward", self.log)
+        controller.load_fence_stream = fence
+        self.queue_burst(controller, node_id=12)
+
+        controller.start_loading()
+
+        me = threading.current_thread().name
+        self.assertEqual(
+            self.entries("stream_wait_stream"),
+            [("stream_wait_stream", self.h2d(controller), fence, me)],
+        )
+        kinds = [entry[0] for entry in self.log]
+        self.assertLess(kinds.index("stream_wait_stream"), kinds.index("load_layer"))
+
+
+class TestAsyncEnqueue(AsyncLoadEnqueueTestBase):
+    def test_producer_is_synchronous_and_the_enqueue_is_not(self):
+        controller = self.make_controller(async_enabled=True)
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        self.queue_burst(controller, node_id=21)
+
+        producer_id = controller.start_loading()
+        producer_event = controller.layer_done_counter.events[producer_id]
+        me = threading.current_thread().name
+
+        # Synchronous half: the slot and the compute-stream start point,
+        # nothing more -- the batch is created with this id as
+        # hicache_consumer_index.
+        self.assertEqual(producer_id, 0)
+        self.assertEqual(controller.load_queue, [])
+        self.assertEqual(producer_event.start_event.recorded_on, me)
+        self.assertEqual(self.entries("load_layer"), [])
+        self.assertEqual(controller.ack_load_queue, [])
+
+        gate.set()
+        controller._drain_load_enqueue()
+
+        # Asynchronous half: every bit of it on the loader thread.
+        self.assertEqual(
+            [entry[2] for entry in self.entries("load_layer")],
+            [LOADER_THREAD_NAME] * self.layer_num,
+        )
+        self.assertEqual(
+            [entry[1] for entry in self.entries("move_indices")],
+            [LOADER_THREAD_NAME],
+        )
+        # Two H2D stream contexts on the async path: the short one that orders
+        # the index move behind start_event, then the transfer body.
+        self.assertEqual(
+            [entry[2] for entry in self.entries("stream_enter")],
+            [LOADER_THREAD_NAME] * 2,
+        )
+        self.assertEqual(len(controller.ack_load_queue), 1)
+        self.assertEqual(controller.ack_load_queue[0].node_ids, [21])
+        self.assertEqual(controller.ack_load_queue[0].num_tokens, 2)
+
+    def test_loader_thread_binds_to_the_scheduler_device(self):
+        controller = self.make_controller(async_enabled=True)
+        self.queue_burst(controller, node_id=22)
+        controller.start_loading()
+        controller._drain_load_enqueue()
+        self.assertEqual(
+            self.device_module.set_device_calls,
+            [(self.device_module.device_index, LOADER_THREAD_NAME)],
+        )
+
+    def test_ack_is_published_only_after_the_last_layer(self):
+        controller = self.make_controller(async_enabled=True)
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        self.queue_burst(controller, node_id=23)
+        controller.start_loading()
+
+        # The worker is parked inside the per-layer loop, past move_indices
+        # and inside the H2D stream context, and the ack must not be visible.
+        self._wait_for(lambda: self.entries("stream_enter"))
+        self.assertEqual(controller.ack_load_queue, [])
+
+        gate.set()
+        controller._drain_load_enqueue()
+        self.assertEqual(len(controller.ack_load_queue), 1)
+
+    def test_every_layer_completes_so_a_consumer_cannot_hang(self):
+        controller = self.make_controller(async_enabled=True)
+        self.queue_burst(controller, node_id=24)
+        producer_id = controller.start_loading()
+        controller.layer_done_counter.set_consumer(producer_id)
+
+        # wait_until blocks on the CPU-side handshake before touching the
+        # device event, so a layer that was never submitted would park this
+        # thread.
+        self._run_with_timeout(
+            lambda: [
+                controller.layer_done_counter.wait_until(layer)
+                for layer in range(self.layer_num)
+            ],
+            "consumer hung waiting for a layer that was never enqueued",
+        )
+
+        producer_event = controller.layer_done_counter.events[producer_id]
+        for layer in range(self.layer_num):
+            self.assertEqual(
+                producer_event.load_events[layer].recorded_on, LOADER_THREAD_NAME
+            )
+
+    def test_bursts_complete_in_submission_order(self):
+        controller = self.make_controller(async_enabled=True)
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        self.queue_burst(controller, node_id=31)
+        first = controller.start_loading()
+        self.queue_burst(controller, node_id=32)
+        second = controller.start_loading()
+
+        self.assertEqual([first, second], [0, 1])
+
+        gate.set()
+        controller._drain_load_enqueue()
+
+        self.assertEqual(
+            [ack.node_ids for ack in controller.ack_load_queue], [[31], [32]]
+        )
+        # One burst's layers never interleave with the next one's: a single
+        # worker keeps the H2D stream, the slot rotation and the acks in one
+        # order.
+        self.assertEqual(
+            [entry[1] for entry in self.entries("load_layer")],
+            list(range(self.layer_num)) * 2,
+        )
+
+    def test_merged_burst_carries_every_node_id(self):
+        controller = self.make_controller(async_enabled=True)
+        self.queue_burst(controller, node_id=41)
+        self.queue_burst(controller, node_id=42)
+        controller.start_loading()
+        controller._drain_load_enqueue()
+        self.assertEqual(len(controller.ack_load_queue), 1)
+        self.assertEqual(controller.ack_load_queue[0].node_ids, [41, 42])
+        self.assertEqual(controller.ack_load_queue[0].num_tokens, 4)
+
+    def test_slot_reuse_waits_for_the_queued_burst(self):
+        controller = self.make_controller(async_enabled=True)
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        # Fill the whole rotation, then ask for the slot the first burst holds.
+        for node_id in (51, 52, 53):
+            self.queue_burst(controller, node_id=node_id)
+            controller.start_loading()
+
+        self.queue_burst(controller, node_id=54)
+        reused = []
+        blocked = threading.Thread(
+            target=lambda: reused.append(controller.start_loading())
+        )
+        blocked.start()
+        blocked.join(timeout=0.5)
+        self.assertTrue(
+            blocked.is_alive(),
+            "slot 0 was handed out again while its burst was still queued",
+        )
+
+        gate.set()
+        blocked.join(timeout=JOIN_TIMEOUT)
+        self.assertFalse(blocked.is_alive())
+        self.assertEqual(reused, [0])
+        controller._drain_load_enqueue()
+        self.assertEqual(
+            [ack.node_ids for ack in controller.ack_load_queue],
+            [[51], [52], [53], [54]],
+        )
+
+    def test_reset_does_not_resurrect_a_drained_ack(self):
+        controller = self.make_controller(async_enabled=True)
+        controller.write_queue = []
+        controller.ack_write_queue = []
+        controller.enable_storage = False
+        controller.storage_stop_event = threading.Event()
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        self.queue_burst(controller, node_id=61)
+        controller.start_loading()
+
+        gate.set()
+        controller.reset()
+        self.assertEqual(controller.ack_load_queue, [])
+
+    def test_fence_is_captured_at_hand_over_and_waited_on_the_loader(self):
+        controller = self.make_controller(async_enabled=True)
+        fence = FakeStream("forward", self.log)
+        controller.load_fence_stream = fence
+        gate = threading.Event()
+        controller.mem_pool_host.gate = gate
+        self.queue_burst(controller, node_id=62)
+        me = threading.current_thread().name
+
+        controller.start_loading()
+
+        # The fence point is taken on the scheduler thread, before the burst
+        # is handed over, so it is the forward stream *now* and not wherever
+        # that stream is once the loader thread gets to the burst.
+        fence_records = [
+            entry
+            for entry in self.entries("record")
+            if entry[1].recorded_stream is fence
+        ]
+        self.assertEqual(len(fence_records), 1)
+        fence_event = fence_records[0][1]
+        self.assertEqual(fence_event.recorded_on, me)
+
+        gate.set()
+        controller._drain_load_enqueue()
+
+        h2d = self.h2d(controller)
+        self.assertEqual(self.entries("stream_wait_stream"), [])
+        fence_waits = [
+            entry for entry in self.entries("event_wait") if entry[1] is fence_event
+        ]
+        self.assertEqual(
+            fence_waits, [("event_wait", fence_event, h2d, LOADER_THREAD_NAME)]
+        )
+        wait_at = self.log.index(fence_waits[0])
+        move_at = self.log.index(self.entries("move_indices")[0])
+        load_at = self.log.index(self.entries("load_layer")[0])
+        self.assertLess(move_at, wait_at)
+        self.assertLess(wait_at, load_at)
+
+
+class UnsettledDeviceIndices:
+    """Stands in for the allocator's device index tensor.
+
+    Its *values* are written by kernels on the compute stream, so the blocking
+    ``.cpu()`` that ends ``move_indices`` for the 'direct' backends only reads
+    real indices once the reader is ordered behind
+    ``producer_event.start_event``. Read any earlier and it hands back garbage
+    -- which in production becomes wild device addresses in the batched copy.
+    """
+
+    GARBAGE = -(2**40)
+
+    def __init__(self, values, is_settled):
+        self._values = torch.tensor(values, dtype=torch.int64)
+        self._is_settled = is_settled
+        self.reads = []
+
+    def cpu(self):
+        out = (
+            self._values.clone()
+            if self._is_settled()
+            else torch.full_like(self._values, self.GARBAGE)
+        )
+        self.reads.append(out.tolist())
+        return out
+
+    def __len__(self):
+        return self._values.numel()
+
+
+class TestAsyncOrdersTheIndexMove(AsyncLoadEnqueueTestBase):
+    """The cross-stream race the split introduces, and the ordering that fixes it.
+
+    ``op.device_indices`` comes out of the allocator, and its values are
+    produced on the *compute* stream. Inline (gate off) the burst runs on the
+    scheduler thread, so the index move's D2H is implicitly behind those
+    kernels. On the loader thread the current stream is the default one and
+    nothing orders it -- the burst has to enter the H2D stream and wait
+    ``start_event`` before it reads.
+    """
+
+    def record_move_stream(self, controller):
+        """Capture the fake current stream at every move_indices call."""
+        moved_on = []
+        wrapped = controller.move_indices
+
+        def recording_move_indices(host_indices, device_indices):
+            moved_on.append(self.device_module.current_stream())
+            return wrapped(host_indices, device_indices)
+
+        controller.move_indices = recording_move_indices
+        return moved_on
+
+    def index_of(self, predicate, message):
+        for position, entry in enumerate(self.log):
+            if predicate(entry):
+                return position
+        self.fail(message)
+
+    def test_move_runs_inside_the_h2d_stream_after_the_start_event_wait(self):
+        controller = self.make_controller(async_enabled=True)
+        moved_on = self.record_move_stream(controller)
+        self.queue_burst(controller, node_id=101)
+
+        producer_id = controller.start_loading()
+        controller._drain_load_enqueue()
+        start_event = controller.layer_done_counter.events[producer_id].start_event
+        h2d = self.h2d(controller)
+
+        # The move saw the H2D stream as the current stream, not the default.
+        self.assertEqual(moved_on, [h2d])
+
+        enter_at = self.index_of(
+            lambda e: e[0] == "stream_enter" and e[1] is h2d,
+            "the burst never entered the H2D stream",
+        )
+        wait_at = self.index_of(
+            lambda e: e[0] == "event_wait" and e[1] is start_event and e[2] is h2d,
+            "the H2D stream never waited on the producer's start_event",
+        )
+        move_at = self.index_of(
+            lambda e: e[0] == "move_indices", "move_indices never ran"
+        )
+        load_at = self.index_of(
+            lambda e: e[0] == "load_layer", "no layer was ever submitted"
+        )
+        self.assertLess(enter_at, wait_at)
+        self.assertLess(wait_at, move_at)
+        self.assertLess(move_at, load_at)
+
+    def test_gate_off_still_moves_on_the_scheduler_stream(self):
+        # The inline path is unchanged: the scheduler thread's current stream
+        # is the compute one, which already orders the D2H, and start_event is
+        # recorded after the move exactly as it always was.
+        controller = self.make_controller(async_enabled=False)
+        moved_on = self.record_move_stream(controller)
+        self.queue_burst(controller, node_id=102)
+
+        controller.start_loading()
+
+        self.assertEqual(moved_on, [self.device_module._default_stream])
+        kinds = [entry[0] for entry in self.log]
+        self.assertLess(kinds.index("move_indices"), kinds.index("stream_enter"))
+
+    def test_unsettled_indices_are_never_read_before_the_wait(self):
+        controller = self.make_controller(async_enabled=True)
+        h2d = self.h2d(controller)
+        # First burst on a fresh controller, so the slot is 0; naming the event
+        # up front keeps the predicate free of any race with the loader thread.
+        start_event = controller.layer_done_counter.events[0].start_event
+
+        def h2d_waited_on_start():
+            return any(
+                entry[0] == "event_wait" and entry[1] is start_event and entry[2] is h2d
+                for entry in self.log
+            )
+
+        # Guard: the sentinel really does bite, so a green run below is not
+        # vacuous -- an unordered read of these indices returns garbage.
+        probe = UnsettledDeviceIndices([5, 6], h2d_waited_on_start)
+        self.assertEqual(probe.cpu().tolist(), [probe.GARBAGE] * 2)
+
+        device_indices = UnsettledDeviceIndices([5, 6], h2d_waited_on_start)
+        controller.load_queue.append(
+            CacheOperation(torch.arange(2, dtype=torch.int64), device_indices, 103)
+        )
+
+        producer_id = controller.start_loading()
+        controller._drain_load_enqueue()
+
+        self.assertEqual(producer_id, 0)
+        self.assertEqual(device_indices.reads, [[5, 6]])
+        self.assertEqual(len(controller.ack_load_queue), 1)
+        self.assertEqual(controller.ack_load_queue[0].node_ids, [103])
+        self.assertEqual(controller.ack_load_queue[0].num_tokens, 2)
+
+
+class TestLoaderThreadFailure(AsyncLoadEnqueueTestBase):
+    def test_failure_is_logged_and_releases_every_waiter(self):
+        controller = self.make_controller(async_enabled=True)
+        controller.mem_pool_host.fail_at_layer = 1
+        self.queue_burst(controller, node_id=71)
+
+        with self.assertLogs(cache_controller.logger, level="ERROR") as logs:
+            producer_id = controller.start_loading()
+            controller._drain_load_enqueue()
+
+        self.assertIn("71", "\n".join(logs.output))
+        self.assertIs(controller.load_enqueue_error, controller.mem_pool_host.failure)
+
+        # A forward already parked on this producer cannot be interrupted, so
+        # the abort path has to release it rather than leave it waiting.
+        producer_event = controller.layer_done_counter.events[producer_id]
+        controller.layer_done_counter.set_consumer(producer_id)
+        self._run_with_timeout(
+            lambda: [
+                controller.layer_done_counter.wait_until(layer)
+                for layer in range(self.layer_num)
+            ],
+            "a failed burst left the consumer blocked",
+        )
+        for layer in range(self.layer_num):
+            self.assertEqual(
+                producer_event.load_events[layer].recorded_on, LOADER_THREAD_NAME
+            )
+
+        # And the ack still lands, or loading_check would never reach the
+        # bursts queued behind this one.
+        self.assertEqual(len(controller.ack_load_queue), 1)
+        self.assertEqual(controller.ack_load_queue[0].node_ids, [71])
+        self.assertEqual(controller.ack_load_queue[0].num_tokens, 0)
+
+    def test_controller_still_serves_the_next_burst(self):
+        controller = self.make_controller(async_enabled=True)
+        controller.mem_pool_host.fail_at_layer = 0
+        self.queue_burst(controller, node_id=81)
+        with self.assertLogs(cache_controller.logger, level="ERROR"):
+            controller.start_loading()
+            controller._drain_load_enqueue()
+
+        controller.mem_pool_host.fail_at_layer = None
+        self.queue_burst(controller, node_id=82)
+        second = controller.start_loading()
+        controller._drain_load_enqueue()
+
+        self.assertEqual(second, 1)
+        self.assertTrue(controller.load_enqueue_thread.is_alive())
+        self.assertEqual(
+            [ack.node_ids for ack in controller.ack_load_queue], [[81], [82]]
+        )
+        self.assertEqual(
+            [entry[1] for entry in self.entries("load_layer")],
+            list(range(self.layer_num)),
+        )
+
+
+class TestShutdown(AsyncLoadEnqueueTestBase):
+    def test_thread_is_a_daemon(self):
+        controller = self.make_controller(async_enabled=True)
+        self.assertTrue(controller.load_enqueue_thread.daemon)
+        self.assertEqual(len(self.loader_threads()), 1)
+
+    def test_stop_joins_and_falls_back_to_the_inline_path(self):
+        controller = self.make_controller(async_enabled=True)
+        self.queue_burst(controller, node_id=91)
+        controller.start_loading()
+
+        with self.assertLogs(cache_controller.logger, level="INFO") as logs:
+            controller.stop_load_enqueue_thread()
+        self.assertIn(
+            "HiCache async load enqueue: downgraded to inline (HiCacheController)",
+            "\n".join(logs.output),
+        )
+
+        self.assertIsNone(controller.load_enqueue_thread)
+        self.assertIsNone(controller.load_enqueue_queue)
+        self.assertFalse(controller.async_load_enqueue)
+        self.assertEqual(self.loader_threads(), [])
+        # The queued burst was drained on the way out, not dropped.
+        self.assertEqual(len(controller.ack_load_queue), 1)
+
+        # Dropping the handshake with the thread is what keeps the rotation
+        # from parking: nothing on the inline path hands _enqueue_done back.
+        self.queue_burst(controller, node_id=92)
+        self._run_with_timeout(
+            controller.start_loading,
+            "start_loading blocked after the loader thread was stopped",
+        )
+        self.assertEqual(len(controller.ack_load_queue), 2)
+        self.assertNotIn(
+            LOADER_THREAD_NAME,
+            [entry[2] for entry in self.entries("load_layer")[-self.layer_num :]],
+        )
+
+    def test_stop_is_idempotent(self):
+        controller = self.make_controller(async_enabled=True)
+        controller.stop_load_enqueue_thread()
+        controller.stop_load_enqueue_thread()
+        self.assertEqual(self.loader_threads(), [])
+
+
+class TestLoadBackEventDone(AsyncLoadEnqueueTestBase):
+    """``is_load_back_event_done`` must not trust a slot's finish_event while
+    the burst that holds the slot is still sitting in the loader queue."""
+
+    def _stub(self, counter):
+        from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+
+        stub = object.__new__(HiRadixCache)
+        stub.cache_controller = SimpleNamespace(layer_done_counter=counter)
+        stub.loading_check = mock.MagicMock()
+        return stub
+
+    def test_queued_slot_is_not_done_until_enqueued(self):
+        counter = LayerDoneCounter(self.layer_num, async_enqueue=True)
+        stub = self._stub(counter)
+        self.assertTrue(stub.is_load_back_event_done(-1))
+
+        slot = counter.update_producer()
+        self.assertFalse(stub.is_load_back_event_done(slot))
+        stub.loading_check.assert_not_called()
+
+        counter.events[slot].mark_enqueue_done()
+        self.assertTrue(stub.is_load_back_event_done(slot))
+        stub.loading_check.assert_called_once()
+
+    def test_gate_off_only_consults_the_device_event(self):
+        counter = LayerDoneCounter(self.layer_num)
+        stub = self._stub(counter)
+        slot = counter.update_producer()
+        self.assertTrue(stub.is_load_back_event_done(slot))
+
+
+class FakeHostPoolGroup:
+    """Duck-typed HostPoolGroup: an anchor KV pool plus one sidecar pool."""
+
+    layout = "page_first_direct"
+
+    def __init__(self, layer_num, log):
+        self.anchor = FakeHostPool(layer_num, log, name="kv")
+        self.sidecar = FakeHostPool(layer_num, log, name="indexer")
+        self.anchor_entry = SimpleNamespace(
+            name=PoolName.KV,
+            host_pool=self.anchor,
+            device_pool=object(),
+            layer_mapper=None,
+            packed_draft_device_pools=(),
+        )
+        sidecar_entry = SimpleNamespace(
+            name=PoolName.INDEXER,
+            host_pool=self.sidecar,
+            device_pool=object(),
+            layer_mapper=None,
+            packed_draft_device_pools=(),
+        )
+        self.entry_map = {
+            PoolName.KV: self.anchor_entry,
+            PoolName.INDEXER: sidecar_entry,
+        }
+
+    @property
+    def gate(self):
+        return self.anchor.gate
+
+    @gate.setter
+    def gate(self, value):
+        self.anchor.gate = value
+
+
+class TestHybridBurst(AsyncLoadEnqueueTestBase):
+    """The hybrid controller inherits the split: its sidecar pool transfers
+    ride the same burst on the loader thread."""
+
+    def make_hybrid_controller(self, async_enabled: bool) -> HybridCacheController:
+        controller = HybridCacheController.__new__(HybridCacheController)
+        return self._wire(
+            controller, async_enabled, FakeHostPoolGroup(self.layer_num, self.log)
+        )
+
+    def queue_hybrid_burst(self, controller, node_id, num_tokens=2):
+        controller.load_queue.append(
+            CacheOperation(
+                torch.arange(num_tokens, dtype=torch.int64),
+                torch.arange(num_tokens, dtype=torch.int64),
+                node_id,
+                pool_transfers=[
+                    PoolTransfer(
+                        name=PoolName.INDEXER,
+                        host_indices=torch.arange(num_tokens, dtype=torch.int64) + 100,
+                        device_indices=torch.arange(num_tokens, dtype=torch.int64)
+                        + 200,
+                    )
+                ],
+            )
+        )
+
+    def _expected_layers(self):
+        expected = []
+        for layer in range(self.layer_num):
+            expected.extend([(layer, "kv"), (layer, "indexer")])
+        return expected
+
+    def test_gate_off_hybrid_burst_runs_inline(self):
+        controller = self.make_hybrid_controller(async_enabled=False)
+        self.queue_hybrid_burst(controller, node_id=201)
+        me = threading.current_thread().name
+
+        controller.start_loading()
+
+        self.assertEqual(
+            [(entry[1], entry[3]) for entry in self.entries("load_layer")],
+            self._expected_layers(),
+        )
+        self.assertEqual({entry[2] for entry in self.entries("load_layer")}, {me})
+        ack = controller.ack_load_queue[0]
+        self.assertEqual(ack.node_ids, [201])
+        self.assertEqual(
+            ack.num_tokens_by_pool,
+            {PoolName.KV.value: 2, PoolName.INDEXER.value: 2},
+        )
+
+    def test_gate_on_hybrid_burst_runs_on_the_loader_thread(self):
+        controller = self.make_hybrid_controller(async_enabled=True)
+        self.queue_hybrid_burst(controller, node_id=202)
+
+        producer_id = controller.start_loading()
+        self.assertEqual(producer_id, 0)
+        controller._drain_load_enqueue()
+
+        self.assertEqual(
+            [(entry[1], entry[3]) for entry in self.entries("load_layer")],
+            self._expected_layers(),
+        )
+        self.assertEqual(
+            {entry[2] for entry in self.entries("load_layer")}, {LOADER_THREAD_NAME}
+        )
+        # Both index moves (KV and sidecar) happen behind the start_event wait.
+        self.assertEqual(
+            [entry[1] for entry in self.entries("move_indices")],
+            [LOADER_THREAD_NAME] * 2,
+        )
+        ack = controller.ack_load_queue[0]
+        self.assertEqual(ack.node_ids, [202])
+        self.assertEqual(
+            ack.num_tokens_by_pool,
+            {PoolName.KV.value: 2, PoolName.INDEXER.value: 2},
+        )
+
+    def test_failed_hybrid_burst_still_releases_and_acks(self):
+        controller = self.make_hybrid_controller(async_enabled=True)
+        controller.mem_pool_host.sidecar.fail_at_layer = 1
+        self.queue_hybrid_burst(controller, node_id=203)
+
+        with self.assertLogs(cache_controller.logger, level="ERROR"):
+            producer_id = controller.start_loading()
+            controller._drain_load_enqueue()
+
+        controller.layer_done_counter.set_consumer(producer_id)
+        self._run_with_timeout(
+            lambda: [
+                controller.layer_done_counter.wait_until(layer)
+                for layer in range(self.layer_num)
+            ],
+            "a failed hybrid burst left the consumer blocked",
+        )
+        self.assertEqual([ack.node_ids for ack in controller.ack_load_queue], [[203]])
+
+
+class FakeDeviceKVPool:
+    device = "cpu"
+    layer_num = 3
+
+    def register_layer_transfer_counter(self, counter):
+        self.counter = counter
+
+
+class FakeAllocator:
+    def __init__(self):
+        self.pool = FakeDeviceKVPool()
+
+    def get_kvcache(self):
+        return self.pool
+
+
+class FakeInitHostPool:
+    layout = "page_first_direct"
+    layer_num = 3
+    entry_map = {}
+    entries = None
+
+    def __init__(self):
+        self.anchor_entry = SimpleNamespace(name=PoolName.KV, host_pool=self)
+
+
+class TestActivationSignature(AsyncLoadEnqueueTestBase):
+    """The startup log has to describe what the process will actually do."""
+
+    def _build(self, cls, **kwargs):
+        controller = cls(
+            token_to_kv_pool_allocator=FakeAllocator(),
+            mem_pool_host=FakeInitHostPool(),
+            page_size=1,
+            tp_group=None,
+            load_cache_event=threading.Event(),
+            **kwargs,
+        )
+        self.addCleanup(controller.stop_load_enqueue_thread)
+        return controller
+
+    def _gate_on(self):
+        patcher = mock.patch.object(
+            envs.SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE, "get", lambda: True
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_enabled_line_names_the_concrete_class(self):
+        self._gate_on()
+        with self.assertLogs(cache_controller.logger, level="INFO") as logs:
+            controller = self._build(HybridCacheController)
+        self.assertIn(
+            "HiCache async load enqueue: enabled (HybridCacheController)",
+            "\n".join(logs.output),
+        )
+        # And the claim is true: the worker is still there after __init__.
+        self.assertTrue(controller.async_load_enqueue)
+        self.assertIsNotNone(controller.load_enqueue_thread)
+
+    def test_base_line_names_the_base_class(self):
+        self._gate_on()
+        with self.assertLogs(cache_controller.logger, level="INFO") as logs:
+            self._build(HiCacheController)
+        self.assertIn(
+            "HiCache async load enqueue: enabled (HiCacheController)",
+            "\n".join(logs.output),
+        )
+
+    def test_a_transfer_layer_override_keeps_the_handshake(self):
+        # The replacement LayerDoneCounter has to carry async_enqueue, or the
+        # forward would wait on device events the loader has not recorded yet.
+        self._gate_on()
+        controller = self._build(HybridCacheController, transfer_layer_num=5)
+        self.assertEqual(controller.layer_num, 5)
+        for event in controller.layer_done_counter.events:
+            self.assertIsNotNone(event._recorded)
+            self.assertEqual(len(event._recorded), 5)
+
+    def test_gate_off_says_disabled(self):
+        with self.assertLogs(cache_controller.logger, level="INFO") as logs:
+            controller = self._build(HybridCacheController)
+        self.assertIn(
+            "HiCache async load enqueue: disabled (HybridCacheController)",
+            "\n".join(logs.output),
+        )
+        self.assertIsNone(controller.load_enqueue_thread)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -1,5 +1,6 @@
 """Unit tests for HiCache staged write-back host-pool dispatch."""
 
+import threading
 import unittest
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -238,6 +239,15 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller.l2_transfer_engine.submit_host_to_device.return_value = completion
         controller.layer_num = 2
         controller.ack_load_queue = []
+        # Inline (synchronous) load path: no loader thread, real burst body.
+        controller.load_enqueue_queue = None
+        controller._ack_load_lock = threading.Lock()
+        controller._enqueue_load_burst.side_effect = lambda *args, **kwargs: (
+            HiCacheController._enqueue_load_burst(controller, *args, **kwargs)
+        )
+        controller._append_load_ack.side_effect = lambda ack: (
+            HiCacheController._append_load_ack(controller, ack)
+        )
 
         self.assertEqual(HybridCacheController.start_loading(controller), 0)
 


### PR DESCRIPTION
## Motivation

Closes #38470

`HiCacheController.start_loading` submits the whole host->device load-back burst inline on the scheduler thread. With `--hicache-io-backend direct` and the `page_first_direct` layout every per-layer `load_to_device_per_layer` builds a batched-copy descriptor on the CPU (~2.4 ms per layer in our profile), so one burst on a 78-layer model with two host pools keeps the scheduler thread busy for ~375 ms. By the time the batch is built and the forward launches, every copy has already landed and the layer-wise pipeline (`LayerDoneCounter.wait_until` in the attention layers) overlaps ~0.04 % of the copy time.

This PR adds `SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE` (default off). With it on, `start_loading` only does the producer-slot hand-out and `start_event.record()` on the scheduler thread, then hands the index move, the per-layer enqueue and the ack to a single FIFO daemon thread (`hicache-load-enqueue`). With it off the call sequence is byte-for-byte the previous one (the unit test asserts the exact stream/event sequence).

## Modifications

`python/sglang/srt/managers/cache_controller.py`

- `LayerLoadingEvent(num_layers, async_enqueue=False)`: per-layer CPU-side `recorded` flags. Waiting on a device event that was never recorded is a no-op, so `wait()` first blocks on the flag (logging every 30 s if it is still unset), then waits on the device event. A per-slot `enqueue_done` flag is the rotation's backpressure: `update_producer` waits on it before checking `finish_event`, because while a burst is still queued the slot's `finish_event` is the previous rotation's and `query()` would pass. `rearm()`, `is_enqueue_done()`, `mark_enqueue_done()`, `disable_async_handshake()`.
- `HiCacheController`: `_init_load_enqueue_thread`, `_load_enqueue_thread_func` (single consumer; the H2D stream ordering, the 3-slot rotation and `ack_load_queue` popped in order are all FIFO), `_abort_load_burst`, `_drain_load_enqueue`, `stop_load_enqueue_thread` (joins, then falls back to the inline path and drops the handshake). Startup logs `HiCache async load enqueue: enabled/disabled (<ClassName>)`.
- `start_loading` split into the scheduler-thread half and `_enqueue_load_burst(op, producer_event, start_event_recorded, fence_event)`:
  - inline: index move, `start_event.record()`, fence, submit, ack, exactly as before;
  - loader thread: `op.device_indices` is written by the allocator on the compute stream, so the index move runs under the H2D stream after `start_event.wait(h2d_stream)`; the overlap-scheduling fence is captured on the scheduler thread as an event recorded on `load_fence_stream` at hand-over time and waited on by the loader before submitting.
- Loader failure: every layer event is completed on the H2D stream and a zero-token ack is published, so a forward parked on `wait_until` and the later acks behind this one cannot hang. The error is logged with the node ids and latched in `load_enqueue_error`; the KV for those nodes is stale.
- `reset()` drains the loader first, and `_append_load_ack` takes `_ack_load_lock` so a loader-thread append cannot land after `reset()`'s `clear()`.

`python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py`: the replacement `LayerDoneCounter` built for `transfer_layer_num` carries `async_enqueue`.

`python/sglang/srt/mem_cache/hiradix_cache.py`, `python/sglang/srt/mem_cache/unified_radix_cache.py`: `is_load_back_event_done` returns False while the slot's burst is still queued (the `getattr` keeps the FlexKV counter, which has its own event class, untouched).

`python/sglang/srt/environ.py`: `SGLANG_HICACHE_ASYNC_LOAD_ENQUEUE = EnvBool(False)`.

Tests

- New `test/registered/unit/mem_cache/test_hicache_async_load_enqueue.py` (CPU, `base-a-test-cpu`): swaps the `device_module` of the controller and of `L2TransferEngine` for a fake that logs the exact stream/event call sequence with the calling thread. Covers: gate off creates no thread and keeps the pre-split call sequence (including the fence `wait_stream`); producer hand-out is synchronous and the enqueue is not; loader binds to the scheduler's device; ack only after the last layer; every layer completes so a consumer cannot hang; bursts complete in submission order; slot reuse blocks on a queued burst; `reset()` does not resurrect an ack; the fence event is recorded at hand-over and waited on the loader; the index move runs under the H2D stream after the `start_event` wait (with a sentinel that returns garbage if read early); loader failure logs, releases the consumer and still acks, and the next burst is served; shutdown joins and falls back to inline; `is_load_back_event_done` guard; hybrid burst with a sidecar pool inline and on the loader thread; activation log line and `transfer_layer_num` counter carry-over.
- `test_hicache_staged_write_back_dispatch.py::test_hybrid_load_forwards_merged_pool_transfers` builds its controller with `mock.Mock(spec=...)`; it now wires the inline burst body so the split does not turn it into a no-op.

## Accuracy Tests

No numerical change: the same copies are issued on the same stream, only the thread that issues them changes. Gate off is the existing path.

## Speed Tests and Profiling

Prefill-only H100 TP=8 deployment, hierarchical cache, `io_backend=direct`, `page_first_direct`, 500 requests, same prompt set, gate off vs on:

| metric | change |
|---|---|
| throughput | +8.8 % |
| wall time | -8.1 % |
| TTFT mean | -7.9 % |
| TTFT p50 | -10.0 % |
| TTFT p95 | 22.12 s -> 20.41 s |
| TTFT p99 | flat |

Per-burst `start_loading` on the scheduler thread drops from ~375 ms to the slot hand-out.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34208615291](https://github.com/sgl-project/sglang/actions/runs/34208615291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34208615111](https://github.com/sgl-project/sglang/actions/runs/34208615111)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34208615213](https://github.com/sgl-project/sglang/actions/runs/34208615213)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->