### PR TITLE
[Docs] Add measured JoyEcho H200 residency and BCG recipe

### DIFF
--- a/docs/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -15,7 +15,7 @@ import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 
 Choose JoyEcho over a standard LTX pipeline when shots must share audiovisual memory. Its distilled 832×480 path prioritizes long-form continuity and throughput rather than the higher-resolution two-stage quality modes offered by LTX-2.3.
 
-Use `jdopensource/JoyAI-Echo` as `--model-path`; SGLang materializes the monolithic release through the built-in [JoyAI-Echo overlay](https://huggingface.co/Niehen6174/JoyAI-Echo-overlay).
+SGLang materializes the Echo 1.0 monolithic release through the built-in [JoyAI-Echo overlay](https://huggingface.co/Niehen6174/JoyAI-Echo-overlay). Prepare the pinned checkpoint below before running the examples.
 
 | Aspect | Standard LTX-2.3 | JoyEcho |
 | --- | --- | --- |
@@ -41,11 +41,33 @@ For platform-specific setup, see the [SGLang Diffusion installation guide](/docs
 
 ## 3. Model Deployment
 
+### 3.1 Prepare the Echo 1.0 checkpoint
+
+The native overlay requires `JoyAI-Echo-release.safetensors`. The upstream repository's Echo 1.5 revision does not contain that file. Download the [Echo 1.0 revision](https://huggingface.co/jdopensource/JoyAI-Echo/tree/4187f9a53c6eff3a76c51e79bd27f70d10f7591b) into the Hugging Face cache:
+
+```bash
+JOY_ECHO_MODEL_PATH=$(python - <<'PY'
+from huggingface_hub import snapshot_download
+
+print(snapshot_download(
+    repo_id="jdopensource/JoyAI-Echo",
+    revision="4187f9a53c6eff3a76c51e79bd27f70d10f7591b",
+    allow_patterns=["JoyAI-Echo-release.safetensors", "*.json", "*.md", "LICENSE"],
+))
+PY
+)
+```
+
+Use the returned cache path as `--model-path` and keep `--model-id jdopensource/JoyAI-Echo` when using local weights. The model ID lets BCG select JoyEcho's support policy. Initial startup also downloads and materializes the overlay and its text encoder dependencies.
+
+### 3.2 Serve the model
+
 JoyEcho uses the default `JoyEchoPipeline` registered for `jdopensource/JoyAI-Echo`. A single high-VRAM GPU (for example H100 or H200) is enough for the common 832x480 / 121-frame / 8-step setting.
 
 ```bash
 sglang serve \
-  --model-path jdopensource/JoyAI-Echo
+  --model-path "$JOY_ECHO_MODEL_PATH" \
+  --model-id jdopensource/JoyAI-Echo
 ```
 
 Optional environment variable for long runs:
@@ -58,7 +80,8 @@ For multi-GPU serving, tensor parallelism (TP) and **Ulysses sequence parallelis
 
 ```bash
 sglang serve \
-  --model-path jdopensource/JoyAI-Echo \
+  --model-path "$JOY_ECHO_MODEL_PATH" \
+  --model-id jdopensource/JoyAI-Echo \
   --num-gpus 2 \
   --ulysses-degree 2
 ```
@@ -84,7 +107,8 @@ JoyEcho SP currently targets **Ulysses-only** parallelism (`ulysses_degree=2`, `
 
 ```bash
 sglang generate \
-  --model-path jdopensource/JoyAI-Echo \
+  --model-path "$JOY_ECHO_MODEL_PATH" \
+  --model-id jdopensource/JoyAI-Echo \
   --prompt "A curious raccoon walks through a sunlit forest path" \
   --height 480 --width 832 --num-frames 121 --fps 25 \
   --num-inference-steps 8 --seed 42 \
@@ -96,7 +120,6 @@ Disable the memory bank for standalone clips with a config file:
 ```bash
 cat > /tmp/joy_echo_single.json <<'EOF'
 {
-  "model_path": "jdopensource/JoyAI-Echo",
   "prompt": "A curious raccoon walks through a sunlit forest path",
   "enable_memory_bank": false,
   "seed": 42,
@@ -108,7 +131,9 @@ cat > /tmp/joy_echo_single.json <<'EOF'
 }
 EOF
 
-sglang generate --config /tmp/joy_echo_single.json --save-output
+sglang generate --config /tmp/joy_echo_single.json \
+  --model-path "$JOY_ECHO_MODEL_PATH" --model-id jdopensource/JoyAI-Echo \
+  --save-output
 ```
 
 ### 4.3 Multi-shot generation
@@ -127,7 +152,6 @@ Pass multiple prompts as a list in a config file:
 ```bash
 cat > /tmp/joy_echo_4shot.json <<'EOF'
 {
-  "model_path": "jdopensource/JoyAI-Echo",
   "prompt": [
     "Shot 0: A raccoon wakes up in a cozy attic.",
     "Shot 1: The raccoon climbs down and opens the back door.",
@@ -145,14 +169,17 @@ cat > /tmp/joy_echo_4shot.json <<'EOF'
 }
 EOF
 
-sglang generate --config /tmp/joy_echo_4shot.json --save-output
+sglang generate --config /tmp/joy_echo_4shot.json \
+  --model-path "$JOY_ECHO_MODEL_PATH" --model-id jdopensource/JoyAI-Echo \
+  --save-output
 ```
 
 You can also pass prompts from a text file (one prompt per line) with `--prompt-path`:
 
 ```bash
 sglang generate \
-  --model-path jdopensource/JoyAI-Echo \
+  --model-path "$JOY_ECHO_MODEL_PATH" \
+  --model-id jdopensource/JoyAI-Echo \
   --prompt-path /tmp/joy_echo_shots.txt \
   --seed 42 \
   --height 480 --width 832 --num-frames 121 --fps 25 \
@@ -168,6 +195,40 @@ sglang generate \
 | `reset_memory_bank` | `true` | Clear the bank and shot counter at the start of a new session (`request_id` change or first shot). |
 
 Set `enable_memory_bank=false` when you want independent shots without cross-shot continuity.
+
+### 4.5 Measured two-H200 single-shot configuration
+
+For short independent clips, keep the text and audio/video components on GPU with `--component-residency=all=resident`. Full-stage profiles showed that this removes repeated host-to-device weight copies between component uses.
+
+The following configuration was measured on two H200s with Ulysses degree 2, TP1, PyTorch 2.11.0+cu130, 640x384, 33 frames, 8 steps and seed 42. It disables compilation and the memory bank:
+
+```bash
+cat > joy_echo_h200.json <<'EOF'
+{"enable_memory_bank": false}
+EOF
+
+CUDA_VISIBLE_DEVICES=0,1 sglang generate \
+  --model-path "$JOY_ECHO_MODEL_PATH" --model-id jdopensource/JoyAI-Echo \
+  --config joy_echo_h200.json --prompt "A curious raccoon" \
+  --width 640 --height 384 --num-frames 33 --num-inference-steps 8 --seed 42 \
+  --num-gpus 2 --ulysses-degree 2 \
+  --performance-mode manual --enable-torch-compile=false --quality lossless \
+  --component-residency=all=resident --warmup-mode request \
+  --save-output --perf-dump-path joy_echo_h200.json.perf
+```
+
+For BCG, add `--enable-breakable-cuda-graph --warmup-resolutions 640x384 --warmup-num-frames 33`. Check for successful `[Diffusion BCG] captured` logs and absence of request signature misses. Keep the same model ID, resolution, frame count and quality as warmup.
+
+Two fresh-process saved requests per configuration, after request warmup:
+
+| Lossless mode | Auto residency E2E | All resident E2E | Reduction | Peak reserved per rank, auto → resident |
+| --- | ---: | ---: | ---: | ---: |
+| Eager | 2.563 s | 2.366 s | 7.65% | 46.43 → 69.32 GiB |
+| BCG | 1.229 s | 1.058 s | 13.88% | 48.77–48.88 → 69.32 GiB |
+
+Loading, warmup and profiling are excluded from these timings. The paired eager profiles remove 71 pinned host-to-device copies (13.07 GB, 278.86 ms on the profiled rank), with the same 77,045 kernel launches. All eight lossless outputs have pixel-identical video frames; audio differences are comparable to baseline repeat variability. These results cover this compact single-shot workload, rather than the default 121-frame or multi-shot memory-bank workload.
+
+Use `quality=lossless` for this recipe. High-mode output did not pass the separate quality comparison, and high + BCG is rejected by the runtime. If a larger request exceeds available memory, return to auto residency or keep only selected components resident.
 
 ## 5. Practical Tips
 


### PR DESCRIPTION
## Summary

Document a measured two-H200 JoyEcho configuration that keeps text and audio/video components resident between uses. Full-stage profiles showed repeated weight copies outside denoising; `--component-residency=all=resident` removes them and lowers warm-request E2E by **7.65% in eager** and **13.88% in BCG** on the fixed lossless single-shot workload below.

Also make the examples reproducible with the native Echo 1.0 overlay: current upstream Echo 1.5 lacks `JoyAI-Echo-release.safetensors`, so the cookbook downloads the immutable Echo 1.0 revision and uses its HF cache path. Explicit `--model-id jdopensource/JoyAI-Echo` preserves the correct BCG support identity for local weights. Existing examples use this same pinned path.

This is a cookbook configuration change. Runtime defaults and kernels are unchanged.

## H200 benchmark

- Native `JoyEchoPipeline`; official source `jdopensource/JoyAI-Echo@4187f9a53c6eff3a76c51e79bd27f70d10f7591b`, overlay `Niehen6174/JoyAI-Echo-overlay@0a19f315c96532b7a5f61bcd765d1fefdd83dc7d`.
- Both arms: SGLang `00a7c22370aa8d3483b0f3e5d3c1be05f86144c0`, PyTorch 2.11.0+cu130, same two H200s, Ulysses2/TP1, 640x384, 33 frames, 8 DMD steps, seed42, prompt `A curious raccoon`, memory bank disabled, no torch.compile.
- Only residency differs: A is auto; B is `all=resident`. Same checkpoint and request warmup. E2E is synchronized perf-dump `total_duration_ms`, excluding loading, warmup and profiling.
- Each mode uses fresh-process A-B-B-A. The docs-only PR is based on `482e9f257bb9d9ac57c2245c93768a96ec70edbe`; the full-model measurements were recorded on the stated benchmark commit.

| Lossless mode | Auto E2E runs | Resident E2E runs | Mean reduction |
| --- | ---: | ---: | ---: |
| Eager | 2.582913 / 2.542221 s | 2.352539 / 2.380271 s | **7.655%** |
| BCG | 1.265393 / 1.192250 s | 1.052789 / 1.063762 s | **13.879%** |

| Lossless mode | Auto mean denoise | Resident mean denoise | Auto mean E2E | Resident mean E2E | Reserved memory per rank, auto → resident |
| --- | ---: | ---: | ---: | ---: | ---: |
| Eager | 2.075750 s | 2.067924 s | 2.562567 s | 2.366405 s | 46.434 → 69.316 GiB |
| BCG | 0.758393 s | 0.752895 s | 1.228821 s | 1.058275 s | 48.77–48.88 → 69.316 GiB |

All four BCG cells captured successfully and had no invalid capture/signature or fallback signals. Denoising changes by less than1%; the E2E benefit comes mainly from component residency outside denoising. These numbers apply to the compact 33-frame single-shot workload. The default 121-frame and multi-shot memory-bank workloads require separate measurements.

## Kernel and full-stage profile comparison

There is no new kernel to microbenchmark in this docs-only change. The paired full-stage eager traces show the same77,045 kernel launches and identify the eliminated data movement on rank0:

| Profile measurement | Auto residency | All resident |
| --- | ---: | ---: |
| Kernel launches | 77,045 | 77,045 |
| Pinned H2D copies | 71 | 0 |
| Pinned H2D bytes | 13,065,092,096 | 0 |
| Pinned H2D time | 278.856 ms | 0 |
| Text-encoding pinned copies | 48 / 10,759,913,472 bytes / 231.043 ms | 0 |
| AV-processing pinned copies | 20 / 1,847,433,216 bytes / 38.861 ms | 0 |

The remaining H2D payload in the resident trace is29,034 pageable bytes. Copy totals are per profiled rank; they are not summed across ranks as wall time. Profiling introduces substantial rank skew in collective timings, so performance claims use only the unprofiled saved requests above.

[Auto profile digest](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/auto-profile.json), [resident profile digest](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/resident-profile.json).

## Actual output comparison

All8 accepted MP4s were rehashed. Every decoded video frame is pixel-identical across auto/resident and eager/BCG: 33 frames, SSIM1, zero pixel error. The contact sheet compares auto lossless eager above with resident lossless BCG below.

![Actual JoyEcho baseline and resident video frames](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/comparison.jpg)

| Mode | Auto videos with audio | Resident videos with audio |
| --- | --- | --- |
| Lossless eager | [A1](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-eager-a1.mp4), [A2](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-eager-a2.mp4) | [B1](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-eager-b1.mp4), [B2](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-eager-b2.mp4) |
| Lossless BCG | [A1](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-bcg-a1.mp4), [A2](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-bcg-a2.mp4) | [B1](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-bcg-b1.mp4), [B2](https://github.com/BBuf/sglang/raw/refs/heads/pr-media/diffusion-prs/joyecho-residency-h200/lossless-bcg-b2.mp4) |

Audio has native run-to-run variation, so the MP4 files are not byte-identical:

| Mode | A/A SNR | B/B SNR | A/B SNR range |
| --- | ---: | ---: | ---: |
| Eager | 34.729 dB | 34.449 dB | 32.453–38.584 dB |
| BCG | 34.437 dB | 35.117 dB | 33.514–35.014 dB |

Cross-configuration audio differences are comparable to intrinsic repeated-run variation. All28 pairs among the eight lossless files span32.254–38.584dB.

High mode is excluded from the recommendation: its baseline already fails the lossless output comparison (mean frame SSIM0.825854, worst0.796242, PSNR24.46394dB; audio approximately4.3dB). Residency does not cause this drift. High+BCG captures but the actual request is rejected with `cannot be used with breakable cuda graphs`; no timing from that request is accepted.

[All8 raw accepted measurements and SHA256 hashes](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/benchmark-results.json), [video quality including the rejected high-mode comparison](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/video-quality.json), [audio pairs](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/joyecho-residency-h200/audio-quality.json).

## Reproduce

Follow cookbook section3.1 to set `JOY_ECHO_MODEL_PATH` to the pinned Echo1.0 snapshot. Select two idle H200s with `CUDA_VISIBLE_DEVICES`.

```bash
cat > joy_echo_h200.json <<'EOF'
{"enable_memory_bank": false}
EOF

SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1 sglang generate \
  --model-path "$JOY_ECHO_MODEL_PATH" --model-id jdopensource/JoyAI-Echo \
  --config joy_echo_h200.json --prompt 'A curious raccoon' \
  --width=640 --height=384 --num-frames=33 --num-inference-steps=8 --seed=42 \
  --num-gpus=2 --ulysses-degree=2 \
  --performance-mode=manual --enable-torch-compile=false --quality=lossless \
  --component-residency=all=resident --warmup-mode=request \
  --save-output --perf-dump-path=joy_echo_h200.perf.json
```

For A remove only `--component-residency=all=resident`. For both BCG arms add `--enable-breakable-cuda-graph --warmup-resolutions 640x384 --warmup-num-frames 33`, retaining the explicit model ID. Use separate `--profile --profile-all-stages` runs for diagnostics and exclude their timings.

## Validation and cleanup

- Full pre-commit and `git diff --check` passed for the cookbook change. All10 Bash blocks and embedded Python/JSON parse successfully without executing downloads.
- Snapshot ID, required monolith presence, native local-cache resolution and model-ID/BCG flags were checked against the recorded successful launch and current source. No runtime implementation or GPU test suite is changed.
- All8 formal saved outputs are present, hash-verified and decoded for video/audio comparison. Ten-second GPU snapshots show only expected campaign processes on the selected pair; snapshots do not prove continuous exclusivity.
- After completing all model checks, both task-owned retained caches were deleted:46,141,522,028 logical bytes for the source and119,384,519,558 logical bytes for the materialized model/dependencies. Both ledgers report zero files/weights/bytes. Per-cell overlays were also cleaned; logical cache/hardlink accounting is not unique physical storage usage.
- Full Mintlify documentation checks passed with Node 22.23.2: `mint validate` and `mint broken-links` (no broken links).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34249337312](https://github.com/sgl-project/sglang/actions/runs/34249337312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34249338386](https://github.com/sgl-project/sglang/actions/runs/34249338386)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->