### PR TITLE
[AMD] Restore AITER verify runtime sizing reverted by #34647

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1525,8 +1525,8 @@ class AiterAttnBackend(AttentionBackend):
                     run_graph=False,
                 )
             else:
+                draft_num = forward_batch.input_ids.shape[0] // bs
                 bs = len(forward_batch.req_pool_indices)
-                draft_num = spec_info.draft_token_num
 
                 if self._use_unified_verify:
                     page_table, qo_indptr, max_q_len, swa_page_table = (
@@ -2770,7 +2770,9 @@ class AiterAttnBackend(AttentionBackend):
                         v=v_unified,
                         out=o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
                         cu_seqlens_q=self.forward_metadata.qo_indptr,
-                        seqused_k=forward_batch.seq_lens + self.num_draft_tokens,
+                        seqused_k=(
+                            forward_batch.seq_lens + self.forward_metadata.max_q_len
+                        ),
                         max_seqlen_q=self.forward_metadata.max_q_len,
                         max_seqlen_k=max_kv_len,
                         softmax_scale=layer.scaling,


### PR DESCRIPTION
Restores the two #31221 hunks that #34647 accidentally reverted:

- non-MLA eager verify: size `draft_num` from the runtime input width (`input_ids.shape[0] // bs`) instead of the fixed `spec_info.draft_token_num`
- unified verify launch: size `seqused_k` from the per-batch metadata width (`forward_metadata.max_q_len`) instead of the fixed `num_draft_tokens`

#31221 (merged Aug 1) derived AITER SBD verify widths from the runtime input. #34647 (merged Sep 1, an MLA Gluon decode feature developed on a ~3-week-old branch) restored the old fixed expressions verbatim in these two hunks, reintroducing the SBD verify-width regression for non-MLA speculative decoding. The CUDA-graph half of #31221 (`verify_tokens_per_req`) was unaffected and is untouched here; MLA keeps its fixed draft length as in #31221.

## Test plan

- Restored hunks are byte-identical to #31221's merged hunks (verified by diff).
- `python -m py_compile` passes on the touched file.
- Verified downstream, where the equivalent SBD width tests pass with these hunks applied.

## Original commits

- `1700461552`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34329772918](https://github.com/sgl-project/sglang/actions/runs/34329772918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34329772599](https://github.com/sgl-project/sglang/actions/runs/34329772599)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34329772797](https://github.com/sgl-project/sglang/actions/runs/34329772797)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->