### PR TITLE
fix(npu-sdpa): apply cross_attention_custom_mask in ascend torch-native sdpa backend

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1612,6 +1612,9 @@ class AscendAttnBackend(AttentionBackend):
                     o_ = attn_output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
                     # add forward_batch.encoder_lens and is_cross_attention arguments for cross attention scene
+                    cross_attn_custom_mask = getattr(
+                        forward_batch, "cross_attention_custom_mask", None
+                    )
                     attn_output = self.native_attn.run_sdpa_forward_extend(
                         q_,
                         o_,
@@ -1635,6 +1638,7 @@ class AscendAttnBackend(AttentionBackend):
                         ),
                         logit_cap=layer.logit_cap,
                         logit_capping_method=layer.logit_capping_method,
+                        cross_attention_custom_mask=cross_attn_custom_mask,
                     )
                     attn_output = attn_output.view(
                         -1, layer.tp_q_head_num * layer.v_head_dim

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_torch_native_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_torch_native_backend.py
@@ -74,6 +74,7 @@ class AscendTorchNativeAttnBackend:
         full_to_swa_mapping: Optional[torch.Tensor] = None,
         logit_cap: float = 0.0,
         logit_capping_method: str = "tanh",
+        cross_attention_custom_mask: Optional[torch.Tensor] = None,
     ):
         """Run the extend forward by using torch native sdpa op.
 
@@ -107,6 +108,7 @@ class AscendTorchNativeAttnBackend:
         query = query.movedim(0, query.dim() - 2)
 
         start_q, start_kv = 0, 0
+        mask_offset = 0  # running offset into packed cross_attention_custom_mask
         for seq_idx in range(seq_lens.shape[0]):
             # Need optimize the performance later.
 
@@ -177,6 +179,60 @@ class AscendTorchNativeAttnBackend:
                 # scaled_dot_product_attention() expects query, key, and value to have the same dtype
                 per_req_key = per_req_key.to(per_req_query.dtype)
                 per_req_value = per_req_value.to(per_req_query.dtype)
+
+            if is_cross_attention:
+                # Cross-attention: query = new text tokens (extend_seq_len rows,
+                # unpadded), key/value = encoder (vision) tokens (encoder_len).
+                # Q and KV lengths legitimately differ, so the padded
+                # per_req_query_redundant / causal-mask self-attention path does
+                # not apply. An optional frame-level custom mask
+                # (cross_attention_custom_mask, packed [extend*encoder] per req)
+                # controls which vision tokens each text token may attend to —
+                # required for correct multi-turn, multi-image cross-attention.
+                per_req_attn_mask = None
+                if cross_attention_custom_mask is not None:
+                    kv_len = per_req_key.shape[1]  # = encoder_len
+                    q_len_r = extend_seq_len_q
+                    mask_slice = cross_attention_custom_mask[
+                        mask_offset : mask_offset + q_len_r * kv_len
+                    ].reshape(q_len_r, kv_len)
+                    # Packed mask: 1=visible, 0=masked. sdpa bool mask:
+                    # True=visible, False=masked.
+                    per_req_attn_mask = mask_slice.bool().unsqueeze(0).unsqueeze(0)
+                    mask_offset += q_len_r * kv_len
+
+                if logit_cap > 0:
+                    per_req_out = (
+                        self.scaled_dot_product_attention_with_softcapping(
+                            per_req_query.unsqueeze(0),
+                            per_req_key.unsqueeze(0),
+                            per_req_value.unsqueeze(0),
+                            enable_gqa=enable_gqa,
+                            scale=scaling,
+                            is_causal=False,
+                            logit_cap=logit_cap,
+                            logit_capping_method=logit_capping_method,
+                        )
+                        .squeeze(0)
+                        .movedim(query.dim() - 2, 0)
+                    )
+                else:
+                    per_req_out = (
+                        scaled_dot_product_attention(
+                            per_req_query.unsqueeze(0),
+                            per_req_key.unsqueeze(0),
+                            per_req_value.unsqueeze(0),
+                            enable_gqa=enable_gqa,
+                            scale=scaling,
+                            is_causal=False,
+                            attn_mask=per_req_attn_mask,
+                        )
+                        .squeeze(0)
+                        .movedim(query.dim() - 2, 0)
+                    )
+                output[start_q:end_q, :, :] = per_req_out
+                start_q, start_kv = end_q, end_kv
+                continue
 
             if logit_cap > 0:
                 per_req_out_redundant = (


### PR DESCRIPTION
## Problem

MossVL sets `forward_batch.cross_attention_custom_mask` to control **frame-level cross-attention visibility** in multi-turn, multi-image dialogue (a text token may only attend to the vision tokens of its own turn). The flashinfer backend consumes this mask, but the Ascend torch-native sdpa backend (`run_sdpa_forward_extend`) ignored it. On NPU every text token attended every cached vision token, corrupting cross-attention for multi-image conversations (e.g. the model mixes content from a previous image into the current answer).

## Root Cause

`run_sdpa_forward_extend` had no `cross_attention_custom_mask` parameter, so the mask was never reachable. Its single self/cross-attention loop always ran the padded-query + causal-mask self-attention path, which is wrong for cross-attention (Q length = `extend_seq_len`, KV length = `encoder_len`; they legitimately differ and must not be padded to a common length with a causal mask).

## Fix

1. Add `cross_attention_custom_mask: Optional[torch.Tensor] = None` to `run_sdpa_forward_extend`.
2. Add a dedicated cross-attention branch (entered when `is_cross_attention`) that:
   - uses the **unpadded** `per_req_query` (extend_seq_len rows) against the encoder KV,
   - slices the per-request packed mask `[extend_len x encoder_len]` (1 = visible) into a bool sdpa `attn_mask` (True = visible) using a running `mask_offset`,
   - runs sdpa with `is_causal=False` (cross-attention has no causal constraint) and `attn_mask=per_req_attn_mask`,
   - `continue`s so the self-attention path is skipped for that request.
3. `ascend_backend.py` extracts the mask from `forward_batch` and passes it at the native-sdpa extend call site.

The self-attention path (SWA, prefix cache, MLA) is unchanged.

## Testing

- Syntax check passed on both modified files.
- On a live MOSS-VL sglang server on NPU, a 2-image multi-turn prompt now produces correct per-turn cross-attention (the second turn no longer attends to the first image's tokens); the mask offset accounting is per-request and resets each extend call.

## Compatibility

- CUDA / other devices: no change (only the Ascend torch-native sdpa backend and its NPU caller are touched).
- NPU self-attention (no `is_cross_attention`): code path unchanged; `cross_attention_custom_mask` defaults to `None` and the branch is not entered.
- NPU cross-attention without a mask (single-image): `cross_attention_custom_mask` is `None` → `per_req_attn_mask` stays `None` → plain causal-off sdpa, same as before but with correct unpadded query sizing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35574851774](https://github.com/sgl-project/sglang/actions/runs/35574851774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35574851551](https://github.com/sgl-project/sglang/actions/runs/35574851551)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35574851730](https://github.com/sgl-project/sglang/actions/runs/35574851730)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->