### PR TITLE
[Docs] Prefer --mem-fraction-static in benchmark profiling guide

### DIFF
--- a/docs/docs/developer_guide/benchmark_and_profiling.mdx
+++ b/docs/docs/developer_guide/benchmark_and_profiling.mdx
@@ -149,7 +149,7 @@ export SGLANG_TORCH_PROFILER_DIR=/root/sglang/profile_log
 python3 -m sglang.bench_one_batch --model-path meta-llama/Llama-3.1-8B-Instruct --batch 32 --input-len 1024 --output-len 10 --profile
 
 # profile multiple batches with bench_offline_throughput.py
-python -m sglang.bench_offline_throughput --model-path meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompts 10 --profile --mem-frac=0.8
+python -m sglang.bench_offline_throughput --model-path meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompts 10 --profile --mem-fraction-static 0.8
 ```
 
 ### Profile a server with `sglang.profiler`
@@ -376,7 +376,7 @@ RuntimeError: !stack.empty() INTERNAL ASSERT FAILED at "/pytorch/torch/csrc/auto
 This is likely a PyTorch Bug reported in [Bug: vLLM Profiler](https://github.com/vllm-project/vllm/issues/18240) and [Bug: torch.profiler.profile](https://github.com/pytorch/pytorch/issues/101632). As a workaround, you may disable `with_stack` with an environment variable such as follows:
 ```bash Command
 export SGLANG_PROFILE_WITH_STACK=False
-python -m sglang.bench_offline_throughput --model-path meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompts 10 --profile --mem-frac=0.8
+python -m sglang.bench_offline_throughput --model-path meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompts 10 --profile --mem-fraction-static 0.8
 ```
 
 ### View traces


### PR DESCRIPTION
## Summary
- In `docs/docs/developer_guide/benchmark_and_profiling.mdx`, replace ghost `--mem-frac=0.8` with `--mem-fraction-static 0.8` in the two `bench_offline_throughput` profiling examples.

## Why
`python -m sglang.bench_offline_throughput` builds its CLI from `ServerArgs.add_cli_args`. The registered memory flag is `--mem-fraction-static`; `--mem-frac` is not registered anywhere in the SGLang Python tree, so the documented command fails argparse with an unrecognized-arguments error.

## Repro
```bash
# HEAD checked: e634ba78a43b (main)
# Ghost: no --mem-frac registration
rg -n '"--mem-frac"|'"'"'--mem-frac'"'"'' python/sglang || true
# Live flag: --mem-fraction-static on Schedule / ServerArgs
rg -n 'mem_fraction_static' python/sglang/srt/arg_groups/fields/schedule.py
# Offline bench wires ServerArgs CLI
rg -n 'ServerArgs.add_cli_args' python/sglang/benchmark/offline_throughput.py
# Doc sites (before fix)
rg -n 'mem-frac' docs/docs/developer_guide/benchmark_and_profiling.mdx
```

Expected before: docs show `--mem-frac=0.8` twice; runtime rejects `--mem-frac`.
Expected after: docs show `--mem-fraction-static 0.8`.

## Test plan
- [ ] Confirm `rg '--mem-frac' docs/docs/developer_guide/benchmark_and_profiling.mdx` is empty
- [ ] Confirm both profiling snippets use `--mem-fraction-static 0.8`
- [ ] Optional: `python -m sglang.bench_offline_throughput -h` lists `--mem-fraction-static` and not `--mem-frac`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34215081777](https://github.com/sgl-project/sglang/actions/runs/34215081777)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34215081580](https://github.com/sgl-project/sglang/actions/runs/34215081580)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->