### PR TITLE
[Refactor] Price hybrid SWA pools from a declarative pricing table

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from bisect import bisect_right
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -143,6 +144,55 @@ def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
         "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
         f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
     )
+
+
+class PoolRole(Enum):
+    """Whether a pricing-table row belongs to the target model or a draft worker."""
+
+    TARGET = "target"
+    DRAFT = "draft"
+
+
+@dataclass
+class PoolPriceEntry:
+    """One row of a pool pricing table: the per-token price of one pool.
+
+    ``cell_ratio`` applies only when summing the unified-budget coefficient
+    (cell size) -- e.g. SWA rows are priced at ``swa_full_tokens_ratio`` of a
+    full token in hybrid mode. Draft-pool byte sums always use the raw price.
+    Flat additive prices (a DFLASH draft pool with its own geometry) use
+    ``num_layers=1``.
+
+    Step 1 of table-driven pool pricing: rows replace hand-written per-class
+    formulas. Per-request fixed rows (the Mamba/GDN state pool) arrive with
+    MambaPoolConfigurator in step 2.
+    """
+
+    name: str
+    role: PoolRole
+    bytes_per_token: int
+    num_layers: int = 1
+    cell_ratio: float = 1.0
+
+
+def _sum_price_table(entries: list[PoolPriceEntry], *, for_coeff: bool) -> float:
+    """Reduce pricing-table rows to a single bytes-per-token figure.
+
+    Rows sharing a price and ratio are grouped (layer counts summed) and terms
+    are emitted in declaration order, so the arithmetic reproduces the previous
+    hand-written formulas bit-for-bit; golden tests freeze the values.
+    """
+    grouped: dict[tuple[int, float], int] = {}
+    for entry in entries:
+        key = (entry.bytes_per_token, entry.cell_ratio if for_coeff else 1.0)
+        grouped[key] = grouped.get(key, 0) + entry.num_layers
+    total = 0
+    for (price, ratio), num_layers in grouped.items():
+        if for_coeff and ratio != 1.0:
+            total = total + ratio * price * num_layers
+        else:
+            total = total + price * num_layers
+    return total
 
 
 class MemoryPoolConfigurator:
@@ -655,43 +705,64 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
 
         self._draft_cell_size = _dflash_draft_cell_size(kvc)
 
-        self._recompute_cell_size()
-
-    def _recompute_cell_size(self) -> None:
-        # Bytes per token of max_total_num_tokens.
+        # Pricing table: one row per (pool, role).
         #
-        # Hybrid (full_layers > 0): max_total = full_tokens, so cell_size accounts
-        # for both pools: F*nf + r*S*ns (where swa_tokens = full_tokens * r).
+        # Hybrid (full_layers > 0): max_total = full_tokens, so the coefficient
+        # accounts for both pools: F*nf + r*S*ns (swa_tokens = full_tokens * r),
+        # i.e. SWA rows carry swa_full_tokens_ratio as their cell_ratio.
         #
         # All-SWA (full_layers == 0): max_total = swa_tokens directly. The ratio
         # is meaningless here -- there is no full pool to relate to, and every
-        # token beyond the sliding window can be evicted. So cell_size = S*ns,
-        # with no ratio factor applied.
-        if self._full_layers_num == 0:
-            self._cell_size = (
-                self._swa_per_token * self._swa_layers_num
-                + self._full_per_token * self._draft_full_layers_num
-                + self._swa_per_token * self._draft_swa_layers_num
-                + self._swa_per_token * self._draft_swa_full_layers_num
-                + self._draft_cell_size
-            )
-        else:
-            self._cell_size = (
-                self._full_per_token
-                * (self._full_layers_num + self._draft_full_layers_num)
-                + self._swa_per_token * self._draft_swa_full_layers_num
-                + self._swa_full_tokens_ratio
-                * self._swa_per_token
-                * (self._swa_layers_num + self._draft_swa_layers_num)
-                + self._draft_cell_size
-            )
+        # token beyond the sliding window can be evicted -- so SWA rows price
+        # flat (cell_ratio = 1.0).
+        swa_cell_ratio = (
+            self._swa_full_tokens_ratio if self._full_layers_num > 0 else 1.0
+        )
+        self._price_table = [
+            PoolPriceEntry(
+                "full", PoolRole.TARGET, self._full_per_token, self._full_layers_num
+            ),
+            PoolPriceEntry(
+                "full",
+                PoolRole.DRAFT,
+                self._full_per_token,
+                self._draft_full_layers_num,
+            ),
+            PoolPriceEntry(
+                "swa_full_capacity",
+                PoolRole.DRAFT,
+                self._swa_per_token,
+                self._draft_swa_full_layers_num,
+            ),
+            PoolPriceEntry(
+                "swa",
+                PoolRole.TARGET,
+                self._swa_per_token,
+                self._swa_layers_num,
+                cell_ratio=swa_cell_ratio,
+            ),
+            PoolPriceEntry(
+                "swa",
+                PoolRole.DRAFT,
+                self._swa_per_token,
+                self._draft_swa_layers_num,
+                cell_ratio=swa_cell_ratio,
+            ),
+            PoolPriceEntry("dflash_draft", PoolRole.DRAFT, self._draft_cell_size),
+        ]
+        self._recompute_cell_size()
+
+    def _recompute_cell_size(self) -> None:
+        # Bytes per token of max_total_num_tokens, reduced from the pricing
+        # table; declaration order preserves the previous formula's arithmetic.
+        self._cell_size = _sum_price_table(self._price_table, for_coeff=True)
 
     def _draft_pool_bytes_per_token(self) -> int:
         return int(
-            self._full_per_token * self._draft_full_layers_num
-            + self._swa_per_token
-            * (self._draft_swa_layers_num + self._draft_swa_full_layers_num)
-            + self._draft_cell_size
+            _sum_price_table(
+                [e for e in self._price_table if e.role is PoolRole.DRAFT],
+                for_coeff=False,
+            )
         )
 
     def _max_unified_full_tokens(

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -1141,5 +1141,93 @@ class TestSWAPoolFloor(CustomTestCase):
         self.assertEqual(sizes.c4_state_pool_size, 0)
 
 
+class TestHybridSWAPriceTable(CustomTestCase):
+    """Golden values: the pricing table reproduces the closed-form sizing."""
+
+    def _build(self, mr):
+        with mock_cpu_env():
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            return create_memory_pool_configurator(mr)
+
+    @staticmethod
+    def _swa_target_row(cfg):
+        from sglang.srt.model_executor.pool_configurator import PoolRole
+
+        return next(
+            e for e in cfg._price_table if e.name == "swa" and e.role is PoolRole.TARGET
+        )
+
+    def test_hybrid_no_draft(self):
+        mr = _make_model_runner(
+            self,
+            is_hybrid_swa=True,
+            full_attention_layer_ids=[0],
+            swa_attention_layer_ids=[1],
+            swa_num_kv_heads=4,
+            swa_full_tokens_ratio=0.5,
+        )
+        cfg = self._build(mr)
+        # full = swa = 4*(64+64)*2 = 1024 bytes/token/layer.
+        # cell = F*1 + 0.5*S*1 = 1536; no draft rows contribute.
+        self.assertEqual(cfg._cell_size, 1536)
+        self.assertEqual(cfg._draft_pool_bytes_per_token(), 0)
+        self.assertEqual(len(cfg._price_table), 6)
+        self.assertEqual(self._swa_target_row(cfg).cell_ratio, 0.5)
+
+    def test_all_swa_prices_flat(self):
+        mr = _make_model_runner(
+            self,
+            is_hybrid_swa=True,
+            full_attention_layer_ids=[],
+            swa_attention_layer_ids=[0, 1],
+            swa_num_kv_heads=4,
+            swa_full_tokens_ratio=0.5,
+        )
+        cfg = self._build(mr)
+        # All-SWA: the ratio is meaningless; cell = S*2 = 2048, int arithmetic.
+        self.assertEqual(cfg._cell_size, 2048)
+        self.assertIsInstance(cfg._cell_size, int)
+        self.assertEqual(self._swa_target_row(cfg).cell_ratio, 1.0)
+
+    def test_eagle_draft_rows(self):
+        mr = _make_model_runner(
+            self,
+            is_hybrid_swa=True,
+            full_attention_layer_ids=[0],
+            swa_attention_layer_ids=[1],
+            swa_num_kv_heads=4,
+            swa_full_tokens_ratio=0.5,
+        )
+        mr.spec_algorithm.is_eagle.return_value = True
+        mr.spec_algorithm.is_none.return_value = False
+        mr.spec_aux_config.eagle_draft_num_layers = 2
+        mr.spec_aux_config.eagle_draft_swa_num_layers = 1
+        cfg = self._build(mr)
+        # draft_full = 1, draft_swa = 1:
+        # cell = F*(1+1) + 0.5*S*(1+1) = 3072; draft pool = F*1 + S*1 = 2048.
+        self.assertEqual(cfg._cell_size, 3072)
+        self.assertEqual(cfg._draft_pool_bytes_per_token(), 2048)
+
+    def test_dflash_flat_row(self):
+        mr = _make_model_runner(
+            self,
+            is_hybrid_swa=True,
+            full_attention_layer_ids=[0],
+            swa_attention_layer_ids=[1],
+            swa_num_kv_heads=4,
+            swa_full_tokens_ratio=0.5,
+        )
+        mr.spec_algorithm.is_dflash_family.return_value = True
+        mr.spec_algorithm.is_none.return_value = False
+        mr.spec_aux_config.dflash_draft_cell_size_per_token = 100
+        cfg = self._build(mr)
+        # cell = F*1 + 0.5*S*1 + 100 = 1636; draft pool = 100.
+        self.assertEqual(cfg._cell_size, 1636)
+        self.assertEqual(cfg._draft_pool_bytes_per_token(), 100)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Step 1 of table-driven pool pricing: replace `HybridSWAPoolConfigurator`'s hand-written `F*nf + r*S*ns` formula with `PoolPriceEntry` rows (one per pool/role, coefficient-only `cell_ratio`) reduced by a shared grouping helper. Declaration order and price-grouped reduction keep the arithmetic bit-identical; golden tests freeze cell size and draft-pool bytes for hybrid / all-SWA / EAGLE draft / DFLASH. No behavior change; Default/DSV4 untouched. Mamba/GDN per-request fixed rows land with `MambaPoolConfigurator` in step 2, filling the factory's reserved slot.

## Motivation

Pool sizing math is hand-written in four styles: `DefaultPoolConfigurator._compute_cell_size` (a long MLA/DSA-indexer/sparse/MHA/FP4/mxfp8 conditional, QSA added on top, #37500), `HybridSWAPoolConfigurator` (two-price formula plus three draft terms), `DSV4PoolConfigurator` (five-pool fraction sum, request-scoped pools patched in via `finalize_with_max_running_requests`), and the mamba state pool priced outside the configurator entirely (`KVCacheConfigurator._handle_max_mamba_cache`, feeding `resolve_max_num_reqs`). Draft KV pricing alone has three implementations (EAGLE layer ratio, DFLASH flat additive, DSV4 `_spec_infl`). Every new architecture edits formulas in yet another style — last 30 days: QSA (#37500), GLM-5.3 (#36507), NPU sparse-KV offload (#33089), unified SWA spec memory (#36403), plus a DSV4 revert→reland (#38163/#38192); more in flight (#31967, #37798). The factory already reserves the spot: `# Future: MambaPoolConfigurator`.

Plan, each step behavior-preserving and independently mergeable:
1. This PR: table abstraction on HybridSWA, golden-tested.
2. `MambaPoolConfigurator`: mamba state as per-request fixed rows; `resolve_max_num_reqs` composition unchanged.
3. Migrate Default / DSV4 behind golden tests.

## Modifications

- New `PoolRole` / `PoolPriceEntry` / `_sum_price_table`; HybridSWA becomes a six-row table (full/swa × target/draft, `swa_full_capacity`, `dflash_draft`). All derived values (`_cell_size`, `_draft_pool_bytes_per_token`, `_max_unified_full_tokens`, `SWAChunkCap`, `_solve_pool_sizes`) read from the table.
- Declaration order mirrors the old term order and rows group by (price, ratio) before multiplying: hybrid float arithmetic reproduced term-for-term, all-SWA stays integer.
- New `TestHybridSWAPriceTable`: four golden cases asserting cell size, draft-pool bytes, per-row ratios.

Step 2 adds per-request fixed rows (mamba/c128 state) as a basis axis rather than new formula sites:

```python
class TokenBasis(Enum):
    PER_POOL_TOKEN = auto()
    RATIO_OF_FULL = auto()       # today's cell_ratio
    PER_REQUEST_FIXED = auto()   # slots × bytes_per_slot × num_req_slots
```

with the solver subtracting the fixed bias before dividing by the coefficient — what `DSV4PoolConfigurator.calculate_pool_sizes` does by hand for its three fixed pools.

In-flight overlap: #36729 (unified-memory byte budget, allocator side — orthogonal, conflicts mechanical, will rebase if it lands first); #31967 / #37798 (new pool dtypes on the Default side — motivation, not conflict). Mamba runtime PRs (#38521, #37613, #37943, #36713, #36770, #37074, #37594) don't touch sizing math.

## Accuracy Tests

Pure refactor, no model-output impact. The existing suite (hybrid, all-SWA, EAGLE-draft, DFLASH, SWAChunkCap) is unchanged and must pass as-is; four new golden cases freeze the values.

```
python -m pytest test/registered/unit/model_executor/test_pool_configurator.py -v
```

## Speed Tests and Profiling

N/A — the table is reduced once at engine init.

## Checklist

- [x] Format your code according to the `https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit`.
- [x] Add unit tests according to the `https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests`.
- [ ] Update documentation according to the `https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations`.
- [ ] Provide accuracy and speed benchmark results according to the `https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy` and `https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed`.
- [x] Follow the SGLang code style `https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance`.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the `https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process`.
2. Get approvals from `https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS` and other reviewers.
3. Trigger CI tests with `https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests` or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
