### PR TITLE
[Bug] qwen3_coder: stop harvesting phantom tool_calls from quoted markup

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -58,6 +59,11 @@ class Qwen3CoderDetector(BaseFormatDetector):
         # Initialize attributes that were missing in the original PR
         self.current_func_name: Optional[str] = None
 
+        # Set when a <function=NAME> inside a genuine <tool_call> wrapper
+        # names a tool that was not declared -- the rest of that call region
+        # is then dropped instead of streamed as a phantom delta.tool_calls.
+        self._suppress_current_call: bool = False
+
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
 
@@ -90,6 +96,25 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     return {}
         logger.warning(f"Tool '{func_name}' is not defined in the tools list.")
         return {}
+
+    def _is_declared_tool(self, func_name: str, tools: Optional[list[Tool]]) -> bool:
+        """Whether ``func_name`` should be emitted as a tool call.
+
+        True when it matches a declared function tool, when unknown tool
+        calls are being forwarded (``SGLANG_FORWARD_UNKNOWN_TOOLS``), or when
+        there is nothing to validate against. Mirrors
+        ``base_format_detector.parse_base_json``, which drops names outside
+        the declared set unless that env var is set.
+        """
+        if not tools or envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
+            return True
+        for config in tools:
+            try:
+                if config.type == "function" and config.function.name == func_name:
+                    return True
+            except AttributeError:
+                continue
+        return False
 
     def _get_param_type(self, param_schema: Any) -> str:
         """Infer the parser conversion type from a JSON schema parameter."""
@@ -201,6 +226,11 @@ class Qwen3CoderDetector(BaseFormatDetector):
 
                     name_end = func_body.index(">")
                     func_name = func_body[:name_end]
+                    if not self._is_declared_tool(func_name, tools):
+                        logger.warning(
+                            f"Model attempted to call undefined function: {func_name}"
+                        )
+                        continue
                     params_str = func_body[name_end + 1 :]
 
                     param_config = self._get_arguments_config(func_name, tools)
@@ -270,6 +300,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # 1. Priority detection: check if it's the start of Tool Call
             # -------------------------------------------------------
             if current_slice.startswith(self.tool_call_start_token):
+                self._suppress_current_call = False
                 self.parsed_pos += len(self.tool_call_start_token)
                 self.is_inside_tool_call = True
                 continue
@@ -277,10 +308,35 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # -------------------------------------------------------
             # 2. Function Name: <function=name>
             # -------------------------------------------------------
-            if current_slice.startswith(self.tool_call_prefix):
+            # Recognize the tool-call structure tags (this branch and 3-5
+            # below) only while inside a <tool_call>...</tool_call> wrapper:
+            # the same <function=/<parameter= markup quoted in ordinary
+            # assistant prose (a fenced example, an echoed payload, reasoning
+            # about tool syntax) is not an invocation. has_tool_call() and
+            # the non-streaming detect_and_parse() both require the wrapper
+            # token; the streaming path must agree, or a bare "<function=X>"
+            # in prose is streamed as a phantom delta.tool_calls named X.
+            if self.is_inside_tool_call and current_slice.startswith(
+                self.tool_call_prefix
+            ):
                 end_angle = current_slice.find(">")
                 if end_angle != -1:
                     func_name = current_slice[len(self.tool_call_prefix) : end_angle]
+
+                    if not self._is_declared_tool(func_name, tools):
+                        # A genuine <tool_call> wrapper, but the name is not a
+                        # declared tool: an example the model quoted (fenced
+                        # or in its reasoning) or a near-miss truncation.
+                        # Emit the literal tag as text and swallow the rest
+                        # of this call region instead of a phantom call.
+                        logger.warning(
+                            f"Model attempted to call undefined function: {func_name}"
+                        )
+                        self._suppress_current_call = True
+                        self.current_func_name = None
+                        normal_text_chunks.append(current_slice[: end_angle + 1])
+                        self.parsed_pos += end_angle + 1
+                        continue
 
                     self.current_tool_id += 1
                     self.current_tool_name_sent = True
@@ -305,7 +361,11 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # -------------------------------------------------------
             # 3. Parameter: <parameter=name>value...
             # -------------------------------------------------------
-            if current_slice.startswith(self.parameter_prefix):
+            if (
+                self.is_inside_tool_call
+                and not self._suppress_current_call
+                and current_slice.startswith(self.parameter_prefix)
+            ):
                 name_end = current_slice.find(">")
                 if name_end != -1:
                     value_start_idx = name_end + 1
@@ -389,7 +449,14 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # -------------------------------------------------------
             # 4. Function End: </function>
             # -------------------------------------------------------
-            if current_slice.startswith(self.function_end_token):
+            if self.is_inside_tool_call and current_slice.startswith(
+                self.function_end_token
+            ):
+                if self._suppress_current_call:
+                    self._suppress_current_call = False
+                    self.current_func_name = None
+                    self.parsed_pos += len(self.function_end_token)
+                    continue
                 if not self.json_started:
                     calls.append(
                         ToolCallItem(tool_index=self.current_tool_id, parameters="{")
@@ -406,9 +473,12 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # -------------------------------------------------------
             # 5. Tool Call End: </tool_call>
             # -------------------------------------------------------
-            if current_slice.startswith(self.tool_call_end_token):
+            if self.is_inside_tool_call and current_slice.startswith(
+                self.tool_call_end_token
+            ):
                 self.parsed_pos += len(self.tool_call_end_token)
                 self.is_inside_tool_call = False  # [FIX] Exit tool call region
+                self._suppress_current_call = False
                 continue
 
             # -------------------------------------------------------

--- a/test/registered/unit/function_call/test_qwen3_coder_detector.py
+++ b/test/registered/unit/function_call/test_qwen3_coder_detector.py
@@ -1,0 +1,202 @@
+"""Unit tests for Qwen3CoderDetector -- phantom tool-call over-capture.
+
+qwen3_coder_detector emitted ``tool_calls`` from tool-call markup the model
+only *quotes* (fenced examples, echoed payloads, reasoning about tool syntax).
+Two failure layers, both covered here:
+
+1. Bare ``<function=NAME>`` in prose (no wrapper). ``parse_streaming_increment``
+   matched the structure tags anywhere in the buffer; the non-streaming
+   ``detect_and_parse`` did not (it bails unless the ``<tool_call>`` wrapper is
+   present). Fix: gate the streaming ``<function=`` / ``<parameter=`` /
+   ``</function>`` / ``</tool_call>`` branches on ``self.is_inside_tool_call``.
+
+2. ``<tool_call><function=NAME>`` where ``NAME`` is a placeholder / near-miss
+   (``run_command`` for a declared ``run_commands``). Layer 1 still harvested
+   it -- identically in stream and non-stream, because neither path validated
+   the name. Fix: ``_is_declared_tool()`` -- in both paths a name that is not a
+   declared tool is dropped (honoring ``SGLANG_FORWARD_UNKNOWN_TOOLS``), the
+   same policy ``base_format_detector.parse_base_json`` uses for the JSON
+   detectors.
+
+No server, no model loading -- pure parser unit test.
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+# Tokens assembled from fragments so this source file never carries a
+# contiguous tool call that a transcript-scanning agent could self-harvest.
+FN_OPEN = "<" + "function="
+FN_CLOSE = "<" + "/function" + ">"
+PAR_OPEN = "<" + "parameter="
+PAR_CLOSE = "<" + "/parameter" + ">"
+TC_OPEN = "<" + "tool_call" + ">"
+TC_CLOSE = "<" + "/tool_call" + ">"
+
+
+def _tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="run_commands",
+                parameters={
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                },
+            ),
+        )
+    ]
+
+
+# (1) Bare, wrapper-less <function=...> the way docs abbreviate example markup.
+BARE_PROSE = (
+    "Here is what a call looks like:\n```text\n"
+    + FN_OPEN
+    + "..."
+    + ">\n"
+    + PAR_OPEN
+    + "path"
+    + ">\n/etc/hosts\n"
+    + PAR_CLOSE
+    + "\n(truncated -- no closing function tag)\n"
+    + FN_OPEN
+    + "example_function_name"
+    + ">\n```\nThat is all.\n"
+)
+
+# (2) A full <tool_call> wrapper the model wrote around an *example*, naming a
+# tool that was never declared (the classic near-miss: run_command[s]).
+WRAPPED_EXAMPLE = (
+    "For instance you might emit:\n```\n"
+    + TC_OPEN
+    + "\n"
+    + FN_OPEN
+    + "run_command"
+    + ">\n"
+    + PAR_OPEN
+    + "command"
+    + ">\nls\n"
+    + PAR_CLOSE
+    + "\n"
+    + FN_CLOSE
+    + "\n"
+    + TC_CLOSE
+    + "\n```\n-- but don't actually do that here.\n"
+)
+
+# (2b) Same, but inline in reasoning prose rather than a fence.
+REASONING_MARKUP = (
+    "If I were to emit "
+    + TC_OPEN
+    + FN_OPEN
+    + "placeholder_tool"
+    + ">"
+    + FN_CLOSE
+    + TC_CLOSE
+    + " that would be wrong. Answer: 42."
+)
+
+# A genuine, wrapper-delimited invocation of a *declared* tool -- must parse.
+GENUINE_CALL = (
+    "sure\n"
+    + TC_OPEN
+    + "\n"
+    + FN_OPEN
+    + "run_commands"
+    + ">\n"
+    + PAR_OPEN
+    + "command"
+    + ">\necho hi\n"
+    + PAR_CLOSE
+    + "\n"
+    + FN_CLOSE
+    + "\n"
+    + TC_CLOSE
+    + "\ndone"
+)
+
+
+def _stream(text, tools, *, chunk=None):
+    detector = Qwen3CoderDetector()
+    pieces = (
+        [text]
+        if chunk is None
+        else [text[i : i + chunk] for i in range(0, len(text), chunk)]
+    )
+    names, args = [], []
+    for piece in pieces:
+        r = detector.parse_streaming_increment(piece, tools)
+        for c in r.calls or []:
+            if getattr(c, "name", None):
+                names.append(c.name)
+            if getattr(c, "parameters", None):
+                args.append(c.parameters)
+    return names, "".join(args)
+
+
+def _nonstream(text, tools):
+    r = Qwen3CoderDetector().detect_and_parse(text, tools)
+    return [c.name for c in r.calls or []]
+
+
+class TestQwen3CoderPhantomToolCall(CustomTestCase):
+    def setUp(self):
+        self.tools = _tools()
+
+    # ---- layer 1: bare markup in prose --------------------------------
+    def test_bare_markup_nonstream(self):
+        self.assertEqual(_nonstream(BARE_PROSE, self.tools), [])
+
+    def test_bare_markup_stream(self):
+        for chunk in (None, 1, 7):
+            names, _ = _stream(BARE_PROSE, self.tools, chunk=chunk)
+            self.assertEqual(names, [], f"chunk={chunk}: {names}")
+
+    # ---- layer 2: wrapped example naming an undeclared tool ----------
+    def test_wrapped_example_nonstream(self):
+        self.assertEqual(_nonstream(WRAPPED_EXAMPLE, self.tools), [])
+
+    def test_wrapped_example_stream(self):
+        for chunk in (None, 1, 5, 13):
+            names, _ = _stream(WRAPPED_EXAMPLE, self.tools, chunk=chunk)
+            self.assertEqual(names, [], f"chunk={chunk}: {names}")
+
+    def test_reasoning_markup_both_paths(self):
+        self.assertEqual(_nonstream(REASONING_MARKUP, self.tools), [])
+        names, _ = _stream(REASONING_MARKUP, self.tools, chunk=6)
+        self.assertEqual(names, [])
+
+    def test_forward_unknown_tools_still_forwards_wrapped(self):
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+            self.assertEqual(_nonstream(WRAPPED_EXAMPLE, self.tools), ["run_command"])
+            names, _ = _stream(WRAPPED_EXAMPLE, self.tools)
+            self.assertEqual(names, ["run_command"])
+
+    # ---- parity: the two paths must agree on every input ------------
+    def test_stream_nonstream_name_parity(self):
+        for text in (BARE_PROSE, WRAPPED_EXAMPLE, REASONING_MARKUP, GENUINE_CALL):
+            s, _ = _stream(text, self.tools)
+            ns = _nonstream(text, self.tools)
+            self.assertEqual(sorted(s), sorted(ns), f"disagreement on {text[:40]!r}")
+
+    # ---- no regression for genuine calls --------------------------
+    def test_genuine_call_stream(self):
+        for chunk in (None, 1, 4):
+            names, args = _stream(GENUINE_CALL, self.tools, chunk=chunk)
+            self.assertEqual(names, ["run_commands"], f"chunk={chunk}")
+            self.assertIn("echo hi", args)
+
+    def test_genuine_call_nonstream(self):
+        self.assertEqual(_nonstream(GENUINE_CALL, self.tools), ["run_commands"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`Qwen3CoderDetector` emits phantom `tool_calls` from tool-call markup that the
model only **quotes** — fenced examples, echoed payloads, or reasoning about
tool-call syntax. Downstream, agent clients reject the invented names
(`AI_NoSuchToolError: Model tried to call unavailable tool '...'`) and abort an
otherwise-valid turn. Real captured names: `...`, `example_function_name`, and a
near-miss `run_command` for a declared `run_commands`.

It reproduces deterministically against a raw SGLang worker
(`--tool-call-parser qwen3_coder`), no proxy/client in the loop. There are two
independent gaps:

| input (declared tool: `run_commands`) | before | after |
|---|---|---|
| bare `<function=…>` in prose — **stream** | phantom `['...', …]` | `[]` |
| bare `<function=…>` in prose — non-stream | `[]` | `[]` |
| `<tool_call><function=run_command>…</tool_call>` example — **stream & non-stream** | phantom `['run_command']` | `[]` |
| markup in reasoning prose — stream & non-stream | phantom | `[]` |
| genuine `<tool_call><function=run_commands>…</tool_call>` | `['run_commands']` | `['run_commands']` (args intact) |

## Modifications

`python/sglang/srt/function_call/qwen3_coder_detector.py`:

1. **Wrapper gate.** `parse_streaming_increment` matched `<function=` /
   `<parameter=` / `</function>` / `</tool_call>` **anywhere in the buffer**.
   `detect_and_parse` does not — it returns early unless the `<tool_call>`
   wrapper is present, the same precondition `has_tool_call()` uses. Gate the
   four streaming branches on `self.is_inside_tool_call` so the streaming path
   agrees with the non-streaming one; bare `<function=...>` in prose then flows
   through the existing normal-text handler (which already checks the flag).

2. **Declared-name check.** Neither parse path validated the harvested name, so
   a `<tool_call>`-wrapped *example* still produced a phantom call — identically
   in stream and non-stream. `_is_declared_tool()`: in both `detect_and_parse`
   and `parse_streaming_increment`, a `<function=NAME>` whose `NAME` is not a
   declared function tool is dropped, honoring `SGLANG_FORWARD_UNKNOWN_TOOLS`
   (same policy `base_format_detector.parse_base_json` applies for the JSON
   detectors). New streaming state `self._suppress_current_call` tracks the
   swallowed call region across increments.

No behavior change for genuine calls (declared name inside a wrapper) — names
and argument fragments stream/parse identically.

## Accuracy Tests

N/A — parser only, no model forward / kernel changes.

## Speed Tests and Profiling

N/A — the added work is one membership check over the (typically single-digit)
declared-tools list per `<function=` token.

## Checklist

- [x] Format code with pre-commit (isort 7.0.0, ruff v0.15.1 `F401,F821,UP037` — clean)
- [x] Add unit tests — `test/registered/unit/function_call/test_qwen3_coder_detector.py`
      (bare markup, wrapped example naming an undeclared tool, markup in
      reasoning prose, `SGLANG_FORWARD_UNKNOWN_TOOLS` opt-in, stream/non-stream
      name parity, genuine call whole/char-by-char/chunked)
- [ ] Update documentation — N/A
- [ ] Accuracy/speed benchmarks — N/A (parser only)
- [x] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34312202135](https://github.com/sgl-project/sglang/actions/runs/34312202135)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34312201935](https://github.com/sgl-project/sglang/actions/runs/34312201935)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34312202038](https://github.com/sgl-project/sglang/actions/runs/34312202038)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->