### PR TITLE
[SpecDecode] Add opt-in compact TP4 linear target verification

### DIFF
--- a/benchmark/kernels/bench_compact_spec_verify.py
+++ b/benchmark/kernels/bench_compact_spec_verify.py
@@ -10,12 +10,12 @@ from pathlib import Path
 import torch
 import torch.distributed as dist
 
-from sglang.srt.speculative.compact_verify.core import Verify
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
     MultimemAllGatherer,
 )
 from sglang.srt.distributed.parallel_state import cleanup_dist_env_and_memory
+from sglang.srt.speculative.compact_verify.core import Verify
 from sglang.srt.speculative.compact_verify.engine import (
     ServingVerifier,
     runtime_supported,

--- a/benchmark/kernels/bench_compact_spec_verify.py
+++ b/benchmark/kernels/bench_compact_spec_verify.py
@@ -1,0 +1,223 @@
+"""Serving-path operator comparison against SGLang's multimem gather."""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.speculative.compact_verify.core import Verify
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
+    MultimemAllGatherer,
+)
+from sglang.srt.distributed.parallel_state import cleanup_dist_env_and_memory
+from sglang.srt.speculative.compact_verify.engine import (
+    ServingVerifier,
+    runtime_supported,
+)
+
+
+def fixture(b, k, v, rank, tp, kind):
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(1847)
+    # Identical full fixture on all ranks; release target full logits before timing.
+    target = torch.randn((b, k + 1, v), generator=gen, device=device).to(torch.bfloat16)
+    q = torch.softmax(
+        target[:, :k].float()
+        + 0.5 * torch.randn((b, k, v), generator=gen, device=device),
+        -1,
+    )
+    candidates = torch.randint(
+        v, (b, k + 1), generator=gen, device=device, dtype=torch.int32
+    )
+    coins = torch.rand((b, k + 1), generator=gen, device=device)
+    final = torch.rand(b, generator=gen, device=device)
+    if kind == "identical":
+        q = torch.softmax(target[:, :k].float(), -1)
+    candidates[:, 1:] = (
+        torch.multinomial(q.reshape(-1, v), 1, generator=gen).view(b, k).int()
+    )
+    if kind == "all_accept":
+        coins.zero_()
+    elif kind in ("first_reject", "last_reject"):
+        step = 0 if kind == "first_reject" else k - 1
+        coins.zero_()
+        coins[:, step] = 0.999
+        for i in range(b):
+            target[i, step, candidates[i, step + 1]] = -20
+    local = target[..., rank * (v // tp) : (rank + 1) * (v // tp)].contiguous()
+    return Verify(local, q, candidates, coins, final)
+
+
+def _init_distributed():
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.runtime_context import publish
+    from sglang.srt.server_args import ServerArgs
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    publish(ServerArgs(model_path="dummy", tp_size=world_size), role="scheduler")
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+    return rank, world_size
+
+
+def measure(fn):
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
+    values = []
+    for _ in range(30):
+        dist.barrier()
+        start, end = (
+            torch.cuda.Event(enable_timing=True),
+            torch.cuda.Event(enable_timing=True),
+        )
+        start.record()
+        output = fn()
+        end.record()
+        end.synchronize()
+        value = torch.tensor(
+            start.elapsed_time(end) * 1000, device="cuda", dtype=torch.float64
+        )
+        dist.all_reduce(value, op=dist.ReduceOp.MAX)
+        values.append(value.item())
+        del output
+    return {
+        "samples_us": values,
+        "p50_us": statistics.median(values),
+        "p90_us": float(torch.tensor(values, dtype=torch.float64).quantile(0.9)),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    rank, tp = _init_distributed()
+    assert tp == 4 and runtime_supported()
+    root = Path(__file__).resolve().parents[2]
+    assert not subprocess.check_output(
+        ["git", "status", "--porcelain"], cwd=root, text=True
+    ).strip()
+    sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+    obj = fixture(128, 7, 154880, rank, tp, "random")
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    initial_alloc = torch.cuda.memory_allocated()
+    initial_free = torch.cuda.mem_get_info()[0]
+    gather = MultimemAllGatherer(max_tokens=1024, enabled=True, skip_entry_sync=True)
+    group = get_tp_group()
+
+    def baseline():
+        full = gather(obj.local.flatten(0, 1)).float().view(128, 8, 154880)
+        p = torch.softmax(full, -1)
+        output = obj.sample(p, obj.q, obj.candidates, obj.idx, obj.coins)
+        for value in output:
+            group.broadcast(value, 0)
+        return output
+
+    for _ in range(3):
+        expected = baseline()
+    assert gather._state is not None and gather._state.symm_mem_hdl.multicast_ptr != 0
+    del expected
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    graph_a = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(stream):
+        with torch.cuda.graph(graph_a):
+            output_a = baseline()
+    stream.synchronize()
+    a_memory = {
+        "extra_peak_allocated": torch.cuda.max_memory_allocated() - initial_alloc,
+        "extra_live_device": initial_free - torch.cuda.mem_get_info()[0],
+    }
+    graph_a.replay()
+    torch.cuda.synchronize()
+    before_c_alloc = torch.cuda.memory_allocated()
+    before_c_free = torch.cuda.mem_get_info()[0]
+    torch.cuda.reset_peak_memory_stats()
+    runner = ServingVerifier(
+        obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+    )
+    output_c = runner.run()
+    torch.cuda.synchronize()
+    for actual, expected in zip(output_c[:3], output_a):
+        torch.testing.assert_close(actual.flatten(), expected.flatten(), rtol=0, atol=0)
+    c_memory = {
+        "extra_peak_allocated": torch.cuda.max_memory_allocated() - before_c_alloc,
+        "extra_live_device": before_c_free - torch.cuda.mem_get_info()[0],
+    }
+
+    def candidate():
+        runner.bind(
+            obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+        )
+        return runner.run()
+
+    reports = []
+    for repairs in (0, 5):
+        runner.force_flags.zero_()
+        runner.force_flags[:repairs] = True
+        reports.append(
+            {
+                "forced_repairs": repairs,
+                "blocks": [
+                    measure(fn)
+                    for fn in (graph_a.replay, candidate, candidate, graph_a.replay)
+                ],
+            }
+        )
+    memory = [None] * 4
+    dist.all_gather_object(memory, {"baseline": a_memory, "candidate": c_memory})
+    graph_a.reset()
+    runner.close()
+    cleanup_dist_env_and_memory()
+    if rank == 0:
+        result = {
+            "source": sha,
+            "status": "PASS",
+            "baseline": "SGLang multimem + original sampler + TP broadcast, captured",
+            "candidate": "serving graph including input/pointer binding",
+            "batch": 128,
+            "drafts": 7,
+            "cells": reports,
+            "memory_per_rank": memory,
+            "normal_shutdown": True,
+        }
+        args.output.write_text(json.dumps(result, indent=2))
+        print(
+            json.dumps(
+                {
+                    "source": sha,
+                    "status": "PASS",
+                    "p50_blocks": [[x["p50_us"] for x in r["blocks"]] for r in reports],
+                    "memory": memory,
+                }
+            ),
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2928,6 +2928,11 @@ def get_moe_tensor_parallel_rank():
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
+    import sys
+
+    compact = sys.modules.get("sglang.srt.speculative.compact_verify.engine")
+    if compact is not None:
+        compact.close_all()
     get_parallel().clear_derived_widths()
     dwdp_mgr = get_global_dwdp_manager()
     if dwdp_mgr is not None:
@@ -2982,6 +2987,11 @@ def destroy_model_parallel():
 
 
 def destroy_distributed_environment():
+    import sys
+
+    compact = sys.modules.get("sglang.srt.speculative.compact_verify.engine")
+    if compact is not None:
+        compact.close_all()
     global _WORLD, _MODEL_PARALLEL_GROUP_TIMEOUT
     if _WORLD:
         _WORLD.destroy()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1200,6 +1200,9 @@ class Envs:
     # Logits and log-probability processing
     # ===================================================================
     SGLANG_RETURN_ORIGINAL_LOGPROB = EnvBool(False)
+    # Opt-in TP4 linear rejection verifier for the qualified GB200 runtime.
+    SGLANG_ENABLE_COMPACT_SPEC_VERIFY = EnvBool(False)
+    SGLANG_COMPACT_SPEC_VERIFY_SHADOW = EnvBool(False)
     # Sanitize NaN logits before sampling kernels and log a throttled warning
     # (see sanitize_nan_logits).
     SGLANG_SANITIZE_NAN_LOGITS = EnvBool(False)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -232,6 +232,7 @@ class LogitsProcessorOutput:
 
     # Scheduler-local output copied alongside the ordinary generation result.
     auxiliary_device_output: Optional[DeviceAuxiliaryOutput] = None
+    compact_verify_sharded: bool = False
 
 
 @dataclasses.dataclass
@@ -239,6 +240,7 @@ class LogitsMetadata:
     forward_mode: ForwardMode
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.NULL
     next_token_logits_buffer: Optional[torch.Tensor] = None
+    compact_verify_sharded: bool = False
 
     extend_return_logprob: bool = False
     extend_return_top_logprob: bool = False
@@ -506,6 +508,7 @@ class LogitsProcessor(nn.Module):
             # Decode mode or extend mode without return_logprob.
             return LogitsProcessorOutput(
                 next_token_logits=sampled_logits,
+                compact_verify_sharded=logits_metadata.compact_verify_sharded,
                 hidden_states=hidden_states_to_store,
                 mm_input_embeds=logits_metadata.mm_input_embeds,
             )
@@ -810,6 +813,52 @@ class LogitsProcessor(nn.Module):
 
         if self.logit_scale is not None:
             logits.mul_(self.logit_scale)
+
+        if (
+            envs.SGLANG_ENABLE_COMPACT_SPEC_VERIFY.get()
+            and logits_metadata.forward_mode.is_target_verify()
+        ):
+            from sglang.srt.speculative.compact_verify.config import configured
+
+            if (
+                configured()
+                and self.vocab_size == 154880
+                and self.do_tensor_parallel_all_gather
+                and not self.do_tensor_parallel_all_gather_dp_attn
+                and not self.use_attn_tp_group
+                and not self.final_logit_softcapping
+                and isinstance(lm_head, VocabParallelEmbedding)
+                and getattr(lm_head, "enable_tp", False)
+                and lm_head.org_vocab_size == lm_head.num_embeddings == 154880
+                and logits.dtype == torch.bfloat16
+                and logits.shape[-1] == 38720
+                and not hasattr(lm_head, "apply_lora")
+            ):
+                shard = lm_head.shard_indices
+                if (
+                    shard.org_vocab_start_index == get_parallel().tp_rank * 38720
+                    and shard.org_vocab_end_index - shard.org_vocab_start_index == 38720
+                ):
+                    logits_metadata.compact_verify_sharded = True
+                    if not getattr(self, "_logged_compact_verify", False):
+                        logger.info(
+                            "COMPACT_SPEC_LOGITS owner_sharded=True local_vocab=38720 rows=%d",
+                            logits.shape[0],
+                        )
+                        self._logged_compact_verify = True
+                    buffer = (
+                        logits_metadata.next_token_logits_buffer
+                        if use_logits_buffer
+                        else None
+                    )
+                    if (
+                        buffer is not None
+                        and buffer.shape == logits.shape
+                        and buffer.dtype == logits.dtype
+                    ):
+                        buffer.copy_(logits)
+                        return buffer
+                    return logits
 
         used_tp_lm_head_all_to_all = False
         if self.do_tensor_parallel_all_gather:

--- a/python/sglang/srt/model_executor/graph_shared_output.py
+++ b/python/sglang/srt/model_executor/graph_shared_output.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class GraphSharedOutput:
     """``(max_rows, vocab)`` logits buffer, shared by every cuda-graph runner."""
 
-    _process_shared: Optional[GraphSharedOutput] = None
+    _process_shared: GraphSharedOutput | None = None
 
     def __init__(
         self,
@@ -26,12 +26,13 @@ class GraphSharedOutput:
     ) -> None:
         self.device = torch.device(device)
         self.max_rows = max_rows
-        self._logits_buffers: Dict[int, torch.Tensor] = {}
+        self._logits_buffers: dict[int, torch.Tensor] = {}
+        self._compact_logits_buffer = None
 
     @classmethod
     def create_for_model_runner(
         cls, model_runner: ModelRunner
-    ) -> Optional[GraphSharedOutput]:
+    ) -> GraphSharedOutput | None:
         cuda_graph_config = get_exec().graph.cuda_graph_config
         if cuda_graph_config is None:
             return None
@@ -45,6 +46,11 @@ class GraphSharedOutput:
             return None
 
         device = torch.device(model_runner.device)
+        from sglang.srt.speculative.compact_verify.config import sharded_graph_output
+
+        if sharded_graph_output(model_runner):
+            # Do not enlarge the draft runner's full-vocab pool to target R.
+            return cls(device=device, max_rows=max_rows)
         shared = cls._process_shared
         if (
             shared is not None
@@ -67,3 +73,11 @@ class GraphSharedOutput:
             )
             self._logits_buffers[vocab_size] = buffer
         return buffer[:rows]
+
+    def get_compact_logits_buffer(self, *, rows: int) -> torch.Tensor:
+        assert rows <= self.max_rows
+        if self._compact_logits_buffer is None:
+            self._compact_logits_buffer = torch.zeros(
+                (self.max_rows, 38720), device=self.device, dtype=torch.bfloat16
+            )
+        return self._compact_logits_buffer[:rows]

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -407,14 +407,23 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             assert self.require_mlp_tp_gather or self.require_attn_tp_gather
 
         # --- buffers ---------------------------------------------------
+        from sglang.srt.speculative.compact_verify.config import sharded_graph_output
+
+        logits_buffer = (
+            self.model_runner.graph_shared_output.get_compact_logits_buffer(
+                rows=self.max_num_token
+            )
+            if sharded_graph_output(self.model_runner)
+            else self.model_runner.graph_shared_output.get_logits_buffer(
+                self.model_runner.model_config.vocab_size, rows=self.max_num_token
+            )
+        )
         self.buffers: DecodeInputBuffers = DecodeInputBuffers.create(
             device=self.device,
             max_bs=self.max_bs,
             max_num_token=self.max_num_token,
             hidden_size=self.model_runner.model_config.hidden_size,
-            next_token_logits_buffer=self.model_runner.graph_shared_output.get_logits_buffer(
-                self.model_runner.model_config.vocab_size, rows=self.max_num_token
-            ),
+            next_token_logits_buffer=logits_buffer,
             dtype=self.model_runner.model_config.dtype,
             dp_size=self.dp_size,
             pp_size=self.pp_size,
@@ -1503,6 +1512,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
             return LogitsProcessorOutput(
                 next_token_logits=next_token_logits,
+                compact_verify_sharded=output.compact_verify_sharded,
                 full_logits=full_logits,
                 hidden_states=(
                     output.hidden_states[: self.raw_num_token]

--- a/python/sglang/srt/speculative/compact_verify/README.md
+++ b/python/sglang/srt/speculative/compact_verify/README.md
@@ -1,0 +1,62 @@
+# Compact linear speculative verification
+
+Opt in with `SGLANG_ENABLE_COMPACT_SPEC_VERIFY=1`. The qualified route is
+single-node TP4 on SM100, BF16 GLM vocabulary 154880, linear rejection sampling,
+temperature 1 and no penalties, grammar, top-k/top-p/min-p or requested logprobs.
+Unqualified builds and request features use the original verifier. The engine
+checks the exact Torch revision and binary checksum before using this route.
+
+ASIS
+```text
+local target logits [R,V/TP]
+    -> full gather [R,V] -> full target probabilities [R,V]
+    -> acceptance and recovery
+```
+
+PR
+```text
+local target logits [R,V/TP]
+    -> selected probabilities and error intervals [R]
+    -> uncertain rows: original softmax in bounded peer-read chunks
+    -> acceptance -> one recovery/bonus row per request
+```
+
+## Numerical contract
+
+The input to the reference exponential is the FP32 shifted logit. The SM100
+instruction sequence in `exp_dag.py` was compared exhaustively with the pinned
+Torch exponential for all 1,115,684,865 negative FP32 bit patterns from -0 to
+-64, plus positive zero. Profiling confirmed the corresponding Torch kernel
+variants; reference SASS uses the same normal-range exponential operations.
+Power-of-two exponent scaling remains exact in this normal range even where
+the reference fuses it into an accumulation FMA.
+
+For V154880 the reference per-thread sum plus block reduction has depth less
+than 2048. With FP32 unit roundoff u=2^-24, gamma_2048 is about 0.000122085.
+FP64 local/global accumulation has gamma_(V+4) below 1.8e-11. Including final
+division and interval endpoint rounding, the relative deviation from the
+FP64 center is below 0.000122160 under this qualified operation contract.
+The interval radius 2^-10 is conservative. FP32 shifted ranges wider than 64,
+or nonfinite ranges, are recomputed through original row softmax.
+
+A decision is used directly only outside the interval. Every ambiguous row
+uses the original FP32 softmax, and recovery uses the original sampler's CDF
+kernel and random coins. This is a pinned-build argument, not a portability
+guarantee for arbitrary Torch/CUDA releases or devices.
+
+## Graph and ownership contract
+
+Local target inputs use stable symmetric storage. The draft probability tensor
+is not copied: a device pointer is rebound before replay, with `record_stream`
+protecting its lifetime. Idle graph caches do not retain that full tensor.
+All ranks share the root repair descriptor. NCCL stays outside conditional
+bodies; peer reads and original row softmax perform repairs inside them.
+
+The common branch repairs up to eight rows. A second branch processes all
+remaining rows in bounded chunks, so no invalid acceptance count can escape
+because of queue overflow. This finishes before SGLang updates KV/Mamba state.
+Both branches reuse one scratch pair. Captured graphs must be reset before
+their communication groups are destroyed; the distributed cleanup hooks do so.
+
+`SGLANG_COMPACT_SPEC_VERIFY_SHADOW=1` enables the expensive same-logits reference
+comparison. Use it for validation only, not performance measurements.

--- a/python/sglang/srt/speculative/compact_verify/README.md
+++ b/python/sglang/srt/speculative/compact_verify/README.md
@@ -60,3 +60,15 @@ their communication groups are destroyed; the distributed cleanup hooks do so.
 
 `SGLANG_COMPACT_SPEC_VERIFY_SHADOW=1` enables the expensive same-logits reference
 comparison. Use it for validation only, not performance measurements.
+
+## Tests
+
+```bash
+PYTHONPATH=python pytest test/registered/unit/sampling/test_compact_verify_config.py
+CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python COMPACT_TEST_OUTPUT=/tmp/compact_verify.json \
+  torchrun --standalone --nproc-per-node=4 test/manual/test_compact_spec_verify.py
+```
+
+The manual test requires the qualified runtime and four GPUs. Acquire their
+lease before running it. It covers live q-pointer changes, index permutation,
+the source NaN-q rule, repair overflow, actual `eagle_sample`, and clean shutdown.

--- a/python/sglang/srt/speculative/compact_verify/__init__.py
+++ b/python/sglang/srt/speculative/compact_verify/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in compact linear speculative verification for a pinned runtime."""

--- a/python/sglang/srt/speculative/compact_verify/config.py
+++ b/python/sglang/srt/speculative/compact_verify/config.py
@@ -1,0 +1,58 @@
+"""CPU-side eligibility for the optional compact verifier."""
+
+from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_device, get_parallel, get_spec
+
+
+def configured():
+    if not envs.SGLANG_ENABLE_COMPACT_SPEC_VERIFY.get():
+        return False
+    p, s = get_parallel(), get_spec()
+    return (
+        get_device().device == "cuda"
+        and p.tp_size == 4
+        and p.pp_size == 1
+        and p.dp_size == 1
+        and p.dcp_size == 1
+        and p.attn_cp_size == 1
+        and p.nnodes == 1
+        and p.attn_dp_size in (None, 1)
+        and s.speculative_use_rejection_sampling
+        and s.speculative_eagle_topk == 1
+        and s.speculative_algorithm in ("EAGLE", "EAGLE3", "NEXTN")
+    )
+
+
+def sharded_graph_output(model_runner):
+    import torch
+
+    return (
+        configured()
+        and not model_runner.is_draft_worker
+        and model_runner.model_config.vocab_size == 154880
+        and model_runner.model_config.dtype == torch.bfloat16
+        and not getattr(
+            model_runner.model_config.hf_config, "final_logit_softcapping", None
+        )
+    )
+
+
+def sampling_supported(verify, batch, grammar_mask):
+    s = batch.sampling_info
+    return (
+        grammar_mask is None
+        and not batch.return_logprob
+        and verify.tree_topk == 1
+        and verify.max_tree_depth == verify.draft_token_num
+        and verify.draft_token_num >= 2
+        and not s.is_any_greedy
+        and not s.need_top_k_sampling
+        and not s.need_top_p_sampling
+        and not s.need_min_p_sampling
+        and not s.has_custom_logit_processor
+        and s.acc_additive_penalties is None
+        and s.acc_scaling_penalties is None
+        and s.logit_bias is None
+        and all(req.sampling_params.temperature == 1.0 for req in batch.reqs)
+        and not any(s.return_sampling_masks or [])
+    )

--- a/python/sglang/srt/speculative/compact_verify/core.py
+++ b/python/sglang/srt/speculative/compact_verify/core.py
@@ -1,0 +1,73 @@
+"""Shared storage and original-sampler reference for compact verification."""
+
+import torch
+import torch.distributed as dist
+
+
+def load_reference():
+    from sglang.kernels.ops.speculative.reject_sampling import (
+        chain_speculative_sampling_triton,
+    )
+
+    return chain_speculative_sampling_triton
+
+
+class Verify:
+    def __init__(self, local, q, candidates, coins, final_coins):
+        self.local, self.q = local, q
+        self.candidates, self.coins, self.final_coins = candidates, coins, final_coins
+        self.b, self.s, self.lv = local.shape
+        self.r = self.b * self.s
+        self.tp, self.rank = dist.get_world_size(), dist.get_rank()
+        self.v = self.lv * self.tp
+        self.idx = torch.arange(self.r, device=local.device, dtype=torch.int32).view(
+            self.b, self.s
+        )
+        self.ref = load_reference()
+        self.batch_idx = torch.arange(self.b, device=local.device)
+        # Acceptance at row j consumes candidate j+1; bonus row statistic unused.
+        self.targets = (
+            torch.cat((candidates[:, 1:], candidates[:, :1]), 1).reshape(-1).long()
+        )
+        self.local_ids = (self.targets - self.rank * self.lv).clamp(0, self.lv - 1)
+        self.owned = (self.targets >= self.rank * self.lv) & (
+            self.targets < (self.rank + 1) * self.lv
+        )
+        self.row_idx = torch.arange(self.r, device=local.device)
+
+    def gather(self, local):
+        shape = local.shape
+        out = torch.empty((self.tp, *shape), device=local.device, dtype=local.dtype)
+        dist.all_gather_into_tensor(
+            out.view(-1, shape[-1]), local.reshape(-1, shape[-1]).contiguous()
+        )
+        return out.movedim(0, -2).reshape(*shape[:-1], self.v)
+
+    def sample(self, p, q, candidates, idx, coins):
+        b, s = candidates.shape
+        predict = torch.zeros((b, s), dtype=torch.int32, device=p.device)
+        accept_idx = torch.full_like(predict, -1)
+        count = torch.empty(b, dtype=torch.int32, device=p.device)
+        self.ref(
+            predict,
+            accept_idx,
+            count,
+            candidates,
+            idx,
+            None,
+            None,
+            coins,
+            self.final_coins,
+            p,
+            q,
+            1.0,
+            1.0,
+            True,
+        )
+        return predict, accept_idx, count
+
+    def baseline(self):
+        full = self.gather(self.local).float()
+        p = torch.softmax(full, -1)
+        result = self.sample(p, self.q, self.candidates, self.idx, self.coins)
+        return (*result, p)

--- a/python/sglang/srt/speculative/compact_verify/engine.py
+++ b/python/sglang/srt/speculative/compact_verify/engine.py
@@ -1,0 +1,241 @@
+"""Graph cache and live draft-probability binding for compact verification."""
+
+import atexit
+import hashlib
+import logging
+from collections import OrderedDict
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+
+from sglang.srt.environ import envs
+from sglang.srt.speculative.compact_verify.peer_graph import ConditionalPeerVerify
+
+logger = logging.getLogger(__name__)
+_cache = OrderedDict()
+_runtime_ok = None
+
+
+@triton.jit
+def _q_selected(
+    Ptr,
+    Candidates,
+    Out,
+    K: tl.constexpr,
+    S: tl.constexpr,
+    V: tl.constexpr,
+    R: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    ptr = tl.load(Ptr).to(tl.pointer_type(tl.float32))
+    token = tl.load(Candidates + (i // K) * S + i % K + 1, i < R, other=0)
+    value = tl.load(ptr + i * V + token, i < R, other=0)
+    tl.store(Out + i, value, i < R)
+
+
+@triton.jit
+def _accept_pointer(P, Ptr, Candidates, Coins, Count, S: tl.constexpr, V: tl.constexpr):
+    b = tl.program_id(0)
+    qptr = tl.load(Ptr).to(tl.pointer_type(tl.float32))
+    n, active = 0, 1
+    for j in range(S - 1):
+        token = tl.load(Candidates + b * S + j + 1)
+        p = tl.load(P + b * S + j)
+        q = tl.load(qptr + (b * (S - 1) + j) * V + token)
+        u = tl.load(Coins + b * S + j)
+        active = active & (u * q < p)
+        n += active
+    tl.store(Count + b, n)
+
+
+@triton.jit
+def _q_recovery(
+    Ptr, Counts, Out, K: tl.constexpr, V: tl.constexpr, BLOCK: tl.constexpr
+):
+    b, tile = tl.program_id(0), tl.program_id(1)
+    col = tile * BLOCK + tl.arange(0, BLOCK)
+    row = tl.minimum(tl.load(Counts + b), K - 1)
+    ptr = tl.load(Ptr).to(tl.pointer_type(tl.float32))
+    q = tl.load(ptr + (b * K + row) * V + col, col < V, other=0)
+    tl.store(Out + b * V + col, q, col < V)
+
+
+def runtime_supported():
+    global _runtime_ok
+    if _runtime_ok is None:
+        _runtime_ok = (
+            torch.version.git_version == "cf30153c4c131c8164ee7798e5022d810682e2cb"
+            and torch.cuda.is_available()
+            and torch.cuda.get_device_capability() == (10, 0)
+            and dist.get_world_size() == 4
+            and dist.get_backend() == "nccl"
+        )
+        if _runtime_ok:
+            library = Path(torch.__file__).parent / "lib/libtorch_cuda.so"
+            with library.open("rb") as source:
+                _runtime_ok = (
+                    hashlib.file_digest(source, "sha256").hexdigest()
+                    == "3db19ad428ce41d67d5267cae04872e101a4cf72449eee27cfc4c424f6eb50b7"
+                )
+        if not _runtime_ok:
+            logger.warning("COMPACT_SPEC_VERIFY fallback=unqualified_runtime")
+    return _runtime_ok
+
+
+class ServingVerifier(ConditionalPeerVerify):
+    def __init__(self, local, q, candidates, coins, final_coins, indices):
+        super().__init__(
+            local,
+            q,
+            candidates.clone(),
+            coins.clone(),
+            final_coins.clone(),
+            capacity=min(8, local.shape[0] * local.shape[1]),
+        )
+        # The shared buffer is also the stable graph input. No second local-logit
+        # buffer or full draft-q staging buffer is required.
+        self.local = self.shared
+        self.qptr = torch.empty(1, dtype=torch.int64, device=local.device)
+        self.dummy_q = torch.zeros((1, 1, 1), device=local.device)
+        self.bind(local, q, candidates, coins, final_coins, indices)
+        self.graph = None
+
+    def bind(self, local, q, candidates, coins, final_coins, indices):
+        self.local.copy_(local)
+        self.candidates.copy_(candidates)
+        self.coins.copy_(coins)
+        self.final_coins.copy_(final_coins)
+        self.idx.copy_(indices)
+        # Keep the tensor alive and record its use on the graph replay stream;
+        # only its pointer, not B*K*V probability data, is staged.
+        self.q = q
+        pointer = torch.tensor([q.data_ptr()], dtype=torch.int64, pin_memory=True)
+        self.qptr.copy_(pointer, non_blocking=True)
+        q.record_stream(torch.cuda.current_stream())
+
+    def uncertainty_flags(self, p):
+        k = self.s - 1
+        q = torch.empty((self.b, k), device=p.device, dtype=torch.float32)
+        _q_selected[(triton.cdiv(self.b * k, 256),)](
+            self.qptr, self.candidates, q, k, self.s, self.v, self.b * k, 256
+        )
+        product = (self.coins[:, :k] * q).double()
+        lo = self.lower.view(self.b, self.s)[:, :k]
+        hi = self.upper.view(self.b, self.s)[:, :k]
+        flags = ~((product < lo) | (product >= hi))
+        return torch.cat(
+            (flags, torch.zeros((self.b, 1), device=p.device, dtype=torch.bool)), 1
+        ).flatten()
+
+    def finish(self, p):
+        count = torch.empty(self.b, device=p.device, dtype=torch.int32)
+        _accept_pointer[(self.b,)](
+            p, self.qptr, self.candidates, self.coins, count, self.s, self.v
+        )
+        dist.broadcast(count, 0)
+        recovery_p = torch.softmax(
+            self.gather(self.local[self.batch_idx, count.long()]).float(), -1
+        )
+        recovery_q = torch.empty_like(recovery_p)
+        _q_recovery[(self.b, triton.cdiv(self.v, 2048))](
+            self.qptr, count, recovery_q, self.s - 1, self.v, 2048
+        )
+        recovery_q = torch.where(torch.isnan(recovery_q), 0, recovery_q)
+        difference = recovery_p - recovery_q
+        residual = torch.where(
+            (count == self.s - 1)[:, None],
+            recovery_p,
+            torch.where(difference > 0, difference, 0),
+        )
+        final_idx = torch.arange(self.b, device=p.device, dtype=torch.int32)[:, None]
+        final, _, _ = self.sample(
+            residual[:, None],
+            self.dummy_q,
+            self.candidates[:, :1].contiguous(),
+            final_idx,
+            self.coins[:, :1].contiguous(),
+        )
+        positions = torch.arange(self.s, device=p.device)[None, :]
+        shifted = torch.cat((self.candidates[:, 1:], self.candidates[:, :1]), 1).int()
+        local_predict = torch.where(positions < count[:, None], shifted, 0)
+        local_predict.scatter_(1, count.long()[:, None], final)
+        predict = torch.zeros_like(local_predict).flatten()
+        predict.scatter_(0, self.idx.flatten().long(), local_predict.flatten())
+        accepted = torch.where(positions <= count[:, None], self.idx, -1)
+        dist.broadcast(predict, 0)
+        dist.broadcast(accepted, 0)
+        return predict, accepted, count, p
+
+    def run(self):
+        if self.graph is None:
+            self.graph, self.output = self.capture()
+        self.graph.replay()
+        return self.output
+
+    def close(self):
+        if self.graph is not None:
+            torch.cuda.synchronize()
+            self.graph.reset()
+            self.graph = None
+
+
+def close_all():
+    for runner in _cache.values():
+        runner.close()
+    _cache.clear()
+
+
+atexit.register(close_all)
+
+
+def sample(local, q, candidates, coins, final_coins, indices):
+    if not runtime_supported():
+        return None
+    b, s = candidates.shape
+    if not 1024 <= b * s <= 4096 or (b * s) % 16:
+        return None
+    if local.dtype != torch.bfloat16 or local.shape != (b * s, 38720):
+        return None
+    if (
+        q is None
+        or q.dtype != torch.float32
+        or q.shape != (b, s - 1, 154880)
+        or not q.is_contiguous()
+    ):
+        return None
+    key = (b, s)
+    local = local.view(b, s, 38720)
+    if key not in _cache:
+        if len(_cache) >= 2:
+            _, old = _cache.popitem(last=False)
+            old.close()
+        _cache[key] = ServingVerifier(local, q, candidates, coins, final_coins, indices)
+        logger.info(
+            "COMPACT_SPEC_VERIFY route=conditional_peer rows=%d full_target_gather=False",
+            b * s,
+        )
+    else:
+        _cache[key].bind(local, q, candidates, coins, final_coins, indices)
+        _cache.move_to_end(key)
+    output = _cache[key].run()
+    if envs.SGLANG_COMPACT_SPEC_VERIFY_SHADOW.get():
+        runner = _cache[key]
+        reference = runner.baseline()
+        for actual, expected in zip(output[:3], reference[:3]):
+            torch.testing.assert_close(
+                actual.flatten(), expected.flatten(), rtol=0, atol=0
+            )
+        logger.info(
+            "COMPACT_SPEC_VERIFY_SHADOW exact=True rows=%d repaired_rows=%d range_fallback_rows=%d",
+            b * s,
+            int(output[4]),
+            int(runner.domain_invalid_rows.sum()),
+        )
+    # The graph follows qptr; keep no full draft distribution in an idle cache.
+    # record_stream() in bind protects the input until replay has consumed it.
+    _cache[key].q = None
+    return output[0], output[2] + 1, output[1]

--- a/python/sglang/srt/speculative/compact_verify/engine.py
+++ b/python/sglang/srt/speculative/compact_verify/engine.py
@@ -44,7 +44,7 @@ def _accept_pointer(P, Ptr, Candidates, Coins, Count, S: tl.constexpr, V: tl.con
     n, active = 0, 1
     for j in range(S - 1):
         token = tl.load(Candidates + b * S + j + 1)
-        p = tl.load(P + b * S + j)
+        p = tl.load(P + b * S + j).to(tl.float32)
         q = tl.load(qptr + (b * (S - 1) + j) * V + token)
         u = tl.load(Coins + b * S + j)
         active = active & (u * q < p)

--- a/python/sglang/srt/speculative/compact_verify/exp_dag.py
+++ b/python/sglang/srt/speculative/compact_verify/exp_dag.py
@@ -1,0 +1,83 @@
+"""Normal-range exp sequence audited against the pinned SM100 Torch binary."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def reference_exp(x):
+    return tl.inline_asm_elementwise(
+        """{
+        .reg .f32 a,n,k,r,e,s;
+        .reg .b32 bits;
+        fma.rn.sat.f32 a, $1, 0f3bbb989d, 0f3f000000;
+        fma.rm.f32 n, a, 0f437c0000, 0f4b400001;
+        add.rn.f32 k, n, 0fcb40007f;
+        neg.f32 k, k;
+        fma.rn.f32 r, $1, 0f3fb8aa3b, k;
+        fma.rn.f32 r, $1, 0f32a57060, r;
+        ex2.approx.ftz.f32 e, r;
+        mov.b32 bits, n;
+        shl.b32 bits, bits, 23;
+        mov.b32 s, bits;
+        mul.rn.f32 $0, s, e;
+        }""",
+        constraints="=f,f",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def partial_stats(
+    Z,
+    Maximum,
+    Targets,
+    Out,
+    R: tl.constexpr,
+    L: tl.constexpr,
+    T: tl.constexpr,
+    START: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row, tile = tl.program_id(0), tl.program_id(1)
+    col = tile * BLOCK + tl.arange(0, BLOCK)
+    z = tl.load(Z + row * L + col, col < L, other=0).to(tl.float32)
+    m = tl.load(Maximum + row)
+    e = reference_exp(z - m)
+    e = tl.where(col < L, e, 0)
+    target = tl.load(Targets + row)
+    total = tl.sum(e.to(tl.float64), 0)
+    selected = tl.sum(tl.where(col + START == target, e, 0).to(tl.float64), 0)
+    tl.store(Out + row * T + tile, total)
+    tl.store(Out + R * T + row * T + tile, selected)
+
+
+@triton.jit
+def gather_peer_rows(
+    P0, P1, P2, P3, Rows, Out, L: tl.constexpr, V: tl.constexpr, BLOCK: tl.constexpr
+):
+    slot, tile = tl.program_id(0), tl.program_id(1)
+    row = tl.maximum(tl.load(Rows + slot), 0)
+    col = tile * BLOCK + tl.arange(0, BLOCK)
+    owner, local_col = col // L, col % L
+    offset = row * L + local_col
+    a = tl.load(P0 + offset, (col < V) & (owner == 0), other=0, volatile=True)
+    b = tl.load(P1 + offset, (col < V) & (owner == 1), other=0, volatile=True)
+    c = tl.load(P2 + offset, (col < V) & (owner == 2), other=0, volatile=True)
+    d = tl.load(P3 + offset, (col < V) & (owner == 3), other=0, volatile=True)
+    value = tl.where(owner == 0, a, tl.where(owner == 1, b, tl.where(owner == 2, c, d)))
+    tl.store(Out + slot * V + col, value.to(tl.float32), col < V)
+
+
+@triton.jit
+def patch_from_softmax(
+    P, Probs, Rows, Targets, N: tl.constexpr, V: tl.constexpr, BLOCK: tl.constexpr
+):
+    slot = tl.arange(0, BLOCK)
+    row = tl.load(Rows + slot, slot < N, other=-1)
+    token = tl.load(Targets + tl.maximum(row, 0), (slot < N) & (row >= 0), other=0)
+    value = tl.load(Probs + slot * V + token, (slot < N) & (row >= 0), other=0)
+    tl.store(P + row, value, (slot < N) & (row >= 0))

--- a/python/sglang/srt/speculative/compact_verify/peer_graph.py
+++ b/python/sglang/srt/speculative/compact_verify/peer_graph.py
@@ -1,0 +1,84 @@
+"""Bounded GPU-only repairs through conditional peer reads, experimental."""
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as sm
+import triton
+
+from sglang.srt.speculative.compact_verify.exp_dag import (
+    gather_peer_rows,
+    patch_from_softmax,
+)
+from sglang.srt.speculative.compact_verify.queue import _queue
+from sglang.srt.speculative.compact_verify.source_bound import SourceBoundVerify
+
+
+class ConditionalPeerVerify(SourceBoundVerify):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shared = sm.empty(
+            *self.local.shape, dtype=self.local.dtype, device=self.local.device
+        )
+        self.shared.copy_(self.local)
+        self.handle = sm.rendezvous(self.shared, dist.group.WORLD)
+        self.peers = [
+            self.handle.get_buffer(r, (self.r, self.lv), self.local.dtype)
+            for r in range(4)
+        ]
+        self.scratch = torch.empty(
+            (self.capacity, self.v), device=self.local.device, dtype=torch.float32
+        )
+        self.probs = torch.empty_like(self.scratch)
+
+    def _body(self, graph):
+        self.shared.copy_(self.local)
+        # Stats collectives occur after publication of each rank's local copy.
+        p = self.selected_probabilities()
+        # Outside the interval domain: repair every row using the original
+        # softmax rather than exposing an invalid acceptance count to consumers.
+        flags = self.uncertainty_flags(p) | self.force_flags | self.domain_invalid_rows
+        descriptor = torch.full((self.r + 1,), -1, dtype=torch.int32, device=p.device)
+        if self.rank == 0:
+            _queue[(1,)](
+                flags, descriptor, self.r, self.r, triton.next_power_of_2(self.r)
+            )
+        dist.broadcast(descriptor, 0)
+
+        def repair_leaf(start, stop):
+            n = stop - start
+            ids = descriptor[start:stop]
+            gather_peer_rows[(n, triton.cdiv(self.v, 2048))](
+                *self.peers, ids, self.scratch, self.lv, self.v, 2048
+            )
+            torch.softmax(self.scratch[:n], -1, out=self.probs[:n])
+            patch_from_softmax[(1,)](
+                p, self.probs, ids, self.targets, n, self.v, triton.next_power_of_2(n)
+            )
+
+        graph.begin_capture_to_if_node(descriptor[-1] > 0)
+        first = min(self.capacity, self.r)
+        repair_leaf(0, first)
+        if self.r > first:
+            graph.begin_capture_to_if_node(descriptor[-1] > first)
+            # Rare overflow scans bounded chunks. Keeping a single overflow
+            # body avoids one CUDA stream/conditional handle per chunk.
+            for start in range(first, self.r, self.capacity):
+                repair_leaf(start, min(start + self.capacity, self.r))
+            graph.end_capture_to_conditional_node()
+        graph.end_capture_to_conditional_node()
+        output = self.finish(p)
+        return (*output, descriptor[-1])
+
+    def capture(self):
+        # Compile kernels and initialize NCCL outside conditional capture.
+        super().fixed()
+        dist.barrier()
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            graph = torch.cuda.CUDAGraph()
+            graph.capture_begin()
+            output = self._body(graph)
+            graph.capture_end()
+        stream.synchronize()
+        return graph, output

--- a/python/sglang/srt/speculative/compact_verify/queue.py
+++ b/python/sglang/srt/speculative/compact_verify/queue.py
@@ -1,0 +1,77 @@
+"""Queue kernels and bounded eager warmup for the graph verifier.
+
+The serving graph repairs every queued row before returning acceptance.
+"""
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.compact_verify.core import Verify
+
+
+@triton.jit
+def _queue(Flags, Descriptor, R: tl.constexpr, C: tl.constexpr, BLOCK: tl.constexpr):
+    row = tl.arange(0, BLOCK)
+    flags = tl.load(Flags + row, row < R, other=0).to(tl.int32)
+    slot = tl.cumsum(flags) - 1
+    tl.store(Descriptor + slot, row, (flags != 0) & (slot < C))
+    tl.store(Descriptor + C, tl.sum(flags))
+
+
+@triton.jit
+def _patch(P, Repaired, Descriptor, C: tl.constexpr, BLOCK: tl.constexpr):
+    slot = tl.arange(0, BLOCK)
+    row = tl.load(Descriptor + slot, slot < C, other=-1)
+    p = tl.load(Repaired + slot, slot < C, other=0)
+    tl.store(P + row, p, (slot < C) & (row >= 0))
+
+
+class FixedQueueVerify(Verify):
+    def __init__(self, local, q, candidates, coins, final_coins, capacity=16):
+        super().__init__(local, q, candidates, coins, final_coins)
+        if capacity < 1:
+            raise ValueError("capacity must be positive")
+        self.capacity = capacity
+        self.force_flags = torch.zeros(self.r, dtype=torch.bool, device=local.device)
+
+    def uncertainty_flags(self, p):
+        raise NotImplementedError("a qualified probability enclosure is required")
+
+    def fixed(self):
+        p = self.selected_probabilities()
+        flags = self.uncertainty_flags(p)
+        flags = flags | self.force_flags
+        descriptor = torch.full(
+            (self.capacity + 1,), -1, dtype=torch.int32, device=p.device
+        )
+        if self.rank == 0:
+            _queue[(1,)](
+                flags, descriptor, self.r, self.capacity, triton.next_power_of_2(self.r)
+            )
+        dist.broadcast(descriptor, 0)
+        rows = descriptor[: self.capacity].long().clamp(min=0)
+        local = self.local.view(self.r, self.lv)[rows]
+        local = torch.where((descriptor[: self.capacity] >= 0)[:, None], local, 0)
+        repaired = torch.softmax(self.gather(local).float(), -1)
+        selected = repaired.gather(1, self.targets[rows, None]).flatten()
+        _patch[(1,)](
+            p,
+            selected,
+            descriptor,
+            self.capacity,
+            triton.next_power_of_2(self.capacity),
+        )
+        output = self.finish(p)
+        overflow = descriptor[-1] > self.capacity
+        # Never expose plausible token/count/index outputs for overflow batches.
+        masked = tuple(torch.where(overflow, -1, value) for value in output[:3])
+        return (*masked, p, overflow, descriptor[-1])
+
+    def compact(self):
+        # Conservative experimental dispatch: 1024 is the smallest tested
+        # winning R for this fixed queue, not a measured optimal crossover.
+        if self.r < 1024:
+            return self.baseline()
+        return self.fixed()[:4]

--- a/python/sglang/srt/speculative/compact_verify/source_bound.py
+++ b/python/sglang/srt/speculative/compact_verify/source_bound.py
@@ -1,0 +1,81 @@
+"""Qualified exponent terms and conservative normalization intervals.
+
+The serving entry checks the pinned runtime. See README.md for the bounded
+input domain, binary validation and positive-sum rounding argument.
+"""
+
+import torch
+import torch.distributed as dist
+import triton
+
+from sglang.srt.speculative.compact_verify.exp_dag import partial_stats
+from sglang.srt.speculative.compact_verify.queue import FixedQueueVerify
+
+
+class SourceBoundVerify(FixedQueueVerify):
+    radius = 2**-10
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if torch.version.git_version != "cf30153c4c131c8164ee7798e5022d810682e2cb":
+            raise ValueError("unreviewed Torch revision")
+        if self.v != 154880 or self.tp != 4 or self.local.dtype != torch.bfloat16:
+            raise ValueError("bound supports only BF16 TP4 V154880")
+
+    def selected_probabilities(self):
+        self.targets = (
+            torch.cat((self.candidates[:, 1:], self.candidates[:, :1]), 1)
+            .reshape(-1)
+            .long()
+        )
+        z = self.local.view(self.r, self.lv)
+        lo, hi = torch.aminmax(z, dim=-1)
+        valid = torch.isfinite(lo) & torch.isfinite(hi)
+        bounds = torch.stack((hi.float(), -lo.float(), (~valid).float()))
+        dist.all_reduce(bounds, op=dist.ReduceOp.MAX)
+        # Softmax depends on the shifted range, not absolute logit magnitude.
+        # exp(-64)/154880 remains a normal FP32 probability.
+        self.domain_invalid_rows = (bounds[2] != 0) | (bounds[0] + bounds[1] > 64)
+        self.domain_invalid = self.domain_invalid_rows.any()
+        # Use the verified exp instruction DAG and emit only tile statistics;
+        # no full local FP32/FP64 exponential tensor is materialized.
+        tiles = triton.cdiv(self.lv, 2048)
+        partials = torch.empty((2, self.r, tiles), device=z.device, dtype=torch.float64)
+        partial_stats[(self.r, tiles)](
+            z,
+            bounds[0],
+            self.targets,
+            partials,
+            self.r,
+            self.lv,
+            tiles,
+            self.rank * self.lv,
+            2048,
+            num_warps=8,
+        )
+        stats = partials.sum(-1)
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+        center = stats[1] / stats[0]
+        self.lower = center * (1 - self.radius)
+        self.upper = center * (1 + self.radius)
+        return center
+
+    def uncertainty_flags(self, p):
+        q = self.q.gather(2, self.candidates[:, 1:].long()[..., None]).squeeze(-1)
+        product = (self.coins[:, : self.s - 1] * q).double()
+        lo = self.lower.view(self.b, self.s)[:, : self.s - 1]
+        hi = self.upper.view(self.b, self.s)[:, : self.s - 1]
+        flags = ~((product < lo) | (product >= hi))
+        return torch.cat(
+            (flags, torch.zeros((self.b, 1), device=p.device, dtype=torch.bool)), 1
+        ).flatten()
+
+    def fixed(self):
+        result = super().fixed()
+        invalid = result[4] | self.domain_invalid
+        return (
+            *(torch.where(invalid, -1, v) for v in result[:3]),
+            result[3],
+            invalid,
+            result[5],
+        )

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -741,6 +741,55 @@ def eagle_sample(
     sampling_info = batch.sampling_info
     next_token_logits = logits_output.next_token_logits
 
+    if logits_output.compact_verify_sharded:
+        from sglang.srt.speculative.compact_verify.config import sampling_supported
+        from sglang.srt.speculative.compact_verify.engine import (
+            runtime_supported,
+        )
+        from sglang.srt.speculative.compact_verify.engine import (
+            sample as compact_sample,
+        )
+
+        q = verify_input.draft_probs
+        width = verify_input.draft_token_num
+        if (
+            sampling_supported(verify_input, batch, grammar_mask)
+            and 1024 <= next_token_logits.shape[0] <= 4096
+            and next_token_logits.shape[0] % 16 == 0
+            and q is not None
+            and q.dtype == torch.float32
+            and q.shape == (bs, width - 1, 154880)
+            and q.is_contiguous()
+            and runtime_supported()
+            and SIMULATE_ACC_LEN < 0
+        ):
+            candidates = verify_input.draft_token.reshape(bs, width)
+            coins, final_coins = _verify_coins(
+                sampling_info=sampling_info,
+                seq_lens=batch.seq_lens,
+                draft_token_num=width,
+                candidates=candidates,
+                device=device,
+            )
+            result = compact_sample(
+                next_token_logits,
+                q,
+                candidates,
+                coins,
+                final_coins,
+                verify_input.retrieve_index,
+            )
+            if result is None:
+                raise RuntimeError(
+                    "compact verifier eligibility changed after random coins were drawn"
+                )
+            return result
+        # Unsupported request features keep the original verifier, including
+        # its original RNG consumption and full logits for requested logprobs.
+        next_token_logits = get_tp_group().all_gather(next_token_logits, dim=-1).float()
+        logits_output.next_token_logits = next_token_logits
+        logits_output.compact_verify_sharded = False
+
     sanitize_nan_logits(next_token_logits, "verify: target model logits")
 
     # Apply penalty

--- a/test/manual/test_compact_spec_verify.py
+++ b/test/manual/test_compact_spec_verify.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -46,7 +47,6 @@ def fixture(b, k, v, rank, tp, kind):
     return Verify(local, q, candidates, coins, final)
 
 
-
 def compare(a, b):
     for actual, expected in zip(a[:3], b[:3]):
         torch.testing.assert_close(actual.flatten(), expected.flatten(), atol=0, rtol=0)
@@ -56,7 +56,9 @@ def main():
     rank = int(os.environ["RANK"])
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
     dist.init_process_group("nccl")
-    result = {"tests": [], "status": "FAIL"}
+    root = Path(__file__).resolve().parents[2]
+    assert Path(engine.__file__).resolve().is_relative_to(root / "python")
+    result = {"tests": [], "status": "FAIL", "source": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()}
     runner = None
     try:
         assert engine.runtime_supported()

--- a/test/manual/test_compact_spec_verify.py
+++ b/test/manual/test_compact_spec_verify.py
@@ -96,6 +96,17 @@ def main():
         )
         compare(runner.run(), runner.baseline())
         result["tests"].append("reference_nan_q_rule")
+        tiny_local = obj.local.clone()
+        tiny_local[0, 0].fill_(-90)
+        if rank == 0:
+            tiny_local[0, 0, 1] = 0
+        tiny_q = obj.q.clone()
+        tiny_q[0, 0, 0] = 0
+        tiny_candidates = obj.candidates.clone()
+        tiny_candidates[0, 1] = 0
+        runner.bind(tiny_local, tiny_q, tiny_candidates, obj.coins, obj.final_coins, obj.idx)
+        compare(runner.run(), runner.baseline())
+        result["tests"].append("subnormal_reference_probability")
         runner.bind(
             obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
         )

--- a/test/manual/test_compact_spec_verify.py
+++ b/test/manual/test_compact_spec_verify.py
@@ -104,7 +104,9 @@ def main():
         tiny_q[0, 0, 0] = 0
         tiny_candidates = obj.candidates.clone()
         tiny_candidates[0, 1] = 0
-        runner.bind(tiny_local, tiny_q, tiny_candidates, obj.coins, obj.final_coins, obj.idx)
+        runner.bind(
+            tiny_local, tiny_q, tiny_candidates, obj.coins, obj.final_coins, obj.idx
+        )
         compare(runner.run(), runner.baseline())
         result["tests"].append("subnormal_reference_probability")
         runner.bind(

--- a/test/manual/test_compact_spec_verify.py
+++ b/test/manual/test_compact_spec_verify.py
@@ -58,7 +58,13 @@ def main():
     dist.init_process_group("nccl")
     root = Path(__file__).resolve().parents[2]
     assert Path(engine.__file__).resolve().is_relative_to(root / "python")
-    result = {"tests": [], "status": "FAIL", "source": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()}
+    result = {
+        "tests": [],
+        "status": "FAIL",
+        "source": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip(),
+    }
     runner = None
     try:
         assert engine.runtime_supported()

--- a/test/manual/test_compact_spec_verify.py
+++ b/test/manual/test_compact_spec_verify.py
@@ -1,0 +1,165 @@
+"""TP4 integration checks for live draft pointers and SGLang eagle_sample."""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.speculative import eagle_utils
+from sglang.srt.speculative.compact_verify import engine
+from sglang.srt.speculative.compact_verify.core import Verify
+
+
+def fixture(b, k, v, rank, tp, kind):
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(1847)
+    # Identical full fixture on all ranks; release target full logits before timing.
+    target = torch.randn((b, k + 1, v), generator=gen, device=device).to(torch.bfloat16)
+    q = torch.softmax(
+        target[:, :k].float()
+        + 0.5 * torch.randn((b, k, v), generator=gen, device=device),
+        -1,
+    )
+    candidates = torch.randint(
+        v, (b, k + 1), generator=gen, device=device, dtype=torch.int32
+    )
+    coins = torch.rand((b, k + 1), generator=gen, device=device)
+    final = torch.rand(b, generator=gen, device=device)
+    if kind == "identical":
+        q = torch.softmax(target[:, :k].float(), -1)
+    candidates[:, 1:] = (
+        torch.multinomial(q.reshape(-1, v), 1, generator=gen).view(b, k).int()
+    )
+    if kind == "all_accept":
+        coins.zero_()
+    elif kind in ("first_reject", "last_reject"):
+        step = 0 if kind == "first_reject" else k - 1
+        coins.zero_()
+        coins[:, step] = 0.999
+        for i in range(b):
+            target[i, step, candidates[i, step + 1]] = -20
+    local = target[..., rank * (v // tp) : (rank + 1) * (v // tp)].contiguous()
+    return Verify(local, q, candidates, coins, final)
+
+
+
+def compare(a, b):
+    for actual, expected in zip(a[:3], b[:3]):
+        torch.testing.assert_close(actual.flatten(), expected.flatten(), atol=0, rtol=0)
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("nccl")
+    result = {"tests": [], "status": "FAIL"}
+    runner = None
+    try:
+        assert engine.runtime_supported()
+        obj = fixture(4, 3, 154880, rank, 4, "random")
+        runner = engine.ServingVerifier(
+            obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+        )
+        for step in range(4):
+            # Fresh q allocation each time: the captured graph must follow the
+            # updated pointer without copying a full B*K*V staging tensor.
+            q = torch.softmax(obj.q.log() + 0.05 * step, -1).contiguous()
+            local = (-obj.local if step % 2 else obj.local).contiguous()
+            candidates = (obj.candidates + step * 13) % obj.v
+            coins = 1 - obj.coins if step % 2 else obj.coins
+            indices = obj.idx.flip(1).contiguous() if step % 2 else obj.idx
+            runner.bind(local, q, candidates, coins, obj.final_coins, indices)
+            actual = runner.run()
+            compare(actual, runner.baseline())
+            result["tests"].append(f"pointer_and_indices_{step}")
+        shifted = (obj.local + 32).contiguous()
+        runner.bind(shifted, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx)
+        compare(runner.run(), runner.baseline())
+        assert not bool(runner.domain_invalid_rows.any())
+        result["tests"].append("shift_invariant_domain")
+        nan_q = obj.q.clone()
+        nan_q[0, 0, obj.candidates[0, 1]] = float("nan")
+        runner.bind(
+            obj.local, nan_q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+        )
+        compare(runner.run(), runner.baseline())
+        result["tests"].append("reference_nan_q_rule")
+        runner.bind(
+            obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+        )
+        for forced in (0, 1, 8, 9, 16):
+            runner.force_flags.zero_()
+            runner.force_flags[:forced] = True
+            compare(runner.run(), runner.baseline())
+        result["tests"].append("repair_chunk_boundaries")
+        runner.close()
+        runner = None
+        # Enter through the actual eagle_sample function at a qualifying size.
+        obj = fixture(256, 3, 154880, rank, 4, "random")
+        sampling = SimpleNamespace(
+            is_any_greedy=False,
+            need_top_k_sampling=False,
+            need_top_p_sampling=False,
+            need_min_p_sampling=False,
+            has_custom_logit_processor=False,
+            acc_additive_penalties=None,
+            acc_scaling_penalties=None,
+            logit_bias=None,
+            return_sampling_masks=None,
+        )
+        verify = SimpleNamespace(
+            draft_probs=obj.q,
+            tree_topk=1,
+            max_tree_depth=4,
+            draft_token_num=4,
+            draft_token=obj.candidates.flatten(),
+            retrieve_index=obj.idx,
+        )
+        batch = SimpleNamespace(
+            device="cuda",
+            forward_mode=SimpleNamespace(is_idle=lambda: False),
+            seq_lens=torch.ones(256, device="cuda", dtype=torch.int32),
+            sampling_info=sampling,
+            return_logprob=False,
+            reqs=[SimpleNamespace(sampling_params=SimpleNamespace(temperature=1.0))]
+            * 256,
+        )
+        original_coins = eagle_utils._verify_coins
+        eagle_utils._verify_coins = lambda **kwargs: (obj.coins, obj.final_coins)
+        logits = LogitsProcessorOutput(
+            next_token_logits=obj.local.flatten(0, 1), compact_verify_sharded=True
+        )
+        predict, lengths, indices = eagle_utils.eagle_sample(verify, batch, logits)
+        ref_predict, ref_indices, ref_counts, _ = obj.baseline()
+        compare((predict, indices, lengths - 1), (ref_predict, ref_indices, ref_counts))
+        assert engine._cache[(256, 4)].q is None
+        cached = engine._cache[(256, 4)]
+        cached.bind(
+            obj.local, obj.q, obj.candidates, obj.coins, obj.final_coins, obj.idx
+        )
+        cached.force_flags.fill_(True)
+        compare(cached.run(), cached.baseline())
+        result["tests"].append("all_1024_rows_repaired")
+        eagle_utils._verify_coins = original_coins
+        result["tests"].append("actual_eagle_sample_1024")
+        result["status"] = "PASS"
+    finally:
+        if runner is not None:
+            runner.close()
+        engine.close_all()
+        dist.barrier()
+        dist.destroy_process_group()
+        result["normal_shutdown"] = True
+        if rank == 0:
+            Path(os.environ["COMPACT_TEST_OUTPUT"]).write_text(
+                json.dumps(result, indent=2)
+            )
+            print(json.dumps(result), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/sampling/test_compact_verify_config.py
+++ b/test/registered/unit/sampling/test_compact_verify_config.py
@@ -1,0 +1,129 @@
+from fractions import Fraction
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers import logits_processor as lp
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
+from sglang.srt.speculative.compact_verify import config
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+register_cpu_ci(est_time=15, suite="base-c-test-cpu")
+
+
+def test_conservative_rounding_enclosure():
+    u32, u64 = Fraction(1, 2**24), Fraction(1, 2**53)
+    g32 = 2048 * u32 / (1 - 2048 * u32)
+    g64 = 154884 * u64 / (1 - 154884 * u64)
+    lo = (1 - g64) * (1 - u32) / ((1 + g32) * (1 + u64))
+    hi = (1 + g64) * (1 + u32) / ((1 - g32) * (1 - u64))
+    radius = Fraction(1, 1024)
+    assert (1 - radius) * (1 + u64) < lo
+    assert (1 + radius) * (1 - u64) > hi
+
+
+def inputs():
+    sampling = SimpleNamespace(
+        is_any_greedy=False,
+        need_top_k_sampling=False,
+        need_top_p_sampling=False,
+        need_min_p_sampling=False,
+        has_custom_logit_processor=False,
+        acc_additive_penalties=None,
+        acc_scaling_penalties=None,
+        logit_bias=None,
+        return_sampling_masks=None,
+    )
+    batch = SimpleNamespace(
+        sampling_info=sampling,
+        return_logprob=False,
+        reqs=[SimpleNamespace(sampling_params=SimpleNamespace(temperature=1.0))],
+    )
+    verify = SimpleNamespace(tree_topk=1, max_tree_depth=4, draft_token_num=4)
+    return verify, batch
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "is_any_greedy",
+        "need_top_k_sampling",
+        "need_top_p_sampling",
+        "need_min_p_sampling",
+        "has_custom_logit_processor",
+    ],
+)
+def test_sampling_flags_fall_back(field):
+    verify, batch = inputs()
+    assert config.sampling_supported(verify, batch, None)
+    setattr(batch.sampling_info, field, True)
+    assert not config.sampling_supported(verify, batch, None)
+
+
+@pytest.mark.parametrize(
+    "field", ["acc_additive_penalties", "acc_scaling_penalties", "logit_bias"]
+)
+def test_modifiers_fall_back(field):
+    verify, batch = inputs()
+    setattr(batch.sampling_info, field, torch.zeros(1))
+    assert not config.sampling_supported(verify, batch, None)
+
+
+def test_temperature_logprob_grammar_and_tree_fall_back():
+    verify, batch = inputs()
+    batch.reqs[0].sampling_params.temperature = 0.7
+    assert not config.sampling_supported(verify, batch, None)
+    batch.reqs[0].sampling_params.temperature = 1.0
+    batch.return_logprob = True
+    assert not config.sampling_supported(verify, batch, None)
+    batch.return_logprob = False
+    assert not config.sampling_supported(verify, batch, object())
+    verify.tree_topk = 2
+    assert not config.sampling_supported(verify, batch, None)
+
+
+def test_compact_graph_buffer_does_not_allocate_full_vocabulary():
+    buffers = GraphSharedOutput(device=torch.device("cpu"), max_rows=4)
+    local = buffers.get_compact_logits_buffer(rows=2)
+    assert local.shape == (2, 38720) and local.dtype == torch.bfloat16
+    assert buffers._logits_buffers == {}
+    assert buffers.get_compact_logits_buffer(rows=1).data_ptr() == local.data_ptr()
+
+
+def test_local_projection_bypasses_gather(monkeypatch):
+    monkeypatch.setenv("SGLANG_ENABLE_COMPACT_SPEC_VERIFY", "1")
+    monkeypatch.setattr(config, "configured", lambda: True)
+    monkeypatch.setattr(lp, "get_parallel", lambda: SimpleNamespace(tp_rank=0))
+    processor = object.__new__(lp.LogitsProcessor)
+    torch.nn.Module.__init__(processor)
+    processor.do_tensor_parallel_all_gather_dp_attn = False
+    processor.do_tensor_parallel_all_gather = True
+    processor.use_attn_tp_group = False
+    processor.vocab_size = 154880
+    processor.logit_scale = None
+    processor.final_logit_softcapping = None
+    local = torch.ones((2, 38720), dtype=torch.bfloat16)
+    processor._compute_lm_head = lambda *_: local
+    processor._logits_gatherer = lambda *_: pytest.fail("full gather called")
+    head = object.__new__(VocabParallelEmbedding)
+    torch.nn.Module.__init__(head)
+    head.enable_tp = True
+    head.org_vocab_size = head.num_embeddings = 154880
+    head.shard_indices = SimpleNamespace(
+        org_vocab_start_index=0, org_vocab_end_index=38720
+    )
+    meta = lp.LogitsMetadata(
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        capture_hidden_mode=CaptureHiddenMode.NULL,
+        next_token_logits_buffer=torch.empty_like(local),
+    )
+    result = processor._get_logits(torch.zeros(2, 1), head, meta)
+    assert (
+        meta.compact_verify_sharded
+        and result.data_ptr() == meta.next_token_logits_buffer.data_ptr()
+    )
+    torch.testing.assert_close(result, local)


### PR DESCRIPTION
# [SpecDecode] Add opt-in compact TP4 linear target verification

## Summary

Speculative verification currently gathers a full target vocabulary and builds
target probabilities for every draft position. Acceptance usually needs only
the proposed token's probability. This change keeps target logits sharded,
computes compact statistics, and rechecks numerically uncertain rows with the
original softmax before updating acceptance state.

ASIS
```text
local target logits [R, V/TP]
    -> full AllGather [R, V]
    -> target softmax [R, V]
    -> rejection sampling
```

PR
```text
local target logits [R, V/TP]
    -> selected probabilities + conservative intervals [R]
    -> uncertain rows: bounded peer-read scratch + original softmax
    -> acceptance
    -> one recovery/bonus row per request + existing sampler
```

Full draft probabilities remain inputs. The graph cache follows their live
pointer and does not copy or retain another full draft-probability tensor.
The target model's graph output buffer is owner-sharded BF16.

## Initial scope

Disabled by default. Enable with `SGLANG_ENABLE_COMPACT_SPEC_VERIFY=1`.
The first route is qualified for single-node TP4 SM100, BF16 vocabulary 154880,
linear EAGLE/NEXTN-style rejection sampling, temperature 1, and 1024-4096
verification rows in supported shapes. The engine checks the pinned Torch
revision and binary checksum. Unsupported request features or builds reconstruct
full logits and use the original verifier.

Top-k/top-p/min-p, penalties, grammar, custom processors, requested logprobs,
DP/CP/PP and multi-node combinations are excluded from the compact sampler.

## Correctness and lifetime

- The production exponential instruction sequence matched the pinned Torch
  exponential across all 1,115,684,865 negative FP32 values from -0 through -64,
  plus positive zero. Profiling confirmed the expected kernels.
- An exact-rational regression checks the conservative rounding enclosure for
  the qualified normalization path. Rows outside its range are rechecked.
- A common repair branch handles eight rows; a second branch processes all
  remaining rows in bounded chunks. No overflow result reaches KV/Mamba updates.
- Rejection recovery uses the original sampler and coins. Draft-buffer pointer
  changes, token-index permutations and the reference NaN-q rule are covered.
- Captured graphs are released before communicator teardown.

This is a qualified-build contract, not a numerical portability claim across
arbitrary CUDA/Torch releases. The same-logits debug oracle is available through
`SGLANG_COMPACT_SPEC_VERIFY_SHADOW=1`.

## Performance: extra peak allocation 1.27 GB → 412 MB (-67.6%), live device memory 2.26 GB → 1.25 GB (-44.8%)

GB200 TP4, V154880, batch 128, seven drafts, 1024 verification rows. Both arms
use CUDA graphs; the reference includes SGLang's multimem full gather, original
sampler and TP output broadcasts. Candidate timing includes input/pointer
binding. Five warmups and mirrored G-C-C-G blocks, 30 samples per block; latency
is maximum-rank CUDA-event time.

| Rechecked rows | Reference p50 | Compact p50 | Speedup |
| ---: | ---: | ---: | ---: |
| 0 | 1634.448 us | 1067.152 us | 1.53x |
| 5 | 1638.288 us | 1125.040 us | 1.46x |

Extra peak PyTorch allocation decreased from 1,270,884,864 to 412,052,992 bytes
(67.6%). Extra live device memory after setup/capture decreased from
2,260,729,856 to 1,247,805,440 bytes (44.8%). These are operator measurements,
not total-model memory or full-request speedups.

## Validation

- CPU routing/buffer/numerical tests: 12 passed.
- TP4 integration: live q pointers, index permutations, repair boundaries,
  all 1024 rows requiring repair, actual `eagle_sample`, and normal shutdown pass.
- GLM-5.2 NEXTN serving with target model CUDA graphs enabled: 128 requests,
  16 output tokens each; same-logits reference checks pass and server exits 0.
- Repository checks pass.

The clean review branch removes the earlier greedy experiment stack. CPU and
TP4 integration tests were run on this branch, including the final FP32
acceptance comparison and subnormal-probability case. Benchmark and manual GPU
reproducers are included. No full-request speedup claim is made.

## Full-serving E2E measurement

GLM-5.2 on GB200 TP4, NEXTN with seven drafts, 128 requests per batch,
16 input and 16 output tokens per request, temperature 1, top-p 1, top-k -1.
Decode CUDA graphs were enabled, radix caching disabled, and the same-logits
shadow oracle disabled in both performance arms. Both used seed 20260909 and
identical diagnostic logging on review commit
`7b1bf82e9760adfc438537debfd9cd71b04666d3`.

We ran four fresh servers in baseline/compact/compact/baseline order, with
three warmup batches and ten measured batches per server (20 per arm).
Timing is client HTTP batched-request wall time, excluding server startup.

| Metric | Baseline | Compact |
| --- | ---: | ---: |
| Median batch latency | 1.581004 s | 1.569206 s |
| Mean batch latency | 1.627891 s | 1.583275 s |
| p90 batch latency | 1.781827 s | 1.667145 s |
| Logged scheduler steps, total | 290 | 283 |
| Accepted / proposed drafts | 29.773% | 29.148% |

The observed median was 0.75% lower and mean 2.74% lower. These are descriptive
results, not an established E2E speedup: scheduler work differed between arms,
and latency closely tracked scheduler-step count. An earlier three-sample
comparison showed a 5.94% higher compact median, which did not reproduce here.
All four servers completed successfully and exited 0; GPU compute processes
were absent between blocks and after completion. Speculation was active in
both arms; this was not a comparison against non-speculative decoding.

The compact sampler requires at least 1024 verification rows. With eight rows
per request, only the full B128 portion qualifies; each measured batch logged
three full-B128 decode steps before requests began finishing. Smaller batches
fall back to the original verifier, even though model graphs remain enabled.
Multiplying three eligible invocations by the separately measured 0.51-0.57 ms
operator saving predicts only about 1.5-1.7 ms, or 0.10-0.11% of baseline E2E.
This is a simple estimate, not a serving profile; it excludes fallback-path
and scheduling differences. The excess observed improvement cannot be
attributed to the compact kernel from this experiment. The demonstrated
performance claim remains the qualified operator speedup and memory reduction.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34350977970](https://github.com/sgl-project/sglang/actions/runs/34350977970)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34350977433](https://github.com/sgl-project/sglang/actions/runs/34350977433)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34350977731](https://github.com/sgl-project/sglang/actions/runs/34350977731)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->