### PR TITLE
[Fix] Stamp sequence-parallel state on dummy forward batches

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1509,6 +1509,10 @@ class ModelRunner:
 
     def prepare_dummy_forward_batch(self, forward_batch: ForwardBatch) -> ForwardBatch:
         """Customize a runner-created dummy batch before attention metadata initialization."""
+        # Dummy runs bypass the MLP-sync/scatter passes that stamp real batches.
+        forward_batch.attn_tp_sequence_sharded = self.attn_tp_sequence_sharded(
+            forward_batch._forward_num_tokens()
+        )
         return forward_batch
 
     def attn_tp_sequence_sharded(self, num_tokens: int) -> bool:

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -107,6 +107,39 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         self.assertTrue(runner.attn_tp_sequence_sharded(num_tokens=4))
         mock_require_gathered_buffer.assert_called_once_with()
 
+    def test_dummy_batch_sharding_tracks_forward_token_width(self):
+        """Warmup must use the runner's SP policy, including embedding widths."""
+
+        class TokenGatedRunner(ModelRunner):
+            def attn_tp_sequence_sharded(self, num_tokens):
+                return num_tokens == 4
+
+        runner = TokenGatedRunner.__new__(TokenGatedRunner)
+        for num_ids, num_embeds, expected in (
+            (4, None, True),
+            (5, None, False),
+            (5, 4, True),
+            (4, 5, False),
+            (0, None, False),
+        ):
+            with self.subTest(num_ids=num_ids, num_embeds=num_embeds):
+                batch = ForwardBatch(
+                    forward_mode=ForwardMode.EXTEND,
+                    batch_size=1,
+                    input_ids=torch.arange(num_ids),
+                    input_embeds=(
+                        torch.empty(num_embeds, 8) if num_embeds is not None else None
+                    ),
+                    req_pool_indices=torch.tensor([0]),
+                    seq_lens=torch.tensor([num_ids]),
+                    out_cache_loc=torch.arange(num_ids),
+                    seq_lens_sum=num_ids,
+                    attn_tp_sequence_sharded=not expected,
+                )
+
+                self.assertIs(runner.prepare_dummy_forward_batch(batch), batch)
+                self.assertEqual(batch.attn_tp_sequence_sharded, expected)
+
     def test_low_free_memory_still_captures_prefill_graph(self):
         eager_runner = object()
         prefill_runner = object()


### PR DESCRIPTION
## Motivation

Warmup and autotuning batches bypass the preparation passes used by real batches, so their attention-TP sharding flag can disagree with the model runner's sequence-parallel policy.

## Modifications

Set the flag through the existing per-forward policy before dummy attention metadata is initialized. Cover token-ID and embedding widths, empty input, and stale flags in the existing runner unit suite.

## Accuracy Tests

- Runner unit suite: 10 tests and 7 subtests passed.
- All five new regression subtests fail before the fix and pass after it.
- Pre-commit passed on both changed files.
- No model math changed; model-level accuracy tests were not run.

## Speed Tests and Profiling

Not run; this changes warmup metadata preparation.

## Original commits

- `3cfd1ec3947c9c8a3565d720eb2c54f70e1ffd61`

## Checklist

- [x] Format code with pre-commit.
- [x] Add regression coverage.
- [x] Follow SGLang code style.
- [x] No documentation change required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34278150578](https://github.com/sgl-project/sglang/actions/runs/34278150578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34278150136](https://github.com/sgl-project/sglang/actions/runs/34278150136)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34278150420](https://github.com/sgl-project/sglang/actions/runs/34278150420)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->