### PR TITLE
docs: fix stale args param name and a doubled 'with with'

### DIFF
--- a/python/sglang/srt/configs/internvl.py
+++ b/python/sglang/srt/configs/internvl.py
@@ -140,7 +140,7 @@ class InternLM2Config(PretrainedConfig):
 
         if not isinstance(self.rope_scaling, dict) or len(self.rope_scaling) != 2:
             raise ValueError(
-                "`rope_scaling` must be a dictionary with with two fields, `type` and `factor`, "
+                "`rope_scaling` must be a dictionary with two fields, `type` and `factor`, "
                 f"got {self.rope_scaling}"
             )
         rope_scaling_type = self.rope_scaling.get("type", None)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -839,7 +839,7 @@ def prepare_server_args(argv: list[str]) -> ServerArgs:
     Prepare the server arguments from the command line arguments.
 
     Args:
-        args: The command line arguments. Typically, it should be `sys.argv[1:]`
+        argv: The command line arguments. Typically, it should be `sys.argv[1:]`
             to ensure compatibility with `parse_args` when no arguments are passed.
 
     Returns:


### PR DESCRIPTION
- `srt/server_args.py`: `prepare_server_args(argv)`'s Args block documented `args`
- `srt/configs/internvl.py`: the rope_scaling `ValueError` (user-visible) read "must be a dictionary **with with** two fields"

Docstring/strings only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34267101544](https://github.com/sgl-project/sglang/actions/runs/34267101544)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34267101139](https://github.com/sgl-project/sglang/actions/runs/34267101139)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34267101552](https://github.com/sgl-project/sglang/actions/runs/34267101552)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->