### PR TITLE
fix(attention): resolve hybrid backend for FP8 DSA metadata

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -638,9 +638,7 @@ class DeepseekMHAForwardMixin:
 
         Returns: (kv_a, k_pe) both in BF16
         """
-        backend = get_attn_backend()
-        if isinstance(backend, TboAttnBackend):  # if enable tbo, get primary backend
-            backend = backend.primary
+        backend = resolve_attn_backend(forward_batch)
         kv_indices = backend.forward_metadata.page_table_1_flattened
         assert kv_indices is not None, (
             "page_table_1_flattened should have been generated for FP8 MHA path"

--- a/test/registered/unit/models/test_deepseek_fp8_dsa_backend.py
+++ b/test/registered/unit/models/test_deepseek_fp8_dsa_backend.py
@@ -1,0 +1,87 @@
+"""CPU regression for FP8 DSA metadata resolution in hybrid models."""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    HybridLinearAttnBackend,
+)
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.models.deepseek_common.attention_forward_methods import forward_mha
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
+    DeepseekMHAForwardMixin,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _TokenToKVPool:
+    def __init__(self, key_buffer: torch.Tensor):
+        self.key_buffer = key_buffer
+
+    def get_key_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.key_buffer
+
+
+class _Backend(AttentionBackend):
+    needs_cpu_seq_lens = False
+
+    def __init__(self, token_to_kv_pool: _TokenToKVPool):
+        self.token_to_kv_pool = token_to_kv_pool
+        self.req_to_token_pool = None
+        self.kv_index_translator = None
+        self.max_context_len = 8
+
+
+class _ForwardMetadata:
+    def __init__(self, page_table: torch.Tensor):
+        self.page_table_1_flattened = page_table
+
+
+class _AttentionLayer:
+    layer_id = 0
+
+
+class _MHALayer:
+    attn_mha = _AttentionLayer()
+    kv_lora_rank = 2
+
+
+class TestDeepseekFP8DSABackend(CustomTestCase):
+    def test_cached_prefix_uses_full_attention_metadata(self):
+        """A hybrid FP8 DSA cached-prefix read uses the full backend page table."""
+        key_buffer = torch.arange(24, dtype=torch.bfloat16).reshape(6, 1, 4)
+        page_table = torch.tensor([3, 5], dtype=torch.int32)
+        token_to_kv_pool = _TokenToKVPool(key_buffer)
+        full_backend = _Backend(token_to_kv_pool)
+        full_backend.forward_metadata = _ForwardMetadata(page_table)
+        hybrid_backend = HybridLinearAttnBackend(
+            full_attn_backend=full_backend,
+            linear_attn_backend=_Backend(token_to_kv_pool),
+            full_attn_layers=[0],
+        )
+
+        with (
+            forward_context(ForwardContext(attn_backend=hybrid_backend)),
+            mock.patch.object(
+                forward_mha,
+                "dequantize_k_cache_paged",
+                side_effect=lambda cache, indices: cache[indices],
+            ),
+        ):
+            kv_a, k_pe = DeepseekMHAForwardMixin._get_mla_kv_buffer_from_fp8_for_dsa(
+                _MHALayer(), object()
+            )
+
+        expected = key_buffer[page_table]
+        torch.testing.assert_close(kv_a, expected[:, :, :2].squeeze(1))
+        torch.testing.assert_close(k_pe, expected[:, :, 2:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Addresses #38477.

For hybrid GLM-5 models using DSA with an FP8 KV cache, the cached-prefix MHA path reads `forward_metadata` from the outer `HybridLinearAttnBackend`. That wrapper does not own the DSA page-table metadata; its full-attention child does.

This PR uses the existing backend resolver and adds a regression that exercises a real `HybridLinearAttnBackend` published through the real per-forward context.

## Modifications

- Resolve the active full-attention backend with `resolve_attn_backend(forward_batch)` before reading the FP8 DSA page table.
- Add one CPU bug-regression test that:
  - constructs the real hybrid wrapper,
  - publishes it through `ForwardContext`,
  - substitutes only the dequantization kernel boundary,
  - verifies cached-prefix KV is selected by the full backend's page table.

## Accuracy Tests

The regression was verified red before the production change with:

```text
AttributeError: 'NoneType' object has no attribute 'page_table_1_flattened'
```

After the change:

```bash
PYTHONPATH=python python test/registered/unit/models/test_deepseek_fp8_dsa_backend.py
PYTHONPATH=python python test/registered/unit/models/test_deepseek_mla_dispatch.py
```

Results: 1/1 new regression passed; 7/7 related MLA dispatch tests passed.

Live MI355 cached-prefix validation is in progress for:
- `zai-org/GLM-5.3-Flash`
- `amd/GLM-5.3-Flash-Quark-MXFP4`

## Speed Tests and Profiling

Not applicable. The change replaces a local unwrap with the resolver already used by adjacent MHA paths and does not alter kernels or scheduling.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add a focused bug-regression unit test and prove red-before/green-after.
- [x] Follow the repository's current test-admission and code-style guidance.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34246929073](https://github.com/sgl-project/sglang/actions/runs/34246929073)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34246928582](https://github.com/sgl-project/sglang/actions/runs/34246928582)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34246929188](https://github.com/sgl-project/sglang/actions/runs/34246929188)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->