### PR TITLE
[diffusion] ci: don't fail the nightly when a perf dump is unreadable

### DIFF
--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -394,22 +394,41 @@ def _build_sglang_payload(case: dict) -> dict:
     return payload
 
 
-def _read_perf_dump(perf_dump_path: str, timeout: float = 10.0) -> dict | None:
-    """Read a perf dump JSON written by the server.
+def _read_perf_dump(perf_dump_path: str, timeout: float = 30.0) -> dict | None:
+    """Read a perf dump JSON written by the server, or None with a reason logged.
 
-    The server writes the file asynchronously after the HTTP response,
-    so we poll briefly.
+    The server writes the file after the HTTP response, so poll briefly. When
+    the poll gives up, say which of the three things went wrong -- the file
+    never appeared, it never parsed, or it parsed without total_duration_ms --
+    because "did not write performance data" covered all three and made the
+    intermittent nightly failures undiagnosable from the log alone.
     """
     deadline = time.time() + timeout
+    last_reason = "file never appeared"
     while time.time() < deadline:
         try:
             with open(perf_dump_path) as f:
                 data = json.load(f)
             if data.get("total_duration_ms") is not None:
                 return data
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+            last_reason = f"parsed but has no total_duration_ms (keys: {sorted(data)})"
+        except FileNotFoundError:
+            last_reason = "file never appeared"
+        except json.JSONDecodeError as exc:
+            last_reason = f"never parsed as JSON ({exc})"
         time.sleep(0.5)
+
+    directory = os.path.dirname(perf_dump_path) or "."
+    try:
+        siblings = sorted(f for f in os.listdir(directory) if f.startswith("perf_"))[
+            -8:
+        ]
+    except OSError as exc:
+        siblings = [f"<unreadable: {exc}>"]
+    print(
+        f"  WARNING: no server perf dump after {timeout:.0f}s — {last_reason}."
+        f" {directory} holds: {siblings}"
+    )
     return None
 
 
@@ -840,6 +859,7 @@ def run_single(
 
         latency_samples: list[float] = []
         perf_dumps: list[dict] = []
+        missing_perf_dumps = 0
         for sample_index in range(measurement_repeats):
             perf_dump_path = None
             if framework == "sglang":
@@ -862,22 +882,33 @@ def run_single(
             latency_samples.append(round(latency, 3))
 
             if perf_dump_path:
+                # The measurement is the client-side latency recorded above; the
+                # server dump is supplementary stage telemetry, and the dashboard
+                # already renders rows whose server_latency_s is absent. Losing it
+                # should not discard a good measurement or fail the nightly.
                 perf_dump = _read_perf_dump(perf_dump_path)
                 if perf_dump is None:
-                    raise RuntimeError(
-                        f"Server did not write performance data to {perf_dump_path}"
+                    missing_perf_dumps += 1
+                else:
+                    perf_dumps.append(perf_dump)
+                    print(
+                        "  Server-side latency: "
+                        f"{perf_dump['total_duration_ms'] / 1000.0:.2f}s"
                     )
-                perf_dumps.append(perf_dump)
-                print(
-                    "  Server-side latency: "
-                    f"{perf_dump['total_duration_ms'] / 1000.0:.2f}s"
-                )
 
         result["latency_samples_s"] = latency_samples
         result["measurement_count"] = len(latency_samples)
         result["latency_s"] = round(statistics.median(latency_samples), 3)
         if perf_dumps:
             result.update(_summarize_perf_dumps(perf_dumps))
+        if missing_perf_dumps:
+            # Surfaced in the artifact so an intermittent dump race stays visible
+            # instead of silently thinning the server-side medians.
+            result["missing_perf_dumps"] = missing_perf_dumps
+            print(
+                f"  NOTE: {missing_perf_dumps}/{measurement_repeats} server perf "
+                "dump(s) unreadable; client-side latency is unaffected"
+            )
 
     except Exception as e:
         result["error"] = server_error.get("message", str(e))


### PR DESCRIPTION
## Problem

The diffusion nightly has been red since 2026-09-05 on `Server did not write performance data to ...`, and the case it hits moves around:

| run | failing cases |
|---|---|
| [09-05](https://github.com/sgl-project/sglang/actions/runs/33970864867) | `ltx2.3_twostage_ti2v_2gpus` (repeat 2), `wan22_i2v_a14b_720p` (repeat 2) |
| [09-07](https://github.com/sgl-project/sglang/actions/runs/34131440112) | `ltx2.3_twostage_ti2v_2gpus` (repeat 1), `wan22_t2v_a14b_720p` (repeat 2) |

Only the heavy video cases are ever affected. In **both** runs the server had already logged `Metrics dumped to <the exact path the client then reported missing>` about ten seconds before the client gave up:

```
15:30:35.839  [server] Metrics dumped to: .../perf_wan22_t2v_a14b_720p_measured_2.json
15:30:45.998  ERROR: Server did not write performance data to .../perf_wan22_t2v_a14b_720p_measured_2.json
```

The paths match byte for byte, `dump_benchmark_report` writes synchronously before it logs, and client and server share a filesystem (no container in this job), so I could not reproduce the race from the logs. **This PR does not claim to fix that race.**

## What it does change

**The reaction is disproportionate.** The measurement is the client-side latency, already recorded by the time the dump is read; the server dump is supplementary stage telemetry, and `generate_diffusion_dashboard.py` already renders rows whose `server_latency_s` is absent. Failing the case — and with it the whole nightly — because the extra telemetry could not be read conflates the two. An unreadable dump is now counted in `missing_perf_dumps` on the result and reported, and the case keeps its latency.

**The message covered three different faults,** which is why the logs cannot settle the cause: the file never appeared, it never parsed, or it parsed without `total_duration_ms`. Those are now distinguished, and the warning lists what the directory actually holds, so the next occurrence is diagnosable:

```
WARNING: no server perf dump after 30s — parsed but has no total_duration_ms (keys: [...]).
  /path/comparison-logs holds: ['perf_..._measured.json', ...]
```

Poll timeout goes 10s → 30s, since 10 was arbitrary and every failure landed exactly on it.

## Testing

Exercised all four paths of `_read_perf_dump` directly: a good dump returns; a missing file, a dump without `total_duration_ms`, and an unparseable dump each return `None` with their own reason and a directory listing. pre-commit clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34313434832](https://github.com/sgl-project/sglang/actions/runs/34313434832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34313434659](https://github.com/sgl-project/sglang/actions/runs/34313434659)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34313435082](https://github.com/sgl-project/sglang/actions/runs/34313435082)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->