### PR TITLE
fix(npu-graph): allow text-only decode with uniformly-zero encoder_lens

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -724,14 +724,22 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 is_bs_supported and forward_batch.can_run_decode_cuda_graph
             )
 
-        # NOTE: cuda graph cannot handle mixed batch (encoder_len = 0)
-        # If mixed batch cannot be supported, then encoder_lens can be removed in cuda graph
-        # because the full_text_row_masked_out_mask tensor will always be ones
-        is_encoder_lens_supported = (
-            torch.all(forward_batch.encoder_lens > 0)
-            if self.is_encoder_decoder
-            else True
-        )
+        # NOTE: cuda graph cannot handle a mixed batch where some requests have
+        # an encoder (encoder_lens > 0) and some do not (encoder_lens = 0),
+        # because the cross-attention path differs. However, a batch where ALL
+        # requests are text-only (encoder_lens uniformly 0) is safe for graph
+        # replay: the graph was captured with cross-attention included, and at
+        # replay time full_text_row_masked_out_mask zeros the cross-attention
+        # output, making it equivalent to skipping. Allow graph replay when
+        # encoder lengths are uniformly zero or uniformly positive, but reject
+        # mixed batches.
+        if self.is_encoder_decoder:
+            encoder_lens = forward_batch.encoder_lens
+            is_encoder_lens_supported = bool(
+                (encoder_lens == 0).all() or (encoder_lens > 0).all()
+            )
+        else:
+            is_encoder_lens_supported = True
 
         is_tbo_supported = (
             forward_batch.can_run_tbo if self.enable_two_batch_overlap else True
@@ -766,11 +774,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             forward_batch.can_run_decode_cuda_graph if self.require_mlp_sync else True
         )
 
-        is_encoder_lens_supported = (
-            torch.all(forward_batch.encoder_lens > 0)
-            if self.is_encoder_decoder
-            else True
-        )
+        if self.is_encoder_decoder:
+            encoder_lens = forward_batch.encoder_lens
+            is_encoder_lens_supported = bool(
+                (encoder_lens == 0).all() or (encoder_lens > 0).all()
+            )
+        else:
+            is_encoder_lens_supported = True
 
         capture_hidden_mode_matches = (
             forward_batch.capture_hidden_mode <= self.capture_hidden_mode


### PR DESCRIPTION
## Problem

On Ascend NPU, every text-only decode step on encoder-decoder models (MossVL, Mllama, Whisper, ...) fell back to the eager path because `can_run()` required `torch.all(forward_batch.encoder_lens > 0)`. A pure-text decode batch has `encoder_lens` uniformly 0, so the guard failed and cuda-graph replay was never used — costing ~40% throughput on MOSS-VL-Instruct-0708 (910B2C, measured 28.4 → 46.3 tok/s after this fix).

## Root Cause

`DecodeCudaGraphRunner.can_run()` (two call sites: the admission check and the ragged-capture check) used:

```python
is_encoder_lens_supported = (
    torch.all(forward_batch.encoder_lens > 0)
    if self.is_encoder_decoder
    else True
)
```

which treats 'all-positive' as the only supported state. A uniformly-zero batch is actually safe for graph replay: the graph is captured with cross-attention included, and at replay time `full_text_row_masked_out_mask` zeros the cross-attention output, making it equivalent to skipping cross-attention entirely.

## Fix

Allow graph replay when `encoder_lens` are **uniformly zero OR uniformly positive**, and reject only mixed batches (some 0, some >0), which would require different cross-attention behavior within one captured graph:

```python
if self.is_encoder_decoder:
    encoder_lens = forward_batch.encoder_lens
    is_encoder_lens_supported = bool(
        (encoder_lens == 0).all() or (encoder_lens > 0).all()
    )
else:
    is_encoder_lens_supported = True
```

Applies to both call sites (the main admission check and the ragged-capture path).

## Benchmark

MOSS-VL-Instruct-0708, Ascend 910B2C, text-only decode:

| | Before | After |
|---|---|---|
| tok/s | 28.4 | 46.3 (+63%) |
| graph replay | never (always eager) | every text-only step |

## Testing

- `python -c "import ast; ast.parse(open('python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py').read())"` — syntax OK
- Verified on a live MOSS-VL sglang server on NPU: text-only prompts now hit the graph path (no eager fallback in the logs), multimodal prompts unaffected (mixed batches still rejected).

## Compatibility

- CUDA/other backends: no behavior change (the `is_encoder_decoder` branch only fires on encoder-decoder models, which on CUDA already handle `encoder_lens=0` correctly via the flashinfer path; the eager-fallback guard is the one being relaxed).
- Mixed batches (0 and >0 in one batch) are still rejected, so no correctness change for multimodal prefill+decode overlap.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35574844218](https://github.com/sgl-project/sglang/actions/runs/35574844218)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35574844025](https://github.com/sgl-project/sglang/actions/runs/35574844025)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35574844259](https://github.com/sgl-project/sglang/actions/runs/35574844259)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->