### PR TITLE
[Qwen4] Release weight-loader references without waiting for cyclic GC

### DIFF
--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1910,7 +1910,10 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     )
                 )
 
+        warned_ple_downcast = False
+
         def load_qwen4_exp_ple_shard(name: str, loaded_weight: torch.Tensor) -> bool:
+            nonlocal warned_ple_downcast
             if ".ngram_embedding.shard_" not in name:
                 return False
             import re
@@ -1957,8 +1960,8 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 emb.weight.dtype == torch.float8_e4m3fn
                 and loaded_weight.dtype != torch.float8_e4m3fn
             ):
-                if not getattr(load_qwen4_exp_ple_shard, "_warned_downcast", False):
-                    load_qwen4_exp_ple_shard._warned_downcast = True
+                if not warned_ple_downcast:
+                    warned_ple_downcast = True
                     logger.warning(
                         "PLE checkpoint shards are %s but the embedding storage "
                         "is fp8 (ple_embedding_dtype / fp8 quant config); "

--- a/test/registered/unit/models/test_qwen4_loader_lifetime.py
+++ b/test/registered/unit/models/test_qwen4_loader_lifetime.py
@@ -1,0 +1,85 @@
+"""Loading must not retain replaced parameters until cyclic garbage collection."""
+
+import gc
+import unittest
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.models import qwen4_exp
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _TinyPLE(qwen4_exp.Qwen4ExpNGramEmbedding):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+        self.ngram_embedding = torch.nn.Embedding(
+            4, 2, _weight=torch.ones(4, 2).to(torch.float8_e4m3fn)
+        )
+        self.ngram_embedding.org_vocab_size = 4
+        self.ngram_embedding.shard_indices = SimpleNamespace(
+            org_vocab_start_index=0, org_vocab_end_index=4
+        )
+
+
+class _TinyModel(torch.nn.Module):
+    _load_qwen4_exp_ple_buffer = (
+        qwen4_exp.Qwen4ExpForConditionalGeneration._load_qwen4_exp_ple_buffer
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(num_experts=None, split_ngram_parts=2)
+        self.weight = torch.nn.Parameter(torch.ones(2, 2))
+
+
+class TestQwen4LoaderLifetime(CustomTestCase):
+    def test_replaced_parameter_is_released_without_cyclic_gc(self):
+        model = _TinyModel()
+        old_weight = weakref.ref(model.weight)
+        gc.collect()
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            loaded = qwen4_exp.Qwen4ExpForConditionalGeneration.load_weights(model, [])
+            self.assertEqual(loaded, set())
+            # ModelOpt postprocessing also replaces parameters after load_weights.
+            model.weight = torch.nn.Parameter(torch.zeros(2, 2))
+            self.assertIsNone(old_weight())
+        finally:
+            gc.collect()
+            if gc_was_enabled:
+                gc.enable()
+
+    def test_downcast_warning_is_once_per_load(self):
+        model = _TinyModel()
+        model.ple = _TinyPLE()
+        shards = [
+            (
+                f"ple.ngram_embedding.shard_{i}.weight",
+                torch.ones(2, 2, dtype=torch.bfloat16),
+            )
+            for i in range(2)
+        ]
+        with patch.object(qwen4_exp.logger, "warning") as warning:
+            for expected_warnings in (1, 2):
+                loaded = qwen4_exp.Qwen4ExpForConditionalGeneration.load_weights(
+                    model, shards
+                )
+                self.assertEqual(loaded, {"ple.ngram_embedding.weight"})
+                self.assertEqual(warning.call_count, expected_warnings)
+        torch.testing.assert_close(
+            model.ple.ngram_embedding.weight.float(), torch.ones(4, 2)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The nested PLE shard loader in `Qwen4ExpForConditionalGeneration.load_weights` reads an attribute on itself to implement a once-per-load warning. That self-reference creates a function/closure cycle which also retains the loading-time `params_dict`. Parameters replaced by subsequent weight processing remain alive until cyclic GC runs.

## Modifications

Use a nonlocal boolean for the warning flag. Preserve the once-per-load warning and weight-loading behavior without retaining the loader function itself.

Add a regression test against the actual `load_weights` method, using tiny CPU parameters and disabling automatic cyclic GC. A second test loads two PLE shards twice and checks both tensor contents and one warning per load.

## Accuracy Tests

Isolated testing on base `4ccff141dbe992794f9da6c3aa23535b4f72000d`, using `lmsysorg/sglang:dev-cu13-qwen38-next-local`:

```text
pytest -q test/registered/unit/models/test_qwen4_loader_lifetime.py
Before: 1 failed, 1 passed (the replaced parameter is still alive).
After:  2 passed.
```

The test imports and executes the production method; it does not copy or rewrite its body. This change does not alter quantization arithmetic.

## Speed Tests and Profiling

The issue was diagnosed while serving `nv-community/Qwen3.8-Flash-Next-NVFP4` on one RTX PRO 6000 with the turbo patch stack. In that configuration, stale initial MoE scale buffers and an online-FP8-replaced BF16 head totaled 8.215 GiB. With the fix, those references are released promptly rather than at a later cyclic collection.

This is an earlier-release result, not an additional 8.215 GiB steady-state saving for every configuration. Automatic KV sizing may consume reclaimed memory. The deployed combination also passed structured JSON, ten concurrent 32K-input requests, and a 240K-input request; those are combined-stack smoke results, not isolated accuracy or throughput benchmarks for this PR.

## Attribution

Changed-file pre-commit checks, including registered-test validation, passed locally. Upstream CI has not been run by this submission.

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for [sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo) and the SM120 optimization work that enabled this investigation. This reference-lifetime fix was developed during validation of that stack; the original optimization work remains credited to its authors.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829704177](https://github.com/sgl-project/sglang/actions/runs/34829704177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829703979](https://github.com/sgl-project/sglang/actions/runs/34829703979)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829704121](https://github.com/sgl-project/sglang/actions/runs/34829704121)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->