### PR TITLE
[AMD] [Docker] Fix ROCm 7.0 nightly TileLang build flake on apt.llvm.org

### DIFF
--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -1,12 +1,6 @@
 name: Release Docker Images Nightly ROCm7.0 (AMD)
 on:
   workflow_dispatch:
-    inputs:
-      skip_push:
-        description: 'Build images but do not push to Docker Hub (PR / debug)'
-        required: false
-        type: boolean
-        default: false
   schedule:
     - cron: '0 12 * * *'
 
@@ -94,24 +88,18 @@ jobs:
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
           docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.skip_push }}" = "true" ]; then
-            echo "skip_push=true: built rocm/sgl-dev:${tag}-${{ env.DATE }} but not pushing"
-          else
-            docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
-          fi
+          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local
       # registry mirror can run even if a later step in this job (lmsys push)
       # fails. By default this step only runs when the previous step succeeded,
       # so the artifact only exists when an image actually landed on Docker Hub.
       - name: Save published image tag
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         run: |
           mkdir -p image-tag
           echo "${{ env.IMAGE_TAG }}" > "image-tag/${{ matrix.gpu_arch }}.txt"
 
       - name: Upload image tag artifact
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         uses: actions/upload-artifact@v4
         with:
           name: image-tag-${{ matrix.gpu_arch }}
@@ -119,14 +107,12 @@ jobs:
           retention-days: 1
 
       - name: Login to Docker Hub (lmsys)
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to lmsysorg/sglang-rocm
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         run: |
           docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
           docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}

--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -1,6 +1,12 @@
 name: Release Docker Images Nightly ROCm7.0 (AMD)
 on:
   workflow_dispatch:
+    inputs:
+      skip_push:
+        description: 'Build images but do not push to Docker Hub (PR / debug)'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '0 12 * * *'
 
@@ -88,18 +94,24 @@ jobs:
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
           docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
-          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.skip_push }}" = "true" ]; then
+            echo "skip_push=true: built rocm/sgl-dev:${tag}-${{ env.DATE }} but not pushing"
+          else
+            docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
+          fi
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local
       # registry mirror can run even if a later step in this job (lmsys push)
       # fails. By default this step only runs when the previous step succeeded,
       # so the artifact only exists when an image actually landed on Docker Hub.
       - name: Save published image tag
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         run: |
           mkdir -p image-tag
           echo "${{ env.IMAGE_TAG }}" > "image-tag/${{ matrix.gpu_arch }}.txt"
 
       - name: Upload image tag artifact
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         uses: actions/upload-artifact@v4
         with:
           name: image-tag-${{ matrix.gpu_arch }}
@@ -107,12 +119,14 @@ jobs:
           retention-days: 1
 
       - name: Login to Docker Hub (lmsys)
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to lmsysorg/sglang-rocm
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_push != true }}
         run: |
           docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
           docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -816,21 +816,55 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   "$VENV_PIP" install --upgrade "setuptools>=77.0.3,<80" wheel "cmake==4.3.4" ninja scikit-build-core && \
   "$VENV_PIP" cache purge || true; \
   \
-  # Locate ROCm llvm-config; fallback to installing LLVM 18 if missing
+  # Locate ROCm llvm-config. The ROCm 7.0 vLLM base (rocm/sgl-dev:rocm7-vllm-20250904)
+  # puts /opt/rocm/llvm/bin on PATH but ships no llvm-config; newer ROCm layouts
+  # keep it under lib/llvm. Search both before installing a fallback.
+  # Do NOT fall back to apt.llvm.org first: amd-docker-scale runners often cannot
+  # reach it (curl: (7) Couldn't connect to server), which flakes the gfx942/gfx950
+  # ROCm 7.0 nightly. Distro LLVM is already reachable via the Ubuntu HTTPS mirror.
+  # TVM requires LLVM >= 15; jammy has llvm-15, noble has llvm-18. Do not install
+  # unversioned llvm-dev (it ships llvm-config-14/16 and can shadow ROCm's).
   LLVM_CONFIG_PATH=""; \
-  for p in /opt/rocm/llvm/bin/llvm-config /opt/rocm/llvm-*/bin/llvm-config /opt/rocm-*/llvm*/bin/llvm-config; do \
+  for p in \
+      /opt/rocm/llvm/bin/llvm-config \
+      /opt/rocm/lib/llvm/bin/llvm-config \
+      /opt/rocm/llvm-*/bin/llvm-config \
+      /opt/rocm-*/llvm/bin/llvm-config \
+      /opt/rocm-*/lib/llvm/bin/llvm-config \
+      /opt/rocm-*/llvm*/bin/llvm-config; do \
     if [ -x "$p" ]; then LLVM_CONFIG_PATH="$p"; break; fi; \
   done; \
   if [ -z "$LLVM_CONFIG_PATH" ]; then \
-    echo "[TileLang] ROCm llvm-config not found; installing LLVM 18..."; \
-    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm.list; \
+    LLVM_CONFIG_PATH="$(find /opt/rocm /opt/rocm-* -path "*/bin/llvm-config" \( -type f -o -type l \) -print -quit 2>/dev/null || true)"; \
+  fi; \
+  if [ -z "$LLVM_CONFIG_PATH" ]; then \
+    echo "[TileLang] ROCm llvm-config not found; installing distro LLVM"; \
+    . /etc/os-release; \
+    apt-get update; \
+    case "${VERSION_CODENAME}" in \
+      noble|oracular|plucky) \
+        apt-get install -y --no-install-recommends llvm-18 || true; \
+        LLVM_CONFIG_PATH="$(command -v llvm-config-18 || true)"; \
+        ;; \
+      *) \
+        apt-get install -y --no-install-recommends llvm-15 llvm-15-tools || true; \
+        LLVM_CONFIG_PATH="$(command -v llvm-config-15 || true)"; \
+        ;; \
+    esac; \
+    rm -rf /var/lib/apt/lists/*; \
+  fi; \
+  if [ -z "$LLVM_CONFIG_PATH" ]; then \
+    echo "[TileLang] Distro LLVM unavailable; last-resort apt.llvm.org LLVM 18"; \
+    mkdir -p /etc/apt/keyrings; \
+    . /etc/os-release; \
+    curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors --connect-timeout 20 https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-18 main" > /etc/apt/sources.list.d/llvm.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends llvm-18; \
     rm -rf /var/lib/apt/lists/*; \
-    LLVM_CONFIG_PATH="$(command -v llvm-config-18)"; \
-    if [ -z "$LLVM_CONFIG_PATH" ]; then echo "ERROR: llvm-config-18 not found after install"; exit 1; fi; \
+    LLVM_CONFIG_PATH="$(command -v llvm-config-18 || true)"; \
   fi; \
+  if [ -z "$LLVM_CONFIG_PATH" ]; then echo "ERROR: llvm-config not found after install"; exit 1; fi; \
   echo "[TileLang] Using LLVM_CONFIG at: $LLVM_CONFIG_PATH"; \
   export PATH="$(dirname "$LLVM_CONFIG_PATH"):/usr/local/bin:${PATH}"; \
   export LLVM_CONFIG="$LLVM_CONFIG_PATH"; \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -816,14 +816,12 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   "$VENV_PIP" install --upgrade "setuptools>=77.0.3,<80" wheel "cmake==4.3.4" ninja scikit-build-core && \
   "$VENV_PIP" cache purge || true; \
   \
-  # Locate ROCm llvm-config. The ROCm 7.0 vLLM base (rocm/sgl-dev:rocm7-vllm-20250904)
-  # puts /opt/rocm/llvm/bin on PATH but ships no llvm-config; newer ROCm layouts
-  # keep it under lib/llvm. Search both before installing a fallback.
-  # Do NOT fall back to apt.llvm.org first: amd-docker-scale runners often cannot
-  # reach it (curl: (7) Couldn't connect to server), which flakes the gfx942/gfx950
-  # ROCm 7.0 nightly. Distro LLVM is already reachable via the Ubuntu HTTPS mirror.
-  # TVM requires LLVM >= 15; jammy has llvm-15, noble has llvm-18. Do not install
-  # unversioned llvm-dev (it ships llvm-config-14/16 and can shadow ROCm's).
+  # Locate ROCm llvm-config. Search the classic /opt/rocm/llvm layout and the
+  # newer lib/llvm layout (ROCm 10). The ROCm 7.0 vLLM base ships
+  # /opt/rocm/llvm/bin on PATH but no llvm-config; amd-docker-scale cannot
+  # reliably reach apt.llvm.org, so that flavor installs Ubuntu llvm-15
+  # (TVM requires >= 15). Other GPU_ARCH values keep the historical
+  # apt.llvm.org llvm-18 fallback. Do not install unversioned llvm-dev.
   LLVM_CONFIG_PATH=""; \
   for p in \
       /opt/rocm/llvm/bin/llvm-config \
@@ -837,28 +835,22 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   if [ -z "$LLVM_CONFIG_PATH" ]; then \
     LLVM_CONFIG_PATH="$(find /opt/rocm /opt/rocm-* -path "*/bin/llvm-config" \( -type f -o -type l \) -print -quit 2>/dev/null || true)"; \
   fi; \
-  if [ -z "$LLVM_CONFIG_PATH" ]; then \
-    echo "[TileLang] ROCm llvm-config not found; installing distro LLVM"; \
-    . /etc/os-release; \
+  # Ubuntu llvm-15 only for unsuffixed GPU_ARCH (ROCm 7.0 gfx942/gfx950).
+  # gfx942-rocm720 / *-rocm724 / *-rocm1000 already build TileLang against
+  # llvm-18 from apt.llvm.org (7.2) or ROCm's own llvm-config (10); do not
+  # switch those flavors to jammy llvm-15.
+  if [ -z "$LLVM_CONFIG_PATH" ] && { [ "$GPU_ARCH" = "gfx942" ] || [ "$GPU_ARCH" = "gfx950" ]; }; then \
+    echo "[TileLang] ROCm 7.0 llvm-config missing; installing Ubuntu llvm-15"; \
     apt-get update; \
-    case "${VERSION_CODENAME}" in \
-      noble|oracular|plucky) \
-        apt-get install -y --no-install-recommends llvm-18 || true; \
-        LLVM_CONFIG_PATH="$(command -v llvm-config-18 || true)"; \
-        ;; \
-      *) \
-        apt-get install -y --no-install-recommends llvm-15 llvm-15-tools || true; \
-        LLVM_CONFIG_PATH="$(command -v llvm-config-15 || true)"; \
-        ;; \
-    esac; \
+    apt-get install -y --no-install-recommends llvm-15 llvm-15-tools || true; \
     rm -rf /var/lib/apt/lists/*; \
+    LLVM_CONFIG_PATH="$(command -v llvm-config-15 || true)"; \
   fi; \
   if [ -z "$LLVM_CONFIG_PATH" ]; then \
-    echo "[TileLang] Distro LLVM unavailable; last-resort apt.llvm.org LLVM 18"; \
+    echo "[TileLang] ROCm llvm-config not found; installing LLVM 18 from apt.llvm.org"; \
     mkdir -p /etc/apt/keyrings; \
-    . /etc/os-release; \
     curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors --connect-timeout 20 https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-18 main" > /etc/apt/sources.list.d/llvm.list; \
+    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" > /etc/apt/sources.list.d/llvm.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends llvm-18; \
     rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

The scheduled **Release Docker Images Nightly ROCm7.0 (AMD)** job failed on 2026-09-08:

https://github.com/sgl-project/sglang/actions/runs/34225926540/job/102059916867

`publish (gfx950, all)` died in TileLang because the ROCm 7.0 vLLM base has no `llvm-config` and the fallback (`apt.llvm.org` LLVM 18) is unreachable from `amd-docker-scale` (`curl: (7) Couldn't connect to server`).

This is a network flake, not a gfx950-only code regression: gfx942 on the same run reached apt.llvm.org and passed.

## Modifications

`docker/rocm.Dockerfile` only:

- Search the newer `/opt/rocm/lib/llvm` layout as well as `/opt/rocm/llvm`.
- For unsuffixed `GPU_ARCH` (`gfx942` / `gfx950`, ROCm 7.0), install Ubuntu **llvm-15** when ROCm's `llvm-config` is missing (TVM requires LLVM >= 15).
- Leave ROCm 7.2 / 10 on their current path: 7.2 still uses apt.llvm.org llvm-18; 10 still uses `/opt/rocm/llvm/bin/llvm-config`.

## Accuracy Tests

N/A — Docker packaging only.

## Verification

Full ROCm 7.0 image build on this branch (no Hub push):
https://github.com/sgl-project/sglang/actions/runs/34304243566

Both `gfx942` and `gfx950` succeeded with `LLVM_CONFIG=/usr/bin/llvm-config-15`, TileLang installed, and zero `apt.llvm.org` fetches.

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c032f8b-983b-4e8c-a46b-93722af40a1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c032f8b-983b-4e8c-a46b-93722af40a1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34324068440](https://github.com/sgl-project/sglang/actions/runs/34324068440)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34324068024](https://github.com/sgl-project/sglang/actions/runs/34324068024)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34324068160](https://github.com/sgl-project/sglang/actions/runs/34324068160)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->