### PR TITLE
[AMD][DSV4] Skip the paged SWA page return under the per-request ring

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -485,6 +485,11 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 ), "swa pages do not match the mapped pages"
         self.clear_full_to_swa_mapping(mapping_indices)
 
+        if self._swa_req_ring:
+            # Ring slots are owned by the req slot, never lent by the paged
+            # allocator; returning them over-credits its available_size().
+            return
+
         if self.free_group is not None:
             # Resolve ownership now, as above.
             self.swa_page_ids_group.append(swa_pages)
@@ -547,7 +552,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.swa_page_ids_group:
             swa_page_ids_group = self.swa_page_ids_group
             self.swa_page_ids_group = []
-            self.swa_attn_allocator.free_page_ids(torch.cat(swa_page_ids_group))
+            if not self._swa_req_ring:
+                self.swa_attn_allocator.free_page_ids(torch.cat(swa_page_ids_group))
         if self.swa_free_group:
             swa_free_group = self.swa_free_group
             self.swa_free_group = []

--- a/test/registered/unit/mem_cache/test_swa_ring_page_return.py
+++ b/test/registered/unit/mem_cache/test_swa_ring_page_return.py
@@ -60,9 +60,7 @@ def _make_self(*, swa_req_ring: bool, page_size: int = PAGE_SIZE):
 
     mapping = torch.zeros(64, dtype=torch.int64)
     # Peer pages for the rows under test; page 2 of the paged SWA pool.
-    mapping[0:page_size] = torch.arange(
-        2 * page_size, 3 * page_size, dtype=torch.int64
-    )
+    mapping[0:page_size] = torch.arange(2 * page_size, 3 * page_size, dtype=torch.int64)
     alloc.full_to_swa_index_mapping = mapping
 
     alloc.swa_attn_allocator = _CountingPagedAllocator(size=page_size * POOL_PAGES)

--- a/test/registered/unit/mem_cache/test_swa_ring_page_return.py
+++ b/test/registered/unit/mem_cache/test_swa_ring_page_return.py
@@ -1,0 +1,131 @@
+"""Regression for the paged SWA page return under the per-request ring.
+
+Both free paths returned SWA pages to the paged swa_attn_allocator
+unconditionally. Under the per-request ring that allocator is vestigial and its
+slots are owned by the req slot rather than lent per free, so the return
+over-credited available_size() past size and tripped the assert at the end of
+free_group_end, killing the scheduler on the first decode that frees.
+
+The mapping clear in _free_swa_pages must still run in ring mode: without it,
+translate_loc_from_full_to_swa reads stale peer indices and the failure becomes
+wrong KV instead of a crash.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+PAGE_SIZE = 8
+POOL_PAGES = 4
+
+
+class _CountingPagedAllocator:
+    """Paged allocator that really tracks credit, so over-crediting is visible.
+
+    A MagicMock would only record the call; the bug is that the call moves
+    available_size() past size, which is what the production assert checks.
+    """
+
+    def __init__(self, *, size: int):
+        self.size = size
+        self.debug_mode = False
+        self._free_tokens = 0  # fully allocated to start
+
+    def available_size(self) -> int:
+        return self._free_tokens
+
+    def free_page_ids(self, page_ids: torch.Tensor) -> None:
+        self._free_tokens += int(page_ids.numel()) * PAGE_SIZE
+
+    def free_group_end(self) -> None:
+        """The full-side allocator defers its own frees; nothing to settle here."""
+
+
+def _make_self(*, swa_req_ring: bool, page_size: int = PAGE_SIZE):
+    """Build a real instance without __init__; free_group_end calls zero-arg
+    super(), which requires an instance of the class rather than a stub."""
+    alloc = object.__new__(SWATokenToKVPoolAllocator)
+
+    alloc.page_size = page_size
+    alloc._swa_req_ring = swa_req_ring
+    alloc.free_group = None
+    alloc.swa_free_group = []
+    alloc.swa_page_ids_group = []
+
+    mapping = torch.zeros(64, dtype=torch.int64)
+    # Peer pages for the rows under test; page 2 of the paged SWA pool.
+    mapping[0:page_size] = torch.arange(
+        2 * page_size, 3 * page_size, dtype=torch.int64
+    )
+    alloc.full_to_swa_index_mapping = mapping
+
+    alloc.swa_attn_allocator = _CountingPagedAllocator(size=page_size * POOL_PAGES)
+    alloc.full_attn_allocator = _CountingPagedAllocator(size=page_size * POOL_PAGES)
+    return alloc
+
+
+class TestSWARingPageReturn(CustomTestCase):
+    def test_group_drain_keeps_paged_credit_within_size_in_ring_mode(self):
+        """Pre-fix this over-credits and the production assert raises."""
+        alloc = _make_self(swa_req_ring=True)
+        alloc.swa_page_ids_group = [torch.arange(POOL_PAGES + 4, dtype=torch.int64)]
+
+        alloc.free_group_end()
+
+        self.assertEqual(alloc.swa_attn_allocator.available_size(), 0)
+        self.assertLessEqual(
+            alloc.swa_attn_allocator.available_size(),
+            alloc.swa_attn_allocator.size,
+        )
+        # Pile still drains, or it leaks into the next group.
+        self.assertEqual(alloc.swa_page_ids_group, [])
+
+    def test_group_drain_returns_pages_without_ring(self):
+        alloc = _make_self(swa_req_ring=False)
+        alloc.swa_page_ids_group = [torch.arange(2, dtype=torch.int64)]
+
+        alloc.free_group_end()
+
+        self.assertEqual(alloc.swa_attn_allocator.available_size(), 2 * PAGE_SIZE)
+        self.assertEqual(alloc.swa_page_ids_group, [])
+
+    def test_direct_free_keeps_paged_credit_at_zero_in_ring_mode(self):
+        alloc = _make_self(swa_req_ring=True)
+        free_index = torch.arange(0, PAGE_SIZE, dtype=torch.int64)
+
+        alloc._free_swa_pages(free_index, start_pos=0)
+
+        self.assertEqual(alloc.swa_attn_allocator.available_size(), 0)
+        # Nothing deferred either: the ring must not queue what it never returns.
+        self.assertEqual(alloc.swa_page_ids_group, [])
+
+    def test_direct_free_clears_mapping_in_ring_mode(self):
+        """Guards the early-return trap: skipping the clear leaves stale peers."""
+        alloc = _make_self(swa_req_ring=True)
+        free_index = torch.arange(0, PAGE_SIZE, dtype=torch.int64)
+        self.assertTrue(bool((alloc.full_to_swa_index_mapping[free_index] > 0).any()))
+
+        alloc._free_swa_pages(free_index, start_pos=0)
+
+        self.assertTrue(
+            bool((alloc.full_to_swa_index_mapping[free_index] == 0).all()),
+            "ring mode must still clear full_to_swa before returning",
+        )
+
+    def test_direct_free_returns_pages_without_ring(self):
+        alloc = _make_self(swa_req_ring=False)
+        free_index = torch.arange(0, PAGE_SIZE, dtype=torch.int64)
+
+        alloc._free_swa_pages(free_index, start_pos=0)
+
+        self.assertEqual(alloc.swa_attn_allocator.available_size(), PAGE_SIZE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--attention-backend dsv4` with `--page-size 256` crashes both TP ranks in the
warmup decode, immediately after the server reports it is ready:

```
File "python/sglang/srt/mem_cache/allocator/swa.py", line 559, in free_group_end
    assert self.swa_attn_allocator.available_size() <= self.swa_attn_allocator.size
AssertionError
```

Deterministic, 3/3 runs, both ranks identically. The HTTP layer binds and then
the scheduler dies underneath it, so the process exits via SIGQUIT rather than
failing at startup.

Under the per-request SWA ring, the paged `swa_attn_allocator` is vestigial:
`available_size()` returns the full-attn allocator's size and
`swa_available_size()` computes `req_slots * ring_cost`, so nothing consults the
paged allocator's internal counter. Ring slots are owned by the req slot for its
lifetime and recycled with it -- they are never lent out per free. Returning
pages to the paged allocator therefore credits capacity it never lent, its
`available_size()` climbs past `size`, and the assert at the end of
`free_group_end` fires.

The two halves reached `main` a day apart and each is correct alone:

- The `_free_swa_pages` -> `free_page_ids` path for `page_size > 1` (#38159).
- The per-request SWA ring, re-landed gated (#38192). The gating covers the
  allocation and translation paths (`_swa_req_ring` guards in `alloc_extend`,
  `alloc_decode`, `available_size`, `swa_available_size`) but not the two free
  sites.

Triggering it requires `page_size > 1` **and** the ring simultaneously, which is
exactly DSV4 on ROCm -- the backend forces `page_size` to 256 and the ring comes
from the model's `sliding_window`. No CI lane covers that intersection, and the
reland landed the day after the free path changed underneath it.

## Modifications

Skip the page return when the ring is active, at both free sites in
`SWATokenToKVPoolAllocator`:

- `_free_swa_pages`: return early in ring mode, **after**
  `clear_full_to_swa_mapping`. The mapping clear must still run -- skipping it
  leaves stale peer indices for `translate_loc_from_full_to_swa`, which would
  turn a clean crash into wrong KV reads.
- `free_group_end`: guard the grouped drain with `not self._swa_req_ring`. The
  list is still drained; only the page return is skipped.

`test/registered/unit/mem_cache/test_swa_ring_page_return.py` (`base-a-test-cpu`,
no GPU) covers both free paths in ring and non-ring mode. The two ring cases
fail on the pre-fix code with the same `swa.py` assert seen on the GPU and pass
on the fix; the non-ring cases guard against disabling the page return outright,
and one case pins the mapping clear that must still run in ring mode.

+7 -1 in `swa.py`, no API or behavior change off the ring path.

## Accuracy Tests

DeepSeek-V4-Flash, 2x MI45x (gfx1250), `--tp 2 --attention-backend dsv4
--page-size 256 --kv-cache-dtype fp8_e4m3`, ROCm 10.1.

Booting is not sufficient evidence here: the warmup request is 19 tokens and
never wraps the 256-token ring. Two checks that do exercise it, both against a
reference build that predates #38159/#38192 (`v0.5.19.dev20260906+g5bebe7a033`):

- 5 greedy prompts (`temperature=0`), including two of 614 and 620 tokens that
  force the ring to wrap: `output_ids` **bit-identical** to the reference on all
  5. Greedy decoding is deterministic, so this is an exact-match oracle on the
  KV path, not a smoke test.
- 32 concurrent 600+-token requests, exercising ring-slot recycling across the
  256 slots: 32/32 correct answers, zero asserts or exceptions in the log.

End-to-end on the fixed build, GSM8K full set (1319 questions, 5-shot,
`temperature=0`, `--parallel 128`):

```
Accuracy:          0.936
Invalid:           0.000
Latency:           447.437 s
Output throughput: 265.407 token/s
```

Unit coverage reproduces the failure without hardware: the two ring-mode cases
in `test_swa_ring_page_return.py` fail on the pre-fix code at the same
`swa.py:559` assert seen on the GPU, and pass on the fix (5 passed, 7 s, CPU).

Without the fix the same config cannot serve a single request.

## Speed Tests and Profiling

No performance work; the change removes calls on the ring path and touches
nothing else. Worth noting the fix restores the intended sizing rather than
degrading it -- `max_total_num_tokens` is 44,482,560 on the fixed build vs
28,960,000 on the pre-#38192 build used as the accuracy reference (+54%), since
falling back to that build also gives up the unified-KV pool sizing.

Serving throughput on the fixed build, from the GSM8K run above: 265.407 token/s
output at `--parallel 128`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @hnyls2002 @ispobock @alphabetc1 (allocator CODEOWNERS), @yuttian1 (#38192)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34306364007](https://github.com/sgl-project/sglang/actions/runs/34306364007)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34306363799](https://github.com/sgl-project/sglang/actions/runs/34306363799)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34306363963](https://github.com/sgl-project/sglang/actions/runs/34306363963)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->