### PR TITLE
[Qwen4] Preserve request cancellation after tokenizer cleanup

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2948,10 +2948,13 @@ class Scheduler(
         if req is None:
             return
         if self.chunked_req is not req:
-            # Already past chunked prefill; the running-batch abort path handles
-            # it. Drop the marker once the request is actually gone.
             if req.finished() or req.req_pool_idx is None:
                 self._pending_chunked_abort_req = None
+                return
+            # The request left the chunked slot while its abort was deferred,
+            # so retry the abort against wherever it now sits.
+            self._pending_chunked_abort_req = None
+            self.abort_request(AbortReq(rid=req.rid))
             return
 
         prepare_abort(req, "Aborted")

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1985,12 +1985,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        if (
-            not abort_all
-            and self.server_args.tokenizer_worker_num == 1
-            and rid not in self.rid_to_state
-        ):
-            return
+        # Tokenizer state may already be gone while the scheduler still owns
+        # the request. Let the scheduler resolve the abort in that case too.
         req = AbortReq(rid=rid, abort_all=abort_all)
         self._dispatch_to_scheduler(req)
         if self.enable_metrics:
@@ -3419,17 +3415,24 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             time_stats.set_created_time(created_time)
 
     def _discard_pending_req_states(self, obj):
-        """Drop rid_to_state entries created by _init_req_state for *obj*.
+        """Abort pending scheduler work before discarding tokenizer state.
 
-        Safe to call after a partial/failed dispatch: only entries still present
-        are removed, and the scheduler-response path looks up state with
-        ``.get(...)`` so a later output for a discarded rid is ignored, not fatal.
+        Cleanup must still remove local state if the scheduler socket fails,
+        without masking the handler's original cancellation or dispatch error.
         """
         if not hasattr(obj, "is_single") or obj.is_single:
             rids = [obj.rid]
         else:
             rids = obj.rid
         for rid in rids:
+            if rid in self.rid_to_state:
+                try:
+                    self._dispatch_to_scheduler(AbortReq(rid=rid))
+                except Exception:
+                    logger.exception(
+                        "Failed to abort request during disconnect cleanup: %s",
+                        rid,
+                    )
             self.rid_to_state.pop(rid, None)
 
     def _should_dispatch_to_encoder(

--- a/test/registered/unit/managers/test_cancelled_request_cleanup.py
+++ b/test/registered/unit/managers/test_cancelled_request_cleanup.py
@@ -1,0 +1,87 @@
+"""Cancellation must reach the scheduler even after tokenizer state is gone."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestCancelledRequestCleanup(CustomTestCase):
+    def test_abort_without_tokenizer_state_still_dispatches(self):
+        manager = SimpleNamespace(
+            rid_to_state={},
+            enable_metrics=False,
+            server_args=SimpleNamespace(tokenizer_worker_num=1),
+            _dispatch_to_scheduler=Mock(),
+        )
+        TokenizerManager.abort_request(manager, "cancelled")
+        self.assertEqual(
+            manager._dispatch_to_scheduler.call_args.args[0].rid, "cancelled"
+        )
+        manager._dispatch_to_scheduler.reset_mock()
+        TokenizerManager.abort_request(manager)
+        manager._dispatch_to_scheduler.assert_not_called()
+        TokenizerManager.abort_request(manager, abort_all=True)
+        self.assertTrue(manager._dispatch_to_scheduler.call_args.args[0].abort_all)
+
+    def test_discard_aborts_tracked_requests_before_removing_state(self):
+        for single in (True, False):
+            with self.subTest(single=single):
+                states = {"a": object(), "b": object()}
+                dispatched = []
+
+                def dispatch(req):
+                    self.assertIn(req.rid, states)
+                    dispatched.append(req.rid)
+
+                manager = SimpleNamespace(
+                    rid_to_state=states, _dispatch_to_scheduler=dispatch
+                )
+                obj = SimpleNamespace(
+                    is_single=single, rid="a" if single else ["a", "missing", "b"]
+                )
+                TokenizerManager._discard_pending_req_states(manager, obj)
+                self.assertEqual(dispatched, ["a"] if single else ["a", "b"])
+                self.assertEqual(set(states), {"b"} if single else set())
+
+    def test_socket_failure_does_not_prevent_local_cleanup(self):
+        manager = SimpleNamespace(
+            rid_to_state={"a": object()},
+            _dispatch_to_scheduler=Mock(side_effect=RuntimeError("socket closed")),
+        )
+        TokenizerManager._discard_pending_req_states(manager, SimpleNamespace(rid="a"))
+        self.assertEqual(manager.rid_to_state, {})
+
+    def test_deferred_abort_retries_after_request_leaves_chunked_slot(self):
+        req = SimpleNamespace(rid="a", req_pool_idx=3, finished=lambda: False)
+        scheduler = SimpleNamespace(
+            _pending_chunked_abort_req=req, chunked_req=None, abort_request=Mock()
+        )
+        Scheduler.process_pending_chunked_abort(scheduler)
+        self.assertIsNone(scheduler._pending_chunked_abort_req)
+        self.assertEqual(scheduler.abort_request.call_args.args[0].rid, "a")
+
+    def test_completed_deferred_abort_is_cleared_without_dispatch(self):
+        for finished, pool_idx in ((True, 3), (False, None)):
+            req = SimpleNamespace(
+                rid="a", req_pool_idx=pool_idx, finished=lambda: finished
+            )
+            scheduler = SimpleNamespace(
+                _pending_chunked_abort_req=req, chunked_req=None, abort_request=Mock()
+            )
+            Scheduler.process_pending_chunked_abort(scheduler)
+            self.assertIsNone(scheduler._pending_chunked_abort_req)
+            scheduler.abort_request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Cancellation can leave scheduler work alive when tokenizer state has already been removed. A deferred chunked-prefill abort can also remain pending after the request leaves the chunked slot.

## Modifications

- Forward explicit nonempty aborts even when the tokenizer no longer tracks the request.
- Send an abort for tracked pending requests before discarding tokenizer state; still clean up local state if the scheduler socket fails.
- Retry a deferred chunked abort through the normal scheduler abort path after the request moves out of the chunked slot.
- Preserve the empty-ID guard and completed-request handling.

This is the cancellation subset of turbo patch 0005. The separate admission-loop/batch-full change and logging-only changes are intentionally excluded. This PR does not claim to resolve every overlap-scheduling cancellation window.

## Accuracy Tests

Isolated base-image RED/GREEN at `qwen4-main-squashed` commit `4ccff141dbe992794f9da6c3aa23535b4f72000d`:

```text
pytest -q test/registered/unit/managers/test_cancelled_request_cleanup.py
Before: abort dispatch, deferred retry, and single/batch cleanup assertions fail.
After:  5 tests passed, including both single/batch subcases.
```

Tests call production manager/scheduler methods and mock the scheduler dispatch boundary. They also cover empty IDs, abort-all, completed requests, missing state, and socket failure. End-to-end overlapping cancellation stress remains useful upstream CI coverage; it is not claimed as completed here.

## Speed Tests and Profiling

No model-math or throughput change is claimed. The intended effect is to stop work whose consumer has cancelled.

## Attribution

Adapted from `0005-abort-ghost-fixes.patch` in [mratsim/sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo/tree/000b6b5aa2b6ca4529319925286e1f2ec91a2dad).

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for diagnosing abandoned-request behavior and publishing the original fixes. His contribution is retained in the commit's co-author attribution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829709538](https://github.com/sgl-project/sglang/actions/runs/34829709538)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829709250](https://github.com/sgl-project/sglang/actions/runs/34829709250)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829709500](https://github.com/sgl-project/sglang/actions/runs/34829709500)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->