### PR TITLE
[Diffusion] Enable lossless BCG for FLUX.1-dev

### DIFF
--- a/docs/cookbook/diffusion/FLUX/FLUX.mdx
+++ b/docs/cookbook/diffusion/FLUX/FLUX.mdx
@@ -49,6 +49,31 @@ See [Performance Optimization](/docs/sglang-diffusion/performance-optimization) 
 - `--ulysses-degree`: The degree of DeepSpeed-Ulysses-style SP in USP
 - `--ring-degree`: The degree of ring attention-style SP in USP
 
+### 3.3 Breakable CUDA graph for FLUX.1-dev
+
+For repeated `quality=lossless` requests, FLUX.1-dev supports breakable CUDA graph (BCG) execution with the native backend. BCG captures DiT segments during startup and replays them for the warmed resolutions. It can reduce recurring host launch overhead without enabling `torch.compile`.
+
+The following configuration was validated on two NVIDIA H200 GPUs with BF16 weights, PyTorch 2.13, and CUDA 13.0. Set `HF_TOKEN` to a Hugging Face token with access to the checkpoint before downloading it.
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 sglang generate \
+  --model-path black-forest-labs/FLUX.1-dev \
+  --backend sglang \
+  --num-gpus 2 --tp-size 2 \
+  --component-residency dit=resident \
+  --enable-torch-compile false \
+  --enable-breakable-cuda-graph \
+  --warmup-resolutions 1024x1024 \
+  --quality lossless \
+  --width 1024 --height 1024 \
+  --num-inference-steps 50 --guidance-scale 3.5 --seed 42 \
+  --prompt "A futuristic cyberpunk city at night, neon lights reflecting on wet streets"
+```
+
+Confirm `[Diffusion BCG] captured` in the log, then compare warmed request latency with eager execution on the same GPUs. Capture time and graph memory are additional startup costs. Add other served resolutions to `--warmup-resolutions`; a request with an uncaptured signature falls back to eager.
+
+FLUX.1-dev uses a fixed 512-token T5 conditioning sequence, so changing `--bcg-text-buckets` does not create additional prompt-length graphs. Its request-gated DiT fusions at `quality=high` and `extra-high` cannot be combined with BCG: the runtime rejects those requests because the captured graph uses the lossless branches. FLUX.2 and quantized transformer overrides require separate validation.
+
 ## 4. API Usage
 
 For complete API documentation, please refer to the [official API usage guide](/docs/sglang-diffusion/api/openai_api).

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -165,6 +165,7 @@ DEFAULT_BCG_TEXT_BUCKETS = (64, 128, 256, 512, 1024)
 
 BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
     {
+        "black-forest-labs/flux.1-dev",
         "comfy-org/ideogram-4",
         "efficient-large-model/sana1.5_1.6b_1024px_diffusers",
         "efficient-large-model/sana-video_2b_480p_diffusers",
@@ -172,6 +173,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
         "sana-video_2b_480p_diffusers",
         "fal/ideogram-v4-fast",
         "fal/ideogram-v4-instant",
+        "flux.1-dev",
         "glm-image",
         "ideogram-4",
         "ideogram-4-fp8",
@@ -203,6 +205,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
 
 BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS = frozenset(
     {
+        "FluxPipelineConfig",
         "GlmImagePipelineConfig",
         "Ideogram4PipelineConfig",
         "JoyEchoPipelineConfig",
@@ -741,7 +744,7 @@ class ServerArgs(DisaggServerArgsMixin):
             return
 
         logger.warning(
-            "[Diffusion BCG] disabled for %s: only Ideogram-4, "
+            "[Diffusion BCG] disabled for %s: only FLUX.1-dev, Ideogram-4, "
             "jdopensource/JoyAI-Echo, Lightricks/LTX-2, LongCat-Image, "
             "MiniMax-H3, Qwen/Qwen-Image, Qwen/Qwen-Image-2512, SANA1.5, "
             "SANA-Video, Tongyi-MAI/Z-Image/Z-Image-Turbo, and "

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
@@ -37,6 +37,10 @@ class OtherTransformer2DModel(torch.nn.Module):
     pass
 
 
+class FluxTransformer2DModel(torch.nn.Module):
+    pass
+
+
 class Ideogram4Transformer2DModel(torch.nn.Module):
     pass
 
@@ -132,6 +136,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.zimage_model = ZImageTransformer2DModel()
         self.sana_video_model = SanaVideoTransformer3DModel()
         self.other_model = OtherTransformer2DModel()
+        self.flux_model = FluxTransformer2DModel()
 
     def _patch_buckets(self, *buckets: int):
         resolved = tuple(sorted({b for b in buckets if b > 0}))
@@ -519,6 +524,26 @@ class TestDiffusionBCGPadding(unittest.TestCase):
             "SanaVideoPipelineConfig",
             BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS,
         )
+
+    def test_flux_unmasked_conditioning_keeps_one_signature_for_all_buckets(self):
+        # FLUX attends to all 512 T5 tokens, including tokenizer padding.
+        # Adding unmasked tokens would change attention and generated pixels.
+        kwargs = {
+            "hidden_states": torch.zeros(1, 4096, 64, dtype=torch.bfloat16),
+            "encoder_hidden_states": torch.ones(1, 512, 4096, dtype=torch.bfloat16),
+            "pooled_projections": torch.ones(1, 768, dtype=torch.bfloat16),
+            "timestep": torch.zeros(1),
+            "guidance": torch.full((1,), 3.5, dtype=torch.bfloat16),
+            "freqs_cis": (torch.zeros(4608, 64), torch.ones(4608, 64)),
+        }
+        signature = _signature_kwargs(kwargs)
+        for bucket in (64, 128, 256, 512, 1024):
+            with self.subTest(bucket=bucket):
+                out = self.stage._bcg_pad_prompt_kwargs(
+                    kwargs, current_model=self.flux_model, force_bucket=bucket
+                )
+                self.assertIs(out, kwargs)
+                self.assertEqual(_signature_kwargs(out), signature)
 
     def test_dynamic_varlen_mask_meta_rebuilds_once_per_replay_token(self):
         builder = DynamicVarlenMaskMeta()

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -17,6 +17,10 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     PipelineConfig,
 )
 from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import Cosmos3Config
+from sglang.multimodal_gen.configs.pipeline_configs.flux import (
+    Flux2PipelineConfig,
+    FluxPipelineConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.helios import (
     HeliosDistilledConfig,
 )
@@ -60,6 +64,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     WanT2V720PConfig,
 )
 from sglang.multimodal_gen.configs.pipeline_configs.zimage import ZImagePipelineConfig
+from sglang.multimodal_gen.configs.sample.flux import FluxSamplingParams
 from sglang.multimodal_gen.registry import (
     _get_config_info,
     get_non_diffusers_pipeline_name,
@@ -818,6 +823,48 @@ class TestWarmupModeNormalization(unittest.TestCase):
         sa.warmup_resolutions = None
         sa.bcg_text_buckets = None
         sa._validate_breakable_cuda_graph()  # must not raise
+
+    def test_flux_bcg_resolves_hub_and_local_checkpoint_warmup(self):
+        for model_path, model_id in (
+            ("black-forest-labs/FLUX.1-dev", None),
+            ("/models/FLUX.1-dev", None),
+            ("/cache/models--black-forest-labs--FLUX.1-dev/snapshots/revision", None),
+            ("/models/pinned-checkpoint", "black-forest-labs/FLUX.1-dev"),
+        ):
+            with self.subTest(model_path=model_path, model_id=model_id):
+                sa = ServerArgs.__new__(ServerArgs)
+                sa.model_path = model_path
+                sa.model_id = model_id
+                sa.pipeline_class_name = "FluxPipeline"
+                sa.pipeline_config = FluxPipelineConfig()
+                sa.enable_breakable_cuda_graph = True
+                # Resolve native sampling defaults without loading checkpoint
+                # metadata for the synthetic local paths in this unit test.
+                with patch(
+                    "sglang.multimodal_gen.runtime.warmup_request_builder."
+                    "get_model_sampling_defaults",
+                    return_value=FluxSamplingParams(),
+                ):
+                    sa._adjust_breakable_cuda_graph_support()
+                sa._adjust_warmup()
+
+                self.assertTrue(sa.enable_breakable_cuda_graph)
+                self.assertEqual(sa.warmup_resolutions, ["1024x1024"])
+                self.assertEqual(sa.warmup_mode, "server")
+
+    def test_flux_bcg_requires_both_supported_checkpoint_and_pipeline(self):
+        for model_path, config in (
+            ("black-forest-labs/FLUX.2-dev", Flux2PipelineConfig()),
+            ("black-forest-labs/FLUX.1-schnell", FluxPipelineConfig()),
+            ("black-forest-labs/FLUX.1-dev", Flux2PipelineConfig()),
+        ):
+            with self.subTest(model_path=model_path, config=type(config).__name__):
+                sa = ServerArgs.__new__(ServerArgs)
+                sa.model_path = model_path
+                sa.pipeline_config = config
+                sa.enable_breakable_cuda_graph = True
+                sa._adjust_breakable_cuda_graph_support()
+                self.assertFalse(sa.enable_breakable_cuda_graph)
 
     def test_disagg_role_disables_server_warmup(self):
         from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType


### PR DESCRIPTION
## Summary

Enable native FLUX.1-dev breakable CUDA graph execution for lossless requests. `--enable-breakable-cuda-graph` previously disabled itself for this model; the existing runner now captures its DiT segments and replays them for warmed shapes.

On 2× H200 at 1024×1024 / 50 steps, two A/B/B/A rounds reduce warmed engine E2E from **4.315577 s to 4.177754 s (-3.194%)**, and denoise from **4.119540 s to 3.911356 s (-5.054%)**. All eight formal PNGs are byte-identical. Peak reserved memory rises from **19.473 GiB to 20.707 GiB** in the rank-0 perf dump.

The implementation adds FLUX.1-dev model IDs and `FluxPipelineConfig` to the existing support checks. FLUX keeps its unmasked, fixed 512-token T5 conditioning, so the generic runner can copy fresh conditioning/timestep/guidance inputs into the captured buffers. Existing TP graph registration, signature fallback, and quality-fusion checks apply. The patch also adds warmup/model-reference and conditioning-shape tests, plus a cookbook example.

## Benchmark

- Native `black-forest-labs/FLUX.1-dev` at checkpoint `3de623fc3c33e44ffbe2bad470d0f45bccf2eb21`; BF16, TP2 on the same two H200 GPUs throughout.
- PyTorch `2.13.0+cu130`, Triton `3.7.1`, driver `595.71.05`; loaded NCCL reports `2.28.9`.
- 1024×1024, 50 steps, guidance 3.5, seed 42, `quality=lossless`, `dit=resident`, other component residency `auto`; `torch.compile` disabled.
- Prompt: `A futuristic cyberpunk city at night, neon lights reflecting on wet streets`.
- Baseline: `482e9f257bb9d9ac57c2245c93768a96ec70edbe`, eager. Measured candidate: `5e91bc39e7a421be979448661b1b5d93db35cb48`, BCG. Final head `3d51468a54b8fad047b1d679c0968ac2919613e7` adds only tests/docs; its runtime file is byte-identical to the measured candidate.
- The preset uses one-step request warmup for eager. BCG forces synthetic server warmup/capture at the declared 1024×1024 shape (50 steps). Both warmup paths are excluded from measured request latency; the results compare those native operating modes.
- E2E is the warmed **engine** duration from the unprofiled perf dump, including encoding, denoise, and decode. Checkpoint download, startup/warmup, and final PNG writing are excluded. Profiler export wall time is excluded from all performance claims.

| Run order | Eager E2E (s) | BCG E2E (s) | Eager denoise (s) | BCG denoise (s) |
| --- | ---: | ---: | ---: | ---: |
| Round 1 — A1 | 4.315031 | | 4.119472 | |
| Round 1 — B1 | | 4.104417 | | 3.905989 |
| Round 1 — B2 | | 4.105608 | | 3.907831 |
| Round 1 — A2 | 4.306322 | | 4.105668 | |
| Round 2 — A1 | 4.337554 | | 4.144473 | |
| Round 2 — B1 | | 4.385315 | | 3.917348 |
| Round 2 — B2 | | 4.115677 | | 3.914257 |
| Round 2 — A2 | 4.303404 | | 4.108547 | |
| **Mean** | **4.315577** | **4.177754** | **4.119540** | **3.911356** |

Per-round E2E reductions are **4.771%** and **1.620%**. Round 2 B1 spent 371.106 ms in text encoding versus roughly 98–102 ms in neighboring requests; that sample remains in the aggregate. No samples were discarded.

[All benchmark rows and conditions](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/benchmark.json) · [raw perf dumps and scripts](https://github.com/BBuf/sglang/tree/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200)

## Profile comparison

The paired full-stage traces cover two denoise steps on rank 0, using the same checkpoint, shape, prompt, seed, topology, and respective source commits. Overlapping GPU stage annotations are unioned; no selected kernel crosses a stage boundary.

| Two-step denoise diagnostic | Eager | BCG |
| --- | ---: | ---: |
| GPU kernels | 2,847 | 2,847 |
| Host per-kernel launches, CUDA runtime + driver | 2,847 | 157 |
| `cudaGraphLaunch` calls | 0 | 116 |
| Captured segments per step | 0 | 58 |
| Cumulative GPU kernel time (ms) | 144.160 | 147.284 |
| Profiled CPU stage duration (ms) | 278.175 | 160.611 |

BCG reduces recurring host launches; the cumulative device time does not improve. Most GEMMs, attention, and existing fused LN/modulation kernels keep their counts. The existing graph-aware custom all-reduce path changes from 228 push calls to 152 pull + 76 push calls. Collective durations include rank waiting, so they are not interpreted as pure communication bandwidth. The profiled CPU durations are diagnostic and differ substantially from the unprofiled timings above.

[Eager profile digest](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/profile-a-digest.json) · [BCG profile digest](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/profile-b-digest.json). Raw trace sizes and SHA-256 hashes are recorded in those digests.

Existing FLUX optimizations from #34126, #34004, #33819, and #33818 were reviewed before choosing the graph replay path. Their fused arithmetic and quality gates are reused.

## Output comparison

All eight 50-step benchmark PNGs have SHA-256 `a713777ad67b4e82915aef972612f243d6f4cbd8db9aebdfdff976b4c7d2c7d3`.

| Eager, 50 steps | BCG, 50 steps |
| --- | --- |
| ![Eager FLUX city](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/lossless-r1-1-a.png) | ![BCG FLUX city](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/lossless-r1-2-b.png) |

[All saved benchmark images](https://github.com/BBuf/sglang/tree/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200) · [Replay correctness results](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/replay-correctness.json)

On final head, persistent native generators at TP1 and TP2 each served six requests across three warmed resolutions, changed prompts and seeds, repeated an earlier request, then requested one deliberately uncaptured resolution. All **12 eager/BCG image pairs (24 PNGs)** are byte-identical within their respective topology. Each rank captured exactly three graphs at warmup, with zero serving recaptures; only the final 640×512 request used the expected eager fallback. These six-step images validate replay state and are separate from the 50-step performance rows.

`quality=high + BCG` was tested and rejected by the existing DiT fusion compatibility check. The graph captures the lossless branches, so this PR does not claim high/extra-high BCG support. The baseline high eager image has SSIM 0.975800 and PSNR 32.3649 dB against lossless on this prompt; that separate existing quality tradeoff is not used in the lossless speedup.

## Reproduce

Use an `HF_TOKEN` with access to the checkpoint. Run on each pinned source checkout and keep the same GPUs and request parameters:

```bash
CUDA_VISIBLE_DEVICES=0,1 \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1 \
NCCL_NVLS_ENABLE=0 \
sglang generate \
  --backend sglang \
  --model-path black-forest-labs/FLUX.1-dev \
  --revision 3de623fc3c33e44ffbe2bad470d0f45bccf2eb21 \
  --num-gpus 2 --tp-size 2 \
  --component-residency dit=resident \
  --enable-torch-compile false \
  --warmup-mode request \
  --quality lossless \
  --width 1024 --height 1024 \
  --num-inference-steps 50 --guidance-scale 3.5 --seed 42 \
  --prompt "A futuristic cyberpunk city at night, neon lights reflecting on wet streets" \
  --save-output --output-file-name eager.png \
  --perf-dump-path eager.json
```

For BCG, add `--enable-breakable-cuda-graph --warmup-resolutions 1024x1024` and use distinct output/perf filenames; the runtime automatically changes warmup mode to `server`. Run A/B/B/A twice. For diagnostic traces, use two steps and add `--profile --profile-all-stages`; compare unprofiled requests for latency. The cookbook documents warmed resolution matching and the additional startup/graph memory cost.

## Validation

- [x] 52 warmup/padding/TP graph-capture unit tests and 16 subtests pass.
- [x] Two 50-step A/B/B/A rounds; all eight saved PNGs byte-identical.
- [x] Paired full-stage profiles; both two-step PNGs byte-identical.
- [x] Persistent TP1/TP2 replay checks on final head: changed prompt/seed, three warmed resolutions, repeated request, and deliberate uncaptured-resolution fallback.
- [x] Four changed files pass pre-commit; Mint build validation and broken-links checks pass.
- [x] Task-owned FLUX checkpoint cache removed: 57,890,215,216 logical bytes / 9 weight files to zero, with an independent directory-absence check. [Cleanup ledger](https://raw.githubusercontent.com/BBuf/sglang/cd9fb01d765a260a8d37ea876de9f0200f627b92/diffusion-prs/flux1-bcg-h200/weight-cleanup.jsonl).

Other FLUX variants, quantized transformer overrides, and other hardware require their own validation.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34300355195](https://github.com/sgl-project/sglang/actions/runs/34300355195)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34300355947](https://github.com/sgl-project/sglang/actions/runs/34300355947)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34300355213](https://github.com/sgl-project/sglang/actions/runs/34300355213)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->