### PR TITLE
[Bug] Keep experimental_sgl_trtllm MoE-LoRA reachable for unquantized models

### DIFF
--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -1023,6 +1023,17 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         global_backend = get_moe_runner_backend()
         if base_layer.runner is not None:
             runner_backend = base_layer.runner.runner_backend
+            # UnquantizedFusedMoEMethod.create_moe_runner resolves experimental_sgl_trtllm to the
+            # stock FLASHINFER_TRTLLM runner, because the two share the kernels and the weight
+            # layout. That erases the identity the experimental LoRA dispatch below keys on, so an
+            # unquantized MoE served with --moe-runner-backend experimental_sgl_trtllm --enable-lora
+            # falls through to get_moe_quant_info(), which no quant method implements for
+            # 'flashinfer_trtllm', and raises at LoRA-layer init. Restore what the user asked for.
+            if (
+                global_backend.is_experimental_sgl_trtllm()
+                and runner_backend.is_flashinfer_trtllm()
+            ):
+                runner_backend = global_backend
         elif not global_backend.is_auto():
             runner_backend = global_backend
         else:


### PR DESCRIPTION
## Summary

On `main` (`5097f9ac95`), serving an **unquantized (BF16) MoE** with
`--moe-runner-backend experimental_sgl_trtllm --enable-lora` fails at LoRA-layer init:

```
NotImplementedError: UnquantizedFusedMoEMethod does not expose quant info for 'flashinfer_trtllm'
  File "python/sglang/srt/layers/quantization/base_config.py", line 135, in get_moe_quant_info
```

The backend's own BF16 LoRA code path
(`srt/lora/trtllm_lora_temp/lora_layer.py` → `FlashInferTrtllmBf16MoeQuantInfo`, and
`lora_dispatch.py::fused_experts_none_to_experimental_sgl_trtllm_bf16_lora`) is therefore
**dead code today** — nothing can reach it.

## Why

Two correct-in-isolation decisions compose into a hole.

1. `UnquantizedFusedMoEMethod.create_moe_runner` resolves `experimental_sgl_trtllm` to the **stock**
   runner, because the two share the trtllm-gen kernels and weight layout
   (`srt/layers/quantization/unquant.py:864-869`):

   ```python
   if self.use_flashinfer_trtllm_moe:
       backend = (MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED
                  if get_moe_runner_backend().is_flashinfer_trtllm_routed()
                  else MoeRunnerBackend.FLASHINFER_TRTLLM)
   ```
   `use_flashinfer_trtllm_moe` is true for `experimental_sgl_trtllm`
   (`fused_moe_triton/layer.py:384-387` via `moe/utils.py:is_flashinfer_trtllm`).

2. `FusedMoEWithLoRA` then reads the backend back off the runner
   (`srt/lora/layers.py:1022-1024`), so the `EXPERIMENTAL_SGL_TRTLLM` identity the experimental
   dispatch keys on at `:1044` is already gone. `FLASHINFER_TRTLLM` is neither marlin nor triton,
   so it falls through to `get_moe_quant_info()` — which **no quant method overrides**
   (`grep -rn "def get_moe_quant_info" python/sglang/srt/` returns only the base class), and whose
   base implementation handles `is_triton()` only.

`base_layer.runner` is always populated by then: `FusedMoE.__init__` calls `create_moe_runner`
unconditionally at `fused_moe_triton/layer.py:498` and assigns `self.runner` at `:532`.

## This is a regression, from #32665

`git log -L 1020,1026:python/sglang/srt/lora/layers.py` attributes the change to
**#32665 "[MoE] Add extension points for custom runner backends"** (`ed39568e79`), which flipped:

```diff
-        # Determine runner backend: prefer server arg, fall back to quant method's runner
+        # Use the runner selected by the quant method so per-format backend resolution
+        # stays identical between base and LoRA forwards.
         global_backend = get_moe_runner_backend()
-        if not global_backend.is_auto():
+        if base_layer.runner is not None:
+            runner_backend = base_layer.runner.runner_backend
+        elif not global_backend.is_auto():
```

Before it, the server arg won and the experimental identity survived. The quantized paths are
unaffected because `ModelOptNvFp4FusedMoEMethod` / `CompressedTensorsFusedMoEMethod` do not
rewrite the backend the same way, which is why `experimental_sgl_marlin` and the NVFP4
`experimental_sgl_trtllm` configurations still work.

## Impact

The BF16 Inkling LoRA recipe in the cookbook
(`docs/src/snippets/configs/thinkingmachines/inkling.jsx:1098-1136` —
`--moe-runner-backend experimental_sgl_trtllm`, no `--quantization`, marked `verified: true`)
cannot boot on current main. The verification predates #32665.

## Reproduction

Any unquantized MoE with a MoE LoRA adapter. Ours:

```python
sgl.Engine(
    model_path="Qwen/Qwen3-30B-A3B-Instruct-2507",   # BF16 MoE
    tp_size=4,
    enable_lora=True, max_lora_rank=32,
    lora_paths={"my_lora": <adapter>},               # yushengsu/lora-diff-Qwen3-30B-A3B-Instruct-2507
    moe_runner_backend="experimental_sgl_trtllm",
    lora_use_virtual_experts=True,
    experts_shared_outer_loras=True,
)
```
with `SGLANG_EXPERIMENTAL_LORA_OPTI=1`. Raises during init on 8×B200,
`lmsysorg/sglang:latest` (sglang 0.5.19 / flashinfer 0.6.18). Swapping
`moe_runner_backend="triton"` boots normally, which is what
`test/registered/lora/test_lora_qwen3_30b_a3b_instruct_2507_logprob_diff.py` pins today.

## Proposed fix

Restore the configured backend when the quant method has resolved it onto its stock sibling,
which keeps #32665's per-format resolution intact everywhere else
(`srt/lora/layers.py`, 6 lines):

```python
        if base_layer.runner is not None:
            runner_backend = base_layer.runner.runner_backend
            if (
                global_backend.is_experimental_sgl_trtllm()
                and runner_backend.is_flashinfer_trtllm()
            ):
                runner_backend = global_backend
```

An alternative, if maintainers prefer the fix on the other side, is for
`UnquantizedFusedMoEMethod` to keep `EXPERIMENTAL_SGL_TRTLLM` in `create_moe_runner` and let the
runner registry map it — but that touches the base forward path, whereas this does not.

Either way the gap deserves a **registered test**: there is currently no end-to-end test that sets
a non-triton MoE runner together with `--enable-lora`, which is why this went unnoticed. The
existing Qwen3-30B-A3B logprob test is one `MOE_RUNNER_BACKEND` constant away from covering it.

## A second gap behind the first

With the fix above applied, the same configuration gets past init and then fails at LoRA weight
load:

```
AssertionError: LoRA buffer shape torch.Size([32, 192]) does not match weight shape torch.Size([32, 256]).
```

`FusedMoE.__init__` pads `intermediate_size_per_partition` up to a multiple of 128 for the trtllm
kernels (`fused_moe_triton/layer.py:390-395`), but the LoRA memory pool sizes its expert buffers
from the **unpadded** value. Qwen3-30B-A3B has `moe_intermediate_size = 768`, so TP=4 gives 192,
which pads to 256 and asserts; TP=2 gives 384 = 3×128 and does not.

So any unquantized MoE whose `moe_intermediate_size / tp_size` is not a multiple of 128 cannot serve
LoRA on this backend even once the backend is reachable. This is independent of the first bug and
reproduces on pristine `main` with only the 6-line fix applied.

Both are the same underlying story: **no registered test sets a non-triton MoE runner together with
`--enable-lora`**, so neither the enum collapse nor the padding mismatch had anything to catch it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34327588728](https://github.com/sgl-project/sglang/actions/runs/34327588728)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34327588473](https://github.com/sgl-project/sglang/actions/runs/34327588473)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34327588777](https://github.com/sgl-project/sglang/actions/runs/34327588777)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->