### PR TITLE
[kv-shard 4/4] PD transfer and e2e test

### DIFF
--- a/python/sglang/srt/arg_groups/kv_shard_hook.py
+++ b/python/sglang/srt/arg_groups/kv_shard_hook.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolution and validation for logical-page KV cache sharding."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from sglang.srt.arg_groups.overrides import (
+    attention_backends_of,
+    declare_resolution,
+    model_config_of,
+    resolved_view,
+    resolving_view,
+    use_mla_backend,
+)
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.cuda_graph_config import Backend, Phase, with_phase
+
+logger = logging.getLogger(__name__)
+
+
+def kv_shard_group_size(server_args: Any) -> int:
+    """Return the active KV-shard group size, or one when disabled."""
+    cfg = resolving_view(server_args)
+    if not cfg.enable_kv_cache_sharding:
+        return 1
+    if cfg.attn_cp_size > 1:
+        return cfg.attn_cp_size
+    if use_mla_backend(server_args):
+        # Plain-TP MLA is validated below, so attn_tp_size == tp_size here.
+        return cfg.tp_size
+    return 1
+
+
+def validate_kv_shard_attention_backend(server_args: Any, cfg: Any = None) -> None:
+    cfg = cfg or resolving_view(server_args)
+    prefill_backend, _ = attention_backends_of(resolved_view(server_args))
+    if prefill_backend == "fa3":
+        return
+    if prefill_backend != "trtllm_mla":
+        raise ValueError(
+            "--enable-kv-cache-sharding currently requires the fa3 prefill "
+            "attention backend, or trtllm_mla for plain-TP MLA; "
+            f"got {prefill_backend!r}."
+        )
+    if not use_mla_backend(server_args):
+        raise ValueError("KV sharding with trtllm_mla requires an MLA model.")
+    if cfg.attn_cp_size > 1:
+        raise ValueError(
+            "KV sharding with trtllm_mla only supports plain-TP MLA "
+            "(attn_cp_size must be 1)."
+        )
+    if cfg.disable_chunked_prefix_cache:
+        raise ValueError("KV sharding with trtllm_mla requires chunked prefix caching.")
+
+
+def handle_kv_cache_sharding(server_args: Any, gpu_mem: Optional[float] = None) -> None:
+    """Validate KV sharding and declare its derived eager-prefill settings."""
+    cfg = resolving_view(server_args)
+    if not cfg.enable_kv_cache_sharding:
+        return
+
+    if cfg.disaggregation_mode != "prefill":
+        raise ValueError(
+            "--enable-kv-cache-sharding is only supported on PD prefill "
+            "workers: a rank's pool holds only its stripe of every cached "
+            "page, which is incompatible with local decode."
+        )
+    if cfg.speculative_algorithm is not None:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support speculative decoding."
+        )
+    if cfg.dllm_algorithm is not None:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support diffusion language "
+            "models: DLLM admission bypasses the shard-scratch budget and "
+            "resolves out of PD-prefill mode."
+        )
+    if cfg.radix_cache_backend is not None:
+        raise ValueError(
+            "--enable-kv-cache-sharding requires the built-in "
+            "UnifiedRadixCache with a rotation-aware UnifiedTreeCore and does "
+            "not support "
+            f"--radix-cache-backend={cfg.radix_cache_backend!r}."
+        )
+    if envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE.get():
+        raise ValueError(
+            "--enable-kv-cache-sharding is incompatible with "
+            "SGLANG_EXPERIMENTAL_CPP_RADIX_TREE: the C++ tree does not carry "
+            "KV-shard rotation metadata."
+        )
+    tree_core_backend = envs.SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND.get()
+    if tree_core_backend != "python":
+        raise ValueError(
+            "--enable-kv-cache-sharding requires the Python UnifiedTreeCore: "
+            f"SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND={tree_core_backend!r} is "
+            "not supported for sharded KV."
+        )
+    if cfg.enable_unified_cache_external_linker:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support "
+            "--enable-unified-cache-external-linker: load-back allocates "
+            "through the flat allocator API."
+        )
+    if cfg.enable_streaming_session:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support streaming sessions: "
+            "their virtual nodes do not carry KV-shard rotation metadata."
+        )
+    if cfg.enable_session_radix_cache:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support session radix cache yet."
+        )
+    if cfg.enable_flexkv:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support --enable-flexkv: "
+            "FlexKV load-back allocates through the stock flat allocator API."
+        )
+    if cfg.enable_unified_memory:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support --enable-unified-memory: "
+            "the unified pool uses a different virtual-id allocator and layout."
+        )
+    if cfg.dcp_size > 1:
+        raise ValueError(
+            "--enable-kv-cache-sharding and decode context parallelism "
+            "(--dcp-size) are mutually exclusive users of the widened "
+            "allocator index space."
+        )
+    if cfg.enable_hierarchical_cache:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support "
+            "--enable-hierarchical-cache yet: HiCache backup/load assumes "
+            "each rank holds full pages."
+        )
+    if cfg.enable_lmcache:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support --enable-lmcache."
+        )
+    if cfg.enable_hisparse:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support --enable-hisparse: "
+            "HiSparse selects a non-sharded allocator and assumes each rank "
+            "owns complete KV pages."
+        )
+    if cfg.enable_dynamic_chunking:
+        raise ValueError(
+            "--enable-kv-cache-sharding requires fixed chunk sizes; disable "
+            "--enable-dynamic-chunking."
+        )
+    if cfg.enable_two_batch_overlap:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support "
+            "--enable-two-batch-overlap: the sharded pool's per-batch gather "
+            "plan is a process-wide singleton, but TBO rebuilds attention "
+            "metadata multiple times per extend forward and clobbers the plan."
+        )
+
+    model_config = model_config_of(server_args)
+    if model_config.is_encoder_decoder:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support encoder-decoder "
+            "models: cross-attention uses a separate encoder page table that "
+            "is not part of the sharded gather plan."
+        )
+    if model_config.attention_chunk_size is not None:
+        raise ValueError(
+            "--enable-kv-cache-sharding does not support chunked/local-attention "
+            "models yet: local-attention metadata is built from the page table "
+            "before the scratch translation."
+        )
+
+    validate_kv_shard_attention_backend(server_args, cfg)
+    if cfg.disaggregation_transfer_backend not in ("mooncake", "nixl"):
+        raise ValueError(
+            "--enable-kv-cache-sharding currently only supports the mooncake "
+            "and nixl transfer backends: both route sends through "
+            "CommonKVSender._prepare_send_indices and pair destinations by "
+            "fancy index. Got --disaggregation-transfer-backend "
+            f"{cfg.disaggregation_transfer_backend!r}."
+        )
+    if envs.SGLANG_DISAGG_STAGING_BUFFER.get():
+        raise ValueError(
+            "--enable-kv-cache-sharding is incompatible with "
+            "SGLANG_DISAGG_STAGING_BUFFER (the staging path assumes "
+            "contiguous send slices)."
+        )
+
+    if use_mla_backend(server_args):
+        from sglang.srt.configs.model_config import is_deepseek_dsa
+
+        if is_deepseek_dsa(model_config.hf_config):
+            raise ValueError(
+                "--enable-kv-cache-sharding does not support DSA models yet "
+                "(indexer buffers are not striped)."
+            )
+        if cfg.attn_cp_size <= 1:
+            if cfg.enable_dp_attention:
+                raise ValueError(
+                    "--enable-kv-cache-sharding for MLA models without "
+                    "prefill CP shards across attention-TP and requires plain "
+                    "TP attention; disable --enable-dp-attention."
+                )
+            if cfg.tp_size <= 1:
+                raise ValueError(
+                    "--enable-kv-cache-sharding for MLA models without "
+                    "prefill CP shards across attention-TP ranks and needs "
+                    "tp_size > 1."
+                )
+    elif not cfg.enable_prefill_cp or cfg.attn_cp_size <= 1:
+        raise ValueError(
+            "--enable-kv-cache-sharding for GQA models shards across "
+            "attention-CP ranks and requires --enable-prefill-cp with "
+            "attn_cp_size > 1."
+        )
+
+    page_size = cfg.page_size if cfg.page_size is not None else 1
+    if page_size <= 1:
+        raise ValueError(
+            "--enable-kv-cache-sharding requires a real page size "
+            "(--page-size 64 recommended): the physical page is the P/D "
+            "transfer descriptor and gather-copy unit; page_size=1 "
+            "degenerates both into per-token operations."
+        )
+    granule = kv_shard_group_size(server_args) * page_size
+    chunk_size = cfg.chunked_prefill_size
+    if chunk_size is None or chunk_size <= 0:
+        raise ValueError(
+            "--enable-kv-cache-sharding requires chunked prefill "
+            "(--chunked-prefill-size > 0)."
+        )
+
+    declarations = {}
+    if chunk_size % granule != 0:
+        rounded = (chunk_size + granule - 1) // granule * granule
+        declarations["chunked_prefill_size"] = rounded
+
+        # The raw input, deliberately not the resolving view: the question is
+        # whether the user pinned mem_fraction_static, and the resolved value
+        # would answer yes for every run. Reading the record's field directly
+        # is what test_resolution_reads_the_declarations forbids.
+        raw_mem_fraction = (getattr(server_args, "_raw_input", None) or {}).get(
+            "mem_fraction_static"
+        )
+        activation_delta_mb = 1.5 * (max(rounded, 2048) - max(chunk_size, 2048))
+        if raw_mem_fraction is None and activation_delta_mb > 0:
+            if not gpu_mem or cfg.mem_fraction_static is None:
+                raise ValueError(
+                    "Cannot safely auto-round --chunked-prefill-size for KV "
+                    "sharding without a known device-memory capacity; pass a "
+                    f"multiple of shard_size * page_size ({granule})."
+                )
+            corrected_mem_fraction = (
+                float(cfg.mem_fraction_static) - activation_delta_mb / gpu_mem
+            )
+            if corrected_mem_fraction <= 0:
+                raise ValueError(
+                    "Auto-rounding --chunked-prefill-size for KV sharding "
+                    "would consume all automatically reserved GPU memory; "
+                    f"pass a smaller multiple of {granule}."
+                )
+            declarations["mem_fraction_static"] = corrected_mem_fraction
+
+        logger.warning(
+            "Rounding --chunked-prefill-size up from %d to %d "
+            "(a multiple of shard_size * page_size = %d) for KV sharding.",
+            chunk_size,
+            rounded,
+            granule,
+        )
+
+    if cfg.cuda_graph_config.prefill.backend != Backend.DISABLED:
+        logger.warning(
+            "Prefill CUDA graph (%s) is incompatible with "
+            "--enable-kv-cache-sharding; disabling it.",
+            cfg.cuda_graph_config.prefill.backend,
+        )
+        declarations["cuda_graph_config"] = with_phase(
+            cfg.cuda_graph_config, Phase.PREFILL, backend=Backend.DISABLED
+        )
+
+    if declarations:
+        declare_resolution(
+            server_args,
+            "handle_kv_cache_sharding",
+            **declarations,
+        )

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1784,6 +1784,12 @@ def post_capture_kv_sizing_planned(server_args: Any) -> bool:
     False for any config the runtime won't post-capture-size, else it gets an
     under-reserved fraction."""
     cfg = resolving_view(server_args)
+    # Logical-page sharding always runs prefill eagerly. This predicate runs
+    # before the sharding hook disables prefill capture, so gate on the feature
+    # itself to retain eager activation headroom in the memory heuristic.
+    if cfg.enable_kv_cache_sharding:
+        return False
+
     mla_enabled = use_mla_backend(server_args)
     if not envs.SGLANG_ENABLE_POST_CAPTURE_KV_SIZING.get():
         return False

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -294,6 +294,12 @@ def run_resolution_pipeline(server_args: Any) -> None:
     # Handle context parallelism.
     handle_context_parallelism(server_args)
 
+    # Validate logical-page KV cache sharding after its page size, attention
+    # backend, memory budget, and shard topology have all resolved.
+    from sglang.srt.arg_groups.kv_shard_hook import handle_kv_cache_sharding
+
+    handle_kv_cache_sharding(server_args, gpu_mem)
+
     # Handle MoE configurations.
     from sglang.srt.arg_groups.moe_hook import (
         handle_a2a_moe,
@@ -363,6 +369,11 @@ def run_resolution_pipeline(server_args: Any) -> None:
     # Model-capability adjustments that legacy code applied at model-load
     # time; last declarations of the resolution, mirroring that order.
     handle_model_capability_adjustments(server_args)
+
+    # Capability adjustments can late-force a different attention backend or
+    # disable chunked prefill. Re-run the idempotent sharding gate over the
+    # final resolving view.
+    handle_kv_cache_sharding(server_args, gpu_mem)
 
     # Validate after all batch-size declarations are visible.
     validate_deepep_v2_speculative_draft(server_args)

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -29,6 +29,7 @@ from sglang.srt.disaggregation.base.conn import (
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     filter_kv_indices_for_cp_rank,
+    filter_kv_indices_for_shard_rank,
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.environ import envs
@@ -102,6 +103,9 @@ class PrefillServerInfo:
     kv_cache_dtype: Optional[str]
     follow_bootstrap_room: bool
     enable_dsa_cache_layer_split: bool = False
+    # Prefill stores each KV page on exactly one shard-group rank
+    # (logical-page KV sharding); decode must pull from every shard rank.
+    enable_kv_cache_sharding: bool = False
 
     # PD true-retraction rebootstrap: the prefill's HTTP API port. The decode
     # already knows the prefill host (the bootstrap_addr host), so it can POST
@@ -128,6 +132,7 @@ class PrefillServerInfo:
         )
         self.follow_bootstrap_room = bool(self.follow_bootstrap_room)
         self.enable_dsa_cache_layer_split = bool(self.enable_dsa_cache_layer_split)
+        self.enable_kv_cache_sharding = bool(self.enable_kv_cache_sharding)
         self.prefill_http_port = (
             int(self.prefill_http_port) if self.prefill_http_port is not None else None
         )
@@ -190,6 +195,27 @@ class CommonKVManager(BaseKVManager):
         self.pp_size = get_parallel().pp_size
         self.pp_rank = self.kv_args.pp_rank
         self.local_ip = get_local_ip_auto()
+        # Logical-page KV sharding (prefill side): the group whose ranks each
+        # hold a disjoint 1/N of every page, chosen by topology (mirrors
+        # mem_cache.page_interleave.get_kv_shard_group): an active attn-CP
+        # group takes precedence; without CP, MLA shards across attn-TP.
+        # (0, 1) when sharding is off (including on decode workers).
+        if (
+            get_parallel().enable_kv_cache_sharding
+            and disaggregation_mode == DisaggregationMode.PREFILL
+        ):
+            if self.attn_cp_size > 1:
+                self.kv_shard_rank = self.attn_cp_rank
+                self.kv_shard_size = self.attn_cp_size
+            elif self.is_mla_backend:
+                self.kv_shard_rank = self.attn_tp_rank
+                self.kv_shard_size = self.attn_tp_size
+            else:
+                self.kv_shard_rank = 0
+                self.kv_shard_size = 1
+        else:
+            self.kv_shard_rank = 0
+            self.kv_shard_size = 1
         cp_sharded_prefill = self.attn_cp_size > 1 and (
             self.is_hybrid_mla_backend or get_parallel().enable_dsa_cache_layer_split
         )
@@ -202,6 +228,9 @@ class CommonKVManager(BaseKVManager):
             envs.SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER.get()
             or cp_sharded_prefill
             or hybrid_decode_pulls_all_ranks
+            # Under CP-axis sharding no rank holds the full KV, so every CP
+            # rank must participate in the transfer.
+            or (get_parallel().enable_kv_cache_sharding and self.attn_cp_size > 1)
         )
 
         # bind zmq socket
@@ -321,6 +350,16 @@ class CommonKVManager(BaseKVManager):
             and dst_dcp_size > 1
             and (self.is_mla_backend or self.is_hybrid_mla_backend)
         ):
+            if self.kv_shard_size > 1:
+                # The relayout path indexes chunks by kv_chunk.index_slice.start,
+                # but the shard send filter replaces that slice with a fancy
+                # index of owned positions. Fail here instead of deep in the
+                # transfer worker.
+                raise RuntimeError(
+                    "KV cache sharding cannot serve a decode instance that "
+                    f"requires DCP relayout (decode dcp_size={dst_dcp_size}). "
+                    "Disable --enable-kv-cache-sharding or --dcp-size."
+                )
             return True
 
         raise RuntimeError(
@@ -679,7 +718,26 @@ class CommonKVManager(BaseKVManager):
         """Compute TP/CP/PP rank mapping and store on the PrefillServerInfo object.
         Deterministic for a given (bootstrap_addr, decode engine) pair."""
         # TP rank mapping
-        if self.attn_tp_size == info.attn_tp_size:
+        if (
+            info.enable_kv_cache_sharding
+            and self.is_mla_backend
+            and info.attn_cp_size == 1
+        ):
+            # Logical-page KV sharding on the attn-TP axis (MLA prefill
+            # without CP — with CP active the shard axis is the CP group and
+            # the CP fan-in below handles it): every decode rank pulls its
+            # full latent KV from ALL prefill TP ranks (each sends the pages
+            # it owns, paired positionally), which needs equal TP sizes.
+            assert self.attn_tp_size == info.attn_tp_size, (
+                "MLA KV cache sharding requires equal prefill/decode attn TP "
+                f"sizes, got prefill={info.attn_tp_size} decode={self.attn_tp_size}"
+            )
+            target_tp_rank = self.kv_args.engine_rank % self.attn_tp_size
+            target_tp_ranks = list(range(info.attn_tp_size))
+            # Every decode TP rank registers with every prefill TP rank.
+            required_dst_info_num = self.attn_tp_size
+            required_prefill_response_num = info.attn_tp_size
+        elif self.attn_tp_size == info.attn_tp_size:
             target_tp_rank = self.kv_args.engine_rank % self.attn_tp_size
             required_dst_info_num = 1
             required_prefill_response_num = 1
@@ -733,6 +791,9 @@ class CommonKVManager(BaseKVManager):
             pull_from_all_cp_ranks = (
                 self.enable_all_cp_ranks_for_transfer
                 or info.enable_dsa_cache_layer_split
+                # CP-axis KV sharding: each prefill CP rank holds a disjoint
+                # 1/N of every page, so decode must pull from all of them.
+                or info.enable_kv_cache_sharding
             )
             if not pull_from_all_cp_ranks:
                 # Only retrieve from prefill CP rank 0 when not using all ranks
@@ -822,6 +883,7 @@ class CommonKVManager(BaseKVManager):
             "kv_cache_dtype": self.kv_cache_dtype_str,
             "load_balance_method": get_parallel().load_balance_method,
             "enable_dsa_cache_layer_split": get_parallel().enable_dsa_cache_layer_split,
+            "enable_kv_cache_sharding": get_parallel().enable_kv_cache_sharding,
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a
             # router-injected pd_rebootstrap_prefill_url.
@@ -1289,7 +1351,17 @@ class CommonKVSender(BaseKVSender):
         self.curr_idx += len(kv_indices)
         is_last_chunk = self.curr_idx == self.num_kv_indices
 
-        if (
+        if self.kv_mgr.kv_shard_size > 1:
+            # Logical-page KV sharding: send only the pages this rank owns
+            # (ownership derived from the logical page ids in kv_indices),
+            # paired with their canonical positions (an index array replaces
+            # the contiguous slice).
+            kv_indices, index_slice = filter_kv_indices_for_shard_rank(
+                self.kv_mgr,
+                kv_indices,
+                index_slice,
+            )
+        elif (
             self.kv_mgr.enable_all_cp_ranks_for_transfer
             and not get_parallel().enable_dsa_cache_layer_split
         ):
@@ -1437,14 +1509,26 @@ class CommonKVReceiver(BaseKVReceiver):
                             target_pp_rank,
                         )
                         if bootstrap_info is not None:
-                            if self.kv_mgr.is_mla_backend:
+                            # TP-axis KV sharding (MLA without CP) needs every
+                            # prefill TP rank to be a real sender; CP-axis
+                            # sharding keeps MLA's one-real-TP-rank rule (the
+                            # pages fan in across CP ranks instead). Keep the
+                            # prefill_info read behind the MLA test: only that
+                            # branch consults it.
+                            if self.kv_mgr.is_mla_backend and not (
+                                self.prefill_info.enable_kv_cache_sharding
+                                and self.prefill_info.attn_cp_size == 1
+                            ):
                                 # For MLA: target_tp_rank is the selected real rank, others are dummy ranks
                                 bootstrap_info["is_dummy"] = not bool(
                                     target_tp_rank == self.target_tp_rank
                                     or self.target_tp_rank is None
                                 )
                             else:
-                                # For non-MLA: all target_tp_ranks are selected real ranks
+                                # For non-MLA — and for MLA under logical-page
+                                # KV sharding, where every prefill TP rank
+                                # sends the pages it owns — all
+                                # target_tp_ranks are selected real ranks
                                 bootstrap_info["is_dummy"] = False
                             logger.debug(
                                 f"Fetched bootstrap info: {bootstrap_info} for DP {self.prefill_dp_rank} CP {target_cp_rank} TP {target_tp_rank} PP {target_pp_rank}"
@@ -1680,6 +1764,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.kv_cache_dtype: Optional[str] = None
         self.follow_bootstrap_room: Optional[bool] = None
         self.enable_dsa_cache_layer_split: Optional[bool] = None
+        self.enable_kv_cache_sharding: Optional[bool] = None
         self.prefill_http_port: Optional[int] = None
         self.prefill_port_table: Dict[
             int, Dict[int, Dict[int, Dict[int, PrefillRankInfo]]]
@@ -1781,6 +1866,11 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 data.get("enable_dsa_cache_layer_split", False)
             )
 
+        if self.enable_kv_cache_sharding is None:
+            self.enable_kv_cache_sharding = bool(
+                data.get("enable_kv_cache_sharding", False)
+            )
+
         if system_dp_size == 1:
             dp_group = attn_dp_rank
         else:
@@ -1845,6 +1935,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                     else True
                 ),
                 enable_dsa_cache_layer_split=bool(self.enable_dsa_cache_layer_split),
+                enable_kv_cache_sharding=bool(self.enable_kv_cache_sharding),
                 prefill_http_port=self.prefill_http_port,
             )
             return web.json_response(dataclasses.asdict(info), status=200)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2393,7 +2393,16 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
             )
-        self._record_transfer_indices(kv_indices, state_indices)
+        # Nonzero CP ranks still enqueue the final chunk so their completion
+        # notification is emitted, but the worker suppresses replicated state
+        # from those ranks. Keep the transfer metric aligned with the bytes
+        # that are actually sent.
+        metric_state_indices = (
+            None
+            if self.kv_mgr._should_skip_cp_replicated_state_transfer()
+            else state_indices
+        )
+        self._record_transfer_indices(kv_indices, metric_state_indices)
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1159,9 +1159,17 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     dst_info = self.decode_kv_args_table[req.agent_name]
                     decode_tp_size = dst_info.decode_tp_size
 
+                    notif = (
+                        f"{req.room}_kv_{kv_chunk.chunk_id}"
+                        f"_{int(kv_chunk.is_last_chunk)}_{self.transfer_source_rank}"
+                    )
+
                     # Skip KV RDMA transfer when there are no pages to send
-                    # (e.g., decode-side radix cache matched the entire prefix).
-                    # Aux data is still sent below when is_last_chunk=True.
+                    # (decode-side radix cache matched the entire prefix, this
+                    # rank owns no page of the chunk under KV cache sharding, or
+                    # this rank holds no attention KV at all). The chunk id is
+                    # still accounted for below, and aux data is still sent when
+                    # is_last_chunk=True.
                     if (
                         len(kv_chunk.prefill_kv_indices) > 0
                         and self.kv_args.kv_data_ptrs
@@ -1189,11 +1197,6 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                                 )
 
                         src_prefill_kv_indices = kv_chunk.prefill_kv_indices
-
-                        notif = (
-                            f"{req.room}_kv_{kv_chunk.chunk_id}"
-                            f"_{int(kv_chunk.is_last_chunk)}_{self.transfer_source_rank}"
-                        )
 
                         # Decide which kv send path to use:
                         #   1. Staging (heterogeneous TP, both sides have
@@ -1304,6 +1307,18 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
                         if kv_xfer_handle is not None:
                             handles.append(kv_xfer_handle)
+                    elif not kv_chunk.is_last_chunk:
+                        # Zero pages for this rank on a non-final chunk: deliver
+                        # the chunk notif standalone. chunk_id advances whenever
+                        # the request as a whole has pages to send, so a rank
+                        # that happens to own none of this chunk's pages (KV
+                        # cache sharding assigns them round-robin) still has to
+                        # claim the id -- the receiver requires every id in
+                        # [0, expected) from every source rank, and a silently
+                        # skipped id hangs it until the transfer timeout. The
+                        # final chunk instead reports its count through the aux
+                        # "nokv" marker below.
+                        self.agent.send_notif(req.agent_name, notif.encode("ascii"))
 
                     if kv_chunk.is_last_chunk:
                         dst_info = self.decode_kv_args_table[req.agent_name]
@@ -1327,9 +1342,11 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
                         if kv_chunk.prefill_aux_index is None:
                             raise RuntimeError("Missing aux index for last chunk")
-                        # A no-KV notification still identifies its PP source.
-                        # Empty non-final chunks do not consume chunk IDs, so a
-                        # final no-KV chunk_id equals the prior KV chunk count.
+                        # A no-KV notification still identifies its PP source and
+                        # reports chunk_id as the expected KV-chunk count: the
+                        # final chunk carried nothing, and every earlier id was
+                        # claimed either by its RDMA transfer or by the
+                        # standalone notif above.
                         aux_notif = f"{req.room}_aux"
                         if (
                             len(kv_chunk.prefill_kv_indices) == 0

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -63,6 +63,7 @@ from sglang.srt.managers.schedule_batch import (
     Req,
     ScheduleBatch,
 )
+from sglang.srt.mem_cache.allocator.page_interleave import page_interleave_shard_size
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     kv_to_page_num,
@@ -172,8 +173,13 @@ class PrefillBootstrapQueue:
         self.gloo_group = gloo_group
         self.scheduler = scheduler
         self.scheduler_stage_metrics = scheduler_stage_metrics
+        # Capacity bound in the allocator's (logical) token units — widened
+        # by the shard-group size under logical-page KV sharding.
         self.max_total_num_tokens = (
             self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
+            * page_interleave_shard_size(
+                self.scheduler.tp_worker.model_runner.token_to_kv_pool_allocator
+            )
         )
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get():
@@ -386,6 +392,21 @@ class PrefillBootstrapQueue:
             self.scheduler.token_to_kv_pool_allocator.page_size,
         )
         req.disagg_kv_sender.init(num_pages, req.metadata_buffer_index)
+        if (
+            get_parallel().enable_kv_cache_sharding
+            and self.kv_manager.kv_shard_size > 1
+        ):
+            # Logical-page KV sharding: chunk starts must stay page-aligned —
+            # the sender samples one wire entry per physical page (stride
+            # ps), so an off-page start would misalign every sample.
+            # Ownership itself is value-derived (owner = logical page % N in
+            # filter_kv_indices_for_shard_rank), independent of where send
+            # position 0 sits.
+            physical_page_size = self.token_to_kv_pool.page_size
+            assert decode_prefix_len % physical_page_size == 0, (
+                f"decode-cached prefix ({decode_prefix_len}) must be "
+                f"page-aligned under KV sharding"
+            )
         req.pending_bootstrap = False
         return True
 
@@ -638,6 +659,8 @@ class SchedulerDisaggregationPrefillMixin:
 
             # Update last_batch
             self.last_batch = batch
+            if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
+                self.invariant_checker.self_check_during_busy()
 
     @torch.no_grad()
     def event_loop_overlap_disagg_prefill(self: Scheduler) -> None:
@@ -691,6 +714,8 @@ class SchedulerDisaggregationPrefillMixin:
 
             # Update last_batch
             self.last_batch = batch
+            if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
+                self.invariant_checker.self_check_during_busy()
 
     def process_batch_result_disagg_prefill(
         self: Scheduler,
@@ -1157,9 +1182,9 @@ class SchedulerDisaggregationPrefillMixin:
         if cached_end <= req.start_send_idx:
             return
         if cached_end % self.token_to_kv_pool_allocator.page_size != 0:
-            # DCP radix hits can end on a logical cache-page boundary that is
-            # not a complete physical DCP page. The regular final send covers
-            # the full range; only skip this optional early-send optimization.
+            # Under DCP the allocator page is wider than the kernel page and
+            # a radix hit may end inside one. The regular final send covers the
+            # full range; only this optional early send is skipped.
             return
         # Early-send issues the KV read before this step's forward is enqueued,
         # but under overlap scheduling the PRIOR step's prefill forward may still
@@ -1342,6 +1367,10 @@ class SchedulerDisaggregationPrefillMixin:
                     kv_indices
                 )
             )
+            # Under logical-page KV sharding these remain logical page ids:
+            # PageInterleavePoolAllocator intentionally inherits the identity
+            # transfer translation. The sender derives ownership from each id
+            # and emits the owning rank's local page id.
             page_indices = kv_to_page_indices(kv_indices, page_size)
             segment_is_last = last_chunk and is_final_segment
             if not req.disagg_kv_sender.should_send_kv_chunk(

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -705,6 +705,36 @@ def _get_cp_rank_page_bounds(
     return local_start, local_start + n_pages
 
 
+def filter_kv_indices_for_shard_rank(
+    kv_mgr: CommonKVManager,
+    kv_indices: np.ndarray,
+    index_slice: slice,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Ownership-driven page filter for logical-page KV cache sharding.
+
+    ``kv_indices`` holds one entry per PHYSICAL page position of this chunk;
+    the entry value is the LOGICAL page id ``l = loc // ps``, identical on
+    every rank (mirrored ``req_to_token``). Ownership is derived from the
+    value — owner rank ``l % shard_size`` — so the filter is independent of
+    the allocator's placement policy. The owned entries are emitted as wire
+    values ``l // shard_size``: the owner's local page id in its own pool, so
+    the decode side needs no change.
+
+    Returns the owned wire values and an int64 positions array (in the
+    request's canonical send-position space) replacing the contiguous
+    ``index_slice`` contract — decode-side dst pairing is positional and
+    consumes a fancy index the same way it consumes a slice.
+    """
+    shard_rank = kv_mgr.kv_shard_rank
+    shard_size = kv_mgr.kv_shard_size
+    chunk_start = index_slice.start if index_slice.start is not None else 0
+    chunk_end = index_slice.stop if index_slice.stop is not None else chunk_start
+    positions = np.arange(chunk_start, chunk_end, dtype=np.int64)
+    logical_pages = np.asarray(kv_indices)
+    owned = logical_pages % shard_size == shard_rank
+    return logical_pages[owned] // shard_size, positions[owned]
+
+
 def filter_kv_indices_for_cp_rank(
     kv_mgr: CommonKVManager,
     kv_indices: np.ndarray,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -443,6 +443,9 @@ class Envs:
     SGLANG_ENABLE_NVTX_OPERATIONS = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_OPERATIONS_ENABLE_PROFILE"
     )
+    # NVTX ranges for the logical-page KV sharding forward path (plan
+    # capture, layer-ahead prefix gather, compute-side slot waits).
+    SGLANG_ENABLE_NVTX_KV_SHARD = EnvBool(False)
     SGLANG_RECORD_STEP_TIME = EnvBool(False)
     SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE = EnvBool(False)
     # Opt-in: emit one CUDA-graph capture trace per captured batch size (per-bs).

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -22,6 +22,10 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
 )
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.kv_shard_hooks import (
+    get_kv_shard_pool,
+    prepare_kv_shard_forward,
+)
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
@@ -49,6 +53,7 @@ from sglang.srt.utils.common import get_device_capability
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.mem_cache.page_interleave_pool import PageInterleaveKVPoolMixin
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 from sgl_kernel import merge_state_v2
@@ -148,6 +153,10 @@ class FlashAttentionBackend(AttentionBackend):
     needs_cpu_seq_lens: bool = False
     supports_ragged_verify_graph: bool = True
 
+    # Set from the pool type in __init__; the class default keeps the extend
+    # metadata guard readable on instances built with __new__ (test stubs).
+    _kv_shard_pool: Optional[PageInterleaveKVPoolMixin] = None
+
     # Chunked-prefix attention reads the stable ForwardBatch cu-seqlens and
     # KV-index buffers directly, so it needs no backend-private replay state.
     supports_full_cuda_graph_chunked_prefix = True
@@ -207,6 +216,12 @@ class FlashAttentionBackend(AttentionBackend):
             isinstance(model_runner.token_to_kv_pool, SWAKVPool)
             and model_runner.token_to_kv_pool.swa_layer_nums > 0
         )
+
+        self._kv_shard_pool = get_kv_shard_pool(self.token_to_kv_pool)
+        # begin_shard_extend builds the owner-major gather plan from host-side
+        # prefix/final lengths. Normal FA3 metadata is device-only, so opt the
+        # sharded variant back into FutureMap's CPU mirror publication.
+        self.needs_cpu_seq_lens = self._kv_shard_pool is not None
 
         self.topk = get_spec().speculative_eagle_topk or 0
         self.speculative_num_steps = speculative_num_steps
@@ -1133,6 +1148,23 @@ class FlashAttentionBackend(AttentionBackend):
                         forward_batch.out_cache_loc
                     )
                 )
+
+        # Logical-page KV sharding: capture the batch's gather plan and swap the
+        # page table to scratch rows. During a sharded extend, attention reads
+        # the assembled [prefix | chunk] scratch, never the striped pool rows;
+        # the plan capture also kicks the first layer's prefix gather.
+        #
+        # Runs after KVIndexTranslator and before the `// page_size` reduction.
+        # The unified-memory UnifiedKVPool and page-interleaved pools are
+        # alternatives, so at most one translation fires.
+        if self._kv_shard_pool is not None and prepare_kv_shard_forward(
+            self._kv_shard_pool,
+            self.req_to_token,
+            forward_batch,
+        ):
+            metadata.page_table = self._kv_shard_pool.translate_loc_to_scratch(
+                metadata.page_table
+            ).to(torch.int32)
 
         # Convert the page table to a strided format which is needed by FA3 API
         if self.page_size > 1 and not _unified_read:

--- a/python/sglang/srt/layers/attention/kv_shard_hooks.py
+++ b/python/sglang/srt/layers/attention/kv_shard_hooks.py
@@ -1,0 +1,67 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Logical-page KV-shard helpers shared by attention backends.
+
+Page-interleaved pools build one gather plan per extend batch. Keeping pool
+detection and that begin/end lifecycle here prevents each compatible attention
+backend from implementing a subtly different version of the contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.mem_cache.page_interleave_pool import PageInterleaveKVPoolMixin
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def get_kv_shard_pool(token_to_kv_pool) -> Optional[PageInterleaveKVPoolMixin]:
+    """Return the page-interleaved pool, if logical-page sharding is active."""
+    return (
+        token_to_kv_pool
+        if isinstance(token_to_kv_pool, PageInterleaveKVPoolMixin)
+        else None
+    )
+
+
+def prepare_kv_shard_forward(
+    pool: PageInterleaveKVPoolMixin,
+    req_to_token: torch.Tensor,
+    forward_batch: ForwardBatch,
+) -> bool:
+    """Update the pool's gather plan and report whether this is an extend."""
+    if not forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed():
+        pool.end_shard_extend()
+        return False
+
+    req_pool_indices = forward_batch.req_pool_indices
+    prefix_lens = forward_batch.extend_prefix_lens_cpu
+    seq_lens = forward_batch.seq_lens_cpu
+    if req_pool_indices is None or prefix_lens is None or seq_lens is None:
+        raise RuntimeError(
+            "KV-sharded attention requires request indices and CPU length metadata"
+        )
+
+    pool.begin_shard_extend(
+        req_to_token,
+        req_pool_indices,
+        prefix_lens,
+        seq_lens,
+    )
+    return True

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -50,6 +50,10 @@ from sglang.srt.layers.attention.flashinfer_mla_backend import (
     FlashInferMLAAttnBackend,
     FlashInferMLAMultiStepDraftBackend,
 )
+from sglang.srt.layers.attention.kv_shard_hooks import (
+    get_kv_shard_pool,
+    prepare_kv_shard_forward,
+)
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
 from sglang.srt.layers.dcp.layout import get_dcp_lens
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
@@ -239,6 +243,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         self.q_data_type = model_runner.dtype
         self.page_size = model_runner.page_size
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self._kv_shard_pool = get_kv_shard_pool(model_runner.token_to_kv_pool)
+        self.needs_cpu_seq_lens |= self._kv_shard_pool is not None
 
         # Workspace allocation
         self.workspace_size = DEFAULT_WORKSPACE_SIZE_MB * 1024 * 1024
@@ -812,6 +818,13 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""
+        if self._kv_shard_pool is not None:
+            prepare_kv_shard_forward(
+                self._kv_shard_pool,
+                self.req_to_token,
+                forward_batch,
+            )
+
         self._decode_kernel_loc = None
         # Delegate to parent for non-decode modes.
         if (

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1133,6 +1133,15 @@ class Req(ReqDllmMixin):
         # per-component nodes this req skipped locking (e.g. mamba on the decode
         # hold, already COW'd), so their dec releases only what it took.
         self.skip_lock_node_ids: dict = {}
+        # Logical-page KV sharding: rotation base of the chain this request
+        # extends (owner of position-page P is (base + P) % shard_size).
+        # Refreshed at every sharded alloc — read through last_node, or drawn
+        # least-full for a new chain — and consumed by the radix insert to
+        # stamp new tree nodes. Allocation itself must NOT read it back when
+        # a tree node is available (the cache_unfinished_req dedup rebind
+        # would make it stale); the only allocation-time reader is the
+        # ChunkCache fallback, which has no tree nodes and no rebind.
+        self.kv_rotation_base: Optional[int] = None
 
         # Whether or not if it is chunked. It increments whenever
         # it is chunked, and decrement whenever chunked request is
@@ -1820,6 +1829,7 @@ class Req(ReqDllmMixin):
         self.indexer_topk = None
         self.last_node = None
         self.kv.cache_protected_len = 0
+        self.kv_rotation_base = None
         self.num_matched_prefix_tokens = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -585,6 +585,41 @@ class PrefillAdder:
         self.dsa_prefill_cp_in_seq_split = is_dsa_prefill_cp_in_seq_split()
         self.max_running_requests = max_running_requests
         self.prefill_context_parallel_enabled = is_prefill_context_parallel_enabled()
+        # Logical-page KV sharding: the physical-page quantum all mid-request
+        # chunk boundaries must land on; 0 when sharding is off. A sharded
+        # batch may hold several requests, but only as many as the assembly
+        # scratch fits — _kv_shard_reserve_scratch gates each admission.
+        from sglang.srt.mem_cache.allocator.page_interleave import (
+            page_interleave_shard_size,
+        )
+
+        kv_shard_size = page_interleave_shard_size(self.token_to_kv_pool_allocator)
+        self.kv_shard_granule = (
+            self.token_to_kv_pool_allocator.page_size if kv_shard_size > 1 else 0
+        )
+        self.kv_shard_size = kv_shard_size
+        # Assembly-scratch admission budget: a sharded batch's padded prefix
+        # gather spans N * sum_i ceil(prefix_pages_i / N) pages and its
+        # ps-ceiled extends fill the chunk region — both must fit the
+        # per-batch scratch the pool provisioned (PageShardSpec), so
+        # _kv_shard_reserve_scratch gates every admission below. None when
+        # sharding is off.
+        self.kv_shard_scratch_spec = (
+            self.token_to_kv_pool_allocator.shard_spec if kv_shard_size > 1 else None
+        )
+        self.kv_shard_block_bound_pages = 0
+        self.kv_shard_chunk_pages = 0
+        # Per-request KV reserve charged at admission. Stock alloc_extend can
+        # consume up to one extra page per request beyond the extend length;
+        # under sharding the min-class admission gate needs one page per
+        # class (the ceil(K/N) rounding of cyclic class draws, phase-
+        # agnostic) — reserve N*ps so admission defers (NO_TOKEN) instead of
+        # over-committing into the alloc path's fail-loud RuntimeError.
+        self.per_req_token_overhead = (
+            kv_shard_size * self.kv_shard_granule
+            if self.kv_shard_granule
+            else self.page_size
+        )
         self.prefill_max_requests = prefill_max_requests
         self.prefill_delayer_single_pass = prefill_delayer_single_pass
         self.max_prefill_bs = max_prefill_bs
@@ -842,8 +877,9 @@ class PrefillAdder:
         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
 
-        # alloc_extend reserves an extra page_size per request to make sure the budget doesn't over-commit
-        page_overhead = self.page_size
+        # alloc_extend reserves an extra page_size per request to make sure the
+        # budget doesn't over-commit (widened under KV sharding — see __init__).
+        page_overhead = self.per_req_token_overhead
         # `mamba_gap_reserve` (shared Mamba pool only; 0 otherwise) charges the new
         # mamba state's shared-gap cost to BOTH full budgets: the slot is allocated
         # immediately (counts against `cur_rem`) and held for the request lifetime
@@ -954,6 +990,50 @@ class PrefillAdder:
         # carried from a previous scheduling of this req.
         req.skip_lock_node_ids = {}
 
+    def _kv_shard_reserve_scratch(self, prefix_len: int, extend_len: int) -> bool:
+        """Reserve assembly-scratch capacity for one sharded admission.
+
+        The batch's prefix gather is padded to
+        ``N * sum_i ceil(prefix_pages_i / N)`` pages (each request's chain is
+        one cyclic rotation run, so a rank owns at most ceil(K_i/N) of its
+        pages) and each extend fills ``ceil(extend_i / ps)`` chunk pages.
+        Returns False — caller defers the request to a later batch — when
+        either region would overflow; a single request always fits (the
+        regions are sized for one full-context prefix and one max chunk).
+        True (no-op) when sharding is off.
+        """
+        if self.kv_shard_scratch_spec is None:
+            return True
+        ps = self.kv_shard_granule
+        shard_size = self.kv_shard_size
+        block = self.kv_shard_block_bound_pages + -(-(prefix_len // ps) // shard_size)
+        chunk = self.kv_shard_chunk_pages + -(-extend_len // ps)
+        if (
+            shard_size * block * ps > self.kv_shard_scratch_spec.max_prefix_tokens
+            or chunk * ps > self.kv_shard_scratch_spec.chunk_tokens
+        ):
+            if self.kv_shard_block_bound_pages == 0 and self.kv_shard_chunk_pages == 0:
+                # First reservation of the pass: a single request must always
+                # fit (the regions are sized for one full-context prefix and
+                # one max chunk). Reaching here means an admission path
+                # bypassed the chunking the sizing assumes (e.g. chunked
+                # prefill silently disabled after the sharding validation) —
+                # deferring would retry the same queue head forever, a
+                # silent scheduling livelock. Fail loud instead.
+                raise RuntimeError(
+                    "request cannot fit the sharded assembly scratch even in "
+                    f"an empty batch (prefix_len={prefix_len}, extend_len="
+                    f"{extend_len}, max_prefix_tokens="
+                    f"{self.kv_shard_scratch_spec.max_prefix_tokens}, "
+                    f"chunk_tokens={self.kv_shard_scratch_spec.chunk_tokens}); "
+                    "KV sharding requires chunked prefill sized within the "
+                    "assembly scratch"
+                )
+            return False
+        self.kv_shard_block_bound_pages = block
+        self.kv_shard_chunk_pages = chunk
+        return True
+
     def add_dllm_staging_req(self, req: Req):
         assert self.dllm_config is not None
         _rem_tokens = self._get_dllm_remain_tokens()
@@ -1010,6 +1090,21 @@ class PrefillAdder:
                 if self.is_hybrid_swa:
                     return req
                 _rem_tokens = self.rem_chunk_tokens
+            if self.kv_shard_granule:
+                # Logical-page KV sharding: mid-request chunk boundaries land
+                # on the physical page so the next chunk's prefix stays
+                # page-aligned (an off-page boundary would straddle one page
+                # across the prefix/chunk scratch regions and break the
+                # stride-ps wire sampling). Floor the ABSOLUTE boundary so
+                # alignment holds regardless of where the prefix hit landed.
+                # When flooring would leave no budget, fall back to
+                # rem_chunk_tokens like the <= 0 case above — alignment then
+                # self-heals on the next chunk.
+                prefix_len = len(req.prefix_indices)
+                floored = (
+                    prefix_len + _rem_tokens
+                ) // self.kv_shard_granule * self.kv_shard_granule - prefix_len
+                _rem_tokens = floored if floored > 0 else self.rem_chunk_tokens
 
         # A mid-chunk rank prefills this pass regardless of the delayer
         # verdict, so report prefillable=True and ignore the result.
@@ -1027,6 +1122,16 @@ class PrefillAdder:
         )
         truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
+        # The continuing chunk is admitted first and a single request always
+        # fits the scratch by construction (regions sized for one
+        # full-context prefix + one max chunk). NOT inside an assert: the
+        # call carries the batch's reservation accounting and must survive
+        # python -O.
+        reserved = self._kv_shard_reserve_scratch(
+            prefix_len=len(req.prefix_indices), extend_len=new_len
+        )
+        if not reserved:
+            raise RuntimeError("chunked request exceeds the sharded assembly scratch")
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
@@ -1065,7 +1170,9 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        paged_input = self.ceil_paged_tokens(cand_extend_input_len)
+        paged_input = (
+            self.ceil_paged_tokens(cand_extend_input_len) + self.per_req_token_overhead
+        )
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into the
         # budget gate so admission can't over-commit (0 for baseline / non-Mamba).
         paged_input += self._mamba_gap_budget_for_req(req)
@@ -1116,9 +1223,7 @@ class PrefillAdder:
         if not self.is_hybrid_swa:
             # Skip this logic for swa. The SWA has different memory management, and
             # this mechanism is underestimating the memory usage.
-            cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(
-                cand_extend_input_len
-            )
+            cur_rem_tokens = self.cur_rem_tokens - paged_input
             tokens_freed = 0
             for i, (tokens_left, tokens_occupied) in enumerate(self.req_states):
                 # tokens_left gives a reservative calculation as the last token is not stored
@@ -1160,6 +1265,11 @@ class PrefillAdder:
                 return tile_stop
 
             # Non-chunked prefill — the whole sequence is committed this iter.
+            if not self._kv_shard_reserve_scratch(
+                prefix_len=len(req.prefix_indices),
+                extend_len=cand_extend_input_len,
+            ):
+                return AddReqResult.OTHER
             req.set_extend_range(
                 len(req.prefix_indices), len(req.full_untruncated_fill_ids)
             )
@@ -1180,6 +1290,12 @@ class PrefillAdder:
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
+
+            # Keep this after the non-mutating tile gate: reserving shard
+            # scratch updates this pass's accounting and must only happen for
+            # a request that will actually be admitted.
+            if not self._kv_shard_reserve_scratch(prefix_len=0, extend_len=trunc_len):
+                return AddReqResult.OTHER
 
             assert len(req.prefix_indices) == 0
             req.set_extend_range(
@@ -1203,7 +1319,7 @@ class PrefillAdder:
         # TODO support cp with multiple requests
         # Enabling context parallelism currently presents precision issues;
         # therefore, the prefill-batch setting is temporarily set to 1.
-        if (self.dsa_prefill_cp_in_seq_split) and len(self.can_run_list) >= 1:
+        if self.dsa_prefill_cp_in_seq_split and len(self.can_run_list) >= 1:
             return AddReqResult.OTHER
 
         if (x := self.prefill_max_requests) is not None and len(self.can_run_list) >= x:
@@ -1222,7 +1338,7 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        total_tokens = cand_extend_input_len + max_new + self.page_size
+        total_tokens = cand_extend_input_len + max_new + self.per_req_token_overhead
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into
         # `total_tokens` so both `rem_total_tokens` gates reflect the joint budget.
         # Read before `init_load_back` binds `req.mamba_pool_idx` — after that
@@ -1361,6 +1477,10 @@ class PrefillAdder:
                     return tile_stop
 
                 # Non-chunked prefill — the whole sequence is committed this iter.
+                if not self._kv_shard_reserve_scratch(
+                    prefix_len=len(req.prefix_indices), extend_len=input_tokens
+                ):
+                    return AddReqResult.OTHER
                 req.set_extend_range(
                     len(req.prefix_indices), len(req.full_untruncated_fill_ids)
                 )
@@ -1398,6 +1518,14 @@ class PrefillAdder:
 
                 now_input_len = trunc_len + len(req.prefix_indices)
                 now_input_len = now_input_len // self.page_size * self.page_size
+                if self.kv_shard_granule:
+                    # Floor the absolute boundary to the sharding granule so
+                    # later chunks' prefixes stay aligned. Redundant while the
+                    # granule equals self.page_size, and load-bearing if it
+                    # ever widens.
+                    now_input_len = (
+                        now_input_len // self.kv_shard_granule * self.kv_shard_granule
+                    )
                 trunc_len = now_input_len - len(req.prefix_indices)
 
                 if trunc_len <= 0:
@@ -1407,6 +1535,14 @@ class PrefillAdder:
                     tile_stop := self._check_prefill_tile_budget(trunc_len)
                 ) is not None:
                     return tile_stop
+
+                # Keep this after the non-mutating tile gate: reserving shard
+                # scratch updates this pass's accounting and must only happen
+                # for a request that will actually be admitted.
+                if not self._kv_shard_reserve_scratch(
+                    prefix_len=len(req.prefix_indices), extend_len=trunc_len
+                ):
+                    return AddReqResult.OTHER
 
                 # Chunked prefill
                 req.set_extend_range(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -16,6 +16,7 @@
 import dataclasses
 import faulthandler
 import logging
+import math
 import os
 import signal
 import sys
@@ -278,6 +279,7 @@ from sglang.srt.managers.utils import (
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
+from sglang.srt.mem_cache.allocator.page_interleave import page_interleave_shard_size
 from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
@@ -430,6 +432,11 @@ class Scheduler(
     SchedulerMlxOverlapMixin,
 ):
     """A scheduler that manages a tensor parallel GPU worker."""
+
+    # Factor by which KV sharding widens the allocator's index space over one
+    # rank's physical pool. Resolved in init_memory_pool_and_cache; the class
+    # default keeps readers that run before the pool exists at stock 1x units.
+    kv_shard_widening: int = 1
 
     # Class-level default so on_idle's stall gate works even if a fork
     # overrides init_load_publisher (which would otherwise not set it).
@@ -606,6 +613,9 @@ class Scheduler(
         self.swa_tokens_per_layer = result.swa_tokens_per_layer
         self.req_to_token_pool = result.req_to_token_pool
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
+        self.kv_shard_widening = page_interleave_shard_size(
+            self.token_to_kv_pool_allocator
+        )
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
         if self.enable_hierarchical_cache:
@@ -1658,6 +1668,7 @@ class Scheduler(
         """Initialize deterministic inference configuration for different attention backends."""
         if not get_exec().deterministic.enable_deterministic_inference:
             self.truncation_align_size = None
+            self._apply_kv_shard_truncation_align()
             return
 
         backend_sizes = {
@@ -1671,6 +1682,21 @@ class Scheduler(
         self.truncation_align_size = (
             get_int_env_var(env_var, default_size) if env_var else None
         )
+        self._apply_kv_shard_truncation_align()
+
+    def _apply_kv_shard_truncation_align(self):
+        # Logical-page KV sharding: every chunk boundary must land on a
+        # physical-page boundary (the allocator's working quantum) so no
+        # page straddles the prefix/chunk scratch regions and the stride-ps
+        # wire sampling stays exact. Compose with the deterministic-inference
+        # value via lcm when both are set.
+        if self.kv_shard_widening <= 1:
+            return
+        granule = self.token_to_kv_pool_allocator.page_size
+        if self.truncation_align_size is None:
+            self.truncation_align_size = granule
+        else:
+            self.truncation_align_size = math.lcm(self.truncation_align_size, granule)
 
     def init_request_dispatcher(self):
         self._request_dispatcher = TypeBasedDispatcher(
@@ -2295,8 +2321,12 @@ class Scheduler(
             enable_hisparse=self.enable_hisparse,
             full_tokens_per_layer=self.full_tokens_per_layer,
             swa_tokens_per_layer=self.swa_tokens_per_layer,
+            # DCP and logical-page KV sharding widen the allocator's index
+            # space; the observer's total must be in the same (logical) units
+            # as allocator.available_size() and the radix counters.
             max_total_num_tokens=self.max_total_num_tokens
-            * get_parallel().attn_dcp_size,
+            * get_parallel().attn_dcp_size
+            * self.kv_shard_widening,
             get_last_batch=lambda: self.last_batch,
             get_running_batch=lambda: self.running_batch,
         )
@@ -2309,7 +2339,7 @@ class Scheduler(
             page_size=self.page_size,
             full_tokens_per_layer=self.full_tokens_per_layer,
             swa_tokens_per_layer=self.swa_tokens_per_layer,
-            max_total_num_tokens=self.max_total_num_tokens,
+            max_total_num_tokens=self.max_total_num_tokens * self.kv_shard_widening,
             tree_cache=self.tree_cache,
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             req_to_token_pool=self.req_to_token_pool,
@@ -2367,7 +2397,9 @@ class Scheduler(
             disaggregation_mode=self.disaggregation_mode,
             ps=self.ps,
             server_args=self.server_args,
-            max_total_num_tokens=self.max_total_num_tokens,
+            # KV sharding widens the allocator's index space, so the capacity
+            # reported to the router is widened too. DCP is deliberately not.
+            max_total_num_tokens=self.max_total_num_tokens * self.kv_shard_widening,
             max_running_requests=self.max_running_requests,
             pool_stats_observer=self.pool_stats_observer,
             tp_worker=self.tp_worker,
@@ -2474,19 +2506,23 @@ class Scheduler(
             max_new_tokens = min(max_new_tokens, self.max_new_tokens_limit)
 
         # Keep this bound consistent with PrefillAdder's admission budget:
-        # ceil_page(input_len) + max_new_tokens + page_size must be strictly
-        # smaller than max_total_num_tokens. Otherwise a request can be accepted
-        # into the waiting queue but can never be scheduled, blocking the queue
-        # and eventually making health checks fail.
+        # ceil_page(input_len) + max_new_tokens + per-request page overhead must
+        # be strictly smaller than max_total_num_tokens. Otherwise a request can
+        # be accepted into the waiting queue but can never be scheduled, blocking
+        # the queue and eventually making health checks fail. PrefillAdder charges
+        # one page per shard, and measures the budget with
+        # allocator.available_size(), so widen both capacity and overhead here.
         paged_input_len = -(-input_len // self.page_size) * self.page_size
         req.sampling_params.max_new_tokens = max(
             0,
             min(
                 max_new_tokens,
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens * get_parallel().attn_dcp_size
+                self.max_total_num_tokens
+                * get_parallel().attn_dcp_size
+                * self.kv_shard_widening
                 - paged_input_len
-                - self.page_size
+                - self.page_size * self.kv_shard_widening
                 - 1,
             ),
         )

--- a/python/sglang/srt/managers/scheduler_components/invariant_checker.py
+++ b/python/sglang/srt/managers/scheduler_components/invariant_checker.py
@@ -118,17 +118,39 @@ class SchedulerInvariantChecker:
             session_held = self.pool_stats_observer.session_held_tokens()
             total = self.max_total_num_tokens
         full_evictable_size = ps.full_evictable_size
-        allocator = self.token_to_kv_pool_allocator
-        if get_parallel().dcp_enabled and allocator.page_size > 1:
-            # DCP stores logical tokens in widened physical pages.  Prefix cache
-            # counters are logical-token based, while the allocator frees whole
-            # physical pages, so round cached tokens up to physical page units.
-            full_evictable_size = (
-                (full_evictable_size + allocator.page_size - 1)
-                // allocator.page_size
-                * allocator.page_size
-            )
         full_available = ps.full_available_size
+        allocator = self.token_to_kv_pool_allocator
+        class_watermark_msg = ""
+        from sglang.srt.mem_cache.allocator.page_interleave import (
+            page_interleave_shard_size,
+        )
+
+        kv_shard_size = page_interleave_shard_size(allocator)
+        widened_page_alloc = (
+            get_parallel().dcp_enabled or kv_shard_size > 1
+        ) and allocator.page_size > 1
+        if widened_page_alloc:
+            if kv_shard_size > 1:
+                # Rotated owner-classed KV sharding: the accounting identity
+                # needs the AGGREGATE free size — the admission-facing
+                # available_size() is the min-class capacity floor and
+                # under-reports the aggregate by the (bounded) class skew.
+                # The per-class free-page watermarks are exported alongside so
+                # a skewed class shows up in the log.
+                round_to = allocator.physical_page_size
+                full_available = allocator.aggregate_free_size()
+                class_watermark_msg = (
+                    f", class_free_pages={allocator.class_free_page_counts()}"
+                )
+            else:
+                # DCP stores logical tokens in widened allocator pages. Prefix
+                # cache counters are logical-token based, while the allocator
+                # frees whole pages, so round cached tokens up to allocator
+                # page units.
+                round_to = allocator.page_size
+            full_evictable_size = (
+                (full_evictable_size + round_to - 1) // round_to * round_to
+            )
         if isinstance(allocator, UnifiedMambaSWATokenToKVPoolAllocator):
             # Pair the static per-layer total with the conserve view, never the
             # byte-coordinated one -- see `conserve_full_available_size`.
@@ -142,12 +164,13 @@ class SchedulerInvariantChecker:
             total,
             uncached,
         )
-        if leak and get_parallel().dcp_enabled and allocator.page_size > 1:
-            # Radix/Mamba cache accounting is logical-token based while DCP full
-            # KV allocation is physical-page based. Partial physical pages can
-            # leave a small page-level slack even when all pages are owned by
-            # either the allocator or the prefix cache.
-            return False, f"{msg}, dcp_physical_page_slack_allowed=True"
+        msg += class_watermark_msg
+        if leak and widened_page_alloc:
+            # Radix/Mamba cache accounting is logical-token based while
+            # allocation is page based. Partial allocator pages
+            # can leave a small page-level slack even when all pages are owned
+            # by either the allocator or the prefix cache.
+            return False, f"{msg}, widened_page_slack_allowed=True"
         return leak, msg
 
     def _check_swa_pool(self, ps: PoolStats, uncached: int = 0) -> Tuple[bool, str]:
@@ -383,14 +406,21 @@ class SchedulerInvariantChecker:
         idx = torch.as_tensor([rpi for _, rpi, _ in active], device=rtt.device)
         allocs = torch.as_tensor([al for _, _, al in active], device=rtt.device)
         mask = torch.arange(row_width, device=rtt.device)[None, :] < allocs[:, None]
-        owner_pages = rtt[idx][mask] // self.page_size
+        owner_locs = rtt[idx][mask]
 
         # Sub-allocators to check: a flat allocator is its own single sub; a
-        # hybrid-SWA wrapper exposes full_attn_allocator + swa_attn_allocator.
+        # hybrid-SWA wrapper exposes full_attn_allocator + swa_attn_allocator;
+        # the classed sharding allocator keeps per-class lists instead of a
+        # flat free_pages and exposes them through get_all_free_pages().
+        from sglang.srt.mem_cache.allocator.page_interleave import (
+            page_interleave_shard_size,
+        )
+
         alloc = self.token_to_kv_pool_allocator
         sub_allocs = (
             [alloc]
             if getattr(alloc, "free_pages", None) is not None
+            or page_interleave_shard_size(alloc) > 1
             else [
                 sub
                 for n in ("full_attn_allocator", "swa_attn_allocator")
@@ -401,6 +431,10 @@ class SchedulerInvariantChecker:
         if not sub_allocs:
             return
 
+        # Page ids in the ALLOCATOR's page units (== the physical page for
+        # the classed sharding allocator, whose free lists hold logical page
+        # ids in the same unit).
+        owner_pages = owner_locs // sub_allocs[0].page_size
         # Check B: every sub-pool's free set has no duplicate pages.
         for i, sub in enumerate(sub_allocs):
             free = sub.get_all_free_pages()

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -540,10 +540,24 @@ class TpModelWorker(BaseTpWorker):
         self.model_runner.hisparse_coordinator = coordinator
 
     def get_worker_info(self):
+        from sglang.srt.mem_cache.allocator.page_interleave import (
+            page_interleave_shard_size,
+        )
+
+        # Decode context parallelism and logical-page KV sharding each widen
+        # the scheduler-visible index space over the physical per-rank pool
+        # (dcp_size splits a sequence across ranks; KV sharding stripes each
+        # logical page across shard_size ranks). At most one factor is above 1
+        # -- they are validated mutually exclusive -- so the product is the
+        # active widening and degenerates to 1x when neither is on.
+        kv_capacity = (
+            self.model_runner.effective_max_total_num_tokens
+            * self.ps.attn_dcp_size
+            * page_interleave_shard_size(self.model_runner.token_to_kv_pool_allocator)
+        )
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
-            - 1,
+            kv_capacity - 1,
         )
         return (
             self.model_runner.req_to_token_pool.schedulable_token_capacity(

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -17,6 +17,7 @@ from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_write_dsv4_decode,
     maybe_write_dsv4_extend,
 )
+from sglang.srt.mem_cache.allocator.page_interleave import page_interleave_shard_size
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.common import (
     MAMBA_STATE_PER_REQ_NO_CACHE,
@@ -181,13 +182,24 @@ def alloc_paged_token_slots_extend(
     req_pool_indices: Optional[torch.Tensor] = None,
     batch=None,
 ):
-    # Over estimate the number of tokens: assume each request needs a new page.
+    # Over estimate the number of tokens: assume each request needs a new page
+    # (one page per CLASS per request under sharding — the min-class
+    # availability floor must cover every request's ceil(K_i/N) rounding,
+    # matching the N*ps per-request admission reserve).
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    num_tokens = extend_num_tokens + len(seq_lens_cpu) * (
+        allocator.page_size * page_interleave_shard_size(allocator)
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     is_dsv4 = req_pool_indices is not None and hasattr(allocator, "c128_attn_allocator")
     extra_alloc_kwargs = {}
+    kv_shard_rotation_bases = None
+    if page_interleave_shard_size(allocator) > 1:
+        kv_shard_rotation_bases = _kv_shard_rotation_bases(
+            tree_cache=tree_cache, batch=batch, prefix_lens_cpu=prefix_lens_cpu
+        )
+        extra_alloc_kwargs["rotation_bases"] = kv_shard_rotation_bases
     if is_dsv4:
         extra_alloc_kwargs["req_pool_indices"] = req_pool_indices
         # Per-call per-req table for the C128 KV last_loc lookup.
@@ -223,7 +235,53 @@ def alloc_paged_token_slots_extend(
             tree_cache.pretty_print()
         raise RuntimeError(error_msg)
 
+    if kv_shard_rotation_bases is not None:
+        # The allocator resolved None entries (new chains) in place from the
+        # least-full class at each request's turn; record the bases for the
+        # radix insert to stamp onto new tree nodes (UnifiedTreeNode.rotation_base).
+        for req, base in zip(batch.reqs, kv_shard_rotation_bases):
+            req.kv_rotation_base = base
+
     return out_cache_loc
+
+
+def _kv_shard_rotation_bases(
+    tree_cache: BasePrefixCache, batch: ScheduleBatch, prefix_lens_cpu: torch.Tensor
+) -> list:
+    """Per-request rotation bases ``b_i`` of the batch's chains, host-only.
+
+    The owner class of position-page P is ``(b_i + P) % shard_size``. Rules:
+
+    - Read through ``req.last_node`` at alloc time, never a value cached on
+      the request: ``cache_unfinished_req`` can rebind a chunked request onto
+      another chain's canonical locs between chunks, changing the base. The
+      read goes through ``tree_cache.rotation_base_of`` because the node
+      handle is tree-specific (a NodeId on the unified tree).
+    - A request without a cached prefix starts a new chain: None here — the
+      allocator draws from the least-full class at that request's turn (so
+      the draw sees earlier requests' pops in the same batch) and resolves
+      the entry in place.
+    - ChunkCache has no tree nodes (``last_node`` is None); its chunked
+      continuations fall back to the base recorded on the request at the
+      previous chunk's alloc (no cross-request reuse, no rebind there).
+    """
+    assert batch is not None and len(batch.reqs) == len(prefix_lens_cpu)
+    bases = []
+    for i, req in enumerate(batch.reqs):
+        if int(prefix_lens_cpu[i]) == 0:
+            bases.append(None)
+            continue
+        node_base = tree_cache.rotation_base_of(req.last_node)
+        if node_base is not None:
+            bases.append(node_base)
+        else:
+            assert req.kv_rotation_base is not None, (
+                "sharded extend with a cached prefix but no rotation base: "
+                "req.last_node carries none and the request recorded none "
+                "at a previous alloc"
+            )
+            bases.append(req.kv_rotation_base)
+    return bases
 
 
 def alloc_req_slots(
@@ -273,7 +331,9 @@ def alloc_req_slots(
 def _alloc_page_size(batch: ScheduleBatch) -> int:
     # DCP swaps in an allocator whose page_size is the configured page_size *
     # dcp_size, so it can be > 1 even when tree_cache.page_size is 1; branch on
-    # the real allocator's page_size there. Elsewhere the two are equal.
+    # the real allocator's page_size there. Elsewhere the two are equal --
+    # including under KV sharding, which widens the index space but keeps the
+    # allocator page at the physical page.
     if (_is_hip or _is_cuda) and get_parallel().dcp_enabled:
         return batch.tree_cache.token_to_kv_pool_allocator.page_size
     return batch.tree_cache.page_size

--- a/python/sglang/srt/mem_cache/allocator/page_interleave.py
+++ b/python/sglang/srt/mem_cache/allocator/page_interleave.py
@@ -1,0 +1,406 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Allocator for logical-page KV sharding (see mem_cache/page_interleave.py).
+
+Rotated owner-classed page allocation:
+physical pages are handed out one at a time from N mirrored per-rank class
+free lists. Logical page ``l = loc // ps`` is owned by rank ``l % N`` and is
+that rank's local physical page ``l // N``, so class ``r``'s free list IS
+rank ``r``'s free pages. Ownership is derived from ``loc`` everywhere (write
+filter, gather plan, scratch translation, P/D send filter), which makes any
+class choice correct; balance is pure policy:
+
+- ``class(position-page P of a chain) = (b + P) % N`` where ``b`` is the
+  chain's rotation base — a new chain draws ``b`` from the least-full class,
+  an extension continues from the phase recorded on ``req.last_node``
+  (``TreeNode.rotation_base``). Within one cached prefix the owners are
+  exactly cyclic, so per-rank page counts differ by <= 1 and the prefix
+  gather stays a regular padded allgather.
+
+Every list, cursor decision, and pop is a pure function of the mirrored
+alloc/free stream, so the state is byte-identical across shard-group ranks
+by construction (SPMD, no consensus protocol). A freed page is immediately
+reusable: nothing strands a page until its whole logical group is free.
+
+``available_size`` reports the MIN-CLASS capacity floor
+(``N * min_r free_pages(r) * ps``): in-flight P/D transfers lock tree nodes,
+so an aggregate gate could admit a request whose tight class has nothing
+evictable — fail-loud where min-class admission defers. Rotation plus
+least-full seeding keeps the classes near-balanced, so the floor tracks the
+aggregate within the bounded skew.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class PageInterleavePoolAllocator(PagedTokenToKVPoolAllocator):
+    """Classed paged allocator over the shard-widened logical index space.
+
+    The inherited ``page_size`` is the PHYSICAL page — the working quantum of
+    every seam that reads it (radix-tree match, chunk flooring, admission
+    reserve arithmetic, free alignment, wire sampling). The widening is pure
+    index space: ``size`` logical slots = ``shard_size`` x one rank's
+    physical slots; per-rank HBM is unchanged.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        physical_page_size: int,
+        shard_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: KVCache,
+        need_sort: bool,
+        shard_spec=None,
+    ):
+        assert shard_size > 1, "PageInterleavePoolAllocator requires shard_size > 1"
+        # Set before super().__init__: the base constructor calls clear(),
+        # which builds the class lists from these.
+        self.physical_page_size = physical_page_size
+        self.shard_size = shard_size
+        # PageShardSpec (None only in unit tests): carries the assembly
+        # scratch capacities the PrefillAdder gates batch admission on.
+        self.shard_spec = shard_spec
+        super().__init__(
+            size * shard_size,
+            page_size=physical_page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kvcache,
+            need_sort=need_sort,
+        )
+
+    def clear(self):
+        # Logical pages l ∈ [0, shard_size) are reserved — physical page 0 of
+        # every rank (loc ∈ [0, shard_size * ps) is the padded/trash range).
+        # Class r's free list holds the allocatable logical pages with
+        # l % shard_size == r, ascending — exactly rank r's free physical
+        # pages 1..pages_per_rank at local page l // shard_size.
+        pages_per_rank = self.num_pages // self.shard_size
+        self.class_free_pages: List[torch.Tensor] = [
+            torch.arange(1, pages_per_rank + 1, dtype=torch.int64, device=self.device)
+            * self.shard_size
+            + r
+            for r in range(self.shard_size)
+        ]
+        self.class_release_pages: List[torch.Tensor] = [
+            torch.empty((0,), dtype=torch.int64, device=self.device)
+            for _ in range(self.shard_size)
+        ]
+        # None: free right away. A list: hold frees until free_group_end().
+        self.free_group = None
+        # free_segment() routes back to free(), so this stays empty; the paged
+        # base's free_group_end() reads it unconditionally.
+        self.free_page_reps_group = []
+        # Neutralize the base single-list attributes: every consumer of this
+        # allocator must go through the classed API (or fail loud on None),
+        # never a stale flat free list.
+        self.free_pages = None
+        self.release_pages = None
+
+    # ---- classed accounting ---------------------------------------------------
+
+    def class_free_page_counts(self) -> List[int]:
+        """Free pages per class (free + release) — the per-class watermarks
+        exported at the scheduler invariant-checker seam."""
+        return [
+            len(free) + len(release)
+            for free, release in zip(self.class_free_pages, self.class_release_pages)
+        ]
+
+    def available_size(self) -> int:
+        # Min-class capacity floor: a K-page request needs up to
+        # ceil(K / N) pages of EACH class (cyclic draws), so admission must
+        # gate on the tightest class, not the aggregate — the aggregate can
+        # be large while one class is fully protected by locked chains.
+        return self.shard_size * self.page_size * min(self.class_free_page_counts())
+
+    def aggregate_free_size(self) -> int:
+        """Total free logical slots across all classes — the accounting
+        identity's `available` term (the invariant checker); NOT an admission
+        gate (see available_size)."""
+        return self.page_size * sum(self.class_free_page_counts())
+
+    def least_full_class(self) -> int:
+        """Rotation base for a new chain: the class with the most free pages,
+        ties broken by the lowest class id. A pure function of the mirrored
+        class fills (SPMD-safe). Least-full seeding self-corrects the
+        per-chain <= 1-page remainders instead of letting them drift."""
+        counts = self.class_free_page_counts()
+        return max(range(self.shard_size), key=lambda r: (counts[r], -r))
+
+    def merge_and_sort_free(self):
+        for r in range(self.shard_size):
+            if len(self.class_release_pages[r]) > 0:
+                merged = torch.cat(
+                    (self.class_free_pages[r], self.class_release_pages[r])
+                )
+                self.class_free_pages[r], _ = torch.sort(merged)
+                self.class_release_pages[r] = torch.empty(
+                    (0,), dtype=torch.int64, device=self.device
+                )
+
+    # ---- alloc / free -----------------------------------------------------------
+
+    def alloc(self, need_size: int):
+        raise NotImplementedError(
+            "PageInterleavePoolAllocator allocates through alloc_extend only "
+            "(class draws follow the chain's rotation; a bare alloc has no "
+            "rotation base)"
+        )
+
+    @staticmethod
+    def _class_counts(start_class: int, new_pages: int, shard_size: int) -> List[int]:
+        """Pages drawn from each class by a cyclic run of ``new_pages`` pages
+        starting at ``start_class`` — closed-form, host-only."""
+        return [
+            new_pages // shard_size
+            + (1 if (c - start_class) % shard_size < new_pages % shard_size else 0)
+            for c in range(shard_size)
+        ]
+
+    def alloc_extend(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        num_new_pages: int = None,
+        rotation_bases: Optional[List[Optional[int]]] = None,
+    ):
+        """Pop one page per new position-page, class ``(b_i + P) % N`` per
+        request.
+
+        ``rotation_bases`` carries one entry per request: the chain's
+        rotation base, or None for a new chain. None entries are resolved IN
+        PLACE from the least-full class at that request's turn — a draw sees
+        the pops of earlier requests in the same batch, keeping the balance
+        policy exact at bs > 1 — and the caller reads the resolved values
+        back to stamp the requests for the radix insert.
+
+        Sync-free: per-class pop counts are closed-form from the host
+        lengths and the host rotation bases (the reason the base is host
+        metadata on radix nodes rather than derived from device locs).
+        Returns None when some needed class cannot supply its pages — the
+        caller's admission gate (min-class available_size + the N*ps
+        per-request reserve) makes that unreachable outside true OOM.
+        """
+        ps, shard_size = self.page_size, self.shard_size
+        bs = len(prefix_lens_cpu)
+        assert rotation_bases is not None and len(rotation_bases) == bs, (
+            "sharded alloc_extend needs one rotation base slot per request "
+            "(alloc_paged_token_slots_extend derives them from req.last_node)"
+        )
+
+        # Pass 1 (host, mirrored): resolve draw-at-turn bases and check the
+        # per-class supply against simulated fills, so the batch either
+        # commits whole or defers whole.
+        sim_counts = self.class_free_page_counts()
+        start_classes: List[int] = []
+        new_pages_list: List[int] = []
+        for i in range(bs):
+            prefix_len = int(prefix_lens_cpu[i])
+            seq_len = int(seq_lens_cpu[i])
+            assert prefix_len % ps == 0, (
+                f"sharded extends start page-aligned (the radix-tree match "
+                f"quantum and the chunk flooring guarantee it), got "
+                f"prefix_len={prefix_len}, page_size={ps}"
+            )
+            new_pages = -(-seq_len // ps) - prefix_len // ps
+            assert new_pages > 0
+            if rotation_bases[i] is None:
+                # New chain: least-full over the simulated fills (mirrored).
+                rotation_bases[i] = max(
+                    range(shard_size), key=lambda r: (sim_counts[r], -r)
+                )
+            start_class = (rotation_bases[i] + prefix_len // ps) % shard_size
+            start_classes.append(start_class)
+            new_pages_list.append(new_pages)
+            for c, need in enumerate(
+                self._class_counts(start_class, new_pages, shard_size)
+            ):
+                sim_counts[c] -= need
+            if self.debug_mode and prefix_len > 0:
+                # Owner congruence of the prefix end: the host-tracked phase
+                # must agree with the loc-derived owner (one D2H sync, debug
+                # only). A mismatch means a stale rotation base — the pool's
+                # plan would translate into the wrong rank's scratch block.
+                actual = int(last_loc[i].item()) // ps % shard_size
+                expected = (start_class - 1) % shard_size
+                assert actual == expected, (
+                    f"rotation base out of sync with the prefix locs (req "
+                    f"{i}): owner of the last prefix page is {actual}, host "
+                    f"phase says {expected}"
+                )
+        assert extend_num_tokens == sum(
+            int(seq_lens_cpu[i]) - int(prefix_lens_cpu[i]) for i in range(bs)
+        )
+        if min(sim_counts) < 0:
+            return None
+        # Under need_sort the pops slice class_free_pages only; merge the
+        # release lists in whenever any class's free list alone is shorter
+        # than its total need (= total count - simulated remainder).
+        needs = [
+            total - remaining
+            for total, remaining in zip(self.class_free_page_counts(), sim_counts)
+        ]
+        if self.need_sort and any(
+            needs[c] > len(self.class_free_pages[c]) for c in range(shard_size)
+        ):
+            self.merge_and_sort_free()
+
+        # Pass 2: commit the pops, one position-ordered page vector per
+        # request, concatenated in batch order (= out_cache_loc order).
+        out_parts = []
+        for i in range(bs):
+            new_pages = new_pages_list[i]
+            start_class = start_classes[i]
+            counts = self._class_counts(start_class, new_pages, shard_size)
+            # Interleave the class pops into one position-ordered page
+            # vector: position-page j draws class (start_class + j) % N, so
+            # class c fills plan slots (c - start_class) % N, +N, +2N, ...
+            pages = torch.empty((new_pages,), dtype=torch.int64, device=self.device)
+            for c in range(shard_size):
+                if counts[c] == 0:
+                    continue
+                pages[
+                    torch.arange(
+                        (c - start_class) % shard_size,
+                        new_pages,
+                        shard_size,
+                        device=self.device,
+                    )
+                ] = self.class_free_pages[c][: counts[c]]
+                self.class_free_pages[c] = self.class_free_pages[c][counts[c] :]
+            extend_len = int(seq_lens_cpu[i]) - int(prefix_lens_cpu[i])
+            offsets = torch.arange(extend_len, dtype=torch.int64, device=self.device)
+            out_parts.append(pages[offsets // ps] * ps + offsets % ps)
+        out_indices = torch.cat(out_parts) if len(out_parts) > 1 else out_parts[0]
+
+        if self.debug_mode:
+            assert len(torch.unique(out_indices)) == len(out_indices)
+        return out_indices
+
+    def alloc_decode(
+        self,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+    ):
+        raise NotImplementedError(
+            "PageInterleavePoolAllocator does not support decode allocation "
+            "(logical-page KV sharding runs on prefill nodes only)"
+        )
+
+    def free(self, free_index: torch.Tensor):
+        if free_index.numel() == 0:
+            return
+
+        if self.free_group is not None:
+            # Match the base allocator's ownership contract: callers may
+            # overwrite req_to_token views before free_group_end consumes the
+            # deferred indices.
+            self.free_group.append(self._copy_for_free_group(free_index))
+            return
+
+        # The tree quantum is the physical page, so every free covers whole
+        # pages (any partial in-page coverage means the rest of that page
+        # belongs to the same free). Split by owner class; a freed page is
+        # immediately reusable — nothing strands.
+        pages = torch.unique(free_index.long() // self.page_size)
+        owners = pages % self.shard_size
+        for r in range(self.shard_size):
+            freed = pages[owners == r]
+            if freed.numel() == 0:
+                continue
+            if self.need_sort:
+                self.class_release_pages[r] = torch.cat(
+                    (freed, self.class_release_pages[r])
+                )
+            else:
+                self.class_free_pages[r] = torch.cat((freed, self.class_free_pages[r]))
+
+        if self.debug_mode:
+            self.debug_check_classes()
+
+    def free_segment(self, free_index: torch.Tensor, *, start_pos: int):
+        # Back to the base contract (plain free): the paged override derives
+        # page representatives by striding and hands them to _release_page_ids,
+        # which writes the stock free_pages list this allocator does not use.
+        # start_pos buys nothing here — free() keys pages by owner class, which
+        # needs the page ids anyway.
+        self.free(free_index)
+
+    def _release_page_ids(self, *page_ids: torch.Tensor):
+        raise NotImplementedError(
+            "PageInterleavePoolAllocator keeps free pages in per-owner class "
+            "lists; a caller reaching the stock free_pages list would leak them"
+        )
+
+    def _debug_check_no_duplicate_pages(self):
+        # The base sweep concatenates the neutralized flat lists; the classed
+        # census is the equivalent check here.
+        self.debug_check_classes()
+
+    # ---- state / debug ----------------------------------------------------------
+
+    def resize(self, config) -> None:
+        raise NotImplementedError(
+            "post-capture KV resizing is not supported under logical-page KV sharding"
+        )
+
+    def get_all_free_pages(self) -> torch.Tensor:
+        """All free logical page ids across classes (free + release) — for
+        the scheduler invariant checker's use-after-free / double-free sweep
+        (page unit = the physical page = self.page_size). The paged base
+        reads the flat lists this allocator neutralizes, so the classed
+        census is the override."""
+        return torch.cat(self.class_free_pages + self.class_release_pages)
+
+    def debug_check_classes(self):
+        for r in range(self.shard_size):
+            merged = torch.cat((self.class_free_pages[r], self.class_release_pages[r]))
+            assert bool((merged % self.shard_size == r).all()), (
+                f"page of another owner leaked into class {r}"
+            )
+            assert len(torch.unique(merged)) == len(merged), (
+                f"double free: duplicate pages in class {r}"
+            )
+
+
+def page_interleave_shard_size(allocator: BaseTokenToKVPoolAllocator) -> int:
+    """Shard-group size of a widened allocator, or 1 for stock allocators.
+
+    The scheduler-side seam predicate: the sites that must treat the
+    index space as shard-widened (capacity reporting, admission reserve,
+    rotation-base plumbing, invariant slack) branch on this, exactly
+    parallel to their existing DCP conditions.
+    """
+    if isinstance(allocator, PageInterleavePoolAllocator):
+        return allocator.shard_size
+    return 1

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -80,6 +80,11 @@ class InsertParams:
     priority: int = 0
     track_adopted_ranges: bool = False
 
+    # Logical-page KV sharding: rotation base of the chain the inserted
+    # values belong to (stamped onto new tree nodes; None when sharding is
+    # off). See UnifiedTreeNode.rotation_base.
+    rotation_base: Optional[int] = None
+
 
 @dataclasses.dataclass
 class InsertResult:
@@ -90,6 +95,13 @@ class InsertResult:
     last_device_node: Any = None
     mamba_exist: bool = False
     swa_branch_inserted: bool = False
+
+    # Logical-page KV sharding: the un-matched tail was NOT inserted because
+    # its rotation base disagrees with the matched chain's (a cross-chain
+    # graft would break the cyclic-owner gather contract). The tail's pages
+    # stay owned by the inserting request; callers must not dedup/rebind
+    # past prefix_len.
+    rotation_tail_declined: bool = False
     inserted_host_node: Any = None
     host_insert_dropped: bool = False
     adopted_ranges: Optional[dict[ComponentType, list[tuple[int, int]]]] = None
@@ -367,6 +379,17 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def get_prefix_hash_values(self, node: Any) -> list[str]:
         """The hash chain of the node's ancestors, in root-to-parent order."""
         return node.get_prefix_hash_values(node.parent)
+
+    def rotation_base_of(self, node: Any) -> Optional[int]:
+        """Logical-page KV sharding: the rotation base stamped on ``node``.
+
+        ``node`` is whatever this cache stores in ``req.last_node`` (a NodeId
+        for the unified tree, None for caches without tree nodes). None means
+        "no base available here", which sends the alloc path to the base the
+        request recorded at its previous alloc. Tree caches that keep the
+        per-chain base override this. See UnifiedTreeNode.rotation_base.
+        """
+        return None
 
     @abstractmethod
     def cache_finished_req(self, req: Req, is_insert: bool = True, **kwargs):

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -10,6 +10,7 @@ from sglang.kernels.ops.memory.common import (
     _get_last_loc_safe_kernel as _get_last_loc_safe_kernel,
 )
 from sglang.kernels.ops.memory.common import get_last_loc_kernel as get_last_loc_kernel
+from sglang.srt.mem_cache.allocator.page_interleave import page_interleave_shard_size
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.hicache_storage import PoolTransfer
@@ -188,6 +189,32 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
             tree_cache.evict_for_alloc(
                 EvictParams(num_tokens=num_tokens - available_size)
             )
+            _evict_until_allocatable(tree_cache, allocator, num_tokens)
+
+
+def _evict_until_allocatable(
+    tree_cache: BasePrefixCache, allocator, num_tokens: int
+) -> None:
+    """Keep evicting the shortfall until `num_tokens` are allocatable.
+
+    Under classed page sharding available_size() reports the MIN-CLASS
+    capacity floor, so a single evict() sized in tokens can raise that floor by
+    less than the number of tokens it freed: the evicted pages spread across
+    all owner classes. Looping is deterministic, so it stays mirrored across
+    the ranks of a shard group. Stock allocators need no extra pass.
+    """
+    if page_interleave_shard_size(allocator) <= 1:
+        return
+    while True:
+        available_size = allocator.available_size()
+        if available_size >= num_tokens:
+            return
+        shortfall = num_tokens - available_size
+        result = tree_cache.evict(
+            EvictParams(num_tokens=max(shortfall, allocator.page_size))
+        )
+        if result.num_tokens_evicted == 0:
+            return
 
 
 def retraction_backup(
@@ -306,12 +333,16 @@ def _release_overallocated_kv_indices(
             f"Unexpected overallocated KV cache, {req.kv.kv_committed_len=}, {req.kv.kv_allocated_len=}"
         )
 
+    # Align to the ALLOCATOR's page, which under DCP is wider than the kernel
+    # page: paged free() releases the whole page containing any freed index, so
+    # a boundary aligned only to the kernel page could free a widened page whose
+    # head rows are still live.
     if page_size > 1:
         start_p = ceil_align(start_p, page_size)
 
     if start_p < end_p:
-        # start_p is aligned to the allocator's physical page size above, so it
-        # never shares a page with cache_finished_req's tail free in this group.
+        # start_p is aligned to the allocator's page above, so it never shares a
+        # page with cache_finished_req's tail free in this group.
         tree_cache.free_kv_row(req.kv, [(start_p, end_p)])
 
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -193,7 +193,9 @@ def _pp_local_per_request_bytes(
 
 
 if TYPE_CHECKING:
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+    from sglang.srt.mem_cache.page_interleave import PageShardSpec
     from sglang.srt.mem_cache.unified_memory_pool import (
         UnifiedKVPool,
         UnifiedPoolBundle,
@@ -271,12 +273,17 @@ class KVCacheConfigurator:
     kv_cache_dtype_str: Optional[str] = None
     mambaish_config: Optional[Any] = field(init=False)
     hybrid_gdn_config: Optional[Any] = field(init=False)
+    kv_shard_rank: Optional[int] = field(init=False)
+    kv_shard_size: int = field(init=False)
+    kv_shard_spec: Optional[PageShardSpec] = field(init=False)
+    kv_shard_group: Optional[GroupCoordinator] = field(init=False)
     is_hybrid_swa_mtp_draft: bool = field(init=False)
     draft_swa_full_capacity: bool = field(init=False)
 
     def __post_init__(self) -> None:
         self.mambaish_config = mambaish_config(self.model_config)
         self.hybrid_gdn_config = hybrid_gdn_config(self.model_config)
+        self._resolve_kv_shard()
         self.is_hybrid_swa_mtp_draft = (
             self.is_draft_worker
             and self.draft_model_idx is not None
@@ -286,6 +293,40 @@ class KVCacheConfigurator:
         )
         self.draft_swa_full_capacity = self.is_hybrid_swa_mtp_draft and (
             self.draft_model_idx in self.model_config.swa_attention_layer_ids
+        )
+
+    def _resolve_kv_shard(self) -> None:
+        """Resolve the logical-page KV sharding identity: ``(rank, size)`` of
+        the shard group, or ``(None, 1)`` when sharding is off. Consumed by the
+        pool builders and by the widened allocator branch."""
+        from sglang.srt.mem_cache.page_interleave import get_kv_shard_group_info
+
+        self.kv_shard_rank, self.kv_shard_size = get_kv_shard_group_info(self)
+        self.kv_shard_spec = None
+        self.kv_shard_group = None
+        if self.kv_shard_rank is None:
+            return
+
+        from sglang.srt.mem_cache.page_interleave import (
+            PageShardSpec,
+            get_kv_shard_group,
+        )
+        from sglang.srt.utils.common import ceil_align
+
+        granule = self.kv_shard_size * self.page_size
+        self.kv_shard_group = get_kv_shard_group(self.use_mla_backend)
+        self.kv_shard_spec = PageShardSpec(
+            shard_rank=self.kv_shard_rank,
+            shard_size=self.kv_shard_size,
+            page_size=self.page_size,
+            # Under rotated owner-classed allocation a K-page prefix gathers as
+            # exactly N * ceil(K / N) pages, which is bounded by
+            # ceil_align(context_len, granule). The chunk region is sized
+            # per-page because chunk boundaries are page-size floored.
+            max_prefix_tokens=ceil_align(self.model_config.context_len, granule),
+            chunk_tokens=ceil_align(
+                get_schedule().chunked_prefill_size, self.page_size
+            ),
         )
 
     def _build_fp4_quant_method(self, *, num_layers: int):
@@ -586,6 +627,17 @@ class KVCacheConfigurator:
             is_dsv4_model=is_dsv4_model,
             req_to_token_pool=req_to_token_pool,
         )
+
+        if self.kv_shard_rank is not None:
+            from sglang.srt.mem_cache.page_interleave_pool import (
+                PageInterleaveKVPoolMixin,
+            )
+
+            if not isinstance(token_to_kv_pool, PageInterleaveKVPoolMixin):
+                raise ValueError(
+                    "--enable-kv-cache-sharding does not support this model "
+                    f"family (pool {type(token_to_kv_pool).__name__})."
+                )
 
         if draft_virtual_id_space is not None:
             assert token_to_kv_pool.size >= draft_virtual_id_space, (
@@ -1643,7 +1695,17 @@ class KVCacheConfigurator:
         return token_to_kv_pool
 
     def _build_mla_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
-        token_to_kv_pool = MLATokenToKVPool(
+        mla_pool_cls = MLATokenToKVPool
+        mla_pool_kwargs = {}
+        if self.kv_shard_rank is not None:
+            from sglang.srt.mem_cache.page_interleave_pool import (
+                PageInterleaveMLATokenToKVPool,
+            )
+
+            mla_pool_cls = PageInterleaveMLATokenToKVPool
+            mla_pool_kwargs["shard_spec"] = self.kv_shard_spec
+            mla_pool_kwargs["shard_group"] = self.kv_shard_group
+        token_to_kv_pool = mla_pool_cls(
             max_total_num_tokens,
             page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
@@ -1654,6 +1716,7 @@ class KVCacheConfigurator:
             enable_memory_saver=get_exec().features.enable_memory_saver,
             start_layer=self.layer_info.start_layer,
             end_layer=self.layer_info.end_layer,
+            **mla_pool_kwargs,
         )
         return token_to_kv_pool
 
@@ -1844,6 +1907,24 @@ class KVCacheConfigurator:
             pool_kwargs["quant_method"] = quant_method
         else:
             pool_kwargs["post_capture_active"] = self.post_capture_kv_active
+        if self.kv_shard_rank is not None:
+            from sglang.srt.mem_cache.page_interleave_pool import (
+                PageInterleaveMHATokenToKVPool,
+            )
+
+            # The striped pool subclasses the plain per-layer MHA pool; the
+            # mxfp8 / NoOp / page-major variants have incompatible buffer
+            # layouts, and a quantized KV cache has no striped store path.
+            assert pool_cls is MHATokenToKVPool, (
+                "--enable-kv-cache-sharding is incompatible with "
+                f"the {pool_cls.__name__} pool"
+            )
+            assert quant_method is None, (
+                "--enable-kv-cache-sharding is incompatible with a quantized KV cache"
+            )
+            pool_cls = PageInterleaveMHATokenToKVPool
+            pool_kwargs["shard_spec"] = self.kv_shard_spec
+            pool_kwargs["shard_group"] = self.kv_shard_group
         token_to_kv_pool = pool_cls(
             max_total_num_tokens,
             page_size=self.pool_page_size,
@@ -1959,6 +2040,23 @@ class KVCacheConfigurator:
                             kvcache=token_to_kv_pool,
                             need_sort=need_sort,
                             host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                        )
+                    elif self.kv_shard_size > 1:
+                        # Logical-page sharding: index space widened xN over
+                        # the stock 1x pool; the allocator page stays physical.
+                        from sglang.srt.mem_cache.allocator.page_interleave import (
+                            PageInterleavePoolAllocator,
+                        )
+
+                        token_to_kv_pool_allocator = PageInterleavePoolAllocator(
+                            sizes.max_total_num_tokens,
+                            physical_page_size=self.page_size,
+                            shard_size=self.kv_shard_size,
+                            dtype=self.kv_cache_dtype,
+                            device=self.device,
+                            kvcache=token_to_kv_pool,
+                            need_sort=need_sort,
+                            shard_spec=self.kv_shard_spec,
                         )
                     elif (
                         get_schedule().page_size == 1 and not get_parallel().dcp_enabled

--- a/python/sglang/srt/mem_cache/page_interleave.py
+++ b/python/sglang/srt/mem_cache/page_interleave.py
@@ -1,0 +1,86 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Logical-page KV sharding: placement arithmetic and shard-group resolution.
+
+A *logical page* is ``shard_size`` consecutive, ``shard_size``-aligned physical
+pages — one per rank of the shard group. Everything above the memory pool
+(radix tree, allocator free list, ``req_to_token``, scheduler budgets) sees
+only logical token slots, identical on every rank (SPMD); everything below
+sees only its own physical pages; the boundary is the pure bijection below.
+
+The shard group is the group across which KV storage is replicated today and
+therefore can be striped without extra compute-time communication:
+
+- GQA/MHA models: the **attention CP group** — prefill CP already allgathers
+  the full chunk's K/V to every CP rank (``cp_allgather_and_save_kv_cache``).
+- MLA models: the **attention TP group** — the latent KV projection is
+  ``ReplicatedLinear``, so every attn-TP rank computes identical latent KV.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import msgspec
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class PageShardSpec(msgspec.Struct, frozen=True):
+    """Everything both sides of any transfer need to reproduce the layout."""
+
+    shard_rank: int
+    shard_size: int
+    page_size: int  # physical page size (kernel-visible)
+    max_prefix_tokens: int  # scratch prefix-region capacity, granule-aligned
+    chunk_tokens: int  # scratch chunk-region capacity, granule-aligned
+
+    @property
+    def logical_page_size(self) -> int:
+        """The N*page_size span of one logical page. It bounds the assembly
+        scratch and rounds chunked_prefill_size; the allocator and the tree
+        both keep drawing and matching at the physical ``page_size``."""
+        return self.shard_size * self.page_size
+
+
+class PageInterleavePlacement:
+    """``loc = Q*(N*ps) + r*ps + o`` -> owner ``r``, local physical row ``Q*ps + o``.
+
+    Pure, stateless and invertible, so nothing has to be stored or kept
+    coherent to translate. Because the allocator is
+    mirrored, logical group ``Q`` resolves to local rows ``[Q*ps, (Q+1)*ps)``
+    on every rank, so a reader computes a peer's source offset from arithmetic
+    alone. Owned tokens form ``page_size``-long contiguous runs in both the
+    logical and the local space.
+    """
+
+    def __init__(self, spec: PageShardSpec):
+        self.spec = spec
+
+    def owner_of(self, loc: torch.Tensor) -> torch.Tensor:
+        ps, n = self.spec.page_size, self.spec.shard_size
+        return (loc % (n * ps)) // ps
+
+    def local_index(self, loc: torch.Tensor) -> torch.Tensor:
+        ps, n = self.spec.page_size, self.spec.shard_size
+        return (loc // (n * ps)) * ps + loc % ps
+
+    def local_mask(self, loc: torch.Tensor, rank: int) -> torch.Tensor:
+        return self.owner_of(loc) == rank
+
+    def filter_local(self, loc: torch.Tensor, rank: int) -> torch.Tensor:
+        """Logical slots -> this rank's physical pool rows, order-preserving."""
+        return self.local_index(loc[self.local_mask(loc, rank)])

--- a/python/sglang/srt/mem_cache/page_interleave.py
+++ b/python/sglang/srt/mem_cache/page_interleave.py
@@ -23,8 +23,8 @@ sees only its own physical pages; the boundary is the pure bijection below.
 The shard group is the group across which KV storage is replicated today and
 therefore can be striped without extra compute-time communication:
 
-- GQA/MHA models: the **attention CP group** — prefill CP already allgathers
-  the full chunk's K/V to every CP rank (``cp_allgather_and_save_kv_cache``).
+- GQA/MHA models: the **attention CP group** — the prefill CP strategy
+  materializes the full chunk's K/V on every CP rank before the pool write.
 - MLA models: the **attention TP group** — the latent KV projection is
   ``ReplicatedLinear``, so every attn-TP rank computes identical latent KV.
 """
@@ -32,9 +32,13 @@ therefore can be striped without extra compute-time communication:
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import msgspec
 import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -84,3 +88,26 @@ class PageInterleavePlacement:
     def filter_local(self, loc: torch.Tensor, rank: int) -> torch.Tensor:
         """Logical slots -> this rank's physical pool rows, order-preserving."""
         return self.local_index(loc[self.local_mask(loc, rank)])
+
+
+def get_kv_shard_group(use_mla_backend: bool) -> GroupCoordinator:
+    """The group KV pages are striped across — the axis that replicates KV
+    at rest, chosen by topology:
+
+    - An active attention-CP group takes precedence: prefill CP replicates
+      KV storage across CP ranks for every attention type (GQA via the
+      full-chunk allgather, MLA via rebuild_cp_kv_cache).
+    - Without CP, MLA latent KV is still replicated across attention-TP
+      (ReplicatedLinear projection), so the attn-TP group is the shard axis.
+    - GQA without CP has no replicated axis (KV is head-sharded across TP);
+      the returned trivial CP group has world_size 1, which disables
+      sharding in get_kv_shard_group_info.
+    """
+    from sglang.srt.runtime_context import get_parallel
+
+    cp_group = get_parallel().attn_cp_group
+    if cp_group.world_size > 1:
+        return cp_group
+    if use_mla_backend:
+        return get_parallel().attn_tp_group
+    return cp_group

--- a/python/sglang/srt/mem_cache/page_interleave.py
+++ b/python/sglang/srt/mem_cache/page_interleave.py
@@ -32,13 +32,14 @@ therefore can be striped without extra compute-time communication:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import msgspec
 import torch
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.parallel_state import GroupCoordinator
+    from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,12 @@ class PageInterleavePlacement:
         return self.local_index(loc[self.local_mask(loc, rank)])
 
 
+def is_kv_cache_sharding_enabled(kvc: KVCacheConfigurator) -> bool:
+    from sglang.srt.runtime_context import get_parallel
+
+    return not kvc.is_draft_worker and get_parallel().enable_kv_cache_sharding
+
+
 def get_kv_shard_group(use_mla_backend: bool) -> GroupCoordinator:
     """The group KV pages are striped across — the axis that replicates KV
     at rest, chosen by topology:
@@ -111,3 +118,51 @@ def get_kv_shard_group(use_mla_backend: bool) -> GroupCoordinator:
     if use_mla_backend:
         return get_parallel().attn_tp_group
     return cp_group
+
+
+def get_kv_shard_group_info(
+    kvc: KVCacheConfigurator,
+) -> Tuple[Optional[int], int]:
+    """``(shard_rank, shard_size)`` for the KV pool; ``(None, 1)`` disables."""
+    if not is_kv_cache_sharding_enabled(kvc):
+        return None, 1
+    group = get_kv_shard_group(kvc.use_mla_backend)
+    if group.world_size <= 1:
+        return None, 1
+    return group.rank_in_group, group.world_size
+
+
+def compute_page_shard_scratch_bytes(kvc: KVCacheConfigurator) -> int:
+    """Fixed HBM cost of the double-buffered assembly scratch, charged against
+    the KV budget before pool sizing. Two slots, each ``[max prefix | chunk |
+    trash page]`` rows of ONE layer's KV."""
+    shard_rank, shard_size = get_kv_shard_group_info(kvc)
+    if shard_rank is None:
+        return 0
+
+    from sglang.srt.runtime_context import get_parallel, get_schedule
+    from sglang.srt.utils.common import ceil_align
+
+    model_config = kvc.model_config
+    granule = shard_size * kvc.page_size
+    # Rotated owner-classed allocation keeps per-rank owned counts within 1, so
+    # a K-page prefix gathers as exactly N * ceil(K / N) pages, bounded by
+    # ceil_align(context_len, granule). The chunk region is sized per-page
+    # because chunk boundaries are page-size floored.
+    rows = (
+        ceil_align(model_config.context_len, granule)
+        + ceil_align(get_schedule().chunked_prefill_size, kvc.page_size)
+        + kvc.page_size
+    )
+    kv_size = torch._utils._element_size(kvc.kv_cache_dtype)
+    if kvc.use_mla_backend:
+        row_bytes = (
+            model_config.kv_lora_rank + model_config.qk_rope_head_dim
+        ) * kv_size
+    else:
+        row_bytes = (
+            model_config.get_num_kv_heads(get_parallel().attn_tp_size)
+            * (model_config.head_dim + model_config.v_head_dim)
+            * kv_size
+        )
+    return 2 * rows * row_bytes

--- a/python/sglang/srt/mem_cache/page_interleave_pool.py
+++ b/python/sglang/srt/mem_cache/page_interleave_pool.py
@@ -1,0 +1,720 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""KV pools striped at logical-page granularity across a shard group.
+
+Per-layer pool tensors keep the stock shape and size — identical rows on every
+rank; only the written rows differ: each rank persists the rows it owns under
+the pure placement bijection (``mem_cache/page_interleave.py``).
+
+Central consequence for the forward pass: during a sharded prefill, extend
+attention never reads the KV pool — a rank's pool holds only its stripe of
+the prefix *and* of the current chunk. Attention reads a per-layer assembled
+scratch slot laid out ``[prefix region | chunk region | trash page]``:
+
+- The prefix is NCCL-allgathered from the shard group into the slot one layer
+  ahead, on a dedicated side stream with a dedicated ``PyNcclCommunicator``
+  ahead. Under rotated
+  owner-classed allocation the owners of a cached prefix's pages are exactly
+  cyclic, so per-rank owned counts differ by <= 1: each rank sends its own
+  prefix pages in local-page order, padded to ``ceil(prefix_pages / N)`` pages
+  with the (never referenced) trash page — a *regular* in-place allgather,
+  owner-major output, no reorder pass.
+- The chunk region is staged locally on the compute stream where the write
+  path already holds the full chunk (GQA CP allgathers K/V before the pool
+  write; MLA latent is replicated across the shard group at write time).
+- The trash page absorbs padded/dummy locations (the reserved logical pages
+  covering loc < N*ps, and any location outside the current batch's plan).
+
+Scratch addressing goes through a per-batch ``logical page -> scratch
+page`` lookup (``_page_pos``, one int32 per logical page, rebuilt in
+``begin_shard_extend``): purely local, mirrored by construction, and valid
+for any consumer index vector (attention page tables, MLA prefix
+``kv_indices``), not just whole-prefix position arithmetic.
+
+Layer-ahead pipelining needs no model changes: acquiring layer ``l``'s slot
+for reading kicks layer ``l+1``'s gather. Reads happen in SPMD lockstep on
+every rank, so the collective order is symmetric by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import (
+    GPU_MEMORY_TYPE_KV_CACHE,
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+    RadixAttention,
+    unwrap_write_loc,
+)
+from sglang.srt.mem_cache.page_interleave import (
+    PageInterleavePlacement,
+    PageShardSpec,
+)
+from sglang.srt.mem_cache.utils import (
+    get_mla_kv_buffer_triton,
+    set_mla_kv_buffer_triton,
+)
+from sglang.srt.utils.nvtx_utils import kv_shard_nvtx_method, kv_shard_nvtx_range
+
+if TYPE_CHECKING:
+    from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
+
+logger = logging.getLogger(__name__)
+
+
+class _ScratchSlot:
+    """One half of the double buffer: scratch tensors + ready event.
+
+    ``resident_key`` identifies what the slot currently holds — ``(layer_id,
+    epoch)`` — so repeated reads of the same layer skip the re-gather and a
+    new batch (epoch bump) retires stale residency without any invalidation
+    walk.
+    """
+
+    def __init__(self, tensors: Dict[str, torch.Tensor], device_module):
+        self.tensors = tensors
+        self.ready = device_module.Event()
+        self.resident_key: Optional[Tuple[int, int]] = None
+
+
+class PageInterleaveKVPoolMixin:
+    """Shard-generic state and mechanics; mixed into concrete pools below.
+
+    Subclasses call ``_init_page_shard_state`` after the base pool has created
+    its buffers, and implement ``_scratch_tensor_specs`` (per-slot tensors) and
+    ``_gather_pairs`` (pool buffer -> scratch tensor pairs of one layer).
+    """
+
+    # ---- init ---------------------------------------------------------------
+
+    def _init_page_shard_state(
+        self, shard_spec: PageShardSpec, shard_group: GroupCoordinator
+    ):
+        from sglang.srt.distributed.device_communicators.pynccl import (
+            PyNcclCommunicator,
+        )
+
+        spec = shard_spec
+        assert spec.shard_size > 1, "page-interleave sharding needs shard_size > 1"
+        assert spec.shard_size == shard_group.world_size
+        assert spec.shard_rank == shard_group.rank_in_group
+        assert spec.page_size == self.page_size
+        # The prefix region must fit N * ceil(prefix_pages / N) pages for any
+        # prefix, i.e. be a multiple of the full-group span; the chunk region
+        # is per-page.
+        assert spec.max_prefix_tokens % spec.logical_page_size == 0
+        assert spec.chunk_tokens % spec.page_size == 0
+
+        self.shard_spec = spec
+        self.placement = PageInterleavePlacement(spec)
+        self.shard_rank = spec.shard_rank
+        self.shard_size = spec.shard_size
+        self.device_module = torch.get_device_module(self.device)
+
+        # Dedicated communicator + stream so the layer-ahead gathers never
+        # interleave with the group's main collectives.
+        self.kv_gather_comm: PyNcclCommunicator = PyNcclCommunicator(
+            group=shard_group.cpu_group, device=shard_group.device
+        )
+        self.kv_gather_stream = self.device_module.Stream()
+
+        # Scratch: [prefix | chunk | trash page], double-buffered.
+        scratch_rows = spec.max_prefix_tokens + spec.chunk_tokens + spec.page_size
+        self._chunk_base = spec.max_prefix_tokens
+        self._trash_base = spec.max_prefix_tokens + spec.chunk_tokens
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            with (
+                torch.cuda.use_mem_pool(self.custom_mem_pool)
+                if self.custom_mem_pool
+                else nullcontext()
+            ):
+                self._slots = [
+                    _ScratchSlot(
+                        self._scratch_tensor_specs(scratch_rows), self.device_module
+                    )
+                    for _ in range(2)
+                ]
+                # Per-batch absolute scratch-page index of every logical page.
+                # Unplanned pages initially target the trash page. Logical page
+                # ids run [0, N * (size/ps + 1)) — N per physical page of one
+                # rank's pool incl. the reserved padded page.
+                self._page_pos = torch.full(
+                    (spec.shard_size * (self.size // spec.page_size + 2),),
+                    self._trash_base // spec.page_size,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+
+        from sglang.srt.utils import get_bool_env_var
+
+        self._epoch = 0
+        self._shard_extend_active = False
+        self._block_pages = 0
+        # Strictly larger than any local physical page id: the owner-major
+        # sort key of logical page l is (l % N) * stride + l // N.
+        self._local_page_stride = self.size // spec.page_size + 2
+        self._debug_plan_checks = get_bool_env_var("SGLANG_DEBUG_MEMORY_POOL")
+        self._send_rows: Optional[torch.Tensor] = None
+        self._write_plan_key = None
+        self._write_plan: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self._translate_cache: Dict[Tuple[int, int], torch.Tensor] = {}
+
+        logger.info(
+            "Page-interleave KV sharding enabled: shard_rank=%d shard_size=%d "
+            "page_size=%d scratch_rows=%d x2",
+            self.shard_rank,
+            self.shard_size,
+            spec.page_size,
+            scratch_rows,
+        )
+
+    def set_kv_buffer_prefix_valid(self, *args, **kwargs):
+        raise NotImplementedError(
+            "prefix-valid commit is unsupported under logical-page KV sharding "
+            "(it writes pool rows directly, bypassing the ownership filter)"
+        )
+
+    # ---- subclass hooks -------------------------------------------------------
+
+    def _scratch_tensor_specs(self, rows: int) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError
+
+    def _gather_pairs(self, local_layer: int) -> List[Tuple[torch.Tensor, str]]:
+        """(pool buffer of ``local_layer``, scratch tensor name) pairs."""
+        raise NotImplementedError
+
+    # ---- per-batch plan -------------------------------------------------------
+
+    @kv_shard_nvtx_method("kv_shard.begin_extend", color="green")
+    def begin_shard_extend(
+        self,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        prefix_lens_cpu: List[int],
+        seq_lens_cpu: List[int],
+    ) -> None:
+        """Capture the batch's gather plan and kick the first layer's gather.
+
+        Called once per scheduled extend batch, at attention-metadata build
+        time (after ``req_to_token`` holds the batch's allocation). All inputs
+        are mirrored across ranks, so every rank derives the identical plan.
+        """
+        spec = self.shard_spec
+        ps, shard_size = spec.page_size, spec.shard_size
+
+        # Per-request page samples. One logical page per position-page
+        # (whole-page draws + ps-aligned chunk starts), so stride-ps sampling
+        # enumerates each request's pages in position order — no run
+        # collapsing. block_pages (the padded allgather block) is the
+        # sync-free host bound sum_i ceil(K_i / N): each request's prefix is
+        # ONE cyclic rotation run (graft-declined inserts + per-request
+        # bases), so a rank owns at most ceil(K_i / N) of its pages, and the
+        # cross-request dedup below only shrinks per-rank counts.
+        empty = torch.empty((0,), dtype=torch.int64, device=self.device)
+        prefix_parts = []
+        chunk_parts = []
+        block_pages = 0
+        for i in range(len(prefix_lens_cpu)):
+            prefix_len, seq_len = int(prefix_lens_cpu[i]), int(seq_lens_cpu[i])
+            assert prefix_len % ps == 0, (
+                f"sharded prefill requires physical-page-aligned prefixes "
+                f"(the radix-tree match quantum), got prefix_len="
+                f"{prefix_len}, page_size={ps}"
+            )
+            row = req_to_token[req_pool_indices[i]]
+            if prefix_len:
+                pages_i = row[:prefix_len:ps].long() // ps
+                prefix_parts.append(pages_i)
+                block_pages += -(-(prefix_len // ps) // shard_size)
+                if self._debug_plan_checks:
+                    # Owner-congruence: each request's prefix owners must be
+                    # exactly cyclic — the block bound above relies on it. A
+                    # broken rotation would overflow a rank's block and the
+                    # translation would silently address the wrong scratch
+                    # rows. Fail loud instead (debug mode syncs).
+                    owners = pages_i % shard_size
+                    expected = (
+                        int(owners[0])
+                        + torch.arange(
+                            owners.numel(), dtype=torch.int64, device=self.device
+                        )
+                    ) % shard_size
+                    assert torch.equal(owners, expected), (
+                        f"sharded prefix owners of request {i} are not "
+                        f"cyclic — rotation base out of sync "
+                        f"(owners[:16]={owners[:16].tolist()})"
+                    )
+            if seq_len > prefix_len:
+                chunk_parts.append(row[prefix_len:seq_len:ps].long() // ps)
+
+        # A prefix page shared by several requests gathers into ONE scratch
+        # slot (torch.unique sorts — deterministic, mirrored); chunk pages
+        # are per-request fresh allocations, disjoint by construction.
+        prefix_pages = torch.unique(torch.cat(prefix_parts)) if prefix_parts else empty
+        chunk_pages = torch.cat(chunk_parts) if chunk_parts else empty
+        n_prefix = prefix_pages.numel()
+        n_chunk = chunk_pages.numel()
+        n_prefix_slots = shard_size * block_pages
+        assert n_prefix_slots * ps <= spec.max_prefix_tokens, (
+            f"prefix ({n_prefix} pages, padded gather span "
+            f"{n_prefix_slots * ps} tokens) exceeds the scratch prefix "
+            f"capacity ({spec.max_prefix_tokens}) — the PrefillAdder scratch "
+            f"reservation should have deferred this batch"
+        )
+        assert n_chunk * ps <= spec.chunk_tokens, (
+            f"chunk ({n_chunk * ps} tokens) exceeds the scratch chunk "
+            f"capacity ({spec.chunk_tokens})"
+        )
+
+        self._page_pos.fill_(self._trash_base // ps)
+        if n_prefix:
+            # Owner-major slot assignment: sort the batch's unique pages by
+            # (owner, local page) so rank r's pages are contiguous at
+            # r * block_pages in local-page order — the same order rank r
+            # packs its send block below, on every rank (mirrored).
+            owners = prefix_pages % shard_size
+            local_pages = prefix_pages // shard_size
+            order = torch.argsort(owners * self._local_page_stride + local_pages)
+            sorted_pages = prefix_pages[order]
+            sorted_owners = owners[order]
+            counts = torch.bincount(sorted_owners, minlength=shard_size)
+            starts = torch.cumsum(counts, 0) - counts
+            within = (
+                torch.arange(n_prefix, dtype=torch.int64, device=self.device)
+                - starts[sorted_owners]
+            )
+            self._page_pos[sorted_pages] = (sorted_owners * block_pages + within).to(
+                torch.int32
+            )
+        if n_chunk:
+            self._page_pos[chunk_pages] = torch.arange(
+                self._chunk_base // ps,
+                self._chunk_base // ps + n_chunk,
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+        self._epoch += 1
+        self._block_pages = block_pages
+        self._shard_extend_active = True
+        self._translate_cache.clear()
+        if block_pages:
+            # This rank's owned pages in slot order (already local-sorted) —
+            # logical page l is its local physical page l // N — padded to
+            # the regular allgather block with the reserved trash page
+            # (local page 0), whose rows the plan never references.
+            own_local = sorted_pages[sorted_owners == self.shard_rank] // shard_size
+            n_pad = block_pages - own_local.numel()
+            if n_pad:
+                own_local = torch.cat(
+                    [
+                        own_local,
+                        torch.zeros((n_pad,), dtype=torch.int64, device=self.device),
+                    ]
+                )
+            self._send_rows = (
+                own_local[:, None] * ps
+                + torch.arange(ps, dtype=torch.int64, device=self.device)
+            ).reshape(-1)
+            self._prefetch_layer(self.start_layer)
+        else:
+            self._send_rows = None
+
+    def end_shard_extend(self) -> None:
+        """Mark no sharded extend in flight (non-extend forward modes)."""
+        self._shard_extend_active = False
+
+    # ---- translation ----------------------------------------------------------
+
+    @kv_shard_nvtx_method("kv_shard.translate_loc", color="magenta")
+    def translate_loc_to_scratch(self, loc: torch.Tensor) -> torch.Tensor:
+        """Logical token slots -> rows of the current batch's scratch slots.
+
+        ``_page_pos`` holds every logical page's absolute scratch page slot:
+        prefix pages owner-major in ``[0, N * block_pages)`` (rank ``l % N``'s
+        pages contiguous at ``rank * block_pages``, local-page order), chunk
+        pages in batch-sequence order at ``_chunk_base``, and anything outside
+        the plan at the trash page.
+        """
+        ps = self.shard_spec.page_size
+        loc64 = loc.long()
+        scratch_page = self._page_pos[loc64 // ps].long()
+        return scratch_page * ps + loc64 % ps
+
+    # ---- the layer-ahead gather -------------------------------------------------
+
+    def _prefetch_layer(self, layer_id: int) -> None:
+        """Kick the allgather assembling ``layer_id``'s prefix into its slot,
+        on the gather stream. Idempotent per ``(layer_id, epoch)``."""
+        local_layer = layer_id - self.start_layer
+        if local_layer >= self.layer_num:
+            return
+        slot = self._slots[layer_id % 2]
+        key = (layer_id, self._epoch)
+        if slot.resident_key == key:
+            return
+        with kv_shard_nvtx_range("kv_shard.prefetch_layer", color="orange"):
+            block = self._block_pages * self.shard_spec.page_size
+            # Order the gather after all prior compute-stream work: the
+            # previous tenant's reads (attention of layer_id - 2) and the pool
+            # writes that produced the prefix rows.
+            self.kv_gather_stream.wait_stream(self.device_module.current_stream())
+            with self.device_module.stream(self.kv_gather_stream):
+                for pool_buf, name in self._gather_pairs(local_layer):
+                    scratch = slot.tensors[name]
+                    send = scratch[
+                        self.shard_rank * block : (self.shard_rank + 1) * block
+                    ]
+                    torch.index_select(pool_buf, 0, self._send_rows, out=send)
+                    # In-place regular allgather: send is exactly the rank's
+                    # block of the output, every rank contributes `block` rows.
+                    with self.kv_gather_comm.change_state(enable=True):
+                        self.kv_gather_comm.all_gather(
+                            scratch[: self.shard_size * block], send
+                        )
+                slot.ready.record(self.kv_gather_stream)
+            slot.resident_key = key
+
+    def _acquire_slot_for_read(self, layer_id: int) -> _ScratchSlot:
+        """Block the compute stream on the slot's ready event (a no-op when
+        the layer-ahead gather already landed) and kick the next layer's
+        gather. A residency miss is a caller bug — the batch plan captured by
+        ``begin_shard_extend`` must have prefetched this layer."""
+        assert self._shard_extend_active, (
+            "sharded pool read outside an active sharded extend batch "
+            "(begin_shard_extend not called?)"
+        )
+        slot = self._slots[layer_id % 2]
+        if self._block_pages:
+            assert slot.resident_key == (layer_id, self._epoch), (
+                f"prefix scratch miss for layer {layer_id} "
+                f"(resident={slot.resident_key}, epoch={self._epoch})"
+            )
+            with kv_shard_nvtx_range("kv_shard.acquire_slot", color="yellow"):
+                self.device_module.current_stream().wait_event(slot.ready)
+                self._prefetch_layer(layer_id + 1)
+        return slot
+
+    def _translate_loc_cached(self, loc: torch.Tensor) -> torch.Tensor:
+        """Per-batch memoized ``translate_loc_to_scratch`` for the per-layer
+        callers: the same loc tensors (``out_cache_loc`` at every layer's
+        ``set_kv_buffer``; the prefix ``kv_indices`` at every layer's
+        ``get_mla_kv_buffer``) arrive at all layers of a forward, and the
+        plan is frozen per batch — so each distinct loc tensor is translated
+        once per batch instead of once per layer. ``begin_shard_extend`` clears
+        the cache when it installs a new plan."""
+        key = (loc.data_ptr(), loc.numel())
+        rows = self._translate_cache.get(key)
+        if rows is None:
+            rows = self.translate_loc_to_scratch(loc)
+            self._translate_cache[key] = rows
+        return rows
+
+    # ---- write plan (owner filter), cached per (loc tensor, epoch) --------------
+
+    def _get_write_plan(self, loc: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """(owned positions into ``loc``, their local physical rows).
+
+        The same ``out_cache_loc`` tensor is passed for every layer of a
+        forward, so the owner filter is computed once per batch, not per
+        layer.
+        """
+        key = (loc.data_ptr(), loc.numel(), self._epoch)
+        if self._write_plan_key != key:
+            owned_idx = torch.nonzero(
+                self.placement.local_mask(loc, self.shard_rank)
+            ).squeeze(1)
+            local_rows = self.placement.local_index(loc[owned_idx])
+            self._write_plan_key = key
+            self._write_plan = (owned_idx, local_rows)
+        return self._write_plan
+
+
+class PageInterleaveMHATokenToKVPool(PageInterleaveKVPoolMixin, MHATokenToKVPool):
+    """MHA/GQA pool striped across the attention CP group.
+
+    The write path relies on the prefill CP strategy materializing the full
+    chunk's K/V before ``set_kv_buffer`` receives the full (unsplit)
+    ``out_cache_loc`` on every rank. Each rank persists only its stripe and
+    stages the full chunk into the current layer's scratch chunk region
+    (extend attention reads prefix *and* chunk through the scratch page table).
+    """
+
+    def __init__(
+        self,
+        *args,
+        shard_spec: PageShardSpec,
+        shard_group: GroupCoordinator,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        assert not self.use_hnd, "KV sharding supports the NHD layout only"
+        assert self.kv_cache_layout == "nhd", (
+            f"KV sharding supports the NHD layout only, got {self.kv_cache_layout}"
+        )
+        assert not self.post_capture_active
+        self._init_page_shard_state(shard_spec, shard_group)
+
+    def _scratch_tensor_specs(self, rows: int) -> Dict[str, torch.Tensor]:
+        return {
+            "k": torch.zeros(
+                (rows, self.head_num, self.head_dim),
+                dtype=self.store_dtype,
+                device=self.device,
+            ),
+            "v": torch.zeros(
+                (rows, self.head_num, self.v_head_dim),
+                dtype=self.store_dtype,
+                device=self.device,
+            ),
+        }
+
+    def _gather_pairs(self, local_layer: int):
+        return [
+            (self.k_buffer[local_layer], "k"),
+            (self.v_buffer[local_layer], "v"),
+        ]
+
+    def set_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc_info,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale: Optional[float] = None,
+        v_scale: Optional[float] = None,
+        layer_id_override: Optional[int] = None,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+    ):
+        assert dcp_kv_mask is None, "DCP is mutually exclusive with KV sharding"
+        loc, _, _ = unwrap_write_loc(loc_info)
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+
+        if cache_k.dtype != self.dtype:
+            if k_scale is not None:
+                cache_k = cache_k / k_scale
+            if v_scale is not None:
+                cache_v = cache_v / v_scale
+            cache_k = cache_k.to(self.dtype)
+            cache_v = cache_v.to(self.dtype)
+        if self.store_dtype != self.dtype:
+            cache_k = cache_k.view(self.store_dtype)
+            cache_v = cache_v.view(self.store_dtype)
+
+        with kv_shard_nvtx_range("kv_shard.set_kv_buffer", color="blue"):
+            if self._shard_extend_active:
+                # Stage the full chunk into this layer's slot on the compute
+                # stream: ordered before this layer's attention read for free
+                # and disjoint from the gather stream, which only writes the
+                # prefix region. Padded locations translate to the trash page.
+                slot = self._slots[layer_id % 2]
+                rows = self._translate_loc_cached(loc)
+                slot.tensors["k"][rows] = cache_k
+                slot.tensors["v"][rows] = cache_v
+
+            owned_idx, local_rows = self._get_write_plan(loc)
+            if owned_idx.numel() > 0:
+                self._store_kv_layer(
+                    layer_id - self.start_layer,
+                    local_rows,
+                    cache_k.index_select(0, owned_idx),
+                    cache_v.index_select(0, owned_idx),
+                )
+
+    def get_key_buffer(self, layer_id: int):
+        if self._shard_extend_active:
+            slot = self._acquire_slot_for_read(layer_id)
+            k = slot.tensors["k"]
+            return k.view(self.dtype) if self.store_dtype != self.dtype else k
+        return super().get_key_buffer(layer_id)
+
+    def get_value_buffer(self, layer_id: int):
+        if self._shard_extend_active:
+            slot = self._acquire_slot_for_read(layer_id)
+            v = slot.tensors["v"]
+            return v.view(self.dtype) if self.store_dtype != self.dtype else v
+        return super().get_value_buffer(layer_id)
+
+
+class PageInterleaveMLATokenToKVPool(PageInterleaveKVPoolMixin, MLATokenToKVPool):
+    """MLA latent pool striped across its shard group (the attn-CP group when
+    prefill CP is active, the attn-TP group otherwise — see
+    ``page_interleave.get_kv_shard_group``).
+
+    The latent KV reaching the write path is identical on every shard-group
+    rank (``ReplicatedLinear`` projection across attn-TP; the CP allgather of
+    ``rebuild_cp_kv_cache`` across attn-CP), so the write filter needs no
+    compute-time communication. Read consumers, all served from the assembled
+    scratch: the chunked-prefix MHA path fetches prefix rows through
+    ``get_mla_kv_buffer``; the absorbed-MLA and one-shot paths read
+    ``get_key_buffer``/``get_value_buffer`` through the translated page
+    table. The current chunk is staged into the slot at write time so the
+    page-table consumers cover ``[prefix | chunk]`` uniformly.
+    """
+
+    def __init__(
+        self,
+        *args,
+        shard_spec: PageShardSpec,
+        shard_group: GroupCoordinator,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        assert not self.use_dsa, "DSA models are not supported by KV sharding yet"
+        self._init_page_shard_state(shard_spec, shard_group)
+
+    def _scratch_tensor_specs(self, rows: int) -> Dict[str, torch.Tensor]:
+        return {
+            "kv": torch.zeros(
+                (rows, 1, self.kv_cache_dim),
+                dtype=self.store_dtype,
+                device=self.device,
+            ),
+        }
+
+    def _gather_pairs(self, local_layer: int):
+        return [(self.kv_buffer[local_layer], "kv")]
+
+    def _scratch_kv(self, slot: _ScratchSlot) -> torch.Tensor:
+        kv = slot.tensors["kv"]
+        if self.store_dtype != self.dtype:
+            return kv.view(self.dtype)
+        return kv
+
+    def set_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc_info,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        layer_id_override: Optional[int] = None,
+    ):
+        loc, _, _ = unwrap_write_loc(loc_info)
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+        with kv_shard_nvtx_range("kv_shard.set_kv_buffer", color="blue"):
+            if self._shard_extend_active:
+                # Stage the full chunk into this layer's slot (compute
+                # stream): the absorbed / one-shot readers cover the current
+                # chunk through the translated page table too.
+                slot = self._slots[layer_id % 2]
+                rows = self._translate_loc_cached(loc)
+                staged_k = cache_k
+                if staged_k.dtype != self.dtype:
+                    staged_k = staged_k.to(self.dtype)
+                self._scratch_kv(slot)[rows] = staged_k
+            owned_idx, local_rows = self._get_write_plan(loc)
+            if owned_idx.numel() == 0:
+                return
+            super().set_kv_buffer(
+                layer,
+                local_rows,
+                cache_k.index_select(0, owned_idx),
+                cache_v,
+                layer_id_override=layer_id_override,
+            )
+
+    def set_mla_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        cache_k_nope: torch.Tensor,
+        cache_k_rope: torch.Tensor,
+        layer_id_override: Optional[int] = None,
+    ):
+        layer_id = (
+            layer_id_override if layer_id_override is not None else layer.layer_id
+        )
+        with kv_shard_nvtx_range("kv_shard.set_kv_buffer", color="blue"):
+            if self._shard_extend_active:
+                slot = self._slots[layer_id % 2]
+                rows = self._translate_loc_cached(loc)
+                staged_nope, staged_rope = cache_k_nope, cache_k_rope
+                if staged_nope.dtype != self.dtype:
+                    staged_nope = staged_nope.to(self.dtype)
+                    staged_rope = staged_rope.to(self.dtype)
+                if self.store_dtype != self.dtype:
+                    staged_nope = staged_nope.view(self.store_dtype)
+                    staged_rope = staged_rope.view(self.store_dtype)
+                set_mla_kv_buffer_triton(
+                    slot.tensors["kv"], rows, staged_nope, staged_rope
+                )
+            owned_idx, local_rows = self._get_write_plan(loc)
+            if owned_idx.numel() == 0:
+                return
+            super().set_mla_kv_buffer(
+                layer,
+                local_rows,
+                cache_k_nope.index_select(0, owned_idx),
+                cache_k_rope.index_select(0, owned_idx),
+                layer_id_override=layer_id_override,
+            )
+
+    def get_kv_buffer_shape(self):
+        # Shape probes (e.g. the eager runner's DCP-metadata prep) must not
+        # route through the attention getters below — they may run before
+        # this batch's metadata build while the previous batch's shard-extend
+        # flag is still set.
+        k = self.kv_buffer[0]
+        return k.shape, k[..., : self.kv_lora_rank].shape
+
+    def get_key_buffer(self, layer_id: int):
+        # During a sharded extend the pool holds only this rank's stripe;
+        # page-table readers (absorbed MLA, incl. the CP zigzag wrapper) get
+        # the assembled scratch — metadata.page_table is already translated
+        # to scratch rows.
+        if self._shard_extend_active:
+            return self._scratch_kv(self._acquire_slot_for_read(layer_id))
+        return super().get_key_buffer(layer_id)
+
+    def get_value_buffer(self, layer_id: int):
+        if self._shard_extend_active:
+            kv = self._scratch_kv(self._acquire_slot_for_read(layer_id))
+            return kv[..., : self.kv_lora_rank]
+        return super().get_value_buffer(layer_id)
+
+    def get_mla_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        dst_dtype: Optional[torch.dtype] = None,
+    ):
+        slot = self._acquire_slot_for_read(layer.layer_id)
+        rows = self._translate_loc_cached(loc)
+        kv_buffer = slot.tensors["kv"]
+        if self.store_dtype != self.dtype:
+            kv_buffer = kv_buffer.view(self.dtype)
+        dst_dtype = dst_dtype or self.dtype
+        cache_k_nope = torch.empty(
+            (loc.shape[0], 1, self.kv_lora_rank),
+            dtype=dst_dtype,
+            device=kv_buffer.device,
+        )
+        cache_k_rope = torch.empty(
+            (loc.shape[0], 1, self.qk_rope_head_dim),
+            dtype=dst_dtype,
+            device=kv_buffer.device,
+        )
+        get_mla_kv_buffer_triton(kv_buffer, rows, cache_k_nope, cache_k_rope)
+        return cache_k_nope, cache_k_rope

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -18,7 +18,12 @@ from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.srt.runtime_context import get_disagg, get_memory, get_serving
+from sglang.srt.runtime_context import (
+    get_disagg,
+    get_memory,
+    get_parallel,
+    get_serving,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -100,6 +105,10 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
         from sglang.srt.mem_cache.chunk_cache import SWAChunkCache
 
         return SWAChunkCache(params)
+
+    if get_parallel().enable_kv_cache_sharding:
+        logger.info("Using UnifiedRadixCache for logical-page KV sharding.")
+        return _create_unified_radix_cache(ctx, server_args, params)
 
     if envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE.get():
         # lazy import to avoid JIT overhead

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -139,6 +139,14 @@ class UnifiedTreeNode:
         # Anchor NodeId of an in-flight H->D load-back reading this node's
         # host slots; such host copies must not be reclaimed until the ack.
         self.load_back_pending_id: Optional[int] = None
+        # Logical-page KV sharding: rotation base of the chain this node's Full
+        # KV pages belong to — the owner rank of position-page P along the chain
+        # is (rotation_base + P) % shard_size. A host-side mirror of the
+        # loc-derived owners (the Full value is a device tensor; reading it
+        # would put a D2H sync on the alloc path): set at insert from the
+        # inserting request's host base, copied on split, read through
+        # req.last_node at alloc time. None when sharding is off.
+        self.rotation_base: Optional[int] = None
 
     def component(self, component_type: ComponentType) -> ComponentData:
         return self.component_data[component_type]
@@ -511,6 +519,13 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     def is_root(self, node_id: NodeId) -> bool:
         """Whether the node is the tree root."""
         return self.node_by_id(node_id) is self.root_node
+
+    supports_rotation_base = True
+
+    def rotation_base_of(self, node_id: NodeId) -> Optional[int]:
+        """Logical-page KV sharding: the node's chain rotation base, or None
+        when sharding is off (and on the root, which starts no chain)."""
+        return self.node_by_id(node_id).rotation_base
 
     def get_last_hash_value(self, node_id: NodeId) -> Optional[str]:
         """The node's last page hash, or None when it was never hashed."""
@@ -960,6 +975,20 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 ),
             )
 
+        if params.rotation_base is not None:
+            conflict = self._rotation_conflict(key, params.rotation_base)
+            if conflict is not None:
+                total_prefix_length, node = conflict
+                return InsertStepResult(
+                    actions=[],
+                    result=InsertResult(
+                        prefix_len=total_prefix_length,
+                        last_device_node=node.id,
+                        rotation_tail_declined=True,
+                        adopted_ranges={} if params.track_adopted_ranges else None,
+                    ),
+                )
+
         self._ongoing_insert_walk_state = _InsertWalkState(
             phase=_InsertPhase.WALK,
             node=self.root_node,
@@ -973,6 +1002,52 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             ),
         )
         return self._advance_insert()
+
+    def _rotation_conflict(
+        self, key: RadixKey, rotation_base: int
+    ) -> Optional[tuple[int, UnifiedTreeNode]]:
+        """Logical-page KV sharding: refuse an insert that would splice two
+        rotation runs into one cached path.
+
+        Read-only mirror of ``_insert_walk_step``'s matching. Returns
+        ``(matched_len, deepest_matched_node)`` when the chain this key lands on
+        was allocated under a different rotation base than the inserting
+        request's pages, else None.
+
+        Grafting across a base discontinuity would create a cached path whose
+        page owners are not one cyclic run — the padded-allgather / ``k // N``
+        translation contract — so later readers would crash on a negative pad or
+        silently read the wrong rank's scratch rows. Such a discontinuity means
+        two requests sharing a prefix were planned in pipelined batches before
+        either's insert landed, or the match was capped below the cached prefix.
+
+        Unlike the flat radix tree, the unified insert transfers page ownership
+        at three points, not just the tail graft: the tail leaf
+        (``_add_new_node``), an evicted node restored from the request's fresh
+        pages (``_unevict_node_on_insert``), and a component re-pointing a
+        matched node's Full value at the request's pages
+        (``update_component_on_insert_overlap``). All three are downstream of
+        this same predicate, so it is evaluated once, up front, and declines the
+        whole insert — which also keeps the walk's duplicate frees from running,
+        as the declined request stays on its own pages.
+        """
+        node = self.root_node
+        total_prefix_length = 0
+        while len(key) > 0:
+            child_key = key.child_key(self.page_size)
+            if child_key not in node.children:
+                break
+            child = node.children[child_key]
+            prefix_len = child.key.match(key, page_size=self.page_size)
+            node = child
+            total_prefix_length += prefix_len
+            key = key[prefix_len:]
+            if prefix_len < len(child.key):
+                # The walk would split here; the fragment inherits this base.
+                break
+        if node is self.root_node or node.rotation_base == rotation_base:
+            return None
+        return total_prefix_length, node
 
     def resume_insert(self) -> InsertStepResult:
         """Continue the suspended insert after its step actions were executed."""
@@ -1110,7 +1185,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 state.total_prefix_length + len(state.key),
             )
             state.target_node = self._add_new_node(
-                state.node, state.key, state.value, priority=state.priority
+                state.node,
+                state.key,
+                state.value,
+                priority=state.priority,
+                rotation_base=state.params.rotation_base,
             )
             state.is_new_leaf = True
         else:
@@ -1185,6 +1264,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.creation_time = child.creation_time
         # Split fragments stay on the anchor's root path for the ack's walk.
         new_node.load_back_pending_id = child.load_back_pending_id
+        # The rotation base is constant along a chain (position-page P keeps
+        # owner (b + P) % N on both sides of the split).
+        new_node.rotation_base = child.rotation_base
 
         self._for_each_component_lru(child, UnifiedLRUList.remove_node)
 
@@ -1233,10 +1315,16 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         key: RadixKey,
         value: torch.Tensor,
         priority: int = 0,
+        rotation_base: Optional[int] = None,
     ) -> UnifiedTreeNode:
         new_node = self._new_node(priority=priority)
         new_node.parent = parent
         new_node.key = key
+        # Chain-constant under sharding: the pre-flight decline in
+        # begin_insert() guarantees this tail continues the matched prefix's
+        # rotation, so stamping the inserting request's base keeps every node
+        # on a root path carrying the same base.
+        new_node.rotation_base = rotation_base
         new_node.component_data[BASE_COMPONENT_TYPE].value = value.clone()
         parent.children[key.child_key(self.page_size)] = new_node
         self.component_evictable_size_[BASE_COMPONENT_TYPE] += len(value)

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -184,6 +184,22 @@ class UnifiedTreeCoreInterface(ABC):
         """Whether the node is the tree root."""
         ...
 
+    # Logical-page KV sharding: whether this core stamps and honors
+    # UnifiedTreeNode.rotation_base. A core that does not cannot serve a
+    # sharded allocator (it would never decline a cross-base graft), and
+    # UnifiedRadixCache.__init__ rejects that pairing at construction.
+    supports_rotation_base: bool = False
+
+    def rotation_base_of(self, node_id: NodeId) -> Optional[int]:
+        """Logical-page KV sharding: the node's chain rotation base, or None
+        when sharding is off (and on the root, which starts no chain).
+
+        Concrete, not abstract: a core that does not track rotation bases
+        stays constructible, and its None means "sharding is off" -- never
+        "sharding is on but unknown", which the constructor gate rules out.
+        """
+        return None
+
     @abstractmethod
     def get_last_hash_value(self, node_id: NodeId) -> Optional[str]:
         """The node's last page hash, or None when it was never hashed."""

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -13,6 +13,9 @@ import torch
 from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.environ import envs
 from sglang.srt.managers.cache_controller import CacheOperation
+from sglang.srt.mem_cache.allocator.page_interleave import (
+    page_interleave_shard_size,
+)
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     DecLockRefParams,
@@ -199,6 +202,22 @@ class UnifiedRadixCache(BasePrefixCache):
         # Components execute boundary actions through the tree core.
         for component in self.components.values():
             component.tree_core = self.tree_core
+
+        if (
+            page_interleave_shard_size(params.token_to_kv_pool_allocator) > 1
+            and not self.tree_core.supports_rotation_base
+        ):
+            # A core that does not model rotation_base would never decline a
+            # cross-base graft, and the resulting cached path's page owners are
+            # not one cyclic run: later readers take a negative allgather pad or
+            # silently read another rank's scratch rows. Fail at construction
+            # rather than corrupt reads at serve time.
+            raise ValueError(
+                "logical-page KV sharding requires a tree core that tracks "
+                "rotation bases; "
+                f"SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND={self._tree_core_backend!r} "
+                "does not."
+            )
 
         # Session ref tracking (--enable-session-radix-cache).
         self.session_refs = UnifiedSessionRefTracker(
@@ -873,6 +892,7 @@ class UnifiedRadixCache(BasePrefixCache):
             insert_params = InsertParams(
                 prev_prefix_len=req.kv.cache_protected_len,
                 priority=getattr(req, "priority", 0) or 0,
+                rotation_base=req.kv_rotation_base,
             )
 
             # components prepare insert data + return effective cache_len
@@ -909,8 +929,17 @@ class UnifiedRadixCache(BasePrefixCache):
             insert_params.value = values
             result = self.insert(insert_params)
 
-            # Free unaligned tail (+ deferred truncation tail)
-            ranges = [(page_aligned_len, len(kv_indices))]
+            # Free unaligned tail (+ deferred truncation tail). A rotation
+            # decline inserted nothing, so the whole span past the protected
+            # prefix stayed request-owned and is released here instead.
+            free_from = (
+                # min(): the protected prefix can already run past a truncated
+                # cache_len, and free_kv_row takes ascending ranges only.
+                min(req.kv.cache_protected_len, len(kv_indices))
+                if result.rotation_tail_declined
+                else page_aligned_len
+            )
+            ranges = [(free_from, len(kv_indices))]
             if tail_free_start is not None:
                 ranges.append((tail_free_start, len(kv_indices_full)))
             self.free_kv_row(req.kv, ranges)
@@ -960,6 +989,7 @@ class UnifiedRadixCache(BasePrefixCache):
             prev_prefix_len=req.kv.cache_protected_len,
             chunked=chunked,
             priority=getattr(req, "priority", 0) or 0,
+            rotation_base=req.kv_rotation_base,
         )
         effective_cache_len = len(token_ids)
         for comp in self._components_tuple:
@@ -1005,6 +1035,23 @@ class UnifiedRadixCache(BasePrefixCache):
         insert_params.key = radix_key
         insert_params.value = values
         result = self.insert(insert_params)
+
+        if result.rotation_tail_declined:
+            # Rotation-base discontinuity with the matched chain (pipelined
+            # batches raced this request's insert against another chain over
+            # the same prefix). Adopting the canonical locs would leave this
+            # request's row mixing two rotation runs, which the cyclic-owner
+            # gather contract forbids -- keep the request entirely on its own
+            # pages: no dedup free, no rebind, no protection change. The insert
+            # declined before its walk, so nothing was freed underneath us. The
+            # final cache_finished_req releases everything past the protected
+            # prefix.
+            req.prefix_indices = kv_indices_orig.to(dtype=torch.int64, copy=True)
+            for comp in self._components_tuple:
+                comp.cleanup_after_caching_req(
+                    req, is_finished=False, insert_params=insert_params
+                )
+            return
 
         # Match prefix. SWA insertion retains one extra window before the
         # page-aligned boundary, so the normal match remains safe to repoint.
@@ -1667,6 +1714,11 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def get_prefix_hash_values(self, node_id: NodeId) -> list[str]:
         return self.tree_core.get_prefix_hash_values(node_id)
+
+    def rotation_base_of(self, node_id: Optional[NodeId]) -> Optional[int]:
+        if node_id is None:
+            return None
+        return self.tree_core.rotation_base_of(node_id)
 
     def query_storage_hit_length(
         self,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -206,6 +206,14 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             else get_schedule().max_total_tokens or kvc.model_config.context_len
         )
 
+        # Logical-page KV sharding reserves a fixed double-buffered assembly
+        # scratch next to the pool; charge it before token sizing.
+        from sglang.srt.mem_cache.page_interleave import (
+            compute_page_shard_scratch_bytes,
+        )
+
+        self._fixed_overhead_bytes = compute_page_shard_scratch_bytes(kvc)
+
         # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
         # Assumes draft and target share the same per-layer KV size (head_dim,
         # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
@@ -453,6 +461,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
+        available_bytes = max(available_bytes - self._fixed_overhead_bytes, 0)
         max_total_num_tokens = (
             available_bytes // self._cell_size
             if self._cell_size

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -111,6 +111,22 @@ def _handle_attention_backend(attn, forward_batch, backend_name):
     if is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph():
         return AttnForwardMethod.MLA
 
+    # Logical-page KV sharding: a rank's pool holds only its stripe of the
+    # prefix and of the current chunk, so extend reads go through the
+    # assembled scratch. Under prefill CP (shard axis = attn-CP) the
+    # CP-aware absorbed-MLA path is required — it reads the scratch through
+    # the translated page table (get_key_buffer). Without CP the
+    # chunked-prefix MHA path is used: it fetches the prefix
+    # through get_mla_kv_buffer and attends the current chunk from
+    # activations.
+    if (
+        get_parallel().enable_kv_cache_sharding
+        and forward_batch.forward_mode.is_extend_without_speculative()
+    ):
+        if mla_use_prefill_cp(forward_batch):
+            return _dispatch_mla_subtype(attn, forward_batch)
+        return AttnForwardMethod.MHA_CHUNKED_KV
+
     # MLA prefill CP forces absorbed MLA regardless of prefix length: the
     # CP path gathers latent KV via rebuild_cp_kv_cache and feeds the
     # backend's absorbed-MLA kernel.
@@ -145,8 +161,12 @@ def handle_attention_flashinfer(attn, forward_batch):
 
 
 def handle_attention_fa3(attn, forward_batch):
-    # when deterministic inference is enabled, use MLA
-    if get_exec().deterministic.enable_deterministic_inference:
+    # when deterministic inference is enabled, use MLA; absorbed MLA cannot read
+    # a sharded pool, so KV sharding stays on the chunked MHA path below.
+    if (
+        get_exec().deterministic.enable_deterministic_inference
+        and not get_parallel().enable_kv_cache_sharding
+    ):
         return _dispatch_mla_subtype(attn, forward_batch)
     else:
         return _handle_attention_backend(attn, forward_batch, "fa3")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1088,6 +1088,15 @@ class ServerArgs:
         "Enable attention tensor-parallel weight slicing during decode under context parallel (cp_size>1). Slices the replicated attention linears to the local CP partition, eliminating redundant decode GEMMs.",
         NS("parallel"),
     ] = False
+    enable_kv_cache_sharding: A[
+        bool,
+        "Shard at-rest KV cache storage at page granularity across the group "
+        "that currently replicates it (attention-CP ranks for GQA models "
+        "under prefill CP; attention-TP ranks for MLA models), multiplying "
+        "the group's unique KV capacity. Prefill workers of PD "
+        "disaggregation only.",
+        NS("parallel"),
+    ] = False
     # DP attention
     enable_dp_attention: A[
         bool,

--- a/python/sglang/srt/utils/nvtx_utils.py
+++ b/python/sglang/srt/utils/nvtx_utils.py
@@ -38,9 +38,10 @@ logger = logging.getLogger(__name__)
 
 _SCHEDULER_NVTX = envs.SGLANG_ENABLE_NVTX_SCHEDULER.get()
 _OPERATIONS_NVTX = envs.SGLANG_ENABLE_NVTX_OPERATIONS.get()
+_KV_SHARD_NVTX = envs.SGLANG_ENABLE_NVTX_KV_SHARD.get()
 
 _nvtx_module = None
-if _SCHEDULER_NVTX or _OPERATIONS_NVTX:
+if _SCHEDULER_NVTX or _OPERATIONS_NVTX or _KV_SHARD_NVTX:
     try:
         import nvtx as _nvtx_module  # type: ignore
     except ImportError:
@@ -54,6 +55,7 @@ NVTX_AVAILABLE = _nvtx_module is not None
 # package is importable. The record_function path is independent of both.
 NVTX_SCHEDULER_ENABLED = _SCHEDULER_NVTX and NVTX_AVAILABLE
 NVTX_OPERATIONS_ENABLED = _OPERATIONS_NVTX and NVTX_AVAILABLE
+NVTX_KV_SHARD_ENABLED = _KV_SHARD_NVTX and NVTX_AVAILABLE
 
 # Default nvtx colors for statically-named spans (only used on the nvtx path).
 _NVTX_COLOR_MAP = {
@@ -117,3 +119,5 @@ def profile_method(
 # ranges only when that subsystem's gate is on.
 scheduler_nvtx_method = partial(profile_method, nvtx_enabled=NVTX_SCHEDULER_ENABLED)
 operations_nvtx_range = partial(profile_range, nvtx_enabled=NVTX_OPERATIONS_ENABLED)
+kv_shard_nvtx_range = partial(profile_range, nvtx_enabled=NVTX_KV_SHARD_ENABLED)
+kv_shard_nvtx_method = partial(profile_method, nvtx_enabled=NVTX_KV_SHARD_ENABLED)

--- a/test/manual/test_page_interleave_gather.py
+++ b/test/manual/test_page_interleave_gather.py
@@ -1,0 +1,338 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Multi-GPU test for logical-page KV sharding pools (2 GPUs, real NCCL).
+
+Two phases, run in separate process groups (one mp.spawn each):
+
+1. MLA pool sharded across the attention-TP group: replicated writes are
+   owner-filtered into disjoint pool stripes; a later batch's chunked-prefix
+   read (get_mla_kv_buffer) assembles the full prefix from all ranks via the
+   layer-ahead NCCL allgather and must return the canonical bytes.
+2. MHA pool sharded across the attention-CP group: the post-allgather full
+   chunk is staged into the scratch chunk region and owner-persisted; a later
+   batch reads prefix+chunk through the translated page table (the scratch),
+   and the assembled rows must match the canonical bytes.
+
+Run: CUDA_VISIBLE_DEVICES=0,1 python test/manual/test_page_interleave_gather.py
+
+"""
+
+import os
+from types import SimpleNamespace
+
+import torch
+import torch.multiprocessing as mp
+
+WORLD = 2
+LAYER_NUM = 4
+PAGE_SIZE = 16
+GRANULE = WORLD * PAGE_SIZE
+SIZE = PAGE_SIZE * 64  # physical token slots per rank
+KV_LORA_RANK = 128
+QK_ROPE = 32
+HEAD_NUM = 2
+HEAD_DIM = 32
+DTYPE = torch.bfloat16
+
+
+def _mla_value(loc, dim):
+    """Deterministic canonical latent value for logical slot ``loc``."""
+    loc = loc.to(torch.float32)
+    return (loc.unsqueeze(-1) + torch.arange(dim, device=loc.device) * 0.001).to(DTYPE)
+
+
+def _dist_init(rank, world, port, attn_cp_size):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world)
+    os.environ.setdefault("no_proxy", "127.0.0.1,localhost")
+    torch.cuda.set_device(rank)
+
+    from sglang.srt.distributed import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    init_distributed_environment(
+        world_size=world,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world,
+        attention_context_model_parallel_size=attn_cp_size,
+    )
+
+
+def _make_spec(shard_rank, max_prefix_groups=16, chunk_groups=4):
+    from sglang.srt.mem_cache.page_interleave import PageShardSpec
+
+    return PageShardSpec(
+        shard_rank=shard_rank,
+        shard_size=WORLD,
+        page_size=PAGE_SIZE,
+        max_prefix_tokens=max_prefix_groups * GRANULE,
+        chunk_tokens=chunk_groups * GRANULE,
+    )
+
+
+def _fake_req_to_token(groups, seq_len, device):
+    """req_to_token row where sequence group j is allocator group groups[j]."""
+    row = torch.zeros((1, len(groups) * GRANULE), dtype=torch.int32, device=device)
+    for j, q in enumerate(groups):
+        row[0, j * GRANULE : (j + 1) * GRANULE] = torch.arange(
+            q * GRANULE, (q + 1) * GRANULE, dtype=torch.int32, device=device
+        )
+    return row[:, :seq_len] if seq_len < row.shape[1] else row
+
+
+def _check(rank, name, got, expect, atol=0.0):
+    ok = torch.allclose(got.float(), expect.float(), atol=atol, rtol=0)
+    max_err = (got.float() - expect.float()).abs().max().item()
+    print(f"[rank {rank}] {name}: max_err={max_err:.6f} {'OK' if ok else 'FAIL'}")
+    assert ok, f"[rank {rank}] {name} mismatch (max_err={max_err})"
+
+
+def _run_mla(rank, world, port):
+    _dist_init(rank, world, port, attn_cp_size=1)
+
+    from sglang.srt.mem_cache.page_interleave import get_kv_shard_group
+    from sglang.srt.mem_cache.page_interleave_pool import (
+        PageInterleaveMLATokenToKVPool,
+    )
+    from sglang.srt.runtime_context import get_parallel
+
+    group = get_parallel().attn_tp_group
+    assert group.world_size == world
+    # Topology-first shard-group selection: no CP here, so MLA falls back to
+    # the attn-TP axis, while GQA has no replicated axis (world_size 1).
+    assert get_kv_shard_group(use_mla_backend=True) is group
+    assert get_kv_shard_group(use_mla_backend=False).world_size == 1
+    spec = _make_spec(shard_rank=group.rank_in_group)
+
+    pool = PageInterleaveMLATokenToKVPool(
+        SIZE,
+        page_size=PAGE_SIZE,
+        dtype=DTYPE,
+        kv_lora_rank=KV_LORA_RANK,
+        qk_rope_head_dim=QK_ROPE,
+        layer_num=LAYER_NUM,
+        device=f"cuda:{rank}",
+        enable_memory_saver=False,
+        start_layer=0,
+        end_layer=LAYER_NUM - 1,
+        shard_spec=spec,
+        shard_group=group,
+    )
+    device = pool.kv_buffer[0].device
+
+    # ---- chunk 1: replicated write, owner-filtered persist -----------------
+    # "Allocator" hands out fragmented groups (identical on every rank).
+    chunk1_groups = [5, 2, 9]
+    chunk1_locs = _fake_req_to_token(chunk1_groups, 3 * GRANULE, device)[0].long()
+    for layer_id in range(LAYER_NUM):
+        layer = SimpleNamespace(layer_id=layer_id)
+        vals = _mla_value(chunk1_locs + layer_id * 1000, KV_LORA_RANK + QK_ROPE)
+        pool.set_mla_kv_buffer(
+            layer,
+            chunk1_locs,
+            vals[:, :KV_LORA_RANK].unsqueeze(1),
+            vals[:, KV_LORA_RANK:].unsqueeze(1),
+        )
+    torch.cuda.synchronize()
+    torch.distributed.barrier()
+
+    # Pool holds only the owned stripe: group Q sits at local rows [Q*ps,(Q+1)*ps)
+    # on every rank, holding that rank's page of the group.
+    for q in chunk1_groups:
+        local_rows = torch.arange(q * PAGE_SIZE, (q + 1) * PAGE_SIZE, device=device)
+        owned_locs = (
+            q * GRANULE
+            + group.rank_in_group * PAGE_SIZE
+            + torch.arange(PAGE_SIZE, device=device)
+        )
+        got = pool.kv_buffer[0][local_rows, 0, :].view(DTYPE)
+        expect = _mla_value(owned_locs, KV_LORA_RANK + QK_ROPE)
+        _check(rank, f"mla owned stripe g{q}", got, expect)
+
+    # ---- chunk 2: prefix gather + staged chunk, both read styles -----------
+    seq_groups = chunk1_groups + [12]  # one new chunk group
+    prefix_len = 3 * GRANULE
+    seq_len = prefix_len + GRANULE
+    req_to_token = _fake_req_to_token(seq_groups, seq_len, device)
+    chunk2_locs = req_to_token[0, prefix_len:seq_len].long()
+    pool.begin_shard_extend(req_to_token, torch.tensor([0]), [prefix_len], [seq_len])
+
+    for layer_id in range(LAYER_NUM):
+        layer = SimpleNamespace(layer_id=layer_id)
+        # Write the current chunk (stages it into the slot + persists the
+        # owned stripe), like the extend forward does before attention.
+        chunk_vals = _mla_value(chunk2_locs + layer_id * 1000, KV_LORA_RANK + QK_ROPE)
+        pool.set_mla_kv_buffer(
+            layer,
+            chunk2_locs,
+            chunk_vals[:, :KV_LORA_RANK].unsqueeze(1),
+            chunk_vals[:, KV_LORA_RANK:].unsqueeze(1),
+        )
+        # Chunked-prefix MHA style: fetch an arbitrary sub-range of the
+        # prefix through get_mla_kv_buffer.
+        sub = chunk1_locs[PAGE_SIZE // 2 : prefix_len - 3]
+        k_nope, k_rope = pool.get_mla_kv_buffer(layer, sub, DTYPE)
+        expect = _mla_value(sub + layer_id * 1000, KV_LORA_RANK + QK_ROPE)
+        _check(
+            rank,
+            f"mla prefix read l{layer_id}",
+            k_nope[:, 0, :],
+            expect[:, :KV_LORA_RANK],
+        )
+        _check(
+            rank,
+            f"mla prefix rope l{layer_id}",
+            k_rope[:, 0, :],
+            expect[:, KV_LORA_RANK:],
+        )
+        # Absorbed-MLA style (what MLA-under-CP uses): read [prefix | chunk]
+        # from get_key_buffer through the translated page table.
+        all_locs = req_to_token[0, :seq_len].long()
+        rows = pool.translate_loc_to_scratch(all_locs)
+        kv_scratch = pool.get_key_buffer(layer_id)
+        _check(
+            rank,
+            f"mla absorbed read l{layer_id}",
+            kv_scratch[rows, 0, :],
+            _mla_value(all_locs + layer_id * 1000, KV_LORA_RANK + QK_ROPE),
+        )
+
+    torch.distributed.barrier()
+    if rank == 0:
+        print("PASS: MLA page-interleave shard (attn-TP axis)")
+
+
+def _run_mha(rank, world, port):
+    _dist_init(rank, world, port, attn_cp_size=world)
+
+    from sglang.srt.mem_cache.page_interleave import get_kv_shard_group
+    from sglang.srt.mem_cache.page_interleave_pool import (
+        PageInterleaveMHATokenToKVPool,
+    )
+    from sglang.srt.runtime_context import get_parallel
+
+    group = get_parallel().attn_cp_group
+    assert group.world_size == world
+    # Topology-first shard-group selection: with an active CP group, both
+    # GQA and MLA shard across CP (CP replicates KV for every attention
+    # type; the TP axis is only the no-CP MLA fallback).
+    assert get_kv_shard_group(use_mla_backend=False) is group
+    assert get_kv_shard_group(use_mla_backend=True) is group
+    spec = _make_spec(shard_rank=group.rank_in_group)
+
+    pool = PageInterleaveMHATokenToKVPool(
+        SIZE,
+        page_size=PAGE_SIZE,
+        dtype=DTYPE,
+        head_num=HEAD_NUM,
+        head_dim=HEAD_DIM,
+        layer_num=LAYER_NUM,
+        device=f"cuda:{rank}",
+        enable_memory_saver=False,
+        start_layer=0,
+        end_layer=LAYER_NUM - 1,
+        enable_alt_stream=False,
+        shard_spec=spec,
+        shard_group=group,
+    )
+    device = pool.k_buffer[0].device
+
+    def kv_value(locs, layer_id, is_v):
+        base = locs.to(torch.float32) + layer_id * 1000 + (500000 if is_v else 0)
+        return (
+            base.view(-1, 1, 1)
+            + torch.arange(HEAD_NUM, device=device).view(1, -1, 1) * 0.01
+            + torch.arange(HEAD_DIM, device=device).view(1, 1, -1) * 0.0001
+        ).to(DTYPE)
+
+    # ---- chunk 1 (prefix-less batch): stage + owner-persist ----------------
+    chunk1_groups = [7, 3]
+    chunk1_locs = _fake_req_to_token(chunk1_groups, 2 * GRANULE, device)[0].long()
+    req_to_token = _fake_req_to_token(chunk1_groups, 2 * GRANULE, device)
+    pool.begin_shard_extend(req_to_token, torch.tensor([0]), [0], [2 * GRANULE])
+    for layer_id in range(LAYER_NUM):
+        layer = SimpleNamespace(layer_id=layer_id)
+        pool.set_kv_buffer(
+            layer,
+            chunk1_locs,
+            kv_value(chunk1_locs, layer_id, False),
+            kv_value(chunk1_locs, layer_id, True),
+        )
+        # The current chunk must be readable through the scratch right away.
+        k_scratch = pool.get_key_buffer(layer_id)
+        rows = pool.translate_loc_to_scratch(chunk1_locs)
+        _check(
+            rank,
+            f"mha chunk stage l{layer_id}",
+            k_scratch[rows],
+            kv_value(chunk1_locs, layer_id, False),
+        )
+    torch.cuda.synchronize()
+    torch.distributed.barrier()
+
+    # ---- chunk 2: prefix gathered from peers via translated page table -----
+    seq_groups = chunk1_groups + [11]
+    prefix_len = 2 * GRANULE
+    seq_len = prefix_len + GRANULE
+    req_to_token = _fake_req_to_token(seq_groups, seq_len, device)
+    chunk2_locs = req_to_token[0, prefix_len:seq_len].long()
+    pool.begin_shard_extend(req_to_token, torch.tensor([0]), [prefix_len], [seq_len])
+
+    for layer_id in range(LAYER_NUM):
+        layer = SimpleNamespace(layer_id=layer_id)
+        pool.set_kv_buffer(
+            layer,
+            chunk2_locs,
+            kv_value(chunk2_locs, layer_id, False),
+            kv_value(chunk2_locs, layer_id, True),
+        )
+        all_locs = req_to_token[0, :seq_len].long()
+        rows = pool.translate_loc_to_scratch(all_locs)
+        k_scratch = pool.get_key_buffer(layer_id)
+        v_scratch = pool.get_value_buffer(layer_id)
+        _check(
+            rank,
+            f"mha seq read k l{layer_id}",
+            k_scratch[rows],
+            kv_value(all_locs, layer_id, False),
+        )
+        _check(
+            rank,
+            f"mha seq read v l{layer_id}",
+            v_scratch[rows],
+            kv_value(all_locs, layer_id, True),
+        )
+
+    torch.distributed.barrier()
+    if rank == 0:
+        print("PASS: MHA page-interleave shard (attn-CP axis)")
+
+
+def main():
+    mp.spawn(_run_mla, args=(WORLD, 29811), nprocs=WORLD, join=True)
+    mp.spawn(_run_mha, args=(WORLD, 29812), nprocs=WORLD, join=True)
+    print("PASS: all page-interleave gather tests")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -408,6 +408,8 @@ class TestGetDcpLens(CustomTestCase):
                 kv_cache_dtype=torch.bfloat16,
                 device="cpu",
                 is_draft_worker=False,
+                kv_shard_size=1,
+                kv_shard_spec=None,
             )
             # The allocator widens from get_parallel(), not from the injected
             # server_args stand-in -- drive the cause, not the effect.

--- a/test/registered/models_e2e/test_kv_cache_sharding_gqa_cp.py
+++ b/test/registered/models_e2e/test_kv_cache_sharding_gqa_cp.py
@@ -1,0 +1,93 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""E2E test for logical-page KV cache sharding on a GQA model under prefill CP.
+
+Prefill CP replicates GQA KV storage across attention-CP ranks; with
+``--enable-kv-cache-sharding`` each CP rank stores only its page-interleaved
+stripe (~CPx unique KV capacity for the group), extend attention reads the
+assembled scratch through the translated FA3 page table, and each CP rank
+sends only its owned pages to decode.
+
+PD-disaggregation fixture, 8 GPUs: prefill TP4 (attn-CP 2) on GPUs 0-3,
+decode TP2 on GPUs 4-5.
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+
+register_cuda_ci(est_time=900, stage="base-c", runner_config="8-gpu-h200")
+
+
+class TestGQACPKVCacheSharding(PDDisaggregationServerBase, GSM8KMixin):
+    model = "Qwen/Qwen3-30B-A3B-FP8"
+
+    gsm8k_accuracy_thres = 0.90
+    gsm8k_num_questions = 200
+    gsm8k_num_threads = 128
+
+    # Canonical zigzag prefill CP plus KV sharding across the attn-CP group.
+    extra_prefill_args = [
+        "--tp",
+        "4",
+        "--moe-dp-size",
+        "2",
+        "--ep-size",
+        "2",
+        "--attn-cp-size",
+        "2",
+        "--enable-prefill-cp",
+        "--cp-strategy",
+        "zigzag",
+        "--attention-backend",
+        "fa3",
+        "--enable-kv-cache-sharding",
+        "--page-size",
+        "64",
+        "--chunked-prefill-size",
+        "4096",
+        "--max-prefill-tokens",
+        "4096",
+        "--mem-fraction-static",
+        "0.8",
+    ]
+    # Decode attn-TP matches the prefill attn-TP (tp 4 / cp 2 -> attn_tp 2):
+    # the owner-strided send filter pairs pages positionally per (tp, cp)
+    # sender; a TP-size mismatch would add non-MLA head slicing on top and
+    # fragment every page transfer.
+    extra_decode_args = [
+        "--tp",
+        "2",
+        "--attention-backend",
+        "fa3",
+        "--page-size",
+        "64",
+        "--mem-fraction-static",
+        "0.8",
+        "--base-gpu-id",
+        "4",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.launch_all()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models_e2e/test_kv_cache_sharding_mla.py
+++ b/test/registered/models_e2e/test_kv_cache_sharding_mla.py
@@ -1,0 +1,81 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""E2E test for logical-page KV cache sharding on an MLA model.
+
+MLA latent KV is replicated across attention-TP ranks; with
+``--enable-kv-cache-sharding`` each prefill TP rank stores only its
+page-interleaved stripe (~TPx unique KV capacity for the group), reads the
+prefix through the assembled scratch (chunked-prefix MHA path), and sends only
+its owned pages to decode (which pulls from every prefill TP rank).
+
+Uses the PD-disaggregation fixture because KV sharding is a PD-prefill-only
+feature. 4 GPUs: prefill TP2 on GPUs 0-1, decode TP2 on GPUs 2-3.
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import DEFAULT_MLA_MODEL_NAME_FOR_TEST
+
+register_cuda_ci(est_time=900, stage="base-c", runner_config="4-gpu-h100")
+
+
+class TestMLAKVCacheSharding(PDDisaggregationServerBase, GSM8KMixin):
+    model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
+
+    gsm8k_accuracy_thres = 0.70
+    gsm8k_num_questions = 200
+    gsm8k_num_threads = 128
+
+    extra_prefill_args = [
+        "--tp",
+        "2",
+        "--attention-backend",
+        "fa3",
+        "--enable-kv-cache-sharding",
+        "--page-size",
+        "64",
+        "--chunked-prefill-size",
+        "2048",
+        "--max-prefill-tokens",
+        "2048",
+        "--mem-fraction-static",
+        "0.8",
+    ]
+
+    extra_decode_args = [
+        "--tp",
+        "2",
+        "--attention-backend",
+        "fa3",
+        "--page-size",
+        "64",
+        "--mem-fraction-static",
+        "0.8",
+        "--base-gpu-id",
+        "2",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.launch_all()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
@@ -9,11 +9,13 @@ on the shared CommonKVManager.
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVTransferMetric
 from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVSender
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVSender
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -70,6 +72,50 @@ def _make_sender(kv_mgr):
 
 
 class TestKVTransferReplicaMetric(CustomTestCase):
+    def test_mooncake_does_not_count_cp_replicated_state_that_is_skipped(self):
+        state_indices = [np.array([9], dtype=np.int32)]
+
+        for cp_rank, expected_kv_count, expected_state_count in (
+            (0, 2, 1),
+            (1, 0, 0),
+        ):
+            with self.subTest(cp_rank=cp_rank):
+                mgr = SimpleNamespace(
+                    kv_shard_rank=cp_rank,
+                    kv_shard_size=2,
+                    add_transfer_request=Mock(),
+                    _should_skip_cp_replicated_state_transfer=(
+                        lambda cp_rank=cp_rank: cp_rank != 0
+                    ),
+                )
+                sender = MooncakeKVSender.__new__(MooncakeKVSender)
+                sender.kv_mgr = mgr
+                sender.bootstrap_room = 17
+                sender.aux_index = 3
+                sender.curr_idx = 0
+                sender.num_kv_indices = 2
+                sender.trace_ctx = Mock()
+                sender._transfer_metric = KVTransferMetric()
+                sender._transfer_num_kv_indices = 0
+                sender._transfer_num_state_indices = 0
+
+                # Both logical pages are owned by rank 0, so rank 1 must still
+                # enqueue an empty final chunk but must not count the replicated
+                # state that Mooncake's worker skips for nonzero CP ranks.
+                sender.send(
+                    np.array([0, 2], dtype=np.int32),
+                    state_indices=state_indices,
+                )
+
+                self.assertEqual(sender._transfer_num_kv_indices, expected_kv_count)
+                self.assertEqual(
+                    sender._transfer_num_state_indices, expected_state_count
+                )
+                mgr.add_transfer_request.assert_called_once()
+                call = mgr.add_transfer_request.call_args
+                self.assertTrue(call.args[3])
+                self.assertEqual(len(call.args[1]), expected_kv_count)
+
     def test_mla_scales_kv_and_state_bytes_by_fan_out(self):
         # CP rank 0 replicates to 4 decode TP ranks; both kv and state scale.
         mgr = _make_kv_mgr(is_mla_backend=True)

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -535,6 +535,18 @@ class TestNixlTransferWorker(CustomTestCase):
         self.assertIn(room, mgr.req_to_decode_prefix_len)
         mgr.send_kvcache.assert_called_once()
 
+    def test_empty_non_last_chunk_sends_standalone_notification(self):
+        room = 24
+        mgr = self._make_manager(room)
+        mgr.agent.send_notif = MagicMock()
+        mgr.send_kvcache = MagicMock()
+        chunk = self._make_chunk(room, [], is_last_chunk=False)
+
+        self._run_worker_once(mgr, chunk)
+
+        mgr.agent.send_notif.assert_called_once_with("agent", b"24_kv_0_0_0")
+        mgr.send_kvcache.assert_not_called()
+
     def test_dcp_destinations_use_disjoint_pack_regions_before_chunk_barrier(self):
         room = 23
         mgr = self._make_manager(room)

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -16,11 +16,13 @@ class TestRegisterToBootstrap(CustomTestCase):
     """Tests for CommonKVManager.register_to_bootstrap retry/backoff behavior."""
 
     def setUp(self):
-        # register_to_bootstrap reads get_parallel().load_balance_method /
-        # .enable_dsa_cache_layer_split and get_serving().port from the
-        # published config.
+        # register_to_bootstrap reads get_parallel().load_balance_method,
+        # .enable_dsa_cache_layer_split, and .enable_kv_cache_sharding plus
+        # get_serving().port from the published config.
         override = get_context().override_server_args(
-            load_balance_method="follow_bootstrap_room", port=30000
+            load_balance_method="follow_bootstrap_room",
+            port=30000,
+            enable_kv_cache_sharding=True,
         )
         override.install()
         self.addCleanup(override.restore)
@@ -177,12 +179,14 @@ class TestRegisterToBootstrap(CustomTestCase):
             "rank_port",
             "page_size",
             "kv_cache_dtype",
+            "enable_kv_cache_sharding",
             # Self-registered HTTP API port used to derive the PD retract
             # rebootstrap /generate URL on the decode side.
             "prefill_http_port",
         ]
         for field in required_fields:
             self.assertIn(field, payload)
+        self.assertIs(payload["enable_kv_cache_sharding"], True)
         self.assertEqual(payload["prefill_http_port"], 30000)
 
     @patch("sglang.srt.disaggregation.common.conn.time")

--- a/test/registered/unit/layers/attention/test_flashattention_pa_swa_prefill_lens_size.py
+++ b/test/registered/unit/layers/attention/test_flashattention_pa_swa_prefill_lens_size.py
@@ -25,6 +25,7 @@ import torch
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
 from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
+from sglang.srt.mem_cache.page_interleave_pool import PageInterleaveKVPoolMixin
 from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -32,7 +33,13 @@ from sglang.test.test_utils import CustomTestCase
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 
 
-def _make_prefill_aware_swa_runner(*, pool_size: int, max_context_len: int = 64):
+class _FakeShardPool(PageInterleaveKVPoolMixin):
+    pass
+
+
+def _make_prefill_aware_swa_runner(
+    *, pool_size: int, max_context_len: int = 64, token_to_kv_pool=None
+):
     """A minimal fake ModelRunner that reaches FlashAttentionBackend.__init__'s
     is_prefill_aware_swa branch (mirrors how models like
     python/sglang/srt/models/unlimited_ocr.py opt in)."""
@@ -63,7 +70,7 @@ def _make_prefill_aware_swa_runner(*, pool_size: int, max_context_len: int = 64)
         enable_prefill_cp=False,
         enable_dp_attention=False,
     )
-    token_to_kv_pool = object()
+    token_to_kv_pool = token_to_kv_pool if token_to_kv_pool is not None else object()
     token_to_kv_pool_allocator = object()
     return SimpleNamespace(
         sliding_window_size=None,
@@ -94,6 +101,16 @@ def _make_prefill_aware_swa_runner(*, pool_size: int, max_context_len: int = 64)
 
 @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
 class TestPrefillAwareSwaPrefillLensBound(CustomTestCase):
+    def test_sharded_pool_requests_cpu_sequence_lengths(self):
+        runner = _make_prefill_aware_swa_runner(
+            pool_size=8, token_to_kv_pool=_FakeShardPool()
+        )
+
+        with get_context().override_server_args():
+            backend = FlashAttentionBackend(runner)
+
+        self.assertTrue(backend.needs_cpu_seq_lens)
+
     def test_buffer_covers_full_req_pool_idx_range(self):
         pool_size = 8
         runner = _make_prefill_aware_swa_runner(pool_size=pool_size)

--- a/test/registered/unit/layers/attention/test_kv_shard_hooks.py
+++ b/test/registered/unit/layers/attention/test_kv_shard_hooks.py
@@ -1,0 +1,112 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.kv_shard_hooks import (
+    get_kv_shard_pool,
+    prepare_kv_shard_forward,
+)
+from sglang.srt.mem_cache.page_interleave_pool import PageInterleaveKVPoolMixin
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _RecordingPool(PageInterleaveKVPoolMixin):
+    def __init__(self):
+        self.begin_args = None
+        self.begin_calls = 0
+        self.end_calls = 0
+
+    def begin_shard_extend(self, *args):
+        self.begin_args = args
+        self.begin_calls += 1
+
+    def end_shard_extend(self):
+        self.end_calls += 1
+
+
+def _batch(mode: ForwardMode):
+    return SimpleNamespace(
+        forward_mode=mode,
+        req_pool_indices=torch.tensor([3], dtype=torch.int64),
+        extend_prefix_lens_cpu=[64],
+        seq_lens_cpu=torch.tensor([128], dtype=torch.int64),
+    )
+
+
+def test_detects_only_page_interleaved_pools():
+    pool = _RecordingPool()
+
+    assert get_kv_shard_pool(pool) is pool
+    assert get_kv_shard_pool(object()) is None
+
+
+@pytest.mark.parametrize(
+    "mode, active",
+    [
+        (ForwardMode.EXTEND, True),
+        (ForwardMode.MIXED, True),
+        (ForwardMode.SPLIT_PREFILL, True),
+        (ForwardMode.DECODE, False),
+        (ForwardMode.IDLE, False),
+        (ForwardMode.TARGET_VERIFY, False),
+        (ForwardMode.DRAFT_EXTEND_V2, False),
+    ],
+)
+def test_prepare_updates_the_pool_lifecycle(mode, active):
+    pool = _RecordingPool()
+    req_to_token = torch.arange(8)
+    batch = _batch(mode)
+
+    assert prepare_kv_shard_forward(pool, req_to_token, batch) is active
+    assert pool.begin_calls == int(active)
+    assert pool.end_calls == int(not active)
+    if active:
+        assert all(
+            actual is expected
+            for actual, expected in zip(
+                pool.begin_args,
+                (
+                    req_to_token,
+                    batch.req_pool_indices,
+                    batch.extend_prefix_lens_cpu,
+                    batch.seq_lens_cpu,
+                ),
+            )
+        )
+    else:
+        assert pool.begin_args is None
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["req_pool_indices", "extend_prefix_lens_cpu", "seq_lens_cpu"],
+)
+def test_extend_requires_host_metadata(missing_field):
+    batch = _batch(ForwardMode.EXTEND)
+    setattr(batch, missing_field, None)
+
+    with pytest.raises(RuntimeError, match="requires request indices and CPU"):
+        prepare_kv_shard_forward(_RecordingPool(), torch.empty(0), batch)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/managers/test_kv_page_invariants.py
+++ b/test/registered/unit/managers/test_kv_page_invariants.py
@@ -2,6 +2,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -94,6 +95,26 @@ class TestKVPageInvariants(CustomTestCase):
         )
         with self.assertRaises(ValueError):
             chk._check_kv_page_invariants()
+
+    def test_classed_allocator_without_flat_free_list_is_checked(self):
+        chk, rtt, _tc, alloc = _make_checker(page_size=4, row_width=8)
+        alloc.free_pages = None
+        alloc.get_all_free_pages = MagicMock(
+            return_value=torch.tensor([5, 6], dtype=torch.int64)
+        )
+        rtt[0, :1] = torch.tensor([5 * alloc.page_size])
+        chk.get_last_batch = lambda: SimpleNamespace(
+            reqs=[_FakeOwner(0, 1, 1, rid="classed")]
+        )
+
+        with patch(
+            "sglang.srt.mem_cache.allocator.page_interleave.page_interleave_shard_size",
+            return_value=2,
+        ):
+            with self.assertRaisesRegex(ValueError, "use-after-free"):
+                chk._check_kv_page_invariants()
+
+        alloc.get_all_free_pages.assert_called()
 
     def test_free_pool_duplicate_raises(self):
         chk, rtt, tc, alloc = _make_checker(free_pages=torch.tensor([3, 3, 4]))

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -501,6 +501,39 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
 
+    @patch(
+        "sglang.srt.mem_cache.allocator.page_interleave.page_interleave_shard_size",
+        return_value=4,
+    )
+    def test_ignore_eos_reserves_all_shard_class_pages(self, _shard_size):
+        """Disabled-radix admission must charge one page per shard class."""
+        self.mock_tree_cache.disable = True
+        self.mock_token_allocator.page_size = 16
+        self.mock_token_allocator.shard_spec = SimpleNamespace(
+            max_prefix_tokens=1024, chunk_tokens=1024
+        )
+        self.mock_token_allocator.available_size.return_value = 64
+        adder = self.create_adder(self.create_running_batch(), page_size=16)
+
+        req = self.create_mock_req("ignore_eos", priority=0, max_new_tokens=1)
+        req.sampling_params.ignore_eos = True
+        req.origin_input_ids = list(range(16))
+        req.full_untruncated_fill_ids = list(range(16))
+        req.last_node = MagicMock()
+        req.set_extend_range = MagicMock(
+            side_effect=lambda start, end: setattr(
+                req, "extend_range", Range(start, end)
+            )
+        )
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.NO_TOKEN)
+        self.assertEqual(adder.can_run_list, [])
+        req.set_extend_range.assert_not_called()
+
     def _build_hybrid_swa_chunked_req(
         self,
         *,

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -16,7 +16,8 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
     Rules enforced when clipping a request's max_new_tokens:
       1. context: input_len + max_new_tokens < max_req_len
       2. admission budget (PrefillAdder):
-         ceil_page(input_len) + max_new_tokens + page_size < max_total_num_tokens
+         ceil_page(input_len) + max_new_tokens + page_size * shard_widening
+         < max_total_num_tokens * shard_widening
       3. env limit: <= SGLANG_MAX_NEW_TOKENS_LIMIT when set and positive
       4. never above the requested value
       5. min_new_tokens <= max_new_tokens afterwards
@@ -50,11 +51,13 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
         max_req_len: int = 128,
         max_total_num_tokens: int = 1024,
         page_size: int = 1,
+        kv_shard_widening: int = 1,
     ) -> Scheduler:
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.max_req_len = max_req_len
         scheduler.max_total_num_tokens = max_total_num_tokens
         scheduler.page_size = page_size
+        scheduler.kv_shard_widening = kv_shard_widening
         scheduler.max_new_tokens_limit = envs.SGLANG_MAX_NEW_TOKENS_LIMIT.get()
         return scheduler
 
@@ -76,6 +79,7 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
 
         input_len = len(req.origin_input_ids)
         page_size = scheduler.page_size
+        shard_widening = scheduler.kv_shard_widening
         paged_input_len = -(-input_len // page_size) * page_size
         limit = scheduler.max_new_tokens_limit
         limit_active = limit is not None and limit > 0
@@ -83,7 +87,8 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
         def satisfies_rules(candidate: int) -> bool:
             context_ok = input_len + candidate < scheduler.max_req_len
             budget_ok = (
-                paged_input_len + candidate + page_size < scheduler.max_total_num_tokens
+                paged_input_len + candidate + page_size * shard_widening
+                < scheduler.max_total_num_tokens * shard_widening
             )
             limit_ok = not limit_active or candidate <= limit
             requested_ok = requested is None or candidate <= requested
@@ -143,6 +148,29 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
                 self._init_and_check(scheduler, req),
                 max_total_num_tokens - paged_input_len - page_size - 1,
             )
+
+    def test_sharded_budget_reserves_one_page_per_shard(self):
+        max_total_num_tokens, page_size, input_len, shard_widening = 8, 4, 8, 3
+        scheduler = self._new_scheduler(
+            max_req_len=128,
+            max_total_num_tokens=max_total_num_tokens,
+            page_size=page_size,
+            kv_shard_widening=shard_widening,
+        )
+        req = self._new_req(max_new_tokens=64, input_len=input_len)
+
+        max_new_tokens = self._init_and_check(scheduler, req)
+
+        widened_capacity = max_total_num_tokens * shard_widening
+        per_req_overhead = page_size * shard_widening
+        self.assertEqual(
+            max_new_tokens,
+            widened_capacity - input_len - per_req_overhead - 1,
+        )
+        self.assertLess(
+            input_len + max_new_tokens + per_req_overhead,
+            widened_capacity,
+        )
 
     def test_min_new_tokens_clamped_to_limit(self):
         with envs.SGLANG_MAX_NEW_TOKENS_LIMIT.override(16):

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -87,6 +87,7 @@ class MockReq:
             cache_protected_len=cache_protected_len,
             swa_evicted_seqlen=0,
         )
+        self.kv_rotation_base = None
 
     def get_fill_ids(self):
         return self.full_untruncated_fill_ids[: self.extend_range.end]

--- a/test/registered/unit/mem_cache/test_page_interleave_shard.py
+++ b/test/registered/unit/mem_cache/test_page_interleave_shard.py
@@ -30,6 +30,8 @@ Pins the pure arithmetic that rotated owner-classed allocation hangs on:
 5. ``begin_shard_extend`` plan capture (page positions, padded send rows,
    owner-congruence guard) with the gather stubbed out, following the
    SimpleNamespace binding pattern of ``test_dsa_layer_shard_utils.py``.
+6. The value-derived P/D ownership send filter
+   ``filter_kv_indices_for_shard_rank``.
 """
 
 import unittest
@@ -37,8 +39,10 @@ import unittest.mock
 from array import array
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 
+from sglang.srt.disaggregation.utils import filter_kv_indices_for_shard_rank
 from sglang.srt.mem_cache.allocator.page_interleave import (
     PageInterleavePoolAllocator,
     page_interleave_shard_size,
@@ -1127,6 +1131,58 @@ class TestWritePlan(CustomTestCase):
         owned_idx, local_rows = PageInterleaveKVPoolMixin._get_write_plan(stub, loc)
         self.assertEqual(owned_idx.numel(), 0)
         self.assertEqual(local_rows.numel(), 0)
+
+
+class TestShardSendFilter(CustomTestCase):
+    """Value-derived P/D ownership partition: owner = logical page % N, wire
+    value = logical page // N — independent of positions, so it stays
+    correct under any placement policy."""
+
+    def test_partition_and_positional_pairing(self):
+        mgr = SimpleNamespace(kv_shard_rank=0, kv_shard_size=N)
+        # A base-2 rotated chain: owners are NOT position-congruent.
+        logical_pages = np.array(_chain_pages(base=2, n_pages=9), dtype=np.int64)
+        sl = slice(0, 9)
+        got = {}
+        for r in range(N):
+            mgr.kv_shard_rank = r
+            wire, pos = filter_kv_indices_for_shard_rank(mgr, logical_pages, sl)
+            got[r] = (wire, pos)
+            # Ownership by VALUE (l % N == r), wire id = owner's local page.
+            np.testing.assert_array_equal(logical_pages[pos] % N, r)
+            np.testing.assert_array_equal(wire, logical_pages[pos] // N)
+        # Disjoint cover of all positions.
+        all_pos = np.sort(np.concatenate([got[r][1] for r in range(N)]))
+        np.testing.assert_array_equal(all_pos, np.arange(9))
+
+    def test_wire_value_is_the_owner_local_page(self):
+        """The wire byte contract: l // N == loc // (N * ps) — the owner-local
+        page id, so the decode side needs no change."""
+        mgr = SimpleNamespace(kv_shard_rank=1, kv_shard_size=N)
+        logical_pages = np.array(_chain_pages(base=0, n_pages=8), dtype=np.int64)
+        locs = logical_pages * PS  # page-head loc of each entry
+        wire, pos = filter_kv_indices_for_shard_rank(mgr, logical_pages, slice(0, 8))
+        np.testing.assert_array_equal(wire, locs[pos] // (N * PS))
+
+    def test_mid_request_chunk_positions_canonical(self):
+        mgr = SimpleNamespace(kv_shard_rank=2, kv_shard_size=N)
+        logical_pages = np.array(
+            _chain_pages(base=1, n_pages=32)[20:32], dtype=np.int64
+        )
+        wire, pos = filter_kv_indices_for_shard_rank(mgr, logical_pages, slice(20, 32))
+        # Positions are canonical (chunk-global), values from this chunk.
+        self.assertTrue(((pos >= 20) & (pos < 32)).all())
+        np.testing.assert_array_equal(logical_pages[pos - 20] % N, 2)
+        np.testing.assert_array_equal(wire, logical_pages[pos - 20] // N)
+
+    def test_rank_owning_nothing_in_chunk(self):
+        """A short chunk can leave a rank with zero pages; the filter must
+        return empty arrays, not error."""
+        mgr = SimpleNamespace(kv_shard_rank=3, kv_shard_size=N)
+        pages = np.array(_chain_pages(base=0, n_pages=2), dtype=np.int64)  # owners 0,1
+        wire, pos = filter_kv_indices_for_shard_rank(mgr, pages, slice(0, 2))
+        self.assertEqual(len(wire), 0)
+        self.assertEqual(len(pos), 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_page_interleave_shard.py
+++ b/test/registered/unit/mem_cache/test_page_interleave_shard.py
@@ -24,6 +24,12 @@ Pins the pure arithmetic that rotated owner-classed allocation hangs on:
 3. The host rotation base on ``UnifiedTreeNode`` — stamped at insert, copied
    on split, read through ``last_node``, and the pre-flight that declines an
    insert whose pages carry a different base than the chain it would join.
+4. ``translate_loc_to_scratch`` — the per-batch page->scratch-page lookup mapping
+   any consumer index vector onto the owner-major ``[prefix | chunk | trash]``
+   scratch, checked against a brute-force reference.
+5. ``begin_shard_extend`` plan capture (page positions, padded send rows,
+   owner-congruence guard) with the gather stubbed out, following the
+   SimpleNamespace binding pattern of ``test_dsa_layer_shard_utils.py``.
 """
 
 import unittest
@@ -45,6 +51,7 @@ from sglang.srt.mem_cache.page_interleave import (
     PageInterleavePlacement,
     PageShardSpec,
 )
+from sglang.srt.mem_cache.page_interleave_pool import PageInterleaveKVPoolMixin
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache.components import ComponentType
 from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
@@ -761,6 +768,365 @@ class TestRotationGraftDecline(CustomTestCase):
         released = torch.cat(freed) if freed else torch.empty(0, dtype=torch.int64)
         # Only the 8 duplicate rows go back; the tail stays live in the tree.
         self.assertEqual(set(released.tolist()), set(own_locs[:8].tolist()))
+
+
+def _chain_pages(base, n_pages, local_start=5):
+    """Logical page ids of one chain: page P has owner (base + P) % N and an
+    arbitrary (here: increasing) local page on its owner."""
+    counter = {r: local_start for r in range(N)}
+    pages = []
+    for p in range(n_pages):
+        r = (base + p) % N
+        pages.append(counter[r] * N + r)
+        counter[r] += 1
+    return pages
+
+
+def _chain_row(pages, seq_len):
+    row = torch.empty(seq_len, dtype=torch.int32)
+    for i in range(seq_len):
+        row[i] = pages[i // PS] * PS + i % PS
+    return row
+
+
+def _make_pool_stub(spec, shard_rank=0, debug=True, table_pages=4096):
+    """A SimpleNamespace carrying exactly the state begin_shard_extend /
+    translate_loc_to_scratch read."""
+    stub = SimpleNamespace()
+    stub.shard_spec = spec
+    stub.shard_rank = shard_rank
+    stub.device = "cpu"
+    stub.start_layer = 0
+    stub._chunk_base = spec.max_prefix_tokens
+    stub._trash_base = spec.max_prefix_tokens + spec.chunk_tokens
+    stub._page_pos = torch.full(
+        (table_pages,), stub._trash_base // PS, dtype=torch.int32
+    )
+    stub._local_page_stride = table_pages
+    stub._epoch = 0
+    stub._write_plan_key = stub._write_plan = None
+    stub._translate_cache = {}
+    stub._debug_plan_checks = debug
+    stub.translate_loc_to_scratch = lambda loc: (
+        PageInterleaveKVPoolMixin.translate_loc_to_scratch(stub, loc)
+    )
+    stub.prefetched = []
+    stub._prefetch_layer = lambda layer_id: stub.prefetched.append(layer_id)
+    return stub
+
+
+def _run_begin(stub, prefix_lens, seq_lens, rows):
+    width = max(r.numel() for r in rows)
+    padded = [
+        torch.cat([r, torch.zeros(width - r.numel(), dtype=torch.int32)]) for r in rows
+    ]
+    PageInterleaveKVPoolMixin.begin_shard_extend(
+        stub,
+        torch.stack(padded),
+        torch.arange(len(rows)),
+        prefix_lens,
+        seq_lens,
+    )
+    return stub
+
+
+def _reference_prefix_slots(per_request_prefix_pages):
+    """Brute-force reference of the owner-major slot assignment: the batch's
+    unique prefix pages sorted by (owner, local page), rank r's pages
+    contiguous at r * block; block = sum of per-request ceil(K_i / N)."""
+    block = sum(-(-len(pages) // N) for pages in per_request_prefix_pages)
+    uniq = sorted({p for pages in per_request_prefix_pages for p in pages})
+    slots = {}
+    counts = {r: 0 for r in range(N)}
+    for page in sorted(uniq, key=lambda p: (p % N, p // N)):
+        owner = page % N
+        slots[page] = owner * block + counts[owner]
+        counts[owner] += 1
+    return slots, block
+
+
+class TestBeginShardExtendPlan(CustomTestCase):
+    def test_plan_with_rotated_prefix(self):
+        """7 prefix pages of a base-2 chain + 9 chunk pages (last partial):
+        owner-major slots, send rows owner-filtered in the same order and
+        padded to the block bound ceil(7/4) = 2 pages."""
+        pages = _chain_pages(base=2, n_pages=16)
+        prefix_len, seq_len = 7 * PS, 16 * PS - 5
+        row = _chain_row(pages, seq_len)
+        slots, block = _reference_prefix_slots([pages[:7]])
+        for rank in range(N):
+            stub = _run_begin(
+                _make_pool_stub(_make_spec(), rank), [prefix_len], [seq_len], [row]
+            )
+            self.assertEqual(stub._block_pages, block)
+            self.assertTrue(stub._shard_extend_active)
+            self.assertEqual(stub._epoch, 1)
+            self.assertEqual(stub.prefetched, [0])  # first layer kicked
+            for page, slot in slots.items():
+                self.assertEqual(int(stub._page_pos[page]), slot)
+            for j, page in enumerate(pages[7:]):
+                self.assertEqual(int(stub._page_pos[page]), stub._chunk_base // PS + j)
+            own = sorted((p for p in pages[:7] if p % N == rank), key=lambda p: p // N)
+            expect = torch.cat(
+                [torch.arange((p // N) * PS, (p // N + 1) * PS) for p in own]
+            )
+            if len(own) < block:  # padded with the trash page (local page 0)
+                expect = torch.cat([expect, torch.arange((block - len(own)) * PS)])
+            self.assertTrue(torch.equal(stub._send_rows, expect))
+
+    def test_multi_request_plan_shared_prefix_dedup(self):
+        """bs > 1: request 0 and request 1 share a 3-page cached prefix
+        (request 1 extends it by 2 pages); request 2 is an unrelated base-2
+        chain. Shared pages must gather into ONE slot (no duplicate plan
+        entries), the block is the per-request ceil sum, and every request's
+        locs translate through the same table."""
+        chain_a = _chain_pages(base=0, n_pages=5)
+        chain_c = _chain_pages(base=2, n_pages=4, local_start=20)
+        # rows: request 0 = A[:3] prefix + 1 chunk page; request 1 = A[:5]
+        # prefix + 2 chunk pages; request 2 = C[:2] prefix + 2 chunk pages.
+        chunk0 = _chain_pages(base=3, n_pages=1, local_start=40)
+        chunk1 = _chain_pages(base=1, n_pages=2, local_start=50)
+        chunk2 = _chain_pages(base=0, n_pages=2, local_start=60)
+        rows = [
+            _chain_row(chain_a[:3] + chunk0, 4 * PS),
+            _chain_row(chain_a[:5] + chunk1, 7 * PS),
+            _chain_row(chain_c[:2] + chunk2, 4 * PS - 3),
+        ]
+        stub = _run_begin(
+            _make_pool_stub(_make_spec()),
+            [3 * PS, 5 * PS, 2 * PS],
+            [4 * PS, 7 * PS, 4 * PS - 3],
+            rows,
+        )
+        slots, block = _reference_prefix_slots([chain_a[:3], chain_a[:5], chain_c[:2]])
+        self.assertEqual(block, 1 + 2 + 1)
+        self.assertEqual(stub._block_pages, block)
+        for page, slot in slots.items():
+            self.assertEqual(int(stub._page_pos[page]), slot)
+        # Chunk slots are absolute scratch pages in batch order.
+        for j, page in enumerate(chunk0 + chunk1 + chunk2):
+            self.assertEqual(int(stub._page_pos[page]), stub._chunk_base // PS + j)
+        # Shared pages: both requests' locs hit the SAME scratch rows.
+        shared_loc_r0 = rows[0][:PS].long()
+        shared_loc_r1 = rows[1][:PS].long()
+        t0 = PageInterleaveKVPoolMixin.translate_loc_to_scratch(stub, shared_loc_r0)
+        t1 = PageInterleaveKVPoolMixin.translate_loc_to_scratch(stub, shared_loc_r1)
+        self.assertTrue(torch.equal(t0, t1))
+        # Per-rank send lists fit the block and pad with the trash page.
+        all_prefix = sorted(set(chain_a[:5] + chain_c[:2]))
+        for rank in range(N):
+            stub_r = _run_begin(
+                _make_pool_stub(_make_spec(), rank),
+                [3 * PS, 5 * PS, 2 * PS],
+                [4 * PS, 7 * PS, 4 * PS - 3],
+                rows,
+            )
+            own = sorted((p for p in all_prefix if p % N == rank), key=lambda p: p // N)
+            self.assertLessEqual(len(own), block)
+            self.assertEqual(stub_r._send_rows.numel(), block * PS)
+            expect_head = torch.cat(
+                [torch.arange((p // N) * PS, (p // N + 1) * PS) for p in own]
+            )
+            self.assertTrue(
+                torch.equal(stub_r._send_rows[: len(own) * PS], expect_head)
+            )
+
+    def test_send_order_follows_local_page_not_position(self):
+        """A freed-and-reused page can give a chain a LOWER local page id at
+        a later position. Slot assignment and send packing must both order
+        by local page id (they only need to agree — a mismatch reads the
+        wrong rank rows)."""
+        # Owner-0 pages appear at positions 0 and 4 with locals 9 then 3.
+        pages = [9 * N + 0, 5 * N + 1, 5 * N + 2, 5 * N + 3, 3 * N + 0]
+        row = _chain_row(pages, 5 * PS)
+        stub = _run_begin(
+            _make_pool_stub(_make_spec(), shard_rank=0),
+            [5 * PS],
+            [5 * PS + PS],
+            [torch.cat([row, _chain_row([7 * N + 1], PS)])],
+        )
+        slots, block = _reference_prefix_slots([pages])
+        self.assertEqual(block, 2)
+        # local 3 gets owner-0's first slot although it sits at position 4.
+        self.assertEqual(int(stub._page_pos[3 * N + 0]), 0)
+        self.assertEqual(int(stub._page_pos[9 * N + 0]), 1)
+        expect = torch.cat(
+            [torch.arange(3 * PS, 4 * PS), torch.arange(9 * PS, 10 * PS)]
+        )
+        self.assertTrue(torch.equal(stub._send_rows, expect))
+
+    def test_plan_without_prefix(self):
+        pages = _chain_pages(base=0, n_pages=2)
+        stub = _run_begin(
+            _make_pool_stub(_make_spec()), [0], [PS + 5], [_chain_row(pages, PS + 5)]
+        )
+        self.assertEqual(stub._block_pages, 0)
+        self.assertTrue(stub._shard_extend_active)
+        self.assertEqual(stub.prefetched, [])  # nothing to gather
+        self.assertIsNone(stub._send_rows)
+        self.assertEqual(int(stub._page_pos[pages[0]]), stub._chunk_base // PS)
+        self.assertEqual(int(stub._page_pos[pages[1]]), stub._chunk_base // PS + 1)
+
+    def test_unaligned_prefix_rejected(self):
+        # The tree quantum is the PHYSICAL page: a prefix that is not a
+        # ps-multiple can never come out of match_prefix.
+        pages = _chain_pages(base=0, n_pages=4)
+        with self.assertRaises(AssertionError):
+            _run_begin(
+                _make_pool_stub(_make_spec()),
+                [PS + 3],
+                [4 * PS],
+                [_chain_row(pages, 4 * PS)],
+            )
+
+    def test_owner_congruence_guard(self):
+        """A rotation-base bug that breaks a request's prefix-owner
+        cyclicity invalidates the sync-free block bound (a rank can own more
+        than ceil(K/N) pages); the debug guard must catch it at plan time."""
+        pages = _chain_pages(base=1, n_pages=8)
+        pages[2], pages[5] = pages[5], pages[2]  # same multiset, not cyclic
+        with self.assertRaises(AssertionError) as ctx:
+            _run_begin(
+                _make_pool_stub(_make_spec()),
+                [6 * PS],
+                [8 * PS],
+                [_chain_row(pages, 8 * PS)],
+            )
+        self.assertIn("cyclic", str(ctx.exception))
+
+
+class TestScratchTranslation(CustomTestCase):
+    def _plan(self, base=2, n_prefix=7, n_chunk=9, rank=1):
+        pages = _chain_pages(base=base, n_pages=n_prefix + n_chunk)
+        seq_len = (n_prefix + n_chunk) * PS
+        stub = _run_begin(
+            _make_pool_stub(_make_spec(), rank),
+            [n_prefix * PS],
+            [seq_len],
+            [_chain_row(pages, seq_len)],
+        )
+        return stub, pages[:n_prefix], pages[n_prefix:]
+
+    def _reference_row(self, stub, prefix_pages, chunk_pages, loc):
+        """Brute-force reference: owner-major (owner, local-page)-sorted
+        prefix slots, sequence-order chunk."""
+        spec = stub.shard_spec
+        page, off = loc // PS, loc % PS
+        if page in prefix_pages:
+            slots, _ = _reference_prefix_slots([prefix_pages])
+            return slots[page] * PS + off
+        if page in chunk_pages:
+            k = chunk_pages.index(page)
+            return spec.max_prefix_tokens + k * PS + off
+        return stub._trash_base + off
+
+    def test_translation_matches_reference(self):
+        stub, prefix_pages, chunk_pages = self._plan()
+        locs = (
+            [p * PS + o for p in prefix_pages + chunk_pages for o in (0, 3, PS - 1)]
+            + list(range(0, N))  # reserved pages -> trash
+            + [3000, 3001]  # off-plan -> trash
+        )
+        got = PageInterleaveKVPoolMixin.translate_loc_to_scratch(
+            stub, torch.tensor(locs, dtype=torch.int64)
+        )
+        expect = torch.tensor(
+            [self._reference_row(stub, prefix_pages, chunk_pages, l) for l in locs],
+            dtype=torch.int64,
+        )
+        self.assertTrue(torch.equal(got, expect))
+
+    def test_translation_is_injective_over_the_plan(self):
+        stub, prefix_pages, chunk_pages = self._plan(base=3, n_prefix=5, n_chunk=4)
+        locs = [p * PS + o for p in prefix_pages + chunk_pages for o in range(PS)]
+        rows = PageInterleaveKVPoolMixin.translate_loc_to_scratch(
+            stub, torch.tensor(locs, dtype=torch.int64)
+        )
+        self.assertEqual(len(torch.unique(rows)), len(locs))
+        # Prefix rows stay inside the (padded) gather span, chunk rows inside
+        # the chunk region.
+        n_prefix_tokens = len(prefix_pages) * PS
+        self.assertTrue(
+            bool((rows[:n_prefix_tokens] < N * stub._block_pages * PS).all())
+        )
+        self.assertTrue(
+            bool(
+                (rows[n_prefix_tokens:] >= stub.shard_spec.max_prefix_tokens).all()
+                and (rows[n_prefix_tokens:] < stub._trash_base).all()
+            )
+        )
+
+    def test_int32_page_table_input(self):
+        stub, prefix_pages, chunk_pages = self._plan(base=0, n_prefix=4, n_chunk=1)
+        table = torch.tensor(
+            [prefix_pages[0] * PS, prefix_pages[1] * PS, chunk_pages[0] * PS, 0],
+            dtype=torch.int32,
+        )
+        rows = PageInterleaveKVPoolMixin.translate_loc_to_scratch(stub, table)
+        self.assertEqual(rows.dtype, torch.int64)
+        # Page-aligned inputs land on page-aligned scratch rows (the FA3
+        # stride-divide contract).
+        self.assertTrue(bool((rows[:3] % PS == 0).all()))
+        self.assertEqual(int(rows[3]), stub._trash_base)
+
+    def test_translation_cache_cleared_with_new_plan(self):
+        pages = _chain_pages(base=0, n_pages=2)
+        stub = _make_pool_stub(_make_spec())
+
+        # The first batch treats page 0 as part of the current chunk.
+        _run_begin(stub, [0], [PS], [_chain_row(pages[:1], PS)])
+        loc = _chain_row(pages[:1], PS).long()
+        first = PageInterleaveKVPoolMixin._translate_loc_cached(stub, loc)
+        again = PageInterleaveKVPoolMixin._translate_loc_cached(stub, loc)
+        self.assertIs(again, first)
+
+        # The next batch reuses the same loc tensor after page 0 becomes a
+        # cached prefix. Installing the new plan must discard the old mapping.
+        _run_begin(stub, [PS], [2 * PS], [_chain_row(pages, 2 * PS)])
+        fresh = PageInterleaveKVPoolMixin._translate_loc_cached(stub, loc)
+        self.assertIsNot(fresh, first)
+        self.assertFalse(torch.equal(fresh, first))
+
+
+class TestWritePlan(CustomTestCase):
+    def test_owner_filter_cached_per_loc_tensor(self):
+        spec = _make_spec(shard_rank=2)
+        stub = SimpleNamespace()
+        stub.placement = PageInterleavePlacement(spec)
+        stub.shard_rank = 2
+        stub._epoch = 1
+        stub._write_plan_key = stub._write_plan = None
+
+        loc = torch.arange(5 * GS, 7 * GS)  # two whole groups
+        owned_idx, local_rows = PageInterleaveKVPoolMixin._get_write_plan(stub, loc)
+        self.assertEqual(owned_idx.numel(), 2 * PS)
+        # Owned rows are ps-contiguous runs at [Q*ps, (Q+1)*ps).
+        self.assertTrue(
+            torch.equal(
+                local_rows,
+                torch.cat([torch.arange(5 * PS, 6 * PS), torch.arange(6 * PS, 7 * PS)]),
+            )
+        )
+        # Same tensor + same epoch -> cached (identity).
+        again = PageInterleaveKVPoolMixin._get_write_plan(stub, loc)
+        self.assertIs(again[0], owned_idx)
+        # Epoch bump invalidates.
+        stub._epoch = 2
+        fresh = PageInterleaveKVPoolMixin._get_write_plan(stub, loc)
+        self.assertIsNot(fresh[0], owned_idx)
+
+    def test_partial_tail_page_may_own_nothing(self):
+        spec = _make_spec(shard_rank=3)
+        stub = SimpleNamespace()
+        stub.placement = PageInterleavePlacement(spec)
+        stub.shard_rank = 3
+        stub._epoch = 1
+        stub._write_plan_key = stub._write_plan = None
+        # 10 tokens: all inside owner-0's page of the group.
+        loc = torch.arange(8 * GS, 8 * GS + 10)
+        owned_idx, local_rows = PageInterleaveKVPoolMixin._get_write_plan(stub, loc)
+        self.assertEqual(owned_idx.numel(), 0)
+        self.assertEqual(local_rows.numel(), 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_page_interleave_shard.py
+++ b/test/registered/unit/mem_cache/test_page_interleave_shard.py
@@ -1,0 +1,767 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for logical-page KV cache sharding (CPU only).
+
+Pins the pure arithmetic that rotated owner-classed allocation hangs on:
+
+1. The placement bijection ``loc = Q*(N*ps) + r*ps + o`` — owner / local-row
+   round-trip, disjoint equal partition across ranks.
+2. ``PageInterleavePoolAllocator`` — N mirrored class free lists, rotated
+   class draws (owners exactly cyclic along a chain), least-full root
+   seeding, min-class admission accounting, zero stranding (a freed page is
+   immediately reusable).
+3. The host rotation base on ``UnifiedTreeNode`` — stamped at insert, copied
+   on split, read through ``last_node``, and the pre-flight that declines an
+   insert whose pages carry a different base than the chain it would join.
+"""
+
+import unittest
+import unittest.mock
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.allocator.page_interleave import (
+    PageInterleavePoolAllocator,
+    page_interleave_shard_size,
+)
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.page_interleave import (
+    PageInterleavePlacement,
+    PageShardSpec,
+)
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+N = 4  # shard size
+PS = 16  # physical page size
+GS = N * PS  # full-group span (N physical pages)
+
+
+def _make_spec(shard_rank=0, max_prefix_groups=64, chunk_pages=32):
+    return PageShardSpec(
+        shard_rank=shard_rank,
+        shard_size=N,
+        page_size=PS,
+        max_prefix_tokens=max_prefix_groups * GS,
+        chunk_tokens=chunk_pages * PS,
+    )
+
+
+def _make_allocator(pages_per_rank=32, need_sort=False):
+    return PageInterleavePoolAllocator(
+        size=pages_per_rank * PS,  # physical token slots of one rank
+        physical_page_size=PS,
+        shard_size=N,
+        dtype=torch.bfloat16,
+        device="cpu",
+        kvcache=None,
+        need_sort=need_sort,
+    )
+
+
+def _alloc_extend_batch(alloc, prefix_lens, seq_lens, rotation_bases, last_locs=None):
+    """Drive alloc_extend for a batch; rotation_bases is resolved in place."""
+    if last_locs is None:
+        last_locs = [-1] * len(prefix_lens)
+    return alloc.alloc_extend(
+        prefix_lens=torch.tensor(prefix_lens, dtype=torch.int64),
+        prefix_lens_cpu=torch.tensor(prefix_lens, dtype=torch.int64),
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int64),
+        seq_lens_cpu=torch.tensor(seq_lens, dtype=torch.int64),
+        last_loc=torch.tensor(last_locs, dtype=torch.int64),
+        extend_num_tokens=sum(s - p for p, s in zip(prefix_lens, seq_lens)),
+        rotation_bases=rotation_bases,
+    )
+
+
+def _alloc_extend(alloc, prefix_len, seq_len, rotation_base, last_loc=-1):
+    return _alloc_extend_batch(
+        alloc, [prefix_len], [seq_len], [rotation_base], [last_loc]
+    )
+
+
+class TestPlacement(CustomTestCase):
+    def test_owner_local_round_trip(self):
+        pl = PageInterleavePlacement(_make_spec())
+        loc = torch.arange(0, 37 * GS + 5)
+        owner = pl.owner_of(loc)
+        local = pl.local_index(loc)
+        # Reconstruct loc from (group, owner, in-page offset): the bijection.
+        group = loc // GS
+        self.assertTrue(torch.equal(group * GS + owner * PS + loc % PS, loc))
+        # Local rows are group-major: [Q*ps, (Q+1)*ps) — identical on every
+        # rank (symmetric allocation); owner only selects WHICH rank stores.
+        self.assertTrue(torch.equal(local, group * PS + loc % PS))
+
+    def test_filter_local_partitions_disjoint_and_equal(self):
+        pl = PageInterleavePlacement(_make_spec())
+        loc = torch.arange(0, 10 * GS)
+        parts = [pl.filter_local(loc, r) for r in range(N)]
+        self.assertEqual(sum(p.numel() for p in parts), loc.numel())
+        # Equal shares of whole groups.
+        self.assertEqual(len({p.numel() for p in parts}), 1)
+        # Every rank's local rows for a full range are the same integers
+        # (each rank stores its own stripe at the SAME rows).
+        for p in parts[1:]:
+            self.assertTrue(torch.equal(p, parts[0]))
+
+    def test_owned_tokens_form_page_runs(self):
+        pl = PageInterleavePlacement(_make_spec(shard_rank=2))
+        loc = torch.arange(0, 3 * GS)
+        mask = pl.local_mask(loc, 2)
+        # Owner-2 tokens are exactly [2*ps, 3*ps) of every group.
+        expect = (loc % GS >= 2 * PS) & (loc % GS < 3 * PS)
+        self.assertTrue(torch.equal(mask, expect))
+
+
+class TestClassedAllocator(CustomTestCase):
+    def test_index_space_widened_classes_mirror_ranks(self):
+        alloc = _make_allocator(pages_per_rank=32)
+        self.assertEqual(alloc.size, 32 * PS * N)  # logical slots
+        self.assertEqual(alloc.page_size, PS)  # the PHYSICAL page quantum
+        self.assertEqual(page_interleave_shard_size(alloc), N)
+        # Class r holds exactly rank r's allocatable pages: l % N == r,
+        # local pages 1..32 (page 0 reserved on every rank).
+        self.assertEqual(alloc.class_free_page_counts(), [32] * N)
+        for r in range(N):
+            pages = alloc.class_free_pages[r]
+            self.assertTrue(bool((pages % N == r).all()))
+            self.assertTrue(torch.equal(pages // N, torch.arange(1, 33)))
+
+    def test_rotation_worked_example_zero_stranding(self):
+        """Two-turn worked example at ps=16: turn 1 allocates cyclic owners
+        from the root base; the turn-boundary free returns its page whole and
+        immediately reusable; turn 2 continues the rotation and reuses the
+        freed page before any fresh one."""
+        alloc = _make_allocator()
+        total = alloc.available_size()
+
+        # Turn 1: 122 tokens = 8 position-pages, root base 0.
+        base = alloc.least_full_class()
+        self.assertEqual(base, 0)  # all classes equal -> lowest id
+        out = _alloc_extend(alloc, 0, 122, base)
+        pages = out[::PS] // PS
+        # Owners exactly cyclic from the base; in-page offsets positional.
+        self.assertTrue(torch.equal(pages % N, torch.arange(8) % N))
+        self.assertTrue(torch.equal(out % PS, torch.arange(122) % PS))
+
+        # Boundary: cache 112 (7 pages), free the sub-ps tail's page whole.
+        alloc.free(out[112:122])
+        # Page 7's owner is (0 + 7) % 4 = 3: back on class 3, reusable now.
+        self.assertEqual(alloc.class_free_page_counts(), [30, 30, 30, 31])
+
+        # Turn 2: prefix 112, extend to 244 (9 new pages P7..P15).
+        out2 = _alloc_extend(alloc, 112, 244, base, last_loc=int(out[111]))
+        pages2 = out2[::PS] // PS
+        self.assertTrue(torch.equal(pages2 % N, (7 + torch.arange(9)) % N))
+        # The freed page is the class-3 head: reused before any fresh page.
+        self.assertEqual(int(pages2[0]), int(pages[7]))
+        # Nothing stranded: freeing the chain restores full capacity.
+        alloc.free(out[:112])
+        alloc.free(out2)
+        self.assertEqual(alloc.available_size(), total)
+        self.assertEqual(alloc.class_free_page_counts(), [32] * N)
+
+    def test_min_class_admission_accounting(self):
+        """available_size is the MIN-CLASS floor: draining one class must
+        zero the admission budget even while the aggregate stays large —
+        an aggregate gate would over-admit into the alloc path's fail-loud
+        RuntimeError when the tight class is protected."""
+        alloc = _make_allocator(pages_per_rank=4)
+        outs = [_alloc_extend(alloc, 0, PS, rotation_base=3) for _ in range(4)]
+        self.assertEqual(alloc.class_free_page_counts(), [4, 4, 4, 0])
+        self.assertEqual(alloc.available_size(), 0)
+        self.assertEqual(alloc.aggregate_free_size(), 12 * PS)
+        # A draw needing the empty class defers (None), never raises.
+        self.assertIsNone(_alloc_extend(alloc, 0, N * PS, rotation_base=0))
+        # A free of one class-3 page lifts the floor by one page per class.
+        alloc.free(outs[0])
+        self.assertEqual(alloc.available_size(), N * PS)
+
+    def test_least_full_root_seeding(self):
+        """Roots draw from the class with the most free pages (ties: lowest
+        id). Uniform 1-page roots therefore spread with skew <= 1."""
+        alloc = _make_allocator(pages_per_rank=32)
+        for i in range(2 * N + 1):
+            base = alloc.least_full_class()
+            _alloc_extend(alloc, 0, PS, rotation_base=base)
+            counts = alloc.class_free_page_counts()
+            self.assertLessEqual(max(counts) - min(counts), 1, counts)
+        # 9 single-page roots at N=4: classes filled 3,2,2,2.
+        self.assertEqual(alloc.class_free_page_counts(), [29, 30, 30, 30])
+
+    def test_chain_rotation_run_property(self):
+        """Within one chain (root + arbitrary ps-aligned extensions) the
+        owners are exactly cyclic, so per-rank owned page counts differ by
+        <= 1 — the padded-allgather block contract ceil(K/N). Guards the
+        class-interleave scatter in alloc_extend."""
+        for shard_size in (2, 4, 8):
+            alloc = PageInterleavePoolAllocator(
+                size=256 * PS,
+                physical_page_size=PS,
+                shard_size=shard_size,
+                dtype=torch.bfloat16,
+                device="cpu",
+                kvcache=None,
+                need_sort=False,
+            )
+            lens = [3 * PS, 5 * PS, PS, 7 * PS]  # chunked extensions
+            base = alloc.least_full_class()
+            chain = []
+            prefix = 0
+            for ext in lens:
+                out = _alloc_extend(alloc, prefix, prefix + ext, base)
+                chain.append(out)
+                prefix += ext
+            locs = torch.cat(chain)
+            pages = locs[::PS] // PS
+            owners = pages % shard_size
+            expect = torch.arange(pages.numel()) % shard_size
+            self.assertTrue(torch.equal(owners, (int(owners[0]) + expect) % shard_size))
+            per_rank = torch.bincount(owners, minlength=shard_size)
+            self.assertLessEqual(int(per_rank.max() - per_rank.min()), 1)
+
+    def test_free_splits_by_owner_class(self):
+        alloc = _make_allocator()
+        out = _alloc_extend(alloc, 0, 6 * PS, rotation_base=1)
+        before = alloc.class_free_page_counts()
+        # Free pages 2 and 3 of the chain (owners 3 and 0) in one call, via
+        # the free-group batching path the scheduler uses.
+        alloc.free_group_begin()
+        alloc.free(out[2 * PS : 3 * PS])
+        alloc.free(out[3 * PS : 4 * PS])
+        alloc.free_group_end()
+        after = alloc.class_free_page_counts()
+        deltas = [a - b for a, b in zip(after, before)]
+        self.assertEqual(deltas, [1, 0, 0, 1])  # classes (1+2)%4=3 and (1+3)%4=0
+
+    def test_grouped_free_owns_indices_before_caller_mutation(self):
+        """Deferred frees must snapshot req_to_token views: the scheduler may
+        overwrite the backing row before free_group_end consumes them."""
+        alloc = _make_allocator()
+        out = _alloc_extend(alloc, 0, 2 * PS, rotation_base=2)
+        first_page = out[:PS]
+        owner = int(first_page[0] // PS % N)
+        before = alloc.class_free_page_counts()
+
+        alloc.free_group_begin()
+        alloc.free(first_page)
+        first_page.zero_()
+        alloc.free_group_end()
+
+        after = alloc.class_free_page_counts()
+        self.assertEqual(after[owner], before[owner] + 1)
+        self.assertEqual(
+            [after[r] - before[r] for r in range(N)],
+            [1 if r == owner else 0 for r in range(N)],
+        )
+
+    def test_free_segment_returns_pages_to_their_classes(self):
+        # The radix cache frees through free_segment/free_segments. The paged
+        # base routes those to the stock free_pages list, which this allocator
+        # never reads, so the override must land them in the class lists.
+        alloc = _make_allocator()
+        total = alloc.available_size()
+        out = _alloc_extend(alloc, 0, 3 * PS, rotation_base=2)
+        self.assertLess(alloc.available_size(), total)
+        alloc.free_segment(out, start_pos=0)
+        self.assertEqual(alloc.available_size(), total)
+        self.assertEqual(alloc.class_free_page_counts(), [32] * N)
+
+    def test_free_segments_splits_at_a_page_boundary(self):
+        alloc = _make_allocator()
+        total = alloc.available_size()
+        out = _alloc_extend(alloc, 0, 4 * PS, rotation_base=0)
+        # Two disjoint ascending segments of one request's kv row.
+        alloc.free_segments([(out[: 2 * PS], 0), (out[2 * PS :], 2 * PS)])
+        self.assertEqual(alloc.available_size(), total)
+        self.assertEqual(alloc.class_free_page_counts(), [32] * N)
+
+    def test_need_sort_merges_per_class(self):
+        alloc = _make_allocator(pages_per_rank=4, need_sort=True)
+        out = _alloc_extend(alloc, 0, 4 * N * PS, rotation_base=0)  # everything
+        self.assertEqual(alloc.available_size(), 0)
+        alloc.free(out)  # lands in the per-class release lists
+        self.assertEqual(alloc.available_size(), 4 * N * PS)
+        # A fresh draw forces the per-class merge+sort and succeeds.
+        out2 = _alloc_extend(alloc, 0, N * PS, rotation_base=0)
+        self.assertIsNotNone(out2)
+        pages = out2[::PS] // PS
+        self.assertTrue(torch.equal(pages % N, torch.arange(N) % N))
+
+    def test_unsupported_paths_fail_loud(self):
+        alloc = _make_allocator()
+        with self.assertRaises(NotImplementedError):
+            alloc.alloc(GS)
+        with self.assertRaises(NotImplementedError):
+            alloc.alloc_decode(
+                torch.tensor([PS + 1]), torch.tensor([PS + 1]), torch.tensor([PS - 1])
+            )
+
+    def test_batch_alloc_per_request_rotation(self):
+        """bs > 1: each request draws its own cyclic run; out_cache_loc is
+        the batch-order concatenation (write_cache_indices' contract), and a
+        None base is resolved from the least-full class AT THAT REQUEST'S
+        TURN — the draw must see earlier requests' pops in the same batch,
+        or uniform short batches would all pile onto one class."""
+        alloc = _make_allocator()
+        # req0: extension of a base-1 chain with a 2-page prefix;
+        # req1 and req2: new chains (drawn in place).
+        bases = [1, None, None]
+        out = _alloc_extend_batch(
+            alloc,
+            prefix_lens=[2 * PS, 0, 0],
+            seq_lens=[5 * PS, 3 * PS, PS],
+            rotation_bases=bases,
+            # req0's last prefix page must carry owner (1 + 1) % 4 = 2.
+            last_locs=[(5 * N + 2) * PS + PS - 1, -1, -1],
+        )
+        self.assertEqual(out.numel(), 3 * PS + 3 * PS + PS)
+        # Batch-order concatenation, per-request cyclic owners.
+        pages = out[::PS] // PS
+        self.assertTrue(
+            torch.equal(pages[:3] % N, (1 + 2 + torch.arange(3)) % N)  # req0
+        )
+        b1, b2 = bases[1], bases[2]
+        self.assertIsNotNone(b1)
+        self.assertIsNotNone(b2)
+        self.assertTrue(torch.equal(pages[3:6] % N, (b1 + torch.arange(3)) % N))
+        self.assertEqual(int(pages[6]) % N, b2)
+        # req1's draw saw req0's pops (classes 3,0,1 used once each -> class
+        # 2 is fullest... all equal except used {3,0,1} -> least-full = 2);
+        # req2's draw saw req1's pops on top.
+        self.assertEqual(b1, 2)
+        self.assertEqual(b2, 1)  # after req1 used {2,3,0}: class 1 fullest
+        # The whole batch is one no-duplicate allocation.
+        self.assertEqual(len(torch.unique(out)), out.numel())
+
+    def test_batch_alloc_defers_whole_when_a_class_is_short(self):
+        """A batch either commits whole or returns None (mirrored decision):
+        partial commits would desync the free lists from the retry."""
+        alloc = _make_allocator(pages_per_rank=2)
+        counts_before = alloc.class_free_page_counts()
+        out = _alloc_extend_batch(
+            alloc,
+            prefix_lens=[0, 0],
+            seq_lens=[4 * PS, 5 * PS],  # 9 pages: class need exceeds 2 somewhere
+            rotation_bases=[0, 0],
+        )
+        self.assertIsNone(out)
+        self.assertEqual(alloc.class_free_page_counts(), counts_before)
+
+
+class TestEvictUntilAllocatable(CustomTestCase):
+    """The evict-then-allocate contract under min-class accounting: one
+    evict() sized in tokens can raise the tight class by less than the
+    tokens it freed (evicted pages spread across classes), so the alloc
+    path iterates. Guards the two termination conditions of
+    _evict_until_allocatable."""
+
+    def _allocator_with_tight_class(self):
+        alloc = _make_allocator(pages_per_rank=4)
+        # Four 1-page chains, all in class 3: the tight class.
+        outs = [_alloc_extend(alloc, 0, PS, rotation_base=3) for _ in range(4)]
+        assert alloc.available_size() == 0
+        return alloc, outs
+
+    def _tree_stub(self, alloc, frees):
+        from sglang.srt.mem_cache.base_prefix_cache import EvictResult
+
+        stub = SimpleNamespace(calls=0)
+
+        def evict(params):
+            stub.calls += 1
+            if not frees:
+                return EvictResult(num_tokens_evicted=0)
+            head = frees.pop(0)
+            alloc.free(head)
+            return EvictResult(num_tokens_evicted=head.numel())
+
+        stub.evict = evict
+        return stub
+
+    def test_iterates_until_min_class_covers(self):
+        from sglang.srt.mem_cache.common import _evict_until_allocatable
+
+        alloc, outs = self._allocator_with_tight_class()
+        # Each round frees ONE class-3 page (a whole 1-page chain): reaching
+        # a min-class floor of 2 pages takes 2 rounds.
+        tree = self._tree_stub(alloc, list(outs))
+        _evict_until_allocatable(tree, alloc, 2 * N * PS)
+        self.assertGreaterEqual(alloc.available_size(), 2 * N * PS)
+        self.assertEqual(tree.calls, 2)
+
+    def test_terminates_when_tree_dry(self):
+        from sglang.srt.mem_cache.common import _evict_until_allocatable
+
+        alloc, _ = self._allocator_with_tight_class()
+        tree = self._tree_stub(alloc, [])  # nothing evictable
+        _evict_until_allocatable(tree, alloc, PS)
+        self.assertEqual(alloc.available_size(), 0)  # need unmet, but no hang
+        self.assertEqual(tree.calls, 1)
+
+
+def _unified_tree(page_size=4, pool_size=256, disable=False):
+    """A CPU-only UnifiedRadixCache with only the Full component."""
+    dtype = torch.float16
+    kv_pool = MHATokenToKVPool(
+        size=pool_size,
+        page_size=page_size,
+        dtype=dtype,
+        head_num=2,
+        head_dim=8,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    allocator = PagedTokenToKVPoolAllocator(
+        size=pool_size,
+        page_size=page_size,
+        dtype=dtype,
+        device="cpu",
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    req_pool = ReqToTokenPool(
+        size=8,
+        max_context_len=128,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    return UnifiedRadixCache(
+        CacheInitParams(
+            disable=disable,
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=page_size,
+            eviction_policy="lru",
+            tree_components=(ComponentType.FULL,),
+        )
+    )
+
+
+def _insert(tree, tokens, rotation_base=None, value=None):
+    if value is None:
+        value = tree.token_to_kv_pool_allocator.alloc(len(tokens))
+    return tree.insert(
+        InsertParams(
+            key=RadixKey(array("q", tokens)),
+            value=value.to(dtype=torch.int64),
+            rotation_base=rotation_base,
+        )
+    )
+
+
+def _node(tree, node_id):
+    return tree.tree_core.node_by_id(node_id)
+
+
+def _match_len(tree, tokens):
+    res = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
+    return len(res.device_indices)
+
+
+class TestUnifiedRotationBase(CustomTestCase):
+    """The host rotation base on UnifiedTreeNode: the one new piece of
+    metadata. The Full component's value is a device tensor, so the base must
+    survive inserts and splits purely host-side or the alloc path gains a D2H
+    sync."""
+
+    def test_insert_stamps_split_copies(self):
+        tree = _unified_tree()
+        _insert(tree, list(range(12)), rotation_base=2)
+        # A shorter lookup splits the node at the match boundary: BOTH halves
+        # keep the chain's base (position-page P keeps owner (b+P)%N on both
+        # sides of any split).
+        probe = list(range(8)) + [99, 98, 97, 96]
+        _insert(tree, probe, rotation_base=2)
+        res = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", probe))))
+        tail = _node(tree, res.last_device_node)
+        self.assertEqual(tail.rotation_base, 2)
+        parent = tail.parent
+        self.assertEqual(parent.rotation_base, 2)
+        for child in parent.children.values():
+            self.assertEqual(child.rotation_base, 2)
+
+    def test_new_chain_gets_its_own_base(self):
+        tree = _unified_tree()
+        _insert(tree, list(range(8)), rotation_base=1)
+        _insert(tree, list(range(100, 108)), rotation_base=3)
+        r1 = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", range(8)))))
+        r2 = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", range(100, 108))))
+        )
+        self.assertEqual(_node(tree, r1.last_device_node).rotation_base, 1)
+        self.assertEqual(_node(tree, r2.last_device_node).rotation_base, 3)
+
+    def test_extension_tail_node_stamped_from_request(self):
+        tree = _unified_tree()
+        _insert(tree, list(range(8)), rotation_base=1)
+        # A longer insert of the same chain dedups the prefix and stamps the
+        # tail node with the (same, chain-constant) base.
+        _insert(tree, list(range(16)), rotation_base=1)
+        res = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", range(16)))))
+        self.assertEqual(_node(tree, res.last_device_node).rotation_base, 1)
+
+    def test_unsharded_inserts_keep_none(self):
+        tree = _unified_tree()
+        _insert(tree, list(range(8)))
+        res = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", range(8)))))
+        self.assertIsNone(_node(tree, res.last_device_node).rotation_base)
+
+    def test_rotation_base_of_reads_through_the_cache_boundary(self):
+        """The alloc path holds a NodeId, not a node: the base must be
+        readable through the tree-cache API (BasePrefixCache.rotation_base_of
+        defaults to None, so an unsharded cache sends the alloc path to the
+        request's recorded base)."""
+        tree = _unified_tree()
+        _insert(tree, list(range(8)), rotation_base=2)
+        res = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", range(8)))))
+        self.assertEqual(tree.rotation_base_of(res.last_device_node), 2)
+        self.assertIsNone(tree.rotation_base_of(None))
+        self.assertIsNone(tree.rotation_base_of(tree.tree_core.root_node_handle()))
+
+
+class TestShardedCoreGate(CustomTestCase):
+    """A tree core that does not model rotation_base would never decline a
+    cross-base graft. Pairing one with a sharded allocator must fail at
+    construction, not produce wrong-owner gathers at serve time."""
+
+    def test_python_core_supports_rotation_base(self):
+        tree = _unified_tree()
+        self.assertTrue(tree.tree_core.supports_rotation_base)
+
+    def test_sharded_allocator_rejects_a_core_without_rotation_base(self):
+        tree = _unified_tree()
+        params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=tree.req_to_token_pool,
+            token_to_kv_pool_allocator=_make_allocator(pages_per_rank=8),
+            page_size=PS,
+            eviction_policy="lru",
+            tree_components=(ComponentType.FULL,),
+        )
+        with unittest.mock.patch.object(
+            UnifiedTreeCore, "supports_rotation_base", False
+        ):
+            with self.assertRaisesRegex(ValueError, "rotation bases"):
+                UnifiedRadixCache(params)
+
+    def test_unsharded_allocator_accepts_any_core(self):
+        params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=ReqToTokenPool(
+                size=8, max_context_len=128, device="cpu", enable_memory_saver=False
+            ),
+            token_to_kv_pool_allocator=_unified_tree().token_to_kv_pool_allocator,
+            page_size=4,
+            eviction_policy="lru",
+            tree_components=(ComponentType.FULL,),
+        )
+        with unittest.mock.patch.object(
+            UnifiedTreeCore, "supports_rotation_base", False
+        ):
+            UnifiedRadixCache(params)  # no raise: sharding is off
+
+
+class _GraftReq:
+    """Minimal Req stand-in for cache_unfinished/finished_req."""
+
+    def __init__(self, fill_ids, req_pool_idx=0):
+        self.fill_ids = list(fill_ids)
+        self.origin_input_ids = array("q", fill_ids)
+        self.output_ids = array("q", [])
+        self.kv = SimpleNamespace(
+            req_pool_idx=req_pool_idx,
+            cache_protected_len=0,
+            swa_evicted_seqlen=0,
+        )
+        self.extra_key = None
+        self.cache_salt = None
+        self.prefix_indices = torch.empty(0, dtype=torch.int64)
+        self.last_node = None
+        self.priority = 0
+        self.kv_rotation_base = None
+        self.swa_uuid_for_lock = None
+        self.swa_prefix_lock_released = False
+        self.skip_lock_node_ids = {}
+        self.finished_reason = None
+        self.session = None
+
+    def get_fill_ids(self):
+        return array("q", self.fill_ids)
+
+
+class TestRotationGraftDecline(CustomTestCase):
+    """The overlap disagg-prefill loop plans batch t+1 before batch t's radix
+    insert lands, so two requests sharing a prefix can allocate under
+    different rotation bases. Grafting the second one's tail under the first
+    chain leaves the cached path's page owners not one cyclic run, so a later
+    reader either crashes on a negative allgather pad or silently reads the
+    wrong rank's scratch rows. Inserts must refuse the graft.
+
+    Unlike the flat radix tree, the unified insert also transfers page
+    ownership inside the MATCHED region (an evicted node restored from the
+    request's fresh pages, a component re-pointing a matched node's Full value
+    at them). The decline therefore runs before the walk and refuses the whole
+    insert, which additionally keeps the walk's duplicate frees from running
+    under a request that is about to keep its own pages.
+    """
+
+    PS = 4  # tree quantum for these tests
+
+    def _tree_with_spy(self):
+        """Record every KV row release. The unified tree frees through two
+        seams: the caller's free_kv_row -> free_segments, and the insert
+        walk's FreeDeviceKV -> free_segment."""
+        tree = _unified_tree(page_size=self.PS)
+        allocator = tree.token_to_kv_pool_allocator
+        freed = []
+        real_free_segments = allocator.free_segments
+        real_free_segment = allocator.free_segment
+
+        def spy_segments(segments):
+            freed.extend(torch.as_tensor(seg).clone() for seg, _start in segments)
+            return real_free_segments(segments)
+
+        def spy_segment(free_index, *, start_pos):
+            freed.append(torch.as_tensor(free_index).clone())
+            return real_free_segment(free_index, start_pos=start_pos)
+
+        allocator.free_segments = spy_segments
+        allocator.free_segment = spy_segment
+        return tree, freed
+
+    def _seed_chain(self, tree, tokens, base):
+        _insert(tree, tokens, rotation_base=base)
+
+    def _own_row(self, tree, req, n_tokens):
+        """Give the request its own allocated KV row and return the locs."""
+        locs = tree.token_to_kv_pool_allocator.alloc(n_tokens).to(dtype=torch.int64)
+        tree.req_to_token_pool.req_to_token[req.kv.req_pool_idx, :n_tokens] = locs
+        return locs
+
+    def test_foreign_base_tail_declined(self):
+        tree = _unified_tree(page_size=self.PS)
+        self._seed_chain(tree, list(range(12)), base=1)
+        # Same 8-token prefix, different suffix, allocated under base 3.
+        key = list(range(8)) + [90, 91, 92, 93]
+        res = _insert(tree, key, rotation_base=3)
+        self.assertTrue(res.rotation_tail_declined)
+        self.assertEqual(res.prefix_len, 8)
+        # The suffix is NOT cached: a full-key match stops at the seam.
+        self.assertEqual(_match_len(tree, key), 8)
+
+    def test_empty_page_aligned_key_insert(self):
+        """A finished request with fewer cached tokens than one tree page
+        inserts an EMPTY page-aligned key; the empty-key early return must
+        precede the rotation pre-flight."""
+        tree = _unified_tree(page_size=self.PS)
+        res = _insert(tree, [1, 2], rotation_base=1)
+        self.assertEqual(res.prefix_len, 0)
+        self.assertFalse(res.rotation_tail_declined)
+
+    def test_same_base_tail_attaches(self):
+        tree = _unified_tree(page_size=self.PS)
+        self._seed_chain(tree, list(range(12)), base=1)
+        key = list(range(8)) + [90, 91, 92, 93]
+        res = _insert(tree, key, rotation_base=1)
+        self.assertFalse(res.rotation_tail_declined)
+        self.assertEqual(_match_len(tree, key), 12)
+
+    def test_no_matched_chain_never_declines(self):
+        """A request that matches nothing starts its own chain: the guard
+        only fires against an EXISTING chain's base."""
+        tree = _unified_tree(page_size=self.PS)
+        self._seed_chain(tree, list(range(12)), base=1)
+        res = _insert(tree, list(range(50, 62)), rotation_base=3)
+        self.assertFalse(res.rotation_tail_declined)
+        self.assertEqual(_match_len(tree, list(range(50, 62))), 12)
+
+    def test_unsharded_insert_onto_a_based_chain_never_declines(self):
+        """rotation_base=None means sharding is off for this insert: the
+        pre-flight must not fire, or every unsharded path would stop caching."""
+        tree = _unified_tree(page_size=self.PS)
+        self._seed_chain(tree, list(range(8)), base=1)
+        key = list(range(8)) + [90, 91, 92, 93]
+        res = _insert(tree, key, rotation_base=None)
+        self.assertFalse(res.rotation_tail_declined)
+        self.assertEqual(_match_len(tree, key), 12)
+
+    def test_full_match_under_a_foreign_base_declines(self):
+        """No tail to graft, but the unified insert would still hand the
+        request's pages to the matched chain (unevict-on-insert, component
+        Full re-point). The pre-flight declines that too."""
+        tree = _unified_tree(page_size=self.PS)
+        self._seed_chain(tree, list(range(12)), base=1)
+        res = _insert(tree, list(range(12)), rotation_base=3)
+        self.assertTrue(res.rotation_tail_declined)
+
+    def test_cache_unfinished_decline_keeps_request_on_own_pages(self):
+        tree, freed = self._tree_with_spy()
+        self._seed_chain(tree, list(range(8)), base=1)
+        req = _GraftReq(list(range(8)) + [90, 91, 92, 93])
+        req.kv_rotation_base = 3
+        own_locs = self._own_row(tree, req, 12)
+        tree.cache_unfinished_req(req)
+        # No dedup free, no rebind: the request keeps its own locs whole.
+        self.assertEqual([t.tolist() for t in freed], [])
+        self.assertTrue(torch.equal(req.prefix_indices, own_locs))
+        self.assertEqual(req.kv.cache_protected_len, 0)
+        self.assertTrue(
+            torch.equal(tree.req_to_token_pool.req_to_token[0, :12], own_locs)
+        )
+
+    def test_cache_finished_decline_frees_duplicates_and_suffix(self):
+        tree, freed = self._tree_with_spy()
+        self._seed_chain(tree, list(range(8)), base=1)
+        req = _GraftReq(list(range(8)) + [90, 91, 92, 93])
+        req.kv_rotation_base = 3
+        own_locs = self._own_row(tree, req, 12)
+        tree.cache_finished_req(req, kv_len_to_handle=12)
+        released = torch.cat(freed)
+        # Everything past the protected prefix is released: the duplicates of
+        # the matched region AND the declined tail (nothing leaks, nothing is
+        # grafted).
+        self.assertEqual(set(released.tolist()), set(own_locs.tolist()))
+        self.assertEqual(_match_len(tree, req.fill_ids), 8)
+
+    def test_cache_finished_same_base_keeps_the_tail_cached(self):
+        """Control for the decline test: with an agreeing base the tail is
+        grafted and only the matched duplicates are freed."""
+        tree, freed = self._tree_with_spy()
+        self._seed_chain(tree, list(range(8)), base=1)
+        req = _GraftReq(list(range(8)) + [90, 91, 92, 93])
+        req.kv_rotation_base = 1
+        own_locs = self._own_row(tree, req, 12)
+        tree.cache_finished_req(req, kv_len_to_handle=12)
+        self.assertEqual(_match_len(tree, req.fill_ids), 12)
+        released = torch.cat(freed) if freed else torch.empty(0, dtype=torch.int64)
+        # Only the 8 duplicate rows go back; the tail stays live in the tree.
+        self.assertEqual(set(released.tolist()), set(own_locs[:8].tolist()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -42,6 +42,7 @@ def _make_ctx(
     disable_radix_cache=False,
     effective_chunked_prefill_size=None,
     full_tokens_per_layer=None,
+    enable_kv_cache_sharding=False,
 ):
     # The factory reads the published bags for the cache-backend leaves, so the
     # fixture publishes them; the instance stays for the whole-object contract
@@ -53,6 +54,7 @@ def _make_ctx(
         enable_lmcache=enable_lmcache,
         enable_flexkv=False,
         enable_unified_cache_external_linker=False,
+        enable_kv_cache_sharding=enable_kv_cache_sharding,
     )
     return TreeCacheBuildContext(
         server_args=server_args,
@@ -184,6 +186,20 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             ChunkCache.assert_called_once_with(ctx.params)
             self.assertIs(result, ChunkCache.return_value)
 
+    def test_kv_sharding_keeps_chunk_cache_when_radix_is_disabled(self):
+        ctx = _make_ctx(
+            self,
+            effective_chunked_prefill_size=512,
+            disable_radix_cache=True,
+            enable_kv_cache_sharding=True,
+        )
+        with patch("sglang.srt.mem_cache.chunk_cache.ChunkCache") as ChunkCache:
+            ChunkCache.return_value = MagicMock()
+            result = default_radix_cache_factory(ctx)
+
+        ChunkCache.assert_called_once_with(ctx.params)
+        self.assertIs(result, ChunkCache.return_value)
+
     def test_swa_chunk_cache_when_chunked_prefill_disable_and_hybrid_swa(self):
         ctx = _make_ctx(
             self,
@@ -236,6 +252,22 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
                 params=ctx.params, server_args=ctx.server_args
             )
             self.assertIs(result, fake_module.RadixCacheCpp.return_value)
+
+    def test_kv_sharding_uses_unified_radix_cache(self):
+        ctx = _make_ctx(self, enable_kv_cache_sharding=True)
+        fake_components = MagicMock()
+        fake_radix = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "sglang.srt.mem_cache.unified_cache.components": fake_components,
+                "sglang.srt.mem_cache.unified_radix_cache": fake_radix,
+            },
+        ):
+            result = default_radix_cache_factory(ctx)
+
+        fake_radix.UnifiedRadixCache.assert_called_once_with(ctx.params)
+        self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_unified_radix_cache_is_the_default(self):
         ctx = _make_ctx(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -31,6 +31,10 @@ from sglang.srt.arg_groups.kv_cache_hook import (
     handle_cache_compatibility,
     validate_prefill_only_disable_kv_cache_args,
 )
+from sglang.srt.arg_groups.kv_shard_hook import (
+    handle_kv_cache_sharding,
+    validate_kv_shard_attention_backend,
+)
 from sglang.srt.arg_groups.mamba_hook import handle_mamba_backend
 from sglang.srt.arg_groups.memory_hook import handle_gpu_memory_settings
 from sglang.srt.arg_groups.model_path_hook import handle_load_format
@@ -41,7 +45,9 @@ from sglang.srt.arg_groups.moe_hook import (
 )
 from sglang.srt.arg_groups.overrides import (
     cutedsl_moe_max_num_tokens,
+    declare_resolution,
     max_speculative_num_draft_tokens,
+    post_capture_kv_sizing_planned,
     resolution_result,
 )
 from sglang.srt.arg_groups.parallel_hook import (
@@ -65,6 +71,7 @@ from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 from sglang.srt.arg_groups.validation_hook import (
     check_two_batch_overlap,
 )
+from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.entrypoints.sidecar import (
     SGLANG_GRPC_ENDPOINT_ENV,
     Sidecar,
@@ -2896,6 +2903,224 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         # require dp-attention there.
         args = self._args(moe_a2a_backend="deepep", enable_dp_attention=False)
         check_two_batch_overlap(args)
+
+
+class TestKvCacheShardingCompatibility(CustomTestCase):
+    def _args(self, **overrides):
+        model_config = overrides.pop("model_config", None)
+        args = ServerArgs(
+            model_path="dummy",
+            enable_kv_cache_sharding=True,
+            disaggregation_mode="prefill",
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        args._model_config = model_config or SimpleNamespace(
+            is_encoder_decoder=False,
+            attention_chunk_size=None,
+            attention_arch=AttentionArch.MHA,
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+        )
+        return args
+
+    def _rounding_args(self, *, raw_mem_fraction, resolved_mem_fraction):
+        args = self._args(
+            tp_size=2,
+            page_size=64,
+            chunked_prefill_size=2050,
+            attention_backend="fa3",
+            disaggregation_transfer_backend="mooncake",
+            mem_fraction_static=resolved_mem_fraction,
+            cuda_graph_config=CudaGraphConfig(
+                prefill=PhaseConfig(backend=Backend.DISABLED)
+            ),
+        )
+        args._model_config = SimpleNamespace(
+            is_encoder_decoder=False,
+            attention_chunk_size=None,
+            attention_arch=AttentionArch.MLA,
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+        )
+        args._raw_input = {"mem_fraction_static": raw_mem_fraction}
+        args._resolved_overrides = [
+            (
+                "_handle_gpu_memory_settings",
+                {"mem_fraction_static": resolved_mem_fraction},
+            )
+        ]
+        return args
+
+    def test_encoder_decoder_is_rejected_before_backend_setup(self):
+        args = self._args(model_config=SimpleNamespace(is_encoder_decoder=True))
+
+        with self.assertRaisesRegex(ValueError, "does not support encoder-decoder"):
+            handle_kv_cache_sharding(args)
+
+    def test_trtllm_mla_accepts_plain_tp_with_chunked_prefix_cache(self):
+        args = self._rounding_args(raw_mem_fraction=0.8, resolved_mem_fraction=0.8)
+        args.attention_backend = "trtllm_mla"
+
+        with (
+            patch.object(
+                envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE, "get", return_value=False
+            ),
+            patch.object(envs.SGLANG_DISAGG_STAGING_BUFFER, "get", return_value=False),
+        ):
+            handle_kv_cache_sharding(args, 80 * 1024)
+
+        self.assertEqual(resolution_result(args, "chunked_prefill_size"), 2176)
+
+    def test_trtllm_mla_rejects_unsupported_shard_topologies(self):
+        cases = (
+            (False, 1, False, "requires an MLA model"),
+            (True, 2, False, "only supports plain-TP MLA"),
+            (True, 1, True, "requires chunked prefix caching"),
+        )
+        for is_mla, attn_cp_size, disable_chunked_prefix_cache, error in cases:
+            with self.subTest(error=error):
+                args = self._args()
+                args.attention_backend = "trtllm_mla"
+                args._model_config.attention_arch = (
+                    AttentionArch.MLA if is_mla else AttentionArch.MHA
+                )
+                view = SimpleNamespace(
+                    attn_cp_size=attn_cp_size,
+                    disable_chunked_prefix_cache=disable_chunked_prefix_cache,
+                )
+
+                with self.assertRaisesRegex(ValueError, error):
+                    validate_kv_shard_attention_backend(args, view)
+
+    def test_hisparse_allocator_is_rejected(self):
+        args = self._args(enable_hisparse=True)
+
+        with self.assertRaisesRegex(ValueError, "does not support --enable-hisparse"):
+            handle_kv_cache_sharding(args)
+
+    def test_incompatible_cache_tree_modes_are_rejected(self):
+        cases = (
+            ({"radix_cache_backend": "custom"}, "built-in UnifiedRadixCache"),
+            (
+                {"enable_unified_cache_external_linker": True},
+                "does not support --enable-unified-cache-external-linker",
+            ),
+            (
+                {"enable_streaming_session": True},
+                "does not support streaming sessions",
+            ),
+            (
+                {"enable_session_radix_cache": True},
+                "does not support session radix cache yet",
+            ),
+        )
+        for overrides, error in cases:
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, error):
+                    handle_kv_cache_sharding(self._args(**overrides))
+
+    def test_rust_unified_tree_core_is_rejected(self):
+        with envs.SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND.override("rust"):
+            with self.assertRaisesRegex(ValueError, "requires the Python"):
+                handle_kv_cache_sharding(self._args())
+
+    def test_post_capture_kv_sizing_keeps_eager_prefill_headroom(self):
+        prefill_graph = SimpleNamespace(backend=Backend.BREAKABLE, bs=[4096])
+        args = ServerArgs(
+            model_path="dummy",
+            enable_kv_cache_sharding=True,
+            device="cuda",
+            dcp_size=1,
+            kv_cache_dtype="auto",
+            prefill_only_disable_kv_cache=False,
+            enable_memory_saver=False,
+            disaggregation_mode="prefill",
+            cuda_graph_config=CudaGraphConfig(prefill=prefill_graph),
+            chunked_prefill_size=4096,
+        )
+        with (
+            patch(
+                "sglang.srt.arg_groups.overrides.use_mla_backend",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.arg_groups.overrides.max_prefill_buffer_tokens",
+                return_value=4096,
+            ),
+            patch(
+                "sglang.srt.arg_groups.overrides.model_config_of",
+                return_value=SimpleNamespace(
+                    hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"])
+                ),
+            ),
+            patch.object(
+                envs.SGLANG_ENABLE_POST_CAPTURE_KV_SIZING,
+                "get",
+                return_value=True,
+            ),
+            patch.object(
+                envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL,
+                "get",
+                return_value=None,
+            ),
+        ):
+            self.assertFalse(post_capture_kv_sizing_planned(args))
+            args.enable_kv_cache_sharding = False
+            self.assertTrue(post_capture_kv_sizing_planned(args))
+
+    def test_chunk_rounding_expands_automatic_activation_headroom(self):
+        args = self._rounding_args(raw_mem_fraction=None, resolved_mem_fraction=0.9)
+        gpu_mem = 80 * 1024
+
+        with (
+            patch.object(
+                envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE, "get", return_value=False
+            ),
+            patch.object(envs.SGLANG_DISAGG_STAGING_BUFFER, "get", return_value=False),
+        ):
+            handle_kv_cache_sharding(args, gpu_mem)
+
+        rounded = 2176  # ceil(2050 / (tp_size * page_size)) * 128
+        expected_fraction = 0.9 - 1.5 * (rounded - 2050) / gpu_mem
+        self.assertEqual(resolution_result(args, "chunked_prefill_size"), rounded)
+        self.assertAlmostEqual(
+            resolution_result(args, "mem_fraction_static"), expected_fraction
+        )
+
+    def test_chunk_rounding_preserves_explicit_mem_fraction(self):
+        args = self._rounding_args(raw_mem_fraction=0.8, resolved_mem_fraction=0.8)
+
+        with (
+            patch.object(
+                envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE, "get", return_value=False
+            ),
+            patch.object(envs.SGLANG_DISAGG_STAGING_BUFFER, "get", return_value=False),
+        ):
+            handle_kv_cache_sharding(args, 80 * 1024)
+
+        self.assertEqual(resolution_result(args, "chunked_prefill_size"), 2176)
+        self.assertEqual(resolution_result(args, "mem_fraction_static"), 0.8)
+
+    def test_final_pass_rejects_late_model_capability_overrides(self):
+        cases = (
+            ({"attention_backend": "triton"}, "requires the fa3"),
+            ({"chunked_prefill_size": -1}, "requires chunked prefill"),
+        )
+        with (
+            patch.object(
+                envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE, "get", return_value=False
+            ),
+            patch.object(envs.SGLANG_DISAGG_STAGING_BUFFER, "get", return_value=False),
+        ):
+            for declarations, error in cases:
+                with self.subTest(declarations=declarations):
+                    args = self._rounding_args(
+                        raw_mem_fraction=0.8, resolved_mem_fraction=0.8
+                    )
+                    handle_kv_cache_sharding(args, 80 * 1024)
+                    declare_resolution(args, "late_model_capability", **declarations)
+
+                    with self.assertRaisesRegex(ValueError, error):
+                        handle_kv_cache_sharding(args, 80 * 1024)
 
 
 class TestDcpKvEventContract(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The PR that makes the feature work end to end.

A sharded prefill rank holds only its stripe of every cached page, so the transfer changes on both ends: each prefill rank ships the pages it owns, and decode pulls from every rank of the shard group instead of one. Ownership is derived from the *value* (`owner = logical_page % N`), not the position, so the filter stays correct under any allocator placement policy — and the wire value is already the owner's local page id, so the decode side needs no change.

Validated PD-disaggregated on both arms: MLA sharded across attention-TP (GSM8K 0.82) and GQA under prefill CP sharded across attention-CP (GSM8K 0.935), both added here as registered E2E tests.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->