### PR TITLE
[XPU] Rename sgl-kernel dependency to sglang-kernel-xpu

### DIFF
--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -54,7 +54,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
+  "sglang-kernel-xpu @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
   "smg-grpc-servicer>=0.5.0",
   "soundfile==0.13.1",
   "tiktoken",


### PR DESCRIPTION
## Summary

`sgl-project/sgl-kernel-xpu#462` renamed the Python package to `sglang-kernel-xpu` (root `pyproject.toml`, merged 2026-09-09). pip enforces strict name consistency between a URL requirement's left-hand identity and the metadata built from the source, so `python/pyproject_xpu.toml`'s existing `sgl-kernel @ git+…sgl-kernel-xpu.git` line now trips:

```
WARNING: Generating metadata for package sgl-kernel produced metadata for project name sglang-kernel-xpu.
Fix your #egg=sgl-kernel fragments.
Discarding git+https://github.com/sgl-project/sgl-kernel-xpu.git: … expected 'sgl-kernel', but metadata has 'sglang-kernel-xpu'
```

pip then falls back to the unrelated CUDA `sgl-kernel` package on PyPI, which cannot satisfy the XPU install, and the resolver bails out with `No matching distribution found for sgl-kernel (unavailable)`.

## Fix

One-line rename of the requirement identity to match the new source package name.

## Notes

- The analogous CUDA path in `python/pyproject.toml` (`sglang-kernel==0.4.6.post1`) already tracks the same rename; only the XPU line was missed.
- No other file in the sglang tree references the old `sgl-kernel` name for `sgl-kernel-xpu` (`grep -rn "sgl-kernel @" .` confirms only this line).

## Test plan

- [ ] `pip install -e .` against `pyproject_xpu.toml` on a Python 3.12 XPU env resolves cleanly (no `Discarding git+…` warning, `sglang-kernel-xpu` builds and installs).
- [ ] Downstream `sgl-project/sglang-omni` XPU docker build (`docker build -f docker/xpu.Dockerfile .`) still works when pins are rolled forward past 2026-09-09.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34318359374](https://github.com/sgl-project/sglang/actions/runs/34318359374)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34318359187](https://github.com/sgl-project/sglang/actions/runs/34318359187)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34318359363](https://github.com/sgl-project/sglang/actions/runs/34318359363)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->