### PR TITLE
docs(cookbook): add Ascend NPU (Atlas 800I A3) deployment scenarios for Qwen3.6

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.6.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.6.mdx
@@ -90,13 +90,20 @@ For the full Docker setup and other installation methods, please refer to the [o
 
 For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
 
+On Ascend NPUs (Atlas 800I A2 / A3), use the official Ascend container image instead — see [SGLang Installation with NPU Support](../../../docs/hardware-platforms/ascend-npus/getting-started/installation) and the [Ascend NPU quickstart](../../../docs/hardware-platforms/ascend-npus/getting-started/quick_start):
+
+```bash Command
+# Atlas 800I A3, stable release (daily build: main-cann9.0.0-a3)
+docker pull quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16
+```
+
 ## 3. Model Deployment
 
 This section provides deployment configurations optimized for different hardware platforms and use cases.
 
 ### 3.1 Basic Configuration
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and capabilities.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and capabilities, including Ascend NPU (Atlas 800I A3) scenarios.
 
 
 <Qwen36Deployment />
@@ -112,6 +119,7 @@ This section provides deployment configurations optimized for different hardware
 - **CUDA IPC Transport**: Add `SGLANG_USE_CUDA_IPC_TRANSPORT=1` as an environment variable to use CUDA IPC for transferring multimodal features, significantly improving TTFT (Time To First Token). Note: this consumes additional memory proportional to image size, so you may need to lower `--mem-fraction-static` or `--max-running-requests`.
 - **Multimodal Attention Backend**: Use `--mm-attention-backend fa3` on H100/H200 for better vision performance, or `--mm-attention-backend fa4` on B200/B300.
 - For processing large images or videos, you may need to lower `--mem-fraction-static` to leave room for image feature tensors.
+- **Ascend NPU (Atlas 800I A3):** Each card has 2 dies, so `--tp-size` is twice the card count (1 card → `--tp-size 2`). Add `--attention-backend ascend --device npu` and `--mamba-ssm-dtype bfloat16`, keep the default V1 mamba radix cache strategy (V2 requires NVIDIA FLA kernels), and run speculative decoding with the built-in MTP weights via `--speculative-algorithm NEXTN`. See [Deploying on Ascend NPUs](#ascend-npu-deployment) below.
 - Hardware requirements:
     - **35B-A3B BF16**: ~70GB for weights. TP=1 fits on all supported hardware.
     - **35B-A3B FP8**: ~35GB for weights. TP=1 fits on all supported hardware.
@@ -166,6 +174,55 @@ All Qwen3.6 variants (MoE 35B-A3B and Dense 27B) fit on a single supported GPU. 
 
 
 - **Xeon CPU service configuration:** Please refer to the `Notes` part in the serving engine launching section in [the SGLang CPU server document](../../../docs/hardware-platforms/cpu_server#launch-of-the-serving-engine) to better understand how to configure the arguments, especially for TP (tensor parallel) and NUMA binding settings.
+
+<a id="ascend-npu-deployment" title="Referenced by the configuration tips above. Verify before removing."></a>
+
+### 3.3 Deploying on Ascend NPUs (Atlas 800I A3)
+
+Both Qwen3.6 variants are supported on Ascend NPUs via the `ascend` attention backend. Single-node deployment runs prefill and decode in the same process (PD mixed mode), which is what the commands from the generator above produce. These recipes are verified with SGLang v0.5.16 in the official Ascend container image:
+
+```bash Command
+docker pull quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16
+```
+
+Launch the container with the host Ascend driver mounted in (see the [Ascend NPU quickstart](../../../docs/hardware-platforms/ascend-npus/getting-started/quick_start) for the full `docker run` command), then run the generated `sglang serve` command inside it. Map only the `davinci` devices you need — one A3 card exposes two dies, so a 1-card deployment passes `--device /dev/davinci0 --device /dev/davinci1` plus `davinci_manager` and `hisi_hdc`.
+
+**Weights**: BF16 checkpoints are available from [Qwen](https://huggingface.co/Qwen) (also mirrored on ModelScope); the W8A8 (modelslim) checkpoint for the 27B variant is [Eco-Tech/Qwen3.6-27B-w8a8](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8) (36.45 GB — small enough to fit a single 64GB die, so `--tp-size 1` also works). Set `SGLANG_USE_MODELSCOPE=1` to resolve the `Qwen/...` and `Eco-Tech/...` paths from ModelScope, or pre-download the weights and pass the local directory as `--model-path`.
+
+| Model | Checkpoint | Weights | 1 Card (TP 2) | 2 Cards (TP 4) |
+| --- | --- | --- | --- | --- |
+| Qwen3.6-27B | [Qwen/Qwen3.6-27B](https://huggingface.co/Qwen/Qwen3.6-27B) | ~54 GB (BF16) | ✓ | ✓ |
+| Qwen3.6-27B (W8A8) | [Eco-Tech/Qwen3.6-27B-w8a8](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8) | ~36 GB | ✓ | ✓ |
+| Qwen3.6-35B-A3B | [Qwen/Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) | ~70 GB (BF16) | ✓ | ✓ |
+
+**Verified performance (PD mixed, single node):**
+
+| Model | Cards | Quantization | Dataset | TPOT |
+| --- | --- | --- | --- | --- |
+| Qwen3.6-27B | 1 | BF16 | 1024x1024 (30)+1024 | 50ms |
+| Qwen3.6-27B | 1 | BF16 | 1080p_30+256 | 50ms |
+| Qwen3.6-27B | 1 | BF16 | 64k+1k (90% prefix cache hit rate) | 50ms |
+| Qwen3.6-27B | 1 | W8A8 INT8 | 3.5k+1.5k | 50ms |
+| Qwen3.6-27B | 1 | W8A8 INT8 | 64k+1k | 50ms |
+| Qwen3.6-27B | 2 | W8A8 INT8 | 16k+1k | 50ms |
+| Qwen3.6-27B | 2 | W8A8 INT8 | 64k+1k | 50ms |
+| Qwen3.6-27B | 2 | W8A8 INT8 | 128k+1k | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 254k+1k | 16.1ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 3.5k+1.5k | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 64k+1k | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 64k+1k (90% prefix cache hit rate) | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 128k+1k | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 128k+1k (90% prefix cache hit rate) | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 1024x1024 (30)+1024 | 50ms |
+| Qwen3.6-35B-A3B | 1 | BF16 | 1080p_30+256 | 50ms |
+| Qwen3.6-35B-A3B | 2 | BF16 | 984k+1k | 40.91ms |
+
+Each scenario's full recipe — host tuning, performance environment variables, exact launch flags, and `bench_serving` commands — lives in the Ascend NPU best practices: [Qwen3.6-27B](../../../docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_27b) · [Qwen3.6-35B-A3B](../../../docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_6_35b_a3b).
+
+<Note>
+- Multimodal serving on A3 additionally enables `--enable-multimodal --mm-attention-backend ascend_attn`; see the image-input best-practice scenarios for the full flag set.
+- Accuracy evaluation and performance testing methodologies on Ascend NPUs are documented in the [Ascend NPU evaluation guides](../../../docs/hardware-platforms/ascend-npus/evaluation/accuracy_evaluation).
+</Note>
 
 ## 4. Model Invocation
 

--- a/docs/src/snippets/autoregressive/qwen36-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen36-deployment.jsx
@@ -10,6 +10,17 @@ export const Qwen36Deployment = () => {
         { id: 'b200', label: 'B200', default: false },
         { id: 'b300', label: 'B300', default: false },
         { id: 'xeon', label: 'XEON', default: false },
+        { id: 'a3', label: 'A3 (NPU)', default: false },
+      ],
+    },
+    // Atlas 800I A3: 1 card = 2 dies, so --tp-size is twice the card count.
+    npuCards: {
+      name: 'npuCards',
+      title: 'Ascend Cards',
+      condition: (values) => values.hardware === 'a3',
+      items: [
+        { id: '1', label: '1 Card (2 dies)', default: true },
+        { id: '2', label: '2 Cards (4 dies)', default: false },
       ],
     },
     modelSize: {
@@ -24,7 +35,16 @@ export const Qwen36Deployment = () => {
       name: 'quantization',
       title: 'Quantization',
       // NVFP4 checkpoints are available for both model sizes on Blackwell (B200/B300).
+      // On Ascend NPU the verified options are BF16 for both sizes and W8A8
+      // (modelslim) for the 27B dense variant.
       getDynamicItems: (values) => {
+        if (values.hardware === 'a3') {
+          const items = [{ id: 'bf16', label: 'BF16', default: true }];
+          if (values.modelSize === '27b') {
+            items.push({ id: 'w8a8', label: 'W8A8', default: false });
+          }
+          return items;
+        }
         const items = [
           { id: 'fp8', label: 'FP8', default: true },
           { id: 'bf16', label: 'BF16', default: false },
@@ -65,12 +85,17 @@ export const Qwen36Deployment = () => {
             disabledReason: isXeon ? 'Speculative decoding is not supported on Xeon' : '' },
         ];
       },
-      commandRule: (value) => value === 'enabled' ? '--speculative-algorithm EAGLE \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4' : null,
+      commandRule: (value, values) => {
+        if (value !== 'enabled') return null;
+        // Ascend NPU uses the built-in MTP weights via the NEXTN algorithm.
+        const algo = values.hardware === 'a3' ? 'NEXTN' : 'EAGLE';
+        return `--speculative-algorithm ${algo} \\\n  --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 \\\n  --speculative-num-draft-tokens 4`;
+      },
     },
     mambaCache: {
       name: 'mambaCache',
       title: 'Mamba Radix Cache',
-      condition: (values) => values.hardware !== 'xeon',
+      condition: (values) => values.hardware !== 'xeon' && values.hardware !== 'a3',
       getDynamicItems: (values) => {
         const mtpEnabled = values.speculative === 'enabled';
         if (mtpEnabled) {
@@ -164,6 +189,35 @@ export const Qwen36Deployment = () => {
   const generateCommand = () => {
     const { hardware, modelSize, quantization, speculative } = values;
     const sizeConfig = modelConfigs[modelSize];
+
+    // Atlas 800I A3 (Ascend NPU): PD-mixed single-node serving. Follows the
+    // verified recipes in the Ascend NPU best practices — ascend attention
+    // backend, bfloat16 mamba state, NEXTN speculative decoding on the built-in
+    // MTP weights, and modelslim W8A8 checkpoints for the 27B dense variant.
+    if (hardware === 'a3') {
+      const cards = Number(values.npuCards) || 1;
+      const modelName = quantization === 'w8a8'
+        ? `Eco-Tech/Qwen3.6-${sizeConfig.baseName}-w8a8`
+        : `Qwen/Qwen3.6-${sizeConfig.baseName}`;
+      let cmd = `sglang serve --model-path ${modelName}`;
+      cmd += ` \\\n  --tp-size ${cards * 2} --nnodes 1`;
+      cmd += ` \\\n  --attention-backend ascend --device npu`;
+      if (quantization === 'w8a8') {
+        cmd += ` \\\n  --quantization modelslim`;
+      }
+      const reasoningRule = options.reasoning.commandRule(values.reasoning, values);
+      if (reasoningRule) cmd += ` \\\n  ${reasoningRule}`;
+      const toolcallRule = options.toolcall.commandRule(values.toolcall, values);
+      if (toolcallRule) cmd += ` \\\n  ${toolcallRule}`;
+      if (speculative === 'enabled') {
+        cmd += ` \\\n  --speculative-algorithm NEXTN --speculative-num-steps 3 \\\n  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`;
+      }
+      cmd += ` \\\n  --mamba-ssm-dtype bfloat16`;
+      cmd += ` \\\n  --mem-fraction-static 0.7`;
+      cmd += ` \\\n  --host 0.0.0.0 --port 30000`;
+      return cmd;
+    }
+
     const hwConfig = sizeConfig?.[hardware]?.[quantization];
     if (!hwConfig) {
       return '# Please select a valid hardware and quantization combination';
@@ -210,7 +264,7 @@ export const Qwen36Deployment = () => {
       if (key === 'quantization' || key === 'hardware' || key === 'modelSize') continue;
       if (option.condition && !option.condition(values)) continue;
       if (!option.commandRule) continue;
-      const rule = option.commandRule(adjustedValues[key]);
+      const rule = option.commandRule(adjustedValues[key], values);
       if (rule) {
         cmd += ` \\\n  ${rule}`;
       }


### PR DESCRIPTION
## Summary

Extend the Qwen3.6 cookbook with **Ascend NPU (Atlas 800I A3) deployment scenarios** (task: Ascend/sglang#1219):

- **Interactive command generator** (`qwen36-deployment.jsx`): new `A3 (NPU)` hardware option with a card-count selector (each A3 card has 2 dies, so `--tp-size` is twice the card count), BF16 for both variants plus modelslim W8A8 for the 27B dense variant, NEXTN speculative decoding on the built-in MTP weights, `ascend` attention backend, and bfloat16 mamba state (the V2 mamba radix cache stays NVIDIA-only and is hidden on NPU).
- **Cookbook page** (`Qwen3.6.mdx`): Ascend container image in the install section, an A3 configuration-tips bullet, and a new *Deploying on Ascend NPUs* section — weight checkpoints (incl. [Eco-Tech/Qwen3.6-27B-w8a8](https://www.modelscope.cn/models/Eco-Tech/Qwen3.6-27B-w8a8)), model/card matrix, verified PD-mixed benchmark summary, and links to the Ascend NPU best-practice recipes and evaluation guides.

Recipes follow the verified Qwen3.6-27B / Qwen3.6-35B-A3B Atlas 800I A3 PD-mixed scenarios in `docs/docs/hardware-platforms/ascend-npus`.

## Verification (real Atlas 800I A3, 1 card / 2 dies x 64GB, CANN 9.0.0, SGLang v0.5.16)

1xA3 PD co-located (PD mixed, single-node) deployment verified on hardware with **Qwen3.6-27B**:

- **Service startup**: BF16 checkpoint starts cleanly on both TP1 (single die) and TP2 (both dies) — no hangs, no abnormal logs, no runtime errors.
- **Functional**: `/generate` and `/v1/chat/completions` return valid responses (factual/math spot checks all correct).
- **Performance**: `bench_serving` (random, in3500/out1500, max-concurrency 54 — same shape as the documented W8A8 1P scenario): **TPOT 31.2 ms**, better than the 50 ms reference target from the best-practice page.
- Lint: `node docs/scripts/check_cookbook_configs.mjs` passes; JSX compiles (esbuild); page verified rendering in `mint dev`.

Two environment findings (pip-installed stack; not reproducible in the official `quay.io/ascend/sglang` image per the published best-practice numbers), will be reported upstream separately:

- TP2 requires a recent `sgl-kernel-npu` (>= 2026.9.x): the public 2026.05.01.post3 wheel linked from the version-mapping table crashes in `mega_chunk_gdn` with split heads.
- The W8A8 (modelslim) checkpoint loads and serves, but produces garbled output on the public pip stack (weights byte-verified; tested with upstream v0.5.16 and Ascend fork main, both kernel versions).

## How to test

```bash
cd docs
node scripts/check_cookbook_configs.mjs
mint dev   # open /cookbook/autoregressive/Qwen/Qwen3.6 and select 'A3 (NPU)'
```

Task: Ascend/sglang#1219 · cc @amote-i

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34349574361](https://github.com/sgl-project/sglang/actions/runs/34349574361)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34349574075](https://github.com/sgl-project/sglang/actions/runs/34349574075)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->