### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3-Next tutorial

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_next_80b_a3b_instruct.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_next_80b_a3b_instruct.mdx
@@ -27,7 +27,7 @@ v0.5.16 or a later version.
 | Data Parallelism              | `--dp-size 2`                                                                                 |
 | Expert Parallelism            | `--ep-size 4 \`<br/>`--moe-a2a-backend deepep \`<br/>`--deepep-mode auto`                     |
 | Quantization                  | `--quantization modelslim`                                                                    |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 2 4 8` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 2 4 8` |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4 \`<br/>`--speculative-draft-model-quantization unquant \`<br/>`--speculative-draft-model-path /path/to/draft-model-weights` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 | DP LM Head                    | `--enable-dp-lm-head`                                                                         |
@@ -219,3 +219,4 @@ guidance, see [Optimization on Ascend NPU](/docs/hardware-platforms/ascend-npus/
 ## FAQ
 
 For common environment, installation, and general parameter issues, please refer to the [Ascend NPU FAQ](/docs/hardware-platforms/ascend-npus/faq).
+


### PR DESCRIPTION
## Summary
Update the Ascend Qwen3-Next tutorial NPU Graph row to prefer current CUDA graph CLIs:
- `--disable-cuda-graph` → `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`
- `--cuda-graph-bs` → `--cuda-graph-bs-decode`

Best-practices for the same model already prefer `--cuda-graph-bs-decode`; this aligns the tutorial table.

## Repro
```bash
# Deprecated aliases still accepted but docs should prefer current names
# From python/sglang/srt/server_args.py (DeprecatedAliasStoreAction / DeprecatedStoreTrueAction):
#   --cuda-graph-bs      → --cuda-graph-bs-decode
#   --disable-cuda-graph → --cuda-graph-backend-{decode,prefill}=disabled

curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_next_80b_a3b_instruct.mdx \
  | rg -n 'disable-cuda-graph|cuda-graph-bs[^-]'
# Expect hits on the NPU Graph table row before this change.
```

## Test plan
- [ ] Docs preview / markdown table renders
- [ ] No remaining `--disable-cuda-graph` / bare `--cuda-graph-bs` in this tutorial

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34211266578](https://github.com/sgl-project/sglang/actions/runs/34211266578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34211266273](https://github.com/sgl-project/sglang/actions/runs/34211266273)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->