### PR TITLE
[Bugfix] Defer DeepEP imports and honor the DeepGEMM disable flag

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -15,6 +15,9 @@ _is_musa = is_musa()
 
 
 def _compute_enable_deep_gemm():
+    if not envs.SGLANG_ENABLE_JIT_DEEPGEMM.get():
+        return False
+
     sm_version = get_device_sm()
     if (_is_cuda and sm_version < 90) or (_is_musa and sm_version < 31):
         return False
@@ -33,7 +36,7 @@ def _compute_enable_deep_gemm():
     except ImportError:
         return False
 
-    return envs.SGLANG_ENABLE_JIT_DEEPGEMM.get()
+    return True
 
 
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -45,21 +45,7 @@ _use_zbal = _is_npu and envs.SGLANG_ZBAL_LOCAL_MEM_SIZE.get() > 0
 if TYPE_CHECKING:
     from sglang.srt.batch_overlap.single_batch_overlap import CombineOverlapArgs
 
-try:
-    if _use_zbal:
-        from zbal.zbal.deepep_adaptor import Config
-        from zbal.zbal_buffer import Buffer
-    else:
-        from deep_ep import Buffer, Config
-
-    if not _is_npu:
-        from sglang.kernels.ops.quantization.fp8_kernel import (
-            sglang_per_token_group_quant_fp8,
-        )
-
-    use_deepep = True
-except ImportError:
-    use_deepep = False
+use_deepep = False
 
 from enum import Enum, IntEnum, auto
 
@@ -73,6 +59,33 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 logger = logging.getLogger(__name__)
 
 _NVSHMEM_QP_DEPTH_DEFAULT = 1024
+
+
+def _ensure_deepep_available() -> None:
+    global use_deepep, Buffer, Config, sglang_per_token_group_quant_fp8
+
+    if use_deepep:
+        return
+
+    # DeepEP initializes its JIT runtime on import, so load it only when used.
+    try:
+        if _use_zbal:
+            from zbal.zbal.deepep_adaptor import Config
+            from zbal.zbal_buffer import Buffer
+        else:
+            from deep_ep import Buffer, Config
+
+        if not _is_npu:
+            from sglang.kernels.ops.quantization.fp8_kernel import (
+                sglang_per_token_group_quant_fp8,
+            )
+    except ImportError as exc:
+        raise ImportError(
+            "DeepEP is not available. Please install a compatible DeepEP package from "
+            "https://github.com/deepseek-ai/deepep."
+        ) from exc
+
+    use_deepep = True
 
 
 def _set_nvshmem_qp_depth(num_max_dispatch_tokens_per_rank: int) -> None:
@@ -210,6 +223,7 @@ class DeepEPBuffer:
         if state.buffer is not None:
             return state.buffer
 
+        _ensure_deepep_available()
         state.hidden_size = hidden_size
         state.num_max_dispatch_tokens_per_rank = num_max_dispatch_tokens_per_rank
         state.num_experts = num_experts
@@ -336,6 +350,7 @@ class DeepEPConfig(BaseDispatcherConfig):
     _instance = None
 
     def __init__(self):
+        _ensure_deepep_available()
         config_str = get_deepep_config()
         if config_str:
             config_parsed = load_json_config(config_str)
@@ -373,11 +388,7 @@ class _DeepEPDispatcherImplBase:
         params_dtype: torch.dtype,
         deepep_mode: DeepEPMode,
     ):
-        if not use_deepep:
-            raise ImportError(
-                "DeepEP is not installed. Please install DeepEP package from "
-                "https://github.com/deepseek-ai/deepep."
-            )
+        _ensure_deepep_available()
 
         self.group = group
         self.router_topk = router_topk

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep_v2.py
@@ -34,22 +34,7 @@ _EXPERT_ALIGNMENT = 128
 _deepep_v2_import_error: Optional[BaseException] = None
 _fp8_quant_import_error: Optional[BaseException] = None
 sglang_per_token_group_quant_fp8 = None
-
-try:
-    from deep_ep import ElasticBuffer
-
-    use_deepep_v2 = True
-except (ImportError, OSError) as exc:
-    use_deepep_v2 = False
-    _deepep_v2_import_error = exc
-
-if use_deepep_v2:
-    try:
-        from sglang.kernels.ops.quantization.fp8_kernel import (
-            sglang_per_token_group_quant_fp8,
-        )
-    except (ImportError, OSError) as exc:
-        _fp8_quant_import_error = exc
+use_deepep_v2: Optional[bool] = None
 
 
 class DeepEPv2DispatchOutput(NamedTuple):
@@ -93,10 +78,31 @@ def _raise_deepep_v2_import_error() -> None:
     raise ImportError(
         "DeepEP v2 (ElasticBuffer) is not available. Install DeepEP v2 from "
         "https://github.com/deepseek-ai/DeepEP." + detail
-    )
+    ) from _deepep_v2_import_error
 
 
 def _ensure_deepep_v2_available() -> None:
+    global use_deepep_v2, ElasticBuffer, _deepep_v2_import_error
+    global sglang_per_token_group_quant_fp8, _fp8_quant_import_error
+
+    # Defer both imports until this backend is used, including on CUDA hosts.
+    if use_deepep_v2 is None:
+        try:
+            from deep_ep import ElasticBuffer
+
+            use_deepep_v2 = True
+        except (ImportError, OSError) as exc:
+            use_deepep_v2 = False
+            _deepep_v2_import_error = exc
+
+        if use_deepep_v2:
+            try:
+                from sglang.kernels.ops.quantization.fp8_kernel import (
+                    sglang_per_token_group_quant_fp8,
+                )
+            except (ImportError, OSError) as exc:
+                _fp8_quant_import_error = exc
+
     if not use_deepep_v2:
         _raise_deepep_v2_import_error()
 
@@ -112,7 +118,7 @@ def _ensure_fp8_quant_available() -> None:
         raise ImportError(
             "DeepEP v2 FP8 dispatch requires the SGLang FP8 quantization kernel."
             + detail
-        )
+        ) from _fp8_quant_import_error
 
 
 def _get_allow_hybrid_mode() -> bool:
@@ -429,6 +435,7 @@ class DeepEPv2Dispatcher(BaseDispatcher):
         params_dtype: torch.dtype,
     ):
         super().__init__()
+        _ensure_deepep_v2_available()
         if params_dtype != torch.bfloat16:
             raise NotImplementedError(
                 "DeepEP v2 dispatch adapter currently expects BF16 model activations, "


### PR DESCRIPTION
## Motivation

Importing the common MoE token dispatcher eagerly imports DeepEP and initializes its JIT runtime, even when no DeepEP backend is selected. DeepGEMM is also probed and imported before `SGLANG_ENABLE_JIT_DEEPGEMM` is checked. Initialization failures in an unused or explicitly disabled backend can therefore prevent unrelated inference workloads from starting.

This follows the lazy-import approach used for Mooncake EP in #12641.

## Modifications

- Defer classic and v2 DeepEP imports, including their FP8 quantization dependencies, until the corresponding backend functionality is used.
- Preserve NPU/ZBAL backend selection and chain the original dependency errors when reporting import failures.
- Check `SGLANG_ENABLE_JIT_DEEPGEMM` before hardware capability probing or importing DeepGEMM, including the SM120 entry-point probe.

## Accuracy Tests

No accuracy benchmark was run; these changes only affect backend initialization.

Manual import-interception checks were run in fresh Python processes against `30e7a3072` and `c8609578c`, importing both DeepEP dispatcher adapters:

| Check | Before | After |
| --- | --- | --- |
| DeepEP remains unimported when unused | FAIL: import attempted | PASS: no import attempted |
| DeepGEMM remains unimported with `SGLANG_ENABLE_JIT_DEEPGEMM=0` | FAIL: import attempted | PASS: no import attempted |

The DeepEP check treated DeepGEMM as unavailable in both runs to isolate the two behaviors. The checks intercepted import attempts before dependency initialization.

Existing unit tests passed with `SGLANG_ENABLE_JIT_DEEPGEMM=0`:

- `test/registered/unit/layers/moe/test_deepep_v2_buffer_lifecycle.py`: 10 tests passed.
- `test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py`: 4 tests passed.

A serving smoke test passed on `c8609578c`: `Qwen/Qwen3-0.6B` started with `--moe-a2a-backend none` and `SGLANG_ENABLE_JIT_DEEPGEMM=0`, and a `/generate` request returned 32 completion tokens.

Multi-GPU DeepEP communication was not tested locally.

## Speed Tests and Profiling

Not run. This PR changes backend initialization only; communication and computation kernels are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Pre-commit checks passed for all three modified files.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No new test files; manual regression checks and existing unit tests were run as described above.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation changes needed.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not run for this initialization-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34262595179](https://github.com/sgl-project/sglang/actions/runs/34262595179)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34262594731](https://github.com/sgl-project/sglang/actions/runs/34262594731)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34262595104](https://github.com/sgl-project/sglang/actions/runs/34262595104)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->