### PR TITLE
Do not require expert-location metadata when no EPLB dispatch algorithm is set

### DIFF
--- a/python/sglang/srt/eplb/expert_location_dispatch.py
+++ b/python/sglang/srt/eplb/expert_location_dispatch.py
@@ -41,11 +41,14 @@ class ExpertLocationDispatchInfo:
     @classmethod
     def init_new(cls, layer_id: int):
         ep_dispatch_algorithm = get_exec().moe.ep_dispatch_algorithm
-        expert_location_metadata = get_global_expert_location_metadata()
-        assert expert_location_metadata is not None
-
         if ep_dispatch_algorithm is None:
             return None
+
+        expert_location_metadata = get_global_expert_location_metadata()
+        assert expert_location_metadata is not None, (
+            "no expert location metadata: the model class is missing "
+            "get_model_config_for_expert_location"
+        )
 
         return cls(
             ep_dispatch_algorithm=ep_dispatch_algorithm,

--- a/test/registered/unit/eplb/test_dispatch_info_init_new.py
+++ b/test/registered/unit/eplb/test_dispatch_info_init_new.py
@@ -1,0 +1,52 @@
+"""``ExpertLocationDispatchInfo.init_new`` must not require metadata it discards.
+
+With no ``ep_dispatch_algorithm`` — the default — ``init_new`` returns ``None``
+before reading the global expert-location metadata. A model class that does not
+define ``get_model_config_for_expert_location`` leaves that metadata ``None``,
+and asserting on it first turned EPLB-off serving into a bare ``AssertionError``.
+When an algorithm *is* configured the metadata is genuinely required, and the
+assert names the missing hook.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt import runtime_context as rc
+from sglang.srt.eplb import expert_location_dispatch
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestInitNewWithoutMetadata(CustomTestCase):
+    def setUp(self):
+        rc.reset_context()
+        rc.publish(ServerArgs(model_path="dummy"), role="test")
+        # The state a model class without the expert-location hook leaves behind.
+        self._patch = patch.object(
+            expert_location_dispatch,
+            "get_global_expert_location_metadata",
+            lambda: None,
+        )
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        rc.reset_context()
+
+    def test_returns_none_without_dispatch_algorithm(self):
+        self.assertIsNone(rc.get_exec().moe.ep_dispatch_algorithm)
+        self.assertIsNone(ExpertLocationDispatchInfo.init_new(layer_id=0))
+
+    def test_assert_names_the_hook_when_an_algorithm_is_set(self):
+        rc.get_context().override("test", ep_dispatch_algorithm="static")
+        with self.assertRaises(AssertionError) as ctx:
+            ExpertLocationDispatchInfo.init_new(layer_id=0)
+        self.assertIn("get_model_config_for_expert_location", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`ExpertLocationDispatchInfo.init_new` asserts that the global expert-location metadata is not `None` **before** checking whether an `ep_dispatch_algorithm` is configured at all:

```python
ep_dispatch_algorithm = get_exec().moe.ep_dispatch_algorithm
expert_location_metadata = get_global_expert_location_metadata()
assert expert_location_metadata is not None

if ep_dispatch_algorithm is None:
    return None
```

With the default (`ep_dispatch_algorithm is None`) the function was about to return `None` and discard the value it just asserted on. So any model whose class does not define `get_model_config_for_expert_location` crashes on a bare `AssertionError` — with EPLB switched off, on a value nothing would have read.

## Modifications

Move the metadata read after the early return, and give the assert a message, so the case that legitimately requires the metadata (an EPLB dispatch algorithm *is* configured) names the missing hook instead of showing an empty traceback.

This is not a substitute for a model adding the hook — EPLB needs it — but it stops the absence from being fatal by default.

## Accuracy Tests

No behaviour change on any configured path: when `ep_dispatch_algorithm` is set, the metadata is read and asserted exactly as before; when it is not, the function returns `None` as it always intended to.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Formatted with the repo's `ruff-format` / `ruff --select=F401,F821,UP037` (pinned versions from `.pre-commit-config.yaml`).
- [ ] No unit test added — the change is a reordering with no new branch. Happy to add one if you would prefer the early return pinned.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34312563289](https://github.com/sgl-project/sglang/actions/runs/34312563289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34312563080](https://github.com/sgl-project/sglang/actions/runs/34312563080)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34312563324](https://github.com/sgl-project/sglang/actions/runs/34312563324)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->