### PR TITLE
[Fix] SWA allocator: skip unmapped reps in the segment free path (page-0 double free)

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -22,9 +22,6 @@ if _is_npu:
     )
 
 
-# free_swa releases whatever the mapping points at, so an entry that reads as the
-# padding slot would push slot 0 into the SWA free list and hand it out twice.
-_SWA_PEER_MAPPED = Invariant("swa.peer_mapped", Bucket.FATAL_UNCONTAINABLE, IsTrue())
 # free_full leaves the mapping alone, so a live entry would strand its SWA peer.
 _SWA_PEER_RELEASED = Invariant("swa.peer_released", Bucket.GUARD, IsTrue())
 
@@ -463,11 +460,21 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def _free_swa_pages(self, free_index: torch.Tensor, *, start_pos: int):
         ps = self.page_size
         assert start_pos % ps == 0, f"segment start {start_pos} is not page-aligned"
-        # First token of every page the segment touches; the caller allocated
-        # each one, so a dead entry means the caller wanted free_full.
+        # First token of every page the segment touches.
         reps = free_index[::ps]
         swa_tokens = self.full_to_swa_index_mapping[reps]
-        expect(_SWA_PEER_MAPPED, swa_tokens > 0, msg="caller wants free_full")
+        # A rep that reads as the padding slot (0) owns no SWA page. That is a
+        # legitimate state, not a caller bug: SWAComponent.evict_component
+        # deliberately hands us the FULL indices of nodes whose slots have no
+        # SWA pair -- window-evicted tails, and every prefix the external cache
+        # linker loaded with the SWA component skipped under unified KV.
+        # free_page_ids() does no dedup ("no page twice, no dedup"), so keeping
+        # these would push reserved page 0 once per unmapped rep and drive
+        # swa_attn_allocator.available_size() past .size -- the assert in
+        # free_group_end() -- and, unguarded, hand the padding slot out as a
+        # real KV page. Drop them, exactly as _release_swa() does on the
+        # set-shaped path.
+        swa_tokens = swa_tokens[swa_tokens > 0]
 
         if ps == 1:
             swa_pages = swa_tokens


### PR DESCRIPTION
## Bug

`SWATokenToKVPoolAllocator.free_group_end()` asserts on all ranks a second after
the server goes live, whenever an external cache linker is attached under
unified KV:

```
File ".../mem_cache/allocator/swa.py", line 559, in free_group_end
  assert self.swa_attn_allocator.available_size() <= self.swa_attn_allocator.size
AssertionError
```

`available_size() > size` is an over-free: more SWA pages were returned than exist.

## Root cause

`SWAComponent.evict_component()` deliberately passes the node's **FULL** indices,
and says why:

> Pass full indices to free_swa so slots with no SWA pair are skipped. Freeing
> swa_value directly would double free those entries since they all map to the
> same sentinel slot.

But `apply_component_action()` calls `free_swa_segment()`, not `free_swa()`. The
two paths do not have the same contract:

* `free_swa()` -> `_release_swa()` filters `swa_indices > 0`.
* `free_swa_segment()` -> `_free_swa_pages()` does **not** filter. Its only guard is
  `expect(_SWA_PEER_MAPPED, swa_tokens > 0, ...)`, which is signal-only and off by
  default: `resolve_level()` returns `OFF` unless `SGLANG_INVARIANT_CHECK` /
  `SGLANG_ENABLE_ASYNC_ASSERT` is set, and `Bucket.FATAL_UNCONTAINABLE` forbids a
  `recover`. In a normal run it neither detects nor repairs anything.

So a rep with no SWA peer reads 0, becomes `swa_pages = 0 // page_size` = 0, and
`free_page_ids()` is documented *"Free exactly these pages; no page twice, no
dedup."* Reserved page 0 therefore goes back on the free list once per unmapped
rep until `available_size()` passes `size`.

Page 0 is the padding slot (`free_pages = torch.arange(1, num_pages + 1)`), so
unguarded this hands the padding slot out as a real KV page; the assert is
catching genuine corruption.

## Why it is a regression

Before `_free_swa_pages()` existed, `free_swa()` routed `page_size > 1` through
`_expand_to_full_pages()` -> `_release_swa()`, which filters `> 0`. `page_size > 1`
was safe by construction; only the `page_size == 1` branch carried the bare
`expect`, with the comment *"A filter here would make the output shape
data-dependent, which costs a device-to-host sync."* The fixed-shape segment path
routes `page_size > 1` around that filter.

The allocator's own debug check already encodes the intended semantics --
`torch.unique(ref[ref > 0] // ps)` excludes unmapped entries -- so with
`SGLANG_DEBUG_MEMORY_POOL=1` the current code fails that assert too.

## Fix

Drop unmapped reps in `_free_swa_pages()`, exactly as `_release_swa()` already does
on the set-shaped path.

## Reproducer

Standalone, no model required -- builds a real `SWATokenToKVPoolAllocator`
(page_size=256) and exercises `free_swa_segment()`:

| scenario | before | after |
|---|---|---|
| normal decode, every page has an SWA peer | PASS | PASS |
| externally loaded prefix, no SWA peers | **FAIL** `[0,0,0,0]`, available 5120 > size 4096 | PASS, frees nothing |
| half window-evicted, half live | **FAIL** `[1,2,0,0]`, available 4608 > size 4096 | PASS, frees only `[1,2]` |

## End-to-end

DeepSeek-V4-Pro FP4, TP8 + DP attention, EAGLE MTP, page_size 256, concurrency
256, agentic trace replay, external linker on all 8 ranks.

* Unpatched: 8/8 ranks assert ~1s after `The server is fired up and ready to roll!`
* Patched: full 3628s replay, 11450 requests, `errors=0`, zero asserts.

## Note on the sync

The filter is a boolean index, so the output shape is data-dependent and it costs
a D2H sync -- the thing the fixed-shape path was built to avoid. In a follow-up I
can move the filter to the release points (`free_group_end()` plus the ungrouped
free) so it runs once per free group instead of once per call; that keeps
`_free_swa_pages()` fixed-shape. Filing the straightforward version first since it
is the one with end-to-end validation behind it.

## Context

Found while running the AMD DeepSeek-V4 unified-KV external-linker arm from
sgl-project/sglang#38269. That PR is not the cause and does not need to change:
its branch predates `_free_swa_pages()`, and the defect is on `main` independently.
The linker just makes the unmapped-slot case common, because it installs FULL
slots whose SWA component was skipped under unified KV. Window-evicted tails can
reach the same path without any linker.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34232788705](https://github.com/sgl-project/sglang/actions/runs/34232788705)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34232788466](https://github.com/sgl-project/sglang/actions/runs/34232788466)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34232788658](https://github.com/sgl-project/sglang/actions/runs/34232788658)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->