### PR TITLE
Point Ling-3.0-flash-VL cookbook install section at the model image

### DIFF
--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
@@ -29,7 +29,7 @@ git clone https://github.com/JustinTong0323/sglang.git --branch ling3flash-vl-co
 cd sglang
 pip install --upgrade pip
 pip install uv
-uv pip install -e "python[all]"
+uv pip install -e "python"
 uv pip install torchcodec==0.16.0  # optional, preferred video-decode backend
 ```
 

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
@@ -22,14 +22,14 @@ pip install uv
 uv pip install --prerelease=allow sglang
 ```
 
-Then run the **Python** output of the command panel below in that environment.
+Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sgl-project/sglang#38526 (or newer) — until it merges, use the Docker path below or install sglang from that PR's branch.
 
 </Tab>
 
 <Tab title="Docker">
 
 ```bash Command
-docker pull lmsysorg/sglang:dev
+docker pull lmsysorg/sglang:dev-Ling-3.0-flash-VL
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
@@ -22,7 +22,18 @@ pip install uv
 uv pip install --prerelease=allow sglang
 ```
 
-Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sgl-project/sglang#38526 (or newer) — until it merges, use the Docker path below or install sglang from that PR's branch.
+Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sgl-project/sglang#38526 (or newer); until it merges, install from the support branch:
+
+```bash Command
+git clone https://github.com/JustinTong0323/sglang.git --branch ling3flash-vl-code --depth 1
+cd sglang
+pip install --upgrade pip
+pip install uv
+uv pip install -e "python[all]"
+uv pip install torchcodec==0.16.0  # optional, preferred video-decode backend
+```
+
+Video input needs `decord` or `torchcodec` in the environment; audio is not supported. Downloading the checkpoint requires `HF_TOKEN`.
 
 </Tab>
 

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
@@ -22,7 +22,7 @@ pip install uv
 uv pip install --prerelease=allow sglang
 ```
 
-Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sgl-project/sglang#38526 (or newer); until it merges, install from the support branch:
+Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sglang with sgl-project/sglang#38526 (or newer); until it merges, install directly from the PR head:
 
 ```bash Command
 pip install --upgrade pip

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx
@@ -25,11 +25,9 @@ uv pip install --prerelease=allow sglang
 Then run the **Python** output of the command panel below in that environment. Ling-3.0-flash-VL support requires sgl-project/sglang#38526 (or newer); until it merges, install from the support branch:
 
 ```bash Command
-git clone https://github.com/JustinTong0323/sglang.git --branch ling3flash-vl-code --depth 1
-cd sglang
 pip install --upgrade pip
 pip install uv
-uv pip install -e "python"
+uv pip install "sglang @ git+https://github.com/sgl-project/sglang.git@refs/pull/38526/head#subdirectory=python"
 uv pip install torchcodec==0.16.0  # optional, preferred video-decode backend
 ```
 


### PR DESCRIPTION
Docs-only follow-up to #38434. Two install-section fixes on `docs/cookbook/autoregressive/InclusionAI/Ling-3.0-flash-VL.mdx`:

- **Docker tab**: pull the published model image `lmsysorg/sglang:dev-Ling-3.0-flash-VL` (multi-arch, contains the VL support and torchcodec) instead of the generic `lmsysorg/sglang:dev`, which does not yet include it.
- **Python tab**: adds the complete pre-merge install flow — `uv pip install "sglang @ git+https://github.com/sgl-project/sglang.git@refs/pull/38526/head#subdirectory=python"` (tracks the PR head directly, no fork needed) plus environment notes (video needs decord or torchcodec, audio unsupported).

One file, +11/-2; no other changes.
