### PR TITLE
[Fix] MiniMax H3: honor requested inference step count

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/time_request.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/time_request.py
@@ -45,15 +45,12 @@ def minimax_h3_time_shift_sigmas(
     base = torch.linspace(
         1.0,
         0.0,
-        int(num_steps),
+        int(num_steps) + 1,
         device="cpu",
         dtype=torch.float32,
     )
     shifted = float(shift_scale) * base / (1 + (float(shift_scale) - 1) * base)
     shifted, _ = torch.unique_consecutive(shifted, return_counts=True)
-    # A one-point request is still exactly one point.  Normal serving uses
-    # multiple points, but preserving the requested cardinality keeps
-    # ``num_inference_steps`` the sole schedule-size control.
-    if num_steps > 1 and shifted[-1].item() > 0.0:
+    if shifted[-1].item() > 0.0:
         shifted = torch.cat([shifted, torch.tensor([0.0], dtype=shifted.dtype)])
     return [float(value) for value in shifted.tolist()]

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_denoise_loop.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_denoise_loop.py
@@ -30,6 +30,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.m
     _build_cube_attn_metadata,
     _precompute_refined_prompt_embeds,
 )
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.time_request import (
+    minimax_h3_time_shift_sigmas,
+)
 
 
 def _branch(
@@ -62,6 +65,22 @@ def _branch(
         token_tags=packed["token_tags"] if token_tags is None else token_tags,
         device=torch.device("cpu"),
     )
+
+
+def test_time_shift_sigmas_build_exact_denoise_step_count():
+    for num_steps in (1, 2, 10, 50):
+        for shift_scale in (3.0, 12.0):
+            sigmas = minimax_h3_time_shift_sigmas(
+                num_steps=num_steps,
+                shift_scale=shift_scale,
+            )
+
+            assert len(sigmas) == num_steps + 1
+            assert sigmas[0] == 1.0
+            assert sigmas[-1] == 0.0
+            assert all(
+                current > following for current, following in zip(sigmas, sigmas[1:])
+            )
 
 
 def test_precomputed_timestep_plan_matches_full_unique_reference():


### PR DESCRIPTION
`minimax_h3_time_shift_sigmas(num_steps=N)` currently returns `N` sigma points, but the H3 denoise loop executes `len(sigmas) - 1` transitions. A 1-step request therefore fails admission, and every larger request performs one fewer denoise update than requested.

This change builds `N + 1` sigma endpoints and adds coverage for 1, 2, 10, and 50 requested steps with both H3 video and audio shift scales.

Validation:

- `PYTHONPATH=.pytest-deps:python .../python -m pytest -q python/sglang/multimodal_gen/test/unit/test_minimax_h3_denoise_loop.py` — 5 passed.
- H200 end-to-end smoke: 1 requested step executed `1/1` denoise update and produced a 1344×768, 124-frame H.264 video with AAC audio.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34340435561](https://github.com/sgl-project/sglang/actions/runs/34340435561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34340435322](https://github.com/sgl-project/sglang/actions/runs/34340435322)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34340435563](https://github.com/sgl-project/sglang/actions/runs/34340435563)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->