### PR TITLE
[Fix] Add missing evict_for_alloc to bench_one_batch dummy tree cache

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -497,6 +497,9 @@ class TreeCacheNamespace(SimpleNamespace):
     def evict(self, params: EvictParams):
         pass
 
+    def evict_for_alloc(self, params: EvictParams):
+        pass
+
 
 @torch.no_grad
 def extend(reqs, model_runner):


### PR DESCRIPTION
## Motivation

`sglang.benchmark.one_batch` crashes with an `AttributeError` instead of running,
whenever the decode allocation path decides it needs to evict:

```
File "/usr/local/lib/python3.12/dist-packages/sglang/srt/mem_cache/common.py", line 133, in evict_from_tree_cache
    tree_cache.evict_for_alloc(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TreeCacheNamespace' object has no attribute 'evict_for_alloc'
```

`TreeCacheNamespace` (`python/sglang/benchmark/one_batch.py`) is the dummy
tree-cache the benchmark injects into `ScheduleBatch` so it can exercise
allocation without prefix caching. It is not a `BasePrefixCache` subclass — it
duck-types the interface by hand, implementing `supports_swa`,
`supports_mamba`, `is_chunk_cache`, `is_tree_cache` and `evict`.

The allocation path no longer calls `evict()`. #33091
("[unified-memory] Stop eviction when shared allocation capacity is sufficient",
`2511743bd`, 2026-08-26) switched both call sites in
`evict_from_tree_cache()` from `tree_cache.evict(...)` to
`tree_cache.evict_for_alloc(...)`, and added `evict_for_alloc` to
`BasePrefixCache` as a non-abstract method defaulting to `return self.evict(params)`.

Real cache classes inherit that default for free, so nothing in `srt/` broke.
The hand-rolled benchmark stub inherits nothing and was not updated — it still
only provides `evict`. The stub predates the switch (added in #24470,
`3c3f0bd55`, 2026-05-07), and because `evict_for_alloc` is not abstract there is
no static or runtime signal that the stub is now incomplete.

**Scope: benchmark tooling only.** Production serving paths
(`sglang.launch_server` → scheduler → radix cache) are unaffected, because they
use real `BasePrefixCache` subclasses.

### Why this went unnoticed

`evict_from_tree_cache()` only reaches `evict_for_alloc` when the pool is
short on space; otherwise it returns early. Under common models and batch
sizes the benchmark never takes that branch, so it stayed green.

Reproducing it needs the estimated demand to exceed available space. Observed on
DeepSeek-V4 (H200, TP4, `bench_one_batch --batch-size 128 --input-len 32
--output-len 2 --disable-radix-cache`):

- the DSV4 attention backend forces `page_size = 256`
- `alloc_paged_token_slots_decode()` deliberately over-estimates, assuming one
  fresh page per request: `num_tokens = 128 * 256 = 32768`
- `DeepSeekV4HiSparseTokenToKVPoolAllocator.available_size()` returns
  `min(logical, hisparse)`; with pool sizes `full=524288, c4=131072, c128=4096`
  the binding constraint is `4096`

`4096 < 32768` → eviction branch → `AttributeError`. Prefill runs in the same
config complete normally, since they never hit the shortfall branch. Note the
crash happens even with `--disable-radix-cache`: the benchmark constructs this
stub unconditionally, and its `is_chunk_cache()` returns `False`, so the
early return in `evict_from_tree_cache()` does not apply.

Practical impact: the run dies before a single decode step, so a
`--profile`/nsys capture of this config contains only load plus warmup prefill
and no decode kernels, while the profile file is still written and looks valid.

## Modifications

One change, in `python/sglang/benchmark/one_batch.py`:

```diff
     def evict(self, params: EvictParams):
         pass

+    def evict_for_alloc(self, params: EvictParams):
+        pass
```

Add the missing `evict_for_alloc` to `TreeCacheNamespace`, mirroring its
existing no-op `evict`.

Why a no-op is the correct behavior, not just a silencer:

- The benchmark stub has no radix tree and no cached prefixes, so there is
  nothing to reclaim — "evicted nothing" is the truthful answer.
- It matches the base-class contract. `BasePrefixCache.evict_for_alloc`
  defaults to `return self.evict(params)`; the stub's `evict` is already a
  no-op, so delegating would be a no-op too. Written directly as `pass` for
  clarity.
- Both call sites in `evict_from_tree_cache()` discard the return value, so no
  `EvictResult` needs to be constructed and returning `None` is safe.

After the fix, eviction is a no-op and allocation proceeds to
`allocator.alloc_decode(...)`. If space genuinely runs out, the existing check
in `alloc_paged_token_slots_decode()` raises the actionable
`RuntimeError: Decode out of memory. Try to lower your batch size.` instead of
an unrelated `AttributeError`.

### Note for reviewers

The root cause is that `TreeCacheNamespace` duck-types `BasePrefixCache` rather
than subclassing it, so non-abstract methods added to the base class are
silently missing from the stub, with no failure until a specific runtime branch
is hit. This PR is the minimal fix. Making the stub inherit from
`BasePrefixCache` would prevent recurrence but requires satisfying the abstract
methods; happy to do that instead if maintainers prefer.

## Accuracy Tests

Not applicable — benchmark harness only, no kernel or model forward changes. The
stub is used solely by `sglang/benchmark/one_batch.py` and cannot affect model
outputs.

## Speed Tests and Profiling

Not applicable — the added method is a no-op on a path that previously raised.
No effect on inference speed.

<!-- TODO(you): optionally paste the "Decode. latency: ..." line from a
     successful post-fix run to show the benchmark now completes. -->

## Verification performed

The failing call path was exercised directly with the real
`evict_from_tree_cache()` and the values observed in the crash
(`num_tokens=32768`, `available_size=4096`), i.e. the exact branch that raised:

```python
from sglang.benchmark.one_batch import TreeCacheNamespace
from sglang.srt.mem_cache.common import evict_from_tree_cache

class FakeAlloc:
    page_size = 256
    def available_size(self): return 4096      # c128 pool: the binding constraint

tc = TreeCacheNamespace(
    page_size=256, device="cpu", token_to_kv_pool_allocator=FakeAlloc()
)
evict_from_tree_cache(tc, 128 * 256)           # 32768 > 4096 -> eviction branch
# before: AttributeError: 'TreeCacheNamespace' object has no attribute 'evict_for_alloc'
# after:  returns cleanly
```

Before: `AttributeError`. After: returns cleanly.

<!-- TODO(you): before submitting, confirm the full 4-GPU DSV4 decode benchmark
     now runs to completion and prints "Decode. latency: ...". This had not been
     re-run at the time this draft was written. -->

## Checklist

- [ ] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes on the checklist for this PR:

- **pre-commit**: run `pre-commit run --files python/sglang/benchmark/one_batch.py`
  before submitting. The change is a 2-line addition matching surrounding style.
- **unit tests**: none added yet, but this does qualify as a "Bug regression"
  case under `.claude/rules/unit-test-admission.md` (a bug that actually
  happened, and the snippet above already fails on pre-fix code and passes on
  the fix). Happy to add it as a test if maintainers want it; the reason it is
  not included is that the natural home for a `benchmark/` stub regression test
  is not obvious, not that the case is inadmissible.
- **accuracy / speed**: not applicable, see sections above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34450358285](https://github.com/sgl-project/sglang/actions/runs/34450358285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34450357716](https://github.com/sgl-project/sglang/actions/runs/34450357716)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34450357850](https://github.com/sgl-project/sglang/actions/runs/34450357850)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->