### PR TITLE
[KV Cache] Add first-class versioned KV-hint transport

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -83,6 +83,22 @@ message ChoiceConstraint {
   repeated string values = 1;
 }
 
+// Versioned, cache-neutral request metadata. Actions are transported without
+// being interpreted by the runtime.
+message KvHintAction {
+  optional string action_id = 1;
+  optional string action_type = 2;
+  optional string action_version = 3;
+  // UTF-8 JSON encoding of an object. The native bridge validates the shape.
+  optional bytes payload_json = 4;
+}
+
+message KvHints {
+  optional string protocol_version = 1;
+  optional string message_id = 2;
+  repeated KvHintAction actions = 3;
+}
+
 // ---- Text-based generate (text in, text out) ----
 
 message TextGenerateRequest {
@@ -103,6 +119,7 @@ message TextGenerateRequest {
   optional int32 priority = 15;
   optional bool require_reasoning = 16;
   optional uint32 max_thinking_tokens = 17;
+  optional KvHints kv_hints = 18;
 }
 
 message TextGenerateResponse {
@@ -130,6 +147,7 @@ message GenerateRequest {
   optional int32 priority = 14;
   optional bool require_reasoning = 15;
   optional uint32 max_thinking_tokens = 16;
+  optional KvHints kv_hints = 17;
 }
 
 message GenerateResponse {

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -60,6 +60,7 @@ from sglang.srt.entrypoints.engine_info_bootstrap_server import (
 from sglang.srt.entrypoints.engine_score_mixin import EngineScoreMixin
 from sglang.srt.entrypoints.EngineBase import EngineBase
 from sglang.srt.environ import envs
+from sglang.srt.kv_hints import KvHintsRequest
 from sglang.srt.managers.data_parallel_controller import (
     SCHEDULER_PIDS_ARG,
     run_data_parallel_controller_process,
@@ -431,6 +432,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        kv_hints: KvHintsRequest = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -450,6 +452,7 @@ class Engine(EngineScoreMixin, EngineBase):
             mm_hashes=mm_hashes,
             mm_content_hashes=mm_content_hashes,
             cache_salt=cache_salt,
+            kv_hints=kv_hints,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,
@@ -544,6 +547,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        kv_hints: KvHintsRequest = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -563,6 +567,7 @@ class Engine(EngineScoreMixin, EngineBase):
             mm_hashes=mm_hashes,
             mm_content_hashes=mm_content_hashes,
             cache_salt=cache_salt,
+            kv_hints=kv_hints,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,

--- a/python/sglang/srt/kv_hints.py
+++ b/python/sglang/srt/kv_hints.py
@@ -1,0 +1,60 @@
+"""Cache-neutral types and ingress validation for KV-hint metadata."""
+
+from collections.abc import Mapping
+from typing import Any, Optional, Union
+
+import msgspec
+
+from sglang.srt.utils.msgspec_utils import msgspec_struct_pydantic_core_schema
+
+SUPPORTED_KV_HINTS_PROTOCOL_VERSION = "0.1"
+
+
+class KvHintAction(msgspec.Struct, kw_only=True):
+    action_id: str
+    action_type: str
+    action_version: str
+    payload: dict[str, Any]
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+class KvHints(msgspec.Struct, kw_only=True):
+    protocol_version: str
+    message_id: str
+    actions: list[KvHintAction]
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+KvHintsInput = Optional[Union[KvHints, Mapping[str, Any]]]
+KvHintsRequest = Union[KvHintsInput, list[KvHintsInput]]
+
+
+def normalize_kv_hints(value: KvHintsInput) -> Optional[KvHints]:
+    """Validate one envelope and return a canonical, independently owned copy."""
+    if value is None:
+        return None
+    if isinstance(value, KvHints):
+        builtins = msgspec.to_builtins(value)
+    elif isinstance(value, Mapping):
+        builtins = msgspec.to_builtins(dict(value))
+    else:
+        raise ValueError("kv_hints must be an object or None")
+
+    try:
+        hints = msgspec.convert(builtins, type=KvHints, strict=True)
+    except (TypeError, msgspec.ValidationError) as exc:
+        raise ValueError(f"Invalid kv_hints: {exc}") from exc
+
+    if hints.protocol_version != SUPPORTED_KV_HINTS_PROTOCOL_VERSION:
+        raise ValueError(
+            "Unsupported kv_hints protocol_version "
+            f"{hints.protocol_version!r}; expected "
+            f"{SUPPORTED_KV_HINTS_PROTOCOL_VERSION!r}"
+        )
+    return hints

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -52,6 +52,11 @@ from pydantic import PlainValidator
 
 from sglang.srt.beam_search.types import BeamSearchSequence
 from sglang.srt.environ import envs
+from sglang.srt.kv_hints import (
+    KvHints,
+    KvHintsRequest,
+    normalize_kv_hints,
+)
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.schedule_batch import (
@@ -351,6 +356,9 @@ class GenerateReqInput:
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[Union[List[str], str]] = None
 
+    # Versioned, cache-neutral request metadata. Canonicalized during normalization.
+    kv_hints: KvHintsRequest = None
+
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
         if isinstance(self.rid, list):
@@ -402,6 +410,8 @@ class GenerateReqInput:
 
         self._validate_inputs()
         self._determine_batch_size()
+        if self.kv_hints is not None:
+            self._canonicalize_kv_hints()
         if self.session_id is not None and self.session_params is not None:
             raise ValueError("session_id and session_params cannot both be set.")
         self._handle_parallel_sampling()
@@ -412,6 +422,26 @@ class GenerateReqInput:
             self._normalize_batch_inputs()
 
         self._validate_rid_uniqueness()
+
+    def _canonicalize_kv_hints(self):
+        """Validate hints against the original logical batch."""
+        if self.is_single:
+            if isinstance(self.kv_hints, list):
+                raise ValueError(
+                    "kv_hints must be an object or None for a single request"
+                )
+            self.kv_hints = normalize_kv_hints(self.kv_hints)
+            return
+
+        if not isinstance(self.kv_hints, list):
+            raise ValueError(
+                "kv_hints must be a per-item list for a multi-request batch"
+            )
+        if len(self.kv_hints) != self.batch_size:
+            raise ValueError(
+                "The length of kv_hints should be equal to the batch size."
+            )
+        self.kv_hints = [normalize_kv_hints(item) for item in self.kv_hints]
 
     def _validate_inputs(self):
         """Validate that the input configuration is valid."""
@@ -560,7 +590,17 @@ class GenerateReqInput:
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
         self._normalize_cache_salt(num)
+        if self.kv_hints is not None:
+            self._expand_kv_hints(num)
         self._normalize_bootstrap_params(num)
+
+    def _expand_kv_hints(self, num):
+        """Fan out canonical hints without sharing mutable containers."""
+        if isinstance(self.kv_hints, list):
+            source = self.kv_hints * self.parallel_sample_num
+        else:
+            source = [self.kv_hints] * num
+        self.kv_hints = [normalize_kv_hints(item) for item in source]
 
     def _expand_inputs(self, num):
         """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling."""
@@ -952,6 +992,7 @@ class GenerateReqInput:
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
             cache_salt=(self.cache_salt[i] if self.cache_salt is not None else None),
+            kv_hints=(self.kv_hints[i] if self.kv_hints is not None else None),
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,
@@ -1067,6 +1108,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
+
+    # Canonical, versioned KV-hint metadata. Transport only.
+    kv_hints: Optional[KvHints] = None
 
     def wrap_pickle_fields(self):
         self.time_stats = wrap_as_pickle(self.time_stats)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -95,6 +95,7 @@ from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
+from sglang.srt.kv_hints import KvHints
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
@@ -971,6 +972,7 @@ class Req(ReqDllmMixin):
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
         cache_salt: Optional[str] = None,
+        kv_hints: Optional[KvHints] = None,
     ):
         # Input and output info
         self.rid = rid
@@ -1047,6 +1049,9 @@ class Req(ReqDllmMixin):
 
         self.extra_key = extra_key
         self.cache_salt = cache_salt or None
+        if kv_hints is not None and not isinstance(kv_hints, KvHints):
+            raise TypeError("Req.kv_hints must be KvHints or None")
+        self.kv_hints = kv_hints
         self.lora_id = lora_id
         self.routing_key = routing_key
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2771,6 +2771,7 @@ class Scheduler(
                 routing_key=recv_req.routing_key,
                 extra_key=recv_req.extra_key,
                 cache_salt=recv_req.cache_salt,
+                kv_hints=getattr(recv_req, "kv_hints", None),
                 http_worker_ipc=recv_req.http_worker_ipc,
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1429,6 +1429,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 cache_salt=obj.cache_salt,
+                kv_hints=obj.kv_hints,
                 routing_key=obj.routing_key,
                 token_type_ids=token_type_ids,
                 need_wait_for_mm_inputs=obj.need_wait_for_mm_inputs,

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -313,6 +313,7 @@ class Session:
             routing_key=req.routing_key,
             extra_key=req.extra_key,
             cache_salt=req.cache_salt,
+            kv_hints=getattr(req, "kv_hints", None),
             http_worker_ipc=req.http_worker_ipc,
             time_stats=req.time_stats,
         )

--- a/rust/sglang-grpc/src/utils/py_utils.rs
+++ b/rust/sglang-grpc/src/utils/py_utils.rs
@@ -9,6 +9,8 @@ fn json_value_to_py<'py>(py: Python<'py>, v: &serde_json::Value) -> PyResult<Py<
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 Ok(i.into_pyobject(py)?.into_any().unbind())
+            } else if let Some(u) = n.as_u64() {
+                Ok(u.into_pyobject(py)?.into_any().unbind())
             } else if let Some(f) = n.as_f64() {
                 Ok(f.into_pyobject(py)?.into_any().unbind())
             } else {

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use crate::proto;
 
+const SUPPORTED_KV_HINTS_PROTOCOL_VERSION: &str = "0.1";
+
 fn regex_escape_literal(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for character in value.chars() {
@@ -178,6 +180,68 @@ fn insert_disaggregated_params(
     }
 }
 
+fn required_string<'a>(value: &'a Option<String>, field: &str) -> Result<&'a str, String> {
+    value
+        .as_deref()
+        .ok_or_else(|| format!("kv_hints.{field} is required"))
+}
+
+fn kv_hints_to_json(hints: &Option<proto::KvHints>) -> Result<Option<serde_json::Value>, String> {
+    let Some(hints) = hints else {
+        return Ok(None);
+    };
+
+    let protocol_version = required_string(&hints.protocol_version, "protocol_version")?;
+    if protocol_version != SUPPORTED_KV_HINTS_PROTOCOL_VERSION {
+        return Err(format!(
+            "unsupported kv_hints protocol_version {protocol_version:?}; expected {SUPPORTED_KV_HINTS_PROTOCOL_VERSION:?}"
+        ));
+    }
+    let message_id = required_string(&hints.message_id, "message_id")?;
+
+    let actions = hints
+        .actions
+        .iter()
+        .enumerate()
+        .map(|(index, action)| {
+            let action_id =
+                required_string(&action.action_id, &format!("actions[{index}].action_id"))?;
+            let action_type = required_string(
+                &action.action_type,
+                &format!("actions[{index}].action_type"),
+            )?;
+            let action_version = required_string(
+                &action.action_version,
+                &format!("actions[{index}].action_version"),
+            )?;
+            let payload_json = action
+                .payload_json
+                .as_deref()
+                .ok_or_else(|| format!("kv_hints.actions[{index}].payload_json is required"))?;
+            let payload = serde_json::from_slice::<serde_json::Value>(payload_json)
+                .map_err(|err| format!("invalid kv_hints.actions[{index}].payload_json: {err}"))?;
+            if !payload.is_object() {
+                return Err(format!(
+                    "kv_hints.actions[{index}].payload_json must encode a JSON object"
+                ));
+            }
+
+            Ok(serde_json::json!({
+                "action_id": action_id,
+                "action_type": action_type,
+                "action_version": action_version,
+                "payload": payload,
+            }))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(Some(serde_json::json!({
+        "protocol_version": protocol_version,
+        "message_id": message_id,
+        "actions": actions,
+    })))
+}
+
 fn now_timestamp() -> f64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -243,6 +307,9 @@ pub(crate) fn build_text_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    if let Some(kv_hints) = kv_hints_to_json(&req.kv_hints)? {
+        d.insert("kv_hints".into(), kv_hints);
+    }
     insert_generation_controls(
         &mut d,
         req.priority,
@@ -296,6 +363,9 @@ pub(crate) fn build_generate_dict(
     }
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
+    }
+    if let Some(kv_hints) = kv_hints_to_json(&req.kv_hints)? {
+        d.insert("kv_hints".into(), kv_hints);
     }
     insert_generation_controls(
         &mut d,
@@ -556,5 +626,68 @@ mod tests {
         for request in [conflicting, empty_choice, empty_legacy_regex] {
             assert!(build_generate_dict("request", &request).is_err());
         }
+    }
+
+    fn sample_kv_hints() -> proto::KvHints {
+        proto::KvHints {
+            protocol_version: Some(SUPPORTED_KV_HINTS_PROTOCOL_VERSION.into()),
+            message_id: Some("message-1".into()),
+            actions: vec![proto::KvHintAction {
+                action_id: Some("action-1".into()),
+                action_type: Some("future.action".into()),
+                action_version: Some("87.4".into()),
+                payload_json: Some(
+                    br#"{"unsigned":18446744073709551615,"nested":{"items":[1,2]}}"#.to_vec(),
+                ),
+            }],
+        }
+    }
+
+    #[test]
+    fn generate_dicts_lower_kv_hints_identically() {
+        let text_req = proto::TextGenerateRequest {
+            kv_hints: Some(sample_kv_hints()),
+            ..Default::default()
+        };
+        let token_req = proto::GenerateRequest {
+            kv_hints: Some(sample_kv_hints()),
+            ..Default::default()
+        };
+
+        let text = build_text_generate_dict("text", &text_req).unwrap();
+        let token = build_generate_dict("token", &token_req).unwrap();
+
+        assert_eq!(text["kv_hints"], token["kv_hints"]);
+        assert_eq!(
+            text["kv_hints"]["actions"][0]["payload"]["unsigned"],
+            serde_json::json!(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn generate_dicts_reject_malformed_kv_hints() {
+        let mut invalid_version = sample_kv_hints();
+        invalid_version.protocol_version = Some("0.2".into());
+        let mut non_object_payload = sample_kv_hints();
+        non_object_payload.actions[0].payload_json = Some(br#"[]"#.to_vec());
+        let mut missing_payload = sample_kv_hints();
+        missing_payload.actions[0].payload_json = None;
+
+        for kv_hints in [invalid_version, non_object_payload, missing_payload] {
+            let request = proto::GenerateRequest {
+                kv_hints: Some(kv_hints),
+                ..Default::default()
+            };
+            assert!(build_generate_dict("request", &request).is_err());
+        }
+    }
+
+    #[test]
+    fn generate_dicts_omit_kv_hints_when_absent() {
+        let text = build_text_generate_dict("text", &Default::default()).unwrap();
+        let token = build_generate_dict("token", &Default::default()).unwrap();
+
+        assert!(!text.contains_key("kv_hints"));
+        assert!(!token.contains_key("kv_hints"));
     }
 }

--- a/test/registered/unit/managers/test_kv_hints_transport.py
+++ b/test/registered/unit/managers/test_kv_hints_transport.py
@@ -1,0 +1,582 @@
+"""Contract tests for the cache-neutral, versioned KV-hint transport."""
+
+import ast
+import asyncio
+import inspect
+import re
+import subprocess
+from array import array
+from pathlib import Path
+from types import SimpleNamespace
+
+import msgspec
+import pytest
+from pydantic import TypeAdapter
+
+from sglang.srt.managers.io_struct import (
+    GenerateReqInput,
+    SessionParams,
+    TokenizedGenerateReqInput,
+    msgpack_decode,
+    msgpack_encode,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=15, suite="stage-b-test-cpu-intel")
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PROTO_PATH = REPO_ROOT / "proto/sglang/runtime/v1/sglang.proto"
+RUST_REQUEST_UTILS = REPO_ROOT / "rust/sglang-grpc/src/utils/request_utils.rs"
+RUST_SERVER = REPO_ROOT / "rust/sglang-grpc/src/server.rs"
+
+
+def _kv_types():
+    # Kept local so a pre-implementation run collects one useful failure per test.
+    from sglang.srt.kv_hints import (  # noqa: PLC0415
+        KvHintAction,
+        KvHints,
+        normalize_kv_hints,
+    )
+
+    return KvHintAction, KvHints, normalize_kv_hints
+
+
+def _raw_hints(message_id="message-1", payload=None):
+    return {
+        "protocol_version": "0.1",
+        "message_id": message_id,
+        "actions": [
+            {
+                "action_id": f"action-{message_id}",
+                "action_type": "future.action",
+                "action_version": "87.4",
+                "payload": (
+                    {"nested": {"items": [1, 2]}, "unsigned": 2**64 - 1}
+                    if payload is None
+                    else payload
+                ),
+            }
+        ],
+    }
+
+
+def _normalize_request(**kwargs):
+    req = GenerateReqInput(**kwargs)
+    req.normalize_batch_and_arguments()
+    return req
+
+
+def _minimal_tokenized(**kwargs):
+    values = {
+        "rid": "request-1",
+        "input_text": "hello",
+        # None avoids coupling this metadata test to the separately covered
+        # array-extension codec; TokenizedGenerateReqInput explicitly permits it.
+        "input_ids": None,
+        "input_embeds": None,
+        "mm_inputs": None,
+        "token_type_ids": None,
+        "sampling_params": SamplingParams(),
+        "return_logprob": False,
+        "logprob_start_len": -1,
+        "top_logprobs_num": 0,
+        "token_ids_logprob": None,
+        "stream": False,
+    }
+    values.update(kwargs)
+    return TokenizedGenerateReqInput(**values)
+
+
+def _proto_descriptor(tmp_path):
+    descriptor_path = tmp_path / "sglang.pb"
+    subprocess.run(
+        [
+            "protoc",
+            f"--proto_path={REPO_ROOT / 'proto'}",
+            "--include_imports",
+            f"--descriptor_set_out={descriptor_path}",
+            str(PROTO_PATH.relative_to(REPO_ROOT / "proto")),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    from google.protobuf import descriptor_pb2  # noqa: PLC0415
+
+    file_set = descriptor_pb2.FileDescriptorSet()
+    file_set.ParseFromString(descriptor_path.read_bytes())
+    return next(item for item in file_set.file if item.package == "sglang.runtime.v1")
+
+
+def _message(descriptor, name):
+    return next(item for item in descriptor.message_type if item.name == name)
+
+
+def _field(message, name):
+    return next(item for item in message.field if item.name == name)
+
+
+def _function_source(source, function_name, next_function_name):
+    start = source.index(f"fn {function_name}")
+    end = source.index(f"fn {next_function_name}", start)
+    return source[start:end]
+
+
+def test_kh001_canonical_types_exist_with_exact_fields():
+    KvHintAction, KvHints, _ = _kv_types()
+
+    assert issubclass(KvHintAction, msgspec.Struct)
+    assert issubclass(KvHints, msgspec.Struct)
+    assert KvHintAction.__struct_fields__ == (
+        "action_id",
+        "action_type",
+        "action_version",
+        "payload",
+    )
+    assert KvHints.__struct_fields__ == (
+        "protocol_version",
+        "message_id",
+        "actions",
+    )
+
+
+def test_kh002_legal_mapping_becomes_nested_canonical_objects():
+    KvHintAction, KvHints, normalize = _kv_types()
+
+    hints = normalize(_raw_hints())
+
+    assert isinstance(hints, KvHints)
+    assert isinstance(hints.actions[0], KvHintAction)
+    assert hints.actions[0].payload["unsigned"] == 2**64 - 1
+
+
+def test_kh003_unsupported_envelope_version_is_rejected():
+    _, _, normalize = _kv_types()
+    raw = _raw_hints()
+    raw["protocol_version"] = "0.2"
+
+    with pytest.raises(ValueError, match="protocol_version"):
+        normalize(raw)
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {},
+        {"protocol_version": "0.1", "message_id": "missing-actions"},
+        {"protocol_version": 1, "message_id": "m", "actions": []},
+        {"protocol_version": "0.1", "message_id": "m", "actions": {}},
+        {"protocol_version": "0.1", "message_id": "m", "actions": [None]},
+        {
+            "protocol_version": "0.1",
+            "message_id": "m",
+            "actions": [
+                {
+                    "action_id": "a",
+                    "action_type": "future.action",
+                    "action_version": "1",
+                    "payload": [],
+                }
+            ],
+        },
+    ],
+)
+def test_kh004_malformed_structure_is_rejected(malformed):
+    _, _, normalize = _kv_types()
+
+    with pytest.raises(ValueError):
+        normalize(malformed)
+
+
+def test_kh005_unknown_action_type_and_version_are_preserved():
+    _, _, normalize = _kv_types()
+
+    hints = normalize(_raw_hints())
+
+    assert hints.actions[0].action_type == "future.action"
+    assert hints.actions[0].action_version == "87.4"
+
+
+def test_kh006_normalization_breaks_all_mutable_aliases():
+    _, _, normalize = _kv_types()
+    raw = _raw_hints()
+
+    hints = normalize(raw)
+    cloned = normalize(hints)
+    raw["actions"][0]["payload"]["nested"]["items"].append(3)
+    raw["actions"][0]["action_type"] = "mutated"
+
+    assert hints.actions[0].action_type == "future.action"
+    assert hints.actions[0].payload["nested"]["items"] == [1, 2]
+    assert cloned == hints
+    assert cloned is not hints
+    assert cloned.actions is not hints.actions
+    assert cloned.actions[0].payload is not hints.actions[0].payload
+    assert (
+        cloned.actions[0].payload["nested"]["items"]
+        is not hints.actions[0].payload["nested"]["items"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_field", "input_value"),
+    [("text", "hello"), ("input_ids", [1, 2])],
+    ids=["KH010-text", "KH011-input-ids"],
+)
+def test_kh010_kh011_native_request_parsing_and_normalization(input_field, input_value):
+    _, KvHints, _ = _kv_types()
+    parsed = TypeAdapter(GenerateReqInput).validate_python(
+        {input_field: input_value, "kv_hints": _raw_hints()}
+    )
+
+    parsed.normalize_batch_and_arguments()
+
+    assert isinstance(parsed.kv_hints, KvHints)
+
+
+def test_kh012_per_item_batch_hints_keep_item_alignment():
+    _, KvHints, _ = _kv_types()
+
+    req = _normalize_request(
+        text=["a", "b", "c"],
+        kv_hints=[_raw_hints("m0"), None, _raw_hints("m2")],
+    )
+
+    assert [item.message_id if item else None for item in req.kv_hints] == [
+        "m0",
+        None,
+        "m2",
+    ]
+    assert isinstance(req.kv_hints[0], KvHints)
+    assert isinstance(req.kv_hints[2], KvHints)
+
+
+def test_kh013_batch_length_mismatch_is_rejected():
+    with pytest.raises(ValueError, match="kv_hints"):
+        _normalize_request(
+            text=["a", "b"],
+            kv_hints=[_raw_hints("only-one")],
+        )
+
+
+def test_kh014_scalar_hint_is_rejected_for_true_batch():
+    with pytest.raises(ValueError, match="kv_hints"):
+        _normalize_request(text=["a", "b"], kv_hints=_raw_hints())
+
+
+def test_kh015_single_request_parallel_sampling_clones_without_aliases():
+    req = _normalize_request(
+        text="hello", sampling_params={"n": 3}, kv_hints=_raw_hints("one")
+    )
+
+    assert [item.message_id for item in req.kv_hints] == ["one"] * 3
+    assert len({id(item) for item in req.kv_hints}) == 3
+    assert len({id(item.actions) for item in req.kv_hints}) == 3
+    assert len({id(item.actions[0].payload) for item in req.kv_hints}) == 3
+    assert (
+        len({id(item.actions[0].payload["nested"]["items"]) for item in req.kv_hints})
+        == 3
+    )
+
+
+def test_kh016_batch_parallel_sampling_keeps_current_main_order_and_no_aliases():
+    req = _normalize_request(
+        text=["a", "b"],
+        sampling_params={"n": 2},
+        kv_hints=[_raw_hints("m0"), _raw_hints("m1")],
+    )
+
+    assert req.text == ["a", "b", "a", "b"]
+    assert [item.message_id for item in req.kv_hints] == ["m0", "m1", "m0", "m1"]
+    assert len({id(item.actions[0].payload) for item in req.kv_hints}) == 4
+
+
+def test_kh020_getitem_keeps_the_correct_canonical_item():
+    req = _normalize_request(
+        text=["a", "b"],
+        kv_hints=[_raw_hints("m0"), _raw_hints("m1")],
+    )
+
+    assert req[0].kv_hints.message_id == "m0"
+    assert req[1].kv_hints.message_id == "m1"
+
+
+def test_kh021_tokenizer_manager_forwards_only_canonical_hints():
+    _, KvHints, _ = _kv_types()
+    from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: PLC0415
+
+    class FakeSamplingParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def normalize(self, tokenizer):
+            return None
+
+        def verify(self, vocab_size):
+            return None
+
+    manager = object.__new__(TokenizerManager)
+    manager.preferred_sampling_params = {}
+    manager.sampling_params_class = FakeSamplingParams
+    manager.tokenizer = None
+    manager.model_config = SimpleNamespace(vocab_size=128)
+    manager.fake_bootstrap_room_counter = 0
+    req = _normalize_request(
+        text="hello", bootstrap_room=7, kv_hints=_raw_hints("tokenizer")
+    )
+    manager.rid_to_state = {
+        req.rid: SimpleNamespace(
+            time_stats=SimpleNamespace(set_tokenize_finish_time=lambda: None)
+        )
+    }
+
+    tokenized = manager._create_tokenized_object(req, "hello", [1, 2])
+
+    assert isinstance(tokenized.kv_hints, KvHints)
+    assert tokenized.kv_hints == req.kv_hints
+
+
+def test_kh022_real_ipc_codec_preserves_nested_canonical_structure():
+    KvHintAction, KvHints, normalize = _kv_types()
+    hints = normalize(_raw_hints("ipc"))
+    req = _minimal_tokenized(kv_hints=hints)
+
+    req.wrap_pickle_fields()
+    decoded = msgpack_decode(msgpack_encode(req))
+    decoded.unwrap_pickle_fields()
+
+    assert isinstance(decoded.kv_hints, KvHints)
+    assert isinstance(decoded.kv_hints.actions[0], KvHintAction)
+    assert decoded.kv_hints == hints
+
+
+def test_kh023_session_reconstruction_preserves_canonical_hints():
+    _, KvHints, normalize = _kv_types()
+    from sglang.srt.session.session_controller import Session  # noqa: PLC0415
+
+    tokenized = _minimal_tokenized(
+        session_params=SessionParams(id="session-1"),
+        kv_hints=normalize(_raw_hints("session")),
+    )
+    session = Session(0, session_id="session-1")
+
+    req = session.create_req(tokenized, tokenizer=None, vocab_size=128)
+
+    assert isinstance(req.kv_hints, KvHints)
+    assert req.kv_hints == tokenized.kv_hints
+
+
+def test_kh024_scheduler_constructs_req_with_canonical_hints(monkeypatch):
+    _, KvHints, normalize = _kv_types()
+    from sglang.srt.disaggregation.utils import DisaggregationMode  # noqa: PLC0415
+    from sglang.srt.managers import scheduler as scheduler_module  # noqa: PLC0415
+
+    real_req_type = scheduler_module.Req
+    with pytest.raises(TypeError, match="KvHints or None"):
+        real_req_type(
+            "unvalidated",
+            "hello",
+            array("q", [1]),
+            SamplingParams(),
+            kv_hints=_raw_hints("raw-is-not-internal"),
+        )
+
+    captured = {}
+
+    class FakeReq:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+            self.rid = args[0]
+            self.return_logprob = kwargs["return_logprob"]
+            self.finished_reason = None
+
+        def set_finish_with_abort(self, *args, **kwargs):
+            self.finished_reason = "aborted"
+
+    fake_scheduler = SimpleNamespace(
+        enable_session_radix_cache=False,
+        model_config=SimpleNamespace(hf_eos_token_id={2}, vocab_size=128),
+        disaggregation_mode=DisaggregationMode.NULL,
+        metrics_reporter=SimpleNamespace(enable_metrics=False),
+        metrics_collector=None,
+        dllm_config=None,
+        tokenizer=None,
+        _maybe_namespace_elastic_radix_cache=lambda req: None,
+        init_req_max_new_tokens=lambda req: None,
+        _add_request_to_queue=lambda req: None,
+    )
+    monkeypatch.setattr(scheduler_module, "Req", FakeReq)
+    hints = normalize(_raw_hints("scheduler"))
+    tokenized = _minimal_tokenized(kv_hints=hints, bootstrap_port=1)
+
+    scheduler_module.Scheduler.handle_generate_request(
+        fake_scheduler, tokenized, mm_input_error="expected stop"
+    )
+
+    assert isinstance(captured["kv_hints"], KvHints)
+    assert captured["kv_hints"] == hints
+
+
+class _CapturingTokenizerManager:
+    def __init__(self):
+        self.request = None
+
+    async def generate_request(self, request, _raw_request):
+        request.normalize_batch_and_arguments()
+        self.request = request
+        yield {"ok": True}
+
+
+def _bare_engine():
+    from sglang.srt.entrypoints.engine import Engine  # noqa: PLC0415
+
+    engine = object.__new__(Engine)
+    engine.tokenizer_manager = _CapturingTokenizerManager()
+    return engine
+
+
+def test_kh030_engine_generate_constructs_and_forwards_hints():
+    _, KvHints, _ = _kv_types()
+    engine = _bare_engine()
+    engine.loop = asyncio.new_event_loop()
+    try:
+        result = engine.generate(prompt="hello", kv_hints=_raw_hints("sync-engine"))
+    finally:
+        engine.loop.close()
+
+    assert result == {"ok": True}
+    assert isinstance(engine.tokenizer_manager.request.kv_hints, KvHints)
+    assert engine.tokenizer_manager.request.kv_hints.message_id == "sync-engine"
+
+
+def test_kh031_engine_async_generate_constructs_and_forwards_hints():
+    _, KvHints, _ = _kv_types()
+    engine = _bare_engine()
+
+    result = asyncio.run(
+        engine.async_generate(prompt="hello", kv_hints=_raw_hints("async-engine"))
+    )
+
+    assert result == {"ok": True}
+    assert isinstance(engine.tokenizer_manager.request.kv_hints, KvHints)
+    assert engine.tokenizer_manager.request.kv_hints.message_id == "async-engine"
+
+
+def test_kh040_grpc_text_has_typed_appended_field_and_lowering(tmp_path):
+    descriptor = _proto_descriptor(tmp_path)
+    field = _field(_message(descriptor, "TextGenerateRequest"), "kv_hints")
+    source = RUST_REQUEST_UTILS.read_text()
+    body = _function_source(source, "build_text_generate_dict", "build_generate_dict")
+
+    assert field.number == 18
+    assert field.type_name == ".sglang.runtime.v1.KvHints"
+    assert "req.kv_hints" in body
+
+
+def test_kh041_grpc_tokenized_has_typed_appended_field_and_lowering(tmp_path):
+    descriptor = _proto_descriptor(tmp_path)
+    field = _field(_message(descriptor, "GenerateRequest"), "kv_hints")
+    source = RUST_REQUEST_UTILS.read_text()
+    body = _function_source(source, "build_generate_dict", "build_text_embed_dict")
+
+    assert field.number == 17
+    assert field.type_name == ".sglang.runtime.v1.KvHints"
+    assert "req.kv_hints" in body
+
+
+def test_kh042_grpc_paths_share_json_equivalent_lowering(tmp_path):
+    descriptor = _proto_descriptor(tmp_path)
+    action = _message(descriptor, "KvHintAction")
+    payload = _field(action, "payload_json")
+    source = RUST_REQUEST_UTILS.read_text()
+
+    assert payload.number == 4
+    assert payload.type == payload.TYPE_BYTES
+    assert source.count("kv_hints_to_json(&req.kv_hints)") == 2
+    assert source.count('d.insert("kv_hints"') == 2
+    assert (
+        "n.as_u64()"
+        in (REPO_ROOT / "rust/sglang-grpc/src/utils/py_utils.rs").read_text()
+    )
+
+
+def test_kh043_grpc_malformed_input_maps_to_invalid_argument():
+    from sglang.srt.kv_hints import (  # noqa: PLC0415
+        SUPPORTED_KV_HINTS_PROTOCOL_VERSION,
+    )
+
+    source = RUST_REQUEST_UTILS.read_text()
+    server = RUST_SERVER.read_text()
+    rust_version = re.search(
+        r'SUPPORTED_KV_HINTS_PROTOCOL_VERSION: &str = "([^"]+)"', source
+    )
+
+    assert rust_version is not None
+    assert rust_version.group(1) == SUPPORTED_KV_HINTS_PROTOCOL_VERSION
+    assert "payload_json" in source
+    assert "JSON object" in source
+    assert source.count("kv_hints_to_json(&req.kv_hints)") == 2
+    assert server.count("map_err(Status::invalid_argument)") >= 2
+
+
+def test_kh050_absent_hints_remain_none_through_normalization_and_ipc():
+    req = _normalize_request(text="hello")
+    batch_req = _normalize_request(text=["hello", "world"])
+    tokenized = _minimal_tokenized(kv_hints=None)
+    tokenized.wrap_pickle_fields()
+    decoded = msgpack_decode(msgpack_encode(tokenized))
+    decoded.unwrap_pickle_fields()
+
+    assert req.kv_hints is None
+    assert batch_req.kv_hints is None
+    assert decoded.kv_hints is None
+
+
+def test_kh051_hints_never_enter_sampling_parameters():
+    req = _normalize_request(
+        text="hello",
+        sampling_params={"temperature": 0.25},
+        kv_hints=_raw_hints("isolated"),
+    )
+
+    assert "kv_hints" not in req.sampling_params
+    assert req.sampling_params == {"temperature": 0.25}
+    assert "kv_hints" not in inspect.signature(SamplingParams).parameters
+
+
+def test_kh052_transport_is_inert_and_has_no_backend_or_handler_coupling():
+    _, _, _ = _kv_types()
+    module_source = (REPO_ROOT / "python/sglang/srt/kv_hints.py").read_text()
+    prohibited_roots = [
+        REPO_ROOT / "python/sglang/srt/mem_cache",
+        REPO_ROOT / "python/sglang/srt/managers/cache_controller.py",
+        REPO_ROOT / "python/sglang/srt/disaggregation",
+    ]
+
+    tree = ast.parse(module_source)
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    }
+    assert all(
+        not module.startswith(
+            (
+                "sglang.srt.mem_cache",
+                "sglang.srt.disaggregation",
+                "sglang.srt.managers.cache_controller",
+            )
+        )
+        for module in imported_modules
+    )
+    assert not any(
+        isinstance(node, (ast.FunctionDef, ast.ClassDef))
+        and re.search(r"(manager|dispatcher|execute)", node.name, re.IGNORECASE)
+        for node in ast.walk(tree)
+    )
+    for root in prohibited_roots:
+        paths = [root] if root.is_file() else root.rglob("*.py")
+        assert all("kv_hints" not in path.read_text() for path in paths)


### PR DESCRIPTION
## Summary

Add a cache-neutral, typed, versioned `KvHints` metadata channel from native HTTP, Python Engine, and native gRPC through request normalization, tokenization, msgpack IPC, Session reconstruction, and scheduler `Req`.

## Motivation

The KV-hint RFC needs a stable transport contract before any cache implementation consumes actions. This PR provides only the cache-neutral typed/versioned transport. It does not contain or replace the KVCR backend in #36409; that follow-up can consume this canonical envelope.

## Canonical wire contract

Python owns cache-neutral msgspec structs:

```python
class KvHintAction(msgspec.Struct, kw_only=True):
    action_id: str
    action_type: str
    action_version: str
    payload: dict[str, Any]

class KvHints(msgspec.Struct, kw_only=True):
    protocol_version: str
    message_id: str
    actions: list[KvHintAction]
```

The only supported envelope version is `0.1`; action versions remain independent open strings. Unknown action types/versions and valid JSON-object payloads are transported without action-specific interpretation. Missing/wrong fields, non-object payloads, and unsupported envelope versions are rejected. Ingress conversion creates independent nested containers so caller-owned mappings and parallel samples do not alias.

Native gRPC adds typed `KvHints` / `KvHintAction` messages. Both text and tokenized requests use the same Rust lowering helper. `payload_json` is explicitly named bytes containing a JSON object, avoiding a new dependency and protobuf `Struct` integer precision loss. Existing field numbers are untouched; the new request fields are appended as 18 and 17 respectively. Lowering errors follow the existing `INVALID_ARGUMENT` mapping.

## Propagation

- Native `/generate` text and input-ID payloads parse through `GenerateReqInput` and canonicalize before fan-out.
- `Engine.generate` and `Engine.async_generate` accept the same keyword-only contract and forward it through the same normalizer.
- Tokenizer construction and actual msgpack IPC carry only canonical `KvHints` or `None`.
- Session reconstruction and normal scheduler construction preserve the value.
- `Req` rejects a plain dict at the scheduler boundary.
- Hints never enter sampling parameters and remain inert.

## Batch and parallel-sampling semantics

- A single request accepts one mapping/canonical envelope or `None`.
- A true multi-request batch requires a per-item list with exact original batch length when hints are present; scalar envelope broadcast is rejected.
- `None` remains the allocation-free no-hint path.
- A single logical request with `n > 1` preserves IDs but gives every derived request independent mutable containers.
- Batch plus `n > 1` follows current-main block order (`item0,item1,item0,item1`).

## No-hint compatibility

No-hint public and sampling behavior remains unchanged. A confirmatory benchmark used 31 alternating-start ABBA blocks with 1.022–1.147 seconds of timed work per cell. No-hint cold-miss fan-out measured +1.538% median overhead with a one-sided 95% upper bound of +1.669%; warm-cache access measured +1.503% with an upper bound of +1.983%. End-to-end normalization plus fan-out remained below +0.61% for batch sizes 1, 8, 32, and 128. The tokenized msgpack envelope adds one trailing nil byte when hints are absent.

## Tests

- New transport suite: 32 passed on candidate; identical test-only baseline failed 32 as expected in two independent runs.
- Related existing normalization/schema/session suite: 38 passed.
- `protoc` descriptor build: passed with libprotoc 25.3.
- ruff lint/selected format, isort, and `git diff --check`: passed.
- New registered-test taxonomy validation: passed.
- Rust 1.92 `cargo test -p sglang-grpc --locked`: 16 passed.
- Rust 1.92 `cargo clippy -p sglang-grpc --all-targets --locked -- -D warnings`: passed.
- Rust 1.92 `cargo test --workspace --locked`: 312 passed.
- Rust 1.92 workspace clippy with `-D warnings` and `cargo fmt --all -- --check`: passed.

An earlier approximately 10 ms-per-sample exploratory microbenchmark was excluded from the threshold decision because it was too short to resolve a 3% boundary reliably.

## Explicit non-goals

No action manager/dispatcher/execution, cache or storage integration, cache controller, remote transfer, capability discovery, lifecycle/recovery, telemetry, policy, authentication, provider cache-control API, or OpenAI-compatible schema is added.

## Risk and rollback

Risks are the deliberate strict true-batch contract, the trailing optional IPC field, and JSON-object validation in the native gRPC bridge. Tests pin batch order/deep-copy behavior, Python/Rust protocol-version equality, proto field numbers, no-hint behavior, and Rust lowering semantics. Rollback is a single revert because no data migration or action execution is introduced.

Refs #36224

Related to #36409

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34301156504](https://github.com/sgl-project/sglang/actions/runs/34301156504)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34301156321](https://github.com/sgl-project/sglang/actions/runs/34301156321)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34301156615](https://github.com/sgl-project/sglang/actions/runs/34301156615)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->