### PR TITLE
Improve total prefix cache tokens available when using hicache + write back

### DIFF
--- a/python/sglang/srt/arg_groups/fields/memory.py
+++ b/python/sglang/srt/arg_groups/fields/memory.py
@@ -123,6 +123,15 @@ class Memory:
             choices=["direct", "kernel", "kernel_ascend"],
         ),
     ] = "kernel"
+    hicache_serialize_load_back: A[
+        bool,
+        "Load a prefix back from host one radix node at a time, completing each "
+        "node's H2D before evicting for the next, instead of submitting the "
+        "whole batch's chains together after admission closes. Under write_back "
+        "this bounds how much device memory one eviction has to clear, and lets "
+        "each loaded node be reclaimed as a host duplicate to fund the next one, "
+        "rather than forcing the write-back cascade to destroy sole host copies.",
+    ] = False
     hicache_mem_layout: A[
         str,
         Arg(

--- a/python/sglang/srt/arg_groups/fields/memory.py
+++ b/python/sglang/srt/arg_groups/fields/memory.py
@@ -85,6 +85,13 @@ class Memory:
         bool,
         "Track per-session references on UnifiedRadixCache KV: eviction consumes unreferenced entries before referenced ones, and closing a session only dereferences its KV.",
     ] = False
+    allow_subagent_keepalive: A[
+        bool,
+        "Refresh a parent session's UnifiedRadixCache LRU whenever one of its "
+        "subagents issues a request. Requests carry session_id / "
+        "parent_session_id; the parent's KV is kept hot while it is blocked on "
+        "the subagent it spawned.",
+    ] = False
     radix_cache_backend: A[
         Optional[str],
         "Name of a radix-cache backend previously registered via register_radix_cache_backend. Omit this flag to use the built-in default cache selection chain.",

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -429,6 +429,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_params: Optional[Dict] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
@@ -469,6 +470,7 @@ class Engine(EngineScoreMixin, EngineBase):
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,
+            parent_session_id=parent_session_id,
             session_params=session_params,
             priority=priority,
         )
@@ -542,6 +544,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_params: Optional[Dict] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
@@ -582,6 +585,7 @@ class Engine(EngineScoreMixin, EngineBase):
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,
+            parent_session_id=parent_session_id,
             session_params=session_params,
             priority=priority,
         )

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -178,6 +178,10 @@ class GenerateReqInput:
     # Stable identity shared by requests in the same session. Unlike
     # session_params, this does not alter or reconstruct the prompt.
     session_id: Optional[str] = field(default=None, kw_only=True)
+    # Session that spawned this one, when the caller is a subagent. Consumed
+    # only by --allow-subagent-keepalive, which refreshes the parent session's
+    # prefix-cache LRU while the parent is blocked on this request.
+    parent_session_id: Optional[str] = field(default=None, kw_only=True)
     # The input prompt. It can be a single prompt or a batch of prompts.
     text: Optional[Union[List[str], str]] = None
     # The token ids for text.
@@ -882,6 +886,7 @@ class GenerateReqInput:
         sub = GenerateReqInput(
             rid=self.rid[i],
             session_id=self.session_id,
+            parent_session_id=self.parent_session_id,
             text=self.text[i] if self.text is not None else None,
             input_ids=self.input_ids[i] if self.input_ids is not None else None,
             input_embeds=(
@@ -2177,6 +2182,19 @@ class OpenSessionReqInput(BaseReq, kw_only=True):
 
 
 class CloseSessionReqInput(BaseReq, kw_only=True):
+    session_id: str
+
+
+class SubagentKeepaliveReqInput(BaseReq, kw_only=True):
+    """Refresh the prefix-cache LRU of a session that is blocked on a subagent.
+
+    Emitted by the tokenizer manager (``--allow-subagent-keepalive``) when a
+    request declares a ``parent_session_id``. It is a control request, so the
+    scheduler broadcasts it to every attention-DP rank: the parent's KV lives on
+    whichever rank served its last turn, which is not in general the rank the
+    subagent's own request was routed to.
+    """
+
     session_id: str
 
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -171,6 +171,7 @@ from sglang.srt.managers.io_struct import (
     ShutdownReq,
     SlowDownReqInput,
     SlowDownReqOutput,
+    SubagentKeepaliveReqInput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     UnloadLoRAAdapterReqInput,
@@ -1722,6 +1723,7 @@ class Scheduler(
                 (AbortReq, self.abort_request),
                 (OpenSessionReqInput, self.open_session),
                 (CloseSessionReqInput, self.close_session),
+                (SubagentKeepaliveReqInput, self.handle_subagent_keepalive),
                 (
                     UpdateWeightFromDiskReqInput,
                     self.weight_updater.update_weights_from_disk,
@@ -5593,6 +5595,15 @@ class Scheduler(
             or not self.enable_session_radix_cache
         ):
             self.session_controller.close(recv_req)
+
+    def handle_subagent_keepalive(self, recv_req: SubagentKeepaliveReqInput):
+        """Refresh a parent session's prefix-cache LRU while its subagent runs.
+
+        Broadcast to every rank, so a rank that never served this session just
+        misses the lookup and returns.
+        """
+        self.tree_cache.bump_session_keepalive(recv_req.session_id)
+        return None
 
     def maybe_sleep_on_idle(self):
         if self.idle_sleeper is not None:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -83,6 +83,7 @@ from sglang.srt.managers.io_struct import (
     ScaleElasticEPReqOutput,
     SessionParams,
     ShutdownReq,
+    SubagentKeepaliveReqInput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     UpdateWeightFromDiskReqInput,
@@ -812,6 +813,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             # Log the request
             self.request_logger.log_received_request(obj, self.tokenizer, request)
+
+            self._maybe_send_subagent_keepalive(obj)
 
             async with self.is_pause_cond:
                 await self.is_pause_cond.wait_for(lambda: not self.is_pause)
@@ -1572,6 +1575,25 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 (not get_parallel().enable_dp_attention)
                 and (not self._batch_has_text(batch_size, requests))
             )
+        )
+
+    def _maybe_send_subagent_keepalive(self, obj: Any) -> None:
+        """Keep a parent session's prefix cache hot while its subagent runs.
+
+        The parent's KV lives on whichever attention-DP rank served its last
+        turn, which is not in general the rank this subagent request is routed
+        to, so this goes out as a control request: the DP controller hands
+        control requests to rank 0, whose scheduler broadcasts them over the
+        full TP group. Every rank then refreshes the session if it holds it and
+        ignores it otherwise.
+        """
+        if not get_memory().allow_subagent_keepalive:
+            return
+        parent_session_id = getattr(obj, "parent_session_id", None)
+        if not parent_session_id:
+            return
+        self._dispatch_to_scheduler(
+            SubagentKeepaliveReqInput(session_id=parent_session_id)
         )
 
     async def _send_one_request(

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -488,6 +488,15 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def take_events(self):
         return [] if self.kv_events is None else self.kv_events.take()
 
+    def bump_session_keepalive(self, session_id: str) -> bool:
+        """Refresh the LRU of the cached path that a session ended on.
+
+        Called on every rank for a broadcast keepalive, so the default is a
+        no-op miss rather than an error; only caches that index their tree by
+        session id can honour it. Returns whether anything was refreshed.
+        """
+        return False
+
     def supports_swa(self) -> bool:
         return False
 

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -35,6 +35,7 @@ class CacheInitParams:
     enable_metrics: bool = False
     enable_kv_cache_events: bool = False
     enable_session_radix_cache: bool = False
+    allow_subagent_keepalive: bool = False
 
     enable_mamba_extra_buffer: bool = False
     enable_mamba_extra_buffer_lazy: bool = False

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -314,6 +314,7 @@ def build_kv_cache(
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=get_memory().enable_session_radix_cache,
+        allow_subagent_keepalive=get_memory().allow_subagent_keepalive,
         enable_mamba_extra_buffer=get_exec().mamba.enable_mamba_extra_buffer,
         enable_mamba_extra_buffer_lazy=get_exec().mamba.enable_mamba_extra_buffer_lazy,
         pp_rank=ps.pp_rank,

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -506,6 +506,34 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         """
         return self._node_arena[node_id]
 
+    def refresh_lru_to_root(self, node_id: NodeId) -> bool:
+        """Re-age a cached path as if it had just been matched.
+
+        This is the refresh half of ``_match_post_processor``: aux components
+        move to MRU, and Full's ``last_access_time`` is rewritten from a
+        decreasing counter so every ancestor sorts older than its child. Both
+        the device and the host eviction heaps order Full by
+        ``last_access_time``, so one walk protects the path on both tiers.
+
+        Returns False when the node is no longer in the arena, i.e. its KV was
+        already reclaimed and there is nothing left to keep alive.
+        """
+        node = self._node_arena.get(node_id)
+        if node is None:
+            return False
+
+        for comp in self.components:
+            if comp.component_type == BASE_COMPONENT_TYPE:
+                continue  # Full uses last_access_time, not LRU
+            comp.refresh_lru(LRURefreshPhase.MATCH_END, node, self.root_node)
+
+        cur_time = get_and_increase_time_counter()
+        while node:
+            node.last_access_time = cur_time
+            cur_time -= 0.00001
+            node = node.parent
+        return True
+
     def is_backuped(self, node_id: NodeId) -> bool:
         """Whether the node's KV is already backed up to host."""
         return self._node_arena[node_id].backuped

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -2121,6 +2121,33 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             return empty_kv, {}
         return kv_xfer, comp_xfers
 
+    def split_full_load_back_spec(self, kv_xfer: PoolTransfer) -> list[PoolTransfer]:
+        """One Full transfer per source node, in the chain's root-first order.
+
+        A node only counts as a reclaimable host duplicate once its KV is on
+        device (``_is_settled_full_host_duplicate``), so every node of a chain
+        that has not been loaded yet is a sole host copy. Loading the chain as
+        one transfer therefore demands a device eviction sized for the whole
+        chain at the moment none of it can fund the write-back that eviction
+        cascades into, and the host pressure falls through to a destructive
+        ``_evict_host_leaf``. Loaded root-first one at a time, each node becomes
+        a duplicate at its own ack and pays for the next node's write-back.
+        """
+        transfers: list[PoolTransfer] = []
+        for nid in kv_xfer.nodes_to_load or ():
+            host_value = (
+                self.node_by_id(nid).component_data[BASE_COMPONENT_TYPE].host_value
+            )
+            assert host_value is not None
+            transfers.append(
+                PoolTransfer(
+                    name=PoolName.KV,
+                    host_indices=host_value,
+                    nodes_to_load=[nid],
+                )
+            )
+        return transfers
+
     def prefetch_anchor_info(
         self, node_id: NodeId
     ) -> tuple[Optional[str], Optional[str]]:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import replace
 from queue import Queue
 from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional, Sequence, TypeVar
@@ -117,6 +118,14 @@ COMPONENT_REGISTRY: dict[ComponentType, type[TreeComponent]] = {
 
 logger = logging.getLogger(__name__)
 
+# Cap on --allow-subagent-keepalive's session -> tail-node map. Sized well above
+# any plausible live conversation count so eviction only ever drops sessions that
+# have been silent for a long time; a dropped entry costs one missed keepalive.
+_SESSION_TAIL_LIMIT = 65536
+
+# How often bump_session_keepalive reports its cumulative hit rate.
+_KEEPALIVE_LOG_INTERVAL = 256
+
 
 class _OngoingWriteThrough(NamedTuple):
     """Tracks an in-flight D→H write-through operation."""
@@ -206,6 +215,15 @@ class UnifiedRadixCache(BasePrefixCache):
             tree_core=self.tree_core,
             enable_session_radix_cache=self.enable_session_radix_cache,
         )
+
+        # Subagent keepalive (--allow-subagent-keepalive): session id -> the
+        # NodeId that session's last completed turn ended on. Bounded LRU; a
+        # dropped entry only costs a missed keepalive. NodeIds come from a
+        # monotonic counter and are never reused, so a stale id can only miss.
+        self.allow_subagent_keepalive = params.allow_subagent_keepalive
+        self._session_tail_node: OrderedDict[str, NodeId] = OrderedDict()
+        self._keepalive_hits = 0
+        self._keepalive_misses = 0
 
         self.sidecar_pool_specs: list[SidecarPoolSpec] = []
 
@@ -1014,6 +1032,9 @@ class UnifiedRadixCache(BasePrefixCache):
                 req.finished_reason, FINISH_ABORT
             ):
                 self.session_refs.register_session_ref(req)
+
+        if self.allow_subagent_keepalive and is_insert and result is not None:
+            self._record_session_tail(req)
 
     def cache_unfinished_req(self, req: Req, chunked: bool = False, **kwargs) -> None:
         if self.session.try_cache_unfinished_req(req, chunked=chunked, **kwargs):
@@ -3314,6 +3335,74 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def release_radix_session(self, session_id: str) -> int:
         return self.session_refs.release_radix_session(session_id)
+
+    # ---- Subagent keepalive API (--allow-subagent-keepalive) ----
+
+    def _record_session_tail(self, req: Req) -> None:
+        """Remember which node a session's last completed turn ended on."""
+        session_id = req.session_id
+        node_id = req.last_node
+        if not session_id or node_id is None:
+            return
+        if self.tree_core.is_root(node_id):
+            # Nothing of this turn survived in the tree; a keepalive on the root
+            # would refresh the whole cache, so forget the session instead.
+            self._session_tail_node.pop(session_id, None)
+            return
+        self._session_tail_node[session_id] = node_id
+        self._session_tail_node.move_to_end(session_id)
+        while len(self._session_tail_node) > _SESSION_TAIL_LIMIT:
+            self._session_tail_node.popitem(last=False)
+
+    def bump_session_keepalive(self, session_id: str) -> bool:
+        """Re-age a parent session's cached path while its subagent runs.
+
+        An agent that spawns a subagent resumes as soon as the subagent returns,
+        so its KV is idle-but-live for the whole subagent run and would
+        otherwise age out and be re-prefilled. Refreshing on every subagent
+        request keeps the parent as recently-used as its own child's traffic.
+
+        This is broadcast to every attention-DP rank, so a miss (unknown
+        session, or one whose path has since been reclaimed) is the normal case
+        and returns False without touching the tree.
+        """
+        if not self.allow_subagent_keepalive or not session_id:
+            return False
+        node_id = self._session_tail_node.get(session_id)
+        if node_id is not None and self.tree_core.refresh_lru_to_root(node_id):
+            self._session_tail_node.move_to_end(session_id)
+            self._keepalive_hits += 1
+            self._maybe_log_keepalive_rate()
+            return True
+
+        if node_id is not None:
+            # Path already reclaimed -- drop it so the map does not grow a tail
+            # of dead sessions.
+            self._session_tail_node.pop(session_id, None)
+        self._keepalive_misses += 1
+        self._maybe_log_keepalive_rate()
+        return False
+
+    def _maybe_log_keepalive_rate(self) -> None:
+        """Periodically report how often keepalives find their parent.
+
+        A keepalive is broadcast to every attention-DP rank but only the rank
+        holding that session can act on it, so a low hit rate here is the
+        expected shape rather than a fault -- what it does tell you is whether
+        the feature is reaching any cached parent at all, which is otherwise
+        invisible.
+        """
+        total = self._keepalive_hits + self._keepalive_misses
+        # Always log the first one: on a short run the interval alone can leave the
+        # feature with no evidence that it ran at all.
+        if total != 1 and total % _KEEPALIVE_LOG_INTERVAL:
+            return
+        logger.info(
+            "subagent keepalive: %d/%d refreshed a live parent path (%d sessions tracked)",
+            self._keepalive_hits,
+            total,
+            len(self._session_tail_node),
+        )
 
     # ---- Streaming session API (delegates to composed StreamingSession) ----
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -245,6 +245,8 @@ class UnifiedRadixCache(BasePrefixCache):
         # constructs the pipeline collaborator (None = cache mode).
         self.host_memory_mode = "cache"
         self.buffer_pipeline: Optional[BufferModePipeline] = None
+        # --hicache-serialize-load-back; resolved in init_hicache.
+        self.serialize_load_back = False
         # Write-side dedupe: beliefs about what storage already holds, so
         # re-inserts of hot prefixes skip the redundant backup.
         self.storage_existence_cache = StorageExistenceCache()
@@ -481,6 +483,15 @@ class UnifiedRadixCache(BasePrefixCache):
                     pool=PoolName.KV.value,
                 )
         self.load_back_threshold = 10
+        # --hicache-serialize-load-back: submit and complete each request's H2D
+        # inside its own admission instead of after the batch is formed.
+        # Meaningless in buffer mode, which stages load-backs through its own
+        # pipeline rather than through ongoing_load_back.
+        self.serialize_load_back = (
+            get_memory().hicache_serialize_load_back
+            and self.cache_controller is not None
+            and self.buffer_pipeline is None
+        )
         self.prefetch_stop_policy = get_memory().hicache_storage_prefetch_policy
 
         # Runtime attach/detach of the L3 backend (startup, admin API, atexit).
@@ -1600,6 +1611,16 @@ class UnifiedRadixCache(BasePrefixCache):
             self.dec_host_lock_ref(node_id, host_anchor_params)
             return False
 
+        if self.serialize_load_back:
+            return self._load_back_per_node(
+                anchor_id=node_id,
+                kv_xfer=kv_xfer,
+                comp_xfers=comp_xfers,
+                sidecar_xfers=sidecar_xfers,
+                ancestor_lock_params=ancestor_lock_params,
+                host_anchor_params=host_anchor_params,
+            )
+
         avail = self._component_available_size(ComponentType.FULL)
         if avail < kv_tokens:
             needed = kv_tokens - avail
@@ -1637,6 +1658,135 @@ class UnifiedRadixCache(BasePrefixCache):
         )
 
         return True
+
+    def _load_back_per_node(
+        self,
+        *,
+        anchor_id: NodeId,
+        kv_xfer: PoolTransfer,
+        comp_xfers: dict[ComponentType, list[PoolTransfer]],
+        sidecar_xfers: list[PoolTransfer],
+        ancestor_lock_params: DecLockRefParams,
+        host_anchor_params: DecLockRefParams,
+    ) -> bool:
+        """Load the anchor's chain a node at a time, draining each H->D.
+
+        Each step evicts only what that node needs, and its ack registers the
+        node as a host duplicate that the next step's write-back can reclaim
+        instead of destroying an unrelated session's sole host copy. The anchor
+        host pin taken by the caller is held across the whole loop: it keeps the
+        chain out of ``evictable_host_leaves`` (an ancestor with a host-resident
+        child is not a host leaf), so the chain cannot evict itself mid-load.
+
+        Aux components ride the final step. Their specs are anchor-scoped (Mamba
+        keys off the request's pool slot), so they stay a single commit, and a
+        chain that cannot finish reports total failure rather than a Full prefix
+        deeper than the aux state meant to accompany it.
+        """
+        aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
+        # A KV-derived sidecar cannot ride the final step with the rest. It carries
+        # no indices of its own -- the controller resolves them from the operation
+        # it travels on -- so one attached to the last step is restored for that
+        # step's node only, and the rest of the chain keeps whatever its freshly
+        # allocated slots held. Each step builds its own below.
+        aux_xfers.extend(x for x in sidecar_xfers if x.indices_from_pool != PoolName.KV)
+        # An anchor whose Full KV is already resident still arrives here for its
+        # aux transfers; that aux-only load is the single-step case.
+        steps = self.tree_core.split_full_load_back_spec(kv_xfer) or [kv_xfer]
+
+        loaded_locks: list[tuple[NodeId, DecLockRefParams]] = []
+        try:
+            for i, step_xfer in enumerate(steps):
+                is_last = i == len(steps) - 1
+                step_tokens = len(step_xfer.host_indices)
+                if step_tokens and not self._evict_for_load_back(step_tokens):
+                    return False
+
+                step_id = anchor_id if is_last else step_xfer.nodes_to_load[0]
+                host_step_params = self.inc_host_lock_ref(step_id).to_dec_params()
+                step_pools = self._build_sidecar_transfers(
+                    CacheTransferPhase.LOAD_BACK, step_xfer, {}
+                )
+                if is_last:
+                    step_pools = aux_xfers + step_pools
+                device_indices = self.cache_controller.load(
+                    host_indices=step_xfer.host_indices,
+                    node_id=step_id,
+                    extra_pools=step_pools or None,
+                )
+                if device_indices is None:
+                    self.dec_host_lock_ref(step_id, host_step_params)
+                    return False
+
+                self._apply_cache_actions(
+                    self.tree_core.commit_load_back(
+                        step_id,
+                        device_indices,
+                        step_xfer,
+                        comp_xfers if is_last else {},
+                    )
+                )
+                self.ongoing_load_back[step_id] = _OngoingLoadBack(
+                    step_id,
+                    self.inc_lock_ref(step_id).to_dec_params(),
+                    host_step_params,
+                )
+                # Outlives the ack that drops the lock above: the next step's
+                # eviction must not reclaim what this one just brought in.
+                loaded_locks.append(
+                    (step_id, self.inc_lock_ref(step_id).to_dec_params())
+                )
+                self._drain_serialized_load_back()
+            return True
+        finally:
+            for nid, params in loaded_locks:
+                self.dec_lock_ref(nid, params)
+            self.dec_lock_ref(anchor_id, ancestor_lock_params)
+            self.dec_host_lock_ref(anchor_id, host_anchor_params)
+
+    def _evict_for_load_back(self, num_tokens: int) -> bool:
+        """Free device room for one load-back step.
+
+        Asks the same question the batched path asks for a whole chain, and
+        answers it the same way: evicting for Full can cascade to peer
+        components, so feasibility is re-read from the allocator rather than
+        inferred from how many tokens the eviction reported freeing.
+        """
+        avail = self._component_available_size(ComponentType.FULL)
+        if avail >= num_tokens:
+            return True
+        self.evict_for_alloc(EvictParams(num_tokens=num_tokens - avail))
+        return self._component_available_size(ComponentType.FULL) >= num_tokens
+
+    def _drain_serialized_load_back(self) -> None:
+        """Finish one load-back step's H->D before anything else is admitted.
+
+        By default a load-back only queues a CacheOperation; the batch's
+        transfers are merged and submitted once, after admission has closed
+        (``ready_to_load_host_cache``). Nothing loaded that way is a host
+        duplicate until that single ack, so a whole batch of chains competes for
+        host room that none of them can release.
+
+        Draining here is what makes the step boundary mean anything: duplicate
+        registration happens in ``finish_load_back`` at ack time, so the next
+        step's eviction only sees this step's node as reclaimable once the ack
+        has landed. It costs no transfer parallelism -- the batched path
+        serializes on the same host_to_device_stream anyway.
+
+        Draining also keeps at most one producer outstanding, which the
+        3-slot ``LayerDoneCounter`` ring requires: ``update_producer`` asserts
+        the slot it wraps onto has already finished.
+
+        The batch's later ``ready_to_load_host_cache`` finds an empty queue and
+        returns -1, so the forward runs with no layer-transfer consumer, which
+        is correct: the load already completed.
+        """
+        producer_id = self.cache_controller.start_loading()
+        if producer_id < 0:
+            return
+        # Exactly one ack is outstanding in this mode, so skip the cross-rank
+        # count consensus in loading_check(None) -- each rank drains its own.
+        self.loading_check(finish_count=1)
 
     def _build_sidecar_transfers(
         self,

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -584,6 +584,9 @@ class StreamingSession(BasePrefixCache):
     def take_events(self):
         return self.inner.take_events()
 
+    def bump_session_keepalive(self, session_id: str) -> bool:
+        return self.inner.bump_session_keepalive(session_id)
+
     def supports_swa(self):
         return self.inner.supports_swa()
 

--- a/test/registered/unit/mem_cache/test_hicache_kv_integrity.py
+++ b/test/registered/unit/mem_cache/test_hicache_kv_integrity.py
@@ -1,0 +1,1274 @@
+"""End-to-end KV *content* checks for UnifiedRadixCache + HiCache, on CPU.
+
+Every other unit test in this directory asserts bookkeeping: which node is in
+which leaf set, what a lock_ref is, how many transfers were issued. None asserts
+what a served request actually depends on -- that the KV slots a match hands
+back hold the bytes that were cached under those token ids. A cache can keep
+every counter consistent, pass ``sanity_check``, and still serve one request
+another request's KV; that reaches the client as a plausible completion or an
+immediate stop token, never as an error, so there is nothing in a log to find.
+
+This file runs the real stack -- ``UnifiedRadixCache``, ``HiCacheController``,
+the host pool, real D->H and H->D copies -- over fixed workloads, and checks
+every matched prefix byte for byte. Each KV slot is stamped with its token id,
+so a mismatch names the position, the layer, and the token that should be there.
+
+The two fixture knobs that decide what gets covered:
+
+* ``deferred_dma`` holds each copy until the fixture releases it, instead of
+  letting it land at submit time. It is what makes an ack-before-copy bug
+  visible: acking a write-back whose D->H has not run corrupts 150 prefixes in
+  this file's workload with it on, and none with it off.
+* the workload shape decides chain length. A conversation that only grows is one
+  radix node, and its load-back is a single step, so ``branching_corpus`` is
+  what puts several evicted nodes on one root path and makes
+  ``split_full_load_back_spec`` do anything.
+
+What is faked: accelerator streams and events, ``transfer_kv_direct`` (a CUDA op
+restated in torch as the indexed copy it is), the host-memory budget check, and
+``cudaHostRegister``. Admission, load-back, eviction, write-back, and the
+controller's queues, acks and layer counter are all the shipped code.
+
+Two things stay out of reach here: the unaligned page tail (the CPU fixture has
+no ``alloc_extend``, so sequences are page-aligned) and anything that needs two
+TP ranks.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import contextlib
+import random
+import unittest
+import unittest.mock as mock
+from typing import Optional
+
+import msgspec
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.allocator import (
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InitLoadBackParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.hicache_storage import PoolName, SidecarPoolSpec
+from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import build_pool_entry
+from sglang.srt.mem_cache.l2_transfer import TransferCompletion
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.test_utils import CustomTestCase
+
+FULL = ComponentType.FULL
+
+# fp32 KV so a token id round-trips through the pools exactly.
+KV_DTYPE = torch.float32
+HEAD_NUM = 1
+HEAD_DIM = 4
+LAYER_NUM = 2
+# Admission reserves decode headroom it never spends here. Charging it is what
+# keeps the batch from over-committing the pool, so it has to be realistic
+# rather than 1 -- at 1 the reservation is too small to hold anything back.
+MAX_NEW_TOKENS = 8
+
+
+# ---------------------------------------------------------------------------
+# CPU stand-ins for the accelerator primitives the transfer path uses
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    """A completion flag, not a timestamp.
+
+    ``pending`` events carry the transfer itself: nothing is copied until the
+    event completes, which is what makes the fixture able to hold a DMA in
+    flight while the tree keeps mutating around it.
+    """
+
+    def __init__(self, enable_timing: bool = False):
+        self.enable_timing = enable_timing
+        self.work = None
+        self.done = True
+
+    def arm(self, work) -> "_FakeEvent":
+        self.work = work
+        self.done = False
+        return self
+
+    def complete(self) -> None:
+        if self.done:
+            return
+        self.done = True
+        if self.work is not None:
+            self.work()
+            self.work = None
+
+    def record(self, *args, **kwargs):
+        pass
+
+    def synchronize(self):
+        self.complete()
+
+    def query(self):
+        return self.done
+
+    def wait(self, *args, **kwargs):
+        pass
+
+    def elapsed_time(self, other):
+        return 0.0
+
+
+class _FakeStream:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def wait_event(self, *args, **kwargs):
+        pass
+
+    def synchronize(self):
+        pass
+
+
+class _FakeDeviceModule:
+    Event = _FakeEvent
+    Stream = _FakeStream
+
+    @staticmethod
+    @contextlib.contextmanager
+    def stream(stream):
+        yield
+
+    @staticmethod
+    def current_stream():
+        return _FakeStream()
+
+    @staticmethod
+    def synchronize():
+        pass
+
+
+class DeferredTransferEngine:
+    """``L2TransferEngine`` with the copies held until the fixture releases them.
+
+    The shipped engine issues each copy onto an accelerator stream and returns;
+    the data lands later. Running the copy inline on CPU would hide every bug
+    that needs a transfer to still be reading a host slot, or writing a device
+    slot, while the tree hands that slot to someone else -- which is most of
+    what the write-back and load-back pins exist to prevent.
+
+    One queue per direction, completed in order, as a stream would.
+    """
+
+    def __init__(self, io_backend: str):
+        self.io_backend = io_backend
+        self.host_to_device: list[_FakeEvent] = []
+        self.device_to_host: list[_FakeEvent] = []
+
+    def submit_device_to_host(self, transfers):
+        def work():
+            for transfer in transfers:
+                transfer.host_pool.backup_from_device_all_layer(
+                    transfer.device_pool,
+                    transfer.host_indices,
+                    transfer.device_indices,
+                    self.io_backend,
+                )
+
+        finish = _FakeEvent().arm(work)
+        self.device_to_host.append(finish)
+        return TransferCompletion(_FakeEvent(), finish, False)
+
+    def submit_host_to_device(
+        self, transfers, *, layer_num, start_event=None, on_layer_done=None
+    ):
+        primary = transfers[0] if transfers else None
+
+        def work():
+            for layer_id in range(layer_num):
+                for transfer in transfers:
+                    local_layer_id = (
+                        transfer.layer_mapper(layer_id)
+                        if transfer.layer_mapper is not None
+                        else layer_id
+                    )
+                    if local_layer_id is None or (
+                        transfer is not primary
+                        and transfer.layer_mapper is None
+                        and layer_id >= transfer.host_pool.layer_num
+                    ):
+                        continue
+                    transfer.host_pool.load_to_device_per_layer(
+                        transfer.device_pool,
+                        transfer.host_indices,
+                        transfer.device_indices,
+                        local_layer_id,
+                        self.io_backend,
+                        is_draft=transfer.is_draft,
+                    )
+                if on_layer_done is not None:
+                    on_layer_done(layer_id)
+
+        finish = _FakeEvent().arm(work)
+        self.host_to_device.append(finish)
+        return TransferCompletion(_FakeEvent(), finish, False)
+
+    def _release(self, queue: list, count: Optional[int]) -> int:
+        take = len(queue) if count is None else min(count, len(queue))
+        for event in queue[:take]:
+            event.complete()
+        del queue[:take]
+        # Anything the cache force-synchronized is already done; drop it so the
+        # queues stay a picture of what is still in flight.
+        queue[:] = [event for event in queue if not event.done]
+        return take
+
+    def release_host_to_device(self, count: Optional[int] = None) -> int:
+        return self._release(self.host_to_device, count)
+
+    def release_device_to_host(self, count: Optional[int] = None) -> int:
+        return self._release(self.device_to_host, count)
+
+    @property
+    def in_flight(self) -> int:
+        return sum(
+            1
+            for queue in (self.device_to_host, self.host_to_device)
+            for event in queue
+            if not event.done
+        )
+
+
+def _transfer_kv_direct(src_layers, dst_layers, src_indices, dst_indices, page_size):
+    """torch restatement of ``sgl_kernel.kvcacheio.transfer_kv_direct``.
+
+    The kernel coalesces runs of consecutive indices and copies one src buffer
+    into one dst buffer per layer; ``page_size`` only guards divisibility. The
+    observable result is an indexed copy.
+    """
+    assert len(src_layers) == len(dst_layers)
+    assert src_indices.numel() == dst_indices.numel()
+    assert page_size > 0 and src_indices.numel() % page_size == 0
+    for src, dst in zip(src_layers, dst_layers):
+        dst[dst_indices] = src[src_indices].to(dst.dtype)
+
+
+def cpu_hicache_patches():
+    """Patches that make the real HiCache stack constructible and runnable on CPU."""
+    import sglang.srt.managers.cache_controller as cache_controller
+    import sglang.srt.mem_cache.l2_transfer as l2_transfer
+    import sglang.srt.mem_cache.pool_host.base as pool_host_base
+    import sglang.srt.mem_cache.pool_host.common as pool_host_common
+    import sglang.srt.mem_cache.pool_host.mha as pool_host_mha
+
+    fake_device = _FakeDeviceModule()
+    return [
+        mock.patch.object(cache_controller, "device_module", fake_device),
+        mock.patch.object(l2_transfer, "device_module", fake_device),
+        mock.patch.object(l2_transfer, "_timing_events_supported", lambda: False),
+        # psutil reports the whole box; a shared login node can read as negative
+        # free memory long before the fixture's few MB matter.
+        mock.patch.object(pool_host_base, "host_memory_budget_bytes", lambda: 1 << 34),
+        mock.patch.object(
+            pool_host_common,
+            "_cuda_host_register",
+            lambda buf, granularity_bytes=None: None,
+        ),
+        mock.patch.object(pool_host_common, "_cuda_host_unregister", lambda buf: None),
+        mock.patch.object(
+            pool_host_mha, "transfer_kv_direct", _transfer_kv_direct, create=True
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+class HiCacheFixture:
+    """A real UnifiedRadixCache with a real HiCache controller, on CPU.
+
+    ``device_size`` and ``host_ratio`` are the two knobs that create pressure:
+    small device pool forces L1 eviction (and, under write_back, the D->H write
+    that funds it), small host pool forces host reclaim.
+    """
+
+    def __init__(
+        self,
+        stack: contextlib.ExitStack,
+        *,
+        device_size: int = 96,
+        host_ratio: float = 3.0,
+        page_size: int = 1,
+        serialize_load_back: bool = False,
+        allow_subagent_keepalive: bool = False,
+        write_policy: str = "write_back",
+        deferred_dma: bool = False,
+    ):
+        server_args = ServerArgs(
+            model_path="dummy",
+            page_size=page_size,
+            hicache_io_backend="direct",
+            hicache_mem_layout="layer_first",
+            hicache_write_policy=write_policy,
+            hicache_host_memory_mode="cache",
+            hicache_ratio=host_ratio,
+            hicache_serialize_load_back=serialize_load_back,
+        )
+        set_global_server_args_for_scheduler(server_args)
+
+        self.page_size = page_size
+        self.kv_pool = MHATokenToKVPool(
+            size=device_size,
+            page_size=page_size,
+            dtype=KV_DTYPE,
+            head_num=HEAD_NUM,
+            head_dim=HEAD_DIM,
+            layer_num=LAYER_NUM,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        allocator_cls = (
+            TokenToKVPoolAllocator if page_size == 1 else PagedTokenToKVPoolAllocator
+        )
+        allocator_kwargs = {} if page_size == 1 else {"page_size": page_size}
+        self.allocator = allocator_cls(
+            size=device_size,
+            dtype=KV_DTYPE,
+            device="cpu",
+            kvcache=self.kv_pool,
+            need_sort=False,
+            **allocator_kwargs,
+        )
+        self.req_pool = ReqToTokenPool(
+            size=64, max_context_len=4096, device="cpu", enable_memory_saver=False
+        )
+        params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            page_size=page_size,
+            eviction_policy="lru",
+            tree_components=(FULL,),
+            allow_subagent_keepalive=allow_subagent_keepalive,
+        )
+        self.cache = UnifiedRadixCache(params)
+        for patch in cpu_hicache_patches():
+            stack.enter_context(patch)
+        self.cache.init_hicache(server_args, params)
+        stack.callback(self.cache.release_host_resources)
+        self.engine = None
+        if deferred_dma:
+            self.engine = DeferredTransferEngine(
+                self.cache.cache_controller.l2_transfer_engine.io_backend
+            )
+            self.cache.cache_controller.l2_transfer_engine = self.engine
+        # Cache every node in both directions; the fixture is about placement,
+        # not about the size heuristics.
+        self.cache.write_through_threshold = 1
+        self.cache.load_back_threshold = 1
+        self.device_size = device_size
+        self.host_pool = self.cache.cache_controller.mem_pool_host
+        # Pools reserve slot 0 as padding, so read the free counts rather than
+        # assuming they equal the configured sizes.
+        self.sidecar = None
+        self.device_capacity = self.allocator.available_size()
+        self.host_capacity = self.host_pool.available_size()
+        self._next_rid = 0
+
+    # -- KV fingerprints ----------------------------------------------------
+
+    def stamp(self, indices: torch.Tensor, tokens) -> None:
+        """Write each token id into every layer of its own KV slot."""
+        stamp = torch.tensor(tokens, dtype=KV_DTYPE).view(-1, 1, 1)
+        for layer in range(LAYER_NUM):
+            self.kv_pool.k_buffer[layer][indices] = stamp.expand(-1, HEAD_NUM, HEAD_DIM)
+            self.kv_pool.v_buffer[layer][indices] = -stamp.expand(
+                -1, HEAD_NUM, HEAD_DIM
+            )
+
+    def read_stamps(self, indices: torch.Tensor, layer: int = 0) -> list[int]:
+        if indices.numel() == 0:
+            return []
+        return self.kv_pool.k_buffer[layer][indices][:, 0, 0].to(torch.int64).tolist()
+
+    def check_stamps(self, indices: torch.Tensor, tokens) -> Optional[str]:
+        """None if every layer of every slot holds its token's stamp."""
+        for layer in range(LAYER_NUM):
+            k = self.read_stamps(indices, layer)
+            if k != list(tokens):
+                return f"k_buffer layer {layer}: expected {list(tokens)}, got {k}"
+            v = (
+                self.kv_pool.v_buffer[layer][indices][:, 0, 0].to(torch.int64).tolist()
+                if indices.numel()
+                else []
+            )
+            if v != [-t for t in tokens]:
+                return (
+                    f"v_buffer layer {layer}: expected {[-t for t in tokens]}, got {v}"
+                )
+        return None
+
+    # -- KV-derived sidecar pool --------------------------------------------
+
+    def attach_sidecar(self) -> None:
+        """Register a second pool whose indices come from the KV pool.
+
+        This is the shape NSA/DSA models run with: their stack registers
+        ``SidecarPoolSpec(pool_name=INDEXER, indices_from_pool=KV)``, and the
+        controller resolves such a transfer's indices from the operation it
+        travels on. Nothing else in the fixture has one, and a cache that moves
+        Full KV correctly can still leave the sidecar behind.
+        """
+        device_pool = MHATokenToKVPool(
+            size=self.device_size,
+            page_size=self.page_size,
+            dtype=KV_DTYPE,
+            head_num=HEAD_NUM,
+            head_dim=HEAD_DIM,
+            layer_num=LAYER_NUM,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        host_pool = MHATokenToKVPoolHost(
+            device_pool=device_pool,
+            host_to_device_ratio=2.0,
+            host_size=0,
+            page_size=self.page_size,
+            layout="layer_first",
+            pin_memory=False,
+            device="cpu",
+        )
+        self.cache.register_sidecar_pool(
+            SidecarPoolSpec(pool_name=PoolName.INDEXER, indices_from_pool=PoolName.KV),
+            build_pool_entry(
+                name=PoolName.INDEXER,
+                host_pool=host_pool,
+                device_pool=device_pool,
+                layer_mapping={i: i for i in range(LAYER_NUM)},
+                transfer_layer_num=LAYER_NUM,
+            ),
+        )
+        self.sidecar = device_pool
+
+    def stamp_sidecar(self, indices: torch.Tensor, tokens) -> None:
+        stamp = torch.tensor(tokens, dtype=KV_DTYPE).view(-1, 1, 1)
+        for layer in range(LAYER_NUM):
+            self.sidecar.k_buffer[layer][indices] = stamp.expand(-1, HEAD_NUM, HEAD_DIM)
+
+    def check_sidecar(self, indices: torch.Tensor, tokens) -> Optional[str]:
+        for layer in range(LAYER_NUM):
+            got = (
+                self.sidecar.k_buffer[layer][indices][:, 0, 0].to(torch.int64).tolist()
+                if indices.numel()
+                else []
+            )
+            if got != list(tokens):
+                wrong = sum(1 for a, b in zip(got, tokens) if a != b)
+                return (
+                    f"sidecar layer {layer}: {wrong}/{len(got)} slots hold "
+                    f"another request's tokens"
+                )
+        return None
+
+    # -- plumbing -----------------------------------------------------------
+
+    def make_req(self, tokens, *, session_id: str = "") -> Req:
+        req = Req(
+            rid=str(self._next_rid),
+            origin_input_text="",
+            origin_input_ids=list(tokens),
+            sampling_params=SamplingParams(
+                temperature=0, max_new_tokens=MAX_NEW_TOKENS
+            ),
+            session_id=session_id,
+        )
+        self._next_rid += 1
+        req.output_ids = []
+        req.parent_session_id = ""
+        self.req_pool.alloc([req])
+        return req
+
+    def release_host_to_device(self, count: Optional[int] = None) -> int:
+        """Let queued H->D transfers land. No-op with an inline engine."""
+        return 0 if self.engine is None else self.engine.release_host_to_device(count)
+
+    def release_device_to_host(self, count: Optional[int] = None) -> int:
+        """Let queued D->H write-backs land. No-op with an inline engine."""
+        return 0 if self.engine is None else self.engine.release_device_to_host(count)
+
+    def alloc_with_eviction(self, need: int) -> Optional[torch.Tensor]:
+        """``alloc_token_slots``: evict only the shortfall, then allocate."""
+        available = self.allocator.available_size()
+        if available < need:
+            self.cache.evict(EvictParams(num_tokens=need - available))
+        return self.allocator.alloc(need)
+
+    def alloc_extend(self, req: Req, extend_len: int) -> Optional[torch.Tensor]:
+        """``PagedTokenToKVPoolAllocator.alloc_extend``, in torch.
+
+        The shipped one is a Triton kernel, so a CPU fixture has to restate it:
+        finish the prefix's partial page from ``last_loc + 1``, then take whole
+        pages for the rest. Restating it is what buys the page_size > 1 shape --
+        an unaligned prefix, which is the only case where
+        ``cache_protected_len`` differs from ``len(prefix_indices)``.
+        """
+        page_size = self.page_size
+        if page_size == 1:
+            return self.alloc_with_eviction(extend_len)
+
+        prefix_len = req.extend_range.start
+        parts: list[torch.Tensor] = []
+        remaining = extend_len
+        partial = prefix_len % page_size
+        if partial and remaining:
+            last_loc = int(
+                self.req_pool.req_to_token[req.kv.req_pool_idx, prefix_len - 1]
+            )
+            take = min(page_size - partial, remaining)
+            parts.append(torch.arange(last_loc + 1, last_loc + 1 + take))
+            remaining -= take
+        if remaining:
+            # Whole pages; the last page's unused tail stays with the request
+            # until the page is released.
+            pages = self.alloc_with_eviction(-(-remaining // page_size) * page_size)
+            if pages is None:
+                return None
+            parts.append(pages[:remaining])
+        return torch.cat(parts) if parts else torch.empty(0, dtype=torch.int64)
+
+    @property
+    def budget(self) -> int:
+        """What ``PrefillAdder.rem_total_tokens`` starts from."""
+        return self.allocator.available_size() + self.cache.evictable_size()
+
+    # -- conservation -------------------------------------------------------
+
+    def _tree_nodes(self):
+        stack = [self.cache.tree_core.root_node]
+        while stack:
+            node = stack.pop()
+            stack.extend(node.children.values())
+            if node is not self.cache.tree_core.root_node:
+                yield node
+
+    def slot_census(self) -> tuple[int, int]:
+        """(device, host) slots the tree currently owns."""
+        device = host = 0
+        for node in self._tree_nodes():
+            data = node.component_data[FULL]
+            if data.value is not None:
+                device += len(data.value)
+            if data.host_value is not None:
+                host += len(data.host_value)
+        return device, host
+
+    def conservation_error(self, request_held: int = 0) -> Optional[str]:
+        """Every slot is owned by a tree node, held by a live request, or free.
+
+        A load-back that overwrites a node's device indices, or drops a
+        ``host_value`` it still owns, strands the old slots: they are in no node
+        and in no free list, and the pool shrinks until allocation fails.
+
+        ``request_held`` covers a chunked request's prefilled tail, which is in
+        ``req_to_token`` but not yet in the tree.
+        """
+        device_owned, host_owned = self.slot_census()
+        device_total = device_owned + request_held + self.allocator.available_size()
+        if device_total != self.device_capacity:
+            return (
+                f"device slots: {device_owned} owned + {request_held} in flight + "
+                f"{self.allocator.available_size()} free = {device_total}, "
+                f"expected {self.device_capacity}"
+            )
+        host_total = host_owned + self.host_pool.available_size()
+        if host_total != self.host_capacity:
+            return (
+                f"host slots: {host_owned} owned + "
+                f"{self.host_pool.available_size()} free = {host_total}, "
+                f"expected {self.host_capacity}"
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# A scheduler loop, in the order scheduler.py runs it
+# ---------------------------------------------------------------------------
+
+
+class StepResult(msgspec.Struct):
+    admitted: list[str] = []
+    deferred: int = 0
+    prefix_lens: dict[str, int] = {}
+    host_hits: dict[str, int] = {}
+    corruption: list[str] = []
+    chunked: int = 0
+
+    @property
+    def total_host_hit(self) -> int:
+        return sum(self.host_hits.values())
+
+
+class MiniScheduler:
+    """The cache-facing half of the scheduler loop, over a fixed arrival trace.
+
+    Only the calls that reach the cache are modelled, in the order
+    ``get_next_batch_to_run`` -> ``get_new_batch_prefill`` -> forward ->
+    ``process_batch_result`` makes them:
+
+        release the previous step's write-backs, check_hicache_events
+        stash the in-flight chunk         cache_unfinished_req(chunked=True)
+        admit the chunk                   add_chunked_req (no load-back)
+        admit new requests                match_prefix -> init_load_back -> lock
+        ready_to_load_host_cache          the batched H->D
+        allocate, evicting the shortfall
+        forward                           read the prefix, write the extension
+        completion                        cache_finished_req
+
+    ``max_prefill_tokens`` is the served ``--max-prefill-tokens``: a request
+    longer than it is prefilled over several steps, and between chunks its
+    partial KV goes into the tree and its prefix is re-matched. Its prefix has
+    to stay intact across every one of those steps, which is a longer exposure
+    than a single-shot request ever gets.
+    """
+
+    def __init__(
+        self,
+        fx: HiCacheFixture,
+        *,
+        max_prefill_tokens: Optional[int] = None,
+        keepalive: bool = False,
+    ):
+        self.fx = fx
+        self.max_prefill_tokens = max_prefill_tokens or 1 << 30
+        self.keepalive = keepalive
+        self.waiting: list[Req] = []
+        self.chunked_req: Optional[Req] = None
+
+    # -- arrival -------------------------------------------------------------
+
+    def submit(self, tokens, *, session_id="", parent_session_id="") -> None:
+        req = self.fx.make_req(tokens, session_id=session_id)
+        req.parent_session_id = parent_session_id
+        self.waiting.append(req)
+
+    # -- one iteration -------------------------------------------------------
+
+    def step(self) -> StepResult:
+        fx, cache = self.fx, self.fx.cache
+        fx.release_device_to_host()
+        cache.check_hicache_events()
+
+        result = StepResult()
+        self._stash_previous_chunk()
+
+        can_run: list[Req] = []
+        committed = 0
+        if self.chunked_req is not None:
+            committed += self._admit_chunk(self.chunked_req, can_run, result)
+
+        # A truncated request spends the batch's whole chunk budget, so it is
+        # the last one admitted -- scheduler.py asserts one chunked request at
+        # a time.
+        while self.waiting and self.chunked_req is None:
+            req = self.waiting[0]
+            if committed + len(req.origin_input_ids) + MAX_NEW_TOKENS > (
+                fx.device_capacity
+            ):
+                result.deferred += 1
+                break
+            self.waiting.pop(0)
+            committed += self._admit(req, can_run, result)
+
+        # The batched H->D for everything admitted above. Serialized load-back
+        # has already drained its own transfers, so this finds an empty queue.
+        consumer_index = cache.ready_to_load_host_cache()
+        self._allocate(can_run)
+        # Only the forward waits on the load. Admission and allocation above ran
+        # with it in flight, which is the window the load-back pins must cover.
+        fx.release_host_to_device()
+        self._forward(can_run, result, consumer_index)
+        self._complete(can_run)
+        return result
+
+    # -- the pieces ----------------------------------------------------------
+
+    def _stash_previous_chunk(self) -> None:
+        """scheduler.get_next_batch_to_run: cache the chunk that just ran."""
+        req = self.chunked_req
+        if req is None or req.extend_range.end <= len(req.prefix_indices):
+            return
+        self.fx.cache.cache_unfinished_req(req, chunked=True)
+
+    def _admit_chunk(self, req: Req, can_run: list[Req], result: StepResult) -> int:
+        """PrefillAdder.add_chunked_req. No match, no load-back: the chunk
+        carries the prefix_indices cache_unfinished_req left on it."""
+        req.init_next_round_input()
+        prefix_len = len(req.prefix_indices)
+        remaining = len(req.full_untruncated_fill_ids) - prefix_len
+        take = min(remaining, self.max_prefill_tokens)
+        req.set_extend_range(prefix_len, prefix_len + take)
+        can_run.append(req)
+        result.admitted.append(req.rid)
+        result.prefix_lens[req.rid] = prefix_len
+        result.host_hits.setdefault(req.rid, 0)
+        result.chunked += 1
+        if take == remaining:
+            self.chunked_req = None
+        return req.extend_range.end
+
+    def _admit(self, req: Req, can_run: list[Req], result: StepResult) -> int:
+        """PrefillAdder.add_one_req, down to the calls that touch the cache."""
+        cache = self.fx.cache
+        if self.keepalive and req.parent_session_id:
+            # What a subagent request does to its parent on arrival.
+            cache.bump_session_keepalive(req.parent_session_id)
+
+        req.init_next_round_input(cache)
+        result.host_hits[req.rid] = req.host_hit_length
+
+        guard = cache.inc_lock_ref(req.last_node)
+        guard_node = req.last_node
+        if req.needs_host_load_back():
+            new_indices, req.last_node = cache.init_load_back(
+                InitLoadBackParams(
+                    best_match_node=req.best_match_node,
+                    host_hit_length=req.host_hit_length,
+                    req=req,
+                )
+            )
+            req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
+            req.kv.cache_protected_len = len(req.prefix_indices)
+        # _req_inc_lock_ref, then release the guard.
+        cache.inc_lock_ref(req.last_node)
+        req.skip_lock_node_ids = {}
+        cache.dec_lock_ref(guard_node, guard.to_dec_params())
+
+        prefix_len = len(req.prefix_indices)
+        take = min(len(req.origin_input_ids) - prefix_len, self.max_prefill_tokens)
+        req.set_extend_range(prefix_len, prefix_len + take)
+        if req.extend_range.end < len(req.origin_input_ids):
+            assert self.chunked_req is None, "one chunked request at a time"
+            self.chunked_req = req
+            result.chunked += 1
+
+        can_run.append(req)
+        result.admitted.append(req.rid)
+        result.prefix_lens[req.rid] = prefix_len
+        return req.extend_range.end
+
+    def _allocate(self, can_run: list[Req]) -> None:
+        """alloc_for_extend: evict the shortfall, then write req_to_token."""
+        fx = self.fx
+        for req in can_run:
+            extend = fx.alloc_extend(req, req.extend_range.length)
+            assert extend is not None, (
+                f"req {req.rid} could not allocate {req.extend_range.length} "
+                f"slots (available {fx.allocator.available_size()}, "
+                f"evictable {fx.cache.evictable_size()})"
+            )
+            req.out_cache_loc = extend
+            prefix_len = len(req.prefix_indices)
+            fx.req_pool.write(
+                (req.kv.req_pool_idx, slice(0, prefix_len)), req.prefix_indices
+            )
+            fx.req_pool.write(
+                (req.kv.req_pool_idx, slice(prefix_len, req.extend_range.end)), extend
+            )
+
+    def _forward(
+        self, can_run: list[Req], result: StepResult, consumer_index: int
+    ) -> None:
+        """Read what the attention would read, then write this chunk's KV."""
+        fx = self.fx
+        for req in can_run:
+            seen = fx.req_pool.req_to_token[
+                req.kv.req_pool_idx, : req.extend_range.start
+            ]
+            expected = req.origin_input_ids[: req.extend_range.start]
+            problem = fx.check_stamps(seen, expected)
+            if problem is not None:
+                result.corruption.append(
+                    f"req {req.rid} (prefix {req.extend_range.start}, host hit "
+                    f"{result.host_hits.get(req.rid, 0)}, chunk "
+                    f"[{req.extend_range.start}:{req.extend_range.end}), "
+                    f"consumer {consumer_index}): {problem}"
+                )
+            if fx.sidecar is not None:
+                problem = fx.check_sidecar(seen, expected)
+                if problem is not None:
+                    result.corruption.append(
+                        f"req {req.rid} (prefix {req.extend_range.start}, host "
+                        f"hit {result.host_hits.get(req.rid, 0)}): {problem}"
+                    )
+            new_tokens = req.origin_input_ids[
+                req.extend_range.start : req.extend_range.end
+            ]
+            fx.stamp(req.out_cache_loc, new_tokens)
+            if fx.sidecar is not None:
+                fx.stamp_sidecar(req.out_cache_loc, new_tokens)
+
+    def request_held_slots(self) -> int:
+        """Device slots a chunked request holds beyond what the tree owns.
+
+        Page-rounded: the allocator hands out whole pages, so the tail of the
+        request's last page is held by it even though no token uses it yet.
+        """
+        req = self.chunked_req
+        if req is None or req.extend_range is None:
+            return 0
+        page_size = self.fx.page_size
+        held = -(-req.extend_range.end // page_size) * page_size
+        return max(0, held - req.kv.cache_protected_len)
+
+    def _complete(self, can_run: list[Req]) -> None:
+        for req in can_run:
+            if req is self.chunked_req:
+                continue
+            self.fx.cache.cache_finished_req(
+                req, kv_len_to_handle=len(req.origin_input_ids)
+            )
+            self.fx.req_pool.free(req)
+
+
+def run_step(fx: HiCacheFixture, batch: list[list[int]]) -> StepResult:
+    """One unchunked step, for tests that do not need the loop's state."""
+    scheduler = MiniScheduler(fx)
+    for tokens in batch:
+        scheduler.submit(tokens)
+    return scheduler.step()
+
+
+# ---------------------------------------------------------------------------
+# Workloads
+# ---------------------------------------------------------------------------
+
+
+def branching_corpus(*, depth: int, fanout: int, seg: int) -> list[list[int]]:
+    """Leaves of a prefix tree: a shared root segment, then `depth` levels that
+    branch `fanout` ways, each adding `seg` tokens.
+
+    Chain length is the whole point. A radix node is created by divergence, so a
+    single conversation that only grows is one node and its load-back is one
+    step -- the per-node walk never runs. Branching is what puts several evicted
+    nodes on one root path, which is the shape ``split_full_load_back_spec``
+    exists to split. Every token id is globally unique, so a KV stamp identifies
+    which branch and which level wrote it.
+    """
+    leaves: list[list[int]] = []
+
+    def walk(prefix: list[int], level: int, path: list[int]) -> None:
+        if level == depth:
+            leaves.append(prefix)
+            return
+        for branch in range(fanout):
+            base = 10_000 * (level + 1) + 1_000 * branch + 100 * len(path)
+            walk(prefix + list(range(base, base + seg)), level + 1, path + [branch])
+
+    walk(list(range(1, seg + 1)), 0, [])
+    return leaves
+
+
+def replay(
+    corpus: list[list[int]], *, steps: int, per_step: int, seed: int
+) -> list[list[list[int]]]:
+    """Fixed, seeded reuse order over a corpus. Reuse order is what schedules
+    eviction, so it is an input, not a source of flakiness -- the same seed
+    replays the same tree, evictions and load-backs on every run."""
+    rng = random.Random(seed)
+    return [[list(rng.choice(corpus)) for _ in range(per_step)] for _ in range(steps)]
+
+
+def growing_sessions(
+    *, sessions: int, turns: int, base_len: int, turn_len: int, per_step: int
+) -> list[list[list[int]]]:
+    """Conversations resumed round-robin, each turn appending to its own prefix.
+
+    More sessions than fit on device is the point: a session nobody touched this
+    step is unlocked, so it is what eviction takes, and its next turn matches on
+    the host tier.
+    """
+    convs = {
+        s: list(range(100_000 * (s + 1), 100_000 * (s + 1) + base_len))
+        for s in range(sessions)
+    }
+    counters = {s: 0 for s in range(sessions)}
+    steps: list[list[list[int]]] = []
+    cursor = 0
+    for _ in range(turns * sessions // per_step):
+        step = []
+        for _ in range(per_step):
+            session = cursor % sessions
+            cursor += 1
+            step.append(list(convs[session]))
+            counters[session] += 1
+            start = 100_000 * (session + 1) + 1_000 * counters[session]
+            convs[session] = convs[session] + list(range(start, start + turn_len))
+        steps.append(step)
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class HiCacheKVIntegrityTest(CustomTestCase):
+    """A matched prefix must hold the KV it was cached under.
+
+    Nothing else in this directory checks the bytes. A load-back that commits
+    the wrong device indices, or reads a host slot that has been handed to
+    another node, keeps every counter consistent and every sanity_check green
+    while serving one request another request's KV -- which reaches the client
+    as a plausible completion or an immediate stop token, never as an error.
+    """
+
+    def _drive(self, steps, *, sidecar: bool = False, **fixture_kwargs):
+        """Run a workload; return (corruption, host-hit tokens, load-backs)."""
+        with contextlib.ExitStack() as stack:
+            fixture = HiCacheFixture(stack, **fixture_kwargs)
+            if sidecar:
+                fixture.attach_sidecar()
+            chain_lengths: list[int] = []
+            split = fixture.cache.tree_core.split_full_load_back_spec
+
+            def counting_split(kv_xfer):
+                out = split(kv_xfer)
+                chain_lengths.append(len(out))
+                return out
+
+            fixture.cache.tree_core.split_full_load_back_spec = counting_split
+
+            corruption, host_hits = [], 0
+            for step in steps:
+                result = run_step(fixture, step)
+                corruption.extend(result.corruption)
+                host_hits += result.total_host_hit
+                leak = fixture.conservation_error()
+                self.assertIsNone(leak, leak)
+                fixture.cache.sanity_check()
+            return corruption, host_hits, chain_lengths
+
+    def _assert_intact(self, steps, *, sidecar: bool = False, **fixture_kwargs):
+        corruption, host_hits, chains = self._drive(
+            steps, sidecar=sidecar, **fixture_kwargs
+        )
+        self.assertGreater(
+            host_hits,
+            0,
+            "the workload never hit the host tier, so it never exercised "
+            "load-back; shrink device_size or lengthen the workload",
+        )
+        self.assertEqual(
+            corruption,
+            [],
+            f"{len(corruption)} corrupted prefixes:\n" + "\n".join(corruption[:5]),
+        )
+        return chains
+
+    # -- growing conversations ----------------------------------------------
+
+    def test_growing_sessions_batched(self):
+        steps = growing_sessions(
+            sessions=12, turns=8, base_len=16, turn_len=8, per_step=2
+        )
+        self._assert_intact(steps, device_size=96, host_ratio=2.5)
+
+    def test_growing_sessions_serialized(self):
+        steps = growing_sessions(
+            sessions=12, turns=8, base_len=16, turn_len=8, per_step=2
+        )
+        self._assert_intact(
+            steps, device_size=96, host_ratio=2.5, serialize_load_back=True
+        )
+
+    # -- branching corpus, which is what makes chains longer than one node ---
+
+    def test_branching_corpus_batched(self):
+        steps = replay(
+            branching_corpus(depth=6, fanout=2, seg=8),
+            steps=120,
+            per_step=2,
+            seed=20260908,
+        )
+        self._assert_intact(steps, device_size=128, host_ratio=1.6)
+
+    def test_branching_corpus_serialized(self):
+        steps = replay(
+            branching_corpus(depth=6, fanout=2, seg=8),
+            steps=120,
+            per_step=2,
+            seed=20260908,
+        )
+        chains = self._assert_intact(
+            steps, device_size=128, host_ratio=1.6, serialize_load_back=True
+        )
+        self.assertGreater(
+            max(chains, default=0),
+            2,
+            "no load-back split into more than two steps, so the per-node walk "
+            "was never really exercised",
+        )
+
+    def test_branching_corpus_serialized_deferred_dma(self):
+        """Same replay with the copies held in flight past admission, eviction
+        and allocation, so a transfer is only correct if the tokens it named
+        still belong to it when it lands.
+
+        Distinct from the inline runs above, not a duplicate of them: an ack
+        that fires before its D->H copy has run corrupts 150 prefixes in this
+        workload with deferral on and none with it off, because inline copies
+        make the ack and the copy the same instant.
+        """
+        steps = replay(
+            branching_corpus(depth=6, fanout=2, seg=8),
+            steps=120,
+            per_step=2,
+            seed=20260908,
+        )
+        self._assert_intact(
+            steps,
+            device_size=128,
+            host_ratio=1.6,
+            serialize_load_back=True,
+            deferred_dma=True,
+            sidecar=True,
+        )
+
+    def test_branching_corpus_batched_deferred_dma(self):
+        steps = replay(
+            branching_corpus(depth=6, fanout=2, seg=8),
+            steps=120,
+            per_step=2,
+            seed=20260908,
+        )
+        self._assert_intact(steps, device_size=128, host_ratio=1.6, deferred_dma=True)
+
+    # -- paged --------------------------------------------------------------
+
+    def test_paged_branching_corpus_serialized(self):
+        """page_size > 1 is the served configuration; the radix key, the host
+        pool and the allocator are all page-indexed there."""
+        steps = replay(
+            branching_corpus(depth=5, fanout=2, seg=8),
+            steps=80,
+            per_step=2,
+            seed=20260908,
+        )
+        self._assert_intact(
+            steps,
+            device_size=256,
+            host_ratio=1.6,
+            page_size=4,
+            serialize_load_back=True,
+            sidecar=True,
+        )
+
+    def test_paged_branching_corpus_batched(self):
+        steps = replay(
+            branching_corpus(depth=5, fanout=2, seg=8),
+            steps=80,
+            per_step=2,
+            seed=20260908,
+        )
+        self._assert_intact(steps, device_size=256, host_ratio=1.6, page_size=4)
+
+    def test_the_stamp_check_reports_a_planted_mismatch(self):
+        """Keep the detector honest.
+
+        Every case in this file is an assertion that ``check_stamps`` found
+        nothing. If a refactor ever left it comparing something vacuous -- an
+        empty slice, a list against itself -- the whole file would go green and
+        stay green. So plant a corrupted slot and require it to be named.
+        """
+        with contextlib.ExitStack() as stack:
+            fixture = HiCacheFixture(stack, device_size=32, host_ratio=2.0)
+            indices = fixture.allocator.alloc(4)
+            tokens = [11, 22, 33, 44]
+            fixture.stamp(indices, tokens)
+            self.assertIsNone(fixture.check_stamps(indices, tokens))
+
+            fixture.stamp(indices[2:3], [99])
+            problem = fixture.check_stamps(indices, tokens)
+            self.assertIsNotNone(problem, "a corrupted slot went unreported")
+            self.assertIn("99", problem)
+
+            # A layer the workload never reads must still be checked: a
+            # per-layer transfer bug can leave layer 0 right and layer 1 wrong.
+            fixture.stamp(indices[2:3], [33])
+            fixture.kv_pool.k_buffer[LAYER_NUM - 1][indices[1]] = 0
+            self.assertIsNotNone(fixture.check_stamps(indices, tokens))
+
+    # -- KV-derived sidecar pools -------------------------------------------
+
+    def test_serialized_load_back_restores_a_kv_derived_sidecar(self):
+        """A KV-derived sidecar must be restored for the whole chain, not just
+        the node the last step happened to load.
+
+        Such a sidecar (NSA/DSA register one as ``INDEXER``) carries no indices;
+        the controller resolves them from the operation it rides on. Attaching
+        one built for the whole chain to the final per-node step restores it for
+        that node's tokens only, and every earlier node of the chain keeps
+        whatever its freshly allocated slots held -- another request's data. The
+        Full KV is correct throughout, so nothing in the tree looks wrong; the
+        model just attends with someone else's index state.
+        """
+        steps = replay(
+            branching_corpus(depth=6, fanout=2, seg=8),
+            steps=120,
+            per_step=2,
+            seed=20260908,
+        )
+        for serialize in (False, True):
+            with self.subTest(serialize_load_back=serialize):
+                with contextlib.ExitStack() as stack:
+                    fixture = HiCacheFixture(
+                        stack,
+                        device_size=128,
+                        host_ratio=1.6,
+                        serialize_load_back=serialize,
+                    )
+                    fixture.attach_sidecar()
+                    chains: list[int] = []
+                    split = fixture.cache.tree_core.split_full_load_back_spec
+
+                    def counting_split(kv_xfer):
+                        out = split(kv_xfer)
+                        chains.append(len(out))
+                        return out
+
+                    fixture.cache.tree_core.split_full_load_back_spec = counting_split
+                    scheduler = MiniScheduler(fixture)
+                    corruption = []
+                    for step in steps:
+                        for tokens in step:
+                            scheduler.submit(tokens)
+                        corruption.extend(scheduler.step().corruption)
+                    if serialize:
+                        self.assertGreater(
+                            max(chains, default=0),
+                            1,
+                            "no load-back split into more than one step, so the "
+                            "sidecar could not have been left behind either way",
+                        )
+                    self.assertEqual(
+                        corruption,
+                        [],
+                        f"{len(corruption)} requests read a stale prefix:\n"
+                        + "\n".join(corruption[:5]),
+                    )
+
+
+class SerializedLoadBackControllerTest(CustomTestCase):
+    """The serialized path's contract with the real cache controller.
+
+    ``test_serialized_load_back.py`` covers the same code against a fake
+    controller and a stubbed drain. These run it against the shipped
+    ``HiCacheController`` -- its queues, its acks, its layer counter.
+    """
+
+    STEPS = replay(
+        branching_corpus(depth=5, fanout=2, seg=8),
+        steps=80,
+        per_step=2,
+        seed=20260908,
+    )
+
+    def test_drain_leaves_no_queued_transfer_for_the_batch(self):
+        """Draining inside admission is what lets the batch's
+        ``ready_to_load_host_cache`` return -1 and the forward skip the layer
+        wait. A transfer left queued would be submitted with no consumer, and a
+        left-over ack would be miscounted by the next ``loading_check``."""
+        with contextlib.ExitStack() as stack:
+            fixture = HiCacheFixture(
+                stack, device_size=128, host_ratio=1.6, serialize_load_back=True
+            )
+            controller = fixture.cache.cache_controller
+            saw_load_back = False
+            for step in self.STEPS:
+                result = run_step(fixture, step)
+                saw_load_back = saw_load_back or bool(result.total_host_hit)
+                self.assertEqual(
+                    controller.load_queue, [], "a load-back transfer stayed queued"
+                )
+                self.assertEqual(
+                    controller.ack_load_queue, [], "a load-back ack stayed unconsumed"
+                )
+            self.assertTrue(saw_load_back, "workload never exercised load-back")
+
+    def test_per_node_drains_do_not_trip_the_producer_ring(self):
+        """``LayerDoneCounter`` has three slots and ``update_producer`` asserts
+        the slot it wraps onto has finished. Per-node draining issues one
+        producer per node instead of one per batch, so it laps the ring far
+        sooner than the batched path ever does."""
+        with contextlib.ExitStack() as stack:
+            fixture = HiCacheFixture(
+                stack, device_size=128, host_ratio=1.6, serialize_load_back=True
+            )
+            counter = fixture.cache.cache_controller.layer_done_counter
+            producers = 0
+            update = counter.update_producer
+
+            def counting_update():
+                nonlocal producers
+                producers += 1
+                return update()
+
+            counter.update_producer = counting_update
+            for step in self.STEPS:
+                run_step(fixture, step)
+            self.assertGreater(
+                producers,
+                counter.num_counters,
+                "the run never lapped the producer ring, so the assert it "
+                "guards was never reached",
+            )
+
+    def test_serialized_load_back_does_not_reuse_less_than_the_batched_path(self):
+        """Splitting the load-back exists to raise reuse, not to trade it away.
+
+        Loading a chain as one transfer demands device room for the whole chain
+        at the moment none of it is a reclaimable host duplicate, so the
+        write-back that eviction cascades into can only be funded by destroying
+        a sole host copy -- someone else's cached prefix. Per-node steps make
+        each node a duplicate at its own ack. On a fixed replay the effect is
+        measurable: the serialized run must reuse at least as many prefix tokens
+        as the batched one.
+        """
+        reused = {}
+        for serialize in (False, True):
+            with contextlib.ExitStack() as stack:
+                fixture = HiCacheFixture(
+                    stack,
+                    device_size=128,
+                    host_ratio=1.6,
+                    serialize_load_back=serialize,
+                )
+                total = 0
+                for step in self.STEPS:
+                    result = run_step(fixture, step)
+                    self.assertEqual(result.corruption, [])
+                    total += sum(result.prefix_lens.values())
+                reused[serialize] = total
+        self.assertGreater(reused[False], 0, "the control run reused nothing")
+        self.assertGreaterEqual(
+            reused[True],
+            reused[False],
+            f"serialized load-back reused {reused[True]} prefix tokens against "
+            f"{reused[False]} for the batched path; the split is supposed to "
+            f"protect host copies, not cost them",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_serialized_load_back.py
+++ b/test/registered/unit/mem_cache/test_serialized_load_back.py
@@ -1,0 +1,273 @@
+"""Tests for --hicache-serialize-load-back on UnifiedRadixCache.
+
+Load-back must not clear device room for a whole chain at once: under write_back
+that eviction cascades into a host write whose only non-destructive funding is
+reclaimable host duplicates, and a chain that has not been loaded yet contains
+none. Per-node steps make each node a duplicate at its own ack.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.test_utils import CustomTestCase
+
+FULL = ComponentType.FULL
+NODE_LEN = 4
+CHAIN = [[10, 11, 12, 13], [20, 21, 22, 23], [30, 31, 32, 33]]
+
+
+def make_cache(serialize_load_back: bool):
+    """FULL-only, page_size=1, CPU cache; hicache is stubbed by the tests."""
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy", page_size=1))
+    dtype = torch.float16
+    kv_pool = MHATokenToKVPool(
+        size=64,
+        page_size=1,
+        dtype=dtype,
+        head_num=2,
+        head_dim=8,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    allocator = TokenToKVPoolAllocator(
+        size=64,
+        dtype=dtype,
+        device="cpu",
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    req_pool = ReqToTokenPool(
+        size=8, max_context_len=128, device="cpu", enable_memory_saver=False
+    )
+    params = CacheInitParams(
+        disable=False,
+        req_to_token_pool=req_pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=1,
+        eviction_policy="lru",
+        tree_components=(FULL,),
+    )
+    cache = UnifiedRadixCache(params)
+    cache.serialize_load_back = serialize_load_back
+    # Set by the hicache init branch, which a controller-less cache skips.
+    cache.load_back_threshold = 10
+    cache.tree_core.is_write_back = True
+    return cache, allocator
+
+
+class _FakeController:
+    """Records each load and hands back freshly allocated device slots."""
+
+    def __init__(self, allocator):
+        self.allocator = allocator
+        self.loads = []
+
+    def load(self, *, host_indices, node_id, extra_pools=None):
+        device_indices = self.allocator.alloc(len(host_indices))
+        assert device_indices is not None
+        self.loads.append(
+            {
+                "node_id": node_id,
+                "host_indices": host_indices.tolist(),
+                "extra_pools": extra_pools,
+            }
+        )
+        return device_indices
+
+
+class SerializedLoadBackTest(CustomTestCase):
+    def setUp(self):
+        self.cache, self.allocator = make_cache(serialize_load_back=True)
+        self.controller = _FakeController(self.allocator)
+        self.cache.cache_controller = self.controller
+        self.events = []
+        self.cache.evict_for_alloc = self._record_evict
+        self.cache._drain_serialized_load_back = self._fake_drain
+
+    def _record_evict(self, params):
+        self.events.append(("evict", params.num_tokens))
+        raise AssertionError("no eviction expected: the pool has room")
+
+    def _fake_drain(self):
+        """Stand in for start_loading + loading_check on the queued step."""
+        step_id = next(reversed(self.cache.ongoing_load_back))
+        node, lock_params, host_lock_params = self.cache.ongoing_load_back.pop(step_id)
+        self.cache.dec_lock_ref(node, lock_params)
+        self.cache.dec_host_lock_ref(node, host_lock_params)
+        self.cache.tree_core.finish_load_back(node)
+        self.events.append(("drain", step_id))
+
+    def _build_evicted_chain(self):
+        """Insert CHAIN as a path, then move every node but the root's child
+        to host-only, which is the shape ``build_load_back_spec`` walks."""
+        tokens = [t for seg in CHAIN for t in seg]
+        device_indices = self.allocator.alloc(len(tokens))
+        self.cache.insert(
+            InsertParams(key=RadixKey(token_ids=tokens), value=device_indices)
+        )
+
+        # Split into one node per CHAIN segment by matching each prefix.
+        for i in range(1, len(CHAIN)):
+            prefix = [t for seg in CHAIN[:i] for t in seg]
+            self.cache.match_prefix(MatchPrefixParams(key=RadixKey(token_ids=prefix)))
+
+        anchor = self.cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(token_ids=tokens))
+        ).best_match_node
+        node_id = anchor if isinstance(anchor, int) else anchor.id
+
+        chain = []
+        node = self.cache.tree_core.node_by_id(node_id)
+        while node is not None and node is not self.cache.tree_core.root_node:
+            chain.append(node)
+            node = node.parent
+        chain.reverse()
+
+        # Host-only: keep the device values as the host image, drop the device
+        # side. Real eviction does this through the controller.
+        for node in chain:
+            cd = node.component_data[FULL]
+            self.allocator.free(cd.value)
+            cd.host_value = cd.value.cpu()
+            cd.value = None
+            self.cache.tree_core._update_evictable_leaf_sets(node)
+        return node_id, chain
+
+    def test_split_partitions_the_chain_root_first(self):
+        node_id, chain = self._build_evicted_chain()
+        kv_xfer, _ = self.cache.tree_core.build_load_back_spec(node_id)
+        steps = self.cache.tree_core.split_full_load_back_spec(kv_xfer)
+
+        self.assertEqual([s.nodes_to_load for s in steps], [[n.id] for n in chain])
+        # The anchor is last: _load_back_per_node relies on it to attach aux.
+        self.assertEqual(steps[-1].nodes_to_load, [node_id])
+        flat = [t for s in steps for t in s.host_indices.tolist()]
+        self.assertEqual(flat, kv_xfer.host_indices.tolist())
+
+    def test_split_of_a_resident_anchor_is_empty(self):
+        """An anchor loaded only for aux state has no Full chain to split."""
+        empty = PoolTransfer(
+            name=PoolName.KV,
+            host_indices=torch.empty((0,), dtype=torch.int64),
+            nodes_to_load=[],
+        )
+        self.assertEqual(self.cache.tree_core.split_full_load_back_spec(empty), [])
+
+    def test_each_node_loads_and_drains_before_the_next(self):
+        node_id, chain = self._build_evicted_chain()
+        kv_xfer, comp_xfers = self.cache.tree_core.build_load_back_spec(node_id)
+        host_anchor = self.cache.inc_host_lock_ref(node_id).to_dec_params()
+        ancestor = self.cache.inc_lock_ref(node_id).to_dec_params()
+
+        loaded = self.cache._load_back_per_node(
+            anchor_id=node_id,
+            kv_xfer=kv_xfer,
+            comp_xfers=comp_xfers,
+            sidecar_xfers=[],
+            ancestor_lock_params=ancestor,
+            host_anchor_params=host_anchor,
+        )
+
+        self.assertTrue(loaded)
+        self.assertEqual(len(self.controller.loads), len(chain))
+        for load, node in zip(self.controller.loads, chain):
+            self.assertEqual(len(load["host_indices"]), NODE_LEN)
+        # One drain per load, and every load is followed by its own drain.
+        self.assertEqual(self.events, [("drain", n.id) for n in chain])
+        # Only the final step carries the anchor id, so aux commits once.
+        self.assertEqual(self.controller.loads[-1]["node_id"], node_id)
+
+    def test_each_acked_node_becomes_a_reclaimable_duplicate(self):
+        """The point of the split: a loaded node funds the next node's
+        write-back instead of the cascade destroying a sole host copy."""
+        node_id, chain = self._build_evicted_chain()
+        kv_xfer, comp_xfers = self.cache.tree_core.build_load_back_spec(node_id)
+
+        seen_at_load = []
+        inner_load = self.controller.load
+
+        def counting_load(**kwargs):
+            seen_at_load.append(len(self.cache.tree_core.full_host_duplicates))
+            return inner_load(**kwargs)
+
+        self.controller.load = counting_load
+        self.cache._load_back_per_node(
+            anchor_id=node_id,
+            kv_xfer=kv_xfer,
+            comp_xfers=comp_xfers,
+            sidecar_xfers=[],
+            ancestor_lock_params=self.cache.inc_lock_ref(node_id).to_dec_params(),
+            host_anchor_params=self.cache.inc_host_lock_ref(node_id).to_dec_params(),
+        )
+
+        # Nothing is reclaimable before the first load; each ack adds one.
+        self.assertEqual(seen_at_load, list(range(len(chain))))
+        for node in chain:
+            self.assertIn(node.id, self.cache.tree_core.full_host_duplicates)
+            self.assertTrue(self.cache.tree_core._can_reclaim_full_host_duplicate(node))
+
+    def test_batched_load_back_has_no_duplicates_to_draw_on(self):
+        """Control for the split: loading the chain as one transfer reaches its
+        eviction with zero reclaimable duplicates, so a host pool under pressure
+        can only fund the write-back by destroying a sole copy."""
+        node_id, chain = self._build_evicted_chain()
+        self.cache.serialize_load_back = False
+        seen_at_load = []
+        inner_load = self.controller.load
+
+        def counting_load(**kwargs):
+            seen_at_load.append(len(self.cache.tree_core.full_host_duplicates))
+            return inner_load(**kwargs)
+
+        self.controller.load = counting_load
+        result = self.cache.inc_lock_ref(node_id)
+        self.cache._load_back_transfers(
+            node_id=node_id,
+            mem_quota=None,
+            req=None,
+            result=result,
+            ancestor_lock_params=result.to_dec_params(),
+            host_anchor_params=self.cache.inc_host_lock_ref(node_id).to_dec_params(),
+        )
+
+        # One transfer for the whole chain, and nothing had become reclaimable.
+        self.assertEqual(seen_at_load, [0])
+        self.assertEqual(len(self.controller.loads), 1)
+        self.assertEqual(
+            len(self.controller.loads[0]["host_indices"]), NODE_LEN * len(chain)
+        )
+
+    def test_no_device_lock_survives_the_loop(self):
+        node_id, chain = self._build_evicted_chain()
+        kv_xfer, comp_xfers = self.cache.tree_core.build_load_back_spec(node_id)
+        self.cache._load_back_per_node(
+            anchor_id=node_id,
+            kv_xfer=kv_xfer,
+            comp_xfers=comp_xfers,
+            sidecar_xfers=[],
+            ancestor_lock_params=self.cache.inc_lock_ref(node_id).to_dec_params(),
+            host_anchor_params=self.cache.inc_host_lock_ref(node_id).to_dec_params(),
+        )
+        for node in chain:
+            self.assertEqual(node.component_data[FULL].lock_ref, 0)
+            self.assertEqual(node.component_data[FULL].host_lock_ref, 0)
+        self.assertEqual(self.cache.ongoing_load_back, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_subagent_keepalive.py
+++ b/test/registered/unit/mem_cache/test_subagent_keepalive.py
@@ -1,0 +1,210 @@
+"""Tests for --allow-subagent-keepalive on UnifiedRadixCache."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.test_utils import CustomTestCase
+
+TURN_LEN = 4
+PARENT_TOKENS = [10, 11, 12, 13]
+CHILD_TOKENS = [20, 21, 22, 23]
+THIRD_TOKENS = [30, 31, 32, 33]
+
+
+def make_cache(allow_subagent_keepalive: bool):
+    """FULL-only, page_size=1, CPU cache with room for a handful of turns."""
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy", page_size=1))
+    dtype = torch.float16
+    kv_pool = MHATokenToKVPool(
+        size=64,
+        page_size=1,
+        dtype=dtype,
+        head_num=2,
+        head_dim=8,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    allocator = TokenToKVPoolAllocator(
+        size=64,
+        dtype=dtype,
+        device="cpu",
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    req_pool = ReqToTokenPool(
+        size=8,
+        max_context_len=128,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    params = CacheInitParams(
+        disable=False,
+        req_to_token_pool=req_pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=1,
+        eviction_policy="lru",
+        allow_subagent_keepalive=allow_subagent_keepalive,
+        tree_components=(ComponentType.FULL,),
+    )
+    return UnifiedRadixCache(params), allocator, req_pool
+
+
+class SubagentKeepaliveTestBase(CustomTestCase):
+    allow_subagent_keepalive = True
+
+    def setUp(self):
+        self.cache, self.allocator, self.req_pool = make_cache(
+            self.allow_subagent_keepalive
+        )
+        self._rid = 0
+
+    def finish_turn(self, tokens, session_id):
+        """Run one request of ``session_id`` to completion through the cache."""
+        req = Req(
+            rid=str(self._rid),
+            origin_input_text="",
+            origin_input_ids=array("q", tokens),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+            session_id=session_id,
+        )
+        self._rid += 1
+        self.req_pool.alloc([req])
+        req.output_ids = array("q")
+
+        kv_indices = self.allocator.alloc(len(tokens))
+        self.req_pool.write((req.kv.req_pool_idx, slice(0, len(tokens))), kv_indices)
+        req.kv.kv_committed_len = len(tokens)
+        req.last_node = self.cache.root_node.id
+        req.kv.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(
+            len(req.prefix_indices), len(req.full_untruncated_fill_ids)
+        )
+
+        self.cache.cache_finished_req(
+            req, is_insert=True, kv_len_to_handle=req.effective_kv_committed_len()
+        )
+        return req
+
+    def match_len(self, tokens) -> int:
+        return len(
+            self.cache.match_prefix(
+                MatchPrefixParams(key=RadixKey(array("q", tokens)))
+            ).device_indices
+        )
+
+
+class TestSubagentKeepaliveEnabled(SubagentKeepaliveTestBase):
+    allow_subagent_keepalive = True
+
+    def test_keepalive_promotes_the_parent_over_a_newer_session(self):
+        """A bumped parent outranks the subagent turn that came after it."""
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.finish_turn(CHILD_TOKENS, "child")
+
+        self.assertTrue(self.cache.bump_session_keepalive("parent"))
+
+        self.cache.evict(EvictParams(num_tokens=TURN_LEN))
+
+        self.assertEqual(self.match_len(PARENT_TOKENS), TURN_LEN)
+        self.assertEqual(self.match_len(CHILD_TOKENS), 0)
+
+    def test_without_a_keepalive_the_parent_is_evicted_first(self):
+        """Control for the test above: plain LRU drops the older parent."""
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.finish_turn(CHILD_TOKENS, "child")
+
+        self.cache.evict(EvictParams(num_tokens=TURN_LEN))
+
+        self.assertEqual(self.match_len(PARENT_TOKENS), 0)
+        self.assertEqual(self.match_len(CHILD_TOKENS), TURN_LEN)
+
+    def test_keepalive_does_not_promote_past_a_later_bump(self):
+        """Repeated keepalives re-age; the least recently kept session goes first."""
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.finish_turn(CHILD_TOKENS, "child")
+        self.finish_turn(THIRD_TOKENS, "third")
+
+        self.cache.bump_session_keepalive("parent")
+        self.cache.bump_session_keepalive("child")
+
+        self.cache.evict(EvictParams(num_tokens=TURN_LEN))
+
+        self.assertEqual(self.match_len(THIRD_TOKENS), 0)
+        self.assertEqual(self.match_len(PARENT_TOKENS), TURN_LEN)
+        self.assertEqual(self.match_len(CHILD_TOKENS), TURN_LEN)
+
+    def test_unknown_session_is_a_miss(self):
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.assertFalse(self.cache.bump_session_keepalive("never-seen"))
+
+    def test_blank_session_id_is_a_miss(self):
+        self.assertFalse(self.cache.bump_session_keepalive(""))
+
+    def test_reclaimed_path_drops_the_session_entry(self):
+        """Once a session's KV is gone the map must not keep pointing at it."""
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.assertIn("parent", self.cache._session_tail_node)
+
+        self.cache.evict(EvictParams(num_tokens=TURN_LEN))
+
+        self.assertFalse(self.cache.bump_session_keepalive("parent"))
+        self.assertNotIn("parent", self.cache._session_tail_node)
+
+    def test_request_without_a_session_id_is_not_tracked(self):
+        self.finish_turn(PARENT_TOKENS, None)
+        self.assertEqual(len(self.cache._session_tail_node), 0)
+
+    def test_later_turn_replaces_the_recorded_tail(self):
+        """The map tracks the session's newest tail, not its first."""
+        self.finish_turn(PARENT_TOKENS, "parent")
+        first_tail = self.cache._session_tail_node["parent"]
+
+        self.finish_turn(PARENT_TOKENS + THIRD_TOKENS, "parent")
+        second_tail = self.cache._session_tail_node["parent"]
+
+        self.assertNotEqual(first_tail, second_tail)
+        self.assertTrue(self.cache.bump_session_keepalive("parent"))
+
+
+class TestSubagentKeepaliveDisabled(SubagentKeepaliveTestBase):
+    allow_subagent_keepalive = False
+
+    def test_nothing_is_recorded(self):
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.assertEqual(len(self.cache._session_tail_node), 0)
+
+    def test_bump_is_inert(self):
+        self.finish_turn(PARENT_TOKENS, "parent")
+        self.finish_turn(CHILD_TOKENS, "child")
+
+        self.assertFalse(self.cache.bump_session_keepalive("parent"))
+
+        self.cache.evict(EvictParams(num_tokens=TURN_LEN))
+
+        # Same verdict as plain LRU: the flag changes nothing when it is off.
+        self.assertEqual(self.match_len(PARENT_TOKENS), 0)
+        self.assertEqual(self.match_len(CHILD_TOKENS), TURN_LEN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_unified_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_lock_ref.py
@@ -25,6 +25,7 @@ class TestUnifiedRadixLockRefScenarios(unittest.TestCase):
         cache._dec_req_lock = MagicMock()
         cache._components_tuple = ()
         cache.enable_session_radix_cache = False
+        cache.allow_subagent_keepalive = False
 
         kv = SimpleNamespace(req_pool_idx=0, cache_protected_len=0)
         req = SimpleNamespace(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently, `UnifiedRadixCache` can incur significant overhead during request admission in https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py#L3888-L3892.
When admitting a batch of request that has prefixes only in host memory, we do for each request
1. Try allocate device memory for entire request
2. If device memory is insufficient, evict older device memory
3. Write back is triggered on device memory eviction, which tries to allocate host memory
4. If host memory is insufficient, discards duplicate tokens (both on host and device), then discards LRU tokens
5. Marks both the device and host memory as pinned and cannot be evicted
6. Runs H2D

We don't unmark the memory as pinned until the **next** iteration, so the next few requests in the batch still won't be able to use the host memory even if H2D completed. During benchmarks, a particular configuration has ~1.7M tokens on device and ~3M tokens on host, which should give us ~4.7M tokens of prefix cache. However, the real usable tokens before prefixes are dropped is closer to half of that at ~2.3M.

This PR fixes this by serializing the H2D. When `--hicache-serialize-load-back` is set, H2D pins memory one node by a time, such that the next node's H2D can reclaim the now duplicated memory of the previous node. This has a perf hit on the H2D so should not be on by default. A follow-up PR will improve the cache operations to alleviate the perf hit.

A second more minor feature is to allow subagents to refresh their parent requests' LRU age. A parent request will resume once subagents finish, but doesn't share a prefix. Thus, the parent can easily age away before the the subagent finishes. This feature is a no-op unless routers sends parent metadata. This is enabled by `--allow-subagent-keepalive`.

Together, these changes moves the same benchmark usable tokens from ~2.3M to ~3.3M, a ~44% increase. The remaining ~1.4M tokens is unreachable because LRU is an imperfect heuristic for when a request can be dropped. The only way to get to ~4.7M is to have better information of whether a request has finished and can be safely dropped.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
9. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
10. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34445114523](https://github.com/sgl-project/sglang/actions/runs/34445114523)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34445114393](https://github.com/sgl-project/sglang/actions/runs/34445114393)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34445114550](https://github.com/sgl-project/sglang/actions/runs/34445114550)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->