### PR TITLE
[AMD] GLM-5.2 NextN: cast draft fused MoE to per-channel FP8

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -958,6 +958,9 @@ class Envs:
     SGLANG_MOE_NVFP4_DISPATCH = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_GEMM_IN_ATTN = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE = EnvBool(False)
+    # GLM NextN (MTP): cast the draft layer's bf16 fused MoE to per-channel FP8
+    # on load. Unrelated to the NVFP4 block-FP8 NextN path above.
+    SGLANG_GLM_NEXTN_MOE_PTPC = EnvBool(False)
     SGLANG_QUANT_ALLOW_DOWNCASTING = EnvBool(False)
     SGLANG_FP8_IGNORED_LAYERS = EnvStr("")
     SGLANG_FP4_IGNORED_LAYERS = EnvStr("")

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_fp8_moe.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.quantization.fp8_utils import normalize_e4m3fn_to_e4m3fnuz
 from sglang.srt.layers.quantization.quark.schemes import QuarkMoEScheme
 from sglang.srt.layers.quantization.utils import all_close_1d, per_tensor_dequantize
-from sglang.srt.utils import get_bool_env_var, is_hip, set_weight_attrs
+from sglang.srt.utils import get_bool_env_var, is_hip, print_info_once, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -30,8 +30,6 @@ _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
-
-    from sglang.kernels.ops.moe.rocm_moe_utils import rocm_fused_experts_tkw1
 
 
 class QuarkW8A8FP8MoE(QuarkMoEScheme):
@@ -238,74 +236,84 @@ class QuarkW8A8FP8MoE(QuarkMoEScheme):
                 f"Unsupported weight quantization strategy: {self.weight_qscheme}."
             )
 
-        if (
-            _use_aiter
-            and self.is_weight_per_channel
-            and self.moe_runner_config.apply_router_weight_on_input
-        ):
+        # Triton reads the canonical layout; only AITER wants the shuffled one,
+        # which aiter.fused_moe selects on via the is_shuffled tag.
+        if _use_aiter and self.runner.runner_backend.is_aiter():
             with torch.no_grad():
-                # Pre-shuffle weights
                 layer.w13_weight = torch.nn.Parameter(
                     shuffle_weight(layer.w13_weight.data, (16, 16)),
                     requires_grad=False,
                 )
+                layer.w13_weight.is_shuffled = True
                 torch.cuda.empty_cache()
                 layer.w2_weight = torch.nn.Parameter(
                     shuffle_weight(layer.w2_weight.data, (16, 16)),
                     requires_grad=False,
                 )
+                layer.w2_weight.is_shuffled = True
                 torch.cuda.empty_cache()
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
+        from sglang.srt.layers.moe.utils import (
+            get_moe_a2a_backend,
+            get_moe_runner_backend,
+        )
+
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        moe_runner_backend = get_moe_runner_backend()
+        a2a_supports_aiter = get_moe_a2a_backend().supports_aiter()
+        # AITER's per_Token fused MoE needs per-channel weight scales; the
+        # per-tensor scheme has no equivalent there.
+        use_aiter_runner = (
+            _use_aiter
+            and self.is_weight_per_channel
+            and a2a_supports_aiter
+            and (moe_runner_backend.is_auto() or moe_runner_backend.is_aiter())
+        )
+        self.runner = MoeRunner(
+            MoeRunnerBackend.AITER if use_aiter_runner else MoeRunnerBackend.TRITON,
+            moe_runner_config,
+        )
+        print_info_once(
+            f"QuarkW8A8FP8MoE runner={self.runner.runner_backend.value} "
+            f"(use_aiter={_use_aiter} per_channel={self.is_weight_per_channel} "
+            f"a2a_supports_aiter={a2a_supports_aiter} "
+            f"requested={moe_runner_backend.value})"
+        )
 
     def apply_weights(
         self,
         layer: torch.nn.Module,
         dispatch_output: StandardDispatchOutput,
     ) -> CombineInput:
-
-        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
-
-        x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
-
-        moe_runner_config = self.moe_runner_config
-
-        if (
-            _use_aiter
-            and self.is_weight_per_channel
-            and moe_runner_config.apply_router_weight_on_input
-        ):
-            topk_weights, topk_ids, _ = topk_output
-            output = rocm_fused_experts_tkw1(
-                hidden_states=x,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                activation=moe_runner_config.activation,
-                apply_router_weight_on_input=moe_runner_config.apply_router_weight_on_input,
-                use_fp8_w8a8=True,
-                per_channel_quant=self.is_weight_per_channel,
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
-                a1_scale=layer.w13_input_scale,
-                a2_scale=layer.w2_input_scale,
+        if self.runner.runner_backend.is_aiter():
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                AiterMoeQuantInfo,
+                AiterQuantType,
             )
-            return StandardCombineInput(hidden_states=output)
-        else:
-            quant_info = TritonMoeQuantInfo(
+
+            quant_info = AiterMoeQuantInfo(
                 w13_weight=layer.w13_weight,
                 w2_weight=layer.w2_weight,
-                use_fp8_w8a8=True,
-                per_channel_quant=self.is_weight_per_channel,
+                quant_type=AiterQuantType.PER_TOKEN,
                 w13_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
                 a13_scale=layer.w13_input_scale,
                 a2_scale=layer.w2_input_scale,
+                expert_mask=layer.dispatcher.expert_mask_gpu,
             )
             return self.runner.run(dispatch_output, quant_info)
+
+        quant_info = TritonMoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            use_fp8_w8a8=True,
+            per_channel_quant=self.is_weight_per_channel,
+            w13_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            a13_scale=layer.w13_input_scale,
+            a2_scale=layer.w2_input_scale,
+        )
+        return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -14,6 +14,7 @@
 
 import concurrent.futures
 import logging
+import re
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -58,6 +59,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_xpu,
     _use_aiter_gfx95,
     awq_dequantize_func,
+    enable_glm_nextn_moe_ptpc,
     enable_nextn_moe_bf16_cast_to_fp8,
     is_wint4afp8_or_wint4a16_config,
 )
@@ -227,6 +229,7 @@ class DeepseekV2WeightLoaderMixin:
         weights = self._maybe_quant_weights_to_fp8_ue8m0(
             weights, NVFP4_CKPT_FP8_ATTN_QUANT_MODULES, nextn_conf
         )
+        weights = self._maybe_quant_glm_nextn_moe_to_ptpc(weights, nextn_conf)
 
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -884,6 +887,67 @@ class DeepseekV2WeightLoaderMixin:
             self._mark_nextn_moe_weights_as_ue8m0()
 
         return list(weights_dict.items())
+
+    def _maybe_quant_glm_nextn_moe_to_ptpc(self, weights, nextn_conf: NextNConfig):
+        """Cast the GLM NextN fused-expert weights from bf16 to per-channel FP8.
+
+        The GLM-5.2 MXFP4 checkpoint ships the draft layer's routed and shared
+        experts in bf16. This pairs with the QuarkW8A8FP8MoE scheme that
+        GlmMoeDsaForCausalLMNextN injects for that module.
+
+        Args:
+            weights: Iterable of (weight_name, weight_tensor) pairs
+            nextn_conf: NextN configuration
+
+        Returns:
+            weights unchanged when the cast is off, otherwise a generator that
+            also emits a ``.weight_scale`` next to each cast weight.
+        """
+        if not isinstance(nextn_conf, NextNEnabledConfig):
+            return weights
+        if not enable_glm_nextn_moe_ptpc(self.quant_config):
+            return weights
+        # DeepSeek shares this mixin but gets no matching scheme, so the cast
+        # weights would have nowhere to load.
+        if "glm" not in self.config.model_type.lower():
+            return weights
+
+        layer_prefix = nextn_conf.nextn_layer_prefix
+        # Only routed experts get QuarkW8A8FP8MoE; shared_experts stay bf16.
+        expert_proj_re = re.compile(
+            r"mlp\.experts\.\d+\.(gate_proj|up_proj|down_proj)\.weight$"
+        )
+        # e4m3fn even on MI300; QuarkW8A8FP8MoE converts to fnuz where needed.
+        fp8_max = torch.finfo(torch.float8_e4m3fn).max
+        log_info_on_rank0(
+            logger,
+            "GLM NextN MoE PTPC: casting draft expert weights under "
+            f"{layer_prefix}.mlp to fp8_e4m3 per-channel",
+        )
+
+        def _cast() -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, tensor in weights:
+                if not (
+                    name.startswith(layer_prefix + ".") and expert_proj_re.search(name)
+                ):
+                    yield name, tensor
+                    continue
+                if tensor.ndim != 2:
+                    raise ValueError(
+                        f"{name}: PTPC cast expects a 2D expert weight, "
+                        f"got {tuple(tensor.shape)}"
+                    )
+                weight = tensor.to(torch.float32)
+                # One scale per output channel, matching the "per_channel" qscheme.
+                scale = weight.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+                scale /= fp8_max
+                yield (
+                    name,
+                    (weight / scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn),
+                )
+                yield name[: -len("weight")] + "weight_scale", scale.squeeze(-1)
+
+        return _cast()
 
     def _mark_nextn_moe_weights_as_ue8m0(self):
         """Mark NextN MoE weight scales as UE8M0 format to avoid requantization."""

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -59,9 +59,9 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_xpu,
     _use_aiter_gfx95,
     awq_dequantize_func,
-    enable_glm_nextn_moe_ptpc,
     enable_nextn_moe_bf16_cast_to_fp8,
     is_wint4afp8_or_wint4a16_config,
+    should_apply_glm_nextn_moe_ptpc,
 )
 from sglang.srt.utils import bind_or_assign, get_bool_env_var, log_info_on_rank0
 
@@ -893,7 +893,7 @@ class DeepseekV2WeightLoaderMixin:
 
         The GLM-5.2 MXFP4 checkpoint ships the draft layer's routed and shared
         experts in bf16. This pairs with the QuarkW8A8FP8MoE scheme that
-        GlmMoeDsaForCausalLMNextN injects for that module.
+        GlmMoeDsaForCausalLMNextN injects, using the same apply gate.
 
         Args:
             weights: Iterable of (weight_name, weight_tensor) pairs
@@ -905,11 +905,11 @@ class DeepseekV2WeightLoaderMixin:
         """
         if not isinstance(nextn_conf, NextNEnabledConfig):
             return weights
-        if not enable_glm_nextn_moe_ptpc(self.quant_config):
-            return weights
-        # DeepSeek shares this mixin but gets no matching scheme, so the cast
-        # weights would have nowhere to load.
-        if "glm" not in self.config.model_type.lower():
+        if not should_apply_glm_nextn_moe_ptpc(
+            self.quant_config,
+            nextn_conf.nextn_layer_id,
+            model_type=getattr(self.config, "model_type", "") or "",
+        ):
             return weights
 
         layer_prefix = nextn_conf.nextn_layer_prefix

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -138,12 +138,45 @@ def enable_nextn_moe_bf16_cast_to_fp8(
 def enable_glm_nextn_moe_ptpc(
     quant_config: Optional[QuantizationConfig],
 ) -> bool:
-    """Per-channel FP8, unlike ``enable_nextn_moe_bf16_cast_to_fp8``'s block FP8."""
+    """Per-channel FP8, unlike ``enable_nextn_moe_bf16_cast_to_fp8``'s block FP8.
+
+    Env + quark only. Use ``should_apply_glm_nextn_moe_ptpc`` to apply.
+    """
     return (
         envs.SGLANG_GLM_NEXTN_MOE_PTPC.get()
         and quant_config is not None
         and quant_config.get_name() == "quark"
     )
+
+
+def glm_nextn_mtp_fused_experts_excluded(
+    quant_config: Optional[QuantizationConfig],
+    num_hidden_layers: int,
+) -> bool:
+    """True if Quark excluded MTP fused experts (bf16 in the checkpoint)."""
+    exclude_layers = getattr(quant_config, "exclude_layers", None) or []
+    layer_prefix = f"model.layers.{num_hidden_layers}."
+    return any(
+        name.startswith(layer_prefix) and ".mlp.experts." in name
+        for name in exclude_layers
+    )
+
+
+def should_apply_glm_nextn_moe_ptpc(
+    quant_config: Optional[QuantizationConfig],
+    num_hidden_layers: int,
+    model_type: Optional[str] = None,
+) -> bool:
+    """Apply PTPC-FP8 only when MTP fused experts are Quark-excluded.
+
+    ``model_type`` is required on the DeepSeek-shared loader mixin; the GLM
+    NextN class may omit it.
+    """
+    if not enable_glm_nextn_moe_ptpc(quant_config):
+        return False
+    if model_type is not None and "glm" not in model_type.lower():
+        return False
+    return glm_nextn_mtp_fused_experts_excluded(quant_config, num_hidden_layers)
 
 
 def is_wint4afp8_or_wint4a16_config(

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -135,6 +135,17 @@ def enable_nextn_moe_bf16_cast_to_fp8(
     )
 
 
+def enable_glm_nextn_moe_ptpc(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    """Per-channel FP8, unlike ``enable_nextn_moe_bf16_cast_to_fp8``'s block FP8."""
+    return (
+        envs.SGLANG_GLM_NEXTN_MOE_PTPC.get()
+        and quant_config is not None
+        and quant_config.get_name() == "quark"
+    )
+
+
 def is_wint4afp8_or_wint4a16_config(
     quant_config: Optional[QuantizationConfig],
 ) -> bool:

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -82,7 +82,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.deepseek_common.utils import enable_glm_nextn_moe_ptpc
+from sglang.srt.models.deepseek_common.utils import should_apply_glm_nextn_moe_ptpc
 from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 from sglang.srt.models.utils import WeightsMapper, apply_qk_norm
@@ -1511,30 +1511,30 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
         # "model.decoder.mlp.experts", which expanded per-expert leaf excludes
         # do not match. So that module needs its own entry: bf16 as in the
         # checkpoint, or the scheme matching the on-load PTPC-FP8 cast.
-        if any(".mlp.experts." in name for name in mtp_excluded):
-            if enable_glm_nextn_moe_ptpc(quant_config):
-                mtp_layer_quant_config = quant_config.quant_config.setdefault(
-                    "layer_quant_config", {}
-                )
-                mtp_layer_quant_config["model.decoder.mlp.experts"] = {
-                    "weight": {
-                        "dtype": "fp8_e4m3",
-                        "is_dynamic": False,
-                        "qscheme": "per_channel",
-                    },
-                    # Dynamic per_channel is QuarkW8A8FP8MoE's per-token input.
-                    "input_tensors": {
-                        "dtype": "fp8_e4m3",
-                        "is_dynamic": True,
-                        "qscheme": "per_channel",
-                    },
-                }
-                logger.info(
-                    "SGLANG_GLM_NEXTN_MOE_PTPC=1: MTP fused MoE "
-                    "(model.decoder.mlp.experts) runs as PTPC-FP8"
-                )
-            else:
-                names.add("model.decoder.mlp.experts")
+        # Same gate as the weight-loader cast (Quark-excluded = bf16 in ckpt).
+        if should_apply_glm_nextn_moe_ptpc(quant_config, config.num_hidden_layers):
+            mtp_layer_quant_config = quant_config.quant_config.setdefault(
+                "layer_quant_config", {}
+            )
+            mtp_layer_quant_config["model.decoder.mlp.experts"] = {
+                "weight": {
+                    "dtype": "fp8_e4m3",
+                    "is_dynamic": False,
+                    "qscheme": "per_channel",
+                },
+                # Dynamic per_channel is QuarkW8A8FP8MoE's per-token input.
+                "input_tensors": {
+                    "dtype": "fp8_e4m3",
+                    "is_dynamic": True,
+                    "qscheme": "per_channel",
+                },
+            }
+            logger.info(
+                "SGLANG_GLM_NEXTN_MOE_PTPC=1: MTP fused MoE "
+                "(model.decoder.mlp.experts) runs as PTPC-FP8"
+            )
+        elif any(".mlp.experts." in name for name in mtp_excluded):
+            names.add("model.decoder.mlp.experts")
 
         quant_config.exclude_layers = list(names)
         return quant_config

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -14,6 +14,7 @@
 
 """Inference-only GLM-4.5, GLM-4.6 and GLM-4.7 model compatible with HuggingFace weights"""
 
+import copy
 import logging
 import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
@@ -81,6 +82,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.deepseek_common.utils import enable_glm_nextn_moe_ptpc
 from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 from sglang.srt.models.utils import WeightsMapper, apply_qk_norm
@@ -1468,6 +1470,12 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
         if quant_config is None or quant_config.get_name() != "quark":
             return quant_config
 
+        # The caller reuses this QuarkConfig for the target model and lm_head,
+        # so the draft-only rewrites below need a private copy of the wrapper
+        # and of the dict its schemes are read from.
+        quant_config = copy.copy(quant_config)
+        quant_config.quant_config = copy.deepcopy(quant_config.quant_config)
+
         layer_prefix = f"model.layers.{config.num_hidden_layers}"
 
         # Quark's per-module scheme selection (e.g. MTP self_attn in PTPC-FP8
@@ -1500,16 +1508,34 @@ class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
             names.add(self._map_mtp_ckpt_name(name, layer_prefix))
 
         # Fused routed experts are queried by the coarse module prefix
-        # "model.decoder.mlp.experts". Expanded per-expert leaf excludes do not
-        # match that prefix, so add the coarse prefix when any routed expert in
-        # the MTP layer is excluded. This keeps only that fused MoE module bf16
-        # while allowing the remaining draft modules to use their quant config.
+        # "model.decoder.mlp.experts", which expanded per-expert leaf excludes
+        # do not match. So that module needs its own entry: bf16 as in the
+        # checkpoint, or the scheme matching the on-load PTPC-FP8 cast.
         if any(".mlp.experts." in name for name in mtp_excluded):
-            names.add("model.decoder.mlp.experts")
+            if enable_glm_nextn_moe_ptpc(quant_config):
+                mtp_layer_quant_config = quant_config.quant_config.setdefault(
+                    "layer_quant_config", {}
+                )
+                mtp_layer_quant_config["model.decoder.mlp.experts"] = {
+                    "weight": {
+                        "dtype": "fp8_e4m3",
+                        "is_dynamic": False,
+                        "qscheme": "per_channel",
+                    },
+                    # Dynamic per_channel is QuarkW8A8FP8MoE's per-token input.
+                    "input_tensors": {
+                        "dtype": "fp8_e4m3",
+                        "is_dynamic": True,
+                        "qscheme": "per_channel",
+                    },
+                }
+                logger.info(
+                    "SGLANG_GLM_NEXTN_MOE_PTPC=1: MTP fused MoE "
+                    "(model.decoder.mlp.experts) runs as PTPC-FP8"
+                )
+            else:
+                names.add("model.decoder.mlp.experts")
 
-        import copy
-
-        quant_config = copy.copy(quant_config)
         quant_config.exclude_layers = list(names)
         return quant_config
 

--- a/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
+++ b/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
@@ -1,0 +1,101 @@
+"""CI for SGLANG_GLM_NEXTN_MOE_PTPC=1 (GLM-5.2 NextN per-channel FP8 draft MoE).
+
+The feature is off by default. Without a case that turns the flag on, CI never
+touches the Quark scheme rewrite and cannot claim the path works. These tests
+exercise that ON wiring on CPU (and AMD stage-a, same file) without loading a
+70B MXFP4 checkpoint: they check enable_glm_nextn_moe_ptpc and
+GlmMoeDsaForCausalLMNextN._resolve_nextn_quant_config.
+
+A full serve+generate job still needs the MXFP4 weights in the runner cache;
+register that separately as nightly if the checkpoint is present.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.models.deepseek_common.utils import enable_glm_nextn_moe_ptpc
+from sglang.srt.models.glm4_moe import GlmMoeDsaForCausalLMNextN
+from sglang.test.ci.ci_register import register_amd_ci, register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_amd_ci(est_time=10, suite="stage-a-test-1-gpu-small-amd")
+
+LAYER = 78
+PREFIX = f"model.layers.{LAYER}"
+EXPERT_LEAF = f"{PREFIX}.mlp.experts.0.w1"
+
+
+def _quark_cfg(*, exclude=None, layer_quant=None):
+    return SimpleNamespace(
+        get_name=lambda: "quark",
+        quant_config={"layer_quant_config": dict(layer_quant or {}), "exclude": []},
+        exclude_layers=list(
+            exclude
+            if exclude is not None
+            else [EXPERT_LEAF, f"{PREFIX}.self_attn.q_proj"]
+        ),
+    )
+
+
+class TestEnableGlmNextnMoePtpc(CustomTestCase):
+    def test_off_by_default(self):
+        self.assertFalse(enable_glm_nextn_moe_ptpc(_quark_cfg()))
+
+    def test_on_requires_quark(self):
+        with patch(
+            "sglang.srt.models.deepseek_common.utils.envs.SGLANG_GLM_NEXTN_MOE_PTPC.get",
+            return_value=True,
+        ):
+            self.assertTrue(enable_glm_nextn_moe_ptpc(_quark_cfg()))
+            self.assertFalse(
+                enable_glm_nextn_moe_ptpc(SimpleNamespace(get_name=lambda: "fp8"))
+            )
+            self.assertFalse(enable_glm_nextn_moe_ptpc(None))
+
+
+class TestResolveNextnQuantConfigPtpcOn(CustomTestCase):
+    def _resolve(self, cfg, flag: bool):
+        model = GlmMoeDsaForCausalLMNextN.__new__(GlmMoeDsaForCausalLMNextN)
+        hf = SimpleNamespace(num_hidden_layers=LAYER)
+        with patch(
+            "sglang.srt.models.deepseek_common.utils.envs.SGLANG_GLM_NEXTN_MOE_PTPC.get",
+            return_value=flag,
+        ):
+            return model._resolve_nextn_quant_config(hf, cfg)
+
+    def test_flag_off_excludes_fused_experts(self):
+        src = _quark_cfg()
+        out = self._resolve(src, flag=False)
+        self.assertIn("model.decoder.mlp.experts", out.exclude_layers)
+        self.assertNotIn(
+            "model.decoder.mlp.experts",
+            out.quant_config.get("layer_quant_config", {}),
+        )
+
+    def test_flag_on_assigns_ptpc_scheme_instead_of_bf16_exclude(self):
+        src = _quark_cfg()
+        out = self._resolve(src, flag=True)
+        self.assertNotIn("model.decoder.mlp.experts", out.exclude_layers)
+        scheme = out.quant_config["layer_quant_config"]["model.decoder.mlp.experts"]
+        self.assertEqual(scheme["weight"]["dtype"], "fp8_e4m3")
+        self.assertEqual(scheme["weight"]["qscheme"], "per_channel")
+        self.assertFalse(scheme["weight"]["is_dynamic"])
+        self.assertEqual(scheme["input_tensors"]["dtype"], "fp8_e4m3")
+        self.assertEqual(scheme["input_tensors"]["qscheme"], "per_channel")
+        self.assertTrue(scheme["input_tensors"]["is_dynamic"])
+
+    def test_flag_on_does_not_mutate_caller_config(self):
+        src = _quark_cfg()
+        orig_exclude = list(src.exclude_layers)
+        orig_layer = dict(src.quant_config.get("layer_quant_config") or {})
+        self._resolve(src, flag=True)
+        self.assertEqual(src.exclude_layers, orig_exclude)
+        self.assertEqual(src.quant_config.get("layer_quant_config") or {}, orig_layer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
+++ b/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
@@ -2,9 +2,7 @@
 
 The feature is off by default. Without a case that turns the flag on, CI never
 touches the Quark scheme rewrite and cannot claim the path works. These tests
-exercise that ON wiring on CPU without loading a 70B MXFP4 checkpoint: they
-check enable_glm_nextn_moe_ptpc and
-GlmMoeDsaForCausalLMNextN._resolve_nextn_quant_config.
+exercise that ON wiring on CPU without loading a 70B MXFP4 checkpoint.
 
 A full serve+generate job still needs the MXFP4 weights in the runner cache;
 register that separately as nightly if the checkpoint is present.
@@ -16,7 +14,16 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from sglang.srt.models.deepseek_common.utils import enable_glm_nextn_moe_ptpc
+import torch
+
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    DeepseekV2WeightLoaderMixin,
+    NextNEnabledConfig,
+)
+from sglang.srt.models.deepseek_common.utils import (
+    enable_glm_nextn_moe_ptpc,
+    should_apply_glm_nextn_moe_ptpc,
+)
 from sglang.srt.models.glm4_moe import GlmMoeDsaForCausalLMNextN
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -26,6 +33,11 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 LAYER = 78
 PREFIX = f"model.layers.{LAYER}"
 EXPERT_LEAF = f"{PREFIX}.mlp.experts.0.w1"
+ATTN_LEAF = f"{PREFIX}.self_attn.q_proj"
+EXPERT_WEIGHT = f"{PREFIX}.mlp.experts.0.gate_proj.weight"
+_PTPC_ENV = (
+    "sglang.srt.models.deepseek_common.utils.envs.SGLANG_GLM_NEXTN_MOE_PTPC.get"
+)
 
 
 def _quark_cfg(*, exclude=None, layer_quant=None):
@@ -33,10 +45,17 @@ def _quark_cfg(*, exclude=None, layer_quant=None):
         get_name=lambda: "quark",
         quant_config={"layer_quant_config": dict(layer_quant or {}), "exclude": []},
         exclude_layers=list(
-            exclude
-            if exclude is not None
-            else [EXPERT_LEAF, f"{PREFIX}.self_attn.q_proj"]
+            exclude if exclude is not None else [EXPERT_LEAF, ATTN_LEAF]
         ),
+    )
+
+
+def _nextn_conf():
+    return NextNEnabledConfig(
+        num_nextn_layers=1,
+        nextn_layer_id=LAYER,
+        nextn_layer_prefix=PREFIX,
+        nextn_spec_weight_names=[],
     )
 
 
@@ -46,7 +65,7 @@ class TestEnableGlmNextnMoePtpc(CustomTestCase):
 
     def test_on_requires_quark(self):
         with patch(
-            "sglang.srt.models.deepseek_common.utils.envs.SGLANG_GLM_NEXTN_MOE_PTPC.get",
+            _PTPC_ENV,
             return_value=True,
         ):
             self.assertTrue(enable_glm_nextn_moe_ptpc(_quark_cfg()))
@@ -55,13 +74,32 @@ class TestEnableGlmNextnMoePtpc(CustomTestCase):
             )
             self.assertFalse(enable_glm_nextn_moe_ptpc(None))
 
+    def test_apply_requires_excluded_mtp_experts(self):
+        with patch(
+            _PTPC_ENV,
+            return_value=True,
+        ):
+            self.assertTrue(
+                should_apply_glm_nextn_moe_ptpc(_quark_cfg(), LAYER, model_type="glm4")
+            )
+            self.assertFalse(
+                should_apply_glm_nextn_moe_ptpc(
+                    _quark_cfg(exclude=[ATTN_LEAF]), LAYER, model_type="glm4"
+                )
+            )
+            self.assertFalse(
+                should_apply_glm_nextn_moe_ptpc(
+                    _quark_cfg(), LAYER, model_type="deepseek_v3"
+                )
+            )
+
 
 class TestResolveNextnQuantConfigPtpcOn(CustomTestCase):
     def _resolve(self, cfg, flag: bool):
         model = GlmMoeDsaForCausalLMNextN.__new__(GlmMoeDsaForCausalLMNextN)
         hf = SimpleNamespace(num_hidden_layers=LAYER)
         with patch(
-            "sglang.srt.models.deepseek_common.utils.envs.SGLANG_GLM_NEXTN_MOE_PTPC.get",
+            _PTPC_ENV,
             return_value=flag,
         ):
             return model._resolve_nextn_quant_config(hf, cfg)
@@ -94,6 +132,54 @@ class TestResolveNextnQuantConfigPtpcOn(CustomTestCase):
         self._resolve(src, flag=True)
         self.assertEqual(src.exclude_layers, orig_exclude)
         self.assertEqual(src.quant_config.get("layer_quant_config") or {}, orig_layer)
+
+    def test_flag_on_skips_ptpc_when_experts_not_excluded(self):
+        src = _quark_cfg(exclude=[ATTN_LEAF])
+        out = self._resolve(src, flag=True)
+        self.assertNotIn("model.decoder.mlp.experts", out.exclude_layers)
+        self.assertNotIn(
+            "model.decoder.mlp.experts",
+            out.quant_config.get("layer_quant_config", {}),
+        )
+
+    def test_flag_on_skips_ptpc_when_mtp_not_in_exclude(self):
+        src = _quark_cfg(exclude=[])
+        out = self._resolve(src, flag=True)
+        self.assertNotIn(
+            "model.decoder.mlp.experts",
+            out.quant_config.get("layer_quant_config", {}),
+        )
+
+
+class TestMaybeQuantGlmNextnMoeToPtpc(CustomTestCase):
+    def _cast(self, cfg, flag: bool, model_type: str = "glm4"):
+        loader = DeepseekV2WeightLoaderMixin.__new__(DeepseekV2WeightLoaderMixin)
+        loader.quant_config = cfg
+        loader.config = SimpleNamespace(model_type=model_type)
+        weights = [(EXPERT_WEIGHT, torch.ones(4, 8, dtype=torch.bfloat16))]
+        with patch(
+            _PTPC_ENV,
+            return_value=flag,
+        ):
+            return list(
+                loader._maybe_quant_glm_nextn_moe_to_ptpc(weights, _nextn_conf())
+            )
+
+    def test_flag_on_casts_excluded_bf16_experts(self):
+        out = self._cast(_quark_cfg(), flag=True)
+        names = [name for name, _ in out]
+        self.assertIn(EXPERT_WEIGHT, names)
+        self.assertIn(EXPERT_WEIGHT[: -len("weight")] + "weight_scale", names)
+        weight = dict(out)[EXPERT_WEIGHT]
+        self.assertEqual(weight.dtype, torch.float8_e4m3fn)
+
+    def test_flag_on_does_not_cast_when_experts_not_excluded(self):
+        src = _quark_cfg(exclude=[ATTN_LEAF])
+        out = self._cast(src, flag=True)
+        self.assertEqual(len(out), 1)
+        name, tensor = out[0]
+        self.assertEqual(name, EXPERT_WEIGHT)
+        self.assertEqual(tensor.dtype, torch.bfloat16)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
+++ b/test/registered/unit/models/test_glm_nextn_moe_ptpc.py
@@ -2,8 +2,8 @@
 
 The feature is off by default. Without a case that turns the flag on, CI never
 touches the Quark scheme rewrite and cannot claim the path works. These tests
-exercise that ON wiring on CPU (and AMD stage-a, same file) without loading a
-70B MXFP4 checkpoint: they check enable_glm_nextn_moe_ptpc and
+exercise that ON wiring on CPU without loading a 70B MXFP4 checkpoint: they
+check enable_glm_nextn_moe_ptpc and
 GlmMoeDsaForCausalLMNextN._resolve_nextn_quant_config.
 
 A full serve+generate job still needs the MXFP4 weights in the runner cache;
@@ -18,11 +18,10 @@ from unittest.mock import patch
 
 from sglang.srt.models.deepseek_common.utils import enable_glm_nextn_moe_ptpc
 from sglang.srt.models.glm4_moe import GlmMoeDsaForCausalLMNextN
-from sglang.test.ci.ci_register import register_amd_ci, register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
-register_amd_ci(est_time=10, suite="stage-a-test-1-gpu-small-amd")
 
 LAYER = 78
 PREFIX = f"model.layers.{LAYER}"


### PR DESCRIPTION
## Motivation

Layer 78 of GLM-5.2 is the MTP draft layer. The MXFP4 checkpoint ships its routed
and shared experts in bf16 — 71.7 MB per expert against 19.0 MB for an MXFP4
decoder layer — and MTP reads that layer once per draft step. In bandwidth-bound
decode it therefore costs more than its share of the parameter count suggests.

While wiring the quantized path up it turned out `QuarkW8A8FP8MoE` could never
reach its AITER runner, so every quark per-channel FP8 MoE on ROCm was silently
running Triton.

## Modifications

- **Cast the GLM NextN fused-expert weights to per-channel FP8 at load time**
  (`deepseek_weight_loader.py`), and point quark's per-module scheme selection at
  the matching `QuarkW8A8FP8MoE` scheme (`glm4_moe.py`). Off by default behind
  `SGLANG_GLM_NEXTN_MOE_PTPC`. The loader additionally requires a GLM
  `model_type`: the mixin is shared with DeepSeek, where no matching scheme
  exists and the cast weights would have nowhere to load.

- **Fix the AITER runner selection in `QuarkW8A8FP8MoE`.** The AITER branch was
  gated on `moe_runner_config.apply_router_weight_on_input`, which no model that
  resolves to a quark scheme sets, so the branch was unreachable. Select the
  runner from what the kernel actually requires — per-channel weight scales,
  AITER built in, and an a2a backend that supports it — and route `apply_weights`
  through `AiterMoeQuantInfo`. Preshuffling now keys off the selected runner
  rather than the same dead flag, so the canonical layout is preserved when
  Triton runs.

- **Copy the `QuarkConfig` before the NextN remap** in
  `_resolve_nextn_quant_config`. The caller keeps that object for the target model
  and for `lm_head`, so the draft-only rewrite was mutating shared state. A no-op
  for GLM-5.2-MXFP4, whose `layer_quant_config` is empty, but wrong for any
  checkpoint that sets one.

### On the runner default

`auto` now resolves to AITER for this scheme, matching what its siblings in the
same directory already do — `quark_w4a4_mxfp4_moe.py` and
`quark_w4a8_mxfp4_moe.py` both promote `auto` to AITER when the a2a backend
supports it. `QuarkW8A8FP8MoE` was the one left on Triton, and only because of
the dead flag, so this restores consistency rather than introducing a new default.

It does matter which runner wins: FP8 experts on the Triton path are *slower*
than the bf16 they replace (TPOT p50 +7.5% to +11.6% across five synthetic
scenarios), because that path dequantizes inside the kernel. AITER's per-token CK
fused MoE consumes the FP8 weights and per-channel scales directly. Leaving the
runner as-is would therefore make `SGLANG_GLM_NEXTN_MOE_PTPC=1` a regression.

`--moe-runner-backend triton` restores the previous path, and the resolution is
logged once at startup (`QuarkW8A8FP8MoE runner=...`) so a fallback is visible
rather than surfacing later as an unexplained regression.

### Why per-channel and not 128x128 block FP8

Both are FP8, so the weight bytes are identical (9.0 GB either way); only the
scale metadata differs, by 8 MB out of 9 GB. Decode here is purely
bandwidth-bound, so the two hit the same roofline — measured, both reach
5.5–6.0 TB/s on MI355X.

Benchmarked on the real layer-78 shape with both formats tuned by aiter's MoE
tuner, the best non-FLAT block kernel is 1.6–25% *slower* than the best
per-channel one at every token count from 1 to 128. Block's one win — 55.5 us
against 114.9 us end-to-end at token 1 — comes from a FLAT kernel that skips
host-side sorting, and that kernel drops `expert_mask`, so it faults under EP.
Accuracy is a wash (mean relative error vs bf16: 0.065 per-channel, 0.064 block).

## Accuracy Tests

GSM8K 5-shot, `lm_eval` `local-chat-completions`, temperature 0, 1319 problems,
MTP enabled with real verification (no synthetic acceptance length).

| | flexible-extract | strict-match |
|---|---:|---:|
| baseline (bf16 draft experts) | 0.9416 ± 0.0065 | 0.9424 ± 0.0064 |
| this PR (`SGLANG_GLM_NEXTN_MOE_PTPC=1`) | 0.9371 ± 0.0067 | 0.9371 ± 0.0067 |
| delta | −0.45 pp | −0.53 pp |
| 2 × combined stderr | ±1.86 pp | ±1.85 pp |

Both deltas are well inside noise.

Speculative decoding is lossless at temperature 0 — an accepted draft token is by
construction the target model's argmax — and only the draft layer is requantized,
so this is a regression guard rather than a precision measurement. It is what
would catch a bad weight scale or the shared-config mutation fixed above.

### Draft acceptance is unchanged

The end-user speedup is the kernel gain multiplied by any change in acceptance, so
the cast is only worthwhile if the FP8 draft proposes as well as the bf16 one.
Measured on the GSM8K run above, with synthetic acceptance disabled:

| | accept len | accept rate | decode steps |
|---|---:|---:|---:|
| baseline | 2.810 ± 0.030 | 0.362 | 1057 |
| this PR | 2.829 ± 0.036 | 0.366 | 1142 |

+0.68%, against a 95% CI of ±1.7% on the difference, and it holds per batch size.

## Speed Tests and Profiling

aiperf AgentX trace, GLM-5.2-MXFP4 on MI355X, TP4/EP4, concurrency 8, 3600 s per
arm, one run per arm, 0 errors on both. All 473 other `ServerArgs` identical.
Acceptance was pinned in both arms with `SGLANG_SIMULATE_ACC_LEN=3.61` to isolate
the kernel from the acceptance measurement above.

| | baseline | this PR | |
|---|---:|---:|---:|
| **Interactivity p90** (tok/s/user) | 110.42 | 120.66 | **+9.3%** |
| Interactivity p50 | 173.42 | 181.74 | +4.8% |
| TTFT p50 | 0.597 s | 0.528 s | −11.5% |
| TTFT p90 | 1.555 s | 1.367 s | −12.1% |
| TTFT p95 | 2.200 s | 1.819 s | −17.3% |
| TPOT p50 | 5.77 ms | 5.50 ms | −4.7% |
| TPOT p90 | 9.06 ms | 8.29 ms | −8.5% |
| TPOT p95 | 10.79 ms | 10.36 ms | −4.0% |
| E2E p50 | 3.80 s | 3.45 s | −9.2% |
| E2E p95 | 29.12 s | 26.80 s | −8.0% |
| Output throughput | 355.2 tok/s | 359.4 tok/s | +1.2% |
| Requests completed | 1143 | 1153 | +0.9% |
| GPU prefix-cache hit | 95.80% | 95.88% | +0.08 pp |
| NextN weights per GPU | 5.46 GB | 3.17 GB | **−2.29 GB** |

Interactivity is `1/ITL` at the matching percentile, so those rows restate TPOT
rather than measuring separately.

**Where the decode win comes from.** The server's own decode log, compared at
matched `#running-req` (99% of decode steps), separates the kernel from the
scheduling response to it:

| avg ITL | ms | vs baseline |
|---|---:|---:|
| baseline | 5.259 | — |
| swap in this PR's per-batch kernel timings, hold the batch mix | 5.168 | **−1.74%** |
| hold baseline kernel, swap in this PR's batch mix | 5.229 | −0.57% |
| this PR | 5.144 | −2.19% |

The kernel itself is worth about 1.7%. Faster decode shortens residency, so at
fixed concurrency the batch-size distribution shifts down (37.6% → 40.1% of steps
at batch 1, where ITL is lowest), worth another 0.6%. The client-side percentiles
move further still, from prefill interleaving and scheduling outside the decode
step, which the decode log does not resolve.

That 1.7% is what the weights predict. MoE decode only reads routed experts, and
the draft runs one token per forward while verify runs six: at batch 1 the draft
touches 8 of 256 experts and each target layer touches 44.4. Those two effects
nearly cancel, so one draft forward reads 1.198 GB against 1.201 GB for one target
layer — five draft forwards cost about five target layers out of 78, or 6.1% of
the bytes moved per iteration. Halving the draft's expert bytes takes each draft
forward to 0.876 GB, i.e. 1.67% of the total at batch 1, 1.99% at batch 2 and
2.43% at batch 4, against measured 1.41%, 2.18% and 1.68%.

The corollary is that this lever is now spent: eliminating the draft forwards
entirely would only be worth 6.5%, and the remaining 4.8% is per-forward fixed
cost — five kernel launches, five all-to-all rounds under EP4, five sync points —
which no change in weight precision can reach.

**Controls checked.** The 1.9% KV-pool difference did not bind: peak pool
occupancy was 0.78 / 0.67 and theoretical cache hit rate was identical (0.97627 /
0.97632). The baseline arm paid 52 JIT compiles in-window (none in the second arm,
which inherited the warm cache), but that inflates only the moments, not the
percentiles, so `itl.mean` and `itl.std` are excluded here and only percentiles
are quoted. Decode gain by time window is +1.50% (0–10 min, containing the
compiles), +1.72%, +2.17%, +1.55% — the compile-affected window shows the
*smallest* gain, so the JIT is not driving it.

**Not quoted:** per-chip total throughput (+1.47%), because input is 99.2% of that
counter and 95.8% of it is prefix-cache reads — GEMM-bearing prompt tokens rose
only 0.44%.

Single run per arm, so treat the magnitudes as indicative.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

No unit test: the path needs a ROCm GPU with AITER and a GLM-5.2 MXFP4 checkpoint,
and it is off by default. Happy to add one if there is a fixture for this.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34496374987](https://github.com/sgl-project/sglang/actions/runs/34496374987)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34496374572](https://github.com/sgl-project/sglang/actions/runs/34496374572)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34496374781](https://github.com/sgl-project/sglang/actions/runs/34496374781)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->