### PR TITLE
[test] Fix image prompts in send_one.py

### DIFF
--- a/python/sglang/test/send_one.py
+++ b/python/sglang/test/send_one.py
@@ -150,12 +150,10 @@ def send_one_prompt(
     # If need image
     if args.image:
         assert args.batch_size == 1 and not args.random_input_len
-        args.prompt = (
-            "Human: Describe this image in a very short sentence.\n\nAssistant:"
-        )
+        prompt = "Human: Describe this image in a very short sentence.\n\nAssistant:"
         image_data = "https://raw.githubusercontent.com/sgl-project/sglang/main/examples/assets/example_image.png"
     elif args.many_images:
-        args.prompt = (
+        prompt = (
             "Human: I have one reference image and many images."
             "Describe their relationship in a very short sentence.\n\nAssistant:"
         )


### PR DESCRIPTION
Assign image-specific prompts to the local variable used to build the request payload. Previously, --image and --many-images updated args.prompt after the local prompt was initialized, leaving requests with stale text.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34248291682](https://github.com/sgl-project/sglang/actions/runs/34248291682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34248291452](https://github.com/sgl-project/sglang/actions/runs/34248291452)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34248298043](https://github.com/sgl-project/sglang/actions/runs/34248298043)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->