### PR TITLE
 Export a decoder side type so KV event consumers can read `cache_salt`

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -963,6 +963,7 @@
               "docs/advanced_features/sgl_model_gateway",
               "docs/advanced_features/llm-d",
               "docs/advanced_features/deterministic_inference",
+              "docs/advanced_features/kv_events",
               "docs/advanced_features/observability",
               "docs/advanced_features/model_loading",
               "docs/advanced_features/object_storage",

--- a/docs/docs/advanced_features/kv_events.mdx
+++ b/docs/docs/advanced_features/kv_events.mdx
@@ -1,0 +1,150 @@
+---
+title: "KV Cache Events"
+metatags:
+    description: "Subscribe to SGLang's KV cache event stream: event types, the msgspec wire format, replay, and the cache_salt metadata a salted request attaches to stored blocks."
+---
+
+SGLang can publish a live stream of KV cache placement events. The events provide data like which token blocks a
+replica just stored, which it evicted and when it cleared everything. KV aware routers
+(the [SGLang model gateway](./sgl_model_gateway), [llm-d](./llm-d), NVIDIA Dynamo)
+subscribe to it to keep a global index of where each prefix lives, so they can route a
+request to the replica that already holds its prefix.
+
+## Enabling the stream
+
+```bash Command
+python3 -m sglang.launch_server \
+  --model-path meta-llama/Llama-3.1-8B-Instruct \
+  --kv-events-config '{"publisher": "zmq", "endpoint": "tcp://*:5557", "topic": "kv-events"}'
+```
+
+| Field | Meaning |
+| --- | --- |
+| `publisher` | `zmq` to publish, `null` to disable (default). |
+| `endpoint` | PUB address. A wildcard host (`tcp://*:5557`) binds. A concrete host connects. |
+| `replay_endpoint` | Optional ROUTER address for replaying missed batches. |
+| `buffer_steps` | Batches retained for replay (default `10000`). |
+| `hwm` | ZeroMQ high-water mark. Batches are dropped past it if a consumer falls behind. |
+| `max_queue_size` | In-memory publish queue depth. |
+| `topic` | SUB filter prefix. Empty subscribes to everything. |
+
+Each independent KV cache publishes on its own port, rank `r` binds `port + r`. Rather
+than hard coding that, read the `kv_events` block from `/server_info` which reports
+`endpoint_host`, `endpoint_port_base`, `topic`, `block_size` and `dp_size`. Substitute
+the worker's own host when `endpoint_host` is a wildcard.
+
+## Frames on the wire
+
+The publisher sends three ZeroMQ frames per batch: the topic, an 8-byte big-endian
+sequence number and a [msgspec](https://jcristharif.com/msgspec/) msgpack payload
+holding one `KVEventBatch`. Sequence numbers are monotonic per publisher, so a consumer
+can detect a gap and ask the replay ROUTER for the missing range (send the starting
+sequence number as 8 big-endian bytes. The reply is a stream of `(seq, payload)` pairs
+terminated by `(-1, b"")`).
+
+A batch carries `ts`, `attn_dp_rank`, and a list of events:
+
+| Event | Fields | Meaning |
+| --- | --- | --- |
+| `BlockStored` | `block_hashes`, `parent_block_hash`, `token_ids`, `block_size`, `lora_id`, `medium` | Blocks became resident. `parent_block_hash` links the first block to the prefix it extends, so consumers can rebuild the tree. |
+| `BlockRemoved` | `block_hashes`, `medium` | Blocks were evicted. |
+| `AllBlocksCleared` | — | The whole cache was reset. |
+
+`medium` names the tier: `GPU`, `CPU_PINNED`, `DISK` or `EXTERNAL`.
+
+## Decoding a batch
+
+```python
+import msgspec
+import zmq
+
+from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStoredView,
+    KVEventBatchView,
+)
+
+decoder = msgspec.msgpack.Decoder(KVEventBatchView)
+
+socket = zmq.Context.instance().socket(zmq.SUB)
+socket.connect("tcp://127.0.0.1:5557")
+socket.setsockopt_string(zmq.SUBSCRIBE, "kv-events")
+
+while True:
+    _topic, _seq, payload = socket.recv_multipart()
+    batch = decoder.decode(payload)
+    for event in batch.events:
+        if isinstance(event, BlockStoredView):
+            index(event.block_hashes, salt=event.cache_salt)
+        elif isinstance(event, BlockRemoved):
+            forget(event.block_hashes)
+        elif isinstance(event, AllBlocksCleared):
+            forget_all()
+```
+
+`KVEventBatchView` is the consumer side type. It decodes every shape the publisher emits,
+including the salted stores described below. `KVEventBatch` is the publisher side type.
+It also decodes the stream but reports salted stores as a plain `BlockStored` with the
+salt dropped.
+
+## Salted blocks
+
+A request may pass `cache_salt` to keep its prefixes in a namespace of their own, so two
+tenants sending the same prompt do not share cache entries:
+
+```python
+import requests
+
+requests.post(
+    "http://127.0.0.1:30000/v1/chat/completions",
+    json={
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "messages": [{"role": "user", "content": "Summarize the attached contract."}],
+        "cache_salt": "tenant-a",
+    },
+)
+```
+
+Blocks stored for a salted request carry the salt as trailing metadata:
+
+```python
+event.cache_salt        # "tenant-a", or None for an unsalted request
+event.metadata          # BlockStoredMetadata(cache_salt="tenant-a"), or None
+```
+
+What to expect from the stream:
+
+- **Only `BlockStored` carries it.** Every block of every node stored for a salted
+  request repeats the salt. `BlockRemoved` and `AllBlocksCleared` do not carry metadata
+  and do not need to.
+- **Hashes are salt namespaced, not salt disambiguated.** The salt seeds the hash chain
+  (`sha256(b"sglang-cache-salt-v1\0" + salt)`), so a salted prefix and the identical
+  unsalted prefix produce entirely different `block_hashes`. Hashes are therefore unique
+  across tenants on their own which is why a later `BlockRemoved` needs no salt to be
+  unambiguous.
+- **Index the hashes you receive, do not recompute them.** A consumer cannot derive a
+  block hash from `token_ids` plus `cache_salt`. The chain is SGLang's and it differs
+  from other engines'. Treat `cache_salt` as a label on an emitted hash, not as an input
+  to a shared key derivation function.
+- **The salt is client supplied and echoed on the PUB socket.** It identifies the tenant
+  a block belongs to. Keep the socket on a trusted network, and think of the salt as you
+  would any tenant identifier when logging or forwarding it.
+
+<Note>
+`cache_salt` namespaces the in-process radix tree and the KV event hashes. Keys written
+to external HiCache L3 / remote storage backends are derived from tokens only, so the
+salt does not isolate cache entries at that tier.
+</Note>
+
+## Compatibility
+
+Salted stores extend the `BlockStored` array with one trailing element rather than adding
+a field to every event, so an unsalted event keeps its exact legacy shape. A consumer
+built against the older, unsalted schema keeps working unchanged. It reads the elements
+it knows and ignores the trailing metadata. Reading the salt is opt-in by decoding
+`KVEventBatchView` instead of `KVEventBatch`.
+
+The view is decode only. Publishers must emit `BlockStored` or `BlockStoredWithMetadata`.
+Encoding a `BlockStoredView` that has no metadata appends a trailing `null` that
+legacy consumers do not expect.

--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -301,11 +301,65 @@ class AllBlocksCleared(KVCacheEvent):
 
 
 class KVEventBatch(EventBatch):
-    # BlockStoredWithMetadata deliberately stays out of this tagged union.
-    # Existing typed consumers decode its shared "BlockStored" tag as the base
-    # type and ignore the trailing metadata; adding both types would give
-    # msgspec duplicate tags and make the union invalid.
+    """Publisher side batch which defines the shape the scheduler encodes onto the wire.
+
+    `BlockStoredWithMetadata` deliberately stays out of this tagged union.
+    Existing typed consumers decode its shared "BlockStored" tag as the base
+    type and ignore the trailing metadata. Adding both types would give msgspec
+    duplicate tags and make the union invalid.
+
+    Consumers that need that metadata decode `KVEventBatchView` instead. It is the same
+    wire bytes, one shape that accepts both.
+    """
+
     events: list[Union[BlockStored, BlockRemoved, AllBlocksCleared]]
+
+
+class BlockStoredView(BlockStored, tag="BlockStored", kw_only=True):
+    """Decoder side view of a stored block event, salted or not.
+
+    One "BlockStored" tag carries two array shapes. The legacy 7 element form
+    and the 8 element form a salted request appends a `BlockStoredMetadata` to.
+    Neither producer struct reads both. The base one is blind to the trailing
+    element, the metadata one rejects events without it. They cannot share a union,
+    since msgspec requires unique tags. This view is the consumer counterpart.
+    `metadata` is optional, so one decoder handles a mixed stream.
+
+    Decode only. Encoding a view whose `metadata` is None`` appends a
+    trailing `null` that legacy 7 element readers do not expect
+    (`omit_defaults` does not trim trailing defaults in `array_like`
+    structs), so publish `BlockStored` / `BlockStoredWithMetadata` instead.
+    """
+
+    metadata: Optional[BlockStoredMetadata] = None
+
+    @property
+    def cache_salt(self) -> Optional[str]:
+        """Salt of the request that stored these blocks or `None`.
+
+        Identifies which tenant namespace the hashes belong to. It is not an
+        input a consumer can recompute an emitted hash from. The salt seeds
+        the hash chain, so consumers must index the hashes as emitted.
+        """
+        return self.metadata.cache_salt if self.metadata is not None else None
+
+
+class KVEventBatchView(EventBatch):
+    """Decoder side counterpart of `KVEventBatch`.
+
+    Decodes the bytes a publisher emits and additionally surfaces the
+    `cache_salt` a salted `BlockStored` carries::
+
+        batch = msgspec.msgpack.Decoder(KVEventBatchView).decode(payload)
+        for event in batch.events:
+            if isinstance(event, BlockStoredView):
+                index(event.block_hashes, salt=event.cache_salt)
+
+    `BlockStoredView` subclasses `BlockStored`, so consumers already
+    branching on the producer types keep working unchanged.
+    """
+
+    events: list[Union[BlockStoredView, BlockRemoved, AllBlocksCleared]]
 
 
 class EventPublisher(ABC):

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -1,30 +1,65 @@
-"""Unit tests for srt/disaggregation/kv_events KV-event publisher rank selection.
+"""Unit tests for srt/disaggregation/kv_events publisher rank selection and
+the KV event wire contract.
 
 Covers the data-parallel rank used to offset each scheduler's KV-event
 publisher port, across pure DP, DP-attention, and single-replica modes. The
 port offset must make every independent KV cache publish on a distinct port so
 the router can subscribe per replica (the `dp_size` it reads from
 `/server_info`).
+
+Also covers the two array shapes a `BlockStored` event takes on the wire:
+salted and unsalted. The consumer side type that decodes both is included also.
 """
 
+import hashlib
+import time
 import unittest
+import uuid
+from array import array
+from typing import Union
+from unittest.mock import Mock, patch
 
 import msgspec
+import torch
+import zmq
 
 from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
     BlockStored,
     BlockStoredMetadata,
+    BlockStoredView,
     BlockStoredWithMetadata,
     KVEventBatch,
+    KVEventBatchView,
     StorageMedium,
     ZmqEventPublisher,
     resolve_load_pub_range,
     select_kv_publisher_dp_rank,
 )
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, InsertParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+
+def _block_stored(cache_salt=None, *, block_hashes=(123,), token_ids=(1, 2)):
+    """A BlockStored in the shape its producer would emit it."""
+    kwargs = dict(
+        block_hashes=list(block_hashes),
+        parent_block_hash=None,
+        token_ids=list(token_ids),
+        block_size=len(token_ids),
+        lora_id=None,
+        medium=StorageMedium.GPU,
+    )
+    if cache_salt is None:
+        return BlockStored(**kwargs)
+    return BlockStoredWithMetadata(
+        **kwargs, metadata=BlockStoredMetadata(cache_salt=cache_salt)
+    )
 
 
 class TestResolveLoadPubRange(CustomTestCase):
@@ -187,18 +222,7 @@ class TestSelectKvPublisherDpRank(CustomTestCase):
 
 class TestBlockStoredWireFormat(CustomTestCase):
     def _event(self, metadata=None):
-        event_type = BlockStored if metadata is None else BlockStoredWithMetadata
-        kwargs = dict(
-            block_hashes=[123],
-            parent_block_hash=None,
-            token_ids=[1, 2],
-            block_size=2,
-            lora_id=None,
-            medium=StorageMedium.GPU,
-        )
-        if metadata is not None:
-            kwargs["metadata"] = metadata
-        return event_type(**kwargs)
+        return _block_stored(None if metadata is None else metadata.cache_salt)
 
     def test_unsalted_event_keeps_legacy_array_shape(self):
         decoded = msgspec.msgpack.decode(msgspec.msgpack.encode(self._event()))
@@ -222,6 +246,256 @@ class TestBlockStoredWireFormat(CustomTestCase):
             msgspec.msgpack.encode(batch), type=KVEventBatch
         )
         self.assertEqual(round_tripped.events[0].block_hashes, [123])
+
+
+class _WithMetadataBatch(KVEventBatch):
+    """The batch a consumer reaches for first. The producer's metadata struct
+    which rejects every unsalted event on the same stream."""
+
+    events: list[BlockStoredWithMetadata]
+
+
+class _AmbiguousBatch(KVEventBatch):
+    """Both producer structs in one union. Rejected for duplicate tags."""
+
+    events: list[Union[BlockStored, BlockStoredWithMetadata]]
+
+
+class TestBlockStoredViewDecoding(CustomTestCase):
+    """The consumer side shape for a stream that mixes salted and unsalted stores.
+
+    A salted request appends a metadata element under the same "BlockStored"
+    tag, so one stream carries two array lengths. Each producer struct reads
+    exactly one of them and the two cannot share a union which left the salt
+    undecodable by any exported type. `BlockStoredView` is what a consumer
+    decodes instead.
+    """
+
+    @staticmethod
+    def _payload(*events):
+        return msgspec.msgpack.encode(KVEventBatch(ts=1.0, events=list(events)))
+
+    def test_producer_structs_cannot_decode_a_mixed_stream(self):
+        # The metadata struct rejects the unsalted events
+        # sharing its stream and msgspec rejects the union that would have
+        # covered both shapes together.
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.msgpack.decode(
+                self._payload(_block_stored()), type=_WithMetadataBatch
+            )
+        with self.assertRaises(TypeError):
+            msgspec.msgpack.Decoder(_AmbiguousBatch)
+
+    def test_view_decodes_both_shapes_from_one_stream(self):
+        payload = self._payload(
+            _block_stored(block_hashes=(11,)),
+            _block_stored("tenant-a", block_hashes=(22,)),
+            BlockRemoved(block_hashes=[11], medium=StorageMedium.GPU),
+            AllBlocksCleared(),
+        )
+        batch = msgspec.msgpack.Decoder(KVEventBatchView).decode(payload)
+
+        self.assertEqual(
+            [type(event) for event in batch.events],
+            [BlockStoredView, BlockStoredView, BlockRemoved, AllBlocksCleared],
+        )
+        self.assertEqual(
+            [event.cache_salt for event in batch.events[:2]], [None, "tenant-a"]
+        )
+        self.assertEqual(
+            [event.block_hashes[0] for event in batch.events[:2]], [11, 22]
+        )
+
+    def test_view_keeps_every_legacy_field_positioned(self):
+        # The optional element is appended, so both array lengths must still
+        # land each legacy field on the same attribute.
+        for salt in (None, "tenant-a"):
+            with self.subTest(cache_salt=salt):
+                payload = self._payload(
+                    _block_stored(salt, block_hashes=(11,), token_ids=(7, 8, 9))
+                )
+                event = (
+                    msgspec.msgpack.Decoder(KVEventBatchView).decode(payload).events[0]
+                )
+
+                self.assertEqual(event.block_hashes, [11])
+                self.assertIsNone(event.parent_block_hash)
+                self.assertEqual(event.token_ids, [7, 8, 9])
+                self.assertEqual(event.block_size, 3)
+                self.assertIsNone(event.lora_id)
+                self.assertEqual(event.medium, StorageMedium.GPU)
+                self.assertEqual(event.cache_salt, salt)
+
+    def test_view_stays_a_block_stored_subclass(self):
+        # Consumers branch on isinstance(event, BlockStored). Redeclaring the
+        # view as a standalone struct would silently drop them into the
+        # unhandled event branch.
+        self.assertTrue(issubclass(BlockStoredView, BlockStored))
+
+    def test_view_is_not_wire_safe_to_publish(self):
+        # Pins why the producer keeps two structs. omit_defaults does not trim
+        # a trailing default in an array_like struct, so publishing the view
+        # would append a null that legacy 7 element consumers do not expect.
+        view = BlockStoredView(
+            block_hashes=[1],
+            parent_block_hash=None,
+            token_ids=[1, 2],
+            block_size=2,
+            lora_id=None,
+            medium=StorageMedium.GPU,
+        )
+        self.assertEqual(len(msgspec.msgpack.decode(msgspec.msgpack.encode(view))), 8)
+
+
+class TestKVEventStreamRoundTrip(CustomTestCase):
+    """Real cache -> publisher -> ZMQ -> consumer, over a mixed salt stream.
+
+    Guards the path the issue reports as broken end to end. A subscriber to a
+    live stream could read the block hashes but never the salt that namespaces
+    them because no exported type decoded both event shapes. One capture
+    serves every case below and the frame is the fixture.
+    """
+
+    TOPIC = "kv-events"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.events = cls._record_real_events()
+        cls.payload = cls._round_trip(cls.events)
+
+    @staticmethod
+    def _page_hashes(token_ids, prior_hash=None, page_size=None):
+        """Pure python stand-in for ``get_hash_str``.
+
+        The native page hash is a JIT compiled, Linux only C++ extension. The
+        wire contract under test does not depend on which digest it produces,
+        only on the recorder chaining and namespacing them.
+        """
+
+        def digest(chunk, prior):
+            hasher = hashlib.sha256()
+            if prior:
+                hasher.update(bytes.fromhex(prior))
+            for token in chunk:
+                for element in token if isinstance(token, tuple) else (token,):
+                    hasher.update(int(element).to_bytes(4, "little", signed=False))
+            return hasher.hexdigest()
+
+        if page_size is None:
+            return digest(token_ids, prior_hash)
+        hashes = []
+        running = prior_hash
+        for start in range(0, len(token_ids), page_size):
+            running = digest(token_ids[start : start + page_size], running)
+            hashes.append(running)
+        return hashes
+
+    @classmethod
+    def _record_real_events(cls):
+        """Drive a real RadixCache: one unsalted request, two tenants, evict."""
+        allocator = Mock()
+        allocator.device = torch.device("cpu")
+        with patch("sglang.srt.mem_cache.utils.get_hash_str", cls._page_hashes):
+            cache = RadixCache.create_simulated(
+                mock_allocator=allocator, page_size=4, enable_kv_cache_events=True
+            )
+            cache.take_events()  # drop the AllBlocksCleared from construction
+
+            for tokens, salt in (
+                ([1, 2, 3, 4, 5, 6, 7, 8], None),
+                ([1, 2, 3, 4, 9, 10, 11, 12], "tenant-a"),
+                ([21, 22, 23, 24], "tenant-b"),
+            ):
+                cache.insert(
+                    InsertParams(
+                        key=RadixKey(array("q", tokens), cache_salt=salt),
+                        value=torch.tensor(tokens, dtype=torch.int64),
+                    )
+                )
+            cache.evict(EvictParams(num_tokens=4))
+            return cache.take_events()
+
+    @classmethod
+    def _round_trip(cls, events):
+        """Publish through a real ZmqEventPublisher and return the raw frame."""
+        endpoint = f"inproc://kv-events-{uuid.uuid4().hex}"
+        publisher = ZmqEventPublisher(
+            attn_dp_rank=0, endpoint=endpoint, topic=cls.TOPIC
+        )
+        cls.addClassCleanup(publisher.shutdown)
+        subscriber = zmq.Context.instance().socket(zmq.SUB)
+        cls.addClassCleanup(subscriber.close, 0)
+        subscriber.connect(endpoint)
+        subscriber.setsockopt_string(zmq.SUBSCRIBE, cls.TOPIC)
+
+        # PUB drops whatever is sent before the subscription propagates, so
+        # republish until a frame arrives.
+        payload = None
+        deadline = time.monotonic() + 30
+        while payload is None and time.monotonic() < deadline:
+            publisher.publish(KVEventBatch(ts=time.time(), events=events))
+            if subscriber.poll(200):
+                _topic, _seq, payload = subscriber.recv_multipart()
+        if payload is None:
+            raise AssertionError("publisher delivered no frame")
+        while subscriber.poll(100):  # drain the republished duplicates
+            subscriber.recv_multipart()
+        return payload
+
+    def _decode(self, batch_type):
+        return msgspec.msgpack.Decoder(batch_type).decode(self.payload)
+
+    def test_salted_stream_round_trips_to_a_typed_consumer(self):
+        produced = [event for event in self.events if isinstance(event, BlockStored)]
+        self.assertEqual(
+            [type(event) for event in produced],
+            [BlockStored, BlockStoredWithMetadata, BlockStoredWithMetadata],
+        )
+
+        batch = self._decode(KVEventBatchView)
+        stored = [event for event in batch.events if isinstance(event, BlockStoredView)]
+        self.assertEqual(
+            [event.cache_salt for event in stored], [None, "tenant-a", "tenant-b"]
+        )
+        self.assertEqual(
+            [event.block_hashes for event in stored],
+            [event.block_hashes for event in produced],
+        )
+        self.assertTrue(
+            any(isinstance(event, BlockRemoved) for event in batch.events),
+            "eviction should reach the consumer as BlockRemoved",
+        )
+
+    def test_salt_namespaces_the_hashes_a_consumer_indexes(self):
+        # The salted request shares a 4 token prefix with the unsalted one yet
+        # emits its own chain. Consumers must index emitted hashes per salt,
+        # not treat an equal prefix as an equal block.
+        stored = [
+            event
+            for event in self._decode(KVEventBatchView).events
+            if isinstance(event, BlockStoredView)
+        ]
+        unsalted, salted = stored[0], stored[1]
+
+        self.assertEqual(unsalted.token_ids[:4], salted.token_ids[:4])
+        self.assertNotEqual(unsalted.block_hashes[0], salted.block_hashes[0])
+
+    def test_legacy_consumers_still_decode_the_same_frame(self):
+        # The fix is decoder side only. The bytes a legacy KVEventBatch
+        # consumer sees must be unchanged, salt or no salt.
+        legacy = self._decode(KVEventBatch)
+        view = self._decode(KVEventBatchView)
+
+        self.assertEqual(
+            [event.block_hashes for event in legacy.events],
+            [event.block_hashes for event in view.events],
+        )
+        self.assertFalse(
+            any(isinstance(event, BlockStoredView) for event in legacy.events),
+            "moving the view into KVEventBatch would change what legacy "
+            "consumers decode",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`cache_salt` was added to the KV event stream in #30827 and the producer side works fine. The consumer side does not as nothing exported can decode the resulting stream.

Salted nodes emit `BlockStoredWithMetadata` which serializes as the legacy 7 element `BlockStored` array plus a trailing metadata element. So one stream carries two array shapes under the same `"BlockStored"` tag and neither producer struct reads both. `BlockStored` ignores the trailing element. `BlockStoredWithMetadata` declares `metadata` as required, so it rejects every unsalted event sharing the stream. They can't go in one union either because msgspec needs unique tags:

```python
msgspec.msgpack.Decoder(KVEventBatch).decode(payload)
# ValidationError: Expected `array` of at least length 8, got 7

Union[BlockStored, BlockStoredWithMetadata]
# TypeError: must have unique tag values
```

The only shape that decodes both is a hand rolled struct that isn't exported . So the feature is invisible to anyone consuming `KVEventBatch` through the public types.

The wire format is fine and backward compatible. A legacy consumer gets the 7 elements it expects and ignores the rest and unsalted events keep their exact legacy shape. The two struct producer split is also the right call. `omit_defaults=True` however doesn't trim a trailing `None` in `array_like` structs and as a result a single optional field on the producer breaks the wire. This is a missing decoder side type, not a format bug and the producer stays as is.

Closes #38561 

## Modifications

`kv_events.py`: Adds `BlockStoredView` (same as `BlockStored` but `metadata` is optional) and the `KVEventBatchView` union built from it. One decoder now handles a mixed stream, reading `cache_salt` where it's present and `None` where it isn't. The view subclasses `BlockStored`, so consumers already branching on the producer types keep working unchanged. It's decode only and the docstring says why: publishing a view with no metadata would append a null that legacy consumers don't expect.

`docs/advanced_features/kv_events.mdx`: New page. Covers enabling the stream, the frame and replay protocol, the event types and a decoding example. It also explains to consumers how to handle  events with salt. Only `BlockStored` carries the salt, block hashes are salt namespaced rather than salt disambiguated (which is why `BlockRemoved` needs no salt to stay unambiguous) and you have to index the hashes you're sent rather than recompute them.

Tests: Nine cases in `test/registered/unit/disaggregation/test_kv_events.py`. Half reproduce both failure modes above and pin the fix. The rest are an e2e round trip: a real `RadixCache` records an unsalted request, two tenants and an eviction, publishes through a real `ZmqEventPublisher` and a real ZMQ subscriber decodes the frame with `KVEventBatchView`. That asserts the salts survive the wire, that a salted request emits its own hash chain despite sharing a 4-token prefix with an unsalted one and that a legacy `KVEventBatch` consumer still decodes the same bytes unchanged.

AI assistance was used for implementation and verification.

## Accuracy Tests

N/A. No model output or forward path changes. This is a serialization type plus docs.

## Speed Tests and Profiling

N/A. No runtime path changes. The new types are only constructed by consumers decoding the stream.

## Checklist

- [x] Format your code according to the [Format code with
pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34275336050](https://github.com/sgl-project/sglang/actions/runs/34275336050)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34275335680](https://github.com/sgl-project/sglang/actions/runs/34275335680)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34275336182](https://github.com/sgl-project/sglang/actions/runs/34275336182)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->