### PR TITLE
[AMD][CI] Warn when the miles nightly falls back to a stale image

### DIFF
--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -51,6 +51,7 @@ jobs:
           repo="rocm/sgl-dev"
           base="miles-rocm720-mi35x"
           tag="${{ inputs.image_tag }}"
+          age_days=""
           if [ -z "${tag}" ]; then
             # Walk back from today; the build job pushes a dated tag at 12:00 UTC.
             # Probe with `manifest inspect` so we don't pull a multi-GB image just
@@ -60,6 +61,7 @@ jobs:
               candidate="${base}-${d}"
               if docker manifest inspect "${repo}:${candidate}" >/dev/null 2>&1; then
                 tag="${candidate}"
+                age_days="${i}"
                 break
               fi
             done
@@ -68,8 +70,19 @@ jobs:
             echo "::error::No ${repo}:${base}-<date> image found on Docker Hub for the last 7 days"
             exit 1
           fi
+          # Without this the walk-back is invisible: a broken image build just replays an
+          # older image, the suites stay green against stale code, and whatever landed
+          # meanwhile only turns the nightly red on the day the build is repaired.
+          if [ -n "${age_days}" ] && [ "${age_days}" -gt 0 ]; then
+            echo "::warning::miles image ${repo}:${tag} is ${age_days} day(s) stale; the newer daily builds are missing, so these results do not cover current miles main"
+            {
+              echo "> [!WARNING]"
+              echo "> Ran against \`${repo}:${tag}\`, ${age_days} day(s) older than today's expected tag."
+              echo "> The \`Release Docker Images Nightly Miles ROCm7.2 (AMD)\` builds since then have not published an image."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "MILES_IMAGE=${repo}:${tag}" >> "$GITHUB_ENV"
-          echo "Using miles image: ${repo}:${tag}"
+          echo "Using miles image: ${repo}:${tag} (age_days=${age_days:-unknown})"
 
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

`nightly-test-amd-miles-rocm720.yml` resolves its image by walking back up to 7 days for a dated `rocm/sgl-dev:miles-rocm720-mi35x-<date>` tag. That fallback is load-bearing (a single missed build should not cancel the nightly), but today it is completely silent, so a broken image build is indistinguishable from a healthy one from inside the test job.

This actively misdirected a recent investigation into the [MILES dashboard](https://rocm.github.io/sglang-ci/miles/). `radixark/Megatron-LM@miles-main` was moved onto a much newer NVIDIA base on 2026-08-24 (megatron-core `0.16.0rc0` → `0.19.0`). The ROCm image builds on 08-25, 08-26 and 08-27 then failed hard on an obsolete `git apply` of the fused-kernels patch, so all three nightlies in that window quietly reran `miles-rocm720-mi35x-20260824` and stayed as green as they had been. When [radixark/miles#2768](https://github.com/radixark/miles/pull/2768) repaired the build on 08-27, the 08-28 nightly was the first to see the new Megatron and `tests/e2e/ckpt/test_qwen3_4B_ckpt.py` went red — four days after the change that caused it, with nothing in the run pointing back at the gap.

Three nightlies' worth of "these results do not describe current miles main" was recoverable only by cross-reading the build workflow's history against each test job's log.

## Modifications

In the `Resolve newest miles ROCm 7.2 image` step:

- record how many days back the walk-back went, and
- when the resolved tag is not today's, emit a `::warning::` annotation and a `> [!WARNING]` block in the job's step summary naming the tag and its age.

A tag passed explicitly through the `image_tag` workflow-dispatch input is deliberately left alone — its age is not the workflow's inference to make — and the existing hard error when nothing is found in 7 days is unchanged.

This is observability only. It does not change which image is selected, so a nightly that would pass still passes and one that would fail still fails.

## Accuracy Tests

Not applicable — CI workflow annotation only, no model or kernel code is touched.

## Speed Tests and Profiling

Not applicable.

## Verification

The step body was extracted from the workflow and driven against a stubbed `docker manifest inspect` so the walk-back could be exercised without a registry:

| case | exit | annotation | `MILES_IMAGE` |
| --- | --- | --- | --- |
| image published today | 0 | none | today's tag |
| only a 4-day-old image (the 08-25→08-27 situation) | 0 | `::warning::` + step summary, `age_days=4` | the 4-day-old tag |
| explicit `image_tag` override | 0 | none, `age_days=unknown` | the override |
| nothing in the last 7 days | 1 | pre-existing `::error::` | unset |

`python3 scripts/lint/check_workflow_job_names.py` passes and `git diff --check` is clean.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8ff18fd-14aa-4710-be47-c0316fdbf847?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8ff18fd-14aa-4710-be47-c0316fdbf847&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34360211078](https://github.com/sgl-project/sglang/actions/runs/34360211078)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34360210849](https://github.com/sgl-project/sglang/actions/runs/34360210849)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->