### PR TITLE
[HiCache][bugfix] Fix cudaGetErrorString TypeError masking cudaHostRegister failures

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -156,10 +156,10 @@ def _cuda_host_register(
         while offset < total:
             size = min(chunk_bytes, total - offset)
             ptr = base + offset
-            rc = int(cudart.cudaHostRegister(ptr, size, 0))
-            if rc != 0:
+            rc = cudart.cudaHostRegister(ptr, size, 0)
+            if int(rc) != 0:
                 raise RuntimeError(
-                    f"cudaHostRegister failed (rc={rc}, "
+                    f"cudaHostRegister failed (rc={int(rc)}, "
                     f"{cudart.cudaGetErrorString(rc)}) at offset={offset} size={size} "
                     f"(total={total}, chunk_limit={chunk_bytes}); host buffer is not "
                     f"pinned and device transfers may silently return stale data."
@@ -185,13 +185,13 @@ def _cuda_host_unregister_ranges(
 ) -> list[tuple[int, int]]:
     failed_ranges = []
     for ptr, size in reversed(registered_ranges):
-        rc = int(cudart.cudaHostUnregister(ptr))
-        if rc != 0:
+        rc = cudart.cudaHostUnregister(ptr)
+        if int(rc) != 0:
             failed_ranges.append((ptr, size))
             logger.warning(
                 "cudaHostUnregister failed during %s (rc=%d, %s) for ptr=%#x size=%d",
                 operation,
-                rc,
+                int(rc),
                 cudart.cudaGetErrorString(rc),
                 ptr,
                 size,

--- a/test/registered/unit/mem_cache/test_hicache_host_register.py
+++ b/test/registered/unit/mem_cache/test_hicache_host_register.py
@@ -14,6 +14,7 @@ from sglang.srt.mem_cache.pool_host import mha as mha_pool_host
 from sglang.srt.mem_cache.pool_host import mla as mla_pool_host
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
+    _CUDA_HOST_REGISTERED_RANGES_ATTR,
     _cuda_host_register,
     _cuda_host_unregister,
 )
@@ -63,6 +64,37 @@ class _FakeCudart:
 
     def cudaGetErrorString(self, rc: int) -> str:
         return "injected error"
+
+
+class _FakeCudaError:
+    """Mimics the torch._C._cudart.cudaError pybind enum: int(rc) works,
+    but the object is not an int instance."""
+
+    def __init__(self, value: int):
+        self.value = value
+
+    def __int__(self) -> int:
+        return self.value
+
+
+class _FakePybindCudart:
+    """cudaGetErrorString mimics the real pybind binding, which accepts only
+    the cudaError enum and raises TypeError on a plain int."""
+
+    def __init__(self, register_rc: int = 0, unregister_rc: int = 0):
+        self.register_rc = register_rc
+        self.unregister_rc = unregister_rc
+
+    def cudaHostRegister(self, ptr: int, size: int, flags: int) -> _FakeCudaError:
+        return _FakeCudaError(self.register_rc)
+
+    def cudaHostUnregister(self, ptr: int) -> _FakeCudaError:
+        return _FakeCudaError(self.unregister_rc)
+
+    def cudaGetErrorString(self, rc) -> str:
+        if isinstance(rc, int):
+            raise TypeError("cudaGetErrorString(): incompatible function arguments")
+        return "invalid argument"
 
 
 class TestHiCacheHostRegister(unittest.TestCase):
@@ -353,6 +385,46 @@ class TestHiCacheHostRegister(unittest.TestCase):
             [(base, gib, 0), (base + gib, gib, 0)],
         )
         self.assertEqual(cudart.unregistrations, [base])
+
+    def test_register_failure_reports_cuda_error_string(self):
+        """Regression: the error path must hand the cudaError enum to
+        cudaGetErrorString. Passing int(rc) raises TypeError in the pybind
+        binding, so the real failure (rc/offset/size) never surfaces and
+        startup dies with a bare TypeError."""
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 4096)
+        cudart = _FakePybindCudart(register_rc=1)
+
+        with (
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"cudaHostRegister failed \(rc=1, invalid argument\) "
+                r"at offset=0 size=4096",
+            ),
+        ):
+            _cuda_host_register(buffer)
+
+    def test_unregister_failure_reports_cuda_error_string(self):
+        """Same enum contract on the unregister warning path: a failed
+        cudaHostUnregister must log the CUDA error string and keep the
+        range for a later retry, not crash with TypeError."""
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 4096)
+        cudart = _FakePybindCudart(register_rc=0, unregister_rc=1)
+
+        with mock.patch.object(torch.cuda, "cudart", return_value=cudart):
+            _cuda_host_register(buffer)
+            with self.assertLogs(
+                "sglang.srt.mem_cache.pool_host.common", level="WARNING"
+            ) as logs:
+                _cuda_host_unregister(buffer)
+
+        self.assertIn("invalid argument", "\n".join(logs.output))
+        self.assertEqual(
+            getattr(buffer, _CUDA_HOST_REGISTERED_RANGES_ATTR),
+            [(base, 4096)],
+        )
 
     def test_missing_copy_granularity_preserves_single_registration(self):
         gib = 1024**3


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Since #36798 ("Align chunked CUDA host registrations"), `_cuda_host_register` in
`python/sglang/srt/mem_cache/pool_host/common.py` converts the `cudaHostRegister`
return code to `int` and then passes that `int` to `cudart.cudaGetErrorString(rc)`
when building the error message. The pybind11 binding only accepts a
`torch._C._cudart.cudaError` enum, so whenever `cudaHostRegister` actually fails,
the error-reporting path itself raises:

```
20:31:12,173] [ERROR] [PID-1961-MainThread] [sglang.srt.managers.scheduler] >>> Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 5584, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 559, in __init__
    result = kv_cache_builder.build_kv_cache(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/kv_cache_builder.py", line 322, in build_kv_cache
    tree_cache = create_tree_cache(
                 ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/registry.py", line 213, in create_tree_cache
    cache = default_radix_cache_factory(ctx)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/registry.py", line 143, in default_radix_cache_factory
    return _create_unified_radix_cache(ctx, server_args, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/registry.py", line 192, in _create_unified_radix_cache
    cache.init_hicache(server_args, params)
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/unified_radix_cache.py", line 430, in init_hicache
    attach_hybrid_pool_to_unified_cache(
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 1759, in attach_hybrid_pool_to_unified_cache
    result = strategy.build(
             ^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 1528, in build
    host_pool_group, cache_controller = build_anchor_sidecar_stack(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 932, in build_anchor_sidecar_stack
    kv_host_pool = build_kv_host_pool(
                   ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 160, in build_kv_host_pool
    return kv_host_pool_cls(
           ^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/pool_host/mla.py", line 74, in __init__
    super().__init__(
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/pool_host/base.py", line 205, in __init__
    self.kv_buffer = self.init_kv_buffer()
                     ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/pool_host/mla.py", line 203, in init_kv_buffer
    buffer = alloc_func(
             ^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/pool_host/common.py", line 235, in alloc_with_host_register
    _cuda_host_register(buffer, registration_granularity_bytes)
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/pool_host/common.py", line 163, in _cuda_host_register
    f"{cudart.cudaGetErrorString(rc)}) at offset={offset} size={size} "
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cudaGetErrorString(): incompatible function arguments. The following argument types are supported:
    1. (arg0: torch._C._cudart.cudaError) -> str

Invoked with: 1
```

The real failure (return code, offset, size) is completely swallowed, which makes
HiCache host-pool registration failures un-debuggable — the scheduler dies during
startup with a `TypeError` instead of the actual CUDA error. The same latent bug
exists in `_cuda_host_unregister_ranges` (warning path).

Reproduced on torch 2.6.0+cu124:

```python
>>> cudart.cudaGetErrorString(1)
TypeError: cudaGetErrorString(): incompatible function arguments...
```

The existing unit tests did not catch this because their fake cudart accepts an
`int` in `cudaGetErrorString`; the new fakes mimic the pybind signature
faithfully (enum-only) and the new regression tests fail on the pre-fix code.

## Modifications


- `python/sglang/srt/mem_cache/pool_host/common.py`
  - `_cuda_host_register`: keep the raw `cudaError` enum returned by
    `cudaHostRegister`, compare with `int(rc) != 0`, and pass the enum to
    `cudaGetErrorString` so the real error string (e.g. `invalid argument`)
    is reported along with the offset/size context.
  - `_cuda_host_unregister_ranges`: same fix for the rollback/destroy
    warning path.
- `test/registered/unit/mem_cache/test_hicache_host_register.py`
  - Add `_FakeCudaError` / `_FakePybindCudart` fakes that reproduce the
    pybind enum-only signature of `cudaGetErrorString`.
  - Add `test_register_failure_reports_cuda_error_string` and
    `test_unregister_failure_reports_cuda_error_string` regression tests.
    Both fail with `TypeError` on the pre-fix code and pass on the fix;
    all 13 tests in the file pass.

No behavior change on the success path; only error reporting is fixed.

## Accuracy Tests

N/A — error-handling path only; no model output or kernel changes.

## Speed Tests and Profiling

N/A — error-handling path only; the success path executes identical CUDA calls.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests — two regression tests in
  `test/registered/unit/mem_cache/test_hicache_host_register.py`; verified red
  on the pre-fix code and green on the fix.
- [x] Update documentation — N/A, no user-facing behavior change.
- [x] Provide accuracy and speed benchmark results — N/A (see above).
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34927233937](https://github.com/sgl-project/sglang/actions/runs/34927233937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34927233762](https://github.com/sgl-project/sglang/actions/runs/34927233762)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34927233960](https://github.com/sgl-project/sglang/actions/runs/34927233960)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->