### PR TITLE
fix(gpt-oss): stream mxfp4 expert shards to avoid host-RAM OOM at tp=4

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -953,20 +953,22 @@ class GptOssForCausalLM(nn.Module):
             )
 
     def _load_weights_mxfp4(self, weights, is_nextn, weight_name_mapping):
-        mxfp4_weights = []
         normal_weights = []
 
-        for name, weight in weights:
-            if (
-                ".experts" in name
-                and self.quant_config is not None
-                and self.quant_config.get_name() == "mxfp4"
-            ):
-                mxfp4_weights.append((name, weight))
-            else:
-                normal_weights.append((name, weight))
+        # Touching an mmap-backed checkpoint tensor COW-faults its pages into
+        # cgroup-charged anonymous memory; buffering them all costs ~61 GB per rank.
+        def _stream_mxfp4_weights():
+            for name, weight in weights:
+                if (
+                    ".experts" in name
+                    and self.quant_config is not None
+                    and self.quant_config.get_name() == "mxfp4"
+                ):
+                    yield name, weight
+                else:
+                    normal_weights.append((name, weight))
 
-        mxfp4_loaded_params = self._load_mxfp4_experts_weights(mxfp4_weights)
+        mxfp4_loaded_params = self._load_mxfp4_experts_weights(_stream_mxfp4_weights())
         self._load_normal_weights(
             normal_weights,
             is_nextn=is_nextn,


### PR DESCRIPTION
## Motivation

`openai/gpt-oss-120b` cannot be loaded at `--tp 4`: every rank is SIGKILLed (`exit code: -9`) during weight load. `GptOssForCausalLM._load_weights_mxfp4` drains its whole weights iterator into a list before loading anything, so every expert tensor in the checkpoint stays resident for the entire load — roughly a full checkpoint (~61 GB for 120b) of host pages per rank, charged to the process' memory cgroup, and worse as `--tp` rises. The cost is host RAM, not VRAM.

Not XPU-specific (safetensors mapping plus cgroup accounting), but untested on other backends.

## Modifications

`python/sglang/srt/models/gpt_oss.py` — `_load_weights_mxfp4` passes `_load_mxfp4_experts_weights` a generator instead of a pre-built `mxfp4_weights` list, so expert shards are consumed and released one at a time. The callee needs no change: it consumes its argument in a single pass with no early exit, so the generator is always drained before `normal_weights` is read. Non-expert tensors are still accumulated, since `_load_normal_weights` needs the complete set. Which bytes reach which parameter is unchanged.

This source change is not the whole fix. The working configuration also passes two **existing** flags, `--weight-loader-disable-mmap` and `--model-loader-extra-config '{"enable_multithread_load": false}'`. Neither half sufficed alone: the patch without the flags still peaked near 106 GiB of cgroup memory; the flags without the patch still peaked near 28 GiB per rank against a 128 GiB cap. Only the combination completed the load. Single-run figures from one host — directional context, not a benchmark.

## Accuracy Tests

`N/A` — no model outputs are affected. The patch only reorders *when* a reference to the same `(name, tensor)` pair is released during weight load.

Functional evidence: 120b at `--tp 4` goes from every rank dying with `exit code: -9` to all 4 ranks reaching "Load weight end" and serving a benchmark.

For explicit output-equivalence on a model that also loads unpatched:

```
TODO: run on this branch and on main, expecting the same accuracy
python3 -m sglang.launch_server --model openai/gpt-oss-20b --port 30000
python3 -m sglang.eval.run_eval --eval-name gsm8k --num-questions 200 --port 30000
```

## Speed Tests and Profiling

No throughput claim, by construction: nothing touched here executes during prefill or decode. Load time is the only timing this can move, and **no A/B against the unpatched path is possible** for the motivating case — that path never completes it.

For a load-time A/B on a model that loads both ways:

```
TODO: time startup to "Load weight end" on this branch vs main
python3 -m sglang.launch_server --model openai/gpt-oss-20b --tp 1 --port 30000
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — Not added: the regression is a host-RAM ceiling during a multi-rank 120b load, impractical to assert in unit CI. Happy to add a test asserting `_load_weights_mxfp4` never holds more than one expert tensor at a time.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — `N/A`, no user-facing interface, flag, or behaviour change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — See the two sections above: accuracy `N/A` with reasoning, no speed claim, TODO commands for either.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34293980070](https://github.com/sgl-project/sglang/actions/runs/34293980070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34293979820](https://github.com/sgl-project/sglang/actions/runs/34293979820)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34293979956](https://github.com/sgl-project/sglang/actions/runs/34293979956)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
