### PR TITLE
Add the expert-location hook to HYV4ForCausalLM

### DIFF
--- a/python/sglang/srt/models/hunyuan_v4.py
+++ b/python/sglang/srt/models/hunyuan_v4.py
@@ -7,6 +7,7 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.srt.distributed import get_pp_group
+from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.attention.index_topk_share import IndexTopKShareState
 from sglang.srt.layers.communicator import AttentionInputs, get_attn_tp_context
 from sglang.srt.layers.layernorm import RMSNorm
@@ -670,6 +671,17 @@ class HYV4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):
         return "HYV4 applies the SwiGLU limit only to routed experts."
+
+    @classmethod
+    def get_model_config_for_expert_location(cls, config):
+        # HYV4's sparse layers are DeepseekV2MoE, but the class inherits only
+        # the weight loader mixin, so it does not get DeepseekV3ForCausalLM's
+        # hook and the expert-location metadata would stay None.
+        return ModelConfigForExpertLocation(
+            num_layers=config.num_hidden_layers,
+            num_logical_experts=config.n_routed_experts,
+            num_groups=config.n_group,
+        )
 
     def __init__(self, config, quant_config=None, prefix=""):
         super().__init__()


### PR DESCRIPTION
## Motivation

`HYV4ForCausalLM` is `nn.Module, DeepseekV2WeightLoaderMixin` (`models/hunyuan_v4.py:667`), so it does not inherit `DeepseekV3ForCausalLM.get_model_config_for_expert_location`, while its sparse layers *are* `DeepseekV2MoE` and do take `forward_deepep`.

`eplb/expert_location.py:758`'s `hasattr(model_class, "get_model_config_for_expert_location")` is therefore False, the expert-location metadata stays `None`, and `eplb/expert_location_dispatch.py`'s `assert expert_location_metadata is not None` fires as a **bare** `AssertionError` with no message, minutes after weight load and during CUDA graph capture — so it reads like a graph or memory failure rather than a missing hook.

## Modifications

Add the classmethod to `HYV4ForCausalLM`. The body is DeepSeek's unchanged: the Hunyuan-V4 config carries `num_hidden_layers`, `n_routed_experts` and `n_group` with the same meaning (78 / 256 / 1 in the released preview checkpoint).

`ModelConfigForExpertLocation` is already imported at module scope by `models/deepseek_v2.py`, which `hunyuan_v4.py` imports, so the new import adds no load-order risk.

Note that `eplb/expert_location_dispatch.py` also reads the metadata before checking whether an EPLB dispatch algorithm is configured at all, which is why this crashes even with EPLB off. That is a separate 3-line fix, sent as its own PR; it does not remove the need for this hook, since EPLB itself does need it.

## Accuracy Tests

No output change: the hook only supplies expert-location metadata that was previously absent. With it, Hunyuan-V4-preview starts and serves on 8x B300 tp8/ep8 where it previously aborted during decode graph capture.

## Speed Tests and Profiling

Not applicable — startup-path only.

## Checklist

- [x] Formatted with the repo's `ruff-format` / `ruff --select=F401,F821,UP037` (pinned versions from `.pre-commit-config.yaml`).
- [ ] No unit test added: there is no existing test that asserts which model classes expose this hook, and adding a per-model registry test seemed out of scope for a 12-line fix. Happy to add one if you would like it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34305635461](https://github.com/sgl-project/sglang/actions/runs/34305635461)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34305635173](https://github.com/sgl-project/sglang/actions/runs/34305635173)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34305635381](https://github.com/sgl-project/sglang/actions/runs/34305635381)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->