### PR TITLE
[AMD][DSv4] Run selected DSv4 attention projections in MXFP4

### DIFF
--- a/python/sglang/srt/layers/quantization/dsv4_fp4_proj.py
+++ b/python/sglang/srt/layers/quantization/dsv4_fp4_proj.py
@@ -1,0 +1,411 @@
+"""Per-forward-mode FP8 -> MXFP4 swap for DeepSeek-V4 attention projections.
+
+The DSv4 "fp4" checkpoint is fp4 only for the routed experts; every attention
+projection is fp8 e4m3 with 128x128 ue8m0 block scales and runs through
+``Fp8LinearMethod`` -> ``aiter_w8a8_block_fp8_linear`` (the aiter CK bpreshuffle
+GEMM). This module requantizes a selected subset of those weights to OCP MXFP4
+(e2m1 data, per-32 e8m0 scales) at load time and reroutes those layers onto
+aiter's ``gemm_a4w4``.
+
+The selection is made **per forward mode**, because the fp4 GEMM only wins at
+some shapes. Measured on MI355X (gfx950, aiter CK/ASM a4w4 vs the fp8 CK
+bpreshuffle GEMM, CUDA-graph timed, DP8/TP8 dp-attention per-rank shapes):
+
+    projection                     N       K   M=8 (decode)  M=8192 (prefill)
+    attn.q_b_proj   (wq_b)     65536    1536       x1.21           x1.63
+    attn.q_a_proj   (wqkv_a)    2048    7168       x0.77           x2.27
+    indexer.wq_b                8192    1536       x0.60           x2.45
+    attn.o_proj_b   (wo_b)      7168   16384       x1.45           x1.95
+
+so ``wqkv_a`` and ``indexer_wq_b`` are worth swapping for prefill but are a
+regression for decode. A projection selected for only one mode keeps **both**
+weights resident and dispatches on the mode; a projection selected for both
+modes keeps only the fp4 weight and frees the fp8 one.
+
+Flags
+-----
+``SGLANG_DSV4_FP4_PROJ``          master enable (0/1, default 0)
+``SGLANG_DSV4_FP4_PROJ_PREFILL``  csv of keys used on prefill-like forwards
+                                  (default ``wq_b,wqkv_a,indexer_wq_b,wo_b``)
+``SGLANG_DSV4_FP4_PROJ_DECODE``   csv of keys used on decode-like forwards
+                                  (default ``wq_b,wo_b``)
+
+Each list also accepts ``all`` and ``none``/empty.
+
+``wo_a`` is deliberately not selectable: with SGLANG_OPT_FP8_WO_A_GEMM (default
+on) it never reaches ``quant_method.apply`` -- the absorb GEMM in
+MqaAttention.forward reads ``.weight``/``.weight_scale_inv`` and runs its own
+batched mxscale BMM -- and aiter has no batched a4w4 to replace it with.
+
+Accuracy (GSM8k strict-match, n=1319, DeepSeek-V4-Pro FP4, MTP depth 3, real
+target verification): baseline 96.82 +- 0.48; each projection swapped on its
+own lands within 0.4 pt of that, all four together at 96.59 +- 0.50 -- inside
+the +-0.70 pt stderr of the difference.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, FrozenSet, List
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Selector key -> predicate on the layer prefix, e.g. "model.layers.3.attn.wq_b"
+# or "model.layers.7.attn.indexer.wq_b".
+SELECTORS = {
+    # attn.q_b_proj: [65536, 1536], every layer plus the MTP head.
+    "wq_b": lambda p: p.endswith(".attn.wq_b"),
+    # attn.q_a_proj: [2048, 7168] when SGLANG_OPT_FUSE_WQA_WKV fuses wq_a+wkv,
+    # otherwise the separate [1536, 7168] / [512, 7168] projections.
+    "wqkv_a": lambda p: (
+        p.endswith(".attn.wqkv_a")
+        or p.endswith(".attn.wq_a")
+        or p.endswith(".attn.wkv")
+    ),
+    # C4 indexer query projection: [8192, 1536], C4 layers only.
+    "indexer_wq_b": lambda p: p.endswith(".indexer.wq_b"),
+    # attn.o_proj_b: [7168, 16384], every layer.
+    "wo_b": lambda p: p.endswith(".attn.wo_b"),
+}
+
+PREFILL = "prefill"
+DECODE = "decode"
+
+_DEFAULT_PREFILL = "wq_b,wqkv_a,indexer_wq_b,wo_b"
+_DEFAULT_DECODE = "wq_b,wo_b"
+
+
+# --------------------------------------------------------------------------
+# configuration
+# --------------------------------------------------------------------------
+
+
+def _parse_keys(env_name: str, default: str) -> FrozenSet[str]:
+    raw = os.environ.get(env_name, default).strip()
+    if not raw or raw.lower() in ("none", "0", "off"):
+        return frozenset()
+    if raw.lower() == "all":
+        return frozenset(SELECTORS)
+    keys = [k.strip() for k in raw.split(",") if k.strip()]
+    unknown = [k for k in keys if k not in SELECTORS]
+    if unknown:
+        raise ValueError(
+            f"{env_name}: unknown selector(s) {unknown}; "
+            f"valid keys are {sorted(SELECTORS)} (or 'all'/'none')"
+        )
+    return frozenset(keys)
+
+
+def is_enabled() -> bool:
+    return os.environ.get("SGLANG_DSV4_FP4_PROJ", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def selected_masks() -> Dict[str, FrozenSet[str]]:
+    """key -> the set of forward modes it should run in fp4 for."""
+    if not is_enabled():
+        return {}
+    prefill = _parse_keys("SGLANG_DSV4_FP4_PROJ_PREFILL", _DEFAULT_PREFILL)
+    decode = _parse_keys("SGLANG_DSV4_FP4_PROJ_DECODE", _DEFAULT_DECODE)
+    masks = {}
+    for key in SELECTORS:
+        modes = set()
+        if key in prefill:
+            modes.add(PREFILL)
+        if key in decode:
+            modes.add(DECODE)
+        if modes:
+            masks[key] = frozenset(modes)
+    return masks
+
+
+def _match(prefix: str, masks: Dict[str, FrozenSet[str]]):
+    for key, modes in masks.items():
+        if SELECTORS[key](prefix):
+            return key, modes
+    return None, None
+
+
+# --------------------------------------------------------------------------
+# forward mode, published by the model's forward
+# --------------------------------------------------------------------------
+
+# Modes whose token count is decode-shaped. TARGET_VERIFY is the MTP
+# verification step (bs * num_draft_tokens rows) and shares the decode CUDA
+# graph; IDLE is a zero-token DP filler that is captured the same way.
+# ForwardMode.is_extend() cannot be used here -- it returns True for
+# TARGET_VERIFY.
+_DECODE_MODE_NAMES = ("DECODE", "TARGET_VERIFY", "IDLE")
+
+# Default to prefill: it is the only value that is always serviceable, because
+# a projection selected for prefill only keeps its fp8 weight too, whereas a
+# projection selected for both modes has had its fp8 weight freed.
+_CURRENT_MODE = PREFILL
+
+
+def current_mode() -> str:
+    return _CURRENT_MODE
+
+
+def _classify(forward_batch) -> str:
+    mode = getattr(forward_batch, "forward_mode", None)
+    return DECODE if getattr(mode, "name", "") in _DECODE_MODE_NAMES else PREFILL
+
+
+def _wrap_model_forward(cls) -> None:
+    """Publish the forward mode around ``cls.forward``.
+
+    This has to sit on the model class rather than on ``ModelRunner.forward``:
+    CUDA-graph capture calls ``model_runner.model.forward(...)`` directly, and
+    the fp8/fp4 branch is a Python-level ``if`` that gets baked into the
+    captured graph. Wrapping here means capture sees the mode it is capturing
+    for. The branch is a pure function of ``forward_mode``, so every graph
+    captured for a given mode bakes the same kernels.
+    """
+    orig = cls.forward
+    if getattr(orig, "_dsv4_fp4_wrapped", False):
+        return
+
+    def forward(self, input_ids, positions, forward_batch, *args, **kwargs):
+        global _CURRENT_MODE
+        prev = _CURRENT_MODE
+        _CURRENT_MODE = _classify(forward_batch)
+        try:
+            return orig(self, input_ids, positions, forward_batch, *args, **kwargs)
+        finally:
+            _CURRENT_MODE = prev
+
+    forward._dsv4_fp4_wrapped = True
+    forward.__name__ = getattr(orig, "__name__", "forward")
+    forward.__doc__ = getattr(orig, "__doc__", None)
+    cls.forward = forward
+
+
+def install_model_hook(cls) -> None:
+    """Called from the DSv4 model modules; no-op unless the swap is enabled."""
+    if not is_enabled():
+        return
+    _wrap_model_forward(cls)
+
+
+# --------------------------------------------------------------------------
+# MXFP4 linear method
+# --------------------------------------------------------------------------
+
+_MXQ = None
+
+
+def _mx_quant():
+    global _MXQ
+    if _MXQ is None:
+        import aiter
+
+        _MXQ = aiter.get_triton_quant(aiter.QuantType.per_1x32)
+    return _MXQ
+
+
+class Fp4ProjLinearMethod:
+    """Mode-dispatching wrapper around the layer's original Fp8LinearMethod.
+
+    On a forward mode the layer was selected for, runs aiter's a4w4 GEMM over
+    the MXFP4 copy of the weight; otherwise delegates to the untouched fp8
+    method, so the non-selected mode is bit-identical to the baseline build.
+    """
+
+    def __init__(self, fp8_method, key: str, modes: FrozenSet[str]):
+        self.fp8_method = fp8_method
+        self.key = key
+        self.modes = modes
+        # Some callers introspect the wrapped method's config.
+        self.quant_config = getattr(fp8_method, "quant_config", None)
+
+    def __getattr__(self, name):
+        # Anything we do not override (block_quant, weight_block_size, ...)
+        # comes from the real fp8 method.
+        try:
+            fp8_method = self.__dict__["fp8_method"]
+        except KeyError:  # pragma: no cover - only during partial construction
+            raise AttributeError(name) from None
+        return getattr(fp8_method, name)
+
+    def create_weights(self, *args, **kwargs):  # pragma: no cover
+        raise RuntimeError(
+            "Fp4ProjLinearMethod is installed after the weights are loaded"
+        )
+
+    def process_weights_after_loading(self, layer):  # pragma: no cover
+        # Conversion already happened; the fp8 method's hook must not run twice.
+        return
+
+    def apply(self, layer, x, bias=None):
+        if _CURRENT_MODE not in self.modes:
+            return self.fp8_method.apply(layer, x, bias)
+
+        if isinstance(x, tuple):
+            raise RuntimeError(
+                f"DSV4_FP4_PROJ: layer {layer._dsv4_fp4_prefix} ({self.key}) was "
+                "handed a pre-quantized fp8 activation, which the a4w4 path "
+                f"cannot consume. Drop '{self.key}' from "
+                "SGLANG_DSV4_FP4_PROJ_PREFILL/_DECODE."
+            )
+
+        import aiter
+
+        x2d = x.view(-1, x.shape[-1])
+        m = x2d.shape[0]
+        qx, sx = _mx_quant()(x2d, shuffle=True)
+        out = aiter.gemm_a4w4(
+            qx,
+            layer._dsv4_fp4_w,
+            sx,
+            layer._dsv4_fp4_s,
+            dtype=torch.bfloat16,
+            bpreshuffle=True,
+        )
+        # gemm_a4w4 pads M up to the kernel tile; drop the padding.
+        out = out[:m]
+        if bias is not None:
+            out = out + bias
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+
+# --------------------------------------------------------------------------
+# weight conversion
+# --------------------------------------------------------------------------
+
+
+def _fp8_needs_bpreshuffle(fp8_method, layer) -> bool:
+    """Whether the fp8 loader would have bpreshuffled this weight.
+
+    Mirrors the gate in Fp8LinearMethod.process_weights_after_loading. We set
+    skip_aiter_bpreshuffle on every selected layer so the fp4 conversion sees a
+    row-major weight, then re-apply the shuffle here for the layers that keep
+    an fp8 weight.
+    """
+    from sglang.srt.layers.quantization.fp8_utils import (
+        _use_aiter_bpreshuffle_gfx95,
+        aiter_w8a8_block_fp8_linear,
+        use_aiter_triton_gemm_w8a8_tuned_gfx950,
+    )
+
+    if not _use_aiter_bpreshuffle_gfx95:
+        return False
+    if fp8_method.w8a8_block_fp8_linear is not aiter_w8a8_block_fp8_linear:
+        return False
+    n, k = layer.weight.shape
+    return not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
+
+
+def _convert_layer(layer, fp8_method, keep_fp8: bool) -> None:
+    """Build the MXFP4 copy from the row-major fp8 block-scale weight."""
+    from aiter.ops.shuffle import shuffle_weight
+
+    from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
+
+    assert not getattr(layer, "aiter_bpreshuffled", False), (
+        f"{layer._dsv4_fp4_prefix}: weight was already bpreshuffled for the fp8 "
+        "kernel; the fp4 conversion needs the row-major layout"
+    )
+
+    w_bf16 = block_quant_dequant(
+        layer.weight.data,
+        layer.weight_scale_inv.data.to(torch.float32),
+        [128, 128],
+        torch.bfloat16,
+    )
+    qw, sw = _mx_quant()(w_bf16, shuffle=True)
+    del w_bf16
+    qw = shuffle_weight(qw, layout=(16, 16))
+
+    if keep_fp8:
+        layer._dsv4_fp4_w = qw
+        layer._dsv4_fp4_s = sw
+        # Restore what the fp8 loader would have done had we not skipped it.
+        if _fp8_needs_bpreshuffle(fp8_method, layer):
+            layer.weight.copy_(shuffle_weight(layer.weight, (16, 16)))
+            layer.aiter_bpreshuffled = True
+    else:
+        # fp4 in every mode: the fp8 weight is dead, hand its storage back.
+        layer.weight = torch.nn.Parameter(qw, requires_grad=False)
+        layer._dsv4_fp4_w = layer.weight
+        layer._dsv4_fp4_s = sw
+        if hasattr(layer, "weight_scale_inv"):
+            delattr(layer, "weight_scale_inv")
+    torch.cuda.empty_cache()
+
+
+# --------------------------------------------------------------------------
+# install
+# --------------------------------------------------------------------------
+
+_INSTALLED = False
+_CONVERTED: List[str] = []
+
+
+def converted_layers() -> List[str]:
+    return list(_CONVERTED)
+
+
+def install() -> None:
+    """Patch the fp8 quant method so selected DSv4 projections gain an fp4 copy.
+
+    Must run before the model is constructed: ``Fp8Config.get_quant_method`` is
+    what tags the layers.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    masks = selected_masks()
+    if not masks:
+        return
+
+    from sglang.srt.layers.linear import LinearBase
+    from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+
+    orig_get = Fp8Config.get_quant_method
+    orig_proc = Fp8LinearMethod.process_weights_after_loading
+
+    def get_quant_method(self, layer, prefix):
+        method = orig_get(self, layer, prefix)
+        if isinstance(layer, LinearBase) and isinstance(method, Fp8LinearMethod):
+            key, modes = _match(prefix, masks)
+            if key is not None:
+                layer._dsv4_fp4_prefix = prefix
+                layer._dsv4_fp4_key = key
+                layer._dsv4_fp4_modes = modes
+                # Keep the fp8 loader from rewriting the weight into the aiter
+                # bpreshuffle layout; the fp4 conversion needs it row-major.
+                layer.skip_aiter_bpreshuffle = True
+        return method
+
+    def process_weights_after_loading(self, layer):
+        orig_proc(self, layer)
+        key = getattr(layer, "_dsv4_fp4_key", None)
+        if key is None:
+            return
+        modes = layer._dsv4_fp4_modes
+        _convert_layer(layer, self, keep_fp8=len(modes) < 2)
+        layer.quant_method = Fp4ProjLinearMethod(self, key, modes)
+        _CONVERTED.append(layer._dsv4_fp4_prefix)
+
+    Fp8Config.get_quant_method = get_quant_method
+    Fp8LinearMethod.process_weights_after_loading = process_weights_after_loading
+    _INSTALLED = True
+
+    both = sorted(k for k, m in masks.items() if len(m) == 2)
+    prefill_only = sorted(k for k, m in masks.items() if m == frozenset({PREFILL}))
+    decode_only = sorted(k for k, m in masks.items() if m == frozenset({DECODE}))
+    logger.info(
+        "DSV4_FP4_PROJ: mxfp4 for prefill+decode=[%s] prefill-only=[%s] "
+        "decode-only=[%s] (the last two keep both weights resident)",
+        ",".join(both),
+        ",".join(prefill_only),
+        ",".join(decode_only),
+    )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4301,3 +4301,15 @@ def _fuse_deepseek_v4_wqkv_a_pair(
             )
         return q
     return torch.cat([q, kv], dim=0)
+
+
+# ---------------------------------------------------------------------------
+# DSV4_FP4_PROJ: optional fp8 -> mxfp4 swap for the attention projection GEMMs,
+# selected per forward mode. Inert unless SGLANG_DSV4_FP4_PROJ=1. Installed at
+# import time because it patches Fp8Config.get_quant_method, which has to be in
+# place before DeepseekV4ForCausalLM builds its linear layers.
+# ---------------------------------------------------------------------------
+from sglang.srt.layers.quantization import dsv4_fp4_proj as _dsv4_fp4_proj  # noqa: E402
+
+_dsv4_fp4_proj.install()
+_dsv4_fp4_proj.install_model_hook(DeepseekV4ForCausalLM)

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -302,3 +302,11 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
 
 
 EntryClass = [DeepseekV4ForCausalLMNextN]
+
+
+# DSV4_FP4_PROJ: the MTP head runs its own forward (it does not call
+# DeepseekV4ForCausalLM.forward), so it needs its own forward-mode publisher.
+from sglang.srt.layers.quantization import dsv4_fp4_proj as _dsv4_fp4_proj  # noqa: E402
+
+_dsv4_fp4_proj.install()
+_dsv4_fp4_proj.install_model_hook(DeepseekV4ForCausalLMNextN)


### PR DESCRIPTION
## Motivation

The DeepSeek-V4-Pro "fp4" checkpoint is fp4 only for the routed experts. Every
attention projection ships as fp8 e4m3 with 128x128 ue8m0 block scales and runs
through `Fp8LinearMethod` -> `aiter_w8a8_block_fp8_linear` (the aiter CK
bpreshuffle GEMM). On MI355X those fp8 projection GEMMs are a measurable slice
of non-communication kernel time, and aiter's `gemm_a4w4` is faster than the
fp8 block-scale GEMM at most of the shapes we actually run.

This PR requantizes a selected subset of those weights to OCP MXFP4 (e2m1 data,
per-32 e8m0 scales) at load time and reroutes those layers onto `gemm_a4w4`.
It is **off by default** and gated behind env vars.

## Summary of changes

| file | change |
|---|---|
| `python/sglang/srt/layers/quantization/dsv4_fp4_proj.py` | **new**, 411 lines. Selector parsing, forward-mode publisher, `Fp4ProjLinearMethod`, load-time fp8 -> MXFP4 conversion, and the `install()` / `install_model_hook()` entry points. |
| `python/sglang/srt/models/deepseek_v4.py` | +12 lines at EOF: `install()` + `install_model_hook(DeepseekV4ForCausalLM)`. |
| `python/sglang/srt/models/deepseek_v4_nextn.py` | +8 lines at EOF: the same hook for `DeepseekV4ForCausalLMNextN`. The MTP head overrides `forward` without calling `super().forward()`, so it needs its own forward-mode publisher. |

No existing code paths are modified. Both entry points return immediately when
the feature is disabled, so an unset `SGLANG_DSV4_FP4_PROJ` is a zero-overhead
no-op -- the module is imported but installs nothing.

### Flags

| var | default | meaning |
|---|---|---|
| `SGLANG_DSV4_FP4_PROJ` | `0` | master enable |
| `SGLANG_DSV4_FP4_PROJ_PREFILL` | `wq_b,wqkv_a,indexer_wq_b,wo_b` | keys run in fp4 on prefill-like forwards; csv, or `all` / `none` |
| `SGLANG_DSV4_FP4_PROJ_DECODE` | `wq_b,wo_b` | keys run in fp4 on decode-like forwards; csv, or `all` / `none` |

Valid keys: `wq_b`, `wqkv_a`, `indexer_wq_b`, `wo_b`. At startup each rank logs
one line:

```
DSV4_FP4_PROJ: mxfp4 for prefill+decode=[wo_b,wq_b] prefill-only=[indexer_wq_b,wqkv_a] decode-only=[] (the last two keep both weights resident)
```

## Microbenchmark

GEMM only, CUDA-graph timed, MI355X (gfx950). Speedup = fp8 block-scale time /
best MXFP4 backend time. `M` is the GEMM's row count: M=8 is decode-shaped
(conc64, DP8, MTP), M=8192 is a prefill chunk. Shapes are per-rank for a
DP8/TP8 dp-attention run, where `attn_tp_size == 1` leaves attention weights
unsharded.

| projection | N | K | M=8 | M=32 | M=512 | M=8192 | fp4 backend @M=8 |
|---|---:|---:|---:|---:|---:|---:|---|
| `attn.q_b_proj` (`wq_b`) | 65536 | 1536 | **x1.21** | x1.19 | x1.75 | x1.63 | ck_asm |
| `attn.q_a_proj` (`wqkv_a`) | 2048 | 7168 | x0.77 | x1.12 | x1.35 | x2.27 | ck_asm |
| `indexer.wq_b` | 8192 | 1536 | x0.60 | x0.91 | x1.71 | x2.45 | ck_asm |
| `attn.o_proj_b` (`wo_b`) | 7168 | 16384 | **x1.45** | x1.68 | x2.55 | x1.95 | triton |

Numerics: relative error against a bf16 reference is ~0.026 for fp8 block-scale
and ~0.16 for MXFP4, across every shape and every M. About 6x worse, and
essentially shape-independent.

## Why the selection is per forward mode

**Two of the four projections are a regression at decode-shaped M.**
`indexer.wq_b` is x0.60 and `attn.q_a_proj` is x0.77 at M=8. Both are small-N
GEMMs where the a4w4 tiling wastes work; the fp4 win only appears once M grows
into the prefill regime, where they become the two *best* of the four (x2.45 and
x2.27). A single global on/off switch forces a bad trade in either direction:
enable them and decode regresses, disable them and prefill leaves the largest
speedups on the table.

So the default is all four in fp4 on prefill, and only `wq_b` + `wo_b` on decode.

A projection selected for one mode only keeps **both** weights resident and
dispatches on the forward mode; the non-selected mode delegates to the untouched
`Fp8LinearMethod` and is bit-identical to the stock build. A projection selected
for both modes frees its fp8 weight. Net weight memory is **-5.27 GiB/GPU**,
computed from the checkpoint shapes (62 layers; `indexer.wq_b` exists on 30 of
them): fp4-only `wq_b` and `wo_b` save 5.91 GiB, dual residency for `wqkv_a` and
`indexer.wq_b` costs 0.64 GiB.

### Why `wo_a` is not selectable

`attn.o_proj_a` microbenches at x3.09-x3.74, the largest apparent win, and is
deliberately excluded. Under `SGLANG_OPT_FP8_WO_A_GEMM` (on by default on
gfx950) it never reaches `quant_method.apply`: the MLA output-absorb runs as a
*batched* GEMM -- activation `[T, G, D]`, weight `[G, R, D]`, output `[T, G, R]`
with `G=16`, `R=1024`, `D=4096` -- through aiter's
`batched_gemm_a8w8_mxscale`. aiter exposes no batched a4w4 equivalent, so an
fp4 `wo_a` needs either a new batched fp4 kernel or 16 separate `gemm_a4w4`
calls per layer per step (16x62 extra launches on the decode critical path).
The x3.09-x3.74 figure models `wo_a` as one dense `[M,4096]x[4096,16384]` GEMM:
same FLOPs and same weight bytes, but one large GEMM beats 16 small ones, so
treat it as a structural upper bound rather than an achievable speedup.

## End-to-end throughput

DeepSeek-V4-Pro on 8x MI355X, 8192 in / 1024 out fixed length, 640 requests,
concurrency 64, `TP=8 EP_SIZE=1` with dp-attention (DP8/TP8), EAGLE MTP depth 3.
Baseline image `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907`
(sglang `e4008de757`); the only difference between arms is the feature flag.

Arms interleaved `A1 B1 A2 B2`, two replicates each, servers fully restarted
between arms, so node drift shows up as within-arm spread rather than as the
effect. `+-` below is the **full spread across replicates**, not a standard
error. Both arms pin `SGLANG_SIMULATE_ACC_LEN=2.49` (the golden acceptance
length for depth 3), so they decode the same number of tokens per step and the
measurement isolates GEMM time rather than a change in MTP acceptance.

| metric | baseline (fp8) | fp4 projections | delta |
|---|---|---|---|
| output tok/s | 2534.01 +- 20.58 | **2571.50 +- 15.45** | **+1.48%** |
| total tok/s | 22806.11 +- 185.19 | 23143.50 +- 139.08 | +1.48% |
| req/s | 2.47 +- 0.02 | 2.51 +- 0.02 | +1.48% |
| benchmark duration (s) | 258.63 +- 2.10 | 254.86 +- 1.53 | -1.46% |
| mean TTFT (ms) | 2352.22 +- 1.34 | 2250.39 +- 93.66 | -4.33% |
| mean TPOT (ms) | 22.86 +- 0.19 | 22.59 +- 0.24 | -1.19% |
| p99 TPOT (ms) | 25.20 +- 0.05 | 25.07 +- 0.57 | -0.54% |

Per run:

| arm | output tok/s | mean TTFT ms | mean TPOT ms | duration s |
|---|---|---|---|---|
| baseline_rep1 | 2523.72 | 2352.9 | 22.96 | 259.7 |
| baseline_rep2 | 2544.30 | 2351.6 | 22.77 | 257.6 |
| fp4proj_rep1 | 2563.77 | 2203.6 | 22.71 | 255.6 |
| fp4proj_rep2 | 2579.23 | 2297.2 | 22.47 | 254.1 |

All four arms completed 640/640 requests with identical token counts
(5,242,880 in / 655,360 out).

**Throughput improvement: +1.48%.** Both patched runs beat both baseline runs,
and the +37.5 tok/s gap is larger than either arm's replicate spread (20.6 and
15.5 tok/s), so the direction is solid even at n=2 per arm. The TPOT gain
(-1.19%) is the trustworthy signal: it is the decode path, where only `wq_b` and
`wo_b` are in fp4, and it is consistent across replicates. The mean-TTFT delta
(-4.33%) is directionally right for a prefill running all four projections in
fp4, but the patched arm's own spread on that metric (+-93.7 ms) is comparable
to the delta, so read it as "prefill did not regress" rather than as a measured
4% win.

The modest end-to-end number is expected and consistent with the trace: 71.3% of
kernel time is NCCL, and these four GEMMs are 11.9% of non-NCCL kernel time, so
per-GEMM speedups of x1.21-x2.45 cannot translate proportionally.

## Accuracy

GSM8k, 5-shot, lm-eval, full test split (n=1319), MTP depth 3 with **real**
target verification (`SGLANG_SIMULATE_ACC_LEN` unset). Same runner, same config,
same `EVAL_LIMIT` for every row.

Each projection swapped in isolation, plus the shipped per-mode default:

| config | projections in MXFP4 | strict-match | flexible-extract | delta vs baseline (strict) |
|---|---|---|---|---|
| baseline | none (fp8 everywhere) | 96.82 +- 0.48 | 96.74 +- 0.49 | - |
| `wq_b` | `attn.q_b_proj` | 96.66 +- 0.49 | 96.59 +- 0.50 | -0.15 pt |
| `wqkv_a` | `attn.q_a_proj` | 96.89 +- 0.48 | 96.82 +- 0.48 | +0.08 pt |
| `indexer_wq_b` | `indexer.wq_b` | 96.44 +- 0.51 | 96.36 +- 0.52 | -0.38 pt |
| `wo_b` | `attn.o_proj_b` | 96.74 +- 0.49 | 96.66 +- 0.49 | -0.08 pt |
| all four, both modes | all of the above | 96.59 +- 0.50 | 96.59 +- 0.50 | -0.23 pt |
| **shipped default** | 4 on prefill, 2 on decode | **96.66 +- 0.49** | 96.66 +- 0.49 | **-0.15 pt** |

**No measurable accuracy loss.** The standard error of the difference is
+-0.69 pt, and every delta in the table -- including the positive one -- is
inside it. A single GSM8k pass on this model also has roughly +-2 pt run-to-run
variance, so these rows should be read as "no change detected", not as a ranking
of the swaps.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34230145773](https://github.com/sgl-project/sglang/actions/runs/34230145773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34230145360](https://github.com/sgl-project/sglang/actions/runs/34230145360)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34230145546](https://github.com/sgl-project/sglang/actions/runs/34230145546)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->