### PR TITLE
[Qwen4][SM120] Port opt-in online MXFP8 and rowwise FP8 weights

### DIFF
--- a/python/sglang/kernels/ops/gemm/sm120_online_fp8.py
+++ b/python/sglang/kernels/ops/gemm/sm120_online_fp8.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Online FP8 weights for sm120 (RTX PRO 6000 Blackwell).
+
+Single switch SGLANG_SM120_ONLINE_MXFP8, propagated to ``online_fp8_enabled``
+by ``initialize_bf16_gemm_config`` on SM120. What it arms, all rowwise fp8
+(one fp32 scale per output row, halving bytes on bandwidth-bound GEMVs):
+  - HyperConnection mix pair: created on meta, the checkpoint shard is
+    quantized on CPU and the Parameter swapped at load (attach_rowwise_ingest).
+  - lm_head: quantized and swapped at the model's post_load_weights, read
+    through the fp8 branch in LogitsProcessor. Its scale rides the Parameter
+    because the NEXTN draft shares the target lm_head object via
+    set_embed_and_head and never revisits the target module.
+  - Decode-size lm_head GEMVs before that swap: the lazy fp8 copy cached next
+    to the bf16 original (maybe_sm120_fp8_lm_head).
+The large projections are covered by the model-side hook in qwen4_exp.py
+(MXFP8 from load time). Replacement is per-module, all-or-nothing, and final:
+reader asserts fire if any code still expects a bf16 original. Kernels are
+split-free: an atomic + fp32->bf16 epilogue costs more than the split-K gains
+on these shapes.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+# Decode row counts (bs <= 8, verify <= 16, eager draft slack).
+_MAX_M = 32
+
+# Set by initialize_bf16_gemm_config from SGLANG_SM120_ONLINE_MXFP8.
+online_fp8_enabled = False
+
+
+@triton.jit
+def _fp8w_gemv_kernel(
+    x_ptr,
+    w_ptr,
+    scale_ptr,
+    out_ptr,
+    M,
+    N,
+    K,
+    stride_xm,
+    stride_xk,
+    stride_wn,
+    stride_wk,
+    stride_om,
+    stride_on,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    OUT_BF16: tl.constexpr,
+):
+    """Weight-only FP8: w is float8_e4m3fn with per-output-row fp32 scales."""
+    pid_n = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    rm = tl.arange(0, BLOCK_M)
+    n_mask = rn < N
+    m_mask = rm < M
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    k_per = tl.cdiv(K, SPLIT_K)
+    k_start = pid_k * k_per
+    k_end = tl.minimum(k_start + k_per, K)
+    for k0 in tl.range(k_start, k_end, BLOCK_K, num_stages=NUM_STAGES):
+        rk = k0 + tl.arange(0, BLOCK_K)
+        k_mask = rk < k_end
+        xb = tl.load(
+            x_ptr + rm[:, None] * stride_xm + rk[None, :] * stride_xk,
+            mask=m_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        wb = tl.load(
+            w_ptr + rn[:, None] * stride_wn + rk[None, :] * stride_wk,
+            mask=n_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.bfloat16)
+        acc += tl.dot(xb, tl.trans(wb), out_dtype=tl.float32)
+    scale = tl.load(scale_ptr + rn, mask=n_mask, other=0.0)
+    acc = acc * scale[None, :]
+    if OUT_BF16:
+        tl.store(
+            out_ptr + rm[:, None] * stride_om + rn[None, :] * stride_on,
+            acc.to(tl.bfloat16),
+            mask=m_mask[:, None] & n_mask[None, :],
+        )
+    else:
+        tl.atomic_add(
+            out_ptr + rm[:, None] * stride_om + rn[None, :] * stride_on,
+            acc,
+            mask=m_mask[:, None] & n_mask[None, :],
+            sem="relaxed",
+        )
+
+
+# fp8 weight-only cache: weight key -> (fp8 weight, per-row fp32 scale).
+# Populated during eager warmup, before CUDA graph capture. A capture-time miss falls back to the caller's
+# bf16 path, so no allocation ever lands inside a graph.
+_fp8w_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+_fp8w_cache_bytes = 0
+_FP8W_CACHE_MAX_BYTES = 6 * 1024**3
+
+
+def _quantize_rowwise_fp8(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    n = w.shape[0]
+    w_q = torch.empty_like(w, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(n, dtype=torch.float32, device=w.device)
+    # Chunk rows: a full-tensor fp32 temp of the 1.27 GB lm_head would need ~5 GB that a
+    # 0.96-mem-fraction server does not have.
+    step = max(1, (64 * 1024 * 1024) // max(1, w.shape[1] * 4))
+    for i in range(0, n, step):
+        blk = w[i : i + step].float()
+        amax = blk.abs().amax(dim=1, keepdim=True).clamp_min(1e-8)
+        s = amax / 448.0
+        w_q[i : i + step] = (blk / s).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        scale[i : i + step] = s.squeeze(1)
+    return w_q, scale
+
+
+def _get_fp8_weight(weight: torch.Tensor):
+    global _fp8w_cache_bytes
+    if weight.dtype != torch.bfloat16:
+        return None
+    # data_ptr alone can be reused by the allocator after a free, and an in-place weight update
+    # (copy_) keeps the ptr. Shape + _version make the key safe for both.
+    key = (weight.data_ptr(), weight.shape[0], weight.shape[1], weight._version)
+    hit = _fp8w_cache.get(key)
+    if hit is not None:
+        return hit
+    if torch.cuda.is_current_stream_capturing():
+        return None
+    if _fp8w_cache_bytes + weight.numel() + weight.shape[0] * 4 > _FP8W_CACHE_MAX_BYTES:
+        return None
+    entry = _quantize_rowwise_fp8(weight)
+    _fp8w_cache[key] = entry
+    _fp8w_cache_bytes += entry[0].numel() + entry[1].numel() * 4
+    return entry
+
+
+def maybe_sm120_fp8_lm_head(
+    hidden_states: torch.Tensor, weight: torch.Tensor
+) -> Optional[torch.Tensor]:
+    """
+    FP8 weight-only lm_head GEMV for decode-size row counts, or None to let the caller keep
+    the cuBLAS bf16 path (which reads 2x the bytes).
+
+    Only reached while the bf16 original is still resident: after post_load_weights replaces
+    the head, the fp8 branch in LogitsProcessor calls sm120_fp8_lm_head_logits directly.
+    """
+    if not online_fp8_enabled:
+        return None
+    if hidden_states.dim() != 2 or hidden_states.shape[0] > _MAX_M:
+        return None
+    if hidden_states.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        return None
+    entry = _get_fp8_weight(weight)
+    if entry is None:
+        return None
+    w_q, scale = entry
+    m, k = hidden_states.shape
+    n = w_q.shape[0]
+    out = torch.empty((m, n), dtype=torch.bfloat16, device=hidden_states.device)
+    _fp8w_gemv_kernel[(triton.cdiv(n, 32), 1)](
+        hidden_states,
+        w_q,
+        scale,
+        out,
+        m,
+        n,
+        k,
+        hidden_states.stride(0),
+        hidden_states.stride(1),
+        w_q.stride(0),
+        w_q.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_N=32,
+        BLOCK_K=128,
+        BLOCK_M=max(16, triton.next_power_of_2(m)),
+        SPLIT_K=1,
+        NUM_STAGES=4,
+        OUT_BF16=True,
+        num_warps=4,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Load-time replacement
+# ---------------------------------------------------------------------------
+# After replacement there is no bf16 fallback: the reader asserts fire instead
+# of reading freed memory.
+
+_SCALE_ATTR = "_sm120_rowwise_scale"
+
+
+def rowwise_scale_of(weight: torch.Tensor):
+    return getattr(weight, _SCALE_ATTR, None)
+
+
+def dequant_rowwise_weight(
+    weight: torch.Tensor, dtype: torch.dtype = torch.bfloat16
+) -> torch.Tensor:
+    """bf16 view of a replaced weight, for the prefill torch.compile paths."""
+    scale = rowwise_scale_of(weight)
+    assert scale is not None, "sm120 fp8 weight lost its rowwise scale"
+    return (weight.to(torch.float32) * scale[:, None]).to(dtype)
+
+
+_rowwise_load_stats = {"weights": 0, "bytes_avoided": 0}
+
+
+def rowwise_mix_enabled(params_dtype: torch.dtype) -> bool:
+    """True when HyperConnection mix projections should be born rowwise fp8.
+    Also false when CUDA is unavailable."""
+    return (
+        online_fp8_enabled
+        and params_dtype == torch.bfloat16
+        and torch.cuda.is_available()
+    )
+
+
+def _rowwise_ingest_weight(module, param, loaded_weight, *args, **kwargs) -> None:
+    """
+    weight_loader for a meta-born rowwise fp8 weight, bound to the module at attach.
+    The checkpoint shard is quantized on CPU with the same math as _quantize_rowwise_fp8 (the bf16-to-e4m3 cast is round-to-nearest-even on either host).
+
+    Replaces the whole Parameter because set_data cannot change dtype in place.
+
+    The draft head tie runs after load, so the new object is the one every reader sees.
+    """
+    assert param.shape == loaded_weight.shape, (
+        f"sm120 online FP8: checkpoint shard {tuple(loaded_weight.shape)} does not "
+        f"fit the rowwise meta weight {tuple(param.shape)}"
+    )
+    assert (
+        loaded_weight.dtype == torch.bfloat16
+    ), f"sm120 online FP8: rowwise ingest expects bf16, got {loaded_weight.dtype}"
+    cpu_w = loaded_weight if loaded_weight.device.type == "cpu" else loaded_weight.cpu()
+    w_q, scale = _quantize_rowwise_fp8(cpu_w)
+    device = torch.cuda.current_device()
+    new_param = torch.nn.Parameter(w_q.to(device), requires_grad=False)
+    setattr(new_param, _SCALE_ATTR, scale.to(device))
+    module.weight = new_param
+    _rowwise_load_stats["weights"] += 1
+    _rowwise_load_stats["bytes_avoided"] += (
+        loaded_weight.numel() * loaded_weight.element_size()
+    )
+
+
+def attach_rowwise_ingest(linears) -> int:
+    """Point each Linear's weight at the rowwise ingest loader.
+
+    Requires weights created with device="meta" and rejects a materialized
+    tensor, so a creation-site slip cannot leave a half-meta module behind.
+    """
+    attached = 0
+    for lin in linears:
+        weight = getattr(lin, "weight", None)
+        if not isinstance(weight, torch.nn.Parameter) or weight.dim() != 2:
+            return 0
+        if weight.device.type != "meta":
+            raise RuntimeError(
+                "sm120 online FP8: rowwise attach expects a meta-born weight, "
+                f"got a {weight.device} tensor (creation site did not request rowwise)"
+            )
+        if weight.dtype != torch.bfloat16:
+            raise RuntimeError(
+                f"sm120 online FP8: rowwise attach expects bf16 dtype, got {weight.dtype}"
+            )
+        weight.weight_loader = functools.partial(_rowwise_ingest_weight, lin)
+        attached += 1
+    return attached
+
+
+def replace_linears_with_fp8_copies(linears) -> int:
+    """
+    Swap each linear's bf16 weight for its rowwise fp8 quantization and return
+    the freed bf16 bytes. All-or-nothing: any ineligible weight or an in-flight graph capture
+    leaves every module untouched.
+    """
+    originals = []
+    for lin in linears:
+        weight = getattr(lin, "weight", None)
+        if (
+            not isinstance(weight, torch.nn.Parameter)
+            or weight.dim() != 2
+            or weight.dtype != torch.bfloat16
+            or not weight.is_cuda
+        ):
+            return 0
+        originals.append(weight.data)
+    if torch.cuda.is_current_stream_capturing():
+        return 0
+    freed = 0
+    for lin, original in zip(linears, originals):
+        w_q, scale = _quantize_rowwise_fp8(original)
+        param = torch.nn.Parameter(w_q, requires_grad=False)
+        setattr(param, _SCALE_ATTR, scale)
+        lin.weight = param
+        freed += original.numel() * original.element_size()
+    return freed
+
+
+# The bf16 original is gone after replacement, so prefill-row logits dequantize
+# row blocks at a time. The block caps the fp32 temp.
+_DEQUANT_ROWS = 8192
+
+
+def sm120_fp8_lm_head_logits(
+    hidden_states: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    """Logits from a replaced (rowwise fp8) lm_head weight."""
+    scale = rowwise_scale_of(weight)
+    assert scale is not None, (
+        "sm120 online FP8: fp8 lm_head weight without its rowwise scale "
+        "(replacement attaches it to the Parameter)"
+    )
+    m, k = hidden_states.shape
+    n = weight.shape[0]
+    out = torch.empty((m, n), dtype=torch.bfloat16, device=hidden_states.device)
+    if m <= _MAX_M:
+        _fp8w_gemv_kernel[(triton.cdiv(n, 32), 1)](
+            hidden_states,
+            weight,
+            scale,
+            out,
+            m,
+            n,
+            k,
+            hidden_states.stride(0),
+            hidden_states.stride(1),
+            weight.stride(0),
+            weight.stride(1),
+            out.stride(0),
+            out.stride(1),
+            BLOCK_N=32,
+            BLOCK_K=128,
+            BLOCK_M=max(16, triton.next_power_of_2(m)),
+            SPLIT_K=1,
+            NUM_STAGES=4,
+            OUT_BF16=True,
+            num_warps=4,
+        )
+        return out
+    block = max(1, min(_DEQUANT_ROWS, (64 * 1024 * 1024) // max(1, k * 4)))
+    for i in range(0, n, block):
+        w_bf = (
+            weight[i : i + block].to(torch.float32) * scale[i : i + block, None]
+        ).to(torch.bfloat16)
+        out[:, i : i + w_bf.shape[0]] = hidden_states @ w_bf.t()
+    return out

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -971,6 +971,9 @@ class Envs:
     # Enable the allowlisted low-M BF16 Split-K GEMM path on Blackwell. Shapes
     # outside the measured allowlist continue to use CuTe DSL/cuBLAS.
     SGLANG_ENABLE_BF16_SPLITK_GEMM = EnvBool(True)
+    # Opt in to SM120 online quantization of otherwise-unquantized Qwen4 weights:
+    # MXFP8 projections and rowwise FP8 HyperConnection / lm_head weights.
+    SGLANG_SM120_ONLINE_MXFP8 = EnvBool(False)
     # Route decode-size HC mix through the fused CuTe split-K GEMM pair
     # instead of the persistent Triton mix.
     SGLANG_HC_MIX_CUDA = EnvBool(True)

--- a/python/sglang/srt/layers/hc_mix_triton.py
+++ b/python/sglang/srt/layers/hc_mix_triton.py
@@ -48,6 +48,8 @@ def _hc_mix_persistent_kernel(
     t_raw_ptr,
     out_ptr,
     counters_ptr,
+    s_down_ptr,
+    s_up_ptr,
     K,
     LOWRANK,
     HS,
@@ -60,6 +62,7 @@ def _hc_mix_persistent_kernel(
     BLOCK_K: tl.constexpr,
     BLOCK_J: tl.constexpr,
     BLOCK_R: tl.constexpr,
+    FP8W: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs_m = tl.arange(0, ROWS)
@@ -92,7 +95,12 @@ def _hc_mix_persistent_kernel(
             mask=mask_n[:, None],
             other=0.0,
         )
+        if FP8W:
+            w = w.to(x_ptr.dtype.element_ty)
         acc = tl.dot(xt, tl.trans(w))
+        if FP8W:
+            s = tl.load(s_down_ptr + n, mask=mask_n, other=0.0)
+            acc = acc * s[None, :]
         tl.atomic_add(
             t_raw_ptr + offs_m[:, None] * LOWRANK + n[None, :],
             acc,
@@ -130,7 +138,12 @@ def _hc_mix_persistent_kernel(
                 mask=mask_gj[:, None] & mask_r[None, :],
                 other=0.0,
             )
+            if FP8W:
+                w = w.to(x_ptr.dtype.element_ty)
             acc = tl.dot(t, tl.trans(w), acc)
+        if FP8W:
+            s_up = tl.load(s_up_ptr + gj_flat, mask=mask_gj, other=0.0)
+            acc = acc * s_up[None, :]
         gate = tl.sigmoid(tl.reshape(acc, (ROWS, HC, BLOCK_J)))
         xg = tl.load(
             x_ptr
@@ -182,6 +195,19 @@ def _deterministic_inference() -> bool:
     return _deterministic_inference_cached
 
 
+def _fp8_pair_if_replaced(w_down: torch.Tensor, w_up: torch.Tensor):
+    """((w_q, s), (w_q, s)) when both weights are the replaced fp8 pair, else None."""
+    if not (w_down.dtype == torch.float8_e4m3fn and w_up.dtype == torch.float8_e4m3fn):
+        return None
+    from sglang.kernels.ops.gemm import sm120_online_fp8 as _gemm_mod
+
+    s_down = _gemm_mod.rowwise_scale_of(w_down)
+    s_up = _gemm_mod.rowwise_scale_of(w_up)
+    if s_down is None or s_up is None:
+        return None
+    return (w_down, s_down), (w_up, s_up)
+
+
 def fused_hc_mix_supported(
     hyper_input_normed: torch.Tensor, w_down: torch.Tensor, w_up: torch.Tensor
 ) -> bool:
@@ -189,18 +215,47 @@ def fused_hc_mix_supported(
     # device-scope atomics, so summation order varies across replays.
     if _deterministic_inference():
         return False
-    return (
+    if not (
         hyper_input_normed.is_cuda
         and hyper_input_normed.dtype in (torch.bfloat16, torch.float16)
-        and w_down.dtype == hyper_input_normed.dtype
-        and w_up.dtype == hyper_input_normed.dtype
         and hyper_input_normed.shape[0] <= _FUSED_MIX_MAX_ROWS
         and hyper_input_normed.dim() == 2
         and hyper_input_normed.shape[1] % 2048 == 0
         and hyper_input_normed.is_contiguous()
         and w_down.is_contiguous()
         and w_up.is_contiguous()
-    )
+    ):
+        return False
+    if (
+        w_down.dtype == hyper_input_normed.dtype
+        and w_up.dtype == hyper_input_normed.dtype
+    ):
+        return True
+    return _fp8_pair_if_replaced(w_down, w_up) is not None
+
+
+def _maybe_fp8_weights(w_down: torch.Tensor, w_up: torch.Tensor):
+    """
+    Per-row-scaled fp8 operands for the mix, or None for the bf16 path. The mix pair is born
+    rowwise fp8 at checkpoint ingest when rowwise_mix_enabled holds, so the common path serves
+    the module's own weights.
+
+    Otherwise the bf16 tensors quantize on first use and come from the sm120_online_fp8 weight cache.
+
+    Halves the weight bytes read per mix.
+    """
+    from sglang.kernels.ops.gemm import sm120_online_fp8 as _gemm_mod
+
+    if not _gemm_mod.online_fp8_enabled:
+        return None
+    replaced = _fp8_pair_if_replaced(w_down, w_up)
+    if replaced is not None:
+        return replaced
+    down = _gemm_mod._get_fp8_weight(w_down)
+    up = _gemm_mod._get_fp8_weight(w_up)
+    if down is None or up is None:
+        return None
+    return down, up
 
 
 def fused_hc_mix(
@@ -219,13 +274,21 @@ def fused_hc_mix(
     out = torch.empty((rows, hs), dtype=hyper_input_normed.dtype, device=device)
     if rows == 0:
         return out
+    fp8 = _maybe_fp8_weights(w_down, w_up)
+    if fp8 is not None:
+        (w_down_run, s_down), (w_up_run, s_up) = fp8
+    else:
+        w_down_run, s_down = w_down, w_down  # dummy ptrs, unused when FP8W=False
+        w_up_run, s_up = w_up, w_up
     _hc_mix_persistent_kernel[(num_ctas,)](
         hyper_input_normed,
-        w_down,
-        w_up,
+        w_down_run,
+        w_up_run,
         t_raw,
         out,
         _get_counters(device),
+        s_down,
+        s_up,
         k,
         lowrank,
         hs,
@@ -238,6 +301,7 @@ def fused_hc_mix(
         BLOCK_K=256,
         BLOCK_J=32,
         BLOCK_R=64,
+        FP8W=fp8 is not None,
         num_warps=8,
     )
     return out

--- a/python/sglang/srt/layers/hyperconnection.py
+++ b/python/sglang/srt/layers/hyperconnection.py
@@ -135,28 +135,41 @@ class GatedResidual(HyperConnectionBase):
         )
 
         if use_mix:
+            # sm120 online FP8: the mix pair is created on meta and the checkpoint shards
+            # quantize into rowwise fp8 on the way in, so no bf16 mix bytes occupy device
+            # memory. The bf16 combine weight shares their allocator segment, and a segment
+            # unmaps only when fully free: a materialized pair freed beside it would keep
+            # the whole segment mapped.
+            from sglang.kernels.ops.gemm import sm120_online_fp8 as _online_mod
+
+            _rowwise = _online_mod.rowwise_mix_enabled(config.params_dtype)
+            _mix_device = "meta" if _rowwise else torch.cuda.current_device()
             self.input_mix_weight_down = nn.Linear(
                 self.hidden_size * self.hc_count,
                 self.config.hc_lowrank,
                 bias=False,
-                device=torch.cuda.current_device(),
+                device=_mix_device,
                 dtype=config.params_dtype,
             )
             self.input_mix_weight_up = nn.Linear(
                 self.config.hc_lowrank,
                 self.hc_count * self.hidden_size,
                 bias=False,
-                device=torch.cuda.current_device(),
+                device=_mix_device,
                 dtype=config.params_dtype,
             )
+            if _rowwise:
+                _online_mod.attach_rowwise_ingest(
+                    [self.input_mix_weight_down, self.input_mix_weight_up]
+                )
             from sglang.srt.environ import envs
 
             lowrank = self.config.hc_lowrank
             self._jit_mix_ok = (
                 envs.SGLANG_HC_MIX_CUDA.get()
                 and torch.cuda.is_available()
-                # The CuTe split-K pair is tcgen05 (sm_100 family) only; the
-                # default-on env must not route Hopper/Ada to it.
+                # The CuTe split-K pair is tcgen05 (sm_100 family) only. The default-on env
+                # must not route Hopper/Ada to it.
                 and torch.cuda.get_device_capability()[0] == 10
                 and (self.hc_count * self.hidden_size) % 2048 == 0
                 and self.hidden_size % 8 == 0
@@ -277,10 +290,21 @@ class GatedResidual(HyperConnectionBase):
                 self.hidden_size,
             ).to(self.params_dtype)
         else:
+            w_down = self.input_mix_weight_down.weight
+            w_up = self.input_mix_weight_up.weight
+            if w_down.dtype == torch.float8_e4m3fn:
+                # sm120 online FP8 replacement: prefill rows re-materialize the bf16 operands the torch.compile path expects, row blocks
+                # at a time, from the fp8 pair that stayed resident.
+                from sglang.kernels.ops.gemm.sm120_online_fp8 import (
+                    dequant_rowwise_weight,
+                )
+
+                w_down = dequant_rowwise_weight(w_down, hyper_input_normed.dtype)
+                w_up = dequant_rowwise_weight(w_up, hyper_input_normed.dtype)
             mixed_input = self._mix_compute(
                 hyper_input_normed,
-                self.input_mix_weight_down.weight,
-                self.input_mix_weight_up.weight,
+                w_down,
+                w_up,
                 self.hc_count,
                 self.hidden_size,
             ).to(self.params_dtype)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -737,9 +737,30 @@ class LogitsProcessor(nn.Module):
                     hidden_states.bfloat16(), lm_head.weight.T.bfloat16()
                 )
             else:
-                logits = torch.matmul(
-                    hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
-                )
+                weight = lm_head.weight
+                logits = None
+                if weight.is_cuda and weight.dtype == torch.bfloat16:
+                    from sglang.kernels.ops.gemm.sm120_online_fp8 import (
+                        maybe_sm120_fp8_lm_head,
+                    )
+
+                    logits = maybe_sm120_fp8_lm_head(
+                        hidden_states.to(weight.dtype), weight
+                    )
+                elif weight.dtype == torch.float8_e4m3fn:
+                    # Replaced (sm120 online FP8) or serialized-fp8 lm_head: the scale rides on the weight Parameter, so the NEXTN
+                    # draft that shares the target head reads the same pair.
+                    from sglang.kernels.ops.gemm.sm120_online_fp8 import (
+                        rowwise_scale_of,
+                        sm120_fp8_lm_head_logits,
+                    )
+
+                    if rowwise_scale_of(weight) is not None:
+                        logits = sm120_fp8_lm_head_logits(
+                            hidden_states.bfloat16(), weight
+                        )
+                if logits is None:
+                    logits = torch.matmul(hidden_states.to(weight.dtype), weight.T)
         else:
             # GGUF models
             # TODO: use weight_packed_linear for GGUF models

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -548,6 +548,13 @@ def resolve_mxfp8_dense_gemm_backend() -> Mxfp8DenseGemmBackend:
         return Mxfp8DenseGemmBackend.FLASHINFER_TRTLLM
 
     if backend.is_flashinfer_cutedsl():
+        # SM120/SM121 use the CUTLASS MXFP8 implementation.
+        if get_device_sm() in (120, 121):
+            logger.info(
+                "MXFP8 dense GEMM: --fp8-gemm-backend=flashinfer_cutedsl has no "
+                "kernel for SM120/SM121; using the CUTLASS path."
+            )
+            return Mxfp8DenseGemmBackend.FLASHINFER_CUTLASS
         if not (
             is_blackwell_supported()
             and is_flashinfer_available()

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -195,6 +195,18 @@ def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
         _enable_bf16_splitk_gemm = True
         _precompile_splitk_tactics()
 
+    if (
+        envs.SGLANG_SM120_ONLINE_MXFP8.get()
+        and _is_cuda
+        and torch.cuda.get_device_capability() == (12, 0)
+    ):
+        from sglang.kernels.ops.gemm import sm120_online_fp8 as _online_mod
+
+        _online_mod.online_fp8_enabled = True
+        logger.info(
+            "[mratsim's sm120-turbo r22] SM120 online FP8 enabled (HyperConnection mix pair born meta and ingested rowwise fp8, lm_head replaced at end of load)"
+        )
+
     _BF16_GEMM_BACKEND = backend
 
 

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -774,11 +774,15 @@ def _gather_ple_embedding_from_pinned_kernel(
     )
 
 
+# e2m1 values indexed by 4-bit code: a packed PLE byte dequantizes as lut[low nibble]
+# and lut[high nibble].
+
+
 class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
     """PLE table read directly from host memory (pinned, or a file-backed mmap).
 
-    The table stays in its checkpoint storage dtype (fp8 with a per-tensor
-    weight_scale for fp8 checkpoints, bf16 otherwise); gathers emit bf16.
+    The table stays in its checkpoint storage dtype
+    (fp8 with a per-tensor weight_scale for fp8 checkpoints, bf16 otherwise). Gathers emit bf16.
     """
 
     _COPIED_ATTRIBUTES = (
@@ -1268,6 +1272,26 @@ class Qwen4ExpPLELayer(nn.Module):
         return _pad_token_rows(output, batch.physical_tokens)
 
 
+_ONLINE_MXFP8_METHOD = None
+_ONLINE_MXFP8_RESOLVED = False
+
+
+def _build_mxfp8_linear_method():
+    """An Fp8LinearMethod serving bf16 linears as MXFP8 (dynamic activation)."""
+    from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+
+    return Fp8LinearMethod(
+        Fp8Config(
+            is_checkpoint_fp8_serialized=False,
+            activation_scheme="dynamic",
+            use_mxfp8=True,
+        )
+    )
+
+
+_ONLINE_MXFP8_LOGGED = False
+
+
 class Qwen4ExpLayerExtensionMixin:
     def _init_qwen4_exp_layer_extensions(
         self,
@@ -1322,6 +1346,91 @@ class Qwen4ExpLayerExtensionMixin:
             use_mix=True,
             use_combine=True,
         )
+        self._maybe_convert_linears_to_mxfp8()
+
+    def _maybe_convert_linears_to_mxfp8(self) -> None:
+        """Serve this layer's unquantized bf16 linears as online MXFP8 on sm120.
+
+        With SGLANG_SM120_ONLINE_MXFP8 set, every linear that would run unquantized gets
+        MXFP8 weights: e4m3 with a UE8M0 scale per 32 elements, quantized during
+        process_weights_after_loading and served by flashinfer's block-scale GEMM.
+        Covers attention projections, the dense MLP and the HyperConnection projections.
+        """
+        global _ONLINE_MXFP8_METHOD, _ONLINE_MXFP8_RESOLVED, _ONLINE_MXFP8_LOGGED
+        import logging
+
+        from sglang.srt.environ import envs
+
+        if not envs.SGLANG_SM120_ONLINE_MXFP8.get():
+            return
+
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+        from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+
+        candidates = []
+        for name, module in self.named_modules():
+            # MoE experts and the router gate stay out: experts are NVFP4 already
+            # in both supported checkpoints, and the router is tiny plus load-balance sensitive (keep its topk ranking exact).
+            if name.endswith(".gate") or isinstance(module, FusedMoE):
+                continue
+            if not isinstance(
+                getattr(module, "quant_method", None), UnquantizedLinearMethod
+            ):
+                continue
+            weight = getattr(module, "weight", None)
+            if (
+                not isinstance(weight, torch.nn.Parameter)
+                or weight.dim() != 2
+                or weight.shape[1] % 32
+                or weight.dtype != torch.bfloat16
+            ):
+                continue
+            # The block-scale kernels refuse small problems: the CUTLASS MXFP8 GEMM needs n
+            # and k >= 128 (in_proj_ba ships n=96), and a GEMV of that size gains nothing from quantizing.
+            if weight.shape[0] < 128 or weight.shape[1] < 128:
+                continue
+            candidates.append(module)
+
+        if not _ONLINE_MXFP8_RESOLVED:
+            _ONLINE_MXFP8_RESOLVED = True
+            quant_method = None
+            try:
+                from sglang.srt.utils import is_sm120_supported
+
+                if is_sm120_supported():
+                    quant_method = _build_mxfp8_linear_method()
+                    backend = quant_method.mxfp8_dense_backend
+                    if backend is None or backend.is_unsupported():
+                        quant_method = None
+            except RuntimeError as exc:
+                # The kernel-side capability probe raises RuntimeError for a genuine decline
+                # (no MXFP8 dense kernel for this device). Any other type is a bug in this path
+                # and must crash: staying bf16 silently would hide it.
+                logging.getLogger(__name__).warning(
+                    "[mratsim's sm120-turbo r22] sm120 online MXFP8 unavailable (%s); unquantized "
+                    "linears stay bf16",
+                    exc,
+                )
+                quant_method = None
+            _ONLINE_MXFP8_METHOD = quant_method
+
+        quant_method = _ONLINE_MXFP8_METHOD
+        if quant_method is None:
+            return
+        for module in candidates:
+            weight = getattr(module, "weight", None)
+            if not isinstance(weight, torch.nn.Parameter):
+                continue
+            if weight.dtype != torch.bfloat16:
+                continue
+            module.quant_method = quant_method
+            if not _ONLINE_MXFP8_LOGGED:
+                _ONLINE_MXFP8_LOGGED = True
+                logging.getLogger(__name__).info(
+                    "[mratsim's sm120-turbo r22] sm120 online MXFP8: unquantized linears quantize at "
+                    "load (dense backend=%s)",
+                    quant_method.mxfp8_dense_backend,
+                )
 
     def _prepare_qwen4_exp_attn(
         self,
@@ -1826,6 +1935,73 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         loaded_buffers.add(name)
         return True
 
+    def _log_weight_dtype_census(self):
+        """Log one line per distinct (module family, class, quant method, dtype) combination among
+        resident 2-D weights. The census shows which quant method each module family ended
+        with, so the boot log distinguishes a skipped conversion from an intended bf16 family.
+        """
+        from collections import Counter
+
+        from sglang.kernels.ops.gemm import sm120_online_fp8 as _online
+
+        counts: Counter = Counter()
+        for mod_name, module in self.named_modules():
+            weight = getattr(module, "weight", None)
+            if (
+                weight is None
+                or not isinstance(weight, torch.Tensor)
+                or weight.dim() != 2
+            ):
+                continue
+            method = type(getattr(module, "quant_method", None)).__name__
+            if _online.rowwise_scale_of(weight) is not None:
+                method = "RowwiseFp8"
+            family = ".".join(mod_name.split(".")[:2]) or mod_name
+            counts[(family, type(module).__name__, method, str(weight.dtype))] += 1
+        for (family, cls, method, dtype), n in sorted(counts.items()):
+            logger.info(
+                "[mratsim's sm120-turbo r22] weights %s x%s %s %s x%d",
+                family,
+                cls,
+                method,
+                dtype,
+                n,
+            )
+
+    def post_load_weights(self) -> None:
+        """
+        Replace deferred online-FP8 conversion with resident fp8 weights.
+
+        Runs before CUDA graph capture and before KV pool sizing, so the bytes freed here return
+        to the allocator cache before the pool takes its budget.
+
+        The HyperConnection mix pair is already fp8 (ingested at load), which leaves the lm_head
+        as the only module quantized here.
+
+        Readers are the LogitsProcessor fp8 branch and the draft head that shares
+        this Parameter through set_embed_and_head. Both read the rowwise scale
+        attribute, so the assert fires when a new reader path finds it absent.
+        """
+        from sglang.kernels.ops.gemm import sm120_online_fp8 as _online
+
+        if not _online.online_fp8_enabled:
+            return
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+
+        freed = 0
+        for module in self.modules():
+            if isinstance(module, ParallelLMHead):
+                freed += _online.replace_linears_with_fp8_copies([module])
+        torch.cuda.empty_cache()
+        logger.info(
+            "[mratsim's sm120-turbo r22] sm120 online FP8 replace: %d weights "
+            "rowwise-fp8 at load (%.2f GiB bf16 never materialized), freed "
+            "%.2f GiB (lm_head); the rowwise fp8 tensors are the resident weights",
+            _online._rowwise_load_stats["weights"],
+            _online._rowwise_load_stats["bytes_avoided"] / 2**30,
+            freed / 2**30,
+        )
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
@@ -1937,7 +2113,7 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                         'text_config.ple_embedding_dtype="float8_e4m3fn" instead'
                     )
                 logger.info(
-                    "PLE embedding switched to fp8 storage: %s (%s)",
+                    "[mratsim's sm120-turbo r22] PLE embedding switched to fp8 storage: %s (%s)",
                     mod_prefix,
                     tuple(emb.weight.data.shape),
                 )
@@ -1960,7 +2136,7 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 if not getattr(load_qwen4_exp_ple_shard, "_warned_downcast", False):
                     load_qwen4_exp_ple_shard._warned_downcast = True
                     logger.warning(
-                        "PLE checkpoint shards are %s but the embedding storage "
+                        "[mratsim's sm120-turbo r22] PLE checkpoint shards are %s but the embedding storage "
                         "is fp8 (ple_embedding_dtype / fp8 quant config); "
                         "downcasting is lossy",
                         loaded_weight.dtype,
@@ -2164,6 +2340,12 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         for module in self.modules():
             if isinstance(module, Qwen3_5GatedDeltaNet):
                 module.finalize_fused_in_proj()
+
+        # sglang's serial loader does not call _post_load_weights
+        # (its other call sites serve capture, dummy, sharded, and remote-instance loads), so the model
+        # fires the hook itself.
+        self.post_load_weights()
+        self._log_weight_dtype_census()
 
         return loaded_params
 

--- a/test/registered/unit/layers/quantization/test_sm120_online_fp8.py
+++ b/test/registered/unit/layers/quantization/test_sm120_online_fp8.py
@@ -1,0 +1,55 @@
+"""Numerical and parameter-lifetime coverage for online rowwise FP8 weights."""
+
+import unittest
+import weakref
+
+import torch
+
+from sglang.kernels.ops.gemm import sm120_online_fp8 as fp8
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestOnlineFP8(CustomTestCase):
+    def test_rowwise_quantization_handles_zero_and_signed_rows(self):
+        weight = torch.tensor([[0, 0, 0, 0], [1, -2, 3, -4]], dtype=torch.bfloat16)
+        quant, scale = fp8._quantize_rowwise_fp8(weight)
+        self.assertEqual(quant.dtype, torch.float8_e4m3fn)
+        self.assertTrue(torch.isfinite(scale).all())
+        torch.testing.assert_close(
+            quant.float() * scale[:, None], weight.float(), rtol=0.05, atol=0.01
+        )
+
+    def test_replaced_head_releases_original_and_preserves_logits(self):
+        torch.manual_seed(0)
+        linear = torch.nn.Linear(
+            128, 64, bias=False, device="cuda", dtype=torch.bfloat16
+        )
+        old_weight = weakref.ref(linear.weight)
+        original = linear.weight.detach().clone()
+        freed = fp8.replace_linears_with_fp8_copies([linear])
+        self.assertEqual(freed, original.numel() * original.element_size())
+        self.assertIsNone(old_weight())
+        self.assertIsNotNone(fp8.rowwise_scale_of(linear.weight))
+        for rows in (1, 8, 32, 33):
+            with self.subTest(rows=rows):
+                hidden = torch.randn(rows, 128, device="cuda", dtype=torch.bfloat16)
+                actual = fp8.sm120_fp8_lm_head_logits(hidden, linear.weight)
+                # Decode scales the accumulated dot; prefill reconstructs BF16 weights.
+                if rows <= 32:
+                    reference = (
+                        (hidden.float() @ linear.weight.float().t())
+                        * fp8.rowwise_scale_of(linear.weight)[None, :]
+                    ).to(torch.bfloat16)
+                else:
+                    reference = hidden @ fp8.dequant_rowwise_weight(linear.weight).t()
+                torch.testing.assert_close(actual, reference, rtol=0.02, atol=0.02)
+                baseline = (hidden @ original.t()).float()
+                relative_error = (actual.float() - baseline).norm() / baseline.norm()
+                self.assertLess(relative_error.item(), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Draft for upstream design and numerical review: bring turbo's online FP8 handling of otherwise-unquantized Qwen4 weights to SM120. Large projections use MXFP8; HyperConnection mix and the shared LM head use rowwise FP8 storage.

## Modifications

- Add `SGLANG_SM120_ONLINE_MXFP8=1` as an explicit opt-in; unlike the serving-oriented source patch, it defaults to false here.
- Convert eligible dense projections at loading, ingest meta-born HyperConnection weights rowwise, and replace the LM head with scaled FP8 weights.
- Handle the shared target/draft head and both decode and prefill readers.
- Add SM120/SM121 CUTLASS selection for the source patch's MXFP8 backend compatibility case.

Base: `qwen4-main-squashed` `4ccff141dbe992794f9da6c3aa23535b4f72000d`. The reference-lifetime fix, RecoverSSM, FP8 KV, and machine-specific deployment settings are separate and are not included here.

## Accuracy Tests

Fresh base-image container with this PR's files only, RTX PRO 6000:

```text
pytest -q test/registered/unit/layers/quantization/test_sm120_online_fp8.py
2 passed, 4 logits-shape subcases passed.
```

Coverage includes zero/signed rows, quantization scales, release of the replaced Parameter, scale attachment, and logits at row counts 1/8/32/33. Logits are compared with the corresponding quantized reference; a seeded small-matrix BF16 comparison also checks relative L2 error below 5%. This covers the rowwise path, not end-to-end model accuracy or dense MXFP8 correctness across all shapes.

## Speed Tests and Profiling

The combined deployed stack loaded the NVIDIA ModelOpt checkpoint and completed JSON generation, ten concurrent 32K-input requests, and one 240K-input request. Those are integration smoke results with additional patches. No isolated model-accuracy or throughput improvement is claimed for this draft.

## Before marking ready

Changed-file pre-commit checks, including registered-test validation, passed locally.

- Add full-model BF16/FP8 accuracy comparisons and matched-cache throughput measurements.
- Validate dense MXFP8, HyperConnection, MTP head sharing, graph capture, TP/PP, and unsupported-device behavior.
- Review the lazy FP8 cache's ownership/invalidation for allocator address reuse and weight updates.
- Agree on explicit backend fallback semantics and FlashInfer version requirements.
- Reduce serving-specific diagnostics and review general-purpose placement of the model hooks with maintainers.

## Attribution

Companion PR #38487 currently hits the repository-wide `main` rebase gate (required commit `a5f07b1241fc`) and missing `run-ci` label. This draft intentionally targets the Qwen4 branch and does not request a gate bypass or large-scale CI before the design is agreed.

Adapted from `0003-sm120-online-fp8.patch` in [mratsim/sglang-qwen38fn-sm120-turbo](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo), including the NVIDIA next-local compatibility adaptation described in [turbo PR #6](https://github.com/mratsim/sglang-qwen38fn-sm120-turbo/pull/6).

Thank you to [Mamy Ratsimbazafy (mratsim)](https://github.com/mratsim) for the original online FP8 kernels, weight-loading design, and SM120 serving optimizations. His contribution is retained in the commit's co-author attribution and the source's Apache-2.0 licensing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34858591391](https://github.com/sgl-project/sglang/actions/runs/34858591391)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34858585800](https://github.com/sgl-project/sglang/actions/runs/34858585800)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34858591313](https://github.com/sgl-project/sglang/actions/runs/34858591313)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->