### PR TITLE
[Qwen4] Skip sampler token synchronization for single-rank groups

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -74,6 +74,7 @@ class Sampler(nn.Module):
         self.tp_sync_group = get_tp_group().device_group
         if is_dp_attention_enabled():
             self.tp_sync_group = get_parallel().attn_tp_group.device_group
+        self.tp_sync_world_size = dist.get_world_size(group=self.tp_sync_group)
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -497,6 +498,10 @@ class Sampler(nn.Module):
     def _sync_token_ids_across_tp(
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
+        # A single-rank reduction is an identity. Avoid lazily allocating NCCL
+        # communicator buffers on the first structured-output request.
+        if self.tp_sync_world_size == 1:
+            return
         if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:

--- a/test/registered/unit/sampling/test_sampler_token_sync.py
+++ b/test/registered/unit/sampling/test_sampler_token_sync.py
@@ -1,0 +1,48 @@
+"""Single-rank token synchronization must not launch a collective."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers import sampler
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestSamplerTokenSync(CustomTestCase):
+    def test_sync_conditions_preserve_tokens_and_multi_rank_behavior(self):
+        for size in (1, 2):
+            for forced in (False, True):
+                for grammar in (False, True):
+                    with self.subTest(size=size, forced=forced, grammar=grammar):
+                        group = object()
+                        instance = SimpleNamespace(
+                            tp_sync_world_size=size, tp_sync_group=group
+                        )
+                        tokens = torch.tensor([7, 42], dtype=torch.int64)
+                        info = SimpleNamespace(grammars=[object()] if grammar else None)
+                        with (
+                            patch.object(sampler, "SYNC_TOKEN_IDS_ACROSS_TP", forced),
+                            patch.object(torch.distributed, "all_reduce") as reduce,
+                        ):
+                            sampler.Sampler._sync_token_ids_across_tp(
+                                instance, tokens, info
+                            )
+                        if size > 1 and (forced or grammar):
+                            reduce.assert_called_once_with(
+                                tokens, op=torch.distributed.ReduceOp.MIN, group=group
+                            )
+                        else:
+                            reduce.assert_not_called()
+                        torch.testing.assert_close(tokens, torch.tensor([7, 42]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Structured-output sampling synchronizes token IDs even when the selected synchronization group contains one rank. The reduction is an identity, but the first NCCL collective can lazily initialize a communicator and allocate device buffers after the KV pool is sized.

## Modifications

- Cache the size of the actual selected synchronization group after TP/DP-attention group selection.
- Skip the token-ID all-reduce for a one-rank group.
- Leave multi-rank synchronization conditions and the MIN reduction unchanged.

## Accuracy Tests

Run against the actual sampler method in an isolated base-image container at `qwen4-main-squashed` commit `4ccff141dbe992794f9da6c3aa23535b4f72000d`:

```text
pytest -q test/registered/unit/sampling/test_sampler_token_sync.py
Before: 3 failing single-rank subcases.
After:  1 test passed, all 8 subcases passed.
```

The matrix covers group sizes 1/2, forced synchronization on/off, and grammar on/off. Only the distributed collective is mocked; token values are checked unchanged. Multi-process execution is left to upstream CI.

## Speed Tests and Profiling

No throughput claim. The optimization removes an unnecessary collective and its potential one-rank NCCL initialization. The original turbo deployment completed structured JSON generation; this PR's isolated check verifies the skip and multi-rank call behavior.

## Attribution

Ported and adapted from patch `0006-single-gpu-token-sync.patch` in [mratsim/sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo/tree/000b6b5aa2b6ca4529319925286e1f2ec91a2dad).

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for the original fix and SM120 serving work. The commit includes his co-author attribution; this port adds focused regression coverage and concise upstream-facing comments.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829706912](https://github.com/sgl-project/sglang/actions/runs/34829706912)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829706682](https://github.com/sgl-project/sglang/actions/runs/34829706682)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829706876](https://github.com/sgl-project/sglang/actions/runs/34829706876)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->