### PR TITLE
ci(xpu): card-level LPT sharding launcher for stage-a job

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -147,9 +147,14 @@ jobs:
 
       - name: Run tests
         # Old stage-a (30) + stage-b (120) = 150; +20% headroom for --enable-retry.
+        # Wall-clock drops once SGLANG_XPU_MAX_CONCURRENCY is raised above 1.
         timeout-minutes: 180
+        env:
+          # Serial rollout: matches today's behavior. Ramp once host RAM/CPU
+          # capacity on the intel-bmg runner has been measured.
+          SGLANG_XPU_MAX_CONCURRENCY: 1
         run: |
-          docker exec ci_sglang_xpu bash -c "source /opt/venv/bin/activate && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-a-test-1-gpu-xpu,stage-b-test-1-gpu-xpu --enable-retry"
+          docker exec -e SGLANG_XPU_MAX_CONCURRENCY ci_sglang_xpu bash -c "source /opt/venv/bin/activate && cd /sglang-checkout && bash scripts/ci/xpu/run_card_sharded.sh stage-a-test-1-gpu-xpu,stage-b-test-1-gpu-xpu"
 
       - name: Cleanup container
         if: always()

--- a/scripts/ci/xpu/run_card_sharded.sh
+++ b/scripts/ci/xpu/run_card_sharded.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Card-level LPT sharding launcher for XPU CI.
+#
+# Detects how many XPU cards the runner exposes, then launches one subprocess
+# per card. Each subprocess is pinned via ZE_AFFINITY_MASK and runs its own LPT
+# slice of the suite (auto-partition-id 0..N-1, auto-partition-size N). LPT
+# inside run_suite.py balances test files across the N buckets by est_time.
+#
+# Usage:
+#   bash scripts/ci/xpu/run_card_sharded.sh <suite> [timeout_per_file_seconds]
+#
+# Env knobs:
+#   SGLANG_XPU_MAX_CONCURRENCY  Cap shard count below physical card count.
+#                                Default: live card count.
+
+set -uo pipefail
+
+SUITE="${1:?suite name required as first arg}"
+TIMEOUT_PER_FILE="${2:-1800}"
+
+N=$(python3 -c "
+import torch
+if not (hasattr(torch, 'xpu') and torch.xpu.is_available()):
+    print(0)
+else:
+    live = 0
+    for i in range(torch.xpu.device_count()):
+        try:
+            torch.zeros(1, device=f'xpu:{i}')
+            live += 1
+        except Exception:
+            pass
+    print(live)
+")
+
+if [ "$N" -eq 0 ]; then
+  echo "::error::No live XPU devices available on $(hostname)"
+  exit 1
+fi
+
+echo "Detected $N live XPU card(s) on $(hostname)"
+
+MAX="${SGLANG_XPU_MAX_CONCURRENCY:-$N}"
+if [ "$MAX" -lt "$N" ]; then
+  echo "::warning::Capping shard count at $MAX (live cards: $N)"
+  N="$MAX"
+fi
+
+echo "Launching $N parallel shard(s) on $(hostname) for suite=$SUITE"
+
+LOG_DIR="${RUNNER_TEMP:-/tmp}/shard_logs"
+mkdir -p "$LOG_DIR"
+
+pids=()
+for i in $(seq 0 $((N-1))); do
+  (
+    export ZE_AFFINITY_MASK="$i"
+    export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache_$i"
+    export TRITON_CACHE_DIR="${RUNNER_TEMP:-/tmp}/triton_cache_$i"
+    export TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP:-/tmp}/inductor_cache_$i"
+    export MASTER_PORT=$((29500 + i))
+    cd test
+    python3 run_suite.py --hw xpu --suite "$SUITE" \
+      --auto-partition-id "$i" --auto-partition-size "$N" \
+      --timeout-per-file "$TIMEOUT_PER_FILE" \
+      --enable-retry
+  ) > "$LOG_DIR/shard_$i.log" 2>&1 &
+  pids+=($!)
+done
+
+fail=0
+for idx in "${!pids[@]}"; do
+  if ! wait "${pids[$idx]}"; then
+    echo "::error::Shard $idx FAILED"
+    fail=1
+  else
+    echo "Shard $idx ok"
+  fi
+done
+
+echo "===== Per-shard logs ====="
+for i in $(seq 0 $((N-1))); do
+  echo "::group::shard $i"
+  cat "$LOG_DIR/shard_$i.log" || true
+  echo "::endgroup::"
+done
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Rebuild of #28329 against current `main`. Since that PR was opened, the stage-a/stage-b merge it carried has been landed on `main` independently, so this PR is trimmed down to just the card-level LPT sharding launcher — the piece that isn't yet on `main`.

## Changes

- **`scripts/ci/xpu/run_card_sharded.sh`** (new, +88): detects the runner's live XPU cards (`torch.xpu.device_count()` + a `torch.zeros(1, device='xpu:i')` probe per card), then fans out one subprocess per card. Each subprocess is pinned with `ZE_AFFINITY_MASK` and runs an LPT slice of the suite (`--auto-partition-id 0..N-1 --auto-partition-size N`). Isolated `HF_HOME` / `TRITON_CACHE_DIR` / `TORCHINDUCTOR_CACHE_DIR` / `MASTER_PORT` per shard, so shards don't race on caches or ports. LPT inside `test/run_suite.py`'s `auto_partition` already balances files by `est_time`.
- **`.github/workflows/pr-test-xpu.yml`**: `stage-a-test-1-gpu-xpu → Run tests` step now calls the launcher instead of `run_suite.py` directly. `SGLANG_XPU_MAX_CONCURRENCY=1` defaulted so PR behavior matches today's serial run — raising it once host RAM/CPU capacity on `intel-bmg` is measured cuts wall-clock proportionally.

## Why the launcher

All XPU tests are single-card. With one job per runner, the box's other 3 / 7 cards sat idle while one card ran tests serially. Card-level fan-out lets one job use all cards on its runner.

## Rollout

`SGLANG_XPU_MAX_CONCURRENCY=1` today means the launcher runs a single shard — identical wall-clock and identical isolation to the pre-launcher call. Ramp to `2`, `4`, `N` in a follow-up once we've measured concurrent host memory and CPU on the `intel-bmg` runner. If concurrency needs to be reduced quickly, no code change — just edit the env in the step.

## Test plan

- [ ] Trigger `pr-test-xpu` on this branch → `stage-a-test-1-gpu-xpu` runs, logs show `Detected N live XPU card(s)` and `Shard 0 ok`.
- [ ] With `SGLANG_XPU_MAX_CONCURRENCY=1`, wall-clock and pass/fail match a baseline run of `main`.
- [ ] Bump `SGLANG_XPU_MAX_CONCURRENCY: 2` on a scratch branch and confirm wall-clock roughly halves (or, more conservatively, that both shards pass and the sum of shard times ≤ old wall-clock + retry overhead).

## Supersedes

#28329 — closing that in favor of this rebuild. Divergence with `main` was ~14k commits (`test/srt/run_suite.py` deleted in the meantime), too much to rebase cleanly. This branch is a fresh cut off current `main` (`708f51e4`) with only the delta that's still novel.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34348462158](https://github.com/sgl-project/sglang/actions/runs/34348462158)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34348462004](https://github.com/sgl-project/sglang/actions/runs/34348462004)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34348462273](https://github.com/sgl-project/sglang/actions/runs/34348462273)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->