### PR TITLE
Auto-select flashinfer_mxfp4 for Bailing V3 mixed FP8/MXFP4 checkpoints

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/__init__.py
+++ b/python/sglang/srt/arg_groups/model_overrides/__init__.py
@@ -8,6 +8,7 @@ nobody would own that value, and which module supplied it would come down to
 the order of the imports below. Keep each field owned by one family module.
 """
 
+from sglang.srt.arg_groups.model_overrides import bailing_moe_v3  # noqa: F401
 from sglang.srt.arg_groups.model_overrides import cohere2_moe  # noqa: F401
 from sglang.srt.arg_groups.model_overrides import deepseek_v2  # noqa: F401
 from sglang.srt.arg_groups.model_overrides import deepseek_v4  # noqa: F401

--- a/python/sglang/srt/arg_groups/model_overrides/bailing_moe_v3.py
+++ b/python/sglang/srt/arg_groups/model_overrides/bailing_moe_v3.py
@@ -1,0 +1,48 @@
+"""Config-time override declarations for bailing_moe_v3.
+
+Architectures: BailingMoeV3ForCausalLM,
+BailingMoeV3VLForConditionalGeneration.
+"""
+
+import logging
+from typing import Any
+
+from sglang.srt.arg_groups.model_override_base import (
+    _register_for,
+    model_config_of,
+    resolving_view,
+)
+from sglang.srt.runtime_context import get_platform
+
+logger = logging.getLogger(__name__)
+
+
+@_register_for(
+    "BailingMoeV3ForCausalLM",
+    "BailingMoeV3VLForConditionalGeneration",
+)
+def _bailing_moe_v3_overrides(server_args: Any, hf_config: Any) -> dict:
+    cfg = resolving_view(server_args)
+    if (
+        cfg.moe_runner_backend != "auto"
+        or cfg.device != "cuda"
+        or cfg.moe_a2a_backend != "none"
+        or get_platform().is_hip
+    ):
+        return {}
+    if not (
+        get_platform().is_sm90 or get_platform().is_sm100 or get_platform().is_sm120
+    ):
+        return {}
+
+    model_config = model_config_of(server_args)
+    if model_config.quantization != "fp8" or not model_config.is_fp4_experts:
+        return {}
+
+    model_arch = hf_config.architectures[0]
+    logger.info(
+        "Bailing V3 mixed FP8/MXFP4 checkpoint: "
+        "moe_runner_backend=flashinfer_mxfp4 for %s.",
+        model_arch,
+    )
+    return {"moe_runner_backend": "flashinfer_mxfp4"}

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1686,6 +1686,74 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "flashinfer_trtllm_routed",
         )
 
+    def test_bailing_v3_mixed_mxfp4_selects_native_runner(self):
+        """Packed MXFP4 experts must not reach the FP8 Triton runner."""
+
+        def _args(**kw):
+            defaults = dict(
+                device="cuda",
+                moe_a2a_backend="none",
+                moe_runner_backend="auto",
+                _model_config=SimpleNamespace(quantization="fp8", is_fp4_experts=True),
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        with override_platform(
+            is_sm90=False, is_sm100=True, is_sm120=False, is_hip=False
+        ):
+            for architecture in (
+                "BailingMoeV3ForCausalLM",
+                "BailingMoeV3VLForConditionalGeneration",
+            ):
+                with self.subTest(architecture=architecture):
+                    declarations = collect_model_override_declarations(
+                        architecture,
+                        _args(),
+                        SimpleNamespace(architectures=[architecture]),
+                    )
+                    self.assertEqual(
+                        declarations,
+                        [
+                            (
+                                "_bailing_moe_v3_overrides",
+                                {"moe_runner_backend": "flashinfer_mxfp4"},
+                            )
+                        ],
+                    )
+
+            from sglang.srt.arg_groups.model_overrides.bailing_moe_v3 import (
+                _bailing_moe_v3_overrides,
+            )
+
+            hf = SimpleNamespace(
+                architectures=["BailingMoeV3VLForConditionalGeneration"]
+            )
+            self.assertEqual(
+                _bailing_moe_v3_overrides(_args(moe_runner_backend="triton"), hf),
+                {},
+            )
+            self.assertEqual(
+                _bailing_moe_v3_overrides(_args(moe_a2a_backend="deepep"), hf),
+                {},
+            )
+            self.assertEqual(
+                _bailing_moe_v3_overrides(
+                    _args(
+                        _model_config=SimpleNamespace(
+                            quantization="fp8", is_fp4_experts=False
+                        )
+                    ),
+                    hf,
+                ),
+                {},
+            )
+
+        with override_platform(
+            is_sm90=False, is_sm100=False, is_sm120=False, is_hip=False
+        ):
+            self.assertEqual(_bailing_moe_v3_overrides(_args(), hf), {})
+
     def test_nemotron_h_overrides_at_callable_level(self):
         from sglang.srt.arg_groups.model_overrides.nemotron_h import (
             _nemotron_h_overrides,


### PR DESCRIPTION
## Summary

Mixed FP8/MXFP4 checkpoints (routed experts in e2m1 with e8m0 scales, other linears in FP8 e4m3) currently crash on startup with `--moe-runner-backend auto`: the FP8 quant config does not select its MXFP4 wrapper, `Fp8MoEMethod.create_moe_runner()` falls through to the Triton FP8 MoE runner, and decode CUDA-graph warmup dies. An equivalent auto-resolution exists for DeepSeek V4 but nothing covers Bailing models, so every Bailing mixed checkpoint needs an explicit `--moe-runner-backend flashinfer_mxfp4`.

This PR adds a stateless model-override that selects `flashinfer_mxfp4` for Bailing V3 architectures only when all of the following hold: outer quantization is FP8, `routed_experts_quant_method` is mxfp4 (`is_fp4_experts`), the runner is still `auto`, CUDA is SM90/SM10x/SM120, and A2A is disabled. Explicit runner choices, plain FP8 checkpoints, unsupported GPUs, ROCm, and A2A configurations are untouched.

## Impact

- Affected public checkpoints: `inclusionAI/Ling-3.0-flash-fp4` (text) and `inclusionAI/Ling-3.0-flash-VL-fp4` (VL); both share the mixed FP8/MXFP4 schema.
- With this PR, both serve with no runner flag; verified on 2×GB300 (VL text + image smoke, `finish_reason=stop`) and DGX Spark GB10 TP=1 (SM120 path).
- Without it, the same checkpoints exit 137 during decode graph warmup (traceback through `quantization/fp8.py` → Triton runner).

## Tests

- New registered CPU unit tests in `test/registered/unit/test_model_overrides.py` covering: Bailing mixed checkpoint selects MXFP4; ordinary FP8 checkpoint unchanged; explicit runner choice wins; unsupported GPU/A2A leaves auto.
- 92 tests + 31 subtests pass (run on GPU devbox with torch).

This change is also included in the larger Ling-3.0-flash-VL support PR #38526; it is split out here so the FP4 checkpoints work independently of the VL model landing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34254458317](https://github.com/sgl-project/sglang/actions/runs/34254458317)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34254457899](https://github.com/sgl-project/sglang/actions/runs/34254457899)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34254458123](https://github.com/sgl-project/sglang/actions/runs/34254458123)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->