### PR TITLE
[4/N] Quantization Refactor: unify the scheme ABCs

### DIFF
--- a/python/sglang/srt/layers/quantization/awq/schemes/awq_scheme.py
+++ b/python/sglang/srt/layers/quantization/awq/schemes/awq_scheme.py
@@ -1,54 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional
-
-import torch
-
-from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
-
-if TYPE_CHECKING:
-    from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
 __all__ = ["AWQLinearSchemeBase", "AWQMoESchemeBase"]
 
 
 class AWQLinearSchemeBase(BaseLinearScheme):
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
-    ):
-        raise NotImplementedError
+    """Base class for AWQ linear schemes. The contract is BaseLinearScheme's."""
 
 
 class AWQMoESchemeBase(BaseMoEScheme):
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_moe_runner(
-        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
-    ):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self,
-        layer: torch.nn.Module,
-        dispatch_output: "StandardDispatchOutput",
-    ):
-        raise NotImplementedError
+    """Base class for AWQ MoE schemes. The contract is BaseMoEScheme's."""

--- a/python/sglang/srt/layers/quantization/base_scheme.py
+++ b/python/sglang/srt/layers/quantization/base_scheme.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
 __all__ = ["BaseLinearScheme", "BaseMoEScheme"]
 
@@ -19,6 +23,17 @@ class BaseLinearScheme(ABC):
     # routes them through weight_loader_v2 without flipping the loader for
     # every scheme that shares the same LinearMethod class.
     requires_weight_loader_v2: bool = False
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        """
+        Get minimum device capability.
+
+        Declared rather than abstract: only the config classes that gate on
+        device capability call it, and schemes outside those families are
+        never asked.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def create_weights(self, *args, **kwargs):
@@ -59,6 +74,22 @@ class BaseMoEScheme(ABC):
     of different quantization schemes.
     """
 
+    # Whether the fused W13 parameter is laid out as [up; gate] rather than
+    # the default [gate; up]. Read off the scheme by the MoE method that
+    # owns it and forwarded to the FusedMoE weight loader.
+    load_up_proj_weight_first: bool = False
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        """
+        Get minimum device capability.
+
+        Declared rather than abstract: only the config classes that gate on
+        device capability call it, and schemes outside those families are
+        never asked.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def create_weights(self, *args, **kwargs):
         """
@@ -72,5 +103,35 @@ class BaseMoEScheme(ABC):
         """
         Called after weight loading is complete for any cleanup that
         needs to occur.
+        """
+        raise NotImplementedError
+
+    def create_moe_runner(
+        self, layer: torch.nn.Module, moe_runner_config: "MoeRunnerConfig"
+    ):
+        """
+        Build the MoeRunner this scheme dispatches through.
+
+        Declared rather than abstract: schemes whose family drives the runner
+        from the MoE method instead of the scheme do not implement it.
+        """
+        raise NotImplementedError
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        dispatch_output: "StandardDispatchOutput",
+    ):
+        """
+        Run the forward pass for the particular scheme. This is where
+        scheme-specific dequant/quant steps/kernels should be applied.
+
+        Declared rather than abstract: schemes whose family drives the runner
+        from the MoE method instead of the scheme do not implement it.
+
+        :param layer: torch.nn.Module with the registered weights and
+            other parameters relevant to the particular scheme.
+        :param dispatch_output: output of the token dispatcher
+
         """
         raise NotImplementedError

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
@@ -2,117 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional
-
-import torch
-
-from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
-
-if TYPE_CHECKING:
-    from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
 __all__ = ["CompressedTensorsLinearScheme", "CompressedTensorsMoEScheme"]
 
 
 class CompressedTensorsLinearScheme(BaseLinearScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by CompressedTensors.
+    Base class for the linear schemes supported by CompressedTensors. The
+    contract is BaseLinearScheme's.
     """
-
-    @classmethod
-    def get_min_capability(cls) -> int:
-        """
-        Get minimum device capability.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
-    ):
-        """
-        Run the forward pass for the particular scheme. This is where
-        scheme-specific dequant/quant steps/kernels should be applied.
-
-        :param layer: torch.nn.Module with the registered weights and
-            other parameters relevant to the particular scheme.
-        :param x: input to the layer
-        :param bias: bias parameter
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError
 
 
 class CompressedTensorsMoEScheme(BaseMoEScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by CompressedTensors.
+    Base class for the MoE schemes supported by CompressedTensors. The
+    contract is BaseMoEScheme's.
     """
-
-    load_up_proj_weight_first = False
-
-    @classmethod
-    def get_min_capability(cls) -> int:
-        """
-        Get minimum device capability.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_moe_runner(
-        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
-    ):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self,
-        layer: torch.nn.Module,
-        dispatch_output: "StandardDispatchOutput",
-    ):
-        """
-        Run the forward pass for the particular scheme. This is where
-        scheme-specific dequant/quant steps/kernels should be applied.
-
-        :param layer: torch.nn.Module with the registered weights and
-            other parameters relevant to the particular scheme.
-        :param x: input to the layer
-        :param bias: bias parameter
-
-        """
-        raise NotImplementedError

--- a/python/sglang/srt/layers/quantization/gptq/schemes/gptq_scheme.py
+++ b/python/sglang/srt/layers/quantization/gptq/schemes/gptq_scheme.py
@@ -1,54 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional
-
-import torch
-
-from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
-
-if TYPE_CHECKING:
-    from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
 __all__ = ["GPTQLinearSchemeBase", "GPTQMoESchemeBase"]
 
 
 class GPTQLinearSchemeBase(BaseLinearScheme):
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
-    ):
-        raise NotImplementedError
+    """Base class for GPTQ linear schemes. The contract is BaseLinearScheme's."""
 
 
 class GPTQMoESchemeBase(BaseMoEScheme):
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_moe_runner(
-        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
-    ):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self,
-        layer: torch.nn.Module,
-        dispatch_output: "StandardDispatchOutput",
-    ):
-        raise NotImplementedError
+    """Base class for GPTQ MoE schemes. The contract is BaseMoEScheme's."""

--- a/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_scheme.py
+++ b/python/sglang/srt/layers/quantization/modelslim/schemes/modelslim_scheme.py
@@ -2,11 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from abc import abstractmethod
-from typing import Optional
-
-import torch
-
 from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
 
 __all__ = ["ModelSlimLinearScheme", "ModelSlimMoEScheme"]
@@ -14,61 +9,13 @@ __all__ = ["ModelSlimLinearScheme", "ModelSlimMoEScheme"]
 
 class ModelSlimLinearScheme(BaseLinearScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by ModelSlim.
+    Base class for the linear schemes supported by ModelSlim. The contract is
+    BaseLinearScheme's.
     """
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
-    ):
-        """
-        Run the forward pass for the particular scheme. This is where
-        scheme-specific dequant/quant steps/kernels should be applied.
-
-        :param layer: torch.nn.Module with the registered weights and
-            other parameters relevant to the particular scheme.
-        :param x: input to the layer
-        :param bias: bias parameter
-
-        """
-        raise NotImplementedError
 
 
 class ModelSlimMoEScheme(BaseMoEScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by ModelSlim.
+    Base class for the MoE schemes supported by ModelSlim. The contract is
+    BaseMoEScheme's.
     """
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
@@ -1,116 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional
-
-import torch
-
-from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
-
-if TYPE_CHECKING:
-    from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 
 __all__ = ["QuarkLinearScheme", "QuarkMoEScheme"]
 
 
 class QuarkLinearScheme(BaseLinearScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by Quark.
+    Base class for the linear schemes supported by Quark. The contract is
+    BaseLinearScheme's.
     """
-
-    @classmethod
-    @abstractmethod
-    def get_min_capability(cls) -> int:
-        """
-        Get minimum device capability.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
-    ):
-        """
-        Run the forward pass for the particular scheme. This is where
-        scheme-specific dequant/quant steps/kernels should be applied.
-
-        :param layer: torch.nn.Module with the registered weights and
-            other parameters relevant to the particular scheme.
-        :param x: input to the layer
-        :param bias: bias parameter
-
-        """
-        raise NotImplementedError
 
 
 class QuarkMoEScheme(BaseMoEScheme):
     """
-    Abstract class used to describe the weight creation and forward pass
-    of different quantization schemes supported by Quark.
+    Base class for the MoE schemes supported by Quark. The contract is
+    BaseMoEScheme's.
     """
-
-    @classmethod
-    @abstractmethod
-    def get_min_capability(cls) -> int:
-        """
-        Get minimum device capability.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_weights(self, *args, **kwargs):
-        """
-        Weight creation for the particular scheme. Inputs to this function
-
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def create_moe_runner(
-        self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
-    ):
-        raise NotImplementedError
-
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module):
-        """
-        Called after weight loading is complete for any cleanup that
-        needs to occur.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def apply_weights(
-        self,
-        layer: torch.nn.Module,
-        dispatch_output: "StandardDispatchOutput",
-    ):
-        """
-        Run the forward pass for the particular scheme. This is where
-        scheme-specific dequant/quant steps/kernels should be applied.
-
-        :param layer: torch.nn.Module with the registered weights and
-            other parameters relevant to the particular scheme.
-        :param x: input to the layer
-        :param bias: bias parameter
-
-        """
-        raise NotImplementedError

--- a/test/registered/unit/layers/quantization/test_scheme_abcs.py
+++ b/test/registered/unit/layers/quantization/test_scheme_abcs.py
@@ -1,0 +1,242 @@
+"""Unit tests for the quantization scheme ABCs - CPU-only, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+import importlib
+import inspect
+import pkgutil
+import subprocess
+import sys
+import unittest
+
+from sglang.srt.layers.quantization.awq.schemes.awq_scheme import (
+    AWQLinearSchemeBase,
+    AWQMoESchemeBase,
+)
+from sglang.srt.layers.quantization.base_scheme import BaseLinearScheme, BaseMoEScheme
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_scheme import (
+    CompressedTensorsLinearScheme,
+    CompressedTensorsMoEScheme,
+)
+from sglang.srt.layers.quantization.gptq.schemes.gptq_scheme import (
+    GPTQLinearSchemeBase,
+    GPTQMoESchemeBase,
+)
+from sglang.srt.layers.quantization.modelslim.schemes.modelslim_scheme import (
+    ModelSlimLinearScheme,
+    ModelSlimMoEScheme,
+)
+from sglang.srt.layers.quantization.quark.schemes.quark_scheme import (
+    QuarkLinearScheme,
+    QuarkMoEScheme,
+)
+from sglang.test.test_utils import CustomTestCase
+
+SCHEME_PACKAGES = [
+    "sglang.srt.layers.quantization.awq.schemes",
+    "sglang.srt.layers.quantization.compressed_tensors.schemes",
+    "sglang.srt.layers.quantization.gptq.schemes",
+    "sglang.srt.layers.quantization.modelslim.schemes",
+    "sglang.srt.layers.quantization.quark.schemes",
+]
+
+FAMILY_LINEAR_BASES = [
+    AWQLinearSchemeBase,
+    CompressedTensorsLinearScheme,
+    GPTQLinearSchemeBase,
+    ModelSlimLinearScheme,
+    QuarkLinearScheme,
+]
+
+FAMILY_MOE_BASES = [
+    AWQMoESchemeBase,
+    CompressedTensorsMoEScheme,
+    GPTQMoESchemeBase,
+    ModelSlimMoEScheme,
+    QuarkMoEScheme,
+]
+
+# Set by the class statement itself, so present on any empty class body.
+CLASS_BODY_NOISE = {
+    "__doc__",
+    "__module__",
+    "__qualname__",
+    "__abstractmethods__",
+    "__dict__",
+    "__weakref__",
+    "_abc_impl",
+    "__firstlineno__",
+    "__static_attributes__",
+}
+
+
+def _scheme_classes():
+    """(class, defining module) for every class in every family's schemes package."""
+    seen = set()
+    for package_name in SCHEME_PACKAGES:
+        package = importlib.import_module(package_name)
+        for info in pkgutil.iter_modules(package.__path__):
+            module = importlib.import_module(f"{package_name}.{info.name}")
+            for obj in vars(module).values():
+                if not inspect.isclass(obj):
+                    continue
+                if not issubclass(obj, (BaseLinearScheme, BaseMoEScheme)):
+                    continue
+                key = f"{obj.__module__}.{obj.__qualname__}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                yield obj, key
+
+
+class TestRootContract(CustomTestCase):
+    """The two root ABCs carry the whole scheme contract.
+
+    Which members are abstract is the load-bearing part: `abstractmethod` on a
+    root member makes every scheme in every family that does not define it
+    unconstructible, so widening these sets is a breaking change and not a
+    tightening of types.
+    """
+
+    def test_linear_abstract_methods(self):
+        self.assertEqual(
+            sorted(BaseLinearScheme.__abstractmethods__),
+            ["apply_weights", "create_weights", "process_weights_after_loading"],
+        )
+
+    def test_moe_abstract_methods(self):
+        # `apply_weights` and `create_moe_runner` are deliberately absent:
+        # families whose MoE method drives the MoeRunner leave both to the
+        # method, and the schemes below prove that is not hypothetical.
+        self.assertEqual(
+            sorted(BaseMoEScheme.__abstractmethods__),
+            ["create_weights", "process_weights_after_loading"],
+        )
+
+    def test_declared_but_unimplemented_members_raise(self):
+        class Scheme(BaseMoEScheme):
+            def create_weights(self, *args, **kwargs):
+                raise AssertionError("not reached")
+
+            def process_weights_after_loading(self, layer):
+                raise AssertionError("not reached")
+
+        scheme = Scheme()
+        with self.assertRaises(NotImplementedError):
+            scheme.apply_weights(layer=None, dispatch_output=None)
+        with self.assertRaises(NotImplementedError):
+            scheme.create_moe_runner(layer=None, moe_runner_config=None)
+        with self.assertRaises(NotImplementedError):
+            Scheme.get_min_capability()
+        with self.assertRaises(NotImplementedError):
+            BaseLinearScheme.get_min_capability()
+
+    def test_defaults(self):
+        self.assertIs(BaseLinearScheme.requires_weight_loader_v2, False)
+        self.assertIs(BaseMoEScheme.load_up_proj_weight_first, False)
+
+    def test_the_roots_do_not_import_the_moe_package(self):
+        # base_scheme is imported by every family, so a runtime import of
+        # sglang.srt.layers.moe here would re-enter the quantization <-> moe
+        # cycle that the rest of the package works around with function-local
+        # imports. The MoE types it names are TYPE_CHECKING-only.
+        code = (
+            "import sys;"
+            "import sglang.srt.layers.quantization.base_scheme;"
+            "print([m for m in sys.modules if m.startswith('sglang.srt.layers.moe')])"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        ).stdout
+        self.assertEqual(eval(out.strip()), [])
+
+
+class TestFamilyBases(CustomTestCase):
+    """Each family's base exists to name the family, not to restate the contract.
+
+    Redeclaring `create_weights` and friends on a family base is how ten
+    near-identical copies accumulated; this is the check that catches the
+    eleventh.
+    """
+
+    def test_linear_bases_subclass_the_root_and_add_nothing(self):
+        for base in FAMILY_LINEAR_BASES:
+            with self.subTest(base=base.__name__):
+                self.assertTrue(issubclass(base, BaseLinearScheme))
+                self.assertIsNot(base, BaseLinearScheme)
+                self.assertEqual(set(vars(base)) - CLASS_BODY_NOISE, set())
+
+    def test_moe_bases_subclass_the_root_and_add_nothing(self):
+        for base in FAMILY_MOE_BASES:
+            with self.subTest(base=base.__name__):
+                self.assertTrue(issubclass(base, BaseMoEScheme))
+                self.assertIsNot(base, BaseMoEScheme)
+                self.assertEqual(set(vars(base)) - CLASS_BODY_NOISE, set())
+
+    def test_family_bases_are_distinct_types(self):
+        # The return annotations across the family configs (-> QuarkLinearScheme,
+        # -> CompressedTensorsMoEScheme, ...) only say something if these are
+        # not all the same object.
+        bases = FAMILY_LINEAR_BASES + FAMILY_MOE_BASES
+        self.assertEqual(len({id(base) for base in bases}), len(bases))
+
+    def test_family_bases_stay_abstract(self):
+        for base in FAMILY_LINEAR_BASES + FAMILY_MOE_BASES:
+            with self.subTest(base=base.__name__):
+                self.assertTrue(base.__abstractmethods__)
+
+
+class TestConcreteSchemes(CustomTestCase):
+    def test_every_concrete_scheme_is_constructible(self):
+        """No scheme is left abstract by the shared contract.
+
+        A member that is abstract on a root but unimplemented by a scheme does
+        not fail at import; it fails at model load, on whichever platform owns
+        that scheme.
+        """
+        family_bases = set(FAMILY_LINEAR_BASES) | set(FAMILY_MOE_BASES)
+        roots = {BaseLinearScheme, BaseMoEScheme}
+        checked = 0
+        for cls, key in _scheme_classes():
+            if cls in family_bases or cls in roots:
+                continue
+            with self.subTest(scheme=key):
+                self.assertEqual(sorted(cls.__abstractmethods__), [])
+            checked += 1
+        self.assertGreater(checked, 20, "scheme discovery found almost nothing")
+
+    def test_moe_schemes_may_leave_the_runner_to_their_method(self):
+        """The reason `apply_weights` is declared and not abstract.
+
+        These schemes implement neither `apply_weights` nor `create_moe_runner`;
+        ModelSlim's MoE method owns the MoeRunner. Making either abstract on
+        BaseMoEScheme makes all of them unconstructible.
+        """
+        from sglang.srt.layers.quantization.modelslim.schemes.modelslim_w8a8_int8_moe import (
+            ModelSlimW8A8Int8MoE,
+        )
+
+        self.assertEqual(sorted(ModelSlimW8A8Int8MoE.__abstractmethods__), [])
+        for member in ("apply_weights", "create_moe_runner"):
+            with self.subTest(member=member):
+                owner = next(
+                    cls
+                    for cls in ModelSlimW8A8Int8MoE.__mro__
+                    if member in cls.__dict__
+                )
+                self.assertIs(owner, BaseMoEScheme)
+
+    def test_a_scheme_may_still_override_the_loader_order(self):
+        from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4_moe import (
+            CompressedTensorsW4A4Nvfp4MoE,
+        )
+
+        self.assertIsInstance(
+            CompressedTensorsW4A4Nvfp4MoE.load_up_proj_weight_first, property
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

`base_scheme.py` declares `BaseLinearScheme` and `BaseMoEScheme`, the two ABCs every quantization scheme derives from. Each of the five families then declares its own Linear and MoE base on top of them, and all ten of those restate the same abstract methods the roots already declare, with the docstrings and the exact member set drifting between copies.

This folds the contract into the two roots and leaves each family base as the name of its family.

The roots gain the members that were only ever declared on some of the family bases:

| Member | Was declared on | Now on | Form |
|---|---|---|---|
| `get_min_capability` | `CompressedTensors{Linear,MoE}Scheme`, `Quark{Linear,MoE}Scheme` | both roots | declared, raises |
| `create_moe_runner` | `AWQMoESchemeBase`, `CompressedTensorsMoEScheme`, `GPTQMoESchemeBase`, `QuarkMoEScheme` | `BaseMoEScheme` | declared, raises |
| `apply_weights` (MoE) | the same four | `BaseMoEScheme` | declared, raises |
| `load_up_proj_weight_first` | `CompressedTensorsMoEScheme` | `BaseMoEScheme` | `False` default |

## Why those three are declared and not abstract

ModelSlim's MoE method owns the `MoeRunner`, so its six MoE schemes (`ModelSlimW8A8Int8MoE`, `ModelSlimW4A4Int4MoE`, `ModelSlimW4A4MXFP4MoE`, `ModelSlimW4A8Int8MoE`, `ModelSlimW4A8MXFP4MoE`, `ModelSlimMXFP8MoEScheme`) implement neither `apply_weights` nor `create_moe_runner`. `@abstractmethod` on either makes all six unconstructible. `get_min_capability` is the same shape: only the configs that gate on device capability call it, and the families outside those two never define it.

So each of the three is a plain method that raises `NotImplementedError`, which is what a scheme that does not implement it did before, reached through `AttributeError` rather than a raise.

## Line counts

| File | Before | After |
|---|---|---|
| `base_scheme.py` | 76 | 137 |
| `awq/schemes/awq_scheme.py` | 54 | 13 |
| `gptq/schemes/gptq_scheme.py` | 54 | 13 |
| `compressed_tensors/schemes/compressed_tensors_scheme.py` | 118 | 21 |
| `quark/schemes/quark_scheme.py` | 116 | 19 |
| `modelslim/schemes/modelslim_scheme.py` | 74 | 21 |

## Two things deliberately kept

The family bases stay distinct classes with empty bodies rather than `QuarkLinearScheme = BaseLinearScheme` aliases. The return annotations across `compressed_tensors.py`, `quark.py` and `modelslim.py` (`-> QuarkLinearScheme`, `-> Optional[CompressedTensorsMoEScheme]`, and so on) only say something if those names are not all the same object. Deduplication is identical either way.

`MoeRunnerConfig` and `StandardDispatchOutput` are named under `TYPE_CHECKING` only. `base_scheme` is imported by every family, and a runtime `sglang.srt.layers.moe` import here would re-enter the import cycle the rest of the package works around with function-local imports.

`FusedMoEMethodBase` is untouched.

## Verification

**No concrete scheme's abstract set changed.** Every one of the 59 classes deriving from either root was fingerprinted on both trees: the MRO-resolved owner of each of the 7 contract members, `__abstractmethods__`, and which root it descends from. The class set is identical, and every difference is one of the two intended kinds. Inherited-method ownership moves from a family base to a root, and the four absorbed members appear as inert fallbacks on classes that previously did not have them at all. `__abstractmethods__` changes on the 5 family bases and on nothing else, so every scheme that was constructible stays constructible.

`test/registered/unit/layers/quantization` gives the same failure set before and after, comparing `FAILED` and `SUBFAILED` lines against the base commit (7 pre-existing failures, all needing a GPU).

`test_scheme_abcs.py` adds 12 cases and 69 subtests pinning the split: which members are abstract on each root, that each family base adds nothing back to its `__dict__`, that the five Linear and five MoE bases are ten distinct types, that every scheme the five `schemes/` packages define has an empty abstract set, and that importing `base_scheme` in a fresh interpreter loads no `sglang.srt.layers.moe` module.

Four mutations were run against it and all four go red:

| Mutation | Cases red |
|---|---|
| `@abstractmethod` on `BaseMoEScheme.apply_weights` | 9 |
| Re-add `apply_weights` to `ModelSlimMoEScheme` | 2 |
| Module-level `layers.moe` import in `base_scheme` | 1 |
| `QuarkLinearScheme = BaseLinearScheme` | 1 |

Restoring each returns 12 passed and 69 subtests passed.

Coverage gap worth naming: the NPU and Ascend schemes among the 59 are covered by the fingerprint and the abstract-set check, which is static, and not by execution.

The base branch is `quant-refactor/import-shim-test`, so the diff reads as 7 files. The change itself does not depend on that branch and applies to `main` as is.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829714770](https://github.com/sgl-project/sglang/actions/runs/34829714770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829714769](https://github.com/sgl-project/sglang/actions/runs/34829714769)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829714921](https://github.com/sgl-project/sglang/actions/runs/34829714921)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->