### PR TITLE
[Fix] Explain disabled DP attention in TBO validation

### DIFF
--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -450,8 +450,16 @@ def check_two_batch_overlap(server_args: Any):
         and cfg.moe_a2a_backend == "none"
         and not cfg.enable_dp_attention
     ):
-        raise ValueError(
+        message = (
             "When enabling two batch overlap without an EP a2a backend "
             "(moe_a2a_backend='none'), --enable-dp-attention is required "
             "(DeepSeek-V4 non-EP DP TBO path)."
         )
+        if cfg.dp_size == 1 and cfg.ep_join_mode != "scale":
+            message += (
+                " DP attention is disabled when --dp-size=1 outside EP scale mode, "
+                "even if --enable-dp-attention is explicitly set. "
+                "Set --dp-size to a value greater than 1 together with "
+                "--enable-dp-attention, or disable --enable-two-batch-overlap."
+            )
+        raise ValueError(message)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -42,9 +42,11 @@ from sglang.srt.arg_groups.moe_hook import (
     validate_deepep_v2_speculative_draft,
 )
 from sglang.srt.arg_groups.overrides import (
+    _data_parallelism_defaults,
     cutedsl_moe_max_num_tokens,
     max_speculative_num_draft_tokens,
     resolution_result,
+    run_post_process_pass,
 )
 from sglang.srt.arg_groups.parallel_hook import (
     handle_context_parallelism,
@@ -2782,8 +2784,8 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
     requires --enable-dp-attention. This replaced the removed opt-in
     SGLANG_ENABLE_DP_TBO env: enabling DP TBO now needs no extra flag.
 
-    dummy-model short-circuits __post_init__, so the guard handler is invoked
-    directly (same pattern as TestWaterfillArgs)."""
+    dummy-model short-circuits __post_init__, so the data-parallel defaults
+    pass and the guard handler are invoked directly, in pipeline order."""
 
     def _args(self, **overrides):
         args = ServerArgs(model_path="dummy")
@@ -2792,17 +2794,41 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args.enable_dp_attention = False
         for key, value in overrides.items():
             setattr(args, key, value)
+        run_post_process_pass(args, _data_parallelism_defaults)
         return args
 
     def test_no_a2a_without_dp_attention_raises(self):
-        args = self._args(enable_dp_attention=False)
-        with self.assertRaisesRegex(ValueError, "enable-dp-attention"):
+        args = self._args(tp_size=2, dp_size=2, enable_dp_attention=False)
+        with self.assertRaisesRegex(ValueError, "enable-dp-attention") as exc:
             check_two_batch_overlap(args)
+        self.assertNotIn("--dp-size=1", str(exc.exception))
+
+    def test_single_dp_rank_explains_disabled_dp_attention(self):
+        for requested_dp_attention in (False, True):
+            with self.subTest(enable_dp_attention=requested_dp_attention):
+                args = self._args(
+                    tp_size=4,
+                    dp_size=1,
+                    enable_dp_attention=requested_dp_attention,
+                )
+                # The raw CLI flag can still be true; validation must inspect
+                # the resolved value after the data-parallel defaults pass.
+                self.assertEqual(args.enable_dp_attention, requested_dp_attention)
+                self.assertFalse(resolution_result(args, "enable_dp_attention"))
+                with self.assertRaisesRegex(
+                    ValueError, "--dp-size=1.*--dp-size to a value greater than 1"
+                ) as exc:
+                    check_two_batch_overlap(args)
+                self.assertIn(
+                    "even if --enable-dp-attention is explicitly set",
+                    str(exc.exception),
+                )
+                self.assertIn("disable --enable-two-batch-overlap", str(exc.exception))
 
     def test_no_a2a_with_dp_attention_ok(self):
         # DP TBO path is valid: --enable-dp-attention + --enable-two-batch-overlap
         # with a2a backend 'none' must NOT raise (no SGLANG_ENABLE_DP_TBO needed).
-        args = self._args(enable_dp_attention=True)
+        args = self._args(tp_size=2, dp_size=2, enable_dp_attention=True)
         check_two_batch_overlap(args)
 
     def test_ep_a2a_backend_ok_without_dp_attention(self):
@@ -2810,6 +2836,21 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         # require dp-attention there.
         args = self._args(moe_a2a_backend="deepep", enable_dp_attention=False)
         check_two_batch_overlap(args)
+
+    def test_single_dp_rank_without_tbo_ok(self):
+        args = self._args(enable_two_batch_overlap=False, enable_dp_attention=True)
+        check_two_batch_overlap(args)
+
+    def test_ep_scale_preserves_dp_attention_with_single_dp_rank(self):
+        args = self._args(ep_join_mode="scale", enable_dp_attention=True)
+        self.assertTrue(resolution_result(args, "enable_dp_attention"))
+        check_two_batch_overlap(args)
+
+    def test_ep_scale_without_dp_attention_keeps_original_error(self):
+        args = self._args(ep_join_mode="scale", enable_dp_attention=False)
+        with self.assertRaisesRegex(ValueError, "enable-dp-attention") as exc:
+            check_two_batch_overlap(args)
+        self.assertNotIn("--dp-size=1", str(exc.exception))
 
 
 class TestDcpKvEventContract(CustomTestCase):


### PR DESCRIPTION
## Motivation

Addresses request 1 (the misleading parameter diagnostic) in #36840. This is a partial fix and should not close the issue: full GLM-5.3-Flash TBO support and the other backend limitations are out of scope.

Outside EP scale mode, `_data_parallelism_defaults` resolves DP attention to `False` when `dp_size == 1`, even if the operator explicitly passed `--enable-dp-attention`. The non-EP TBO guard then tells the operator to add the same flag that was just disabled, without explaining the DP-size requirement.

## Modifications

- Keep the existing TBO acceptance/rejection conditions unchanged.
- When the existing guard rejects a single-DP-rank configuration outside EP scale mode, explain why the flag is disabled and suggest increasing `--dp-size` with `--enable-dp-attention`, or disabling TBO.
- Exercise the real data-parallel defaults pass before validation in the existing CPU test class. Cover explicit/omitted DP attention, valid multi-rank DP, EP all-to-all, EP scale exceptions, and TBO disabled.
- Based on upstream `2952c8d5ea`; do not restore the legacy ROCm CP exception removed upstream.

## Accuracy Tests

No model forward, kernel, or output changes. No model checkpoint was loaded.

CPU regression testing was performed on a Linux host with 8 H20 GPUs, using existing Python 3.12.11 / PyTorch 2.13.0 dependencies and the source checkout via `PYTHONPATH`:

```bash
CUDA_VISIBLE_DEVICES=8 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
PYTHONPATH=python python3 \
  test/registered/unit/server_args/test_server_args.py \
  TestTwoBatchOverlapBackend -v
```

`8` is deliberately outside the host's GPU indices `0..7`, hiding all GPUs. This is CPU-only validation, not a GPU inference test. The existing environment emitted a CUDA driver compatibility warning; no driver or dependency changes were made.

| Source | Result with the same new regression tests |
| --- | --- |
| Upstream `2952c8d5ea` | 7 tests run; the two `dp_size=1` subcases fail because the diagnostic omits the DP-size explanation |
| This fix | All 7 tests pass |

The remote source and test files were SHA-256 checked against the submitted files. `git diff --check` and import sorting with the existing `isort 6.1.0` also pass. The full pre-commit suite has not been run; no additional tools were installed.

## Speed Tests and Profiling

Not applicable: only the error message on an already-rejected startup configuration changes. No throughput or model-support improvement is claimed.

## Checklist

- [ ] Run the full repository pre-commit suite (not run; limited checks described above).
- [x] Add CPU regression tests in the existing CI-registered test file.
- [x] Review against the existing code style and keep the change narrowly scoped.
- Documentation: no CLI flags or defaults changed; the actionable diagnostic is updated in code.
- Accuracy/speed benchmarks: not applicable to this diagnostic-only change.

AI assistance was used for implementation and test preparation.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34306913466](https://github.com/sgl-project/sglang/actions/runs/34306913466)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34306913320](https://github.com/sgl-project/sglang/actions/runs/34306913320)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34306913693](https://github.com/sgl-project/sglang/actions/runs/34306913693)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->