### PR TITLE
[Fix] MiMo-V2 video+audio crash when audio is shorter than video (refresh)

### DIFF
--- a/python/sglang/srt/multimodal/processors/mimo_v2.py
+++ b/python/sglang/srt/multimodal/processors/mimo_v2.py
@@ -1003,16 +1003,20 @@ class MiMoProcessor:
                 if i < len(grid_t_timestamps) - 1
                 else int(video_meta["segment_end_time"] * audio_token_per_second)
             )
-            segment_audio_token_len = (
-                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx
+            # Audio may end before the last video grid (e.g. silent tail).
+            # In that case `min(end, audio_token_len) - start` is <= 0; clamp
+            # to 0 so the grid still emits its video tokens with no audio
+            # placeholders, instead of asserting and dropping the request.
+            segment_audio_token_len = max(
+                0,
+                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx,
             )
-            assert segment_audio_token_len > 0
             segment_audio = (
                 processed_audio[
                     audio_start_token_idx : audio_start_token_idx
                     + segment_audio_token_len
                 ]
-                if is_tokenized
+                if is_tokenized and segment_audio_token_len > 0
                 else None
             )
             units.append(


### PR DESCRIPTION
Reopened on top of latest main to avoid stale base from #25515.

Replaces old PR branch: #25515

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34336728308](https://github.com/sgl-project/sglang/actions/runs/34336728308)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34336727786](https://github.com/sgl-project/sglang/actions/runs/34336727786)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34336728160](https://github.com/sgl-project/sglang/actions/runs/34336728160)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->