### PR TITLE
docker(xpu): unblock nightly build (setvars.sh + sgl-kernel rename)

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -91,8 +91,12 @@ RUN echo "Cloning ${SG_LANG_BRANCH} from ${SG_LANG_REPO}" && \
 # major to it -- under build isolation torch is absent and the match is skipped.
 # Pinned (v0.0.10b2) so image builds are reproducible; bump via --build-arg.
 ARG TORCH_MEMORY_SAVER_REF=a5c99f11b18ebb8e9fda71a68812e476ae49e417
-RUN . /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
+# Keep setvars.sh's stderr and don't chain with `&&`: an optional component's
+# vars.sh can exit non-zero while SYCL is still exported. `set -e` fails on pip.
+RUN set -e; \
+    . /opt/intel/oneapi/setvars.sh --force || \
+      echo "setvars.sh exited $? -- continuing; pip will fail loudly if SYCL is missing"; \
     TMS_PLATFORM=xpu pip install --no-cache-dir --no-build-isolation \
-    git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
+      git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
 
 CMD ["bash", "-c", "source /opt/intel/oneapi/setvars.sh --force && exec bash"]

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -54,7 +54,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
+  "sglang-kernel-xpu @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
   "smg-grpc-servicer>=0.5.0",
   "soundfile==0.13.1",
   "tiktoken",


### PR DESCRIPTION
## Summary
Unblock the `Release Docker Images Nightly (Intel XPU)` build. The nightly hits two independent failures in the same pipeline; this PR fixes both.

## 1. `torch_memory_saver` step exits 3 with no visible error
Failing run: [34225492633 step #14](https://github.com/sgl-project/sglang/actions/runs/34225492633/job/102058474661) — layer added by #29935 (2026-09-08).

Offending RUN in `docker/xpu.Dockerfile`:

```dockerfile
RUN . /opt/intel/oneapi/setvars.sh --force >/dev/null 2>&1 && \
    TMS_PLATFORM=xpu pip install --no-cache-dir --no-build-isolation \
    git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
```

- `>/dev/null 2>&1` silences setvars.sh, so which component env script failed never made it into CI.
- `&&` short-circuits: setvars.sh sources many per-component `vars.sh` scripts and returns the last non-zero it hit. An optional component (debugger, MPI, …) can exit non-zero while the compiler / SYCL vars torch_memory_saver actually needs are still exported. When that happens, pip never runs.

Fix — rewrite the RUN to:
1. Keep setvars.sh's stderr so future failures are diagnosable.
2. Log-and-continue on setvars.sh non-zero instead of gating pip on it.
3. Keep pip's failure fatal via `set -e`.

If SYCL really isn't set up, pip will now fail with the actual missing-toolchain error instead of an unexplained exit 3.

## 2. `sgl-kernel` dependency name drifted from the source package
`sgl-project/sgl-kernel-xpu#462` renamed the Python package to `sglang-kernel-xpu` (2026-09-09). pip enforces name consistency between a URL requirement's left-hand identity and the metadata built from the source, so the existing line in `python/pyproject_xpu.toml`:

```
sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git
```

now trips:

```
WARNING: Generating metadata for package sgl-kernel produced metadata for project name sglang-kernel-xpu.
Discarding git+https://github.com/sgl-project/sgl-kernel-xpu.git: … expected 'sgl-kernel', but metadata has 'sglang-kernel-xpu'
```

pip then falls back to the unrelated CUDA `sgl-kernel` on PyPI and the resolver bails with `No matching distribution found for sgl-kernel (unavailable)`.

Fix — one-line rename of the requirement identity to match the source package name. (Analogous CUDA path in `python/pyproject.toml` already tracks this rename; only the XPU line was missed.)

## Test plan
- [ ] Retrigger `Release Docker Images Nightly (Intel XPU)` on this branch → build reaches `Push intel/sglang-dev` and succeeds.
- [ ] `pip install -e .` against `pyproject_xpu.toml` on a Python 3.12 XPU env resolves cleanly (no `Discarding git+…` warning, `sglang-kernel-xpu` builds and installs).
- [ ] If the docker build still fails, the CI log now shows the real setvars.sh error (or the real pip build error), which we couldn't previously see.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34320250639](https://github.com/sgl-project/sglang/actions/runs/34320250639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34329398661](https://github.com/sgl-project/sglang/actions/runs/34329398661)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:white_check_mark: [Run #34320250616](https://github.com/sgl-project/sglang/actions/runs/34320250616)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->