### PR TITLE
fix: interior grid-boundary mamba ch

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2958,8 +2958,22 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Local import: mamba_radix_cache only imports Req under TYPE_CHECKING,
         # so there is no runtime cycle, but schedule_batch stays import-light.
         from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
+        from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
-        if not isinstance(self.tree_cache, MambaRadixCache):
+        tree_cache = self.tree_cache
+        if not isinstance(tree_cache, (MambaRadixCache, UnifiedRadixCache)):
+            return None
+        if isinstance(tree_cache, UnifiedRadixCache) and (
+            # The unified MAMBA component mirrors MambaRadixCache's insert
+            # semantics (issue #22935): checkpoints land only at chunk and
+            # finish boundaries with leaf-only values, which a fresh n-1
+            # lookup splits away. Arm on its no_buffer strategy only; the
+            # interior insert donates FULL + MAMBA values, so mixed
+            # SWA+MAMBA trees stay off.
+            tree_cache.enable_mamba_extra_buffer
+            or not tree_cache.is_mamba_enabled
+            or tree_cache.is_swa_enabled
+        ):
             return None
         mamba_pool = self.req_to_token_pool.mamba_pool
         if mamba_pool.replayssm_write_pos is not None:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -54,6 +54,7 @@ ScheduleBatch -> ForwardBatch
 import copy
 import dataclasses
 import logging
+import math
 import re
 import sys
 from array import array
@@ -896,6 +897,11 @@ class ReqKvInfo:
     mamba_cow_src_index: Optional[torch.Tensor] = None
     # Deferred clear: newly allocated mamba slot needs zeroing on forward stream
     mamba_needs_clear: bool = False
+    # no_buffer interior checkpoint (issue #22935): slot + depth of the grid-boundary
+    # state tracked during a prefill extend; donated to the radix cache at
+    # cache_finished/cache_unfinished time, or freed with the request.
+    mamba_interior_ckpt_idx: Optional[torch.Tensor] = None  # shape: (1,)
+    mamba_interior_ckpt_seqlen: Optional[int] = None
 
     def swa_dead_lo(self, page_size: int) -> int:
         # Lowest SWA position this request may free itself: above the tree-owned
@@ -1845,6 +1851,8 @@ class Req(ReqDllmMixin):
         self.mamba_branching_seqlen = None
         self.kv.mamba_cow_src_index = None
         self.kv.mamba_needs_clear = False
+        self.kv.mamba_interior_ckpt_idx = None
+        self.kv.mamba_interior_ckpt_seqlen = None
         self.already_computed = 0
         assert not self.kv.holds_kv, "expect it is already released"
         self.kv.kv_committed_len = 0
@@ -2689,6 +2697,19 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 mamba_track_mask_cpu.append(track_entry.track_mask)
                 mamba_track_indices_cpu.append(track_entry.track_index)
                 mamba_track_seqlens_cpu.append(track_entry.track_seqlen)
+            elif self.spec_algorithm.is_none():
+                # no_buffer: one interior grid-boundary checkpoint per prefill
+                # extend (issue #22935). Rows append one entry per req so the
+                # tensors below always see the full batch shape.
+                v1_entry = self._mamba_radix_cache_v1_interior_track_entry(req)
+                if v1_entry is None:
+                    mamba_track_mask_cpu.append(False)
+                    mamba_track_indices_cpu.append(0)
+                    mamba_track_seqlens_cpu.append(-1)
+                else:
+                    mamba_track_mask_cpu.append(True)
+                    mamba_track_indices_cpu.append(v1_entry[0])
+                    mamba_track_seqlens_cpu.append(v1_entry[1])
 
             if self.return_logprob:
                 # Find input logprob token ids.
@@ -2789,7 +2810,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_logprob_start_lens = extend_logprob_start_lens
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
-        if get_exec().mamba.enable_mamba_extra_buffer:
+        if get_exec().mamba.enable_mamba_extra_buffer or any(mamba_track_mask_cpu):
             self.mamba_track_indices = torch.tensor(
                 mamba_track_indices_cpu,
                 dtype=torch.int64,
@@ -2805,6 +2826,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 dtype=torch.int64,
                 device=self.device,
             )
+        elif self.mamba_track_mask is not None:
+            # Stale tensors from an earlier batch would re-arm backend tracking.
+            self.mamba_track_indices = None
+            self.mamba_track_mask = None
+            self.mamba_track_seqlens = None
 
         # Collect mamba init info for deferred ops on forward stream
         if any(req.kv.holds_mamba for req in reqs):
@@ -2914,6 +2940,74 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             track_index=track_index,
             track_seqlen=mamba_track_seqlen,
         )
+
+    def _mamba_radix_cache_v1_interior_track_entry(
+        self,
+        req: Req,
+    ) -> Optional[Tuple[int, int]]:
+        """no_buffer counterpart of the V2 track entry: snapshot one interior
+        grid-boundary state per prefill extend into a fresh mamba slot, donated
+        to the radix cache at cache time. This is the O(1)-memory fix for
+        #22935: the default strategy otherwise checkpoints only the extend end,
+        which an n-1 fresh-prefill lookup can never reach after a split.
+
+        Returns (mamba_slot, track_seqlen), or None when this extend has no
+        usable interior boundary or tracking is not applicable."""
+        if not req.kv.holds_mamba:
+            return None
+        # Local import: mamba_radix_cache only imports Req under TYPE_CHECKING,
+        # so there is no runtime cycle, but schedule_batch stays import-light.
+        from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
+
+        if not isinstance(self.tree_cache, MambaRadixCache):
+            return None
+        mamba_pool = self.req_to_token_pool.mamba_pool
+        if mamba_pool.replayssm_write_pos is not None:
+            # ReplaySSM donate depth lags the live state; the interior h
+            # snapshot is unvalidated there, so keep the fix off that config.
+            return None
+        if getattr(self.req_to_token_pool, "mamba_ckpt_pool", None) is not None:
+            # int8 checkpoints store radix states in the quantized pool; the h
+            # snapshot lands in the active bf16 pool and cannot be donated there.
+            return None
+        # Self-heal: a slot left over from an unconsumed earlier extend (e.g. a
+        # skipped cache_unfinished_req) must not leak when we re-arm here.
+        if req.kv.mamba_interior_ckpt_idx is not None:
+            self.req_to_token_pool.mamba_allocator.free(
+                req.kv.mamba_interior_ckpt_idx.unsqueeze(0)
+            )
+            req.kv.mamba_interior_ckpt_idx = None
+            req.kv.mamba_interior_ckpt_seqlen = None
+
+        prefix_len = len(req.prefix_indices)
+        state_chunk_size = getattr(
+            self.model_config.hf_text_config, "mamba_chunk_size", 64
+        )
+        # The snapshot must sit on both the radix page grid and a model-state
+        # boundary, or no h state exists at that depth to snapshot.
+        grid = math.lcm(
+            mamba_checkpoint_grid(self.tree_cache.page_size), state_chunk_size
+        )
+        # Largest grid boundary strictly below the extend end: at the end the
+        # donated last_recurrent_state already covers the boundary, and a node
+        # at the full length would just be re-split away by the n-1 lookup.
+        interior_len = prefix_len + ((req.extend_range.length - 1) // grid) * grid
+        if interior_len <= prefix_len:
+            return None
+
+        slot = self.req_to_token_pool.mamba_allocator.alloc(1)
+        if slot is None:
+            # Best effort: skipping the checkpoint only costs cache hits.
+            return None
+
+        # interior_len is state-aligned, so last_recurrent_state cannot serve
+        # it; the +1 routes the read to h (same convention as _force_track_h,
+        # and the +1 cancels under mamba_track_aligned_lens's floor).
+        track_seqlen = interior_len + 1
+
+        req.kv.mamba_interior_ckpt_idx = slot[0]
+        req.kv.mamba_interior_ckpt_seqlen = interior_len
+        return slot[0].item(), track_seqlen
 
     def _collect_deferred_mamba_cow_and_clear(self, reqs):
         """Collect deferred COW/clear info from requests."""

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1853,6 +1853,9 @@ class Req(ReqDllmMixin):
         self.kv.mamba_needs_clear = False
         self.kv.mamba_interior_ckpt_idx = None
         self.kv.mamba_interior_ckpt_seqlen = None
+        # reset_for_retract itself frees nothing; the armed interior slot must
+        # have been released by release_kv_cache/free_mamba_cache first.
+        assert self.kv.mamba_interior_ckpt_idx is None
         self.already_computed = 0
         assert not self.kv.holds_kv, "expect it is already released"
         self.kv.kv_committed_len = 0
@@ -2962,6 +2965,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         tree_cache = self.tree_cache
         if not isinstance(tree_cache, (MambaRadixCache, UnifiedRadixCache)):
+            return None
+        if tree_cache.disable:
+            # No tree to donate to; arming would only churn the allocator.
             return None
         if isinstance(tree_cache, UnifiedRadixCache) and (
             # The unified MAMBA component mirrors MambaRadixCache's insert

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -612,6 +612,9 @@ class MambaRadixCache(BasePrefixCache):
 
             # Radix Cache takes one ref in memory pool
             # insert the token_ids and kv_indices into the radix tree
+            prev_prefix_len = self._insert_interior_checkpoint(
+                req, token_ids, page_aligned_kv_indices
+            )
             if self.enable_mamba_extra_buffer:
                 mamba_ping_pong_track_buffer_to_keep = (
                     self.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
@@ -652,7 +655,7 @@ class MambaRadixCache(BasePrefixCache):
                     ),
                     value=page_aligned_kv_indices,
                     mamba_value=mamba_value,
-                    prev_prefix_len=req.kv.cache_protected_len,
+                    prev_prefix_len=prev_prefix_len,
                 )
             )
             mamba_exist = result.mamba_exist
@@ -762,6 +765,9 @@ class MambaRadixCache(BasePrefixCache):
                 translate(mamba_value_donated),
             )
 
+        prev_prefix_len = self._insert_interior_checkpoint(
+            req, page_aligned_token_ids, page_aligned_kv_indices, chunked=chunked
+        )
         result = self.insert(
             InsertParams(
                 key=RadixKey(
@@ -771,7 +777,7 @@ class MambaRadixCache(BasePrefixCache):
                 ),
                 value=page_aligned_kv_indices,
                 mamba_value=mamba_value_donated,
-                prev_prefix_len=req.kv.cache_protected_len,
+                prev_prefix_len=prev_prefix_len,
                 chunked=chunked,
             )
         )
@@ -1101,6 +1107,50 @@ class MambaRadixCache(BasePrefixCache):
             self.int8_ckpt_pool.free(mamba_value)
         else:
             self.req_to_token_pool.mamba_allocator.free(mamba_value)
+
+    def _insert_interior_checkpoint(
+        self,
+        req: Req,
+        token_ids: List[int],
+        kv_indices: torch.Tensor,
+        chunked: bool = False,
+    ) -> int:
+        """Insert the no_buffer interior checkpoint tracked during the last extend
+        (issue #22935) as its own tree node, and return the prefix depth the caller
+        must pass as the main insert's prev_prefix_len: after this insert the tree
+        owns KV up to the checkpoint, so a smaller prev would make the main insert
+        free the segment this node just took ownership of."""
+        interior_len = req.kv.mamba_interior_ckpt_seqlen
+        interior_idx = req.kv.mamba_interior_ckpt_idx
+        req.kv.mamba_interior_ckpt_idx = None
+        req.kv.mamba_interior_ckpt_seqlen = None
+        if interior_idx is None or interior_len is None:
+            return req.kv.cache_protected_len
+
+        if not (req.kv.cache_protected_len < interior_len <= len(kv_indices)):
+            # Stale checkpoint beyond what this request still holds; drop the
+            # slot and leave the main insert unchanged.
+            self._free_mamba_value(interior_idx.unsqueeze(0))
+            return req.kv.cache_protected_len
+
+        result = self.insert(
+            InsertParams(
+                key=RadixKey(
+                    token_ids[:interior_len],
+                    req.extra_key,
+                    cache_salt=req.cache_salt,
+                ),
+                value=kv_indices[:interior_len].to(dtype=torch.int64, copy=True),
+                mamba_value=interior_idx.unsqueeze(0),
+                prev_prefix_len=req.kv.cache_protected_len,
+                chunked=chunked,
+            )
+        )
+        if result.mamba_exist:
+            # A checkpointed node already covers this depth; the tracked slot
+            # is a duplicate.
+            self._free_mamba_value(interior_idx.unsqueeze(0))
+        return interior_len
 
     def _match_prefix_helper(
         self, key: RadixKey

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1643,6 +1643,15 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def free_mamba_cache(
         self, req: Req, mamba_ping_pong_track_buffer_to_keep: Optional[int] = None
     ):
+        # A never-consumed interior checkpoint (issue #22935) is always a bf16
+        # mamba_allocator slot: the track builder refuses to arm when the int8
+        # checkpoint pool is enabled.
+        interior_ckpt_idx = req.kv.mamba_interior_ckpt_idx
+        if interior_ckpt_idx is not None:
+            self.mamba_allocator.free(interior_ckpt_idx.unsqueeze(0))
+            req.kv.mamba_interior_ckpt_idx = None
+            req.kv.mamba_interior_ckpt_seqlen = None
+
         mamba_index = req.kv.mamba_pool_idx
         assert mamba_index is not None, "double free? mamba_index is None"
         self.mamba_allocator.free(mamba_index.unsqueeze(0))

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -849,6 +849,59 @@ class UnifiedRadixCache(BasePrefixCache):
             return DecLockRefResult()
         return self.tree_core.dec_host_lock_ref(node_id, params)
 
+    def _insert_mamba_interior_checkpoint(
+        self,
+        req: Req,
+        token_ids: Sequence[int],
+        kv_indices: torch.Tensor,
+        effective_cache_len: int,
+        chunked: bool = False,
+    ) -> int:
+        """Unified-tree port of MambaRadixCache._insert_interior_checkpoint
+        (issue #22935): donate the interior grid-boundary state tracked during
+        the last prefill extend as its own checkpointed node before the main
+        insert. Returns the prev_prefix_len the main insert must pass: the
+        tree owns KV up to the checkpoint after this insert, and a smaller
+        prev would make the main insert free that segment as a duplicate."""
+        interior_len = req.kv.mamba_interior_ckpt_seqlen
+        interior_idx = req.kv.mamba_interior_ckpt_idx
+        req.kv.mamba_interior_ckpt_idx = None
+        req.kv.mamba_interior_ckpt_seqlen = None
+        if interior_idx is None or interior_len is None:
+            return req.kv.cache_protected_len
+
+        # Plain mamba_allocator slot: the track builder in schedule_batch
+        # refuses to arm when the int8 checkpoint pool is enabled.
+        if not (
+            req.kv.cache_protected_len
+            < interior_len
+            <= min(effective_cache_len, len(kv_indices))
+        ):
+            # Stale checkpoint beyond what this insert still owns.
+            self.req_to_token_pool.mamba_allocator.free(interior_idx.unsqueeze(0))
+            return req.kv.cache_protected_len
+
+        radix_key = RadixKey(
+            token_ids[:interior_len],
+            req.extra_key,
+            is_bigram=self.tree_core.is_eagle,
+            cache_salt=req.cache_salt,
+        ).page_aligned(self.page_size)
+        result = self.insert(
+            InsertParams(
+                key=radix_key,
+                value=kv_indices[: len(radix_key)].to(dtype=torch.int64, copy=True),
+                mamba_value=interior_idx.unsqueeze(0),
+                prev_prefix_len=req.kv.cache_protected_len,
+                chunked=chunked,
+            )
+        )
+        if result.mamba_exist:
+            # A checkpointed node already covers this depth; the tracked
+            # slot is a duplicate.
+            self.req_to_token_pool.mamba_allocator.free(interior_idx.unsqueeze(0))
+        return interior_len
+
     def cache_finished_req(
         self, req: Req, is_insert: bool = True, *, kv_len_to_handle: int, **kwargs
     ) -> None:
@@ -886,6 +939,16 @@ class UnifiedRadixCache(BasePrefixCache):
                 )
                 if cl is not None:
                     effective_cache_len = min(effective_cache_len, cl)
+
+            # Donate before the main insert so the interior node's KV segment
+            # becomes tree-owned (issue #22935).
+            if req.kv.mamba_interior_ckpt_idx is not None:
+                insert_params.prev_prefix_len = self._insert_mamba_interior_checkpoint(
+                    req=req,
+                    token_ids=token_ids,
+                    kv_indices=kv_indices,
+                    effective_cache_len=effective_cache_len,
+                )
 
             # Truncate if needed; the tail free is deferred and batched with
             # the unaligned tail below so a shared boundary page is emitted once.
@@ -995,6 +1058,17 @@ class UnifiedRadixCache(BasePrefixCache):
                     req, is_finished=False, insert_params=insert_params
                 )
             return
+
+        # Donate before the main insert so the interior node's KV segment
+        # becomes tree-owned (issue #22935).
+        if req.kv.mamba_interior_ckpt_idx is not None:
+            insert_params.prev_prefix_len = self._insert_mamba_interior_checkpoint(
+                req=req,
+                token_ids=token_ids,
+                kv_indices=kv_indices_orig,
+                effective_cache_len=effective_cache_len,
+                chunked=chunked,
+            )
 
         kv_indices = kv_indices_orig[:effective_cache_len]
 

--- a/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
+++ b/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
@@ -13,6 +13,11 @@ A second class covers the no_buffer interior checkpoint (`_insert_interior_check
 the fix for #22935): the tracked grid-boundary state must land on the tree as its
 own checkpointed node, must revive the tombstone a fresh n-1 lookup created, and
 must hand the main insert a prev_prefix_len that keeps the interior node's KV.
+
+A third class runs the same fix against UnifiedRadixCache, the default tree on
+current main: its MAMBA component mirrors MambaRadixCache's insert semantics
+(checkpoints only at insert ends, values leaf-only), so the no_buffer path has
+the same 0-hit failure, and `_insert_mamba_interior_checkpoint` restores reuse.
 """
 
 import unittest
@@ -20,17 +25,24 @@ from array import array
 from types import SimpleNamespace
 
 import torch
+from test_unified_radix_cache_unittest import CacheConfig, build_fixture
 
+from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    ComponentType,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import (
     ServerArgs,
     set_global_server_args_for_scheduler,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -249,6 +261,143 @@ class TestMambaRadixCacheInteriorCheckpoint(unittest.TestCase):
         )
         self.assertEqual(prev, 7)
         self.assertEqual(cache.req_to_token_pool.mamba_allocator.freed, 1)
+
+
+class TestUnifiedRadixCacheInteriorCheckpoint(CustomTestCase):
+    """The no_buffer interior checkpoint on UnifiedRadixCache, the default
+    tree cache: `cache_finished_req`/`cache_unfinished_req` insert only at
+    their own end depths with leaf-only mamba values, so a lookup that stops
+    short of the end (`n - 1`) finds no reusable state (issue #22935). The
+    tracked grid-boundary state donated before the main insert restores the
+    match at that boundary."""
+
+    cfg = CacheConfig(
+        page_size=1,
+        components=(ComponentType.FULL, ComponentType.MAMBA),
+        enable_mamba_extra_buffer=False,
+        kv_size=256,
+        max_context_len=512,
+    )
+
+    def _make_finished_req(self, cache, allocator, req_to_token_pool, tokens):
+        req = Req(
+            rid=f"unified-interior-{len(tokens)}",
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req_to_token_pool.alloc([req])
+        req.origin_input_ids = array("q", tokens[:-1])
+        req.output_ids = array("q", tokens[-1:])
+        kv_indices = allocator.alloc(len(tokens))
+        req_to_token_pool.write(
+            (req.kv.req_pool_idx, slice(0, len(tokens))), kv_indices
+        )
+        req.kv.kv_committed_len = len(tokens)
+        req.last_node = cache.root_node_handle()
+        req.kv.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(
+            len(req.prefix_indices), len(req.full_untruncated_fill_ids)
+        )
+        return req
+
+    def _arm_interior(self, req_to_token_pool, req, interior_len):
+        slot = req_to_token_pool.mamba_allocator.alloc(1)
+        req.kv.mamba_interior_ckpt_idx = slot[0]
+        req.kv.mamba_interior_ckpt_seqlen = interior_len
+        return slot[0]
+
+    def _finish(self, cache, req):
+        cache.cache_finished_req(
+            req, is_insert=True, kv_len_to_handle=req.effective_kv_committed_len()
+        )
+
+    def test_n1_lookup_returns_zero_without_interior_checkpoint(self):
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        tokens = list(range(1, CHUNK + 30))
+
+        req = self._make_finished_req(cache, allocator, req_to_token_pool, tokens)
+        self._finish(cache, req)
+
+        # The end node's value is beyond the n-1 walk, and no interior node
+        # holds state, so the match reuses nothing.
+        m = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens[:-1]))))
+        self.assertEqual(len(m.device_indices), 0)
+        cache.sanity_check()
+
+    def test_n1_lookup_reuses_interior_checkpoint(self):
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        tokens = list(range(1, CHUNK + 30))
+
+        req = self._make_finished_req(cache, allocator, req_to_token_pool, tokens)
+        self._arm_interior(req_to_token_pool, req, CHUNK)
+        self._finish(cache, req)
+
+        m = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens[:-1]))))
+        self.assertEqual(len(m.device_indices), CHUNK)
+        self.assertIsNone(req.kv.mamba_interior_ckpt_idx)
+        self.assertIsNone(req.kv.mamba_interior_ckpt_seqlen)
+        cache.sanity_check()
+
+    def test_duplicate_interior_checkpoint_is_freed(self):
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        tokens = list(range(1, CHUNK + 30))
+
+        # An earlier request already donated a checkpoint at the boundary.
+        holder = Req(
+            rid="unified-interior-holder",
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req_to_token_pool.alloc([holder])
+        prefix = tokens[:CHUNK]
+        value = allocator.alloc(len(prefix))
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", prefix)),
+                value=value,
+                mamba_value=holder.kv.mamba_pool_idx.unsqueeze(0),
+            )
+        )
+
+        req = self._make_finished_req(cache, allocator, req_to_token_pool, tokens)
+        self._arm_interior(req_to_token_pool, req, CHUNK)
+        avail_after_arm = req_to_token_pool.mamba_allocator.available_size()
+
+        self._finish(cache, req)
+
+        # The existing node covers the depth; the tracked slot is a
+        # duplicate and returns to the allocator.
+        self.assertEqual(
+            req_to_token_pool.mamba_allocator.available_size(), avail_after_arm + 1
+        )
+        m = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens[:-1]))))
+        self.assertEqual(len(m.device_indices), CHUNK)
+        cache.sanity_check()
+
+    def test_stale_interior_checkpoint_is_dropped(self):
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        tokens = list(range(1, CHUNK + 30))
+
+        req = self._make_finished_req(cache, allocator, req_to_token_pool, tokens)
+        # A checkpoint deeper than what the request still holds cannot be
+        # inserted; the slot is freed and the main insert keeps its own
+        # prev_prefix_len.
+        self._arm_interior(req_to_token_pool, req, len(tokens) + 10)
+        avail_after_arm = req_to_token_pool.mamba_allocator.available_size()
+
+        self._finish(cache, req)
+
+        self.assertEqual(
+            req_to_token_pool.mamba_allocator.available_size(), avail_after_arm + 1
+        )
+        m = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens[:-1]))))
+        self.assertEqual(len(m.device_indices), 0)
+        cache.sanity_check()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
+++ b/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
@@ -1,0 +1,129 @@
+"""CPU-only match semantics of MambaRadixCache around split tombstones.
+
+A mamba state is a point value at a node's end depth, so a match may only
+return KV up to the deepest checkpointed node on the matched path. When a
+lookup ends mid-edge, `_split_node` leaves a checkpoint-less internal node and
+the match falls back to that safe boundary — possibly 0 tokens
+(sgl-project/sglang#22935). These tests pin the contract: returned KV never
+exceeds the deepest checkpoint depth, tombstones never block matches that
+continue past them, and the branching signal points at the chunk-aligned
+re-track position.
+"""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.server_args import (
+    ServerArgs,
+    set_global_server_args_for_scheduler,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+CHUNK = 64
+
+
+def _make_cache() -> MambaRadixCache:
+    server_args = ServerArgs(model_path="dummy", page_size=1)
+    # The property would otherwise load the HF config for the dummy model.
+    server_args._mamba_cache_chunk_size = CHUNK
+    set_global_server_args_for_scheduler(server_args)
+    allocator = PagedTokenToKVPoolAllocator(
+        size=4096,
+        page_size=1,
+        dtype=torch.bfloat16,
+        device="cpu",
+        kvcache=None,
+        need_sort=False,
+    )
+    return MambaRadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=None,  # match/insert without cow_mamba never touch it
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+
+
+def _insert(cache: MambaRadixCache, ids: list) -> None:
+    """Insert one finished request: the full path with a checkpoint at its end."""
+    cache.insert(
+        InsertParams(
+            key=RadixKey(array("q", ids)),
+            value=torch.arange(len(ids), dtype=torch.int64),
+            mamba_value=torch.zeros(1, 8),
+        )
+    )
+
+
+def _match(cache: MambaRadixCache, ids: list):
+    return cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", ids))))
+
+
+class TestMambaRadixCacheMatch(unittest.TestCase):
+    def test_n_minus_1_lookup_after_identical_prompt_lands_on_the_safe_boundary(self):
+        # The fresh prefill lookup is capped at input_len - 1, splits the only
+        # checkpointed node mid-edge, and no earlier node on the path has a
+        # checkpoint: the safe boundary is 0 tokens.
+        # https://github.com/sgl-project/sglang/issues/22935
+        cache = _make_cache()
+        _insert(cache, [1, 2, 3])
+        result = _match(cache, [1, 2])
+        self.assertEqual(result.device_indices.numel(), 0)
+        self.assertIsNone(result.mamba_branching_seqlen)
+
+    def test_tombstone_does_not_block_matches_that_continue_past_it(self):
+        # A checkpoint-less split node only caps matches that END at it; a
+        # lookup covering the full edge still resumes at the checkpointed child.
+        cache = _make_cache()
+        _insert(cache, [1, 2, 3])
+        self.assertEqual(_match(cache, [1, 2]).device_indices.numel(), 0)
+        self.assertEqual(_match(cache, [1, 2, 3]).device_indices.numel(), 3)
+
+    def test_match_never_returns_past_the_deepest_checkpoint(self):
+        # Two checkpointed nodes, as per-chunk inserts leave them: the n-1
+        # lookup keeps the first chunk and drops the split partial edge.
+        cache = _make_cache()
+        _insert(cache, list(range(CHUNK)))
+        _insert(cache, list(range(CHUNK + 30)))
+        result = _match(cache, list(range(CHUNK + 29)))
+        self.assertEqual(result.device_indices.numel(), CHUNK)
+
+    def test_branching_signal_points_at_the_chunk_aligned_boundary(self):
+        # The matched path runs past the last checkpoint, so the scheduler is
+        # told to re-track a state at the chunk-aligned boundary.
+        cache = _make_cache()
+        _insert(cache, list(range(CHUNK)))
+        _insert(cache, list(range(CHUNK + 30)))
+        result = _match(cache, list(range(CHUNK + 29)))
+        self.assertEqual(result.mamba_branching_seqlen, CHUNK)
+
+    def test_shared_prefix_divergence_stops_at_the_tombstone(self):
+        # A divergent request shares the [1, 2] edge, but that edge carries no
+        # checkpoint, so the shared part cannot be reused either.
+        # https://github.com/sgl-project/sglang/issues/22935
+        cache = _make_cache()
+        _insert(cache, [1, 2, 3])
+        _insert(cache, [1, 2, 4, 5])
+        result = _match(cache, [1, 2, 4])
+        self.assertEqual(result.device_indices.numel(), 0)
+
+    def test_full_match_returns_kv_through_the_last_checkpoint(self):
+        cache = _make_cache()
+        _insert(cache, list(range(CHUNK)))
+        _insert(cache, list(range(CHUNK + 30)))
+        result = _match(cache, list(range(CHUNK + 30)))
+        self.assertEqual(result.device_indices.numel(), CHUNK + 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
+++ b/test/registered/unit/mem_cache/test_mamba_radix_cache_match.py
@@ -8,10 +8,16 @@ the match falls back to that safe boundary — possibly 0 tokens
 exceeds the deepest checkpoint depth, tombstones never block matches that
 continue past them, and the branching signal points at the chunk-aligned
 re-track position.
+
+A second class covers the no_buffer interior checkpoint (`_insert_interior_checkpoint`,
+the fix for #22935): the tracked grid-boundary state must land on the tree as its
+own checkpointed node, must revive the tombstone a fresh n-1 lookup created, and
+must hand the main insert a prev_prefix_len that keeps the interior node's KV.
 """
 
 import unittest
 from array import array
+from types import SimpleNamespace
 
 import torch
 
@@ -31,6 +37,22 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 CHUNK = 64
 
 
+class _CountingMambaAllocator:
+    """Slot-id allocator standing in for the real mamba allocator: alloc hands
+    out increasing ids, free counts what was returned."""
+
+    def __init__(self):
+        self.next_id = 0
+        self.freed = 0
+
+    def alloc(self, n):
+        self.next_id += n
+        return torch.arange(self.next_id - n, self.next_id, dtype=torch.int64)
+
+    def free(self, slots):
+        self.freed += int(slots.numel())
+
+
 def _make_cache() -> MambaRadixCache:
     server_args = ServerArgs(model_path="dummy", page_size=1)
     # The property would otherwise load the HF config for the dummy model.
@@ -47,26 +69,49 @@ def _make_cache() -> MambaRadixCache:
     return MambaRadixCache(
         CacheInitParams(
             disable=False,
-            req_to_token_pool=None,  # match/insert without cow_mamba never touch it
+            # match/insert without cow_mamba only touch the mamba allocator
+            # (freeing duplicate/dropped checkpoints)
+            req_to_token_pool=SimpleNamespace(
+                mamba_allocator=_CountingMambaAllocator(),
+                mamba_ckpt_pool=None,
+            ),
             token_to_kv_pool_allocator=allocator,
             page_size=1,
         )
     )
 
 
-def _insert(cache: MambaRadixCache, ids: list) -> None:
+def _insert(cache: MambaRadixCache, ids: list, prev_prefix_len: int = 0) -> None:
     """Insert one finished request: the full path with a checkpoint at its end."""
     cache.insert(
         InsertParams(
             key=RadixKey(array("q", ids)),
             value=torch.arange(len(ids), dtype=torch.int64),
             mamba_value=torch.zeros(1, 8),
+            prev_prefix_len=prev_prefix_len,
         )
     )
 
 
 def _match(cache: MambaRadixCache, ids: list):
     return cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", ids))))
+
+
+def _fake_req(
+    cache_protected_len: int = 0,
+    interior_len=None,
+    interior_idx=None,
+) -> SimpleNamespace:
+    """The req surface `_insert_interior_checkpoint` reads."""
+    return SimpleNamespace(
+        kv=SimpleNamespace(
+            cache_protected_len=cache_protected_len,
+            mamba_interior_ckpt_idx=interior_idx,
+            mamba_interior_ckpt_seqlen=interior_len,
+        ),
+        extra_key=None,
+        cache_salt=None,
+    )
 
 
 class TestMambaRadixCacheMatch(unittest.TestCase):
@@ -123,6 +168,87 @@ class TestMambaRadixCacheMatch(unittest.TestCase):
         _insert(cache, list(range(CHUNK + 30)))
         result = _match(cache, list(range(CHUNK + 30)))
         self.assertEqual(result.device_indices.numel(), CHUNK + 30)
+
+
+class TestMambaRadixCacheInteriorCheckpoint(unittest.TestCase):
+    def test_interior_checkpoint_lets_the_n_minus_1_lookup_reuse(self):
+        # Bug regression for sgl-project/sglang#22935: with an interior
+        # checkpoint on the path, the fresh n-1 lookup reuses up to it instead
+        # of falling to 0 tokens.
+        cache = _make_cache()
+        ids = list(range(2 * CHUNK))
+        req = _fake_req(interior_len=CHUNK, interior_idx=torch.tensor(11))
+        prev = cache._insert_interior_checkpoint(
+            req, array("q", ids), torch.arange(len(ids))
+        )
+        self.assertEqual(prev, CHUNK)
+        # The helper consumes the stash exactly once, so a later
+        # free_mamba_cache cannot free the same slot again.
+        self.assertIsNone(req.kv.mamba_interior_ckpt_idx)
+        _insert(cache, ids, prev_prefix_len=prev)
+        self.assertEqual(_match(cache, ids[:-1]).device_indices.numel(), CHUNK)
+
+    def test_interior_checkpoint_revives_the_split_tombstone(self):
+        # The identical-prompt sequence: the first request leaves only the end
+        # checkpoint, the second request's n-1 lookup splits it into a
+        # tombstone, and the second request's tracked interior checkpoint must
+        # land ON that tombstone.
+        cache = _make_cache()
+        ids = list(range(2 * CHUNK))
+        _insert(cache, ids)
+        self.assertEqual(_match(cache, ids[:-1]).device_indices.numel(), 0)
+        req = _fake_req(interior_len=CHUNK, interior_idx=torch.tensor(11))
+        prev = cache._insert_interior_checkpoint(
+            req, array("q", ids), torch.arange(len(ids))
+        )
+        self.assertEqual(prev, CHUNK)
+        self.assertEqual(_match(cache, ids[:-1]).device_indices.numel(), CHUNK)
+
+    def test_main_insert_prev_prefix_len_keeps_the_interior_node_kv(self):
+        # The interior node owns the KV segment below the checkpoint; a main
+        # insert that still claimed that segment as duplicate would free it
+        # (double free). The correct prev leaves the token pool untouched.
+        cache = _make_cache()
+        ids = list(range(2 * CHUNK))
+        req = _fake_req(interior_len=CHUNK, interior_idx=torch.tensor(11))
+        prev = cache._insert_interior_checkpoint(
+            req, array("q", ids), torch.arange(len(ids))
+        )
+        _insert(cache, ids, prev_prefix_len=prev)
+        self.assertEqual(cache.token_to_kv_pool_allocator.available_size(), 4096)
+
+    def test_duplicate_interior_checkpoint_is_freed(self):
+        # A checkpointed node already covers the interior depth: the tracked
+        # slot is a duplicate, must be freed, and the tree must stay unchanged.
+        cache = _make_cache()
+        ids = list(range(2 * CHUNK))
+        req = _fake_req(interior_len=CHUNK, interior_idx=torch.tensor(11))
+        cache._insert_interior_checkpoint(req, array("q", ids), torch.arange(len(ids)))
+        _insert(cache, ids, prev_prefix_len=CHUNK)
+        duplicate = _fake_req(interior_len=CHUNK, interior_idx=torch.tensor(12))
+        prev = cache._insert_interior_checkpoint(
+            duplicate, array("q", ids), torch.arange(len(ids))
+        )
+        self.assertEqual(prev, CHUNK)
+        self.assertEqual(cache.req_to_token_pool.mamba_allocator.freed, 1)
+        self.assertEqual(_match(cache, ids[:-1]).device_indices.numel(), CHUNK)
+
+    def test_stale_interior_checkpoint_is_dropped(self):
+        # A checkpoint deeper than what the request still holds cannot be
+        # inserted; the slot is freed and the main insert keeps its original
+        # prev_prefix_len.
+        cache = _make_cache()
+        ids = list(range(CHUNK + 30))
+        req = _fake_req(
+            cache_protected_len=7,
+            interior_len=len(ids) + CHUNK,
+            interior_idx=torch.tensor(11),
+        )
+        prev = cache._insert_interior_checkpoint(
+            req, array("q", ids), torch.arange(len(ids))
+        )
+        self.assertEqual(prev, 7)
+        self.assertEqual(cache.req_to_token_pool.mamba_allocator.freed, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #22935

## Problem

On the default mamba scheduler strategy (`no_buffer`), a hybrid-SSM request's only radix-tree checkpoints sit at insert end depths (chunk boundary / request finish). A fresh prefill's prefix lookup is capped at `input_len - 1`, which stops mid-edge below the end node: after the split the checkpoint stays on the leaf (`redistribute_on_node_split` clears the parent), so an identical prompt — and every later request sharing the prefix — matches **0 cached tokens**.

This affects both trees implementing the no_buffer strategy:

- `MambaRadixCache`, the class the issue was reported against, and
- `UnifiedRadixCache`'s MAMBA component, **the default tree cache on current main**. Its no_buffer insert path mirrors `MambaRadixCache.cache_finished_req` (same end-only checkpoints, same leaf-only values), so the default-cache switch moved the bug rather than fixing it — reproduced on current main below.

## Fix

Reuse the extra_buffer track machinery on the no_buffer path: each prefill extend snapshots the state at the largest interior grid boundary strictly below the extend end into a fresh mamba slot, and the radix cache inserts it as its own checkpointed node before the main insert.

- `schedule_batch.py`: the no_buffer track entry, armed for both `MambaRadixCache` and the unified no_buffer strategy (off for spec / replayssm / int8-ckpt / SWA-mixed trees)
- `mamba_radix_cache.py` + `unified_radix_cache.py`: `_insert_interior_checkpoint` / `_insert_mamba_interior_checkpoint` donate the tracked state as its own node and hand the main insert the checkpoint depth as `prev_prefix_len`, so the interior node's KV segment is not freed as a duplicate
- `memory_pool.py`: `free_mamba_cache` releases a never-consumed slot

Boundary: `((extend_len - 1) // grid) * grid` with `grid = lcm(mamba_checkpoint_grid(page_size), mamba_chunk_size)` — the snapshot depth must be both page-aligned (a radix node boundary) and state-aligned (an h state exists at that depth to snapshot).

Cost: one extra mamba state per prefill extend, O(1) memory. Chunked prefills gain one interior checkpoint per chunk.

## GPU validation (L20, Qwen3.8-27B fp8, identical 4096-token prompt)

| config | cached_tokens (repeat request) | e2e latency |
|---|---|---|
| no_buffer, main | 0 | 1.49 s (no reuse) |
| no_buffer, this PR | **4032 / 4096** | **0.35 s (4.3x)** |
| extra_buffer, this PR | 4032 (unchanged) | 0.38 s (unchanged) |

Greedy outputs are identical across cached and uncached requests, so the mamba state resume is exact; the extra_buffer default path is unaffected.

## Tests

`test/registered/unit/mem_cache/test_mamba_radix_cache_match.py`, 15 cases: the contract class pins the split/tombstone match semantics; the legacy and unified classes drive the new insert path on both trees (n-1 lookup reuse 0 → 64, duplicate slot freed, stale slot dropped). All pass on CPU and in an installed GPU environment.

## Known boundaries & coverage

**Scope of the fix.** The interior checkpoint covers identical prompts and any divergence at or past the deepest interior boundary of the last extend. Under chunked prefill, every chunk leaves its own interior checkpoint, so a divergent request reuses up to the deepest checkpoint below its divergence point — early divergence degrades gracefully instead of dropping to 0. Prompts shorter than `grid + 1` (grid = lcm(page grid, mamba chunk size), 64 for the validated config) have no interior position to snapshot and are unfixable without kernel changes.

**Configs that keep the previous behavior.** The track entry does not arm under speculative decoding, ReplaySSM, int8 checkpoints, extra_buffer (already covered by its own track), or SWA-mixed unified trees — on those configs the n-1 0-hit behavior remains and needs its own follow-up.

**Interaction with `--mamba-max-states-per-path`.** A small cap evicts the interior checkpoint right after insert (the cap walk preserves the tail and locked nodes but not the interior donor), silently disabling this fix. The default `-1` (unlimited) is unaffected.

**Memory pressure.** Each prefill now holds two tree states instead of one (per chunk under chunked prefill), so under memory pressure old prefixes evict sooner. Admission accounting does not yet count the in-flight armed slot (one per running prefill between extend and cache time); a capacity-pressure soak is left as follow-up.

**Validation coverage.** GPU validation (cached_tokens 0 → 4032/4096, 4.3x TTFT, byte-identical greedy outputs cold vs cached, divergence at and past the boundary both reusing 4032, extra_buffer bit-identical) covers one GDN-family hybrid model (Qwen3.8-27B fp8) on the `no_buffer` strategy. The Mamba2 and KDA attention backends share the same track machinery but were not GPU-validated here.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34371113176](https://github.com/sgl-project/sglang/actions/runs/34371113176)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34371112845](https://github.com/sgl-project/sglang/actions/runs/34371112845)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34371113052](https://github.com/sgl-project/sglang/actions/runs/34371113052)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->