### PR TITLE
[Qwen4] Add opt-in structured-output startup warmup

### DIFF
--- a/python/sglang/srt/entrypoints/warmup.py
+++ b/python/sglang/srt/entrypoints/warmup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, List
 
@@ -159,3 +160,46 @@ async def prefill_shapes(disaggregation_mode: str, tokenizer_manager: TokenizerM
             generate_req_input.bootstrap_host = FAKE_BOOTSTRAP_HOST
 
         await tokenizer_manager.generate_request(generate_req_input, None).__anext__()
+
+
+# Warm one schema and the shared token-mask kernels. Other schemas still need
+# their own grammar compilation on first use.
+_GRAMMAR_WARMUP_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {
+            "topic": {"type": "string"},
+            "items": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["topic", "items"],
+    },
+    sort_keys=True,
+)
+
+
+@warmup("structured_output")
+async def structured_output(
+    disaggregation_mode: str, tokenizer_manager: TokenizerManager
+):
+    """Warm JSON-constrained decoding with --warmups structured_output.
+
+    This compiles one example grammar and launches shared token-mask kernels
+    before serving client traffic. It does not precompile arbitrary schemas
+    or change the KV-cache allocation budget.
+    """
+    req = GenerateReqInput(
+        text="Name a topic and list three items in it.",
+        sampling_params={
+            "max_new_tokens": 32,
+            "temperature": 0.0,
+            "json_schema": _GRAMMAR_WARMUP_SCHEMA,
+        },
+    )
+    if disaggregation_mode != "null":
+        req.bootstrap_room = 0
+        req.bootstrap_host = FAKE_BOOTSTRAP_HOST
+    # Drain the generator rather than taking the first item, so the grammar is installed
+    # and the kernel launch has happened by the time this returns.
+    async for _ in tokenizer_manager.generate_request(req, None):
+        pass
+    logger.info("Structured-output warmup completed.")

--- a/test/registered/unit/entrypoints/test_structured_output_warmup.py
+++ b/test/registered/unit/entrypoints/test_structured_output_warmup.py
@@ -1,0 +1,58 @@
+"""The opt-in JSON warmup must drain responses and surface startup failures."""
+
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.entrypoints.warmup import execute_warmups
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestStructuredOutputWarmup(CustomTestCase):
+    def test_request_and_generator_completion(self):
+        for mode in ("null", "prefill", "decode"):
+            with self.subTest(mode=mode):
+                requests = []
+                completed = []
+
+                async def generate(req, request):
+                    requests.append(req)
+                    yield {"text": "partial"}
+                    yield {"text": "complete"}
+                    completed.append(True)
+
+                manager = SimpleNamespace(generate_request=generate)
+                asyncio.run(execute_warmups(mode, ["structured_output"], manager))
+                self.assertEqual(completed, [True])
+                self.assertEqual(len(requests), 1)
+                req = requests[0]
+                self.assertEqual(
+                    json.loads(req.sampling_params["json_schema"])["type"], "object"
+                )
+                self.assertGreater(req.sampling_params["max_new_tokens"], 0)
+                if mode != "null":
+                    self.assertEqual(req.bootstrap_room, 0)
+                    self.assertEqual(req.bootstrap_host, FAKE_BOOTSTRAP_HOST)
+
+    def test_failure_after_first_response_propagates(self):
+        async def generate(req, request):
+            yield {"text": "partial"}
+            raise RuntimeError("warmup failed")
+
+        with self.assertRaisesRegex(RuntimeError, "warmup failed"):
+            asyncio.run(
+                execute_warmups(
+                    "null",
+                    ["structured_output"],
+                    SimpleNamespace(generate_request=generate),
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The first JSON-constrained request can pay grammar compilation and token-mask kernel initialization costs. An opt-in startup warmup makes this work happen before serving clients and surfaces failures during startup.

## Modifications

Register `structured_output` in the existing warmup registry:

```bash
python -m sglang.launch_server --model-path MODEL_PATH --warmups structured_output
```

Generate a small object/array JSON schema and fully drain the response generator. Match the existing warmups' fake bootstrap fields for disaggregated operation. Default startup behavior is unchanged.

The warmup compiles one example schema and exercises shared token-mask kernels. Arbitrary user schemas still require their own compilation. It does not change KV pool sizing or guarantee additional GPU headroom.

## Accuracy Tests

On an isolated base-image container at `qwen4-main-squashed` commit `4ccff141dbe992794f9da6c3aa23535b4f72000d`:

```text
pytest -q test/registered/unit/entrypoints/test_structured_output_warmup.py
2 passed, 3 mode subcases passed.
```

Tests execute the actual registry dispatcher, verify the schema request and generator completion, and check propagation of an exception after the first response. Disaggregation checks cover request fields, not a launched PD cluster.

## Speed Tests and Profiling

No steady-state throughput claim. The original equivalent turbo warmup ran in a deployed RTX PRO 6000 stack that subsequently completed JSON-schema generation. This port's registry name is generalized and its behavioral contract is covered by the tests above.

## Attribution

Changed-file pre-commit checks passed. Companion PR #38487 currently hits the repository-wide `main` rebase gate (required commit `a5f07b1241fc`) and missing `run-ci` label. This PR intentionally targets the current Qwen4 branch; maintainer guidance is needed for CI on that branch. No gate bypass is requested.

Adapted from `0007-warm-grammar-path-before-serving.patch` in [mratsim/sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo/tree/000b6b5aa2b6ca4529319925286e1f2ec91a2dad).

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for the structured-output warmup and SM120 optimization work. The commit retains his co-author attribution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829711449](https://github.com/sgl-project/sglang/actions/runs/34829711449)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829711221](https://github.com/sgl-project/sglang/actions/runs/34829711221)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829711351](https://github.com/sgl-project/sglang/actions/runs/34829711351)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->