### PR TITLE
fix(rocm): support unified KV in DSV4 multi-stream

### DIFF
--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -412,7 +412,8 @@ def handle_model_specific_adjustments(server_args: Any):
             envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
             envs.SGLANG_OPT_USE_TILELANG_MHC_POST.set(False)
             envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
-            envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
+            if not envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.is_set():
+                envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
             envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
 
     elif model_arch in ["GptOssForCausalLM"]:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -928,7 +928,7 @@ class MQALayer(MqaAttentionBase):
             self.register_buffer("sin_cache", sin_cache, persistent=False)
 
         if alt_streams is not None and (
-            (_is_cuda and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get())
+            ((_is_cuda or _is_hip) and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get())
             or (_is_npu and envs.SGLANG_NPU_USE_MULTI_STREAM.get())
         ):
             self.alt_streams = alt_streams[:3]
@@ -1276,7 +1276,7 @@ class MQALayer(MqaAttentionBase):
         attn_backend,
         q_out: Optional[torch.Tensor] = None,
         x_quant=None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """ATOM-style ROCm path: overlap compressors, keep Q/KV on main stream."""
         assert self.alt_streams is not None
         assert len(self.alt_streams) >= 1
@@ -1330,14 +1330,34 @@ class MQALayer(MqaAttentionBase):
                 else self.wkv(x_linear)[0]
             )
 
+            from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+                is_unified_kv_triton,
+            )
             from sglang.kernels.ops.attention.fused_qk_norm_rope_store import (
                 fused_qk_norm_rope_swa_store,
             )
 
             token_to_kv_pool = get_token_to_kv_pool()
-            swa_loc = attn_backend.get_swa_out_cache_loc(forward_batch)
-            swa_cache = token_to_kv_pool.get_swa_raw_buffer(self.layer_id)
-            swa_page_size = token_to_kv_pool.swa_kv_pool.page_size
+            unified = is_unified_kv_triton()
+            fuse_verify = (
+                envs.SGLANG_OPT_FUSED_QK_NORM_ROPE_VERIFY.get()
+                and forward_batch.forward_mode.is_target_verify()
+            )
+            if unified and fuse_verify:
+                kv = kv.contiguous()
+                swa_cache, swa_loc = None, None
+                swa_page_size, bf16_store = 1, True
+            elif unified:
+                swa_cache = token_to_kv_pool.get_unified_kv(self.layer_id)
+                swa_loc = attn_backend.get_unified_swa_loc(forward_batch)
+                swa_page_size, bf16_store = 1, True
+            else:
+                swa_cache = token_to_kv_pool.get_swa_raw_buffer(self.layer_id)
+                swa_loc = attn_backend.get_swa_out_cache_loc(forward_batch)
+                swa_page_size, bf16_store = (
+                    token_to_kv_pool.swa_kv_pool.page_size,
+                    False,
+                )
 
             q = fused_qk_norm_rope_swa_store(
                 q=q,
@@ -1355,13 +1375,17 @@ class MQALayer(MqaAttentionBase):
                 swa_page_size=swa_page_size,
                 q_out=q_out,
                 dtype=x.dtype,
+                bf16_store=bf16_store,
             )
+            if not (unified and fuse_verify):
+                kv = None
         else:
             q_lora = self.q_norm(q_lora)
             q = self._compute_q_b(q_lora, positions, q_out)
             self._compute_kv_to_cache(
                 x_linear, positions, forward_batch, attn_backend, qkv_a=qkv_a
             )
+            kv = None
 
         del qkv_a
 
@@ -1379,7 +1403,7 @@ class MQALayer(MqaAttentionBase):
         elif self.compressor is not None:
             current_stream.wait_stream(stream_compressor)
 
-        return q
+        return q, kv
 
     def _forward_prepare(
         self,
@@ -1650,10 +1674,10 @@ class MQALayer(MqaAttentionBase):
         attn_sink = self._local_attn_sink()
 
         if enable_multi_stream:
-            # Multi-stream path always fuses cache write into the K kernel,
-            # so the bf16 KV intermediate is gone.
+            # Unified target-verify defers its causally indexed cache write to
+            # the backend; other multi-stream paths write during preparation.
             if _is_hip:
-                q = self._forward_prepare_multi_stream_hip(
+                q, kv = self._forward_prepare_multi_stream_hip(
                     x,
                     positions,
                     forward_batch,
@@ -1670,6 +1694,7 @@ class MQALayer(MqaAttentionBase):
                     q_out,
                     x_quant=x_quant,
                 )
+                kv = None
             else:
                 q = self._forward_prepare_multi_stream(
                     x,
@@ -1679,7 +1704,7 @@ class MQALayer(MqaAttentionBase):
                     q_out,
                     x_quant=x_quant,
                 )
-            kv = None
+                kv = None
         else:
             q, kv = self._forward_prepare(
                 x,


### PR DESCRIPTION
## Motivation

On ROCm, explicitly enabling `SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=1` with `unified_kv_triton` makes the generic HIP path access the legacy SWA pool. The unified pool has no legacy `swa_kv_pool`, so full decode graph capture fails with:

```text
AttributeError: 'NoneType' object has no attribute 'kv_buffer'
```

The ROCm default remains disabled. The dedicated path in #37812 is not affected.

## Modifications

- Preserve an explicit ROCm multi-stream opt-in and retain the alternate streams on HIP.
- Use the unified cache and location for decode.
- Return contiguous KV to the backend for target-verify cache writes.

## Accuracy Tests

- Existing DSV4 policy tests: `2 passed, 2 subtests passed`.
- 8x MI355X: full decode graph capture completed, health returned 200, and a 64-token completion succeeded with no restart, OOM, fatal error, or HTTP 5xx.

## Speed Tests and Profiling

Not measured. This PR is a correctness fix for the experimental opt-in path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34335925958](https://github.com/sgl-project/sglang/actions/runs/34335925958)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34335925835](https://github.com/sgl-project/sglang/actions/runs/34335925835)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34335926201](https://github.com/sgl-project/sglang/actions/runs/34335926201)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->