### PR TITLE
[Diffusion] Key the VAE decode-dtype store by module layout

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -159,10 +159,17 @@ def _should_use_channels_last_3d(
 
 
 def _decode_dtype_store_path(
-    component_model_path: str, component_name: str, dtype: torch.dtype
+    component_model_path: str, component_name: str, dtype: torch.dtype, vae=None
 ) -> str:
+    # The module layout is part of the key: two runtime versions that expose a
+    # different parameter set for the same checkpoint must not share a store.
+    layout = ""
+    if vae is not None:
+        layout = "|" + ",".join(
+            f"{name}:{tuple(tensor.shape)}" for name, tensor in vae.state_dict().items()
+        )
     key = hashlib.sha1(
-        f"{os.path.realpath(component_model_path)}|{component_name}|{dtype}".encode()
+        f"{os.path.realpath(component_model_path)}|{component_name}|{dtype}{layout}".encode()
     ).hexdigest()[:16]
     return os.path.join(
         envs.SGLANG_DIFFUSION_CACHE_ROOT, "decode_dtype_store", f"{key}.safetensors"
@@ -211,7 +218,7 @@ def _rehome_cast_weights_to_file(
 
     Returns (weights held, file-backed?).
     """
-    path = _decode_dtype_store_path(component_model_path, component_name, dtype)
+    path = _decode_dtype_store_path(component_model_path, component_name, dtype, vae)
     try:
         if os.path.exists(path):
             mapped = _load_store(path)

--- a/python/sglang/multimodal_gen/test/unit/test_vae_decoder_store.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_decoder_store.py
@@ -61,7 +61,7 @@ def test_the_cast_weights_end_up_file_backed(tmp_path):
         vae, _server_args(), "video_vae", str(model_path)
     )
 
-    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16)
+    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16, vae)
     import os
 
     assert os.path.exists(path)
@@ -101,7 +101,8 @@ def test_a_second_start_adopts_the_store_without_casting(tmp_path):
 def test_a_mismatched_store_is_discarded_and_the_cast_kept(tmp_path):
     model_path = tmp_path / "ckpt"
     model_path.mkdir()
-    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16)
+    vae = _TinyVAE()
+    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16, vae)
     import os
 
     os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -109,7 +110,6 @@ def test_a_mismatched_store_is_discarded_and_the_cast_kept(tmp_path):
 
     save_file({"blocks.0.weight": torch.zeros(4, 4, dtype=torch.float16)}, path)
 
-    vae = _TinyVAE()
     _hold_decoder_weights_in_decode_dtype(
         vae, _server_args(), "video_vae", str(model_path)
     )
@@ -127,8 +127,33 @@ def test_the_store_kill_switch_keeps_the_copies_in_memory(monkeypatch, tmp_path)
         vae, _server_args(), "video_vae", str(model_path)
     )
 
-    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16)
+    path = _decode_dtype_store_path(str(model_path), "video_vae", torch.float16, vae)
     import os
 
     assert not os.path.exists(path)
     assert all(b.weight.dtype == torch.float16 for b in vae.blocks)
+
+
+def test_module_layouts_do_not_share_a_store(tmp_path):
+    """A runtime exposing a different parameter set must not evict another's store."""
+    model_path = tmp_path / "ckpt"
+    model_path.mkdir()
+    first = _TinyVAE()
+    _hold_decoder_weights_in_decode_dtype(
+        first, _server_args(), "video_vae", str(model_path)
+    )
+    first_path = _decode_dtype_store_path(
+        str(model_path), "video_vae", torch.float16, first
+    )
+    other = _TinyVAE()
+    other.blocks.append(nn.Linear(8, 8))
+    _hold_decoder_weights_in_decode_dtype(
+        other, _server_args(), "video_vae", str(model_path)
+    )
+    other_path = _decode_dtype_store_path(
+        str(model_path), "video_vae", torch.float16, other
+    )
+    import os
+
+    assert first_path != other_path
+    assert os.path.exists(first_path) and os.path.exists(other_path)


### PR DESCRIPTION
## Motivation

`_decode_dtype_store_path` keys the decode-dtype store on `(checkpoint realpath, component name, dtype)`. That key does not distinguish two runtime versions that build a different module for the same checkpoint, so both map to one file. The second one loads a store whose tensor set does not match its module — observed as a 144-tensor store against a module wanting 288 — takes the `existing decode-dtype store does not match the module` path, re-casts, and overwrites. Start the other version again and it does the same in reverse: two alternating starts each throw away the other's cast.

## Modifications

Fold the module's `state_dict` layout (parameter names and shapes) into the hashed key, so different layouts land in different files. `vae` is optional: callers without the module keep the old key, and `_rehome_cast_weights_to_file` — the one caller that owns the module — passes it.

Extracted from #37822; the rest of that PR (read-only checkpoint mappings, `readonly_safetensors`, the `loader/utils` and `safetensors_mmap` wiring) is already on main via #38441, and this fix was the only part left.

## Accuracy Tests

Not applicable — the stored weights are unchanged; only the file they are stored in changes.

## Benchmarking and Profiling

Not applicable — no steady-state path changes. The effect is on startup: a version pair that used to re-cast the decoder on every alternating start now finds its own store.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests: `test_module_layouts_do_not_share_a_store` covers two modules with different parameter sets keeping separate stores; the existing store tests now pass the module through.
- [x] `test_vae_decoder_store.py` + `test_vae_loader.py` — 43 passed on an H200.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34220794696](https://github.com/sgl-project/sglang/actions/runs/34220794696)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34220831965](https://github.com/sgl-project/sglang/actions/runs/34220831965)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34220794509](https://github.com/sgl-project/sglang/actions/runs/34220794509)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->