### PR TITLE
[Fix] MiMo-V2 video+audio crash when audio is shorter than video (refresh)

### DIFF
--- a/python/sglang/srt/multimodal/processors/mimo_v2.py
+++ b/python/sglang/srt/multimodal/processors/mimo_v2.py
@@ -1003,16 +1003,20 @@ class MiMoProcessor:
                 if i < len(grid_t_timestamps) - 1
                 else int(video_meta["segment_end_time"] * audio_token_per_second)
             )
-            segment_audio_token_len = (
-                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx
+            # Audio may end before the last video grid (e.g. silent tail).
+            # In that case `min(end, audio_token_len) - start` is <= 0; clamp
+            # to 0 so the grid still emits its video tokens with no audio
+            # placeholders, instead of asserting and dropping the request.
+            segment_audio_token_len = max(
+                0,
+                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx,
             )
-            assert segment_audio_token_len > 0
             segment_audio = (
                 processed_audio[
                     audio_start_token_idx : audio_start_token_idx
                     + segment_audio_token_len
                 ]
-                if is_tokenized
+                if is_tokenized and segment_audio_token_len > 0
                 else None
             )
             units.append(

--- a/test/registered/unit/multimodal/test_mimo_v2_audio_tail.py
+++ b/test/registered/unit/multimodal/test_mimo_v2_audio_tail.py
@@ -1,0 +1,31 @@
+from sglang.srt.multimodal.processors.mimo_v2 import MiMoProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestMiMoVideoAudioUnits(CustomTestCase):
+    def test_audio_shorter_than_video_keeps_video_tail(self):
+        processor = object.__new__(MiMoProcessor)
+        processor.temporal_patch_size = 2
+        processor.temporal_compression_ratio = 1
+        processor.merge_size = 2
+        processor.use_video_timestamps = True
+        processor.audio_token_per_second = 2
+
+        units = processor._build_video_audio_units(
+            thw_grid=(3, 4, 4),
+            timestamps=[0, 0.5, 1, 1.5, 2, 2.5],
+            video_meta={"segment_end_time": 3},
+            processed_audio=[10, 11, 12],
+            is_tokenized=True,
+            audio_token_len=3,
+        )
+
+        self.assertEqual([unit["segment_audio_token_len"] for unit in units], [2, 1, 0])
+        self.assertEqual([unit["num_video_tokens"] for unit in units], [4, 4, 4])
+        self.assertEqual([unit["audio_start_token_idx"] for unit in units], [0, 2, 4])
+        self.assertEqual(units[0]["segment_audio"], [10, 11])
+        self.assertEqual(units[1]["segment_audio"], [12])
+        self.assertIsNone(units[2]["segment_audio"])


### PR DESCRIPTION
This is a refresh of #25515 against current main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34683626893](https://github.com/sgl-project/sglang/actions/runs/34683626893)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34683626804](https://github.com/sgl-project/sglang/actions/runs/34683626804)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34683626884](https://github.com/sgl-project/sglang/actions/runs/34683626884)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->