### PR TITLE
[AMD] Restore AMD CI registrations dropped by #37436

### DIFF
--- a/test/registered/debug_utils/test_tensor_dump_forward_hook.py
+++ b/test/registered/debug_utils/test_tensor_dump_forward_hook.py
@@ -14,11 +14,12 @@ from sglang.srt.layers.linear import LinearBase
 from sglang.srt.models.qwen2 import Qwen2MLP
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils import add_prefix, get_device
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.layer_ut_utils import init_single_process_dist
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=15, suite="stage-b-test-1-gpu-small-amd")
 
 TEST_HIDDEN_SIZE = 32
 

--- a/test/registered/debug_utils/test_tensor_dump_forward_hook.py
+++ b/test/registered/debug_utils/test_tensor_dump_forward_hook.py
@@ -19,6 +19,8 @@ from sglang.test.layer_ut_utils import init_single_process_dist
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, stage="base-b", runner_config="1-gpu-small")
+# Backend-specific: the hook resolves get_device() and the matching distributed
+# backend, so only an AMD run exercises the HIP device and dump path.
 register_amd_ci(est_time=15, suite="stage-b-test-1-gpu-small-amd")
 
 TEST_HIDDEN_SIZE = 32

--- a/test/registered/observability/test_tracing.py
+++ b/test/registered/observability/test_tracing.py
@@ -34,7 +34,7 @@ from sglang.srt.observability.trace import (
 )
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.network import get_zmq_socket
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 
 # CI registration
 register_cuda_ci(est_time=113, stage="extra-a", runner_config="1-gpu-small")
+register_amd_ci(est_time=113, suite="stage-b-test-1-gpu-small-amd")
 
 
 # ============================================================================

--- a/test/registered/observability/test_tracing.py
+++ b/test/registered/observability/test_tracing.py
@@ -47,6 +47,9 @@ logger = logging.getLogger(__name__)
 
 # CI registration
 register_cuda_ci(est_time=113, stage="extra-a", runner_config="1-gpu-small")
+# Backend-specific: the span assertions require PREFILL_FORWARD/DECODE_FORWARD
+# to be emitted from the scheduler forward path, which ROCm reaches through its
+# own attention backend and graph replay.
 register_amd_ci(est_time=113, suite="stage-b-test-1-gpu-small-amd")
 
 

--- a/test/registered/openai_server/function_call/test_anthropic_tool_use.py
+++ b/test/registered/openai_server/function_call/test_anthropic_tool_use.py
@@ -30,6 +30,8 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=50, stage="base-b", runner_config="1-gpu-large")
+# Backend-specific: streaming tool-argument assembly is rebuilt from
+# incremental decode output, so ROCm chunk-boundary divergence surfaces here.
 register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=54, suite="stage-b-test-cpu-intel")
 

--- a/test/registered/openai_server/function_call/test_anthropic_tool_use.py
+++ b/test/registered/openai_server/function_call/test_anthropic_tool_use.py
@@ -17,6 +17,7 @@ import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import (
+    register_amd_ci,
     register_cpu_ci,
     register_cuda_ci,
 )
@@ -29,6 +30,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=50, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=140, suite="stage-b-test-1-gpu-small-amd")
 register_cpu_ci(est_time=54, suite="stage-b-test-cpu-intel")
 
 # System message to guide Llama3.2 to produce proper tool call format

--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -5,7 +5,11 @@ import openai
 
 from sglang.srt.utils import is_npu, kill_process_tree
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-from sglang.test.ci.ci_register import register_cuda_ci, register_npu_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_npu_ci,
+)
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -16,6 +20,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=100, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=73, suite="stage-b-test-1-gpu-small-amd")
 # Backend-specific: Ascend uses a local model mirror and its native
 # attention backend, while sharing the protocol assertions below.
 register_npu_ci(est_time=400, suite="full-1-npu-a3", nightly=True)

--- a/test/registered/openai_server/function_call/test_openai_function_calling.py
+++ b/test/registered/openai_server/function_call/test_openai_function_calling.py
@@ -20,6 +20,8 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=100, stage="base-b", runner_config="1-gpu-large")
+# Backend-specific: the llama3 and pythonic parsers run on real decoded text,
+# so ROCm decode divergence surfaces as tool calls that no longer parse.
 register_amd_ci(est_time=73, suite="stage-b-test-1-gpu-small-amd")
 # Backend-specific: Ascend uses a local model mirror and its native
 # attention backend, while sharing the protocol assertions below.

--- a/test/registered/reasoning/test_reasoning.py
+++ b/test/registered/reasoning/test_reasoning.py
@@ -4,7 +4,7 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.reasoning_kit import (
     ReasoningTokenUsageMixin,
     SeparateReasoningMixin,
@@ -18,6 +18,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=129, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=200, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestEnableThinking(

--- a/test/registered/reasoning/test_reasoning.py
+++ b/test/registered/reasoning/test_reasoning.py
@@ -18,6 +18,9 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=129, stage="base-b", runner_config="1-gpu-large")
+# Backend-specific: the thinking-token and separate-reasoning assertions read
+# decoded output from a 30B MoE, so a ROCm fused-MoE or sampling regression
+# shows up here as malformed reasoning_content that CUDA cannot catch.
 register_amd_ci(est_time=200, suite="stage-b-test-1-gpu-small-amd")
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

[#37436](https://github.com/sgl-project/sglang/pull/37436) stripped `register_amd_ci` from API/control-plane tests that NVIDIA still gates every PR. Those files accounted for most of the 2026-09-07 coverage drop (94.9% → 92.8%).

This restores AMD on the four high-signal files from that drop, plus the tensor-dump hook that #37436 re-enabled on CUDA only. HTTP/2, request-length/stop validation, engine child PIDs, request-queue validation, and priority metrics stay CUDA/CPU-only — those are backend-agnostic control-plane checks.

## Modifications

Re-add enabled `register_amd_ci(..., suite="stage-b-test-1-gpu-small-amd")` on:

| File | ROCm path only an AMD run covers | `est_time` |
|---|---|---:|
| `openai_server/function_call/test_openai_function_calling.py` | `llama3` and `pythonic` parsers run on real decoded text, so ROCm decode divergence surfaces as tool calls that no longer parse; NPU nightly registration was kept in #37436 | 73s |
| `openai_server/function_call/test_anthropic_tool_use.py` | Streaming tool-argument assembly is rebuilt from incremental decode output, so ROCm chunk-boundary divergence surfaces here | 140s |
| `reasoning/test_reasoning.py` | Thinking-token and separate-reasoning assertions read decoded output from a 30B MoE (`Qwen3-30B-A3B`), so a ROCm fused-MoE or sampling regression shows up as malformed `reasoning_content` | 200s |
| `debug_utils/test_tensor_dump_forward_hook.py` | Hook resolves `get_device()` and the matching distributed backend, so only AMD exercises the HIP device and dump path; CUDA was re-enabled in #37436 | 15s |
| `observability/test_tracing.py` | Span assertions require `PREFILL_FORWARD`/`DECODE_FORWARD` to be emitted from the scheduler forward path, which ROCm reaches through its own attention backend and graph replay; CUDA stays `extra-a` | 113s |

Per the admission ratchet that #37436 added to `test/README.md` — a file registered on CUDA plus another accelerator must carry a nearby `backend-specific:` comment naming the path or failure mode only that backend can catch — each restored registration now has that rationale in source. All five are far under the 1,200 weighted accelerator-second default-lane cap, so no `ci-cost-override:` is needed. `scripts/lint/check_registered_tests.py` passes.

Not restored (intentionally CUDA/CPU-only): HTTP/2 server, large-max-new-tokens / matched-stop / request-length validation, engine child PIDs, request-queue validation, priority metrics. The grok aggregate stub deleted in #37436 is also left out — MI30x grok evals already live in the split nightly files.

### Coverage effect

Against the [AMD coverage dashboard](https://rocm.github.io/sglang-ci/coverage/) snapshot of 2026-09-10 06:35 UTC, where all five files appear on the `NVIDIA Tests Not Run on AMD` list with one registration each (four `core`, one `extra`, all per-commit):

| Metric | Now | With this PR |
|---|---:|---:|
| Headline (AMD enabled ÷ NVIDIA-comparable enabled) | 91.3% (639 / 700) | **92.0%** (644 / 700) |
| PR % (AMD per-commit ÷ NVIDIA per-commit) | 75.3% (497 / 660) | **76.1%** (502 / 660) |
| Gap files / registrations | 247 / 258 | **242 / 253** |
| `core` tier coverage | 113.7% (316 / 278) | **115.1%** (320 / 278) |
| `extra` tier coverage | 55.3% (42 / 76) | **56.6%** (43 / 76) |

PR % is the number worth reading here. The dashboard notes that the headline is carried up by AMD's much larger nightly surface (Nightly % is 142/40, over 100%), while PR % is what a pull request actually gates on. These five restorations land entirely in the per-commit lane, so they move both.

Runner cost is about **9 min** added to `stage-b-test-1-gpu-small-amd` (serial `est_time`; the suite is partitioned 14 ways, so wall-clock impact is roughly one partition-slot).

For context on why this is worth doing now rather than later: the gap has grown from 222 files on 2026-09-06 to 247 on 2026-09-10 because NVIDIA registrations are being added at roughly two per day while `amd_enabled` has been flat (645 → 639). Headline coverage slid 94.9% → 91.3% over those four days without a single AMD registration being removed after #37436.

## Accuracy Tests

N/A — CI registration only; no model/kernel code changes.

## Speed Tests and Profiling

N/A

## Manual AMD CI

Dispatched `pr-test-amd-rocm720.yml` on `8295c54` because the PR was draft when first opened (pull_request AMD gate skipped). **All five restored files passed on ROCm 10 and ROCm 7.2.** Workflow-level `failure` is from pre-existing suite tests (`test_deterministic.py`, LoRA ROUGE, HIPBLAS MoE, DSV4/MI35x/8-gpu), not this PR.

| File | Part | ROCm 10 | ROCm 7.2 |
|---|---|---|---|
| `test_anthropic_tool_use.py` | 5 | [passed](https://github.com/sgl-project/sglang/actions/runs/34294614934/job/102288500507) 108s | [passed](https://github.com/sgl-project/sglang/actions/runs/34294617039/job/102288522671) 113s |
| `test_reasoning.py` | 9 | [passed](https://github.com/sgl-project/sglang/actions/runs/34294614934/job/102288500638) 301s | [passed](https://github.com/sgl-project/sglang/actions/runs/34294617039/job/102288522758) 232s |
| `test_tensor_dump_forward_hook.py` | 9 | passed 15s (same jobs) | passed 14s |
| `test_tracing.py` | 12 | [passed](https://github.com/sgl-project/sglang/actions/runs/34294614934/job/102288500590) 232s | [passed](https://github.com/sgl-project/sglang/actions/runs/34294617039/job/102288522776) 210s |
| `test_openai_function_calling.py` | 11 | [passed](https://github.com/sgl-project/sglang/actions/runs/34324559624/job/102378839412) 149s | [passed](https://github.com/sgl-project/sglang/actions/runs/34324562121/job/102378839935) 143s |

Runs:

- Full suite, ROCm 10: https://github.com/sgl-project/sglang/actions/runs/34294614934
- Full suite, ROCm 7.2: https://github.com/sgl-project/sglang/actions/runs/34294617039
- Targeted `stage-b-test-1-gpu-small-amd` + `continue_on_error` (needed so part 11 did not fail-fast on `test_deterministic.py` before the OpenAI function-calling file): [ROCm 10](https://github.com/sgl-project/sglang/actions/runs/34324559624), [ROCm 7.2](https://github.com/sgl-project/sglang/actions/runs/34324562121)

`e7d4073` only adds the `backend-specific:` comments above the registrations, so the AMD results above still apply.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e985d98-e0c7-4961-92fa-d4c49a53cf15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e985d98-e0c7-4961-92fa-d4c49a53cf15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34421363232](https://github.com/sgl-project/sglang/actions/runs/34421363232)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34421363043](https://github.com/sgl-project/sglang/actions/runs/34421363043)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34421363223](https://github.com/sgl-project/sglang/actions/runs/34421363223)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->