### PR TITLE
[multimodal] Add per-processor default image count limit

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -233,6 +233,11 @@ class BaseMultimodalProcessor(ABC):
     # `process_and_combine_mm_data` -- resolves that clone instead of
     # `self._processor`, so isolation does not depend on the subclass.
     supports_mm_processor_concurrency = True
+    # Safety net against OOM from oversized image batches: each 4K image can
+    # cost ~1 GiB of GPU memory in the fast image processor. Processors that
+    # support more images override this; an explicit
+    # --limit-mm-data-per-request takes priority over this default.
+    IMAGE_NUM_LIMITATION = 5
 
     def __init__(
         self, hf_config, server_args, _processor, transport_mode, *args, **kwargs
@@ -1191,6 +1196,42 @@ class BaseMultimodalProcessor(ABC):
         BaseMultimodalProcessor._validate_one_modality(Modality.VIDEO, video_data)
         BaseMultimodalProcessor._validate_one_modality(Modality.AUDIO, audio_data)
 
+    def _get_image_limit(self) -> Optional[int]:
+        """The effective per-request image count limit, or None for no limit.
+
+        An explicit ``--limit-mm-data-per-request`` image entry wins over this
+        processor's ``IMAGE_NUM_LIMITATION`` default, mirroring the priority
+        order documented on the constant.
+        """
+        cli_limit = (get_mm().limit_mm_data_per_request or {}).get("image")
+        if cli_limit is not None:
+            return int(cli_limit)
+        return self.IMAGE_NUM_LIMITATION
+
+    def validate_image_num_limitation(self, image_data: Optional[list]) -> None:
+        """Reject requests with more images than the effective limit.
+
+        Runs before any image is fetched or decoded, so an oversized request
+        never reaches the ~1 GiB-per-4K-image preprocessing path.
+        Preprocessed single-item inputs (processor_output /
+        precomputed_embedding) are exempt: they carry no decode cost.
+        """
+        if not image_data:
+            return
+        if self._is_preprocessed_input(image_data[0] if len(image_data) == 1 else None):
+            return
+        limit = self._get_image_limit()
+        if limit is None or limit <= 0:
+            return
+        count = len(image_data)
+        if count > limit:
+            raise ValueError(
+                f"This model accepts at most {limit} image(s) per request, "
+                f"but {count} were provided. Raise the limit with "
+                "--limit-mm-data-per-request '{\"image\": N}' if your "
+                "use case needs more."
+            )
+
     def _process_loaded_mm_data(self, modality, raw_data, result):
         images, videos, audios = [], [], []
 
@@ -1223,6 +1264,7 @@ class BaseMultimodalProcessor(ABC):
         audio_sample_rate: Optional[int] = None,
     ) -> BaseMultiModalProcessorOutput:
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
+        self.validate_image_num_limitation(image_data)
 
         input_ids = prompt if isinstance(prompt, list) else None
         if input_ids is not None and self._all_mm_data_is_preprocessed(

--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -34,6 +34,9 @@ class InternVLProcessor(BaseMultimodalProcessor):
     IMAGENET_MEAN = [0.485, 0.456, 0.406]
     IMAGENET_STD = [0.229, 0.224, 0.225]
     IMAGE_MAX_NUM = 12
+    # IMAGE_MAX_NUM bounds dynamic-patch tiling per image, not the image count;
+    # InternVL's own demos exercise up to 12 images per request.
+    IMAGE_NUM_LIMITATION = 12
 
     DEFAULT_VIDEO_NUM_FRAMES = 32
     VIDEO_MAX_NUM = 1

--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -227,6 +227,10 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
         ):
             return self._process_precomputed_image_data(image_data)
 
+        # This processor does not route through load_mm_data, so enforce the
+        # image count limit here before any image is fetched or decoded.
+        self.validate_image_num_limitation(image_data)
+
         modalities = request_obj.modalities or ["image"]
         aspect_ratio = getattr(self.hf_config, "image_aspect_ratio", None)
         grid_pinpoints = (

--- a/test/registered/unit/multimodal/test_image_num_limitation.py
+++ b/test/registered/unit/multimodal/test_image_num_limitation.py
@@ -1,0 +1,175 @@
+"""Unit tests for the per-processor default image count limit.
+
+`IMAGE_NUM_LIMITATION` is a safety net against OOM from oversized image
+batches (each 4K image can cost ~1 GiB of GPU memory in the fast image
+processor). An explicit ``--limit-mm-data-per-request`` image entry takes
+priority over the processor default.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.runtime_context import get_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_processor(
+    image_num_limitation=None,
+    cli_limit=None,
+):
+    """Create a BaseMultimodalProcessor via the real __init__ with mocked deps.
+
+    cli_limit, when set, is published as --limit-mm-data-per-request
+    {"image": N} so the priority order against the class default is exercised.
+    """
+    if image_num_limitation is not None:
+
+        class _Processor(BaseMultimodalProcessor):
+            IMAGE_NUM_LIMITATION = image_num_limitation
+
+    else:
+        _Processor = BaseMultimodalProcessor
+
+    override = get_context().override_server_args(
+        mm_process_config={},
+        allowed_media_domains=[],
+        mm_processor_worker_num=0,
+        mm_io_worker_num=0,
+        mm_preprocess_cache_size_mb=None,
+        tokenizer_worker_num=1,
+        trust_mm_content_hashes=False,
+        media_url_max_file_size_mb=64,
+        limit_mm_data_per_request=({"image": cli_limit} if cli_limit else None),
+    )
+    override.install()
+
+    server_args = ServerArgs(
+        model_path="dummy",
+        mm_process_config={},
+        allowed_media_domains=[],
+        mm_processor_worker_num=0,
+        mm_io_worker_num=0,
+        mm_preprocess_cache_size_mb=None,
+        tokenizer_worker_num=1,
+        trust_mm_content_hashes=False,
+        media_url_max_file_size_mb=64,
+        disable_fast_image_processor=False,
+        limit_mm_data_per_request=({"image": cli_limit} if cli_limit else None),
+    )
+
+    with patch.object(_Processor, "__abstractmethods__", set()):
+        proc = _Processor(
+            hf_config=MagicMock(),
+            server_args=server_args,
+            _processor=MagicMock(),
+            transport_mode=None,
+        )
+    if proc.mm_processor_executor is not None:
+        proc.mm_processor_executor.shutdown()
+    return override, proc
+
+
+def _image_list(count):
+    # Opaque non-dict items: the limit check runs before any decoding, so the
+    # items never need to be real images.
+    return [f"image-{i}" for i in range(count)]
+
+
+class TestImageNumLimitation(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._overrides = []
+
+    def _make(self, **kwargs):
+        override, proc = _make_processor(**kwargs)
+        self._overrides.append(override)
+        return proc
+
+    def tearDown(self):
+        for override in reversed(self._overrides):
+            override.restore()
+        super().tearDown()
+
+    def test_default_limit_enforced(self):
+        proc = self._make()
+        with self.assertRaisesRegex(ValueError, "at most 5 image"):
+            proc.validate_image_num_limitation(_image_list(6))
+
+    def test_within_default_limit_passes(self):
+        proc = self._make()
+        # Must not raise.
+        proc.validate_image_num_limitation(_image_list(5))
+        proc.validate_image_num_limitation(_image_list(0))
+        proc.validate_image_num_limitation(None)
+
+    def test_subclass_override_enforced(self):
+        proc = self._make(image_num_limitation=12)
+        with self.assertRaisesRegex(ValueError, "at most 12 image"):
+            proc.validate_image_num_limitation(_image_list(13))
+        proc.validate_image_num_limitation(_image_list(12))
+
+    def test_cli_limit_takes_priority(self):
+        # CLI asks for 2: it must win over both the class default (5) and a
+        # subclass override (12).
+        proc = self._make(image_num_limitation=12, cli_limit=2)
+        with self.assertRaisesRegex(ValueError, "at most 2 image"):
+            proc.validate_image_num_limitation(_image_list(3))
+        proc.validate_image_num_limitation(_image_list(2))
+
+    def test_cli_limit_can_raise_default(self):
+        proc = self._make(cli_limit=8)
+        proc.validate_image_num_limitation(_image_list(8))
+        with self.assertRaisesRegex(ValueError, "at most 8 image"):
+            proc.validate_image_num_limitation(_image_list(9))
+
+    def test_error_message_mentions_cli_flag(self):
+        proc = self._make()
+        with self.assertRaisesRegex(ValueError, r"--limit-mm-data-per-request"):
+            proc.validate_image_num_limitation(_image_list(99))
+
+    def test_preprocessed_single_item_exempt(self):
+        # A single processor_output / precomputed_embedding dict carries no
+        # decode cost, so the limit must not reject it.
+        proc = self._make()
+        proc.validate_image_num_limitation(
+            [{"format": "processor_output", "pixel_values": None}]
+        )
+
+
+class TestLoadMmDataRejectsOversized(CustomTestCase):
+    """The limit must fire inside load_mm_data, before any image is fetched."""
+
+    def test_load_mm_data_rejects_oversized_batch(self):
+        override, proc = _make_processor()
+        self.addCleanup(override.restore)
+        mm_tokens = SimpleNamespace(
+            image_token="<image>",
+            video_token="<video>",
+            audio_token=None,
+        )
+        with patch.object(
+            BaseMultimodalProcessor,
+            "fast_load_mm_data",
+            new=lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not load")),
+        ):
+            with self.assertRaisesRegex(ValueError, "at most 5 image"):
+                import asyncio
+
+                asyncio.run(
+                    proc.load_mm_data(
+                        prompt="hello <image> world",
+                        multimodal_tokens=mm_tokens,
+                        image_data=_image_list(6),
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Each 4K image can cost ~1 GiB of GPU memory in the fast image processor, so an oversized image batch can OOM the server. The existing --limit-mm-data-per-request flag only protects deployments that set it explicitly (default None = no protection).

Add IMAGE_NUM_LIMITATION = 5 on BaseMultimodalProcessor as a per-processor safety net, enforced in load_mm_data before any image is fetched or decoded. InternVL overrides it to 12 (its own demos exercise that many; IMAGE_MAX_NUM is dynamic-patch tiling, not an image count, so it stays untouched). LLaVA bypasses load_mm_data and gets the same check in its process_mm_data_async. An explicit --limit-mm-data-per-request image entry keeps priority over the class default.

Revives #19606; fixes #8540.

## Motivation

Fixes #8540. Without any limit configured, a single request can carry an
unbounded number of images, each costing ~1 GiB of GPU memory in the fast
image processor (measured for 4K images), which can OOM the server. The
existing `--limit-mm-data-per-request` flag (added in #15418) only protects
deployments that set it explicitly — its default is `None`, i.e. no
protection. This PR adds a per-processor default as a safety net, following
the direction hnyls2002 pointed to when closing #21838.

## Modifications

- **`base_processor.py`**: `IMAGE_NUM_LIMITATION = 5` class constant;
  `_get_image_limit()` resolves the effective limit (a CLI
  `--limit-mm-data-per-request` image entry takes priority over the class
  default); `validate_image_num_limitation()` rejects oversized batches in
  `load_mm_data()` before any image is fetched or decoded. Preprocessed
  single-item inputs (processor_output / precomputed_embedding) are exempt
  since they carry no decode cost.
- **`internvl.py`**: `IMAGE_NUM_LIMITATION = 12` override (InternVL's own
  demos exercise that many). `IMAGE_MAX_NUM` is deliberately left untouched
  — it bounds dynamic-patch tiling per image, not the image count.
- **`llava.py`**: LLaVA's `process_mm_data_async` bypasses `load_mm_data`,
  so it gets the same check inline before its multi-image gather loop.
- **`test_image_num_limitation.py`**: 8 pure-CPU unit tests — default limit
  enforced, within-limit pass-through, subclass override, CLI priority (both
  directions), error message mentions the CLI flag, preprocessed-input
  exemption, and an integration check that `load_mm_data` rejects before any
  loading happens.

Priority order: `--limit-mm-data-per-request` CLI flag > processor
`IMAGE_NUM_LIMITATION` constant > no protection (limit <= 0 or None
disables).

## Accuracy Tests

Not applicable — this is a request-validation guard that raises before any
model code runs; it does not affect model outputs. Requests within the limit
take the identical code path as before (pure additive check with an early
return for empty/None image lists).

## Speed Tests and Profiling

Not applicable — the check is an O(1) `len()` comparison on the request's
image list, run once per request before any media work. No hot-path code was
touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34334279870](https://github.com/sgl-project/sglang/actions/runs/34334279870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34334279747](https://github.com/sgl-project/sglang/actions/runs/34334279747)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34334280032](https://github.com/sgl-project/sglang/actions/runs/34334280032)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->