### PR TITLE
[AMD][CI] Fix UMBP test buffer after MoRI upgrade

### DIFF
--- a/test/registered/unit/mem_cache/test_umbp_store.py
+++ b/test/registered/unit/mem_cache/test_umbp_store.py
@@ -12,6 +12,7 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import mori.umbp  # noqa: F401
+import torch
 
 from sglang.test.ci.ci_register import register_amd_ci
 
@@ -43,8 +44,9 @@ class MockHostKVCache:
         total_bytes = num_pages * 2 * element_size  # K+V for each page
         self._buffer = (ctypes.c_char * total_bytes)()
         self._buffer_ptr = ctypes.addressof(self._buffer)
-        self.kv_buffer = MagicMock()
-        self.kv_buffer.data_ptr.return_value = self._buffer_ptr
+        self.kv_buffer = torch.frombuffer(
+            self._buffer, dtype=torch.uint8, count=total_bytes
+        )
 
     def get_page_buffer_meta(self, indices):
         """Return (ptr_list, element_size_list) for MHA page_first layout.


### PR DESCRIPTION
## Motivation

MoRI 1.2.3 now inspects the host buffer before the UMBP set/get test. The test used a pretend tensor that only supplied an address, so asking it for a size produced another mock and raised `MagicMock > int`. 
https://github.com/sgl-project/sglang/actions/runs/34295926746/job/102292496026#step:6:5758

Real `HostKVCache` buffers are PyTorch tensors, so this is a test setup issue.

## Modifications

Use a zero-copy PyTorch view over the test's existing memory. It keeps the same bytes and address while behaving like the real production buffer. No production code is changed.

## Tests
Test passed
<img width="1627" height="1130" alt="image" src="https://github.com/user-attachments/assets/3c61c8cc-51d5-4fab-83fa-97bf7d4ee9b9" />
https://github.com/sgl-project/sglang/actions/runs/34341218263

## Accuracy Tests

Not applicable; this only changes a unit-test fixture.

## Speed Tests and Profiling

Not applicable; runtime code is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34341191025](https://github.com/sgl-project/sglang/actions/runs/34341191025)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34341190418](https://github.com/sgl-project/sglang/actions/runs/34341190418)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34341191104](https://github.com/sgl-project/sglang/actions/runs/34341191104)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->