### PR TITLE
[Fix] Close a Harmony final block at <|end|>, not only <|return|>

### DIFF
--- a/python/sglang/srt/parser/harmony_parser.py
+++ b/python/sglang/srt/parser/harmony_parser.py
@@ -315,7 +315,12 @@ class CanonicalStrategy:
 
         # Each channel type has specific valid end tokens
         if channel_type == "final":
-            while end_pos < len(tokens) and tokens[end_pos].type != "RETURN":
+            # A final message closes with <|return|> when the turn ends, and with
+            # <|end|> when another message follows; both terminate the block.
+            while end_pos < len(tokens) and tokens[end_pos].type not in (
+                "RETURN",
+                "END",
+            ):
                 end_pos += 1
         elif channel_type == "analysis":
             while end_pos < len(tokens) and tokens[end_pos].type not in ("END", "CALL"):

--- a/test/registered/unit/parser/test_harmony_parser.py
+++ b/test/registered/unit/parser/test_harmony_parser.py
@@ -183,6 +183,25 @@ class TestCanonicalStrategy(CustomTestCase):
         self.assertEqual(events[0].content, "")
         self.assertEqual(remaining, "")
 
+    def test_parse_final_block_closed_by_end_token(self):
+        """A final block closed by <|end|> keeps the token out of its content.
+
+        Only <|return|> closed a final block, so a final message ending in <|end|>
+        found no terminator, ran to the end of the input, and carried the marker
+        into the answer served to the client.
+        """
+        text = (
+            "<|start|><|channel|>analysis<|message|>reasoning<|end|>"
+            "<|start|><|channel|>final<|message|>answer<|end|>"
+        )
+        events, remaining = self.strategy.parse(text)
+
+        self.assertEqual(
+            [(e.event_type, e.content) for e in events],
+            [("reasoning", "reasoning"), ("normal", "answer")],
+        )
+        self.assertEqual(remaining, "")
+
 
 class TestTextStrategy(CustomTestCase):
     def setUp(self):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1219,6 +1219,22 @@ class TestGptOssDetector(CustomTestCase):
         self.assertIn("reasoning part", all_reasoning)
         self.assertIn("answer", all_normal)
 
+    def test_non_streaming_final_closed_by_end_token(self):
+        """Non-streaming output of a final block closed by <|end|> drops the marker.
+
+        The marker used to survive in normal_text, so a client rendered the answer
+        with a trailing <|end|>. Streaming the same text already dropped it.
+        """
+        text = (
+            "<|start|><|channel|>analysis<|message|>reasoning part<|end|>"
+            "<|start|><|channel|>final<|message|>answer<|end|>"
+        )
+
+        result = self.detector.detect_and_parse(text)
+
+        self.assertEqual(result.reasoning_text, "reasoning part")
+        self.assertEqual(result.normal_text, "answer")
+
 
 class TestMiniMaxAppendThinkDetector(CustomTestCase):
     """Test cases for MiniMaxAppendThinkDetector."""


### PR DESCRIPTION
## Motivation

`CanonicalStrategy._parse_block` picks a terminator per channel type. `analysis` and `commentary` stop at `END` or `CALL`, but `final` stopped only at `RETURN`:

```python
if channel_type == "final":
    while end_pos < len(tokens) and tokens[end_pos].type != "RETURN":
        end_pos += 1
```

A final message closed with `<|end|>` therefore found no terminator, fell through to the "no end token found" branch, and took its content as `text[content_start:]`, which is everything to the end of the input. The literal `<|end|>` stayed in the block content.

Both terminators are valid in Harmony: `<|return|>` closes the turn, and `<|end|>` closes a message when another one follows.

For GPT-OSS the marker reaches the client as part of the answer. Non-streaming parse of

```
<|start|><|channel|>analysis<|message|>THINK<|end|><|start|><|channel|>final<|message|>ANSWER<|end|>
```

returned `normal_text = 'ANSWER<|end|>'`. Streaming the same text already returned `'ANSWER'`, so the streaming and non-streaming paths disagreed on the same input. With `<|return|>` instead, both paths were already correct, which is why this stayed hidden.

Two existing cases already feed a final block closed by `<|end|>`, `test_canonical_standalone_end_token_filtered` and `test_tool_call_raw_text`, but both assert with `assertIn`, which still passes while the marker is attached. On current `main`, `test_tool_call_raw_text` produces `normal_text = 'function_dataresult<|end|>'`.

## Modifications

1. `harmony_parser.py`: the `final` channel now stops at `RETURN` or `END`. The existing `RETURN` handling that absorbs trailing `TEXT` is unchanged, and the "no end token" fallback still covers an unterminated final block.
2. `test_harmony_parser.py`: one case in `TestCanonicalStrategy` asserting the exact event sequence for an analysis block followed by a final block closed by `<|end|>`.
3. `test_reasoning_parser.py`: one case in `TestGptOssDetector` asserting the exact non-streaming `reasoning_text` and `normal_text`, which is the layer where the marker was user visible.

Scope note: I did not add these to `TestStreamingChunkSizeInvariance`. Its `_assert_invariant` sweeps chunk sizes down to 1, which splits the Harmony control tokens themselves. That is a separate concern from this fix, and Harmony control tokens are single vocabulary entries, so real token streaming delivers them whole.

Adjacent but distinct from #37722, which adds a `finish()` flush for incomplete blocks at stream end and does not change the terminator scan in `_parse_block`.

## Accuracy Tests

Not applicable. No model forward, kernel, or sampling code is touched, and model output is unchanged. This only changes how already generated text is split into reasoning and content.

Unit test evidence, run as CI runs it:

```bash
python3 test/registered/unit/parser/test_harmony_parser.py
python3 test/registered/unit/parser/test_reasoning_parser.py
python3 test/registered/unit/function_call/test_function_call_parser.py
```

| Suite | Before | After |
| --- | --- | --- |
| `test_harmony_parser` | 43 pass | 44 pass |
| `test_reasoning_parser` | 121 pass | 122 pass |
| `test_function_call_parser` | 243 pass | 243 pass |

Both new cases fail on the pre-fix code with `('normal', 'answer<|end|>')` against the expected `('normal', 'answer')`, and pass with the fix. No existing case changed result.

## Speed Tests and Profiling

Not applicable. The change adds one membership test to a loop that already ran over the same tokens, and it runs on generated text outside the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable, no user facing option or behaviour is documented for this path.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable, see the two sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34258080887](https://github.com/sgl-project/sglang/actions/runs/34258080887)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34258080428](https://github.com/sgl-project/sglang/actions/runs/34258080428)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34258080648](https://github.com/sgl-project/sglang/actions/runs/34258080648)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->