### PR TITLE
[Diffusion] Fuse the Wan VAE conv bias epilogue and tile the RMSNorm+SiLU kernel

### DIFF
--- a/python/sglang/kernels/ops/diffusion/README.md
+++ b/python/sglang/kernels/ops/diffusion/README.md
@@ -116,7 +116,7 @@ Several norms look interchangeable and are not. Start here.
 |---|---|---|---|
 | `triton_group_norm_silu` / `apply_group_norm_silu` | Triton | close | NCHW-contiguous, any channels-per-group, always applies SiLU |
 | `group_norm_silu_4d` / `group_norm_silu_rows` | Triton | close | **channels_last only**; power-of-two `C <= 2048`; optional SiLU. This is what lets a VAE decoder run channels_last end-to-end with no `nchwToNhwc` |
-| `wan_rmsnorm_silu` | Triton | close | dense `channels_last_3d` 5D (`stride(C) == 1`), Wan VAE channel-first RMSNorm + SiLU |
+| `wan_rmsnorm_silu` | Triton | close | dense `channels_last_3d` 5D (`stride(C) == 1`), Wan VAE channel-first RMSNorm + SiLU; `[ROWS, C]` tiles (~3 TB/s at C = 96); optional `conv_bias` folds the preceding conv's bias with aten `add_` arithmetic |
 | `rmsnorm_scale` / `rmsnorm_tanh_residual` | Triton | bf16-native statistics | Z-Image (matches its own reference exactly), Ideogram 4 (gated) |
 | `zimage_qk_rmsnorm_native` | Triton | bit-exact | Z-Image per-head QK RMSNorm |
 | `fused_qk_head_layernorm` | Triton | bit-exact | per-head LN on q/k, `dim_head % 4 == 0`, `<= 128` |
@@ -162,12 +162,22 @@ tensor copy per residual site.
 `fused_pack_segmented_qkv`, `fused_scatter_to_padded`,
 `fused_causal_conv3d_cat_pad_cuda`,
 `cat_pad_channels_last_3d`, `dup_up3d_add`, `nearest_upsample_nhwc`,
-`fused_temb_table_slices`,
+`conv_bias_epilogue`, `fused_temb_table_slices`,
 and `ltx2_ada_values9` are bit-exact data movement or same-order arithmetic.
 `fused_layernorm_modulate_fp8_quant_raw` folds FLUX.2 LayerNorm, adaLN
 modulation, and static FP8 quantization. `try_flux2_token_cat_fp8` and
 `try_flux2_token_cat_nvfp4` fuse branch concatenation directly into the
 quantized representation selected by the FLUX.2 checkpoint path.
+
+`conv_bias_epilogue` exists because PyTorch's cuDNN conv path adds the bias as
+a separate broadcast `add_` after `cudnn_convolution`, and on channels_last
+outputs aten does not vectorise that add (1.5 TB/s vs 4.1 TB/s here on H200;
+~10% of a Wan 2.1 decode). Run the conv without bias and apply the bias in one
+pass with aten's exact arithmetic (fp32 add, one rounding), optionally fused
+with the residual add that follows (`x.dtype(x.dtype(conv + b) + h)`, the two
+roundings of the eager chain). The Wan decoder defers `conv1`'s bias into the
+following norm (`WanRMS_norm.forward(x, conv_bias=...)`, absorbed by the fused
+kernel under the gate) and fuses `conv2`'s bias with the block's residual add.
 
 `nearest_upsample_nhwc` replaces `nn.Upsample(nearest / nearest-exact,
 integer factor)` on a dense channels_last input with a Triton gather: same

--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -399,6 +399,13 @@ _SPECS: tuple[tuple[str, KernelBackend, str, frozenset, str], ...] = (
         "Wan causal VAE main + DupUp3D(src).",
     ),
     (
+        "diffusion.conv_bias_epilogue",
+        KernelBackend.TRITON,
+        "modulate.conv_bias_epilogue_triton:conv_bias_epilogue",
+        _CUDA,
+        "Bit-exact conv bias (+ residual) epilogue on channels_last outputs.",
+    ),
+    (
         "diffusion.nearest_upsample_nhwc",
         KernelBackend.TRITON,
         "layout.nearest_upsample_nhwc_triton:nearest_upsample_nhwc",
@@ -549,6 +556,8 @@ _EXPORTS: dict[str, str] = {
     "fused_scatter_to_padded": "layout.varlen_pack_pad_triton",
     "cat_pad_channels_last_3d": "layout.wan_causal_cache_triton",
     "dup_up3d_add": "layout.wan_causal_cache_triton",
+    "conv_bias_epilogue": "modulate.conv_bias_epilogue_triton",
+    "can_use_conv_bias_epilogue": "modulate.conv_bias_epilogue_triton",
     "nearest_upsample_nhwc": "layout.nearest_upsample_nhwc_triton",
     "can_use_nearest_upsample_nhwc": "layout.nearest_upsample_nhwc_triton",
     "try_flux2_token_cat_nvfp4": "layout.flux2_token_cat_nvfp4_jit",

--- a/python/sglang/kernels/ops/diffusion/modulate/conv_bias_epilogue_triton.py
+++ b/python/sglang/kernels/ops/diffusion/modulate/conv_bias_epilogue_triton.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bit-exact conv bias epilogue for channels_last VAE decoders.
+
+PyTorch's cuDNN convolution path does not fuse the bias: ``F.conv{2,3}d``
+runs ``cudnn_convolution`` and then ``output.add_(bias.view(1, C, 1, ...))``
+as a separate broadcast kernel. On a channels_last(_3d) output that broadcast
+add is not vectorised by aten (measured 1.5 TB/s on H200 for a
+``[1, 96, 4, 480, 832]`` bf16 tensor, against 4.1 TB/s for this kernel), and
+in the Wan 2.1 VAE decoder it costs ~10% of the whole decode.
+
+Two entry points, both exact replicas of the aten arithmetic:
+
+- ``conv_bias_epilogue(x, bias)`` computes ``x.dtype(float(x) + float(bias))``
+  per element: one fp32 add, one rounding, exactly ``x.add_(bias)``.
+- ``conv_bias_epilogue(x, bias, residual)`` additionally adds the residual the
+  way the eager ``conv(x) + h`` chain does: ``x.dtype(x.dtype(x + bias) + h)``,
+  i.e. the intermediate is rounded to ``x.dtype`` before the second add, so
+  the result is bitwise identical to the two-op chain while reading ``x`` and
+  ``h`` once and writing once.
+
+``bias`` may be fp32 while ``x`` is half precision (the autocast case); it is
+cast to ``x.dtype`` first, which is what autocast does before calling the conv.
+Layout: the output is ``empty_like(x)`` so it keeps ``x``'s dense
+channels_last(_3d) strides, exactly like the in-place aten ``add_``.
+
+Verified (``torch.equal`` vs aten): ``[1, 96, 4, 480, 832]``,
+``[1, 192, 4, 240, 416]``, ``[1, 384, 2, 120, 208]``, ``[1, 384, 1, 60, 104]``
+bf16 and the 4D ``[4, 96, 480, 832]`` conv2d output; end-to-end inside the
+Wan 2.1 decoder (81 frames, 480x832).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton  # type: ignore
+import triton.language as tl  # type: ignore
+
+_MAX_INT32 = 2**31 - 1
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+
+
+@triton.jit
+def _conv_bias_epilogue_kernel(
+    x_ptr,
+    bias_ptr,
+    res_ptr,
+    out_ptr,
+    total,
+    C,
+    HAS_RES: tl.constexpr,
+    IDX64: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if IDX64:
+        offs = pid.to(tl.int64) * BLOCK + tl.arange(0, BLOCK).to(tl.int64)
+    else:
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+    # Dense channels_last: the channel is the fastest-varying index.
+    c = offs % C
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    b = tl.load(bias_ptr + c, mask=mask).to(tl.float32)
+    # aten add_: fp32 opmath, one rounding to x.dtype.
+    y = (x + b).to(out_ptr.dtype.element_ty)
+    if HAS_RES:
+        # Eager ``conv_out + h`` rounds the biased conv output first, then
+        # adds the residual with a second rounding.
+        h = tl.load(res_ptr + offs, mask=mask).to(tl.float32)
+        y = (y.to(tl.float32) + h).to(out_ptr.dtype.element_ty)
+    tl.store(out_ptr + offs, y, mask=mask)
+
+
+def _dense_channels_last(x: torch.Tensor) -> bool:
+    """Dense NHWC / NDHWC with ``C > 1`` and canonical strides on every dim
+    (``C == 1`` is also NCHW-contiguous, and the kernel adds the channel index
+    unscaled, so it needs ``stride(C) == 1`` unambiguously)."""
+    if x.dim() == 4:
+        n, c, h, w = x.shape
+        return c > 1 and x.stride() == (h * w * c, 1, w * c, c)
+    if x.dim() == 5:
+        n, c, t, h, w = x.shape
+        return c > 1 and x.stride() == (t * h * w * c, 1, h * w * c, w * c, c)
+    return False
+
+
+def _bias_ok(x: torch.Tensor, bias: torch.Tensor) -> bool:
+    return (
+        isinstance(bias, torch.Tensor)
+        and bias.is_cuda
+        and bias.device == x.device
+        and bias.numel() == x.shape[1]
+        and (bias.dtype == x.dtype or bias.dtype == torch.float32)
+    )
+
+
+def can_use_conv_bias_epilogue(
+    x: torch.Tensor,
+    bias: torch.Tensor,
+    residual: torch.Tensor | None = None,
+) -> bool:
+    """True when ``x.add_(bias)`` (optionally ``+ residual``) can be replaced by
+    the fused kernel with identical values and layout. Never raises."""
+    return (
+        isinstance(x, torch.Tensor)
+        and x.is_cuda
+        and not (
+            torch.is_grad_enabled()
+            and (x.requires_grad or (residual is not None and residual.requires_grad))
+        )
+        and x.dim() in (4, 5)
+        and x.numel() > 0
+        and x.dtype in _SUPPORTED_DTYPES
+        and _dense_channels_last(x)
+        and _bias_ok(x, bias)
+        and (
+            residual is None
+            or (
+                isinstance(residual, torch.Tensor)
+                and residual.device == x.device
+                and residual.dtype == x.dtype
+                and residual.shape == x.shape
+                and residual.stride() == x.stride()
+            )
+        )
+    )
+
+
+def conv_bias_epilogue(
+    x: torch.Tensor,
+    bias: torch.Tensor,
+    residual: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x.dtype(x + bias)`` or ``x.dtype(x.dtype(x + bias) + residual)`` on a
+    dense channels_last tensor, bit-exact vs aten. Raises on unsupported input;
+    guard with :func:`can_use_conv_bias_epilogue`."""
+    if not can_use_conv_bias_epilogue(x, bias, residual):
+        raise ValueError(
+            "unsupported input for conv_bias_epilogue: needs a CUDA dense "
+            f"channels_last bf16/fp16/fp32 4D/5D tensor with C > 1, got shape "
+            f"{tuple(x.shape)} strides {tuple(x.stride())} dtype {x.dtype}"
+        )
+    # Same cast autocast applies to the bias before the conv call.
+    bias = bias.reshape(-1).to(x.dtype).contiguous()
+    out = torch.empty_like(x)
+    total = out.numel()
+    BLOCK = 4096
+    grid = (triton.cdiv(total, BLOCK),)
+    with torch.get_device_module().device(x.device):
+        _conv_bias_epilogue_kernel[grid](
+            x,
+            bias,
+            x if residual is None else residual,
+            out,
+            total,
+            x.shape[1],
+            HAS_RES=residual is not None,
+            IDX64=total >= _MAX_INT32,
+            BLOCK=BLOCK,
+        )
+    return out

--- a/python/sglang/kernels/ops/diffusion/norm/wan_rmsnorm_silu_triton.py
+++ b/python/sglang/kernels/ops/diffusion/norm/wan_rmsnorm_silu_triton.py
@@ -3,8 +3,19 @@
 
 Fuses the Wan VAE ``WanRMS_norm -> SiLU`` chain
 (``SiLU(F.normalize(x, dim=1) * scale * gamma + bias)`` on channel-first 5D
-activations) into one kernel for ``channels_last_3d`` tensors: one program
-reduces one (b, t, h, w) pixel's channel row with fully coalesced loads.
+activations) into one kernel for ``channels_last_3d`` tensors. Each program
+handles a ``[ROWS, C]`` tile of consecutive (b, t, h, w) pixels: the channel
+rows are contiguous in memory, so loads and stores stay fully coalesced, and
+tiling several pixels per program keeps every thread busy at the decoder's
+small channel counts (96 - 384). A one-pixel-per-program layout ran at
+0.63 TB/s on H200 for ``[1, 96, 4, 480, 832]`` bf16; this one runs at ~3 TB/s.
+
+``conv_bias`` folds the preceding convolution's bias into the same pass:
+PyTorch's cuDNN conv adds its bias as a separate ``add_`` kernel, so the
+caller can run the conv without bias and hand it here. It is applied as
+``x.dtype(float(x) + float(conv_bias))`` before the statistics, the exact
+arithmetic of aten's ``add_``, so the norm sees the same values it would
+have read from the biased tensor.
 
 Numerics contract: fp32 channel-norm statistics, every step materialized at
 the same dtype boundary as eager ``WanRMS_norm.forward`` (including the
@@ -33,45 +44,60 @@ def _wan_rmsnorm_silu_kernel(
     gamma_ptr,
     bias_ptr,
     out_ptr,
+    conv_bias_ptr,
+    n_rows,
     channels: tl.constexpr,
     rms_scale,
     eps,
     has_bias: tl.constexpr,
+    has_conv_bias: tl.constexpr,
+    rows: tl.constexpr,
     block_c: tl.constexpr,
 ):
-    row = tl.program_id(0).to(tl.int64)
-    offsets = tl.arange(0, block_c)
-    mask = offsets < channels
+    pid = tl.program_id(0).to(tl.int64)
+    row_ids = pid * rows + tl.arange(0, rows).to(tl.int64)
+    col_ids = tl.arange(0, block_c)
+    col_mask = col_ids < channels
+    mask = (row_ids[:, None] < n_rows) & col_mask[None, :]
     # Dense channels-last-3d stores each pixel as one contiguous channel row.
     # Address it directly instead of recovering b/t/h/w with integer div/mod.
-    row_offsets = row * channels + offsets
+    offsets = row_ids[:, None] * channels + col_ids[None, :]
 
-    x = tl.load(x_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
-    norm = tl.sqrt(tl.sum(x * x, axis=0))
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    if has_conv_bias:
+        # The conv's own bias add (aten add_): fp32 add, one rounding to x.dtype.
+        conv_bias = tl.load(conv_bias_ptr + col_ids, mask=col_mask, other=0.0)
+        x = (x + conv_bias.to(tl.float32)[None, :]).to(x_ptr.dtype.element_ty)
+        x = x.to(tl.float32)
+    norm = tl.sqrt(tl.sum(x * x, axis=1))
     inv_norm = 1.0 / tl.maximum(norm, eps)
 
     # Eager op boundaries: normalize/*scale in x.dtype; *gamma/+bias in the
     # promoted output dtype; SiLU in fp32, stored in the output dtype.
-    y = (x * inv_norm).to(x_ptr.dtype.element_ty)
-    gamma = tl.load(gamma_ptr + offsets, mask=mask, other=1.0)
+    y = (x * inv_norm[:, None]).to(x_ptr.dtype.element_ty)
+    gamma = tl.load(gamma_ptr + col_ids, mask=col_mask, other=1.0)
     y = (y * rms_scale).to(x_ptr.dtype.element_ty)
-    y = (y.to(tl.float32) * gamma.to(tl.float32)).to(out_ptr.dtype.element_ty)
+    y = (y.to(tl.float32) * gamma.to(tl.float32)[None, :]).to(out_ptr.dtype.element_ty)
     if has_bias:
-        bias = tl.load(bias_ptr + offsets, mask=mask, other=0.0)
-        y = (y.to(tl.float32) + bias.to(tl.float32)).to(out_ptr.dtype.element_ty)
+        bias = tl.load(bias_ptr + col_ids, mask=col_mask, other=0.0)
+        y = (y.to(tl.float32) + bias.to(tl.float32)[None, :]).to(
+            out_ptr.dtype.element_ty
+        )
     y = y.to(tl.float32)
     y = y * tl.sigmoid(y)
 
-    tl.store(out_ptr + row_offsets, y, mask=mask)
+    tl.store(out_ptr + offsets, y, mask=mask)
 
 
 def _fake_wan_rmsnorm_silu(
     x: torch.Tensor,
     gamma: torch.Tensor,
     bias: torch.Tensor,
+    conv_bias: torch.Tensor,
     rms_scale: float,
     eps: float,
     has_bias: bool,
+    has_conv_bias: bool,
 ) -> torch.Tensor:
     dtype = torch.promote_types(x.dtype, gamma.dtype)
     return torch.empty_strided(x.shape, x.stride(), device=x.device, dtype=dtype)
@@ -85,27 +111,36 @@ def _triton_wan_rmsnorm_silu_cuda(
     x: torch.Tensor,
     gamma: torch.Tensor,
     bias: torch.Tensor,
+    conv_bias: torch.Tensor,
     rms_scale: float,
     eps: float,
     has_bias: bool,
+    has_conv_bias: bool,
 ) -> torch.Tensor:
     bsz, channels, t_size, h_size, w_size = x.shape
+    n_rows = bsz * t_size * h_size * w_size
     # Preserve the input strides so the VAE keeps its channels_last_3d layout.
     dtype = torch.promote_types(x.dtype, gamma.dtype)
     out = torch.empty_strided(x.shape, x.stride(), device=x.device, dtype=dtype)
     block_c = triton.next_power_of_2(channels)
-    num_warps = 1 if block_c <= 64 else 4 if block_c <= 512 else 8
+    # ~4K elements per program: 32 pixels at C <= 128 down to 4 at C = 1024.
+    rows = max(4, min(32, 4096 // block_c))
+    num_warps = 8 if rows * block_c >= 2048 else 4
 
     with torch.get_device_module().device(x.device):
-        _wan_rmsnorm_silu_kernel[(bsz * t_size * h_size * w_size,)](
+        _wan_rmsnorm_silu_kernel[(triton.cdiv(n_rows, rows),)](
             x,
             gamma,
             bias,
             out,
+            conv_bias,
+            n_rows,
             channels,
             rms_scale,
             eps,
             has_bias,
+            has_conv_bias,
+            rows,
             block_c,
             num_warps=num_warps,
         )
@@ -126,6 +161,7 @@ def can_use_wan_rmsnorm_silu(
     x: torch.Tensor,
     gamma: torch.Tensor,
     bias: torch.Tensor | None,
+    conv_bias: torch.Tensor | None = None,
 ) -> bool:
     return (
         x.is_cuda
@@ -141,6 +177,7 @@ def can_use_wan_rmsnorm_silu(
         and x.stride(1) == 1
         and _affine_supported(x, gamma)
         and (bias is None or _affine_supported(x, bias))
+        and (conv_bias is None or _affine_supported(x, conv_bias))
     )
 
 
@@ -150,22 +187,33 @@ def wan_rmsnorm_silu(
     bias: torch.Tensor | None = None,
     rms_scale: float | None = None,
     eps: float = 1e-12,
+    conv_bias: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Fused ``SiLU(F.normalize(x, dim=1) * rms_scale * gamma + bias)``.
 
-    Guard with :func:`can_use_wan_rmsnorm_silu`.
+    With ``conv_bias`` the input is first biased exactly like aten's conv bias
+    ``add_`` (``x.dtype(x + conv_bias)``), so ``wan_rmsnorm_silu(conv_nobias,
+    ..., conv_bias=b)`` equals ``wan_rmsnorm_silu(conv_nobias.add_(b), ...)``
+    bit for bit. Guard with :func:`can_use_wan_rmsnorm_silu`.
     """
-    if not can_use_wan_rmsnorm_silu(x, gamma, bias):
+    if not can_use_wan_rmsnorm_silu(x, gamma, bias, conv_bias):
         raise ValueError("unsupported input for wan_rmsnorm_silu")
 
     channels = x.shape[1]
     gamma = gamma.reshape(channels).contiguous()
     has_bias = bias is not None
     bias = gamma if bias is None else bias.reshape(channels).contiguous()
+    has_conv_bias = conv_bias is not None
+    # autocast casts the conv bias to the activation dtype before the conv.
+    conv_bias = (
+        gamma
+        if conv_bias is None
+        else conv_bias.reshape(channels).to(x.dtype).contiguous()
+    )
     if rms_scale is None:
         rms_scale = channels**0.5
     return _triton_wan_rmsnorm_silu_cuda(
-        x, gamma, bias, float(rms_scale), eps, has_bias
+        x, gamma, bias, conv_bias, float(rms_scale), eps, has_bias, has_conv_bias
     )
 
 

--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/existing-fast-paths.md
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/existing-fast-paths.md
@@ -231,6 +231,16 @@ framework-specific optimization workflow.
   reduction order of the eager RMSNorm that follows under fp32 autocast
   (Wan pipelines decode with fp32 VAE weights under bf16 autocast, where this
   was measured non-bit-exact even though the add itself is commutative).
+- `conv_bias_epilogue` (`modulate/conv_bias_epilogue_triton.py`): PyTorch's
+  cuDNN conv adds its bias as a separate unvectorised `add_` on channels_last
+  outputs (~10% of a Wan 2.1 decode). `WanCausalConv3d._conv_with_epilogue`
+  runs the conv without bias and applies it in one bit-exact pass, fused with
+  the residual add for `conv2` (`residual=`) and deferred into `norm2` for
+  `conv1` (`skip_bias=` + `WanRMS_norm.forward(x, conv_bias=...)`; the gated
+  `wan_rmsnorm_silu` absorbs it via `conv_bias=`). `wan_rmsnorm_silu` itself
+  now tiles `[ROWS, C]` pixels per program (0.63 -> ~3 TB/s at C = 96); its
+  reduction tree changed, which moves ~2e-6 of the elements by one bf16 ulp
+  relative to the previous kernel, within the same quality-gated contract.
 - The Qwen-Image VAE (`autoencoder_kl_qwenimage.py`) uses the same
   `cat_pad_channels_last_3d` + compact-cache helper for every causal conv
   slot; single-frame image decodes keep the compact cache at the reference

--- a/python/sglang/multimodal_gen/runtime/models/vaes/wan_vae_cuda_opt.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/wan_vae_cuda_opt.py
@@ -24,8 +24,10 @@ logger = init_logger(__name__)
 
 try:
     from sglang.kernels.ops.diffusion import (
+        can_use_conv_bias_epilogue,
         can_use_nearest_upsample_nhwc,
         can_use_wan_rmsnorm_silu,
+        conv_bias_epilogue,
         nearest_upsample_nhwc,
         wan_rmsnorm_silu,
     )
@@ -51,11 +53,25 @@ class FusedWanRMSNormSiLU(nn.Module):
         self.scale = float(norm.scale)
         self._sgl_gate = gate
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, conv_bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """``conv_bias`` is a preceding conv's deferred bias (see
+        ``WanCausalConv3d._conv_with_epilogue``): folded into the fused kernel
+        when the gate is on, otherwise applied first with aten's arithmetic."""
         if self._sgl_gate.enabled and not torch.compiler.is_compiling():
             bias = self.bias if isinstance(self.bias, torch.Tensor) else None
-            if can_use_wan_rmsnorm_silu(x, self.gamma, bias):
-                return wan_rmsnorm_silu(x, self.gamma, bias, rms_scale=self.scale)
+            if can_use_wan_rmsnorm_silu(x, self.gamma, bias, conv_bias):
+                return wan_rmsnorm_silu(
+                    x, self.gamma, bias, rms_scale=self.scale, conv_bias=conv_bias
+                )
+        if conv_bias is not None:
+            if not torch.compiler.is_compiling() and can_use_conv_bias_epilogue(
+                x, conv_bias
+            ):
+                x = conv_bias_epilogue(x, conv_bias)  # bit-exact, vectorised
+            else:
+                x = x + conv_bias.to(x.dtype).view(1, -1, 1, 1, 1)
         # WanRMS_norm.forward (channel-first) + SiLU, same ops in the same
         # order, so the off-path stays bit-identical.
         return F.silu(F.normalize(x, dim=1) * self.scale * self.gamma + self.bias)

--- a/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
@@ -56,13 +56,22 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 
 if current_platform.is_cuda():
     try:
-        from sglang.kernels.ops.diffusion import cat_pad_channels_last_3d, dup_up3d_add
+        from sglang.kernels.ops.diffusion import (
+            can_use_conv_bias_epilogue,
+            cat_pad_channels_last_3d,
+            conv_bias_epilogue,
+            dup_up3d_add,
+        )
     except ImportError:  # pragma: no cover
         cat_pad_channels_last_3d = None
         dup_up3d_add = None
+        conv_bias_epilogue = None
+        can_use_conv_bias_epilogue = None
 else:
     cat_pad_channels_last_3d = None
     dup_up3d_add = None
+    conv_bias_epilogue = None
+    can_use_conv_bias_epilogue = None
 
 CACHE_T = 2
 
@@ -115,8 +124,13 @@ def _run_cached_causal_conv(
     x: torch.Tensor,
     cache_list: list,
     idx: int,
+    residual: torch.Tensor | None = None,
+    skip_bias: bool = False,
 ) -> torch.Tensor:
     """Run one causal conv, consuming and refreshing its feature-cache slot.
+
+    ``residual`` / ``skip_bias`` are forwarded to the conv epilogue (see
+    ``WanCausalConv3d.forward``).
 
     Fast path (bit-exact with the aten chain, pure data movement plus zero
     fill): build the conv input (cache frames + hidden state + padding)
@@ -139,7 +153,7 @@ def _run_cached_causal_conv(
         pair = cat_pad_channels_last_3d(x, payload, conv._padding, keep_cache_t=CACHE_T)
         if pair is not None:
             inp, cache_list[idx] = pair
-            return nn.Conv3d.forward(conv, inp)
+            return conv._conv_with_epilogue(inp, residual, skip_bias)
     # Original aten path (bit-identical bookkeeping).
     cache_x = x[:, :, -CACHE_T:, :, :].clone()
     if cache_x.shape[2] < 2 and payload is not None:
@@ -153,7 +167,7 @@ def _run_cached_causal_conv(
             [torch.zeros_like(cache_x).to(cache_x.device), cache_x],
             dim=2,
         )
-    out = conv(x) if payload is None else conv(x, payload)
+    out = conv(x, payload, residual=residual, skip_bias=skip_bias)
     cache_list[idx] = cache_x
     return out
 
@@ -292,7 +306,40 @@ class WanCausalConv3d(nn.Conv3d):
         )
         self.padding = (0, 0, 0)
 
-    def forward(self, x, cache_x=None):
+    def _conv_with_epilogue(self, inp, residual=None, skip_bias=False):
+        """Convolution plus its bias epilogue.
+
+        PyTorch's cuDNN conv adds the bias as a separate broadcast ``add_``
+        kernel after ``cudnn_convolution``; on channels_last_3d outputs that
+        add is unvectorised and, in this decoder, costs about as much as the
+        residual add that usually follows. So run the conv without bias and
+        apply the bias in one fused Triton pass that reproduces aten's
+        arithmetic exactly (fp32 add, one rounding), optionally together with
+        the residual (``x.dtype(x.dtype(conv + bias) + residual)``, the two
+        roundings of the eager ``conv(x) + h`` chain). ``skip_bias`` returns
+        the raw conv output so a following fused norm can absorb the bias.
+        Falls back to the aten ops with identical arithmetic.
+        """
+        bias = self.bias
+        if skip_bias or bias is None:
+            out = self._conv_forward(inp, self.weight, None if skip_bias else bias)
+            return out if residual is None else out + residual
+        if (
+            conv_bias_epilogue is not None
+            and not torch.compiler.is_compiling()
+            and inp.is_cuda
+        ):
+            out = self._conv_forward(inp, self.weight, None)
+            if can_use_conv_bias_epilogue(out, bias, residual):
+                return conv_bias_epilogue(out, bias, residual)
+            # Same ops aten runs inside conv3d: bias cast to the activation
+            # dtype (autocast), fp32 add, one rounding.
+            out = out.add_(bias.to(out.dtype).view(1, -1, 1, 1, 1))
+        else:
+            out = self._conv_forward(inp, self.weight, bias)
+        return out if residual is None else out + residual
+
+    def forward(self, x, cache_x=None, *, residual=None, skip_bias=False):
         padding = list(self._padding)
         if (
             any(padding)
@@ -304,13 +351,13 @@ class WanCausalConv3d(nn.Conv3d):
         ):
             inp = cat_pad_channels_last_3d(x, cache_x, padding)
             if inp is not None:
-                return super().forward(inp)
+                return self._conv_with_epilogue(inp, residual, skip_bias)
         x = causal_conv3d_cat_pad(x, cache_x, padding)
         x = (
             x if current_platform.is_amp_supported() else x.to(self.weight.dtype)
         )  # casting needed if amp isn't supported
         x = match_conv3d_input_format(x, self.weight)
-        return super().forward(x)
+        return self._conv_with_epilogue(x, residual, skip_bias)
 
 
 class WanRMS_norm(nn.Module):
@@ -334,7 +381,11 @@ class WanRMS_norm(nn.Module):
         self.gamma = nn.Parameter(torch.ones(shape))
         self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
 
-    def forward(self, x):
+    def forward(self, x, conv_bias=None):
+        if conv_bias is not None:
+            # A preceding conv deferred its bias here (see
+            # ``WanCausalConv3d._conv_with_epilogue``); same aten add.
+            x = x + conv_bias.to(x.dtype).view(1, -1, 1, 1, 1)
         return (
             F.normalize(x, dim=(1 if self.channel_first else -1))
             * self.scale
@@ -448,37 +499,42 @@ def residual_block_forward(self, x):
     x = self.norm1(x)
     x = self.nonlinearity(x)
 
+    # conv1's bias is deferred into norm2 (fused RMSNorm+SiLU absorbs it in
+    # the same pass; the eager norm adds it first with the same arithmetic).
+    defer_bias = self.conv1.bias is not None
     _feat_cache = feat_cache.get()
     _feat_idx = feat_idx.get()
     if _feat_cache is not None:
         idx = _feat_idx
-        x = _run_cached_causal_conv(self.conv1, x, _feat_cache, idx)
+        x = _run_cached_causal_conv(
+            self.conv1, x, _feat_cache, idx, skip_bias=defer_bias
+        )
         _feat_idx += 1
         feat_cache.set(_feat_cache)
         feat_idx.set(_feat_idx)
     else:
-        x = self.conv1(x)
+        x = self.conv1(x, skip_bias=defer_bias)
 
     # Second normalization and activation
-    x = self.norm2(x)
+    x = self.norm2(x, conv_bias=self.conv1.bias if defer_bias else None)
     x = self.nonlinearity(x)
 
     # Dropout
     x = self.dropout(x)
 
+    # conv2's bias and the residual add are one epilogue pass (bit-exact with
+    # the eager ``conv2(x) + h`` chain).
     _feat_cache = feat_cache.get()
     _feat_idx = feat_idx.get()
     if _feat_cache is not None:
         idx = _feat_idx
-        x = _run_cached_causal_conv(self.conv2, x, _feat_cache, idx)
+        x = _run_cached_causal_conv(self.conv2, x, _feat_cache, idx, residual=h)
         _feat_idx += 1
         feat_cache.set(_feat_cache)
         feat_idx.set(_feat_idx)
     else:
-        x = self.conv2(x)
-
-    # Add residual connection
-    return x + h
+        x = self.conv2(x, residual=h)
+    return x
 
 
 def attention_block_forward(self, x):

--- a/test/registered/kernels/ops/diffusion/test_conv_bias_epilogue.py
+++ b/test/registered/kernels/ops/diffusion/test_conv_bias_epilogue.py
@@ -1,0 +1,98 @@
+"""``conv_bias_epilogue``: bit-exact conv bias (+ residual) epilogue.
+
+Oracle: aten itself. ``F.conv3d`` adds its bias as ``out.add_(bias.view(...))``
+(fp32 opmath, one rounding), and the eager residual chain is ``conv(x) + h``
+with a second rounding. The kernel must reproduce both exactly, keep the
+input's dense channels_last(_3d) strides, and refuse anything else through
+its predicate (never by raising from ``can_use_``).
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.diffusion import (
+    can_use_conv_bias_epilogue,
+    conv_bias_epilogue,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+DEVICE = "cuda"
+
+
+def _dense(shape, dtype):
+    fmt = torch.channels_last_3d if len(shape) == 5 else torch.channels_last
+    return torch.randn(shape, device=DEVICE, dtype=dtype).contiguous(memory_format=fmt)
+
+
+def _bias_view(bias, ndim):
+    return bias.view(1, -1, *([1] * (ndim - 2)))
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "x_dtype,bias_dtype",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.bfloat16, torch.float32),
+        (torch.float16, torch.float32),
+        (torch.float32, torch.float32),
+    ],
+)
+@pytest.mark.parametrize(
+    "shape", [(1, 96, 2, 30, 52), (2, 192, 1, 15, 26), (4, 96, 30, 52), (1, 3, 4, 8, 8)]
+)
+def test_conv_bias_epilogue_matches_aten(x_dtype, bias_dtype, shape):
+    x = _dense(shape, x_dtype)
+    c = shape[1]
+    bias = torch.randn(c, device=DEVICE, dtype=bias_dtype)
+    # autocast casts the bias to the activation dtype before the conv call.
+    ref = x.clone().add_(_bias_view(bias.to(x_dtype), x.dim()))
+    assert can_use_conv_bias_epilogue(x, bias)
+    out = conv_bias_epilogue(x, bias)
+    assert out.stride() == x.stride()
+    assert torch.equal(out, ref)
+
+    h = _dense(shape, x_dtype)
+    ref_res = ref + h
+    assert can_use_conv_bias_epilogue(x, bias, h)
+    out_res = conv_bias_epilogue(x, bias, h)
+    assert out_res.stride() == x.stride()
+    assert torch.equal(out_res, ref_res)
+
+
+@torch.no_grad()
+def test_conv_bias_epilogue_equals_conv_with_bias():
+    # End-to-end oracle: F.conv3d with bias vs conv without bias + epilogue.
+    conv = torch.nn.Conv3d(48, 64, 3, padding=1).to(DEVICE, torch.bfloat16)
+    conv.weight.data = conv.weight.data.to(memory_format=torch.channels_last_3d)
+    x = _dense((1, 48, 3, 12, 20), torch.bfloat16)
+    ref = conv(x)
+    raw = torch.nn.functional.conv3d(x, conv.weight, None, padding=1)
+    assert can_use_conv_bias_epilogue(raw, conv.bias)
+    assert torch.equal(conv_bias_epilogue(raw, conv.bias), ref)
+
+
+@torch.no_grad()
+def test_conv_bias_epilogue_rejects_unsupported_inputs():
+    x = _dense((1, 96, 2, 6, 6), torch.bfloat16)
+    bias = torch.randn(96, device=DEVICE, dtype=torch.bfloat16)
+    assert not can_use_conv_bias_epilogue(x.contiguous(), bias)  # NCDHW
+    assert not can_use_conv_bias_epilogue(x, bias[:95])  # wrong width
+    assert not can_use_conv_bias_epilogue(x, bias.to(torch.float16))  # dtype
+    assert not can_use_conv_bias_epilogue(x, bias, x.contiguous())  # residual layout
+    assert not can_use_conv_bias_epilogue(
+        x, bias, x.to(torch.float32)
+    )  # residual dtype
+    assert not can_use_conv_bias_epilogue(x[:, :, :0], bias)  # empty
+    x1 = torch.randn(1, 1, 2, 3, 4, device=DEVICE, dtype=torch.bfloat16)
+    assert x1.is_contiguous(memory_format=torch.channels_last_3d)
+    assert not can_use_conv_bias_epilogue(x1, bias[:1])  # C == 1 is ambiguous
+    with pytest.raises(ValueError):
+        conv_bias_epilogue(x.contiguous(), bias)
+    with torch.enable_grad():
+        xg = x.clone().requires_grad_(True)
+        assert not can_use_conv_bias_epilogue(xg, bias)
+        with pytest.raises(ValueError):
+            conv_bias_epilogue(xg, bias)

--- a/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
+++ b/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
@@ -1074,6 +1074,76 @@ def test_wan_vae_rejects_empty_input() -> None:
     assert not can_use_wan_rmsnorm_silu(x, gamma, None)
 
 
+def _wan_tiny_decoder(seed=0):
+    torch.manual_seed(seed)
+    dec = wanvae.WanDecoder3d(
+        dim=16, z_dim=4, dim_mult=[1, 1], num_res_blocks=1, temperal_upsample=[True]
+    ).to("cuda", torch.bfloat16)
+    for m in dec.modules():
+        if isinstance(m, nn.Conv3d):
+            m.weight.data = m.weight.data.to(memory_format=torch.channels_last_3d)
+    return dec
+
+
+def _wan_decode_chunks(dec, chunks):
+    # Mirrors AutoencoderKLWan.decode: one latent frame per chunk, feature
+    # cache threaded through the contextvars the decoder reads.
+    n_conv = sum(isinstance(m, wanvae.WanCausalConv3d) for m in dec.modules())
+    cache = [None] * n_conv
+    outs = []
+    for i, z in enumerate(chunks):
+        tok_c = wanvae.feat_cache.set(cache)
+        tok_i = wanvae.feat_idx.set(0)
+        tok_f = wanvae.first_chunk.set(i == 0)
+        try:
+            outs.append(dec(z))
+        finally:
+            wanvae.feat_cache.reset(tok_c)
+            wanvae.feat_idx.reset(tok_i)
+            wanvae.first_chunk.reset(tok_f)
+    return torch.cat(outs, dim=2)
+
+
+@torch.no_grad()
+def test_wan_vae_conv_epilogue_wiring_is_bit_exact() -> None:
+    # The lossless decoder (fused cat+pad, conv bias epilogue, bias+residual
+    # fold, bias deferred into norm2) must equal the pure aten module chain.
+    dec = _wan_tiny_decoder()
+    chunks = [_wan_cl3d((1, 4, 1, 6, 6), torch.bfloat16) for _ in range(3)]
+    fast = _wan_decode_chunks(dec, chunks)
+    saved = (
+        wanvae.cat_pad_channels_last_3d,
+        wanvae.conv_bias_epilogue,
+        wanvae.can_use_conv_bias_epilogue,
+    )
+    wanvae.cat_pad_channels_last_3d = None
+    wanvae.conv_bias_epilogue = None
+    wanvae.can_use_conv_bias_epilogue = None
+    try:
+        eager = _wan_decode_chunks(dec, chunks)
+    finally:
+        (
+            wanvae.cat_pad_channels_last_3d,
+            wanvae.conv_bias_epilogue,
+            wanvae.can_use_conv_bias_epilogue,
+        ) = saved
+    assert torch.equal(fast, eager)
+    # Deferred conv1 bias through the gated wrapper, gate off: still exact.
+    gate = VaeFastPathGate()
+    wan_vae_cuda_opt._install_norm_silu(
+        dec,
+        gate,
+        residual_block_cls=wanvae.WanResidualBlock,
+        rms_norm_cls=WanRMS_norm,
+        label="test",
+    )
+    assert torch.equal(_wan_decode_chunks(dec, chunks), eager)
+    gate.enabled = True
+    out = _wan_decode_chunks(dec, chunks)
+    rel = ((out.float() - eager.float()).norm() / eager.float().norm()).item()
+    assert rel < 2e-2, rel
+
+
 @torch.no_grad()
 def test_wan_vae_time_interleave_matches_stack_and_keeps_layout() -> None:
     # time_conv output [B, 2C, T, H, W] -> interleaved [B, C, 2T, H, W].

--- a/test/registered/kernels/ops/diffusion/test_norm.py
+++ b/test/registered/kernels/ops/diffusion/test_norm.py
@@ -272,6 +272,43 @@ def test_wan_rmsnorm_silu_numerics(x_dtype, affine_dtype, atol, rtol):
 
 
 @torch.no_grad()
+@pytest.mark.parametrize(
+    "shape", [(1, 96, 2, 37, 53), (2, 384, 1, 9, 13), (1, 1024, 1, 5, 7)]
+)
+def test_wan_rmsnorm_silu_multirow_tiles_cover_ragged_rows(shape):
+    # Row counts that are not multiples of the per-program tile, at the three
+    # tile configurations the channel count selects (32 / 8 / 4 rows).
+    x = _cl3d(shape, torch.bfloat16)
+    c = shape[1]
+    gamma = torch.randn((c, 1, 1, 1), device=DEVICE, dtype=torch.float32)
+    expected = F.silu(F.normalize(x, dim=1) * c**0.5 * gamma)
+    actual = wan_rmsnorm_silu(x, gamma)
+    assert actual.stride() == x.stride()
+    torch.testing.assert_close(actual, expected, atol=1.5e-1, rtol=3e-2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "x_dtype,bias_dtype",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.bfloat16, torch.float32),
+        (torch.float32, torch.float32),
+    ],
+)
+def test_wan_rmsnorm_silu_conv_bias_fold_is_exact(x_dtype, bias_dtype):
+    # Folding the preceding conv's bias must reproduce aten's add_ (fp32 add,
+    # one rounding to x.dtype) so the kernel sees exactly the biased tensor.
+    x = _cl3d((1, 96, 2, 10, 14), x_dtype)
+    gamma = torch.randn((96, 1, 1, 1), device=DEVICE, dtype=torch.float32)
+    conv_bias = torch.randn(96, device=DEVICE, dtype=bias_dtype)
+    biased = x.clone().add_(conv_bias.to(x_dtype).view(1, 96, 1, 1, 1))
+    assert can_use_wan_rmsnorm_silu(x, gamma, None, conv_bias)
+    folded = wan_rmsnorm_silu(x, gamma, conv_bias=conv_bias)
+    assert torch.equal(folded, wan_rmsnorm_silu(biased, gamma))
+
+
+@torch.no_grad()
 def test_wan_rmsnorm_silu_rejects_empty_input():
     x = torch.empty(1, 96, 0, 2, 2, device=DEVICE, dtype=torch.bfloat16).to(
         memory_format=torch.channels_last_3d


### PR DESCRIPTION
<!-- PR body draft for branch `wav` (commit 0e2a6f4df). Local working note, do not commit this file. -->

## Motivation

Follow-up to #38020 and #38182. Two costs in the Wan 2.1 VAE decoder that kernel-level profiles hide, found by grouping a `quality=high` decode at the aten-op level (`key_averages(group_by_input_shape=True)`):

1. **The conv bias is a separate, unvectorised kernel.** PyTorch's cuDNN path runs `cudnn_convolution` and then `output.add_(bias.view(1, C, 1, 1, 1))`. On channels_last outputs aten does not vectorise that broadcast add: 1.5 TB/s on H200 for `[1, 96, 4, 480, 832]` bf16. It shows up only as `aten::conv3d` minus `aten::cudnn_convolution`: 797 launches, 278 ms of a 2847 ms lossless decode and 227 ms of a 1876 ms high decode on a shared GPU (~10% in both modes).
2. **`wan_rmsnorm_silu` ran one pixel per program** with 4 warps over 96-384 channels: 0.63 TB/s on the largest shape, 16% of the high-quality decode.

## Modifications

**New kernel, lossless (bit-exact, unconditional)**

- `kernels/ops/diffusion/modulate/conv_bias_epilogue_triton.py`: `x.dtype(float(x) + float(bias))`, the exact arithmetic of aten's `add_` (fp32 opmath, one rounding), optionally fused with the residual add as `x.dtype(x.dtype(x + bias) + h)`, i.e. the two roundings of the eager `conv(x) + h` chain. 4.1 TB/s. `bias` may be fp32 on a half-precision `x` (autocast): it is cast to `x.dtype` first, which is what autocast does before the conv call. The output is `empty_like(x)`, so it keeps the dense channels_last(_3d) strides like the in-place `add_`. Predicate requires `C > 1` with canonical strides and never raises; the kernel validates and raises `ValueError`.
- `WanCausalConv3d._conv_with_epilogue`: runs the conv without bias and applies it through the kernel; falls back to the exact aten ops (`out.add_(bias.to(out.dtype).view(...))`).
- `residual_block_forward`: conv2's bias and the block's residual add become one pass (`residual=h`); conv1's bias is deferred into norm2 (`skip_bias=True` + `WanRMS_norm.forward(x, conv_bias=...)`, where the eager norm adds it first with the same arithmetic).

**Quality-gated**

- `wan_rmsnorm_silu` tiles `[ROWS, C]` consecutive pixels per program (32 rows at `C <= 128` down to 4 at `C = 1024`): 0.63 -> ~3 TB/s at `C = 96`. The 2D reduction tree moves ~2e-6 of the elements by one bf16 ulp relative to the previous kernel, while both differ from eager on ~20% of elements, so the gated contract is unchanged. Optional `conv_bias=` folds the deferred conv1 bias into the same pass, applied exactly like aten's `add_` before the statistics.
- `FusedWanRMSNormSiLU.forward(x, conv_bias=None)`: folded under the gate, otherwise applied by the bit-exact epilogue kernel before the eager chain.

**Tests / docs**

- New `test_conv_bias_epilogue.py`: aten oracle (`x.clone().add_(bias)`, `+ h`) for bf16/fp16/fp32 x fp32/half bias, 4D and 5D, stride identity; `F.conv3d` with bias vs conv-without-bias + epilogue; predicate rejections (NCDHW, wrong bias width/dtype, residual layout/dtype, empty, `C == 1`, `requires_grad`).
- `test_norm.py`: ragged multi-row tiles at the three tile configurations; `conv_bias` fold equals the kernel on the pre-biased tensor bit for bit.
- `test_model_fast_paths.py`: a three-chunk tiny `WanDecoder3d` decode through the feature cache, fused path vs pure aten (`torch.equal`); deferred bias through the gated wrapper with the gate off (exact) and on (bounded relative error).
- README selection matrix and `existing-fast-paths.md` updated.

## Accuracy Tests

1x H200, Wan 2.1 VAE weights (`Wan-AI/Wan2.1-I2V-14B-480P-Diffusers`), 81 frames 480x832.

**Lossless**

- Standalone decode, bf16 weights: `torch.equal` vs `main`: True.
- Standalone decode, fp32 weights + bf16 autocast (the Wan T2V pipeline setting): `torch.equal` vs `main`: True.
- End-to-end `sglang generate`, TurboWan2.1-T2V-1.3B, 4 steps, seed 1, 6 prompts: all 6 mp4s **md5-identical** to `main` (and to the outputs of the two previous PRs).
- Peak decode memory unchanged.

**Quality path**

Standalone high vs `main` lossless on the same latent: PSNR 58.4 dB (bf16), 59.1 dB (fp32 + autocast), unchanged from before this PR; the multi-row norm kernel differs from the previous gated kernel on ~2e-6 of elements by one bf16 ulp.

## Speed Tests and Profiling

**Standalone VAE decode**, torch.profiler GPU kernel self time, idle H200:

| weights / autocast | path | before | this PR |
|---|---|---|---|
| bf16 | lossless | 1324 ms / 7850 kernels | 1253 ms / 7599 |
| bf16 | high | 1112 ms / 4006 | 935 ms / 3420 |
| fp32 + bf16 autocast | lossless | 1593 ms | 1530 ms |
| fp32 + bf16 autocast | high | 1215 ms | 1056 ms |

Per-kernel (bf16, high): `_wan_rmsnorm_silu_kernel` 177 -> 57 ms over 609 launches; the 797 aten bias `add_` launches are replaced by 396 `_conv_bias_epilogue_kernel` launches totalling 22 ms (649 launches / 35 ms on the lossless path). Qwen-Image 1024x1024 high: 43.3 -> 39.4 ms (shared norm kernel), lossless unchanged and still bit-exact.

**End-to-end**, TurboWan2.1-T2V-1.3B, 4 steps, 81f 480x832, `main` from a `git worktree` of the base commit, 6 prompts, median of the 5 warm requests. The decode stage is ~60% of a warm request. This box is shared; runs whose `DmdDenoisingStage` (identical code on both sides) drifted were discarded, and the cleanest interleaved pair is reported:

| stage | main | this PR |
|---|---|---|
| `DecodingStage`, high | 932 ms | 785 ms (-15.8%) |
| `DecodingStage`, lossless | 1535 ms | 1501 ms (-2.2%) |
| `DmdDenoisingStage` | ~890 ms | ~890 ms |

Micro-benchmarks behind the design (idle H200, bf16 `[1, 96, 4, 480, 832]`): aten bias `add_` 0.409 ms (1.5 TB/s), Triton bias add 0.150 ms (4.1 TB/s), aten `add_` + residual `add` 0.621 ms vs fused 0.215 ms; norm 0.970 ms -> 0.201 ms.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (ruff format / ruff check with the pre-commit pinned v0.15.1, isort, codespell: clean)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test_conv_bias_epilogue.py`, `test_norm.py`, `test_layout.py`, `test_model_fast_paths.py`: 393 passed, 1 skipped)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34327993512](https://github.com/sgl-project/sglang/actions/runs/34327993512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34327993130](https://github.com/sgl-project/sglang/actions/runs/34327993130)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34327993453](https://github.com/sgl-project/sglang/actions/runs/34327993453)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->