### PR TITLE
[Docs] Drop non-CLI --custom-sigquit-handler from Ascend support_features

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/reference/support_features.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/reference/support_features.mdx
@@ -697,12 +697,6 @@ click [Server Arguments](../../../advanced_features/server_arguments).
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>bool flag (set to enable)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Special for GPU</td>
     </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--custom-sigquit-handler`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Only for engine</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>A2, A3</td>
-    </tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
## Summary
Ascend `support_features.mdx` still documents `--custom-sigquit-handler` as a CLI flag. That name is only a Python engine field (`Optional[Callable]`, no `Arg()`), so it is not a server CLI option. #38413 already cleaned the same ghost from `server_arguments.mdx`; this PR removes the leftover Ascend table row.

## Repro
1. On upstream `main` (`554f8179` or newer), open:
   `docs/docs/hardware-platforms/ascend-npus/reference/support_features.mdx`
   and search for `` `--custom-sigquit-handler` `` — the Device / process table still lists it as Ascend-supported (default `None`, "Only for engine", A2/A3).
2. Raw check:
   ```bash
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/docs/docs/hardware-platforms/ascend-npus/reference/support_features.mdx \
     | rg -n 'custom-sigquit-handler'
   ```
3. Field definition (not CLI):
   ```bash
   curl -sL https://raw.githubusercontent.com/sgl-project/sglang/main/python/sglang/srt/arg_groups/fields/device.py \
     | rg -n -C3 'custom_sigquit_handler'
   ```
   Shows `custom_sigquit_handler: Optional[Callable] = None` with no `Arg(...)` wrapper, so it is not registered as a CLI flag.
4. Contrast with #38413, which only updates `docs/docs/advanced_features/server_arguments.mdx`.

## Change
- Remove the `--custom-sigquit-handler` table row from Ascend `support_features.mdx` so the docs no longer claim a non-existent CLI flag.

## Test plan
- [x] Confirmed row present on main via raw URL before edit
- [x] Confirmed `device.py` field has no `Arg()`
- [x] After edit, file no longer contains `custom-sigquit-handler`
- [ ] Docs preview / maintainer spot-check of the Device table

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34220988325](https://github.com/sgl-project/sglang/actions/runs/34220988325)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34220987917](https://github.com/sgl-project/sglang/actions/runs/34220987917)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->