### PR TITLE
[MoE] Add opt-in NCCL EP LL CUDA Graph lifecycle (depends on #32329)

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -737,6 +737,7 @@
               "docs/advanced_features/quantized_kv_cache",
               "docs/advanced_features/dp_dpa_smg_guide",
               "docs/advanced_features/expert_parallelism",
+              "docs/advanced_features/nccl_ep_cuda_graph",
               "docs/advanced_features/lora",
               "docs/advanced_features/pd_disaggregation",
               "docs/advanced_features/epd_disaggregation",

--- a/docs_new/docs/advanced_features/expert_parallelism.mdx
+++ b/docs_new/docs/advanced_features/expert_parallelism.mdx
@@ -69,6 +69,9 @@ DeepEP and Mooncake backends support two modes for token dispatch: `normal` mode
 
 Currently, DeepEP, Mooncake, NIXL-EP, `ascend_fuseep` and MORI only support cases where `ep_size = tp_size`. For hybrid EP and TP (i.e., `ep_size < tp_size`), only the `none` backend (All-Reduce or All-Gather-based dispatching) is supported.
 
+For the opt-in NCCL EP low-latency decode path, see
+[NCCL EP CUDA Graphs](/docs/advanced_features/nccl_ep_cuda_graph).
+
 ### Backends for MoE Computation
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>

--- a/docs_new/docs/advanced_features/nccl_ep_cuda_graph.mdx
+++ b/docs_new/docs/advanced_features/nccl_ep_cuda_graph.mdx
@@ -1,0 +1,108 @@
+---
+title: "NCCL EP CUDA Graphs"
+description: "Install NCCL EP and opt in to serialized low-latency decode with persistent CUDA Graph resources."
+---
+
+NCCL EP can run low-latency MoE dispatch and combine inside SGLang's full decode
+CUDA Graph backend. Enable it with `--moe-a2a-backend nccl_ep` and
+`--enable-nccl-ep-cuda-graph`. Without the Graph option, NCCL EP runs eagerly.
+
+## Requirements and installation
+
+Use CUDA GPUs with compute capability SM90 or newer, on one node with peer
+access between the participating GPUs. The tested configuration uses Python
+3.12, the official PyTorch `2.11.0+cu130` wheel, CUDA Toolkit 13.0,
+`nccl4py==0.4.1`, `nccl-extensions==0.1.0`, and NCCL 2.30.7.
+`nccl-extensions` provides `nccl.ep`; `nccl4py` alone provides the core binding.
+
+In a dedicated CUDA 13 environment, install from the repository root:
+
+```bash
+python -m pip install torch==2.11.0 --index-url https://download.pytorch.org/whl/cu130
+python -m pip install -e 'python[nccl_ep]'
+python -m pip install --force-reinstall --no-deps nvidia-nccl-cu13==2.30.7
+```
+
+The last command explicitly overrides PyTorch's NCCL 2.28.9 dependency pin.
+`pip check` will report that single version conflict. The two-GPU synthetic
+validation used this combination; other dependency conflicts need to be resolved
+separately. Repeat the NCCL override if a later PyTorch installation replaces it.
+Installing the optional extra alone does not select this newer runtime.
+
+Set `CUDA_HOME` to the CUDA 13 Toolkit and put its `bin` directory on `PATH`.
+NCCL EP compiles specialized kernels at first use, so `nvcc` and matching CUDA
+headers must be available. Driver compatibility shown by `nvidia-smi`, the
+Toolkit reported by `nvcc --version`, and `torch.version.cuda` describe different
+components.
+
+Check the actual library selected by the binding:
+
+```bash
+python - <<'PY_CHECK'
+import torch
+import nccl.core as core
+import nccl.ep as ep
+
+print("Torch CUDA build:", torch.version.cuda)
+print("Torch NCCL compile-time version:", torch.cuda.nccl.version())
+print("Loaded NCCL:", core.get_version().libnccl)
+print("EP library:", ep.get_lib_version())
+assert callable(getattr(ep.Handle, "update", None))
+PY_CHECK
+```
+
+## Enable decode capture
+
+Add these options to your existing compatible MoE launch configuration:
+
+```bash
+--moe-a2a-backend nccl_ep \
+--nccl-ep-mode low_latency \
+--enable-nccl-ep-cuda-graph
+```
+
+Configure batch-size buckets through the existing
+[CUDA Graph options](/docs/advanced_features/server_arguments).
+The largest decode bucket determines the Graph allocation capacity, which must
+be at most 1024 tokens per rank.
+
+The initial Graph path requires BF16 dispatcher inputs and compatible MoE layers
+with the same communicator, expert count, hidden size, top-k and dtype. Supported
+hidden sizes are 2048, 2560, 4096, 5120, 6144, 7168 and 8192; top-k must be at most
+9. This describes the communication input, not a new expert-compute backend.
+
+Prefill runs eagerly. Prefill Graphs, piecewise or breakable decode Graphs,
+speculative decoding, TBO/SBO, PDMux, EPLB, elastic EP, multiple nodes, Torch
+compile and memory saver are outside this initial scope. Unsupported opt-in
+configurations raise an error during setup.
+
+## Resource ownership
+
+Each capture generation owns one dedicated Graph group and one persistent LL
+handle. Compatible layers and batch-size buckets share those resources in strict
+serial order. This policy controls ownership of the group's shared communication
+state; the external API can create multiple handles.
+
+Capture retains fixed-capacity storage for tokens, routing, weights and receive
+buffers. Bucket descriptors use the same base storage. `Handle.update` runs
+outside capture when preparing a bucket; replay reads the current buffer contents
+without invoking the Python update path. Routing values can change while the
+captured operation structure and buffer addresses remain fixed.
+
+Stream ordering covers input writes, forward execution and already-queued output
+consumers. Concurrent host submissions are rejected. Eager execution uses a
+separate group. Recapture and shutdown wait for device work, release the Graph
+executables, then close their handle and group.
+
+## Validation scope
+
+The model-free tests cover native and SGLang dispatch/combine, changing routing,
+8/16/32-token buckets, two compatible layers, recapture, cross-stream ordering,
+masked padding and controlled host capture failure. They compare against an
+independent CPU oracle using weighted synthetic experts. Full-model accuracy and
+real expert GEMM performance have not been evaluated for this Graph path.
+
+See the [reproduction instructions](https://github.com/sgl-project/sglang/tree/main/test/nccl_ep_test)
+for one-GPU lifecycle tests and the two-GPU correctness, benchmark and profiling
+commands. See [expert parallelism](/docs/advanced_features/expert_parallelism) for
+the surrounding MoE configuration.

--- a/docs_new/docs/advanced_features/nccl_ep_cuda_graph.mdx
+++ b/docs_new/docs/advanced_features/nccl_ep_cuda_graph.mdx
@@ -58,6 +58,7 @@ Add these options to your existing compatible MoE launch configuration:
 ```bash
 --moe-a2a-backend nccl_ep \
 --nccl-ep-mode low_latency \
+--dtype bfloat16 \
 --enable-nccl-ep-cuda-graph
 ```
 
@@ -71,7 +72,21 @@ with the same communicator, expert count, hidden size, top-k and dtype. Supporte
 hidden sizes are 2048, 2560, 4096, 5120, 6144, 7168 and 8192; top-k must be at most
 9. This describes the communication input, not a new expert-compute backend.
 
-Prefill runs eagerly. Prefill Graphs, piecewise or breakable decode Graphs,
+NCCL EP sets the expert-parallel size to the tensor-parallel size, so you do not
+need to repeat `--ep` when setting `--tp`. Both eager and Graph execution require
+BF16 inputs and an FP8 or W4A-FP8 expert-compute configuration. The current
+float32 group scales are incompatible with `DEEPGEMM_BLACKWELL` UE8M0 scales;
+the capability check reports this before communicator creation. SM120 with
+float32 group scales remains eligible.
+
+Prefill runs eagerly through LL. After DP divides the chunk size, SGLang limits
+each rank's chunk to `--nccl-ep-num-max-dispatch-tokens-per-rank` (default 1024),
+rounded down to a KV page boundary. Long prompts then run in multiple chunks.
+Unchunked prefill and PP dynamic chunking are unsupported. Decode-only
+disaggregation skips this prefill requirement. SBO/TBO are unsupported for every
+NCCL EP compute backend, including eager execution.
+
+Prefill Graphs, piecewise or breakable decode Graphs,
 speculative decoding, TBO/SBO, PDMux, EPLB, elastic EP, multiple nodes, Torch
 compile and memory saver are outside this initial scope. Unsupported opt-in
 configurations raise an error during setup.

--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -1566,7 +1566,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-moe-a2a-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>MOE A2A backend for EAGLE speculative decoding, see `--moe-a2a-backend` for options. Same as moe a2a backend if unset.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>none</code>, <code>deepep</code>, <code>mooncake</code>, <code>nixl</code>, <code>mori</code>, <code>ascend_fuseep</code>, <code>flashinfer</code>, <code>megamoe</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>none</code>, <code>deepep</code>, <code>nccl_ep</code>, <code>mooncake</code>, <code>nixl</code>, <code>mori</code>, <code>ascend_fuseep</code>, <code>flashinfer</code>, <code>megamoe</code></td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-draft-model-quantization`</td>
@@ -1737,6 +1737,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>none</code>, <code>deepep</code>, <code>mooncake</code>, <code>nixl</code>, <code>mori</code>, <code>ascend_fuseep</code>, <code>flashinfer</code>, <code>megamoe</code></td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-nccl-ep-cuda-graph`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable serialized NCCL EP low-latency full decode CUDA Graphs. Requires `--moe-a2a-backend nccl_ep`; see [requirements and scope](/docs/advanced_features/nccl_ep_cuda_graph).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--moe-runner-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the runner backend for MoE.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,6 +98,8 @@ default = true
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
+# NCCL EP MoE A2A backend (low-latency decode); needs NCCL >= 2.29 + sm_90+.
+nccl_ep = ["nccl4py[cu13]"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,8 +98,8 @@ default = true
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
-# NCCL EP MoE A2A backend (low-latency decode); needs NCCL >= 2.29 + sm_90+.
-nccl_ep = ["nccl4py[cu13]"]
+# NCCL EP LL (SM90+). See the NCCL EP guide for the NCCL runtime override.
+nccl_ep = ["nccl4py[cu13]==0.4.1", "nccl-extensions==0.1.0"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2078,7 +2078,16 @@ def _cutlass_moe_env_override(view: Any) -> dict:
 
 # Every A2A backend that forces expert parallelism to span the TP group.
 _A2A_EP_SPANNING_BACKENDS = frozenset(
-    {"megamoe", "deepep", "mooncake", "nixl", "ascend_fuseep", "flashinfer", "mori"}
+    {
+        "megamoe",
+        "deepep",
+        "mooncake",
+        "nixl",
+        "ascend_fuseep",
+        "flashinfer",
+        "mori",
+        "nccl_ep",
+    }
 )
 
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -52,6 +52,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.platforms.device_mixin import _DEVICE_TO_DISTRIBUTED_BACKEND
 from sglang.srt.runtime_context import (
     get_global_dwdp_manager,
+    get_resources,
     set_global_dwdp_manager,
 )
 from sglang.srt.utils import (
@@ -2680,6 +2681,13 @@ def get_moe_tensor_parallel_rank():
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
+    buffers = get_resources().buffers
+    if "nccl_ep_state" in buffers or "nccl_ep_graph_resources" in buffers:
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep_graph import (
+            destroy_nccl_ep_resources,
+        )
+
+        destroy_nccl_ep_resources()
     dwdp_mgr = get_global_dwdp_manager()
     if dwdp_mgr is not None:
         dwdp_mgr.cleanup()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -688,6 +688,7 @@ class Envs:
     SGLANG_DEEPEP_BF16_DISPATCH = EnvBool(False)  # This argument is deprecated
     SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_DEEPEP_LL_COMBINE_SEND_NUM_SMS = EnvInt(32)
+    SGLANG_NCCL_EP_MAX_NUM_SMS = EnvInt(0)  # 0 = use default (20)
     SGLANG_BLACKWELL_OVERLAP_SHARED_EXPERTS_OUTSIDE_SBO = EnvBool(False)
     # Force dynamic Waterfill with runtime EP all-reduce instead of the default
     # static local-batch path.

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -283,6 +283,7 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
         or get_moe_a2a_backend().is_deepep()
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
+        or get_moe_a2a_backend().is_nccl_ep()
     ):
         return DeepEPMoE
     return FusedMoE

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -277,6 +277,13 @@ class DeepEPMoE(FusedMoE):
 
 
 def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
+    if get_moe_a2a_backend().is_nccl_ep() and not isinstance(
+        quant_config, (Fp8Config, W4AFp8Config)
+    ):
+        raise ValueError(
+            "NCCL EP LL requires FP8 or W4A-FP8 quantization; "
+            "unquantized and other MoE compute methods are unsupported."
+        )
     # [TODO] kk, temporary solution
     if (
         get_moe_a2a_backend().is_mori()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -144,6 +144,13 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             num_local_experts=moe_runner_config.num_local_experts,
             hidden_size=moe_runner_config.hidden_size,
         )
+    elif a2a_backend.is_nccl_ep():
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+        return NcclEpDispatcher(
+            moe_runner_config=moe_runner_config,
+            ep_group=get_tp_group(),
+        )
     else:
         raise NotImplementedError(f"Unsupported a2a backend: {a2a_backend}")
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
@@ -1,0 +1,603 @@
+"""NCCL EP low-latency MoE dispatch/combine backend (``--moe-a2a-backend nccl_ep``).
+
+Mirrors the DeepEP LL contract (DEEPEP_LL output, reuses DeepEPMoE.compute).
+NCCL EP carries bf16 on the wire, so we quantize the bf16 recv to fp8 (group 128)
+after dispatch. LL (decode) only; HT (prefill) is a follow-up.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
+from sglang.srt.layers.moe.token_dispatcher.deepep import (
+    DeepEPLLCombineInput,
+    DeepEPLLDispatchOutput,
+    DeepEPPDispatchHooks,
+)
+from sglang.srt.layers.moe.topk import TopKOutput
+from sglang.srt.layers.moe.utils import (
+    get_nccl_ep_mode,
+    get_nccl_ep_num_max_dispatch_tokens_per_rank,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
+    from sglang.srt.layers.moe.fused_moe_triton.layer import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.base import DispatchOutput
+
+logger = logging.getLogger(__name__)
+
+# NCCL EP LL dispatch accepts only these hidden sizes (hardcoded in SWITCH_HIDDEN)
+# and requires hidden % 128 == 0.
+_NCCL_EP_LL_SUPPORTED_HIDDEN = {2048, 2560, 4096, 5120, 6144, 7168, 8192}
+
+# LL top-k upper bound (kNumMaxTopK). Models with topk>9 (e.g. Nemotron Super)
+# fall back to DeepEP LL — upstream issue #2103.
+_NCCL_EP_LL_MAX_TOPK = 9
+
+# Mirror DeepEP's per-rank dispatch budget cap.
+_NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP = 1024
+_NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK = 1024
+
+# fp8 per-token-group quant block size for the LL GEMM path (cutlass w4a8 moe).
+_NCCL_EP_FP8_GROUP_SIZE = 128
+
+
+def _parse_ver_str(s: str):
+    """Parse the leading ``X.Y.Z`` from a version string into a 3-tuple, or None."""
+    parts = s.split(".")
+    try:
+        return tuple(int(x) for x in parts[:3])
+    except ValueError:
+        return None
+
+
+def _nccl_runtime_version():
+    """Return the linked NCCL version as a (major, minor, patch) tuple, or None.
+
+    Prefers nccl4py's version query (may differ from torch's bundled NCCL via
+    LD_PRELOAD); falls back to torch.
+    """
+    try:
+        import nccl
+
+        # nccl.get_version() -> VersionInfo with a .nccl LibraryInfo carrying .version.
+        vi = nccl.get_version()
+        lib_info = getattr(vi, "nccl", None)
+        ver_obj = getattr(lib_info, "version", None) if lib_info is not None else None
+        if ver_obj is not None:
+            return _parse_ver_str(str(ver_obj))
+    except Exception:
+        pass
+    try:
+        v = torch.cuda.nccl.version()
+        if isinstance(v, (tuple, list)):
+            return tuple(int(x) for x in v[:3])
+    except Exception:
+        pass
+    return None
+
+
+def nccl_ep_unavailable_reason() -> str | None:
+    """Return why NCCL EP is unavailable (None = available), for fallback logs."""
+    if importlib.util.find_spec("nccl.ep") is None:
+        return "nccl4py (nccl.ep) not importable"
+    if not torch.cuda.is_available():
+        return "no CUDA device"
+    cc = torch.cuda.get_device_capability(0)[0]  # Hopper (sm_90) or Blackwell.
+    if cc < 9:
+        return f"GPU arch sm_{cc}x not supported (need Hopper/Blackwell sm_90+)"
+    ver = _nccl_runtime_version()
+    if ver is None:
+        return "could not read NCCL version"
+    if (ver[0], ver[1]) < (2, 29):
+        return f"NCCL {'.'.join(map(str, ver))} < 2.29 (need Device API/GIN)"
+    return None
+
+
+def is_nccl_ep_available() -> bool:
+    """Whether nccl4py + NCCL >= 2.29 + Hopper/Blackwell are usable here."""
+    return nccl_ep_unavailable_reason() is None
+
+
+# ----------------------------- Buffer (Group/Handle lifecycle) -----------------------------
+
+_nccl_ep_runtime = None  # cached import of nccl.ep / nccl.core
+
+
+def _load_nccl_ep():
+    global _nccl_ep_runtime
+    if _nccl_ep_runtime is not None:
+        return _nccl_ep_runtime
+    import nccl.core as nccl_core
+    import nccl.ep as nccl_ep
+
+    _nccl_ep_runtime = (nccl_core, nccl_ep)
+    return _nccl_ep_runtime
+
+
+class NcclEpBuffer:
+    """Process-wide NCCL EP group + static recv buffers (mirrors DeepEPBuffer).
+
+    State lives on ``ctx.resources.buffers["nccl_ep_state"]``; the group is
+    created once from the sglang EP group's ``ncclComm_t``.
+    """
+
+    @classmethod
+    def _state(cls):
+        from types import SimpleNamespace
+
+        from sglang.srt.runtime_context import get_resources
+
+        buffers = get_resources().buffers
+        state = buffers.get("nccl_ep_state")
+        if state is None:
+            state = SimpleNamespace(
+                group=None,
+                num_experts=None,
+                num_local_experts=None,
+                hidden_size=None,
+                max_dispatch_tokens_per_rank=None,
+                max_recv_tokens_per_rank=None,
+                # Pre-allocated scratch (fixed shapes); reused per dispatch/combine step.
+                recv_tokens=None,
+                expert_counters=None,
+                expert_offsets=None,
+                recv_total=None,
+                combined=None,
+            )
+            buffers["nccl_ep_state"] = state
+        return state
+
+    @classmethod
+    def get_buffer(
+        cls,
+        ep_group: "GroupCoordinator",
+        hidden_size: int,
+        num_experts: int,
+        num_local_experts: int,
+        max_dispatch_tokens_per_rank: int,
+    ) -> "NcclEpBuffer":
+        state = cls._state()
+        if state.group is None:
+            state.num_experts = num_experts
+            state.num_local_experts = num_local_experts
+            state.hidden_size = hidden_size
+            state.max_dispatch_tokens_per_rank = max_dispatch_tokens_per_rank
+            # LL auto = nRanks * max_dispatch_tokens_per_rank.
+            world_size = ep_group.world_size
+            state.max_recv_tokens_per_rank = world_size * max_dispatch_tokens_per_rank
+            cls._create_group(state, ep_group)
+        return state
+
+    @classmethod
+    def _create_group(cls, state, ep_group: "GroupCoordinator"):
+        nccl_core, nccl_ep = _load_nccl_ep()
+
+        pynccl = ep_group.pynccl_comm
+        if pynccl is None or not getattr(pynccl, "available", False):
+            raise RuntimeError(
+                "NCCL EP requires a live PyNccl communicator on the EP group "
+                "(pynccl_comm unavailable)."
+            )
+        comm_ptr = pynccl.comm.value  # ncclComm_t (c_void_p) -> int
+        wrapped_comm = nccl_core.Communicator(ptr=comm_ptr)
+
+        # Explicit rdma_buffer_size keeps create_handle local (no collective/realloc).
+        rdma_buffer_size = cls._low_latency_rdma_size_hint(
+            nccl_ep, state, ep_group.world_size
+        )
+        cfg = nccl_ep.GroupConfig(
+            algorithm=nccl_ep.Algorithm.LOW_LATENCY,
+            num_experts=state.num_experts,
+            max_dispatch_tokens_per_rank=state.max_dispatch_tokens_per_rank,
+            max_recv_tokens_per_rank=0,  # 0 = auto = nRanks * max_dispatch
+            max_token_bytes=state.hidden_size * 2,  # bf16 = 2 bytes/elem
+            rdma_buffer_size=rdma_buffer_size,
+            max_num_sms=cls._resolve_max_num_sms(state.num_experts),
+        )
+        state.group = nccl_ep.Group.create(wrapped_comm, cfg)
+        logger.info(
+            "NCCL EP group created: num_experts=%d world_size=%d hidden=%d "
+            "max_dispatch_tokens_per_rank=%d rdma_buffer_size=%d",
+            state.num_experts,
+            ep_group.world_size,
+            state.hidden_size,
+            state.max_dispatch_tokens_per_rank,
+            rdma_buffer_size,
+        )
+        cls._alloc_scratch(state, ep_group.device)
+
+    @staticmethod
+    def _alloc_scratch(state, device: torch.device):
+        """Allocate fixed-shape dispatch/combine scratch once, reused across steps
+        (counters re-zeroed per dispatch). recv_tokens need not be cleared — the
+        kernel writes the valid region, bounded downstream by expert_counters.
+        """
+        e_local = state.num_local_experts
+        h = state.hidden_size
+        max_recv = state.max_recv_tokens_per_rank
+        max_send = state.max_dispatch_tokens_per_rank
+        state.recv_tokens = torch.empty(
+            (e_local, max_recv, h), dtype=torch.bfloat16, device=device
+        )
+        state.expert_counters = torch.zeros(
+            (e_local,), dtype=torch.int32, device=device
+        )
+        state.expert_offsets = torch.zeros(
+            (e_local + 1,), dtype=torch.int32, device=device
+        )
+        state.recv_total = torch.zeros((1,), dtype=torch.int32, device=device)
+        # Upper bound = max dispatch tokens per rank; sliced to [:t] per combine.
+        state.combined = torch.empty(
+            (max_send, h), dtype=torch.bfloat16, device=device
+        )
+
+    @staticmethod
+    def _low_latency_rdma_size_hint(nccl_ep, state, world_size: int) -> int:
+        """Worst-case RDMA buffer size for LL (explicit so handle init is local).
+
+        Prefers a nccl4py native hint; falls back to a conservative upper bound
+        from the max recv footprint (E_local * max_recv * H * 2 bytes bf16), x4
+        for send+recv+slack.
+        """
+        hint_fn = getattr(nccl_ep, "get_low_latency_rdma_size_hint", None)
+        if callable(hint_fn):
+            try:
+                return int(
+                    hint_fn(
+                        state.max_dispatch_tokens_per_rank,
+                        state.hidden_size,
+                        world_size,
+                        state.num_experts,
+                    )
+                )
+            except Exception:
+                pass  # signature mismatch; fall through to the bound below
+        per_slot = state.num_local_experts * state.max_recv_tokens_per_rank
+        per_slot *= state.hidden_size * 2  # bf16 bytes
+        return int(per_slot * 4)
+
+    @staticmethod
+    def _resolve_max_num_sms(num_experts: int) -> int:
+        """Cap LL EP-group SMs so overlap compute can run alongside dispatch.
+
+        LL requires ceil(num_experts / max_num_sms) <= 14, i.e. a floor of
+        ceil(num_experts / 14). Default 20 (leaves most SMs for compute, like
+        DeepEP's communicate_num_sms); overridable via SGLANG_NCCL_EP_MAX_NUM_SMS.
+        """
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_NCCL_EP_MAX_NUM_SMS.is_set() and envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get() > 0:
+            val = envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get()
+        else:
+            val = 20  # conservative default for H100 (132 SMs)
+
+        min_required = (num_experts + 13) // 14  # ceil(num_experts / 14)
+        if val < min_required:
+            logger.warning(
+                "NCCL EP max_num_sms=%d below LL minimum %d (num_experts=%d); "
+                "clamping to %d.",
+                val,
+                min_required,
+                num_experts,
+                min_required,
+            )
+            val = min_required
+        return val
+
+    @classmethod
+    def destroy(cls):
+        state = cls._state()
+        g = state.group
+        if g is not None:
+            try:
+                g.destroy()
+            except Exception:
+                pass
+            state.group = None
+
+
+# ----------------------------- Dispatcher (LL path) -----------------------------
+
+
+class _Stage(Enum):
+    INITIAL = auto()
+    AFTER_DISPATCH_A = auto()
+    AFTER_DISPATCH_B = auto()
+    AFTER_COMBINE_A = auto()
+
+
+class NcclEpDispatcher(BaseDispatcher):
+    """NCCL EP low-latency token dispatcher.
+
+    Mirrors the DeepEP LL contract: ``dispatch`` returns a
+    ``DeepEPLLDispatchOutput`` (DEEPEP_LL format), reusing the DeepEP compute
+    path. NCCL EP carries bf16 on the wire; we quantize bf16->fp8 (group 128)
+    after dispatch to feed ``apply_deepep_ll``.
+    """
+
+    def __init__(self, moe_runner_config: "MoeRunnerConfig", ep_group: "GroupCoordinator"):
+        super().__init__()
+        nccl_core, nccl_ep = _load_nccl_ep()
+        self._nccl_ep = nccl_ep
+
+        self.ep_group = ep_group
+        self.router_topk = moe_runner_config.top_k
+        self.num_experts = moe_runner_config.num_experts
+        self.num_local_experts = moe_runner_config.num_local_experts
+        self.hidden_size = moe_runner_config.hidden_size
+        self.params_dtype = moe_runner_config.params_dtype
+        self.world_size = ep_group.world_size
+
+        # Resolve dispatch mode. LOW_LATENCY only this PR; HT raises at resolve() time.
+        self.mode = get_nccl_ep_mode().resolve(is_extend_in_batch=False)
+
+        # Blackwell guard: our fp8 post-quant emits float32 group scales, which
+        # diverge from DeepEP's UE8M0 scales under DEEPGEMM_BLACKWELL. Fail fast
+        # rather than silently mis-quantize.
+        try:
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            if getattr(deep_gemm_wrapper, "DEEPGEMM_BLACKWELL", False):
+                raise NotImplementedError(
+                    "NCCL EP LL fp8 post-quant emits float32 group scales, which diverge "
+                    "from DeepEP's UE8M0 scales when DEEPGEMM_BLACKWELL is set. Fall back "
+                    "to --moe-a2a-backend deepep on Blackwell for now."
+                )
+        except ImportError:
+            pass  # deep_gemm_wrapper absent -> DeepGEMM-Blackwell path not active.
+
+        # Deterministic-inference guard: NCCL EP is not determinism-audited yet.
+        try:
+            from sglang.srt.runtime_context import get_exec
+
+            if get_exec().deterministic.enable_deterministic_inference:
+                raise NotImplementedError(
+                    "NCCL EP is not deterministic-inference-audited yet. Use "
+                    "--moe-a2a-backend deepep with --enable-deterministic-inference, "
+                    "or remove the flag (deterministic support tracked as a follow-up)."
+                )
+        except (ImportError, AttributeError):
+            pass  # exec flags not materialized yet; gated in server_args post-processing.
+
+        # Per-rank dispatch budget.
+        budget = get_nccl_ep_num_max_dispatch_tokens_per_rank()
+        if budget <= 0:
+            budget = _NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK
+        assert (
+            budget <= _NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP
+        ), f"NCCL EP max_dispatch_tokens_per_rank {budget} exceeds cap {_NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP}"
+        self.num_max_dispatch_tokens_per_rank = budget
+
+        # Validate LL hard constraints early (fail fast at init, not at first dispatch).
+        if self.hidden_size not in _NCCL_EP_LL_SUPPORTED_HIDDEN:
+            raise ValueError(
+                f"NCCL EP LL only supports hidden in {sorted(_NCCL_EP_LL_SUPPORTED_HIDDEN)} "
+                f"(got {self.hidden_size}); use --moe-a2a-backend deepep for this model."
+            )
+        if self.router_topk > _NCCL_EP_LL_MAX_TOPK:
+            raise ValueError(
+                f"NCCL EP LL supports topk <= {_NCCL_EP_LL_MAX_TOPK} (got {self.router_topk}); "
+                f"fall back to DeepEP LL (upstream nccl_ep issue #2103)."
+            )
+
+        self.buffer = NcclEpBuffer.get_buffer(
+            ep_group,
+            self.hidden_size,
+            self.num_experts,
+            self.num_local_experts,
+            self.num_max_dispatch_tokens_per_rank,
+        )
+
+        self.handle = None
+
+        # Staged execution state machine (mirrors deepep.py _Stage).
+        self._stage = _Stage.INITIAL
+        self._dispatch_intermediate_state = None
+        self._combine_intermediate_state = None
+
+        # SBO dispatch hook: deepseek_v2.py registers a hook via
+        # register_deepep_dispatch_hook to run shared experts between
+        # dispatch_a (send_only) and dispatch_b (complete).
+        self._dispatch_hooks = DeepEPPDispatchHooks()
+
+        # Lazily imported; fp8 quant is only needed for the fp8 (w4afp8) GEMM path.
+        self._quant_fp8 = None
+
+    def set_quant_config(self, quant_config: dict) -> None:
+        self.quant_config = quant_config
+
+    # _Stage state machine: guards a/b call order. handle's continue_fn is a
+    # single slot — calling combine(send_only=1) before dispatch_b (complete)
+    # would overwrite the dispatch continue_fn.
+    def _update_stage(self, old_stage, new_stage):
+        assert self._stage == old_stage, (
+            f"NCCL EP stage mismatch: expected {old_stage}, got {self._stage}"
+        )
+        self._stage = new_stage
+
+    def register_deepep_dispatch_hook(self, hook):
+        return self._dispatch_hooks.register_hook(hook)
+
+    # ---- three-phase dispatch/combine (staged execution) ----
+    def dispatch(
+        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+    ) -> DispatchOutput:
+        self.dispatch_a(hidden_states, topk_output)
+        if self._dispatch_hooks is not None:
+            self._dispatch_hooks(self)
+        return self.dispatch_b()
+
+    def dispatch_a(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
+        self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+
+        nccl_ep = self._nccl_ep
+        topk_weights = topk_output.topk_weights.to(torch.float32)
+        topk_ids = topk_output.topk_ids.to(torch.int64)
+
+        t = hidden_states.shape[0]
+        if t > self.num_max_dispatch_tokens_per_rank:
+            raise ValueError(
+                f"NCCL EP: decode batch ({t}) exceeds per-rank dispatch budget "
+                f"{self.num_max_dispatch_tokens_per_rank}; increase "
+                f"--nccl-ep-num-max-dispatch-tokens-per-rank or reduce batch."
+            )
+
+        if self.handle is not None:
+            try:
+                self.handle.destroy()
+            except Exception:
+                pass
+            self.handle = None
+
+        state = self.buffer
+
+        stream = torch.cuda.current_stream()
+
+        handle = state.group.create_handle(
+            layout=nccl_ep.Layout.EXPERT_MAJOR,
+            topk_idx=nccl_ep.Tensor(topk_ids),
+            config=nccl_ep.HandleConfig(),
+            stream=stream.cuda_stream,
+        )
+        self.handle = handle
+
+        # Reuse pre-allocated scratch; counters re-zeroed each dispatch.
+        recv_tokens = state.recv_tokens
+        expert_counters = state.expert_counters.zero_()
+        expert_offsets = state.expert_offsets.zero_()
+        recv_total = state.recv_total.zero_()
+
+        inputs = nccl_ep.DispatchInputs(tokens=nccl_ep.Tensor(hidden_states))
+        outputs = nccl_ep.DispatchOutputs(tokens=nccl_ep.Tensor(recv_tokens))
+        layout_info = nccl_ep.LayoutInfo(
+            expert_counters=nccl_ep.Tensor(expert_counters),
+            expert_offsets=nccl_ep.Tensor(expert_offsets),
+            recv_total_counter=nccl_ep.Tensor(recv_total),
+        )
+        handle.dispatch(
+            inputs,
+            outputs,
+            layout_info=layout_info,
+            config=nccl_ep.DispatchConfig(send_only=1),
+            stream=stream.cuda_stream,
+        )
+
+        self._dispatch_intermediate_state = (
+            recv_tokens,
+            expert_counters,
+            topk_ids,
+            topk_weights,
+            t,
+            hidden_states,
+        )
+
+    def dispatch_b(self) -> DispatchOutput:
+        self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+
+        (
+            recv_tokens,
+            expert_counters,
+            topk_ids,
+            topk_weights,
+            t,
+            hidden_states,
+        ) = self._dispatch_intermediate_state
+        del self._dispatch_intermediate_state
+
+        stream = torch.cuda.current_stream()
+        self.handle.complete(config=0, stream=stream.cuda_stream)
+
+        hs_fp8, hs_scale = self._quantize_fp8(recv_tokens, expert_counters)
+
+        expected_m = (
+            hidden_states.shape[0] * self.world_size * topk_ids.shape[1]
+            + self.num_experts
+        ) // self.num_experts
+
+        self._dispatched_topk_weights = topk_weights
+        self._dispatched_t = t
+
+        return DeepEPLLDispatchOutput(
+            hs_fp8,
+            hs_scale,
+            topk_ids,
+            topk_weights,
+            expert_counters,
+            expected_m,
+        )
+
+    def _quantize_fp8(self, recv_tokens_bf16: torch.Tensor, masked_m: torch.Tensor):
+        if self._quant_fp8 is None:
+            from sglang.kernels.ops.quantization.fp8_kernel import (
+                sglang_per_token_group_quant_fp8,
+            )
+
+            self._quant_fp8 = sglang_per_token_group_quant_fp8
+        # recv_tokens_bf16 is 3D [E_local, max_recv, H]; the quant helper supports
+        # 3D + masked_m. masked_m=expert_counters matches DeepEPLLDispatchOutput.
+        return self._quant_fp8(
+            recv_tokens_bf16,
+            group_size=_NCCL_EP_FP8_GROUP_SIZE,
+            masked_m=masked_m,
+        )
+
+    def combine(self, combine_input) -> torch.Tensor:
+        self.combine_a(combine_input)
+        return self.combine_b()
+
+    def combine_a(self, combine_input):
+        self._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
+
+        nccl_ep = self._nccl_ep
+        if isinstance(combine_input, DeepEPLLCombineInput):
+            expert_outputs = combine_input.hidden_states
+            topk_weights = combine_input.topk_weights
+        else:
+            expert_outputs = combine_input
+            topk_weights = self._dispatched_topk_weights
+
+        t = self._dispatched_t  # bounded in dispatch_a.
+
+        # Reuse pre-allocated [max_send, H] buffer.
+        combined = self.buffer.combined[:t]
+
+        stream = torch.cuda.current_stream()
+        inputs = nccl_ep.CombineInputs(tokens=nccl_ep.Tensor(expert_outputs))
+        outputs = nccl_ep.CombineOutputs(
+            tokens=nccl_ep.Tensor(combined),
+            topk_weights=nccl_ep.Tensor(topk_weights),
+        )
+        self.handle.combine(
+            inputs,
+            outputs,
+            config=nccl_ep.CombineConfig(send_only=1),
+            stream=stream.cuda_stream,
+        )
+
+        self._combine_intermediate_state = combined
+
+    def combine_b(self) -> torch.Tensor:
+        self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
+
+        combined = self._combine_intermediate_state
+        del self._combine_intermediate_state
+
+        stream = torch.cuda.current_stream()
+        try:
+            self.handle.complete(config=0, stream=stream.cuda_stream)
+        finally:
+            if self.handle is not None:
+                try:
+                    self.handle.destroy()
+                except Exception:
+                    pass
+                self.handle = None
+        return combined

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
@@ -83,6 +83,17 @@ def _nccl_runtime_version():
     return None
 
 
+def _nccl_ep_scale_unavailable_reason() -> str | None:
+    from sglang.srt.layers import deep_gemm_wrapper
+
+    if deep_gemm_wrapper.DEEPGEMM_BLACKWELL:
+        return (
+            "NCCL EP LL emits float32 FP8 group scales and does not support "
+            "UE8M0 scales required by DEEPGEMM_BLACKWELL"
+        )
+    return None
+
+
 def nccl_ep_unavailable_reason(*, require_graph: bool = False) -> str | None:
     """Return why NCCL EP is unavailable (None = available), for fallback logs."""
     try:
@@ -96,6 +107,8 @@ def nccl_ep_unavailable_reason(*, require_graph: bool = False) -> str | None:
     cc = torch.cuda.get_device_capability(0)[0]  # Hopper (sm_90) or Blackwell.
     if cc < 9:
         return f"GPU arch sm_{cc}x not supported (need Hopper/Blackwell sm_90+)"
+    if reason := _nccl_ep_scale_unavailable_reason():
+        return reason
     ver = _nccl_runtime_version()
     if ver is None:
         return "could not read NCCL version"
@@ -351,6 +364,10 @@ class NcclEpDispatcher(BaseDispatcher):
 
     def __init__(self, moe_runner_config: MoeRunnerConfig, ep_group: GroupCoordinator):
         super().__init__()
+        if moe_runner_config.params_dtype != torch.bfloat16:
+            raise ValueError(
+                "NCCL EP LL requires bfloat16 parameters (--dtype bfloat16)"
+            )
         nccl_core, nccl_ep = _load_nccl_ep()
         self._nccl_ep = nccl_ep
 
@@ -365,20 +382,9 @@ class NcclEpDispatcher(BaseDispatcher):
         # Resolve dispatch mode. LOW_LATENCY only this PR; HT raises at resolve() time.
         self.mode = get_nccl_ep_mode().resolve(is_extend_in_batch=False)
 
-        # Blackwell guard: our fp8 post-quant emits float32 group scales, which
-        # diverge from DeepEP's UE8M0 scales under DEEPGEMM_BLACKWELL. Fail fast
-        # rather than silently mis-quantize.
-        try:
-            from sglang.srt.layers import deep_gemm_wrapper
-
-            if getattr(deep_gemm_wrapper, "DEEPGEMM_BLACKWELL", False):
-                raise NotImplementedError(
-                    "NCCL EP LL fp8 post-quant emits float32 group scales, which diverge "
-                    "from DeepEP's UE8M0 scales when DEEPGEMM_BLACKWELL is set. Fall back "
-                    "to --moe-a2a-backend deepep on Blackwell for now."
-                )
-        except ImportError:
-            pass  # deep_gemm_wrapper absent -> DeepGEMM-Blackwell path not active.
+        # Keep direct dispatcher construction consistent with the public gate.
+        if reason := _nccl_ep_scale_unavailable_reason():
+            raise NotImplementedError(reason)
 
         # Deterministic-inference guard: NCCL EP is not determinism-audited yet.
         try:
@@ -467,6 +473,8 @@ class NcclEpDispatcher(BaseDispatcher):
     def dispatch_a(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
         from .nccl_ep_graph import get_nccl_ep_graph_resources
 
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError("NCCL EP LL dispatch requires bfloat16 hidden states")
         owner = get_nccl_ep_graph_resources()
         graph_owner = owner if owner is not None and owner.capturing else None
         if torch.cuda.is_current_stream_capturing() and graph_owner is None:
@@ -483,9 +491,10 @@ class NcclEpDispatcher(BaseDispatcher):
         t = hidden_states.shape[0]
         if t > self.num_max_dispatch_tokens_per_rank:
             raise ValueError(
-                f"NCCL EP: decode batch ({t}) exceeds per-rank dispatch budget "
-                f"{self.num_max_dispatch_tokens_per_rank}; increase "
-                f"--nccl-ep-num-max-dispatch-tokens-per-rank or reduce batch."
+                f"NCCL EP: batch ({t}) exceeds per-rank dispatch budget "
+                f"{self.num_max_dispatch_tokens_per_rank}; reduce the decode batch "
+                f"or --chunked-prefill-size. The LL budget is capped at "
+                f"{_NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP}."
             )
 
         stream = torch.cuda.current_stream()

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
@@ -65,11 +65,10 @@ def _nccl_runtime_version():
     LD_PRELOAD); falls back to torch.
     """
     try:
-        import nccl
+        import nccl.core as nccl_core
 
-        # nccl.get_version() -> VersionInfo with a .nccl LibraryInfo carrying .version.
-        vi = nccl.get_version()
-        lib_info = getattr(vi, "nccl", None)
+        vi = nccl_core.get_version()
+        lib_info = getattr(vi, "libnccl", None)
         ver_obj = getattr(lib_info, "version", None) if lib_info is not None else None
         if ver_obj is not None:
             return _parse_ver_str(str(ver_obj))
@@ -84,9 +83,13 @@ def _nccl_runtime_version():
     return None
 
 
-def nccl_ep_unavailable_reason() -> str | None:
+def nccl_ep_unavailable_reason(*, require_graph: bool = False) -> str | None:
     """Return why NCCL EP is unavailable (None = available), for fallback logs."""
-    if importlib.util.find_spec("nccl.ep") is None:
+    try:
+        installed = importlib.util.find_spec("nccl.ep") is not None
+    except (ModuleNotFoundError, ValueError):
+        installed = False
+    if not installed:
         return "nccl4py (nccl.ep) not importable"
     if not torch.cuda.is_available():
         return "no CUDA device"
@@ -98,6 +101,13 @@ def nccl_ep_unavailable_reason() -> str | None:
         return "could not read NCCL version"
     if (ver[0], ver[1]) < (2, 29):
         return f"NCCL {'.'.join(map(str, ver))} < 2.29 (need Device API/GIN)"
+    if require_graph:
+        try:
+            _, ep = _load_nccl_ep()
+        except ImportError as error:
+            return f"could not load nccl.ep: {error}"
+        if not callable(getattr(ep.Handle, "update", None)):
+            return "the installed nccl.ep binding lacks Handle.update"
     return None
 
 
@@ -140,6 +150,7 @@ class NcclEpBuffer:
         if state is None:
             state = SimpleNamespace(
                 group=None,
+                configuration=None,
                 num_experts=None,
                 num_local_experts=None,
                 hidden_size=None,
@@ -158,13 +169,29 @@ class NcclEpBuffer:
     @classmethod
     def get_buffer(
         cls,
-        ep_group: "GroupCoordinator",
+        ep_group: GroupCoordinator,
         hidden_size: int,
         num_experts: int,
         num_local_experts: int,
         max_dispatch_tokens_per_rank: int,
-    ) -> "NcclEpBuffer":
+    ) -> NcclEpBuffer:
         state = cls._state()
+        pynccl = ep_group.pynccl_comm
+        if pynccl is None or not getattr(pynccl, "available", False):
+            raise RuntimeError("NCCL EP requires a live PyNccl communicator")
+        configuration = (
+            pynccl.comm.value,
+            ep_group.device,
+            ep_group.world_size,
+            hidden_size,
+            num_experts,
+            num_local_experts,
+            max_dispatch_tokens_per_rank,
+        )
+        if state.group is not None and state.configuration != configuration:
+            raise ValueError(
+                "Incompatible MoE layer for the shared NCCL EP eager group"
+            )
         if state.group is None:
             state.num_experts = num_experts
             state.num_local_experts = num_local_experts
@@ -174,10 +201,11 @@ class NcclEpBuffer:
             world_size = ep_group.world_size
             state.max_recv_tokens_per_rank = world_size * max_dispatch_tokens_per_rank
             cls._create_group(state, ep_group)
+            state.configuration = configuration
         return state
 
     @classmethod
-    def _create_group(cls, state, ep_group: "GroupCoordinator"):
+    def _create_group(cls, state, ep_group: GroupCoordinator):
         nccl_core, nccl_ep = _load_nccl_ep()
 
         pynccl = ep_group.pynccl_comm
@@ -235,9 +263,7 @@ class NcclEpBuffer:
         )
         state.recv_total = torch.zeros((1,), dtype=torch.int32, device=device)
         # Upper bound = max dispatch tokens per rank; sliced to [:t] per combine.
-        state.combined = torch.empty(
-            (max_send, h), dtype=torch.bfloat16, device=device
-        )
+        state.combined = torch.empty((max_send, h), dtype=torch.bfloat16, device=device)
 
     @staticmethod
     def _low_latency_rdma_size_hint(nccl_ep, state, world_size: int) -> int:
@@ -274,7 +300,10 @@ class NcclEpBuffer:
         """
         from sglang.srt.environ import envs
 
-        if envs.SGLANG_NCCL_EP_MAX_NUM_SMS.is_set() and envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get() > 0:
+        if (
+            envs.SGLANG_NCCL_EP_MAX_NUM_SMS.is_set()
+            and envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get() > 0
+        ):
             val = envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get()
         else:
             val = 20  # conservative default for H100 (132 SMs)
@@ -297,10 +326,7 @@ class NcclEpBuffer:
         state = cls._state()
         g = state.group
         if g is not None:
-            try:
-                g.destroy()
-            except Exception:
-                pass
+            g.destroy()
             state.group = None
 
 
@@ -323,7 +349,7 @@ class NcclEpDispatcher(BaseDispatcher):
     after dispatch to feed ``apply_deepep_ll``.
     """
 
-    def __init__(self, moe_runner_config: "MoeRunnerConfig", ep_group: "GroupCoordinator"):
+    def __init__(self, moe_runner_config: MoeRunnerConfig, ep_group: GroupCoordinator):
         super().__init__()
         nccl_core, nccl_ep = _load_nccl_ep()
         self._nccl_ep = nccl_ep
@@ -397,6 +423,9 @@ class NcclEpDispatcher(BaseDispatcher):
         )
 
         self.handle = None
+        self._graph_resources = None
+        self._eager_session = None
+        self._active_buffer = self.buffer
 
         # Staged execution state machine (mirrors deepep.py _Stage).
         self._stage = _Stage.INITIAL
@@ -418,9 +447,9 @@ class NcclEpDispatcher(BaseDispatcher):
     # single slot — calling combine(send_only=1) before dispatch_b (complete)
     # would overwrite the dispatch continue_fn.
     def _update_stage(self, old_stage, new_stage):
-        assert self._stage == old_stage, (
-            f"NCCL EP stage mismatch: expected {old_stage}, got {self._stage}"
-        )
+        assert (
+            self._stage == old_stage
+        ), f"NCCL EP stage mismatch: expected {old_stage}, got {self._stage}"
         self._stage = new_stage
 
     def register_deepep_dispatch_hook(self, hook):
@@ -436,7 +465,16 @@ class NcclEpDispatcher(BaseDispatcher):
         return self.dispatch_b()
 
     def dispatch_a(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
-        self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        from .nccl_ep_graph import get_nccl_ep_graph_resources
+
+        owner = get_nccl_ep_graph_resources()
+        graph_owner = owner if owner is not None and owner.capturing else None
+        if torch.cuda.is_current_stream_capturing() and graph_owner is None:
+            raise RuntimeError(
+                "NCCL EP capture requires the opt-in full decode Graph backend"
+            )
+        if self._stage != _Stage.INITIAL:
+            raise RuntimeError("NCCL EP has an incomplete dispatch/combine transaction")
 
         nccl_ep = self._nccl_ep
         topk_weights = topk_output.topk_weights.to(torch.float32)
@@ -450,24 +488,35 @@ class NcclEpDispatcher(BaseDispatcher):
                 f"--nccl-ep-num-max-dispatch-tokens-per-rank or reduce batch."
             )
 
-        if self.handle is not None:
-            try:
-                self.handle.destroy()
-            except Exception:
-                pass
-            self.handle = None
-
-        state = self.buffer
-
         stream = torch.cuda.current_stream()
-
-        handle = state.group.create_handle(
-            layout=nccl_ep.Layout.EXPERT_MAJOR,
-            topk_idx=nccl_ep.Tensor(topk_ids),
-            config=nccl_ep.HandleConfig(),
-            stream=stream.cuda_stream,
-        )
+        if graph_owner is not None:
+            state, handle, hidden_states, topk_ids, topk_weights = graph_owner.prepare(
+                self, hidden_states, topk_ids, topk_weights
+            )
+            self._graph_resources = graph_owner
+        else:
+            if owner is not None:
+                session = owner.submission_session("transaction")
+                session.__enter__()
+                self._eager_session = session
+            try:
+                if self.handle is not None:
+                    self.handle.destroy()
+                state = self.buffer
+                handle = state.group.create_handle(
+                    layout=nccl_ep.Layout.EXPERT_MAJOR,
+                    topk_idx=nccl_ep.Tensor(topk_ids),
+                    config=nccl_ep.HandleConfig(),
+                    stream=stream.cuda_stream,
+                )
+            except BaseException:
+                if self._eager_session is not None:
+                    self._eager_session.__exit__(None, None, None)
+                    self._eager_session = None
+                raise
+        self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
         self.handle = handle
+        self._active_buffer = state
 
         # Reuse pre-allocated scratch; counters re-zeroed each dispatch.
         recv_tokens = state.recv_tokens
@@ -497,6 +546,11 @@ class NcclEpDispatcher(BaseDispatcher):
             topk_weights,
             t,
             hidden_states,
+            # Native send_only borrows the tensor descriptors until complete.
+            # Retaining the Torch allocations alone does not keep these alive.
+            inputs,
+            outputs,
+            layout_info,
         )
 
     def dispatch_b(self) -> DispatchOutput:
@@ -509,6 +563,9 @@ class NcclEpDispatcher(BaseDispatcher):
             topk_weights,
             t,
             hidden_states,
+            _inputs,
+            _outputs,
+            _layout_info,
         ) = self._dispatch_intermediate_state
         del self._dispatch_intermediate_state
 
@@ -567,7 +624,7 @@ class NcclEpDispatcher(BaseDispatcher):
         t = self._dispatched_t  # bounded in dispatch_a.
 
         # Reuse pre-allocated [max_send, H] buffer.
-        combined = self.buffer.combined[:t]
+        combined = self._active_buffer.combined[:t]
 
         stream = torch.cuda.current_stream()
         inputs = nccl_ep.CombineInputs(tokens=nccl_ep.Tensor(expert_outputs))
@@ -582,22 +639,29 @@ class NcclEpDispatcher(BaseDispatcher):
             stream=stream.cuda_stream,
         )
 
-        self._combine_intermediate_state = combined
+        self._combine_intermediate_state = (combined, inputs, outputs)
 
     def combine_b(self) -> torch.Tensor:
-        self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
-
-        combined = self._combine_intermediate_state
-        del self._combine_intermediate_state
-
+        if self._stage != _Stage.AFTER_COMBINE_A:
+            raise RuntimeError("NCCL EP combine_b requires a pending combine")
+        combined, _inputs, _outputs = self._combine_intermediate_state
         stream = torch.cuda.current_stream()
-        try:
-            self.handle.complete(config=0, stream=stream.cuda_stream)
-        finally:
-            if self.handle is not None:
-                try:
-                    self.handle.destroy()
-                except Exception:
-                    pass
-                self.handle = None
+        # Release ownership only after successful completion. Native/GPU faults
+        # leave an incomplete transaction and require process restart, rather
+        # than allowing another layer to reuse uncertain communication state.
+        self.handle.complete(config=0, stream=stream.cuda_stream)
+        if self._graph_resources is not None:
+            # Later MoE layers reuse the group's combine scratch. Keep this
+            # layer's live output in the captured graph's allocator pool.
+            combined = combined.clone()
+            self._graph_resources.release(self)
+            self._graph_resources = None
+        else:
+            self.handle.destroy()
+            if self._eager_session is not None:
+                self._eager_session.__exit__(None, None, None)
+                self._eager_session = None
+        self.handle = None
+        del self._combine_intermediate_state
+        self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
         return combined

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep_graph.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep_graph.py
@@ -1,0 +1,245 @@
+"""Generation-owned LL resources for serialized full decode CUDA Graphs.
+
+One handle owns a group's mutable communication state across all compatible
+layers and buckets. This is an ownership policy, not an API handle-count limit.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from threading import RLock, get_ident
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.runtime_context import get_resources
+
+
+def get_nccl_ep_graph_resources():
+    return get_resources().buffers.get("nccl_ep_graph_resources")
+
+
+def nccl_ep_eager_session():
+    owner = get_nccl_ep_graph_resources()
+    return owner.submission_session("eager") if owner is not None else nullcontext()
+
+
+def require_nccl_ep_eager_session():
+    owner = get_nccl_ep_graph_resources()
+    if owner is not None:
+        owner.require_session("eager")
+
+
+def destroy_nccl_ep_resources():
+    """Close graph executables and EP groups before releasing coordinators."""
+    owner = get_nccl_ep_graph_resources()
+    if owner is not None:
+        owner.shutdown()
+    state = get_resources().buffers.get("nccl_ep_state")
+    if state is not None and state.group is not None:
+        from .nccl_ep import NcclEpBuffer
+
+        torch.cuda.synchronize()
+        NcclEpBuffer.destroy()
+
+
+class NcclEpGraphResources:
+    def __init__(self, capacity: int, *, shutdown):
+        if not 0 < capacity <= 1024:
+            raise ValueError("NCCL EP Graph capacity must be in [1, 1024]")
+        self.capacity = capacity
+        self.shutdown = shutdown
+        self.state = None
+        self.handle = None
+        self.borrower = None
+        self.capturing = False
+        self.signature = None
+        self.rows = None
+        self._lock = RLock()
+        self._sessions = []
+        self._last_stream = None
+        self._fence = None
+        self._session_thread = None
+
+    def require_session(self, kind):
+        if (
+            not self._sessions
+            or self._session_thread != get_ident()
+            or self._sessions[-1][0] != kind
+        ):
+            raise RuntimeError(f"NCCL EP Graph requires an active {kind}_session")
+
+    def _order_stream(self, stream):
+        previous = self._last_stream
+        if previous is not None and previous != stream:
+            # Record now, including consumers submitted after the last replay
+            # returned. An event recorded at replay's end would miss those reads.
+            self._fence = previous.record_event()
+            stream.wait_event(self._fence)
+        self._last_stream = stream
+
+    @contextmanager
+    def submission_session(self, kind):
+        if not self._lock.acquire(blocking=False):
+            raise RuntimeError("Concurrent NCCL EP Graph submissions are unsupported")
+        entered = False
+        try:
+            if self._sessions and (self._sessions[-1][0], kind) not in {
+                ("replay", "capture"),
+                ("replay", "cleanup"),
+                ("capture", "cleanup"),
+                ("replay", "eager"),
+                ("replay", "transaction"),
+                ("eager", "transaction"),
+            }:
+                raise RuntimeError(
+                    "Overlapping NCCL EP Graph submissions are unsupported"
+                )
+            stream = torch.cuda.current_stream()
+            self._order_stream(stream)
+            self._sessions.append((kind, stream))
+            self._session_thread = get_ident()
+            entered = True
+            yield
+        finally:
+            if entered:
+                self._sessions.pop()
+                if self._sessions:
+                    # Recapture uses a child stream inside execute's replay
+                    # session. Order it back before the parent's input writes.
+                    self._order_stream(self._sessions[-1][1])
+                elif self.state is None and get_nccl_ep_graph_resources() is self:
+                    get_resources().buffers.pop("nccl_ep_graph_resources")
+                if not self._sessions:
+                    self._session_thread = None
+            self._lock.release()
+
+    @contextmanager
+    def capture_session(self):
+        previous = get_nccl_ep_graph_resources()
+        if previous is not None and previous is not self:
+            raise RuntimeError("Another NCCL EP Graph generation is still live")
+        with self.submission_session("capture"):
+            get_resources().buffers["nccl_ep_graph_resources"] = self
+            self.capturing = True
+            try:
+                yield
+            finally:
+                self.capturing = False
+
+    def prepare(self, dispatcher, x, ids, weights):
+        from .nccl_ep import NcclEpBuffer, _load_nccl_ep
+
+        self.require_session("capture")
+        if not self.capturing or self.borrower is not None:
+            raise RuntimeError("NCCL EP Graph requires complete serial transactions")
+        t = x.shape[0]
+        if not 0 < t <= self.capacity:
+            raise ValueError("NCCL EP Graph bucket exceeds its frozen capacity")
+        if x.ndim != 2 or x.shape[1] != dispatcher.hidden_size:
+            raise ValueError(
+                "NCCL EP Graph input hidden size does not match its MoE layer"
+            )
+        if (
+            x.dtype != torch.bfloat16
+            or dispatcher.params_dtype != torch.bfloat16
+            or x.device != dispatcher.ep_group.device
+        ):
+            raise ValueError("NCCL EP Graph requires BF16 inputs on its EP device")
+        if ids.shape != (t, dispatcher.router_topk) or weights.shape != ids.shape:
+            raise ValueError("NCCL EP Graph routing/weight shapes do not match inputs")
+        signature = (
+            dispatcher.ep_group.pynccl_comm.comm.value,
+            x.device,
+            dispatcher.world_size,
+            dispatcher.num_experts,
+            dispatcher.num_local_experts,
+            dispatcher.hidden_size,
+            dispatcher.router_topk,
+            dispatcher.params_dtype,
+        )
+        if self.signature is not None and signature != self.signature:
+            raise ValueError(
+                "Incompatible MoE layer for the shared NCCL EP Graph group"
+            )
+        nccl_core, ep = _load_nccl_ep()
+        stream = torch.cuda.current_stream().cuda_stream
+        if self.state is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError("Initialize NCCL EP Graph resources during warmup")
+            self.signature = signature
+            state = self.state = SimpleNamespace(
+                group=None,
+                num_experts=dispatcher.num_experts,
+                num_local_experts=dispatcher.num_local_experts,
+                hidden_size=dispatcher.hidden_size,
+                max_dispatch_tokens_per_rank=self.capacity,
+                max_recv_tokens_per_rank=dispatcher.world_size * self.capacity,
+            )
+            NcclEpBuffer._alloc_scratch(state, x.device)
+            state.send_tokens = torch.empty(
+                (self.capacity, dispatcher.hidden_size), dtype=x.dtype, device=x.device
+            )
+            state.topk_ids = torch.full(
+                (self.capacity, dispatcher.router_topk),
+                -1,
+                dtype=torch.int64,
+                device=x.device,
+            )
+            state.topk_weights = torch.empty_like(state.topk_ids, dtype=torch.float32)
+            state.wrapped_comm = nccl_core.Communicator(ptr=signature[0])
+            state.group = ep.Group.create(
+                state.wrapped_comm,
+                ep.GroupConfig(
+                    algorithm=ep.Algorithm.LOW_LATENCY,
+                    num_experts=state.num_experts,
+                    num_topk=dispatcher.router_topk,
+                    max_dispatch_tokens_per_rank=self.capacity,
+                    max_recv_tokens_per_rank=0,
+                    max_token_bytes=dispatcher.hidden_size * 2,
+                    rdma_buffer_size=0,  # AUTO: initialize the maximum layout once.
+                    max_num_sms=NcclEpBuffer._resolve_max_num_sms(state.num_experts),
+                ),
+            )
+            self.handle = state.group.create_handle(
+                layout=ep.Layout.EXPERT_MAJOR,
+                topk_idx=ep.Tensor(state.topk_ids),
+                config=ep.HandleConfig(),
+                stream=stream,
+            )
+            self.rows = self.capacity
+        state = self.state
+        send = state.send_tokens[:t]
+        routing = state.topk_ids[:t]
+        factors = state.topk_weights[:t]
+        send.copy_(x)
+        routing.copy_(ids)
+        factors.copy_(weights)
+        if self.rows != t:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "NCCL EP bucket descriptors must be set during warmup"
+                )
+            # Same allocation/base address; only the bucket's descriptor changes.
+            self.handle.update(ep.Tensor(routing), stream=stream)
+            self.rows = t
+        self.borrower = dispatcher
+        return state, self.handle, send, routing, factors
+
+    def release(self, dispatcher):
+        if self.borrower is not dispatcher:
+            raise RuntimeError("NCCL EP Graph transaction ownership mismatch")
+        self.borrower = None
+
+    def close(self):
+        # The backend must wait and reset every executable before this call.
+        if self.borrower is not None:
+            raise RuntimeError("NCCL EP Graph has an incomplete transaction")
+        if self.handle is not None:
+            self.handle.destroy()
+            self.handle = None
+        if self.state is not None and self.state.group is not None:
+            self.state.group.destroy()
+        self.state = self.signature = self.rows = None
+        if not self._sessions and get_nccl_ep_graph_resources() is self:
+            get_resources().buffers.pop("nccl_ep_graph_resources")

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep_graph.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep_graph.py
@@ -15,34 +15,6 @@ import torch
 from sglang.srt.runtime_context import get_resources
 
 
-def get_nccl_ep_graph_resources():
-    return get_resources().buffers.get("nccl_ep_graph_resources")
-
-
-def nccl_ep_eager_session():
-    owner = get_nccl_ep_graph_resources()
-    return owner.submission_session("eager") if owner is not None else nullcontext()
-
-
-def require_nccl_ep_eager_session():
-    owner = get_nccl_ep_graph_resources()
-    if owner is not None:
-        owner.require_session("eager")
-
-
-def destroy_nccl_ep_resources():
-    """Close graph executables and EP groups before releasing coordinators."""
-    owner = get_nccl_ep_graph_resources()
-    if owner is not None:
-        owner.shutdown()
-    state = get_resources().buffers.get("nccl_ep_state")
-    if state is not None and state.group is not None:
-        from .nccl_ep import NcclEpBuffer
-
-        torch.cuda.synchronize()
-        NcclEpBuffer.destroy()
-
-
 class NcclEpGraphResources:
     def __init__(self, capacity: int, *, shutdown):
         if not 0 < capacity <= 1024:
@@ -243,3 +215,31 @@ class NcclEpGraphResources:
         self.state = self.signature = self.rows = None
         if not self._sessions and get_nccl_ep_graph_resources() is self:
             get_resources().buffers.pop("nccl_ep_graph_resources")
+
+
+def get_nccl_ep_graph_resources():
+    return get_resources().buffers.get("nccl_ep_graph_resources")
+
+
+def nccl_ep_eager_session():
+    owner = get_nccl_ep_graph_resources()
+    return owner.submission_session("eager") if owner is not None else nullcontext()
+
+
+def require_nccl_ep_eager_session():
+    owner = get_nccl_ep_graph_resources()
+    if owner is not None:
+        owner.require_session("eager")
+
+
+def destroy_nccl_ep_resources():
+    """Close graph executables and EP groups before releasing coordinators."""
+    owner = get_nccl_ep_graph_resources()
+    if owner is not None:
+        owner.shutdown()
+    state = get_resources().buffers.get("nccl_ep_state")
+    if state is not None and state.group is not None:
+        from .nccl_ep import NcclEpBuffer
+
+        torch.cuda.synchronize()
+        NcclEpBuffer.destroy()

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -36,6 +36,7 @@ class MoeA2ABackend(Enum):
     ASCEND_TP = "ascend_tp"
     FLASHINFER = "flashinfer"
     MEGAMOE = "megamoe"
+    NCCL_EP = "nccl_ep"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -76,6 +77,9 @@ class MoeA2ABackend(Enum):
 
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
+
+    def is_nccl_ep(self):
+        return self == MoeA2ABackend.NCCL_EP
 
     def supports_aiter(self) -> bool:
         return self in (
@@ -197,6 +201,25 @@ class DeepEPMode(Enum):
         return self == DeepEPMode.AUTO
 
 
+class NcclEpMode(Enum):
+    """NCCL EP dispatch algorithm. Only LOW_LATENCY is implemented; HT is a follow-up."""
+
+    LOW_LATENCY = "low_latency"
+    HIGH_THROUGHPUT = "high_throughput"
+    AUTO = "auto"
+
+    def resolve(self, is_extend_in_batch: bool) -> "NcclEpMode":
+        if self == NcclEpMode.HIGH_THROUGHPUT:
+            raise NotImplementedError(
+                "NCCL EP high-throughput (prefill) path is not implemented yet; "
+                "use --nccl-ep-mode low_latency (or auto) for decode."
+            )
+        return NcclEpMode.LOW_LATENCY
+
+    def is_low_latency(self) -> bool:
+        return self == NcclEpMode.LOW_LATENCY
+
+
 class DispatcherOutputDtype(Enum):
     """
     Describes the dispatch output data type for DeepEP.
@@ -301,6 +324,10 @@ def initialize_moe_config(server_args: ServerArgs):
     )
     moe.deepep_mode = DeepEPMode(server_args.deepep_mode)
     moe.deepep_config = server_args.deepep_config or ""
+    moe.nccl_ep_mode = NcclEpMode(server_args.nccl_ep_mode)
+    moe.nccl_ep_num_max_dispatch_tokens_per_rank = int(
+        server_args.nccl_ep_num_max_dispatch_tokens_per_rank or 0
+    )
     moe.tbo_enabled = server_args.enable_two_batch_overlap
     moe.sbo_enabled = server_args.enable_single_batch_overlap
     if moe.sbo_enabled and is_cuda():
@@ -355,6 +382,18 @@ def get_deepep_mode() -> DeepEPMode:
     return moe.deepep_mode
 
 
+def get_nccl_ep_mode() -> NcclEpMode:
+    moe = get_flags().moe
+    if moe.nccl_ep_mode is None:
+        moe.nccl_ep_mode = NcclEpMode.LOW_LATENCY
+    return moe.nccl_ep_mode
+
+
+def get_nccl_ep_num_max_dispatch_tokens_per_rank() -> int:
+    moe = get_flags().moe
+    return moe.nccl_ep_num_max_dispatch_tokens_per_rank or 0
+
+
 def get_deepep_config() -> str:
     moe = get_flags().moe
     if moe.deepep_config is None:
@@ -378,9 +417,9 @@ def is_sbo_enabled() -> bool:
 
 
 def is_deepep_class_backend() -> bool:
-    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, or Mori)."""
+    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, Mori, NCCL EP)."""
     b = get_moe_a2a_backend()
-    return b.is_deepep() or b.is_mooncake() or b.is_mori()
+    return b.is_deepep() or b.is_mooncake() or b.is_mori() or b.is_nccl_ep()
 
 
 def uses_per_rank_fused_shared_slots() -> bool:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -208,7 +208,7 @@ class NcclEpMode(Enum):
     HIGH_THROUGHPUT = "high_throughput"
     AUTO = "auto"
 
-    def resolve(self, is_extend_in_batch: bool) -> "NcclEpMode":
+    def resolve(self, is_extend_in_batch: bool) -> NcclEpMode:
         if self == NcclEpMode.HIGH_THROUGHPUT:
             raise NotImplementedError(
                 "NCCL EP high-throughput (prefill) path is not implemented yet; "

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1060,6 +1060,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
+        # External planning callers must not overwrite EP Graph input buffers
+        # before the backend has ordered the preceding replay and its consumers.
+        require_session = getattr(self.backend, "require_replay_session", None)
+        if require_session is not None:
+            require_session()
         ragged_layout = (
             resolve_ragged_verify_layout(forward_batch)
             if self.ragged_verify_mode

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -167,6 +167,11 @@ class EagerRunner(BaseRunner):
         """Copy the live batch into the fixed-max eager static buffers (sliced to
         this batch's shape) — the eager counterpart of the cuda-graph runners'
         load_batch."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep_graph import (
+            require_nccl_ep_eager_session,
+        )
+
+        require_nccl_ep_eager_session()
         if envs.SGLANG_EAGER_INPUT_NO_COPY.get():
             return replace(forward_batch)
         raw_bs = forward_batch.batch_size
@@ -194,14 +199,21 @@ class EagerRunner(BaseRunner):
     def execute(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None, **kwargs
     ) -> Any:
-        mode = forward_batch.forward_mode
-        if mode.is_decode():
-            return self._execute_decode(forward_batch, pp_proxy_tensors)
-        if mode.is_idle():
-            return self._execute_idle(forward_batch, pp_proxy_tensors)
-        if mode.is_extend(include_draft_extend_v2=True):
-            return self._execute_extend(forward_batch, pp_proxy_tensors)
-        raise ValueError(f"Invalid forward mode for eager runner: {mode}")
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep_graph import (
+            nccl_ep_eager_session,
+        )
+
+        # Eager and Graph registries can alias. Order the whole forward before
+        # load_batch writes shared inputs, including all non-MoE model work.
+        with nccl_ep_eager_session():
+            mode = forward_batch.forward_mode
+            if mode.is_decode():
+                return self._execute_decode(forward_batch, pp_proxy_tensors)
+            if mode.is_idle():
+                return self._execute_idle(forward_batch, pp_proxy_tensors)
+            if mode.is_extend(include_draft_extend_v2=True):
+                return self._execute_extend(forward_batch, pp_proxy_tensors)
+            raise ValueError(f"Invalid forward mode for eager runner: {mode}")
 
     def _resolve_decode_pdmux(
         self,

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -17,7 +17,7 @@ torch.cuda.CUDAGraph per shape.
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
@@ -54,7 +54,19 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         cuda_graph_runner: BaseCudaGraphRunner,
         *,
         enable_memory_saver: bool = False,
+        nccl_ep_capacity: Optional[int] = None,
     ) -> None:
+        self._nccl_ep_resources = None
+        if nccl_ep_capacity is not None:
+            if enable_memory_saver:
+                raise ValueError("NCCL EP Graph does not support memory saver")
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep_graph import (
+                NcclEpGraphResources,
+            )
+
+            self._nccl_ep_resources = NcclEpGraphResources(
+                nccl_ep_capacity, shutdown=self.cleanup
+            )
         self._graphs: Dict[Any, torch.cuda.CUDAGraph] = {}
         self._outputs: Dict[Any, Any] = {}
         self._pool = None
@@ -68,14 +80,28 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
 
     @contextmanager
     def capture_session(self, stream: torch.cuda.Stream):
-        if self._pool is None:
-            self._pool = get_or_create_global_graph_memory_pool(self._device_module)
-        set_graph_pool_id(self._pool)
-        self._capture_stream = stream
-        try:
-            yield
-        finally:
-            self._capture_stream = None
+        context = (
+            self._nccl_ep_resources.capture_session()
+            if self._nccl_ep_resources is not None
+            else nullcontext()
+        )
+        with context:
+            try:
+                if self._pool is None:
+                    self._pool = (
+                        self._device_module.graph_pool_handle()
+                        if self._nccl_ep_resources is not None
+                        else get_or_create_global_graph_memory_pool(self._device_module)
+                    )
+                set_graph_pool_id(self._pool)
+                self._capture_stream = stream
+                yield
+            except BaseException:
+                if self._nccl_ep_resources is not None:
+                    self.cleanup()
+                raise
+            finally:
+                self._capture_stream = None
 
     def capture_one(
         self,
@@ -84,6 +110,12 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         capture_inputs: Optional[Any] = None,
         post_warmup_hook: Optional[Callable[[], None]] = None,
     ) -> None:
+        if self._nccl_ep_resources is not None:
+            self._nccl_ep_resources.require_session("capture")
+            if shape_key in self._graphs:
+                raise ValueError(
+                    "NCCL EP bucket already captured; start a new generation"
+                )
         # Two warmups so kernels are loaded and one-time setup is paid before capture.
         # post_warmup_hook lets the attention backend reset state that warmup mutated.
         for _ in range(2):
@@ -107,8 +139,19 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         else:
             graph_ctx = self._device_module.graph
 
-        with graph_ctx(cuda_graph=graph, pool=self._pool, stream=self._capture_stream):
-            out = forward_fn()
+        try:
+            with graph_ctx(
+                cuda_graph=graph, pool=self._pool, stream=self._capture_stream
+            ):
+                out = forward_fn()
+        except BaseException:
+            if self._nccl_ep_resources is not None:
+                # This executable has not entered _graphs yet. A traceback can
+                # retain it after failure, so reset it before the session closes
+                # the persistent native resources it may have captured.
+                self._device_module.synchronize()
+                graph.reset()
+            raise
 
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = out
@@ -118,7 +161,18 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
 
     @contextmanager
     def replay_session(self):
-        yield
+        context = (
+            self._nccl_ep_resources.submission_session("replay")
+            if self._nccl_ep_resources is not None
+            else nullcontext()
+        )
+        with context:
+            yield
+
+    def require_replay_session(self):
+        """Protect static-input writes as well as the graph launch itself."""
+        if self._nccl_ep_resources is not None:
+            self._nccl_ep_resources.require_session("replay")
 
     def replay(
         self,
@@ -126,10 +180,23 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         static_forward_batch: ForwardBatch,
         **kwargs,
     ) -> Any:
+        self.require_replay_session()
         self._graphs[shape_key].replay()
         return self._outputs[shape_key]
 
     def cleanup(self) -> None:
-        self._graphs.clear()
-        self._outputs.clear()
-        self._pool = None
+        context = (
+            self._nccl_ep_resources.submission_session("cleanup")
+            if self._nccl_ep_resources is not None
+            else nullcontext()
+        )
+        with context:
+            if self._nccl_ep_resources is not None:
+                self._device_module.synchronize()
+                for graph in self._graphs.values():
+                    graph.reset()
+            self._graphs.clear()
+            self._outputs.clear()
+            self._pool = None
+            if self._nccl_ep_resources is not None:
+                self._nccl_ep_resources.close()

--- a/python/sglang/srt/model_executor/runner_backend/utils.py
+++ b/python/sglang/srt/model_executor/runner_backend/utils.py
@@ -37,6 +37,7 @@ from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
 from sglang.srt.model_executor.runner_backend.tc_piecewise_cuda_graph_backend import (
     TcPiecewiseCudaGraphBackend,
 )
+from sglang.srt.runtime_context import get_exec
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
@@ -62,6 +63,11 @@ def resolve_decode_backend(
     backend_name = cfg.decode.backend if cfg is not None else Backend.FULL
 
     enable_memory_saver = model_runner.server_args.enable_memory_saver
+    nccl_ep_capacity = None
+    if getattr(getattr(get_exec(), "moe", None), "enable_nccl_ep_cuda_graph", False):
+        if model_runner.device != "cuda" or backend_name != Backend.FULL:
+            raise ValueError("NCCL EP CUDA Graph requires the full CUDA decode backend")
+        nccl_ep_capacity = cuda_graph_runner.max_num_token
 
     if model_runner.device == "npu":
         from sglang.srt.hardware_backend.npu.graph_runner.npu_cudagraph_backend import (
@@ -97,7 +103,9 @@ def resolve_decode_backend(
             )
             _TC_PIECEWISE_DECODE_FALLBACK_LOGGED = True
     return FullCudaGraphBackend(
-        cuda_graph_runner, enable_memory_saver=enable_memory_saver
+        cuda_graph_runner,
+        enable_memory_saver=enable_memory_saver,
+        nccl_ep_capacity=nccl_ep_capacity,
     )
 
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -710,6 +710,7 @@ class DeepseekV2MoE(nn.Module):
             # not divisible by the global TP size.
             _shared_expert_use_tp1 = (
                 get_moe_a2a_backend().is_deepep()
+                or get_moe_a2a_backend().is_nccl_ep()
                 or get_moe_a2a_backend().is_mooncake()
                 or get_moe_a2a_backend().is_nixl()
                 or get_moe_a2a_backend().is_mori()
@@ -818,6 +819,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_nccl_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
@@ -913,6 +915,9 @@ class DeepseekV2MoE(nn.Module):
                     skip_shared_experts=skip_shared_experts,
                 )
         else:
+            # NCCL EP: use forward_deepep (LL path) for both prefill and decode,
+            # matching DeepEP behavior. The LL dispatch/combine handles arbitrary
+            # batch sizes (bounded by num_max_dispatch_tokens_per_rank).
             return self.forward_deepep(
                 hidden_states, forward_batch, input_ids_global=input_ids_global
             )
@@ -1277,7 +1282,11 @@ class DeepseekV2MoE(nn.Module):
                 self.experts.clear_overlap_args()
                 post_combine_hook_handle.remove()
 
-            assert isinstance(self.experts.dispatcher, MaybeTboDeepEPDispatcher)
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+            assert isinstance(
+                self.experts.dispatcher,
+                (MaybeTboDeepEPDispatcher, NcclEpDispatcher),
+            )
             deepep_dispatch_hook_handle = (
                 self.experts.dispatcher.register_deepep_dispatch_hook(
                     _deepep_dispatch_hook
@@ -1410,7 +1419,10 @@ class DeepseekV2MoE(nn.Module):
             x = shared_output
             # aiter moe call will handle routed_scaling_factor in the function
             # so add _use_aiter condition to eliminate to use self.routed_scaling_factor in add_ call
-            if self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter:
+            if (
+                self.experts.should_fuse_routed_scaling_factor_in_topk
+                or _use_aiter
+            ):
                 x.add_(final_hidden_states)
             else:
                 x.add_(final_hidden_states, alpha=self.routed_scaling_factor)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1283,6 +1283,7 @@ class DeepseekV2MoE(nn.Module):
                 post_combine_hook_handle.remove()
 
             from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
             assert isinstance(
                 self.experts.dispatcher,
                 (MaybeTboDeepEPDispatcher, NcclEpDispatcher),
@@ -1419,10 +1420,7 @@ class DeepseekV2MoE(nn.Module):
             x = shared_output
             # aiter moe call will handle routed_scaling_factor in the function
             # so add _use_aiter condition to eliminate to use self.routed_scaling_factor in add_ call
-            if (
-                self.experts.should_fuse_routed_scaling_factor_in_topk
-                or _use_aiter
-            ):
+            if self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter:
                 x.add_(final_hidden_states)
             else:
                 x.add_(final_hidden_states, alpha=self.routed_scaling_factor)

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -367,6 +367,8 @@ class MoeFlags(_FlagGroupBase):
     tbo_token_distribution_threshold: float | None = None
     disable_fp4_allgather: bool | None = None
     quantization: str | None = None
+    nccl_ep_mode: Any = None  # NcclEpMode | None (typed Any to avoid import cycle)
+    nccl_ep_num_max_dispatch_tokens_per_rank: int = 0
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -277,7 +277,13 @@ MOE_A2A_BACKEND_CHOICES = [
     "flashinfer",
     "megamoe",
     "ascend_tp",
+    "nccl_ep",
 ]
+
+
+def _deepep_importable() -> bool:
+    """Whether the deep_ep package is importable."""
+    return importlib.util.find_spec("deep_ep") is not None
 
 MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
@@ -2199,6 +2205,7 @@ class ServerArgs:
             "flashinfer",
             "megamoe",
             "ascend_tp",
+            "nccl_ep",
         ],
         Arg(
             help="Choose the backend for MoE A2A.",
@@ -2282,6 +2289,16 @@ class ServerArgs:
         "Tuned DeepEP config suitable for your own cluster. It can be either a string with JSON content or a file path.",
         NS("exec.moe"),
     ] = None
+    nccl_ep_mode: A[
+        Literal["low_latency", "auto"],
+        "NCCL EP dispatch algorithm. Only `low_latency` is implemented; `auto` resolves to it. The high-throughput (prefill) path is a follow-up.",
+        NS("exec.moe"),
+    ] = "low_latency"
+    nccl_ep_num_max_dispatch_tokens_per_rank: A[
+        int,
+        "Per-rank dispatch token budget for the NCCL EP group. 0 = use the backend default (capped at 1024).",
+        NS("exec.moe"),
+    ] = 0
     moe_dense_tp_size: A[
         Optional[int],
         Arg(
@@ -6279,6 +6296,23 @@ class ServerArgs:
         # invoked here at the legacy write slots.
         run_post_process_pass(self, _a2a_fusion_adjustments)
 
+        # NCCL EP capability check + fallback — done early so a 'deepep' fallback
+        # flows through the deepep-specific blocks below.
+        if resolved_view(self).moe_a2a_backend == "nccl_ep":
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+                nccl_ep_unavailable_reason,
+            )
+
+            reason = nccl_ep_unavailable_reason()
+            if reason is not None:
+                fallback = "deepep" if _deepep_importable() else "none"
+                logger.warning(
+                    f"NCCL EP MoE requested but unavailable ({reason}); "
+                    f"falling back to moe_a2a_backend='{fallback}'. "
+                    f"Install nccl4py[cu13] on a CUDA13 + NCCL>=2.29 Hopper/Blackwell box."
+                )
+                self.moe_a2a_backend = fallback
+
         a2a_backend = resolved_view(self).moe_a2a_backend
         if self.enable_waterfill:
             self.enforce_shared_experts_fusion = True
@@ -6363,6 +6397,13 @@ class ServerArgs:
                     "must be >= the per-rank MoRI dispatch tokens "
                     "(chunked_prefill_size by default)"
                 )
+
+        if a2a_backend == "nccl_ep":
+            logger.warning(
+                f"NCCL EP MoE is enabled. The expert parallel size is adjusted "
+                f"to be the same as the tensor parallel size[{self.tp_size}]. "
+                f"Only the low-latency (LL) path is implemented; prefill and decode both run through LL."
+            )
 
     def _required_mori_dispatch_tokens_per_rank(self) -> int:
         """Max tokens a single rank dispatches through MoRI in one forward."""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6366,13 +6366,21 @@ class ServerArgs:
             if reason is not None:
                 if self.enable_nccl_ep_cuda_graph:
                     raise ValueError(f"NCCL EP CUDA Graph is unavailable: {reason}")
-                fallback = "deepep" if _deepep_importable() else "none"
+                # Triton consumes standard dispatch output outside NCCL EP;
+                # there is no DeepEP -> Triton format adapter.
+                fallback = (
+                    "deepep"
+                    if resolved_view(self).moe_runner_backend != "triton"
+                    and _deepep_importable()
+                    else "none"
+                )
                 logger.warning(
                     f"NCCL EP MoE requested but unavailable ({reason}); "
                     f"falling back to moe_a2a_backend='{fallback}'. "
                     f"Install nccl4py[cu13] on a CUDA13 + NCCL>=2.29 Hopper/Blackwell box."
                 )
                 self.moe_a2a_backend = fallback
+                run_post_process_pass(self, _a2a_ep_size)
 
         a2a_backend = resolved_view(self).moe_a2a_backend
         if self.enable_waterfill:
@@ -6460,6 +6468,9 @@ class ServerArgs:
                 )
 
         if a2a_backend == "nccl_ep":
+            if self.enable_single_batch_overlap or self.enable_two_batch_overlap:
+                raise ValueError("NCCL EP LL does not support single/two batch overlap")
+            self._handle_nccl_ep_token_budget()
             if not self.enable_nccl_ep_cuda_graph:
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
@@ -6468,6 +6479,42 @@ class ServerArgs:
                 f"to be the same as the tensor parallel size[{self.tp_size}]. "
                 f"Only the low-latency (LL) path is implemented; prefill and decode both run through LL."
             )
+
+    def _handle_nccl_ep_token_budget(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK,
+            _NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP,
+        )
+
+        budget = self.nccl_ep_num_max_dispatch_tokens_per_rank
+        if not 0 <= budget <= _NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP:
+            raise ValueError("NCCL EP LL dispatch budget must be in [0, 1024]")
+        budget = budget or _NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK
+        if self.disaggregation_mode == "decode":
+            return
+        if self.chunked_prefill_size <= 0:
+            raise ValueError(
+                "NCCL EP LL requires chunked prefill; set --chunked-prefill-size"
+            )
+        if self.enable_dynamic_chunking and self.pp_size > 1:
+            raise ValueError("NCCL EP LL does not support PP dynamic chunking")
+
+        # DP has already divided the chunk size. Bound the local scheduler's
+        # budget, including mixed decode tokens, by the native LL capacity.
+        chunk = min(self.chunked_prefill_size, budget)
+        page_size = self._resolved().page_size
+        chunk = chunk // page_size * page_size
+        if chunk <= 0:
+            raise ValueError("NCCL EP LL dispatch budget must fit at least one KV page")
+        if chunk != self.chunked_prefill_size:
+            logger.warning(
+                "NCCL EP LL limits per-rank chunked prefill from %s to %s tokens "
+                "(dispatch budget %s).",
+                self.chunked_prefill_size,
+                chunk,
+                budget,
+            )
+            self.chunked_prefill_size = chunk
 
     def _required_mori_dispatch_tokens_per_rank(self) -> int:
         """Max tokens a single rank dispatches through MoRI in one forward."""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -285,6 +285,7 @@ def _deepep_importable() -> bool:
     """Whether the deep_ep package is importable."""
     return importlib.util.find_spec("deep_ep") is not None
 
+
 MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
     "deep_gemm",
@@ -2294,6 +2295,11 @@ class ServerArgs:
         "NCCL EP dispatch algorithm. Only `low_latency` is implemented; `auto` resolves to it. The high-throughput (prefill) path is a follow-up.",
         NS("exec.moe"),
     ] = "low_latency"
+    enable_nccl_ep_cuda_graph: A[
+        bool,
+        "Enable serialized full decode CUDA Graphs with persistent NCCL EP LL resources.",
+        NS("exec.moe"),
+    ] = False
     nccl_ep_num_max_dispatch_tokens_per_rank: A[
         int,
         "Per-rank dispatch token budget for the NCCL EP group. 0 = use the backend default (capped at 1024).",
@@ -3989,6 +3995,7 @@ class ServerArgs:
         self._apply_cuda_graph_compatibility()
         self._apply_cuda_graph_disaggregation_roles()
         self._validate_cuda_graph_config()
+        self._validate_nccl_ep_cuda_graph_config()
         # Warn on the final resolved config (not inside the compat cascade —
         # that path is skipped when the user explicitly sets the backend,
         # which is the only way to get 'full' for prefill today).
@@ -3996,6 +4003,50 @@ class ServerArgs:
             logger.warning(
                 "cuda_graph_config[prefill].backend='full' is experimental. "
                 "Use breakable or tc_piecewise for production workloads."
+            )
+
+    def _validate_nccl_ep_cuda_graph_config(self):
+        """Validate the initial serialized LL scope before model-specific setup."""
+        if not self.enable_nccl_ep_cuda_graph:
+            return
+        if self.device != "cuda" or self.moe_a2a_backend != "nccl_ep":
+            raise ValueError(
+                "NCCL EP CUDA Graph requires CUDA and --moe-a2a-backend nccl_ep"
+            )
+        if self.cuda_graph_config.decode.backend != Backend.FULL:
+            raise ValueError("NCCL EP CUDA Graph requires the full decode backend")
+        if (
+            (Phase.PREFILL, "backend") in self._cuda_graph_config_locked
+            and self.cuda_graph_config.prefill.backend != Backend.DISABLED
+        ):
+            raise ValueError(
+                "NCCL EP CUDA Graph does not support prefill Graph capture"
+            )
+        self.cuda_graph_config.prefill.backend = Backend.DISABLED
+        if self.nccl_ep_mode not in ("low_latency", "auto"):
+            raise ValueError("NCCL EP CUDA Graph supports only low-latency dispatch")
+        if not 0 <= self.nccl_ep_num_max_dispatch_tokens_per_rank <= 1024:
+            raise ValueError("NCCL EP CUDA Graph dispatch budget must be in [0, 1024]")
+        unsupported = [
+            name.replace("_", "-")
+            for name in (
+                "enable_two_batch_overlap",
+                "enable_single_batch_overlap",
+                "enable_pdmux",
+                "enable_eplb",
+                "elastic_ep_backend",
+                "enable_elastic_expert_backup",
+                "speculative_algorithm",
+                "enable_torch_compile",
+                "enable_memory_saver",
+            )
+            if getattr(self, name)
+        ]
+        if self.nnodes != 1:
+            unsupported.append("multiple nodes")
+        if unsupported:
+            raise ValueError(
+                "NCCL EP CUDA Graph does not support: " + ", ".join(unsupported)
             )
 
     def _parse_cuda_graph_config(self):
@@ -6296,6 +6347,12 @@ class ServerArgs:
         # invoked here at the legacy write slots.
         run_post_process_pass(self, _a2a_fusion_adjustments)
 
+        if (
+            self.enable_nccl_ep_cuda_graph
+            and resolved_view(self).moe_a2a_backend != "nccl_ep"
+        ):
+            raise ValueError("NCCL EP CUDA Graph requires the resolved NCCL EP backend")
+
         # NCCL EP capability check + fallback — done early so a 'deepep' fallback
         # flows through the deepep-specific blocks below.
         if resolved_view(self).moe_a2a_backend == "nccl_ep":
@@ -6303,8 +6360,12 @@ class ServerArgs:
                 nccl_ep_unavailable_reason,
             )
 
-            reason = nccl_ep_unavailable_reason()
+            reason = nccl_ep_unavailable_reason(
+                require_graph=self.enable_nccl_ep_cuda_graph
+            )
             if reason is not None:
+                if self.enable_nccl_ep_cuda_graph:
+                    raise ValueError(f"NCCL EP CUDA Graph is unavailable: {reason}")
                 fallback = "deepep" if _deepep_importable() else "none"
                 logger.warning(
                     f"NCCL EP MoE requested but unavailable ({reason}); "
@@ -6399,6 +6460,9 @@ class ServerArgs:
                 )
 
         if a2a_backend == "nccl_ep":
+            if not self.enable_nccl_ep_cuda_graph:
+                self.cuda_graph_config.decode.backend = Backend.DISABLED
+                self.cuda_graph_config.prefill.backend = Backend.DISABLED
             logger.warning(
                 f"NCCL EP MoE is enabled. The expert parallel size is adjusted "
                 f"to be the same as the tensor parallel size[{self.tp_size}]. "

--- a/test/manual/test_nccl_ep_synthetic.py
+++ b/test/manual/test_nccl_ep_synthetic.py
@@ -9,7 +9,7 @@ Usage (on a 4-GPU node with NCCL >= 2.29):
     CUDA_VISIBLE_DEVICES=4,5,6,7 \
     LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 \
     torchrun --nproc_per_node=4 \
-        test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
+        test/manual/test_nccl_ep_synthetic.py
 
 Covers:
     1. NCCL EP group creation (LL, no-IB RDMA buffer init)
@@ -26,22 +26,10 @@ import os
 import sys
 import traceback
 from types import SimpleNamespace
-from typing import Optional
+from unittest.mock import MagicMock, patch
 
 import torch
 import torch.distributed as dist
-from unittest.mock import patch, MagicMock
-
-# ---- sglang imports (must come after env setup) ----
-from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
-from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
-    NcclEpDispatcher,
-    is_nccl_ep_available,
-    nccl_ep_unavailable_reason,
-    _nccl_runtime_version,
-)
-from sglang.srt.layers.moe.topk import StandardTopKOutput
 
 # ---- monkey-patch runtime_context: NcclEpDispatcher.__init__ calls
 # get_exec().deterministic.enable_deterministic_inference, but we don't
@@ -49,11 +37,25 @@ from sglang.srt.layers.moe.topk import StandardTopKOutput
 # reports deterministic=False (the safe default for a synthetic test).
 import sglang.srt.runtime_context as _rtc
 
+# ---- sglang imports (must come after env setup) ----
+from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+    NcclEpDispatcher,
+    _nccl_runtime_version,
+    is_nccl_ep_available,
+    nccl_ep_unavailable_reason,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+
 class _MockDeterministic:
     enable_deterministic_inference = False
 
+
 class _MockExec:
     deterministic = _MockDeterministic()
+
 
 _original_get_exec = _rtc.get_exec
 
@@ -67,9 +69,9 @@ _rtc.get_exec = _mocked_get_exec
 # ---- test config (mirrors DeepSeek-V3 / GLM-5.2 W4AFP8 constraints) ----
 NUM_EXPERTS = 256
 TOPK = 8
-HIDDEN = 7168          # in LL allowlist; 6144 also works
-NUM_LAYERS = 1         # synthetic: single MoE layer
-BATCH_TOKENS = 128     # per-rank decode tokens (< 1024 budget)
+HIDDEN = 7168  # in LL allowlist; 6144 also works
+NUM_LAYERS = 1  # synthetic: single MoE layer
+BATCH_TOKENS = 128  # per-rank decode tokens (< 1024 budget)
 
 
 def log(rank: int, msg: str):
@@ -116,7 +118,12 @@ def make_moe_runner_config(hidden: int = HIDDEN, topk: int = TOPK):
 
 
 def make_synthetic_inputs(
-    rank: int, batch: int, hidden: int, num_experts: int, topk: int, device: torch.device
+    rank: int,
+    batch: int,
+    hidden: int,
+    num_experts: int,
+    topk: int,
+    device: torch.device,
 ):
     """Create deterministic synthetic hidden_states + topk routing.
 
@@ -138,7 +145,9 @@ def make_synthetic_inputs(
     topk_output = StandardTopKOutput(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
-        router_logits=torch.zeros(batch, num_experts, dtype=torch.float32, device=device),
+        router_logits=torch.zeros(
+            batch, num_experts, dtype=torch.float32, device=device
+        ),
     )
     return hidden_states, topk_output
 
@@ -203,13 +212,13 @@ def test_3_dispatch(rank: int, dispatcher: NcclEpDispatcher, hidden: int):
     dispatch_output = dispatcher.dispatch(hs, topk_output)
 
     # Check output types/shapes
-    assert dispatch_output.hidden_states.dtype == torch.float8_e4m3fn, (
-        f"expected fp8_e4m3fn, got {dispatch_output.hidden_states.dtype}"
-    )
+    assert (
+        dispatch_output.hidden_states.dtype == torch.float8_e4m3fn
+    ), f"expected fp8_e4m3fn, got {dispatch_output.hidden_states.dtype}"
     assert dispatch_output.hidden_states.is_cuda, "hidden_states not on GPU"
-    assert dispatch_output.hidden_states_scale.dtype == torch.float32, (
-        f"expected float32 scale, got {dispatch_output.hidden_states_scale.dtype}"
-    )
+    assert (
+        dispatch_output.hidden_states_scale.dtype == torch.float32
+    ), f"expected float32 scale, got {dispatch_output.hidden_states_scale.dtype}"
 
     # masked_m should reflect actual recv counts (non-zero in general).
     total_recv = dispatch_output.masked_m.sum().item()
@@ -243,9 +252,7 @@ def test_4_fp8_quant_correctness(
     test_x = torch.randn(4, hidden, dtype=torch.bfloat16, device=device)
 
     # sglang kernel (same one NCCL EP calls)
-    q_kernel, s_kernel = sglang_per_token_group_quant_fp8(
-        test_x, group_size=group_size
-    )
+    q_kernel, s_kernel = sglang_per_token_group_quant_fp8(test_x, group_size=group_size)
     # reference
     q_ref, s_ref = reference_fp8_quant(test_x, group_size=group_size)
 
@@ -255,7 +262,9 @@ def test_4_fp8_quant_correctness(
     # different rounding). Check correlation: dequant should be close.
     # scale is [4, 56] (7168/128=56 groups), need to expand to [4, 7168] for broadcast
     s_kernel_expanded = s_kernel.repeat_interleave(group_size, dim=-1).to(torch.float32)
-    s_ref_expanded = s_ref.to(device).repeat_interleave(group_size, dim=-1).to(torch.float32)
+    s_ref_expanded = (
+        s_ref.to(device).repeat_interleave(group_size, dim=-1).to(torch.float32)
+    )
     dq_kernel = q_kernel.to(torch.float32) * s_kernel_expanded
     dq_ref = q_ref.to(torch.float32) * s_ref_expanded
     max_err = (dq_kernel - dq_ref).abs().max().item()
@@ -269,7 +278,9 @@ def test_4_fp8_quant_correctness(
     log(rank, "[4] PASS: bf16->fp8 post-quant matches reference")
 
 
-def test_5_combine(rank: int, dispatcher: NcclEpDispatcher, dispatch_output, topk_output):
+def test_5_combine(
+    rank: int, dispatcher: NcclEpDispatcher, dispatch_output, topk_output
+):
     """Verify combine A2A: real bf16 send/recv back + handle destroy."""
     device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
 
@@ -354,7 +365,9 @@ def test_6_roundtrip_identity(rank: int, ep_group, hidden: int):
     assert torch.isfinite(combined).all(), "combined has NaN/Inf"
 
     # Check shape: [batch, hidden]
-    assert combined.shape[0] == batch, f"expected batch={batch}, got {combined.shape[0]}"
+    assert (
+        combined.shape[0] == batch
+    ), f"expected batch={batch}, got {combined.shape[0]}"
     assert combined.shape[1] == hidden
 
     log(
@@ -376,7 +389,9 @@ def test_7_guard_hidden_allowlist(rank: int, ep_group):
         mock_sd.return_value = MagicMock()
         try:
             NcclEpDispatcher(cfg, ep_group)
-            log(rank, "[7] FAIL: expected ValueError for hidden=3072 (not in allowlist)")
+            log(
+                rank, "[7] FAIL: expected ValueError for hidden=3072 (not in allowlist)"
+            )
             assert False, "should have raised"
         except ValueError as e:
             assert "NCCL EP LL only supports hidden" in str(e)
@@ -466,6 +481,7 @@ def main():
         # Cleanup
         try:
             from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
             NcclEpBuffer.destroy()
         except Exception:
             pass

--- a/test/nccl_ep_test/README.md
+++ b/test/nccl_ep_test/README.md
@@ -1,0 +1,100 @@
+# NCCL EP low-latency CUDA Graph tests
+
+Shared fixtures for the registered unit tests and the two-GPU manual harness.
+The harness exercises the real dispatcher, FP8 conversion, full Graph backend
+and runner input buffers with synthetic experts `f_e(x) = (e + 1) * x`. It does
+not load model weights or run an expert GEMM. The CPU oracle checks receive-row
+contents and multiplicities independently of receive order, then checks weighted
+combine with `rtol=0, atol=0` on exactly representable fixtures.
+
+## Registered tests
+
+From the repository root, with SGLang and pytest installed:
+
+```bash
+python -m pytest -q test/registered/unit/layers/moe/test_nccl_ep_*.py
+```
+
+`test_nccl_ep_oracle.py` and `test_nccl_ep_prefill_fallback.py` are CPU tests.
+The Graph input, lifecycle, configuration and benchmark tests use one CUDA GPU;
+SM89 is sufficient. They replace only the external EP communication with a narrow
+test double. They do not require the NCCL EP optional dependency. Each registered
+test file also supports the CI entrypoint `python file.py -f`.
+
+The inherited four-GPU eager experiment is at
+[`../manual/test_nccl_ep_synthetic.py`](../manual/test_nccl_ep_synthetic.py).
+It is separate from this harness and is not a registered CI test.
+
+## Two-GPU correctness
+
+Install the versions and NCCL override in the
+[NCCL EP guide](../../docs_new/docs/advanced_features/nccl_ep_cuda_graph.mdx).
+The reproduction harness deliberately checks the tested dependency versions,
+including the official Torch `2.11.0+cu130` wheel and actual loaded NCCL 2.30.7.
+Use exactly two visible SM90+ GPUs with direct peer access, on one node. Select a
+CUDA 13 Toolkit through `CUDA_HOME` and `PATH`; JIT setup selects the installed
+EP/NCCL wheel headers and matching CUDA headers.
+
+```bash
+export PYTHONPATH="$PWD/python:$PWD/test${PYTHONPATH:+:$PYTHONPATH}"
+export NCCL_EP_REPORT_DIR="$PWD/nccl-ep-results"
+python -m nccl_ep_test environment
+
+# Each invocation starts fresh processes and records a report for each rank.
+for implementation in native sglang; do
+  timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+    eager --implementation "$implementation"
+  timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+    eager --implementation "$implementation" --identity
+  timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+    capture --implementation "$implementation" --buckets 8 --generations 1
+  timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+    dynamic --implementation "$implementation" --buckets 8 16 32 \
+    --layers 2 --generations 2 --replays 1000
+done
+
+timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test runner
+timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test cleanup
+
+# Separate native input-contract probes; not claims about Graph inputs.
+timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+  zero_length --implementation native
+timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+  duplicates --implementation native
+```
+
+The matrix changes tokens, routes and weights separately and together. It covers
+balanced/hotspot routes, padding with nonzero masked weights, empty-effective
+ranks, all-masked inputs, ABA bucket changes, eager interleaving, multiple layers,
+stream handoffs and recapture. Cleanup injects a controlled host failure after a
+completed transaction. Native/GPU/peer faults require a fresh process; `timeout`
+bounds failures that block a peer. A capability skip exits 77 and is never PASS.
+
+## Matched measurement and profiling
+
+Run measurement after correctness passes. Keep JIT/debug logging and profiling
+disabled during timing. Both modes perform the same copies, two synthetic expert
+layers, receive observations and one retained combine output per layer.
+
+```bash
+timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+  benchmark --buckets 8 16 32 --samples 200 --warmups 20 --rounds 4
+python -m nccl_ep_test summarize --reports \
+  "$NCCL_EP_REPORT_DIR/benchmark-rank0.json" \
+  "$NCCL_EP_REPORT_DIR/benchmark-rank1.json" > "$NCCL_EP_REPORT_DIR/summary.json"
+
+# Profile in a separate correctness run, with graph node tracing enabled.
+nsys profile --trace=cuda,nvtx --cuda-graph-trace=node --sample=none \
+  --force-overwrite=true -o "$NCCL_EP_REPORT_DIR/dynamic" \
+  timeout 15m torchrun --standalone --nproc-per-node=2 --module nccl_ep_test \
+  dynamic --buckets 8 16 32 --layers 2 --generations 2 --replays 1000
+```
+
+Each timing sample waits for its end CUDA event. The summary takes the maximum
+across aligned rank samples before calculating median/p95. These are serial
+synthetic-step latencies including host launch gaps, not isolated communication
+kernel latency or full-model throughput. Capture, warmup, CPU oracle work and
+first-use JIT are excluded from the timed samples. Profiling adds overhead and
+must not be used to derive the unprofiled speedup.
+
+See [the recorded validation](validation.md) for the tested snapshot and results.

--- a/test/nccl_ep_test/__init__.py
+++ b/test/nccl_ep_test/__init__.py
@@ -1,0 +1,1 @@
+"""Weight-free NCCL EP experiments; native mode does not import SGLang runtime."""

--- a/test/nccl_ep_test/__main__.py
+++ b/test/nccl_ep_test/__main__.py
@@ -1,0 +1,119 @@
+"""Two-GPU reproduction entrypoint; run with torchrun --module nccl_ep_test."""
+
+import argparse
+import json
+from pathlib import Path
+
+from .environment import binding_check, prepare_jit, report, snapshot
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "mode",
+        choices=(
+            "environment",
+            "eager",
+            "capture",
+            "dynamic",
+            "runner",
+            "cleanup",
+            "zero_length",
+            "duplicates",
+            "benchmark",
+            "summarize",
+        ),
+    )
+    parser.add_argument(
+        "--implementation", choices=("native", "sglang"), default="sglang"
+    )
+    parser.add_argument("--buckets", type=int, nargs="+", default=[8, 16, 32])
+    parser.add_argument("--replays", type=int, default=1000)
+    parser.add_argument("--layers", type=int, default=2)
+    parser.add_argument("--generations", type=int, default=2)
+    parser.add_argument("--identity", action="store_true")
+    parser.add_argument("--samples", type=int, default=200)
+    parser.add_argument("--warmups", type=int, default=20)
+    parser.add_argument("--rounds", type=int, default=4)
+    parser.add_argument("--reports", type=Path, nargs=2, metavar=("RANK0", "RANK1"))
+    args = parser.parse_args()
+    if args.mode == "environment":
+        return report(
+            "environment",
+            lambda: dict(snapshot(), bindings=binding_check(), jit=prepare_jit()),
+        )
+    if args.mode == "summarize":
+        from .benchmark import summarize_pair
+
+        if args.reports is None:
+            parser.error("summarize requires --reports RANK0 RANK1")
+        print(
+            json.dumps(
+                summarize_pair([json.loads(p.read_text()) for p in args.reports]),
+                indent=2,
+            )
+        )
+        return 0
+    if (
+        min(args.buckets) < 1
+        or max(args.buckets) > 1024
+        or min(args.replays, args.layers, args.generations) < 1
+    ):
+        parser.error("Use buckets in [1, 1024] and positive replays/layers/generations")
+    options = dict(
+        buckets=args.buckets,
+        replays=args.replays,
+        layers=args.layers,
+        generations=args.generations,
+        identity=args.identity,
+    )
+    if args.mode in ("zero_length", "duplicates"):
+        minimum = 8 if args.mode == "zero_length" else 16
+        if args.implementation != "native" or max(args.buckets) < minimum:
+            parser.error(
+                f"{args.mode} requires native execution and capacity >= {minimum}"
+            )
+    if (
+        args.mode in ("runner", "cleanup", "benchmark")
+        and args.implementation != "sglang"
+    ):
+        parser.error(f"{args.mode} requires --implementation sglang")
+    if args.mode == "benchmark":
+        from .benchmark import exercise_benchmark
+
+        if args.identity or args.layers != 2:
+            parser.error("The matched benchmark uses two weighted expert layers")
+        return report(
+            "benchmark",
+            lambda: exercise_benchmark(
+                buckets=args.buckets,
+                samples=args.samples,
+                warmups=args.warmups,
+                rounds=args.rounds,
+            ),
+        )
+    suffix = "_identity" if args.identity else ""
+    if args.implementation == "native":
+        from .native import exercise
+
+        return report(
+            f"native_{args.mode}{suffix}", lambda: exercise(mode=args.mode, **options)
+        )
+    if args.mode == "eager":
+        from .dispatcher import exercise_eager
+
+        operation = lambda: exercise_eager(**options)
+    elif args.mode in ("runner", "cleanup"):
+        from .sglang_graph import exercise_cleanup, exercise_runner
+
+        exercise = exercise_runner if args.mode == "runner" else exercise_cleanup
+        operation = lambda: exercise(**options)
+    else:
+        from .sglang_graph import exercise_graph
+
+        operation = lambda: exercise_graph(mode=args.mode, **options)
+    return report(f"sglang_{args.mode}{suffix}", operation)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/nccl_ep_test/benchmark.py
+++ b/test/nccl_ep_test/benchmark.py
@@ -14,9 +14,9 @@ import torch
 import torch.distributed as dist
 
 from .comparison import compare
-from .dispatcher import forward_layer, initialize
+from .dispatcher import dispatchers_for, forward_layer, initialize
 from .oracle import make_fixture, validate_capacity
-from .sglang_graph import backend_for, dispatchers_for, gpu_inputs
+from .sglang_graph import backend_for, gpu_inputs
 
 METRICS = ("cuda_step_ms", "host_submit_ms", "host_step_ms")
 

--- a/test/nccl_ep_test/benchmark.py
+++ b/test/nccl_ep_test/benchmark.py
@@ -1,0 +1,354 @@
+"""Matched SGLang eager/full-Graph synthetic steps, without EP audit wrappers.
+
+Both modes copy GPU-resident inputs, run two serial MoE layers, and retain the
+same receive/counter/combine observations. CUDA events measure the whole step,
+including host launch gaps, not the sum of EP kernel durations. Each sample
+waits for its end event: this is serial latency, not pipelined throughput.
+"""
+
+import math
+import statistics
+import time
+
+import torch
+import torch.distributed as dist
+
+from .comparison import compare
+from .dispatcher import forward_layer, initialize
+from .oracle import make_fixture, validate_capacity
+from .sglang_graph import backend_for, dispatchers_for, gpu_inputs
+
+METRICS = ("cuda_step_ms", "host_submit_ms", "host_step_ms")
+
+
+def statistics_ms(values):
+    if not values or any(not math.isfinite(x) or x <= 0 for x in values):
+        raise ValueError("Timing samples must be finite and positive")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * 0.95
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    p95 = ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+    return {"count": len(values), "median": statistics.median(values), "p95": p95}
+
+
+def benchmark_steps(
+    rank,
+    coordinator,
+    dispatchers,
+    *,
+    buckets=(8, 16, 32),
+    cases=("balanced", "hotspot"),
+    samples=200,
+    warmups=20,
+    rounds=4,
+    fixture=make_fixture,
+):
+    """Shared real driver; local tests substitute only the EP library/fixtures."""
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep_graph import (
+        nccl_ep_eager_session,
+    )
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    buckets = sorted(set(buckets))
+    if (
+        not buckets
+        or min(buckets) < 1
+        or max(buckets) > 1024
+        or not cases
+        or len(set(cases)) != len(cases)
+        or samples < 2
+        or warmups < 2
+        or rounds < 2
+        or rounds % 2
+        or len(dispatchers) != 2
+    ):
+        raise ValueError(
+            "Use two layers, positive buckets, >=2 samples/warmups, even rounds >=2"
+        )
+    capacity = max(buckets)
+    prepared = {}
+    started = time.perf_counter()
+    for bucket in buckets:
+        for case in cases:
+            pairs = []
+            for step in (0, 1):
+                batches = [
+                    fixture(bucket, case=case, step=step + layer, change="all")
+                    for layer in range(2)
+                ]
+                for batch in batches:
+                    validate_capacity(batch, capacity)
+                pairs.append((batches, [gpu_inputs(batch, rank) for batch in batches]))
+            prepared[bucket, case] = pairs
+    static = [
+        tuple(x.clone() for x in inputs)
+        for inputs in prepared[capacity, cases[0]][0][1]
+    ]
+    torch.cuda.synchronize()
+    input_preparation_seconds = time.perf_counter() - started
+    backend = backend_for(coordinator, capacity)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    records, checked = [], 0
+
+    def forward(bucket, *, graph):
+        outputs = []
+        for dispatcher, inputs in zip(dispatchers, static):
+            received, counters, combined = forward_layer(
+                dispatcher, *(x[:bucket] for x in inputs), rank
+            )
+            # Graph combine already makes its ownership clone. Eager must also
+            # retain each layer's output before the next layer reuses scratch.
+            if not graph:
+                combined = combined.clone()
+            outputs.append((received, counters, combined))
+        return outputs
+
+    def step(mode, bucket, live):
+        session = (
+            backend.replay_session() if mode == "graph" else nccl_ep_eager_session()
+        )
+        with session:
+            for inputs, sources in zip(static, live):
+                for target, source in zip(inputs, sources):
+                    target[:bucket].copy_(source)
+            return (
+                backend.replay(ShapeKey(bucket), None)
+                if mode == "graph"
+                else forward(bucket, graph=False)
+            )
+
+    try:
+        with torch.cuda.stream(stream):
+            coordinator.barrier()
+            started = time.perf_counter()
+            # Pay eager group creation and first-use/JIT before any sampling.
+            for bucket in buckets:
+                step("eager", bucket, prepared[bucket, cases[0]][0][1])
+            stream.synchronize()
+            eager_first_use_seconds = time.perf_counter() - started
+
+            coordinator.barrier()
+            started = time.perf_counter()
+            with backend.capture_session(stream):
+                for bucket in reversed(buckets):
+                    backend.capture_one(
+                        ShapeKey(bucket),
+                        lambda bucket=bucket: forward(bucket, graph=True),
+                    )
+            stream.synchronize()
+            warmup_capture_seconds = time.perf_counter() - started
+
+            # Materialize reusable events outside samples, including their
+            # first record. Neither allocation nor first-use enters timings.
+            events = [
+                (
+                    torch.cuda.Event(enable_timing=True),
+                    torch.cuda.Event(enable_timing=True),
+                )
+                for _ in range(samples)
+            ]
+            for start, end in events:
+                start.record()
+                end.record()
+            stream.synchronize()
+            for bucket in buckets:
+                for case in cases:
+                    pairs = prepared[bucket, case]
+                    for round_index in range(rounds):
+                        order = (
+                            ("eager", "graph")
+                            if round_index % 2 == 0
+                            else ("graph", "eager")
+                        )
+                        for mode in order:
+                            # Exact receive/combine checks of both data variants
+                            # precede warmup; no CPU oracle enters the sample loop.
+                            for batches, live in pairs:
+                                actual = step(mode, bucket, live)
+                                stream.synchronize()
+                                for batch, output in zip(batches, actual):
+                                    compare(batch, rank, *output)
+                                    checked += 1
+                            warmup_started = time.perf_counter()
+                            for iteration in range(warmups):
+                                step(mode, bucket, pairs[iteration % 2][1])
+                            stream.synchronize()
+                            warmup_seconds = time.perf_counter() - warmup_started
+                            coordinator.barrier()
+                            measured = {metric: [] for metric in METRICS}
+                            for iteration, (start, end) in enumerate(events):
+                                live = pairs[iteration % 2][1]
+                                host_started = time.perf_counter()
+                                start.record()
+                                actual = step(mode, bucket, live)
+                                end.record()
+                                submitted = time.perf_counter()
+                                end.synchronize()
+                                completed = time.perf_counter()
+                                measured["cuda_step_ms"].append(start.elapsed_time(end))
+                                measured["host_submit_ms"].append(
+                                    (submitted - host_started) * 1000
+                                )
+                                measured["host_step_ms"].append(
+                                    (completed - host_started) * 1000
+                                )
+                            for batch, output in zip(
+                                pairs[(samples - 1) % 2][0], actual
+                            ):
+                                compare(batch, rank, *output)
+                                checked += 1
+                            records.append(
+                                {
+                                    "bucket": bucket,
+                                    "case": case,
+                                    "round": round_index,
+                                    "mode": mode,
+                                    "warmup_seconds": warmup_seconds,
+                                    "samples": measured,
+                                    "statistics_ms": {
+                                        key: statistics_ms(values)
+                                        for key, values in measured.items()
+                                    },
+                                }
+                            )
+    finally:
+        backend.cleanup()
+    return {
+        "implementation": "sglang_dispatcher_eager_vs_full_graph",
+        "config": {
+            "buckets": buckets,
+            "cases": list(cases),
+            "layers": 2,
+            "samples_per_round": samples,
+            "warmups_per_block": warmups,
+            "rounds": rounds,
+            "seed": 32774,
+            "hidden": 2048,
+            "top_k": 2,
+            "order": "alternate eager/graph and graph/eager by round",
+            "input_sequence": "preloaded step 0/1, alternating every sample",
+        },
+        "measurement_scope": "Serial two-layer synthetic step: GPU input copies, dispatch, FP8 dequant, expert arithmetic, combine and retained observations; excludes fixture/oracle, initial JIT, warmup, capture and barriers",
+        "host_timing_scope": "Includes event recording; host_step_ms also includes end-event synchronization; host_submit_ms is not pure Python overhead",
+        "output_ownership": "One combine clone per layer in both modes; Graph inside dispatcher, eager in driver",
+        "input_preparation_seconds": input_preparation_seconds,
+        "eager_first_use_seconds": eager_first_use_seconds,
+        "warmup_capture_seconds": warmup_capture_seconds,
+        "checked": checked,
+        "tolerance": {"rtol": 0, "atol": 0},
+        "records": records,
+        "model_loaded": False,
+    }
+
+
+def exercise_benchmark(**kwargs):
+    started = time.perf_counter()
+    rank, coordinator, bindings = initialize(max(kwargs["buckets"]), graph_enabled=True)
+    initialization_seconds = time.perf_counter() - started
+    try:
+        result = benchmark_steps(
+            rank, coordinator, dispatchers_for(coordinator, 2), **kwargs
+        )
+    finally:
+        import nccl.core as core
+
+        from sglang.srt.distributed.parallel_state import destroy_model_parallel
+
+        destroy_model_parallel()
+        core.Communicator(ptr=coordinator.pynccl_comm.comm.value).destroy()
+        coordinator.pynccl_comm.available = False
+        coordinator.pynccl_comm.disabled = True
+        dist.destroy_process_group()
+    result.update(
+        bindings=bindings,
+        initialization_seconds=initialization_seconds,
+        native_ep_tested=True,
+        resource_cleanup_returned=True,
+    )
+    return result
+
+
+def summarize_pair(reports):
+    """Align rounds/samples across ranks before computing critical-rank latency."""
+    if len(reports) != 2 or [x.get("rank") for x in reports] != [0, 1]:
+        raise ValueError("Both rank 0 and rank 1 reports are required")
+    if any(x.get("status") != "PASS" for x in reports):
+        raise ValueError("Both benchmark ranks must pass")
+    results = [x["result"] for x in reports]
+    if any(
+        x.get("native_ep_tested") is not True
+        or x.get("resource_cleanup_returned") is not True
+        or x.get("tolerance") != {"rtol": 0, "atol": 0}
+        for x in results
+    ):
+        raise ValueError(
+            "Real EP benchmark, exact checks and completed cleanup required"
+        )
+    if results[0]["config"] != results[1]["config"]:
+        raise ValueError("Rank benchmark configurations differ")
+    config = results[0]["config"]
+    expected = {
+        (bucket, case, rnd, mode)
+        for bucket in config["buckets"]
+        for case in config["cases"]
+        for rnd in range(config["rounds"])
+        for mode in ("eager", "graph")
+    }
+    indexed = []
+    for result in results:
+        mapping = {
+            (r["bucket"], r["case"], r["round"], r["mode"]): r["samples"]
+            for r in result["records"]
+        }
+        if len(mapping) != len(result["records"]) or set(mapping) != expected:
+            raise ValueError("Missing or duplicate benchmark block")
+        for metrics in mapping.values():
+            if set(metrics) != set(METRICS):
+                raise ValueError("Missing timing metric")
+            for values in metrics.values():
+                if len(values) != config["samples_per_round"]:
+                    raise ValueError("Incomplete sample block")
+                statistics_ms(values)
+        indexed.append(mapping)
+    rows = []
+    for bucket in config["buckets"]:
+        for case in config["cases"]:
+            modes = {}
+            for mode in ("eager", "graph"):
+                modes[mode] = {}
+                for metric in METRICS:
+                    values = [
+                        [
+                            value
+                            for rnd in range(config["rounds"])
+                            for value in rank[bucket, case, rnd, mode][metric]
+                        ]
+                        for rank in indexed
+                    ]
+                    modes[mode][metric] = {
+                        "rank0": statistics_ms(values[0]),
+                        "rank1": statistics_ms(values[1]),
+                        "max_rank_per_sample": statistics_ms(
+                            [max(a, b) for a, b in zip(*values)]
+                        ),
+                    }
+            rows.append(
+                {
+                    "bucket": bucket,
+                    "case": case,
+                    "modes": modes,
+                    "median_speedup": {
+                        metric: modes["eager"][metric]["max_rank_per_sample"]["median"]
+                        / modes["graph"][metric]["max_rank_per_sample"]["median"]
+                        for metric in ("cuda_step_ms", "host_step_ms")
+                    },
+                }
+            )
+    return {
+        "config": config,
+        "rows": rows,
+        "units": "ms",
+        "full_model_benchmark": False,
+    }

--- a/test/nccl_ep_test/comparison.py
+++ b/test/nccl_ep_test/comparison.py
@@ -1,0 +1,35 @@
+"""Compare completed GPU results and retain a CPU archive on correctness failure."""
+
+import os
+import time
+from pathlib import Path
+
+import torch
+
+from .oracle import assert_combine_matches, assert_dispatch_matches
+
+
+def compare(batch, rank, received, counters, combined, *, identity=False):
+    try:
+        assert_dispatch_matches(batch, rank, received, counters)
+        assert_combine_matches(batch, rank, combined, identity=identity)
+    except AssertionError:
+        root = Path(os.environ.get("NCCL_EP_REPORT_DIR", "."))
+        root.mkdir(parents=True, exist_ok=True)
+        path = root / f"mismatch-rank{rank}-{time.time_ns()}.pt"
+        torch.save(
+            {
+                "tokens": tuple(x.cpu() for x in batch.tokens),
+                "ids": tuple(x.cpu() for x in batch.expert_ids),
+                "weights": tuple(x.cpu() for x in batch.weights),
+                "num_experts": batch.num_experts,
+                "rank": rank,
+                "identity": identity,
+                "received": received.cpu(),
+                "counters": counters.cpu(),
+                "combined": combined.cpu(),
+            },
+            path,
+        )
+        print(f"Saved correctness failure: {path}", flush=True)
+        raise

--- a/test/nccl_ep_test/dispatcher.py
+++ b/test/nccl_ep_test/dispatcher.py
@@ -1,0 +1,145 @@
+"""Exercise the real SGLang dispatcher with synthetic experts and real PyNccl.
+
+The configuration/coordinator are minimal experiment scaffolding. Communication,
+FP8 post-quantization and combine use the implementation under review unchanged.
+No model weights or replacement communication kernels are involved.
+"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+from itertools import product
+from types import SimpleNamespace
+from typing import Annotated
+
+import torch
+import torch.distributed as dist
+
+from .comparison import compare
+from .environment import binding_check, prepare_jit, require_pair
+from .oracle import (
+    dequantize_fp8,
+    make_fixture,
+    validate_capacity,
+)
+
+
+def initialize(capacity, *, graph_enabled=False):
+    rank, local_rank = require_pair(ep=True)
+    bindings = binding_check()
+    bindings["jit"] = prepare_jit()
+    from sglang.srt.arg_groups.arg_utils import NS
+    from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from sglang.srt.layers.moe.utils import MoeA2ABackend, NcclEpMode
+    from sglang.srt.runtime_context import get_context, get_flags
+
+    @dataclass
+    class LabConfig:
+        enable_deterministic_inference: Annotated[bool, NS("exec.deterministic")] = (
+            False
+        )
+        enable_nccl_ep_cuda_graph: Annotated[bool, NS("exec.moe")] = graph_enabled
+
+    get_context().set_server_args(LabConfig())
+    flags = get_flags().moe
+    flags.a2a_backend = MoeA2ABackend.NCCL_EP
+    flags.nccl_ep_mode = NcclEpMode.LOW_LATENCY
+    flags.nccl_ep_num_max_dispatch_tokens_per_rank = capacity
+    dist.init_process_group("gloo", timeout=timedelta(seconds=120))
+    comm = PyNcclCommunicator(
+        group=dist.group.WORLD, device=local_rank, library_path=bindings["nccl_path"]
+    )
+    if not comm.available:
+        raise RuntimeError("The real PyNccl communicator could not initialize")
+    coordinator = SimpleNamespace(
+        world_size=2,
+        rank=rank,
+        rank_in_group=rank,
+        device=torch.device("cuda", local_rank),
+        pynccl_comm=comm,
+        barrier=dist.barrier,
+    )
+    return rank, coordinator, bindings
+
+
+def forward_layer(dispatcher, x, ids, weights, rank, *, identity=False):
+    """Only GPU work: safe to use as a runner callback once EP capture is enabled.
+
+    Snapshot receive counters, but retain the dispatcher's actual combined
+    output so multi-layer tests can detect scratch aliasing. CPU oracle checks
+    run after the complete forward, outside capture and the staged transaction.
+    """
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+    dispatched = dispatcher.dispatch(x, StandardTopKOutput(weights, ids, None))
+    received = dequantize_fp8(dispatched.hidden_states, dispatched.hidden_states_scale)
+    counters = dispatched.masked_m.clone()
+    factors = torch.arange(rank * 2 + 1, rank * 2 + 3, device=x.device, dtype=x.dtype)
+    expert_output = received if identity else received * factors[:, None, None]
+    combined = dispatcher.combine(
+        DeepEPLLCombineInput(
+            expert_output, dispatched.topk_ids, dispatched.topk_weights
+        )
+    )
+    return received, counters, combined
+
+
+def run_layer(dispatcher, batch, rank, *, identity=False):
+    inputs = tuple(
+        items[rank].cuda() for items in (batch.tokens, batch.expert_ids, batch.weights)
+    )
+    actual = forward_layer(dispatcher, *inputs, rank, identity=identity)
+    compare(batch, rank, *actual, identity=identity)
+
+
+def exercise_eager(*, buckets=(8, 16, 32), layers=2, identity=False, **unused):
+    rank, coordinator, bindings = initialize(max(buckets))
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+        NcclEpBuffer,
+        NcclEpDispatcher,
+    )
+
+    dispatchers = [
+        NcclEpDispatcher(
+            MoeRunnerConfig(
+                num_experts=4,
+                num_local_experts=2,
+                hidden_size=2048,
+                top_k=2,
+                params_dtype=torch.bfloat16,
+                layer_id=layer,
+            ),
+            coordinator,
+        )
+        for layer in range(layers)
+    ]
+    checked = 0
+    for bucket, case, change, step in product(
+        buckets,
+        ("balanced", "hotspot", "padding", "empty_rank", "all_masked"),
+        ("tokens", "routing", "weights", "all"),
+        (0, 1, 0),
+    ):
+        batch = make_fixture(bucket, case=case, step=step, change=change)
+        validate_capacity(batch, max(buckets))
+        for dispatcher in dispatchers:
+            run_layer(dispatcher, batch, rank, identity=identity)
+            checked += 1
+    torch.cuda.synchronize()
+    NcclEpBuffer.destroy()
+    # PyNccl has no destructor in this pinned revision. The experiment owns
+    # its communicator and explicitly closes it through the real core binding.
+    import nccl.core as core
+
+    core.Communicator(ptr=coordinator.pynccl_comm.comm.value).destroy()
+    coordinator.pynccl_comm.available = False
+    coordinator.pynccl_comm.disabled = True
+    dist.destroy_process_group()
+    return {
+        "implementation": "sglang_dispatcher_eager",
+        "checked": checked,
+        "bindings": bindings,
+        "fp8_scales_applied": True,
+        "tolerance": {"rtol": 0, "atol": 0},
+    }

--- a/test/nccl_ep_test/dispatcher.py
+++ b/test/nccl_ep_test/dispatcher.py
@@ -61,6 +61,26 @@ def initialize(capacity, *, graph_enabled=False):
     return rank, coordinator, bindings
 
 
+def dispatchers_for(coordinator, layers):
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+    return [
+        NcclEpDispatcher(
+            MoeRunnerConfig(
+                num_experts=4,
+                num_local_experts=2,
+                hidden_size=2048,
+                top_k=2,
+                params_dtype=torch.bfloat16,
+                layer_id=layer,
+            ),
+            coordinator,
+        )
+        for layer in range(layers)
+    ]
+
+
 def forward_layer(dispatcher, x, ids, weights, rank, *, identity=False):
     """Only GPU work: safe to use as a runner callback once EP capture is enabled.
 
@@ -94,26 +114,9 @@ def run_layer(dispatcher, batch, rank, *, identity=False):
 
 def exercise_eager(*, buckets=(8, 16, 32), layers=2, identity=False, **unused):
     rank, coordinator, bindings = initialize(max(buckets))
-    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
-        NcclEpBuffer,
-        NcclEpDispatcher,
-    )
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
 
-    dispatchers = [
-        NcclEpDispatcher(
-            MoeRunnerConfig(
-                num_experts=4,
-                num_local_experts=2,
-                hidden_size=2048,
-                top_k=2,
-                params_dtype=torch.bfloat16,
-                layer_id=layer,
-            ),
-            coordinator,
-        )
-        for layer in range(layers)
-    ]
+    dispatchers = dispatchers_for(coordinator, layers)
     checked = 0
     for bucket, case, change, step in product(
         buckets,

--- a/test/nccl_ep_test/environment.py
+++ b/test/nccl_ep_test/environment.py
@@ -1,0 +1,214 @@
+"""Read-only server checks; keep driver, Toolkit and Torch CUDA versions separate."""
+
+import ctypes
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+
+class Unavailable(RuntimeError):
+    """A missing hardware capability is SKIP (exit 77), never PASS."""
+
+
+def command(args):
+    try:
+        result = subprocess.run(args, text=True, capture_output=True, timeout=30)
+        return {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {"error": str(error)}
+
+
+def snapshot():
+    nvcc = shutil.which("nvcc")
+    return {
+        "python": sys.executable,
+        "platform": platform.platform(),
+        "libc": platform.libc_ver(),
+        "os_release": platform.freedesktop_os_release(),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "torch_path": torch.__file__,
+        "torch_arch_list": (
+            torch.cuda.get_arch_list() if torch.cuda.is_available() else []
+        ),
+        "nvidia_smi": command(["nvidia-smi"]),
+        "topology": command(["nvidia-smi", "topo", "-m"]),
+        "ffmpeg": command(["ffmpeg", "-version"]),
+        "nvcc": command([nvcc, "--version"]) if nvcc else {"error": "nvcc not in PATH"},
+        "pip_check": command([sys.executable, "-m", "pip", "check"]),
+        "packages": sorted(
+            (dist.metadata["Name"], dist.version)
+            for dist in importlib.metadata.distributions()
+        ),
+        "devices": [
+            {
+                "name": torch.cuda.get_device_name(i),
+                "capability": torch.cuda.get_device_capability(i),
+            }
+            for i in range(torch.cuda.device_count())
+        ],
+    }
+
+
+def binding_check():
+    import nccl.core as core
+    import nccl.ep as ep
+
+    expected = {
+        "nccl4py": "0.4.1",
+        "nccl-extensions": "0.1.0",
+        "nvidia-nccl-cu13": "2.30.7",
+    }
+    for name, version in expected.items():
+        actual = importlib.metadata.version(name)
+        if actual != version:
+            raise RuntimeError(f"{name}: expected {version}, got {actual}")
+    if torch.__version__ != "2.11.0+cu130":
+        raise RuntimeError(
+            f"Expected official Torch 2.11.0+cu130, got {torch.__version__}"
+        )
+    if torch.cuda.nccl.version() != (2, 28, 9):
+        raise RuntimeError("Official Torch NCCL headers differ from 2.28.9")
+    if not callable(getattr(ep.Handle, "update", None)):
+        raise RuntimeError("The selected EP binding does not expose Handle.update")
+    version = core.get_version()
+    nccl_path = Path(version.libnccl.path).resolve()
+    loaded = ctypes.CDLL(str(nccl_path))
+    value = ctypes.c_int()
+    if loaded.ncclGetVersion(ctypes.byref(value)) != 0 or value.value != 23007:
+        raise RuntimeError(f"Unexpected NCCL runtime version {value.value}")
+    ep_version = str(ep.get_lib_version())  # Force native library loading.
+    ep_path = Path(ep.get_lib_path()).resolve()
+    prefix = Path(sys.prefix).resolve()
+    if not nccl_path.is_relative_to(prefix) or not ep_path.is_relative_to(prefix):
+        raise RuntimeError("NCCL/EP loaded outside the selected runtime environment")
+    mapped_nccl = {
+        Path(line.split()[-1]).resolve()
+        for line in Path("/proc/self/maps").read_text().splitlines()
+        if "/" in line and "/libnccl.so" in line
+    }
+    if mapped_nccl != {nccl_path}:
+        raise RuntimeError(
+            f"Multiple or unexpected NCCL libraries loaded: {mapped_nccl}"
+        )
+    return {
+        "torch_nccl_compile_time": torch.cuda.nccl.version(),
+        "nccl_runtime": value.value,
+        "nccl_cuda_variant": str(version.libnccl.cuda_variant),
+        "nccl_path": str(nccl_path),
+        "nccl_sha256": hashlib.file_digest(nccl_path.open("rb"), "sha256").hexdigest(),
+        "ep_version": ep_version,
+        "ep_path": str(ep_path),
+        "ep_sha256": hashlib.file_digest(ep_path.open("rb"), "sha256").hexdigest(),
+        "ep_handle_update": callable(getattr(ep.Handle, "update", None)),
+    }
+
+
+def prepare_jit():
+    """Select the installed wheel's headers and record the actual JIT compiler."""
+    import nccl.ep as ep
+    import nvidia.nccl as nccl_package
+
+    expected = {
+        "NCCL_EP_JIT_SOURCE_DIR": Path(ep.__file__).parent / "include/nccl_ep",
+        "NCCL_EP_JIT_BUILD_INCLUDE_DIR": Path(nccl_package.__path__[0]) / "include",
+    }
+    for variable, path in expected.items():
+        configured = Path(os.environ.get(variable, path)).resolve()
+        if configured != path.resolve():
+            raise RuntimeError(
+                f"{variable} must use the selected wheel headers: {path}"
+            )
+        if not path.is_dir():
+            raise RuntimeError(f"Missing installed headers: {path}")
+        os.environ[variable] = str(configured)
+    toolkit = os.environ.get("CUDA_HOME", os.environ.get("CUDA_PATH"))
+    candidate = os.environ.get("NCCL_EP_JIT_NVCC") or os.environ.get("NVCC")
+    if not candidate:
+        candidate = str(Path(toolkit) / "bin/nvcc") if toolkit else "nvcc"
+    nvcc = shutil.which(candidate)
+    if not nvcc:
+        raise RuntimeError("EP JIT needs nvcc; set CUDA_HOME or NCCL_EP_JIT_NVCC")
+    version = command([nvcc, "--version"])
+    if version.get("returncode") != 0 or not re.search(
+        r"release 13\.", version["stdout"]
+    ):
+        raise RuntimeError(f"Expected CUDA 13.x nvcc for the cu13 EP wheel: {version}")
+    includes = Path(nvcc).resolve().parents[1] / "include"
+    if not (includes / "cuda_runtime.h").is_file():
+        raise RuntimeError(f"Missing matching CUDA headers: {includes}")
+    configured = Path(
+        os.environ.get("NCCL_EP_JIT_CUDA_INCLUDE_DIR", includes)
+    ).resolve()
+    if configured != includes.resolve():
+        raise RuntimeError("The JIT CUDA include path must match the selected nvcc")
+    os.environ["NCCL_EP_JIT_NVCC"] = str(Path(nvcc).resolve())
+    os.environ["NCCL_EP_JIT_CUDA_INCLUDE_DIR"] = str(includes)
+    return {
+        "nvcc": version,
+        "paths": {
+            key: os.environ.get(key)
+            for key in (
+                *expected,
+                "NCCL_EP_JIT_NVCC",
+                "NCCL_EP_JIT_CUDA_INCLUDE_DIR",
+                "NCCL_EP_JIT_CACHE_DIR",
+            )
+        },
+    }
+
+
+def require_pair(*, ep=False):
+    if int(os.environ.get("WORLD_SIZE", "1")) != 2 or torch.cuda.device_count() != 2:
+        raise Unavailable("Use torchrun with exactly two ranks and two visible GPUs")
+    rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(rank)
+    if not torch.cuda.can_device_access_peer(rank, 1 - rank):
+        raise Unavailable(f"GPU {rank} cannot directly access its peer")
+    if ep and torch.cuda.get_device_capability(rank)[0] < 9:
+        raise Unavailable(
+            "NCCL EP requires SM90+; SM89 can run only non-EP experiments"
+        )
+    return int(os.environ["RANK"]), rank
+
+
+def report(stage, operation):
+    """Every entrypoint writes an unambiguous machine-readable terminal status."""
+    status, code = "PASS", 0
+    try:
+        result = operation()
+    except Unavailable as error:
+        status, code, result = "SKIP", 77, {"reason": str(error)}
+    except Exception as error:
+        import traceback
+
+        traceback.print_exc()
+        status, code, result = "FAIL", 1, {"error": repr(error)}
+    payload = {
+        "stage": stage,
+        "rank": int(os.environ.get("RANK", "0")),
+        "status": status,
+        "result": result,
+    }
+    print(json.dumps(payload, indent=2), flush=True)
+    report_dir = os.environ.get("NCCL_EP_REPORT_DIR")
+    if report_dir:
+        path = Path(report_dir)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / f"{stage}-rank{payload['rank']}.json").write_text(
+            json.dumps(payload, indent=2) + "\n"
+        )
+    return code

--- a/test/nccl_ep_test/ep_audit.py
+++ b/test/nccl_ep_test/ep_audit.py
@@ -1,0 +1,203 @@
+"""Observe real EP resource calls without replacing communication operations.
+
+Every wrapped method calls the original binding. Retaining Python references
+also makes explicit destroy/reset necessary; garbage collection cannot satisfy
+the resource-closure check by accident.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import torch
+
+
+class EpAudit:
+    def __init__(self):
+        self.events = []
+        self.groups = {}
+        self.handles = {}
+        self.graphs = []
+        self.stack = ExitStack()
+        self.last_work = -1
+        self.last_wait = -1
+
+    def record(self, operation, **fields):
+        self.events.append({"operation": operation, **fields})
+
+    def __enter__(self):
+        import nccl.ep as ep
+
+        create_group = ep.Group.create
+        create_handle = ep.Group.create_handle
+        update_handle = ep.Handle.update
+        destroy_handle = ep.Handle.destroy
+        destroy_group = ep.Group.destroy
+        dispatch = ep.Handle.dispatch
+        combine = ep.Handle.combine
+        complete = ep.Handle.complete
+        synchronize = torch.cuda.synchronize
+        graph_class = torch.cuda.CUDAGraph
+        audit = self
+
+        def group_create(cls, comm, config):
+            group = create_group(comm, config)
+            key = id(group)
+            audit.groups[key] = {
+                "object": group,
+                "closed": False,
+                "capacity": config.max_dispatch_tokens_per_rank,
+                "rdma_buffer_size": config.rdma_buffer_size,
+            }
+            audit.record(
+                "group_create", group=key, capacity=config.max_dispatch_tokens_per_rank
+            )
+            return group
+
+        def handle_create(group, *args, **kwargs):
+            handle = create_handle(group, *args, **kwargs)
+            audit.handles[id(handle)] = {
+                "object": handle,
+                "group": id(group),
+                "closed": False,
+            }
+            audit.record("handle_create", group=id(group), handle=id(handle))
+            return handle
+
+        def handle_update(handle, *args, **kwargs):
+            if torch.cuda.is_current_stream_capturing():
+                raise AssertionError("Handle.update entered CUDA capture")
+            result = update_handle(handle, *args, **kwargs)
+            audit.record("handle_update", handle=id(handle))
+            return result
+
+        def handle_destroy(handle):
+            if torch.cuda.is_current_stream_capturing():
+                raise AssertionError("Handle.destroy entered CUDA capture")
+            group_key = audit.handles[id(handle)]["group"]
+            if audit.groups[group_key]["rdma_buffer_size"] == 0:
+                live_graphs = [
+                    id(graph)
+                    for graph in audit.graphs
+                    if group_key in graph.audit_groups and not graph.audit_reset
+                ]
+                if live_graphs:
+                    raise AssertionError(
+                        f"Persistent handle freed before graphs: {live_graphs}"
+                    )
+                if audit.last_wait < audit.last_work:
+                    raise AssertionError(
+                        "Persistent handle freed without waiting for GPU work"
+                    )
+            result = destroy_handle(handle)
+            audit.handles[id(handle)]["closed"] = True
+            audit.record("handle_destroy", handle=id(handle))
+            return result
+
+        def group_destroy(group):
+            live = [
+                key
+                for key, value in audit.handles.items()
+                if value["group"] == id(group) and not value["closed"]
+            ]
+            if live:
+                raise AssertionError(f"Destroying group before its handles: {live}")
+            if audit.last_wait < audit.last_work:
+                raise AssertionError("EP group freed without waiting for GPU work")
+            result = destroy_group(group)
+            audit.groups[id(group)]["closed"] = True
+            audit.record("group_destroy", group=id(group))
+            return result
+
+        def device_synchronize(*args, **kwargs):
+            result = synchronize(*args, **kwargs)
+            audit.record("device_synchronize")
+            audit.last_wait = len(audit.events) - 1
+            return result
+
+        def observe_work(method, operation):
+            def wrapped(handle, *args, **kwargs):
+                result = method(handle, *args, **kwargs)
+                audit.record(operation, handle=id(handle))
+                audit.last_work = len(audit.events) - 1
+                return result
+
+            return wrapped
+
+        class ObservedGraph(graph_class):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.audit_reset = False
+                self.audit_groups = set()
+                audit.graphs.append(self)
+                audit.record("graph_create", graph=id(self))
+
+            def capture_begin(self, *args, **kwargs):
+                self.audit_groups = {
+                    key
+                    for key, value in audit.groups.items()
+                    if not value["closed"] and value["rdma_buffer_size"] == 0
+                }
+                return super().capture_begin(*args, **kwargs)
+
+            def capture_end(self):
+                result = super().capture_end()
+                audit.record("graph_capture_end", graph=id(self))
+                audit.last_work = len(audit.events) - 1
+                return result
+
+            def replay(self):
+                result = super().replay()
+                audit.record("graph_replay", graph=id(self))
+                audit.last_work = len(audit.events) - 1
+                return result
+
+            def reset(self):
+                if audit.last_wait < audit.last_work:
+                    raise AssertionError("Graph reset without waiting for GPU work")
+                result = super().reset()
+                self.audit_reset = True
+                audit.record("graph_reset", graph=id(self))
+                return result
+
+        self.stack.enter_context(
+            patch.object(ep.Group, "create", classmethod(group_create))
+        )
+        self.stack.enter_context(patch.object(ep.Group, "create_handle", handle_create))
+        self.stack.enter_context(patch.object(ep.Handle, "update", handle_update))
+        self.stack.enter_context(patch.object(ep.Handle, "destroy", handle_destroy))
+        self.stack.enter_context(patch.object(ep.Group, "destroy", group_destroy))
+        self.stack.enter_context(
+            patch.object(ep.Handle, "dispatch", observe_work(dispatch, "dispatch"))
+        )
+        self.stack.enter_context(
+            patch.object(ep.Handle, "combine", observe_work(combine, "combine"))
+        )
+        self.stack.enter_context(
+            patch.object(ep.Handle, "complete", observe_work(complete, "complete"))
+        )
+        self.stack.enter_context(
+            patch.object(torch.cuda, "synchronize", device_synchronize)
+        )
+        self.stack.enter_context(patch.object(torch.cuda, "CUDAGraph", ObservedGraph))
+        return self
+
+    def __exit__(self, *error):
+        return self.stack.__exit__(*error)
+
+    def assert_closed(self):
+        assert all(
+            item["closed"] for item in self.groups.values()
+        ), "Live EP groups remain"
+        assert all(
+            item["closed"] for item in self.handles.values()
+        ), "Live EP handles remain"
+        assert all(
+            graph.audit_reset for graph in self.graphs
+        ), "CUDA executables were not reset"
+        return {
+            "groups_created": len(self.groups),
+            "handles_created": len(self.handles),
+            "graphs_created": len(self.graphs),
+            "all_explicitly_closed": True,
+            "events": self.events,
+        }

--- a/test/nccl_ep_test/fake_ep.py
+++ b/test/nccl_ep_test/fake_ep.py
@@ -1,0 +1,267 @@
+"""A deliberately narrow external nccl.ep test double backed by CUDA kernels.
+
+Only one rank, two experts, K=2, routes [0,1]/[1,0], and a valid prefix are
+supported. This is not a NCCL EP reference implementation. Its purpose is to
+observe Python resource calls while real CUDA Graph replay bypasses Python.
+"""
+
+import importlib
+import sys
+import weakref
+from contextlib import contextmanager
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+from typing import Annotated
+
+import torch
+
+
+@dataclass
+class Tensor:
+    value: torch.Tensor
+
+
+class FakeLibrary:
+    def __init__(self):
+        self.events = []
+        self.groups = []
+        self.updates = []
+        self.core = ModuleType("nccl.core")
+        self.core.Communicator = SimpleNamespace
+        self.ep = ModuleType("nccl.ep")
+        self.ep.Tensor = Tensor
+        self.ep.Algorithm = SimpleNamespace(LOW_LATENCY="ll")
+        self.ep.Layout = SimpleNamespace(EXPERT_MAJOR="expert_major")
+        # Match the external class boundary so EpAudit can wrap real and fake
+        # bindings in exactly the same way while preserving each implementation.
+        library = self
+
+        class Group(FakeGroup):
+            @classmethod
+            def create(cls, comm, config):
+                return library.create_group(comm, config)
+
+        self.ep.Group = Group
+        self.ep.Handle = FakeHandle
+        for name in (
+            "GroupConfig",
+            "HandleConfig",
+            "DispatchInputs",
+            "DispatchOutputs",
+            "DispatchConfig",
+            "LayoutInfo",
+            "CombineInputs",
+            "CombineOutputs",
+            "CombineConfig",
+        ):
+            setattr(self.ep, name, SimpleNamespace)
+
+    def create_group(self, comm, config):
+        assert not torch.cuda.is_current_stream_capturing(), "Group creation in capture"
+        assert config.num_experts == 2, "Fake EP supports one rank/two experts only"
+        group = self.ep.Group(self, config)
+        self.groups.append(group)
+        self.events.append("group_create")
+        return group
+
+
+class FakeGroup:
+    def __init__(self, library, config):
+        self.library, self.config = library, config
+        self.handles = []
+        self.destroyed = False
+
+    def create_handle(self, *, layout, topk_idx, config, stream):
+        assert (
+            not torch.cuda.is_current_stream_capturing()
+        ), "Handle creation in capture"
+        assert not self.destroyed
+        handle = FakeHandle(self, topk_idx.value)
+        # Multiple handles are legal at this API boundary. The production
+        # graph owner chooses one to control shared communication state.
+        self.handles.append(handle)
+        self.library.events.append("handle_create")
+        return handle
+
+    def destroy(self):
+        assert (
+            not torch.cuda.is_current_stream_capturing()
+        ), "Group destruction in capture"
+        assert not self.destroyed
+        assert all(
+            handle.destroyed for handle in self.handles
+        ), "Live EP handles remain"
+        self.destroyed = True
+        self.library.events.append("group_destroy")
+
+
+class FakeHandle:
+    def __init__(self, group, ids):
+        self.group = group
+        self.ids = ids
+        self.base = ids.data_ptr()
+        self.capacity = group.config.max_dispatch_tokens_per_rank
+        self.pending = None
+        self.destroyed = False
+
+    def update(self, topk_idx, *, stream):
+        assert not torch.cuda.is_current_stream_capturing(), "Handle.update in capture"
+        assert not self.destroyed and self.pending is None
+        assert topk_idx.value.data_ptr() == self.base, "Routing base address changed"
+        assert len(topk_idx.value) <= self.capacity
+        self.ids = topk_idx.value
+        self.group.library.updates.append((self.base, tuple(self.ids.shape)))
+        self.group.library.events.append("handle_update")
+
+    def dispatch(self, inputs, outputs, *, layout_info, config, stream):
+        assert not self.destroyed and self.pending is None
+        assert config.send_only == 1
+        x, received = inputs.tokens.value, outputs.tokens.value
+        assert x.shape[0] == self.ids.shape[0]
+        if not torch.cuda.is_current_stream_capturing():
+            # Do not silently apply this toy layout to unsupported fixtures.
+            routes = self.ids.cpu()
+            valid = (routes >= 0).any(dim=1)
+            n = int(valid.sum())
+            assert valid.tolist() == [True] * n + [False] * (len(routes) - n)
+            assert torch.equal(
+                routes[:n].sort(dim=1).values, torch.tensor([0, 1]).expand(n, 2)
+            )
+            assert (routes[n:] == -1).all()
+        received[:, : len(x)].copy_(x.unsqueeze(0).expand(2, -1, -1))
+        count = (self.ids >= 0).any(dim=1).sum(dtype=torch.int32)
+        layout_info.expert_counters.value.copy_(count.expand(2))
+        # The native send_only continuation borrows tensor descriptors until
+        # complete(). Weak references expose premature wrapper destruction.
+        self.pending_descriptors = [
+            weakref.ref(value)
+            for bundle in (inputs, outputs, layout_info)
+            for value in vars(bundle).values()
+            if isinstance(value, Tensor)
+        ]
+        self.pending = "dispatch"
+        self.group.library.events.append("dispatch")
+
+    def combine(self, inputs, outputs, *, config, stream):
+        assert not self.destroyed and self.pending is None
+        assert config.send_only == 1
+        experts = inputs.tokens.value
+        weights = outputs.topk_weights.value
+        combined = outputs.tokens.value
+        row = torch.arange(len(self.ids), device=self.ids.device)
+        result = torch.zeros_like(combined, dtype=torch.float32)
+        for route in range(2):
+            expert = self.ids[:, route]
+            value = experts[expert.clamp_min(0), row].float()
+            contribution = value * weights[:, route, None]
+            result.add_(torch.where(expert[:, None] >= 0, contribution, 0))
+        combined.copy_(result)
+        self.pending_descriptors = [
+            weakref.ref(value)
+            for bundle in (inputs, outputs)
+            for value in vars(bundle).values()
+            if isinstance(value, Tensor)
+        ]
+        self.pending = "combine"
+        self.group.library.events.append("combine")
+
+    def complete(self, *, config, stream):
+        assert not self.destroyed and self.pending is not None
+        assert all(
+            ref() is not None for ref in self.pending_descriptors
+        ), "EP tensor descriptor released before complete"
+        self.pending_descriptors = []
+        self.pending = None
+        self.group.library.events.append("complete")
+
+    def destroy(self):
+        assert (
+            not torch.cuda.is_current_stream_capturing()
+        ), "Handle destruction in capture"
+        assert not self.destroyed and self.pending is None
+        self.destroyed = True
+        self.group.library.events.append("handle_destroy")
+
+
+@contextmanager
+def replace_ep_modules(modules):
+    # patch.dict(sys.modules) restores the entire dictionary and removes other
+    # modules imported during a test. Re-importing Torch operator registries
+    # after that rollback can register the same native namespace twice.
+    missing = object()
+    previous = {key: sys.modules.get(key, missing) for key in modules}
+    sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is missing:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+@contextmanager
+def dispatcher_environment(*, capacity=32):
+    """Replace only the external EP modules, retain actual SGLang operations."""
+    from sglang.srt.arg_groups.arg_utils import NS
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.utils import MoeA2ABackend, NcclEpMode
+    from sglang.srt.runtime_context import get_context, get_flags, get_resources
+
+    @dataclass
+    class LabConfig:
+        enable_deterministic_inference: Annotated[bool, NS("exec.deterministic")] = (
+            False
+        )
+
+    library = FakeLibrary()
+    root = ModuleType("nccl")
+    root.__path__ = []
+    root.core, root.ep = library.core, library.ep
+    coordinator = SimpleNamespace(
+        world_size=1,
+        rank=0,
+        rank_in_group=0,
+        device=torch.device("cuda", torch.cuda.current_device()),
+        pynccl_comm=SimpleNamespace(available=True, comm=SimpleNamespace(value=32774)),
+        barrier=lambda: None,
+    )
+    context = get_context()
+    with context.preserve_config(), get_flags().moe.override(
+        a2a_backend=MoeA2ABackend.NCCL_EP,
+        nccl_ep_mode=NcclEpMode.LOW_LATENCY,
+        nccl_ep_num_max_dispatch_tokens_per_rank=capacity,
+    ), replace_ep_modules(
+        {"nccl": root, "nccl.core": library.core, "nccl.ep": library.ep}
+    ):
+        context.set_server_args(LabConfig())
+        module = importlib.import_module(
+            "sglang.srt.layers.moe.token_dispatcher.nccl_ep"
+        )
+        importlib.reload(module)
+
+        def dispatcher(*, layer_id):
+            return module.NcclEpDispatcher(
+                MoeRunnerConfig(
+                    num_experts=2,
+                    num_local_experts=2,
+                    hidden_size=2048,
+                    top_k=2,
+                    params_dtype=torch.bfloat16,
+                    layer_id=layer_id,
+                ),
+                coordinator,
+            )
+
+        library.dispatcher = dispatcher
+        library.coordinator = coordinator
+        try:
+            yield library
+        finally:
+            torch.cuda.synchronize()
+            module.NcclEpBuffer.destroy()
+            get_resources().buffers.pop("nccl_ep_state", None)
+            # Restore the import cache while the module remains importable.
+            importlib.reload(module)
+    assert all(group.destroyed for group in library.groups), "Unclosed fake EP group"

--- a/test/nccl_ep_test/local_graph.py
+++ b/test/nccl_ep_test/local_graph.py
@@ -1,0 +1,81 @@
+"""Single-GPU experiment: changing tensor contents preserves Graph topology.
+
+This contains no EP operations and provides no evidence for EP graph safety.
+"""
+
+from itertools import product
+
+import torch
+
+from .environment import Unavailable
+from .oracle import assert_combine_matches, make_fixture
+
+
+def exercise():
+    if not torch.cuda.is_available():
+        raise Unavailable("The non-EP Graph experiment requires one CUDA device")
+    graphs, inputs, outputs, addresses = {}, {}, {}, {}
+    shared = (
+        torch.empty(32, 2048, dtype=torch.bfloat16, device="cuda"),
+        torch.empty(32, 2, dtype=torch.int64, device="cuda"),
+        torch.empty(32, 2, dtype=torch.float32, device="cuda"),
+    )
+    shared_views = {}
+    stream = torch.cuda.Stream()
+    for bucket in (8, 16, 32):
+        batch = make_fixture(bucket)
+        static = tuple(
+            items[0].cuda() for items in (batch.tokens, batch.expert_ids, batch.weights)
+        )
+        x, ids, weights = static
+        shared_x, shared_ids, shared_weights = (tensor[:bucket] for tensor in shared)
+        shared_views[str(bucket)] = [
+            tensor.data_ptr() for tensor in (shared_x, shared_ids, shared_weights)
+        ]
+
+        def forward():
+            shared_x.copy_(x)
+            shared_ids.copy_(ids)
+            shared_weights.copy_(weights)
+            factors = (shared_ids + 1).float() * (shared_ids >= 0)
+            return (
+                shared_x.float()[:, None, :]
+                * factors[:, :, None]
+                * shared_weights[:, :, None]
+            ).sum(1)
+
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(2):
+                forward()
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            result = forward()
+        graphs[bucket], inputs[bucket], outputs[bucket] = graph, static, result
+        addresses[bucket] = [tensor.data_ptr() for tensor in static]
+    checked = 0
+    for change, case, step, bucket in product(
+        ("tokens", "routing", "weights", "all"),
+        ("balanced", "hotspot", "padding", "empty_rank", "all_masked"),
+        (0, 1, 0),
+        (8, 16, 32),
+    ):
+        batch = make_fixture(bucket, case=case, step=step, change=change)
+        static = inputs[bucket]
+        for target, items in zip(
+            static, (batch.tokens, batch.expert_ids, batch.weights)
+        ):
+            target.copy_(items[0])
+        assert addresses[bucket] == [tensor.data_ptr() for tensor in static]
+        graphs[bucket].replay()
+        assert_combine_matches(batch, 0, outputs[bucket])
+        checked += 1
+    torch.cuda.synchronize()
+    return {
+        "checked": checked,
+        "ep_tested": False,
+        "changed_components": ["tokens", "routing", "weights", "all"],
+        "static_addresses": addresses,
+        "shared_buffer_views": shared_views,
+    }

--- a/test/nccl_ep_test/native.py
+++ b/test/nccl_ep_test/native.py
@@ -1,0 +1,336 @@
+"""Weight-free native EP hypothesis test, separate from SGLang integration.
+
+There is one group and handle for all graphs in a generation. Host update only
+prepares shape descriptors before capture; GPU copies supply replay-time routing.
+Passing these tests does not establish SGLang runner integration correctness.
+"""
+
+import time
+from datetime import timedelta
+from itertools import product
+
+import torch
+import torch.distributed as dist
+
+from .comparison import compare
+from .environment import binding_check, prepare_jit, require_pair
+from .oracle import (
+    RoutingBatch,
+    make_fixture,
+    validate_capacity,
+)
+
+
+class NativeEp:
+    def __init__(self, comm, capacity, hidden=2048, *, persistent):
+        import nccl.ep as ep
+
+        self.ep = ep
+        self.capacity = capacity
+        self.hidden = hidden
+        self.persistent = persistent
+        self.handle = None
+        self.prepared_size = None
+        self.group = ep.Group.create(
+            comm,
+            ep.GroupConfig(
+                algorithm=ep.Algorithm.LOW_LATENCY,
+                num_experts=4,
+                num_topk=2,
+                max_dispatch_tokens_per_rank=capacity,
+                max_token_bytes=hidden * 2,
+                rdma_buffer_size=0,
+                max_num_sms=20,
+            ),
+        )
+        self.x = torch.empty(capacity, hidden, dtype=torch.bfloat16, device="cuda")
+        self.ids = torch.full((capacity, 2), -1, dtype=torch.int64, device="cuda")
+        self.weights = torch.zeros(capacity, 2, dtype=torch.float32, device="cuda")
+        self.recv = torch.empty(
+            2, 2 * capacity, hidden, dtype=torch.bfloat16, device="cuda"
+        )
+        self.counts = torch.zeros(2, dtype=torch.int32, device="cuda")
+        self.combined = torch.empty_like(self.x)
+        if persistent:
+            # Initialize maximum layout once, so AUTO's RDMA allocation cannot
+            # grow after graphs have captured pointers into group storage.
+            self.handle = self._create_handle(capacity)
+            self.prepared_size = capacity
+
+    def _create_handle(self, size):
+        return self.group.create_handle(
+            self.ep.Layout.EXPERT_MAJOR,
+            self.ep.Tensor(self.ids[:size]),
+            stream=torch.cuda.current_stream().cuda_stream,
+        )
+
+    def prepare(self, size):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("Handle shape update must happen before capture")
+        if not 0 < size <= self.capacity:
+            raise ValueError("Bucket must fit the frozen capacity")
+        if self.persistent:
+            self.handle.update(
+                self.ep.Tensor(self.ids[:size]),
+                stream=torch.cuda.current_stream().cuda_stream,
+            )
+            self.prepared_size = size
+
+    def run(self, x, ids, weights, *, rank, identity=False):
+        size = len(x)
+        if self.persistent and self.prepared_size != size:
+            raise RuntimeError("Prepare the bucket before warmup/capture")
+        if not self.persistent and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("The eager group must never enter capture")
+        self.x[:size].copy_(x)
+        self.ids[:size].copy_(ids)
+        self.weights[:size].copy_(weights)
+        ep, stream = self.ep, torch.cuda.current_stream().cuda_stream
+        handle = self.handle if self.persistent else self._create_handle(size)
+        self.counts.zero_()
+        # send_only borrows these descriptors for the complete() continuation.
+        dispatch_inputs = ep.DispatchInputs(tokens=ep.Tensor(self.x[:size]))
+        dispatch_outputs = ep.DispatchOutputs(tokens=ep.Tensor(self.recv))
+        layout_info = ep.LayoutInfo(expert_counters=ep.Tensor(self.counts))
+        handle.dispatch(
+            dispatch_inputs,
+            dispatch_outputs,
+            layout_info=layout_info,
+            config=ep.DispatchConfig(send_only=1),
+            stream=stream,
+        )
+        handle.complete(stream=stream)
+        # Copies preserve each layer's observations across shared-buffer reuse.
+        received, counts = self.recv.clone(), self.counts.clone()
+        factors = torch.arange(
+            rank * 2 + 1, rank * 2 + 3, device=x.device, dtype=x.dtype
+        )
+        expert_output = (
+            self.recv.clone() if identity else self.recv * factors[:, None, None]
+        )
+        combine_inputs = ep.CombineInputs(tokens=ep.Tensor(expert_output))
+        combine_outputs = ep.CombineOutputs(
+            tokens=ep.Tensor(self.combined[:size]),
+            topk_weights=ep.Tensor(self.weights[:size]),
+        )
+        handle.combine(
+            combine_inputs,
+            combine_outputs,
+            config=ep.CombineConfig(send_only=1),
+            stream=stream,
+        )
+        handle.complete(stream=stream)
+        output = self.combined[:size].clone()
+        if not self.persistent:
+            handle.destroy()
+        return received, counts, output
+
+    def close(self):
+        # Caller drops graph executables only after device completion, then
+        # closes the handle before the group. No collective barrier on failure.
+        if self.handle is not None:
+            self.handle.destroy()
+            self.handle = None
+        self.group.destroy()
+
+
+def _inputs(batch, rank):
+    return tuple(
+        value[rank].cuda() for value in (batch.tokens, batch.expert_ids, batch.weights)
+    )
+
+
+def _compare(batch, rank, outputs, identity=False):
+    received, counts, combined = outputs
+    compare(batch, rank, received, counts, combined, identity=identity)
+
+
+def exercise(
+    *, mode, buckets=(8, 16, 32), replays=1000, layers=2, generations=2, identity=False
+):
+    rank, _ = require_pair(ep=True)
+    bindings = binding_check()
+    jit = prepare_jit()
+    import nccl.core as core
+
+    dist.init_process_group("gloo", timeout=timedelta(seconds=120))
+    shared = [bytes(core.get_unique_id()) if rank == 0 else None]
+    dist.broadcast_object_list(shared, src=0)
+    comm = core.Communicator.init(2, rank, core.UniqueId.from_bytes(shared[0]))
+    capacity = max(buckets)
+    cases = ("balanced", "hotspot", "padding", "empty_rank", "all_masked")
+    changes = ("tokens", "routing", "weights", "all")
+    eager_modes = ("eager", "zero_length", "duplicates")
+    eager_capacity = capacity if mode in eager_modes else min(1024, capacity * 2)
+    eager_started = time.perf_counter()
+    eager = NativeEp(comm, eager_capacity, persistent=False)
+    warmup_batch = make_fixture(eager_capacity)
+    warmup_inputs = _inputs(warmup_batch, rank)
+    for _ in range(2):
+        warmup_actual = eager.run(*warmup_inputs, rank=rank, identity=identity)
+    torch.cuda.synchronize()
+    _compare(warmup_batch, rank, warmup_actual, identity)
+    eager_warmup_seconds = time.perf_counter() - eager_started
+    checked = 0
+    graph_timings = []
+    eager_timings = []
+    eager_wall_timings = []
+    # On GPU/peer failure, leave collective-owned objects to process exit;
+    # torchrun plus an external timeout bounds failure handling.
+    if mode == "zero_length":
+        full = make_fixture(8)
+        batch = RoutingBatch(
+            (full.tokens[0][:0], full.tokens[1]),
+            (full.expert_ids[0][:0], full.expert_ids[1]),
+            (full.weights[0][:0], full.weights[1]),
+            4,
+        )
+        validate_capacity(batch, capacity)
+        _compare(
+            batch,
+            rank,
+            eager.run(*_inputs(batch, rank), rank=rank, identity=identity),
+            identity,
+        )
+        checked += 1
+    elif mode == "duplicates":
+        batch = make_fixture(8, case="duplicates")
+        validate_capacity(batch, capacity)
+        _compare(
+            batch,
+            rank,
+            eager.run(*_inputs(batch, rank), rank=rank, identity=identity),
+            identity,
+        )
+        checked += 1
+    elif mode == "eager":
+        for bucket, case, change, step in product(buckets, cases, changes, (0, 1, 0)):
+            batch = make_fixture(bucket, case=case, step=step, change=change)
+            validate_capacity(batch, capacity)
+            live_inputs = _inputs(batch, rank)
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            wall_start = time.perf_counter()
+            actual = eager.run(*live_inputs, rank=rank, identity=identity)
+            end.record()
+            end.synchronize()
+            eager_wall_timings.append((time.perf_counter() - wall_start) * 1000)
+            eager_timings.append(start.elapsed_time(end))
+            _compare(batch, rank, actual, identity)
+            checked += 1
+    else:
+        for generation in range(generations):
+            warmup_started = time.perf_counter()
+            graph_ep = NativeEp(comm, capacity, persistent=True)
+            graphs, inputs, outputs = {}, {}, {}
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            for bucket in sorted(buckets, reverse=True):
+                inputs[bucket] = [
+                    _inputs(make_fixture(bucket, step=layer), rank)
+                    for layer in range(layers)
+                ]
+                # Ensure allocations/copies from the producer are visible.
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph_ep.prepare(bucket)
+                    for _ in range(2):
+                        for item in inputs[bucket]:
+                            graph_ep.run(*item, rank=rank, identity=identity)
+                torch.cuda.synchronize()
+                dist.barrier()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph, stream=stream):
+                    out = [
+                        graph_ep.run(*item, rank=rank, identity=identity)
+                        for item in inputs[bucket]
+                    ]
+                graphs[bucket], outputs[bucket] = graph, out
+            torch.cuda.synchronize()
+            warmup_seconds = time.perf_counter() - warmup_started
+            for iteration in range(replays if mode == "dynamic" else 3):
+                bucket = buckets[iteration % len(buckets)]
+                # A -> B -> A at each successive visit, plus bucket alternation.
+                visit = iteration // len(buckets)
+                step = (0, 1, 0)[visit % 3]
+                case = (
+                    cases[(visit // 3) % len(cases)]
+                    if mode == "dynamic"
+                    else "balanced"
+                )
+                change = (
+                    changes[(visit // (3 * len(cases))) % len(changes)]
+                    if mode == "dynamic"
+                    else "all"
+                )
+                batches = [
+                    make_fixture(bucket, case=case, step=step + layer, change=change)
+                    for layer in range(layers)
+                ]
+                for batch, static in zip(batches, inputs[bucket]):
+                    validate_capacity(batch, capacity)
+                    for target, source in zip(static, _inputs(batch, rank)):
+                        target.copy_(source)
+                start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(
+                    enable_timing=True
+                )
+                with torch.cuda.nvtx.range(f"nccl_ep_graph/{bucket}"):
+                    start.record()
+                    graphs[bucket].replay()
+                    end.record()
+                end.synchronize()
+                graph_timings.append(start.elapsed_time(end))
+                for batch, actual in zip(batches, outputs[bucket]):
+                    _compare(batch, rank, actual, identity)
+                    checked += 1
+                if iteration % 17 == 0:
+                    # A separate eager group may change its handle shape.
+                    batch = make_fixture(eager_capacity, case="hotspot", step=1)
+                    validate_capacity(batch, eager_capacity)
+                    _compare(
+                        batch,
+                        rank,
+                        eager.run(*_inputs(batch, rank), rank=rank, identity=identity),
+                        identity,
+                    )
+                    checked += 1
+            torch.cuda.synchronize()
+            for graph in graphs.values():
+                graph.reset()
+            graphs.clear()
+            del graph, out
+            outputs.clear()
+            graph_ep.close()
+            print(
+                f"generation={generation} warmup_and_capture_seconds={warmup_seconds:.3f}",
+                flush=True,
+            )
+    torch.cuda.synchronize()
+    eager.close()
+    comm.destroy()
+    dist.destroy_process_group()
+    return {
+        "implementation": "native",
+        "mode": mode,
+        "graph_capacity": capacity if mode not in eager_modes else None,
+        "eager_capacity": eager_capacity,
+        "checked": checked,
+        "bindings": bindings,
+        "jit": jit,
+        "replay_ms": graph_timings,
+        "eager_ms": eager_timings,
+        "eager_wall_ms": eager_wall_timings,
+        "eager_warmup_seconds": eager_warmup_seconds,
+        "measurement_scope": "Synthetic full step including buffer copies, expert work and observation snapshots; oracle excluded",
+        "buckets": list(buckets),
+        "layers": layers if mode not in eager_modes else 1,
+        "changed_components": (
+            list(changes) if mode in ("eager", "dynamic") else ["all"]
+        ),
+        "generations": generations if mode not in eager_modes else 0,
+        "replays_per_generation": (
+            replays if mode == "dynamic" else 3 if mode == "capture" else 0
+        ),
+        "tolerance": {"rtol": 0, "atol": 0},
+    }

--- a/test/nccl_ep_test/oracle.py
+++ b/test/nccl_ep_test/oracle.py
@@ -1,0 +1,189 @@
+"""CPU oracle, independent of the communication and Graph implementations."""
+
+from collections import Counter
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class RoutingBatch:
+    tokens: tuple[torch.Tensor, ...]
+    expert_ids: tuple[torch.Tensor, ...]
+    weights: tuple[torch.Tensor, ...]
+    num_experts: int
+
+
+def make_fixture(
+    bucket: int,
+    *,
+    case: str = "balanced",
+    step: int = 0,
+    hidden: int = 2048,
+    seed: int = 32774,
+    change: str = "all",
+) -> RoutingBatch:
+    """Exactly representable payloads, distinct rows and nonuniform route weights.
+
+    Powers of two survive BF16 and block FP8 quantize/dequantize. Changing step
+    changes the selected data component without changing any tensor shape.
+    A masked rank retains its bucket size and participates in communication.
+    """
+    if bucket < 0 or hidden < 1:
+        raise ValueError("Expected nonnegative bucket and positive hidden size")
+    cases = {"balanced", "hotspot", "empty_rank", "all_masked", "padding", "duplicates"}
+    if case not in cases:
+        raise ValueError(f"Unknown routing case: {case}")
+    if change not in ("all", "tokens", "routing", "weights"):
+        raise ValueError(f"Unknown dynamic-data component: {change}")
+    token_step = step if change in ("all", "tokens") else 0
+    routing_step = step if change in ("all", "routing") else 0
+    weight_step = step if change in ("all", "weights") else 0
+    tokens, expert_ids, weights = [], [], []
+    for rank in range(2):
+        code = torch.arange(bucket, dtype=torch.int64) + rank * bucket + 1 + seed % 31
+        digit = (torch.arange(hidden) % 8) * 2
+        exponent = (code[:, None] >> digit[None, :]) & 3
+        tokens.append((2.0**exponent * (1 + token_step % 2)).to(torch.bfloat16))
+        first = (torch.arange(bucket) + rank + routing_step) % 4
+        ids = torch.stack((first, (first + 2) % 4), dim=1)
+        if case == "hotspot":
+            ids[:] = torch.tensor([0, 1]) + 2 * (routing_step % 2)
+        elif case == "duplicates":
+            ids[:] = routing_step % 4
+        route_weights = torch.tensor(
+            [0.25, 0.75] if weight_step % 2 == 0 else [0.75, 0.25]
+        )
+        route_weights = route_weights.expand(bucket, 2).clone()
+        if case == "all_masked" or (case == "empty_rank" and rank == routing_step % 2):
+            ids.fill_(-1)
+        elif case == "padding":
+            ids[bucket // 2 :] = -1
+        # CUDA SGLang TopK masks padded ids, but need not zero their weights.
+        # Nonzero weights make stale combine routing observable in the oracle.
+        expert_ids.append(ids)
+        weights.append(route_weights)
+    return RoutingBatch(tuple(tokens), tuple(expert_ids), tuple(weights), 4)
+
+
+def expected_dispatch(batch: RoutingBatch):
+    """Rows for each global expert, including repeated route contributions."""
+    rows = [[] for _ in range(batch.num_experts)]
+    for tokens, ids in zip(batch.tokens, batch.expert_ids):
+        for token in range(tokens.shape[0]):
+            for expert in ids[token].tolist():
+                if expert >= 0:
+                    rows[expert].append(tokens[token].float())
+    hidden = batch.tokens[0].shape[1]
+    return tuple(
+        torch.stack(items) if items else torch.empty((0, hidden)) for items in rows
+    )
+
+
+def assert_dispatch_matches(batch: RoutingBatch, rank: int, received, counters):
+    """Compare all valid elements and multiplicities, independent of receive order."""
+    expected = expected_dispatch(batch)
+    local_experts = batch.num_experts // len(batch.tokens)
+    if not 0 <= rank < len(batch.tokens):
+        raise AssertionError(f"Invalid rank: {rank}")
+    if (
+        received.ndim != 3
+        or received.shape[0] != local_experts
+        or received.shape[2] != batch.tokens[rank].shape[1]
+    ):
+        raise AssertionError(f"Unexpected receive shape: {tuple(received.shape)}")
+    received = received.detach().cpu().float()
+    counts = counters.detach().cpu().tolist()
+    if len(counts) != local_experts:
+        raise AssertionError("Unexpected expert counter shape")
+    for local_expert, count in enumerate(counts):
+        expert = rank * local_experts + local_expert
+        wanted = expected[expert]
+        if count != len(wanted) or not 0 <= count <= received.shape[1]:
+            raise AssertionError(
+                f"Expert {expert}: count={count}, expected={len(wanted)}"
+            )
+        actual = received[local_expert, :count]
+        if not torch.isfinite(actual).all():
+            raise AssertionError(f"Expert {expert}: nonfinite valid payload")
+        actual_rows = Counter(tuple(row) for row in actual.tolist())
+        wanted_rows = Counter(tuple(row) for row in wanted.tolist())
+        if actual_rows != wanted_rows:
+            raise AssertionError(
+                f"Expert {expert}: received token contents/multiplicity differ"
+            )
+
+
+def expected_combine(batch: RoutingBatch, *, identity: bool = False):
+    """Sum weighted synthetic experts in float64, independently per source token."""
+    outputs = []
+    for tokens, ids, weights in zip(batch.tokens, batch.expert_ids, batch.weights):
+        output = torch.zeros_like(tokens, dtype=torch.float64, device="cpu")
+        for token in range(tokens.shape[0]):
+            for route in range(ids.shape[1]):
+                expert = int(ids[token, route])
+                if expert < 0:
+                    continue
+                factor = 1 if identity else expert + 1
+                output[token] += (
+                    tokens[token].double() * factor * float(weights[token, route])
+                )
+        outputs.append(output.float())
+    return tuple(outputs)
+
+
+def assert_combine_matches(batch: RoutingBatch, rank: int, actual, *, identity=False):
+    """Strict comparison for the exactly representable lab fixtures."""
+    wanted = expected_combine(batch, identity=identity)[rank]
+    actual = actual.detach().cpu().float()
+    if not torch.isfinite(actual).all():
+        raise AssertionError("Combined output contains nonfinite values")
+    torch.testing.assert_close(actual, wanted, rtol=0, atol=0)
+
+
+def validate_capacity(batch: RoutingBatch, capacity: int):
+    """Reject unsafe synthetic routes before entering any collective operation."""
+    world = len(batch.tokens)
+    if not world or batch.num_experts <= 0 or batch.num_experts % world:
+        raise ValueError("Experts must divide evenly across nonempty ranks")
+    if len(batch.expert_ids) != world or len(batch.weights) != world:
+        raise ValueError("Missing rank inputs")
+    hidden, topk = batch.tokens[0].shape[1], batch.expert_ids[0].shape[1]
+    for tokens, ids, weights in zip(batch.tokens, batch.expert_ids, batch.weights):
+        if (
+            tokens.ndim != 2
+            or tokens.shape[1] != hidden
+            or ids.shape != (len(tokens), topk)
+            or weights.shape != ids.shape
+        ):
+            raise ValueError("Incompatible token/routing/weight shapes")
+        if len(tokens) > capacity:
+            raise ValueError("Token count exceeds dispatch capacity")
+        if ids.dtype not in (torch.int32, torch.int64):
+            raise ValueError("Expert ids must be integers")
+        if ((ids < -1) | (ids >= batch.num_experts)).any():
+            raise ValueError("Invalid expert id")
+        if not torch.isfinite(tokens).all() or not torch.isfinite(weights).all():
+            raise ValueError("Nonfinite test input")
+    for expert, rows in enumerate(expected_dispatch(batch)):
+        if len(rows) > world * capacity:
+            raise ValueError(
+                f"Expert {expert} exceeds receive capacity {world * capacity}"
+            )
+
+
+def dequantize_fp8(payload: torch.Tensor, scales: torch.Tensor, group_size=128):
+    """Apply every block scale before the synthetic expert's BF16 input cast."""
+    if payload.shape[-1] % group_size:
+        raise ValueError("Hidden size must be divisible by the FP8 group size")
+    expected_shape = (*payload.shape[:-1], payload.shape[-1] // group_size)
+    if tuple(scales.shape) != expected_shape:
+        raise ValueError(
+            f"Expected FP8 scales shaped {expected_shape}, got {scales.shape}"
+        )
+    blocks = payload.float().reshape(*expected_shape, group_size)
+    return (
+        (blocks * scales.float().unsqueeze(-1))
+        .reshape(payload.shape)
+        .to(torch.bfloat16)
+    )

--- a/test/nccl_ep_test/review_validation.md
+++ b/test/nccl_ep_test/review_validation.md
@@ -1,0 +1,68 @@
+# NCCL EP configuration review follow-up
+
+This follow-up addresses configuration findings reported on #38683, #38886,
+#38887 and #38888 on 2026-09-11. Those PRs share a dependency chain, so repeated
+findings are fixed in the Graph parent and inherited by the later branches.
+It does not migrate the stack to a different upstream baseline.
+
+## Findings and scope
+
+| Finding | Resolution | Validation needed |
+| --- | --- | --- |
+| Default EP remains 1 while the dispatcher uses the TP communicator | Include NCCL EP in TP-spanning EP resolution, including fallback resolution | Local public configuration regression; two-rank serving with `--ep` omitted |
+| Default prefill exceeds the LL dispatch budget | Limit the per-DP-rank chunk to the LL budget and KV page boundary; reject unchunked prefill and PP dynamic chunking | Local real PrefillAdder long-prompt/mixed-decode regression; two-rank long-prefill eager/Graph serving |
+| Unavailable NCCL EP falls back to DeepEP with an incompatible Triton runner | Keep Triton and select standard dispatch (`none`) | Local unavailable-device regression with DeepEP importable |
+| Unquantized models reach an unsupported LL compute path | Reject unsupported quantization at MoE implementation selection | Local rejection and FP8/W4A-FP8/non-NCCL-EP controls |
+| SM100 availability disagrees with the dispatcher scale guard | Use the same UE8M0 incompatibility reason in both gates | Local capability/scale-mode controls; this does not enable UE8M0 |
+| Eager FP16 payload is interpreted as BF16 | Reject non-BF16 parameters before group creation and inputs before handle creation | Local real dispatcher with fake external EP, plus BF16 lifecycle regression |
+| Non-Triton eager mode allows unsupported SBO/TBO | Reject overlap for every NCCL EP runner | Local public configuration regression |
+
+The non-FP8 diagnosis must preserve the existing W4A-FP8 compute path. The
+Blackwell diagnosis must distinguish SM120 float32 scales from the
+`DEEPGEMM_BLACKWELL` UE8M0 mode. DeepSeek's `ep_size` accesses cited in the review
+belong to staged overlap operations; serial forward uses `moe_ep_size`.
+Rejecting unsupported overlap is intentional; this patch does not add SBO/TBO.
+
+## Local evidence
+
+The initial public-contract reproducer failed 16 cases and passed one on the
+unmodified Graph parent (`537b7a1`). The corrected regression file contains 27
+passing cases, including a 257-token request processed through the real
+PrefillAdder with and without mixed decode tokens. External EP bindings and GPU
+capability queries are replaced; configuration resolution, scheduling, dispatcher
+guards and ordinary CUDA Graph execution remain real.
+
+On RTX 4060 Laptop (SM89), Torch 2.13.0+cu130:
+
+- Graph-parent NCCL EP suite: 115 passed.
+- Configuration resolution/migration/namespace suite: 195 passed and 21 subtests.
+- Standalone new CI entrypoint with optional NCCL EP imports blocked: 27 passed.
+- Changed-file pre-commit, Mintlify build validation and internal-link checks passed.
+
+```bash
+PYTHONPATH=python:test python3 -m pytest -q \
+  test/registered/unit/layers/moe/test_nccl_ep_*.py
+```
+
+The later branches add their own Triton, zero-token and shared-expert tests.
+Their final counts are recorded in the respective PR descriptions.
+
+## Hardware and performance limits
+
+These fixes do not change communication kernels or persistent Graph ownership.
+No new native NCCL EP execution, model benchmark or Nsight run is claimed for
+this review follow-up. Earlier hardware records remain attached to their tested
+SHAs; they used explicit EP sizes and small prefill chunks and do not prove the
+new default-configuration behavior.
+
+Before certifying the new serving defaults, rerun the native pair and model
+eager/Graph gates on the final stack SHA. Omit `--ep`, retain TP=DP=2, use the
+default chunk size with an explicit LL budget of 64, and send a prompt longer
+than 64 tokens. Check the resolved EP size, actual per-rank prefill size, finite
+outputs, zero-token participation and eager/Graph recovery. Reducing prefill
+chunks can change throughput, so prior short-request timings do not describe
+long-prefill performance. No new profile is required merely to validate rejection
+of an unsupported dtype, scale mode, quantization or overlap option.
+
+Upstream `run-ci` authorization, maintainer approval and integration with the
+unmerged parent baseline remain separate from local correctness results.

--- a/test/nccl_ep_test/runner_inputs.py
+++ b/test/nccl_ep_test/runner_inputs.py
@@ -1,0 +1,254 @@
+"""Model-free fixture for SGLang's real decode load_batch/execute path.
+
+Only model initialization, attention metadata, and the outer capture loop are
+experiment scaffolding. DecodeInputBuffers, registry filling, bucket selection,
+hidden-mode recapture, replay_session, and execute are the production code.
+The backend and forward callback can also be the real NCCL EP implementation.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.cuda_graph_buffer_registry import (
+    build_decode_registry,
+    build_eager_registry,
+)
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner.eager_runner import EagerRunner
+from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+    FullCudaGraphBackend,
+)
+from sglang.srt.model_executor.runner_utils.buffers import DecodeInputBuffers
+from sglang.srt.model_executor.runner_utils.deepep_adapter import (
+    DeepEPCudaGraphRunnerAdapter,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+
+class MetadataObserver:
+    """Attention is outside this MoE experiment; observe its actual replay view."""
+
+    use_captured_forward_metadata_for_breakable_cuda_graph = False
+
+    def __init__(self):
+        self.views = []
+
+    def init_forward_metadata_out_graph(self, view):
+        self.views.append(view)
+
+    def init_forward_metadata(self, view):
+        self.views.append(view)
+
+
+class SyntheticDecodeRunner(DecodeCudaGraphRunner):
+    def __init__(
+        self,
+        forward,
+        tp_group,
+        *,
+        buckets=(8, 16, 32),
+        backend_factory=None,
+        share_inputs=False
+    ):
+        self.device = torch.device("cuda", torch.cuda.current_device())
+        self.device_module = torch.cuda
+        self.model_runner = SimpleNamespace(
+            tp_group=tp_group,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+            is_draft_worker=False,
+            hisparse_coordinator=None,
+            device_timer=None,
+        )
+        self.capture_bs = sorted(set(buckets))
+        self.max_bs = self.max_num_token = max(self.capture_bs)
+        self.captured_req_width = 1
+        self.capture_forward_mode = ForwardMode.DECODE
+        self.capture_hidden_mode = CaptureHiddenMode.NULL
+        self.enable_return_hidden_states = False
+        self.ragged_verify_mode = False
+        self.require_mlp_tp_gather = self.require_mlp_sync = False
+        self.enable_pdmux = self.enable_two_batch_overlap = False
+        self.is_encoder_decoder = self.is_dllm = self.disable_padding = False
+        self.seq_len_fill_value = 1
+        self.attn_backend = MetadataObserver()
+        self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
+        self.buffers = DecodeInputBuffers.create(
+            device=self.device,
+            max_bs=self.max_bs,
+            max_num_token=self.max_num_token,
+            hidden_size=2048,
+            next_token_logits_buffer=torch.empty(self.max_bs, 1, device=self.device),
+            dtype=torch.bfloat16,
+            dp_size=1,
+            pp_size=1,
+            is_encoder_decoder=False,
+            require_mlp_tp_gather=False,
+            seq_len_fill_value=1,
+            encoder_len_fill_value=0,
+            num_tokens_per_req=1,
+            cache_loc_dtype=torch.int64,
+            enable_mamba_track=False,
+        )
+        if share_inputs:
+            self.buffers.share_buffers()
+        self.buffer_registry = build_decode_registry(
+            device=self.device,
+            max_bs=self.max_bs,
+            max_num_token=self.max_num_token,
+            seq_len_fill_value=1,
+            cache_loc_dtype=torch.int64,
+            enable_num_token_non_padded=True,
+            share_pool=False,
+            source=self.buffers,
+        )
+        self.backend = (backend_factory or FullCudaGraphBackend)(self)
+        self.synthetic_forward = forward
+        self.capture_generations = 0
+        self.capture()
+
+    def capture(self):
+        # The callback supplies synthetic experts instead of initializing a
+        # language model. The backend still records actual CUDA Graphs.
+        self.stream = torch.cuda.Stream()
+        self.stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self.stream), self.backend.capture_session(self.stream):
+            for bucket in reversed(self.capture_bs):
+                self.buffers.num_token_non_padded.fill_(bucket)
+                batch = self.static_batch(bucket)
+                self.backend.capture_one(
+                    self._make_graph_key(bucket),
+                    lambda batch=batch: self.synthetic_forward(batch),
+                )
+        torch.cuda.current_stream().wait_stream(self.stream)
+        self.capture_generations += 1
+
+    def static_batch(self, bucket):
+        buffers = self.buffers
+        return ForwardBatch(
+            forward_mode=ForwardMode.DECODE,
+            batch_size=bucket,
+            input_ids=buffers.input_ids[:bucket],
+            req_pool_indices=buffers.req_pool_indices[:bucket],
+            seq_lens=buffers.seq_lens[:bucket],
+            out_cache_loc=buffers.out_cache_loc[:bucket],
+            seq_lens_sum=bucket,
+            positions=buffers.positions[:bucket],
+            num_token_non_padded=buffers.num_token_non_padded,
+            capture_hidden_mode=self.capture_hidden_mode,
+        )
+
+
+class SyntheticEagerRunner(EagerRunner):
+    """Model-free constructor; inherited execute/load_batch use the real registry."""
+
+    def __init__(self, forward, capacity):
+        self.enable_pdmux = False
+        self.model_runner = SimpleNamespace(
+            device_timer=None,
+            attn_backend=MetadataObserver(),
+            model=SimpleNamespace(
+                forward=lambda ids, positions, batch, **kwargs: forward(batch)
+            ),
+            _pp_kwargs=lambda tensors: {},
+            _extend_forward_kwargs=lambda batch, tensors: {},
+            prefill_cuda_graph_runner=None,
+        )
+        self._eager_registry = build_eager_registry(
+            device=torch.device("cuda", torch.cuda.current_device()),
+            max_bs=capacity,
+            max_num_token=capacity,
+            cache_loc_dtype=torch.int64,
+        )
+
+
+def input_batch(values, *, valid_rows=None, hidden_mode=CaptureHiddenMode.NULL):
+    values = torch.as_tensor(values, dtype=torch.int64, device="cuda")
+    count = len(values)
+    return ForwardBatch(
+        forward_mode=ForwardMode.DECODE,
+        batch_size=count,
+        input_ids=values,
+        req_pool_indices=torch.arange(count, device="cuda"),
+        seq_lens=torch.ones(count, dtype=torch.int64, device="cuda"),
+        out_cache_loc=torch.arange(count, device="cuda"),
+        seq_lens_sum=count,
+        seq_lens_cpu=torch.ones(count, dtype=torch.int64),
+        positions=torch.arange(count, device="cuda"),
+        num_token_non_padded=torch.tensor(
+            [count if valid_rows is None else valid_rows],
+            dtype=torch.int32,
+            device="cuda",
+        ),
+        capture_hidden_mode=hidden_mode,
+    )
+
+
+def exercise_inputs(*, recapture=False):
+    """Local ordinary CUDA Graph proof through the actual decode runner."""
+    from sglang.srt.layers.moe.utils import MoeA2ABackend
+    from sglang.srt.runtime_context import get_flags
+
+    get_flags().moe.a2a_backend = MoeA2ABackend.NONE
+
+    def forward(batch):
+        row = torch.arange(batch.batch_size, device="cuda")
+        output = torch.where(
+            row < batch.num_token_non_padded,
+            batch.input_ids * 2 + batch.positions,
+            -torch.ones_like(batch.input_ids),
+        )
+        return LogitsProcessorOutput(next_token_logits=output[:, None])
+
+    runner = SyntheticDecodeRunner(
+        forward, SimpleNamespace(barrier=lambda: None), buckets=(8, 16)
+    )
+    inputs = (
+        input_batch([1, 2, 3, 4, 5]),
+        input_batch(list(range(9)), valid_rows=0),
+        input_batch(
+            [1, 2, 3, 4, 5],
+            hidden_mode=CaptureHiddenMode.FULL if recapture else CaptureHiddenMode.NULL,
+        ),
+    )
+    expected = ([2, 5, 8, 11, 14], [-1] * 9, [2, 5, 8, 11, 14])
+    addresses = (
+        runner.buffers.input_ids.data_ptr(),
+        runner.buffers.positions.data_ptr(),
+    )
+    selected, valid = [], []
+    try:
+        for batch, wanted in zip(inputs, expected):
+            # A changed hidden mode triggers production load_batch's recapture.
+            # can_run_graph would normally select another runner for this
+            # request; call execute directly to cover its recapture contract.
+            actual = runner.execute(batch).next_token_logits
+            torch.testing.assert_close(
+                actual.cpu()[:, 0], torch.tensor(wanted), rtol=0, atol=0
+            )
+            selected.append(runner.attn_backend.views[-1].batch_size)
+            valid.append(int(runner.buffers.num_token_non_padded.item()))
+            assert addresses == (
+                runner.buffers.input_ids.data_ptr(),
+                runner.buffers.positions.data_ptr(),
+            )
+        assert not runner.can_run_graph(input_batch(list(range(17))))
+        return {
+            "selected_buckets": selected,
+            "valid_rows": valid,
+            "recapture_generations": runner.capture_generations,
+            "ep_tested": False,
+            "model_loaded": False,
+            "runner_constructor": "synthetic fixture; real load_batch/execute/backend",
+        }
+    finally:
+        torch.cuda.synchronize()
+        runner.backend.cleanup()

--- a/test/nccl_ep_test/sglang_graph.py
+++ b/test/nccl_ep_test/sglang_graph.py
@@ -11,32 +11,12 @@ import torch
 import torch.distributed as dist
 
 from .comparison import compare
-from .dispatcher import forward_layer, initialize, run_layer
+from .dispatcher import dispatchers_for, forward_layer, initialize, run_layer
 from .ep_audit import EpAudit
 from .oracle import RoutingBatch, expected_combine, make_fixture, validate_capacity
 
 CASES = ("balanced", "hotspot", "padding", "empty_rank", "all_masked")
 CHANGES = ("tokens", "routing", "weights", "all")
-
-
-def dispatchers_for(coordinator, layers):
-    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
-
-    return [
-        NcclEpDispatcher(
-            MoeRunnerConfig(
-                num_experts=4,
-                num_local_experts=2,
-                hidden_size=2048,
-                top_k=2,
-                params_dtype=torch.bfloat16,
-                layer_id=layer,
-            ),
-            coordinator,
-        )
-        for layer in range(layers)
-    ]
 
 
 def backend_for(coordinator, capacity):

--- a/test/nccl_ep_test/sglang_graph.py
+++ b/test/nccl_ep_test/sglang_graph.py
@@ -1,0 +1,452 @@
+"""Real two-rank SGLang LL dispatcher/full-Graph experiments, without weights.
+
+The expert arithmetic and model/attention constructors are synthetic. EP calls,
+FP8 quantization, Graph backend, input registry, and runner execution are real.
+"""
+
+import time
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from .comparison import compare
+from .dispatcher import forward_layer, initialize, run_layer
+from .ep_audit import EpAudit
+from .oracle import RoutingBatch, expected_combine, make_fixture, validate_capacity
+
+CASES = ("balanced", "hotspot", "padding", "empty_rank", "all_masked")
+CHANGES = ("tokens", "routing", "weights", "all")
+
+
+def dispatchers_for(coordinator, layers):
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+    return [
+        NcclEpDispatcher(
+            MoeRunnerConfig(
+                num_experts=4,
+                num_local_experts=2,
+                hidden_size=2048,
+                top_k=2,
+                params_dtype=torch.bfloat16,
+                layer_id=layer,
+            ),
+            coordinator,
+        )
+        for layer in range(layers)
+    ]
+
+
+def backend_for(coordinator, capacity):
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    return FullCudaGraphBackend(
+        SimpleNamespace(
+            device_module=torch.cuda, model_runner=SimpleNamespace(tp_group=coordinator)
+        ),
+        nccl_ep_capacity=capacity,
+    )
+
+
+def gpu_inputs(batch, rank):
+    return tuple(
+        value[rank].cuda() for value in (batch.tokens, batch.expert_ids, batch.weights)
+    )
+
+
+def close_runtime(coordinator, audit):
+    import nccl.core as core
+
+    from sglang.srt.distributed.parallel_state import destroy_model_parallel
+
+    # Public production shutdown first closes registered EP resources. This
+    # experiment owns its additional PyNccl communicator (no __del__ in the
+    # pinned revision), so close that explicitly after observing EP closure.
+    destroy_model_parallel()
+    evidence = audit.assert_closed()
+    core.Communicator(ptr=coordinator.pynccl_comm.comm.value).destroy()
+    coordinator.pynccl_comm.available = False
+    coordinator.pynccl_comm.disabled = True
+    dist.destroy_process_group()
+    evidence["experiment_communicator_destroyed"] = True
+    return evidence
+
+
+def exercise_graph(
+    *, mode, buckets=(8, 16, 32), replays=1000, layers=2, generations=2, identity=False
+):
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    buckets = sorted(set(buckets))
+    capacity, eager_capacity = max(buckets), min(1024, 2 * max(buckets))
+    rank, coordinator, bindings = initialize(eager_capacity, graph_enabled=True)
+    checked, timings, setup_times = 0, [], []
+    # Native/peer failures are bounded by torchrun + the external timeout. Do
+    # not enter collective cleanup or a success barrier from a failure finally.
+    with EpAudit() as audit:
+        dispatchers = dispatchers_for(coordinator, layers)
+        backend = backend_for(coordinator, capacity)
+        static = [
+            gpu_inputs(make_fixture(capacity, step=layer), rank)
+            for layer in range(layers)
+        ]
+        capture_stream = torch.cuda.Stream()
+        replay_streams = (torch.cuda.Stream(), torch.cuda.Stream())
+
+        def forward(bucket):
+            return [
+                forward_layer(
+                    dispatcher,
+                    *(item[:bucket] for item in inputs),
+                    rank,
+                    identity=identity,
+                )
+                for dispatcher, inputs in zip(dispatchers, static)
+            ]
+
+        for generation in range(generations):
+            started = time.perf_counter()
+            capture_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(capture_stream), backend.capture_session(
+                capture_stream
+            ):
+                for bucket in reversed(buckets):
+                    backend.capture_one(
+                        ShapeKey(bucket), lambda bucket=bucket: forward(bucket)
+                    )
+            torch.cuda.synchronize()
+            setup_times.append(time.perf_counter() - started)
+            update_count = sum(
+                item["operation"] == "handle_update" for item in audit.events
+            )
+            count = replays if mode == "dynamic" else 3
+            for iteration in range(count):
+                bucket = buckets[iteration % len(buckets)]
+                visit = iteration // len(buckets)
+                step = (0, 1, 0)[visit % 3]
+                case = (
+                    CASES[(visit // 3) % len(CASES)]
+                    if mode == "dynamic"
+                    else "balanced"
+                )
+                change = (
+                    CHANGES[(visit // (3 * len(CASES))) % len(CHANGES)]
+                    if mode == "dynamic"
+                    else "all"
+                )
+                batches = [
+                    make_fixture(bucket, case=case, step=step + layer, change=change)
+                    for layer in range(layers)
+                ]
+                for batch in batches:
+                    validate_capacity(batch, capacity)
+                live = [gpu_inputs(batch, rank) for batch in batches]
+                stream = replay_streams[iteration % 2]
+                stream.wait_stream(torch.cuda.current_stream())
+                start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(
+                    enable_timing=True
+                )
+                with torch.cuda.stream(
+                    stream
+                ), backend.replay_session(), torch.cuda.nvtx.range(
+                    f"sglang_nccl_ep_graph/{bucket}"
+                ):
+                    start.record()
+                    for inputs, sources in zip(static, live):
+                        for target, source in zip(inputs, sources):
+                            target[:bucket].copy_(source)
+                    actual = backend.replay(ShapeKey(bucket), None)
+                    end.record()
+                end.synchronize()
+                timings.append(start.elapsed_time(end))
+                if iteration % 17 == 0:
+                    # Keep Graph outputs live across larger eager scratch use.
+                    run_layer(
+                        dispatchers[0],
+                        make_fixture(eager_capacity, case="hotspot", step=1),
+                        rank,
+                        identity=identity,
+                    )
+                    checked += 1
+                for batch, output in zip(batches, actual):
+                    compare(batch, rank, *output, identity=identity)
+                    checked += 1
+            assert update_count == sum(
+                item["operation"] == "handle_update" for item in audit.events
+            ), "Python update ran during replay"
+            backend.cleanup()
+        resources = close_runtime(coordinator, audit)
+    return {
+        "implementation": "sglang_dispatcher_full_graph",
+        "mode": mode,
+        "checked": checked,
+        "buckets": buckets,
+        "layers": layers,
+        "generations": generations,
+        "replays_per_generation": count,
+        "graph_capacity": capacity,
+        "eager_capacity": eager_capacity,
+        "changed_components": list(CHANGES) if mode == "dynamic" else ["all"],
+        "replay_ms": timings,
+        "warmup_capture_seconds": setup_times,
+        "measurement_scope": "Synthetic full step including GPU input copies, expert work and observation snapshots; oracle and fixture generation excluded",
+        "bindings": bindings,
+        "resources": resources,
+        "fp8_scales_applied": True,
+        "tolerance": {"rtol": 0, "atol": 0},
+        "model_loaded": False,
+    }
+
+
+def runner_fixture(bucket, values, valid_rows, *, layer=0):
+    """Literal CPU routing table, independent of the GPU router arithmetic."""
+    tables = (
+        {0: [0, 2], 1: [1, 3], 2: [2, 0], 4: [0, 2], 8: [0, 2]},
+        {0: [1, 3], 1: [2, 0], 2: [3, 1], 4: [1, 3], 8: [1, 3]},
+    )
+    tokens, ids, weights = [], [], []
+    pattern = torch.tensor([1, 2, 4, 8] * 4).repeat_interleave(128)
+    for rank in range(2):
+        padded = list(values[rank]) + [0] * (bucket - len(values[rank]))
+        tokens.append((torch.tensor(padded)[:, None] * pattern * 2**layer).bfloat16())
+        routes = torch.tensor([tables[rank][value] for value in padded])
+        routes[valid_rows[rank] :] = -1
+        ids.append(routes)
+        weights.append(
+            torch.tensor(
+                [[0.75, 0.25] if value == 1 else [0.25, 0.75] for value in padded]
+            )
+        )
+    batch = RoutingBatch(tuple(tokens), tuple(ids), tuple(weights), 4)
+    validate_capacity(batch, bucket)
+    return batch
+
+
+def runner_routing(batch, rank):
+    """Synthetic GPU router feeding the real SGLang CUDA padding-mask kernel."""
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    values = batch.input_ids
+    pattern = (2.0 ** (torch.arange(2048, device=values.device) // 128 % 4)).bfloat16()
+    x = values[:, None].bfloat16() * pattern
+
+    def router(**kwargs):
+        first = (values + rank) % 4
+        routes = torch.stack((first, (first + 2) % 4), dim=1).int()
+        left = torch.where(values % 2 == 1, 0.75, 0.25)
+        return torch.stack((left, 1 - left), dim=1), routes
+
+    config = TopKConfig(
+        top_k=2, custom_routing_function=router, allow_routed_experts_capture=False
+    )
+    topk = select_experts(
+        x,
+        torch.zeros(len(values), 4, device=values.device),
+        config,
+        num_token_non_padded=batch.num_token_non_padded,
+    )
+    return x, topk.topk_ids, topk.topk_weights
+
+
+def exercise_runner(
+    *, buckets=(8, 16, 32), layers=2, generations=2, identity=False, **unused
+):
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    from .runner_inputs import SyntheticDecodeRunner, input_batch
+
+    buckets = sorted(set(buckets))
+    if len(buckets) < 2 or buckets[0] < 2:
+        raise ValueError("Runner probe requires at least two buckets, smallest >= 2")
+    rank, coordinator, bindings = initialize(max(buckets), graph_enabled=True)
+    observations, selected, checked = {}, [], 0
+    with EpAudit() as audit:
+        dispatchers = dispatchers_for(coordinator, layers)
+
+        def forward(batch):
+            x, ids, weights = runner_routing(batch, rank)
+            result = [
+                forward_layer(
+                    dispatcher, x * 2**layer, ids, weights, rank, identity=identity
+                )
+                for layer, dispatcher in enumerate(dispatchers)
+            ]
+            if torch.cuda.is_current_stream_capturing():
+                observations[batch.batch_size] = result
+            return LogitsProcessorOutput(
+                next_token_logits=torch.cat([item[2] for item in result], dim=1)
+            )
+
+        runner = SyntheticDecodeRunner(
+            forward,
+            coordinator,
+            buckets=buckets,
+            backend_factory=lambda runner: FullCudaGraphBackend(
+                runner, nccl_ep_capacity=max(buckets)
+            ),
+        )
+        streams = (torch.cuda.Stream(), torch.cuda.Stream())
+        input_addresses = (
+            runner.buffers.input_ids.data_ptr(),
+            runner.buffers.num_token_non_padded.data_ptr(),
+        )
+        for generation in range(generations):
+            pending = []
+            mode = (
+                CaptureHiddenMode.NULL
+                if generation % 2 == 0
+                else CaptureHiddenMode.FULL
+            )
+            for iteration, raw in enumerate(
+                (max(1, buckets[0] - 3), buckets[0] + 1, max(1, buckets[0] - 3))
+            ):
+                bucket = next(value for value in buckets if value >= raw)
+                values = tuple(
+                    [
+                        [1, 2, 4, 8][(row + (0, 1, 0)[iteration] + rank_index) % 4]
+                        for row in range(raw)
+                    ]
+                    for rank_index in range(2)
+                )
+                valid = (0 if iteration == 1 else raw, raw)
+                fixtures = [
+                    runner_fixture(bucket, values, valid, layer=layer)
+                    for layer in range(layers)
+                ]
+                incoming = input_batch(
+                    values[rank], valid_rows=valid[rank], hidden_mode=mode
+                )
+                stream = streams[iteration % 2]
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    output = runner.execute(incoming).next_token_logits
+                    # Queue a caller's read after execute/replay_session returns.
+                    # The next stream's input writes must wait for this consumer.
+                    torch.cuda._sleep(2_000_000)
+                    consumed = output.clone()
+                    captured = [
+                        tuple(item.clone() for item in result)
+                        for result in observations[bucket]
+                    ]
+                pending.append((raw, fixtures, consumed, captured, incoming))
+                selected.append(runner.attn_backend.views[-1].batch_size)
+                assert selected[-1] == bucket
+                assert input_addresses == (
+                    runner.buffers.input_ids.data_ptr(),
+                    runner.buffers.num_token_non_padded.data_ptr(),
+                )
+            torch.cuda.synchronize()
+            for raw, fixtures, output, captured, incoming in pending:
+                for fixture, result in zip(fixtures, captured):
+                    compare(fixture, rank, *result, identity=identity)
+                    checked += 1
+                wanted = torch.cat(
+                    [
+                        expected_combine(fixture, identity=identity)[rank]
+                        for fixture in fixtures
+                    ],
+                    dim=1,
+                )[:raw]
+                torch.testing.assert_close(output.cpu().float(), wanted, rtol=0, atol=0)
+            assert runner.capture_generations == generation + 1
+        runner.backend.cleanup()
+        resources = close_runtime(coordinator, audit)
+    return {
+        "implementation": "sglang_decode_runner",
+        "bindings": bindings,
+        "checked": checked,
+        "selected_buckets": selected,
+        "layers": layers,
+        "generations": runner.capture_generations,
+        "resources": resources,
+        "input_addresses_stable": True,
+        "delayed_output_consumers": True,
+        "actual_topk_padding_mask": True,
+        "tolerance": {"rtol": 0, "atol": 0},
+        "constructor_and_model": "synthetic",
+        "model_loaded": False,
+    }
+
+
+def exercise_cleanup(*, buckets=(8, 16, 32), layers=2, identity=False, **unused):
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    bucket = max(buckets)
+    rank, coordinator, bindings = initialize(bucket, graph_enabled=True)
+    retained_failures, checked = [], 0
+    with EpAudit() as audit:
+        dispatchers = dispatchers_for(coordinator, layers)
+        backend = backend_for(coordinator, bucket)
+        static = [
+            gpu_inputs(make_fixture(bucket, step=layer), rank)
+            for layer in range(layers)
+        ]
+        fail = True
+
+        def forward():
+            result = [
+                forward_layer(dispatcher, *inputs, rank, identity=identity)
+                for dispatcher, inputs in zip(dispatchers, static)
+            ]
+            if fail and torch.cuda.is_current_stream_capturing():
+                raise RuntimeError("controlled failure after completed combine")
+            return result
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                backend.capture_one(ShapeKey(bucket), forward)
+        except RuntimeError as error:
+            if str(error) != "controlled failure after completed combine":
+                raise
+            retained_failures.append(
+                error
+            )  # Keep traceback/executable references alive.
+        else:
+            raise AssertionError("Controlled capture failure did not occur")
+        graph_groups = [
+            item for item in audit.groups.values() if item["rdma_buffer_size"] == 0
+        ]
+        assert len(graph_groups) == 1 and all(item["closed"] for item in graph_groups)
+        assert all(graph.audit_reset for graph in audit.graphs)
+        fail = False
+        with torch.cuda.stream(stream), backend.capture_session(stream):
+            backend.capture_one(ShapeKey(bucket), forward)
+        torch.cuda.current_stream().wait_stream(stream)
+        for step in (0, 1, 0):
+            batches = [
+                make_fixture(bucket, case="hotspot", step=step + layer)
+                for layer in range(layers)
+            ]
+            with backend.replay_session():
+                for batch, inputs in zip(batches, static):
+                    for target, source in zip(inputs, gpu_inputs(batch, rank)):
+                        target.copy_(source)
+                actual = backend.replay(ShapeKey(bucket), None)
+            for batch, result in zip(batches, actual):
+                compare(batch, rank, *result, identity=identity)
+                checked += 1
+        backend.cleanup()
+        resources = close_runtime(coordinator, audit)
+    return {
+        "implementation": "sglang_controlled_capture_failure",
+        "bindings": bindings,
+        "checked": checked,
+        "layers": layers,
+        "generations": 2,
+        "resources": resources,
+        "controlled_failures": len(retained_failures),
+        "failure_traceback_retained": True,
+        "recovery_scope": "host failure after completed combine; GPU/peer faults require process restart",
+        "tolerance": {"rtol": 0, "atol": 0},
+        "model_loaded": False,
+    }

--- a/test/nccl_ep_test/sglang_non_ep.py
+++ b/test/nccl_ep_test/sglang_non_ep.py
@@ -1,0 +1,94 @@
+"""Real SGLang routing-mask and masked FP8 kernels on an ordinary CUDA Graph."""
+
+import torch
+
+from .oracle import dequantize_fp8
+
+
+def exercise_topk_fp8(*, routing_dtype=torch.int32):
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+    from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+    hidden, rows = 2048, 8
+    payload = torch.ones(2, rows, hidden, dtype=torch.bfloat16, device="cuda")
+    ids = torch.tensor([[0, 2]] * rows, dtype=routing_dtype, device="cuda")
+    weights = torch.tensor([[0.25, 0.75]] * rows, device="cuda")
+    valid = torch.tensor([5], dtype=torch.int32, device="cuda")
+    counts = torch.tensor([5, 5], dtype=torch.int32, device="cuda")
+    logits = torch.zeros(rows, 4, device="cuda")
+
+    def router(**kwargs):
+        # A synthetic router is deliberately padding-unaware. The actual
+        # select_experts postprocessing must mask its nonzero padded routes.
+        return weights.clone(), ids.clone()
+
+    config = TopKConfig(
+        top_k=2,
+        custom_routing_function=router,
+        allow_routed_experts_capture=False,
+    )
+
+    def forward():
+        topk = select_experts(payload[0], logits, config, num_token_non_padded=valid)
+        quantized, scales = sglang_per_token_group_quant_fp8(
+            payload, group_size=128, masked_m=counts
+        )
+        return topk, dequantize_fp8(quantized, scales), scales
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            forward()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            topk, reconstructed, scales = forward()
+    torch.cuda.current_stream().wait_stream(stream)
+    observed = []
+    try:
+        for step, count in ((0, 5), (1, 0), (0, 5)):
+            # Distinct block scales exercise all H/128 scale positions.
+            block = torch.arange(hidden, device="cuda") // 128 % 4
+            exact = (2.0 ** (block + step)).to(torch.bfloat16)
+            payload.copy_(exact.expand_as(payload))
+            ids.copy_(
+                torch.tensor([[0, 2] if step == 0 else [1, 3]] * rows, device="cuda")
+            )
+            weights.copy_(
+                torch.tensor(
+                    [[0.25, 0.75] if step == 0 else [0.75, 0.25]] * rows, device="cuda"
+                )
+            )
+            valid.fill_(count)
+            counts.fill_(count)
+            graph.replay()
+            wanted_ids = torch.tensor(
+                [[0, 2] if step == 0 else [1, 3]] * rows, dtype=routing_dtype
+            )
+            wanted_ids[count:] = -1
+            torch.testing.assert_close(topk.topk_ids.cpu(), wanted_ids, rtol=0, atol=0)
+            # Masking must work even though the real CUDA path retains weights.
+            torch.testing.assert_close(topk.topk_weights, weights, rtol=0, atol=0)
+            torch.testing.assert_close(
+                reconstructed[:, :count], payload[:, :count], rtol=0, atol=0
+            )
+            if count:
+                assert (scales[:, :count] > 0).all()
+                assert torch.unique(scales[:, :count]).numel() == 4
+            observed.append(count)
+        return {
+            "valid_rows": observed,
+            "scales_applied": True,
+            "hidden": hidden,
+            "routing_dtype": str(routing_dtype),
+            "ep_tested": False,
+            "operations": [
+                "select_experts CUDA masking",
+                "masked 3D FP8 quant/dequant",
+            ],
+        }
+    finally:
+        torch.cuda.synchronize()
+        graph.reset()

--- a/test/nccl_ep_test/validation.md
+++ b/test/nccl_ep_test/validation.md
@@ -1,0 +1,89 @@
+# Recorded NCCL EP validation
+
+The two-rank execution snapshot is based on PR #32329 commit
+`efd30456466549fd2be6131eaba0edd8972506a4`. The validated implementation patch has
+SHA256 `7227531565825e203c3fdc71fbdf14e013c2ec01a08f03c831aa280d46a67c1e`.
+PR preparation relocates the shared harness, registers the unit tests, provides
+an in-tree CLI, and adds installation metadata/documentation. Those changes must
+not be confused with a fresh two-GPU run of the final submission commit.
+
+## Environment
+
+Recorded on 2026-09-09: two RTX PRO 6000 Blackwell Server Edition GPUs (SM120),
+SYS topology with bidirectional direct CUDA peer access, Ubuntu 22.04.5,
+Python 3.12.12, driver 595.71.05, CUDA Toolkit 13.0.88. The driver advertises CUDA
+compatibility 13.2; Torch's CUDA build is 13.0. The official Torch
+`2.11.0+cu130` wheel was used with `nccl4py==0.4.1`,
+`nccl-extensions==0.1.0`, and the explicit NCCL 2.30.7 override. Torch's NCCL
+compile-time query returns 2.28.9; the actual mapped library returns 23007.
+
+## Correctness
+
+All counts below are per rank unless stated otherwise. All comparisons use
+`rtol=0, atol=0` with exactly representable fixtures.
+
+| Test | Result |
+| --- | --- |
+| CPU oracle | 180 fixtures passed |
+| Native eager, weighted and identity experts | 180 checks per mode |
+| SGLang eager including FP8 conversion, weighted and identity experts | 360 checks per mode |
+| Native / SGLang single-bucket Graph | 4 checks each |
+| Native / SGLang dynamic Graph matrix | 4118 checks each |
+| Actual runner input loading, streams, padding and recapture | 12 checks |
+| Controlled host capture failure, cleanup and fresh capture | 6 checks |
+| Separate native true T=0 / capacity-controlled duplicate-expert probes | Both passed |
+
+Dynamic tests use buckets 8/16/32, two layers, two capture generations and 1000
+replays per generation. The native continuation descriptor-lifetime failure found
+on hardware is covered by the corrected implementation and a weak-reference mock
+regression. All required graph, handle and group closures were observed. The
+matrix verifier checked 27 required reports and the 2942-file source inventory.
+
+The submitted registered tests also passed locally on RTX 4060 Laptop (SM89):
+88 tests across the six NCCL EP files, including real CUDA Graphs with fake EP.
+That local environment uses the historical Torch `2.11.0+cu130.nccl2307` build;
+only the target-hardware results above use the official Torch wheel.
+
+Full-model serving, model accuracy, real expert GEMMs, concurrent replay and
+cross-node execution were not evaluated. True T=0 and duplicate-expert probes
+are native eager input checks, not a SGLang Graph input contract.
+
+## Unprofiled synthetic-step latency
+
+Four rounds of 200 samples per mode/rank, 20 warmups per block, alternating
+mode order. Take the maximum across aligned rank samples before median/p95.
+The measured step includes GPU input copies, two synthetic expert layers,
+receive snapshots, retained combine results and host launch gaps.
+
+| Tokens/rank | Routing | Eager median / p95 (ms) | Graph median / p95 (ms) | Median ratio |
+| --- | --- | --- | --- | --- |
+| 8 | balanced | 0.7774 / 1.1629 | 0.1413 / 0.1671 | 5.50x |
+| 8 | hotspot | 0.7676 / 0.8485 | 0.1440 / 0.1561 | 5.33x |
+| 16 | balanced | 0.7708 / 0.9042 | 0.1526 / 0.1783 | 5.05x |
+| 16 | hotspot | 0.7755 / 0.8583 | 0.1582 / 0.1833 | 4.90x |
+| 32 | balanced | 0.7790 / 0.9509 | 0.1756 / 0.2011 | 4.44x |
+| 32 | hotspot | 0.7747 / 0.8736 | 0.1884 / 0.2143 | 4.11x |
+
+These ratios measure the complete serial synthetic step, not isolated EP kernels
+or model throughput. They do not establish equivalence to a PIX/PXB/NVLink pair.
+
+## Nsight Systems
+
+Nsight Systems 2025.3.1, separate run with CUDA Graph node tracing:
+4000 NVTX replay ranges correspond to 4000 Graph launches; each GPU records
+8000 dispatch and 8000 combine kernel instances as Graph nodes. Recorded replay
+host ranges contain no CUDA device allocation/free, Graph instantiation/destruction,
+or module/library loads. Harness copies and event operations remain present.
+Both rank oracles pass under profiling. Profiling and rank-arrival skew were not
+isolated from communication cost; the profiled dispatch tail is not a SYS-link
+latency measurement.
+
+## Evidence identifiers
+
+The raw matrix, rank JSON, benchmark samples and Nsight trace are retained outside
+the source tree to avoid committing generated binary evidence. The identifiers
+below allow an attached archive to be verified; hashes are not download links.
+
+- Matrix JSON SHA256: `55d6706e00958bb6f1b3c18bd01459dacdab662df7f9af7d7b5b9c41bd57bc57`
+- `server-final-evidence.tar.gz` SHA256: `dc2f588b808ab3375ccc026c0105eee0b16e85c7fb5d31c1a3cafbb415253793`
+- `target-jit-evidence.tar.gz` SHA256: `b8a1b38934712f50d58ff465c127bdb0cf24f94d7c7ae045a8b6a9820e893d82`

--- a/test/nccl_ep_test/validation.md
+++ b/test/nccl_ep_test/validation.md
@@ -4,7 +4,8 @@ The two-rank execution snapshot is based on PR #32329 commit
 `efd30456466549fd2be6131eaba0edd8972506a4`. The validated implementation patch has
 SHA256 `7227531565825e203c3fdc71fbdf14e013c2ec01a08f03c831aa280d46a67c1e`.
 PR preparation relocates the shared harness, registers the unit tests, provides
-an in-tree CLI, and adds installation metadata/documentation. Those changes must
+an in-tree CLI, shares test factories, reorders unchanged resource declarations,
+and adds installation metadata/documentation. Those changes must
 not be confused with a fresh two-GPU run of the final submission commit.
 
 ## Environment
@@ -41,6 +42,11 @@ matrix verifier checked 27 required reports and the 2942-file source inventory.
 
 The submitted registered tests also passed locally on RTX 4060 Laptop (SM89):
 88 tests across the six NCCL EP files, including real CUDA Graphs with fake EP.
+The combined NCCL EP and existing runtime/configuration/input-buffer selection
+passes 202 tests and 8 subtests. Changed production-line coverage is 89% against
+the fixed parent SHA (repository threshold: 60%). Both Mintlify checks and the
+full pre-commit hook set pass.
+
 That local environment uses the historical Torch `2.11.0+cu130.nccl2307` build;
 only the target-hardware results above use the official Torch wheel.
 

--- a/test/registered/unit/layers/moe/test_nccl_ep_benchmark.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_benchmark.py
@@ -1,0 +1,178 @@
+"""Timing driver correctness on real CUDA/fake EP; no communication speed claim."""
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+from nccl_ep_test.benchmark import METRICS, benchmark_steps, summarize_pair
+from nccl_ep_test.oracle import RoutingBatch
+
+
+def local_fixture(bucket, *, case, step, change):
+    assert case == "balanced" and change == "all"
+    x = torch.full((bucket, 2048), 2 ** (step % 3), dtype=torch.bfloat16)
+    ids = torch.tensor([[1, 0] if step % 2 else [0, 1]] * bucket)
+    weights = torch.tensor([[0.75, 0.25] if step % 2 else [0.25, 0.75]] * bucket)
+    return RoutingBatch((x,), (ids,), (weights,), 2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Real CUDA required")
+def test_matched_driver_changes_inputs_and_preserves_both_layer_outputs():
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    with dispatcher_environment(capacity=16) as ep:
+        result = benchmark_steps(
+            0,
+            ep.coordinator,
+            [ep.dispatcher(layer_id=i) for i in range(2)],
+            buckets=(8, 16),
+            cases=("balanced",),
+            samples=4,
+            warmups=2,
+            rounds=2,
+            fixture=local_fixture,
+        )
+        assert result["checked"] == 48
+        assert len(result["records"]) == 8
+        assert [r["mode"] for r in result["records"]] == [
+            "eager",
+            "graph",
+            "graph",
+            "eager",
+        ] * 2
+        assert all(
+            r["statistics_ms"][m]["count"] == 4
+            for r in result["records"]
+            for m in METRICS
+        )
+        # One dedicated Graph group and one separate eager group. The Graph
+        # group keeps a single handle while eager creates per-step handles.
+        assert len(ep.groups) == 2
+        graph = next(g for g in ep.groups if g.config.rdma_buffer_size == 0)
+        assert len(graph.handles) == 1 and graph.destroyed
+    assert "native_ep_tested" not in result
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Real CUDA required")
+def test_benchmark_does_not_publish_timings_after_oracle_failure(monkeypatch, tmp_path):
+    import nccl_ep_test.benchmark as benchmark
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    monkeypatch.setenv("NCCL_EP_REPORT_DIR", str(tmp_path))
+    original = benchmark.forward_layer
+
+    def corrupt(*args, **kwargs):
+        received, counters, combined = original(*args, **kwargs)
+        return received, counters, combined * 0
+
+    monkeypatch.setattr(benchmark, "forward_layer", corrupt)
+    with dispatcher_environment(capacity=8) as ep:
+        with pytest.raises(AssertionError):
+            benchmark_steps(
+                0,
+                ep.coordinator,
+                [ep.dispatcher(layer_id=i) for i in range(2)],
+                buckets=(8,),
+                cases=("balanced",),
+                samples=2,
+                warmups=2,
+                rounds=2,
+                fixture=local_fixture,
+            )
+    assert list(tmp_path.glob("mismatch-rank0-*.pt"))
+
+
+def synthetic_pair():
+    reports = []
+    for rank in (0, 1):
+        records = []
+        for rnd in range(2):
+            for mode in ("eager", "graph"):
+                factor = (2 if mode == "eager" else 1) * (rank + 1)
+                records.append(
+                    {
+                        "bucket": 8,
+                        "case": "balanced",
+                        "round": rnd,
+                        "mode": mode,
+                        "samples": {m: [factor, 2 * factor] for m in METRICS},
+                    }
+                )
+        reports.append(
+            {
+                "rank": rank,
+                "status": "PASS",
+                "synthetic_fixture": True,
+                "result": {
+                    "native_ep_tested": True,
+                    "resource_cleanup_returned": True,
+                    "tolerance": {"rtol": 0, "atol": 0},
+                    "config": {
+                        "buckets": [8],
+                        "cases": ["balanced"],
+                        "rounds": 2,
+                        "samples_per_round": 2,
+                    },
+                    "records": records,
+                },
+            }
+        )
+    return reports
+
+
+def test_summary_aligns_ranks_and_reports_raw_sample_count():
+    summary = summarize_pair(synthetic_pair())
+    row = summary["rows"][0]
+    eager = row["modes"]["eager"]["cuda_step_ms"]
+    assert eager["rank0"]["median"] == 3
+    assert eager["rank1"]["median"] == 6
+    assert eager["max_rank_per_sample"] == {"count": 4, "median": 6, "p95": 8}
+    assert row["median_speedup"] == {"cuda_step_ms": 2, "host_step_ms": 2}
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing_rank",
+        "skip",
+        "local_fake",
+        "config",
+        "block",
+        "duplicate",
+        "samples",
+        "nan",
+    ],
+)
+def test_incomplete_or_invalid_benchmark_cannot_produce_speedup(case):
+    reports = copy.deepcopy(synthetic_pair())
+    result = reports[1]["result"]
+    if case == "missing_rank":
+        reports.pop()
+    elif case == "skip":
+        reports[1]["status"] = "SKIP"
+    elif case == "local_fake":
+        result["native_ep_tested"] = False
+    elif case == "config":
+        result["config"]["rounds"] = 4
+    elif case == "block":
+        result["records"].pop()
+    elif case == "duplicate":
+        result["records"].append(result["records"][0])
+    elif case == "samples":
+        result["records"][0]["samples"]["cuda_step_ms"].pop()
+    else:
+        result["records"][0]["samples"]["cuda_step_ms"][0] = float("nan")
+    with pytest.raises(ValueError):
+        summarize_pair(reports)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_capability_contracts.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_capability_contracts.py
@@ -1,0 +1,234 @@
+"""Public NCCL EP contracts identified by review; native EP is replaced."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from registered.unit.layers.moe.test_nccl_ep_graph_config import (  # noqa: F401
+    ep_bindings,
+    model_path,
+    server_args,
+)
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="The CUDA configuration path is required"
+)
+
+
+@pytest.fixture
+def supported_gpu(monkeypatch):
+    torch.cuda.init()
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (9, 0))
+
+
+@pytest.mark.parametrize("graph", [False, True])
+def test_default_ep_spans_tp(model_path, supported_gpu, graph):
+    args = server_args(model_path, tp_size=2, enable_nccl_ep_cuda_graph=graph)
+    assert args.ep_size == 2
+    assert args._resolved().ep_size == 2
+
+
+@pytest.mark.parametrize("dp", [1, 2])
+@pytest.mark.parametrize("chunk", [None, 8192, 128])
+def test_prefill_fits_native_capacity(model_path, supported_gpu, dp, chunk):
+    kwargs = {} if chunk is None else {"chunked_prefill_size": chunk}
+    args = server_args(
+        model_path,
+        tp_size=2,
+        dp_size=dp,
+        enable_dp_attention=dp == 2,
+        nccl_ep_num_max_dispatch_tokens_per_rank=64,
+        **kwargs,
+    )
+    assert 0 < args.chunked_prefill_size <= 64
+    assert args._resolved().chunked_prefill_size == args.chunked_prefill_size
+
+
+def test_disabled_chunking_is_rejected(model_path, supported_gpu):
+    with pytest.raises(ValueError, match="NCCL EP.*chunked prefill"):
+        server_args(model_path, chunked_prefill_size=-1)
+
+
+@pytest.mark.parametrize("mixed_tokens", [0, 7])
+def test_long_prefill_scheduler_respects_ll_capacity(
+    model_path, supported_gpu, mixed_tokens
+):
+    from types import SimpleNamespace
+
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.managers.schedule_policy import PrefillAdder
+    from sglang.srt.runtime_context import get_context
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    args = server_args(model_path, nccl_ep_num_max_dispatch_tokens_per_rank=64)
+    context = get_context()
+    with context.preserve_config():
+        context.set_server_args(args)
+        req = Req("long", "", list(range(257)), SamplingParams(max_new_tokens=8))
+        req.full_untruncated_fill_ids = req.origin_input_ids
+        req.prefix_indices = []
+        consumed = 0
+        forwards = 0
+        while consumed < 257:
+            adder = PrefillAdder(
+                page_size=1,
+                tree_cache=SimpleNamespace(
+                    supports_mamba=lambda: False, evictable_size=lambda: 0
+                ),
+                token_to_kv_pool_allocator=SimpleNamespace(
+                    available_size=lambda: 10000
+                ),
+                running_batch=None,
+                new_token_ratio=1,
+                rem_input_tokens=args.max_prefill_tokens,
+                rem_chunk_tokens=args.chunked_prefill_size,
+                num_mixed_decode_tokens=mixed_tokens,
+            )
+            remaining = adder.add_chunked_req(req)
+            rows = req.extend_range.length
+            assert 0 < rows + mixed_tokens <= 64
+            consumed += rows
+            req.prefix_indices = list(range(consumed))
+            assert (remaining is None) == (consumed == 257)
+            forwards += 1
+        assert forwards > 1
+
+
+@pytest.mark.parametrize("budget,expected", [(65, 64), (64, 64), (32, 32)])
+def test_prefill_budget_respects_kv_pages(model_path, supported_gpu, budget, expected):
+    args = server_args(
+        model_path, page_size=16, nccl_ep_num_max_dispatch_tokens_per_rank=budget
+    )
+    assert args.chunked_prefill_size == expected
+
+
+def test_budget_smaller_than_a_page_is_rejected(model_path, supported_gpu):
+    with pytest.raises(ValueError, match="NCCL EP.*KV page"):
+        server_args(
+            model_path, page_size=16, nccl_ep_num_max_dispatch_tokens_per_rank=8
+        )
+
+
+def test_pp_dynamic_chunk_growth_is_rejected(model_path, supported_gpu):
+    with pytest.raises(ValueError, match="NCCL EP.*dynamic chunking"):
+        server_args(model_path, pp_size=2, enable_dynamic_chunking=True)
+
+
+@pytest.mark.parametrize(
+    "overlap", ["enable_single_batch_overlap", "enable_two_batch_overlap"]
+)
+def test_non_triton_overlap_is_rejected(model_path, supported_gpu, overlap):
+    with pytest.raises(ValueError, match="NCCL EP.*overlap"):
+        server_args(model_path, moe_runner_backend="deep_gemm", **{overlap: True})
+
+
+def test_triton_unavailable_fallback_uses_standard_dispatch(model_path, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (8, 9))
+    monkeypatch.setattr("sglang.srt.server_args._deepep_importable", lambda: True)
+    args = server_args(model_path, tp_size=2)
+    assert args.moe_a2a_backend == "none"
+    assert args.moe_runner_backend == "triton"
+
+
+def test_deepep_fallback_also_resolves_tp_spanning_ep(model_path, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (8, 9))
+    monkeypatch.setattr("sglang.srt.server_args._deepep_importable", lambda: True)
+    args = server_args(model_path, tp_size=2, moe_runner_backend="deep_gemm")
+    assert args.moe_a2a_backend == "deepep"
+    assert args.ep_size == args._resolved().ep_size == 2
+
+
+def test_blackwell_scale_mode_is_rejected_by_public_gate(model_path, monkeypatch):
+    from sglang.srt.layers import deep_gemm_wrapper
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: (10, 0))
+    monkeypatch.setattr(deep_gemm_wrapper, "DEEPGEMM_BLACKWELL", True)
+    with pytest.raises(ValueError, match="NCCL EP.*UE8M0"):
+        server_args(model_path, enable_nccl_ep_cuda_graph=True)
+
+
+@pytest.mark.parametrize("capability", [(9, 0), (12, 0)])
+def test_float_scale_gpu_remains_available(model_path, monkeypatch, capability):
+    from sglang.srt.layers import deep_gemm_wrapper
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *a, **k: capability)
+    monkeypatch.setattr(deep_gemm_wrapper, "DEEPGEMM_BLACKWELL", False)
+    assert (
+        server_args(model_path, enable_nccl_ep_cuda_graph=True).moe_a2a_backend
+        == "nccl_ep"
+    )
+
+
+def test_supported_quantization_and_other_backends_are_preserved():
+    from sglang.srt.layers.moe.ep_moe.layer import (
+        DeepEPMoE,
+        FusedMoE,
+        get_moe_impl_class,
+    )
+    from sglang.srt.layers.moe.utils import MoeA2ABackend
+    from sglang.srt.layers.quantization.fp8 import Fp8Config
+    from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
+    from sglang.srt.runtime_context import get_flags
+
+    with get_flags().moe.override(a2a_backend=MoeA2ABackend.NCCL_EP):
+        assert get_moe_impl_class(Fp8Config()) is DeepEPMoE
+        assert get_moe_impl_class(W4AFp8Config()) is DeepEPMoE
+    with get_flags().moe.override(a2a_backend=MoeA2ABackend.NONE):
+        assert get_moe_impl_class(None) is FusedMoE
+    with get_flags().moe.override(a2a_backend=MoeA2ABackend.DEEPEP):
+        assert get_moe_impl_class(None) is DeepEPMoE
+
+
+def test_unquantized_moe_is_rejected_before_allocation():
+    from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
+    from sglang.srt.layers.moe.utils import MoeA2ABackend
+    from sglang.srt.runtime_context import get_flags
+
+    with get_flags().moe.override(a2a_backend=MoeA2ABackend.NCCL_EP):
+        with pytest.raises(ValueError, match="NCCL EP.*quant"):
+            get_moe_impl_class(None)
+
+
+def test_fp16_parameters_are_rejected_before_group_creation():
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+    with dispatcher_environment() as env:
+        config = MoeRunnerConfig(
+            num_experts=2,
+            num_local_experts=2,
+            hidden_size=2048,
+            top_k=2,
+            params_dtype=torch.float16,
+        )
+        with pytest.raises(ValueError, match="NCCL EP.*bfloat16"):
+            NcclEpDispatcher(config, env.coordinator)
+        assert env.events.count("group_create") == 0
+
+
+def test_fp16_eager_input_is_rejected_before_handle_creation():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    with dispatcher_environment() as env:
+        dispatcher = env.dispatcher(layer_id=0)
+        x = torch.ones(1, 2048, dtype=torch.float16, device="cuda")
+        ids = torch.tensor([[0, 1]], device="cuda")
+        weights = torch.tensor([[0.5, 0.5]], device="cuda")
+        with pytest.raises(ValueError, match="NCCL EP.*bfloat16"):
+            forward_layer(dispatcher, x, ids, weights, rank=0)
+        assert env.events.count("handle_create") == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_graph_config.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_graph_config.py
@@ -1,0 +1,198 @@
+"""Public configuration contracts; no model weights or EP communication.
+
+External EP bindings and GPU capability queries are replaced. The public
+ServerArgs constructor, dispatcher, and CUDA Graph backend remain real.
+"""
+
+import sys
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="The CUDA configuration path is required"
+)
+
+
+@pytest.fixture(autouse=True)
+def ep_bindings(monkeypatch):
+    from nccl_ep_test.fake_ep import FakeLibrary, replace_ep_modules
+
+    from sglang.srt.layers.moe.token_dispatcher import nccl_ep
+
+    library = FakeLibrary()
+    root = ModuleType("nccl")
+    root.__path__ = []
+    root.core, root.ep = library.core, library.ep
+    library.core.get_version = lambda: SimpleNamespace(
+        libnccl=SimpleNamespace(version="2.30.7")
+    )
+    modules = {"nccl": root, "nccl.core": library.core, "nccl.ep": library.ep}
+    for name, module in modules.items():
+        module.__spec__ = ModuleSpec(name, loader=None, is_package=name == "nccl")
+    monkeypatch.setattr(nccl_ep, "_nccl_ep_runtime", None)
+    with replace_ep_modules(modules):
+        yield library
+
+
+@pytest.fixture
+def model_path(tmp_path, monkeypatch):
+    from transformers import GenerationConfig, Qwen2MoeConfig
+
+    torch.cuda.init()  # Initialize the real device before overriding capability.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    config = Qwen2MoeConfig(
+        hidden_size=2048,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=16,
+        num_key_value_heads=16,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=256,
+        shared_expert_intermediate_size=256,
+    )
+    config.architectures = ["Qwen2MoeForCausalLM"]
+    config.save_pretrained(tmp_path)
+    GenerationConfig().save_pretrained(tmp_path)
+    return str(tmp_path)
+
+
+def server_args(model_path, **overrides):
+    from sglang.srt.server_args import ServerArgs
+
+    options = dict(
+        model_path=model_path,
+        device="cuda",
+        attention_backend="triton",
+        moe_a2a_backend="nccl_ep",
+        moe_runner_backend="triton",
+        tp_size=1,
+        dtype="bfloat16",
+    )
+    options.update(overrides)
+    return ServerArgs(**options)
+
+
+def test_nccl_ep_defaults_to_eager_without_graph_opt_in(model_path, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *args, **kw: (9, 0))
+    args = server_args(model_path)
+    assert args.cuda_graph_config.decode.backend == "disabled"
+    assert args.cuda_graph_config.prefill.backend == "disabled"
+
+
+def test_public_opt_in_reaches_the_persistent_full_graph_backend(
+    model_path, monkeypatch
+):
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+    from sglang.srt.model_executor.runner_backend.utils import resolve_decode_backend
+    from sglang.srt.runtime_context import get_context, get_exec
+
+    with monkeypatch.context() as capability:
+        capability.setattr(
+            torch.cuda, "get_device_capability", lambda *args, **kw: (9, 0)
+        )
+        args = server_args(model_path, enable_nccl_ep_cuda_graph=True)
+    assert args.cuda_graph_config.decode.backend == "full"
+    assert args.cuda_graph_config.prefill.backend == "disabled"
+    with dispatcher_environment(capacity=16) as environment:
+        get_context().set_server_args(args)
+        assert get_exec().moe.enable_nccl_ep_cuda_graph
+        runner = SimpleNamespace(
+            device_module=torch.cuda,
+            max_num_token=16,
+            model_runner=SimpleNamespace(
+                server_args=args,
+                device="cuda",
+                tp_group=environment.coordinator,
+            ),
+        )
+        backend = resolve_decode_backend(runner)
+        dispatcher = environment.dispatcher(layer_id=0)
+        x = torch.ones(8, 2048, dtype=torch.bfloat16, device="cuda")
+        ids = torch.tensor([[0, 1]] * 8, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 8, device="cuda")
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                backend.capture_one(
+                    ShapeKey(8), lambda: forward_layer(dispatcher, x, ids, weights, 0)
+                )
+            with backend.replay_session():
+                result = backend.replay(ShapeKey(8), None)[2]
+            torch.testing.assert_close(result, torch.full_like(x, 1.75), rtol=0, atol=0)
+            assert environment.events.count("handle_create") == 1
+        finally:
+            backend.cleanup()
+
+
+def test_opt_in_does_not_fall_back_on_an_unsupported_gpu(model_path, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *args, **kw: (8, 9))
+    with pytest.raises(ValueError, match="NCCL EP.*sm_8"):
+        server_args(model_path, enable_nccl_ep_cuda_graph=True)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"moe_a2a_backend": "none"},
+        {"cuda_graph_backend_decode": "breakable"},
+        {"cuda_graph_backend_decode": "tc_piecewise"},
+        {"disable_cuda_graph": True},
+        {"cuda_graph_backend_prefill": "full"},
+        {"enable_two_batch_overlap": True},
+        {"enable_single_batch_overlap": True},
+        {"enable_pdmux": True},
+        {"enable_eplb": True},
+        {"elastic_ep_backend": "nixl"},
+        {"enable_elastic_expert_backup": True},
+        {"speculative_algorithm": "EAGLE"},
+        {"enable_torch_compile": True},
+        {"enable_memory_saver": True},
+        {"nnodes": 2},
+        {"nccl_ep_mode": "normal"},
+        {"nccl_ep_num_max_dispatch_tokens_per_rank": 2048},
+    ],
+)
+def test_opt_in_rejects_unsupported_execution_configs(
+    model_path, monkeypatch, overrides
+):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *args, **kw: (9, 0))
+    with pytest.raises(ValueError, match="NCCL EP CUDA Graph"):
+        server_args(model_path, enable_nccl_ep_cuda_graph=True, **overrides)
+
+
+def test_opt_in_requires_the_handle_update_capability(model_path, monkeypatch):
+    import nccl.ep as ep
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *args, **kw: (9, 0))
+    monkeypatch.setattr(ep.Handle, "update", None)
+    with pytest.raises(ValueError, match="Handle.update"):
+        server_args(model_path, enable_nccl_ep_cuda_graph=True)
+
+
+def test_nccl_ep_gate_prefers_the_binding_library_version(model_path, monkeypatch):
+    # The binding reports 2.30.7. Torch's compile-time version query must not
+    # override that primary library identity.
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda *args, **kw: (9, 0))
+    monkeypatch.setattr(torch.cuda.nccl, "version", lambda: (2, 28, 9))
+    args = server_args(model_path, enable_nccl_ep_cuda_graph=True)
+    assert args.moe_a2a_backend == "nccl_ep"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_graph_inputs.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_graph_inputs.py
@@ -1,0 +1,80 @@
+"""Independent expectations shared with the two-rank NCCL EP experiments."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA Graph requires a GPU")
+def test_non_ep_graph_replays_changed_data_at_fixed_addresses():
+    from nccl_ep_test.local_graph import exercise
+
+    result = exercise()
+    assert result["ep_tested"] is False
+    assert result["checked"] == 180
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA Graph requires a GPU")
+def test_bucket_graphs_reuse_maximum_capacity_storage_serially():
+    from nccl_ep_test.local_graph import exercise
+
+    result = exercise()
+    views = result["shared_buffer_views"]
+    assert views["8"] == views["16"] == views["32"]
+    assert result["checked"] == 180
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA Graph requires a GPU")
+def test_sglang_runner_updates_and_pads_the_actual_graph_inputs():
+    from nccl_ep_test.runner_inputs import exercise_inputs
+
+    result = exercise_inputs()
+    assert result["selected_buckets"] == [8, 16, 8]
+    assert result["valid_rows"] == [5, 0, 5]
+    assert result["recapture_generations"] == 1
+    assert result["ep_tested"] is False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA Graph requires a GPU")
+@pytest.mark.parametrize("routing_dtype", [torch.int32, torch.int64])
+def test_real_sglang_topk_mask_and_fp8_scales_change_on_graph_replay(routing_dtype):
+    from nccl_ep_test.sglang_non_ep import exercise_topk_fp8
+
+    result = exercise_topk_fp8(routing_dtype=routing_dtype)
+    assert result["valid_rows"] == [5, 0, 5]
+    assert result["scales_applied"] is True
+    assert result["ep_tested"] is False
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Real CUDA routing mask required"
+)
+def test_server_runner_router_matches_literal_two_rank_fixtures():
+    from nccl_ep_test.runner_inputs import input_batch
+    from nccl_ep_test.sglang_graph import runner_fixture, runner_routing
+
+    values = ([1, 2, 4, 8, 1], [8, 4, 2, 1, 8])
+    for valid in ((5, 5), (0, 5), (2, 3)):
+        fixture = runner_fixture(8, values, valid)
+        for rank in range(2):
+            batch = input_batch(values[rank] + [0, 0, 0], valid_rows=valid[rank])
+            x, ids, weights = runner_routing(batch, rank)
+            torch.testing.assert_close(x.cpu(), fixture.tokens[rank], rtol=0, atol=0)
+            torch.testing.assert_close(
+                ids.cpu().long(), fixture.expert_ids[rank], rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                weights.cpu(), fixture.weights[rank], rtol=0, atol=0
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_graph_lifecycle.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_graph_lifecycle.py
@@ -6,12 +6,13 @@ verify NCCL EP communication, its native layout, or cross-rank correctness.
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from nccl_ep_test.sglang_graph import backend_for as graph_backend
 
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -47,20 +48,6 @@ def test_eager_dispatcher_restores_tokens_and_closes_each_external_handle():
         assert environment.events.count("handle_destroy") == 3
     assert environment.events.count("group_create") == 1
     assert environment.events.count("group_destroy") == 1
-
-
-def graph_backend(coordinator, capacity):
-    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
-        FullCudaGraphBackend,
-    )
-
-    return FullCudaGraphBackend(
-        SimpleNamespace(
-            device_module=torch.cuda,
-            model_runner=SimpleNamespace(tp_group=coordinator),
-        ),
-        nccl_ep_capacity=capacity,
-    )
 
 
 def test_graph_replays_changed_data_without_python_handle_updates():

--- a/test/registered/unit/layers/moe/test_nccl_ep_graph_lifecycle.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_graph_lifecycle.py
@@ -1,0 +1,566 @@
+"""Actual SGLang dispatcher/runner, real CUDA Graphs, fake external EP library.
+
+These tests verify host lifecycle and GPU buffer ownership on SM89. They do not
+verify NCCL EP communication, its native layout, or cross-rank correctness.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=25, stage="base-b", runner_config="1-gpu-small")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Real CUDA execution is required"
+)
+
+
+def test_eager_dispatcher_restores_tokens_and_closes_each_external_handle():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.oracle import (
+        RoutingBatch,
+        assert_combine_matches,
+        assert_dispatch_matches,
+    )
+
+    with dispatcher_environment(capacity=16) as environment:
+        dispatcher = environment.dispatcher(layer_id=0)
+        for reverse in (False, True, False):
+            tokens = torch.tensor([1.0, 2.0, 4.0, 8.0]).repeat(8, 512).bfloat16()
+            ids = torch.tensor([[1, 0] if reverse else [0, 1]] * 8)
+            weights = torch.tensor([[0.25, 0.75]] * 8)
+            batch = RoutingBatch((tokens,), (ids,), (weights,), 2)
+            actual = forward_layer(
+                dispatcher, tokens.cuda(), ids.cuda(), weights.cuda(), 0
+            )
+            assert_dispatch_matches(batch, 0, actual[0], actual[1])
+            assert_combine_matches(batch, 0, actual[2])
+        assert environment.events.count("handle_create") == 3
+        assert environment.events.count("handle_destroy") == 3
+    assert environment.events.count("group_create") == 1
+    assert environment.events.count("group_destroy") == 1
+
+
+def graph_backend(coordinator, capacity):
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    return FullCudaGraphBackend(
+        SimpleNamespace(
+            device_module=torch.cuda,
+            model_runner=SimpleNamespace(tp_group=coordinator),
+        ),
+        nccl_ep_capacity=capacity,
+    )
+
+
+def test_graph_replays_changed_data_without_python_handle_updates():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.oracle import RoutingBatch, assert_combine_matches
+
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    with dispatcher_environment(capacity=16) as environment:
+        dispatcher = environment.dispatcher(layer_id=0)
+        backend = graph_backend(environment.coordinator, 16)
+        x = torch.ones(16, 2048, dtype=torch.bfloat16, device="cuda")
+        ids = torch.tensor([[0, 1]] * 16, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 16, device="cuda")
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                for bucket in (16, 8):
+                    backend.capture_one(
+                        ShapeKey(bucket),
+                        lambda bucket=bucket: forward_layer(
+                            dispatcher, x[:bucket], ids[:bucket], weights[:bucket], 0
+                        ),
+                    )
+            torch.cuda.current_stream().wait_stream(stream)
+            updates = len(environment.updates)
+            for bucket, value, route, weight in (
+                (8, 1, [0, 1], [0.25, 0.75]),
+                (16, 2, [1, 0], [0.75, 0.25]),
+                (8, 4, [0, 1], [0.75, 0.25]),
+                (16, 1, [0, 1], [0.25, 0.75]),
+            ):
+                tokens = torch.full((bucket, 2048), value, dtype=torch.bfloat16)
+                routes = torch.tensor([route] * bucket)
+                factors = torch.tensor([weight] * bucket)
+                batch = RoutingBatch((tokens,), (routes,), (factors,), 2)
+                with backend.replay_session():
+                    x[:bucket].copy_(tokens)
+                    ids[:bucket].copy_(routes)
+                    weights[:bucket].copy_(factors)
+                    actual = backend.replay(ShapeKey(bucket), None)
+                assert_combine_matches(batch, 0, actual[2])
+            assert len(environment.updates) == updates
+            assert environment.events.count("handle_create") == 1
+            assert environment.events.count("handle_destroy") == 0
+        finally:
+            backend.cleanup()
+
+
+def test_graph_output_survives_next_layer_shared_scratch():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    with dispatcher_environment(capacity=8) as environment:
+        first = environment.dispatcher(layer_id=0)
+        second = environment.dispatcher(layer_id=1)
+        backend = graph_backend(environment.coordinator, 8)
+        x = torch.ones(8, 2048, dtype=torch.bfloat16, device="cuda")
+        ids = torch.tensor([[0, 1]] * 8, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 8, device="cuda")
+
+        def forward():
+            earlier = forward_layer(first, x, ids, weights, 0)[2]
+            later = forward_layer(second, x * 2, ids, weights, 0)[2]
+            return earlier, later
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                backend.capture_one(ShapeKey(8), forward)
+            torch.cuda.current_stream().wait_stream(stream)
+            with backend.replay_session():
+                earlier, later = backend.replay(ShapeKey(8), None)
+            torch.testing.assert_close(
+                earlier, torch.full_like(x, 1.75), rtol=0, atol=0
+            )
+            torch.testing.assert_close(later, torch.full_like(x, 3.5), rtol=0, atol=0)
+            assert environment.events.count("handle_create") == 1
+        finally:
+            backend.cleanup()
+
+
+def synthetic_ep_runner(
+    environment,
+    *,
+    buckets=(8, 16),
+    forward_hook=None,
+    before_forward=None,
+    share_inputs=False,
+):
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.runner_inputs import SyntheticDecodeRunner
+
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+        FullCudaGraphBackend,
+    )
+
+    dispatcher = environment.dispatcher(layer_id=0)
+    ids = torch.tensor([[0, 1]] * max(buckets), device="cuda")
+    weights = torch.tensor([[0.25, 0.75]] * max(buckets), device="cuda")
+
+    def forward(batch):
+        if before_forward is not None:
+            before_forward()
+        rows = batch.batch_size
+        x = batch.input_ids[:, None].to(torch.bfloat16).expand(-1, 2048)
+        routes = torch.where(
+            torch.arange(rows, device="cuda")[:, None] < batch.num_token_non_padded,
+            ids[:rows],
+            -1,
+        )
+        output = forward_layer(dispatcher, x, routes, weights[:rows], 0)[2]
+        if forward_hook is not None:
+            forward_hook()
+        return LogitsProcessorOutput(next_token_logits=output[:, :1])
+
+    return SyntheticDecodeRunner(
+        forward,
+        environment.coordinator,
+        buckets=buckets,
+        share_inputs=share_inputs,
+        backend_factory=lambda runner: FullCudaGraphBackend(
+            runner, nccl_ep_capacity=max(buckets)
+        ),
+    )
+
+
+def test_stream_switch_fences_input_writes_and_output_consumers():
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    with dispatcher_environment(capacity=16) as environment:
+        runner = synthetic_ep_runner(environment)
+        first_stream, second_stream = torch.cuda.Stream(), torch.cuda.Stream()
+        try:
+            for second_rows in (5, 9):
+                first_batch = input_batch([1] * 5)
+                second_batch = input_batch([2] * second_rows)
+                first_stream.wait_stream(torch.cuda.current_stream())
+                second_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(first_stream):
+                    first = runner.execute(first_batch).next_token_logits
+                    torch.cuda._sleep(20_000_000)
+                    # This consumer is submitted after replay_session closes.
+                    # Waiting only for an event recorded inside that session
+                    # would still allow the next replay to overwrite its input.
+                    consumed = first.clone()
+                with torch.cuda.stream(second_stream):
+                    second = runner.execute(second_batch).next_token_logits.clone()
+                torch.cuda.synchronize()
+                torch.testing.assert_close(
+                    consumed, torch.full_like(consumed, 1.75), rtol=0, atol=0
+                )
+                torch.testing.assert_close(
+                    second, torch.full_like(second, 3.5), rtol=0, atol=0
+                )
+        finally:
+            runner.backend.cleanup()
+
+
+def test_unprotected_replay_input_updates_are_rejected():
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    with dispatcher_environment(capacity=16) as environment:
+        runner = synthetic_ep_runner(environment)
+        try:
+            with pytest.raises(RuntimeError, match="replay_session"):
+                runner.load_batch(input_batch([1] * 5))
+            with pytest.raises(RuntimeError, match="replay_session"):
+                runner.backend.replay(ShapeKey(8), None)
+            # Rejection leaves the ordinary execute path usable.
+            result = runner.execute(input_batch([2] * 5)).next_token_logits
+            torch.testing.assert_close(
+                result, torch.full_like(result, 3.5), rtol=0, atol=0
+            )
+        finally:
+            runner.backend.cleanup()
+
+
+def test_recapture_closes_executables_before_persistent_resources():
+    from nccl_ep_test.ep_audit import EpAudit
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+    with dispatcher_environment(capacity=16) as environment, EpAudit() as audit:
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        runner = synthetic_ep_runner(environment)
+        try:
+            for mode in (CaptureHiddenMode.NULL, CaptureHiddenMode.FULL):
+                batch = input_batch([2] * 5, hidden_mode=mode)
+                result = runner.execute(batch).next_token_logits
+                torch.testing.assert_close(
+                    result, torch.full_like(result, 3.5), rtol=0, atol=0
+                )
+            assert runner.capture_generations == 2
+        finally:
+            runner.backend.cleanup()
+            NcclEpBuffer.destroy()
+        # Audit retains old Python references and checks GPU wait -> explicit
+        # graph reset -> persistent handle destroy -> group destroy ordering.
+        evidence = audit.assert_closed()
+        assert evidence["groups_created"] == 3  # eager + two Graph generations
+        assert evidence["handles_created"] == 2
+        assert evidence["graphs_created"] == 4
+
+
+def test_failed_capture_can_start_a_fresh_generation():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.ep_audit import EpAudit
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+    with dispatcher_environment(capacity=8) as environment, EpAudit() as audit:
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        dispatcher = environment.dispatcher(layer_id=0)
+        backend = graph_backend(environment.coordinator, 8)
+        x = torch.ones(8, 2048, dtype=torch.bfloat16, device="cuda")
+        ids = torch.tensor([[0, 1]] * 8, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 8, device="cuda")
+        inject_failure = True
+
+        def forward():
+            result = forward_layer(dispatcher, x, ids, weights, 0)
+            if inject_failure and torch.cuda.is_current_stream_capturing():
+                raise RuntimeError("injected failure after completed combine")
+            return result
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with pytest.raises(RuntimeError, match="injected failure") as failure:
+                with torch.cuda.stream(stream), backend.capture_session(stream):
+                    backend.capture_one(ShapeKey(8), forward)
+            # Keep the exception/traceback alive too: relying on local graph GC
+            # is insufficient when failed capture frames retain it.
+            assert failure.value is not None
+            assert all(graph.audit_reset for graph in audit.graphs)
+            assert all(
+                item["closed"]
+                for item in audit.groups.values()
+                if item["rdma_buffer_size"] == 0
+            )
+            inject_failure = False
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                backend.capture_one(ShapeKey(8), forward)
+            with backend.replay_session():
+                result = backend.replay(ShapeKey(8), None)[2]
+            torch.testing.assert_close(result, torch.full_like(x, 1.75), rtol=0, atol=0)
+        finally:
+            # Emergency teardown cannot satisfy the assertions above.
+            torch.cuda.synchronize()
+            for graph in audit.graphs:
+                if not graph.audit_reset:
+                    graph.reset()
+            backend.cleanup()
+            NcclEpBuffer.destroy()
+        assert audit.assert_closed()["handles_created"] == 2
+
+
+def test_eager_graph_alternation_keeps_groups_isolated():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import SyntheticEagerRunner, input_batch
+
+    def delay_graph():
+        if torch.cuda.is_current_stream_capturing():
+            torch.cuda._sleep(20_000_000)
+
+    with dispatcher_environment(capacity=32) as environment:
+        runner = synthetic_ep_runner(
+            environment, before_forward=delay_graph, share_inputs=True
+        )
+        eager = SyntheticEagerRunner(runner.synthetic_forward, 16)
+        graph_stream, eager_stream = torch.cuda.Stream(), torch.cuda.Stream()
+        try:
+            graph_batch, eager_batch = input_batch([1] * 5), input_batch([2] * 5)
+            graph_stream.wait_stream(torch.cuda.current_stream())
+            eager_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(graph_stream):
+                graph_output = runner.execute(graph_batch).next_token_logits.clone()
+            with torch.cuda.stream(eager_stream):
+                eager_output = eager.execute(eager_batch).next_token_logits.clone()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(
+                graph_output, torch.full_like(graph_output, 1.75), rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                eager_output, torch.full_like(eager_output, 3.5), rtol=0, atol=0
+            )
+
+            # A larger eager LL step must not resize or replace Graph resources.
+            dispatcher = environment.dispatcher(layer_id=1)
+            x = torch.full((24, 2048), 4, dtype=torch.bfloat16, device="cuda")
+            ids = torch.tensor([[0, 1]] * 24, device="cuda")
+            weights = torch.tensor([[0.25, 0.75]] * 24, device="cuda")
+            with torch.cuda.stream(eager_stream):
+                eager_stream.wait_stream(torch.cuda.default_stream())
+                large = forward_layer(dispatcher, x, ids, weights, 0)[2].clone()
+            with torch.cuda.stream(graph_stream):
+                repeated = runner.execute(graph_batch).next_token_logits.clone()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(large, torch.full_like(large, 7), rtol=0, atol=0)
+            torch.testing.assert_close(
+                repeated, torch.full_like(repeated, 1.75), rtol=0, atol=0
+            )
+            assert sorted(
+                group.config.max_dispatch_tokens_per_rank
+                for group in environment.groups
+            ) == [16, 32]
+            assert environment.events.count("handle_create") == 3
+            assert environment.events.count("handle_destroy") == 2
+        finally:
+            runner.backend.cleanup()
+
+
+def test_incompatible_layer_rejected_without_replacing_group():
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+    with dispatcher_environment(capacity=16) as environment:
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+        runner = synthetic_ep_runner(environment)
+        try:
+            with pytest.raises(ValueError, match="Incompatible"):
+                NcclEpDispatcher(
+                    MoeRunnerConfig(
+                        num_experts=2,
+                        num_local_experts=2,
+                        hidden_size=4096,
+                        top_k=2,
+                        params_dtype=torch.bfloat16,
+                        layer_id=1,
+                    ),
+                    environment.coordinator,
+                )
+            assert environment.events.count("group_create") == 2
+            assert environment.events.count("group_destroy") == 0
+            result = runner.execute(input_batch([1] * 5)).next_token_logits
+            torch.testing.assert_close(
+                result, torch.full_like(result, 1.75), rtol=0, atol=0
+            )
+        finally:
+            runner.backend.cleanup()
+
+
+def test_model_parallel_shutdown_closes_registered_ep_resources():
+    from nccl_ep_test.ep_audit import EpAudit
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    from sglang.srt.distributed.parallel_state import destroy_model_parallel
+
+    with dispatcher_environment(capacity=16) as environment, EpAudit() as audit:
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        runner = synthetic_ep_runner(environment)
+        runner.execute(input_batch([1] * 5))
+        try:
+            destroy_model_parallel()
+            assert audit.assert_closed()["all_explicitly_closed"]
+        finally:
+            # Preserve test isolation even when the public shutdown is broken.
+            runner.backend.cleanup()
+            torch.cuda.synchronize()
+            NcclEpBuffer.destroy()
+
+
+def test_concurrent_runner_submissions_fail_before_input_writes():
+    from concurrent.futures import ThreadPoolExecutor
+
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import SyntheticEagerRunner, input_batch
+
+    with dispatcher_environment(capacity=16) as environment:
+        runner = synthetic_ep_runner(environment, share_inputs=True)
+        eager = SyntheticEagerRunner(runner.synthetic_forward, 16)
+        batch = input_batch([1] * 5)
+        try:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                with runner.backend.replay_session():
+                    for submit in (runner.execute, eager.execute):
+                        future = pool.submit(submit, batch)
+                        with pytest.raises(RuntimeError, match="Concurrent NCCL EP"):
+                            future.result(timeout=5)
+            result = runner.execute(batch).next_token_logits
+            torch.testing.assert_close(
+                result, torch.full_like(result, 1.75), rtol=0, atol=0
+            )
+        finally:
+            runner.backend.cleanup()
+
+
+def test_failed_combine_does_not_allow_another_transaction():
+    from unittest.mock import patch
+
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import FakeHandle, dispatcher_environment
+
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+    with dispatcher_environment(capacity=8) as environment:
+        dispatcher = environment.dispatcher(layer_id=0)
+        backend = graph_backend(environment.coordinator, 8)
+        x = torch.ones(8, 2048, dtype=torch.bfloat16, device="cuda")
+        ids = torch.tensor([[0, 1]] * 8, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 8, device="cuda")
+        complete = FakeHandle.complete
+
+        def fail_before_combine_completion(handle, *args, **kwargs):
+            if handle.pending == "combine":
+                raise RuntimeError("injected external completion error")
+            return complete(handle, *args, **kwargs)
+
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with pytest.raises(RuntimeError):
+                with torch.cuda.stream(stream), backend.capture_session(stream):
+                    with patch.object(
+                        FakeHandle, "complete", fail_before_combine_completion
+                    ):
+                        forward_layer(dispatcher, x, ids, weights, 0)
+            with pytest.raises(RuntimeError, match="incomplete"):
+                dispatcher.dispatch(x, StandardTopKOutput(weights, ids, None))
+        finally:
+            # This fake raises before invoking any native operation. Complete
+            # its pending work solely for fixture teardown. A real native/GPU
+            # fault requires process restart; this test makes no recovery claim.
+            with torch.cuda.stream(stream):
+                dispatcher.combine_b()
+            backend.cleanup()
+
+
+def test_duplicate_bucket_capture_requires_a_new_generation():
+    from nccl_ep_test.ep_audit import EpAudit
+    from nccl_ep_test.fake_ep import dispatcher_environment
+    from nccl_ep_test.runner_inputs import input_batch
+
+    with dispatcher_environment(capacity=16) as environment, EpAudit() as audit:
+        runner = synthetic_ep_runner(environment)
+        try:
+            with pytest.raises(ValueError, match="already captured"):
+                runner.capture()
+            # Rejection closes the old generation explicitly, even though the
+            # audit still retains every graph object. A fresh capture is usable.
+            assert all(graph.audit_reset for graph in audit.graphs)
+            runner.capture()
+            actual = runner.execute(input_batch([2] * 5)).next_token_logits
+            torch.testing.assert_close(
+                actual, torch.full_like(actual, 3.5), rtol=0, atol=0
+            )
+        finally:
+            runner.backend.cleanup()
+
+
+def test_graph_rejects_broadcastable_wrong_hidden_size_before_dispatch():
+    from nccl_ep_test.dispatcher import forward_layer
+    from nccl_ep_test.fake_ep import dispatcher_environment
+
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+    with dispatcher_environment(capacity=8) as environment:
+        dispatcher = environment.dispatcher(layer_id=0)
+        backend = graph_backend(environment.coordinator, 8)
+        ids = torch.tensor([[0, 1]] * 8, device="cuda")
+        weights = torch.tensor([[0.25, 0.75]] * 8, device="cuda")
+        x = torch.ones(8, 1, dtype=torch.bfloat16, device="cuda")
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(stream), backend.capture_session(stream):
+                with pytest.raises(ValueError, match="hidden size"):
+                    dispatcher.dispatch(x, StandardTopKOutput(weights, ids, None))
+                actual = forward_layer(dispatcher, x.expand(-1, 2048), ids, weights, 0)[
+                    2
+                ]
+            torch.cuda.current_stream().wait_stream(stream)
+            torch.testing.assert_close(
+                actual, torch.full_like(actual, 1.75), rtol=0, atol=0
+            )
+        finally:
+            backend.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_oracle.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_oracle.py
@@ -1,0 +1,167 @@
+"""Independent expectations shared with the two-rank NCCL EP experiments."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from nccl_ep_test.oracle import RoutingBatch, expected_combine
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_weighted_experts_restore_each_source_token():
+    batch = RoutingBatch(
+        tokens=(torch.tensor([[1.0, 2.0], [4.0, 8.0]]), torch.tensor([[2.0, 4.0]])),
+        expert_ids=(torch.tensor([[0, 2], [1, -1]]), torch.tensor([[3, 0]])),
+        weights=(
+            torch.tensor([[0.25, 0.75], [1.0, 0.0]]),
+            torch.tensor([[0.75, 0.25]]),
+        ),
+        num_experts=4,
+    )
+    outputs = expected_combine(batch)
+    torch.testing.assert_close(
+        outputs[0], torch.tensor([[2.5, 5.0], [8.0, 16.0]]), rtol=0, atol=0
+    )
+    torch.testing.assert_close(outputs[1], torch.tensor([[6.5, 13.0]]), rtol=0, atol=0)
+
+
+def test_received_tokens_allow_reordering_and_ignore_padding():
+    from nccl_ep_test.oracle import assert_dispatch_matches
+
+    batch = RoutingBatch(
+        tokens=(torch.tensor([[1.0, 2.0], [4.0, 8.0]]), torch.tensor([[2.0, 4.0]])),
+        expert_ids=(torch.tensor([[0, 2], [1, -1]]), torch.tensor([[3, 0]])),
+        weights=(
+            torch.tensor([[0.25, 0.75], [1.0, 0.0]]),
+            torch.tensor([[0.75, 0.25]]),
+        ),
+        num_experts=4,
+    )
+    received = torch.full((2, 4, 2), float("nan"))
+    received[0, :2] = torch.tensor([[2.0, 4.0], [1.0, 2.0]])
+    received[1, 0] = torch.tensor([4.0, 8.0])
+    assert_dispatch_matches(batch, 0, received, torch.tensor([2, 1]))
+
+
+def test_empty_effective_rank_still_has_fixed_capacity_and_zero_output():
+    from nccl_ep_test.oracle import make_fixture
+
+    batch = make_fixture(8, case="empty_rank", hidden=8)
+    assert batch.tokens[0].shape == batch.tokens[1].shape == (8, 8)
+    assert (batch.expert_ids[0] == -1).all()
+    assert (batch.expert_ids[1] >= 0).all()
+    torch.testing.assert_close(
+        expected_combine(batch)[0], torch.zeros(8, 8), rtol=0, atol=0
+    )
+
+
+@pytest.mark.parametrize("corruption", ["token_order", "routing", "double_count"])
+def test_combine_comparison_rejects_wrong_answers(corruption):
+    from nccl_ep_test.oracle import assert_combine_matches, make_fixture
+
+    batch = make_fixture(8, hidden=8)
+    if corruption == "token_order":
+        actual = expected_combine(batch)[0].roll(1, dims=0)
+    elif corruption == "routing":
+        wrong = RoutingBatch(
+            batch.tokens,
+            tuple((ids + 1) % 4 for ids in batch.expert_ids),
+            batch.weights,
+            4,
+        )
+        actual = expected_combine(wrong)[0]
+    else:
+        actual = expected_combine(batch)[0] * 2
+    with pytest.raises(AssertionError):
+        assert_combine_matches(batch, 0, actual)
+
+
+def test_duplicate_probe_checks_receive_capacity_before_launch():
+    from nccl_ep_test.oracle import make_fixture, validate_capacity
+
+    batch = make_fixture(8, case="duplicates", hidden=8)
+    validate_capacity(batch, 32)
+    with pytest.raises(ValueError, match="Expert 0.*capacity"):
+        validate_capacity(batch, 8)
+
+
+def test_scaled_fp8_payload_requires_scales():
+    from nccl_ep_test.oracle import dequantize_fp8
+
+    source = torch.tensor([1.0, 2.0, 4.0, 8.0]).repeat(32).view(1, 1, 128)
+    scales = torch.tensor([[[8.0 / 448.0]]])
+    quantized = (source / scales).to(torch.float8_e4m3fn)
+    actual = dequantize_fp8(quantized, scales)
+    torch.testing.assert_close(actual, source.to(torch.bfloat16), rtol=0, atol=0)
+    with pytest.raises(AssertionError):
+        torch.testing.assert_close(quantized.float(), source, rtol=0, atol=0)
+
+
+def test_dispatch_comparison_checks_tail_hidden_elements_and_multiplicity():
+    from nccl_ep_test.oracle import assert_dispatch_matches
+
+    batch = RoutingBatch(
+        (torch.ones(1, 128), torch.full((1, 128), 2.0)),
+        (torch.tensor([[0, 0]]), torch.tensor([[2, -1]])),
+        (torch.tensor([[0.25, 0.75]]), torch.tensor([[1.0, 0.0]])),
+        4,
+    )
+    received = torch.zeros(2, 2, 128)
+    received[0] = 1
+    assert_dispatch_matches(batch, 0, received, torch.tensor([2, 0]))
+    received[0, 1, -1] = 2
+    with pytest.raises(AssertionError, match="contents/multiplicity"):
+        assert_dispatch_matches(batch, 0, received, torch.tensor([2, 0]))
+
+
+def test_true_zero_length_rank_is_distinct_from_masked_padding():
+    from nccl_ep_test.oracle import expected_dispatch, make_fixture, validate_capacity
+
+    full = make_fixture(8, hidden=8)
+    batch = RoutingBatch(
+        (full.tokens[0][:0], full.tokens[1]),
+        (full.expert_ids[0][:0], full.expert_ids[1]),
+        (full.weights[0][:0], full.weights[1]),
+        4,
+    )
+    validate_capacity(batch, 8)
+    assert expected_combine(batch)[0].shape == (0, 8)
+    assert sum(len(rows) for rows in expected_dispatch(batch)) == 16
+
+
+def test_padding_oracle_does_not_need_zero_weights_to_mask_a_token():
+    from nccl_ep_test.oracle import make_fixture
+
+    batch = make_fixture(8, case="empty_rank", hidden=8)
+    assert (batch.weights[0] > 0).all()
+    torch.testing.assert_close(
+        expected_combine(batch)[0], torch.zeros(8, 8), rtol=0, atol=0
+    )
+
+
+def test_dynamic_fixtures_separately_expose_stale_tokens_routes_and_weights():
+    from nccl_ep_test.oracle import make_fixture
+
+    # Rank 0, row 0 is [1,4], routed to experts [0,2] with [.25,.75].
+    # Changing all three together can hide individual stale-data errors.
+    expected = {
+        "tokens": [5.0, 20.0],
+        "routing": [3.5, 14.0],
+        "weights": [1.5, 6.0],
+    }
+    for change, row in expected.items():
+        batch = make_fixture(8, step=1, hidden=2, change=change)
+        torch.testing.assert_close(
+            expected_combine(batch)[0][0], torch.tensor(row), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
@@ -1,0 +1,420 @@
+"""Unit tests for NCCL EP staged execution.
+
+Tests the three-phase dispatch/combine split (dispatch_a/dispatch_b,
+combine_a/combine_b), the _Stage state machine, and the DeepEPPDispatchHooks
+mechanism.
+
+CPU-only; no GPU or NCCL required. Uses mocks for parallel state.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import torch
+
+
+class TestNcclEpStageStateMachine(unittest.TestCase):
+    """Test the _Stage enum and _update_stage guard."""
+
+    def test_stage_enum_has_four_states(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import _Stage
+
+        self.assertEqual(len(_Stage), 4)
+        self.assertIn("INITIAL", [s.name for s in _Stage])
+        self.assertIn("AFTER_DISPATCH_A", [s.name for s in _Stage])
+        self.assertIn("AFTER_DISPATCH_B", [s.name for s in _Stage])
+        self.assertIn("AFTER_COMBINE_A", [s.name for s in _Stage])
+
+    def test_update_stage_correct_transition(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        dispatcher._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_DISPATCH_A)
+        dispatcher._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_DISPATCH_B)
+        dispatcher._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_COMBINE_A)
+        dispatcher._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
+        self.assertEqual(dispatcher._stage, _Stage.INITIAL)
+
+    def test_update_stage_wrong_transition_raises(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        with self.assertRaises(AssertionError):
+            dispatcher._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+
+    def test_combine_a_before_dispatch_b_raises(self):
+        """combine_a requires stage AFTER_DISPATCH_B; calling from INITIAL
+        must raise to prevent silent data corruption."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        dispatcher._dispatched_t = 1
+        dispatcher._dispatched_topk_weights = MagicMock()
+        dispatcher._handle = MagicMock()
+        dispatcher._nccl_ep = MagicMock()
+        dispatcher.hidden_size = 64
+        dispatcher.num_max_dispatch_tokens_per_rank = 128
+
+        with self.assertRaises(AssertionError):
+            dispatcher.combine_a(MagicMock())
+
+
+class TestNcclEpDispatchHooks(unittest.TestCase):
+    """Test the DeepEPPDispatchHooks mechanism for SBO."""
+
+    def test_dispatch_hooks_initialized(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+        self.assertIsInstance(dispatcher._dispatch_hooks, DeepEPPDispatchHooks)
+
+    def test_register_deepep_dispatch_hook(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+
+        called = []
+        handle = dispatcher.register_deepep_dispatch_hook(
+            lambda d: called.append(d)
+        )
+        self.assertEqual(len(called), 0)
+
+        dispatcher._dispatch_hooks(dispatcher)
+        self.assertEqual(len(called), 1)
+        self.assertIs(called[0], dispatcher)
+        handle.remove()
+
+    def test_dispatch_calls_hooks_between_a_and_b(self):
+        """dispatch() must call hooks after dispatch_a and before dispatch_b."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+        dispatcher._stage = _Stage.INITIAL
+
+        call_order = []
+
+        def mock_dispatch_a(self, hs, topk_output):
+            call_order.append("dispatch_a")
+            self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+            self._dispatch_intermediate_state = ()
+
+        def mock_dispatch_b(self):
+            call_order.append("dispatch_b")
+            self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+            return "dispatch_output"
+
+        dispatcher.dispatch_a = mock_dispatch_a.__get__(dispatcher)
+        dispatcher.dispatch_b = mock_dispatch_b.__get__(dispatcher)
+
+        dispatcher.register_deepep_dispatch_hook(
+            lambda d: call_order.append("hook")
+        )
+
+        result = dispatcher.dispatch(
+            torch.randn(4, 64, dtype=torch.bfloat16),
+            SimpleNamespace(),
+        )
+        self.assertEqual(result, "dispatch_output")
+        self.assertEqual(call_order, ["dispatch_a", "hook", "dispatch_b"])
+
+
+class TestMaxNumSmsResolution(unittest.TestCase):
+    """Test NcclEpBuffer._resolve_max_num_sms."""
+
+    def test_default_value(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = False
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 20)
+
+    def test_env_override(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 40
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 40)
+
+    def test_minimum_for_large_expert_count(self):
+        """256 experts need at least ceil(256/14)=19 SMs (nccl_ep.cc:1305)."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 1  # too low
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 19)  # clamped to minimum
+
+    def test_minimum_for_small_expert_count(self):
+        """64 experts need at least ceil(64/14)=5 SMs."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 1
+            result = NcclEpBuffer._resolve_max_num_sms(64)
+            self.assertEqual(result, 5)
+
+
+class TestSBOAssertAcceptsNcclEp(unittest.TestCase):
+    """Test that the SBO assert in deepseek_v2.py accepts NcclEpDispatcher."""
+
+    def test_nccl_ep_dispatcher_is_accepted(self):
+        """The assert isinstance(..., (MaybeTboDeepEPDispatcher, NcclEpDispatcher))
+        should pass for NcclEpDispatcher instances."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+        from sglang.srt.batch_overlap.two_batch_overlap import (
+            MaybeTboDeepEPDispatcher,
+        )
+
+        # Create a bare NcclEpDispatcher (no __init__)
+        dispatcher = object.__new__(NcclEpDispatcher)
+        self.assertIsInstance(
+            dispatcher,
+            (MaybeTboDeepEPDispatcher, NcclEpDispatcher),
+        )
+
+
+class TestForwardNormalSkipArConsistency(unittest.TestCase):
+    """Test skip_ar behavior for nccl_ep backend."""
+
+    def test_skip_ar_false_for_nccl_ep(self):
+        from sglang.srt.layers.moe.utils import should_skip_post_experts_all_reduce
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend
+
+        with patch(
+            "sglang.srt.layers.moe.utils.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.NCCL_EP,
+        ):
+            with patch(
+                "sglang.srt.layers.moe.utils.should_skip_mlp_all_reduce",
+                return_value=False,
+            ):
+                with patch(
+                    "sglang.srt.layers.moe.utils.should_use_dp_reduce_scatterv",
+                    return_value=False,
+                ):
+                    with patch(
+                        "sglang.srt.layers.moe.utils.get_server_args"
+                    ) as mock_sa:
+                        mock_sa.return_value = SimpleNamespace(dwdp_size=1)
+                        result = should_skip_post_experts_all_reduce(
+                            is_tp_path=True
+                        )
+
+        self.assertFalse(result)
+
+
+class TestNcclEpFuseAllreduceBehavior(unittest.TestCase):
+    """Test NCCL EP backend causes fuse_mlp_allreduce=False."""
+
+    def test_aiter_fusion_requires_a2a_none(self):
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend
+
+        self.assertFalse(MoeA2ABackend.NCCL_EP.is_none())
+        self.assertTrue(MoeA2ABackend.NONE.is_none())
+
+
+class TestNcclEpDispatcherEpGroupType(unittest.TestCase):
+    """Test that create_moe_dispatcher passes get_tp_group() as ep_group."""
+
+    def test_create_moe_dispatcher_passes_tp_group_as_ep_group(self):
+        from sglang.srt.layers.moe.fused_moe_triton.layer import (
+            create_moe_dispatcher,
+        )
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend, MoeRunnerConfig
+
+        cfg = MoeRunnerConfig(
+            num_experts=256,
+            num_local_experts=32,
+            hidden_size=6144,
+            top_k=8,
+            params_dtype=torch.bfloat16,
+        )
+
+        tp_group_mock = MagicMock(world_size=8)
+
+        with patch(
+            "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.NCCL_EP,
+        ):
+            with patch(
+                "sglang.srt.layers.moe.fused_moe_triton.layer.get_tp_group",
+                return_value=tp_group_mock,
+            ):
+                with patch(
+                    "sglang.srt.layers.moe.token_dispatcher.nccl_ep.NcclEpDispatcher"
+                ) as mock_disp_class:
+                    create_moe_dispatcher(cfg)
+
+                    call_kwargs = mock_disp_class.call_args
+                    self.assertIn("ep_group", call_kwargs.kwargs)
+                    self.assertIs(call_kwargs.kwargs["ep_group"], tp_group_mock)
+
+
+class TestNcclRuntimeVersionParsing(unittest.TestCase):
+    """Test _nccl_runtime_version() handles nccl4py 0.3.x VersionInfo format."""
+
+    def test_returns_none_when_no_nccl4py(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        with patch.dict("sys.modules", {"nccl": None, "nccl.core": None}):
+            with patch("torch.cuda.nccl.version", side_effect=Exception):
+                result = _nccl_runtime_version()
+                # Should return None or fall through gracefully
+                # (may still return torch's version if import fails silently)
+                self.assertTrue(result is None or isinstance(result, tuple))
+
+    def test_parses_versioninfo_namedtuple(self):
+        """nccl4py 0.3.x returns VersionInfo(nccl=LibraryInfo(version=<Version('2.30.7')>...))."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        mock_version_info = SimpleNamespace(
+            nccl=SimpleNamespace(
+                version="2.30.7"
+            )
+        )
+
+        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
+            import sys
+            mock_nccl = MagicMock()
+            mock_nccl.get_version.return_value = mock_version_info
+            sys.modules["nccl"] = mock_nccl
+
+            mock_core = MagicMock()
+            mock_core.get_version.return_value = ""
+            sys.modules["nccl.core"] = mock_core
+
+            with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
+                result = _nccl_runtime_version()
+                self.assertEqual(result, (2, 30, 7))
+
+    def test_falls_back_to_torch_version(self):
+        """When nccl4py returns unparseable data, fall back to torch.cuda.nccl.version."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
+            import sys
+            mock_nccl = MagicMock()
+            mock_nccl.get_version.return_value = None
+            sys.modules["nccl"] = mock_nccl
+
+            mock_core = MagicMock()
+            mock_core.get_version.return_value = None
+            sys.modules["nccl.core"] = mock_core
+
+            with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
+                result = _nccl_runtime_version()
+                self.assertEqual(result, (2, 28, 9))
+
+
+class TestNcclEpCapabilityCheck(unittest.TestCase):
+    """Test is_nccl_ep_available() and nccl_ep_unavailable_reason()."""
+
+    def test_unavailable_reason_returns_str_or_none(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            nccl_ep_unavailable_reason,
+        )
+
+        reason = nccl_ep_unavailable_reason()
+        self.assertTrue(reason is None or isinstance(reason, str))
+
+    def test_is_nccl_ep_available_returns_bool(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            is_nccl_ep_available,
+        )
+
+        result = is_nccl_ep_available()
+        self.assertIsInstance(result, bool)
+
+
+class TestNcclEpHiddenAllowlist(unittest.TestCase):
+    """Test that NcclEpDispatcher enforces the hidden size allowlist."""
+
+    def test_allowed_hidden_sizes(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_SUPPORTED_HIDDEN,
+        )
+
+        # DeepSeek-V2/V3 family hidden sizes
+        for h in [5120, 6144, 7168]:
+            self.assertIn(h, _NCCL_EP_LL_SUPPORTED_HIDDEN)
+
+    def test_disallowed_hidden_sizes(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_SUPPORTED_HIDDEN,
+        )
+
+        for h in [1024, 3072]:
+            self.assertNotIn(h, _NCCL_EP_LL_SUPPORTED_HIDDEN)
+
+
+class TestNcclEpTopkGuard(unittest.TestCase):
+    """Test that NcclEpDispatcher enforces topk <= 9 guard."""
+
+    def test_topk_guard_constant(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_MAX_TOPK,
+        )
+
+        self.assertEqual(_NCCL_EP_LL_MAX_TOPK, 9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
@@ -12,8 +12,8 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import unittest
-from types import SimpleNamespace
-from unittest.mock import patch, MagicMock
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -83,11 +83,11 @@ class TestNcclEpDispatchHooks(unittest.TestCase):
     """Test the DeepEPPDispatchHooks mechanism for SBO."""
 
     def test_dispatch_hooks_initialized(self):
-        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
-            NcclEpDispatcher,
-        )
         from sglang.srt.layers.moe.token_dispatcher.deepep import (
             DeepEPPDispatchHooks,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
         )
 
         dispatcher = object.__new__(NcclEpDispatcher)
@@ -95,20 +95,18 @@ class TestNcclEpDispatchHooks(unittest.TestCase):
         self.assertIsInstance(dispatcher._dispatch_hooks, DeepEPPDispatchHooks)
 
     def test_register_deepep_dispatch_hook(self):
-        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
-            NcclEpDispatcher,
-        )
         from sglang.srt.layers.moe.token_dispatcher.deepep import (
             DeepEPPDispatchHooks,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
         )
 
         dispatcher = object.__new__(NcclEpDispatcher)
         dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
 
         called = []
-        handle = dispatcher.register_deepep_dispatch_hook(
-            lambda d: called.append(d)
-        )
+        handle = dispatcher.register_deepep_dispatch_hook(lambda d: called.append(d))
         self.assertEqual(len(called), 0)
 
         dispatcher._dispatch_hooks(dispatcher)
@@ -118,12 +116,12 @@ class TestNcclEpDispatchHooks(unittest.TestCase):
 
     def test_dispatch_calls_hooks_between_a_and_b(self):
         """dispatch() must call hooks after dispatch_a and before dispatch_b."""
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
             NcclEpDispatcher,
             _Stage,
-        )
-        from sglang.srt.layers.moe.token_dispatcher.deepep import (
-            DeepEPPDispatchHooks,
         )
 
         dispatcher = object.__new__(NcclEpDispatcher)
@@ -145,9 +143,7 @@ class TestNcclEpDispatchHooks(unittest.TestCase):
         dispatcher.dispatch_a = mock_dispatch_a.__get__(dispatcher)
         dispatcher.dispatch_b = mock_dispatch_b.__get__(dispatcher)
 
-        dispatcher.register_deepep_dispatch_hook(
-            lambda d: call_order.append("hook")
-        )
+        dispatcher.register_deepep_dispatch_hook(lambda d: call_order.append("hook"))
 
         result = dispatcher.dispatch(
             torch.randn(4, 64, dtype=torch.bfloat16),
@@ -163,9 +159,7 @@ class TestMaxNumSmsResolution(unittest.TestCase):
     def test_default_value(self):
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
 
-        with patch(
-            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
-        ) as mock_env:
+        with patch("sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS") as mock_env:
             mock_env.is_set.return_value = False
             result = NcclEpBuffer._resolve_max_num_sms(256)
             self.assertEqual(result, 20)
@@ -173,9 +167,7 @@ class TestMaxNumSmsResolution(unittest.TestCase):
     def test_env_override(self):
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
 
-        with patch(
-            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
-        ) as mock_env:
+        with patch("sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS") as mock_env:
             mock_env.is_set.return_value = True
             mock_env.get.return_value = 40
             result = NcclEpBuffer._resolve_max_num_sms(256)
@@ -185,9 +177,7 @@ class TestMaxNumSmsResolution(unittest.TestCase):
         """256 experts need at least ceil(256/14)=19 SMs (nccl_ep.cc:1305)."""
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
 
-        with patch(
-            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
-        ) as mock_env:
+        with patch("sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS") as mock_env:
             mock_env.is_set.return_value = True
             mock_env.get.return_value = 1  # too low
             result = NcclEpBuffer._resolve_max_num_sms(256)
@@ -197,9 +187,7 @@ class TestMaxNumSmsResolution(unittest.TestCase):
         """64 experts need at least ceil(64/14)=5 SMs."""
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
 
-        with patch(
-            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
-        ) as mock_env:
+        with patch("sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS") as mock_env:
             mock_env.is_set.return_value = True
             mock_env.get.return_value = 1
             result = NcclEpBuffer._resolve_max_num_sms(64)
@@ -212,10 +200,10 @@ class TestSBOAssertAcceptsNcclEp(unittest.TestCase):
     def test_nccl_ep_dispatcher_is_accepted(self):
         """The assert isinstance(..., (MaybeTboDeepEPDispatcher, NcclEpDispatcher))
         should pass for NcclEpDispatcher instances."""
-        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
         from sglang.srt.batch_overlap.two_batch_overlap import (
             MaybeTboDeepEPDispatcher,
         )
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
 
         # Create a bare NcclEpDispatcher (no __init__)
         dispatcher = object.__new__(NcclEpDispatcher)
@@ -229,8 +217,8 @@ class TestForwardNormalSkipArConsistency(unittest.TestCase):
     """Test skip_ar behavior for nccl_ep backend."""
 
     def test_skip_ar_false_for_nccl_ep(self):
-        from sglang.srt.layers.moe.utils import should_skip_post_experts_all_reduce
         from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend
+        from sglang.srt.layers.moe.utils import should_skip_post_experts_all_reduce
 
         with patch(
             "sglang.srt.layers.moe.utils.get_moe_a2a_backend",
@@ -248,9 +236,7 @@ class TestForwardNormalSkipArConsistency(unittest.TestCase):
                         "sglang.srt.layers.moe.utils.get_server_args"
                     ) as mock_sa:
                         mock_sa.return_value = SimpleNamespace(dwdp_size=1)
-                        result = should_skip_post_experts_all_reduce(
-                            is_tp_path=True
-                        )
+                        result = should_skip_post_experts_all_reduce(is_tp_path=True)
 
         self.assertFalse(result)
 
@@ -303,7 +289,7 @@ class TestNcclEpDispatcherEpGroupType(unittest.TestCase):
 
 
 class TestNcclRuntimeVersionParsing(unittest.TestCase):
-    """Test _nccl_runtime_version() handles nccl4py 0.3.x VersionInfo format."""
+    """Test the selected nccl4py core VersionInfo API and conservative fallback."""
 
     def test_returns_none_when_no_nccl4py(self):
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
@@ -313,52 +299,36 @@ class TestNcclRuntimeVersionParsing(unittest.TestCase):
         with patch.dict("sys.modules", {"nccl": None, "nccl.core": None}):
             with patch("torch.cuda.nccl.version", side_effect=Exception):
                 result = _nccl_runtime_version()
-                # Should return None or fall through gracefully
-                # (may still return torch's version if import fails silently)
-                self.assertTrue(result is None or isinstance(result, tuple))
+                self.assertIsNone(result)
 
     def test_parses_versioninfo_namedtuple(self):
-        """nccl4py 0.3.x returns VersionInfo(nccl=LibraryInfo(version=<Version('2.30.7')>...))."""
+        """Prefer core.get_version().libnccl over Torch's build-time version."""
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
             _nccl_runtime_version,
         )
 
-        mock_version_info = SimpleNamespace(
-            nccl=SimpleNamespace(
-                version="2.30.7"
-            )
+        mock_core = ModuleType("nccl.core")
+        mock_core.get_version = MagicMock(
+            return_value=SimpleNamespace(libnccl=SimpleNamespace(version="2.30.7"))
         )
-
-        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
-            import sys
-            mock_nccl = MagicMock()
-            mock_nccl.get_version.return_value = mock_version_info
-            sys.modules["nccl"] = mock_nccl
-
-            mock_core = MagicMock()
-            mock_core.get_version.return_value = ""
-            sys.modules["nccl.core"] = mock_core
-
+        mock_nccl = ModuleType("nccl")
+        mock_nccl.core = mock_core
+        with patch.dict("sys.modules", {"nccl": mock_nccl, "nccl.core": mock_core}):
             with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
                 result = _nccl_runtime_version()
                 self.assertEqual(result, (2, 30, 7))
 
     def test_falls_back_to_torch_version(self):
-        """When nccl4py returns unparseable data, fall back to torch.cuda.nccl.version."""
+        """When nccl4py returns unparsable data, fall back to torch.cuda.nccl.version."""
         from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
             _nccl_runtime_version,
         )
 
-        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
-            import sys
-            mock_nccl = MagicMock()
-            mock_nccl.get_version.return_value = None
-            sys.modules["nccl"] = mock_nccl
-
-            mock_core = MagicMock()
-            mock_core.get_version.return_value = None
-            sys.modules["nccl.core"] = mock_core
-
+        mock_core = ModuleType("nccl.core")
+        mock_core.get_version = MagicMock(return_value=None)
+        mock_nccl = ModuleType("nccl")
+        mock_nccl.core = mock_core
+        with patch.dict("sys.modules", {"nccl": mock_nccl, "nccl.core": mock_core}):
             with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
                 result = _nccl_runtime_version()
                 self.assertEqual(result, (2, 28, 9))

--- a/test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
@@ -1,0 +1,486 @@
+"""Synthetic NCCL EP dispatch/combine verification (4-GPU, no model weights).
+
+Runs via torchrun on 4 GPUs. Validates the real NcclEpDispatcher code path
+(comm init -> dispatch A2A -> bf16->fp8 post-quant -> combine A2A -> destroy)
+without loading any model, using synthetic bf16 inputs.
+
+Usage (on a 4-GPU node with NCCL >= 2.29):
+
+    CUDA_VISIBLE_DEVICES=4,5,6,7 \
+    LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 \
+    torchrun --nproc_per_node=4 \
+        test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
+
+Covers:
+    1. NCCL EP group creation (LL, no-IB RDMA buffer init)
+    2. dispatch A2A real send/recv correctness
+    3. bf16->fp8 post-quant numerical correctness (vs reference)
+    4. combine A2A real send/recv + budget assert + handle destroy
+    5. constraint guards (hidden allowlist, topk<=9) fail-fast
+    6. dispatch->combine round-trip consistency (identity expert)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+from types import SimpleNamespace
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from unittest.mock import patch, MagicMock
+
+# ---- sglang imports (must come after env setup) ----
+from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+    NcclEpDispatcher,
+    is_nccl_ep_available,
+    nccl_ep_unavailable_reason,
+    _nccl_runtime_version,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+# ---- monkey-patch runtime_context: NcclEpDispatcher.__init__ calls
+# get_exec().deterministic.enable_deterministic_inference, but we don't
+# run the full sglang server bootstrap. Patch it to return a mock that
+# reports deterministic=False (the safe default for a synthetic test).
+import sglang.srt.runtime_context as _rtc
+
+class _MockDeterministic:
+    enable_deterministic_inference = False
+
+class _MockExec:
+    deterministic = _MockDeterministic()
+
+_original_get_exec = _rtc.get_exec
+
+
+def _mocked_get_exec():
+    return _MockExec()
+
+
+_rtc.get_exec = _mocked_get_exec
+
+# ---- test config (mirrors DeepSeek-V3 / GLM-5.2 W4AFP8 constraints) ----
+NUM_EXPERTS = 256
+TOPK = 8
+HIDDEN = 7168          # in LL allowlist; 6144 also works
+NUM_LAYERS = 1         # synthetic: single MoE layer
+BATCH_TOKENS = 128     # per-rank decode tokens (< 1024 budget)
+
+
+def log(rank: int, msg: str):
+    """Rank-0 tagged log, but each rank prints its own PASS/FAIL."""
+    prefix = f"[rank {rank}]"
+    print(f"{prefix} {msg}", flush=True)
+
+
+def setup_distributed():
+    """Init gloo backend (for metadata) + create NCCL communicator via PyNccl."""
+    dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+
+    torch.cuda.set_device(local_rank)
+
+    # Create a gloo sub-group (PyNcclCommunicator requires non-NCCL backend).
+    cpu_group = dist.new_group(backend="gloo")
+
+    # Build a real NCCL communicator bound to this GPU.
+    pynccl_comm = PyNcclCommunicator(group=cpu_group, device=local_rank)
+
+    # Minimal ep_group mock: NcclEpDispatcher only needs world_size + pynccl_comm.
+    # _create_group reads ep_group.pynccl_comm.comm.value (ncclComm_t ptr).
+    ep_group = SimpleNamespace(
+        world_size=world_size,
+        rank=rank,
+        rank_in_group=rank,
+        pynccl_comm=pynccl_comm,
+    )
+    return rank, world_size, local_rank, ep_group
+
+
+def make_moe_runner_config(hidden: int = HIDDEN, topk: int = TOPK):
+    """Build a minimal MoeRunnerConfig for NcclEpDispatcher.__init__."""
+    return MoeRunnerConfig(
+        num_experts=NUM_EXPERTS,
+        num_local_experts=NUM_EXPERTS // dist.get_world_size(),
+        hidden_size=hidden,
+        top_k=topk,
+        params_dtype=torch.bfloat16,
+    )
+
+
+def make_synthetic_inputs(
+    rank: int, batch: int, hidden: int, num_experts: int, topk: int, device: torch.device
+):
+    """Create deterministic synthetic hidden_states + topk routing.
+
+    Each token routes to `topk` experts. Routing is deterministic per-rank so
+    cross-rank results are reproducible. We use a simple hash: expert_id =
+    (token_idx * 7 + rank * 13) % num_experts, cycled for topk picks.
+    """
+    torch.manual_seed(42 + rank)
+    hidden_states = torch.randn(batch, hidden, dtype=torch.bfloat16, device=device)
+
+    topk_ids = torch.zeros(batch, topk, dtype=torch.int64, device=device)
+    for t in range(batch):
+        for k in range(topk):
+            topk_ids[t, k] = (t * 7 + rank * 13 + k * 31) % num_experts
+
+    # Uniform weights (will be renormalized by dispatcher anyway).
+    topk_weights = torch.ones(batch, topk, dtype=torch.float32, device=device) / topk
+
+    topk_output = StandardTopKOutput(
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        router_logits=torch.zeros(batch, num_experts, dtype=torch.float32, device=device),
+    )
+    return hidden_states, topk_output
+
+
+def reference_fp8_quant(x: torch.Tensor, group_size: int = 128):
+    """Reference per-token-group fp8 (e4m3) quantization in pure PyTorch.
+
+    Mirrors sglang_per_token_group_quant_fp8: scale = max(|x_group|) / 448,
+    x_q = round(x / scale) clamped to fp8 range, cast to fp8_e4m3fn.
+    """
+    assert x.shape[-1] % group_size == 0
+    orig_shape = x.shape
+    n_groups = orig_shape[-1] // group_size
+    x_2d = x.reshape(-1, group_size)
+    # max abs per group -> scale
+    group_max = x_2d.abs().amax(dim=-1, keepdim=True).clamp(min=1e-10)
+    scale = group_max / 448.0
+    x_scaled = (x_2d / scale).round().clamp(-448.0, 448.0)
+    x_q = x_scaled.reshape(orig_shape).to(torch.float8_e4m3fn)
+    scale = scale.reshape(*orig_shape[:-1], n_groups)
+    return x_q, scale
+
+
+def test_1_gate_and_env(rank: int):
+    """Verify is_nccl_ep_available() returns True with LD_PRELOAD'd NCCL >= 2.29."""
+    ver = _nccl_runtime_version()
+    available = is_nccl_ep_available()
+    reason = nccl_ep_unavailable_reason()
+    log(rank, f"[1] NCCL runtime={ver} available={available} reason='{reason}'")
+    assert available, f"NCCL EP not available: {reason}. Need LD_PRELOAD NCCL >= 2.29."
+    assert ver is not None and (ver[0], ver[1]) >= (2, 29), f"NCCL {ver} < 2.29"
+    log(rank, "[1] PASS: gate check (NCCL >= 2.29, sm_90, nccl4py importable)")
+
+
+def test_2_group_creation(rank: int, ep_group, hidden: int):
+    """Verify NCCL EP LOW_LATENCY group can be created (the no-IB RDMA init test)."""
+    cfg = make_moe_runner_config(hidden=hidden)
+    # StandardDispatcher.__init__ calls get_parallel().moe_ep_size which requires
+    # a fully initialized sglang parallel state. In this synthetic test we don't
+    # run the full server bootstrap, so mock StandardDispatcher to avoid the
+    # dependency.
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            dispatcher = NcclEpDispatcher(cfg, ep_group)
+        except Exception as e:
+            log(rank, f"[2] FAIL: group creation raised: {e}")
+            raise
+    log(rank, "[2] PASS: NCCL EP LOW_LATENCY group created (RDMA buffer init OK)")
+    return dispatcher
+
+
+def test_3_dispatch(rank: int, dispatcher: NcclEpDispatcher, hidden: int):
+    """Verify dispatch A2A: real bf16 send/recv across 4 ranks."""
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    hs, topk_output = make_synthetic_inputs(
+        rank, BATCH_TOKENS, hidden, NUM_EXPERTS, TOPK, device
+    )
+
+    dispatch_output = dispatcher.dispatch(hs, topk_output)
+
+    # Check output types/shapes
+    assert dispatch_output.hidden_states.dtype == torch.float8_e4m3fn, (
+        f"expected fp8_e4m3fn, got {dispatch_output.hidden_states.dtype}"
+    )
+    assert dispatch_output.hidden_states.is_cuda, "hidden_states not on GPU"
+    assert dispatch_output.hidden_states_scale.dtype == torch.float32, (
+        f"expected float32 scale, got {dispatch_output.hidden_states_scale.dtype}"
+    )
+
+    # masked_m should reflect actual recv counts (non-zero in general).
+    total_recv = dispatch_output.masked_m.sum().item()
+    log(
+        rank,
+        f"[3] dispatch OK: hs_fp8={tuple(dispatch_output.hidden_states.shape)} "
+        f"scale={tuple(dispatch_output.hidden_states_scale.shape)} "
+        f"total_recv_tokens={total_recv} expected_m={dispatch_output.expected_m}",
+    )
+    return dispatch_output, hs, topk_output
+
+
+def test_4_fp8_quant_correctness(
+    rank: int, dispatcher: NcclEpDispatcher, dispatch_output, hidden: int
+):
+    """Verify bf16->fp8 post-quant matches reference quantization.
+
+    The dispatcher already ran _quantize_fp8 internally during dispatch.
+    We re-run the reference on a known small tensor and compare to the sglang
+    kernel directly, to validate the quant path used by NCCL EP.
+    """
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    group_size = 128
+
+    # Small deterministic test tensor
+    torch.manual_seed(123)
+    test_x = torch.randn(4, hidden, dtype=torch.bfloat16, device=device)
+
+    # sglang kernel (same one NCCL EP calls)
+    q_kernel, s_kernel = sglang_per_token_group_quant_fp8(
+        test_x, group_size=group_size
+    )
+    # reference
+    q_ref, s_ref = reference_fp8_quant(test_x, group_size=group_size)
+
+    # Scales should match closely (both compute max/448)
+    scale_diff = (s_kernel - s_ref.to(device)).abs().max().item()
+    # Quantized values: allow small rounding diff (kernel may use slightly
+    # different rounding). Check correlation: dequant should be close.
+    # scale is [4, 56] (7168/128=56 groups), need to expand to [4, 7168] for broadcast
+    s_kernel_expanded = s_kernel.repeat_interleave(group_size, dim=-1).to(torch.float32)
+    s_ref_expanded = s_ref.to(device).repeat_interleave(group_size, dim=-1).to(torch.float32)
+    dq_kernel = q_kernel.to(torch.float32) * s_kernel_expanded
+    dq_ref = q_ref.to(torch.float32) * s_ref_expanded
+    max_err = (dq_kernel - dq_ref).abs().max().item()
+
+    log(
+        rank,
+        f"[4] fp8 quant: scale_diff={scale_diff:.2e} dequant_max_err={max_err:.2e}",
+    )
+    assert scale_diff < 1e-3, f"scale mismatch: {scale_diff}"
+    assert max_err < 0.5, f"dequant error too large: {max_err}"
+    log(rank, "[4] PASS: bf16->fp8 post-quant matches reference")
+
+
+def test_5_combine(rank: int, dispatcher: NcclEpDispatcher, dispatch_output, topk_output):
+    """Verify combine A2A: real bf16 send/recv back + handle destroy."""
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+
+    # For synthetic test, we don't have real expert weights/GEMM.
+    # The combine needs expert_outputs in DeepEPLLCombineInput format.
+    # We feed back a zero tensor of the expected shape to verify combine
+    # mechanics (A2A communication + handle lifecycle) without GEMM.
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+
+    # dispatch_output.hidden_states is [E_local, max_recv, H] fp8.
+    # combine expects expert_outputs of compatible shape.
+    # Use the fp8 tensor cast back to bf16 as a stand-in (mechanical test).
+    expert_outputs = dispatch_output.hidden_states.to(torch.bfloat16)
+
+    combine_input = DeepEPLLCombineInput(
+        hidden_states=expert_outputs,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+
+    combined = dispatcher.combine(combine_input)
+    assert combined.dtype == torch.bfloat16, f"expected bf16, got {combined.dtype}"
+    assert combined.is_cuda, "combined not on GPU"
+    assert combined.shape[1] == dispatcher.hidden_size
+
+    log(
+        rank,
+        f"[5] combine OK: combined={tuple(combined.shape)} "
+        f"mean={combined.float().mean().item():.4f} "
+        f"handle_destroyed={dispatcher.handle is None}",
+    )
+    assert dispatcher.handle is None, "handle not destroyed after combine"
+    log(rank, "[5] PASS: combine A2A + handle destroy")
+
+
+def test_6_roundtrip_identity(rank: int, ep_group, hidden: int):
+    """Round-trip consistency with identity expert.
+
+    Re-create a fresh dispatcher. Dispatch bf16 input, then for combine feed
+    back the *dispatched bf16 tokens* directly (identity expert = no GEMM).
+    The combine should return tokens in original order with topk weighting.
+
+    This is the strongest end-to-end correctness signal for the A2A layer.
+    """
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    world_size = dist.get_world_size()
+
+    # Fresh dispatcher (previous one destroyed its handle/group)
+    # NcclEpBuffer is process-global singleton; reuse same group.
+    cfg = make_moe_runner_config(hidden=hidden)
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        dispatcher = NcclEpDispatcher(cfg, ep_group)
+
+    batch = BATCH_TOKENS
+    hs, topk_output = make_synthetic_inputs(
+        rank, batch, hidden, NUM_EXPERTS, TOPK, device
+    )
+
+    dispatch_output = dispatcher.dispatch(hs, topk_output)
+
+    # Identity expert: feed the dispatched bf16 tokens back as "expert output".
+    # recv_tokens shape is [E_local, max_recv, H]; combine sends these back.
+    # We use the fp8->bf16 cast (dispatch already quantized; we unquantize).
+    expert_outputs = dispatch_output.hidden_states.to(torch.bfloat16)
+
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+
+    combine_input = DeepEPLLCombineInput(
+        hidden_states=expert_outputs,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+    combined = dispatcher.combine(combine_input)
+
+    # With identity expert + uniform 1/topk weights, combined should be
+    # proportional to the original input (modulo quantization noise + the
+    # fact that combine sums topk weighted copies).
+    # Check: combined is finite (no NaN/Inf from broken A2A).
+    assert torch.isfinite(combined).all(), "combined has NaN/Inf"
+
+    # Check shape: [batch, hidden]
+    assert combined.shape[0] == batch, f"expected batch={batch}, got {combined.shape[0]}"
+    assert combined.shape[1] == hidden
+
+    log(
+        rank,
+        f"[6] roundtrip OK: combined={tuple(combined.shape)} "
+        f"finite=True "
+        f"||combined||={combined.float().norm().item():.2f} "
+        f"||input||={hs.float().norm().item():.2f}",
+    )
+    log(rank, "[6] PASS: dispatch->combine round-trip (identity expert, finite output)")
+
+
+def test_7_guard_hidden_allowlist(rank: int, ep_group):
+    """Verify hidden allowlist guard fires for unsupported hidden size."""
+    cfg = make_moe_runner_config(hidden=3072)  # NOT in allowlist
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            NcclEpDispatcher(cfg, ep_group)
+            log(rank, "[7] FAIL: expected ValueError for hidden=3072 (not in allowlist)")
+            assert False, "should have raised"
+        except ValueError as e:
+            assert "NCCL EP LL only supports hidden" in str(e)
+            log(rank, f"[7] PASS: hidden allowlist guard fired (hidden=3072 rejected)")
+        except Exception as e:
+            log(rank, f"[7] FAIL: wrong exception type: {type(e).__name__}: {e}")
+            raise
+
+
+def test_8_guard_topk(rank: int, ep_group):
+    """Verify topk<=9 guard fires for topk=10."""
+    cfg = make_moe_runner_config(hidden=HIDDEN, topk=10)
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            NcclEpDispatcher(cfg, ep_group)
+            log(rank, "[8] FAIL: expected ValueError for topk=10 (>9)")
+            assert False, "should have raised"
+        except ValueError as e:
+            assert "topk" in str(e).lower()
+            log(rank, f"[8] PASS: topk guard fired (topk=10 rejected)")
+        except Exception as e:
+            log(rank, f"[8] FAIL: wrong exception type: {type(e).__name__}: {e}")
+            raise
+
+
+def main():
+    rank, world_size, local_rank, ep_group = setup_distributed()
+    device = torch.device(f"cuda:{local_rank}")
+
+    log(rank, f"=== NCCL EP Synthetic Verification (world_size={world_size}) ===")
+    log(rank, f"    device={device} hidden={HIDDEN} experts={NUM_EXPERTS} topk={TOPK}")
+    log(rank, f"    batch_tokens_per_rank={BATCH_TOKENS}")
+
+    results = []
+    tests = [
+        ("gate+env", lambda: test_1_gate_and_env(rank)),
+        ("group creation", lambda: test_2_group_creation(rank, ep_group, HIDDEN)),
+        ("dispatch A2A", lambda: None),  # handled inside, needs dispatcher
+        ("fp8 quant", lambda: None),
+        ("combine A2A", lambda: None),
+        ("roundtrip", lambda: None),
+        ("guard hidden", lambda: test_7_guard_hidden_allowlist(rank, ep_group)),
+        ("guard topk", lambda: test_8_guard_topk(rank, ep_group)),
+    ]
+
+    try:
+        # Test 1: gate + environment
+        test_1_gate_and_env(rank)
+        results.append(("1. gate+env", True))
+
+        # Test 2: group creation (returns dispatcher for tests 3-5)
+        dispatcher = test_2_group_creation(rank, ep_group, HIDDEN)
+        results.append(("2. group creation", True))
+
+        # Test 3: dispatch
+        dispatch_output, hs, topk_output = test_3_dispatch(rank, dispatcher, HIDDEN)
+        results.append(("3. dispatch A2A", True))
+
+        # Test 4: fp8 quant correctness
+        test_4_fp8_quant_correctness(rank, dispatcher, dispatch_output, HIDDEN)
+        results.append(("4. fp8 quant", True))
+
+        # Test 5: combine
+        test_5_combine(rank, dispatcher, dispatch_output, topk_output)
+        results.append(("5. combine A2A", True))
+
+        # Test 6: roundtrip (fresh dispatcher, reuses process-global group)
+        test_6_roundtrip_identity(rank, ep_group, HIDDEN)
+        results.append(("6. roundtrip", True))
+
+        # Test 7: guard - hidden allowlist
+        test_7_guard_hidden_allowlist(rank, ep_group)
+        results.append(("7. guard hidden", True))
+
+        # Test 8: guard - topk
+        test_8_guard_topk(rank, ep_group)
+        results.append(("8. guard topk", True))
+
+    except Exception as e:
+        log(rank, f"!!! TEST FAILED: {e}")
+        traceback.print_exc()
+        results.append(("FAILED", False))
+    finally:
+        # Cleanup
+        try:
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+            NcclEpBuffer.destroy()
+        except Exception:
+            pass
+        dist.barrier()
+        dist.destroy_process_group()
+
+    # Summary
+    log(rank, "=== RESULTS ===")
+    for name, ok in results:
+        log(rank, f"  {'PASS' if ok else 'FAIL'}: {name}")
+
+    all_pass = all(ok for _, ok in results)
+    log(rank, f"=== {'ALL PASS' if all_pass else 'SOME FAILED'} ===")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1134,6 +1134,51 @@ class TestWaterfillArgs(CustomTestCase):
         self.assertTrue(server_args.enforce_shared_experts_fusion)
 
 
+class TestNcclEpArgs(CustomTestCase):
+    """NCCL EP MoE A2A backend (--moe-a2a-backend nccl_ep).
+
+    Capability detection falls back to none/deepep when nccl4py is unavailable
+    (the CPU CI case). On a CUDA13 + Hopper/Blackwell box with nccl4py[cu13]
+    installed, the backend stays nccl_ep.
+    """
+
+    def test_nccl_ep_flag_accepted(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="nccl_ep",
+            nccl_ep_mode="low_latency",
+            nccl_ep_num_max_dispatch_tokens_per_rank=1024,
+        )
+        # dummy-model path short-circuits __post_init__; invoke the handler directly.
+        server_args._handle_a2a_moe()
+
+        self.assertEqual(server_args.nccl_ep_mode, "low_latency")
+        self.assertEqual(
+            server_args.nccl_ep_num_max_dispatch_tokens_per_rank, 1024
+        )
+
+    def test_nccl_ep_falls_back_when_unavailable(self):
+        # On CPU CI (no nccl4py / no CUDA), is_nccl_ep_available() is False and
+        # the backend must degrade to 'none' (or 'deepep' if deep_ep importable).
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            is_nccl_ep_available,
+        )
+
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="nccl_ep",
+        )
+        server_args._handle_a2a_moe()
+
+        if is_nccl_ep_available():
+            self.assertEqual(server_args.moe_a2a_backend, "nccl_ep")
+        else:
+            self.assertIn(
+                server_args.moe_a2a_backend, ("none", "deepep"),
+                f"expected fallback to none/deepep, got {server_args.moe_a2a_backend}",
+            )
+
+
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):
     """Validation for --prefill-only-disable-kv-cache.
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1153,9 +1153,7 @@ class TestNcclEpArgs(CustomTestCase):
         server_args._handle_a2a_moe()
 
         self.assertEqual(server_args.nccl_ep_mode, "low_latency")
-        self.assertEqual(
-            server_args.nccl_ep_num_max_dispatch_tokens_per_rank, 1024
-        )
+        self.assertEqual(server_args.nccl_ep_num_max_dispatch_tokens_per_rank, 1024)
 
     def test_nccl_ep_falls_back_when_unavailable(self):
         # On CPU CI (no nccl4py / no CUDA), is_nccl_ep_available() is False and
@@ -1174,7 +1172,8 @@ class TestNcclEpArgs(CustomTestCase):
             self.assertEqual(server_args.moe_a2a_backend, "nccl_ep")
         else:
             self.assertIn(
-                server_args.moe_a2a_backend, ("none", "deepep"),
+                server_args.moe_a2a_backend,
+                ("none", "deepep"),
                 f"expected fallback to none/deepep, got {server_args.moe_a2a_backend}",
             )
 

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -399,6 +399,8 @@ class TestMoeFlagsGroup(_IsolatedServerArgs):
             speculative_moe_a2a_backend=None,
             deepep_mode="auto",
             deepep_config=None,
+            nccl_ep_mode="low_latency",
+            nccl_ep_num_max_dispatch_tokens_per_rank=0,
             enable_two_batch_overlap=False,
             enable_single_batch_overlap=False,
             tbo_token_distribution_threshold=0.48,


### PR DESCRIPTION
Depends on #32329 (`efd30456466549fd2be6131eaba0edd8972506a4`). This is a follow-up for the NCCL EP LL / CUDA Graph workstream of #32774. Review the commits after that SHA; the parent commit retains its original authorship. This PR does not close the roadmap. Retarget/rebase after the dependency lands, then rerun validation on that base.

Focused review: [the follow-up changes](https://github.com/Laceprndpm/sglang/compare/efd30456466549fd2be6131eaba0edd8972506a4...50ecc92553e91fdd850001e0f05b9936e4b44da8). The GitHub PR targets `main` and therefore also displays the unmerged parent change.

## Motivation

The NCCL EP LL path creates and destroys a handle on every forward. CUDA Graph capture/replay needs the handle, communication state and tensor storage to outlive the captured executables, including when routing data or the selected decode bucket changes.

This adds opt-in serialized NCCL EP execution through SGLang's existing full decode CUDA Graph backend. Each capture generation owns one dedicated Graph group and one persistent LL handle. Compatible layers and buckets share them serially to avoid conflicting ownership of the group's communication state; this is not an API restriction on the number of handles.

## Modifications

Review follow-up: resolve NCCL EP to EP=TP, bound prefill after DP partitioning, preserve the Triton runner with a compatible unavailable-backend fallback, and reject unsupported quantization, UE8M0 scales, FP16 payloads and SBO/TBO before communication. FP8/W4A-FP8 and SM120 float32-scale configurations remain eligible. [Finding-by-finding triage and retest scope](https://github.com/Laceprndpm/sglang/blob/50ecc92553e91fdd850001e0f05b9936e4b44da8/test/nccl_ep_test/review_validation.md).

- Add `--enable-nccl-ep-cuda-graph`, capability checks and explicit rejection of unsupported configurations. NCCL EP remains eager without the opt-in; prefill remains eager.
- Prepare maximum-capacity storage and same-base bucket descriptors outside capture. Replay reads updated token/routing/weight data without Python handle updates.
- Retain native EP tensor descriptor bundles through staged `send_only` / `complete()`. Two-rank testing exposed a borrowed-descriptor lifetime failure; the fix has a weak-reference mock regression.
- Preserve outputs across layers, order input writes and output consumers across streams, reject concurrent host submissions, and isolate eager communication resources.
- Close Graph executables before their handle/group during recapture, controlled capture failure and model-parallel shutdown.
- Register CPU/one-GPU tests, add a reusable two-GPU correctness/benchmark harness, and document the installation and initial scope. Add the missing `nccl-extensions` optional dependency; document the explicit NCCL 2.30.7 override required with the official Torch wheel.

Initial scope: BF16 LL inputs, compatible layers, fixed-capacity decode buckets, single node and strict serial submission. HT, prefill/piecewise/breakable Graphs, speculative decoding, SBO/TBO, PDMux, EPLB/elastic EP, Torch compile, memory saver and concurrent replay are excluded.

## Accuracy Tests

Review follow-up at `50ecc92553e91fdd850001e0f05b9936e4b44da8`: 115 local NCCL EP tests passed, including 27 new public-contract regressions. The initial reproducer failed 16 cases on the old parent. Additional parent configuration regression passed 195 tests and 21 subtests; the combined parent run passed 310 tests and 21 subtests under coverage. Executable changed-line coverage for this review fix is 94%. The new CI entrypoint also passed with optional EP imports blocked. Changed-file pre-commit and Mintlify build/link checks passed; full-stack pre-commit passed on `3e41965`.

No new native EP or performance result is claimed for these heads. Before certifying the changed serving defaults, rerun the final-stack pair and eager/Graph serving gates with EP omitted, TP=DP=2, default prefill chunking, an LL budget of 64 and a prompt longer than 64 tokens. Include idle ranks and eager/Graph recovery. Historical hardware results below retain their original tested SHAs and explicit configurations. See the [review validation record](https://github.com/Laceprndpm/sglang/blob/50ecc92553e91fdd850001e0f05b9936e4b44da8/test/nccl_ep_test/review_validation.md).

Two RTX PRO 6000 Blackwell Server Edition GPUs (SM120), SYS topology with direct peer access, Ubuntu 22.04.5, Python 3.12.12, CUDA Toolkit 13.0.88, official Torch `2.11.0+cu130`, nccl4py 0.4.1, nccl-extensions 0.1.0, actual loaded NCCL 2.30.7. Torch's NCCL compile-time query remains 2.28.9; the override is explicit.

| Test | Passed checks per rank |
| --- | ---: |
| Native eager, weighted / identity experts | 180 each |
| SGLang eager including FP8 conversion, weighted / identity experts | 360 each |
| Native / SGLang single-bucket capture | 4 each |
| Native / SGLang dynamic replay matrix | 4118 each |
| Actual runner input/padding/stream/recapture path | 12 |
| Controlled host capture failure and cleanup | 6 |

Dynamic coverage: 8/16/32-token buckets, two layers, two generations, 1000 replays per generation; balanced/hotspot routes, padding, empty-effective ranks, all-masked inputs, ABA bucket changes and eager interleaving. Separate native T=0 and capacity-controlled duplicate-expert probes passed. CPU oracle checks full receive rows/multiplicities and weighted combine with exactly representable fixtures (`rtol=0, atol=0`). Resource closure checks passed.

Local registered NCCL EP tests: 88 passed on RTX 4060 Laptop using real CUDA Graphs and fake external EP. The configuration CI entrypoint also passed with optional NCCL EP imports blocked. The combined selection passes 202 tests and 8 subtests. Changed production-line coverage is 89% against the fixed parent (60% required).

The submitted harness and reproduction commands are in [README.md](https://github.com/Laceprndpm/sglang/blob/537b7a17477a6621efd727f5f088848d754ed3b4/test/nccl_ep_test/README.md); results and raw-evidence hashes are in [validation.md](https://github.com/Laceprndpm/sglang/blob/537b7a17477a6621efd727f5f088848d754ed3b4/test/nccl_ep_test/validation.md). Server execution used the validated implementation snapshot; subsequent submission work relocates tests, shares test factories, adds the CLI, reorders unchanged declarations, formats code and documents packaging.

**Full-model accuracy and actual expert GEMM execution have not been evaluated.** This is ready for review of the implementation and synthetic evidence; model-level acceptance and upstream CI remain pending.

## Speed Tests and Profiling

Unprofiled two-layer synthetic steps on the same SYS pair. Four rounds × 200 samples per mode/rank, 20 warmups per block, alternating mode order. Aggregate the maximum of aligned rank samples before median/p95.

| Tokens/rank | Routing | Eager median / p95 (ms) | Graph median / p95 (ms) | Median ratio |
| --- | --- | --- | --- | --- |
| 8 | balanced | 0.7774 / 1.1629 | 0.1413 / 0.1671 | 5.50x |
| 8 | hotspot | 0.7676 / 0.8485 | 0.1440 / 0.1561 | 5.33x |
| 16 | balanced | 0.7708 / 0.9042 | 0.1526 / 0.1783 | 5.05x |
| 16 | hotspot | 0.7755 / 0.8583 | 0.1582 / 0.1833 | 4.90x |
| 32 | balanced | 0.7790 / 0.9509 | 0.1756 / 0.2011 | 4.44x |
| 32 | hotspot | 0.7747 / 0.8736 | 0.1884 / 0.2143 | 4.11x |

Both modes perform input copies, synthetic expert arithmetic and retained observations. Timing includes host launch gaps; capture, warmup, first-use JIT and CPU oracle work are excluded. These are serial synthetic-step ratios, not isolated EP kernel speedups or model throughput.

A separate Nsight Systems 2025.3.1 run recorded 4000 replay ranges/Graph launches and 8000 dispatch + 8000 combine Graph-node kernel instances per GPU. Recorded replay host ranges contain no CUDA device allocation/free, Graph instantiation/destruction or module/library loads. Harness copies/events remain. Both rank oracles passed under profiling; profiled tails are not interpreted as isolated SYS-link latency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Checklist status: `pre-commit run --all-files --hook-stage pre-commit` passes after three formatter-only corrections inherited from the baseline. The final test selection passes 202 tests and 8 subtests, with 89% changed-line coverage. Mintlify build validation and internal-link checks passed. Synthetic correctness, timing and profiling results are provided above. Full-model accuracy, real expert GEMM execution and serving performance validation remain pending. Upstream CI and maintainer review are pending.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->