### PR TITLE
[Bugfix] Reject W4AFP8 MoE group_size != 128 for cutlass chunk_size

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -64,6 +64,7 @@ def cutlass_w4a8_moe(
     a2_scale: Optional[torch.Tensor] = None,
     apply_router_weight_on_input: bool = False,
     routed_scaling_factor: float = 1.0,
+    group_size: int = 128,
 ) -> torch.Tensor:
     """
     This function computes a w4a8-quantized Mixture of Experts (MoE) layer
@@ -123,6 +124,16 @@ def cutlass_w4a8_moe(
     k = w1_q.size(2) * 2  # w1_q is transposed and packed
     n = w2_q.size(2) * 2  # w2_q is transposed and packed
     topk = topk_ids.size(1)
+
+    if group_size != 128:
+        raise ValueError(
+            "cutlass_w4a8_moe only supports group_size=128 "
+            f"(kernel chunk_size), got {group_size}"
+        )
+    if k % 128 != 0:
+        raise ValueError(
+            f"cutlass_w4a8_moe requires K divisible by 128, got K={k}"
+        )
 
     if apply_router_weight_on_input:
         assert topk == 1, "apply_router_weight_on_input is only implemented for topk=1"
@@ -190,7 +201,7 @@ def cutlass_w4a8_moe(
         b_strides1,
         c_strides1,
         s_strides13,
-        128,
+        group_size,
         topk,
     )
 
@@ -220,7 +231,7 @@ def cutlass_w4a8_moe(
         b_strides2,
         c_strides2,
         s_strides2,
-        128,
+        group_size,
         topk,
     )
 
@@ -262,6 +273,7 @@ def cutlass_w4a8_moe_deepep_normal(
     problem_sizes2: torch.Tensor,
     a1_scale: Optional[torch.Tensor] = None,
     a2_scale: Optional[torch.Tensor] = None,
+    group_size: int = 128,
 ) -> torch.Tensor:
     """
     This function computes a w4a8-quantized Mixture of Experts (MoE) layer
@@ -385,7 +397,7 @@ def cutlass_w4a8_moe_deepep_normal(
         b_strides1,
         c_strides1,
         s_strides13,
-        128,
+        group_size,
         topk,
     )
     intermediate = torch.empty((m * topk, n), device=device, dtype=torch.bfloat16)
@@ -408,7 +420,7 @@ def cutlass_w4a8_moe_deepep_normal(
         b_strides2,
         c_strides2,
         s_strides2,
-        128,
+        group_size,
         topk,
     )
     num_tokens = src2dst.shape[0] // topk
@@ -457,6 +469,7 @@ def cutlass_w4a8_moe_deepep_ll(
     a1_scale: Optional[torch.Tensor] = None,
     a2_scale: Optional[torch.Tensor] = None,
     expected_m: Optional[int] = None,
+    group_size: int = 128,
 ) -> torch.Tensor:
     """
     This function computes a w4a8-quantized Mixture of Experts (MoE) layer
@@ -552,7 +565,7 @@ def cutlass_w4a8_moe_deepep_ll(
         b_strides1,
         c_strides1,
         s_strides13,
-        128,
+        group_size,
         topk,
     )
 
@@ -574,7 +587,7 @@ def cutlass_w4a8_moe_deepep_ll(
         b_strides2,
         c_strides2,
         s_strides2,
-        128,
+        group_size,
         topk,
     )
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
@@ -91,6 +91,13 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
         self.weight_quant = weight_quant
         self.input_quant = input_quant
 
+        if self.group_size != 128:
+            raise ValueError(
+                "CompressedTensorsW4AFP8MoE requires group_size=128 "
+                f"(cutlass_w4a8_moe chunk_size); got {self.group_size}. "
+                "Requantize with group_size=128."
+            )
+
         assert config.symmetric, "Only symmetric quantization is supported"
         assert (
             self.quant_config.quant_format == CompressionFormat.pack_quantized.value
@@ -298,7 +305,6 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
         topk_output = dispatch_output.topk_output
         topk_weights, topk_ids, _ = topk_output
 
-        # TODO: currently, group_size is hardcoded to 128 in the cutlass_w4a8_moe kernel.
         output = cutlass_w4a8_moe(
             x,
             layer.w13_weight_packed,
@@ -321,5 +327,6 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
             layer.a13_scale,
             layer.a2_scale,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor or 1.0,
+            group_size=self.group_size,
         )
         return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -128,6 +128,12 @@ def interleave_scales(scales: torch.Tensor) -> torch.Tensor:
 class W4AFp8MoEMethod(FusedMoEMethodBase):
     def __init__(self, quant_config: W4AFp8Config):
         self.quant_config = quant_config
+        if self.quant_config.group_size != 128:
+            raise ValueError(
+                "W4AFp8MoEMethod requires group_size=128 "
+                f"(cutlass_w4a8_moe chunk_size); got {self.quant_config.group_size}. "
+                "Requantize with group_size=128."
+            )
 
     def create_weights(
         self,
@@ -334,6 +340,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale,
             layer.w2_input_scale,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor or 1.0,
+            group_size=self.quant_config.group_size,
         )
         return StandardCombineInput(hidden_states=output)
 
@@ -379,6 +386,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale,
             layer.w2_input_scale,
             expected_m=expected_m,
+            group_size=self.quant_config.group_size,
         )
 
         return output
@@ -429,6 +437,7 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
                 self.problem_sizes2,
                 layer.w13_input_scale,
                 layer.w2_input_scale,
+                group_size=self.quant_config.group_size,
             )
         else:
             return hidden_states

--- a/test/registered/unit/layers/quantization/test_w4afp8_moe_chunk_size_numerical_ab.py
+++ b/test/registered/unit/layers/quantization/test_w4afp8_moe_chunk_size_numerical_ab.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical A/B for #38573 without sm90 Cutlass.
+
+Checkpoint scales use group_size=64; pre-fix cutlass path used chunk_size=128.
+Oracle: W[n,k] *= scale[n, k // chunk_size].
+"""
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _dequant_group(
+    w: torch.Tensor, scale: torch.Tensor, chunk_size: int
+) -> torch.Tensor:
+    _, k = w.shape
+    idx = (torch.arange(k, device=w.device) // chunk_size).clamp(max=scale.shape[1] - 1)
+    return w.to(torch.float32) * scale[:, idx]
+
+
+class TestW4AFP8ChunkSizeNumericalAB(CustomTestCase):
+    def test_g64_scales_with_chunk_128_diverge(self):
+        torch.manual_seed(0)
+        n, k, group_size, wrong_chunk = 8, 256, 64, 128
+        w = torch.randint(-8, 8, (n, k), dtype=torch.int8).float()
+        n_groups = k // group_size
+        scale = (
+            torch.arange(1, n_groups + 1, dtype=torch.float32)
+            .view(1, -1)
+            .expand(n, -1)
+            .contiguous()
+        )
+        scale = scale * torch.linspace(0.01, 0.08, n).view(-1, 1)
+
+        ref = _dequant_group(w, scale, chunk_size=group_size)
+        buggy = _dequant_group(w, scale, chunk_size=wrong_chunk)
+        self.assertGreater((ref - buggy).abs().max().item(), 1e-3)
+
+        fixed = _dequant_group(w, scale, chunk_size=group_size)
+        self.assertTrue(torch.allclose(fixed, ref))
+
+    def test_g128_chunk_128_identical(self):
+        torch.manual_seed(1)
+        n, k = 4, 256
+        w = torch.randn(n, k)
+        scale = torch.randn(n, k // 128)
+        a = _dequant_group(w, scale, 128)
+        b = _dequant_group(w, scale, 128)
+        self.assertTrue(torch.allclose(a, b))

--- a/test/registered/unit/layers/quantization/test_w4afp8_moe_group_size_guard.py
+++ b/test/registered/unit/layers/quantization/test_w4afp8_moe_group_size_guard.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reject W4AFP8 MoE group_size != 128 (cutlass chunk_size silent-wrong path)."""
+
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a8_fp8_moe import (  # noqa: E402
+    CompressedTensorsW4AFP8MoE,
+)
+from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config, W4AFp8MoEMethod  # noqa: E402
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+def _make_scheme(group_size: int) -> CompressedTensorsW4AFP8MoE:
+    weights = SimpleNamespace(num_bits=4, group_size=group_size, symmetric=True)
+    quant_config = SimpleNamespace(
+        target_scheme_map={"Linear": {"weights": weights}},
+        quant_format="pack-quantized",
+    )
+    return CompressedTensorsW4AFP8MoE(quant_config, weight_quant=None, input_quant=None)
+
+
+class TestW4AFP8MoEGroupSizeGuard(CustomTestCase):
+    def test_compressed_tensors_scheme_rejects_non_128(self):
+        with self.assertRaisesRegex(ValueError, "group_size=128"):
+            _make_scheme(64)
+
+    def test_compressed_tensors_scheme_accepts_128(self):
+        scheme = _make_scheme(128)
+        self.assertEqual(scheme.group_size, 128)
+
+    def test_w4afp8_method_rejects_non_128(self):
+        cfg = W4AFp8Config(group_size=64)
+        with self.assertRaisesRegex(ValueError, "group_size=128"):
+            W4AFp8MoEMethod(cfg)
+
+    def test_w4afp8_method_accepts_128(self):
+        method = W4AFp8MoEMethod(W4AFp8Config(group_size=128))
+        self.assertEqual(method.quant_config.group_size, 128)
+
+    def test_cutlass_w4a8_moe_exposes_group_size(self):
+        import inspect
+
+        from sglang.srt.layers.moe import cutlass_w4a8_moe as mod
+
+        sig = inspect.signature(mod.cutlass_w4a8_moe)
+        self.assertIn("group_size", sig.parameters)
+        self.assertEqual(sig.parameters["group_size"].default, 128)


### PR DESCRIPTION
## Motivation

Fixes #38573.

`CompressedTensorsW4AFP8MoE` / `W4AFp8MoEMethod` size weight scales from checkpoint `group_size`, but `cutlass_w4a8_moe*` always passed literal `chunk_size=128` into `cutlass_w4a8_moe_mm`. A pack-quantized W4A8 MoE with `group_size: 64` therefore loads cleanly and serves silently wrong numbers.

Issue also notes that even with `chunk_size=64` plumbed, results are still wrong when per-rank K is not a multiple of 128 (CUTLASS K-tile assumption). Until that path is proven, reject non-128 at construction and assert `K % 128 == 0` at the kernel entry.

## Modifications

- Add `group_size: int = 128` to `cutlass_w4a8_moe` / deepep variants; pass it through to all six `cutlass_w4a8_moe_mm` calls.
- Reject `group_size != 128` in `CompressedTensorsW4AFP8MoE` and `W4AFp8MoEMethod` with a clear error.
- Assert `K % 128 == 0` in `cutlass_w4a8_moe`.
- Unit test: accept 128 / reject 64 / signature exposes `group_size`.

## Test plan

- [x] unit: `test/registered/unit/layers/quantization/test_w4afp8_moe_group_size_guard.py`
- [ ] CI: same file under `base-a-test-cpu`
- [ ] optional: H100 smoke with g128 checkpoint unchanged

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34317876201](https://github.com/sgl-project/sglang/actions/runs/34317876201)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34317875692](https://github.com/sgl-project/sglang/actions/runs/34317875692)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34317876124](https://github.com/sgl-project/sglang/actions/runs/34317876124)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->