### PR TITLE
Fix HYV4 silently computing one token in attn_tp_size with an a2a MoE backend

### DIFF
--- a/python/sglang/srt/arg_groups/fields/parallel.py
+++ b/python/sglang/srt/arg_groups/fields/parallel.py
@@ -221,14 +221,17 @@ class Parallel:
     ] = False
     disable_attn_tp_gather: A[
         bool,
-        "Disable scheduler-side attn_tp_gather (the upstream SP path "
-        "that pads num_tokens to attn_tp_size and pre-allocates a gathered "
-        "buffer). Use for models that manage SP scatter/gather at the "
-        "model level (e.g., perform their own all_gather/reduce_scatter "
-        "inside attention) and do not consume the upstream gathered_buffer. "
-        "Without this, the cuda graph runner pads num_tokens to attn_tp_size, "
-        "which can cause kernel autotuners to select wrong-sized variants "
-        "at small batches.",
+        Arg(
+            help="Disable scheduler-side attn_tp_gather (the upstream SP path "
+            "that pads num_tokens to attn_tp_size and pre-allocates a gathered "
+            "buffer). Use for models that manage SP scatter/gather at the "
+            "model level (e.g., perform their own all_gather/reduce_scatter "
+            "inside attention) and do not consume the upstream gathered_buffer. "
+            "Without this, the cuda graph runner pads num_tokens to attn_tp_size, "
+            "which can cause kernel autotuners to select wrong-sized variants "
+            "at small batches.",
+            resolvable=True,
+        ),
     ] = False
     enable_p2p_check: A[
         bool,

--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
@@ -82,6 +82,31 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
                         "HYV4 MXFP8: defaulting MoE/FP8 GEMM backends to deep_gemm."
                     )
 
+        # HYV4 manages its attention scatter/gather at the model level: it has
+        # no LayerCommunicator, its layers keep the full padded sequence at
+        # every boundary, and models/hunyuan_v4.py calls
+        # self.mlp(hidden_states, forward_batch) on that full width. It is
+        # therefore the case --disable-attn-tp-gather exists for, and leaving
+        # the gather on is not merely slower, it is silently wrong:
+        # require_attn_tp_gather() is True on "an a2a backend is set" alone, so
+        # the scheduler derives num_token_non_padded as this attn-TP rank's
+        # sequence SHARD, and DeepseekV2MoE.forward_deepep hands that
+        # shard-local count to a full-width batch -- every row at or past it
+        # gets topk_ids = -1. Measured on tp8/ep8 with a 5-token prompt padded
+        # to 8: tokens_per_rank = 1, so ranks 0-4 computed row 0 only and ranks
+        # 5-7 returned exactly 0.0, i.e. one token in eight, with no error and
+        # fluent output. Declared unconditionally rather than gated on
+        # moe_a2a_backend/moe_dense_tp_size: it is a no-op whenever
+        # require_attn_tp_gather() would have returned False anyway, and those
+        # two have post-declaration writers (--enable-waterfill forces
+        # moe_a2a_backend=deepep in a post-process), so a gate here would let
+        # the wrong-output path back in.
+        overrides["disable_attn_tp_gather"] = True
+        logger.info(
+            "HYV4 keeps the full sequence at its MoE and consumes no "
+            "gathered_buffer: disabling attn_tp_gather."
+        )
+
     if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
         # Set attention backend for DeepSeek
         if is_attention_backend_not_set(cfg):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -81,6 +81,7 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "ep_size",
                     "moe_dense_tp_size",
                     "attn_cp_size",
+                    "disable_attn_tp_gather",
                     "dcp_comm_backend",
                     "dcp_replicate_q_proj",
                     "disable_overlap_schedule",
@@ -3004,6 +3005,58 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 )
             with override_platform(is_sm100=False):
                 self.assertEqual(_deepseek_family_overrides(_args(), None), {})
+
+    def test_hyv4_always_disables_attn_tp_gather(self):
+        # HYV4 keeps the full padded sequence at its MoE, so an attn-TP-shard
+        # num_token_non_padded silently zeroes every row past the shard.
+        from sglang.srt.arg_groups.model_overrides.deepseek_v2 import (
+            _deepseek_family_overrides,
+        )
+
+        def _args(**kw):
+            defaults = dict(
+                attention_backend=None,
+                prefill_attention_backend=None,
+                decode_attention_backend=None,
+                enable_prefill_cp=False,
+                dcp_size=1,
+                tp_size=8,
+                dp_size=1,
+                enable_dp_attention=False,
+                moe_a2a_backend="deepep",
+                moe_dense_tp_size=None,
+                disable_attn_tp_gather=False,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        def _run(arch, **kw):
+            with patch(
+                "sglang.srt.configs.model_config.is_deepseek_dsa", return_value=False
+            ):
+                with override_platform(is_sm100=False):
+                    return _deepseek_family_overrides(
+                        _args(**kw), SimpleNamespace(architectures=[arch])
+                    )
+
+        for arch in ("HYV4ForCausalLM", "HYV4ForCausalLMNextN"):
+            # The declaration does not depend on what would have turned the
+            # gather on, because those fields have post-declaration writers.
+            for case, kw in (
+                ("deepep", {}),
+                ("no_a2a_backend", dict(moe_a2a_backend="none")),
+                (
+                    "moe_dense_tp_size",
+                    dict(moe_a2a_backend="none", moe_dense_tp_size=1),
+                ),
+                ("pure_dp_attention", dict(enable_dp_attention=True, dp_size=8)),
+                ("already_disabled", dict(disable_attn_tp_gather=True)),
+            ):
+                with self.subTest(arch=arch, case=case):
+                    self.assertEqual(_run(arch, **kw), {"disable_attn_tp_gather": True})
+
+        # Other members of the family are untouched.
+        self.assertEqual(_run("DeepseekV3ForCausalLM"), {})
 
     def test_qwen3_moe_family_quant_absorption(self):
         from sglang.srt.arg_groups.model_overrides.qwen3_moe import (


### PR DESCRIPTION
## Motivation

Fixes #38606.

HYV4 (Hunyuan-V4) manages its attention scatter/gather at the model level: it has no `LayerCommunicator`, its layers keep the full padded sequence at every boundary, and `models/hunyuan_v4.py` calls `self.mlp(hidden_states, forward_batch)` on that full width (`:606-607`). It never reads the upstream `gathered_buffer`.

`require_attn_tp_gather()` (`utils/common.py:3879`) returns True on "an a2a backend is set" alone (or `moe_dense_tp_size is not None`), so with `--moe-a2a-backend deepep` and `attn_tp_size > 1` the scheduler derives `num_token_non_padded` as this rank's sequence shard, and `DeepseekV2MoE.forward_deepep` hands that shard-local count to a full-width batch: every row at or past it gets `topk_ids = -1` and contributes nothing.

Measured on tp8/ep8 with a 5-token prompt padded to 8, `tokens_per_rank` is 1: ranks 0-4 computed row 0 only and ranks 5-7 returned exactly `0.0` — one token in eight, with no error raised, fluent output, and 16.7% higher throughput than the correct arm. Only a logprob comparison catches it. Full evidence table in #38606.

## Modifications

`--disable-attn-tp-gather` already exists for exactly this case; its own comment says *"Opt-out for models that manage SP scatter/gather at the model level and do not consume the upstream gathered_buffer."* Nothing in the tree declares it today. This PR declares it for HYV4 through the `arg_groups/model_overrides/` registry:

* `arg_groups/model_overrides/deepseek_v2.py` — HYV4 is already claimed by this family module, so the declaration goes in its existing `HYV4ForCausalLM`/`HYV4ForCausalLMNextN` branch.
* `arg_groups/fields/parallel.py` — a field has to be tagged `resolvable=True` for a declaration to reach it, so `disable_attn_tp_gather` gets the tag.
* `test/registered/unit/test_model_overrides.py` — the pinned resolvable-field set is extended in the same commit, as its comment instructs, plus a new test over both HYV4 architectures and five configurations, asserting that other members of the family are untouched.

The declaration is unconditional rather than gated on `moe_a2a_backend`/`moe_dense_tp_size`. It is a no-op whenever `require_attn_tp_gather()` would have returned False anyway, and both of those fields have post-declaration writers (`--enable-waterfill` forces `moe_a2a_backend=deepep` in a post-process), so a gate here would let the wrong-output path back in.

An alternative fix is to give `hunyuan_v4.py` a real `LayerCommunicator` so it consumes the gathered buffer like the DeepSeek models do. That is a much larger change and upstream's design call; this override is correct on its own and the two are not mutually exclusive.

## Accuracy Tests

On 8x B300, tp8/ep8, MXFP8 Hunyuan-V4-preview, first-token top-5 `abs(dlogprob)` against a `--moe-a2a-backend none` reference:

| arm | max abs(dlogprob) |
|---|---|
| `deepep`, before this PR | 7.48 |
| `deepep`, with the gather disabled | **0.410** |
| the `none` reference re-run against itself (noise floor) | 0.593 |

The MXFP8 measurement needed local patches unrelated to this PR to reach the MoE GEMM at activation group 32 at all; the defect and this fix are quantisation-independent, since it is purely a mismatch between the scheduler's `num_token_non_padded` contract and what the model hands its MoE.

## Speed Tests and Profiling

Output tok/s at concurrency 64 goes 2711.81 -> 2324.38, i.e. **this PR makes the arm slower**, because 8x as many tokens are now actually routed. There is no performance claim here; the previous number was the cost of computing one token in eight.

## Checklist

- [x] Formatted with the repo's `ruff-format` / `ruff --select=F401,F821,UP037` (pinned versions from `.pre-commit-config.yaml`).
- [x] Unit test added (`test_hyv4_always_disables_attn_tp_gather`), and the pinned resolvable-field set extended in the same commit.
- [ ] I could not execute `test/registered/unit/test_model_overrides.py` locally — no torch-capable environment on the machine this was written on. Please let CI validate it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34305633701](https://github.com/sgl-project/sglang/actions/runs/34305633701)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34305633487](https://github.com/sgl-project/sglang/actions/runs/34305633487)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34305633669](https://github.com/sgl-project/sglang/actions/runs/34305633669)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->