### PR TITLE
fix(moe): pass expert_start/num_experts in ep_scatter_from_psum

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -1318,6 +1318,8 @@ def ep_scatter_from_psum(
         output_index,
         output_index.stride(0),
         output_index.stride(1),
+        0,
+        num_experts,
         topk_num=recv_topk.shape[1],
         num_warps=num_warps,
         HIDDEN_SIZE=hidden_size,

--- a/test/registered/kernels/ops/moe/test_ep_scatter_from_psum.py
+++ b/test/registered/kernels/ops/moe/test_ep_scatter_from_psum.py
@@ -1,0 +1,106 @@
+"""ep_scatter_from_psum must forward expert_start/num_experts to the shared
+_fwd_kernel_ep_scatter_2 exactly like ep_scatter does.
+
+Regression guard: the psum entry point once omitted the (expert_start,
+num_experts) positional arguments the kernel requires. With them missing the
+call raises at launch, and had it not raised the expert-validity test
+(0 <= expert_id < num_experts) would read the wrong operands. Both failure
+modes are black-box observable through the scatter contract below, so this test
+turns red on the pre-fix code and green on the fix.
+
+The contract (independent of the non-deterministic atomic row assignment, since
+every claim is reached through output_index rather than by fixing row order):
+for each routed (token, k) slot mapping to expert e, output_index gives a valid
+destination row dst, output_tensor[dst]/output_tensor_scale[dst] equal the
+token's own fp8 payload/scale, and m_indices[dst] labels that row as expert e.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import ep_scatter_from_psum
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+
+BLOCK_E = 128
+HIDDEN = 256  # multiple of the 128 quant block
+
+
+def _build_inputs(num_tokens: int, num_experts: int, topk: int, seed: int):
+    torch.manual_seed(seed)
+    device = "cuda"
+
+    # Each token routes to `topk` distinct experts in [0, num_experts).
+    recv_topk = torch.stack(
+        [torch.randperm(num_experts, device=device)[:topk] for _ in range(num_tokens)]
+    ).to(torch.int64)
+
+    valid = torch.bincount(recv_topk.flatten(), minlength=num_experts)
+    # DeepGEMM contiguous layout pads every expert segment to a 128-row multiple.
+    padded = ((valid + BLOCK_E - 1) // BLOCK_E) * BLOCK_E
+    psum = torch.cumsum(padded, dim=0).to(torch.int32)
+    all_tokens = int(psum[-1].item())
+
+    scale_hidden = HIDDEN // 128
+    recv_x = (torch.randn(num_tokens, HIDDEN, device=device) * 0.3).to(
+        torch.float8_e4m3fn
+    )
+    recv_x_scale = torch.rand(num_tokens, scale_hidden, device=device) + 0.5
+
+    output_tensor = torch.empty(all_tokens, HIDDEN, device=device, dtype=recv_x.dtype)
+    output_tensor_scale = torch.empty(
+        all_tokens, scale_hidden, device=device, dtype=torch.float32
+    )
+    m_indices = torch.empty(all_tokens, device=device, dtype=torch.int32)
+    output_index = torch.empty_like(recv_topk)
+    expert_start_loc = torch.empty_like(psum)
+
+    return dict(
+        recv_x=recv_x,
+        recv_x_scale=recv_x_scale,
+        recv_topk=recv_topk,
+        psum_num_recv_tokens_per_expert=psum,
+        expert_start_loc=expert_start_loc,
+        output_tensor=output_tensor,
+        output_tensor_scale=output_tensor_scale,
+        m_indices=m_indices,
+        output_index=output_index,
+    )
+
+
+@requires_cuda
+@pytest.mark.parametrize("num_tokens", [64, 200, 512])
+@pytest.mark.parametrize("topk", [1, 6])
+def test_scatter_contract(num_tokens: int, topk: int):
+    num_experts = 8
+    args = _build_inputs(num_tokens, num_experts, topk, seed=num_tokens + topk)
+    ep_scatter_from_psum(**args)
+
+    recv_topk = args["recv_topk"]
+    dst = args["output_index"]
+    # Every routed slot must land on a real row (no -1 sentinel here: all experts
+    # are local and expert_start=0, so every id is in range).
+    assert torch.all(dst >= 0), dst[dst < 0]
+
+    src_x = args["recv_x"].float()
+    src_s = args["recv_x_scale"]
+    out_x = args["output_tensor"].float()
+    out_s = args["output_tensor_scale"]
+    m_indices = args["m_indices"]
+
+    for t in range(num_tokens):
+        for k in range(topk):
+            e = int(recv_topk[t, k].item())
+            row = int(dst[t, k].item())
+            assert torch.equal(out_x[row], src_x[t]), (t, k, e, row)
+            assert torch.equal(out_s[row], src_s[t]), (t, k, e, row)
+            assert int(m_indices[row].item()) == e, (t, k, e, row)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-x"]))


### PR DESCRIPTION
## Motivation

`_fwd_kernel_ep_scatter_2` takes `expert_start` and `num_experts` as positional
arguments (used for the local-expert validity check `global_expert_id -
expert_start in [0, num_experts)`). #35758 added these positionals and updated
`ep_scatter`, but the `ep_scatter_from_psum` call site was missed, so the kernel
launch raises a missing-argument `TypeError` as soon as the non-expand DeepEP v2
prefill path (`do_expand=False`) invokes it. Nothing in CI reaches this wrapper
today, which is how it stayed broken on `main`.

## Modifications

- Forward `expert_start=0` and `num_experts` in the `ep_scatter_from_psum`
  launch, matching `ep_scatter` (local ids, out-of-range lanes are filtered by
  the kernel's own range check).
- Add a regression test (`test_ep_scatter_from_psum.py`) that routes random
  tokens through `ep_scatter_from_psum` and verifies, via `output_index`, that
  every routed slot lands on a real row carrying the token's payload/scale and
  the correct `m_indices` label — so the launch signature is now exercised in
  CI.

## Notes

Split out from #37261 so it can be cherry-picked independently; that PR keeps
the same fix in its branch since the non-expand baseline it was benchmarked
against depends on it.

## Checklist

- [x] Added a unit test for the fixed launch path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34230809817](https://github.com/sgl-project/sglang/actions/runs/34230809817)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34230809754](https://github.com/sgl-project/sglang/actions/runs/34230809754)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34230809799](https://github.com/sgl-project/sglang/actions/runs/34230809799)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->