### PR TITLE
use private --shm-size instead of --ipc=host to stop /dev/shm leak

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           docker rm -f ci_sglang_${{ matrix.name }} || true
           docker run -dt \
-            -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
+            -v ${{ github.workspace }}:/sglang-checkout/ --shm-size=64g \
             -v $HOME/.cache/huggingface:/root/.cache/huggingface \
             -v $HOME/.cache/sgl_eval:/root/.cache/sgl_eval \
             -e HF_TOKEN="$(cat ~/huggingface_token.txt)" \
@@ -177,7 +177,7 @@ jobs:
         run: |
           docker rm -f ci_sglang_${{ matrix.name }} || true
           docker run -dt \
-            -v ${{ github.workspace }}:/sglang-checkout/ --ipc=host \
+            -v ${{ github.workspace }}:/sglang-checkout/ --shm-size=64g \
             -v $HOME/.cache/huggingface:/root/.cache/huggingface \
             -v $HOME/.cache/sgl_eval:/root/.cache/sgl_eval \
             -e HF_TOKEN="$(cat ~/huggingface_token.txt)" \


### PR DESCRIPTION
  Problem

  PR Test (Xeon) jobs failed intermittently at Check AMX support / import torch with Bus error (core dumped), looking like flaky hardware.

  Root cause: containers ran with --ipc=host, so DeepSpeed CPU all-reduce buffers (deepspeed_allreduce_buffer_*, 259 MB each) landed on the host /dev/shm. When jobs were cancelled/SIGKILLed, the buffers were orphaned and
  never reclaimed — over weeks filling /dev/shm to 100%. Later jobs then mmap'd unbacked shm pages and died with SIGBUS.

  Fix

  The shm all-reduce is single-container/single-machine (TP ranks share shm within one container), so --ipc=host was never needed — only a workaround for the 64 MB default. Switch to a private --shm-size=64g: buffers now die
  with the container on docker rm -f and can't leak to the host. Two-line change.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34319402456](https://github.com/sgl-project/sglang/actions/runs/34319402456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34328676031](https://github.com/sgl-project/sglang/actions/runs/34328676031)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->