### PR TITLE
docker(xpu): drop redundant setvars.sh from torch_memory_saver RUN

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -91,12 +91,9 @@ RUN echo "Cloning ${SG_LANG_BRANCH} from ${SG_LANG_REPO}" && \
 # major to it -- under build isolation torch is absent and the match is skipped.
 # Pinned (v0.0.10b2) so image builds are reproducible; bump via --build-arg.
 ARG TORCH_MEMORY_SAVER_REF=a5c99f11b18ebb8e9fda71a68812e476ae49e417
-# Keep setvars.sh's stderr and don't chain with `&&`: an optional component's
-# vars.sh can exit non-zero while SYCL is still exported. `set -e` fails on pip.
-RUN set -e; \
-    . /opt/intel/oneapi/setvars.sh --force || \
-      echo "setvars.sh exited $? -- continuing; pip will fail loudly if SYCL is missing"; \
-    TMS_PLATFORM=xpu pip install --no-cache-dir --no-build-isolation \
-      git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
+# Base image already applies setvars.sh in its own layers (SETVARS_COMPLETED=1,
+# icpx on PATH, LIBRARY_PATH/CPATH populated), so re-sourcing here is redundant.
+RUN TMS_PLATFORM=xpu pip install --no-cache-dir --no-build-isolation \
+    git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
 
-CMD ["bash", "-c", "source /opt/intel/oneapi/setvars.sh --force && exec bash"]
+CMD ["bash"]


### PR DESCRIPTION
## Summary
Follow-up to #38617. That PR turned a silent exit 3 into a visible one, which surfaced the real bug: `setvars.sh` should not have been in this RUN at all. Removing it fixes the nightly and gets rid of the fragility for good.

Failing nightly run (post-#38617): https://github.com/sgl-project/sglang/actions/runs/34330707892

## Root cause
The base image `intel/deep-learning-essentials:2026.0.0-devel-ubuntu24.04` already runs `setvars.sh` in its own build layers and freezes the resulting env into image ENV. Every subsequent RUN starts with the SYCL toolchain fully wired up:

```
$ docker run --rm intel/deep-learning-essentials:2026.0.0-devel-ubuntu24.04 \
    env | grep -E '^(PATH|LIBRARY_PATH|CMPLR_ROOT|SETVARS_COMPLETED)'
PATH=/opt/intel/oneapi/mpi/…/bin:…/compiler/2026.0/bin:…
LIBRARY_PATH=/opt/intel/oneapi/tcm/1.5/lib:…/compiler/2026.0/lib:…
CMPLR_ROOT=/opt/intel/oneapi/compiler/2026.0
SETVARS_COMPLETED=1
```

Re-sourcing `setvars.sh` in the RUN was redundant. It was also actively breaking the build: `setvars.sh` sees `SETVARS_COMPLETED=1`, refuses to re-run, prints its usage, and exits **3**. `--force` gets dropped by dash's `.` builtin (Docker's default `sh -c` on Ubuntu 24.04), so setvars.sh never actually sees it. The exit-in-a-sourced-script kills the parent shell before pip runs, defeating even the `|| echo …` guard from #38617.

## Fix
Drop the `setvars.sh` invocation from the RUN and let the base image's env do its job:

```dockerfile
RUN TMS_PLATFORM=xpu pip install --no-cache-dir --no-build-isolation \
    git+https://github.com/fzyzcjy/torch_memory_saver.git@${TORCH_MEMORY_SAVER_REF}
```

Also simplify `CMD` for the same reason — the container's ENV already has everything set, so `source setvars.sh --force && exec bash` reduces to just `bash`.

## Why CI didn't catch this
`.github/workflows/release-docker-intel-xpu-nightly.yml` only fires on:

```yaml
on:
  workflow_dispatch:
  schedule:
    - cron: '0 12 * * *'
```

There is **no `pull_request` trigger**. Any PR that touches `docker/xpu.Dockerfile` or `python/pyproject_xpu.toml` can merge without ever building the affected image — the first time the change actually runs is the next nightly, hours after merge. That's exactly the pathway #29935 → the original exit 3, and #38617's diagnostic fix → this exit 3.

Recommended follow-up (kept out of this PR because updating workflow files requires the `workflow` OAuth scope, which the author's token doesn't hold — a maintainer or a second PR can land it):

```yaml
on:
  workflow_dispatch:
  schedule:
    - cron: '0 12 * * *'
  pull_request:
    paths:
      - 'docker/xpu.Dockerfile'
      - 'python/pyproject_xpu.toml'
      - '.github/workflows/release-docker-intel-xpu-nightly.yml'
```

With that in place, any PR that could break the XPU image gets a docker build in CI and can't merge with a broken Dockerfile — the same protection the CUDA image already has.

## Test plan
- [ ] Trigger `Release Docker Images Nightly (Intel XPU)` on this branch → build reaches `Push intel/sglang-dev` and succeeds.
- [ ] `docker run --rm <built-image> python -c "import torch_memory_saver; print(torch_memory_saver.__file__)"` succeeds.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34337535233](https://github.com/sgl-project/sglang/actions/runs/34337535233)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34428340387](https://github.com/sgl-project/sglang/actions/runs/34428340387)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->