### PR TITLE
[diffusion] Honor CPU offload on native transformers fallback

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -47,6 +47,7 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import (
     checkpoint_weights_iterator,
 )
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency import (
+    LAYERWISE_OFFLOAD,
     RESIDENT,
     ComponentResidencyError,
 )
@@ -526,25 +527,52 @@ class ComponentLoader(ABC):
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
             )
+            resolved_component_name = component_name or "component"
+            start_on_cpu = bool(
+                component_name is not None
+                and server_args.should_start_component_on_cpu(resolved_component_name)
+            )
             if uses_native_transformers_quantization(
-                config, component_name or "component"
+                config, resolved_component_name
             ):
-                resolved_component_name = component_name or "component"
                 explicit_residency = server_args.explicit_residency_mode(
                     resolved_component_name
                 )
-                if explicit_residency is not None and explicit_residency != RESIDENT:
+                # Quant TE can component-offload; layerwise is unsupported.
+                if explicit_residency == LAYERWISE_OFFLOAD:
                     raise ComponentCheckpointUnsupportedError(
                         "Transformers-managed quantized component "
-                        f"{resolved_component_name!r} requires resident placement; "
-                        f"got explicit mode {explicit_residency!r}"
+                        f"{resolved_component_name!r} does not support "
+                        "layerwise offload; use component CPU offload or "
+                        "keep it resident"
                     )
-                server_args.require_component_resident(
-                    resolved_component_name,
-                    feature_name="Transformers quantized component",
-                )
+                if start_on_cpu:
+                    load_kwargs["device_map"] = {
+                        "": self.target_device(component_starts_on_cpu=True)
+                    }
+                else:
+                    if (
+                        explicit_residency is not None
+                        and explicit_residency != RESIDENT
+                    ):
+                        raise ComponentCheckpointUnsupportedError(
+                            "Transformers-managed quantized component "
+                            f"{resolved_component_name!r} requires resident "
+                            f"placement; got explicit mode {explicit_residency!r}"
+                        )
+                    server_args.require_component_resident(
+                        resolved_component_name,
+                        feature_name="Transformers quantized component",
+                    )
+                    load_kwargs["device_map"] = {
+                        "": self.target_device(component_starts_on_cpu=False)
+                    }
+                self._native_load_manages_placement = True
+            elif start_on_cpu:
+                # Native fallback used to ignore CPU-offload and materialize on
+                # CUDA during from_pretrained (#34772). Pin device_map to CPU.
                 load_kwargs["device_map"] = {
-                    "": self.target_device(component_starts_on_cpu=False)
+                    "": self.target_device(component_starts_on_cpu=True)
                 }
                 self._native_load_manages_placement = True
             model_class = self.resolve_native_transformers_model_class(config)

--- a/python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py
@@ -396,6 +396,7 @@ class TestTextEncoderClassResolution(unittest.TestCase):
             component_precisions={},
             pipeline_config=SimpleNamespace(text_encoder_precisions=["bf16"]),
             explicit_residency_mode=mock.Mock(return_value=None),
+            should_start_component_on_cpu=mock.Mock(return_value=False),
             require_component_resident=mock.Mock(),
             should_use_fsdp_for_component=mock.Mock(return_value=False),
             revision=None,
@@ -449,6 +450,133 @@ class TestTextEncoderClassResolution(unittest.TestCase):
 
 
 class TestMiniMaxH3CheckpointFilter(unittest.TestCase):
+
+    def test_bitsandbytes_native_load_honors_cpu_offload(self):
+        loaded_encoder = nn.Linear(1, 1)
+        transformers_model_class = SimpleNamespace(
+            from_pretrained=mock.Mock(return_value=loaded_encoder)
+        )
+        server_args = SimpleNamespace(
+            component_precisions={},
+            pipeline_config=SimpleNamespace(text_encoder_precisions=["bf16"]),
+            explicit_residency_mode=mock.Mock(return_value=None),
+            should_start_component_on_cpu=mock.Mock(return_value=True),
+            require_component_resident=mock.Mock(),
+            should_use_fsdp_for_component=mock.Mock(return_value=False),
+            revision=None,
+            trust_remote_code=False,
+        )
+        component_config = {
+            "quantization_config": {
+                "load_in_4bit": True,
+                "quant_method": "bitsandbytes",
+            }
+        }
+
+        loader = TextEncoderLoader()
+        with (
+            mock.patch.object(
+                TextEncoderLoader,
+                "resolve_native_transformers_model_class",
+                return_value=transformers_model_class,
+            ),
+            mock.patch.object(
+                loader,
+                "target_device",
+                side_effect=lambda component_starts_on_cpu: (
+                    torch.device("cpu")
+                    if component_starts_on_cpu
+                    else torch.device("cuda:0")
+                ),
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.runtime.loader.component_loaders."
+                "component_loader.get_hf_config",
+                return_value=component_config,
+            ),
+        ):
+            encoder = loader.load_native(
+                "/model/text_encoder",
+                server_args,
+                "transformers",
+                "text_encoder",
+            )
+
+        self.assertIs(encoder, loaded_encoder)
+        server_args.require_component_resident.assert_not_called()
+        transformers_model_class.from_pretrained.assert_called_once_with(
+            "/model/text_encoder",
+            config=component_config,
+            trust_remote_code=False,
+            revision=None,
+            torch_dtype=torch.bfloat16,
+            device_map={"": torch.device("cpu")},
+        )
+
+    def test_native_fallback_honors_cpu_offload_device_map(self):
+        # #34772: non-quant native from_pretrained must not ignore CPU offload.
+        loaded_encoder = nn.Linear(1, 1)
+        transformers_model_class = SimpleNamespace(
+            from_pretrained=mock.Mock(return_value=loaded_encoder)
+        )
+        server_args = SimpleNamespace(
+            component_precisions={},
+            pipeline_config=SimpleNamespace(text_encoder_precisions=["bf16"]),
+            explicit_residency_mode=mock.Mock(return_value=None),
+            should_start_component_on_cpu=mock.Mock(return_value=True),
+            require_component_resident=mock.Mock(),
+            should_use_fsdp_for_component=mock.Mock(return_value=False),
+            revision=None,
+            trust_remote_code=False,
+        )
+        component_config = SimpleNamespace()  # no quantization_config
+
+        loader = TextEncoderLoader()
+        with (
+            mock.patch.object(
+                TextEncoderLoader,
+                "resolve_native_transformers_model_class",
+                return_value=transformers_model_class,
+            ),
+            mock.patch.object(
+                loader,
+                "target_device",
+                side_effect=lambda component_starts_on_cpu: (
+                    torch.device("cpu")
+                    if component_starts_on_cpu
+                    else torch.device("cuda:0")
+                ),
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.runtime.loader.component_loaders."
+                "component_loader.get_hf_config",
+                return_value=component_config,
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.runtime.loader.component_loaders."
+                "component_loader.uses_native_transformers_quantization",
+                return_value=False,
+            ),
+        ):
+            encoder = loader.load_native(
+                "/model/text_encoder",
+                server_args,
+                "transformers",
+                "text_encoder",
+            )
+
+        self.assertIs(encoder, loaded_encoder)
+        server_args.should_start_component_on_cpu.assert_called_with("text_encoder")
+        transformers_model_class.from_pretrained.assert_called_once_with(
+            "/model/text_encoder",
+            config=component_config,
+            trust_remote_code=False,
+            revision=None,
+            torch_dtype=torch.bfloat16,
+            device_map={"": torch.device("cpu")},
+        )
+
+
     def test_only_known_unconsumed_weights_are_filtered(self):
         encoder = MiniMaxH3Qwen3VLEncoder.__new__(MiniMaxH3Qwen3VLEncoder)
         encoder.selected_lm_layer = 50


### PR DESCRIPTION
## Motivation

Fixes #34772.

After customized component load fails and falls back to native transformers from_pretrained, CPU-offload / component-residency decisions were ignored: large text encoders (e.g. UMT5 / Gemma2) could materialize on CUDA and OOM on 8GB GPUs even with --text-encoder-cpu-offload true.

On current main the old should_offload(model_config=None) helper is gone, but the same failure mode remains: native load did not pin device_map to CPU when should_start_component_on_cpu is true. Transformers-managed quantized TE still forced CUDA device_map as well.

## Modifications

- When residency requests CPU start, pass CPU device_map for native transformers loads (non-quant and quant).
- Keep resident / CUDA behavior when CPU offload is not requested.
- Reject layerwise residency for transformers-managed quant checkpoints with a clearer error.

## Test plan

- [x] unit: test_native_fallback_honors_cpu_offload_device_map
- [x] unit: test_bitsandbytes_native_load_honors_cpu_offload
- [x] unit: test_bitsandbytes_native_load_requires_resident_encoder (unchanged intent)
- [ ] CI: python/sglang/multimodal_gen/test/unit/test_text_encoder_loader.py

## Notes

Supersedes the narrower quant-only change in #38501 (same file). Please close #38501 in favor of this PR if preferred.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34300911734](https://github.com/sgl-project/sglang/actions/runs/34300911734)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34300911609](https://github.com/sgl-project/sglang/actions/runs/34300911609)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34300911584](https://github.com/sgl-project/sglang/actions/runs/34300911584)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->