### PR TITLE
[XPU] Fix MLA decode KV write for rope-in-k models (e.g. MiniCPM3)

### DIFF
--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -883,14 +883,13 @@ class XPUAttentionBackend(AttentionBackend):
                         layer.v_scale,
                     )
                 else:
-                    k_rope_val = (
-                        k_rope if k_rope is not None else k[:, :, layer.v_head_dim :]
-                    )
+                    # Pass k_rope as-is like forward_extend: when rope is folded into
+                    # k (k_rope is None), set_mla_kv_buffer stores the whole kv row.
                     self.token_to_kv_pool.set_mla_kv_buffer(
                         layer,
                         cache_loc,
                         k,
-                        k_rope_val,
+                        k_rope,
                     )
 
         # Use precomputed metadata across all layers


### PR DESCRIPTION
## Motivation
On the intel_xpu backend, `forward_decode` wrote MLA KV by deriving a rope slice
(`k[:, :, v_head_dim:]`) and calling `set_mla_kv_buffer(k, k_rope_slice)`. When a
model folds rope into `k` and passes `k_rope=None` (e.g. MiniCPM3-4B), this took
`set_mla_kv_buffer`'s has-rope path with `nope_dim` set to the full `[nope|rope]`
row width, writing past the kv row and corrupting the cache; decode then read
garbage (gsm8k ~0.34). `forward_extend` already passes `k_rope` as-is, so prefill
was fine, and DeepSeek-family models pass `k_rope` separately, so they were
unaffected.

## Modifications
`forward_decode` passes `k_rope` as-is, matching `forward_extend`: with
`k_rope=None` the no-rope write path stores the whole `[nope|rope]` row; with a
real `k_rope` the has-rope path is unchanged. No behavior change for models that
pass `k_rope`.

Depends on sgl-project/sgl-kernel-xpu#481, which lets `flash_mla_decode` accept
non-DeepSeek latent/rope dims; both are needed for MiniCPM3-4B to decode on the
intel_xpu SYCL kernel. The change is additive and XPU-only — DeepSeek MLA and all
MHA paths keep their original code paths.

## Accuracy Tests
lm_eval gsm8k on `openbmb/MiniCPM3-4B`, Intel Arc Pro B60, tp-1,
`--attention-backend intel_xpu`, greedy:
- 1319 samples, 5-shot: flexible-extract 0.7521 (±0.0119), strict-match 0.7445 (±0.0120).
- limit 50, 5-shot: flexible-extract 0.68, strict-match 0.66.

### No-regression check (DeepSeek-V2-Lite)
Because the change only rewrites the `k_rope=None` branch, models that pass a real
`k_rope` (DeepSeek-family) receive a byte-identical argument to `set_mla_kv_buffer`
— the removed `else` slice was dead code for them — so it is a no-op by
construction. Confirmed empirically on `deepseek-ai/DeepSeek-V2-Lite` (Intel Arc
Pro B60, tp-2, `--prefill-attention-backend triton --decode-attention-backend
intel_xpu` so decode runs on this path, gsm8k 5-shot, limit 5, seed 42), before vs
after this change:

| build | flexible-extract | strict-match |
| --- | --- | --- |
| before (main) | 0.4 | 0.4 |
| after (this PR) | 0.4 | 0.4 |

Identical scores and stderr, as expected for a no-op path.

### Reproduction
sglang is installed editable from this branch; for MiniCPM3-4B the patched
sgl-kernel-xpu wrapper (sgl-project/sgl-kernel-xpu#481) is copied over the installed
wheel before serving.

MiniCPM3-4B (whole MLA path on intel_xpu):
```bash
# server
SGLANG_USE_SGL_XPU=1 sglang serve --model-path openbmb/MiniCPM3-4B --device xpu \
  --tp-size 1 --mem-fraction-static 0.85 --trust-remote-code \
  --host 127.0.0.1 --port 30002 --attention-backend intel_xpu
# client
python -m lm_eval --model local-chat-completions \
  --model_args pretrained=openbmb/MiniCPM3-4B,base_url=http://127.0.0.1:30002/v1/chat/completions,num_concurrent=32,timeout=999999,trust_remote_code=True \
  --tasks gsm8k --num_fewshot 5 --batch_size 32 --seed 42 \
  --apply_chat_template --fewshot_as_multiturn
```

DeepSeek-V2-Lite (decode on intel_xpu; needs tp-2 to fit on 24GB cards):
```bash
# server
SGLANG_USE_SGL_XPU=1 sglang serve --model-path deepseek-ai/DeepSeek-V2-Lite --device xpu \
  --tp-size 2 --mem-fraction-static 0.85 --trust-remote-code \
  --host 127.0.0.1 --port 30012 \
  --prefill-attention-backend triton --decode-attention-backend intel_xpu
# client
python -m lm_eval --model local-completions \
  --model_args model=deepseek-ai/DeepSeek-V2-Lite,base_url=http://127.0.0.1:30012/v1/completions,tokenizer=deepseek-ai/DeepSeek-V2-Lite,num_concurrent=8,timeout=999999 \
  --tasks gsm8k --num_fewshot 5 --limit 5 --batch_size 8 --seed 42
```

## Speed
Decode runs on the intel_xpu SYCL `flash_mla_decode` kernel, ~235 tok/s peak
(`#running-req` up to 32); unchanged path for DeepSeek MLA.

## Checklist
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34336985955](https://github.com/sgl-project/sglang/actions/runs/34336985955)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34336985734](https://github.com/sgl-project/sglang/actions/runs/34336985734)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34336985930](https://github.com/sgl-project/sglang/actions/runs/34336985930)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
