### PR TITLE
[diffusion] Allow component CPU offload for transformers-managed quantized text encoders

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -47,6 +47,7 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import (
     checkpoint_weights_iterator,
 )
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency import (
+    LAYERWISE_OFFLOAD,
     RESIDENT,
     ComponentResidencyError,
 )
@@ -530,22 +531,41 @@ class ComponentLoader(ABC):
                 config, component_name or "component"
             ):
                 resolved_component_name = component_name or "component"
+                start_on_cpu = server_args.should_start_component_on_cpu(
+                    resolved_component_name
+                )
                 explicit_residency = server_args.explicit_residency_mode(
                     resolved_component_name
                 )
-                if explicit_residency is not None and explicit_residency != RESIDENT:
+                # Quant TE can component-offload; layerwise is unsupported.
+                if explicit_residency == LAYERWISE_OFFLOAD:
                     raise ComponentCheckpointUnsupportedError(
                         "Transformers-managed quantized component "
-                        f"{resolved_component_name!r} requires resident placement; "
-                        f"got explicit mode {explicit_residency!r}"
+                        f"{resolved_component_name!r} does not support "
+                        "layerwise offload; use component CPU offload or "
+                        "keep it resident"
                     )
-                server_args.require_component_resident(
-                    resolved_component_name,
-                    feature_name="Transformers quantized component",
-                )
-                load_kwargs["device_map"] = {
-                    "": self.target_device(component_starts_on_cpu=False)
-                }
+                if start_on_cpu:
+                    load_kwargs["device_map"] = {
+                        "": self.target_device(component_starts_on_cpu=True)
+                    }
+                else:
+                    if (
+                        explicit_residency is not None
+                        and explicit_residency != RESIDENT
+                    ):
+                        raise ComponentCheckpointUnsupportedError(
+                            "Transformers-managed quantized component "
+                            f"{resolved_component_name!r} requires resident "
+                            f"placement; got explicit mode {explicit_residency!r}"
+                        )
+                    server_args.require_component_resident(
+                        resolved_component_name,
+                        feature_name="Transformers quantized component",
+                    )
+                    load_kwargs["device_map"] = {
+                        "": self.target_device(component_starts_on_cpu=False)
+                    }
                 self._native_load_manages_placement = True
             model_class = self.resolve_native_transformers_model_class(config)
             return model_class.from_pretrained(

--- a/python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py
@@ -232,6 +232,7 @@ class TestTextEncoderClassResolution(unittest.TestCase):
             component_precisions={},
             pipeline_config=SimpleNamespace(text_encoder_precisions=["bf16"]),
             explicit_residency_mode=mock.Mock(return_value=None),
+            should_start_component_on_cpu=mock.Mock(return_value=False),
             require_component_resident=mock.Mock(),
             should_use_fsdp_for_component=mock.Mock(return_value=False),
             revision=None,
@@ -285,6 +286,70 @@ class TestTextEncoderClassResolution(unittest.TestCase):
 
 
 class TestMiniMaxH3CheckpointFilter(unittest.TestCase):
+
+    def test_bitsandbytes_native_load_honors_cpu_offload(self):
+        loaded_encoder = nn.Linear(1, 1)
+        transformers_model_class = SimpleNamespace(
+            from_pretrained=mock.Mock(return_value=loaded_encoder)
+        )
+        server_args = SimpleNamespace(
+            component_precisions={},
+            pipeline_config=SimpleNamespace(text_encoder_precisions=["bf16"]),
+            explicit_residency_mode=mock.Mock(return_value=None),
+            should_start_component_on_cpu=mock.Mock(return_value=True),
+            require_component_resident=mock.Mock(),
+            should_use_fsdp_for_component=mock.Mock(return_value=False),
+            revision=None,
+            trust_remote_code=False,
+        )
+        component_config = {
+            "quantization_config": {
+                "load_in_4bit": True,
+                "quant_method": "bitsandbytes",
+            }
+        }
+
+        loader = TextEncoderLoader()
+        with (
+            mock.patch.object(
+                TextEncoderLoader,
+                "resolve_native_transformers_model_class",
+                return_value=transformers_model_class,
+            ),
+            mock.patch.object(
+                loader,
+                "target_device",
+                side_effect=lambda component_starts_on_cpu: (
+                    torch.device("cpu")
+                    if component_starts_on_cpu
+                    else torch.device("cuda:0")
+                ),
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.runtime.loader.component_loaders."
+                "component_loader.get_hf_config",
+                return_value=component_config,
+            ),
+        ):
+            encoder = loader.load_native(
+                "/model/text_encoder",
+                server_args,
+                "transformers",
+                "text_encoder",
+            )
+
+        self.assertIs(encoder, loaded_encoder)
+        server_args.require_component_resident.assert_not_called()
+        transformers_model_class.from_pretrained.assert_called_once_with(
+            "/model/text_encoder",
+            config=component_config,
+            trust_remote_code=False,
+            revision=None,
+            torch_dtype=torch.bfloat16,
+            device_map={"": torch.device("cpu")},
+        )
+
+
     def test_only_known_unconsumed_weights_are_filtered(self):
         encoder = MiniMaxH3Qwen3VLEncoder.__new__(MiniMaxH3Qwen3VLEncoder)
         encoder.selected_lm_layer = 50


### PR DESCRIPTION
## Motivation

`ComponentLoader.load_native` always pins transformers-managed quantized text encoders to CUDA (`device_map` + `require_component_resident`), even when `--text-encoder-cpu-offload` / component residency requests CPU start.

On low-VRAM cards this OOMs during TE load when DiT also needs the GPU (e.g. Z-Image Turbo NF4 TE + Nunchaku on RTX 3050 8GB).

Component CPU offload is already wired through the residency manager for TextEncodingStage; only the native quant load path ignored that policy.

## Modifications

- Honor `should_start_component_on_cpu` for transformers-managed quant TE: `device_map` → CPU, skip forcing resident.
- Keep resident behavior when offload is not requested.
- Reject layerwise residency for these checkpoints with a clearer error.

## Test plan

- [x] unit: `test_bitsandbytes_native_load_requires_resident_encoder` (still CUDA `device_map`)
- [x] unit: `test_bitsandbytes_native_load_honors_cpu_offload` (CPU `device_map`, no `require_component_resident`)
- [ ] CI: `python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py`
- [ ] Manual (optional, 8GB): `sglang generate` with `--text-encoder-cpu-offload true --dit-cpu-offload true --dit-layerwise-offload true` + NF4 TE / Nunchaku DiT

## Reproduce (3050)

Expect/actual without this change: OOM in transformers `caching_allocator_warmup` while loading NF4 TE.
With change: TE loads on CPU; residency manager onloads for encode; generation completes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34221837061](https://github.com/sgl-project/sglang/actions/runs/34221837061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34221836855](https://github.com/sgl-project/sglang/actions/runs/34221836855)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34221837139](https://github.com/sgl-project/sglang/actions/runs/34221837139)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->