### PR TITLE
[AMD] Fix the diffusion perf fixture lookup 

### DIFF
--- a/test/registered/amd/conftest.py
+++ b/test/registered/amd/conftest.py
@@ -1,0 +1,10 @@
+"""Make the diffusion perf fixture reachable from this directory.
+
+``DiffusionServerBase`` (subclassed by the diffusion tests here) has an autouse
+fixture that requests ``perf_results``, which is declared in
+``sglang/multimodal_gen/test/server/conftest.py``. pytest resolves conftest.py
+by the collected file's directory, so that declaration never reaches
+``test/registered/``; re-exporting it here is what makes it resolvable.
+"""
+
+from sglang.multimodal_gen.test.server.conftest import perf_results  # noqa: F401

--- a/test/registered/amd/test_wan22_fp8_mla.py
+++ b/test/registered/amd/test_wan22_fp8_mla.py
@@ -101,13 +101,6 @@ FP8_MLA_CASES = [
 class TestWan22FP8MLA(DiffusionServerBase):
     """AMD test for FP8 MLA attention on Wan2.2-T2V-A14B."""
 
-    @classmethod
-    def teardown_class(cls):
-        try:
-            super().teardown_class()
-        except AttributeError:
-            pass
-
     @pytest.fixture(params=FP8_MLA_CASES, ids=lambda c: c.id)
     def case(self, request) -> DiffusionTestCase:
         return request.param

--- a/test/registered/amd/test_zimage_turbo.py
+++ b/test/registered/amd/test_zimage_turbo.py
@@ -106,13 +106,6 @@ def _compute_clip_score(image_bytes: bytes, prompt: str) -> float | None:
 class TestZImageTurboAMD(DiffusionServerBase):
     """AMD nightly test for Z-Image-Turbo text-to-image generation."""
 
-    @classmethod
-    def teardown_class(cls):
-        try:
-            super().teardown_class()
-        except AttributeError:
-            pass
-
     @pytest.fixture(params=AMD_ZIMAGE_CASES, ids=lambda c: c.id)
     def case(self, request) -> DiffusionTestCase:
         return request.param


### PR DESCRIPTION


Fix AMD Nightly Test **nightly-1-gpu-zimage-turbo**

## Motivation
`nightly-1-gpu-zimage-turbo` in `Nightly Test (AMD ROCm 7.2)` has failed every night since Sep 7 ([run #687](https://github.com/sgl-project/sglang/actions/runs/34257518880/job/102166970811)):
```
E       fixture 'perf_results' not found
```
#38185 made `DiffusionServerBase`'s autouse fixture request `perf_results`, which is declared in `python/sglang/multimodal_gen/test/server/conftest.py`. pytest loads conftest.py by the collected file's directory, so the AMD tests in `test/registered/amd/` never see it and error at setup. `test_wan22_fp8_mla.py` fails the same way. (The two `test/registered/xpu/` diffusion tests share the cause; left to the XPU owners.)
## Modifications
Test only, AMD only.
- Add `test/registered/amd/conftest.py` re-exporting `perf_results`, the same way these tests already re-export `diffusion_server`.
- Drop the now-dead `teardown_class` overrides: #38185 removed `DiffusionServerBase.teardown_class`, so `super().teardown_class()` only ever raises into a bare `except AttributeError: pass`.
## Verification
MI300X, ROCm 7.2:
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34354307521](https://github.com/sgl-project/sglang/actions/runs/34354307521)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34354307312](https://github.com/sgl-project/sglang/actions/runs/34354307312)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34354307491](https://github.com/sgl-project/sglang/actions/runs/34354307491)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->