### PR TITLE
fix: count re NOT_LITERAL as one character in stop_regex length bound

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -365,6 +365,9 @@ def _max_length_from_subpattern(subpattern: sre_parse.SubPattern):
     for token, value in subpattern:
         if token in {
             sre_parse.LITERAL,  # `value` is any one character
+            # A single-character negated class: the parser emits NOT_LITERAL rather
+            # than IN, so `[^a]` reaches here while `[^ab]` arrives as IN.
+            sre_parse.NOT_LITERAL,  # Any one character other than `value`
             sre_parse.IN,  # Any character within `value`
             sre_parse.ANY,  # "."
         }:

--- a/test/registered/unit/entrypoints/openai/test_matched_stop.py
+++ b/test/registered/unit/entrypoints/openai/test_matched_stop.py
@@ -54,5 +54,52 @@ class TestRegexPatternMaxLength(unittest.TestCase):
                 self.assertEqual(get_max_seq_length(regex_str), max_len)
 
 
+class TestNegatedCharClassMaxLength(unittest.TestCase):
+    """A single-character negated class must get a finite bound (sglang#30932).
+
+    `[^a]` matches exactly one character, but was bounded at MAX_LEN, which
+    downstream becomes the per-decode-step re-decode tail window.
+    """
+
+    FINITE_CASES = {
+        "[^a]": 1,
+        "[^\n]": 1,
+        # Two or more excluded characters take a different parse path; it stayed
+        # correct throughout and must not regress.
+        "[^ab]": 1,
+        "ab[^,]cd": 5,
+        "[^a][^a]": 2,
+        "[^a]|b": 1,
+        "[^a]{3}": 3,
+    }
+
+    # Controls: a fix that merely weakened the unbounded-repeat branch would make
+    # these finite too.
+    UNBOUNDED_CASES = ["[^a]+", "a+", '"[^"]*"']
+
+    def test_finite_negated_class_bounds(self):
+        for regex_str, expected in self.FINITE_CASES.items():
+            with self.subTest(regex_str=regex_str):
+                self.assertEqual(get_max_seq_length(regex_str), expected)
+
+    def test_unbounded_patterns_stay_unbounded(self):
+        for regex_str in self.UNBOUNDED_CASES:
+            with self.subTest(regex_str=regex_str):
+                self.assertGreaterEqual(get_max_seq_length(regex_str), MAX_LEN)
+
+    def test_no_unhandled_token_warning(self):
+        """Guards the failure mode itself: an opcode falling to the catch-all else.
+
+        The bound would still be sound but silently MAX_LEN, so only the log line
+        distinguishes "unbounded" from "unsupported".
+        """
+        for regex_str in [*self.FINITE_CASES, *self.UNBOUNDED_CASES]:
+            with self.subTest(regex_str=regex_str):
+                with self.assertNoLogs(
+                    "sglang.srt.sampling.sampling_params", level="WARNING"
+                ):
+                    get_max_seq_length(regex_str)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #30932.

`get_max_seq_length` computes an upper bound on how many characters a `stop_regex`
can match. `Req._stop_match_tail_len` uses `stop_regex_max_len + 1` as the number of
trailing tokens to re-decode, and `tail_str` calls `tokenizer.decode(output_ids[-tail_len:])`
on **every decode step**. So a wrong bound is not just cosmetic: it turns O(1) per-step
tail decoding into O(output length), i.e. quadratic over the generation.

`re._parser` compiles a *single*-character negated class into its own `NOT_LITERAL`
opcode, while a two-or-more-character one becomes `IN`:

```
'[^a]'   -> [(NOT_LITERAL, 97)]
'[^ab]'  -> [(IN, [(NEGATE, None), (LITERAL, 97), (LITERAL, 98)])]
```

`_max_length_from_subpattern` handles `{LITERAL, IN, ANY}` as one character each, and
`NOT_LITERAL` appears in no branch — so it falls to the catch-all `else`, logs
`Got unhandled regex token`, and contributes `MAX_LEN = 2**30`:

```
stop_regex='[^,]'   -> stop_regex_max_len=1073741824   decode tail window=1073741825
stop_regex='[^ab]'  -> stop_regex_max_len=1            decode tail window=2
```

`[^\n]` — the usual "any character except newline" idiom — is affected too. The bound is
an over-approximation, so no incorrect token is ever emitted; the cost is purely speed.

## Modifications

- `sampling_params.py`: add `sre_parse.NOT_LITERAL` to the one-character token set. A
  `NOT_LITERAL` matches exactly one character, so it belongs beside `LITERAL`/`IN`/`ANY`.
- `test_matched_stop.py`: add `TestNegatedCharClassMaxLength`, covering the bare case
  (`[^a]`, `[^\n]`), a `NOT_LITERAL` mixed into a literal run (`ab[^,]cd` -> 5), additivity
  (`[^a][^a]` -> 2), the `BRANCH` and `MAX_REPEAT` recursion paths (`[^a]|b` -> 1,
  `[^a]{3}` -> 3), the `IN` path as a no-regression control, and unbounded controls
  (`a+`, `[^a]+`, `"[^"]*"`) so that a fix which merely weakened the `MAX_REPEAT` branch
  would not pass. Since the bug is a *missing enum member* rather than bad arithmetic,
  there is also an `assertNoLogs` guard: the next parser-level opcode special-case fails
  loudly instead of silently degrading to `MAX_LEN`.

The existing file has six patterns and not one negated character class, which is why no
current case could go red.

## Accuracy Tests

Not applicable — the bound only sizes a re-decode window; it does not affect sampling or
model output. Every pattern's bound remains sound (`bound >= true max match length`),
verified against an oracle that exhaustively searches `re.fullmatch` up to length 6
rather than hand-computing the expected values.

## Speed Tests and Profiling

No kernel or forward-path change. The effect is on the per-decode-step tail decode: with
`stop_regex='[^,]'` the window goes from 1073741825 tokens (the whole output, every step)
to 2.

## Checklist

- [x] Format your code according to the Format code with pre-commit
- [x] Add unit tests according to the Run and add unit tests
- [ ] Update documentation — not applicable
- [ ] Provide accuracy and speed benchmark results — not applicable, see above
- [x] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34302355351](https://github.com/sgl-project/sglang/actions/runs/34302355351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34302355263](https://github.com/sgl-project/sglang/actions/runs/34302355263)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34302355368](https://github.com/sgl-project/sglang/actions/runs/34302355368)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->