### PR TITLE
[Scheduler] Opt-in NO_TOKEN admission lookahead with head-prefix pinning

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -584,6 +584,27 @@ class Envs:
     # Internal/testing only - users should not need to change this.
     SGLANG_PREFILL_TILE_BUDGET_MODE = EnvStr("compact")
     SGLANG_PREFILL_DELAYER_MAX_PREFILL_BS_WINDOW_SIZE = EnvInt(16)
+    # NO_TOKEN admission lookahead: when the waiting-queue head is rejected
+    # with NO_TOKEN, keep scanning up to this many further requests in the
+    # same pass instead of breaking. A candidate clears add_one_req's normal
+    # KV budget gate (free + evictable) while the blocked head's matched
+    # prefix is pinned with a tree lock for as long as it stays the blocked
+    # head, so an intruder may evict cold cache (the LRU would have taken it
+    # anyway) but never the head's own prefix. 0 keeps the baseline break.
+    SGLANG_PREFILL_NO_TOKEN_LOOKAHEAD = EnvInt(0)
+    # Starvation bound for the above: once the same head request has been
+    # NO_TOKEN-rejected in more than this many consecutive admission passes,
+    # lookahead is suppressed from that pass on until the head changes or is
+    # admitted.
+    SGLANG_PREFILL_LOOKAHEAD_AGING_PASSES = EnvInt(20)
+    # Allocator headroom the head-prefix pin must leave behind, in full-KV
+    # tokens. An in-flight chunked request allocates its next chunk from
+    # (available + evictable) at batch-run time without passing through the
+    # admission budget, so a pin that swallows the evictable pool leaves it
+    # nothing to evict and crashes the scheduler with "Prefill out of memory".
+    # Unset or 0 reserves max_prefill_tokens (one whole extend); a negative
+    # value raises at scheduler startup rather than silently disabling the gate.
+    SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS = EnvInt(0)
 
     # ===================================================================
     # Scheduler polling, timeouts, and output

--- a/python/sglang/srt/managers/prefill_lookahead.py
+++ b/python/sglang/srt/managers/prefill_lookahead.py
@@ -1,0 +1,397 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Starvation bookkeeping and head-prefix pinning for the prefill admission
+NO_TOKEN lookahead.
+
+Kept free of any sglang import so the policy can be unit-tested without a
+runtime (see test/registered/unit/managers/test_prefill_lookahead.py). The tree
+cache is injected into :class:`HeadPrefixLock` and used through duck typing
+(``inc_lock_ref`` / ``dec_lock_ref`` / ``is_tree_cache``) for the same reason.
+"""
+
+from typing import Any, Callable, Container, Optional, Tuple
+
+# Outcome of :meth:`HeadPrefixLock.sync_head`. The boolean `acquire` returns
+# only separates "locked" from "did not lock"; the scheduler additionally has to
+# tell a no-op refresh apart from a pin the capacity gate refused, because the
+# latter must also suppress the pass's lookahead.
+HEADLOCK_SYNC_IDLE = "idle"
+HEADLOCK_SYNC_HELD = "held"
+HEADLOCK_SYNC_PINNED = "pinned"
+HEADLOCK_SYNC_RELEASED = "released"
+HEADLOCK_SYNC_DENIED_CAPACITY = "denied_capacity"
+
+
+def normalize_headlock_reserve_tokens(value: Optional[int], default: int) -> int:
+    """Validate SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS against ``default``.
+
+    Unset or 0 keeps ``default`` (the scheduler's ``max_prefill_tokens``, the
+    largest extend one batch can ask the allocator for). A negative override
+    would switch the capacity gate off while still reading as configured, so it
+    fails startup here: the env layer downgrades a parse error to a warning plus
+    the default, which would silently run with the gate disabled.
+    """
+    if not value:
+        return max(0, default)
+    if value < 0:
+        raise ValueError(
+            "SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS must be a positive int "
+            f"(unset or 0 uses max_prefill_tokens), got {value!r}"
+        )
+    return value
+
+
+class PrefillLookaheadState:
+    """Scheduler-lifetime state for the waiting-queue admission lookahead.
+
+    Only tracks the *head* of the scan (the first request actually offered to
+    the ``PrefillAdder`` in a pass). Its consecutive-NO_TOKEN age is the
+    starvation signal: once it exceeds ``aging_passes`` the scheduler stops
+    letting later requests jump ahead, which on a prefill-only node is
+    equivalent to reserving KV for the head — admission is the only consumer of
+    freshly released KV there, so refusing to admit anyone else *is* the
+    reservation.
+    """
+
+    def __init__(self, max_candidates: int, aging_passes: int):
+        self.max_candidates = max(0, max_candidates)
+        self.aging_passes = max(0, aging_passes)
+        self.head_rid: Optional[str] = None
+        self.head_age: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_candidates > 0
+
+    @property
+    def uses_head_lock(self) -> bool:
+        """Whether an engaged lookahead pins the blocked head's prefix and lets
+        candidates through the ordinary (free + evictable) budget gate. Always
+        the case once lookahead is on; env=0 builds no lock at all."""
+        return self.enabled
+
+    def observe_head(self, head_rid: str, rejected_no_token: bool) -> int:
+        """Fold this pass's head verdict into the age and return the new age.
+
+        A head that got in, or that failed for a non-KV reason, clears the
+        counter; so does a change of head, since the previous head is no longer
+        the one being starved.
+        """
+        if not rejected_no_token:
+            self.head_rid = None
+            self.head_age = 0
+        elif self.head_rid == head_rid:
+            self.head_age += 1
+        else:
+            self.head_rid = head_rid
+            self.head_age = 1
+        return self.head_age
+
+    @property
+    def aged_out(self) -> bool:
+        """True once the current head has been starved for more passes than
+        allowed, i.e. lookahead must stay off for this pass and the ones after
+        it until the head changes or is admitted."""
+        return self.head_age > self.aging_passes
+
+
+class HeadPrefixLock:
+    """A single-slot tree lock pinning the KV-blocked queue head's prefix.
+
+    Why it exists: a lookahead candidate is admitted through ``add_one_req``'s
+    ordinary budget, whose headroom includes *evictable* KV. In a warm cache
+    that is the only headroom there is, so a free-page-only gate (the first
+    version of this lookahead) admitted nobody. Letting a candidate evict is fine for cold
+    entries — the LRU was going to take them anyway — but not for the prefix the
+    blocked head already matched (and possibly loaded back from host), because
+    losing it turns the head's next pass into a longer prefill, which is the
+    opposite of head-of-line relief. So while the head is blocked we hold a
+    normal ``inc_lock_ref`` on its matched node, which the tree treats exactly
+    like a running request's lock: the whole device-resident chain from that node
+    up to root leaves the evictable leaf set and cannot be evicted or dropped.
+
+    Why a single slot: every extra held lock shrinks the evictable pool that the
+    *other* admissions draw on, so pinning more than the one request we are
+    protecting would trade this head's stall for everyone else's.
+
+    Why the capacity gate: an in-flight chunked request allocates its next chunk
+    straight out of ``available + evictable`` when the batch runs and never
+    passes through the admission budget, so it relies on eviction at alloc time.
+    A pin big enough to swallow the evictable pool leaves it nothing to evict and
+    turns that allocation into ``Prefill out of memory``, which kills the
+    scheduler process. A pin is therefore taken only while ``available +
+    evictable - pin >= reserve_tokens`` (one full ``max_prefill_tokens`` extend),
+    and a lock already held is dropped by :meth:`reconcile` once headroom falls
+    under the reserve. Losing the pin degrades this head to stock admission for
+    as long as the pressure lasts; losing the allocation ends the engine.
+
+    Lifetime is deliberately longer than a pass — an admitted candidate does not
+    allocate its KV until the batch runs — so correctness rests on reconciliation
+    rather than on unwinding every exit path: :meth:`reconcile` runs at the top of
+    each admission pass and drops a lock whose request has left the waiting queue,
+    and :meth:`sync_head` drops or moves it the moment the head changes, is
+    admitted, or re-matches to a different node. Any leak therefore survives at
+    most one pass.
+
+    ``tree_cache`` is duck-typed (``inc_lock_ref`` / ``dec_lock_ref`` /
+    ``is_tree_cache``) so this module keeps its zero-sglang-import property; every
+    implementation in mem_cache/ takes ``(node, params)`` positionally, so no
+    per-class adapter is needed.
+    """
+
+    def __init__(
+        self,
+        tree_cache: Any,
+        logger: Any = None,
+        headroom_fn: Optional[Callable[[], Tuple[int, int]]] = None,
+        reserve_tokens: int = 0,
+    ):
+        self.tree_cache = tree_cache
+        self.logger = logger
+        # Returns (allocator-free, tree-evictable) tokens of the pool an extend
+        # allocates from, split so the skip trace can report both halves. Read
+        # live, never cached: the whole point is what the allocator would see.
+        # None, or a non-positive reserve, leaves the capacity gate off.
+        self.headroom_fn = headroom_fn
+        self.reserve_tokens = max(0, reserve_tokens)
+        # Slot contents; all four move together.
+        self.rid: Optional[str] = None
+        self.node: Any = None
+        self._dec_params: Any = None
+        self.tokens: int = 0
+        # Last acquire attempt, for the caller: the outcome drives this pass's
+        # lookahead, and the two sizes drive the pass's admission budget.
+        self.last_outcome: str = HEADLOCK_SYNC_IDLE
+        self.last_pin_tokens: int = 0
+        self.last_pin_unaccounted: int = 0
+
+    @property
+    def held(self) -> bool:
+        return self.rid is not None
+
+    @property
+    def locked_tokens(self) -> int:
+        """Prefix tokens the current lock covers; 0 when nothing is held.
+
+        This is the matched prefix length, not the eviction-accounting delta:
+        the delta is 0 whenever a running request already protects the same
+        chain, which would make the trace field read as "no lock" while a lock
+        is very much held.
+        """
+        return self.tokens if self.held else 0
+
+    def _debug(self, event: str, rid: Optional[str], tokens: int, reason: str) -> None:
+        if self.logger is None:
+            return
+        self.logger.debug(
+            "prefill_lookahead head lock %s rid=%s tokens=%d reason=%s",
+            event,
+            rid,
+            tokens,
+            reason,
+        )
+
+    def _capacity_allows_pin(self, rid: str, pin_tokens: int) -> bool:
+        """Whether ``pin_tokens`` can leave the evictable set and still leave one
+        ``reserve_tokens`` extend behind for the allocator.
+
+        ``pin_tokens`` is the matched prefix length, an OVER-estimate of what the
+        pin actually takes out of the evictable set (a chain a running request
+        already locks costs nothing), and a lock being refreshed is given no
+        credit for the reference it is about to drop. Both errors point at "skip
+        the pin", which is the side that cannot crash an allocation.
+        """
+        if self.headroom_fn is None or self.reserve_tokens <= 0:
+            return True
+        available, evictable = self.headroom_fn()
+        if available + evictable - pin_tokens >= self.reserve_tokens:
+            return True
+        if self.logger is not None:
+            self.logger.debug(
+                "prefill_lookahead head lock skip rid=%s tokens=%d "
+                "reason=capacity free=%d evictable=%d reserve=%d",
+                rid,
+                pin_tokens,
+                available,
+                evictable,
+                self.reserve_tokens,
+            )
+        return False
+
+    def _headroom_under_reserve(self) -> bool:
+        """Whether the pool can no longer serve one ``reserve_tokens`` extend,
+        with the held lock still counted out of the evictable half."""
+        if self.headroom_fn is None or self.reserve_tokens <= 0:
+            return False
+        available, evictable = self.headroom_fn()
+        return available + evictable < self.reserve_tokens
+
+    def _record_pin(self, result: Any, tokens: int, evictable_before: Any) -> None:
+        """Size the pin just taken, twice, for the pass's admission budget.
+
+        ``last_pin_tokens`` is the evictable -> locked transition: ``delta`` is
+        that amount exactly (0 when a running request already protects the
+        chain), and a cache that leaves it unset (swa_radix_cache,
+        mamba_radix_cache, radix_cache_cpp) falls back to the conservative full
+        prefix. ``abs``, because the sign is not a convention: RadixCache and
+        HiRadixCache report the move as negative while UnifiedRadixCache's FULL
+        component reports the same move as positive.
+
+        ``last_pin_unaccounted`` is the part of it the tree did NOT already take
+        out of its own evictable size — 0 for every cache in mem_cache/, because
+        ``inc_lock_ref`` moves those tokens itself and the admission budget reads
+        that live, so charging the pin on top would double-count it and deny
+        every later candidate in the pass.
+        """
+        delta = getattr(result, "delta", None) if result is not None else None
+        self.last_pin_tokens = tokens if delta is None else abs(delta)
+        if evictable_before is None:
+            self.last_pin_unaccounted = self.last_pin_tokens
+            return
+        moved = evictable_before - self.headroom_fn()[1]
+        self.last_pin_unaccounted = max(0, self.last_pin_tokens - moved)
+
+    def acquire(self, rid: str, node: Any, tokens: int = 0, reason: str = "") -> bool:
+        """Pin ``node``'s prefix chain for ``rid``. Returns True if a new lock
+        was taken, and records the attempt in ``last_outcome`` either way.
+
+        Idempotent for the request/node pair already held, so a head that stays
+        blocked over many passes never stacks references. A different rid or a
+        different node releases the old slot first — the two calls are adjacent
+        in the scheduler thread, so nothing can evict the shared ancestors in
+        between.
+        """
+        # `==`, not `is`: a node handle is a NodeId (a plain int) for
+        # UnifiedRadixCache and a TreeNode object elsewhere. No TreeNode defines
+        # __eq__, so `==` is identity for objects, while `is` on an int id above
+        # CPython's small-int cache would spuriously read as "changed" and churn
+        # the lock every pass.
+        if self.held and self.rid == rid and self.node == node:
+            # Same head, same match: keep the reference we already hold and just
+            # refresh the reported size. Not gated on capacity — no new tokens
+            # leave the evictable set, and the held lock is reconcile's problem.
+            self.tokens = tokens
+            self.last_outcome = HEADLOCK_SYNC_HELD
+            return False
+        if not self._capacity_allows_pin(rid, tokens):
+            # Slot deliberately untouched: a refresh we are not allowed to re-take
+            # keeps the reference it already holds rather than dropping the head's
+            # protection on the way to a pin that is not going to happen.
+            self.last_outcome = HEADLOCK_SYNC_DENIED_CAPACITY
+            return False
+        if self.held:
+            # Same head with a new match is a refresh; a different rid is the
+            # head having changed under us.
+            self.release(reason="refresh_match" if self.rid == rid else "head_changed")
+        # Read after that release, so the move measured in _record_pin isolates
+        # this acquire rather than netting the two operations against each other.
+        evictable_before = None if self.headroom_fn is None else self.headroom_fn()[1]
+        result = self.tree_cache.inc_lock_ref(node)
+        self.rid = rid
+        self.node = node
+        self.tokens = tokens
+        # Replay at release exactly what was skipped at acquire: a chain whose
+        # bottom segment is an evicted tombstone locks only above it, and a
+        # later load-back may turn that tombstone into a real value that some
+        # other request now owns. Mirrors PrefillAdder._lock_node.
+        self._dec_params = (
+            result.to_dec_params()
+            if result is not None and self.tree_cache.is_tree_cache()
+            else None
+        )
+        self._record_pin(result, tokens, evictable_before)
+        self._debug("acquire", rid, tokens, reason or "head_no_token")
+        self.last_outcome = HEADLOCK_SYNC_PINNED
+        return True
+
+    def release(self, reason: str = "") -> bool:
+        """Drop the held lock, if any. Returns True if one was dropped."""
+        if not self.held:
+            return False
+        rid, node, params, tokens = self.rid, self.node, self._dec_params, self.tokens
+        # Clear the slot first: a raising dec must not leave a slot pointing at
+        # a reference we can no longer account for, or the next pass would try
+        # to release it again.
+        self.rid = None
+        self.node = None
+        self._dec_params = None
+        self.tokens = 0
+        try:
+            if params is not None:
+                self.tree_cache.dec_lock_ref(node, params)
+            else:
+                self.tree_cache.dec_lock_ref(node)
+        except Exception:
+            # A lock keeps its node alive, so this should be unreachable; if a
+            # path we have not accounted for did drop the node anyway, losing a
+            # lock ref on a dead node is survivable and killing the scheduler
+            # loop is not. Loud, because it means the audit missed a path.
+            if self.logger is not None:
+                self.logger.warning(
+                    "prefill_lookahead head lock release failed rid=%s reason=%s; "
+                    "slot dropped",
+                    rid,
+                    reason or "unspecified",
+                    exc_info=True,
+                )
+            return True
+        self._debug("release", rid, tokens, reason or "unspecified")
+        return True
+
+    def reconcile(self, alive_rids: Container[str]) -> bool:
+        """Pass-start check: drop the lock if its request left the waiting queue,
+        or if the pool no longer holds one reserve-sized extend.
+
+        The membership arm covers every way a blocked head can vanish without
+        going through the adder — abort, timeout, cancellation, a flush — without
+        hooking any of them. The capacity arm covers the pairing the pin-time
+        gate cannot see: a pin taken while headroom was ample, and an in-flight
+        chunked request that then grows chunk by chunk until its next chunk no
+        longer fits. Returns True if the lock was dropped.
+        """
+        if not self.held:
+            return False
+        if self.rid not in alive_rids:
+            return self.release(reason="rid_left_queue")
+        if self._headroom_under_reserve():
+            return self.release(reason="capacity_pressure")
+        return False
+
+    def sync_head(
+        self,
+        rid: str,
+        node: Any,
+        tokens: int,
+        should_hold: bool,
+        reason: str = "",
+    ) -> str:
+        """Reconcile the slot against this pass's head verdict, and report the
+        outcome as one of the ``HEADLOCK_SYNC_*`` constants.
+
+        ``should_hold`` is True only while the head is the KV-blocked one worth
+        protecting. When it is False the slot is released — that covers the head
+        being admitted (``add_one_req`` took its own lock on the very same chain,
+        so dropping ours takes the count 2 -> 1 and never through 0) as well as a
+        head rejected for a non-KV reason, where pinning buys nothing.
+        """
+        if not should_hold:
+            if self.held:
+                self.release(reason=reason or "head_unblocked")
+                return HEADLOCK_SYNC_RELEASED
+            return HEADLOCK_SYNC_IDLE
+        # acquire() itself handles the four cases: unchanged (no-op), same head
+        # re-matched to a different node (release + re-lock), a new head, and a
+        # pin the capacity gate refuses.
+        self.acquire(rid, node, tokens, reason=reason or "head_no_token")
+        return self.last_outcome

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -34,7 +34,7 @@ import random
 from collections import Counter
 from contextlib import contextmanager
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 import torch
 
@@ -477,6 +477,43 @@ class AddReqResult(Enum):
     OTHER = auto()  # Other reasons to stop adding requests
 
 
+def full_pool_available_and_evictable(
+    token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+    tree_cache: BasePrefixCache,
+) -> Tuple[int, int]:
+    """`(allocator-free, tree-evictable)` tokens of the pool an extend allocates
+    from, kept as two halves so a caller can report both.
+
+    Mirrors `PrefillAdder.rem_total_tokens`' pool selection with the admission
+    offsets left out: this is the raw pair `evict_from_tree_cache` weighs an
+    allocation against when the batch actually runs. It lives outside
+    `PrefillAdder` because the head prefix lock is reconciled at the top of an
+    admission pass, before an adder exists; the two selections must stay in step.
+    """
+    if isinstance(token_to_kv_pool_allocator, PureSWATokenToKVPoolAllocator):
+        return (
+            token_to_kv_pool_allocator.swa_available_size(),
+            tree_cache.swa_evictable_size(),
+        )
+    if isinstance(
+        token_to_kv_pool_allocator,
+        (SWATokenToKVPoolAllocator, DeepSeekV4HiSparseTokenToKVPoolAllocator),
+    ):
+        return (
+            token_to_kv_pool_allocator.full_available_size(),
+            tree_cache.full_evictable_size(),
+        )
+    if tree_cache.supports_mamba():
+        return (
+            token_to_kv_pool_allocator.available_size(),
+            tree_cache.full_evictable_size(),
+        )
+    return (
+        token_to_kv_pool_allocator.available_size(),
+        tree_cache.evictable_size(),
+    )
+
+
 class PrefillAdder:
     def __init__(
         self,
@@ -815,6 +852,22 @@ class PrefillAdder:
 
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
+
+    def charge_head_prefix_pin(self, tokens: int) -> None:
+        """Charge a head prefix pinned mid-pass to both full-KV budgets, so the
+        candidates scanned after it cannot sell KV the head now owns.
+
+        Takes only what the tree did not already account for: every cache in
+        mem_cache/ moves the newly-locked tokens out of `evictable_size()` inside
+        `inc_lock_ref`, and `rem_total_tokens` reads that live, so the usual
+        charge is 0 (see `HeadPrefixLock._record_pin`). The offsets only ever
+        grow, and a budget driven negative reads as NO_TOKEN in `budget_state`,
+        which is the intended refusal, not a broken counter.
+        """
+        if tokens <= 0:
+            return
+        self.rem_total_token_offset += tokens
+        self.cur_rem_token_offset += tokens
 
     def budget_state(self):
         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -200,6 +200,14 @@ from sglang.srt.managers.prefill_delayer import (
     PrefillDelayerSinglePassExecutor,
     RecentPrefillBatchSizeTracker,
 )
+from sglang.srt.managers.prefill_lookahead import (
+    HEADLOCK_SYNC_DENIED_CAPACITY,
+    HEADLOCK_SYNC_IDLE,
+    HEADLOCK_SYNC_PINNED,
+    HeadPrefixLock,
+    PrefillLookaheadState,
+    normalize_headlock_reserve_tokens,
+)
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     MultimodalInputs,
@@ -212,6 +220,7 @@ from sglang.srt.managers.schedule_policy import (
     AddReqResult,
     PrefillAdder,
     SchedulePolicy,
+    full_pool_available_and_evictable,
 )
 from sglang.srt.managers.scheduler_components.batch_result_processor import (
     SchedulerBatchResultProcessor,
@@ -457,6 +466,15 @@ class Scheduler(
         # init_soft_watchdog starts a daemon thread that reads these on its first tick.
         self.forward_ct: int = 0
         self.cur_batch_for_debug: Optional[ScheduleBatch] = None
+        # Admission NO_TOKEN lookahead (off unless the env is set); the head
+        # prefix lock behind it is built in init_running_status once the tree
+        # cache exists.
+        self.prefill_lookahead = PrefillLookaheadState(
+            max_candidates=envs.SGLANG_PREFILL_NO_TOKEN_LOOKAHEAD.get(),
+            aging_passes=envs.SGLANG_PREFILL_LOOKAHEAD_AGING_PASSES.get(),
+        )
+        self.head_prefix_lock: Optional[HeadPrefixLock] = None
+        self.head_prefix_lock_reserve: int = 0
         self.init_soft_watchdog()
 
         # Parse args
@@ -1270,6 +1288,27 @@ class Scheduler(
         )
         self._last_logged_elastic_radix_namespace: Optional[str] = None
         self.session_controller = SessionController(self.tree_cache)
+        # Head-prefix pinning for the NO_TOKEN lookahead. Built only when the
+        # lookahead is enabled, so env=0 keeps a None slot and never touches
+        # the tree cache.
+        if self.prefill_lookahead.uses_head_lock:
+            self.head_prefix_lock_reserve = normalize_headlock_reserve_tokens(
+                envs.SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS.get(),
+                self.max_prefill_tokens,
+            )
+            self.head_prefix_lock = HeadPrefixLock(
+                self.tree_cache,
+                logger=logger,
+                headroom_fn=self._kv_pool_headroom,
+                reserve_tokens=self.head_prefix_lock_reserve,
+            )
+            logger.info(
+                "Prefill NO_TOKEN lookahead: candidates=%d aging_passes=%d "
+                "headlock_reserve_tokens=%d",
+                self.prefill_lookahead.max_candidates,
+                self.prefill_lookahead.aging_passes,
+                self.head_prefix_lock_reserve,
+            )
         self.forward_sleep_time = None
         self._engine_paused = False
 
@@ -3688,11 +3727,100 @@ class Scheduler(
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
+    @property
+    def _prefill_lookahead_applicable(self) -> bool:
+        """Opt-in, and never under priority scheduling: that mode owns the queue
+        order itself (calc_priority / preempt_to_schedule), so an out-of-order
+        admission would contradict it."""
+        return self.prefill_lookahead.enabled and not self.enable_priority_scheduling
+
+    def _kv_pool_headroom(self) -> Tuple[int, int]:
+        """(allocator-free, tree-evictable) tokens of the pool an extend
+        allocates from. The head prefix lock's capacity gate reads exactly the
+        pair `evict_from_tree_cache` weighs a chunk's allocation against, so the
+        gate and the allocator cannot disagree about what "room" means."""
+        return full_pool_available_and_evictable(
+            self.token_to_kv_pool_allocator, self.tree_cache
+        )
+
+    def _mark_prefill_batch_full_no_token(
+        self, running_batch: ScheduleBatch, adder: PrefillAdder
+    ) -> None:
+        """batch_is_full bookkeeping for an admission scan stopped by NO_TOKEN.
+        Extracted so every lookahead exit publishes the identical state."""
+        if self.enable_hierarchical_cache or self.enable_unified_cache_external_linker:
+            # Set batch_is_full after making sure there are requests that can be served
+            running_batch.batch_is_full = len(adder.can_run_list) > 0 or (
+                not running_batch.is_empty()
+            )
+        else:
+            running_batch.batch_is_full = True
+
+    def _reconcile_head_prefix_lock(self) -> None:
+        """Pass-start reconciliation of the head prefix lock.
+
+        The lock is held across passes on purpose (a lookahead admission does
+        not allocate its KV until the batch actually runs), so it cannot be
+        unwound by a try/finally around one pass. Instead of hooking every way a
+        request can leave the queue (abort, timeout, cancellation, flush,
+        retract), the invariant is checked here: a lock whose request is no
+        longer in ``waiting_queue`` is dropped immediately, so any leak lives at
+        most one pass. Identity against *this* pass's head is checked later, at
+        the point the head is actually determined (the effective head is the
+        first request offered to the adder, which prefetch-wait and LoRA skips
+        can move past ``waiting_queue[0]``).
+
+        This is also where a pin that has become unaffordable is given up: the
+        pin-time gate only sees the headroom of the pass that took the lock, and
+        an in-flight chunked request can eat the rest of it one chunk at a time
+        over the passes that follow (see ``HeadPrefixLock.reconcile``).
+        """
+        if self.head_prefix_lock is None or not self.head_prefix_lock.held:
+            return
+        self.head_prefix_lock.reconcile({req.rid for req in self.waiting_queue})
+
+    def _sync_head_prefix_lock(
+        self, req: Req, rejected_no_token: bool, adder: PrefillAdder
+    ) -> str:
+        """Fold this pass's head verdict into the head prefix lock and report the
+        outcome (a ``HEADLOCK_SYNC_*`` constant).
+
+        Called right after the head's ``add_one_req`` and before any lookahead
+        candidate is offered, so the pin is in place before an intruder can reach
+        the allocator. Aging is deliberately not a release condition: while
+        lookahead is withheld for starvation, this lock is exactly what keeps the
+        head's prefix from decaying under it, so a lock held into an aged-out
+        stretch stays held.
+
+        A pin taken here shrinks the KV the rest of the pass may promise, so it
+        is charged to the adder immediately; ``charge_head_prefix_pin`` takes
+        only the part the tree's own accounting missed.
+        """
+        if self.head_prefix_lock is None:
+            return HEADLOCK_SYNC_IDLE
+        outcome = self.head_prefix_lock.sync_head(
+            rid=req.rid,
+            node=req.last_node,
+            tokens=len(req.prefix_indices),
+            # Pin only a head that is genuinely KV-blocked. An admitted head has
+            # add_one_req's own lock on the same chain, and a head rejected for a
+            # non-KV reason is not waiting on eviction, so neither needs ours.
+            should_hold=(
+                rejected_no_token
+                and self._prefill_lookahead_applicable
+                and req.last_node is not None
+            ),
+        )
+        if outcome == HEADLOCK_SYNC_PINNED:
+            adder.charge_head_prefix_pin(self.head_prefix_lock.last_pin_unaccounted)
+        return outcome
+
     def _get_new_batch_prefill_raw(
         self,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor],
         running_batch: ScheduleBatch,
     ) -> Tuple[Optional[ScheduleBatch], ScheduleBatch]:
+        self._reconcile_head_prefix_lock()
         # Check if the grammar is ready in the grammar queue
         if self.grammar_manager.has_waiting_grammars():
             ready_grammar_requests = self.grammar_manager.get_ready_grammar_requests()
@@ -3808,6 +3936,22 @@ class Scheduler(
         mamba_allocator = getattr(self.req_to_token_pool, "mamba_allocator", None)
         if mamba_allocator is not None:
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
+        # NO_TOKEN lookahead, per-pass state. `lookahead_on` latches at the
+        # first NO_TOKEN of the pass; a candidate then clears add_one_req's
+        # ordinary budget (free + evictable) while the head's own matched prefix
+        # is pinned by self.head_prefix_lock, so the only KV an intruder can
+        # take is cache the LRU would have taken anyway.
+        lookahead_on = False
+        lookahead_budget = 0
+        lookahead_admitted = 0
+        lookahead_denied = 0
+        head_offered = False
+        head_age = 0
+        # Latched by the head's sync when the capacity gate refused the pin. No
+        # pin means no protection for the head's prefix, so this pass must not
+        # let anyone interlope; it degrades to the stock break-on-NO_TOKEN. Stays
+        # False for env=0, which never builds a lock to gate.
+        head_lock_denied_capacity = False
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
@@ -3834,6 +3978,12 @@ class Scheduler(
                     req
                 ):
                     break
+
+            if lookahead_on and lookahead_budget <= 0:
+                # Candidate budget spent. Stop before touching this request so
+                # it carries no per-pass side effect into the next pass.
+                self._mark_prefill_batch_full_no_token(running_batch, adder)
+                break
 
             if self.enable_hicache_storage:
                 prefetch_done = self.tree_cache.check_prefetch_progress(req.rid)
@@ -3879,32 +4029,75 @@ class Scheduler(
                     req.storage_hit_length = 0
                     req.storage_hit_start = None
                     req.host_hit_is_storage = False
+            # `lookahead_on` can only be set by an earlier iteration's NO_TOKEN,
+            # so this is exactly "req is a candidate jumping the blocked head",
+            # never the head itself.
+            is_lookahead_candidate = lookahead_on
+            if is_lookahead_candidate:
+                lookahead_budget -= 1
+
             res = adder.add_one_req(
                 req,
                 has_chunked_req=(self.chunked_req is not None),
                 truncation_align_size=self.truncation_align_size,
             )
 
+            added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
+
             if self.enable_lora:
                 running_loras.add(req.lora_id)
 
+            if is_lookahead_candidate and added:
+                lookahead_admitted += 1
+
+            if not head_offered:
+                head_offered = True
+                head_rejected_no_token = res == AddReqResult.NO_TOKEN and not added
+                head_age = self.prefill_lookahead.observe_head(
+                    req.rid, rejected_no_token=head_rejected_no_token
+                )
+                # Before any candidate reaches add_one_req below: this pins the
+                # head's matched prefix so an intruder's eviction cannot take
+                # it; with lookahead off it is a no-op (head_prefix_lock is
+                # None).
+                head_lock_denied_capacity = (
+                    self._sync_head_prefix_lock(req, head_rejected_no_token, adder)
+                    == HEADLOCK_SYNC_DENIED_CAPACITY
+                )
+
             if res != AddReqResult.CONTINUE:
+                keep_scanning = False
                 if res == AddReqResult.NO_TOKEN:
-                    if (
-                        self.enable_hierarchical_cache
-                        or self.enable_unified_cache_external_linker
-                    ):
-                        # Set batch_is_full after making sure there are requests that can be served
-                        running_batch.batch_is_full = len(adder.can_run_list) > 0 or (
-                            not running_batch.is_empty()
+                    if is_lookahead_candidate:
+                        # There is no pre-gate, so a denial is exactly
+                        # "add_one_req said NO_TOKEN" and is counted here.
+                        lookahead_denied += 1
+                    if not lookahead_on:
+                        # One decision per pass, taken at its first NO_TOKEN.
+                        # aged_out is read AFTER observe_head so a head that
+                        # ages out on this very pass already stops lookahead
+                        # here, not only on the next pass. Priority scheduling
+                        # owns the queue order through calc_priority /
+                        # preempt_to_schedule; letting a lower-priority request
+                        # jump the head would contradict it, so that mode keeps
+                        # the baseline break. A pin the capacity gate refused
+                        # keeps it too: without the pin an intruder could evict
+                        # the head's own prefix, which is worse than not
+                        # interloping at all.
+                        lookahead_on = (
+                            self._prefill_lookahead_applicable
+                            and not self.prefill_lookahead.aged_out
+                            and not head_lock_denied_capacity
                         )
-                    else:
-                        running_batch.batch_is_full = True
+                        if lookahead_on:
+                            lookahead_budget = self.prefill_lookahead.max_candidates
+                    keep_scanning = lookahead_on and lookahead_budget > 0
+                    if not keep_scanning:
+                        self._mark_prefill_batch_full_no_token(running_batch, adder)
                 # revert matched mamba idx to avoid memory leak, if req is not added.
                 # Only free if the slot was freshly allocated in this batch (not
                 # pre-existing from a session). Session-held slots have their own
                 # lifecycle and freeing them here causes double-free.
-                added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
                 if not added:
                     # init_next_round_input() may stage deferred Mamba COW/clear
                     # metadata before add_one_req() rejects the request.
@@ -3915,10 +4108,26 @@ class Scheduler(
                             req.kv.mamba_pool_idx.unsqueeze(-1)
                         )
                         req.kv.mamba_pool_idx = None
+                if keep_scanning:
+                    continue
                 break
 
         if mamba_allocator is not None:
             mamba_allocator.alloc_group_end()
+
+        if self.prefill_lookahead.enabled and self.metrics_reporter.enable_metrics:
+            self.metrics_collector.increment_admission_lookahead(
+                admitted=lookahead_admitted,
+                denied=lookahead_denied,
+                # aging_hold is per pass: the head had already been starved past
+                # the bound when this pass began, so lookahead was withheld to
+                # let it catch up.
+                aging_hold=(
+                    self._prefill_lookahead_applicable
+                    and head_age > self.prefill_lookahead.aging_passes
+                ),
+                denied_capacity=head_lock_denied_capacity,
+            )
 
         # Update waiting queue
         can_run_list: List[Req] = adder.can_run_list
@@ -4927,6 +5136,8 @@ class Scheduler(
         if self.is_fully_idle():
             self.cur_batch_for_debug = None
             self.last_batch = None
+            if self.head_prefix_lock is not None:
+                self.head_prefix_lock.release(reason="flush_cache")
             self.tree_cache.reset()
             self.req_to_token_pool.clear()
             self.token_to_kv_pool_allocator.clear()

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -551,6 +551,24 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="Total number of prefill retries.",
             labelnames=labels.keys(),
         )
+        self.admission_lookahead_total = Counter(
+            name="sglang:admission_lookahead_total",
+            documentation=(
+                "Outcomes of the NO_TOKEN admission lookahead "
+                "(SGLANG_PREFILL_NO_TOKEN_LOOKAHEAD). admitted counts "
+                "requests let past a KV-blocked queue head. denied_budget "
+                "counts candidates that add_one_req rejected with NO_TOKEN "
+                "while the head's prefix was pinned. aging_hold counts passes "
+                "where lookahead was withheld because the head had been "
+                "starved for too many consecutive passes. denied_capacity "
+                "counts passes where pinning the head's prefix would have "
+                "left the allocator less than one reserve "
+                "(SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS, default "
+                "max_prefill_tokens) of headroom, so the pin was skipped and "
+                "lookahead withheld for that pass."
+            ),
+            labelnames=list(labels.keys()) + ["result"],
+        )
         self.kv_transfer_bootstrap_ms = Histogram(
             name="sglang:kv_transfer_bootstrap_ms",
             documentation="Histogram of KV transfer bootstrap time in ms.",
@@ -1188,6 +1206,32 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
     def increment_prefill_retries(self, count: int) -> None:
         if count > 0:
             self.num_prefill_retries_total.labels(**self.labels).inc(count)
+
+    def increment_admission_lookahead(
+        self,
+        admitted: int = 0,
+        denied: int = 0,
+        aging_hold: bool = False,
+        denied_capacity: bool = False,
+    ) -> None:
+        if admitted:
+            self.admission_lookahead_total.labels(**self.labels, result="admitted").inc(
+                admitted
+            )
+        if denied:
+            self.admission_lookahead_total.labels(
+                **self.labels, result="denied_budget"
+            ).inc(denied)
+        if aging_hold:
+            self.admission_lookahead_total.labels(
+                **self.labels, result="aging_hold"
+            ).inc(1)
+        if denied_capacity:
+            # One per pass, not per candidate: the gate is consulted once, for
+            # the head, and refusing its pin withholds the whole pass.
+            self.admission_lookahead_total.labels(
+                **self.labels, result="denied_capacity"
+            ).inc(1)
 
     def observe_kv_transfer_metrics(
         self,

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -8,6 +8,11 @@ from sglang.srt.managers.schedule_policy import (
     AddReqResult,
     PrefillAdder,
     estimate_prefill_extend_tile_metrics,
+    full_pool_available_and_evictable,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
 )
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefResult,
@@ -925,6 +930,102 @@ class TestPrefillAdder(CustomTestCase):
             self.create_swa_adder(
                 size_swa=4096, sliding_window=128
             )._swa_req_never_fits(**req)
+        )
+
+    def test_charge_head_prefix_pin_shrinks_both_full_budgets(self):
+        # A head prefix pinned mid-pass must not stay sellable to the lookahead
+        # candidates scanned after it.
+        self.mock_token_allocator.available_size.return_value = 100_000
+        self.mock_tree_cache.full_evictable_size.return_value = 20_000
+        adder = self.create_adder(self.create_running_batch())
+        before_total = adder.rem_total_tokens
+        before_cur = adder.cur_rem_tokens
+
+        adder.charge_head_prefix_pin(30_000)
+
+        self.assertEqual(adder.rem_total_tokens, before_total - 30_000)
+        self.assertEqual(adder.cur_rem_tokens, before_cur - 30_000)
+
+    def test_charge_head_prefix_pin_ignores_a_zero_or_negative_amount(self):
+        adder = self.create_adder(self.create_running_batch())
+        offsets = (adder.rem_total_token_offset, adder.cur_rem_token_offset)
+
+        adder.charge_head_prefix_pin(0)
+        adder.charge_head_prefix_pin(-5)
+
+        self.assertEqual(
+            (adder.rem_total_token_offset, adder.cur_rem_token_offset), offsets
+        )
+
+    def test_charge_head_prefix_pin_past_the_budget_reads_as_no_token(self):
+        # Over-charging is allowed to drive the budget negative: budget_state
+        # then refuses the next candidate, which is the intended outcome.
+        self.mock_token_allocator.available_size.return_value = 1_000
+        self.mock_tree_cache.full_evictable_size.return_value = 1_000
+        adder = self.create_adder(self.create_running_batch())
+
+        adder.charge_head_prefix_pin(10_000)
+
+        self.assertLess(adder.rem_total_tokens, 0)
+        self.assertEqual(adder.budget_state(), AddReqResult.NO_TOKEN)
+
+
+class TestFullPoolAvailableAndEvictable(CustomTestCase):
+    """The head prefix lock's capacity gate reads this outside a PrefillAdder,
+    so it has to pick the same pool halves `rem_total_tokens` does."""
+
+    def create_tree_cache(self, *, supports_mamba: bool) -> MagicMock:
+        tree_cache = MagicMock()
+        tree_cache.supports_mamba.return_value = supports_mamba
+        tree_cache.evictable_size.return_value = 11
+        tree_cache.full_evictable_size.return_value = 22
+        tree_cache.swa_evictable_size.return_value = 33
+        return tree_cache
+
+    def create_token_allocator(self, spec=None) -> MagicMock:
+        # A spec'd MagicMock answers isinstance for its class, which is how the
+        # helper picks the pool.
+        allocator = MagicMock() if spec is None else MagicMock(spec=spec)
+        allocator.available_size.return_value = 1
+        allocator.full_available_size.return_value = 2
+        allocator.swa_available_size.return_value = 3
+        return allocator
+
+    def test_plain_pool_reads_available_and_evictable(self):
+        self.assertEqual(
+            full_pool_available_and_evictable(
+                self.create_token_allocator(),
+                self.create_tree_cache(supports_mamba=False),
+            ),
+            (1, 11),
+        )
+
+    def test_mamba_pool_reads_the_full_evictable_half(self):
+        self.assertEqual(
+            full_pool_available_and_evictable(
+                self.create_token_allocator(),
+                self.create_tree_cache(supports_mamba=True),
+            ),
+            (1, 22),
+        )
+
+    def test_hybrid_swa_reads_the_full_pool(self):
+        self.assertEqual(
+            full_pool_available_and_evictable(
+                self.create_token_allocator(spec=SWATokenToKVPoolAllocator),
+                self.create_tree_cache(supports_mamba=False),
+            ),
+            (2, 22),
+        )
+
+    def test_all_swa_reads_the_swa_pool(self):
+        # Checked before the hybrid arm, because PureSWA subclasses it.
+        self.assertEqual(
+            full_pool_available_and_evictable(
+                self.create_token_allocator(spec=PureSWATokenToKVPoolAllocator),
+                self.create_tree_cache(supports_mamba=False),
+            ),
+            (3, 33),
         )
 
 

--- a/test/registered/unit/managers/test_prefill_lookahead.py
+++ b/test/registered/unit/managers/test_prefill_lookahead.py
@@ -1,0 +1,697 @@
+"""Unit tests for the NO_TOKEN admission lookahead: head-aging policy, guard
+mode selection, the head prefix lock's lifecycle, and its capacity gate.
+
+The module under test is loaded from its file rather than imported through the
+``sglang`` package on purpose: it is deliberately dependency-free, and loading
+it this way keeps the test runnable in a bare checkout with no runtime
+installed. The tree cache is duck-typed for the same reason, so the lock tests
+drive it with a fake that just records inc/dec calls.
+"""
+
+import importlib.util
+import pathlib
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_MODULE_PATH = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / "python"
+    / "sglang"
+    / "srt"
+    / "managers"
+    / "prefill_lookahead.py"
+)
+_spec = importlib.util.spec_from_file_location("_prefill_lookahead", _MODULE_PATH)
+_prefill_lookahead = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_prefill_lookahead)
+PrefillLookaheadState = _prefill_lookahead.PrefillLookaheadState
+HeadPrefixLock = _prefill_lookahead.HeadPrefixLock
+normalize_headlock_reserve_tokens = _prefill_lookahead.normalize_headlock_reserve_tokens
+HEADLOCK_SYNC_DENIED_CAPACITY = _prefill_lookahead.HEADLOCK_SYNC_DENIED_CAPACITY
+HEADLOCK_SYNC_HELD = _prefill_lookahead.HEADLOCK_SYNC_HELD
+HEADLOCK_SYNC_IDLE = _prefill_lookahead.HEADLOCK_SYNC_IDLE
+HEADLOCK_SYNC_PINNED = _prefill_lookahead.HEADLOCK_SYNC_PINNED
+HEADLOCK_SYNC_RELEASED = _prefill_lookahead.HEADLOCK_SYNC_RELEASED
+
+# The shape the capacity gate was written for: 16384-token extends against a
+# 219008-token device pool.
+RESERVE = 16384
+
+
+class FakeIncResult:
+    """Stand-in for IncLockRefResult; ``to_dec_params`` returns a sentinel so a
+    test can assert the release replayed the acquire's skip set. ``delta`` is
+    absent by default, which is how radix_cache_cpp reports."""
+
+    def __init__(self, dec_params, delta=None):
+        self._dec_params = dec_params
+        if delta is not None:
+            self.delta = delta
+
+    def to_dec_params(self):
+        return self._dec_params
+
+
+class FakeTreeCache:
+    """Records inc/dec_lock_ref calls; ``net`` is the outstanding ref count,
+    which every lifecycle test asserts back to 0."""
+
+    def __init__(self, is_tree_cache=True):
+        self._is_tree_cache = is_tree_cache
+        self.inc_calls = []
+        self.dec_calls = []
+        self.raise_on_dec = False
+
+    def is_tree_cache(self):
+        return self._is_tree_cache
+
+    def inc_lock_ref(self, node):
+        self.inc_calls.append(node)
+        return FakeIncResult(dec_params=("dec_params_for", node))
+
+    def dec_lock_ref(self, node, params=None):
+        if self.raise_on_dec:
+            raise KeyError(node)
+        self.dec_calls.append((node, params))
+
+    @property
+    def net(self):
+        return len(self.inc_calls) - len(self.dec_calls)
+
+
+class FakePoolTreeCache(FakeTreeCache):
+    """FakeTreeCache plus the KV accounting the capacity gate reads.
+
+    ``headroom`` is the (allocator-free, tree-evictable) pair the scheduler
+    feeds the lock, and ``inc_lock_ref`` / ``dec_lock_ref`` move a node's tokens
+    between the evictable and locked halves exactly as every tree in mem_cache/
+    does. ``delta_sign`` covers both live conventions: RadixCache reports the
+    move as negative, UnifiedRadixCache's FULL component as positive. The two
+    escape hatches model the caches that fit neither: ``report_delta`` off is
+    swa_radix_cache / mamba_radix_cache / radix_cache_cpp (no delta at all), and
+    ``account_locks`` off is a hypothetical cache whose lock accounting never
+    reaches ``evictable_size()``, which is the only case where a pin still has to
+    be charged to the adder.
+    """
+
+    def __init__(
+        self,
+        free,
+        evictable,
+        node_tokens=None,
+        account_locks=True,
+        report_delta=True,
+        delta_sign=-1,
+    ):
+        super().__init__()
+        self.free = free
+        self.evictable = evictable
+        self.node_tokens = dict(node_tokens or {})
+        self.account_locks = account_locks
+        self.report_delta = report_delta
+        self.delta_sign = delta_sign
+
+    def headroom(self):
+        return (self.free, self.evictable)
+
+    def inc_lock_ref(self, node):
+        self.inc_calls.append(node)
+        moved = self.node_tokens.get(node, 0)
+        if self.account_locks:
+            self.evictable -= moved
+        return FakeIncResult(
+            dec_params=("dec_params_for", node),
+            delta=self.delta_sign * moved if self.report_delta else None,
+        )
+
+    def dec_lock_ref(self, node, params=None):
+        super().dec_lock_ref(node, params)
+        if self.account_locks:
+            self.evictable += self.node_tokens.get(node, 0)
+
+
+def build_gated_lock(cache, reserve=RESERVE, logger=None):
+    return HeadPrefixLock(
+        cache,
+        logger=logger,
+        headroom_fn=cache.headroom,
+        reserve_tokens=reserve,
+    )
+
+
+class TestPrefillLookaheadState(CustomTestCase):
+    def test_disabled_by_default_budget(self):
+        state = PrefillLookaheadState(max_candidates=0, aging_passes=20)
+        self.assertFalse(state.enabled)
+        # Aging still tracks so the trace field stays meaningful when the
+        # feature is off.
+        self.assertEqual(state.observe_head("a", rejected_no_token=True), 1)
+
+    def test_negative_config_is_clamped(self):
+        state = PrefillLookaheadState(max_candidates=-5, aging_passes=-1)
+        self.assertEqual(state.max_candidates, 0)
+        self.assertEqual(state.aging_passes, 0)
+        self.assertFalse(state.enabled)
+
+    def test_consecutive_rejections_accumulate(self):
+        state = PrefillLookaheadState(max_candidates=8, aging_passes=3)
+        for expected in (1, 2, 3):
+            self.assertEqual(
+                state.observe_head("head", rejected_no_token=True), expected
+            )
+            self.assertFalse(state.aged_out)
+        self.assertEqual(state.observe_head("head", rejected_no_token=True), 4)
+        self.assertTrue(state.aged_out)
+
+    def test_admission_resets(self):
+        state = PrefillLookaheadState(max_candidates=8, aging_passes=1)
+        state.observe_head("head", rejected_no_token=True)
+        state.observe_head("head", rejected_no_token=True)
+        self.assertTrue(state.aged_out)
+
+        self.assertEqual(state.observe_head("head", rejected_no_token=False), 0)
+        self.assertFalse(state.aged_out)
+        self.assertIsNone(state.head_rid)
+
+    def test_new_head_restarts_the_count(self):
+        state = PrefillLookaheadState(max_candidates=8, aging_passes=1)
+        state.observe_head("old", rejected_no_token=True)
+        state.observe_head("old", rejected_no_token=True)
+        self.assertTrue(state.aged_out)
+
+        self.assertEqual(state.observe_head("new", rejected_no_token=True), 1)
+        self.assertFalse(state.aged_out)
+        self.assertEqual(state.head_rid, "new")
+
+    def test_zero_aging_passes_disables_lookahead_on_first_rejection(self):
+        state = PrefillLookaheadState(max_candidates=8, aging_passes=0)
+        state.observe_head("head", rejected_no_token=True)
+        self.assertTrue(state.aged_out)
+
+
+class TestLookaheadHeadLockSelection(CustomTestCase):
+    def test_enabled_lookahead_uses_head_lock(self):
+        state = PrefillLookaheadState(max_candidates=8, aging_passes=20)
+        self.assertTrue(state.uses_head_lock)
+
+    def test_disabled_lookahead_builds_no_head_lock(self):
+        # env=0 must not build a head lock.
+        state = PrefillLookaheadState(max_candidates=0, aging_passes=20)
+        self.assertFalse(state.uses_head_lock)
+
+
+class TestHeadPrefixLock(CustomTestCase):
+    def setUp(self):
+        self.cache = FakeTreeCache()
+        self.lock = HeadPrefixLock(self.cache)
+
+    def test_acquire_then_release(self):
+        self.assertTrue(self.lock.acquire("head", node="n1", tokens=128))
+        self.assertTrue(self.lock.held)
+        self.assertEqual(self.lock.locked_tokens, 128)
+        self.assertEqual(self.cache.inc_calls, ["n1"])
+
+        self.assertTrue(self.lock.release(reason="admitted"))
+        self.assertFalse(self.lock.held)
+        self.assertEqual(self.lock.locked_tokens, 0)
+        # The acquire's skip set is replayed at release, not dropped.
+        self.assertEqual(self.cache.dec_calls, [("n1", ("dec_params_for", "n1"))])
+        self.assertEqual(self.cache.net, 0)
+
+    def test_repeat_acquire_is_idempotent(self):
+        self.lock.acquire("head", node="n1", tokens=100)
+        # A head blocked for many passes re-asserts the same lock every pass;
+        # that must not stack references.
+        self.assertFalse(self.lock.acquire("head", node="n1", tokens=140))
+        self.assertEqual(len(self.cache.inc_calls), 1)
+        self.assertEqual(self.cache.dec_calls, [])
+        # ...but the reported size follows the latest match.
+        self.assertEqual(self.lock.locked_tokens, 140)
+
+        self.lock.release()
+        self.assertEqual(self.cache.net, 0)
+
+    def test_repeat_acquire_is_idempotent_for_large_int_node_ids(self):
+        # UnifiedRadixCache hands out NodeId == int; two equal ints above the
+        # small-int cache are not the same object, so identity comparison would
+        # release and re-lock on every pass.
+        self.lock.acquire("head", node=100_001, tokens=10)
+        self.assertFalse(self.lock.acquire("head", node=100_000 + 1, tokens=10))
+        self.assertEqual(len(self.cache.inc_calls), 1)
+        self.assertEqual(self.cache.dec_calls, [])
+
+    def test_release_without_lock_is_a_noop(self):
+        self.assertFalse(self.lock.release())
+        self.assertEqual(self.cache.dec_calls, [])
+
+    def test_refresh_moves_the_lock_to_the_new_node(self):
+        self.lock.acquire("head", node="n1", tokens=100)
+        # Same head, re-matched deeper after a load-back.
+        self.assertTrue(self.lock.acquire("head", node="n2", tokens=300))
+        self.assertEqual(self.cache.inc_calls, ["n1", "n2"])
+        self.assertEqual(self.cache.dec_calls, [("n1", ("dec_params_for", "n1"))])
+        self.assertEqual(self.lock.node, "n2")
+        self.assertEqual(self.lock.locked_tokens, 300)
+        self.assertEqual(self.cache.net, 1)
+
+        self.lock.release()
+        self.assertEqual(self.cache.net, 0)
+
+    def test_head_change_releases_the_old_lock(self):
+        self.lock.acquire("old", node="n1", tokens=100)
+        self.lock.acquire("new", node="n2", tokens=200)
+        self.assertEqual(self.lock.rid, "new")
+        self.assertEqual(self.cache.dec_calls, [("n1", ("dec_params_for", "n1"))])
+        self.assertEqual(self.cache.net, 1)
+
+    def test_reconcile_releases_when_rid_left_the_queue(self):
+        self.lock.acquire("head", node="n1", tokens=100)
+        # Still queued: kept.
+        self.assertFalse(self.lock.reconcile({"head", "other"}))
+        self.assertTrue(self.lock.held)
+        # Aborted / timed out: dropped without any abort-path hook.
+        self.assertTrue(self.lock.reconcile({"other"}))
+        self.assertFalse(self.lock.held)
+        self.assertEqual(self.cache.net, 0)
+
+    def test_reconcile_without_lock_is_a_noop(self):
+        self.assertFalse(self.lock.reconcile(set()))
+        self.assertEqual(self.cache.dec_calls, [])
+
+    def test_sync_head_holds_while_blocked(self):
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=True)
+        self.assertTrue(self.lock.held)
+        # Next pass, same head, still blocked, same match: no churn.
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=True)
+        self.assertEqual(len(self.cache.inc_calls), 1)
+
+    def test_sync_head_releases_when_head_is_admitted(self):
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=True)
+        # add_one_req took its own lock on the same chain; ours must go or the
+        # chain stays pinned forever.
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=False)
+        self.assertFalse(self.lock.held)
+        self.assertEqual(self.cache.net, 0)
+
+    def test_sync_head_refreshes_on_a_new_match(self):
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=True)
+        self.lock.sync_head(rid="head", node="n2", tokens=250, should_hold=True)
+        self.assertEqual(self.cache.inc_calls, ["n1", "n2"])
+        self.assertEqual(self.cache.dec_calls, [("n1", ("dec_params_for", "n1"))])
+        self.assertEqual(self.lock.locked_tokens, 250)
+
+    def test_sync_head_without_a_lock_and_unblocked_head_does_nothing(self):
+        self.lock.sync_head(rid="head", node="n1", tokens=100, should_hold=False)
+        self.assertFalse(self.lock.held)
+        self.assertEqual(self.cache.inc_calls, [])
+        self.assertEqual(self.cache.dec_calls, [])
+
+    def test_non_tree_cache_skips_dec_params(self):
+        cache = FakeTreeCache(is_tree_cache=False)
+        lock = HeadPrefixLock(cache)
+        lock.acquire("head", node="n1", tokens=10)
+        lock.release()
+        # Mirrors PrefillAdder._lock_node: no params for a chunk cache.
+        self.assertEqual(cache.dec_calls, [("n1", None)])
+
+    def test_release_clears_the_slot_even_if_dec_raises(self):
+        logger = _RecordingLogger()
+        lock = HeadPrefixLock(self.cache, logger=logger)
+        lock.acquire("head", node="n1", tokens=10)
+        self.cache.raise_on_dec = True
+        self.assertTrue(lock.release(reason="boom"))
+        # Slot cleared, so the next pass cannot try to release it twice.
+        self.assertFalse(lock.held)
+        self.assertEqual(len(logger.warnings), 1)
+
+    def test_debug_logging_covers_acquire_release_and_refresh(self):
+        logger = _RecordingLogger()
+        lock = HeadPrefixLock(self.cache, logger=logger)
+        lock.acquire("head", node="n1", tokens=10, reason="head_no_token")
+        lock.acquire("head", node="n2", tokens=20)
+        lock.release(reason="admitted")
+        reasons = [args[-1] for args in logger.debugs]
+        self.assertEqual(
+            reasons, ["head_no_token", "refresh_match", "head_no_token", "admitted"]
+        )
+
+
+class TestHeadlockReserveTokens(CustomTestCase):
+    def test_unset_or_zero_uses_max_prefill_tokens(self):
+        self.assertEqual(normalize_headlock_reserve_tokens(None, 16384), 16384)
+        self.assertEqual(normalize_headlock_reserve_tokens(0, 16384), 16384)
+
+    def test_positive_override_wins(self):
+        self.assertEqual(normalize_headlock_reserve_tokens(32768, 16384), 32768)
+
+    def test_negative_override_raises(self):
+        # Silently turning the gate off would put the crash back without any
+        # sign of it in the config, so this fails startup instead.
+        with self.assertRaises(ValueError):
+            normalize_headlock_reserve_tokens(-1, 16384)
+
+    def test_negative_default_is_clamped(self):
+        self.assertEqual(normalize_headlock_reserve_tokens(None, -5), 0)
+
+
+class TestHeadPrefixLockCapacityGate(CustomTestCase):
+    def test_pin_is_skipped_when_it_would_eat_the_reserve(self):
+        cache = FakePoolTreeCache(
+            free=1792, evictable=114_752, node_tokens={"n1": 114_752}
+        )
+        logger = _RecordingLogger()
+        lock = build_gated_lock(cache, logger=logger)
+
+        outcome = lock.sync_head(
+            rid="head", node="n1", tokens=114_752, should_hold=True
+        )
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_DENIED_CAPACITY)
+        self.assertFalse(lock.held)
+        self.assertEqual(cache.inc_calls, [])
+        # The pool an in-flight chunked request evicts from is left as it was.
+        self.assertEqual(cache.headroom(), (1792, 114_752))
+        self.assertEqual(logger.debugs[-1], ("head", 114_752, 1792, 114_752, RESERVE))
+
+    def test_pin_is_taken_when_the_reserve_still_fits_after_it(self):
+        cache = FakePoolTreeCache(
+            free=1792, evictable=114_752, node_tokens={"n1": 40_000}
+        )
+        lock = build_gated_lock(cache)
+
+        outcome = lock.sync_head(rid="head", node="n1", tokens=40_000, should_hold=True)
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_PINNED)
+        self.assertEqual(cache.inc_calls, ["n1"])
+        self.assertGreaterEqual(sum(cache.headroom()), RESERVE)
+
+    def test_exactly_the_reserve_is_still_allowed(self):
+        # `>= reserve`, not `>`: one whole extend still fits.
+        cache = FakePoolTreeCache(
+            free=0, evictable=RESERVE + 1000, node_tokens={"n1": 1000}
+        )
+        lock = build_gated_lock(cache)
+        self.assertEqual(
+            lock.sync_head(rid="head", node="n1", tokens=1000, should_hold=True),
+            HEADLOCK_SYNC_PINNED,
+        )
+
+    def test_gate_is_inert_without_a_headroom_source_or_reserve(self):
+        # Mirrors env=0, which never constructs a lock at all.
+        no_fn = FakePoolTreeCache(
+            free=0, evictable=114_752, node_tokens={"n1": 114_752}
+        )
+        lock = HeadPrefixLock(no_fn, headroom_fn=None, reserve_tokens=RESERVE)
+        self.assertEqual(
+            lock.sync_head(rid="head", node="n1", tokens=114_752, should_hold=True),
+            HEADLOCK_SYNC_PINNED,
+        )
+
+        no_reserve = FakePoolTreeCache(
+            free=0, evictable=114_752, node_tokens={"n1": 114_752}
+        )
+        lock = build_gated_lock(no_reserve, reserve=0)
+        self.assertEqual(
+            lock.sync_head(rid="head", node="n1", tokens=114_752, should_hold=True),
+            HEADLOCK_SYNC_PINNED,
+        )
+
+    def test_denied_refresh_keeps_the_pin_it_already_holds(self):
+        cache = FakePoolTreeCache(
+            free=100_000,
+            evictable=120_000,
+            node_tokens={"n1": 20_000, "n2": 119_000},
+        )
+        lock = build_gated_lock(cache)
+        lock.sync_head(rid="head", node="n1", tokens=20_000, should_hold=True)
+        # An in-flight chunked request has taken the free pages since, so the
+        # deeper re-match no longer fits.
+        cache.free = 0
+
+        outcome = lock.sync_head(
+            rid="head", node="n2", tokens=119_000, should_hold=True
+        )
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_DENIED_CAPACITY)
+        # Dropping n1 on the way to a pin that will not happen would strip the
+        # head of protection it already had.
+        self.assertEqual(lock.node, "n1")
+        self.assertEqual(cache.inc_calls, ["n1"])
+        self.assertEqual(cache.dec_calls, [])
+
+    def test_reasserting_the_same_slot_is_never_re_gated(self):
+        cache = FakePoolTreeCache(
+            free=50_000, evictable=100_000, node_tokens={"n1": 90_000}
+        )
+        lock = build_gated_lock(cache)
+        self.assertEqual(
+            lock.sync_head(rid="head", node="n1", tokens=90_000, should_hold=True),
+            HEADLOCK_SYNC_PINNED,
+        )
+        # Headroom is now under the reserve partly *because of* this pin; the
+        # re-assertion takes nothing new, so gating it would only churn.
+        cache.free = 0
+
+        self.assertEqual(
+            lock.sync_head(rid="head", node="n1", tokens=90_000, should_hold=True),
+            HEADLOCK_SYNC_HELD,
+        )
+        self.assertEqual(cache.inc_calls, ["n1"])
+
+    def test_unblocked_head_still_releases_under_pressure(self):
+        cache = FakePoolTreeCache(
+            free=50_000, evictable=100_000, node_tokens={"n1": 90_000}
+        )
+        lock = build_gated_lock(cache)
+        lock.sync_head(rid="head", node="n1", tokens=90_000, should_hold=True)
+        cache.free = 0
+
+        outcome = lock.sync_head(
+            rid="head", node="n1", tokens=90_000, should_hold=False
+        )
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_RELEASED)
+        self.assertFalse(lock.held)
+        self.assertEqual(cache.net, 0)
+
+
+class TestHeadPrefixLockPinAccounting(CustomTestCase):
+    def test_exact_delta_needs_no_charge_to_the_pass_budget(self):
+        cache = FakePoolTreeCache(
+            free=50_000, evictable=100_000, node_tokens={"n1": 30_000}
+        )
+        lock = build_gated_lock(cache)
+
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        self.assertEqual(lock.last_pin_tokens, 30_000)
+        # inc_lock_ref already took it out of evictable_size(), which
+        # rem_total_tokens reads live; charging it again double-counts the pin.
+        self.assertEqual(lock.last_pin_unaccounted, 0)
+
+    def test_a_positive_delta_is_read_as_the_same_move(self):
+        # UnifiedRadixCache's FULL component reports the
+        # evictable -> protected move as +key_len, RadixCache as -len(key); a
+        # sign-sensitive read would size the pin as a negative.
+        cache = FakePoolTreeCache(
+            free=50_000,
+            evictable=100_000,
+            node_tokens={"n1": 30_000},
+            delta_sign=1,
+        )
+        lock = build_gated_lock(cache)
+
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        self.assertEqual(lock.last_pin_tokens, 30_000)
+        self.assertEqual(lock.last_pin_unaccounted, 0)
+
+    def test_a_chain_a_running_request_already_locks_costs_nothing(self):
+        cache = FakePoolTreeCache(free=50_000, evictable=100_000, node_tokens={"n1": 0})
+        lock = build_gated_lock(cache)
+
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        # delta == 0: the prefix length is not what left the evictable set.
+        self.assertEqual(lock.last_pin_tokens, 0)
+        self.assertEqual(lock.last_pin_unaccounted, 0)
+
+    def test_a_cache_without_a_delta_falls_back_to_the_full_prefix(self):
+        cache = FakePoolTreeCache(
+            free=50_000,
+            evictable=100_000,
+            node_tokens={"n1": 30_000},
+            report_delta=False,
+        )
+        lock = build_gated_lock(cache)
+
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        self.assertEqual(lock.last_pin_tokens, 30_000)
+        self.assertEqual(lock.last_pin_unaccounted, 0)
+
+    def test_a_pin_the_tree_does_not_account_for_is_charged_in_full(self):
+        cache = FakePoolTreeCache(
+            free=50_000,
+            evictable=100_000,
+            node_tokens={"n1": 30_000},
+            account_locks=False,
+        )
+        lock = build_gated_lock(cache)
+
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        # Nothing moved out of evictable_size(), so the rest of the pass would
+        # otherwise keep selling KV the head now owns.
+        self.assertEqual(lock.last_pin_unaccounted, 30_000)
+
+    def test_a_refresh_charges_the_new_lock_only(self):
+        cache = FakePoolTreeCache(
+            free=200_000,
+            evictable=200_000,
+            node_tokens={"n1": 30_000, "n2": 50_000},
+        )
+        lock = build_gated_lock(cache)
+        lock.sync_head(rid="head", node="n1", tokens=30_000, should_hold=True)
+
+        lock.sync_head(rid="head", node="n2", tokens=50_000, should_hold=True)
+
+        # Measured across the inc alone: netting it against the release that
+        # precedes it would make an accounted refresh look unaccounted.
+        self.assertEqual(lock.last_pin_tokens, 50_000)
+        self.assertEqual(lock.last_pin_unaccounted, 0)
+
+
+class TestHeadPrefixLockCapacityRelease(CustomTestCase):
+    def _pinned(self, logger=None):
+        cache = FakePoolTreeCache(
+            free=120_000, evictable=120_000, node_tokens={"n1": 100_000}
+        )
+        lock = build_gated_lock(cache, logger=logger)
+        lock.sync_head(rid="head", node="n1", tokens=100_000, should_hold=True)
+        return cache, lock
+
+    def test_reconcile_keeps_the_lock_while_headroom_holds(self):
+        cache, lock = self._pinned()
+        self.assertFalse(lock.reconcile({"head"}))
+        self.assertTrue(lock.held)
+        self.assertEqual(cache.dec_calls, [])
+
+    def test_reconcile_releases_a_lock_taken_before_the_pressure(self):
+        logger = _RecordingLogger()
+        cache, lock = self._pinned(logger=logger)
+        # An in-flight chunked request grows into the rest of the pool over the
+        # passes that follow — headroom the pin-time gate never got to see.
+        cache.free = 0
+        cache.evictable = 8_000
+
+        self.assertTrue(lock.reconcile({"head"}))
+
+        self.assertFalse(lock.held)
+        self.assertEqual(cache.dec_calls, [("n1", ("dec_params_for", "n1"))])
+        self.assertEqual(
+            logger.debugs[-1], ("release", "head", 100_000, "capacity_pressure")
+        )
+        # The next chunk has something to evict again.
+        self.assertGreaterEqual(sum(cache.headroom()), RESERVE)
+
+    def test_a_released_pin_is_not_immediately_retaken(self):
+        cache, lock = self._pinned()
+        cache.free = 0
+        cache.evictable = 8_000
+        lock.reconcile({"head"})
+
+        # Same pass, same blocked head: re-pinning would undo the release, so
+        # the gate has to refuse it on the headroom the release just restored.
+        outcome = lock.sync_head(
+            rid="head", node="n1", tokens=100_000, should_hold=True
+        )
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_DENIED_CAPACITY)
+        self.assertFalse(lock.held)
+
+    def test_a_departed_rid_is_still_reported_as_such(self):
+        logger = _RecordingLogger()
+        cache, lock = self._pinned(logger=logger)
+        cache.free = 0
+        cache.evictable = 8_000
+
+        self.assertTrue(lock.reconcile({"other"}))
+
+        self.assertEqual(logger.debugs[-1][-1], "rid_left_queue")
+
+    def test_capacity_arm_is_off_without_a_reserve(self):
+        cache = FakePoolTreeCache(free=0, evictable=0, node_tokens={"n1": 100_000})
+        lock = build_gated_lock(cache, reserve=0)
+        lock.sync_head(rid="head", node="n1", tokens=100_000, should_hold=True)
+        self.assertFalse(lock.reconcile({"head"}))
+        self.assertTrue(lock.held)
+
+
+class TestHeadLockOutOfMemoryRegression(CustomTestCase):
+    """The observed out-of-memory shape, at the point the pin is decided.
+
+    A 219008-token device pool with an in-flight chunked prefill holding ~110k,
+    a queue head whose matched prefix (114752) is essentially the whole evictable
+    remainder, and a 4096-token next chunk that allocates through
+    alloc_paged_token_slots_extend — i.e. outside the admission budget, relying
+    on eviction at alloc time.
+    """
+
+    CHUNK = 4096
+    FREE = 1792
+    HEAD_PREFIX = 114_752
+
+    def _crash_state(self):
+        return FakePoolTreeCache(
+            free=self.FREE,
+            evictable=self.HEAD_PREFIX,
+            node_tokens={"head_node": self.HEAD_PREFIX},
+        )
+
+    def test_pin_is_skipped_and_the_next_chunk_still_has_kv_to_evict(self):
+        cache = self._crash_state()
+        lock = build_gated_lock(cache)
+
+        outcome = lock.sync_head(
+            rid="0b67", node="head_node", tokens=self.HEAD_PREFIX, should_hold=True
+        )
+
+        self.assertEqual(outcome, HEADLOCK_SYNC_DENIED_CAPACITY)
+        available, evictable = cache.headroom()
+        self.assertEqual(evictable, self.HEAD_PREFIX)
+        self.assertGreaterEqual(available + evictable, self.CHUNK)
+
+    def test_the_ungated_pin_is_what_starved_the_chunk(self):
+        # Same state with the gate off: evictable goes to 0 and 1792 free pages
+        # cannot serve a 4096-token chunk, which is the RuntimeError that took
+        # the scheduler process down.
+        cache = self._crash_state()
+        lock = HeadPrefixLock(cache, headroom_fn=None, reserve_tokens=0)
+
+        lock.sync_head(
+            rid="0b67", node="head_node", tokens=self.HEAD_PREFIX, should_hold=True
+        )
+
+        self.assertEqual(cache.headroom(), (self.FREE, 0))
+        self.assertLess(sum(cache.headroom()), self.CHUNK)
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.debugs = []
+        self.warnings = []
+
+    def debug(self, _fmt, *args):
+        self.debugs.append(args)
+
+    def warning(self, _fmt, *args, **kwargs):
+        self.warnings.append(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes #38478

`Scheduler._get_new_batch_prefill_raw` walks the waiting queue in FCFS order and `break`s at the first `AddReqResult.NO_TOKEN`. When the head is a large request whose KV budget does not fit, nothing behind it is considered, even when a smaller request, or one with a long prefix hit that needs almost no new KV, would fit right now. The pass ends with an empty or tiny prefill batch and the head is retried next pass. On a prefill-only node under long-prefix multi-turn load this was ~45 % of all idle scheduler rounds.

This PR adds `SGLANG_PREFILL_NO_TOKEN_LOOKAHEAD` (default 0, off). With it set to `N`, after the head's `NO_TOKEN` the loop keeps scanning up to `N` further requests in the same pass. A candidate still goes through `add_one_req`'s ordinary budget (free + evictable), so every existing gate (SWA, Mamba, chunked prefill, DP-attention prefill negotiation) applies unchanged and nothing is over-committed. Three guards make the out-of-order admission safe; the design and the alternatives that were tried are in the issue.

With the env var unset the admission loop takes exactly the current decisions (`lookahead_on` never latches, so the first `NO_TOKEN` still breaks) and the lock object is never constructed.

## Modifications

`python/sglang/srt/managers/prefill_lookahead.py` (new, no sglang imports; the tree cache is injected)

- `PrefillLookaheadState(max_candidates, aging_passes)`: per-head starvation counter. `observe_head` is called once per pass with the head's verdict; `aged_out` is true once the same head has been `NO_TOKEN`-rejected more than `aging_passes` consecutive passes, and lookahead is withheld from that pass on until the head changes or is admitted.
- `HeadPrefixLock(tree_cache, headroom_fn, reserve_tokens)`: one-slot pin on the blocked head's matched node via the cache's normal `inc_lock_ref` / `dec_lock_ref`. `sync_head` folds a pass's head verdict into the lock (pin, keep, release, or refuse) and returns a `HEADLOCK_SYNC_*` outcome; `reconcile(alive_rids)` runs at pass start and drops a lock whose request left the queue or whose headroom fell under the reserve. The capacity gate pins only while `available + evictable - pin >= reserve_tokens`: an in-flight chunked request allocates its next chunk from that pair at batch-run time without going through the admission budget, so a pin that swallows the evictable pool would crash the scheduler with `Prefill out of memory`.
- The pin's accounting follows `IncLockRefResult.delta`: RadixCache reports the evictable -> protected move as `-len(key)`, UnifiedRadixCache's FULL component as `+key_len`, so the lock reads the magnitude and charges only the part the tree did not already move out of `evictable_size()` (`last_pin_unaccounted`).
- `normalize_headlock_reserve_tokens(value, default)`: unset or 0 reserves `default` (the scheduler's `max_prefill_tokens`); a negative value raises at startup rather than silently disabling the gate.

`python/sglang/srt/managers/scheduler.py`

- `__init__` builds `PrefillLookaheadState` from the env; `init_running_status` builds `HeadPrefixLock` only when lookahead is enabled and logs the effective settings.
- Helpers: `_prefill_lookahead_applicable` (opt-in and never under priority scheduling, which owns the queue order through `calc_priority` / `preempt_to_schedule`), `_kv_pool_headroom`, `_mark_prefill_batch_full_no_token` (the existing `batch_is_full` bookkeeping, extracted so every lookahead exit publishes the identical state), `_reconcile_head_prefix_lock`, `_sync_head_prefix_lock`.
- Admission loop: `lookahead_on` latches at the first `NO_TOKEN` of the pass, if lookahead is applicable, the head is not aged out, and the head's pin was not refused for capacity. The head's `observe_head` and `sync_head` run right after the head's `add_one_req` and before any candidate is offered, so the pin is in place before an intruder can reach the allocator. A candidate's `NO_TOKEN` counts as `denied_budget` and the scan continues while budget remains; the mamba revert for a rejected request is unchanged. `flush_cache` releases the lock before `tree_cache.reset()`.
- The head is the first request actually offered to the adder, not `waiting_queue[0]`, since prefetch-wait and LoRA skips can move past it.

`python/sglang/srt/managers/schedule_policy.py`

- `full_pool_available_and_evictable(allocator, tree_cache)`: the pool selection of `PrefillAdder.rem_total_tokens` without the admission offsets, as a module-level function because the lock is reconciled before an adder exists. The two selections must stay in step; the tests pin the four arms (plain, mamba, hybrid SWA, all-SWA).
- `PrefillAdder.charge_head_prefix_pin(tokens)`: adds to both full-KV offsets so candidates scanned after the pin cannot sell KV the head now owns. A budget driven negative reads as `NO_TOKEN` in `budget_state`, which is the intended refusal.

`python/sglang/srt/environ.py`: `SGLANG_PREFILL_NO_TOKEN_LOOKAHEAD = EnvInt(0)`, `SGLANG_PREFILL_LOOKAHEAD_AGING_PASSES = EnvInt(20)`, `SGLANG_PREFILL_HEADLOCK_RESERVE_TOKENS = EnvInt(0)`.

`python/sglang/srt/observability/metrics_collector.py`: `sglang:admission_lookahead_total{result=admitted|denied_budget|aging_hold|denied_capacity}` plus `increment_admission_lookahead`, reported once per pass only when lookahead is enabled and metrics are on.

Tests (CPU, `base-a-test-cpu`)

- New `test/registered/unit/managers/test_prefill_lookahead.py`: aging policy (head change, admission and non-KV rejection clear the counter; aged-out on the very pass it trips); lock lifetime (acquire, keep, release on head change / admission / re-match / drop from queue, double-acquire on the same node is a no-op); `sync_head` outcomes; reserve normalization; capacity gate at pin time and in `reconcile`; pin accounting against a RadixCache-shaped and a UnifiedRadixCache-shaped `inc_lock_ref` delta; a replay of the out-of-memory sequence (pin 114,752 tokens, next chunk 4,096, free 1,792 + evictable 0) showing the gate refuses the pin.
- `test/registered/unit/managers/test_prefill_adder.py`: `charge_head_prefix_pin` (both budgets shrink, zero or negative ignored, over-charge reads as `NO_TOKEN`) and `full_pool_available_and_evictable` for the four pool arms.

## Accuracy Tests

No numerical change: only which requests are admitted in a pass changes, and each still goes through `add_one_req`. Gate off is the existing path.

## Speed Tests and Profiling

Prefill-only H100 TP=8 deployment, hierarchical cache, 500 requests of long shared-prefix multi-turn sessions, two rounds each, gate off vs `N=4`, aging 20, reserve default:

| metric | change |
|---|---|
| throughput | +9.5 % (wall time -8.4 % / -9.1 % over two rounds) |
| TTFT p95 | -8 % |
| passes ending `NO_TOKEN` with nothing admitted | 65 -> 28 per run |
| prefix-cache hit rate | unchanged (97.1 %) |
| head-prefix lock acquire / release | 98 / 98, no leak across both rounds |

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34219414846](https://github.com/sgl-project/sglang/actions/runs/34219414846)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34219414581](https://github.com/sgl-project/sglang/actions/runs/34219414581)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34219414726](https://github.com/sgl-project/sglang/actions/runs/34219414726)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->