### PR TITLE
Make int8 mamba checkpoint pool compatible with Qwen4-Exp PLE side states

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_checkpoint_pool.py
+++ b/python/sglang/srt/mem_cache/mamba_checkpoint_pool.py
@@ -53,6 +53,7 @@ from typing import List, Optional
 import torch
 
 from sglang.srt.mem_cache.allocator.mamba import MambaSlotAllocator
+from sglang.srt.mem_cache.ple_state_pool import SlotIndexedState
 from sglang.srt.runtime_context import get_exec
 
 logger = logging.getLogger(__name__)
@@ -197,6 +198,7 @@ class MambaCheckpointPool:
         conv_dtype: torch.dtype,
         device: str,
         temporal_dtype: Optional[torch.dtype] = None,
+        ple_side_states: Optional[List[SlotIndexedState]] = None,
     ):
         self.num_slots = num_slots
         self.device = device
@@ -224,6 +226,19 @@ class MambaCheckpointPool:
             for shape in conv_shapes
         ]
         self.allocator = MambaSlotAllocator(size=num_slots, device=device)
+        # PLE side-state mirrors: one row-block per cached slot, same dtype as
+        # the source (short-conv bf16 / n-gram context int64). Both are exact
+        # copies, not quantized — the int8 path only touches the temporal state.
+        self.ple_mirrors: List[tuple] = []
+        for st in ple_side_states or []:
+            t, dim = self._ple_source(st)
+            if t is None:
+                continue
+            shape = list(t.shape)
+            shape[dim] = num_slots + 1
+            self.ple_mirrors.append(
+                (st, torch.empty(tuple(shape), dtype=t.dtype, device=device), dim)
+            )
 
     # ---- lifecycle (delegates to the embedded allocator) ----
 
@@ -239,7 +254,22 @@ class MambaCheckpointPool:
     def clear(self) -> None:
         """Release every checkpoint slot (radix flush/reset). The int8 qdata is
         left as-is; slots are reused/overwritten on the next store."""
+        # Mirrors intentionally survive the flush: reads follow a fresh
+        # store into a re-handed slot, same discipline as qdata above.
         self.allocator.clear()
+
+    @staticmethod
+    def _ple_source(st: SlotIndexedState):
+        """Return the side state's main (slot-indexed) tensor and its slot axis.
+        ShortConvPool.conv_state is layer-major (slot dim 1); NGramPool.context
+        is slot-major (dim 0). Mirrors the layout comments in ple_state_pool."""
+        t = getattr(st, "conv_state", None)
+        if t is not None:
+            return t, 1
+        t = getattr(st, "context", None)
+        if t is not None:
+            return t, 0
+        return None, 0
 
     # ---- state transfer between the active MambaPool and this store ----
 
@@ -250,6 +280,14 @@ class MambaCheckpointPool:
         self.temporal.store_from_pool(cache.temporal, active_slots, ckpt_slots)
         for i, c in enumerate(self.conv):
             c[:, ckpt_slots] = cache.conv[i][:, active_slots]
+        for st, mirror, dim in self.ple_mirrors:
+            src, _ = self._ple_source(st)
+            if src is None:
+                continue
+            if dim == 1:
+                mirror[:, ckpt_slots] = src[:, active_slots]
+            else:
+                mirror[ckpt_slots] = src[active_slots]
 
     def load_to_active(self, active_mamba_pool, ckpt_slots, active_slots) -> None:
         """Dequantize temporal + copy conv from checkpoint slots into the active pool
@@ -258,6 +296,14 @@ class MambaCheckpointPool:
         self.temporal.copy_to_pool(cache.temporal, ckpt_slots, active_slots)
         for i, c in enumerate(self.conv):
             cache.conv[i][:, active_slots] = c[:, ckpt_slots].to(cache.conv[i].dtype)
+        for st, mirror, dim in self.ple_mirrors:
+            dst, _ = self._ple_source(st)
+            if dst is None:
+                continue
+            if dim == 1:
+                dst[:, active_slots] = mirror[:, ckpt_slots].to(dst.dtype)
+            else:
+                dst[active_slots] = mirror[ckpt_slots].to(dst.dtype)
 
     @staticmethod
     def estimate_mem_usage_bytes(
@@ -270,6 +316,7 @@ class MambaCheckpointPool:
         conv_shapes: List[tuple],
         conv_dtype: torch.dtype,
         temporal_dtype: torch.dtype,
+        ple_extra_bytes: int = 0,
     ) -> dict:
         """Estimate the pool's HBM footprint (bytes) WITHOUT allocating, so a
         caller can check it against free memory before construction. Mirrors the
@@ -290,12 +337,16 @@ class MambaCheckpointPool:
             "qdata": qdata,
             "scale": scale,
             "conv": conv,
-            "total": qdata + scale + conv,
+            "ple": ple_extra_bytes,
+            "total": qdata + scale + conv + ple_extra_bytes,
         }
 
     def mem_usage_bytes(self) -> int:
         conv_bytes = sum(c.numel() * c.element_size() for c in self.conv)
-        return self.temporal.mem_usage_bytes() + conv_bytes
+        ple_bytes = sum(
+            m.numel() * m.element_size() for _, m, _ in self.ple_mirrors
+        )
+        return self.temporal.mem_usage_bytes() + conv_bytes + ple_bytes
 
 
 def maybe_init_int8_mamba_checkpoint_pool(
@@ -304,6 +355,7 @@ def maybe_init_int8_mamba_checkpoint_pool(
     cache_params,
     mamba_layer_ids: List[int],
     device: str,
+    ple_side_states: Optional[List[SlotIndexedState]] = None,
 ) -> Optional[MambaCheckpointPool]:
     """Build the optional int8 ``MambaCheckpointPool`` when
     ``--enable-int8-mamba-checkpoint`` is set (and a global server-args context
@@ -339,7 +391,23 @@ def maybe_init_int8_mamba_checkpoint_pool(
         temporal_dtype=cache_params.dtype.temporal,
     )
 
-    est = MambaCheckpointPool.estimate_mem_usage_bytes(**kwargs)
+    # Mirror the PLE side states (exact dtype, per cached slot) so a donated
+    # bf16 active slot never orphans its short-conv / n-gram rows.
+    ple_extra = 0
+    for st in ple_side_states or []:
+        t, dim = MambaCheckpointPool._ple_source(st)
+        if t is None:
+            continue
+        others = 1
+        for i, s in enumerate(t.shape):
+            if i != dim:
+                others *= int(s)
+        ple_extra += (ckpt_size + 1) * others * t.element_size()
+    kwargs["ple_side_states"] = list(ple_side_states or [])
+
+    est = MambaCheckpointPool.estimate_mem_usage_bytes(
+        **kwargs, ple_extra_bytes=ple_extra
+    )
     free_bytes = None
     if isinstance(device, str) and device.startswith("cuda"):
         try:
@@ -349,7 +417,8 @@ def maybe_init_int8_mamba_checkpoint_pool(
     logger.info(
         f"int8 mamba checkpoint pool: {ckpt_size} slots, "
         f"{est['total'] / GB:.2f}GB (qdata {est['qdata'] / GB:.2f} + scale "
-        f"{est['scale'] / GB:.2f} + conv {est['conv'] / GB:.2f}); active mamba "
+        f"{est['scale'] / GB:.2f} + conv {est['conv'] / GB:.2f} + ple "
+        f"{est.get('ple', 0) / GB:.2f}); active mamba "
         f"pool {mamba_size} slots"
         + (f"; free HBM {free_bytes / GB:.2f}GB" if free_bytes is not None else "")
     )

--- a/python/sglang/srt/mem_cache/mamba_checkpoint_pool.py
+++ b/python/sglang/srt/mem_cache/mamba_checkpoint_pool.py
@@ -403,8 +403,6 @@ def maybe_init_int8_mamba_checkpoint_pool(
             if i != dim:
                 others *= int(s)
         ple_extra += (ckpt_size + 1) * others * t.element_size()
-    kwargs["ple_side_states"] = list(ple_side_states or [])
-
     est = MambaCheckpointPool.estimate_mem_usage_bytes(
         **kwargs, ple_extra_bytes=ple_extra
     )
@@ -429,7 +427,9 @@ def maybe_init_int8_mamba_checkpoint_pool(
             f"(currently {ckpt_size}) or --mem-fraction-static."
         )
 
-    pool = MambaCheckpointPool(device=device, **kwargs)
+    pool = MambaCheckpointPool(
+        device=device, ple_side_states=list(ple_side_states or []), **kwargs
+    )
     # NOTE: this pool's HBM is NOT subtracted from the KV-cache budget
     # (max_total_num_tokens); it is allocated from --mem-fraction-static headroom.
     # The estimate check above guards against an oversized pool; accounting it in

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1341,21 +1341,18 @@ class HybridReqToTokenPool(ReqToTokenPool):
             maybe_init_int8_mamba_checkpoint_pool,
         )
 
+        ple_states = [
+            p
+            for p in (self.short_conv_pool, self.ngram_pool)
+            if p.enabled
+        ]
         self.mamba_ckpt_pool = maybe_init_int8_mamba_checkpoint_pool(
             mamba_size=mamba_size,
             cache_params=cache_params,
             mamba_layer_ids=mamba_layer_ids,
             device=device,
+            ple_side_states=ple_states,
         )
-        if self.mamba_ckpt_pool is not None and (
-            self.short_conv_pool.enabled or self.ngram_pool.enabled
-        ):
-            # The int8 checkpoint pool frees the bf16 slot after donating its state,
-            # taking the bf16-slot-indexed PLE side states with it.
-            raise ValueError(
-                "--enable-int8-mamba-checkpoint is incompatible with Qwen4-Exp "
-                "PLE side states"
-            )
 
         self.device = device
         req_pool_size = self.req_to_token.shape[0]

--- a/test/registered/mem_cache/test_int8_checkpoint_store.py
+++ b/test/registered/mem_cache/test_int8_checkpoint_store.py
@@ -121,6 +121,42 @@ class TestInt8CheckpointCodec(unittest.TestCase):
             self.assertEqual(est["qdata"] + est["scale"] + est["conv"], est["total"])
             self.assertEqual(est["total"], pool.mem_usage_bytes())
 
+    def test_maybe_init_with_ple_side_states(self):
+        # The factory path must not leak ple_side_states into the estimate kwargs,
+        # and must build ckpt-slot-indexed mirrors for each side state.
+        from types import SimpleNamespace
+
+        import sglang.srt.mem_cache.mamba_checkpoint_pool as mcp
+        from sglang.srt.mem_cache.ple_state_pool import NGramPool, ShortConvPool
+
+        sc = ShortConvPool(
+            size=6, state_shape=(1, 8), layer_ids=[0, 1],
+            dtype=torch.bfloat16, device="cpu",
+        )
+        ng = NGramPool(size=6, context_len=8, eos_token_id=1, device="cpu")
+        params = SimpleNamespace(
+            shape=SimpleNamespace(temporal=(H, V, K), conv=[(4, K)]),
+            dtype=SimpleNamespace(temporal=torch.bfloat16, conv=torch.bfloat16),
+        )
+        fake = SimpleNamespace(
+            mamba=SimpleNamespace(enable_int8_mamba_checkpoint=True,
+                                  int8_mamba_ckpt_size=8)
+        )
+        orig = mcp.get_exec
+        mcp.get_exec = lambda: fake
+        try:
+            pool = mcp.maybe_init_int8_mamba_checkpoint_pool(
+                mamba_size=6, cache_params=params, mamba_layer_ids=[0, 1],
+                device="cpu", ple_side_states=[sc, ng],
+            )
+        finally:
+            mcp.get_exec = orig
+        self.assertIsNotNone(pool)
+        self.assertEqual(len(pool.ple_mirrors), 2)
+        # mirrors are sized to the checkpoint pool, not the active pool
+        self.assertEqual(pool.ple_mirrors[0][1].shape[1], 9)
+        self.assertEqual(pool.ple_mirrors[1][1].shape[0], 9)
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA + fla kernels")
 class TestInt8CheckpointDecodeError(unittest.TestCase):


### PR DESCRIPTION
## What

The `--enable-int8-mamba-checkpoint` pool and Qwen4-Exp PLE side states (`ShortConvPool` / `NGramPool`) were mutually exclusive: combining them raised `ValueError` at pool init, disabling the int8 prefix-cache feature exactly on the hybrid models that benefit most.

## Why it broke

The int8 checkpoint pool frees the bf16 active slot right after donating its state into the checkpoint store. The PLE side states are indexed by that same bf16 slot index and were **not** donated — they got orphaned with the freed slot, so a later cache-hit restore into a fresh slot would read stale/mismatched side-state rows.

## Fix

`MambaCheckpointPool` gains ckpt-slot-indexed **mirror buffers** for each enabled side state:

- exact dtype copies (bf16 conv rows / int64 n-gram context rows) — no quantization, the int8 path only touches the temporal state
- `store_from_active` / `load_to_active` carry the side-state rows alongside temporal + conv, so a donated slot's full state (PLE included) round-trips
- mirrors survive `clear()` by design (same discipline as the qdata)
- `estimate_mem_usage_bytes` gains a `ple` term so the pre-allocation HBM fit-check stays honest
- layout handled per source: `ShortConvPool.conv_state` is layer-major (slot axis 1), `NGramPool.context` is slot-major (axis 0)

Mirror overhead is small — tens of MB versus ~27 MB/slot for the temporal state.

## Test

Extended CPU coverage in `test/registered/mem_cache/test_int8_checkpoint_store.py` style (standalone roundtrip harness): store -> wipe source rows -> load restores temporal, conv-window, short-conv and n-gram rows exactly (int64 dtype fidelity checked); latest-checkpoint-wins + earlier-checkpoint-intact; ple estimate == mirror bytes; alloc/clear availability contract; mirror sizing ckpt_slots+1 and source pools untouched. Existing `test_int8_checkpoint_store.py` still passes (7 tests OK).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34312313954](https://github.com/sgl-project/sglang/actions/runs/34312313954)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34312313687](https://github.com/sgl-project/sglang/actions/runs/34312313687)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34312313882](https://github.com/sgl-project/sglang/actions/runs/34312313882)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->