### PR TITLE
docs(kernels): fix output_dytpe docstring typos in int8/fp8 kernels

### DIFF
--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -1552,7 +1552,7 @@ def w8a8_block_fp8_matmul_triton(
         As: The per-token-group quantization scale for `A`.
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
 
     Returns:
         torch.Tensor: The result of matmul.

--- a/python/sglang/kernels/ops/quantization/int8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/int8_kernel.py
@@ -356,7 +356,7 @@ def w8a8_block_int8_matmul(
         As: The per-token-group quantization scale for `A`.
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
 
     Returns:
         torch.Tensor: The result of matmul.


### PR DESCRIPTION
`w8a8_block_int8_matmul` and `w8a8_block_fp8_matmul_triton` both document an `output_dytpe` parameter — the parameter is `output_dtype`. Docstrings only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34267054522](https://github.com/sgl-project/sglang/actions/runs/34267054522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34267053295](https://github.com/sgl-project/sglang/actions/runs/34267053295)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34267053847](https://github.com/sgl-project/sglang/actions/runs/34267053847)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->