### PR TITLE
[Attention] Size FlashInfer MLA indptr buffers to the padded max batch

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -46,6 +46,7 @@ from sglang.srt.speculative.spec_utils import (
     generate_draft_decode_kv_indices,
 )
 from sglang.srt.utils import (
+    get_cuda_graph_max_batch_size,
     is_flashinfer_available,
     next_power_of_2,
 )
@@ -209,8 +210,9 @@ class FlashInferMhaChunkKVRunner:
 class FlashInferMLAAttnBackend(AttentionBackend):
     """Flashinfer attention kernels."""
 
-    # kv_indptr/qo_indptr are preallocated at (req pool + 1); an extend batch
-    # can never carry more seqs than the pool.
+    # kv_indptr/qo_indptr are preallocated at (padded max bs + 1), where the
+    # padding only covers MLP-sync alignment; an extend batch can never carry
+    # more seqs than the req pool.
     extend_dummy_seqs_capped_by_req_pool: bool = True
 
     # Verify metadata is ragged-layout aware via generate_attn_arg_prefill;
@@ -254,7 +256,10 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             ),
         )
 
-        max_bs = model_runner.req_to_token_pool.size
+        # The eager / cuda-graph runners pad the request count to the
+        # attn-tp (and cp) alignment under MLP sync (DP attention, DeepEP,
+        # MegaMoE), so the dummy batch can exceed req_to_token_pool.size.
+        max_bs = get_cuda_graph_max_batch_size(model_runner.req_to_token_pool.size)
         if kv_indptr_buf is None:
             self.kv_indptr = torch.zeros(
                 (max_bs + 1,), dtype=torch.int32, device=model_runner.device
@@ -1175,7 +1180,10 @@ class FlashInferMLAMultiStepDraftBackend:
         self.speculative_num_steps = speculative_num_steps
         self.generate_draft_decode_kv_indices = generate_draft_decode_kv_indices
 
-        max_bs = model_runner.req_to_token_pool.size * self.topk
+        max_bs = (
+            get_cuda_graph_max_batch_size(model_runner.req_to_token_pool.size)
+            * self.topk
+        )
         self.kv_indptr = torch.zeros(
             (
                 self.speculative_num_steps,


### PR DESCRIPTION
## Motivation

Under MLP sync (DP attention, DeepEP, or `--moe-a2a-backend megamoe`) the eager and cuda-graph runners pad the request count to the attn-tp alignment (`get_eager_max_batch_size` / `get_cuda_graph_max_batch_size`), so the warm-up dummy batch and the largest captured decode batch can be wider than `req_to_token_pool.size`.

`FlashInferMLAAttnBackend` sized `kv_indptr`, `qo_indptr` and `q_indptr_decode` to the raw pool size (and the cuda-graph buffers are clones of those), so the server died at startup:

```
File ".../flashinfer_mla_backend.py", line 889, in call_begin_forward
    kv_indptr[1 : bs + 1] = torch.cumsum(paged_kernel_lens, dim=0)
RuntimeError: The expanded size of the tensor (14) must match the existing size (16) at non-singleton dimension 0.  Target sizes: [14].  Tensor sizes: [16]
```

Hit with Kimi-K3 TP8 + `--moe-a2a-backend megamoe` on the flashinfer MLA backend (the mamba state cache capped `max_running_requests` to 14, attn_tp=8 padded the batch to 16). Any MLA model on the flashinfer backend with an MLP-sync feature and a request cap that is not a multiple of attn_tp reproduces it, e.g. `--tp 4 --enable-dp-attention --dp 2 --attention-backend flashinfer --max-running-requests 3` (per-rank pool 1, padded batch 2). The non-MLA `flashinfer_backend.py` already sizes these buffers with `get_cuda_graph_max_batch_size`; the MLA backend was the only one left on the raw pool size.

## Modifications

- `flashinfer_mla_backend.py`: size `kv_indptr` / `qo_indptr` / `q_indptr_decode` (and the multi-step draft backend's buffers) to `get_cuda_graph_max_batch_size(req_to_token_pool.size)`, matching the non-MLA flashinfer backend.

## Accuracy Tests

No numerics change; the buffers are only allocated larger. Generations were identical before and after the fix in a Kimi-K3 TP8 megamoe run on the flashinfer and trtllm_mla backends.

Manual reproduction with DeepSeek-Coder-V2-Lite-Instruct, `--tp 4 --enable-dp-attention --dp 2 --attention-backend flashinfer --flashinfer-mla-disable-ragged --max-running-requests 3`:
- without the fix: startup crash, `The expanded size of the tensor (1) must match the existing size (2)`
- with the fix: server starts and serves requests at the request cap

(`--flashinfer-mla-disable-ragged` is there because the ragged prefill wrapper rejects the DP-padded q rows, `q.shape[0] (2) does not match qo_indptr[-1] (1)`, which is a separate pre-existing issue not addressed here.)

No new CI test: the combination needs 4 GPUs with DP attention to trigger, and the fix is a one-time alignment with the non-MLA backend rather than a path that is likely to regress.

## Speed Tests and Profiling

Not applicable (startup-time buffer sizing only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34318915899](https://github.com/sgl-project/sglang/actions/runs/34318915899)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34318915607](https://github.com/sgl-project/sglang/actions/runs/34318915607)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34318915886](https://github.com/sgl-project/sglang/actions/runs/34318915886)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->