### PR TITLE
[diffusion] feat: spill large tensors over shared memory like numpy arrays

### DIFF
--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Helpers for transferring large numpy arrays between local scheduler processes."""
+"""Helpers for transferring large arrays between local scheduler processes."""
 
 from __future__ import annotations
 
@@ -10,6 +10,11 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import torch
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
 
 _MIN_FILE_REF_BYTES = 32 << 20
 
@@ -28,6 +33,19 @@ class NumpyArrayFileRef:
                 pass
 
 
+@dataclass
+class TorchTensorFileRef:
+    """A tensor spilled as raw bytes; dtype and shape are restored on the far side."""
+
+    ref: NumpyArrayFileRef
+    dtype: str
+    shape: tuple[int, ...]
+
+    def materialize(self) -> torch.Tensor:
+        flat = torch.from_numpy(self.ref.materialize())
+        return flat.view(getattr(torch, self.dtype)).reshape(self.shape)
+
+
 def is_local_endpoint(endpoint: str) -> bool:
     return endpoint.startswith(
         ("tcp://127.0.0.1:", "tcp://localhost:", "ipc://", "inproc://")
@@ -42,9 +60,25 @@ def spill_large_arrays_to_file_refs(value: Any) -> Any:
 
 
 def _spill_large_arrays_to_file_refs(value: Any, directory: str) -> Any:
+    # A payload that does not fit in shared memory is still deliverable inline,
+    # so a full /dev/shm slows the reply down instead of failing the request.
     if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
         # only spill if the array size is above the threshold. if not, it's not worth it
-        return _spill_array(value, directory)
+        try:
+            return _spill_array(value, directory)
+        except OSError:
+            logger.warning_once(
+                f"Spilling an array to {directory} failed; sending it inline."
+            )
+            return value
+    if _is_large_tensor(value):
+        try:
+            return _spill_tensor(value, directory)
+        except OSError:
+            logger.warning_once(
+                f"Spilling a tensor to {directory} failed; sending it inline."
+            )
+            return value
     if isinstance(value, list):
         return [_spill_large_arrays_to_file_refs(item, directory) for item in value]
     if isinstance(value, tuple):
@@ -55,7 +89,7 @@ def _spill_large_arrays_to_file_refs(value: Any, directory: str) -> Any:
 
 
 def materialize_file_refs(value: Any) -> Any:
-    if isinstance(value, NumpyArrayFileRef):
+    if isinstance(value, (NumpyArrayFileRef, TorchTensorFileRef)):
         return value.materialize()
     if isinstance(value, list):
         return [materialize_file_refs(item) for item in value]
@@ -83,6 +117,25 @@ def _spill_array(array: np.ndarray, directory: str) -> NumpyArrayFileRef:
             pass
         raise
     return NumpyArrayFileRef(path=path)
+
+
+def _is_large_tensor(value: Any) -> bool:
+    return (
+        isinstance(value, torch.Tensor)
+        and value.numel() * value.element_size() >= _MIN_FILE_REF_BYTES
+    )
+
+
+def _spill_tensor(tensor: torch.Tensor, directory: str) -> TorchTensorFileRef:
+    host = tensor.detach().to("cpu", copy=False).contiguous()
+    # Spill the raw bytes: numpy has no bfloat16, and the byte view needs no
+    # dtype table to stay exact.
+    array = host.reshape(-1).view(torch.uint8).numpy()
+    return TorchTensorFileRef(
+        ref=_spill_array(array, directory),
+        dtype=str(host.dtype).removeprefix("torch."),
+        shape=tuple(host.shape),
+    )
 
 
 def _array_ipc_dir() -> str | None:

--- a/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
+++ b/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 
 from sglang.multimodal_gen.runtime import ipc_array
 from sglang.multimodal_gen.runtime.ipc_array import (
     NumpyArrayFileRef,
+    TorchTensorFileRef,
     is_local_endpoint,
     materialize_file_refs,
     spill_large_arrays_to_file_refs,
@@ -66,8 +68,8 @@ def test_spill_removes_temp_file_when_save_fails(monkeypatch, tmp_path):
     monkeypatch.setattr(tempfile, "mkstemp", tracked_mkstemp)
     monkeypatch.setattr(np, "save", fail_save)
 
-    with pytest.raises(OSError, match="simulated write failure"):
-        spill_large_arrays_to_file_refs(array)
+    # A failed spill falls back to sending the payload inline.
+    assert spill_large_arrays_to_file_refs(array) is array
 
     assert created_paths
     assert not created_paths[0].exists()
@@ -79,3 +81,55 @@ def test_local_endpoint_detection():
     assert is_local_endpoint("ipc:///tmp/sgl.sock")
     assert is_local_endpoint("inproc://scheduler")
     assert not is_local_endpoint("tcp://10.0.0.2:30000")
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.uint8])
+def test_spill_large_tensors_round_trips(monkeypatch, tmp_path, dtype):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: str(tmp_path))
+    elements = (
+        ipc_array._MIN_FILE_REF_BYTES // torch.empty((), dtype=dtype).element_size()
+    )
+    tensor = torch.arange(elements, dtype=torch.int64).to(dtype).reshape(2, -1)
+
+    spilled = spill_large_arrays_to_file_refs([tensor])
+
+    assert isinstance(spilled[0], TorchTensorFileRef)
+    spilled_path = Path(spilled[0].ref.path)
+    assert spilled_path.exists()
+
+    materialized = materialize_file_refs(spilled)[0]
+
+    assert materialized.dtype == tensor.dtype
+    assert materialized.shape == tensor.shape
+    assert torch.equal(materialized, tensor)
+    assert not spilled_path.exists()
+
+
+def test_non_contiguous_tensor_round_trips(monkeypatch, tmp_path):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: str(tmp_path))
+    elements = ipc_array._MIN_FILE_REF_BYTES // 2
+    tensor = torch.arange(elements, dtype=torch.float32).reshape(2, -1).T
+
+    materialized = materialize_file_refs(spill_large_arrays_to_file_refs(tensor))
+
+    assert torch.equal(materialized, tensor)
+
+
+def test_small_tensors_are_kept_inline():
+    tensor = torch.zeros(16)
+
+    spilled = spill_large_arrays_to_file_refs((tensor,))
+
+    assert spilled[0] is tensor
+
+
+def test_tensor_spill_falls_back_inline_when_shm_is_full(monkeypatch, tmp_path):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: str(tmp_path))
+    tensor = torch.zeros(ipc_array._MIN_FILE_REF_BYTES, dtype=torch.uint8)
+
+    def fail_save(*args, **kwargs):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(np, "save", fail_save)
+
+    assert spill_large_arrays_to_file_refs(tensor) is tensor


### PR DESCRIPTION
## Motivation

`Scheduler.return_result` spills large **numpy arrays** to `/dev/shm` and sends a
file reference, so the payload never goes through `pickle` or the zmq socket. A
**torch tensor** is not recognised by that path and falls through to
`pickle.dumps`, which copies it to host memory, serialises it, and copies it
again on the client.

Every request that returns its output as a tensor rather than a file path pays
for this. For video generation the payload is gigabytes: a 5 s 1280x704 clip is
a 1.31 GB fp32 tensor, and a 10 s 1344x768 clip is 2.99 GB. That reply can cost
more than the VAE decode that produced it.

## Modifications

`ipc_array` learns about tensors, using the same 32 MiB threshold and the same
`/dev/shm` file the numpy path already uses.

The tensor is spilled as **raw bytes** with its dtype and shape recorded
alongside, rather than via `Tensor.numpy()`. That keeps one code path for every
dtype and, in particular, makes `bfloat16` round-trip exactly — numpy has no
bfloat16, so a dtype-table approach would have to special-case it.

A failed spill (a small `/dev/shm` — the docker default is 64 MB) now falls back
to sending the payload inline instead of raising. Previously a full `/dev/shm`
failed the request outright; now it only makes the reply slower. This applies to
the numpy path too, and is why the existing failure test changed.

## Accuracy Tests

Values are bit-identical across the round trip; only the transport changes. The
new unit tests assert exact equality for float32, bfloat16 and uint8, including
a non-contiguous tensor.

## Speed Tests and Profiling

Transport cost alone (serialise + deserialise), best of 3, on a machine with
`/dev/shm` available:

| payload | size | pickle (today) | spill (this PR) | |
|---|---|---|---|---|
| 5 s 1280x704 video, fp32 | 1308 MB | 3.216 s | **0.995 s** | 3.2x |
| the same as uint8 frames | 327 MB | 0.791 s | **0.246 s** | 3.2x |
| 10 s 1344x768 video, fp32 | 2985 MB | 7.185 s | **2.257 s** | 3.2x |

End to end, on a video request that returns its output as a tensor (1.31 GB
fp32), the whole request goes from **12.05 s to 8.46 s** — it was 4.2 s *slower*
than writing an mp4 to disk, and is now within noise of the path that returns
uint8 frames. Streaming and realtime consumers, which deliberately avoid writing
files, were the ones paying it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34357857903](https://github.com/sgl-project/sglang/actions/runs/34357857903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34357857713](https://github.com/sgl-project/sglang/actions/runs/34357857713)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34357857930](https://github.com/sgl-project/sglang/actions/runs/34357857930)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->