### PR TITLE
[Diffusion] Fuse LongCat Image normalization and modulation

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/longcat_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/longcat_image.py
@@ -35,10 +35,14 @@ from diffusers.models.normalization import (
 from sglang.kernels.ops.diffusion import (
     BitExactFusionGate,
     can_use_fused_inplace_qknorm_rope,
+    can_use_fused_layernorm_modulate,
     can_use_linear_gelu,
     fused_gelu_active,
+    fused_layernorm_modulate,
     fused_linear_gelu_tanh,
+    is_plain_layer_norm,
     mark_fused_gelu_site,
+    modulate_scale_shift,
     residual_gate_add,
     tensors_equal,
 )
@@ -62,6 +66,75 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 _LONGCAT_QKNORM_ROPE = BitExactFusionGate("LongCat fused QKNorm+RoPE")
+_LONGCAT_LN_MOD = BitExactFusionGate("LongCat fused LN+modulate", per_signature=True)
+
+
+def _longcat_norm_modulate(
+    norm: nn.Module,
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    # LayerNorm's reduction depends on the live aten dispatch. Verify each
+    # shape/stride before using the bit-exact fused kernel, outside capture.
+    if (
+        not _LONGCAT_LN_MOD.disabled
+        and is_plain_layer_norm(norm, x.shape[-1])
+        and can_use_fused_layernorm_modulate(x, scale, shift)
+    ):
+        sig = (
+            x.shape,
+            x.stride(),
+            scale.shape,
+            scale.stride(),
+            shift.shape,
+            shift.stride(),
+            norm.eps,
+            x.dtype,
+            x.device,
+        )
+        verified = _LONGCAT_LN_MOD.is_verified(sig)
+        if verified or not (
+            torch.compiler.is_compiling() or torch.cuda.is_current_stream_capturing()
+        ):
+            try:
+                out = fused_layernorm_modulate(x, scale, shift, norm.eps)
+            except Exception as exc:
+                _LONGCAT_LN_MOD.on_exception(exc, logger=logger)
+            else:
+                if verified:
+                    return out
+                reference = modulate_scale_shift(norm(x), scale, shift)
+                return _LONGCAT_LN_MOD.accept_or_fallback(
+                    out, reference, sig=sig, logger=logger
+                )
+    return modulate_scale_shift(norm(x), scale, shift)
+
+
+class _LongCatAdaLayerNormZero(AdaLayerNormZero):
+    def forward(
+        self,
+        x: torch.Tensor,
+        timestep: Optional[torch.Tensor] = None,
+        class_labels: Optional[torch.LongTensor] = None,
+        hidden_dtype: Optional[torch.dtype] = None,
+        emb: Optional[torch.Tensor] = None,
+    ):
+        if self.emb is not None:
+            emb = self.emb(timestep, class_labels, hidden_dtype=hidden_dtype)
+        emb = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb.chunk(
+            6, dim=1
+        )
+        x = _longcat_norm_modulate(self.norm, x, scale_msa, shift_msa)
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+class _LongCatAdaLayerNormZeroSingle(AdaLayerNormZeroSingle):
+    def forward(self, x: torch.Tensor, emb: Optional[torch.Tensor] = None):
+        emb = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa = emb.chunk(3, dim=1)
+        return _longcat_norm_modulate(self.norm, x, scale_msa, shift_msa), gate_msa
 
 
 def _longcat_qknorm_rope_reference(
@@ -268,9 +341,9 @@ class _LongCatJointAttention(nn.Module):
         super().__init__()
         tp_size = get_tp_world_size()
         self.num_local_heads = num_attention_heads // tp_size
-        assert num_attention_heads % tp_size == 0, (
-            f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
-        )
+        assert (
+            num_attention_heads % tp_size == 0
+        ), f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
         self.head_dim = attention_head_dim
         inner_dim = num_attention_heads * attention_head_dim
 
@@ -429,9 +502,9 @@ class _LongCatSingleAttention(nn.Module):
         super().__init__()
         tp_size = get_tp_world_size()
         self.num_local_heads = num_attention_heads // tp_size
-        assert num_attention_heads % tp_size == 0, (
-            f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
-        )
+        assert (
+            num_attention_heads % tp_size == 0
+        ), f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
         self.head_dim = attention_head_dim
         inner_dim = num_attention_heads * attention_head_dim
 
@@ -500,7 +573,7 @@ class _SingleTransformerBlock(nn.Module):
     ):
         super().__init__()
         self.mlp_hidden_dim = int(dim * mlp_ratio)
-        self.norm = AdaLayerNormZeroSingle(dim)
+        self.norm = _LongCatAdaLayerNormZeroSingle(dim)
         # proj_mlp: ColumnParallelLinear with gather_output=False keeps output
         # head-sharded, consistent with attn_output from _LongCatSingleAttention.
         self.proj_mlp = ColumnParallelLinear(
@@ -619,8 +692,8 @@ class _TransformerBlock(nn.Module):
         prefix: str = "",
     ):
         super().__init__()
-        self.norm1 = AdaLayerNormZero(dim)
-        self.norm1_context = AdaLayerNormZero(dim)
+        self.norm1 = _LongCatAdaLayerNormZero(dim)
+        self.norm1_context = _LongCatAdaLayerNormZero(dim)
         self.attn = _LongCatJointAttention(
             dim=dim,
             num_attention_heads=num_attention_heads,
@@ -666,9 +739,8 @@ class _TransformerBlock(nn.Module):
             hidden_states, attn_output, gate_msa.unsqueeze(1)
         )
 
-        norm_hidden_states = self.norm2(hidden_states)
-        norm_hidden_states = (
-            norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        norm_hidden_states = _longcat_norm_modulate(
+            self.norm2, hidden_states, scale_mlp, shift_mlp
         )
         ff_output = self.ff(norm_hidden_states)
         hidden_states = residual_gate_add(
@@ -679,10 +751,8 @@ class _TransformerBlock(nn.Module):
             encoder_hidden_states, context_attn_output, c_gate_msa.unsqueeze(1)
         )
 
-        norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
-        norm_encoder_hidden_states = (
-            norm_encoder_hidden_states * (1 + c_scale_mlp[:, None])
-            + c_shift_mlp[:, None]
+        norm_encoder_hidden_states = _longcat_norm_modulate(
+            self.norm2_context, encoder_hidden_states, c_scale_mlp, c_shift_mlp
         )
         context_ff_output = self.ff_context(norm_encoder_hidden_states)
         encoder_hidden_states = residual_gate_add(

--- a/python/sglang/multimodal_gen/runtime/models/dits/longcat_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/longcat_image.py
@@ -32,17 +32,14 @@ from diffusers.models.normalization import (
     AdaLayerNormZeroSingle,
 )
 
+from sglang.kernels.ops import diffusion as diffusion_ops
 from sglang.kernels.ops.diffusion import (
     BitExactFusionGate,
     can_use_fused_inplace_qknorm_rope,
-    can_use_fused_layernorm_modulate,
     can_use_linear_gelu,
     fused_gelu_active,
-    fused_layernorm_modulate,
     fused_linear_gelu_tanh,
-    is_plain_layer_norm,
     mark_fused_gelu_site,
-    modulate_scale_shift,
     residual_gate_add,
     tensors_equal,
 )
@@ -75,12 +72,15 @@ def _longcat_norm_modulate(
     scale: torch.Tensor,
     shift: torch.Tensor,
 ) -> torch.Tensor:
+    if torch.is_grad_enabled() or torch.compiler.is_compiling():
+        return norm(x) * (1 + scale[:, None]) + shift[:, None]
     # LayerNorm's reduction depends on the live aten dispatch. Verify each
     # shape/stride before using the bit-exact fused kernel, outside capture.
     if (
         not _LONGCAT_LN_MOD.disabled
-        and is_plain_layer_norm(norm, x.shape[-1])
-        and can_use_fused_layernorm_modulate(x, scale, shift)
+        and x.is_cuda
+        and diffusion_ops.is_plain_layer_norm(norm, x.shape[-1])
+        and diffusion_ops.can_use_fused_layernorm_modulate(x, scale, shift)
     ):
         sig = (
             x.shape,
@@ -94,21 +94,19 @@ def _longcat_norm_modulate(
             x.device,
         )
         verified = _LONGCAT_LN_MOD.is_verified(sig)
-        if verified or not (
-            torch.compiler.is_compiling() or torch.cuda.is_current_stream_capturing()
-        ):
+        if verified or not torch.cuda.is_current_stream_capturing():
             try:
-                out = fused_layernorm_modulate(x, scale, shift, norm.eps)
+                out = diffusion_ops.fused_layernorm_modulate(x, scale, shift, norm.eps)
             except Exception as exc:
                 _LONGCAT_LN_MOD.on_exception(exc, logger=logger)
             else:
                 if verified:
                     return out
-                reference = modulate_scale_shift(norm(x), scale, shift)
+                reference = norm(x) * (1 + scale[:, None]) + shift[:, None]
                 return _LONGCAT_LN_MOD.accept_or_fallback(
                     out, reference, sig=sig, logger=logger
                 )
-    return modulate_scale_shift(norm(x), scale, shift)
+    return norm(x) * (1 + scale[:, None]) + shift[:, None]
 
 
 class _LongCatAdaLayerNormZero(AdaLayerNormZero):
@@ -341,9 +339,9 @@ class _LongCatJointAttention(nn.Module):
         super().__init__()
         tp_size = get_tp_world_size()
         self.num_local_heads = num_attention_heads // tp_size
-        assert (
-            num_attention_heads % tp_size == 0
-        ), f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
+        assert num_attention_heads % tp_size == 0, (
+            f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
+        )
         self.head_dim = attention_head_dim
         inner_dim = num_attention_heads * attention_head_dim
 
@@ -502,9 +500,9 @@ class _LongCatSingleAttention(nn.Module):
         super().__init__()
         tp_size = get_tp_world_size()
         self.num_local_heads = num_attention_heads // tp_size
-        assert (
-            num_attention_heads % tp_size == 0
-        ), f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
+        assert num_attention_heads % tp_size == 0, (
+            f"num_attention_heads ({num_attention_heads}) must be divisible by tp_size ({tp_size})"
+        )
         self.head_dim = attention_head_dim
         inner_dim = num_attention_heads * attention_head_dim
 

--- a/test/registered/kernel/diffusion/test_longcat_image_norm_modulate.py
+++ b/test/registered/kernel/diffusion/test_longcat_image_norm_modulate.py
@@ -11,7 +11,7 @@ from sglang.kernels.ops.diffusion import BitExactFusionGate, modulate_scale_shif
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=45, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 
 class TestLongCatNormModulation(CustomTestCase):
@@ -63,6 +63,24 @@ class TestLongCatNormModulation(CustomTestCase):
         norm = torch.nn.LayerNorm(3072, elementwise_affine=False, eps=1e-6).cuda()
         return norm, x, scale, shift
 
+    def test_grad_enabled_uses_differentiable_reference(self):
+        norm, x, scale, shift = self.inputs(seq=17)
+        with torch.inference_mode():
+            longcat._longcat_norm_modulate(norm, x, scale, shift)
+        self.assertTrue(longcat._LONGCAT_LN_MOD.verified)
+        leaves = [t.detach().clone().requires_grad_() for t in (x, scale, shift)]
+        refs = [t.detach().clone().requires_grad_() for t in leaves]
+        with patch.object(longcat.diffusion_ops, "fused_layernorm_modulate") as fused:
+            actual = longcat._longcat_norm_modulate(norm, *leaves)
+            actual.float().sum().backward()
+            fused.assert_not_called()
+        expected = norm(refs[0]) * (1 + refs[1][:, None]) + refs[2][:, None]
+        expected.float().sum().backward()
+        self.assertTrue(torch.equal(actual, expected))
+        for a, b in zip(leaves, refs, strict=True):
+            self.assertIsNotNone(a.grad)
+            self.assertTrue(torch.equal(a.grad, b.grad))
+
     @torch.inference_mode()
     def test_changed_inputs_are_used_by_graph_replay(self):
         norm, x, scale, shift = self.inputs()
@@ -82,7 +100,7 @@ class TestLongCatNormModulation(CustomTestCase):
     def test_unverified_capture_uses_eager_reference(self):
         norm, x, scale, shift = self.inputs(seq=17)
         expected = modulate_scale_shift(norm(x), scale, shift)
-        with patch.object(longcat, "fused_layernorm_modulate") as fused:
+        with patch.object(longcat.diffusion_ops, "fused_layernorm_modulate") as fused:
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
                 actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
@@ -96,12 +114,14 @@ class TestLongCatNormModulation(CustomTestCase):
         norm, x, scale, shift = self.inputs(seq=17)
         expected = norm(x) * (1 + scale[:, None]) + shift[:, None]
         with patch.object(
-            longcat, "fused_layernorm_modulate", return_value=torch.zeros_like(x)
+            longcat.diffusion_ops,
+            "fused_layernorm_modulate",
+            return_value=torch.zeros_like(x),
         ):
             actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
         self.assertTrue(longcat._LONGCAT_LN_MOD.disabled)
         self.assertTrue(torch.equal(actual, expected))
-        with patch.object(longcat, "fused_layernorm_modulate") as fused:
+        with patch.object(longcat.diffusion_ops, "fused_layernorm_modulate") as fused:
             actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
             fused.assert_not_called()
         self.assertTrue(torch.equal(actual, expected))

--- a/test/registered/unit/models/test_longcat_image_norm_modulate.py
+++ b/test/registered/unit/models/test_longcat_image_norm_modulate.py
@@ -1,0 +1,111 @@
+"""LongCat normalization parity and graph-safe fusion dispatch."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from diffusers.models.normalization import AdaLayerNormZero, AdaLayerNormZeroSingle
+
+import sglang.multimodal_gen.runtime.models.dits.longcat_image as longcat
+from sglang.kernels.ops.diffusion import BitExactFusionGate, modulate_scale_shift
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=45, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestLongCatNormModulation(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.original_gate = longcat._LONGCAT_LN_MOD
+        longcat._LONGCAT_LN_MOD = BitExactFusionGate("test", per_signature=True)
+        torch.manual_seed(42)
+
+    def tearDown(self):
+        longcat._LONGCAT_LN_MOD = self.original_gate
+        super().tearDown()
+
+    def require_cuda(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA required")
+
+    @torch.inference_mode()
+    def test_adaln_checkpoint_and_output_parity(self):
+        for device, dtype, dim, seq in [
+            ("cpu", torch.float32, 64, 17),
+            ("cuda", torch.bfloat16, 3072, 512),
+            ("cuda", torch.bfloat16, 3072, 4608),
+        ]:
+            if device == "cuda" and not torch.cuda.is_available():
+                continue
+            for reference_cls, candidate_cls in [
+                (AdaLayerNormZero, longcat._LongCatAdaLayerNormZero),
+                (AdaLayerNormZeroSingle, longcat._LongCatAdaLayerNormZeroSingle),
+            ]:
+                with self.subTest(device=device, seq=seq, cls=reference_cls.__name__):
+                    reference = reference_cls(dim).to(device=device, dtype=dtype)
+                    candidate = candidate_cls(dim).to(device=device, dtype=dtype)
+                    candidate.load_state_dict(reference.state_dict(), strict=True)
+                    x = torch.randn(1, seq, dim, device=device, dtype=dtype)
+                    emb = torch.randn(1, dim, device=device, dtype=dtype)
+                    expected, actual = reference(x, emb=emb), candidate(x, emb=emb)
+                    for a, b in zip(expected, actual, strict=True):
+                        self.assertTrue(torch.equal(a, b))
+                    if device == "cuda":
+                        self.assertTrue(longcat._LONGCAT_LN_MOD.verified)
+                        self.assertFalse(longcat._LONGCAT_LN_MOD.disabled)
+
+    def inputs(self, seq=4096):
+        self.require_cuda()
+        x = torch.randn(1, seq, 3072, device="cuda", dtype=torch.bfloat16)
+        modulation = torch.randn(1, 6 * 3072, device="cuda", dtype=torch.bfloat16)
+        shift, scale, *_ = modulation.chunk(6, dim=-1)
+        norm = torch.nn.LayerNorm(3072, elementwise_affine=False, eps=1e-6).cuda()
+        return norm, x, scale, shift
+
+    @torch.inference_mode()
+    def test_changed_inputs_are_used_by_graph_replay(self):
+        norm, x, scale, shift = self.inputs()
+        longcat._longcat_norm_modulate(norm, x, scale, shift)
+        self.assertTrue(longcat._LONGCAT_LN_MOD.verified)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
+        x.add_(0.25)
+        scale.neg_()
+        shift.mul_(0.5)
+        graph.replay()
+        expected = norm(x) * (1 + scale[:, None]) + shift[:, None]
+        self.assertTrue(torch.equal(actual, expected))
+
+    @torch.inference_mode()
+    def test_unverified_capture_uses_eager_reference(self):
+        norm, x, scale, shift = self.inputs(seq=17)
+        expected = modulate_scale_shift(norm(x), scale, shift)
+        with patch.object(longcat, "fused_layernorm_modulate") as fused:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
+            graph.replay()
+            fused.assert_not_called()
+        self.assertFalse(longcat._LONGCAT_LN_MOD.verified)
+        self.assertTrue(torch.equal(actual, expected))
+
+    @torch.inference_mode()
+    def test_mismatch_disables_fusion_and_returns_reference(self):
+        norm, x, scale, shift = self.inputs(seq=17)
+        expected = norm(x) * (1 + scale[:, None]) + shift[:, None]
+        with patch.object(
+            longcat, "fused_layernorm_modulate", return_value=torch.zeros_like(x)
+        ):
+            actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
+        self.assertTrue(longcat._LONGCAT_LN_MOD.disabled)
+        self.assertTrue(torch.equal(actual, expected))
+        with patch.object(longcat, "fused_layernorm_modulate") as fused:
+            actual = longcat._longcat_norm_modulate(norm, x, scale, shift)
+            fused.assert_not_called()
+        self.assertTrue(torch.equal(actual, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reuse the existing bit-exact `fused_layernorm_modulate` in LongCat's dual/single AdaLN and norm2 sites. The initial profiles showed LayerNorm followed by scale+1, multiply and shift still taking5.4%–6.7% of cumulative kernel time after the previous QKNorm/RoPE and residual-gate optimizations.

The subclasses preserve Diffusers parameters/state-dict names. A per-shape/stride comparison enables fusion only after matching the original chain. Mismatch/JIT failure disables fusion; unsupported inputs, gradients, compilation and unverified capture keep the original formula. Final AdaLayerNormContinuous is unchanged. No new kernel or checkpoint-specific implementation is added.

## H200 setup

1x H200, PyTorch2.11.0+cu130, native pipelines, seed42, prompt rewrite off. All three checkpoints were profiled and validated separately.

| Checkpoint | Request | Steps / guidance |
| --- | --- | --- |
| `meituan-longcat/LongCat-Image` | 1024x1024; `A red panda reading a book beside a sunlit window.` | 50 / 4.5 |
| `meituan-longcat/LongCat-Image-Edit` | 1264x848; cat input; `Make the cat wear a red hat.` | 50 / 4.5 |
| `meituan-longcat/LongCat-Image-Edit-Turbo` | Same editing input and prompt | 8 / 1 |

Measured baseline: `295e64d7000cfbb4d3bf9f4e46efcdacbc4d84a8`; candidate: `7f5848461cb0da7e11a3485806fb283da97a132d` (same model/test content as local77fb7a7288). PR base: `482e9f257bb9d9ac57c2245c93768a96ec70edbe`, whose baseline LongCat model code matches the measured baseline. Final review adds explicit gradient/compile fallback, lazy resolution of new kernel symbols, and current CI registration. Fast-kernel arithmetic is unchanged. Full-model timings below are from the recorded benchmark commits, not a new-base E2E rerun.

Fresh-process A-B-B-A requests use the same GPU, request warmup and saved outputs. E2E is SGLang perf-dump `total_duration_ms`; loading, warmup and profile overhead are excluded. Image lossless eager A1 reuses the immediately preceding same-configuration `base-eager-a2` sample; other rows use their own recorded four-cell matrix.

### Eager end-to-end

| Model | Quality | Baseline runs | PR runs | Mean reduction |
| --- | --- | ---: | ---: | ---: |
| Image | lossless | 7.446897 / 7.449725 s | 7.165762 / 7.175107 s | **3.731%** |
| Image | high | 7.206739 / 7.220042 s | 6.953937 / 6.967295 s | **3.504%** |
| Edit | lossless | 17.175946 / 17.208413 s | 16.705402 / 16.732543 s | **2.752%** |
| Edit | high | 16.781902 / 16.826185 s | 16.356323 / 16.331516 s | **2.738%** |
| Edit-Turbo | lossless | 1.662449 / 1.668380 s | 1.638115 / 1.631985 s | **1.823%** |
| Edit-Turbo | high | 1.631460 / 1.595840 s | 1.587681 / 1.552630 s | **2.695%** |

### Denoise stage

| Model | Quality | Baseline mean | PR mean | Reduction |
| --- | --- | ---: | ---: | ---: |
| Image | lossless | 7.323091 s | 7.045838 s | 3.786% |
| Image | high | 7.144771 s | 6.890551 s | 3.558% |
| Edit | lossless | 16.774165 s | 16.292357 s | 2.872% |
| Edit | high | 16.424011 s | 15.956956 s | 2.844% |
| Edit-Turbo | lossless | 1.324374 s | 1.287778 s | 2.763% |
| Edit-Turbo | high | 1.298517 s | 1.260509 s | 2.927% |

### Breakable CUDA Graph

| Model / quality | Baseline E2E runs | PR E2E runs | Reduction / status |
| --- | ---: | ---: | --- |
| Image / lossless | 7.449374 / 7.467250 s | 7.181330 / 7.194634 s | **3.625%** |
| Image / high | — | — | Rejected: request-time linear+GELU mount differs from warmup graph |
| Edit and Edit-Turbo | — | — | Native support gate disables BCG; no capture |

All four accepted lossless BCG cells captured and replayed without invalid-signature/fallback signals. Source/candidate diagnostic traces each contain186 `cudaGraphLaunch` calls. BCG itself showed no extra speedup over eager here; this table compares the fusion within the same mode. Invalid or disabled BCG fallback timings are excluded.

Peak reserved memory is unchanged within each mode: Image lossless eager30.990GiB / BCG32.336GiB / high eager28.613GiB; Edit/Turbo lossless31.328GiB / high29.791GiB. One Image BCG candidate had a transient14MiB extra context during loading, absent in later measurement snapshots; the second candidate was close in latency. Other final rows did not sample an extra process. Ten-second snapshots do not prove continuous exclusivity.

## Kernel / profile evidence

The [microbenchmark script](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/longcat-ln-modulate-h200/bench_longcat_ln_modulate.py) calls the actual existing fused function vs `F.layer_norm(..., eps=1e-6) * (1+scale[:,None]) + shift[:,None]`, BF16 `[1,S,3072]`:

| S | Original | Fused |
| --- | ---: | ---: |
| 512 | 19.0896 us | 6.3901 us |
| 4096 | 83.2337 us | 25.9894 us |
| 4608 | 96.4625 us | 28.3634 us |

Complete GPU `ProfilerStep` ranges avoid asynchronous trace-edge counting. Kernel time is the mean cumulative device time of three complete profiled steps:

| Model / mode | Kernels per step before -> after | LayerNorm before -> after | New fused calls per step | Kernel time before -> after |
| --- | ---: | ---: | ---: | ---: |
| Image / eager | 1760 -> 1400 | 122 -> 2 | 120 | 138.15 -> 132.25 ms |
| Image / BCG | 1760 -> 1400 | 122 -> 2 | 120 | 139.08 -> 133.96 ms |
| Edit / eager | 1755 -> 1395 | 122 -> 2 | 120 | 328.389 -> 319.164 ms |
| Edit-Turbo / eager | 879 -> 699 | 61 -> 1 | 60 | 160.640 -> 154.279 ms |

Image shapes use S512/4096/4608; Edit/Turbo use S859/8374/9233, D3072. Turbo has one DiT call per step without CFG, so its counts are half Edit's. Scale+1, multiply and shift-add each fall by120 calls/step for Image/Edit and60 for Turbo. Device measurements explain the change; they do not replace E2E.

## Output comparison

All28 formal PNGs were rehashed. Within each model/quality, baseline and PR are byte-identical (SSIM1, zero pixel error). Image lossless eager/BCG outputs also match. High vs lossless is not byte-identical:

| Model | High vs lossless SSIM | PSNR |
| --- | ---: | ---: |
| Image | 0.99469157 | 43.53648 dB |
| Edit | 0.99398641 | 40.15614 dB |
| Edit-Turbo | 0.99290020 | 35.83691 dB |

### Image

| Quality | Baseline | PR |
| --- | --- | --- |
| lossless | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/image-lossless-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/image-lossless-pr.png) |
| high | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/image-high-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/image-high-pr.png) |
### Edit

| Quality | Baseline | PR |
| --- | --- | --- |
| lossless | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-lossless-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-lossless-pr.png) |
| high | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-high-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-high-pr.png) |
### Edit-Turbo

| Quality | Baseline | PR |
| --- | --- | --- |
| lossless | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-turbo-lossless-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-turbo-lossless-pr.png) |
| high | ![Baseline](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-turbo-high-baseline.png) | ![PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/edit-turbo-high-pr.png) |

[All28 measurements and SHA256 hashes](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/longcat-ln-modulate-h200/benchmark-results.json).

## Reproduce

Select one idle H200 with `CUDA_VISIBLE_DEVICES`. Run both commits in A-B-B-A order and repeat for both quality values.

```bash
SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1 sglang generate \
  --backend=sglang --model-path meituan-longcat/LongCat-Image \
  --prompt 'A red panda reading a book beside a sunlit window.' \
  --width=1024 --height=1024 --num-inference-steps=50 --guidance-scale=4.5 \
  --seed=42 --enable-prompt-rewrite=false --performance-mode=manual \
  --quality=lossless --warmup-mode=request --save-output --perf-dump-path image.json

SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1 sglang generate \
  --backend=sglang --model-path meituan-longcat/LongCat-Image-Edit \
  --image-path https://github.com/lm-sys/lm-sys.github.io/releases/download/test/TI2I_Qwen_Image_Edit_Input.jpg \
  --prompt 'Make the cat wear a red hat.' --seed=42 \
  --enable-prompt-rewrite=false --performance-mode=manual \
  --quality=lossless --warmup-mode=request --save-output --perf-dump-path edit.json
```

For Turbo use `meituan-longcat/LongCat-Image-Edit-Turbo`, retaining its native8-step/guidance1 preset. For accepted Image BCG add `--enable-breakable-cuda-graph --warmup-resolutions 1024x1024`. Run separate `--profile --num-profiled-timesteps 3` diagnostics, excluding profiled timings.

## Validation

- Final rebased head `cafc9addfd05ccb17a99011bc49d7b9154250200`: **5 H200 tests passed**, including output/gradient equality after prior signature verification.
- Full pre-commit on both changed files and `git diff --check`: passed.

- Measured candidate:4H200 integration tests passed: strict Diffusers checkpoint/output compatibility, changed-input graph replay, unverified capture and mismatch fallback.
- Final-head tests additionally check gradients after the signature was already verified.
- Each model's task-owned retained cache was removed after completion, leaving zero files/weights/bytes: Image29,318,787,592bytes; Edit29,319,288,298bytes; Turbo29,319,187,912bytes. Per-cell overlays were removed in `finally`; shared read-only seeds were preserved.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34246132100](https://github.com/sgl-project/sglang/actions/runs/34246132100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34246582630](https://github.com/sgl-project/sglang/actions/runs/34246582630)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34246131975](https://github.com/sgl-project/sglang/actions/runs/34246131975)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->