### PR TITLE
[Fix] qwen4_exp: break loader closure self-reference pinning params_dict until cyclic GC

### DIFF
--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1853,7 +1853,12 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     )
                 )
 
+        # A self-reference in the helper would keep params_dict (and
+        # pre-repack Parameters) alive until cyclic GC runs.
+        ple_warned_downcast = False
+
         def load_qwen4_exp_ple_shard(name: str, loaded_weight: torch.Tensor) -> bool:
+            nonlocal ple_warned_downcast
             if ".ngram_embedding.shard_" not in name:
                 return False
             import re
@@ -1900,8 +1905,8 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 emb.weight.dtype == torch.float8_e4m3fn
                 and loaded_weight.dtype != torch.float8_e4m3fn
             ):
-                if not getattr(load_qwen4_exp_ple_shard, "_warned_downcast", False):
-                    load_qwen4_exp_ple_shard._warned_downcast = True
+                if not ple_warned_downcast:
+                    ple_warned_downcast = True
                     logger.warning(
                         "PLE checkpoint shards are %s but the embedding storage "
                         "is fp8 (ple_embedding_dtype / fp8 quant config); "


### PR DESCRIPTION
## Problem

In `Qwen4ExpForConditionalGeneration.load_weights`, the PLE shard loader helper
`load_qwen4_exp_ple_shard` stores its "already warned" flag as a function
attribute on itself:

```python
if not getattr(load_qwen4_exp_ple_shard, "_warned_downcast", False):
    load_qwen4_exp_ple_shard._warned_downcast = True
```

Setting an attribute on a closure creates a reference cycle:
`load_qwen4_exp_ple_shard.__dict__["_warned_downcast"]` → (function) →
`__closure__` → enclosing scope cell → `params_dict` (the full parameter
snapshot). The cycle is only collectable by the cyclic GC, so the entire
`params_dict` — including pre-repack loader-format Parameters — stays alive
until an indeterminate GC run.

On NVFP4/MIXED_PRECISION checkpoints this pins multiple GiB of stale
loader-format weights through weight loading (observed: ~+0.66 GiB/layer
repack transient surviving past load end on 2×L20 48GB cards; with marlin
repack the 48-layer transient accumulates to ~3.5 GiB/rank unless freed
eagerly).

## Fix

Replace the function attribute with a plain enclosing-scope local captured via
`nonlocal`, which breaks the cycle:

```python
ple_warned_downcast = False

def load_qwen4_exp_ple_shard(name, loaded_weight):
    nonlocal ple_warned_downcast
    ...
    if not ple_warned_downcast:
        ple_warned_downcast = True
        logger.warning(...)
```

## Evidence

- `torch.cuda.memory_allocated()` traced per-layer during load
  (`[memdbg] repack begin/END` instrumentation): with the function-attribute
  form, allocated memory does not return to baseline after the PLE branch;
  with the `nonlocal` form, alloc is flat across all 48 layers
  (37.66 GiB constant, 2×L20 TP2, `Qwen3.8-Flash-Next-NVFP4` MIXED_PRECISION).
- Original PR: #38102 (closed unmerged). This re-submission targets `main`
  after #37500 landed (the loader code moved into main at
  `python/sglang/srt/models/qwen4_exp.py:1903`).

## Test

Load any Qwen4-Exp checkpoint with fp8 PLE shards
(`text_config.ple_embedding_dtype=float8_e4m3fn` or MIXED_PRECISION quant
config) and assert `torch.cuda.memory_allocated()` is unchanged before/after
the PLE shard loop.

---
Supersedes #38102 (closed unmerged); rebased onto current `main` after #37500 landed. Patch validated in production on 2×L20 (sm_89) with `Qwen3.8-Flash-Next-NVFP4` MIXED_PRECISION: flat 37.66 GiB alloc across all 48 layers' marlin repack.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34338628990](https://github.com/sgl-project/sglang/actions/runs/34338628990)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34338628682](https://github.com/sgl-project/sglang/actions/runs/34338628682)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34338628879](https://github.com/sgl-project/sglang/actions/runs/34338628879)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->