### PR TITLE
[Docs] Add Ascend A3 deployment to the Hy3 cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Tencent/Hy3.mdx
+++ b/docs/cookbook/autoregressive/Tencent/Hy3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hy3
-description: "Deploy Tencent Hy3 with SGLang — verified launch commands and tuning for the BF16 Mixture-of-Experts model with hybrid thinking, native tool calling, 256K context, and MTP speculative decoding."
+description: "Deploy Tencent Hy3 with SGLang on NVIDIA GPUs and Ascend A3, with launch commands, local model weights, hybrid thinking, tool calling, and evaluation instructions."
 ---
 
 ## Deployment
@@ -9,11 +9,11 @@ description: "Deploy Tencent Hy3 with SGLang — verified launch commands and tu
 
 <Accordion title="Install SGLang">
 
-For all methods and hardware platforms, see the [official SGLang installation guide](../../../docs/get-started/install). The two paths below match the **Python / Docker** toggle in the command panel.
+For all methods and hardware platforms, see the [official SGLang installation guide](/docs/get-started/install). The tabs below cover NVIDIA installation and Ascend A3 setup for the **Python / Docker** toggle in the command panel.
 
 <Tabs>
 
-<Tab title="Python (pip / uv)">
+<Tab title="NVIDIA Python (pip / uv)">
 
 ```bash
 pip install -U uv
@@ -31,18 +31,42 @@ Run the **Python** output of the command panel below in that environment.
 
 </Tab>
 
-<Tab title="Docker">
+<Tab title="NVIDIA Docker">
 
 ```bash Command
 # The image bundles the HYV3 model code and the suffix-aware `hunyuan` parser.
 docker pull lmsysorg/sglang:dev
 ```
 
-For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker), substituting the inner `sglang serve ...` with what the command generator below produces.
+For how to launch the image, see [Install → Method 3: Using Docker](/docs/get-started/install#method-3-using-docker), substituting the inner `sglang serve ...` with what the command generator below produces.
 
 <Note>
 The `dev` image bundles the HYV3 model code, the suffix-aware `hunyuan` reasoning/tool-call parsers, and the MTP draft-module runtime. The same parsers serve both the preview (suffix-less) and the shipping (suffixed) Hy3 tokenizer — no per-model hard-coding.
 </Note>
+
+</Tab>
+
+<Tab title="Ascend A3">
+
+Use a Linux Atlas 800I A3 server with an installed Ascend driver and firmware. Follow the [Ascend installation guide](/docs/hardware-platforms/ascend-npus/getting-started/installation) for the CANN, TorchNPU, and SGLang component versions.
+
+For Docker, pull the image used by the Ascend Hy3 deployment tutorial:
+
+```bash
+docker pull quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16
+```
+
+The **Docker** command below exposes all 16 logical devices, mounts the driver and local model directory, uses host networking and shared memory, and initializes the CANN and Ascend Transformer Boost environments. Check that the host provides at least 64 GiB of shared memory for the 16-device deployment.
+
+For the **Python** command, open a shell in the same official image and initialize the runtime:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+npu-smi info
+```
+
+Adjust the installation paths to your environment. Confirm that all 16 logical devices are available before starting the server.
 
 </Tab>
 
@@ -67,10 +91,22 @@ import { benchmarks } from "/src/snippets/configs/tencent/hy3-benchmarks.jsx";
     <li style={{marginBottom: "0.2rem"}}><strong>Python / Docker</strong> — bare <code>sglang serve …</code> for an existing SGLang env, or a <code>docker run … sglang serve …</code> wrap against the per-hardware image from the <a href="#install">Install SGLang</a> panel above.</li>
     <li style={{marginBottom: "0.2rem"}}><strong>⧉ Copy</strong> — copies the current command (with whichever framing is active) to your clipboard.</li>
     <li style={{marginBottom: "0.2rem"}}><strong>$ cURL</strong> — a sample request against <code>localhost:30000</code> to confirm the server is up.</li>
-    <li style={{marginBottom: "0.2rem"}}><strong>⚙ Env</strong> — edits the placeholders (<code>HOST_IP</code>, <code>PORT</code>, <code>HF_TOKEN</code>, <code>NODE_RANK</code>, <code>NODE0_IP</code>) the command and cURL share. Persists in localStorage across cookbooks.</li>
-    <li><strong>Verified / Not Verified</strong> badge — green when the <code>(hw, variant, quant, strategy, nodes)</code> combo has been run end-to-end on real hardware; yellow when auto-derived from a neighbor and not yet re-checked.</li>
+    <li style={{marginBottom: "0.2rem"}}><strong>⚙ Env</strong> — edits the placeholders (<code>MODEL_PATH</code>, <code>DATASET_PATH</code>, <code>HOST_IP</code>, <code>PORT</code>, <code>HF_TOKEN</code>, <code>NODE_RANK</code>, <code>NODE0_IP</code>) used by the deployment, playground, cURL, and benchmark commands. <code>DATASET_PATH</code> supplies the ShareGPT file for performance evaluation. Values persist in localStorage across cookbooks.</li>
+    <li><strong>Verified / Not Verified</strong> badge — shows whether the <code>(hw, variant, quant, strategy, nodes)</code> combination has completed verification on real hardware.</li>
   </ul>
 </div>
+
+### Ascend setup
+
+The A3 recipe runs prefill and decode in the same serving deployment on one Atlas 800I A3 server. Its 8 physical cards expose 16 logical devices, each with 64 GB of device memory. The recipe uses BF16 weights and tensor parallelism across all 16 devices (`--tp-size 16`). See the [Ascend Hy3 deployment reference](/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/hy3) for the hardware layout and runtime settings.
+
+1. Download the complete [Hy3 BF16 model](https://www.modelscope.cn/models/Tencent-Hunyuan/Hy3), including the weight shards, configuration, and tokenizer files, into one local directory. Reserve space for the approximately 597.60 GB model and at least 30 GB for the container image.
+2. Select **A3**, **BF16**, **Balanced**, and **Single Node** in the deployment panel.
+3. Open **Env** and set `MODEL_PATH` to the absolute model directory, for example `/models/Hy3`. The Docker command mounts this directory read-only at the same path inside the container. Every tensor-parallel worker loads its assigned weights from that directory.
+4. Choose **Python** or **Docker**, copy the generated command, and run it in the prepared environment. The API model name is `tencent/Hy3`, set by `--served-model-name`.
+5. Wait for the server to report that it is ready, then use **cURL** in the panel to send the example request. Expect an HTTP 200 response whose `choices[0].message.content` identifies Paris as the capital of France.
+
+The A3 recipe uses the Ascend attention backend, tensor parallelism across 16 devices, and multi-token prediction with two speculative steps and three draft tokens. See [Benchmark](#4-benchmark) for the tested environment and results.
 
 ## Playground
 
@@ -140,18 +176,24 @@ import { Playground } from "/src/snippets/_playground.jsx";
 
 ## 2. Configuration Tips
 
-**Hardware requirements (BF16, ~590GB weights):**
+**Hardware requirements (BF16, approximately 597.60 GB weights):**
 
 <table style={{width: "100%", borderCollapse: "collapse"}}>
   <thead>
     <tr style={{borderBottom: "2px solid #0052d9"}}>
-      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)"}}>GPU</th>
-      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)"}}>VRAM</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)"}}>Hardware</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)"}}>Device memory</th>
       <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.02)"}}>TP</th>
       <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, backgroundColor: "rgba(255,255,255,0.05)"}}>Notes</th>
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Atlas 800I A3</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>64 GB per logical device</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>16</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>8 physical cards, 16 logical devices, single node</td>
+    </tr>
     <tr>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>H200</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>141GB</td>
@@ -183,8 +225,9 @@ import { Playground } from "/src/snippets/_playground.jsx";
 
 **MTP (Multi-Token Prediction, EAGLE).**
 
-- `low-latency`: steps=3, draft-tokens=4 → largest win at bs=1.
-- `balanced`: MTP disabled — keep the prefill batch moderate so chunked-prefill stays efficient.
+- NVIDIA `low-latency`: steps=3, draft-tokens=4 → largest win at bs=1.
+- NVIDIA `balanced`: MTP disabled — keep the prefill batch moderate so chunked-prefill stays efficient.
+- Ascend A3 `balanced`: steps=2, draft-tokens=3, top-k=1.
 
 **`reasoning_effort` vs `thinking`.** The Hy3 chat template is driven by `reasoning_effort` (`high` / `low` / `no_think`), NOT by the `thinking` flag that some other families use. The default is `no_think` (instant). To opt into thinking, pass `reasoning_effort="high"` on the request (the OpenAI-standard field; sglang forwards it to the template). `reasoning_effort: max` is rejected by sglang — use `high`. For eval, sgl-eval's `--thinking` flag translates to `reasoning_effort="high"` for Hy3, so the benchmark commands below use it as-is.
 
@@ -264,6 +307,45 @@ print("Content:", response.choices[0].message.content)
 ```text Output
 Content: Relativity is Einstein's theory that space, time, mass, and gravity are interconnected and relative, not fixed, fundamentally changing our understanding of the universe.
 ```
+
+</Accordion>
+
+<Accordion title="Ascend A3: thinking mode">
+
+Use the A3 deployment above and set `chat_template_kwargs.reasoning_effort` to `high`. The `auto` reasoning parser returns reasoning in `reasoning_content` and the final answer in `content`.
+
+```bash
+pip install requests
+```
+
+```python
+import requests
+
+response = requests.post(
+    "http://127.0.0.1:30000/v1/chat/completions",
+    json={
+        "model": "tencent/Hy3",
+        "messages": [{
+            "role": "user",
+            "content": "Choose two distinct integers uniformly at random from 1 to 100. What is the probability that their product is divisible by 6? Show the derivation and give the answer as a reduced fraction.",
+        }],
+        "temperature": 0,
+        "max_tokens": 16384,
+        "chat_template_kwargs": {"reasoning_effort": "high"},
+    },
+    timeout=600,
+)
+response.raise_for_status()
+message = response.json()["choices"][0]["message"]
+print(message["reasoning_content"])
+print(message["content"])
+```
+
+The probability is:
+
+$$
+\frac{2042}{4950}=\frac{1021}{2475}.
+$$
 
 </Accordion>
 
@@ -367,3 +449,101 @@ Tool[0] get_weather({"city": "Beijing", "unit": "fahrenheit"})
 ```
 
 </Accordion>
+
+
+## 4. Benchmark
+
+### Ascend A3
+
+The following results use the A3 BF16, Balanced, Single Node recipe.
+
+| Component | Version or configuration |
+| --- | --- |
+| Hardware | 1 Atlas 800I A3, 16 logical NPUs, 96 CPU cores, 1,024 GiB RAM |
+| Model | Hy3 BF16, tensor parallelism 16, EAGLE |
+| Image | `quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16` |
+| SGLang | `0.5.17.dev386+gc5bd3d7dc` (`c5bd3d7dce`), bundled source |
+| CANN / PyTorch / TorchNPU | 9.0.0 / 2.10.0+cpu / 2.10.0 |
+| sgl-kernel-npu / Transformers | 2026.6.1 / 5.12.1 |
+| Ascend driver (`npu-smi`) | 25.5.2 |
+| Reasoning mode | `no_think` |
+
+#### GSM8K accuracy
+
+Use EvalScope 1.11.1 to evaluate all 1,319 test questions with one fixed training example, temperature 0, and seed 42. Set the API host and port to your server.
+
+```bash
+pip install evalscope==1.11.1
+evalscope eval \
+  --model tencent/Hy3 \
+  --api-url http://127.0.0.1:30000/v1 \
+  --api-key EMPTY \
+  --eval-type openai_api \
+  --datasets gsm8k \
+  --dataset-args '{"gsm8k":{"few_shot_num":1,"few_shot_random":false}}' \
+  --generation-config '{"temperature":0,"max_tokens":4096,"extra_body":{"chat_template_kwargs":{"reasoning_effort":"no_think"}}}' \
+  --eval-batch-size 16 --seed 42 --timeout 600
+```
+
+| Test questions | Correct answers | Accuracy |
+| ---: | ---: | ---: |
+| 1,319 | 1,274 | 96.59% |
+
+#### ShareGPT performance
+
+Use the [ShareGPT conversation dataset](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered). The run uses 128 requests, concurrency 16, four warmup requests, seed 42, and temperature 0. Output lengths come from the dataset responses, with `ignore_eos=true`.
+
+On your Linux evaluation machine, create a separate CPU client container. Set `MODEL_PATH` to the local Hy3 model directory and `DATASET_PATH` to the local ShareGPT JSON file. The container mounts these at the same paths and saves results in `hy3-benchmark` under your current directory.
+
+```bash
+MODEL_PATH=/models/Hy3
+DATASET_PATH=/datasets/ShareGPT/ShareGPT_V3_unfiltered_cleaned_split.json
+mkdir -p hy3-benchmark
+
+docker run --rm -it --network host \
+  -e SGLANG_USE_CPU_ENGINE=1 \
+  -e MODEL_PATH="$MODEL_PATH" -e DATASET_PATH="$DATASET_PATH" \
+  -v "$MODEL_PATH:$MODEL_PATH:ro" \
+  -v "$DATASET_PATH:$DATASET_PATH:ro" \
+  -v "$PWD/hy3-benchmark:/results" -w /results \
+  --entrypoint bash \
+  quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16
+```
+
+Prepare the CPU dependencies inside this client container:
+
+```bash
+python3 -m pip uninstall -y torch-npu triton-ascend
+python3 -m pip install --force-reinstall --no-deps triton==3.5.0
+```
+
+Run the benchmark in the client container. Set `--host` and `--port` to your server; `--served-model-name` matches the deployment command.
+
+```bash
+export SGLANG_USE_CPU_ENGINE=1
+
+python3 -m sglang.benchmark.serving \
+  --backend sglang-oai-chat \
+  --host 127.0.0.1 --port 30000 \
+  --model "$MODEL_PATH" --served-model-name tencent/Hy3 \
+  --tokenizer "$MODEL_PATH" \
+  --dataset-name sharegpt --dataset-path "$DATASET_PATH" \
+  --num-prompts 128 --max-concurrency 16 \
+  --seed 42 --warmup-requests 4 --flush-cache \
+  --extra-request-body '{"chat_template_kwargs":{"reasoning_effort":"no_think"}}' \
+  --output-file hy3-a3-sharegpt.jsonl
+```
+
+| Measurement | Result |
+| --- | ---: |
+| Successful / failed requests | 128 / 0 |
+| Measured duration | 149.87 s |
+| Input / output tokens | 43,318 / 29,644 |
+| Output throughput | 197.80 tokens/s |
+| Input + output throughput | 486.83 tokens/s |
+| Request throughput | 0.8541 requests/s |
+| Time to first token, median / P99 | 638.46 / 6,902.88 ms |
+| Time per output token, median / P99 | 59.67 / 188.72 ms |
+| End-to-end latency, median / P99 | 12,080.34 / 64,488.16 ms |
+
+The panel's throughput per logical NPU is the total input-plus-output throughput divided by 16. See [Ascend accuracy evaluation](/docs/hardware-platforms/ascend-npus/evaluation/accuracy_evaluation) and [performance testing](/docs/hardware-platforms/ascend-npus/evaluation/performance_testing) for evaluation tool details.

--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -84,7 +84,8 @@
 //                      `hw|quant|strategy` then `hw|quant` then `hw`;
 //                      falls back to `lmsysorg/sglang:dev`
 //   dockerHostNetworkWhen optional — `(selection, {flags, env}) => boolean`
-//   dockerMounts       optional — additional `-v` mount specs
+//   dockerShmSize      optional — shared memory size for the NPU Docker command
+//   dockerMounts       optional — additional `-v` mount specs, array or `(selection) => array`
 //   dockerRunCommand   optional — command placed after the image and before
 //                      generated server flags; string or `(selection) => string`
 //   runModes           optional — command output tabs to show (`python` and/or
@@ -828,7 +829,7 @@ export const Deployment = ({ config, benchmarks }) => {
             // NPU: --privileged grants the davinci devices (16 dies on an
             // 8-card Atlas 800I A3 node); the host CANN driver/firmware/state
             // must be mounted in.
-            "docker run --privileged --shm-size=16g",
+            `docker run --privileged --shm-size=${config.dockerShmSize || "16g"}`,
             "  --device=/dev/davinci0 --device=/dev/davinci1 --device=/dev/davinci2 --device=/dev/davinci3",
             "  --device=/dev/davinci4 --device=/dev/davinci5 --device=/dev/davinci6 --device=/dev/davinci7",
             "  --device=/dev/davinci8 --device=/dev/davinci9 --device=/dev/davinci10 --device=/dev/davinci11",
@@ -856,7 +857,8 @@ export const Deployment = ({ config, benchmarks }) => {
         // The NPU device block already mounts ~/.cache/.
         ...(vendorOf(sel.hw) === "npu"
           ? [] : ["  -v ~/.cache/huggingface:/root/.cache/huggingface"]),
-        ...(config.dockerMounts || []).map((mount) => `  -v ${mount}`),
+        ...(typeof config.dockerMounts === "function"
+          ? config.dockerMounts(sel) : (config.dockerMounts || [])).map((mount) => `  -v ${mount}`),
         // HF token only for gated checkpoints — configs that declare an HF_TOKEN placeholder.
         ...(config.placeholders && config.placeholders.HF_TOKEN
           ? [`  --env "HF_TOKEN={{HF_TOKEN}}"`] : []),
@@ -906,12 +908,14 @@ export const Deployment = ({ config, benchmarks }) => {
     // [key, label, unit, compute?]. Optional compute(measurement) supplies
     // derived metrics (preferred over measurement[key] when present).
     const pct = (entry && entry.latencyPercentile) || config.latencyPercentile || "P50";
+    const deviceLabel = sel.hw === "a3" ? "logical NPU" : "gpu";
     const SPEED_LABELS = [
       ["ttft_ms",                `TTFT (${pct})`,      "ms"],
       ["tpot_ms",                `TPOT (${pct})`,      "ms"],
       // throughput per gpu = total(input+output)/elapsed/GPU;
       // stored directly in the benchmarks file (= output tok/s/GPU × (isl+osl)/osl).
-      ["tokens_per_sec_per_gpu", "throughput per gpu", "tok/s"],
+      ["tokens_per_sec_per_gpu", `throughput per ${deviceLabel}`, "tok/s"],
+      ["output_tokens_per_sec",  "output throughput", "tok/s"],
       ["interactivity",          "interactivity",   "tokens/s/user",
         (m) => (m.tpot_ms != null && m.tpot_ms !== 0)
           ? Math.round((1000 / m.tpot_ms) * 10) / 10
@@ -1032,7 +1036,7 @@ export const Deployment = ({ config, benchmarks }) => {
       return { title: "Speed", sharedText, colHeaders, rows,
                colCount: measurements.length,
                legend: [
-                 `throughput per gpu = (input+output tokens)/elapsed/GPU`,
+                 `throughput per ${deviceLabel} = (input+output tokens)/elapsed/device count`,
                  `interactivity = 1000/TPOT(ms) (tokens/s/user)`,
                ] };
     };
@@ -1093,7 +1097,7 @@ export const Deployment = ({ config, benchmarks }) => {
   // interpolation happens in the modal where `env` is in scope. Returns null
   // when nothing is renderable (caller hides the button).
   const buildBenchCommands = (entry, sel) => {
-    const bc = config.benchmarkCommands;
+    const bc = (config.benchmarkCommandsByHardware || {})[sel.hw] || config.benchmarkCommands;
     if (!bc) return null;
 
     // One entry per eval with a value AND a template. A template is a string,
@@ -1261,7 +1265,13 @@ export const Deployment = ({ config, benchmarks }) => {
   const saveEnv = (next) => {
     setEnv(next);
     try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch {}
+    window.dispatchEvent(new CustomEvent(STORAGE_KEY, { detail: next }));
   };
+  useEffect(() => {
+    const onEnv = (event) => setEnv((previous) => ({ ...previous, ...event.detail }));
+    window.addEventListener(STORAGE_KEY, onEnv);
+    return () => window.removeEventListener(STORAGE_KEY, onEnv);
+  }, []);
 
   const [sel, setSel] = useState(() => initialSelectionFromCells());
   const INTERNAL_HASH_STATE_KEY = "__sglangDeployInternalHash";

--- a/docs/src/snippets/_playground.jsx
+++ b/docs/src/snippets/_playground.jsx
@@ -1547,13 +1547,32 @@ export const Playground = ({ config }) => {
         ],
       };
       const fabricFlags = HW_MULTINODE_DOCKER_FLAGS[sel.hw] || [];
+      const isNpu = sel.hw === "a3"
+        || (config.hardware || []).some((hw) => hw.id === sel.hw && hw.vendor === "npu");
+      const deviceLines = isNpu
+        ? [
+            `docker run --privileged --shm-size=${config.dockerShmSize || "16g"}`,
+            "  --device=/dev/davinci0 --device=/dev/davinci1 --device=/dev/davinci2 --device=/dev/davinci3",
+            "  --device=/dev/davinci4 --device=/dev/davinci5 --device=/dev/davinci6 --device=/dev/davinci7",
+            "  --device=/dev/davinci8 --device=/dev/davinci9 --device=/dev/davinci10 --device=/dev/davinci11",
+            "  --device=/dev/davinci12 --device=/dev/davinci13 --device=/dev/davinci14 --device=/dev/davinci15",
+            "  --device=/dev/davinci_manager",
+            "  --device=/dev/hisi_hdc",
+            "  -v /usr/local/sbin:/usr/local/sbin",
+            "  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver",
+            "  -v /usr/local/Ascend/firmware:/usr/local/Ascend/firmware",
+            "  -v /etc/ascend_install.info:/etc/ascend_install.info",
+            "  -v /var/queue_schedule:/var/queue_schedule",
+            "  -v ~/.cache/:/root/.cache/",
+          ]
+        : ["docker run --gpus all", "  --shm-size 32g"];
       const dockerLines = [
-        "docker run --gpus all",
-        "  --shm-size 32g",
+        ...deviceLines,
         hostNetwork ? "  --network host" : `  -p ${servePort}:${servePort}`,
         ...(multinode ? fabricFlags.map((x) => "  " + x) : []),
-        "  -v ~/.cache/huggingface:/root/.cache/huggingface",
-        ...(config.dockerMounts || []).map((mount) => `  -v ${mount}`),
+        ...(isNpu ? [] : ["  -v ~/.cache/huggingface:/root/.cache/huggingface"]),
+        ...(typeof config.dockerMounts === "function"
+          ? config.dockerMounts(sel) : (config.dockerMounts || [])).map((mount) => `  -v ${mount}`),
         `  --env "HF_TOKEN={{HF_TOKEN}}"`,
         ...cellEnv.map((e) => `  --env ${e}`),
         "  --ipc=host",
@@ -1988,7 +2007,13 @@ export const Playground = ({ config }) => {
   const saveEnv = (next) => {
     setEnv(next);
     try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch {}
+    window.dispatchEvent(new CustomEvent(STORAGE_KEY, { detail: next }));
   };
+  useEffect(() => {
+    const onEnv = (event) => setEnv((previous) => ({ ...previous, ...event.detail }));
+    window.addEventListener(STORAGE_KEY, onEnv);
+    return () => window.removeEventListener(STORAGE_KEY, onEnv);
+  }, []);
 
   // Base selection — live-linked to the Deployment panel via URL hash + custom event
   // (history.replaceState doesn't fire hashchange, hence the event too).
@@ -2311,7 +2336,9 @@ export const Playground = ({ config }) => {
   const curlEnv = (pdRouter && pdRouter.port != null)
     ? { ...env, CURL_PORT: String(pdRouter.port) }
     : env;
-  const curlText = interpolate(config.curl || "", curlEnv, modelName);
+  const curlTemplate = typeof config.curl === "function"
+    ? config.curl(base, baseCell) : config.curl;
+  const curlText = interpolate(curlTemplate || "", curlEnv, modelName);
   const routerText = pdRouter && pdRouter.command
     ? interpolate(pdRouter.command, {
         ...env,

--- a/docs/src/snippets/configs/tencent/hy3-benchmarks.jsx
+++ b/docs/src/snippets/configs/tencent/hy3-benchmarks.jsx
@@ -3,6 +3,20 @@
 // H200 BF16 low-latency + balanced verified on 8×H200 (sgl-eval, single-shot, temp=0).
 // FP8 cells not yet verified.
 export const benchmarks = [
+  {
+    match: { hw: "a3", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
+    sglang_version: "c5bd3d7dce",
+    accuracy: { gsm8k_pct: 96.59 },
+    latencyPercentile: "P50",
+    speed: [{
+      workload: { dataset: "ShareGPT", isl: 338.42, osl: 231.59, max_concurrency: 16, num_prompts: 128 },
+      ttft_ms: 638.46,
+      tpot_ms: 59.67,
+      tokens_per_sec_per_gpu: 30.43,
+      output_tokens_per_sec: 197.80,
+    }],
+    notes: "2026-09-09: Official image cann9.0.0-a3-v0.5.16, bundled SGLang c5bd3d7dce. GSM8K: 1274/1319 correct with EvalScope 1.11.1 and one fixed demonstration. ShareGPT: 128/128 requests succeeded in 149.87 s; mean input/output lengths are shown. BF16, TP16, EAGLE, no_think, temperature 0. ShareGPT uses ignore_eos.",
+  },
   { match: { hw: "h200",  variant: "default", quant: "bf16", strategy: "low-latency",     nodes: "single" }, gsm8k_pct: 95.75 },
   { match: { hw: "h200",  variant: "default", quant: "bf16", strategy: "balanced",        nodes: "single" }, gsm8k_pct: 95.83 },
   { match: { hw: "b200",  variant: "default", quant: "bf16", strategy: "low-latency",     nodes: "single" } },

--- a/docs/src/snippets/configs/tencent/hy3.jsx
+++ b/docs/src/snippets/configs/tencent/hy3.jsx
@@ -13,7 +13,7 @@
 export const config = {
   modelName: "Hy3",
 
-  supportedHardware: ["h200", "b200", "b300", "gb200", "gb300"],
+  supportedHardware: ["h200", "b200", "b300", "gb200", "gb300", "a3"],
 
   variants: [
     { id: "default", label: "Default" },
@@ -37,6 +37,8 @@ export const config = {
   },
 
   placeholders: {
+    DATASET_PATH: { target: "command", label: "Local ShareGPT dataset (Ascend)", default: "/datasets/ShareGPT/ShareGPT_V3_unfiltered_cleaned_split.json" },
+    MODEL_PATH: { target: "command", label: "Local Hy3 directory (Ascend)", default: "/models/Hy3" },
     HOST_IP:   { target: "command", label: "Bind host",        default: "0.0.0.0"        },
     PORT:      { target: "command", label: "Bind port",        default: "30000"          },
     NODE0_IP:  { target: "command", label: "Head node IP",     default: "<node0-ip>"      },
@@ -46,7 +48,11 @@ export const config = {
     CURL_PORT: { target: "curl",    label: "Server port",       default: "30000"           },
   },
 
-  curl: `curl http://{{CURL_HOST}}:{{CURL_PORT}}/v1/chat/completions \\
+  curl: (sel) => sel.hw === "a3"
+    ? `curl http://{{CURL_HOST}}:{{CURL_PORT}}/v1/chat/completions \\
+-H 'Content-Type: application/json' \\
+-d '{ "model": "{{MODEL_NAME}}", "messages": [{"role":"user","content":"What is the capital of France?"}], "max_tokens": 128, "temperature": 0, "top_p": 1.0, "chat_template_kwargs": {"reasoning_effort":"no_think"} }'`
+    : `curl http://{{CURL_HOST}}:{{CURL_PORT}}/v1/chat/completions \\
 -H 'Content-Type: application/json' \\
 -d '{ "model": "{{MODEL_NAME}}", "messages": [{"role":"user","content":"Hello"}] }'`,
 
@@ -78,6 +84,32 @@ sgl-eval run aime26 \\
     numPromptsByConc: { 1: 32, 16: 32, 64: 128, 256: 512, 1024: 2048 },
   },
 
+  benchmarkCommandsByHardware: {
+    a3: {
+      speed: `export SGLANG_USE_CPU_ENGINE=1
+
+python3 -m sglang.benchmark.serving \\
+  --backend sglang-oai-chat \\
+  --host {{CURL_HOST}} --port {{CURL_PORT}} \\
+  --model "{{MODEL_PATH}}" --served-model-name {{MODEL_NAME}} --tokenizer "{{MODEL_PATH}}" \\
+  --dataset-name sharegpt --dataset-path "{{DATASET_PATH}}" \\
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
+  --seed 42 --warmup-requests 4 --flush-cache \\
+  --extra-request-body '{"chat_template_kwargs":{"reasoning_effort":"no_think"}}' \\
+  --output-file hy3-a3-sharegpt.jsonl`,
+      accuracy: {
+        gsm8k_pct: `evalscope eval \\
+  --model {{MODEL_NAME}} \\
+  --api-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 --api-key EMPTY \\
+  --eval-type openai_api --datasets gsm8k \\
+  --dataset-args '{"gsm8k":{"few_shot_num":1,"few_shot_random":false}}' \\
+  --generation-config '{"temperature":0,"max_tokens":4096,"extra_body":{"chat_template_kwargs":{"reasoning_effort":"no_think"}}}' \\
+  --eval-batch-size 16 --seed 42 --timeout 600`,
+      },
+      numPromptsByConc: { 16: 128 },
+    },
+  },
+
   accuracyLabels: [
     ["gsm8k_pct", "GSM8K (1-shot)", "%"],
     ["aime26_pct", "AIME26",         "%"],
@@ -100,7 +132,16 @@ sgl-eval run aime26 \\
     b300:  "lmsysorg/sglang:dev",
     gb200: "lmsysorg/sglang:dev",
     gb300: "lmsysorg/sglang:dev",
+    a3: "quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16",
   },
+
+  dockerShmSize: "64g",
+  dockerHostNetworkWhen: (sel) => sel.hw === "a3",
+  dockerMounts: (sel) => sel.hw === "a3"
+    ? ['"{{MODEL_PATH}}:{{MODEL_PATH}}:ro"'] : [],
+  dockerRunCommand: (sel) => sel.hw === "a3"
+    ? "bash -lc 'source /usr/local/Ascend/ascend-toolkit/set_env.sh && source /usr/local/Ascend/nnal/atb/set_env.sh && exec sglang serve \"$@\"' --"
+    : "sglang serve",
 
   github: {
     cookbookModel: "tencent/Hy3",
@@ -117,22 +158,22 @@ sgl-eval run aime26 \\
       knobs: [
         { id: "tp", label: "TP", values: [
           null,
-          1,
-          2,
-          4,
-          8,
-          { value: 16, disable: { nodes: ["single"] },
+          { value: 1, disable: { hw: ["a3"] }, disableReason: "The A3 BF16 recipe uses tensor parallelism across 16 devices." },
+          { value: 2, disable: { hw: ["a3"] }, disableReason: "The A3 BF16 recipe uses tensor parallelism across 16 devices." },
+          { value: 4, disable: { hw: ["a3"] }, disableReason: "The A3 BF16 recipe uses tensor parallelism across 16 devices." },
+          { value: 8, disable: { hw: ["a3"] }, disableReason: "The A3 BF16 recipe uses tensor parallelism across 16 devices." },
+          { value: 16, disable: { hw: ["h200", "b200", "b300", "gb200", "gb300"], nodes: ["single"] },
             disableReason: "TP=16 requires 16 ranks — switch the Deploy panel's Nodes to Multi-Nodes first." },
         ]},
         { id: "dpAttn", label: "DP-Attention",
           values: [
             null,
             false,
-            1,
-            2,
-            4,
-            8,
-            { value: 16, disable: { nodes: ["single"] },
+            { value: 1, hide: { hw: ["a3"] } },
+            { value: 2, hide: { hw: ["a3"] } },
+            { value: 4, hide: { hw: ["a3"] } },
+            { value: 8, hide: { hw: ["a3"] } },
+            { value: 16, hide: { hw: ["a3"] }, disable: { nodes: ["single"] },
               disableReason: "DP-Attention=16 requires 16 ranks — switch the Deploy panel's Nodes to Multi-Nodes first." },
           ],
           labels: { "auto": "Auto", "false": "Off" } },
@@ -141,6 +182,7 @@ sgl-eval run aime26 \\
 
     // ----- Card 2: "MoE Parallelism" -----
     moe: {
+      showWhen: (base) => base.hw !== "a3",
       backend: {
         options: [
           { id: null,                label: "Inherited" },
@@ -172,6 +214,7 @@ sgl-eval run aime26 \\
 
     // ----- Card 4: "Speculative Decoding" -----
     speculative: {
+      showWhen: (base) => base.hw !== "a3",
       options: [
         { id: "current",    label: "Inherited from base" },
         { id: "off",        label: "Off (greedy)" },
@@ -192,6 +235,7 @@ sgl-eval run aime26 \\
 
     // ----- Card 5: "PD Disaggregation" -----
     pdDisagg: {
+      showWhen: (base) => base.hw !== "a3",
       modes: [
         { id: "off",     label: "Off" },
         { id: "prefill", label: "Prefill role" },
@@ -223,6 +267,7 @@ sgl-eval run aime26 \\
 
     // ----- Card 6: "Hierarchical KV Cache" -----
     hicache: {
+      excludesHw: ["a3"],
       backends: [
         { id: "null_placeholder", label: "Auto" },
         { id: "file",      label: "File" },
@@ -240,6 +285,44 @@ sgl-eval run aime26 \\
   },
 
   cells: [
+    {
+      match: { hw: "a3", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
+      verified: true,
+      warn: "One Atlas 800I A3 server: 8 cards, 16 devices, 64 GB per device. Set MODEL_PATH to your local Hy3 directory. See [Ascend setup](#ascend-setup).",
+      env: [
+        "SGLANG_SET_CPU_AFFINITY=1",
+        "ASCEND_USE_FIA=1",
+        "STREAMS_PER_DEVICE=32",
+        "HCCL_BUFFSIZE=3000",
+        "HCCL_OP_EXPANSION_MODE=AIV",
+        "HCCL_SOCKET_IFNAME=lo",
+        "GLOO_SOCKET_IFNAME=lo",
+        "SGLANG_ENABLE_SPEC_V2=1",
+        "SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1",
+        "DEEP_NORMAL_MODE_USE_INT8_QUANT=1",
+      ],
+      flags: [
+        '--model-path "{{MODEL_PATH}}"',
+        '--served-model-name "{{MODEL_NAME}}"',
+        "--attention-backend ascend",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
+        "--device npu",
+        "--tp-size 16",
+        "--mem-fraction-static 0.84",
+        "--dtype bfloat16",
+        "--base-gpu-id 0",
+        "--prefill-max-requests 40",
+        "--max-running-requests 40",
+        "--cuda-graph-bs 4 8 16 20 24 28 32 36 40",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 2",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 3",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
     // ====================================================================
     // H200 (141GB) — TP=8 for BF16 (~590GB)
     // ====================================================================


### PR DESCRIPTION
## Motivation

Add a verified Ascend A3 deployment to the Hy3 cookbook. Selecting A3, BF16, Balanced, and Single Node generates a command for one Atlas 800I A3 server, with prefill and decode handled by the same service.

Related task: https://github.com/Ascend/sglang/issues/1212

## Modifications

- Add the official Ascend image, local model path, runtime environment variables, tensor parallelism across 16 logical NPUs, and EAGLE settings to the Hy3 configuration.
- Document installation, model placement, API requests, thinking mode, and reproducible accuracy and performance evaluation. Populate the interactive benchmark panel with measured A3 results.
- Extend the shared Deployment and Playground components to support hardware-dependent model mounts and cURL templates, configurable NPU shared memory, and environment-value synchronization between panels. Add Ascend device and driver mounts to Playground Docker output.
- Allow hardware-specific benchmark commands and display output throughput and throughput per logical NPU in the Deployment panel.

## Accuracy Tests

Validated on one Atlas 800I A3 server with 16 logical NPUs, BF16 weights, tensor parallelism 16, and EAGLE. The serving environment used `quay.io/ascend/sglang:cann9.0.0-a3-v0.5.16` and its bundled SGLang source, `0.5.17.dev386+gc5bd3d7dc` (`c5bd3d7dce`), with CANN 9.0.0 and TorchNPU 2.10.0.

- EvalScope 1.11.1, GSM8K: **1,274 / 1,319 correct (96.59%)**. One fixed training example, seed 42, temperature 0, `no_think`, and `max_tokens=4096`.
- Ordinary chat and thinking-mode requests returned HTTP 200. The tested thinking-mode probability question produced the correct final answer, `1021/2475`.

## Speed Tests and Profiling

ShareGPT, 128 requests, concurrency 16, four warmup requests, seed 42, temperature 0, and `no_think`. Output lengths follow the dataset responses with `ignore_eos=true`.

| Measurement | Result |
| --- | ---: |
| Successful / failed requests | 128 / 0 |
| Duration | 149.87 s |
| Input / output tokens | 43,318 / 29,644 |
| Output throughput | 197.80 tokens/s |
| Input + output throughput | 486.83 tokens/s |
| Time to first token, median / P99 | 638.46 / 6,902.88 ms |
| Time per output token, median / P99 | 59.67 / 188.72 ms |

## Documentation validation

- `node docs/scripts/check_cookbook_configs.mjs`
- `mint validate`
- `mint broken-links --check-anchors --check-redirects`
- Browser verification of A3 selection, generated Python and Docker commands, custom model and dataset paths, benchmark tables, and the existing H200 controls.
- Bash and Python example syntax checks.

## Checklist

- [x] Run the repository pre-commit checks on the five changed files.
- [x] Update documentation and verify the local preview.
- [x] Provide accuracy and speed benchmark results.
- [x] Verify the affected interactive controls in the browser.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34358424803](https://github.com/sgl-project/sglang/actions/runs/34358424803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34358424420](https://github.com/sgl-project/sglang/actions/runs/34358424420)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->