### PR TITLE
[CI] Support Cache-DiT import layouts across runner state

### DIFF
--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -30,8 +30,16 @@ from cache_dit import (
     TaylorSeerCalibratorConfig,
     steps_mask,
 )
-from cache_dit.caching.block_adapters import BlockAdapterRegister
-from cache_dit.parallelism import ParallelismBackend, ParallelismConfig
+
+try:
+    from cache_dit import (
+        BlockAdapterRegister,
+        ParallelismBackend,
+        ParallelismConfig,
+    )
+except ImportError:
+    from cache_dit.caching.block_adapters import BlockAdapterRegister
+    from cache_dit.parallelism import ParallelismBackend, ParallelismConfig
 
 from sglang.multimodal_gen.runtime.distributed.parallel_state import get_dit_group
 

--- a/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py
@@ -22,7 +22,7 @@ class _FakeForwardPattern:
     Pattern_3 = "Pattern_3"
 
 
-def _install_cache_dit_stub():
+def _install_cache_dit_stub(*, top_level_exports=False):
     cache_dit = types.ModuleType("cache_dit")
     cache_dit.enable_calls = []
     cache_dit.disable_calls = []
@@ -74,6 +74,12 @@ def _install_cache_dit_stub():
     parallelism = types.ModuleType("cache_dit.parallelism")
     parallelism.ParallelismBackend = object
     parallelism.ParallelismConfig = object
+
+    if top_level_exports:
+        cache_dit.BlockAdapterRegister = _FakeBlockAdapterRegister
+        cache_dit.ParallelismBackend = parallelism.ParallelismBackend
+        cache_dit.ParallelismConfig = parallelism.ParallelismConfig
+        return {"cache_dit": cache_dit}
 
     return {
         "cache_dit": cache_dit,
@@ -147,8 +153,8 @@ def _install_torch_stub():
     }
 
 
-def _import_module_with_stub():
-    stub_modules = _install_cache_dit_stub()
+def _import_module_with_stub(*, top_level_exports=False):
+    stub_modules = _install_cache_dit_stub(top_level_exports=top_level_exports)
     stub_modules.update(_install_sglang_dependency_stubs())
     stub_modules.update(_install_torch_stub())
     module_path = (
@@ -165,6 +171,22 @@ def _import_module_with_stub():
         assert spec.loader is not None
         spec.loader.exec_module(module)
     return module
+
+
+class TestCacheDitImportCompatibility(unittest.TestCase):
+    def test_imports_legacy_submodule_exports(self):
+        module = _import_module_with_stub()
+
+        self.assertIsNotNone(module.BlockAdapterRegister)
+        self.assertIsNotNone(module.ParallelismBackend)
+        self.assertIsNotNone(module.ParallelismConfig)
+
+    def test_imports_top_level_exports(self):
+        module = _import_module_with_stub(top_level_exports=True)
+
+        self.assertIsNotNone(module.BlockAdapterRegister)
+        self.assertIsNotNone(module.ParallelismBackend)
+        self.assertIsNotNone(module.ParallelismConfig)
 
 
 class TestCacheDitRefreshContext(unittest.TestCase):


### PR DESCRIPTION
[by Codex]

## Summary

- support Cache-DiT 1.5's top-level exports for `BlockAdapterRegister`, `ParallelismBackend`, and `ParallelismConfig`
- retain the legacy submodule imports used by the currently pinned Cache-DiT versions
- add focused unit coverage for both package layouts

## Motivation

A Base CI shard for #38426 failed in `test_flux2_fp8_norm_quant_gate.py` with:

```text
ModuleNotFoundError: No module named 'cache_dit.parallelism'
```

The self-hosted runner had retained `cache-dit==1.5.1` in system Python after a diffusion job from #37774. The later Base job did not install diffusion extras, so it inherited that package while testing source code that still used the legacy submodule import.

This PR extracts only the import-compatibility portion of #37774 so the CI fix can land independently of that larger feature PR. It does not change dependency pins or Cache-DiT runtime behavior.

Failure: https://github.com/sgl-project/sglang/actions/runs/34321708659/job/102392704016

## Validation

- `/usr/bin/python3.11 python/sglang/multimodal_gen/test/unit/test_cache_dit_integration.py` (11 tests passed)
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34352702626](https://github.com/sgl-project/sglang/actions/runs/34352702626)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34352702122](https://github.com/sgl-project/sglang/actions/runs/34352702122)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34352702467](https://github.com/sgl-project/sglang/actions/runs/34352702467)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->