### PR TITLE
[Docs] Prefer current CUDA graph CLIs in Ascend Qwen3.6-35B-A3B tutorial

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_35b_a3b.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_35b_a3b.mdx
@@ -26,7 +26,7 @@ version**.
 |-------------------------------|-----------------------------------------------------------------------------------------------|
 | Tensor Parallelism            | `--tp-size 2`                                                                                 |
 | Chunked Prefill               | auto based on device memory, or set explicit value;<br/>disable with `--chunked-prefill-size -1`; e.g., `--chunked-prefill-size 16384` |
-| NPU Graph                     | enabled by default; disable with `--disable-cuda-graph`;<br/>control range via `--cuda-graph-bs` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs 4 8 16 24 32 48 64 80 96 112 120` |
+| NPU Graph                     | enabled by default; disable with `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`;<br/>control range via `--cuda-graph-bs-decode` or `--cuda-graph-max-bs-decode`; e.g., `--cuda-graph-bs-decode 4 8 16 24 32 48 64 80 96 112 120` |
 | Speculative Decoding          | `--speculative-algorithm NEXTN \`<br/>`--speculative-num-steps 3 \`<br/>`--speculative-eagle-topk 1 \`<br/>`--speculative-num-draft-tokens 4` |
 | Overlap Schedule              | `export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`                                                  |
 


### PR DESCRIPTION
## Summary
Update the Ascend NPU Qwen3.6-35B-A3B tutorial feature table to prefer current CUDA graph CLIs over deprecated aliases.

- `--disable-cuda-graph` → `--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled`
- `--cuda-graph-bs` → `--cuda-graph-bs-decode`

Verified against `python/sglang/srt/server_args.py` deprecated registrations and `python/sglang/srt/arg_groups/fields/exec_.py` live fields (`cuda_graph_backend_*`, `cuda_graph_bs_decode`, `cuda_graph_max_bs_decode`) at HEAD `e634ba78a43b`.

Sibling of the Qwen3.6-27B tutorial row already covered elsewhere; this tutorial file was still on the old names.

## Repro / verification
```bash
# Live preferred flags (fields exist)
rg -n "cuda_graph_bs_decode:|cuda_graph_max_bs_decode:|cuda_graph_backend_decode:|cuda_graph_backend_prefill:" \
  python/sglang/srt/arg_groups/fields/exec_.py

# Deprecated aliases still registered but warn
rg -n 'new_flag="--cuda-graph-bs-decode"|--disable-cuda-graph' python/sglang/srt/server_args.py

# Doc row after fix
rg -n "NPU Graph" docs/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_6_35b_a3b.mdx
```

## Test plan
- [x] Confirmed preferred flags are live argparse fields
- [x] Confirmed old flags are DeprecatedAlias / DeprecatedStoreTrue
- [x] Single-file docs-only change; no runtime code touched

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34216736768](https://github.com/sgl-project/sglang/actions/runs/34216736768)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34216736611](https://github.com/sgl-project/sglang/actions/runs/34216736611)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->