### PR TITLE
[Fix] Hold back the longest partial tool-call marker when streaming

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -111,13 +111,17 @@ class BaseFormatDetector(ABC):
 
     def _ends_with_partial_token(self, buffer: str, bot_token: str) -> int:
         """
-        Check if buffer ends with a partial bot_token.
-        Return the length of the partial bot_token.
+        Length of the longest trailing slice of `buffer` that is a strict prefix of
+        `bot_token`, or 0 when there is none. Callers hold that slice back until the
+        next chunk decides whether it completes the marker.
 
-        For some format, the bot_token is not a token in model's vocabulary, such as
-        `[TOOL_CALLS] [` in Mistral.
+        Longest, so a marker whose prefix repeats inside itself is not cut short and
+        does not leak its leading characters into streamed content.
+
+        For some formats the bot_token is not a single token in the model's
+        vocabulary, such as `[TOOL_CALLS] [` in Mistral, so it can straddle chunks.
         """
-        for i in range(1, min(len(buffer) + 1, len(bot_token))):
+        for i in range(min(len(buffer), len(bot_token) - 1), 0, -1):
             if bot_token.startswith(buffer[-i:]):
                 return i
         return 0

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -661,11 +661,9 @@ class Glm47MoeDetector(BaseFormatDetector):
         has_tool_call = self.bot_token in current_text
 
         if not has_tool_call:
-            # Check if buffer could be the start of a tool call
-            # Keep buffer if it could be a partial match of bot_token
-            is_potential_start = any(
-                self.bot_token.startswith(current_text[-i:])
-                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            # Keep buffering while the tail could still grow into bot_token.
+            is_potential_start = self._ends_with_partial_token(
+                current_text, self.bot_token
             )
 
             if not is_potential_start:

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -450,11 +450,9 @@ class Glm4MoeDetector(BaseFormatDetector):
         has_tool_call = self.bot_token in current_text
 
         if not has_tool_call:
-            # Check if buffer could be the start of a tool call
-            # Keep buffer if it could be a partial match of bot_token
-            is_potential_start = any(
-                self.bot_token.startswith(current_text[-i:])
-                for i in range(1, min(len(current_text), len(self.bot_token)) + 1)
+            # Keep buffering while the tail could still grow into bot_token.
+            is_potential_start = self._ends_with_partial_token(
+                current_text, self.bot_token
             )
 
             if not is_potential_start:

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1207,6 +1207,33 @@ class TestBaseFormatDetector(unittest.TestCase):
             params["city"], "杭州", "Should correctly parse Chinese city name"
         )
 
+    def test_partial_token_match_prefers_the_longest_suffix(self):
+        """A marker whose prefix repeats inside itself is held back whole.
+
+        `<|action_start|> <|plugin|>` starts over with `<|` in the middle, so a
+        shortest-first match holds back only those two characters and streams the
+        rest of the marker to the client as content.
+        """
+        marker = "<|action_start|> <|plugin|>"
+        partial = "<|action_start|> <|"
+
+        self.assertEqual(
+            self.detector._ends_with_partial_token(f"Sure. {partial}", marker),
+            len(partial),
+        )
+
+    def test_partial_token_match_requires_a_strict_prefix(self):
+        """A completed marker is not a partial one, so it is not held back."""
+        marker = "<tool_call>"
+
+        self.assertEqual(self.detector._ends_with_partial_token(marker, marker), 0)
+
+    def test_partial_token_match_returns_zero_without_a_shared_boundary(self):
+        """Text that cannot grow into the marker streams out instead of buffering."""
+        self.assertEqual(
+            self.detector._ends_with_partial_token("all done>", "<tool_call>"), 0
+        )
+
 
 class TestLlama32Detector(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Motivation

`BaseFormatDetector._ends_with_partial_token` reports how many trailing characters of the streaming buffer could still grow into `bot_token`. Callers hold that slice back and stream everything before it to the client.

The scan ran shortest-first, so it returned the *shortest* trailing slice that is a prefix of `bot_token`. When a marker's prefix repeats inside itself, that answer is too short: the caller streams the leading characters of the marker to the client as content and keeps only the tail, so the marker can never be completed and the tool call is missed.

Two markers currently in the tree have that shape:

* InternLM, `<|action_start|> <|plugin|>`: a buffer ending in `<|action_start|> <` holds back 1 character instead of 18, and one ending in `<|action_start|> <|` holds back 2 instead of 19.
* GPT-OSS, `<|start|>assistant<|channel|>commentary`: a buffer ending in `<|start|>assistant<` holds back 1 instead of 19.

The sibling helper in `python/sglang/srt/parser/reasoning_parser.py` already scans longest-first, and its docstring gives exactly this reason. This PR makes the two agree.

Scope note, so reviewers can weigh it correctly: this is latent today rather than a live failure. Of the two affected markers, `internlm_detector.py` uses the result only as a boolean, and the GPT-OSS detector does not call the helper at all. About fourteen other call sites do slice the buffer by this return value, so the change removes a trap for any detector that later adopts a marker of this shape.

## Modifications

1. `base_format_detector.py`: scan longest-first, bounded at `len(bot_token) - 1` so a completed marker is not treated as a partial one. The docstring now states the contract instead of restating the loop.
2. `glm4_moe_detector.py` and `glm47_moe_detector.py`: both carried an identical five-line open-coded copy of this scan. They now call the base class helper. This is behaviour preserving: that branch runs only when `bot_token` is absent from the buffer, so the full-token case the inline version allowed was unreachable.
3. `test/registered/unit/function_call/test_function_call_parser.py`: three cases added to the existing `TestBaseFormatDetector` class, covering the longest-match property, the strict-prefix boundary, and the no-match branch.

No new test file: `TestBaseFormatDetector` already lives in this file, and the GLM classes already own `test_partial_tool_call`, which covers the multi-chunk path the refactor touches.

## Accuracy Tests

Not applicable. No model forward, kernel, or sampling code is touched, and model output is unchanged.

Unit test evidence for the parsing change, run as CI runs it:

```bash
python3 test/registered/unit/function_call/test_function_call_parser.py
```

* `test_partial_token_match_prefers_the_longest_suffix` fails on the pre-fix code with `AssertionError: 2 != 19` and passes with the fix.
* `TestBaseFormatDetector`: 9 of 9 pass.
* `TestGlm4MoeDetector` and `TestGlm47MoeDetector`: 26 of 26 pass, including `test_partial_tool_call` in both.
* Whole file: 243 tests before the change, 246 after, with no new failures.

## Speed Tests and Profiling

Not applicable. The helper is a bounded scan over at most `len(bot_token) - 1` positions in either direction, so only the direction changed. It runs once per streaming chunk while no marker is present, and never in the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable, no user facing behaviour or option changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable, see the two sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34253532819](https://github.com/sgl-project/sglang/actions/runs/34253532819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34253532476](https://github.com/sgl-project/sglang/actions/runs/34253532476)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34253532701](https://github.com/sgl-project/sglang/actions/runs/34253532701)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->