### PR TITLE
Cast fp32 routing weights to bf16 in the Kimi-K3 fused finalize

### DIFF
--- a/python/sglang/srt/layers/k3_ar_fusion.py
+++ b/python/sglang/srt/layers/k3_ar_fusion.py
@@ -371,6 +371,8 @@ def finalize_all_reduce_push_norm(
 
     state = _get_state()
     assert state is not None
+    if expert_weights.dtype != torch.bfloat16:
+        expert_weights = expert_weights.to(torch.bfloat16)
     return mod.finalize_all_reduce_push_norm(
         state.world_size,
         out,


### PR DESCRIPTION
## Motivation

`base-c-test-8-gpu-b300` fails since #33631: `test_kimi_k3_b300.py` aborts during decode CUDA graph capture with `Dtype value [float32] not in the allowed options: [bfloat16]` at `kimi_k3/comm/ar_fusion.cuh` (not OOM, despite what the exception suggests). #33631 forwards the router's fp32 `topk_weights` unpacked; Kimi-K3's fused finalize still declares them bf16.

failure link: https://github.com/sgl-project/sglang/actions/runs/34289320660/job/102278183152

## Modifications

Cast `expert_weights` to bf16 in `finalize_all_reduce_push_norm`. A cast rather than a `view()` reinterpret, since these are real fp32 values. Other paths keep the fp32 accuracy fix from #33631.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34297434160](https://github.com/sgl-project/sglang/actions/runs/34297434160)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34297433754](https://github.com/sgl-project/sglang/actions/runs/34297433754)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34297434037](https://github.com/sgl-project/sglang/actions/runs/34297434037)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->