### PR TITLE
[Qwen4][SM120] Port opt-in GDN accepted-state recovery (RecoverSSM)

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -504,3 +504,204 @@ def fused_sigmoid_gating_delta_rule_update(
     )
     o = o.squeeze(0)
     return o
+
+
+@triton.jit
+def fused_sigmoid_gating_delta_rule_recover_final_state_kernel(
+    A_log,
+    a,
+    dt_bias,
+    softplus_beta,
+    softplus_threshold,
+    k,
+    v,
+    b,
+    h0_source,
+    h0_indices,
+    out_indices,
+    accepted_steps,
+    T,
+    stride_a,
+    stride_k,
+    stride_v,
+    stride_b,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    """Recover h_K directly without writing intermediate states or outputs."""
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = i_n * T
+    accepted_step = tl.load(accepted_steps + i_n)
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_k = k + bos * stride_k + i_h * K + o_k
+    p_v = v + bos * stride_v + i_hv * V + o_v
+    p_b = b + bos * stride_b + i_hv
+
+    p_A_log = A_log + i_hv
+    if IS_KDA:
+        p_a = a + bos * stride_a + i_hv * K + o_k
+        p_dt_bias = dt_bias + i_hv * K + o_k
+    else:
+        p_a = a + bos * stride_a + i_hv
+        p_dt_bias = dt_bias + i_hv
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    idx = tl.load(h0_indices + i_n)
+    p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_v[None, :] * K + o_k[:, None]
+    b_h = tl.load(p_h0, mask=(idx >= 0) & mask_h, other=0).to(tl.float32)
+
+    # The output slot may differ from the read (h_0) slot.
+    # The interval-checkpoint boundary pass reads h_0 from the working slot
+    # and writes the folded boundary state to a separate ping-pong track slot.
+    # out_indices == h0_indices selects the default in-place recovery.
+    # Rows with a negative output index skip the store.
+    out_idx = tl.load(out_indices + i_n)
+    p_out = (
+        h0_source
+        + out_idx * HV * K * V
+        + i_hv * K * V
+        + o_v[None, :] * K
+        + o_k[:, None]
+    )
+
+    b_A_log = tl.load(p_A_log).to(tl.float32)
+    b_A_coeff = -tl.exp(b_A_log)
+    if IS_KDA:
+        b_dt_bias = tl.load(p_dt_bias, mask=mask_k, other=0).to(tl.float32)
+    else:
+        b_dt_bias = tl.load(p_dt_bias).to(tl.float32)
+
+    for step_idx in range(0, T):
+        active = step_idx <= accepted_step
+
+        b_k = tl.load(p_k, mask=active & mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=active & mask_v, other=0).to(tl.float32)
+        b_b = tl.load(p_b, mask=active, other=0).to(tl.float32)
+
+        if IS_KDA:
+            b_a = tl.load(p_a, mask=active & mask_k, other=0).to(tl.float32)
+        else:
+            b_a = tl.load(p_a, mask=active, other=0).to(tl.float32)
+
+        x = b_a + b_dt_bias
+        beta_x = softplus_beta * x
+        softplus_x = tl.where(
+            beta_x <= softplus_threshold,
+            (1.0 / softplus_beta) * tl.log(1.0 + tl.exp(beta_x)),
+            x,
+        )
+        b_g = b_A_coeff * softplus_x
+        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k) + 1e-6))
+
+        if IS_KDA:
+            b_h_gated = b_h * tl.exp(b_g[:, None])
+        else:
+            b_h_gated = b_h * tl.exp(b_g)
+
+        b_v_delta = b_v - tl.sum(b_h_gated * b_k[:, None], 0)
+        b_v_delta *= b_beta
+        b_h_next = b_h_gated + b_k[:, None] * b_v_delta[None, :]
+        b_h = tl.where(active, b_h_next, b_h)
+
+        p_k += stride_k
+        p_v += stride_v
+        p_b += stride_b
+        p_a += stride_a
+
+    tl.store(p_out, b_h.to(p_out.dtype.element_ty), mask=(out_idx >= 0) & mask_h)
+
+
+def fused_sigmoid_gating_delta_rule_recover_final_state(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float,
+    softplus_threshold: float,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    b: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    accepted_steps: torch.Tensor,
+    cache_steps: int,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+    output_state_indices: Optional[torch.Tensor] = None,
+):
+    """Recovery-only GDN recurrence for gdn_mtp_cache_mode=none.
+
+    Writes h_{accepted_step} directly back to the SSM state slot, skipping the output materialization, the intermediate state writes,
+    and the follow-up scatter that the generic target-verify path performs.
+
+    ``output_state_indices`` defaults to ``initial_state_indices``, so recovery restores h_K in place.
+    The interval-checkpoint boundary pass overrides it with the ping-pong track slots (``accepted_steps`` then carries the per-request
+    boundary step) and the folded boundary state is written there instead.
+    Rows with a negative output index are skipped on store.
+    """
+    if output_state_indices is None:
+        output_state_indices = initial_state_indices
+    _, total_tokens, H, K = k.shape
+    HV = v.shape[2]
+    V = v.shape[3]
+    T = cache_steps
+    N = accepted_steps.shape[0]
+    assert total_tokens == N * T
+
+    stride_k = k.stride()[1]
+    stride_v = v.stride()[1]
+    stride_b = b.stride()[-2]
+    stride_a = a.stride()[-2]
+
+    BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    fused_sigmoid_gating_delta_rule_recover_final_state_kernel[(NK, NV, N * HV)](
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=softplus_beta,
+        softplus_threshold=softplus_threshold,
+        k=k,
+        v=v,
+        b=b,
+        h0_source=initial_state_source,
+        h0_indices=initial_state_indices,
+        out_indices=output_state_indices,
+        accepted_steps=accepted_steps,
+        T=T,
+        stride_a=stride_a,
+        stride_k=stride_k,
+        stride_v=stride_v,
+        stride_b=stride_b,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_KDA=is_kda,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )

--- a/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
+++ b/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
@@ -1011,6 +1011,7 @@ def causal_conv1d_update(
     pad_slot_id: int = PAD_SLOT_ID,
     metadata=None,
     validate_data=False,
+    out: Optional[torch.Tensor] = None,
 ):
     """
     x: (batch, dim) or (batch, dim, seqlen)
@@ -1073,7 +1074,18 @@ def causal_conv1d_update(
         assert cache_seqlens is None  # not needed for vLLM - circular buffer
 
     # adopt the strategy in vLLM that overwrite on 'x' directly, rather than creating a new tensor 'o'
-    out = torch.empty_like(x)
+    if out is None:
+        out = torch.empty_like(x)
+    else:
+        # gdn cache_mode=none: callers may pass a persistent `out` buffer so the post-conv output survives until the deferred
+        # accepted-state recovery reads it, avoiding the per-step k/v stash copy on the verify critical path.
+        # Must match x's shape/dtype/device. The kernel writes in place through out's strides.
+        assert (
+            out.shape == x.shape and out.dtype == x.dtype and out.device == x.device
+        ), (
+            f"causal_conv1d_update out= mismatch: out{tuple(out.shape)}/{out.dtype} "
+            f"vs x{tuple(x.shape)}/{x.dtype}"
+        )
     stride_w_dim, stride_w_width = weight.stride()
 
     stride_x_seq, stride_x_dim, stride_x_token = x.stride()  # X (batch, dim, seqlen)

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import logging
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -10,6 +11,7 @@ from sglang.kernels.ops.mamba.mamba_state_indices_triton import (
     fused_replay_state_indices,
 )
 from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+    fused_conv_window_scatter_with_mask,
     fused_mamba_state_scatter_with_mask,
     scatter_mamba_states_after_mtp_verify,
     track_mamba_states_all_layers,
@@ -33,6 +35,7 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_memory,
     mamba_cache_chunk_size,
+    mamba_extra_buffer_enabled,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
@@ -44,6 +47,13 @@ logger = logging.getLogger(__name__)
 
 
 class MambaAttnBackendBase(AttentionBackend):
+    # RecoverSSM (--gdn-mtp-cache-mode=none) is a GDN-only verify protocol.
+    #
+    # GDNAttnBackend overrides this from the resolved mode. It lives on the class so the hybrid
+    # wrapper can copy it off the linear attention backend it wraps, test doubles
+    # included: MagicMock(spec=...) only serves attributes that exist on the class.
+    _recover_ssm: bool = False
+
     def __init__(self, model_runner: ModelRunner):
         super().__init__()
         self.pad_slot_id = PAD_SLOT_ID
@@ -53,10 +63,9 @@ class MambaAttnBackendBase(AttentionBackend):
         self.req_to_token_pool: HybridReqToTokenPool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.enable_unified_memory = model_runner.server_args.enable_unified_memory
-        # Fused replay-prep state-indices fast path (fused_replay_state_indices):
-        # requires the static hybrid pool whose v2p translate is the identity —
-        # the unified pool overrides translate_mamba_indices with an allocator
-        # lookup that is not a flat table gather.
+        # Fused replay-prep state-indices fast path (fused_replay_state_indices): requires
+        # the static hybrid pool whose v2p translate is the identity. The unified pool
+        # overrides translate_mamba_indices with an allocator lookup that is not a flat table gather.
         self._fused_state_indices_ok = (
             str(self.device).startswith("cuda")
             and isinstance(self.req_to_token_pool, HybridReqToTokenPool)
@@ -65,11 +74,12 @@ class MambaAttnBackendBase(AttentionBackend):
         )
         self.forward_metadata: ForwardMetadata = None
         self.state_indices_list = []
-        # Static (max_bs,) track-dest buffer captured by pointer, refreshed in-place
-        # each replay; the captured track-save reads this, not the InputBuffer slot.
+        # Holds the (max_bs,) track destination indices. The eager path passes track indices
+        # per call. Graph capture binds this buffer by pointer and refreshes it in place
+        # before each replay.
         self.mamba_track_indices_buf = None
-        # Per-bs static write-cursor / force-flush buffers for cuda-graph; None
-        # unless --enable-linear-replayssm is set.
+        # Per-bs static write-cursor / force-flush buffers for cuda-graph. None unless
+        # --enable-linear-replayssm is set.
         self.replayssm_write_pos_list = None
         self.replayssm_force_flush_list = None
         self.query_start_loc_list = []
@@ -101,8 +111,8 @@ class MambaAttnBackendBase(AttentionBackend):
         mamba_cache_indices = self.req_to_token_pool.get_mamba_indices(
             forward_batch.req_pool_indices
         )
-        # Translate virtual->physical BEFORE the padding sentinel below, so the
-        # gather reads only real ids; padded rows are then poisoned to -1 (skipped).
+        # Translate virtual->physical BEFORE the padding sentinel below, so the gather reads
+        # only real ids. Padded rows are then poisoned to -1 (skipped).
         mamba_cache_indices = self._translate_mamba_indices(mamba_cache_indices)
         if forward_batch.mamba_track_indices is not None:
             forward_batch.mamba_track_indices = self._translate_mamba_indices(
@@ -148,8 +158,8 @@ class MambaAttnBackendBase(AttentionBackend):
                 # KDA has no radix coordination: flush only on the natural write_pos
                 # == L-1 wrap. GDN adds the radix-aligned force-flush below.
                 is_kda = getattr(mamba_pool, "replayssm_is_kda", False)
-                # Force-flush on the radix track's seq_lens % mamba_track_interval
-                # == 0 boundary so the ring folds into temporal[slot] when read.
+                # Force-flush on the radix track's seq_lens % mamba_track_interval == 0 boundary
+                # so the ring folds into temporal[slot] when read.
                 if not is_kda:
                     force_flush_bool = self._replayssm_track_flush_mask(
                         forward_batch.seq_lens_cpu, bs
@@ -170,8 +180,8 @@ class MambaAttnBackendBase(AttentionBackend):
                         torch.zeros_like(replayssm_write_pos),
                         (replayssm_write_pos + 1) % L,
                     )
-                    # Dedup: rows sharing a slot share write_pos/flush, so the
-                    # scattered value is identical regardless of which row wins.
+                    # Dedup: rows sharing a slot share write_pos/flush, so the scattered value
+                    # is identical regardless of which row wins.
                     uniq_slots, inv = torch.unique(valid_slots, return_inverse=True)
                     next_for_valid = next_pos[valid_mask]
                     new_vals = torch.empty(
@@ -183,8 +193,7 @@ class MambaAttnBackendBase(AttentionBackend):
                     write_pos_buf[uniq_slots] = new_vals
         elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
             if forward_batch.forward_mode.is_draft_extend_v2():
-                # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model;
-                # skip mamba metadata.
+                # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model. Skip mamba metadata.
                 query_start_loc = None
             elif forward_batch.forward_mode.is_target_verify():
                 ragged_layout = forward_batch.spec_info.ragged_verify_layout
@@ -302,8 +311,7 @@ class MambaAttnBackendBase(AttentionBackend):
         the last complete chunk boundary, mamba_track_mask rows only)."""
         conv_state_len = self.conv_states_shape[-1]
 
-        # Shared with the Qwen4-Exp PLE side states so the boundary can never
-        # drift between them.
+        # Shared with the Qwen4-Exp PLE side states so the boundary can never drift between them.
         aligned_len = forward_batch.mamba_track_aligned_lens()
         assert aligned_len is not None, (
             "conv-state tracking requires mamba_track_seqlens and extend_prefix_lens; "
@@ -323,9 +331,9 @@ class MambaAttnBackendBase(AttentionBackend):
     def _init_track_ssm_indices(
         self, mamba_cache_indices: torch.Tensor, forward_batch: ForwardBatch
     ):
-        """src/dst indices to track SSM states for prefix caching: aligned seqs
-        cache last_recurrent_state, unaligned cache intermediate `h` at the last
-        chunk boundary."""
+        """src/dst indices to track SSM states for prefix caching: aligned seqs cache
+        last_recurrent_state, unaligned cache intermediate `h` at the last chunk boundary.
+        """
         chunk_size = mamba_cache_chunk_size()
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
@@ -354,8 +362,7 @@ class MambaAttnBackendBase(AttentionBackend):
         track_ssm_final_src = mamba_cache_indices[mamba_track_mask][is_aligned]
         track_ssm_final_dst = dst_masked[is_aligned]
 
-        # Unaligned: intermediate state from h.
-        # TODO: handle chunk_size % page size != 0
+        # Unaligned: intermediate state from h. TODO: handle chunk_size % page size != 0
         not_aligned = ~is_aligned
         track_ssm_h_src = offset_masked[not_aligned] + (
             lens_masked[not_aligned] // chunk_size
@@ -420,12 +427,12 @@ class MambaAttnBackendBase(AttentionBackend):
             max_num_tokens % max_bs == 0
         ), f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
         draft_token_num = max_num_tokens // max_bs
-        # Per-bs static write-cursor / force-flush buffers, captured by pointer +
-        # refreshed in-place each replay; sized like state_indices_list. None when off.
+        # Per-bs static write-cursor / force-flush buffers, captured by pointer + refreshed
+        # in-place each replay. Sized like state_indices_list. None when off.
         self.replayssm_write_pos_list = [] if self._replayssm_enabled() else None
         self.replayssm_force_flush_list = [] if self._replayssm_enabled() else None
-        # int64 to match DecodeInputBuffers.mamba_track_indices + the track-save
-        # kernel's int64 index load. Refreshed in-place by _replay_metadata.
+        # int64 to match DecodeInputBuffers.mamba_track_indices + the track-save kernel's
+        # int64 index load. Refreshed in-place by _replay_metadata.
         self.mamba_track_indices_buf = torch.zeros(
             (max_bs,), dtype=torch.int64, device=self.device
         )
@@ -519,8 +526,8 @@ class MambaAttnBackendBase(AttentionBackend):
         mamba_indices = self._translate_mamba_indices(mamba_indices)
         self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
 
-        # Capture records the pointer to the static per-bs buffers; their zeros are
-        # overwritten in-place by _replay_metadata before each replay. None when off.
+        # Capture records the pointer to the static per-bs buffers. Their zeros are overwritten
+        # in-place by _replay_metadata before each replay. None when off.
         replayssm_write_pos = (
             self.replayssm_write_pos_list[bs - 1]
             if self.replayssm_write_pos_list is not None
@@ -570,9 +577,8 @@ class MambaAttnBackendBase(AttentionBackend):
                     seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
                 )
         if self._fused_state_indices_ok and self.replayssm_write_pos_list is None:
-            # Single-launch fast path: mapping gather + padding sentinel + store
-            # into the static buffer, plus zeroing padded req_pool_indices rows —
-            # bit-identical to the reference chain below.
+            # Single-launch fast path: mapping gather + padding sentinel + store into the static
+            # buffer, plus zeroing padded req_pool_indices rows. Bit-identical to the reference chain below.
             mamba_indices = fused_replay_state_indices(
                 req_pool_indices=req_pool_indices,
                 mamba_index_mapping=self.req_to_token_pool.req_index_to_mamba_index_mapping,
@@ -584,15 +590,15 @@ class MambaAttnBackendBase(AttentionBackend):
             # Make sure forward metadata is correctly handled for padding reqs
             req_pool_indices[bs - num_padding :] = 0
             mamba_indices = self.req_to_token_pool.get_mamba_indices(req_pool_indices)
-            # Translate using the LIVE v2p table BEFORE the padding sentinel below;
-            # captured Mamba kernels read state_indices_list as PHYSICAL ids.
+            # Translate using the LIVE v2p table BEFORE the padding sentinel below. Captured
+            # Mamba kernels read state_indices_list as PHYSICAL ids.
             mamba_indices = self._translate_mamba_indices(mamba_indices)
             mamba_indices[bs - num_padding :] = -1
             self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
         # Refresh the static track-dest buffer in-place (translated); the captured
         # track-save reads it, leaving the handed-in InputBuffer slot read-only.
-        # Hand out only the refreshed [:bs] prefix — Mamba2's track-save slices
-        # [-num_decodes:], which on the full max_bs buffer binds the stale tail.
+        # Hand out only the refreshed [:bs] prefix. Mamba2's track-save slices [-num_decodes:], which
+        # on the full max_bs buffer binds the stale tail.
         track_buf = None
         if mamba_track_indices is not None:
             assert (
@@ -640,8 +646,8 @@ class MambaAttnBackendBase(AttentionBackend):
                 # TARGET_VERIFY replay must never advance the cursor.
                 if not in_capture and forward_mode.is_decode_or_idle():
                     L = mamba_pool.linear_replayssm_cache_len
-                    # Advance only valid (non-padded) slots; a forced flush empties
-                    # the ring -> next write_pos 0, like the natural L-1 wrap.
+                    # Advance only valid (non-padded) slots. A forced flush empties the ring
+                    # -> next write_pos 0, like the natural L-1 wrap.
                     valid_mask = slots >= 0
                     valid_slots = slots[valid_mask]
                     if valid_slots.numel() > 0:
@@ -975,12 +981,43 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.extend_dummy_seqs_capped_by_req_pool = getattr(
             full_attn_backend, "extend_dummy_seqs_capped_by_req_pool", False
         ) or getattr(linear_attn_backend, "extend_dummy_seqs_capped_by_req_pool", False)
+        # The verify-commit path reads self._recover_ssm, so the wrapper carries the same value
+        # the wrapped GDN backend resolved.
+        self._recover_ssm = linear_attn_backend._recover_ssm
+        # Recovery overlap: eager recovery runs on a dedicated side stream behind
+        # the next step's draft compute. The join ordering is enforced in _no_cache_mtp_recompute.
+        self._recovery_stream: Optional[torch.cuda.Stream] = None
+        self._recovery_event: Optional[torch.cuda.Event] = None
+        self._recovery_event_pending: bool = False
+        # Created with _recovery_stream and reused every step: this is the bs=1
+        # host-latency critical path, where torch.cuda.current_stream() costs ~40us
+        # of interpreter time and torch.cuda.stream() builds a new StreamContext per call.
+        self._recovery_join_event: Optional[torch.cuda.Event] = None
+        self._recovery_stream_ctx: Optional[torch.cuda.StreamContext] = None
+        # One graph replay replaces the per-layer kernel launches. Captured and replayed on
+        # _recovery_stream, so it still overlaps draft_extend and the next draft.
+        # Fixed-address buffers hold the per-step indices. Contents are refreshed
+        # before each replay.
+        self._rec_state_idx_buf: Optional[torch.Tensor] = None
+        self._rec_acc_steps_buf: Optional[torch.Tensor] = None
+        # Interval-checkpoint (mamba radix track) recovery buffers, used only with tracking
+        # (extra_buffer) on: a second pass reconstructs the state at the track boundary
+        # and writes it to the ping-pong track slot.
+        self._rec_track_idx_buf: Optional[torch.Tensor] = None
+        self._rec_track_steps_buf: Optional[torch.Tensor] = None
+        self._rec_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        # Boundary-pass graphs, captured alongside _rec_graphs only with tracking
+        # on. Empty means the boundary runs eager on the side stream.
+        self._rec_boundary_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        # Sorted bucket sizes captured at warmup. None until capture_recovery_graphs() succeeds.
+        # While None, recovery runs eagerly on the side stream.
+        self._rec_capture_bs: Optional[list[int]] = None
 
     @property
     def data_type(self):
-        # KV-cache dtype readers (e.g. the trtllm_mla fused-rope check) reach the
-        # wrapper since split backends are wrapped once (#31439); the full-attn
-        # side owns the KV cache, so its dtype is authoritative.
+        # KV-cache dtype readers (e.g. the trtllm_mla fused-rope check) reach the wrapper since
+        # split backends are wrapped once (#31439). The full-attn side owns the KV cache,
+        # so its dtype is authoritative.
         return self.full_attn_backend.data_type
 
     @property
@@ -998,18 +1035,44 @@ class HybridLinearAttnBackend(AttentionBackend):
         assert layer_id is not None, "either layer or layer_id must be provided"
         return layer_id in self.full_attn_layers
 
+    def _ensure_recovery_stream(self):
+        """Lazily create the recovery side stream and its per-step helpers.
+
+        Both the warmup capture and the serving path enter through here so the cached join event
+        / stream context can never be left unset by whichever one runs first.
+        """
+        if self._recovery_stream is not None:
+            return
+        self._recovery_stream = torch.cuda.Stream()
+        self._recovery_event = torch.cuda.Event()
+        self._recovery_join_event = torch.cuda.Event()
+        self._recovery_stream_ctx = torch.cuda.stream(self._recovery_stream)
+
+    def _wait_recovery_if_pending(self):
+        """Join the side-stream gdn_mtp_cache_mode=none SSM recovery before a target forward reads
+        the SSM pool. The wait also prevents the upcoming forward from overwriting
+        the per-layer recovery stash while the side-stream recovery is still reading it.
+        """
+        if self._recovery_event_pending:
+            # Event.wait() resolves the current stream in C++, ordering
+            # the same as current_stream().wait_event() without the Python wrapper.
+            self._recovery_event.wait()
+            self._recovery_event_pending = False
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
         if forward_batch.forward_mode.is_draft_extend_v2():
-            # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model;
+            # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model.
             # skip linear/mamba metadata (mirrors init_forward_metadata).
             self.full_attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=in_capture
             )
             return
+        if not in_capture:
+            self._wait_recovery_if_pending()
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=in_capture
@@ -1022,8 +1085,7 @@ class HybridLinearAttnBackend(AttentionBackend):
 
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         if forward_batch.forward_mode.is_draft_extend_v2():
-            # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model;
-            # skip linear/mamba metadata (mirrors init_forward_metadata).
+            # DRAFT_EXTEND_V2 runs only full-attn layers in the draft model. Skip linear/mamba metadata (mirrors init_forward_metadata).
             self.full_attn_backend.init_forward_metadata_in_graph(forward_batch)
             return
         for attn_backend in self.attn_backend_list:
@@ -1047,8 +1109,8 @@ class HybridLinearAttnBackend(AttentionBackend):
         self, spec_info: SpecInput, cuda_graph_bs: Optional[int]
     ):
         # Plan-stream fixup after draft completes: forward to both children.
-        # Sub-backends that cannot run under the plan stream keep the fail-loud
-        # NotImplementedError base behavior.
+        # Sub-backends that cannot run under the plan stream keep
+        # the fail-loud NotImplementedError base behavior.
         for attn_backend in self.attn_backend_list:
             attn_backend.update_verify_buffers_to_fill_after_draft(
                 spec_info=spec_info, cuda_graph_bs=cuda_graph_bs
@@ -1060,6 +1122,7 @@ class HybridLinearAttnBackend(AttentionBackend):
             # linear/mamba metadata (it requires query_start_loc).
             self.full_attn_backend.init_forward_metadata(forward_batch)
             return
+        self._wait_recovery_if_pending()
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata(forward_batch)
 
@@ -1225,9 +1288,9 @@ class HybridLinearAttnBackend(AttentionBackend):
     ):
         """Update mamba states after MTP verify via a fused gather-scatter kernel.
 
-        ``req_pool_indices`` serves implementations that must re-derive the state
-        slot ids instead of reusing this step's ``forward_metadata``; the scatter
-        below reads the metadata it just planned.
+        ``req_pool_indices`` serves implementations that must re-derive the state slot ids
+        instead of reusing this step's ``forward_metadata``; the scatter below reads
+        the metadata it just planned.
         """
         del req_pool_indices
         request_number = last_correct_step_indices.shape[0]
@@ -1271,20 +1334,561 @@ class HybridLinearAttnBackend(AttentionBackend):
             )
             return
 
-        scatter_mamba_states_after_mtp_verify(
-            mamba_caches,
-            state_indices_tensor,
-            last_correct_step_indices,
-            mamba_track_indices,
-            mamba_steps_to_track,
-        )
+        # RecoverSSM (gdn_mtp_cache_mode=none) skips the per-draft SSM snapshots, so rerun the recurrence from h_0 over
+        # the accepted prefix and roll back the conv state.
+        # Every other mode (full, ReplaySSM) takes the upstream fused gather-scatter.
+        # The dispatch keys on the resolved mode: server_args rejects none-mode alongside
+        # ReplaySSM, so the modes never share buffer sets.
+        if self._recover_ssm:
+            conv_states = mamba_caches.conv[0]
+            intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
+            # Mamba radix tracking is supported on both recovery paths
+            # (FI native output_state_indices, Triton output-index arg): a second boundary pass
+            # recomputes the tracked prefix state, which none-mode does not cache.
+            self._no_cache_mtp_recompute(
+                accepted_steps=last_correct_step_indices,
+                state_indices_tensor=state_indices_tensor,
+                mamba_track_indices=mamba_track_indices,
+                mamba_steps_to_track=mamba_steps_to_track,
+            )
+            # Conv-state rollback reads the cached deduplicated sliding-window conv entries.
+            fused_conv_window_scatter_with_mask(
+                conv_states,
+                intermediate_conv_window_cache,
+                state_indices_tensor,
+                last_correct_step_indices,
+            )
+            # Conv boundary checkpoint: mirror the SSM boundary pass by writing the tracked
+            # prefix conv window to the ping-pong track slot
+            # (same masked scatter as full mode. Step == -1 rows skip).
+            if mamba_track_indices is not None:
+                fused_conv_window_scatter_with_mask(
+                    conv_states,
+                    intermediate_conv_window_cache,
+                    mamba_track_indices,
+                    mamba_steps_to_track,
+                )
+        else:
+            scatter_mamba_states_after_mtp_verify(
+                mamba_caches,
+                state_indices_tensor,
+                last_correct_step_indices,
+                mamba_track_indices,
+                mamba_steps_to_track,
+            )
 
+        # Qwen4 PLE keeps its own speculative short-conv and n-gram side states.
+        # RecoverSSM replaces only the GDN state commit, so PLE commits its accepted state and radix
+        # boundary snapshot as in full mode.
         self._update_ple_state_after_mtp_verify(
             state_indices_tensor,
             last_correct_step_indices,
             mamba_track_indices,
             mamba_steps_to_track,
         )
+
+    def _persist_kv(self, layer_id, conv_dims, b_rows, cache_steps):
+        """
+        Return post-conv (k, v) as strided views
+        of the persistent conv-out buffer, for the FlashInfer recovery path.
+
+        The buffer is ``_conv_out_persist[layer_id]``, allocated once during verify
+        as [pool_size, cache_steps, conv_dim]. The target verify's conv fills it through
+        its out= argument. Rows [0, b_rows) hold this step's tokens, the row index varying
+        slowest. k covers columns [q_dim, q_dim + k_dim).
+        v covers [q_dim + k_dim, q_dim + k_dim + v_dim). The reshape and slices build shape
+        and stride metadata only. k is [1, n_tok, Hk, Dk] and v is [1, n_tok, Hv, Dv].
+        Here n_tok = b_rows * cache_steps. Every row keeps its features contiguous in the one
+        shared storage, so no tensor data is copied.
+
+        The recovery kernel consumes the views directly. The buffer address never changes
+        after allocation, and the views add no device state, so a captured recovery graph keeps
+        launching against the same memory on every replay.
+        """
+        persist = self.linear_attn_backend._conv_out_persist[layer_id]
+        q_dim, k_dim, v_dim, Hk, Dk, Hv, Dv = conv_dims
+        n_tok = b_rows * cache_steps
+        mixed = persist[:b_rows].reshape(n_tok, q_dim + k_dim + v_dim)
+        k = mixed[:, q_dim : q_dim + k_dim].view(1, n_tok, Hk, Dk)
+        v = mixed[:, q_dim + k_dim : q_dim + k_dim + v_dim].view(1, n_tok, Hv, Dv)
+        return k, v
+
+    def _fi_recovery_launch(
+        self,
+        n,
+        stash_per_layer,
+        pool,
+        gated_delta_rule_mtp,
+        init_idx_buf=None,
+        out_idx_buf=None,
+        acc_steps_buf=None,
+    ):
+        """
+        Launch FlashInfer recovery on the first ``n`` rows of every layer
+        in ``stash_per_layer``. Call sites: warm-compile and graph capture
+        in ``capture_recovery_graphs``, and the eager paths in ``_no_cache_mtp_recompute``.
+
+        Kernel inputs come from two places. a and b are the stash slices ``[:n]``
+        of the [pool_size, T, H] per-layer stash, so the slice is a view. k and v come from
+        ``_persist_kv``, strided views of the persistent conv-out buffer. q and k receive
+        the same view because the kernel l2-norms both sides itself.
+
+        With the default buffers the recovery reconstructs h_K in place: initial and output
+        state share one buffer, the request's working SSM slot, sized by the accepted length.
+        The interval-checkpoint boundary pass overrides ``out_idx_buf``
+        (ping-pong track slot) and ``acc_steps_buf``
+        (the per-request boundary step) while keeping ``init_idx_buf``
+        at the working slot, since h_0 lives there. It must therefore run
+        before the in-place working recovery overwrites h_0 with h_K.
+        """
+        init_idx_buf = self._rec_state_idx_buf if init_idx_buf is None else init_idx_buf
+        out_idx_buf = self._rec_state_idx_buf if out_idx_buf is None else out_idx_buf
+        acc_steps_buf = (
+            self._rec_acc_steps_buf if acc_steps_buf is None else acc_steps_buf
+        )
+        _init_idx = init_idx_buf[:n]
+        # Reuse the SAME slice object when read and write indices alias: the FI kernel picks
+        # its single-pool fast path
+        # by identity: `output_state_indices is initial_state_indices`. A second `buf[:n]`
+        # is a distinct view that silently forces the slower split-pool codegen.
+        _out_idx = _init_idx if out_idx_buf is init_idx_buf else out_idx_buf[:n]
+        _acc_steps = acc_steps_buf[:n]
+        _T = self.linear_attn_backend._no_cache_draft_token_num
+        for layer_id, stash in stash_per_layer.items():
+            layer_ssm_states = pool.mamba2_layer_cache(layer_id).temporal
+            # The FI path always stashes conv_dims (never k/v), so k/v come from the persistent conv-out buffer, reshaped [1, n*T, H, D]
+            # to the [n, T, H, D] the kernel expects (q == k: the kernel l2-norms both).
+            conv_dims = stash["conv_dims"]
+            k_pv, v_pv = self._persist_kv(layer_id, conv_dims, n, _T)
+            q_k = k_pv.view(n, _T, k_pv.shape[2], k_pv.shape[3])
+            v_bat = v_pv.view(n, _T, v_pv.shape[2], v_pv.shape[3])
+            gated_delta_rule_mtp(
+                A_log=stash["A_log_f32"],
+                a=stash["a"][:n],
+                dt_bias=stash["dt_bias"],
+                q=q_k,
+                k=q_k,
+                v=v_bat,
+                b=stash["b"][:n],
+                initial_state_source=layer_ssm_states,
+                initial_state_indices=_init_idx,
+                output_state_indices=_out_idx,
+                accepted_steps=_acc_steps,
+                disable_state_update=False,
+                disable_output=True,
+                use_qk_l2norm_in_kernel=True,
+                scale=None,
+                output=None,
+            )
+
+    def _rec_pad_to_bucket(self, batch_size: int) -> Optional[int]:
+        """Smallest captured bucket >= batch_size, or None when no warmup graphs exist
+        or batch_size exceeds the largest captured bucket (eager fallback).
+        """
+        if not self._rec_capture_bs:
+            return None
+        i = bisect.bisect_left(self._rec_capture_bs, batch_size)
+        if i == len(self._rec_capture_bs):
+            return None
+        return self._rec_capture_bs[i]
+
+    def capture_recovery_graphs(self, capture_bs):
+        """
+        Warmup: capture one FlashInfer recovery graph per batch-size bucket, on the side
+        stream, into a single shared mempool. Serving then pads the real batch up to a bucket
+        and replays (no live capture → no per-step stall / global-mode crash). Must run
+        AFTER a target_verify forward has allocated the per-layer stash at its final addresses (else this is a no-op and recovery falls back to eager side-stream launches).
+
+        Replaying a bucket graph runs the kernel over the whole bucket, writing rows beyond
+        the real batch too. Those rows point at reserved SSM slot 0, which no request can hold
+        (the free list starts at 1), and nothing reads those rows back.
+        """
+        from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+            fi_recovery_kernel,
+        )
+
+        use_fi_recovery = fi_recovery_kernel(self.linear_attn_backend) is not None
+        if not use_fi_recovery:
+            # Triton recovery or non-FI backend: no recovery graphs to capture.
+            # Recovery runs eager on the side stream.
+            return
+        stash_per_layer = getattr(self.linear_attn_backend, "_no_cache_stash", {})
+        if not stash_per_layer:
+            logger.warning(
+                "[mratsim's sm120-turbo r22] gdn recovery: stash not allocated at capture time; "
+                "recovery will run eagerly on the side stream (no cuda graph)."
+            )
+            return
+
+        pool = self.linear_attn_backend.req_to_token_pool
+        from flashinfer.gdn_kernels.gdn_decode_bf16_state import gated_delta_rule_mtp
+
+        dev = pool.mamba2_layer_cache(next(iter(stash_per_layer))).temporal.device
+        if self._rec_state_idx_buf is None:
+            self._rec_state_idx_buf = torch.empty(
+                pool.size, dtype=torch.int32, device=dev
+            )
+            self._rec_acc_steps_buf = torch.empty(
+                pool.size, dtype=torch.int32, device=dev
+            )
+            # Boundary-pass buffers, allocated here so the eager launch reuses
+            # the address-stable ping-pong output slots and boundary steps.
+            self._rec_track_idx_buf = torch.empty(
+                pool.size, dtype=torch.int32, device=dev
+            )
+            self._rec_track_steps_buf = torch.empty(
+                pool.size, dtype=torch.int32, device=dev
+            )
+        # During capture the index buffers hold zeros: only their shape is recorded,
+        # and the real per-step indices are copied in before replay.
+        self._rec_state_idx_buf.fill_(0)
+        self._rec_acc_steps_buf.fill_(0)
+        self._rec_track_idx_buf.fill_(0)
+        self._rec_track_steps_buf.fill_(0)
+
+        # Capture boundary graphs too when mamba radix tracking is on: a server-level decision
+        # made once here. Batches without track indices skip the replay.
+        capture_boundary = mamba_extra_buffer_enabled()
+
+        self._ensure_recovery_stream()
+
+        buckets = sorted({int(b) for b in capture_bs if 0 < int(b) <= pool.size})
+        if not buckets:
+            return
+        try:
+            shared_pool = torch.cuda.graph_pool_handle()
+            # Capture largest first so smaller graphs reuse the shared pool.
+            for B in reversed(buckets):
+                # Warm-compile this bucket's kernel + populate the kernel's per-B argument
+                # defaults OUTSIDE capture (writes to reserved slot 0, so harmless),
+                # so the capture itself is JIT-free and alloc-free.
+                with torch.cuda.stream(self._recovery_stream):
+                    self._fi_recovery_launch(
+                        B, stash_per_layer, pool, gated_delta_rule_mtp
+                    )
+                self._recovery_stream.synchronize()
+
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(
+                    g,
+                    pool=shared_pool,
+                    stream=self._recovery_stream,
+                    capture_error_mode="thread_local",
+                ):
+                    self._fi_recovery_launch(
+                        B, stash_per_layer, pool, gated_delta_rule_mtp
+                    )
+                self._rec_graphs[B] = g
+
+                if capture_boundary:
+                    # Boundary variant: distinct output indices select the kernel's
+                    # split-pool codegen, so it is a separate compiled
+                    # variant, warm-compiled outside capture as well.
+                    with torch.cuda.stream(self._recovery_stream):
+                        self._fi_recovery_launch(
+                            B,
+                            stash_per_layer,
+                            pool,
+                            gated_delta_rule_mtp,
+                            init_idx_buf=self._rec_state_idx_buf,
+                            out_idx_buf=self._rec_track_idx_buf,
+                            acc_steps_buf=self._rec_track_steps_buf,
+                        )
+                    self._recovery_stream.synchronize()
+
+                    gb = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(
+                        gb,
+                        pool=shared_pool,
+                        stream=self._recovery_stream,
+                        capture_error_mode="thread_local",
+                    ):
+                        self._fi_recovery_launch(
+                            B,
+                            stash_per_layer,
+                            pool,
+                            gated_delta_rule_mtp,
+                            init_idx_buf=self._rec_state_idx_buf,
+                            out_idx_buf=self._rec_track_idx_buf,
+                            acc_steps_buf=self._rec_track_steps_buf,
+                        )
+                    self._rec_boundary_graphs[B] = gb
+            self._rec_capture_bs = buckets
+            logger.info(
+                "[mratsim's sm120-turbo r22] gdn recovery: captured %d recovery cuda graphs (buckets=%s, "
+                "boundary=%s)",
+                len(buckets),
+                buckets,
+                capture_boundary,
+            )
+        except RuntimeError as e:
+            # CUDA graph capture raises RuntimeError for every documented decline
+            # (unsupported op in capture, cross-stream misuse). A different exception type
+            # is a bug in this capture body and must crash: falling through to eager would hide it.
+            logger.warning(
+                "[mratsim's sm120-turbo r22] gdn recovery: recovery cuda graph capture failed (%s); "
+                "falling back to eager side-stream recovery.",
+                e,
+            )
+            self._rec_graphs.clear()
+            self._rec_boundary_graphs.clear()
+            self._rec_capture_bs = None
+
+    def _no_cache_mtp_recompute(
+        self,
+        accepted_steps: torch.Tensor,
+        state_indices_tensor: torch.Tensor,
+        mamba_track_indices: Optional[torch.Tensor] = None,
+        mamba_steps_to_track: Optional[torch.Tensor] = None,
+    ):
+        """Recover accepted GDN SSM state for gdn_mtp_cache_mode=none.
+
+        Replays the state-update recurrence over stashed post-conv k/v/a/b and writes
+        h_{accepted_step} directly to the request's SSM state slot.
+
+        When mamba radix tracking is active (extra_buffer), a request's accepted draft window
+        may cross a track boundary. none-mode caches no intermediate state, so it also runs
+        a second FlashInfer boundary pass that folds only ``mamba_steps_to_track`` steps
+        from h_0 and writes the boundary state to the ping-pong track
+        slot ``mamba_track_indices``. That pass reads h_0 from the working slot, so it must run
+        before the in-place working recovery overwrites h_0 with h_K. Requests that cross
+        no boundary carry step == -1 and are redirected to reserved slot 0 / step 0, a slot
+        no request holds.
+        """
+        # Local imports to avoid a circular dependency at module load time.
+        from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
+            fused_sigmoid_gating_delta_rule_recover_final_state,
+        )
+
+        stash_per_layer: dict = getattr(self.linear_attn_backend, "_no_cache_stash", {})
+        if not stash_per_layer:
+            # No GDN layer ran in cache_mode=none for this batch.
+            return
+
+        pool = self.linear_attn_backend.req_to_token_pool
+
+        # Recovery runs outside the captured graph. Derive per-call sizes from current tensors
+        # because the stash spans multiple batch-size captures.
+        batch_size = accepted_steps.shape[0]
+        draft_token_num = self.linear_attn_backend._no_cache_draft_token_num
+        assert draft_token_num is not None, (
+            "draft_token_num not cached — forward_extend was never called "
+            "in target_verify mode before _mamba_verify_update."
+        )
+        actual_seq_len = batch_size * draft_token_num
+        cache_steps = draft_token_num
+
+        # SM100+ with a bf16 state pool recovers via the FlashInfer MTP kernel, reading k/v
+        # as strided views of the persistent conv-out buffer. Everything else uses the Triton
+        # recurrence with a flat stash.
+        from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+            fi_recovery_kernel,
+        )
+
+        use_fi_recovery = fi_recovery_kernel(self.linear_attn_backend) is not None
+
+        # The Triton kernel takes materialized int32 tensors as arguments
+        # (and keeps them alive via record_stream below). The FI path only copies them
+        # into the stable _rec_* buffers, where copy_ narrows int64 on the way in: two
+        # eager dispatches of pure overhead that bs=1 would pay in wall clock.
+        state_idx_i32 = None
+        accepted_steps_i32 = None
+        if not use_fi_recovery:
+            state_idx_i32 = state_indices_tensor.to(torch.int32).contiguous()
+            accepted_steps_i32 = accepted_steps.to(torch.int32).contiguous()
+
+        # The boundary pass runs on both paths: FI uses native output_state_indices, the Triton
+        # kernel a separate output-index arg. Per-step Triton tensors are built below. FI reuses _rec_track_*.
+        do_boundary = mamba_track_indices is not None
+        track_out_i32 = None
+        track_steps_i32 = None
+
+        # One launch per GDN layer, factored into a closure so it runs inline (graph capture)
+        # or on the side stream (eager overlap).
+        B_bucket = None
+        if use_fi_recovery:
+            from flashinfer.gdn_kernels.gdn_decode_bf16_state import (
+                gated_delta_rule_mtp,
+            )
+
+            B = batch_size
+            # Stable fixed-address index buffers. capture_recovery_graphs allocates them
+            # at warmup. Allocate here for the no-warmup path.
+            if self._rec_state_idx_buf is None:
+                pool_size = pool.size
+                dev = state_indices_tensor.device
+                self._rec_state_idx_buf = torch.empty(
+                    pool_size, dtype=torch.int32, device=dev
+                )
+                self._rec_acc_steps_buf = torch.empty(
+                    pool_size, dtype=torch.int32, device=dev
+                )
+                self._rec_track_idx_buf = torch.empty(
+                    pool_size, dtype=torch.int32, device=dev
+                )
+                self._rec_track_steps_buf = torch.empty(
+                    pool_size, dtype=torch.int32, device=dev
+                )
+            B_bucket = self._rec_pad_to_bucket(B)
+            # Refresh stable buffers on the main stream before the side-stream read
+            # (the join event below orders after these copies), batched into one
+            # _foreach_copy_: copy_ narrows the int64 sources itself.
+            from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+                _grouped_foreach_copy_,
+            )
+
+            refresh_dsts = [self._rec_state_idx_buf[:B], self._rec_acc_steps_buf[:B]]
+            refresh_srcs = [state_indices_tensor, accepted_steps]
+            crossed = None
+            if do_boundary:
+                # Boundary output slots come from mamba_track_indices, fold counts
+                # from mamba_steps_to_track. Requests crossing no boundary carry step ==
+                # -1 and redirect to reserved slot 0 / step 0.
+                # clamp(min=0) suffices for the fold count. The output slot still needs masking
+                # (an unmasked non-crossing request would clobber a live ping-pong checkpoint with h_0), applied
+                # in place on the stable buffer to avoid torch.where's alloc.
+                crossed = mamba_steps_to_track >= 0
+                refresh_dsts += [
+                    self._rec_track_idx_buf[:B],
+                    self._rec_track_steps_buf[:B],
+                ]
+                refresh_srcs += [
+                    mamba_track_indices,
+                    mamba_steps_to_track.clamp(min=0),
+                ]
+            _grouped_foreach_copy_(refresh_dsts, refresh_srcs)
+            if do_boundary:
+                self._rec_track_idx_buf[:B].mul_(crossed)
+            if B_bucket is not None and B_bucket > B:
+                # Pad rows [B:bucket] → reserved slot 0 (never a real request, so their recovery output is discarded harmlessly).
+                self._rec_state_idx_buf[B:B_bucket].fill_(0)
+                self._rec_acc_steps_buf[B:B_bucket].fill_(0)
+                if do_boundary:
+                    # The boundary graph is captured at bucket size, so its pad rows need
+                    # a destination too → reserved slot 0.
+                    self._rec_track_idx_buf[B:B_bucket].fill_(0)
+                    self._rec_track_steps_buf[B:B_bucket].fill_(0)
+        elif do_boundary:
+            # Triton boundary: regular per-step tensors. The recover kernel skips negative
+            # output indices, so non-crossing requests get -1 rather
+            # than a discard-slot redirect. The working slot supplies h_0.
+            track_steps_i32 = mamba_steps_to_track.to(torch.int32).contiguous()
+            track_out_i32 = torch.where(
+                track_steps_i32 >= 0,
+                mamba_track_indices.to(torch.int32),
+                torch.full_like(track_steps_i32, -1),
+            ).contiguous()
+
+        def _triton_recover_launch(init_indices, out_indices, acc_steps):
+            # One recover launch per GDN layer: h_0 from init_indices, folded state
+            # to out_indices (in-place, or the track slot for the boundary pass).
+            for layer_id, stash in stash_per_layer.items():
+                layer_cache = pool.mamba2_layer_cache(layer_id)
+                layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]
+
+                conv_dims = stash.get("conv_dims")
+                if conv_dims is not None:
+                    # k/v are strided views of the persistent conv-out buffer, no stash copy.
+                    k_recov, v_recov = self._persist_kv(
+                        layer_id, conv_dims, batch_size, cache_steps
+                    )
+                else:
+                    k_recov = stash["k"][:, :actual_seq_len]
+                    v_recov = stash["v"][:, :actual_seq_len]
+
+                fused_sigmoid_gating_delta_rule_recover_final_state(
+                    A_log=stash["A_log"],
+                    a=stash["a"][:actual_seq_len],
+                    dt_bias=stash["dt_bias"],
+                    softplus_beta=1.0,
+                    softplus_threshold=20.0,
+                    k=k_recov,
+                    v=v_recov,
+                    b=stash["b"][:actual_seq_len],
+                    initial_state_source=layer_ssm_states,
+                    initial_state_indices=init_indices,
+                    accepted_steps=acc_steps,
+                    cache_steps=cache_steps,
+                    use_qk_l2norm_in_kernel=True,
+                    is_kda=False,
+                    output_state_indices=out_indices,
+                )
+
+        def _run_boundary():
+            # Interval-checkpoint recovery: fold mamba_steps_to_track steps from h_0
+            # (working slot) and write the boundary state to the ping-pong track slot.
+            # Must run before _run_recovery() overwrites h_0 with h_K.
+            if use_fi_recovery:
+                self._fi_recovery_launch(
+                    B,
+                    stash_per_layer,
+                    pool,
+                    gated_delta_rule_mtp,
+                    init_idx_buf=self._rec_state_idx_buf,
+                    out_idx_buf=self._rec_track_idx_buf,
+                    acc_steps_buf=self._rec_track_steps_buf,
+                )
+                return
+            _triton_recover_launch(state_idx_i32, track_out_i32, track_steps_i32)
+
+        def _run_recovery():
+            if use_fi_recovery:
+                # One launch per GDN layer, reading the stable index buffers.
+                self._fi_recovery_launch(B, stash_per_layer, pool, gated_delta_rule_mtp)
+                return
+
+            # In-place working recovery: out == init == the working SSM slot.
+            _triton_recover_launch(state_idx_i32, state_idx_i32, accepted_steps_i32)
+
+        # Recovery normally runs eagerly, outside the graph. During CUDA graph capture
+        # the recovery launch must stay on the capture stream with it.
+        if torch.cuda.is_current_stream_capturing():
+            if do_boundary:
+                _run_boundary()
+            _run_recovery()
+            return
+
+        # Eager path: recovery overlaps on a dedicated side stream behind the next step's draft
+        # compute. The next target forward joins on _recovery_event before touching the SSM pool and stash.
+        self._ensure_recovery_stream()
+        # Recovery must observe this step's verify-forward writes: record() resolves the current
+        # stream in C++, so this pair is wait_stream().
+        self._recovery_join_event.record()
+        self._recovery_stream.wait_event(self._recovery_join_event)
+
+        if use_fi_recovery and B_bucket is not None:
+            # Replay this bucket's graph on the side stream
+            # (pure async launch. Capture never happens on the live path). The boundary graph
+            # replays BEFORE the working one, so it reads h_0 before h_K overwrites it.
+            with self._recovery_stream_ctx:
+                if do_boundary:
+                    boundary_graph = self._rec_boundary_graphs.get(B_bucket)
+                    if boundary_graph is not None:
+                        boundary_graph.replay()
+                    else:
+                        _run_boundary()
+                self._rec_graphs[B_bucket].replay()
+        else:
+            # No warmup graph
+            # (Triton fallback, oversized bucket, or capture disabled/failed): eager recovery
+            # on the side stream.
+            with self._recovery_stream_ctx:
+                if do_boundary:
+                    _run_boundary()
+                _run_recovery()
+
+        self._recovery_event.record(self._recovery_stream)
+        # The FI path reads only long-lived stable buffers. The Triton path reads
+        # the per-step tensors on the side stream, where wait_stream orders but does not extend
+        # lifetime, so pin them until recovery is done.
+        if not use_fi_recovery:
+            state_idx_i32.record_stream(self._recovery_stream)
+            accepted_steps_i32.record_stream(self._recovery_stream)
+            if do_boundary:
+                # Triton boundary reads these per-step tensors on the side stream.
+                track_out_i32.record_stream(self._recovery_stream)
+                track_steps_i32.record_stream(self._recovery_stream)
+        self._recovery_event_pending = True
 
     @staticmethod
     def _scatter_speculative_state_with_mask(
@@ -1373,16 +1977,15 @@ class HybridLinearAttnBackend(AttentionBackend):
 
 
 class ShortConvHybridAttnBackend(HybridLinearAttnBackend):
-    """HybridLinearAttnBackend variant for short-conv hybrid models (ZAYA1 CCA,
-    LFM2 short conv).
+    """HybridLinearAttnBackend variant for short-conv hybrid models (ZAYA1 CCA, LFM2 short conv).
 
     The linear sidecar is a :class:`ShortConvAttnBackend
-    <sglang.srt.layers.attention.linear.short_conv_backend.ShortConvAttnBackend>`
-    that owns the per-request conv-state plumbing. The model's conv module
-    reaches it via :meth:`conv_state_metadata` (``get_attn_backend()`` returns
-    this wrapper) and runs its own conv kernel against the returned handle, so
-    the model definition holds no pool access. The sidecar is never reached
-    through the full-vs-linear ``forward_decode`` / ``forward_extend`` dispatch.
+    <sglang.srt.layers.attention.linear.short_conv_backend.ShortConvAttnBackend>` that owns
+    the per-request conv-state plumbing. The model's conv module reaches it via
+    :meth:`conv_state_metadata` (``get_attn_backend()`` returns this wrapper) and runs
+    its own conv kernel against the returned handle, so the model definition holds no pool
+    access. The sidecar is never reached through the full-vs-linear ``forward_decode``
+    / ``forward_extend`` dispatch.
     """
 
     def __init__(
@@ -1391,8 +1994,8 @@ class ShortConvHybridAttnBackend(HybridLinearAttnBackend):
         short_conv_backend: MambaAttnBackendBase,
         full_attn_layers: list,
     ):
-        # Register short_conv_backend as the linear sidecar so it rides in
-        # attn_backend_list and inherits the metadata / cuda-graph fan-out.
+        # Register short_conv_backend as the linear sidecar so it rides in attn_backend_list
+        # and gets the metadata build and cuda-graph capture every list entry gets.
         super().__init__(full_attn_backend, short_conv_backend, full_attn_layers)
         self.short_conv_backend = short_conv_backend
 

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 
@@ -111,6 +111,7 @@ class GDNKernelDispatcher:
         decode_backend: LinearAttnKernelBackend,
         prefill_backend: LinearAttnKernelBackend,
         verify_backend: Optional[LinearAttnKernelBackend] = None,
+        gdn_mtp_cache_mode: str = "full",
     ):
         triton_kernel = TritonGDNKernel()
         self.tree_verify_kernel = triton_kernel
@@ -196,7 +197,7 @@ class GDNKernelDispatcher:
             self.verify_kernel_is_flashinfer = False
         elif (
             decode_backend.is_flashinfer() or prefill_backend.is_flashinfer()
-        ) and flashinfer_kernel.supports_target_verify:
+        ) and flashinfer_kernel.can_target_verify(gdn_mtp_cache_mode):
             self.verify_kernel = flashinfer_kernel
             self.verify_kernel_is_flashinfer = True
         else:
@@ -207,10 +208,16 @@ class GDNKernelDispatcher:
             self.decode_kernel, "supports_packed_decode", False
         )
 
+        verify_suffix = (
+            " (none-mode WY output-only)"
+            if self.verify_kernel_is_flashinfer
+            and not self.verify_kernel.supports_target_verify
+            else ""
+        )
         rank0_log(
             f"GDN kernel dispatcher: decode={self.decode_kernel.__class__.__name__}, "
             f"extend={self.extend_kernel.__class__.__name__}, "
-            f"verify={self.verify_kernel.__class__.__name__} "
+            f"verify={self.verify_kernel.__class__.__name__}{verify_suffix} "
             f"packed_decode={self.supports_packed_decode}"
         )
 
@@ -360,7 +367,10 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
         backends = model_runner.linear_attn_backends
         self.kernel_dispatcher = GDNKernelDispatcher(
-            backends.decode, backends.prefill, backends.verify
+            backends.decode,
+            backends.prefill,
+            backends.verify,
+            model_runner.server_args.gdn_mtp_cache_mode,
         )
         # Sized past the pool for attn_tp-padded warmup/MLP-sync batches (see helper).
         self.verify_intermediate_state_indices = (
@@ -370,6 +380,18 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 model_runner.device,
             )
         )
+        # RecoverSSM: rebuild the accepted SSM state after verify instead of caching per-draft h.
+        # Resolved once from the mode (server_args makes none-mode exclusive with the ReplaySSM flags), so no branch consults
+        # pool buffers.
+        self._recover_ssm = model_runner.server_args.gdn_mtp_cache_mode == "none"
+        # Per-layer persistent buffers for gdn_mtp_cache_mode=none recovery.
+        self._no_cache_stash: Dict[int, Dict[str, torch.Tensor]] = {}
+        # Draft-token count of the first target-verify forward, constant for the serving session.
+        self._no_cache_draft_token_num: Optional[int] = None
+        # FlashInfer-recovery per-layer persistent token-major post-conv buffer [pool_size, draft, conv_dim]: verify
+        # conv writes into it (out=) and recovery reads k/v as strided views. Empty and unused
+        # on the Triton path.
+        self._conv_out_persist: Dict[int, torch.Tensor] = {}
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         super().init_forward_metadata(forward_batch)
@@ -514,6 +536,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
         ssm_states = mamba_cache_params.temporal
         if is_target_verify:
             assert isinstance(mamba_cache_params, MambaPool.SpeculativeState)
+            # In cache_mode=none, target verify skips intermediate SSM writes. Accepted h_K is recovered after verification.
             intermediate_state_cache = mamba_cache_params.intermediate_ssm
             intermediate_conv_window_cache = (
                 mamba_cache_params.intermediate_conv_window[0]
@@ -522,17 +545,33 @@ class GDNAttnBackend(MambaAttnBackendBase):
         else:
             has_initial_states = forward_batch.extend_prefix_lens > 0
 
-        # Page-major envelope: the prefill kernels (CUDA causal_conv1d_fwd,
-        # chunk_gated_delta_rule) write state back in place assuming a contiguous
-        # slot layout, so they silently drop the write to the strided envelope
-        # pool. Run them on contiguous per-sequence copies (identity-indexed) and
-        # scatter the result back. No-op for the default contiguous pool.
-        # CPU kernels (causal_conv1d_fwd_cpu, chunk_gated_delta_rule_cpu) use
-        # proper indexed writes and handle non-contiguous pools directly via
-        # cache_indices, so the gather/scatter round-trip is unnecessary on CPU.
-        # TODO(ch-wan): drop these .contiguous() copies by making the prefill conv
-        # and chunk_gated_delta_rule kernels honor the pool's real slot stride +
-        # int64 indexing, like packed_decode / causal_conv1d_update already do.
+        # Page-major envelope: the prefill
+        # kernels (CUDA causal_conv1d_fwd, chunk_gated_delta_rule) write state back
+        # in place assuming
+        # a contiguous slot layout,
+        # so they silently drop
+        # the write
+        # to the strided envelope pool.
+        # Run them
+        # on contiguous
+        # per-sequence copies
+        # (identity-indexed) and scatter
+        # the result back.
+        # No-op for the default contiguous pool.
+        # CPU kernels (causal_conv1d_fwd_cpu, chunk_gated_delta_rule_cpu) use proper
+        # indexed writes
+        # and handle
+        # non-contiguous pools directly via cache_indices,
+        # so the gather/scatter
+        # round-trip is unnecessary on CPU.
+        # TODO(ch-wan): drop
+        # these .contiguous() copies
+        # by making
+        # the prefill conv
+        # and chunk_gated_delta_rule kernels honor
+        # the pool's real slot stride
+        # + int64 indexing, like packed_decode
+        # / causal_conv1d_update already do.
         needs_state_gather = (
             (not is_target_verify)
             and (not is_cpu())
@@ -554,9 +593,43 @@ class GDNAttnBackend(MambaAttnBackendBase):
         if is_target_verify:
             batch_size = seq_len // forward_batch.spec_info.draft_token_num
             draft_token_num = forward_batch.spec_info.draft_token_num
+            # Choose the recovery kernel before running conv. FlashInfer recovery reads its k/v
+            # as strided views of one conv-out buffer that persists across steps, so the verify
+            # conv call below writes into that buffer (the out= argument further down).
+            #
+            # FlashInfer recovery applies when the decode kernel is FlashInfer and the state
+            # pool is bf16. Otherwise recovery is the Triton kernel with a flat k/v stash.
+            from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+                fi_recovery_kernel,
+            )
+
+            _use_fi_recovery = fi_recovery_kernel(self) is not None
             mixed_qkv_reshaped = mixed_qkv.view(
                 batch_size, draft_token_num, -1
             ).transpose(1, 2)
+            # FI recovery: write the post-conv output straight
+            # into the persistent conv-out buffer
+            # (out=pbuf[:bs].transpose(1, 2), the same strides empty_like(x) produces),
+            # so the downstream view stays no-copy and the buffer address is stable across capture/replay.
+            _conv_out_arg = None
+            if self._recover_ssm and _use_fi_recovery:
+                conv_dim = mixed_qkv_reshaped.shape[1]
+                pool_size = self.req_to_token_pool.size
+                pbuf = self._conv_out_persist.get(layer.layer_id)
+                if (
+                    pbuf is None
+                    or pbuf.shape[0] < pool_size
+                    or pbuf.shape[1] != draft_token_num
+                    or pbuf.shape[2] != conv_dim
+                ):
+                    with torch.inference_mode(False):
+                        pbuf = torch.empty(
+                            (pool_size, draft_token_num, conv_dim),
+                            dtype=mixed_qkv_reshaped.dtype,
+                            device=mixed_qkv_reshaped.device,
+                        )
+                    self._conv_out_persist[layer.layer_id] = pbuf
+                _conv_out_arg = pbuf[:batch_size].transpose(1, 2)
             mixed_qkv_processed = causal_conv1d_update(
                 mixed_qkv_reshaped,
                 conv_states,
@@ -569,6 +642,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 retrieve_next_token=retrieve_next_token,
                 retrieve_next_sibling=retrieve_next_sibling,
                 retrieve_parent_token=retrieve_parent_token,
+                out=_conv_out_arg,
             )
             mixed_qkv = mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
         else:
@@ -630,6 +704,111 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 and getattr(mamba_pool, "replayssm_cache_base", None) is not None
                 and not getattr(mamba_pool, "replayssm_is_kda", False)
             )
+
+            # RecoverSSM (none-mode): keep post-conv GDN inputs for accepted-state recovery. Persistent buffers give CUDA graph replay
+            # stable addresses.
+            if self._recover_ssm:
+                draft_token_num = forward_batch.spec_info.draft_token_num
+                pool_size = self.req_to_token_pool.size
+                max_tokens = pool_size * draft_token_num
+                actual_seq_len = query.shape[1]
+                batch_size = actual_seq_len // draft_token_num
+
+                stash_entry = self._no_cache_stash.get(layer.layer_id)
+                if _use_fi_recovery:
+                    # FlashInfer recovery: k/v are strided views of the conv-out buffer written above, so only a/b, the gating params,
+                    # and the slice geometry are stashed.
+                    # FI wants [B, T, H], so a/b are pre-shaped to [pool_size, T, ...]
+                    # and a [:B] slice keeps the right shape. Presence of ``conv_dims``
+                    # selects the FI view path.
+                    needs_realloc = (
+                        stash_entry is None or "conv_dims" not in stash_entry
+                    )
+                    if needs_realloc:
+                        # Allocate outside inference_mode so buffers can be updated across forward invocations.
+                        with torch.inference_mode(False):
+                            stash_entry = {
+                                "a": torch.empty(
+                                    (pool_size, draft_token_num, *a.shape[1:]),
+                                    dtype=a.dtype,
+                                    device=a.device,
+                                ),
+                                "b": torch.empty(
+                                    (pool_size, draft_token_num, *b.shape[1:]),
+                                    dtype=b.dtype,
+                                    device=b.device,
+                                ),
+                                "A_log": layer.A_log,
+                                "dt_bias": layer.dt_bias,
+                                # A_log is always float32 (all GDN models define it with dtype=torch.float32).
+                                # No detach or cast needed.
+                                "A_log_f32": layer.A_log,
+                            }
+                        self._no_cache_stash[layer.layer_id] = stash_entry
+                    stash_entry["conv_dims"] = (
+                        layer.q_dim,
+                        layer.k_dim,
+                        layer.v_dim,
+                        layer.num_k_heads,
+                        layer.head_k_dim,
+                        layer.num_v_heads,
+                        layer.head_v_dim,
+                    )
+                    # k/v are not copied here: the recovery reads them from the
+                    # _conv_out_persist views.
+                    stash_entry["a"][:batch_size].copy_(
+                        a.view(batch_size, draft_token_num, *a.shape[1:])
+                    )
+                    stash_entry["b"][:batch_size].copy_(
+                        b.view(batch_size, draft_token_num, *b.shape[1:])
+                    )
+                else:
+                    # Triton recovery: flat stash holds the post-conv k/v + a/b.
+                    # This path has no conv-out buffer.
+                    needs_realloc = (
+                        stash_entry is None
+                        or "conv_dims" in stash_entry
+                        or stash_entry["k"].shape[1] < max_tokens
+                    )
+                    if needs_realloc:
+                        with torch.inference_mode(False):
+                            stash_entry = {
+                                "k": torch.empty(
+                                    (key.shape[0], max_tokens, *key.shape[2:]),
+                                    dtype=key.dtype,
+                                    device=key.device,
+                                ),
+                                "v": torch.empty(
+                                    (value.shape[0], max_tokens, *value.shape[2:]),
+                                    dtype=value.dtype,
+                                    device=value.device,
+                                ),
+                                "a": torch.empty(
+                                    (max_tokens, *a.shape[1:]),
+                                    dtype=a.dtype,
+                                    device=a.device,
+                                ),
+                                "b": torch.empty(
+                                    (max_tokens, *b.shape[1:]),
+                                    dtype=b.dtype,
+                                    device=b.device,
+                                ),
+                                "A_log": layer.A_log,
+                                "dt_bias": layer.dt_bias,
+                                "A_log_f32": layer.A_log,
+                            }
+                        self._no_cache_stash[layer.layer_id] = stash_entry
+                    stash_entry["k"][:, :actual_seq_len].copy_(key)
+                    stash_entry["v"][:, :actual_seq_len].copy_(value)
+                    stash_entry["a"][:actual_seq_len].copy_(a)
+                    stash_entry["b"][:actual_seq_len].copy_(b)
+
+                # Do not store per-call sizes or tensor aliases in the stash.
+                # Eager recovery derives them from current runtime tensors.
+                if self._no_cache_draft_token_num is None:
+                    self._no_cache_draft_token_num = (
+                        forward_batch.spec_info.draft_token_num
+                    )
             if use_replayssm_fold:
                 core_attn_out = self._replayssm_fold_target_verify(
                     layer=layer,
@@ -659,12 +838,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
                     draft_token_num=forward_batch.spec_info.draft_token_num,
                 )
             else:
-                # The recurrent fallback needs the per-draft snapshots, which
-                # the pool gates OFF under --enable-linear-replayssm-spec (the
-                # same flag that makes `use_replayssm_spec` true above), so
-                # this branch is unreachable with a None buffer by
-                # construction -- keep it loud rather than silently frozen.
-                assert intermediate_state_cache is not None, (
+                # Outside none-mode a None buffer means ReplaySSM reached the recurrent fallback
+                # its pool gates the snapshots off for.
+                #
+                # The kernel would write no h_K and the commit would replay
+                # a frozen state, a silent mis-decode.
+                assert intermediate_state_cache is not None or self._recover_ssm, (
                     "recurrent target_verify fallback requires intermediate_ssm, "
                     "which is not allocated under --enable-linear-replayssm-spec"
                 )
@@ -711,8 +890,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 ssm_states[cache_indices] = last_recurrent_state
 
             if needs_state_gather:
-                # Scatter the in-place-updated contiguous copies back to the
-                # strided envelope pool (advanced indexing handles the strides).
+                # Scatter the in-place-updated contiguous copies back to the strided envelope pool (advanced indexing handles the strides).
                 conv_states[cache_indices] = conv_states_contig
                 ssm_states[cache_indices] = ssm_states_contig
 

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -19,9 +19,7 @@ import torch
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
-from sglang.srt.runtime_context import (
-    mamba_cache_chunk_size,
-)
+from sglang.srt.runtime_context import get_exec, mamba_cache_chunk_size
 from sglang.srt.utils import is_cuda
 
 if TYPE_CHECKING:
@@ -30,14 +28,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
+# ===========================================================
 # Lazy import for FlashInfer GDN kernels
-# ---------------------------------------------------------------------------
+# ===========================================================
 _flashinfer_gdn_available: Optional[bool] = None
 _flashinfer_chunk_gated_delta_rule = None
 _flashinfer_gated_delta_rule_mtp = None
 _flashinfer_gated_delta_rule_decode = None
 _flashinfer_gated_delta_rule_mtp_bf16 = None
+
+
+def is_flashinfer_gdn_wy_output_only_available() -> bool:
+    """Check the FlashInfer BF16-state WY verify kernel required by none-mode.
+
+    SM120 full-mode verification stays on Triton. A missing WY kernel raises
+    when none-mode is selected instead of silently disabling recovery.
+    """
+    if not is_cuda():
+        return False
+    from flashinfer.gdn_kernels import gated_delta_rule_mtp_wy_output_only
+
+    return callable(gated_delta_rule_mtp_wy_output_only)
 
 
 def maybe_build_flashinfer_checkpoint_plan(
@@ -163,7 +174,19 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major >= 10
+        # The SM120 chunked-prefill DSL kernel accepts float32 initial state and checkpoints
+        # only: flashinfer's gdn_prefill.py gates bf16 to SM100, where the state-pool dtype
+        # is accepted directly.
+        #
+        # cu_seqlens likewise arrives int64 on SM90 and SM120. SM100 keeps int32.
+        # The kernel output writes back through the pool-dtype cast.
+        self._prefill_needs_fp32_state = sm_major >= 12
         self.supports_target_verify = sm_major in (9, 10)
+        self.supports_none_mode_target_verify = (
+            sm_major == 12
+            and self.use_state_pool
+            and is_flashinfer_gdn_wy_output_only_available()
+        )
 
         if sm_major == 9 and self._prefill_fn is None:
             raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
@@ -205,6 +228,16 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             self._mtp_fn = _mtp_bf16_adapted
 
         logger.info("Using FlashInfer GDN kernels")
+
+    def can_target_verify(self, cache_mode: str) -> bool:
+        """Whether this instance may drive target verification in ``cache_mode``.
+
+        SM120 is intentionally admitted only for the output-only WY path used by RecoverSSM.
+        Full mode therefore keeps its established Triton verifier.
+        """
+        return self.supports_target_verify or (
+            cache_mode == "none" and self.supports_none_mode_target_verify
+        )
 
     # ---- decode ----
 
@@ -307,8 +340,16 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             # assigned to a real sequence; clamp them to 0 (the reserved dummy
             # slot) so the FlashInfer kernel never reads out-of-bounds state.
             ssm_cache_indices = cache_indices.clamp(min=0).to(torch.int64)
-            initial_state_fi = ssm_states[ssm_cache_indices].contiguous()
-            cu_seqlens = query_start_loc  # already int32
+            initial_state_fi = (
+                ssm_states[ssm_cache_indices].to(torch.float32)
+                if self._prefill_needs_fp32_state
+                else ssm_states[ssm_cache_indices].contiguous()
+            )
+            cu_seqlens = (
+                query_start_loc.to(torch.int64)
+                if self._prefill_needs_fp32_state
+                else query_start_loc  # SM100: already int32
+            )
         else:
             # SM90: preserve original negative-index handling (remap to last slot).
             ssm_cache_indices = torch.where(
@@ -416,6 +457,40 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             # pool-scoped and may include an extra dummy slot.
             intermediate_states_buffer_mtp = intermediate_states_buffer[:batch_size]
 
+        # gdn_mtp_cache_mode=none verify is output-only (state is recovered separately).
+        # On the SM100/SM120 bf16 state pool, route the verify to the FlashInfer WY
+        # output-only kernel (flashinfer PR#3720): a single launch over all T draft
+        # tokens, doing the T x T GEMM and Neumann inverse on tensor cores.
+        #
+        # Recovery is unaffected: the FI cuda-graph path reads the persistent conv-out views
+        # on the bf16 state pool, otherwise the Triton path reads a flat k/v stash.
+        if self.use_state_pool:
+            if get_exec().mamba.gdn_mtp_cache_mode == "none":
+                from flashinfer.gdn_kernels import (
+                    gated_delta_rule_mtp_wy_output_only,
+                )
+
+                output_wy = gated_delta_rule_mtp_wy_output_only(
+                    A_log=A_log.detach().float(),
+                    a=a_mtp,
+                    dt_bias=dt_bias.detach(),
+                    q=query_mtp,
+                    k=key_mtp,
+                    v=value_mtp,
+                    b=b_mtp,
+                    initial_state_source=ssm_states,
+                    initial_state_indices=cache_indices[:batch_size],
+                    output_state_indices=None,
+                    intermediate_states_buffer=None,
+                    disable_state_update=True,
+                    use_qk_l2norm_in_kernel=True,
+                    scale=None,
+                    output=None,
+                )
+                # The WY output-only kernel returns a layout .view() rejects.
+                # reshape covers it and preserves the logical shape.
+                return output_wy.reshape(1, seq_len, num_v_heads, head_v_dim)
+
         output_fi, _ = self._mtp_fn(
             q=query_mtp,
             k=key_mtp,
@@ -434,3 +509,17 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         )
 
         return output_fi.view(1, seq_len, num_v_heads, head_v_dim)
+
+
+def fi_recovery_kernel(linear_backend):
+    """Return the FlashInfer GDN decode kernel iff it drives none-mode accepted-state recovery
+    (state-pool recovery), else None.
+
+    Single source of truth for the ``use_fi_recovery`` decision.
+    Callers that only need the boolean use ``fi_recovery_kernel(...) is not None``.
+    """
+    dispatcher = getattr(linear_backend, "kernel_dispatcher", None)
+    decode_kernel = getattr(dispatcher, "decode_kernel", None)
+    if isinstance(decode_kernel, FlashInferGDNKernel) and decode_kernel.use_state_pool:
+        return decode_kernel
+    return None

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -2052,19 +2052,24 @@ class KVCacheConfigurator:
         )
 
         has_spec_dec = not self.spec_algorithm.is_none()
-        # ReplaySSM drops the per-step intermediate_ssm scratch, so its mamba budget
-        # no longer reserves the (1 + D/ratio) intermediate factor -- the whole
-        # budget goes to persistent slots (K sized like non-spec), which is how the
-        # freed ~9GB turns into higher max_running.
-        # The ring is allocated per slot but is not part of mamba_cache_per_req;
-        # the solve must charge it too or num_slots is over-provisioned.
+        # ReplaySSM drops the per-step intermediate_ssm scratch, so its mamba budget no longer
+        # reserves the (1 + D/ratio) intermediate factor and the whole budget goes
+        # to persistent slots (K sized like non-spec), which is how the freed ~9GB turns
+        # into higher max_running. The ring is allocated per slot but is not part
+        # of mamba_cache_per_req. The solve must charge it too or num_slots is over-provisioned.
         replayssm_active = get_exec().mamba.enable_linear_replayssm_spec and (
             self.hybrid_gdn_config is not None
             or kimi_linear_config(self.model_config) is not None
         )
+        # gdn_mtp_cache_mode=none (RecoverSSM) also allocates no intermediate_ssm pool
+        # (MambaPool gates the allocation on the same flag), so reserving it here would charge
+        # the KV budget for memory that is never built.
+        no_intermediate_ssm = replayssm_active or (
+            get_exec().mamba.gdn_mtp_cache_mode == "none"
+        )
         if replayssm_active:
-            # GDN sizes the fold window to the draft maximum; the KDA ring
-            # stays --linear-replayssm-cache-len long (mirrors MambaPool).
+            # GDN sizes the fold window to the draft maximum.
+            # the KDA ring stays --linear-replayssm-cache-len long (mirrors MambaPool).
             max_draft_tokens = max_speculative_num_draft_tokens()
             if kimi_linear_config(self.model_config) is not None:
                 record_len = get_exec().mamba.linear_replayssm_cache_len
@@ -2091,10 +2096,11 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=get_schedule().max_mamba_cache_size
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs (+1: the
-            # pool's padding slot, see memory_pool.py). Skipped under replayssm
-            # (no intermediate_ssm allocated).
-            if has_spec_dec and not replayssm_active:
+            # Reserve intermediate memory based
+            # on capped max_num_reqs (+1: the pool's padding slot, see memory_pool.py).
+            # Skipped when no intermediate_ssm
+            # is allocated (replayssm / gdn_mtp_cache_mode=none).
+            if has_spec_dec and not no_intermediate_ssm:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
                     get_schedule().max_running_requests // self.ps.attn_dp_size,
@@ -2116,9 +2122,11 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=get_schedule().max_running_requests
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs (+1: the
-            # pool's padding slot). Skipped under replayssm.
-            if has_spec_dec and not replayssm_active:
+            # Reserve intermediate memory based
+            # on capped max_num_reqs (+1: the pool's padding slot).
+            # Skipped when no intermediate_ssm
+            # is allocated (replayssm / gdn_mtp_cache_mode=none).
+            if has_spec_dec and not no_intermediate_ssm:
                 intermediate_size = (
                     stage_per_req
                     * (get_schedule().max_mamba_cache_size + 1)
@@ -2130,9 +2138,9 @@ class KVCacheConfigurator:
             assert stage_per_req > 0
             per_req = stage_per_req
 
-            # Solve jointly for max_mamba_cache_size (K), including the pool's
-            # +1 padding slot on both buffers (see memory_pool.py):
-            #   (K + 1) * per_req + (K / ratio + 1) * D * per_req = mamba_budget_bytes
+            # Solve jointly for max_mamba_cache_size (K), including the pool's +1 padding slot
+            # on both buffers (see memory_pool.py). Layout: (K + 1) * per_req + (K / ratio + 1)
+            # * D * per_req = mamba_budget_bytes
             mamba_budget = (
                 total_rest_memory
                 * get_schedule().mamba_full_memory_ratio
@@ -2140,7 +2148,7 @@ class KVCacheConfigurator:
             )
             mamba_budget_bytes = mamba_budget * (1 << 30)
 
-            if has_spec_dec and not replayssm_active:
+            if has_spec_dec and not no_intermediate_ssm:
                 ratio = self._calculate_mamba_ratio()
                 D = get_spec().speculative_num_draft_tokens
                 # Joint solve: main_state + intermediate = mamba_budget
@@ -2151,8 +2159,8 @@ class KVCacheConfigurator:
                         // (per_req * (1 + D / ratio))
                     ),
                 )
-                # Intermediate memory is included in mamba_budget, subtract it
-                # so the return value only has main_state subtracted from total
+                # Intermediate memory is included in mamba_budget, subtract it so the return
+                # value only has main_state subtracted from total
                 capped_reqs = min(
                     get_schedule().max_running_requests // self.ps.attn_dp_size,
                     get_schedule().max_mamba_cache_size // ratio,
@@ -2169,9 +2177,8 @@ class KVCacheConfigurator:
                 )
 
         # Validate: max_mamba_cache_size must be positive after memory allocation.
-        # A non-positive value means GPU memory is insufficient for the requested
-        # configuration. Fail fast with actionable advice instead of silently
-        # producing garbled output at runtime.
+        # A non-positive value means GPU memory is insufficient for the requested configuration.
+        # Fail fast with actionable advice instead of silently producing garbled output at runtime.
         if get_schedule().max_mamba_cache_size <= 0:
             raise RuntimeError(
                 f"Not enough GPU memory for hybrid (mamba/linear-attention) state cache. "

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -74,7 +74,7 @@ from sglang.srt.mem_cache.utils import (
     set_mla_kv_scale_buffer_triton,
 )
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
@@ -132,7 +132,9 @@ def conv_window_dedup_enabled(
     )
 
 
-def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
+def get_tensor_size_bytes(t: Optional[Union[torch.Tensor, List[torch.Tensor]]]):
+    if t is None:
+        return 0
     if isinstance(t, list):
         return sum(get_tensor_size_bytes(x) for x in t)
     return np.prod(t.shape) * t.dtype.itemsize
@@ -397,17 +399,23 @@ class MambaPool:
 
     @dataclass(frozen=True, kw_only=True)
     class SpeculativeState(State):
-        # None under --enable-linear-replayssm-spec: the spec ring owns rollback
-        # (verify writes ring records, commit moves cursors), so the per-draft
-        # full-state snapshots are never produced or consumed.
-        intermediate_ssm: Optional[torch.Tensor]
-        intermediate_conv_window: List[torch.Tensor]
+        # None under BOTH
+        # --enable-linear-replayssm-spec (the spec ring owns rollback via cursors)
+        # and gdn_mtp_cache_mode=none (recovery reconstructs h_K after verify). The two modes
+        # are mutually exclusive.
+        # --enable-linear-replayssm-spec (spec ring owns rollback via cursors)
+        # and gdn_mtp_cache_mode=none (recovery reconstructs h_K after verify)
+        # The two
+        # are mutually exclusive.
+        intermediate_ssm: Optional[torch.Tensor] = None
+        # Kept in all modes for accepted conv-state rollback.
+        intermediate_conv_window: Optional[List[torch.Tensor]] = None
 
     def _detect_conv_window_axis(
         self, conv_state_shape: List[Tuple[int, int]], win_len: int
     ) -> int:
-        """Prefer GDN's trailing axis when both match; mixed layer layouts cannot
-        share one overlapping conv-window buffer.
+        """Prefer GDN's trailing axis when both match. Mixed layer layouts cannot share one
+        overlapping conv-window buffer.
         """
         axis = None
         for conv_shape in conv_state_shape:
@@ -695,22 +703,19 @@ class MambaPool:
                         temporal_state_shape[-1],
                         temporal_state_shape[-2],
                     )
-                # Cache intermediate SSM states per draft token during target verify
+                # Cache intermediate SSM states per draft token during target verify.
                 # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
+                # When either mode is on, the intermediate_ssm allocation (~46x the conv state) is skipped:
                 #
-                # ReplaySSM spec-verify owns rollback via the ring + cursors (the
-                # verify kernel never writes per-draft snapshots; the commit never
-                # reads them), so this buffer -- the dominant spec scratch, ~46x
-                # the conv state -- is dead weight there and is skipped. The conv
-                # intermediate windows below STAY (conv rollback consumes them).
-                # The recurrent-verify fallback cannot be reached under the flag
-                # (GDN + linear chain + triton enforced in server_args; the
-                # backend asserts loudly if it ever is).
-                # ReplaySSM skips this dominant scratch (~9GB @ K3 dspark γ=7): the
-                # KDA verify kernel takes intermediate_states_buffer=None (skips the
-                # per-step write, CACHE_INTERMEDIATE_STATES=False) and the commit
-                # replays the ring into the checkpoint instead. This is the memory win.
-                if enable_linear_replayssm_spec:
+                # ReplaySSM spec-verify owns rollback through the ring and cursors: the verify
+                # kernel never writes per-draft snapshots and the commit never reads them.
+                #
+                # gdn_mtp_cache_mode=none reconstructs h_K from the committed h_0 after verify,
+                # and server_args keeps the two modes apart.
+                #
+                # The conv intermediate windows stay populated in both cases: conv rollback consumes them.
+                cache_mode = get_exec().mamba.gdn_mtp_cache_mode
+                if enable_linear_replayssm_spec or cache_mode == "none":
                     intermediate_ssm_state_cache = None
                 else:
                     intermediate_ssm_state_cache = torch.zeros(
@@ -725,8 +730,7 @@ class MambaPool:
                         dtype=ssm_dtype,
                         device="cuda",
                     )
-                # Cache intermediate conv windows (last K-1 inputs) per draft token
-                # during target verify.
+                # Cache intermediate conv windows (last K-1 inputs) per draft token during target verify.
                 #
                 # On CUDA (Triton conv kernel + Triton scatter) we use a
                 # *deduplicated sliding-window* layout: consecutive draft tokens'
@@ -814,13 +818,14 @@ class MambaPool:
                     else 0.0
                 )
                 logger.info(
-                    f"Mamba Cache is allocated. "
+                    f"Mamba Cache is allocated (gdn_mtp_cache_mode={cache_mode}). "
                     f"max_mamba_cache_size: {size}, "
                     f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                     f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
                     f"intermediate_ssm_state_cache size: {intermediate_ssm_gb:.2f}GB "
-                    # Report the deduplicated PHYSICAL conv-window buffers (the view
-                    # over-reports its logical, un-deduplicated size).
+                    # Report
+                    # the deduplicated PHYSICAL
+                    # conv-window buffers (the view over-reports its logical, un-deduplicated size).
                     f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
                 )
             else:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -992,12 +992,39 @@ class ModelRunner:
         self.decode_cuda_graph_runner = capture.decode.runner
         self.graph_memory_usage = capture.memory_usage
         self.graph_time_usage = capture.time_usage
+        # gdn_mtp_cache_mode=none: capture the per-bucket SSM-state recovery graphs now
+        # that target_verify capture above allocated the recovery stash at its final addresses.
+        # Self-guards (no-op in full mode / non-recovery paths).
+        self.maybe_capture_gdn_recovery_graphs()
+
+    def maybe_capture_gdn_recovery_graphs(self):
+        """Capture per-bucket FlashInfer SSM-state recovery cuda graphs at warmup.
+
+        The recovery stash must exist at its final addresses, hence after the decode
+        and target_verify captures. Bucket padding, side-stream replay,
+        and the capture-failure fallback to eager live in HybridLinearAttnBackend.
+        """
+        if self.device != "cuda" or self.is_draft_worker:
+            return
+        if self.server_args.gdn_mtp_cache_mode == "full":
+            return
+
+        from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+            HybridLinearAttnBackend,
+        )
+
+        if not isinstance(self.attn_backend, HybridLinearAttnBackend):
+            return
+        if self.decode_cuda_graph_runner is None:
+            return
+        self.attn_backend.capture_recovery_graphs(
+            self.decode_cuda_graph_runner.capture_bs
+        )
 
     def init_routed_experts_capturer(self):
         if self.is_draft_worker:
-            # Capture is target-only. The draft worker runs in the same process
-            # as its target and inits after it, so installing a capturer here
-            # would overwrite the target's process-global one.
+            # Capture is target-only. The draft worker runs in the same process as its target
+            # and inits after it, so installing a capturer here would overwrite the target's process-global one.
             return
 
         set_global_experts_capturer(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2575,6 +2575,19 @@ class ServerArgs:
     mamba_track_interval: A[
         int, "The interval to track the mamba state during decode.", NS("exec.mamba")
     ] = 256
+    gdn_mtp_cache_mode: A[
+        str,
+        Arg(
+            help="Intermediate h-state cache mode for GDN MTP verify. "
+            "'full' (default) caches h at every draft-token position. "
+            "'none' skips intermediate caching and reconstructs h_K after "
+            "verify by re-running the GDN recurrence from the committed h_0 over "
+            "the accepted draft prefix. 'none' trades extra post-verify recovery "
+            "compute for freeing the intermediate_ssm buffer.",
+            choices=["full", "none"],
+        ),
+        NS("exec.mamba"),
+    ] = "full"
     enable_int8_mamba_checkpoint: A[
         bool,
         "Store radix-cached linear-attn (mamba) states in int8 (separate checkpoint pool) for ~2x cached-prefix capacity at fixed memory.",
@@ -3762,6 +3775,8 @@ class ServerArgs:
         from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 
         handle_speculative_decoding(self)
+
+        self._validate_gdn_mtp_cache_mode()
 
         # Validate the CuteDSL A2A token budget now that num_tokens_per_req is final.
         self._validate_cutedsl_a2a_token_budget()
@@ -5897,6 +5912,46 @@ class ServerArgs:
         else:
             self._validate_mamba_no_buffer(view, model_arch)
 
+    def _validate_gdn_mtp_cache_mode(self):
+        """Reject configs that GDN MTP --gdn-mtp-cache-mode=none cannot serve.
+
+        none-mode target-verify (FlashInfer WY output-only kernel) and the accepted-state recovery both replay a CONTIGUOUS
+        accepted prefix keyed by one scalar accept-length per request, so topk>1 (EAGLE tree) drafts would verify correctly but recover
+        h_K from the wrong linear-prefix tokens -- a silent mis-decode.
+        That is fail-fast here.
+
+        Mamba radix tracking (extra_buffer) IS supported: none-mode caches no intermediate SSM
+        states, so it recomputes the interval-crossing snapshot via a second boundary recovery
+        pass, on both the FlashInfer and Triton recover paths (each writes the folded boundary state to the ping-pong track slot via a separate output-state index).
+
+        none-mode is also rejected alongside either ReplaySSM flag: this is the single point that keeps RecoverSSM and ReplaySSM apart,
+        so the runtime gate (GDNAttnBackend._recover_ssm) can read the mode alone and never has to reason about which ReplaySSM buffers
+        happen to be allocated.
+        """
+        # Sibling validators read the resolved arg bag via `arg_groups.overrides.resolved_view` Use the same accessor here.
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        cfg = resolved_view(self)
+        if cfg.gdn_mtp_cache_mode != "none":
+            return
+        if cfg.enable_linear_replayssm_spec or cfg.enable_linear_replayssm:
+            raise ValueError(
+                "--gdn-mtp-cache-mode=none is mutually exclusive with ReplaySSM "
+                "(--enable-linear-replayssm-spec / --enable-linear-replayssm). "
+                "RecoverSSM rebuilds the accepted state after verify and commits "
+                "it straight to the SSM pool, which neither ReplaySSM ring's "
+                "cursor protocol accounts for -- enable only one."
+            )
+        if cfg.speculative_eagle_topk not in (None, 1):
+            raise ValueError(
+                "--gdn-mtp-cache-mode=none requires a linear draft chain "
+                "(--speculative-eagle-topk in {None, 1}); none-mode WY verify and "
+                "accepted-state recovery reconstruct h_K over a contiguous accepted "
+                "prefix and cannot follow an EAGLE tree, so topk>1 would silently "
+                "commit the wrong SSM state. Got "
+                f"--speculative-eagle-topk={cfg.speculative_eagle_topk!r}."
+            )
+
     def _handle_sampling_backend(self):
         # Moved to the resolution pipeline (arg_groups/overrides.py:
         # _sampling_backend_default), invoked here at its legacy slot.
@@ -6037,9 +6092,8 @@ class ServerArgs:
         # fallback stay below.
         run_post_process_pass(self, _mla_backend_page_constraints)
 
-        # The TRT-LLM / tokenspeed MLA kv-dtype validations moved to the
-        # resolution pipeline (arg_groups/overrides.py:
-        # _mla_kv_cache_dtype_checks), invoked here at their legacy slot.
+        # The TRT-LLM / tokenspeed MLA kv-dtype validations moved to the resolution pipeline
+        # (arg_groups/overrides.py: _mla_kv_cache_dtype_checks), invoked here at their legacy slot.
         from sglang.srt.arg_groups.overrides import _mla_kv_cache_dtype_checks
 
         run_post_process_pass(self, _mla_kv_cache_dtype_checks)

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -38,7 +38,10 @@ from sglang.srt.distributed.parallel_state import (
     patch_tensor_parallel_group,
 )
 from sglang.srt.environ import envs
-from sglang.srt.managers.schedule_batch import set_mamba_track_indices_from_reqs
+from sglang.srt.managers.schedule_batch import (
+    mamba_lazy_spec_in_window,
+    set_mamba_track_indices_from_reqs,
+)
 from sglang.srt.managers.utils import _async_d2h
 from sglang.srt.mem_cache.allocation import (
     assign_req_to_token_pool as assign_req_to_token_pool,
@@ -125,11 +128,10 @@ def fast_sample(probs: torch.Tensor, num_samples: int = 1):
     """Draw from `probs` via the Gumbel-max trick: argmax(probs / Exp(1)).
 
     Distributionally equivalent to torch.multinomial, but avoids multinomial's
-    device-side distribution-validity assert, which the draft CUDA graph would
-    otherwise capture and replay every step. q is clamped off zero so a zero
-    draw can't yield inf/NaN scores that argmax would wrongly select; fp32
-    avoids bf16 argmax ties biasing the draw. Set SGLANG_OPT_USE_GUMBEL_SAMPLE=0
-    to fall back to torch.multinomial.
+    device-side distribution-validity assert, which the draft CUDA graph would otherwise capture
+    and replay every step. q is clamped off zero so a zero draw can't yield inf/NaN scores
+    that argmax would wrongly select. fp32 avoids bf16 argmax ties biasing the draw. Set
+    SGLANG_OPT_USE_GUMBEL_SAMPLE=0 to fall back to torch.multinomial.
     """
     if not envs.SGLANG_OPT_USE_GUMBEL_SAMPLE.get():
         sample_index = torch.multinomial(probs, num_samples=num_samples)
@@ -210,10 +212,9 @@ def draft_kv_indices_used_len(
 
 
 def record_stream_each(tensors, stream):
-    """Call record_stream(stream) on each cuda tensor in `tensors`, skipping
-    non-tensor / non-cuda entries. Tells the caching allocator that the
-    tensors are also used on `stream`, so memory is not recycled while
-    queued work is still in flight after Python refs drop.
+    """Call record_stream(stream) on each cuda tensor in `tensors`, skipping non-tensor
+    / non-cuda entries. Tells the caching allocator that the tensors are also used
+    on `stream`, so memory is not recycled while queued work is still in flight after Python refs drop.
     """
     for t in tensors:
         if isinstance(t, torch.Tensor) and t.is_cuda:
@@ -369,11 +370,10 @@ def sample_simulated_acc_len(
         simulated_values = torch.clamp(simulated_values, min=1.0, max=max_len)
         simulate_acc_len = int(simulated_values.round().item())
     elif simulate_acc_method == "match-expected":
-        # multinomial sampling does not match the expected length
-        # we keep it for the sake of compatibility of existing tests
-        # but it's better to use "match-expected" for the cases that need to
-        # match the expected length, One caveat is that this will only sample
-        # either round down or round up of the expected length
+        # multinomial sampling does not match the expected length we keep it for the sake
+        # of compatibility of existing tests but it's better to use
+        # "match-expected" for the cases that need to match the expected length, One caveat
+        # is that this will only sample either round down or round up of the expected length
         simulate_acc_len = max(1.0, min(max_len, simulate_acc_len))
         lower = int(simulate_acc_len // 1)
         upper = lower + 1 if lower < max_len else lower
@@ -573,8 +573,8 @@ class GrammarTree:
     ) -> GrammarTree:
         tensors = (retrieve_next_token, retrieve_next_sibling, draft_token)
         host = tuple(_async_d2h(t) for t in tensors)
-        # Sources may be mixed -- an algorithm can synthesize part of the tree on
-        # the host -- so the event has to key off whichever one is on device.
+        # Sources may be mixed -- an algorithm can synthesize part of the tree on the host
+        # -- so the event has to key off whichever one is on device.
         device = next((t.device for t in tensors if t.device.type != "cpu"), None)
         if device is None:
             return cls(host, None)
@@ -621,9 +621,9 @@ def build_grammar_vocab_mask(
 ) -> Optional[GrammarMask]:
     """Build the constrained-decoding bitmask over a verify tree and stage it on device.
 
-    Call it after the target verify launch -- every step here is host work, so it all
-    overlaps that forward. ``barrier`` advances the previous batch's FSM over its
-    committed tokens, which the traversal then reads, so it has to run first.
+    Call it after the target verify launch -- every step here is host work, so it all overlaps
+    that forward. ``barrier`` advances the previous batch's FSM over its committed tokens, which
+    the traversal then reads, so it has to run first.
     """
     if barrier is not None:
         barrier()
@@ -675,8 +675,8 @@ def load_token_map(token_map_path: str) -> List[int]:
 
 @contextmanager
 def draft_tp_context(tp_group: GroupCoordinator):
-    # Draft model doesn't use dp and has its own tp group.
-    # We disable mscclpp now because it doesn't support 2 comm groups.
+    # Draft model doesn't use dp and has its own tp group. We disable mscclpp now because
+    # it doesn't support 2 comm groups.
     with patch_tensor_parallel_group(tp_group):
         yield
 
@@ -753,19 +753,72 @@ def move_accept_tokens_to_target_kvcache(
     )
 
 
+def _recover_ssm_track_unreachable(batch: ScheduleBatch) -> bool:
+    """
+    True when no request can reach a mamba track boundary during this verify,
+    so ``prepare_mamba_track_for_verify`` may skip the track plan.
+
+    A track boundary is a sequence position that is a multiple of ``mamba_track_interval``.
+    Reaching one during this step obliges the post-verify commit to write the boundary state
+    to the ping-pong track slot. Under ``--gdn-mtp-cache-mode none`` (RecoverSSM)
+    no intermediate h is cached, so producing that state costs a full re-fold of the interval
+    from h_0, for every GDN layer (see ``HybridLinearAttnBackend._no_cache_mtp_recompute``).
+    The other modes scatter the boundary state out of a cache instead, cheaply, so they always
+    keep the plan.
+
+    How far can the sequence position move during this verify?
+
+        kv_committed_len            CPU counter, refreshed after verify,
+                                    so it may not yet include
+                                    the previous verify's accepted tokens
+             |
+             |  up to max_draft_tokens: this verify's accepted tokens
+             |  up to max_draft_tokens more: the previous verify's
+             |  accepted tokens the GPU already counted into seq_lens
+             v
+        seq_lens upper bound = kv_committed_len + 2 * max_draft_tokens
+
+    A request can cross a boundary iff the two ends of that span sit in different
+    intervals, which is exactly ``mamba_lazy_spec_in_window``. Returning True means no crossing
+    is possible for any request: no checkpoint is due, and dropping the plan skips
+    the boundary re-check without losing a write. The bound must stay conservative
+    -- ``BatchResultProcessor._mamba_check_track_boundary`` computes the ping-pong advance
+    independently, and any checkpoint it treats as due must never have been dropped here.
+    """
+    if get_exec().mamba.gdn_mtp_cache_mode != "none":
+        return False
+    max_draft_tokens = max_speculative_num_draft_tokens()
+    if max_draft_tokens is None:
+        return False
+    mamba_track_interval = get_exec().mamba.mamba_track_interval
+    return not any(
+        mamba_lazy_spec_in_window(req, mamba_track_interval, max_draft_tokens)
+        for req in batch.reqs
+    )
+
+
 def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:
     """Rebuild mamba track indices from reqs before a TARGET_VERIFY forward.
 
-    Spec batches skip the refresh in prepare_for_decode, and filter/merge
-    null these fields, so they must be rebuilt right before verify. Clearing
-    the mask also keeps a stale extend-time mask from triggering in-forward
-    tracking during TARGET_VERIFY; tracking is done in
-    commit_mamba_states_after_verify instead.
+    Spec batches skip the refresh in prepare_for_decode, and filter/merge null these fields,
+    so they must be rebuilt right before verify. Clearing the mask also keeps
+    a stale extend-time mask from triggering in-forward tracking during TARGET_VERIFY.
+    Tracking is done in commit_mamba_states_after_verify instead.
 
-    Lazy: gather the positions planned by mamba_lazy_spec_prepare. Runs
-    inside forward isolation, so it must not mutate req/pool state.
+    Lazy: gather the positions planned by mamba_lazy_spec_prepare. Runs inside forward
+    isolation, so it must not mutate req/pool state.
+
+    RecoverSSM: leave the plan unset on steps where no crossing is reachable, which skips
+    the full per-GDN-layer boundary re-fold.
     """
     if not mamba_extra_buffer_enabled():
+        return
+    if _recover_ssm_track_unreachable(batch):
+        # Cleared explicitly: a plan built for an earlier step would otherwise survive here
+        # and re-run the boundary check against stale slots.
+        batch.mamba_track_indices = None
+        batch.mamba_track_mask = None
+        batch.mamba_track_seqlens = None
         return
     track_positions = None
     if mamba_extra_buffer_lazy_enabled():
@@ -876,9 +929,9 @@ def commit_mamba_states_after_verify(
     req_pool = model_runner.req_to_token_pool
     mamba_pool = getattr(req_pool, "mamba_pool", None)
 
-    # Fold-every-commit: replay the accepted prefix from the ring into
-    # `temporal`; the same fold stores the interval-crossing state to the
-    # track slot, so no SSM scatter or force-flush is needed here.
+    # Fold-every-commit: replay the accepted prefix from the ring into `temporal`. The same fold
+    # stores the interval-crossing state to the track slot, so no SSM scatter
+    # or force-flush is needed here.
     if (
         mamba_pool is not None
         and getattr(mamba_pool, "replayssm_spec_fold", False)
@@ -1044,8 +1097,8 @@ def commit_mamba_states_after_verify(
 
 
 def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
-    """eagle/ngram share a stateless free function; dflash keeps stateful
-    prep on its draft input -- the dispatcher routes.
+    """eagle/ngram share a stateless free function; dflash keeps stateful prep on its draft input
+    -- the dispatcher routes.
     """
     if mamba_extra_buffer_lazy_enabled():
         # Scheduler phase (outside forward isolation).

--- a/test/registered/unit/layers/attention/test_gdn_recover_final_state.py
+++ b/test/registered/unit/layers/attention/test_gdn_recover_final_state.py
@@ -1,0 +1,92 @@
+"""Compare the recovery-only Triton recurrence with a small PyTorch reference."""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_recover_final_state,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestGDNRecoverFinalState(CustomTestCase):
+    def test_accepted_prefix_and_boundary_output_slots(self):
+        torch.manual_seed(0)
+        n, steps, heads, value_heads, width = 3, 4, 1, 2, 32
+        k = torch.randn(1, n * steps, heads, width, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(
+            1, n * steps, value_heads, width, device="cuda", dtype=torch.bfloat16
+        )
+        a = torch.randn(n * steps, value_heads, device="cuda")
+        b = torch.randn(n * steps, value_heads, device="cuda")
+        a_log = torch.randn(value_heads, device="cuda")
+        bias = torch.randn(value_heads, device="cuda")
+        accepted = torch.tensor([-1, 0, 3], device="cuda", dtype=torch.int32)
+        src = torch.arange(n, device="cuda", dtype=torch.int32)
+        for dtype in (torch.float32, torch.bfloat16):
+            for separate in (False, True):
+                with self.subTest(dtype=dtype, separate=separate):
+                    state = (
+                        torch.randn(
+                            5, value_heads, width, width, device="cuda", dtype=dtype
+                        )
+                        * 0.1
+                    )
+                    expected = state.float().clone()
+                    dst = (
+                        torch.tensor([3, -1, 4], device="cuda", dtype=torch.int32)
+                        if separate
+                        else src
+                    )
+                    for row in range(n):
+                        out_slot = int(dst[row])
+                        if out_slot < 0:
+                            continue
+                        h = state[row].float().clone()
+                        for step in range(int(accepted[row]) + 1):
+                            pos = row * steps + step
+                            key = (
+                                k[0, pos]
+                                .float()
+                                .repeat_interleave(value_heads // heads, dim=0)
+                            )
+                            key = key / torch.sqrt(
+                                key.square().sum(-1, keepdim=True) + 1e-6
+                            )
+                            decay = torch.exp(-a_log.exp() * F.softplus(a[pos] + bias))
+                            h = h * decay[:, None, None]
+                            delta = v[0, pos].float() - (h * key[:, None, :]).sum(-1)
+                            delta = delta * b[pos].sigmoid()[:, None]
+                            h = h + delta[:, :, None] * key[:, None, :]
+                        expected[out_slot] = h
+                    fused_sigmoid_gating_delta_rule_recover_final_state(
+                        a_log,
+                        a,
+                        bias,
+                        1.0,
+                        20.0,
+                        k,
+                        v,
+                        b,
+                        state,
+                        src,
+                        accepted,
+                        steps,
+                        use_qk_l2norm_in_kernel=True,
+                        output_state_indices=dst if separate else None,
+                    )
+                    torch.testing.assert_close(
+                        state.float(),
+                        expected.to(dtype).float(),
+                        atol=0.005 if dtype == torch.bfloat16 else 1e-4,
+                        rtol=0.02 if dtype == torch.bfloat16 else 1e-4,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_gdn_recover_ssm_config.py
+++ b/test/registered/unit/server_args/test_gdn_recover_ssm_config.py
@@ -1,0 +1,50 @@
+"""RecoverSSM accepts linear drafts and rejects incompatible replay modes."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestRecoverSSMConfig(CustomTestCase):
+    def test_none_mode_requires_linear_drafts_and_no_replayssm(self):
+        for mode in ("full", "none"):
+            for topk in (None, 1, 2):
+                for replay, replay_spec in (
+                    (False, False),
+                    (True, False),
+                    (False, True),
+                ):
+                    with self.subTest(
+                        mode=mode, topk=topk, replay=replay, replay_spec=replay_spec
+                    ):
+                        cfg = SimpleNamespace(
+                            gdn_mtp_cache_mode=mode,
+                            speculative_eagle_topk=topk,
+                            enable_linear_replayssm=replay,
+                            enable_linear_replayssm_spec=replay_spec,
+                        )
+                        if mode == "none" and (topk == 2 or replay or replay_spec):
+                            with self.assertRaises(ValueError):
+                                ServerArgs._validate_gdn_mtp_cache_mode(cfg)
+                        else:
+                            ServerArgs._validate_gdn_mtp_cache_mode(cfg)
+
+    def test_validation_observes_resolved_overrides(self):
+        cfg = SimpleNamespace(
+            gdn_mtp_cache_mode="full",
+            speculative_eagle_topk=2,
+            enable_linear_replayssm=False,
+            enable_linear_replayssm_spec=False,
+            _resolved_overrides=[("test", {"gdn_mtp_cache_mode": "none"})],
+        )
+        with self.assertRaisesRegex(ValueError, "linear draft chain"):
+            ServerArgs._validate_gdn_mtp_cache_mode(cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Draft for upstream design review: port turbo's RecoverSSM path for linear MTP drafts. Instead of retaining every intermediate SSM state during verification, recover the accepted state from the committed state and accepted token prefix. Preserve radix interval-boundary snapshots through a separate recovery write.

## Modifications

- Add opt-in `--gdn-mtp-cache-mode none`; `full` remains the default.
- Add recovery buffers, Triton recurrence, FlashInfer output-only verification/recovery integration, and graph handling.
- Keep radix boundary tracking while omitting the intermediate SSM pool.
- Reject ReplaySSM combinations and nonlinear EAGLE drafts for this mode.
- Include SM120 FlashInfer prefill dtype compatibility from the source patch.

This draft is based directly on `qwen4-main-squashed` `4ccff141dbe992794f9da6c3aa23535b4f72000d`. It does not include online MXFP8, FP8 KV, or deployment-specific cache sizes.

## Accuracy Tests

Each test ran in a fresh base-image container with this PR's files only, on RTX PRO 6000:

```text
pytest -q test/registered/unit/server_args/test_gdn_recover_ssm_config.py
2 passed, 18 configuration subcases passed.

pytest -q test/registered/unit/layers/attention/test_gdn_recover_final_state.py
1 passed, 4 GPU subcases passed.
```

The GPU test compares the actual recovery Triton kernel with a PyTorch recurrence. It covers accepted indices -1/0/3, grouped value heads, FP32/BF16 state, in-place recovery, separate boundary output slots, and a disabled output slot. Config tests cover both modes, top-k, replay flags, and resolved overrides.

## Speed Tests and Profiling

The combined turbo-derived deployment with this feature, online MXFP8 and FP8 KV completed ten concurrent 32K-input requests and one 240K-input request with MTP enabled. These are combined-stack smoke tests, not isolated state-equivalence or performance evidence for all paths in this PR.

## Before marking ready

- Validate FlashInfer recovery and output-only verification against full-state verification, including all accepted-prefix and radix-boundary cases.
- Add end-to-end MTP accuracy and prefix-reuse comparisons with `full` mode.
- Measure memory/latency at matched cache and concurrency settings.
- Review FlashInfer API/version requirements, graph fallback behavior, and supported-device gating with maintainers.

## Attribution

Changed-file pre-commit checks passed. Companion PR #38487 currently hits the repository-wide `main` rebase gate (required commit `a5f07b1241fc`) and missing `run-ci` label. This draft intentionally targets the Qwen4 branch and does not request a gate bypass or large-scale CI before the design is agreed.

Ported from `0002-sm120-gdn-recover-ssm.patch` in [mratsim/sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo/tree/000b6b5aa2b6ca4529319925286e1f2ec91a2dad), with added regression coverage and formatting cleanup.

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for RecoverSSM and the substantial SM120 optimization work. The port retains his co-author attribution and the original Apache-2.0 licensing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829727720](https://github.com/sgl-project/sglang/actions/runs/34829727720)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829727472](https://github.com/sgl-project/sglang/actions/runs/34829727472)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829727732](https://github.com/sgl-project/sglang/actions/runs/34829727732)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->