### PR TITLE
[DSA] Keep superseded trtllm-gen counter buffers alive for captured CUDA graphs

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -531,6 +531,11 @@ class DeepseekSparseAttnBackend(
             decode_impl=self.dsa_decode_impl,
         )
 
+        # Captured TRT-LLM graphs retain the address of their counter buffer.
+        # Eager prefills may need a larger buffer later; keep previous buffers
+        # alive for this backend's lifetime so those graphs can still replay.
+        self._retired_multi_ctas_kv_counter_buffers: list[torch.Tensor] = []
+
         if uses_flashinfer_sparse_mla:
             self.workspace_buffer = get_buffer(
                 "dsa_flashinfer_sparse_mla_workspace",
@@ -3530,14 +3535,7 @@ class DeepseekSparseAttnBackend(
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
 
-        self._multi_ctas_kv_counter_buffer = (
-            grow_multi_ctas_kv_counter_buffer_if_needed(
-                self._multi_ctas_kv_counter_buffer,
-                torch.device(self.device),
-                self.num_q_heads,
-                batch_size,
-            )
-        )
+        self._ensure_multi_ctas_kv_counter_buffer(batch_size)
 
         q = q_all.view(batch_size, 1, num_heads, head_dim)
         kv = kv_cache.view(-1, 1, self.real_page_size, self.kv_cache_dim)
@@ -3563,6 +3561,15 @@ class DeepseekSparseAttnBackend(
         )
 
         return out
+
+    def _ensure_multi_ctas_kv_counter_buffer(self, batch_size: int) -> None:
+        previous = self._multi_ctas_kv_counter_buffer
+        current = grow_multi_ctas_kv_counter_buffer_if_needed(
+            previous, torch.device(self.device), self.num_q_heads, batch_size
+        )
+        if current is not previous:
+            self._retired_multi_ctas_kv_counter_buffers.append(previous)
+            self._multi_ctas_kv_counter_buffer = current
 
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int

--- a/test/registered/unit/attention/test_dsa_trtllm_counter_lifetime.py
+++ b/test/registered/unit/attention/test_dsa_trtllm_counter_lifetime.py
@@ -1,0 +1,91 @@
+import gc
+import unittest
+import weakref
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTrtllmCounterBufferLifetime(CustomTestCase):
+    """Decode CUDA graphs capture the raw address of the trtllm-gen multi-CTA
+    KV counter buffer. When a larger eager prefill grows the buffer, the
+    backend must keep the superseded tensor alive; otherwise every later graph
+    replay writes through freed storage."""
+
+    def _backend(self, initial_bytes=64):
+        backend = MagicMock(spec=DeepseekSparseAttnBackend)
+        backend.device = "cpu"
+        backend.num_q_heads = 16
+        backend._multi_ctas_kv_counter_buffer = torch.zeros(
+            initial_bytes, dtype=torch.uint8
+        )
+        backend._retired_multi_ctas_kv_counter_buffers = []
+        return backend
+
+    def _ensure(self, backend, batch_size, grow):
+        # A plain function replaces the helper so nothing records (and thereby
+        # keeps alive) the buffer that was passed in.
+        with patch(
+            "sglang.srt.layers.attention.dsa_backend."
+            "grow_multi_ctas_kv_counter_buffer_if_needed",
+            new=grow,
+        ):
+            DeepseekSparseAttnBackend._ensure_multi_ctas_kv_counter_buffer(
+                backend, batch_size
+            )
+
+    def test_growth_retains_captured_buffer(self):
+        backend = self._backend()
+        captured = weakref.ref(backend._multi_ctas_kv_counter_buffer)
+        larger = torch.zeros(128, dtype=torch.uint8)
+
+        self._ensure(backend, 16384, grow=lambda *_: larger)
+        gc.collect()
+
+        self.assertIs(backend._multi_ctas_kv_counter_buffer, larger)
+        self.assertIsNotNone(captured())
+        self.assertEqual(backend._retired_multi_ctas_kv_counter_buffers, [captured()])
+
+    def test_no_growth_leaves_ownership_unchanged(self):
+        backend = self._backend()
+        current = backend._multi_ctas_kv_counter_buffer
+
+        self._ensure(backend, 32, grow=lambda buffer, *_: buffer)
+
+        self.assertIs(backend._multi_ctas_kv_counter_buffer, current)
+        self.assertEqual(backend._retired_multi_ctas_kv_counter_buffers, [])
+
+    def test_repeated_growth_retains_every_generation(self):
+        backend = self._backend()
+        first = backend._multi_ctas_kv_counter_buffer
+        second = torch.zeros(128, dtype=torch.uint8)
+        third = torch.zeros(256, dtype=torch.uint8)
+
+        self._ensure(backend, 16384, grow=lambda *_: second)
+        self._ensure(backend, 32768, grow=lambda *_: third)
+
+        self.assertIs(backend._multi_ctas_kv_counter_buffer, third)
+        self.assertEqual(
+            backend._retired_multi_ctas_kv_counter_buffers, [first, second]
+        )
+
+    def test_retired_buffers_die_with_backend(self):
+        backend = self._backend()
+        captured = weakref.ref(backend._multi_ctas_kv_counter_buffer)
+        larger = torch.zeros(128, dtype=torch.uint8)
+
+        self._ensure(backend, 16384, grow=lambda *_: larger)
+        del backend
+        gc.collect()
+
+        self.assertIsNone(captured())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DeepseekSparseAttnBackend` passes a backend-owned TRT-LLM multi-CTA counter buffer into `flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla` for both prefill and decode. Decode CUDA graphs captured at startup record the buffer's device address. A later eager prefill can require more than the initial 8,192-row capacity, replace the tensor, and release storage still referenced by those graphs.

Concretely: the buffer is sized via `make_persistent_multi_ctas_kv_counter_buffer(..., max_batch_size=max_running_requests)`, i.e. for `max(8192, max_running_requests)` rows. In `_forward_trtllm` the row count is `page_table_1.shape[0]`, which for an eager prefill chunk is the number of query tokens, not requests. The first chunk with more than 8,192 tokens (default `chunked_prefill_size` on >=160 GB GPUs is 16,384) makes `grow_multi_ctas_kv_counter_buffer_if_needed` allocate a larger tensor, and the assignment back to `self._multi_ctas_kv_counter_buffer` drops the only reference to the old one. Graph replay never re-executes that Python assignment, so every later decode replay runs the trtllm-gen semaphore atomics through freed storage. Depending on what the caching allocator does with the block that is silent corruption, a hang inside the attention kernel, or an MMU fault once the segment is unmapped.

This is the same bug class as the MoE workspace / graph-pool issues in #36550, #37168 and flashinfer-ai/flashinfer#4827 (a caller-cached device buffer replaced by a larger prefill while decode graphs still hold its pointer), in a buffer those patches do not touch. `TRTLLMMLABackend` is unaffected because it never grows its counter buffer. The pattern was introduced in #31927 and is present on current `main`.

### What we observed

We serve `zai-org/GLM-5.3-Flash` on 4x B200 (TP=4) from `lmsysorg/sglang@sha256:e6f5482505e7502f791fe4615ad1fbec118cbbd6b44e98f2479b16b98b985ad6` (source `033446bb05`, the `xinyuan/glm-5.3-flash-support` lineage of #36507; PyTorch 2.13.0+cu130, FlashInfer 0.6.17, driver 580.173.02) with:

```
sglang serve --model-path zai-org/GLM-5.3-Flash --tp-size 4 --ep-size 1 \
  --dsa-prefill-backend trtllm --dsa-decode-backend trtllm --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend flashinfer_trtllm --disable-shared-experts-fusion \
  --speculative-algorithm EAGLE --speculative-num-steps 5 --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 6 --speculative-adaptive \
  --max-running-requests 24 --mem-fraction-static 0.83 --cuda-graph-max-bs-decode 32
```

Under normal traffic (long prompts, so repeated 16,384-token eager prefill chunks) the TP0 scheduler died with `torch.AcceleratorError: CUDA error: an illegal memory access was encountered` at the next stream sync (`FutureMap.resolve_seq_lens_cpu`), and the kernel logged `Xid 31 ... FAULT_PDE ACCESS_TYPE_VIRT_ATOMIC` on all four GPUs. Container restart, several minutes of 502s.

Investigating the source of the running image led to the counter buffer lifetime above. We confirmed it with a kernel-level A/B on the same image (compiled `trtllm_paged_attention_decode`, production geometry: 16 TP-local heads, head dim 512, page 64, top-k 2048, FP8 KV, no weights): capture a graph with the 512 KiB counter, grow it to 1 MiB with the unpatched code, let the allocator hand the captured address to an unrelated tensor, replay: the replay stalls inside the trtllm-gen kernel and modifies the unrelated tensor. With this patch the old buffer stays alive and ten replays pass, also with zero errors under `compute-sanitizer`.

We then rebuilt the image with this patch applied and put it back on the host. Since then the crash has not recurred; a targeted run of 2x 27 requests (three uncached 20,025-token prompts, each with eight concurrent short requests) returned 54/54 HTTP 200 with logs showing 16,384-token eager prefill chunks followed by `cuda graph: True` decode and adaptive spec transitions, no CUDA/NCCL error, Xid, or restart.

## Modifications

- `dsa_backend.py`: add `_ensure_multi_ctas_kv_counter_buffer()`. It grows the buffer as before, but when the helper returns a new tensor the previous one is appended to `self._retired_multi_ctas_kv_counter_buffers` instead of being dropped, so addresses baked into already-captured graphs stay valid for the backend's lifetime. The no-growth path is unchanged (one `is` comparison, no allocation or list mutation).
- `test/registered/unit/attention/test_dsa_trtllm_counter_lifetime.py` (CPU CI, `base-a-test-cpu`): pins the ownership contract with weakrefs: growth retains the captured buffer, non-growth changes nothing, repeated growth retains every generation, retired buffers die with the backend.

The retained memory is one generation per growth step (512 KiB -> 1 MiB for 16 TP-local heads at our geometry), per backend instance and TP rank. An alternative would be sizing the persistent buffer up front for the largest possible prefill chunk; retain-on-growth also covers geometries not anticipated at init and keeps the change local to the one call site.

## Accuracy Tests

No numerical change: the same buffer that was passed before is still passed; only the lifetime of the previous allocation changes. Validation on the affected image is described above (kernel A/B, compute-sanitizer, full-model run).

## Speed Tests and Profiling

No kernel or scheduling change; one extra Python `is` comparison per attention call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

https://claude.ai/code/session_01RShk8Kg9CsmYXWwz7kphes

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34228611546](https://github.com/sgl-project/sglang/actions/runs/34228611546)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34228611328](https://github.com/sgl-project/sglang/actions/runs/34228611328)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34228611144](https://github.com/sgl-project/sglang/actions/runs/34228611144)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->