### PR TITLE
[Qwen3.8-Next] Add pipeline-parallel PD prefill with MTP

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/qwen4_exp.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen4_exp.py
@@ -28,8 +28,16 @@ def _qwen4_exp_overrides(server_args: Any, hf_config: Any) -> dict:
     which MambaRadixCache allows only with mamba extra-buffer or --disable-radix-cache.
     """
     cfg = resolving_view(server_args)
-    if cfg.disaggregation_mode != "null":
-        raise ValueError("Qwen4-Exp does not support PD disaggregation yet")
+    if (
+        cfg.disaggregation_mode != "null"
+        and cfg.disaggregation_transfer_backend == "mori"
+        and cfg.pp_size > 1
+    ):
+        raise ValueError(
+            "Qwen4-Exp PD with MORI requires --pp-size 1; MORI does not yet "
+            "exchange the global QSA layer metadata needed to pair compact "
+            "state descriptors across pipeline stages."
+        )
     if cfg.enable_unified_memory:
         raise ValueError("Qwen4-Exp does not support --enable-unified-memory yet")
     overrides: Dict[str, Any] = {}

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -24,6 +24,36 @@ from sglang.srt.utils.runai_utils import is_runai_obj_uri
 logger = logging.getLogger(__name__)
 
 
+def check_pipeline_parallelism(server_args: Any) -> None:
+    cfg = resolving_view(server_args)
+    if cfg.pp_size <= 1:
+        return
+
+    assert cfg.disable_overlap_schedule, (
+        "Pipeline parallelism is not compatible with overlap schedule"
+    )
+    if cfg.speculative_algorithm is not None:
+        assert get_platform().is_cuda or get_platform().is_npu, (
+            "Pipeline-parallel EAGLE prefill is only supported on CUDA and NPU"
+        )
+        assert (
+            cfg.speculative_algorithm.upper() == "EAGLE"
+            and not cfg.enable_multi_layer_eagle
+        ), (
+            "Pipeline parallelism currently only supports EAGLE "
+            "(non-multi-layer) speculative decoding"
+        )
+        assert cfg.disaggregation_mode == "prefill", (
+            "PP + speculative decoding (MTP) is only supported on prefill nodes "
+            "(disaggregation-mode=prefill)"
+        )
+    assert cfg.min_free_slots_delay is None, (
+        "--min-free-slots-delay is not supported with pipeline "
+        "parallelism: allocatable slots per microbatch are bounded by "
+        "pp-max-micro-batch-size, so the threshold may never be reached"
+    )
+
+
 def check_server_args(server_args: Any):
     from sglang.srt.arg_groups.lora_hook import check_lora_server_args
 
@@ -48,34 +78,7 @@ def check_server_args(server_args: Any):
         "Remove --disable-cuda-graph-padding or --enable-torch-compile."
     )
 
-    if cfg.pp_size > 1:
-        if get_platform().is_npu:
-            # NPU: allow PP + EAGLE speculative decoding
-            assert cfg.disable_overlap_schedule, (
-                "Pipeline parallelism is not compatible with overlap schedule"
-            )
-            if cfg.speculative_algorithm is not None:
-                assert (
-                    cfg.speculative_algorithm.upper() == "EAGLE"
-                    and not cfg.enable_multi_layer_eagle
-                ), (
-                    "Pipeline parallelism currently only supports EAGLE "
-                    "(non-multi-layer) speculative decoding"
-                )
-                assert cfg.disaggregation_mode == "prefill", (
-                    "NPU PP + speculative decoding (MTP) is only supported "
-                    "on prefill nodes (disaggregation-mode=prefill)"
-                )
-        else:
-            # Non-NPU: PP + speculative decoding is not supported
-            assert cfg.disable_overlap_schedule and cfg.speculative_algorithm is None, (
-                "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
-            )
-        assert cfg.min_free_slots_delay is None, (
-            "--min-free-slots-delay is not supported with pipeline "
-            "parallelism: allocatable slots per microbatch are bounded by "
-            "pp-max-micro-batch-size, so the threshold may never be reached"
-        )
+    check_pipeline_parallelism(server_args)
 
     assert not (cfg.dp_size > 1 and cfg.nnodes != 1 and not cfg.enable_dp_attention), (
         "multi-node data parallel is not supported unless dp attention!"

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 class StateType(str, enum.Enum):
     MAMBA = "mamba"
+    QSA_PENDING = "qsa_pending"
+    QSA_COMPRESSED = "qsa_compressed"
     SWA = "swa"
     DSA = "dsa"
     # DSA kpool-compress tail: one per-request ring row. The indices encode

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -57,6 +57,7 @@ from sglang.srt.disaggregation.utils import (
     get_dsa_tail_state_indices,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_qsa_pending_state_indices,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -109,7 +110,7 @@ from sglang.srt.runtime_context import (
     get_memory,
     get_parallel,
 )
-from sglang.srt.utils import ceil_align, get_num_new_pages, is_npu
+from sglang.srt.utils import ceil_align, get_num_new_pages, is_cuda, is_npu
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
@@ -129,20 +130,55 @@ def _bootstrap_addr(req: Req) -> str:
     return NetworkAddress(req.bootstrap_host, req.bootstrap_port).to_host_port_str()
 
 
-def _flush_gpudirect_writes_to_cuda_owner() -> None:
-    """Make completed third-party GPU writes visible to CUDA on this device."""
+def _load_cuda_runtime():
     from cuda.bindings import runtime as cuda_rt
 
-    target_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesTarget
-    scope_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesScope
-    flush_target = target_enum.cudaFlushGPUDirectRDMAWritesTargetCurrentDevice
-    flush_scope = scope_enum.cudaFlushGPUDirectRDMAWritesToOwner
-    (err,) = cuda_rt.cudaDeviceFlushGPUDirectRDMAWrites(flush_target, flush_scope)
+    return cuda_rt
+
+
+def _flush_gpudirect_writes_to_cuda_owner() -> None:
+    """Make completed third-party GPU writes visible to CUDA on this device."""
+    try:
+        cuda_rt = _load_cuda_runtime()
+        target_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesTarget
+        scope_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesScope
+        flush_target = target_enum.cudaFlushGPUDirectRDMAWritesTargetCurrentDevice
+        flush_scope = scope_enum.cudaFlushGPUDirectRDMAWritesToOwner
+        (err,) = cuda_rt.cudaDeviceFlushGPUDirectRDMAWrites(flush_target, flush_scope)
+    except (ImportError, AttributeError):
+        logger.warning_once(
+            "CUDA GPUDirect RDMA flush bindings are unavailable; falling back "
+            "to a device synchronization before QSA decode."
+        )
+        torch.cuda.synchronize()
+        return
+
+    unsupported = getattr(cuda_rt.cudaError_t, "cudaErrorNotSupported", None)
+    if unsupported is not None and err == unsupported:
+        logger.warning_once(
+            "CUDA GPUDirect RDMA host flush is unsupported on this device; "
+            "falling back to a device synchronization before QSA decode."
+        )
+        torch.cuda.synchronize()
+        return
+
     if err != cuda_rt.cudaError_t.cudaSuccess:
         raise RuntimeError(
             "Failed to flush GPUDirect RDMA writes before QSA decode: "
             f"CUDA error {int(err)}"
         )
+
+
+def _requires_qsa_gpudirect_flush(transfer_backend: TransferBackend) -> bool:
+    """Whether this transport writes QSA state through NVIDIA GPUDirect."""
+    return (
+        transfer_backend
+        in (
+            TransferBackend.MOONCAKE,
+            TransferBackend.NIXL,
+        )
+        and is_cuda()
+    )
 
 
 class DecodeReqToTokenPool:
@@ -1453,7 +1489,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             def _qsa_pending_payload():
                 # Match the prefill request-pool row positionally; the two
                 # req_pool_idx values need not be equal.
-                return np.array([decode_req.req.req_pool_idx], dtype=np.int32)
+                return get_qsa_pending_state_indices(decode_req.req)
 
             def _swa_ring_payload():
                 # Mirror of prefill _swa_ring_payload using this side's req_pool_idx.
@@ -2355,7 +2391,11 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 and decode_req.hicache_restore_status == HiCacheRestoreResult.PENDING
             )
         }
-        if isinstance(self.token_to_kv_pool, QSATokenToKVPool) and qsa_success_indices:
+        if (
+            isinstance(self.token_to_kv_pool, QSATokenToKVPool)
+            and qsa_success_indices
+            and _requires_qsa_gpudirect_flush(self.scheduler.transfer_backend)
+        ):
             # A single blocking flush covers every QSA request completed by this
             # poll. The CUDA visibility operation is sufficient; a subsequent
             # device-wide synchronize would unnecessarily wait on unrelated work.

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -94,7 +94,6 @@ from sglang.srt.mem_cache.memory_pool import (
     KVCache,
     ReqToTokenPool,
 )
-from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
@@ -110,7 +109,7 @@ from sglang.srt.runtime_context import (
     get_memory,
     get_parallel,
 )
-from sglang.srt.utils import ceil_align, get_num_new_pages, is_cuda, is_npu
+from sglang.srt.utils import ceil_align, get_num_new_pages, is_npu
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
@@ -128,61 +127,6 @@ CLIP_MAX_NEW_TOKEN = envs.SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION.get()
 def _bootstrap_addr(req: Req) -> str:
     # FIXME: make a property of a req
     return NetworkAddress(req.bootstrap_host, req.bootstrap_port).to_host_port_str()
-
-
-def _load_cuda_runtime():
-    from cuda.bindings import runtime as cuda_rt
-
-    return cuda_rt
-
-
-def _flush_gpudirect_writes_to_cuda_owner() -> None:
-    """Make completed third-party GPU writes visible to CUDA on this device."""
-    try:
-        cuda_rt = _load_cuda_runtime()
-        target_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesTarget
-        scope_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesScope
-        flush_target = target_enum.cudaFlushGPUDirectRDMAWritesTargetCurrentDevice
-        flush_scope = scope_enum.cudaFlushGPUDirectRDMAWritesToOwner
-        (err,) = cuda_rt.cudaDeviceFlushGPUDirectRDMAWrites(flush_target, flush_scope)
-        unsupported = cuda_rt.cudaError_t.cudaErrorNotSupported
-    except (ImportError, AttributeError):
-        logger.warning_once(
-            "CUDA GPUDirect RDMA flush bindings are unavailable; falling back "
-            "to a device synchronization before QSA decode."
-        )
-        torch.cuda.synchronize()
-        return
-
-    if err == unsupported:
-        logger.warning_once(
-            "CUDA GPUDirect RDMA host flush is unsupported on this device; "
-            "falling back to a device synchronization before QSA decode."
-        )
-        torch.cuda.synchronize()
-        return
-
-    if err != cuda_rt.cudaError_t.cudaSuccess:
-        raise RuntimeError(
-            "Failed to flush GPUDirect RDMA writes before QSA decode: "
-            f"CUDA error {int(err)}"
-        )
-
-
-def _requires_qsa_gpudirect_flush(transfer_backend: TransferBackend) -> bool:
-    """Whether QSA needs a CUDA-owner visibility operation for this transport.
-
-    This change is intentionally QSA-scoped. Extending the ordering contract to
-    established state types requires a separate audit of each backend/consumer.
-    """
-    return (
-        transfer_backend
-        in (
-            TransferBackend.MOONCAKE,
-            TransferBackend.NIXL,
-        )
-        and is_cuda()
-    )
 
 
 class DecodeReqToTokenPool:
@@ -2138,9 +2082,6 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.metadata_buffers = metadata_buffers
         self.scheduler = scheduler
         self.token_to_kv_pool = scheduler.token_to_kv_pool_allocator.get_kvcache()
-        self._needs_qsa_gpudirect_flush = isinstance(
-            self.token_to_kv_pool, QSATokenToKVPool
-        ) and _requires_qsa_gpudirect_flush(scheduler.transfer_backend)
         self.tree_cache = tree_cache
         self.spec_algorithm = scheduler.spec_algorithm
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -2388,8 +2329,6 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         # Queue-removed but held for deferred release; excluded from the metadata
         # teardown below.
         deferred_indices = set()
-        qsa_writes_flushed = False
-
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
@@ -2454,13 +2393,6 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     and hicache_restore_status == HiCacheRestoreResult.PENDING
                 ):
                     continue
-                if self._needs_qsa_gpudirect_flush and not qsa_writes_flushed:
-                    # Completion comes from a host-side RDMA poll. QSA state is
-                    # consumed directly after this queue releases the request,
-                    # so make it CUDA-visible before the first commit. One
-                    # blocking flush covers every success in this poll.
-                    _flush_gpudirect_writes_to_cuda_owner()
-                    qsa_writes_flushed = True
                 self._commit_transfer_to_req(decode_req)
                 indices_to_remove.add(i)
                 # Check if request was aborted due to corruption

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -170,7 +170,11 @@ def _flush_gpudirect_writes_to_cuda_owner() -> None:
 
 
 def _requires_qsa_gpudirect_flush(transfer_backend: TransferBackend) -> bool:
-    """Whether this transport writes QSA state through NVIDIA GPUDirect."""
+    """Whether QSA needs a CUDA-owner visibility operation for this transport.
+
+    This change is intentionally QSA-scoped. Extending the ordering contract to
+    established state types requires a separate audit of each backend/consumer.
+    """
     return (
         transfer_backend
         in (
@@ -2134,6 +2138,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.metadata_buffers = metadata_buffers
         self.scheduler = scheduler
         self.token_to_kv_pool = scheduler.token_to_kv_pool_allocator.get_kvcache()
+        self._needs_qsa_gpudirect_flush = isinstance(
+            self.token_to_kv_pool, QSATokenToKVPool
+        ) and _requires_qsa_gpudirect_flush(scheduler.transfer_backend)
         self.tree_cache = tree_cache
         self.spec_algorithm = scheduler.spec_algorithm
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -2381,25 +2388,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         # Queue-removed but held for deferred release; excluded from the metadata
         # teardown below.
         deferred_indices = set()
-        qsa_success_indices = {
-            i
-            for i, (decode_req, poll) in enumerate(zip(self.queue, polls))
-            if poll == KVPoll.Success
-            and (rids_to_check is None or decode_req.req.rid in rids_to_check)
-            and not (
-                self.scheduler.enable_decode_hicache
-                and decode_req.hicache_restore_status == HiCacheRestoreResult.PENDING
-            )
-        }
-        if (
-            isinstance(self.token_to_kv_pool, QSATokenToKVPool)
-            and qsa_success_indices
-            and _requires_qsa_gpudirect_flush(self.scheduler.transfer_backend)
-        ):
-            # A single blocking flush covers every QSA request completed by this
-            # poll. The CUDA visibility operation is sufficient; a subsequent
-            # device-wide synchronize would unnecessarily wait on unrelated work.
-            _flush_gpudirect_writes_to_cuda_owner()
+        qsa_writes_flushed = False
 
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
@@ -2465,6 +2454,13 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     and hicache_restore_status == HiCacheRestoreResult.PENDING
                 ):
                     continue
+                if self._needs_qsa_gpudirect_flush and not qsa_writes_flushed:
+                    # Completion comes from a host-side RDMA poll. QSA state is
+                    # consumed directly after this queue releases the request,
+                    # so make it CUDA-visible before the first commit. One
+                    # blocking flush covers every success in this poll.
+                    _flush_gpudirect_writes_to_cuda_owner()
+                    qsa_writes_flushed = True
                 self._commit_transfer_to_req(decode_req)
                 indices_to_remove.add(i)
                 # Check if request was aborted due to corruption

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -145,6 +145,7 @@ def _flush_gpudirect_writes_to_cuda_owner() -> None:
         flush_target = target_enum.cudaFlushGPUDirectRDMAWritesTargetCurrentDevice
         flush_scope = scope_enum.cudaFlushGPUDirectRDMAWritesToOwner
         (err,) = cuda_rt.cudaDeviceFlushGPUDirectRDMAWrites(flush_target, flush_scope)
+        unsupported = cuda_rt.cudaError_t.cudaErrorNotSupported
     except (ImportError, AttributeError):
         logger.warning_once(
             "CUDA GPUDirect RDMA flush bindings are unavailable; falling back "
@@ -153,8 +154,7 @@ def _flush_gpudirect_writes_to_cuda_owner() -> None:
         torch.cuda.synchronize()
         return
 
-    unsupported = getattr(cuda_rt.cudaError_t, "cudaErrorNotSupported", None)
-    if unsupported is not None and err == unsupported:
+    if err == unsupported:
         logger.warning_once(
             "CUDA GPUDirect RDMA host flush is unsupported on this device; "
             "falling back to a device synchronization before QSA decode."

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -93,6 +93,7 @@ from sglang.srt.mem_cache.memory_pool import (
     KVCache,
     ReqToTokenPool,
 )
+from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
@@ -126,6 +127,22 @@ CLIP_MAX_NEW_TOKEN = envs.SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION.get()
 def _bootstrap_addr(req: Req) -> str:
     # FIXME: make a property of a req
     return NetworkAddress(req.bootstrap_host, req.bootstrap_port).to_host_port_str()
+
+
+def _flush_gpudirect_writes_to_cuda_owner() -> None:
+    """Make completed third-party GPU writes visible to CUDA on this device."""
+    from cuda.bindings import runtime as cuda_rt
+
+    target_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesTarget
+    scope_enum = cuda_rt.cudaFlushGPUDirectRDMAWritesScope
+    flush_target = target_enum.cudaFlushGPUDirectRDMAWritesTargetCurrentDevice
+    flush_scope = scope_enum.cudaFlushGPUDirectRDMAWritesToOwner
+    (err,) = cuda_rt.cudaDeviceFlushGPUDirectRDMAWrites(flush_target, flush_scope)
+    if err != cuda_rt.cudaError_t.cudaSuccess:
+        raise RuntimeError(
+            "Failed to flush GPUDirect RDMA writes before QSA decode: "
+            f"CUDA error {int(err)}"
+        )
 
 
 class DecodeReqToTokenPool:
@@ -251,6 +268,10 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm_spec: bool = False,
+        short_conv_layer_ids: Optional[List[int]] = None,
+        short_conv_state_shape: Optional[Tuple[int, int]] = None,
+        ngram_context_len: int = 0,
+        ngram_eos_token_id: int = 0,
     ):
         DecodeReqToTokenPool.__init__(
             self,
@@ -298,6 +319,10 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             mamba_envelope_layout=mamba_envelope_layout,
             enable_linear_replayssm_spec=enable_linear_replayssm_spec,
+            short_conv_layer_ids=short_conv_layer_ids,
+            short_conv_state_shape=short_conv_state_shape,
+            ngram_context_len=ngram_context_len,
+            ngram_eos_token_id=ngram_eos_token_id,
         )
 
     def clear(self):
@@ -1425,6 +1450,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     seq_len,
                 )
 
+            def _qsa_pending_payload():
+                # Match the prefill request-pool row positionally; the two
+                # req_pool_idx values need not be equal.
+                return np.array([decode_req.req.req_pool_idx], dtype=np.int32)
+
             def _swa_ring_payload():
                 # Mirror of prefill _swa_ring_payload using this side's req_pool_idx.
                 # Same window positions and order -> positional match with prefill.
@@ -1455,6 +1485,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     clear_c128_state(int(decode_req.req.kv.req_pool_idx))
             payloads = {
                 StateType.MAMBA: _mamba_payload,
+                StateType.QSA_PENDING: _qsa_pending_payload,
+                StateType.QSA_COMPRESSED: _full_kv_pages_payload,
                 StateType.SWA: _swa_payload,
                 StateType.DSA: _full_kv_pages_payload,
                 StateType.DSA_TAIL: _dsa_tail_payload,
@@ -2065,6 +2097,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.tp_rank = tp_rank
         self.metadata_buffers = metadata_buffers
         self.scheduler = scheduler
+        self.token_to_kv_pool = scheduler.token_to_kv_pool_allocator.get_kvcache()
         self.tree_cache = tree_cache
         self.spec_algorithm = scheduler.spec_algorithm
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -2312,6 +2345,22 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         # Queue-removed but held for deferred release; excluded from the metadata
         # teardown below.
         deferred_indices = set()
+        qsa_success_indices = {
+            i
+            for i, (decode_req, poll) in enumerate(zip(self.queue, polls))
+            if poll == KVPoll.Success
+            and (rids_to_check is None or decode_req.req.rid in rids_to_check)
+            and not (
+                self.scheduler.enable_decode_hicache
+                and decode_req.hicache_restore_status == HiCacheRestoreResult.PENDING
+            )
+        }
+        if isinstance(self.token_to_kv_pool, QSATokenToKVPool) and qsa_success_indices:
+            # A single blocking flush covers every QSA request completed by this
+            # poll. The CUDA visibility operation is sufficient; a subsequent
+            # device-wide synchronize would unnecessarily wait on unrelated work.
+            _flush_gpudirect_writes_to_cuda_owner()
+
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -55,6 +55,7 @@ from sglang.srt.disaggregation.utils import (
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
+from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.observability.mooncake_trace import (
     MooncakeRequestStage,
     mooncake_trace_func,
@@ -1342,6 +1343,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         return st in (
             StateType.SWA,
             StateType.DSA,
+            StateType.QSA_PENDING,
+            StateType.QSA_COMPRESSED,
             StateType.SWA_RING,
             StateType.C128_STATE,
             StateType.BLOCK_SCALE,
@@ -1350,7 +1353,12 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
     def _requires_exact_state_index_match(self, st: StateType) -> bool:
         """State types whose page lists are positional and must not be truncated."""
-        return st in (StateType.SWA_RING, StateType.C128_STATE)
+        return st in (
+            StateType.QSA_PENDING,
+            StateType.QSA_COMPRESSED,
+            StateType.SWA_RING,
+            StateType.C128_STATE,
+        )
 
     def maybe_send_extra(
         self,
@@ -1433,6 +1441,11 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     and self.attn_tp_size
                     != target_rank_registration_info.dst_attn_tp_size
                 ):
+                    if PLE_NGRAM_STATE_LAYER_ID in src_state_layer_ids:
+                        raise RuntimeError(
+                            "Qwen4 PLE PD state transfer currently requires matching "
+                            "prefill/decode attention TP sizes"
+                        )
                     rc = (
                         self._send_mamba_state_slice(
                             req,
@@ -1527,6 +1540,10 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        force_flat=st
+                        in (StateType.QSA_PENDING, StateType.QSA_COMPRESSED),
+                        src_layer_ids=src_state_layer_ids,
+                        dst_layer_ids=dst_state_layer_ids,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -51,11 +51,11 @@ from sglang.srt.disaggregation.utils import (
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
     resolve_dcp_dst_entry_indices,
+    should_send_replicated_state,
     slice_dsa_tail_dst_ptrs_for_pp,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.observability.mooncake_trace import (
     MooncakeRequestStage,
     mooncake_trace_func,
@@ -1441,11 +1441,6 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     and self.attn_tp_size
                     != target_rank_registration_info.dst_attn_tp_size
                 ):
-                    if PLE_NGRAM_STATE_LAYER_ID in src_state_layer_ids:
-                        raise RuntimeError(
-                            "Qwen4 PLE PD state transfer currently requires matching "
-                            "prefill/decode attention TP sizes"
-                        )
                     rc = (
                         self._send_mamba_state_slice(
                             req,
@@ -1495,16 +1490,63 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     or rc
                 )
             elif self._is_generic_kvcache_state_type(st):
-                if (
+                is_qwen4_qsa_state = st in (
+                    StateType.QSA_PENDING,
+                    StateType.QSA_COMPRESSED,
+                )
+                has_heterogeneous_attn_tp = (
                     target_rank_registration_info is not None
-                    and not self.is_mla_backend
-                    and not self.is_hybrid_mla_backend
                     and self.attn_tp_size
                     != target_rank_registration_info.dst_attn_tp_size
+                )
+                if (
+                    has_heterogeneous_attn_tp
+                    and not self.is_mla_backend
+                    and not self.is_hybrid_mla_backend
+                    and not is_qwen4_qsa_state
                 ):
                     raise RuntimeError(
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
                     )
+                if has_heterogeneous_attn_tp and is_qwen4_qsa_state:
+                    if len(src_item_lens) != len(src_data_ptrs) or len(
+                        dst_item_lens
+                    ) != len(dst_data_ptrs):
+                        raise RuntimeError(
+                            f"Replicated {st.upper()} pointer/item-length metadata "
+                            "is inconsistent: "
+                            f"src ptrs={len(src_data_ptrs)} lens={len(src_item_lens)}, "
+                            f"dst ptrs={len(dst_data_ptrs)} lens={len(dst_item_lens)}"
+                        )
+                    qsa_entry_pairs = build_transfer_entry_pairs(
+                        src_state_layer_ids,
+                        dst_state_layer_ids,
+                        len(src_data_ptrs),
+                        len(dst_data_ptrs),
+                        allow_positional_fallback=self.pp_size == 1,
+                    )
+                    layout_mismatches = [
+                        (i, j, src_item_lens[i], dst_item_lens[j])
+                        for i, j in qsa_entry_pairs
+                        if src_item_lens[i] != dst_item_lens[j]
+                    ]
+                    if layout_mismatches:
+                        raise RuntimeError(
+                            f"Replicated {st.upper()} layout differs between mapped "
+                            "prefill and decode entries: "
+                            f"{layout_mismatches}"
+                        )
+                    local_tp_rank_in_group = (
+                        self.kv_args.engine_rank % self.attn_tp_size
+                    )
+                    if not should_send_replicated_state(
+                        src_attn_tp_size=self.attn_tp_size,
+                        dst_attn_tp_size=(
+                            target_rank_registration_info.dst_attn_tp_size
+                        ),
+                        local_tp_rank_in_group=local_tp_rank_in_group,
+                    ):
+                        continue
                 src_indices = list(indices)
                 dst_indices_local = list(dst_indices)
                 if (
@@ -1683,8 +1725,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         compute_mamba_state_slice_byte_blocks).
         """
         logger.warning_once(
-            "Using Mamba state slice transfer for different TP sizes between prefill and decode. "
-            f"Prefill attn_tp_size={self.attn_tp_size}, Decode attn_tp_size={dst_attn_tp_size}. "
+            "Using Mamba state slice transfer for different runtime attention TP "
+            f"sizes: prefill={self.attn_tp_size}, decode={dst_attn_tp_size}. "
             "Performance may be affected."
         )
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1509,13 +1509,10 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
                     )
                 if has_heterogeneous_attn_tp and is_qwen4_qsa_state:
-                    if len(src_item_lens) != len(src_data_ptrs) or len(
-                        dst_item_lens
-                    ) != len(dst_data_ptrs):
+                    if len(dst_item_lens) != len(dst_data_ptrs):
                         raise RuntimeError(
-                            f"Replicated {st.upper()} pointer/item-length metadata "
-                            "is inconsistent: "
-                            f"src ptrs={len(src_data_ptrs)} lens={len(src_item_lens)}, "
+                            f"Replicated {st.upper()} destination pointer/item-length "
+                            "metadata is inconsistent: "
                             f"dst ptrs={len(dst_data_ptrs)} lens={len(dst_item_lens)}"
                         )
                     qsa_entry_pairs = build_transfer_entry_pairs(

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -44,6 +44,7 @@ from sglang.srt.disaggregation.common.utils import (
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
+from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import run_with_deadline
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
@@ -1316,6 +1317,19 @@ class MoriKVManager(CommonKVManager):
             )
 
             if st == "mamba":
+                state_layer_ids = (
+                    self.kv_args.state_layer_ids[i]
+                    if i < len(self.kv_args.state_layer_ids)
+                    else []
+                )
+                if (
+                    peer_info.decode_tp_size != self.attn_tp_size
+                    and PLE_NGRAM_STATE_LAYER_ID in state_layer_ids
+                ):
+                    raise RuntimeError(
+                        "Qwen4 PLE PD state transfer currently requires matching "
+                        "prefill/decode attention TP sizes"
+                    )
                 statuses.extend(
                     self._send_mamba_state(
                         peer_info,
@@ -1329,7 +1343,15 @@ class MoriKVManager(CommonKVManager):
                         dst_dims,
                     )
                 )
-            elif st in ("swa", "dsa", "swa_ring", "c128_state", "minimax_index_k"):
+            elif st in (
+                "swa",
+                "dsa",
+                "qsa_pending",
+                "qsa_compressed",
+                "swa_ring",
+                "c128_state",
+                "minimax_index_k",
+            ):
                 statuses.extend(
                     self._send_swa_dsa_state(
                         peer_info,
@@ -1456,14 +1478,14 @@ class MoriKVManager(CommonKVManager):
                 f"PD state transfer does not support TP-mismatched non-MLA SWA models "
                 f"(prefill_tp_size={self.attn_tp_size}, decode_tp_size={peer_info.decode_tp_size})"
             )
-        if state_type == "minimax_index_k":
+        if state_type in ("qsa_pending", "qsa_compressed", "minimax_index_k"):
             if self.pp_size is not None and self.pp_size > 1:
                 raise RuntimeError(
-                    "PD disagg: PP>1 not supported for MiniMax sparse index yet."
+                    f"PD disagg: PP>1 not supported for {state_type} yet."
                 )
             if peer_info.decode_tp_size != self.attn_tp_size:
                 raise RuntimeError(
-                    "PD disagg: heterogeneous TP not supported for MiniMax sparse index yet."
+                    f"PD disagg: heterogeneous TP not supported for {state_type} yet."
                 )
 
         common_len = min(src_state_indices.size, dst_state_indices.size)
@@ -1482,7 +1504,12 @@ class MoriKVManager(CommonKVManager):
             # These components are position- or request-indexed: truncating
             # silently misaligns rows and corrupts KV. Paged swa/dsa tolerate
             # a 1-page drift -> keep truncation.
-            if state_type in ("swa_ring", "c128_state"):
+            if state_type in (
+                "qsa_pending",
+                "qsa_compressed",
+                "swa_ring",
+                "c128_state",
+            ):
                 raise RuntimeError(
                     f"{state_type.upper()} state index length mismatch: "
                     f"src={src_state_indices.size}, dst={dst_state_indices.size}"

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -44,7 +44,6 @@ from sglang.srt.disaggregation.common.utils import (
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import run_with_deadline
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
@@ -1317,18 +1316,10 @@ class MoriKVManager(CommonKVManager):
             )
 
             if st == "mamba":
-                state_layer_ids = (
-                    self.kv_args.state_layer_ids[i]
-                    if i < len(self.kv_args.state_layer_ids)
-                    else []
-                )
-                if (
-                    peer_info.decode_tp_size != self.attn_tp_size
-                    and PLE_NGRAM_STATE_LAYER_ID in state_layer_ids
-                ):
+                if peer_info.decode_tp_size != self.attn_tp_size and 0 in src_dims:
                     raise RuntimeError(
-                        "Qwen4 PLE PD state transfer currently requires matching "
-                        "prefill/decode attention TP sizes"
+                        "Replicated Mamba PD state transfer currently requires "
+                        "matching prefill/decode attention TP sizes"
                     )
                 statuses.extend(
                     self._send_mamba_state(

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1480,8 +1480,13 @@ class MoriKVManager(CommonKVManager):
             )
         if state_type in ("qsa_pending", "qsa_compressed", "minimax_index_k"):
             if self.pp_size is not None and self.pp_size > 1:
+                # MORI registration does not exchange state_layer_ids. Compact
+                # sparse-state lists therefore cannot be paired safely across
+                # pipeline stages until that metadata is added to its protocol.
                 raise RuntimeError(
-                    f"PD disagg: PP>1 not supported for {state_type} yet."
+                    f"MORI PD disaggregation requires PP=1 for {state_type}; "
+                    "PP>1 needs peer state_layer_ids for global-layer descriptor "
+                    "pairing."
                 )
             if peer_info.decode_tp_size != self.attn_tp_size:
                 raise RuntimeError(

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1504,6 +1504,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         bypass_prepped: bool = False,
         src_layer_ids: Optional[List[int]] = None,
         dst_layer_ids: Optional[List[int]] = None,
+        dst_item_lens: Optional[List[int]] = None,
     ):
         """Generic KV cache transfer supporting both MHA and MLA architectures.
         Used by both send_kvcache and maybe_send_extra.
@@ -1573,6 +1574,16 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     len(dst_data_ptrs),
                     allow_positional_fallback=self.pp_size == 1,
                 )
+                # The source item length is used as the destination stride, so
+                # the paired entries must have identical layouts.
+                if dst_item_lens is not None:
+                    for i, j in pairs:
+                        if item_lens[i] != dst_item_lens[j]:
+                            raise RuntimeError(
+                                f"{state_type} item length mismatch for paired "
+                                f"entries src[{i}]={item_lens[i]} "
+                                f"dst[{j}]={dst_item_lens[j]}"
+                            )
                 layers_params = [
                     (src_data_ptrs[i], dst_data_ptrs[j], item_lens[i]) for i, j in pairs
                 ]
@@ -2517,6 +2528,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     force_flat=st in (StateType.QSA_PENDING, StateType.QSA_COMPRESSED),
                     src_layer_ids=src_lids,
                     dst_layer_ids=dst_lids,
+                    dst_item_lens=dst_lens,
                 )
             elif st == StateType.MINIMAX_INDEX_K:
                 # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -48,6 +48,7 @@ from sglang.srt.disaggregation.utils import (
     slice_dsa_tail_dst_ptrs_for_pp,
 )
 from sglang.srt.environ import envs
+from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import run_with_deadline
@@ -1502,6 +1503,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         dst_mem_kind: str = "VRAM",
         force_flat: bool = False,
         bypass_prepped: bool = False,
+        src_layer_ids: Optional[List[int]] = None,
+        dst_layer_ids: Optional[List[int]] = None,
     ):
         """Generic KV cache transfer supporting both MHA and MLA architectures.
         Used by both send_kvcache and maybe_send_extra.
@@ -1563,17 +1566,31 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         logger.debug(f"sending kvcache to {peer_name} with notif {notif}")
         # Make descs
         if self.is_mla_backend or force_flat:
-            src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs, state_type)
-            )
-            layers_params = [
-                (
-                    src_kv_ptrs[layer_id],
-                    dst_kv_ptrs[layer_id],
-                    item_lens[layer_id],
+            if src_layer_ids or dst_layer_ids:
+                pairs = build_transfer_entry_pairs(
+                    src_layer_ids or [],
+                    dst_layer_ids or [],
+                    len(src_data_ptrs),
+                    len(dst_data_ptrs),
+                    allow_positional_fallback=self.pp_size == 1,
                 )
-                for layer_id in range(layers_current_pp_stage)
-            ]
+                layers_params = [
+                    (src_data_ptrs[i], dst_data_ptrs[j], item_lens[i]) for i, j in pairs
+                ]
+            else:
+                src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
+                    self.get_mla_kv_ptrs_with_pp(
+                        src_data_ptrs, dst_data_ptrs, state_type
+                    )
+                )
+                layers_params = [
+                    (
+                        src_kv_ptrs[layer_id],
+                        dst_kv_ptrs[layer_id],
+                        item_lens[layer_id],
+                    )
+                    for layer_id in range(layers_current_pp_stage)
+                ]
         else:
             src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
                 self.get_mha_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
@@ -2396,6 +2413,11 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
             if st == StateType.MAMBA:
                 if self.attn_tp_size != decode_tp_size:
+                    if PLE_NGRAM_STATE_LAYER_ID in src_lids:
+                        raise RuntimeError(
+                            "Qwen4 PLE PD state transfer currently requires matching "
+                            "prefill/decode attention TP sizes"
+                        )
                     h = self._send_mamba_state_slice(
                         peer_name,
                         src_indices,
@@ -2458,7 +2480,13 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     state_type=st,
                     force_flat=True,
                 )
-            elif st in (StateType.SWA, StateType.SWA_RING, StateType.C128_STATE):
+            elif st in (
+                StateType.SWA,
+                StateType.QSA_PENDING,
+                StateType.QSA_COMPRESSED,
+                StateType.SWA_RING,
+                StateType.C128_STATE,
+            ):
                 if not self.is_mla_backend and self.attn_tp_size != decode_tp_size:
                     raise RuntimeError(
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
@@ -2484,6 +2512,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     dst_gpu_id=dst_gpu_id,
                     notif=comp_notif,
                     state_type=st,
+                    force_flat=st in (StateType.QSA_PENDING, StateType.QSA_COMPRESSED),
+                    src_layer_ids=src_lids,
+                    dst_layer_ids=dst_lids,
                 )
             elif st == StateType.MINIMAX_INDEX_K:
                 # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -48,7 +48,6 @@ from sglang.srt.disaggregation.utils import (
     slice_dsa_tail_dst_ptrs_for_pp,
 )
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.ple_state_pool import PLE_NGRAM_STATE_LAYER_ID
 from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import run_with_deadline
@@ -2416,10 +2415,10 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
             if st == StateType.MAMBA:
                 if self.attn_tp_size != decode_tp_size:
-                    if PLE_NGRAM_STATE_LAYER_ID in src_lids:
+                    if 0 in src_dims:
                         raise RuntimeError(
-                            "Qwen4 PLE PD state transfer currently requires matching "
-                            "prefill/decode attention TP sizes"
+                            "Replicated Mamba PD state transfer currently requires "
+                            "matching prefill/decode attention TP sizes"
                         )
                     h = self._send_mamba_state_slice(
                         peer_name,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1612,6 +1612,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 for layer_id in range(layers_current_pp_stage)
             ]
 
+        if not layers_params:
+            return None
+
         src_addrs = []
         src_lens = []
         dst_addrs = []

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -48,6 +48,7 @@ from sglang.srt.disaggregation.utils import (
     get_dsa_tail_state_indices,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_qsa_pending_state_indices,
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
@@ -1323,7 +1324,7 @@ class SchedulerDisaggregationPrefillMixin:
             def _qsa_pending_payload():
                 # Raw index-K/RoPE state is one full compression-group ring per
                 # request, addressed by the request-pool slot rather than KV pages.
-                return np.array([req.req_pool_idx], dtype=np.int32)
+                return get_qsa_pending_state_indices(req)
 
             def _swa_ring_payload():
                 # Unified_kv SWA ring rows (req_pool_idx*ring_stride + pos%ring_stride)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1320,6 +1320,11 @@ class SchedulerDisaggregationPrefillMixin:
                     seq_len,
                 )
 
+            def _qsa_pending_payload():
+                # Raw index-K/RoPE state is one full compression-group ring per
+                # request, addressed by the request-pool slot rather than KV pages.
+                return np.array([req.req_pool_idx], dtype=np.int32)
+
             def _swa_ring_payload():
                 # Unified_kv SWA ring rows (req_pool_idx*ring_stride + pos%ring_stride)
                 # for the last `window` positions, in ascending position order so
@@ -1354,6 +1359,8 @@ class SchedulerDisaggregationPrefillMixin:
             )
             payloads = {
                 StateType.MAMBA: _mamba_payload,
+                StateType.QSA_PENDING: _qsa_pending_payload,
+                StateType.QSA_COMPRESSED: _full_kv_pages_payload,
                 StateType.SWA: _swa_payload,
                 StateType.DSA: _full_kv_pages_payload,
                 StateType.DSA_TAIL: _dsa_tail_payload,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1302,6 +1302,7 @@ def setup_state_kv_args(
         MHATokenToKVPoolMXFP8,
         MiniMaxSparseKVPool,
     )
+    from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
     from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 
     kv_args.state_types = []
@@ -1443,6 +1444,29 @@ def setup_state_kv_args(
                     dsa_item_lens,
                 )
                 append_dsa_tail(dsa_pool)
+            if isinstance(token_to_kv_pool, QSATokenToKVPool):
+                qsa_ptrs, qsa_lens, qsa_item_lens = (
+                    token_to_kv_pool.get_qsa_pending_state_buf_infos()
+                )
+                append_state_component(
+                    kv_args,
+                    StateType.QSA_PENDING,
+                    qsa_ptrs,
+                    qsa_lens,
+                    qsa_item_lens,
+                    layer_ids=token_to_kv_pool.get_qsa_pending_state_layer_ids(),
+                )
+                compressed_ptrs, compressed_lens, compressed_item_lens = (
+                    token_to_kv_pool.get_qsa_compressed_state_buf_infos()
+                )
+                append_state_component(
+                    kv_args,
+                    StateType.QSA_COMPRESSED,
+                    compressed_ptrs,
+                    compressed_lens,
+                    compressed_item_lens,
+                    layer_ids=token_to_kv_pool.get_qsa_compressed_state_layer_ids(),
+                )
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
             tail_ptrs, tail_lens, tail_item_lens = [], [], []
             if isinstance(token_to_kv_pool, DSATokenToKVPool):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -779,6 +779,41 @@ def is_mla_backend(target_kv_pool) -> bool:
     return isinstance(target_kv_pool, (MLATokenToKVPool, DeepSeekV4TokenToKVPool))
 
 
+def should_send_replicated_state(
+    *,
+    src_attn_tp_size: int,
+    dst_attn_tp_size: int,
+    local_tp_rank_in_group: int,
+) -> bool:
+    """Elect writers for state replicated within an attention-TP group.
+
+    Scatter (one source rank to several destination ranks) is a broadcast, so
+    the source sends to every destination registration. Aggregation has several
+    equivalent source copies targeting one destination; only the first source
+    in each aggregation group writes it.
+    """
+    if src_attn_tp_size <= 0 or dst_attn_tp_size <= 0:
+        raise ValueError(
+            "Attention TP sizes must be positive for replicated-state transfer"
+        )
+    larger_tp_size = max(src_attn_tp_size, dst_attn_tp_size)
+    smaller_tp_size = min(src_attn_tp_size, dst_attn_tp_size)
+    if larger_tp_size % smaller_tp_size != 0:
+        raise ValueError(
+            "One attention TP size must divide the other for replicated-state "
+            f"transfer: src={src_attn_tp_size}, dst={dst_attn_tp_size}"
+        )
+    if not 0 <= local_tp_rank_in_group < src_attn_tp_size:
+        raise ValueError(
+            "Source attention TP rank is out of range for replicated-state "
+            f"transfer: rank={local_tp_rank_in_group}, size={src_attn_tp_size}"
+        )
+    if src_attn_tp_size <= dst_attn_tp_size:
+        return True
+    writers_per_decode = src_attn_tp_size // dst_attn_tp_size
+    return local_tp_rank_in_group % writers_per_decode == 0
+
+
 def compute_mamba_state_slice_blocks(
     src_dim: int,
     dst_dim: int,
@@ -868,8 +903,28 @@ def compute_mamba_state_slice_byte_blocks(
 
     ``outer_count`` is one for the usual ``[slice_dim, ...]`` layout. Kimi
     conv state is ``[K - 1, slice_dim]``, so each logical channel slice expands
-    into one byte block per convolution row.
+    into one byte block per convolution row. A zero src/dst dim marks an item
+    replicated across attention TP and copies the whole item from an elected
+    source rank.
     """
+    if (src_dim == 0) != (dst_dim == 0):
+        raise ValueError(
+            "Mamba state replication metadata differs between prefill and decode"
+        )
+    if src_dim == 0:
+        if src_item_len != dst_item_len:
+            raise ValueError(
+                "Replicated Mamba state item lengths differ between prefill and "
+                f"decode: {src_item_len} != {dst_item_len}"
+            )
+        if not should_send_replicated_state(
+            src_attn_tp_size=src_attn_tp_size,
+            dst_attn_tp_size=dst_attn_tp_size,
+            local_tp_rank_in_group=local_tp_rank_in_group,
+        ):
+            return []
+        return [(0, 0, src_item_len)]
+
     src_bytes_per_dim = src_item_len // (src_dim * outer_count)
     dst_bytes_per_dim = dst_item_len // (dst_dim * outer_count)
     logical_blocks = compute_mamba_state_slice_blocks(

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -127,6 +127,14 @@ def get_dsv4_c128_state_indices(
     return np.array([page], dtype=np.int32)
 
 
+def get_qsa_pending_state_indices(req: Req) -> np.ndarray:
+    """Return the request-pool row that owns a QSA pending-state ring."""
+    req_pool_idx = req.kv.req_pool_idx
+    if req_pool_idx is None:
+        raise ValueError("QSA pending-state transfer requires an allocated request row")
+    return np.array([int(req_pool_idx)], dtype=np.int32)
+
+
 class DisaggregationMode(Enum):
     NULL = "null"
     PREFILL = "prefill"

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1037,10 +1037,12 @@ def build_kv_layer_ids(
     draft_ids = _draft_entry_layer_ids(
         pool=draft_token_to_kv_pool, num_entries=num_draft_entries
     )
-    # Rank the draft's own ids by first appearance, so the band stays dense and
-    # contiguous whatever the draft config numbers its layers.
-    band_index = {lid: i for i, lid in enumerate(dict.fromkeys(draft_ids))}
-    return layer_ids + [num_hidden_layers + band_index[lid] for lid in draft_ids]
+    return layer_ids + _remap_draft_layer_ids(draft_ids, num_hidden_layers)
+
+
+def _remap_draft_layer_ids(layer_ids: List[int], num_hidden_layers: int) -> List[int]:
+    band_index = {layer_id: i for i, layer_id in enumerate(dict.fromkeys(layer_ids))}
+    return [num_hidden_layers + band_index[layer_id] for layer_id in layer_ids]
 
 
 def _draft_entry_layer_ids(*, pool, num_entries: int) -> List[int]:
@@ -1511,16 +1513,50 @@ def setup_state_kv_args(
                 qsa_ptrs, qsa_lens, qsa_item_lens = (
                     token_to_kv_pool.get_qsa_pending_state_buf_infos()
                 )
+                qsa_layer_ids = token_to_kv_pool.get_qsa_pending_state_layer_ids()
+                compressed_ptrs, compressed_lens, compressed_item_lens = (
+                    token_to_kv_pool.get_qsa_compressed_state_buf_infos()
+                )
+                compressed_layer_ids = (
+                    token_to_kv_pool.get_qsa_compressed_state_layer_ids()
+                )
+                if isinstance(draft_token_to_kv_pool, QSATokenToKVPool):
+                    if total_kv_layers is None:
+                        raise ValueError(
+                            "QSA draft state transfer requires total_kv_layers"
+                        )
+                    draft_ptrs, draft_lens, draft_item_lens = (
+                        draft_token_to_kv_pool.get_qsa_pending_state_buf_infos()
+                    )
+                    draft_layer_ids = _remap_draft_layer_ids(
+                        draft_token_to_kv_pool.get_qsa_pending_state_layer_ids(),
+                        total_kv_layers,
+                    )
+                    qsa_ptrs += draft_ptrs
+                    qsa_lens += draft_lens
+                    qsa_item_lens += draft_item_lens
+                    qsa_layer_ids += draft_layer_ids
+
+                    (
+                        draft_compressed_ptrs,
+                        draft_compressed_lens,
+                        draft_compressed_item_lens,
+                    ) = draft_token_to_kv_pool.get_qsa_compressed_state_buf_infos()
+                    draft_compressed_layer_ids = _remap_draft_layer_ids(
+                        draft_token_to_kv_pool.get_qsa_compressed_state_layer_ids(),
+                        total_kv_layers,
+                    )
+                    compressed_ptrs += draft_compressed_ptrs
+                    compressed_lens += draft_compressed_lens
+                    compressed_item_lens += draft_compressed_item_lens
+                    compressed_layer_ids += draft_compressed_layer_ids
                 append_state_component(
                     kv_args,
                     StateType.QSA_PENDING,
                     qsa_ptrs,
                     qsa_lens,
                     qsa_item_lens,
-                    layer_ids=token_to_kv_pool.get_qsa_pending_state_layer_ids(),
-                )
-                compressed_ptrs, compressed_lens, compressed_item_lens = (
-                    token_to_kv_pool.get_qsa_compressed_state_buf_infos()
+                    layer_ids=qsa_layer_ids,
                 )
                 append_state_component(
                     kv_args,
@@ -1528,7 +1564,7 @@ def setup_state_kv_args(
                     compressed_ptrs,
                     compressed_lens,
                     compressed_item_lens,
-                    layer_ids=token_to_kv_pool.get_qsa_compressed_state_layer_ids(),
+                    layer_ids=compressed_layer_ids,
                 )
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
             tail_ptrs, tail_lens, tail_item_lens = [], [], []

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -256,7 +256,14 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             return max(1, int(sequence_lengths.max()))
         spec_info = forward_batch.spec_info
-        draft_window = int(spec_info.draft_token_num) if spec_info is not None else 0
+        draft_window = int(
+            getattr(
+                spec_info,
+                "draft_token_num",
+                getattr(spec_info, "num_tokens_per_req", 0),
+            )
+            or 0
+        )
         return max(1, int(seq_lens_cpu.max()) + draft_window)
 
     @staticmethod

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -256,6 +256,8 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             return max(1, int(sequence_lengths.max()))
         spec_info = forward_batch.spec_info
+        # Target verify exposes ``draft_token_num`` while draft-extend exposes
+        # ``num_tokens_per_req``. Both modes use this gather-width bound.
         draft_window = int(
             getattr(
                 spec_info,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1029,14 +1029,21 @@ class KVCacheConfigurator:
 
         if not isinstance(self.mambaish_config, Qwen4ExpTextConfig):
             return {}
+        short_conv_layer_ids = [
+            i
+            for i in self.mambaish_config.short_conv_layer_ids
+            if self.layer_info.start_layer <= i < self.layer_info.end_layer
+        ]
         return {
-            "short_conv_layer_ids": [
-                i
-                for i in self.mambaish_config.short_conv_layer_ids
-                if self.layer_info.start_layer <= i < self.layer_info.end_layer
-            ],
-            "short_conv_state_shape": self.mambaish_config.short_conv_state_shape,
-            "ngram_context_len": self.mambaish_config.ngram_context_len,
+            "short_conv_layer_ids": short_conv_layer_ids,
+            "short_conv_state_shape": (
+                self.mambaish_config.short_conv_state_shape
+                if short_conv_layer_ids
+                else None
+            ),
+            "ngram_context_len": (
+                self.mambaish_config.ngram_context_len if short_conv_layer_ids else 0
+            ),
             "ngram_eos_token_id": int(self.mambaish_config.eos_token_id),
         }
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1024,6 +1024,22 @@ class KVCacheConfigurator:
                     mamba_layer_ids.append(layer_id)
         return mamba_layer_ids
 
+    def _get_ple_req_pool_kwargs(self) -> dict[str, Any]:
+        from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
+
+        if not isinstance(self.mambaish_config, Qwen4ExpTextConfig):
+            return {}
+        return {
+            "short_conv_layer_ids": [
+                i
+                for i in self.mambaish_config.short_conv_layer_ids
+                if self.layer_info.start_layer <= i < self.layer_info.end_layer
+            ],
+            "short_conv_state_shape": self.mambaish_config.short_conv_state_shape,
+            "ngram_context_len": self.mambaish_config.ngram_context_len,
+            "ngram_eos_token_id": int(self.mambaish_config.eos_token_id),
+        }
+
     def _build_hybrid_mamba_decode_req_pool(
         self,
         *,
@@ -1031,23 +1047,9 @@ class KVCacheConfigurator:
         extra_max_context_len: int,
         pre_alloc_size: int,
     ) -> ReqToTokenPool:
-        from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
         from sglang.srt.disaggregation.decode import (
             HybridMambaDecodeReqToTokenPool,
         )
-
-        ple_kwargs = {}
-        if isinstance(self.mambaish_config, Qwen4ExpTextConfig):
-            ple_kwargs = dict(
-                short_conv_layer_ids=[
-                    i
-                    for i in self.mambaish_config.short_conv_layer_ids
-                    if self.layer_info.start_layer <= i < self.layer_info.end_layer
-                ],
-                short_conv_state_shape=self.mambaish_config.short_conv_state_shape,
-                ngram_context_len=self.mambaish_config.ngram_context_len,
-                ngram_eos_token_id=int(self.mambaish_config.eos_token_id),
-            )
 
         req_to_token_pool = HybridMambaDecodeReqToTokenPool(
             size=max_num_reqs,
@@ -1063,7 +1065,7 @@ class KVCacheConfigurator:
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             mamba_size=get_schedule().max_mamba_cache_size,
             start_layer=self.layer_info.start_layer,
-            **ple_kwargs,
+            **self._get_ple_req_pool_kwargs(),
             linear_replayssm_cache_len=get_exec().mamba.linear_replayssm_cache_len,
             mamba_envelope_layout=get_memory().enable_page_major_kv_layout,
             # ReplaySSM spec-verify is for linear-attn models (GDN fold or KDA
@@ -1121,20 +1123,6 @@ class KVCacheConfigurator:
                 "--enable-linear-replayssm-spec with DSPARK/DFLASH requires a KDA "
                 "(kimi_linear) model; got a non-KDA model."
             )
-        from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
-
-        ple_kwargs = {}
-        if isinstance(self.mambaish_config, Qwen4ExpTextConfig):
-            ple_kwargs = dict(
-                short_conv_layer_ids=[
-                    i
-                    for i in self.mambaish_config.short_conv_layer_ids
-                    if self.layer_info.start_layer <= i < self.layer_info.end_layer
-                ],
-                short_conv_state_shape=self.mambaish_config.short_conv_state_shape,
-                ngram_context_len=self.mambaish_config.ngram_context_len,
-                ngram_eos_token_id=int(self.mambaish_config.eos_token_id),
-            )
         req_to_token_pool = HybridReqToTokenPool(
             size=max_num_reqs,
             mamba_size=get_schedule().max_mamba_cache_size,
@@ -1146,7 +1134,7 @@ class KVCacheConfigurator:
             mamba_layer_ids=self._get_mamba_layer_ids_for_req_pool(),
             enable_mamba_extra_buffer=get_exec().mamba.enable_mamba_extra_buffer,
             enable_mamba_extra_buffer_lazy=get_exec().mamba.enable_mamba_extra_buffer_lazy,
-            **ple_kwargs,
+            **self._get_ple_req_pool_kwargs(),
             # A PD prefill server never runs TARGET_VERIFY, so skip the
             # verify-only per-draft-token state snapshots (see the draft-head
             # case above: None => the pool skips SpeculativeState).

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1031,9 +1031,23 @@ class KVCacheConfigurator:
         extra_max_context_len: int,
         pre_alloc_size: int,
     ) -> ReqToTokenPool:
+        from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
         from sglang.srt.disaggregation.decode import (
             HybridMambaDecodeReqToTokenPool,
         )
+
+        ple_kwargs = {}
+        if isinstance(self.mambaish_config, Qwen4ExpTextConfig):
+            ple_kwargs = dict(
+                short_conv_layer_ids=[
+                    i
+                    for i in self.mambaish_config.short_conv_layer_ids
+                    if self.layer_info.start_layer <= i < self.layer_info.end_layer
+                ],
+                short_conv_state_shape=self.mambaish_config.short_conv_state_shape,
+                ngram_context_len=self.mambaish_config.ngram_context_len,
+                ngram_eos_token_id=int(self.mambaish_config.eos_token_id),
+            )
 
         req_to_token_pool = HybridMambaDecodeReqToTokenPool(
             size=max_num_reqs,
@@ -1049,6 +1063,7 @@ class KVCacheConfigurator:
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             mamba_size=get_schedule().max_mamba_cache_size,
             start_layer=self.layer_info.start_layer,
+            **ple_kwargs,
             linear_replayssm_cache_len=get_exec().mamba.linear_replayssm_cache_len,
             mamba_envelope_layout=get_memory().enable_page_major_kv_layout,
             # ReplaySSM spec-verify is for linear-attn models (GDN fold or KDA

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1112,12 +1112,6 @@ class MambaPool:
             "replayssm_beta",
         }
     )
-    _REPLICATED_TRANSFER_STATE_FIELDS = frozenset(
-        {
-            "ple_short_conv",
-            "ple_ngram",
-        }
-    )
 
     def _iter_transfer_state_entries(self):
         """Yield ``[slot, ...]`` state entries and their transfer metadata."""
@@ -1154,11 +1148,11 @@ class MambaPool:
         while Kimi conv state uses the second per-slot axis.
         """
         dim_per_tensor = []
-        for field, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
+        for _, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
             # Zero is a protocol marker for request state replicated across the
             # attention-TP group. Heterogeneous PD copies the whole item from one
             # elected source rank instead of slicing it as a TP-sharded tensor.
-            if field in self._REPLICATED_TRANSFER_STATE_FIELDS:
+            if slice_axis is None:
                 dim_per_tensor.append(0)
                 continue
             # state_tensor shape: [size+1, sliceable_dim, ...]. Kimi conv state
@@ -1180,7 +1174,11 @@ class MambaPool:
         """Get the number of rows preceding each tensor's TP slice axis."""
         outer_counts = []
         for _, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
-            outer_count = math.prod(state_tensor.shape[1 : 1 + slice_axis])
+            outer_count = (
+                1
+                if slice_axis is None
+                else math.prod(state_tensor.shape[1 : 1 + slice_axis])
+            )
             outer_counts.append(outer_count)
         return outer_counts
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1112,6 +1112,12 @@ class MambaPool:
             "replayssm_beta",
         }
     )
+    _REPLICATED_TRANSFER_STATE_FIELDS = frozenset(
+        {
+            "ple_short_conv",
+            "ple_ngram",
+        }
+    )
 
     def _iter_transfer_state_entries(self):
         """Yield ``[slot, ...]`` state entries and their transfer metadata."""
@@ -1148,7 +1154,13 @@ class MambaPool:
         while Kimi conv state uses the second per-slot axis.
         """
         dim_per_tensor = []
-        for _, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
+        for field, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
+            # Zero is a protocol marker for request state replicated across the
+            # attention-TP group. Heterogeneous PD copies the whole item from one
+            # elected source rank instead of slicing it as a TP-sharded tensor.
+            if field in self._REPLICATED_TRANSFER_STATE_FIELDS:
+                dim_per_tensor.append(0)
+                continue
             # state_tensor shape: [size+1, sliceable_dim, ...]. Kimi conv state
             # transposes the two per-slot axes to [K-1, dim].
             axis = 1 + slice_axis

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1113,8 +1113,8 @@ class MambaPool:
         }
     )
 
-    def _iter_transfer_state_tensors(self):
-        """Yield transferable state tensors with their per-slot slice axis."""
+    def _iter_transfer_state_entries(self):
+        """Yield ``[slot, ...]`` state entries and their transfer metadata."""
         for field, value in vars(self.mamba_cache).items():
             if field in self._NON_TRANSFER_STATE_FIELDS or value is None:
                 continue
@@ -1125,20 +1125,20 @@ class MambaPool:
                 # empty. Advertising it fails the whole batch registration.
                 if state_tensor.numel() == 0:
                     continue
-                yield field, state_tensor, slice_axis
+                for layer_index, layer_id in enumerate(self.mamba_layer_ids):
+                    yield field, state_tensor[layer_index], slice_axis, layer_id
+
+        for sibling in self._slot_siblings:
+            yield from sibling.iter_transfer_state_entries()
 
     def get_contiguous_buf_infos(self):
         """Get transferable state buffer information for RDMA registration."""
         data_ptrs, data_lens, item_lens = [], [], []
 
-        for _, state_tensor, _ in self._iter_transfer_state_tensors():
-            data_ptrs += [
-                state_tensor[i].data_ptr() for i in range(self.num_mamba_layers)
-            ]
-            data_lens += [state_tensor[i].nbytes for i in range(self.num_mamba_layers)]
-            item_lens += [
-                state_tensor[i][0].nbytes for i in range(self.num_mamba_layers)
-            ]
+        for _, state_tensor, _, _ in self._iter_transfer_state_entries():
+            data_ptrs.append(state_tensor.data_ptr())
+            data_lens.append(state_tensor.nbytes)
+            item_lens.append(state_tensor[0].nbytes)
         return data_ptrs, data_lens, item_lens
 
     def get_state_dim_per_tensor(self):
@@ -1148,13 +1148,11 @@ class MambaPool:
         while Kimi conv state uses the second per-slot axis.
         """
         dim_per_tensor = []
-        for _, state_tensor, slice_axis in self._iter_transfer_state_tensors():
-            # state_tensor shape: [num_layers, size+1, sliceable_dim, ...]
-            # Kimi conv state transposes the two per-slot axes to [K-1, dim].
-            axis = 2 + slice_axis
-            sliceable_dim = state_tensor.shape[axis]
-            # Repeat for each layer since we have per-layer data_ptrs
-            dim_per_tensor += [sliceable_dim] * self.num_mamba_layers
+        for _, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
+            # state_tensor shape: [size+1, sliceable_dim, ...]. Kimi conv state
+            # transposes the two per-slot axes to [K-1, dim].
+            axis = 1 + slice_axis
+            dim_per_tensor.append(state_tensor.shape[axis])
         return dim_per_tensor
 
     def get_state_layer_ids(self):
@@ -1164,15 +1162,14 @@ class MambaPool:
         the state list tensor-major x layer. Lets PD transfer match entries
         by layer id when prefill (PP stage) holds a subset of the mamba layers.
         """
-        state_tensor_count = sum(1 for _ in self._iter_transfer_state_tensors())
-        return list(self.mamba_layer_ids) * state_tensor_count
+        return [layer_id for _, _, _, layer_id in self._iter_transfer_state_entries()]
 
     def get_state_slice_outer_counts(self):
         """Get the number of rows preceding each tensor's TP slice axis."""
         outer_counts = []
-        for _, state_tensor, slice_axis in self._iter_transfer_state_tensors():
-            outer_count = math.prod(state_tensor.shape[2 : 2 + slice_axis])
-            outer_counts += [outer_count] * self.num_mamba_layers
+        for _, state_tensor, slice_axis, _ in self._iter_transfer_state_entries():
+            outer_count = math.prod(state_tensor.shape[1 : 1 + slice_axis])
+            outer_counts.append(outer_count)
         return outer_counts
 
     def get_state_conv_shard_groups(self):
@@ -1187,14 +1184,14 @@ class MambaPool:
         those tensors keep the single contiguous slice.
         """
         subdims_per_tensor = []
-        for field, _, _ in self._iter_transfer_state_tensors():
+        for field, _, _, _ in self._iter_transfer_state_entries():
             # Only conv_state carries a q/k/v decomposition.
             subdims = (
                 list(self.conv_shard_groups)
                 if field == "conv" and self.conv_shard_groups is not None
                 else None
             )
-            subdims_per_tensor += [subdims] * self.num_mamba_layers
+            subdims_per_tensor.append(subdims)
         return subdims_per_tensor
 
     def get_kv_size_bytes(self):

--- a/python/sglang/srt/mem_cache/ple_state_pool.py
+++ b/python/sglang/srt/mem_cache/ple_state_pool.py
@@ -127,14 +127,14 @@ class ShortConvPool:
         self.conv_state[:, indices] = data.to(self.conv_state.device, non_blocking=True)
 
     def iter_transfer_state_entries(self):
-        """Yield per-layer ``[slot, ...]`` tensors for PD state transfer."""
+        """Yield replicated per-layer state for PD transfer."""
         if self.conv_state is None:
             return
         for layer_id, layer_index in self.layer_map.items():
             yield (
                 "ple_short_conv",
                 self.conv_state[layer_index],
-                0,
+                None,
                 layer_id,
             )
 
@@ -237,6 +237,6 @@ class NGramPool:
         )
 
     def iter_transfer_state_entries(self):
-        """Yield the request-wide N-gram history for PD state transfer."""
+        """Yield replicated request-wide N-gram history for PD transfer."""
         if self.context is not None:
-            yield "ple_ngram", self.context, 0, PLE_NGRAM_STATE_LAYER_ID
+            yield "ple_ngram", self.context, None, PLE_NGRAM_STATE_LAYER_ID

--- a/python/sglang/srt/mem_cache/ple_state_pool.py
+++ b/python/sglang/srt/mem_cache/ple_state_pool.py
@@ -13,6 +13,11 @@ from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
+# State layer IDs are serialized as uint32 by the disaggregation protocols.
+# Reserve the largest value for PLE's request-wide N-gram state, which is not
+# owned by any model layer.
+PLE_NGRAM_STATE_LAYER_ID = (1 << 32) - 1
+
 
 class SlotIndexedState(Protocol):
     """Per-request state addressed by MambaPool slot index,
@@ -26,6 +31,8 @@ class SlotIndexedState(Protocol):
     def get_cpu_slots(self, indices: torch.Tensor) -> Any: ...
 
     def load_cpu_slots(self, data: Any, indices: torch.Tensor) -> None: ...
+
+    def iter_transfer_state_entries(self): ...
 
 
 class ShortConvPool:
@@ -118,6 +125,18 @@ class ShortConvPool:
         if self.conv_state is None or data is None:
             return
         self.conv_state[:, indices] = data.to(self.conv_state.device, non_blocking=True)
+
+    def iter_transfer_state_entries(self):
+        """Yield per-layer ``[slot, ...]`` tensors for PD state transfer."""
+        if self.conv_state is None:
+            return
+        for layer_id, layer_index in self.layer_map.items():
+            yield (
+                "ple_short_conv",
+                self.conv_state[layer_index],
+                0,
+                layer_id,
+            )
 
 
 class NGramPool:
@@ -216,3 +235,8 @@ class NGramPool:
         self.context[indices.to(dtype=torch.long)] = data.to(
             self.context.device, non_blocking=True
         )
+
+    def iter_transfer_state_entries(self):
+        """Yield the request-wide N-gram history for PD state transfer."""
+        if self.context is not None:
+            yield "ple_ngram", self.context, 0, PLE_NGRAM_STATE_LAYER_ID

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -240,10 +240,9 @@ class QSATokenToKVPool(HybridLinearKVPool):
         if not self.full_attention_layer_id_mapping:
             return [], [], []
         tensors = [*self.qsa_key_state_buffer_pool, self.qsa_rope_position_buffer]
-        return (
-            [tensor.data_ptr() for tensor in tensors],
-            [tensor.nbytes for tensor in tensors],
-            [tensor[0].nbytes * self.qsa_compress_ratio for tensor in tensors],
+        return self._get_paged_state_buf_infos(
+            tensors,
+            self.qsa_compress_ratio,
         )
 
     def get_qsa_pending_state_layer_ids(self):

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -233,6 +233,12 @@ class QSATokenToKVPool(HybridLinearKVPool):
 
     def get_qsa_pending_state_buf_infos(self):
         """Per-request pending key-state and RoPE ring transfer buffers."""
+        # A PP stage without a local QSA layer never writes the shared RoPE
+        # ring.  Do not register it as a transfer source: otherwise that stage
+        # can race with a QSA-owning stage and overwrite valid positions with
+        # its zero-initialized or stale contents.
+        if not self.full_attention_layer_id_mapping:
+            return [], [], []
         tensors = [*self.qsa_key_state_buffer_pool, self.qsa_rope_position_buffer]
         return (
             [tensor.data_ptr() for tensor in tensors],
@@ -242,6 +248,8 @@ class QSATokenToKVPool(HybridLinearKVPool):
 
     def get_qsa_pending_state_layer_ids(self):
         """Global layer metadata for the compact QSA pending-state list."""
+        if not self.full_attention_layer_id_mapping:
+            return []
         return [
             *self.full_attention_layer_id_mapping.keys(),
             QSA_ROPE_STATE_LAYER_ID,

--- a/python/sglang/srt/mem_cache/qsa_kv_pool.py
+++ b/python/sglang/srt/mem_cache/qsa_kv_pool.py
@@ -1,12 +1,25 @@
-"""KV pools carrying the QSA sparse-attention indexer caches."""
+"""KV pools carrying the QSA sparse-attention indexer caches.
+
+``QSATokenToKVPool`` (compressed, Qwen4-Exp) adds the per-request pending
+index-key/RoPE ring and the paged compressed-K cache on top of the hybrid
+full/linear KV pool. ``QwenDSATokenToKVPool`` (tokenwise,
+Qwen3Next-DSA) adds only the flat per-token index-K cache.
+"""
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import List, Optional
 
 import torch
 
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.mem_cache.memory_pool import GB, HybridLinearKVPool, MambaPool
+
+# State layer IDs are serialized as uint32 by the disaggregation protocols.
+# Reserve the value below PLE's request-wide sentinel for QSA's request-wide
+# RoPE ring, which is shared by all full-attention layers.
+QSA_ROPE_STATE_LAYER_ID = (1 << 32) - 2
 
 
 def _index_k_bytes(*, kv_heads: int, head_dim: int, dtype: torch.dtype) -> int:
@@ -119,31 +132,49 @@ class QSATokenToKVPool(HybridLinearKVPool):
             )
         self.qsa_num_request_slots = int(num_request_slots)
         ring_slots = self.qsa_num_request_slots * self.qsa_compress_ratio
-        self.qsa_key_state_buffer_pool = [
-            torch.zeros(
-                (ring_slots, self.qsa_index_kv_heads, self.qsa_index_head_dim),
+        # These buffers participate in Mooncake PD transfer just like the base
+        # KV and Mamba pools.  Keep their allocation in the same memory-saver
+        # and Mooncake custom-pool regions; otherwise MNNVL cannot resolve the
+        # ordinary CUDA allocation when the first QSA state page is sent.
+        allocation_pool = self.full_kv_pool
+        with (
+            allocation_pool.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE),
+            (
+                torch.cuda.use_mem_pool(allocation_pool.custom_mem_pool)
+                if allocation_pool.enable_custom_mem_pool
+                else nullcontext()
+            ),
+        ):
+            self.qsa_key_state_buffer_pool = [
+                torch.zeros(
+                    (
+                        ring_slots,
+                        self.qsa_index_kv_heads,
+                        self.qsa_index_head_dim,
+                    ),
+                    dtype=self.index_state_dtype,
+                    device=device,
+                )
+                for _ in full_attention_layer_ids
+            ]
+            # RoPE coordinates are layer-independent. Keep the exact Qwen4-Exp
+            # MRoPE position of every incomplete key so compression can rotate
+            # the pooled key with the group's real starting coordinate.
+            self.qsa_rope_position_buffer = torch.zeros(
+                (ring_slots, 3), dtype=torch.int64, device=device
+            )
+            # One contiguous allocation behind per-layer views: every layer's
+            # compressed pages are addressable from a single base pointer.
+            self.qsa_compressed_flat = torch.zeros(
+                (
+                    len(full_attention_layer_ids),
+                    self.qsa_compressed_capacity
+                    * self.qsa_index_kv_heads
+                    * self.qsa_index_head_dim,
+                ),
                 dtype=self.index_state_dtype,
                 device=device,
             )
-            for _ in full_attention_layer_ids
-        ]
-        # Layer-independent MRoPE coordinate of every pending key;
-        # the compress kernel rotates the pooled key at the group's real start position.
-        self.qsa_rope_position_buffer = torch.zeros(
-            (ring_slots, 3), dtype=torch.int64, device=device
-        )
-        # One contiguous allocation behind per-layer views: every layer's
-        # compressed pages are addressable from a single base pointer.
-        self.qsa_compressed_flat = torch.zeros(
-            (
-                len(full_attention_layer_ids),
-                self.qsa_compressed_capacity
-                * self.qsa_index_kv_heads
-                * self.qsa_index_head_dim,
-            ),
-            dtype=self.index_state_dtype,
-            device=device,
-        )
         self.qsa_compressed_k_buffer_pool = [
             self.qsa_compressed_flat[layer_offset].view(
                 self.qsa_compressed_capacity,
@@ -191,6 +222,45 @@ class QSATokenToKVPool(HybridLinearKVPool):
     ) -> None:
         buffer = self.get_qsa_compressed_k_buffer(layer_id)
         buffer[loc.long()] = compressed_k.to(buffer.dtype)
+
+    @staticmethod
+    def _get_paged_state_buf_infos(tensors, page_size: int):
+        return (
+            [tensor.data_ptr() for tensor in tensors],
+            [tensor.nbytes for tensor in tensors],
+            [tensor[0].nbytes * page_size for tensor in tensors],
+        )
+
+    def get_qsa_pending_state_buf_infos(self):
+        """Per-request pending key-state and RoPE ring transfer buffers."""
+        tensors = [*self.qsa_key_state_buffer_pool, self.qsa_rope_position_buffer]
+        return (
+            [tensor.data_ptr() for tensor in tensors],
+            [tensor.nbytes for tensor in tensors],
+            [tensor[0].nbytes * self.qsa_compress_ratio for tensor in tensors],
+        )
+
+    def get_qsa_pending_state_layer_ids(self):
+        """Global layer metadata for the compact QSA pending-state list."""
+        return [
+            *self.full_attention_layer_id_mapping.keys(),
+            QSA_ROPE_STATE_LAYER_ID,
+        ]
+
+    def get_qsa_compressed_state_layer_ids(self):
+        """Global layer metadata for the compact compressed-K list."""
+        return list(self.full_attention_layer_id_mapping.keys())
+
+    def get_qsa_compressed_state_buf_infos(self):
+        """Per-full-page compressed-K transfer buffers.
+
+        One full KV page maps to one compressed page because the full page size
+        is an integer multiple of the compression ratio.
+        """
+        return self._get_paged_state_buf_infos(
+            self.qsa_compressed_k_buffer_pool,
+            self.qsa_compressed_page_size,
+        )
 
     def get_kv_size_bytes(self):
         k_size, v_size = super().get_kv_size_bytes()

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import msgspec
 from torch import nn
 
+from sglang.srt.runtime_context import get_disagg
 from sglang.srt.utils import is_npu
 
 if TYPE_CHECKING:
@@ -158,7 +159,10 @@ def resolve_layer_indices(
     if loop_num > 1:
         num_effective_layers = num_effective_layers * loop_num
 
-    if not is_npu():
+    supports_prefill_pp_mtp = (
+        spec_algorithm.is_eagle() and get_disagg().disaggregation_mode == "prefill"
+    )
+    if not is_npu() and not supports_prefill_pp_mtp:
         _assert_pp_mtp_compat(
             model_has_mtp_layers=model_has_mtp_layers,
             spec_algorithm=spec_algorithm,

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -2,7 +2,7 @@
 
 import math
 from contextlib import nullcontext
-from typing import Any, Iterable, Optional, Set, Tuple
+from typing import Any, Iterable, Optional, Set, Tuple, Union
 
 import msgspec
 import sympy
@@ -44,9 +44,13 @@ from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scat
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
-from sglang.srt.layers.utils import get_layer_id
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    ForwardMode,
+    PPProxyTensors,
+)
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
     get_req_to_token_pool,
@@ -1572,6 +1576,8 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
     decoder_layer_types = ALL_DECODER_LAYER_TYPES
 
     def _build_embed_tokens(self, config: Qwen4ExpTextConfig) -> nn.Module:
+        if not self.pp_group.is_first_rank:
+            return PPMissingLayer()
         return VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -1589,7 +1595,10 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
         super().__init__(config, quant_config, prefix, is_nextn)
         self.hc_count = config.hc_count
         self.hidden_size = config.hidden_size
-        self.has_ple = bool(config.ple_layer_ids)
+        self.has_ple = any(
+            self.layers[layer_id].ple is not None
+            for layer_id in range(self.start_layer, self.end_layer)
+        )
         self.ple_ngram_size = int(config.ngram_size) if self.has_ple else None
         self.ple_ngram_eos_token_id = (
             int(config.eos_token_id) if self.ple_ngram_size is not None else None
@@ -1604,7 +1613,11 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
             rms_norm_eps=config.rms_norm_eps,
             hc_per_branch_norm=True,
         )
-        self.hyper_connection_mixer = GatedResidual(hc_config, use_combine=False)
+        self.hyper_connection_mixer = (
+            GatedResidual(hc_config, use_combine=False)
+            if self.pp_group.is_last_rank
+            else PPMissingLayer()
+        )
 
     def forward(
         self,
@@ -1612,11 +1625,18 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         inputs_embeds: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        if inputs_embeds is not None:
-            hidden_states = inputs_embeds
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor], PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_tokens(input_ids)
+            residual = None
         else:
-            hidden_states = self.embed_tokens(input_ids)
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
 
         ple_batch = (
             _prepare_ple_batch(
@@ -1628,12 +1648,11 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
             if self.has_ple
             else None
         )
-        residual = None
         aux_hidden_states = []
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
             if i + 1 < self.end_layer:
-                next_ple = getattr(self.layers[i + 1], "ple", None)
+                next_ple = self.layers[i + 1].ple
                 if next_ple is not None:
                     next_ple.start_prefetch(ple_batch, forward_batch)
             with get_global_expert_distribution_recorder().with_current_layer(i):
@@ -1651,6 +1670,14 @@ class Qwen4ExpModel(Qwen3_5ForCausalLM):
                 )
 
         _commit_ple_batch(ple_batch, forward_batch)
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
 
         hc_hidden_states = hidden_states
         hidden_states, _ = self.hyper_connection_mixer.mix(hidden_states)
@@ -1694,7 +1721,10 @@ class Qwen4ExpVLModel(Qwen4ExpModel):
             positions=positions,
             forward_batch=forward_batch,
             inputs_embeds=input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
+        if isinstance(model_output, PPProxyTensors):
+            return model_output
         if isinstance(model_output, tuple):
             hidden_states, self.last_hc_hidden_states = model_output
             return hidden_states
@@ -1730,8 +1760,21 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
 
     @torch.no_grad()
-    def forward(self, *args, **kwargs):
-        output = super().forward(*args, **kwargs)
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ):
+        output = super().forward(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            get_embedding=get_embedding,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
         hc_hidden_states = self.model.last_hc_hidden_states
         if hc_hidden_states is not None and isinstance(output, LogitsProcessorOutput):
             output.hidden_states = hc_hidden_states
@@ -1956,6 +1999,12 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
             elif name.endswith(".v_proj.v_scale"):
                 name = name.replace(".v_proj.v_scale", ".attn.v_scale")
 
+            layer_id = get_layer_id(name)
+            if layer_id is not None and (
+                layer_id < self.start_layer or layer_id >= self.end_layer
+            ):
+                continue
+
             if self._load_qwen4_exp_ple_buffer(
                 name, loaded_weight, buffers, loaded_buffers
             ):
@@ -1981,9 +2030,9 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 )
                 weight_loader(lm_head_param, loaded_weight)
 
-            layer_id = get_layer_id(name)
-            if layer_id is not None and (
-                layer_id < self.start_layer or layer_id >= self.end_layer
+            if (
+                not self.pp_group.is_last_rank
+                and "model.hyper_connection_mixer." in name
             ):
                 continue
 

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -1759,6 +1759,15 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
             self.visual.deepstack_visual_indexes if self.visual is not None else []
         )
 
+    def get_embed_and_head(self):
+        embed = (
+            self.model.language_model.embed_tokens.weight
+            if self.pp_group.is_first_rank
+            else None
+        )
+        head = self.lm_head.weight if self.pp_group.is_last_rank else None
+        return embed, head
+
     @torch.no_grad()
     def forward(
         self,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1215,13 +1215,18 @@ class EAGLEWorkerV2(BaseSpecWorker):
     @property
     def last_shared_read_runner(self):
         # Per the base contract: the step's last shared-buffer-reading phase is
-        # draft_extend, which runs on the draft runner.
+        # draft_extend when this rank owns the draft. Non-last PP ranks execute
+        # only the target prefill.
+        if self._draft_worker is None:
+            return self._target_worker.model_runner
         return self._draft_worker.draft_runner
 
     @property
     def spec_v2_attn_backends(self) -> tuple:
         # Every attn backend a spec_v2 forward touches; consumed by
         # decide_needs_cpu_seq_lens to gate the seq_lens_cpu D2H.
+        if self._draft_worker is None:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self._draft_worker.draft_attn_backend,

--- a/test/registered/kernel/qsa/test_qsa.py
+++ b/test/registered/kernel/qsa/test_qsa.py
@@ -1,4 +1,5 @@
 import sys
+from contextlib import contextmanager
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -33,6 +34,8 @@ from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
     QwenSparseAttnBackend,
     QwenSparseMultiStepDraftBackend,
 )
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -42,6 +45,58 @@ COMPRESS_RATIO = 4
 TOKEN_TOPK = 2048
 BLOCK_TOPK = TOKEN_TOPK // COMPRESS_RATIO
 FINAL_TOPK = TOKEN_TOPK + COMPRESS_RATIO - 1
+
+
+def test_qsa_allocations_follow_parent_mooncake_scope(monkeypatch):
+    active_scopes = set()
+    allocations = 0
+    original_zeros = torch.zeros
+
+    @contextmanager
+    def scope(name):
+        active_scopes.add(name)
+        try:
+            yield
+        finally:
+            active_scopes.remove(name)
+
+    def init_parent(pool, **_):
+        pool.full_kv_pool = SimpleNamespace(
+            memory_saver_adapter=SimpleNamespace(
+                region=lambda _: scope("memory_saver")
+            ),
+            enable_custom_mem_pool=True,
+            custom_mem_pool=object(),
+        )
+
+    def allocate(*args, **kwargs):
+        nonlocal allocations
+        assert active_scopes == {"memory_saver", "custom_pool"}
+        allocations += 1
+        return original_zeros(*args, **kwargs)
+
+    monkeypatch.setattr(HybridLinearKVPool, "__init__", init_parent)
+    monkeypatch.setattr(QSATokenToKVPool, "get_kv_size_bytes", lambda _: (0, 0))
+    monkeypatch.setattr(torch.cuda, "use_mem_pool", lambda _: scope("custom_pool"))
+    monkeypatch.setattr("sglang.srt.mem_cache.qsa_kv_pool.torch.zeros", allocate)
+
+    QSATokenToKVPool(
+        size=8,
+        dtype=torch.bfloat16,
+        page_size=4,
+        head_num=1,
+        head_dim=8,
+        full_attention_layer_ids=[1, 3],
+        device="cpu",
+        mamba_pool=object(),
+        qsa_index_kv_heads=1,
+        qsa_index_head_dim=8,
+        qsa_compress_ratio=2,
+        qsa_token_topk=4,
+        num_request_slots=3,
+    )
+
+    assert allocations == 4
 
 
 @pytest.mark.parametrize(

--- a/test/registered/kernel/qsa/test_qsa.py
+++ b/test/registered/kernel/qsa/test_qsa.py
@@ -1,5 +1,4 @@
 import sys
-from contextlib import contextmanager
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -34,8 +33,6 @@ from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
     QwenSparseAttnBackend,
     QwenSparseMultiStepDraftBackend,
 )
-from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
-from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -45,58 +42,6 @@ COMPRESS_RATIO = 4
 TOKEN_TOPK = 2048
 BLOCK_TOPK = TOKEN_TOPK // COMPRESS_RATIO
 FINAL_TOPK = TOKEN_TOPK + COMPRESS_RATIO - 1
-
-
-def test_qsa_allocations_follow_parent_mooncake_scope(monkeypatch):
-    active_scopes = set()
-    allocations = 0
-    original_zeros = torch.zeros
-
-    @contextmanager
-    def scope(name):
-        active_scopes.add(name)
-        try:
-            yield
-        finally:
-            active_scopes.remove(name)
-
-    def init_parent(pool, **_):
-        pool.full_kv_pool = SimpleNamespace(
-            memory_saver_adapter=SimpleNamespace(
-                region=lambda _: scope("memory_saver")
-            ),
-            enable_custom_mem_pool=True,
-            custom_mem_pool=object(),
-        )
-
-    def allocate(*args, **kwargs):
-        nonlocal allocations
-        assert active_scopes == {"memory_saver", "custom_pool"}
-        allocations += 1
-        return original_zeros(*args, **kwargs)
-
-    monkeypatch.setattr(HybridLinearKVPool, "__init__", init_parent)
-    monkeypatch.setattr(QSATokenToKVPool, "get_kv_size_bytes", lambda _: (0, 0))
-    monkeypatch.setattr(torch.cuda, "use_mem_pool", lambda _: scope("custom_pool"))
-    monkeypatch.setattr("sglang.srt.mem_cache.qsa_kv_pool.torch.zeros", allocate)
-
-    QSATokenToKVPool(
-        size=8,
-        dtype=torch.bfloat16,
-        page_size=4,
-        head_num=1,
-        head_dim=8,
-        full_attention_layer_ids=[1, 3],
-        device="cpu",
-        mamba_pool=object(),
-        qsa_index_kv_heads=1,
-        qsa_index_head_dim=8,
-        qsa_compress_ratio=2,
-        qsa_token_topk=4,
-        num_request_slots=3,
-    )
-
-    assert allocations == 4
 
 
 @pytest.mark.parametrize(

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -3,6 +3,8 @@ from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
@@ -14,6 +16,7 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.runtime_context import get_context, publish, reset_context
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -346,6 +349,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue.queue = [decode_req]
         queue.enable_staging = False
         queue.enable_deferred_kv_release = False
+        queue.token_to_kv_pool = object()
         queue.gloo_group = MagicMock()
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
         queue.tp_rank = 0
@@ -404,6 +408,44 @@ class TestDecodeQueueCleanup(CustomTestCase):
 
         self.assertIs(receiver.kv_mgr, manager)
         self.assertFalse(receiver.abort_notified)
+
+    def test_qsa_successes_share_one_gpudirect_visibility_flush(self):
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.queue = [
+            SimpleNamespace(
+                req=SimpleNamespace(rid=f"req-{i}", finished_reason=None),
+                hicache_restore_status=None,
+                metadata_buffer_index=i,
+            )
+            for i in range(2)
+        ]
+        queue.scheduler = SimpleNamespace(
+            enable_decode_hicache=False,
+            enable_hisparse=False,
+            metrics_reporter=SimpleNamespace(enable_metrics=False),
+        )
+        queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
+        queue.enable_staging = False
+        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1, 2])
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())
+
+        with (
+            patch.object(
+                DecodeTransferQueue,
+                "_poll_with_metadata_gate",
+                return_value=[KVPoll.Success, KVPoll.Success],
+            ),
+            patch.object(DecodeTransferQueue, "_commit_transfer_to_req"),
+            patch(
+                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner"
+            ) as flush,
+            patch.object(torch.cuda, "synchronize") as synchronize,
+        ):
+            transferred = queue.pop_transferred()
+
+        self.assertEqual([req.rid for req in transferred], ["req-0", "req-1"])
+        flush.assert_called_once_with()
+        synchronize.assert_not_called()
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -12,7 +12,7 @@ from sglang.srt.disaggregation.decode import (
     HiCacheRestoreResult,
 )
 from sglang.srt.disaggregation.fake.conn import FakeKVManager, FakeKVReceiver
-from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.disaggregation.utils import DisaggregationMode, TransferBackend
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
@@ -423,6 +423,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             enable_decode_hicache=False,
             enable_hisparse=False,
             metrics_reporter=SimpleNamespace(enable_metrics=False),
+            transfer_backend=TransferBackend.MOONCAKE,
         )
         queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
         queue.enable_staging = False
@@ -439,6 +440,10 @@ class TestDecodeQueueCleanup(CustomTestCase):
             patch(
                 "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner"
             ) as flush,
+            patch(
+                "sglang.srt.disaggregation.decode._requires_qsa_gpudirect_flush",
+                return_value=True,
+            ),
             patch.object(torch.cuda, "synchronize") as synchronize,
         ):
             transferred = queue.pop_transferred()
@@ -446,6 +451,70 @@ class TestDecodeQueueCleanup(CustomTestCase):
         self.assertEqual([req.rid for req in transferred], ["req-0", "req-1"])
         flush.assert_called_once_with()
         synchronize.assert_not_called()
+
+    def test_qsa_mori_success_does_not_run_cuda_flush(self):
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.queue = [
+            SimpleNamespace(
+                req=SimpleNamespace(rid="req", finished_reason=None),
+                hicache_restore_status=None,
+                metadata_buffer_index=0,
+            )
+        ]
+        queue.scheduler = SimpleNamespace(
+            enable_decode_hicache=False,
+            enable_hisparse=False,
+            metrics_reporter=SimpleNamespace(enable_metrics=False),
+            transfer_backend=TransferBackend.MORI,
+        )
+        queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
+        queue.enable_staging = False
+        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1])
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())
+
+        with (
+            patch.object(
+                DecodeTransferQueue,
+                "_poll_with_metadata_gate",
+                return_value=[KVPoll.Success],
+            ),
+            patch.object(DecodeTransferQueue, "_commit_transfer_to_req"),
+            patch(
+                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner"
+            ) as flush,
+            patch("sglang.srt.disaggregation.decode.is_cuda", return_value=True),
+        ):
+            transferred = queue.pop_transferred()
+
+        self.assertEqual([req.rid for req in transferred], ["req"])
+        flush.assert_not_called()
+
+    def test_qsa_gpudirect_flush_falls_back_when_unsupported(self):
+        cuda_rt = SimpleNamespace(
+            cudaFlushGPUDirectRDMAWritesTarget=SimpleNamespace(
+                cudaFlushGPUDirectRDMAWritesTargetCurrentDevice=1
+            ),
+            cudaFlushGPUDirectRDMAWritesScope=SimpleNamespace(
+                cudaFlushGPUDirectRDMAWritesToOwner=2
+            ),
+            cudaError_t=SimpleNamespace(cudaSuccess=0, cudaErrorNotSupported=801),
+            cudaDeviceFlushGPUDirectRDMAWrites=MagicMock(return_value=(801,)),
+        )
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.decode._load_cuda_runtime",
+                return_value=cuda_rt,
+            ),
+            patch.object(torch.cuda, "synchronize") as synchronize,
+        ):
+            from sglang.srt.disaggregation.decode import (
+                _flush_gpudirect_writes_to_cuda_owner,
+            )
+
+            _flush_gpudirect_writes_to_cuda_owner()
+
+        synchronize.assert_called_once_with()
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -350,6 +350,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue.enable_staging = False
         queue.enable_deferred_kv_release = False
         queue.token_to_kv_pool = object()
+        queue._needs_qsa_gpudirect_flush = False
         queue.gloo_group = MagicMock()
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
         queue.tp_rank = 0
@@ -410,6 +411,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         self.assertFalse(receiver.abort_notified)
 
     def test_qsa_successes_share_one_gpudirect_visibility_flush(self):
+        call_order = []
         queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
         queue.queue = [
             SimpleNamespace(
@@ -426,6 +428,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             transfer_backend=TransferBackend.MOONCAKE,
         )
         queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
+        queue._needs_qsa_gpudirect_flush = True
         queue.enable_staging = False
         queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1, 2])
         queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())
@@ -436,19 +439,21 @@ class TestDecodeQueueCleanup(CustomTestCase):
                 "_poll_with_metadata_gate",
                 return_value=[KVPoll.Success, KVPoll.Success],
             ),
-            patch.object(DecodeTransferQueue, "_commit_transfer_to_req"),
-            patch(
-                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner"
-            ) as flush,
-            patch(
-                "sglang.srt.disaggregation.decode._requires_qsa_gpudirect_flush",
-                return_value=True,
+            patch.object(
+                DecodeTransferQueue,
+                "_commit_transfer_to_req",
+                side_effect=lambda _: call_order.append("commit"),
             ),
+            patch(
+                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner",
+                side_effect=lambda: call_order.append("flush"),
+            ) as flush,
             patch.object(torch.cuda, "synchronize") as synchronize,
         ):
             transferred = queue.pop_transferred()
 
         self.assertEqual([req.rid for req in transferred], ["req-0", "req-1"])
+        self.assertEqual(call_order, ["flush", "commit", "commit"])
         flush.assert_called_once_with()
         synchronize.assert_not_called()
 
@@ -468,6 +473,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             transfer_backend=TransferBackend.MORI,
         )
         queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
+        queue._needs_qsa_gpudirect_flush = False
         queue.enable_staging = False
         queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1])
         queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -3,8 +3,6 @@ from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import torch
-
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
@@ -12,11 +10,10 @@ from sglang.srt.disaggregation.decode import (
     HiCacheRestoreResult,
 )
 from sglang.srt.disaggregation.fake.conn import FakeKVManager, FakeKVReceiver
-from sglang.srt.disaggregation.utils import DisaggregationMode, TransferBackend
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
-from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
 from sglang.srt.runtime_context import get_context, publish, reset_context
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -350,7 +347,6 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue.enable_staging = False
         queue.enable_deferred_kv_release = False
         queue.token_to_kv_pool = object()
-        queue._needs_qsa_gpudirect_flush = False
         queue.gloo_group = MagicMock()
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
         queue.tp_rank = 0
@@ -409,118 +405,6 @@ class TestDecodeQueueCleanup(CustomTestCase):
 
         self.assertIs(receiver.kv_mgr, manager)
         self.assertFalse(receiver.abort_notified)
-
-    def test_qsa_successes_share_one_gpudirect_visibility_flush(self):
-        call_order = []
-        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
-        queue.queue = [
-            SimpleNamespace(
-                req=SimpleNamespace(rid=f"req-{i}", finished_reason=None),
-                hicache_restore_status=None,
-                metadata_buffer_index=i,
-            )
-            for i in range(2)
-        ]
-        queue.scheduler = SimpleNamespace(
-            enable_decode_hicache=False,
-            enable_hisparse=False,
-            metrics_reporter=SimpleNamespace(enable_metrics=False),
-            transfer_backend=TransferBackend.MOONCAKE,
-        )
-        queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
-        queue._needs_qsa_gpudirect_flush = True
-        queue.enable_staging = False
-        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1, 2])
-        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())
-
-        with (
-            patch.object(
-                DecodeTransferQueue,
-                "_poll_with_metadata_gate",
-                return_value=[KVPoll.Success, KVPoll.Success],
-            ),
-            patch.object(
-                DecodeTransferQueue,
-                "_commit_transfer_to_req",
-                side_effect=lambda _: call_order.append("commit"),
-            ),
-            patch(
-                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner",
-                side_effect=lambda: call_order.append("flush"),
-            ) as flush,
-            patch.object(torch.cuda, "synchronize") as synchronize,
-        ):
-            transferred = queue.pop_transferred()
-
-        self.assertEqual([req.rid for req in transferred], ["req-0", "req-1"])
-        self.assertEqual(call_order, ["flush", "commit", "commit"])
-        flush.assert_called_once_with()
-        synchronize.assert_not_called()
-
-    def test_qsa_mori_success_does_not_run_cuda_flush(self):
-        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
-        queue.queue = [
-            SimpleNamespace(
-                req=SimpleNamespace(rid="req", finished_reason=None),
-                hicache_restore_status=None,
-                metadata_buffer_index=0,
-            )
-        ]
-        queue.scheduler = SimpleNamespace(
-            enable_decode_hicache=False,
-            enable_hisparse=False,
-            metrics_reporter=SimpleNamespace(enable_metrics=False),
-            transfer_backend=TransferBackend.MORI,
-        )
-        queue.token_to_kv_pool = object.__new__(QSATokenToKVPool)
-        queue._needs_qsa_gpudirect_flush = False
-        queue.enable_staging = False
-        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[1])
-        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(free=MagicMock())
-
-        with (
-            patch.object(
-                DecodeTransferQueue,
-                "_poll_with_metadata_gate",
-                return_value=[KVPoll.Success],
-            ),
-            patch.object(DecodeTransferQueue, "_commit_transfer_to_req"),
-            patch(
-                "sglang.srt.disaggregation.decode._flush_gpudirect_writes_to_cuda_owner"
-            ) as flush,
-            patch("sglang.srt.disaggregation.decode.is_cuda", return_value=True),
-        ):
-            transferred = queue.pop_transferred()
-
-        self.assertEqual([req.rid for req in transferred], ["req"])
-        flush.assert_not_called()
-
-    def test_qsa_gpudirect_flush_falls_back_when_unsupported(self):
-        cuda_rt = SimpleNamespace(
-            cudaFlushGPUDirectRDMAWritesTarget=SimpleNamespace(
-                cudaFlushGPUDirectRDMAWritesTargetCurrentDevice=1
-            ),
-            cudaFlushGPUDirectRDMAWritesScope=SimpleNamespace(
-                cudaFlushGPUDirectRDMAWritesToOwner=2
-            ),
-            cudaError_t=SimpleNamespace(cudaSuccess=0, cudaErrorNotSupported=801),
-            cudaDeviceFlushGPUDirectRDMAWrites=MagicMock(return_value=(801,)),
-        )
-
-        with (
-            patch(
-                "sglang.srt.disaggregation.decode._load_cuda_runtime",
-                return_value=cuda_rt,
-            ),
-            patch.object(torch.cuda, "synchronize") as synchronize,
-        ):
-            from sglang.srt.disaggregation.decode import (
-                _flush_gpudirect_writes_to_cuda_owner,
-            )
-
-            _flush_gpudirect_writes_to_cuda_owner()
-
-        synchronize.assert_called_once_with()
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -33,9 +33,11 @@ from sglang.srt.disaggregation.mooncake.conn import (
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     build_transfer_entry_pairs,
+    compute_mamba_state_slice_byte_blocks,
     get_dsv4_c4_state_indices,
     get_dsv4_c128_state_indices,
     setup_state_kv_args,
+    should_send_replicated_state,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import should_use_dsa_fused_topk
@@ -236,6 +238,48 @@ class TestQwen4StateWire(unittest.TestCase):
             ),
             [(0, 2), (1, 3)],
         )
+
+    def test_replicated_state_tp_policy(self):
+        for src_tp, dst_tp, rank, expected in (
+            (4, 1, 0, True),
+            (4, 1, 1, False),
+            (1, 4, 0, True),
+            (4, 4, 3, True),
+        ):
+            with self.subTest(src_tp=src_tp, dst_tp=dst_tp, rank=rank):
+                self.assertEqual(
+                    should_send_replicated_state(
+                        src_attn_tp_size=src_tp,
+                        dst_attn_tp_size=dst_tp,
+                        local_tp_rank_in_group=rank,
+                    ),
+                    expected,
+                )
+
+        common = dict(
+            src_item_len=96,
+            dst_item_len=96,
+            src_dim=0,
+            dst_dim=0,
+            outer_count=1,
+            src_attn_tp_size=4,
+            dst_attn_tp_size=1,
+            dst_tp_rank_in_group=0,
+        )
+        self.assertEqual(
+            compute_mamba_state_slice_byte_blocks(**common, local_tp_rank_in_group=0),
+            [(0, 0, 96)],
+        )
+        self.assertEqual(
+            compute_mamba_state_slice_byte_blocks(**common, local_tp_rank_in_group=1),
+            [],
+        )
+        with self.assertRaisesRegex(ValueError, "must divide"):
+            should_send_replicated_state(
+                src_attn_tp_size=3,
+                dst_attn_tp_size=2,
+                local_tp_rank_in_group=0,
+            )
 
 
 class TestGroupConcurrentContiguous(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -237,6 +237,36 @@ class TestQwen4StateWire(unittest.TestCase):
             [[24, QSA_ROPE_STATE_LAYER_ID], [24]],
         )
 
+    def test_qsa_stage_without_qsa_layers_does_not_register_rope_ring(self):
+        pool = object.__new__(QSATokenToKVPool)
+        pool.full_kv_pool = object()
+        pool.get_state_buf_infos = lambda: ([10], [100], [20])
+        pool.get_state_dim_per_tensor = lambda: [4]
+        pool.get_state_conv_shard_groups = lambda: [None]
+        pool.get_state_slice_outer_counts = lambda: [1]
+        pool.get_state_layer_ids = lambda: [2]
+        pool.page_size = 4
+        pool.qsa_compress_ratio = 2
+        pool.qsa_compressed_page_size = 2
+        pool.full_attention_layer_id_mapping = {}
+        pool.qsa_key_state_buffer_pool = []
+        pool.qsa_rope_position_buffer = torch.zeros((6, 3), dtype=torch.int64)
+        pool.qsa_compressed_k_buffer_pool = []
+
+        kv_args = SimpleNamespace()
+        setup_state_kv_args(kv_args, pool)
+
+        # Keep the component slots aligned across PP stages, but expose no QSA
+        # buffers or layer ids from a stage that cannot produce their contents.
+        self.assertEqual(
+            kv_args.state_types,
+            [StateType.MAMBA, StateType.QSA_PENDING, StateType.QSA_COMPRESSED],
+        )
+        self.assertEqual(kv_args.state_data_ptrs[1:], [[], []])
+        self.assertEqual(kv_args.state_data_lens[1:], [[], []])
+        self.assertEqual(kv_args.state_item_lens[1:], [[], []])
+        self.assertEqual(kv_args.state_layer_ids[1:], [[], []])
+
     def test_compact_qsa_entries_map_by_global_layer_id(self):
         self.assertEqual(
             build_transfer_entry_pairs(

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -196,15 +196,8 @@ class TestCPReplicatedStateTransfer(unittest.TestCase):
 
 
 class TestQwen4StateWire(unittest.TestCase):
-    def test_qsa_pending_payload_uses_nested_request_pool_row(self):
-        req = SimpleNamespace(kv=ReqKvInfo(req_pool_idx=7))
-
-        np.testing.assert_array_equal(
-            get_qsa_pending_state_indices(req),
-            np.array([7], dtype=np.int32),
-        )
-
-    def test_qsa_registers_request_ring_and_page_state_separately(self):
+    @staticmethod
+    def _qsa_pool(layer_id: int):
         pool = object.__new__(QSATokenToKVPool)
         pool.full_kv_pool = object()
         pool.get_state_buf_infos = lambda: ([10], [100], [20])
@@ -215,12 +208,24 @@ class TestQwen4StateWire(unittest.TestCase):
         pool.page_size = 4
         pool.qsa_compress_ratio = 2
         pool.qsa_compressed_page_size = 2
-        pool.full_attention_layer_id_mapping = {24: 0}
+        pool.full_attention_layer_id_mapping = {layer_id: 0}
         pool.qsa_key_state_buffer_pool = [torch.zeros((6, 1, 8), dtype=torch.bfloat16)]
         pool.qsa_rope_position_buffer = torch.zeros((6, 3), dtype=torch.int64)
         pool.qsa_compressed_k_buffer_pool = [
             torch.zeros((6, 1, 8), dtype=torch.bfloat16)
         ]
+        return pool
+
+    def test_qsa_pending_payload_uses_nested_request_pool_row(self):
+        req = SimpleNamespace(kv=ReqKvInfo(req_pool_idx=7))
+
+        np.testing.assert_array_equal(
+            get_qsa_pending_state_indices(req),
+            np.array([7], dtype=np.int32),
+        )
+
+    def test_qsa_registers_request_ring_and_page_state_separately(self):
+        pool = self._qsa_pool(24)
 
         kv_args = SimpleNamespace()
         setup_state_kv_args(kv_args, pool)
@@ -235,6 +240,34 @@ class TestQwen4StateWire(unittest.TestCase):
         self.assertEqual(
             kv_args.state_layer_ids[1:],
             [[24, QSA_ROPE_STATE_LAYER_ID], [24]],
+        )
+
+    def test_qsa_draft_state_uses_reserved_layer_id_band(self):
+        target_pool = self._qsa_pool(24)
+        draft_pool = self._qsa_pool(0)
+
+        kv_args = SimpleNamespace()
+        setup_state_kv_args(
+            kv_args,
+            target_pool,
+            draft_token_to_kv_pool=draft_pool,
+            total_kv_layers=48,
+        )
+
+        self.assertEqual(
+            kv_args.state_types,
+            [StateType.MAMBA, StateType.QSA_PENDING, StateType.QSA_COMPRESSED],
+        )
+        self.assertEqual(
+            kv_args.state_layer_ids[1:],
+            [
+                [24, QSA_ROPE_STATE_LAYER_ID, 48, 49],
+                [24, 48],
+            ],
+        )
+        self.assertEqual(
+            [len(entries) for entries in kv_args.state_data_ptrs[1:]],
+            [4, 2],
         )
 
     def test_qsa_stage_without_qsa_layers_does_not_register_rope_ring(self):

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -32,6 +32,7 @@ from sglang.srt.disaggregation.mooncake.conn import (
 )
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
+    build_transfer_entry_pairs,
     get_dsv4_c4_state_indices,
     get_dsv4_c128_state_indices,
     setup_state_kv_args,
@@ -41,6 +42,10 @@ from sglang.srt.layers.attention.dsa.utils import should_use_dsa_fused_topk
 from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
 from sglang.srt.managers.schedule_batch import ReqKvInfo
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.qsa_kv_pool import (
+    QSA_ROPE_STATE_LAYER_ID,
+    QSATokenToKVPool,
+)
 from sglang.srt.runtime_context import get_context
 from sglang.srt.speculative.eagle_disaggregation import (
     build_eagle_disagg_draft_input,
@@ -185,6 +190,52 @@ class TestCPReplicatedStateTransfer(unittest.TestCase):
                 manager._get_dsa_cache_transfer_skip_flags(None),
                 (False, True),
             )
+
+
+class TestQwen4StateWire(unittest.TestCase):
+    def test_qsa_registers_request_ring_and_page_state_separately(self):
+        pool = object.__new__(QSATokenToKVPool)
+        pool.full_kv_pool = object()
+        pool.get_state_buf_infos = lambda: ([10], [100], [20])
+        pool.get_state_dim_per_tensor = lambda: [4]
+        pool.get_state_conv_shard_groups = lambda: [None]
+        pool.get_state_slice_outer_counts = lambda: [1]
+        pool.get_state_layer_ids = lambda: [2]
+        pool.page_size = 4
+        pool.qsa_compress_ratio = 2
+        pool.qsa_compressed_page_size = 2
+        pool.full_attention_layer_id_mapping = {24: 0}
+        pool.qsa_key_state_buffer_pool = [torch.zeros((6, 1, 8), dtype=torch.bfloat16)]
+        pool.qsa_rope_position_buffer = torch.zeros((6, 3), dtype=torch.int64)
+        pool.qsa_compressed_k_buffer_pool = [
+            torch.zeros((6, 1, 8), dtype=torch.bfloat16)
+        ]
+
+        kv_args = SimpleNamespace()
+        setup_state_kv_args(kv_args, pool)
+
+        self.assertEqual(
+            kv_args.state_types,
+            [StateType.MAMBA, StateType.QSA_PENDING, StateType.QSA_COMPRESSED],
+        )
+        # Pending entries are whole two-row request rings; compressed-K remains
+        # a two-row compressed page corresponding to one four-token KV page.
+        self.assertEqual(kv_args.state_item_lens[1:], [[32, 48], [32]])
+        self.assertEqual(
+            kv_args.state_layer_ids[1:],
+            [[24, QSA_ROPE_STATE_LAYER_ID], [24]],
+        )
+
+    def test_compact_qsa_entries_map_by_global_layer_id(self):
+        self.assertEqual(
+            build_transfer_entry_pairs(
+                [24, QSA_ROPE_STATE_LAYER_ID],
+                [0, 12, 24, QSA_ROPE_STATE_LAYER_ID],
+                2,
+                4,
+            ),
+            [(0, 2), (1, 3)],
+        )
 
 
 class TestGroupConcurrentContiguous(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -36,6 +36,7 @@ from sglang.srt.disaggregation.utils import (
     compute_mamba_state_slice_byte_blocks,
     get_dsv4_c4_state_indices,
     get_dsv4_c128_state_indices,
+    get_qsa_pending_state_indices,
     setup_state_kv_args,
     should_send_replicated_state,
 )
@@ -195,6 +196,14 @@ class TestCPReplicatedStateTransfer(unittest.TestCase):
 
 
 class TestQwen4StateWire(unittest.TestCase):
+    def test_qsa_pending_payload_uses_nested_request_pool_row(self):
+        req = SimpleNamespace(kv=ReqKvInfo(req_pool_idx=7))
+
+        np.testing.assert_array_equal(
+            get_qsa_pending_state_indices(req),
+            np.array([7], dtype=np.int32),
+        )
+
     def test_qsa_registers_request_ring_and_page_state_separately(self):
         pool = object.__new__(QSATokenToKVPool)
         pool.full_kv_pool = object()

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.base.conn import KVPoll, StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
 from sglang.srt.disaggregation.common.utils import pack_int_lists
@@ -338,6 +338,34 @@ class TestNixlKVSenderChunkPolicy(CustomTestCase):
         self.assertTrue(sender.should_send_kv_chunk(0, last_chunk=True))
         self.assertFalse(sender.should_send_kv_chunk(0, last_chunk=False))
         self.assertTrue(sender.should_send_kv_chunk(3, last_chunk=False))
+
+
+class TestNixlEmptyStateTransfer(CustomTestCase):
+    def test_empty_pp_state_component_is_a_noop(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.agent = StagingFakeAgent()
+        mgr.is_mla_backend = False
+        mgr.pp_size = 2
+        mgr.kv_args = SimpleNamespace(prefill_start_layer=0, kv_data_ptrs=[1])
+
+        handle = mgr._send_kvcache_generic(
+            peer_name="decode",
+            src_data_ptrs=[],
+            dst_data_ptrs=[],
+            item_lens=[],
+            prefill_data_indices=np.array([3], dtype=np.int32),
+            dst_data_indices=np.array([5], dtype=np.int32),
+            dst_gpu_id=0,
+            notif="qsa-empty",
+            state_type=StateType.QSA_PENDING,
+            force_flat=True,
+            src_layer_ids=[],
+            dst_layer_ids=[],
+        )
+
+        self.assertIsNone(handle)
+        self.assertEqual(mgr.agent.get_xfer_descs_calls, [])
+        self.assertEqual(mgr.agent.initialize_xfer_calls, [])
 
 
 class TestNixlAbortHandling(CustomTestCase):

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -367,6 +367,31 @@ class TestNixlEmptyStateTransfer(CustomTestCase):
         self.assertEqual(mgr.agent.get_xfer_descs_calls, [])
         self.assertEqual(mgr.agent.initialize_xfer_calls, [])
 
+    def test_paired_state_entries_reject_item_length_mismatch(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.agent = StagingFakeAgent()
+        mgr.is_mla_backend = False
+        mgr.pp_size = 1
+        mgr.kv_args = SimpleNamespace(prefill_start_layer=0, kv_data_ptrs=[1])
+
+        with self.assertRaisesRegex(RuntimeError, "item length mismatch"):
+            mgr._send_kvcache_generic(
+                peer_name="decode",
+                src_data_ptrs=[10],
+                dst_data_ptrs=[20],
+                item_lens=[32],
+                prefill_data_indices=np.array([3], dtype=np.int32),
+                dst_data_indices=np.array([5], dtype=np.int32),
+                dst_gpu_id=0,
+                notif="qsa-mismatch",
+                state_type=StateType.QSA_PENDING,
+                force_flat=True,
+                src_layer_ids=[24],
+                dst_layer_ids=[24],
+                dst_item_lens=[48],
+            )
+        self.assertEqual(mgr.agent.initialize_xfer_calls, [])
+
 
 class TestNixlAbortHandling(CustomTestCase):
     def _make_manager(self, request_status=None):

--- a/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
@@ -56,6 +56,18 @@ class TestMambaStateTransferBuffers(unittest.TestCase):
 
         self.assertEqual(len(pool.get_state_dim_per_tensor()), len(lens))
 
+    def test_sibling_declares_replicated_transfer_without_field_name_coupling(self):
+        pool = _pool(torch.zeros(NUM_LAYERS, NUM_SLOTS, 6, 7, 8))
+
+        class ReplicatedSibling:
+            def iter_transfer_state_entries(self):
+                yield "future_sibling", torch.zeros(NUM_SLOTS, 9), None, 123
+
+        pool._slot_siblings = [ReplicatedSibling()]
+
+        self.assertEqual(pool.get_state_dim_per_tensor()[-1], 0)
+        self.assertEqual(pool.get_state_slice_outer_counts()[-1], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
@@ -15,6 +15,8 @@ def _pool(temporal: torch.Tensor, num_conv: int = 2) -> MambaPool:
     """A MambaPool stub carrying only what the transfer accessors read."""
     pool = object.__new__(MambaPool)
     pool.num_mamba_layers = NUM_LAYERS
+    pool.mamba_layer_ids = list(range(NUM_LAYERS))
+    pool._slot_siblings = []
     pool.conv_slice_axis = 0
     pool.mamba_cache = MambaPool.State(
         conv=[torch.zeros(NUM_LAYERS, NUM_SLOTS, 4, 5) for _ in range(num_conv)],

--- a/test/registered/unit/mem_cache/test_qsa_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_qsa_kv_pool.py
@@ -1,6 +1,8 @@
+import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
@@ -60,3 +62,7 @@ def test_qsa_allocations_follow_parent_mooncake_scope(monkeypatch):
     )
 
     assert allocations == 4
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/mem_cache/test_qsa_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_qsa_kv_pool.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.srt.mem_cache.qsa_kv_pool import QSATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_qsa_allocations_follow_parent_mooncake_scope(monkeypatch):
+    active_scopes = set()
+    allocations = 0
+    original_zeros = torch.zeros
+
+    @contextmanager
+    def scope(name):
+        active_scopes.add(name)
+        try:
+            yield
+        finally:
+            active_scopes.remove(name)
+
+    def init_parent(pool, **_):
+        pool.full_kv_pool = SimpleNamespace(
+            memory_saver_adapter=SimpleNamespace(
+                region=lambda _: scope("memory_saver")
+            ),
+            enable_custom_mem_pool=True,
+            custom_mem_pool=object(),
+        )
+
+    def allocate(*args, **kwargs):
+        nonlocal allocations
+        assert active_scopes == {"memory_saver", "custom_pool"}
+        allocations += 1
+        return original_zeros(*args, **kwargs)
+
+    monkeypatch.setattr(HybridLinearKVPool, "__init__", init_parent)
+    monkeypatch.setattr(QSATokenToKVPool, "get_kv_size_bytes", lambda _: (0, 0))
+    monkeypatch.setattr(torch.cuda, "use_mem_pool", lambda _: scope("custom_pool"))
+    monkeypatch.setattr("sglang.srt.mem_cache.qsa_kv_pool.torch.zeros", allocate)
+
+    QSATokenToKVPool(
+        size=8,
+        dtype=torch.bfloat16,
+        page_size=4,
+        head_num=1,
+        head_dim=8,
+        full_attention_layer_ids=[1, 3],
+        device="cpu",
+        mamba_pool=object(),
+        qsa_index_kv_heads=1,
+        qsa_index_head_dim=8,
+        qsa_compress_ratio=2,
+        qsa_token_topk=4,
+        num_request_slots=3,
+    )
+
+    assert allocations == 4

--- a/test/registered/unit/model_executor/model_runner_components/test_layer_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_layer_setup.py
@@ -2,16 +2,77 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.model_executor.model_runner_components.layer_setup import (
     compute_attention_and_moe_layers,
+    resolve_layer_indices,
 )
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 
 class TestComputeAttentionAndMoeLayers(unittest.TestCase):
+    @staticmethod
+    def _mtp_model_config():
+        return SimpleNamespace(
+            num_nextn_predict_layers=1,
+            num_hidden_layers=48,
+            num_attention_layers=12,
+            hf_config=SimpleNamespace(
+                architectures=["Qwen4ExpForConditionalGeneration"]
+            ),
+        )
+
+    def test_pd_prefill_mtp_allows_pipeline_layer_shard(self):
+        model = SimpleNamespace(start_layer=0, end_layer=24)
+
+        with (
+            patch(
+                "sglang.srt.model_executor.model_runner_components.layer_setup."
+                "get_disagg",
+                return_value=SimpleNamespace(disaggregation_mode="prefill"),
+            ),
+            patch(
+                "sglang.srt.model_executor.model_runner_components.layer_setup.is_npu",
+                return_value=False,
+            ),
+        ):
+            layer_info = resolve_layer_indices(
+                model=model,
+                model_config=self._mtp_model_config(),
+                is_draft_worker=False,
+                spec_algorithm=SpeculativeAlgorithm.EAGLE,
+            )
+
+        self.assertEqual(layer_info.start_layer, 0)
+        self.assertEqual(layer_info.end_layer, 24)
+        self.assertEqual(layer_info.num_effective_layers, 24)
+
+    def test_non_pd_mtp_rejects_pipeline_layer_shard(self):
+        model = SimpleNamespace(start_layer=0, end_layer=24)
+
+        with (
+            patch(
+                "sglang.srt.model_executor.model_runner_components.layer_setup."
+                "get_disagg",
+                return_value=SimpleNamespace(disaggregation_mode="null"),
+            ),
+            patch(
+                "sglang.srt.model_executor.model_runner_components.layer_setup.is_npu",
+                return_value=False,
+            ),
+            self.assertRaisesRegex(AssertionError, "PP is not compatible with MTP"),
+        ):
+            resolve_layer_indices(
+                model=model,
+                model_config=self._mtp_model_config(),
+                is_draft_worker=False,
+                spec_algorithm=SpeculativeAlgorithm.EAGLE,
+            )
+
     def test_deepseek_mla_registers_mha_companion(self):
         attn_mqa = SimpleNamespace()
         attn_mha = SimpleNamespace()

--- a/test/registered/unit/models/test_qwen4_exp_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen4_exp_pipeline_parallel.py
@@ -16,6 +16,7 @@ from sglang.srt.models.qwen4_exp import (
     Qwen4ExpModel,
     Qwen4ExpVLModel,
 )
+from sglang.srt.models.qwen4_exp_mtp import Qwen4ExpForCausalLMMTP
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -70,6 +71,21 @@ class TestQwen4ExpPipelineParallel(CustomTestCase):
         signature = inspect.signature(Qwen4ExpForConditionalGeneration.forward)
 
         self.assertIn("pp_proxy_tensors", signature.parameters)
+
+    def test_last_stage_exposes_head_without_first_stage_embedding(self):
+        model = Qwen4ExpForConditionalGeneration.__new__(
+            Qwen4ExpForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        model.model = nn.Module()
+        model.model.language_model = nn.Module()
+        model.lm_head = nn.Linear(3, 4, bias=False)
+        model.pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=True)
+
+        embed, head = model.get_embed_and_head()
+
+        self.assertIsNone(embed)
+        self.assertIs(head, model.lm_head.weight)
 
     def test_nonfirst_stage_does_not_allocate_token_embedding(self):
         model = Qwen4ExpModel.__new__(Qwen4ExpModel)
@@ -211,6 +227,22 @@ class TestQwen4ExpPipelineParallel(CustomTestCase):
         self.assertEqual(nonowner_kwargs["short_conv_layer_ids"], [])
         self.assertIsNone(nonowner_kwargs["short_conv_state_shape"])
         self.assertEqual(nonowner_kwargs["ngram_context_len"], 0)
+
+    def test_mtp_loads_target_embedding_on_last_pipeline_stage(self):
+        model = Qwen4ExpForCausalLMMTP.__new__(Qwen4ExpForCausalLMMTP)
+        nn.Module.__init__(model)
+        model.model = nn.Module()
+        model.model.embed_tokens = nn.Embedding(4, 3)
+        model.config = SimpleNamespace(num_experts=None)
+        model.quant_config = None
+        expected = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+
+        loaded = model.load_weights(
+            [("model.language_model.embed_tokens.weight", expected)]
+        )
+
+        self.assertEqual(loaded, {"model.embed_tokens.weight"})
+        torch.testing.assert_close(model.model.embed_tokens.weight, expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_qwen4_exp_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen4_exp_pipeline_parallel.py
@@ -1,0 +1,217 @@
+import inspect
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.models.qwen4_exp import (
+    Qwen4ExpForConditionalGeneration,
+    Qwen4ExpModel,
+    Qwen4ExpVLModel,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.ple = None
+
+    def forward(self, *, hidden_states, residual, **kwargs):
+        return hidden_states + 1, residual
+
+
+class _FailEmbedding(nn.Module):
+    def forward(self, input_ids):
+        raise AssertionError("a non-first PP stage must not run token embedding")
+
+
+class _FinalMixer(nn.Module):
+    def mix(self, hidden_states):
+        return hidden_states.unflatten(-1, (2, 3)).mean(dim=-2), None
+
+
+class TestQwen4ExpPipelineParallel(CustomTestCase):
+    @staticmethod
+    def _make_model(*, is_first_rank: bool, is_last_rank: bool):
+        model = Qwen4ExpModel.__new__(Qwen4ExpModel)
+        nn.Module.__init__(model)
+        model.pp_group = SimpleNamespace(
+            is_first_rank=is_first_rank,
+            is_last_rank=is_last_rank,
+        )
+        model.embed_tokens = _FailEmbedding()
+        model.layers = nn.ModuleList([_FakeLayer()])
+        model._start_layer = 0
+        model._end_layer = 1
+        model.has_ple = False
+        model.hyper_connection_mixer = (
+            _FinalMixer() if is_last_rank else PPMissingLayer()
+        )
+        return model
+
+    @staticmethod
+    def _forward_batch():
+        return SimpleNamespace(
+            forward_mode=SimpleNamespace(is_idle=lambda: False),
+        )
+
+    def test_public_forward_declares_pp_proxy_tensors(self):
+        signature = inspect.signature(Qwen4ExpForConditionalGeneration.forward)
+
+        self.assertIn("pp_proxy_tensors", signature.parameters)
+
+    def test_nonfirst_stage_does_not_allocate_token_embedding(self):
+        model = Qwen4ExpModel.__new__(Qwen4ExpModel)
+        nn.Module.__init__(model)
+        model.pp_group = SimpleNamespace(is_first_rank=False)
+
+        embedding = model._build_embed_tokens(SimpleNamespace())
+
+        self.assertIsInstance(embedding, PPMissingLayer)
+
+    def test_middle_stage_forwards_hyper_connection_stream(self):
+        model = self._make_model(is_first_rank=False, is_last_rank=False)
+        hidden_states = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+        residual = torch.zeros_like(hidden_states)
+        proxy = PPProxyTensors(
+            {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+        )
+
+        with patch(
+            "sglang.srt.models.qwen4_exp.get_global_expert_distribution_recorder"
+        ) as recorder:
+            recorder.return_value.with_current_layer.return_value = nullcontext()
+            output = model(
+                input_ids=torch.zeros(2, dtype=torch.long),
+                positions=torch.arange(2),
+                forward_batch=self._forward_batch(),
+                pp_proxy_tensors=proxy,
+            )
+
+        self.assertIsInstance(output, PPProxyTensors)
+        torch.testing.assert_close(output["hidden_states"], hidden_states + 1)
+        torch.testing.assert_close(output["residual"], residual)
+
+    def test_last_stage_contracts_only_after_local_layers(self):
+        model = self._make_model(is_first_rank=False, is_last_rank=True)
+        hidden_states = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+        residual = torch.zeros_like(hidden_states)
+
+        with patch(
+            "sglang.srt.models.qwen4_exp.get_global_expert_distribution_recorder"
+        ) as recorder:
+            recorder.return_value.with_current_layer.return_value = nullcontext()
+            output, hc_hidden_states = model(
+                input_ids=torch.zeros(2, dtype=torch.long),
+                positions=torch.arange(2),
+                forward_batch=self._forward_batch(),
+                pp_proxy_tensors=PPProxyTensors(
+                    {
+                        "hidden_states": hidden_states,
+                        "residual": residual,
+                    }
+                ),
+            )
+
+        torch.testing.assert_close(hc_hidden_states, hidden_states + 1)
+        torch.testing.assert_close(
+            output,
+            (hidden_states + 1).unflatten(-1, (2, 3)).mean(dim=-2),
+        )
+
+    def test_vl_model_threads_pp_proxy_to_language_model(self):
+        model = Qwen4ExpVLModel.__new__(Qwen4ExpVLModel)
+        nn.Module.__init__(model)
+        model.last_hc_hidden_states = None
+        proxy = PPProxyTensors(
+            {
+                "hidden_states": torch.ones(2, 6),
+                "residual": torch.zeros(2, 6),
+            }
+        )
+        forward_batch = SimpleNamespace(input_ids=torch.ones(2, dtype=torch.long))
+
+        with patch.object(Qwen4ExpModel, "forward", return_value=proxy) as forward:
+            output = model(
+                input_ids=torch.ones(2, dtype=torch.long),
+                positions=torch.arange(2),
+                forward_batch=forward_batch,
+                pp_proxy_tensors=proxy,
+            )
+
+        self.assertIs(output, proxy)
+        self.assertIs(forward.call_args.kwargs["pp_proxy_tensors"], proxy)
+
+    def test_nonlocal_ple_and_final_mixer_weights_are_skipped(self):
+        model = Qwen4ExpForConditionalGeneration.__new__(
+            Qwen4ExpForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        language_model = nn.Module()
+        language_model.start_layer = 12
+        language_model.end_layer = 24
+        model.model = language_model
+        model.config = SimpleNamespace(
+            num_experts=None,
+            tie_word_embeddings=False,
+            encoder_only=False,
+            split_ngram_parts=128,
+        )
+        model.quant_config = None
+        model.language_model_only = True
+        model.pp_group = SimpleNamespace(is_last_rank=False)
+
+        loaded = model.load_weights(
+            [
+                (
+                    "model.layers.1.ple.ple_embedding.ngram_embedding.shard_0.weight",
+                    torch.ones(1),
+                ),
+                (
+                    "model.hyper_connection_mixer.hc_norm.weight",
+                    torch.ones(1),
+                ),
+            ]
+        )
+        self.assertEqual(loaded, set())
+
+    def test_ple_request_state_is_allocated_only_on_owning_stage(self):
+        config = Qwen4ExpTextConfig(
+            hidden_size=16,
+            hc_count=2,
+            ple_layer_ids=[2],
+            ngram_size=3,
+            ple_conv_kernel_size=4,
+            eos_token_id=1,
+        )
+        configurator = KVCacheConfigurator.__new__(KVCacheConfigurator)
+        configurator.mambaish_config = config
+
+        configurator.layer_info = SimpleNamespace(start_layer=0, end_layer=12)
+        owner_kwargs = configurator._get_ple_req_pool_kwargs()
+        configurator.layer_info = SimpleNamespace(start_layer=12, end_layer=24)
+        nonowner_kwargs = configurator._get_ple_req_pool_kwargs()
+
+        self.assertEqual(owner_kwargs["short_conv_layer_ids"], [1])
+        self.assertEqual(owner_kwargs["ngram_context_len"], 2)
+        self.assertEqual(nonowner_kwargs["short_conv_layer_ids"], [])
+        self.assertIsNone(nonowner_kwargs["short_conv_state_shape"])
+        self.assertEqual(nonowner_kwargs["ngram_context_len"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -63,6 +63,7 @@ from sglang.srt.arg_groups.serving_hook import (
 )
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 from sglang.srt.arg_groups.validation_hook import (
+    check_pipeline_parallelism,
     check_two_batch_overlap,
 )
 from sglang.srt.entrypoints.sidecar import (
@@ -105,6 +106,33 @@ _mock_device.start()
 
 
 class TestPrepareServerArgs(CustomTestCase):
+    def test_cuda_pipeline_parallel_mtp_allows_pd_prefill(self):
+        args = ServerArgs(
+            model_path="dummy",
+            pp_size=2,
+            disable_overlap_schedule=True,
+            speculative_algorithm="EAGLE",
+            disaggregation_mode="prefill",
+        )
+
+        with override_platform(is_cuda=True, is_npu=False):
+            check_pipeline_parallelism(args)
+
+    def test_cuda_pipeline_parallel_mtp_rejects_decode(self):
+        args = ServerArgs(
+            model_path="dummy",
+            pp_size=2,
+            disable_overlap_schedule=True,
+            speculative_algorithm="EAGLE",
+            disaggregation_mode="decode",
+        )
+
+        with (
+            override_platform(is_cuda=True, is_npu=False),
+            self.assertRaisesRegex(AssertionError, "only supported on prefill"),
+        ):
+            check_pipeline_parallelism(args)
+
     def test_ple_embedding_offload_rejects_generic_weight_offload(self):
         for generic_offload in (
             {"cpu_offload_gb": 1},

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -391,6 +391,15 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
             (target_backend, decode_backend, fallback_backend),
         )
 
+    def test_non_last_pp_uses_only_target_runner(self):
+        target_runner = SimpleNamespace(attn_backend=object())
+        worker = object.__new__(EAGLEWorkerV2)
+        worker._target_worker = SimpleNamespace(model_runner=target_runner)
+        worker._draft_worker = None
+
+        self.assertIs(worker.last_shared_read_runner, target_runner)
+        self.assertEqual(worker.spec_v2_attn_backends, (target_runner.attn_backend,))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -615,19 +615,20 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_qwen4_pd_support_and_remaining_limits(self):
         qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")
-        for mode in ("prefill", "decode"):
-            with self.subTest(mode=mode):
-                self._construct(*qwen4, disaggregation_mode=mode)
+        with override_platform(is_cuda=True):
+            for mode in ("prefill", "decode"):
+                with self.subTest(mode=mode):
+                    self._construct(*qwen4, disaggregation_mode=mode)
 
-        with self.assertRaisesRegex(ValueError, "enable-unified-memory"):
-            self._construct(*qwen4, enable_unified_memory=True)
-        with self.assertRaisesRegex(ValueError, "MORI requires --pp-size 1"):
-            self._construct(
-                *qwen4,
-                disaggregation_mode="prefill",
-                disaggregation_transfer_backend="mori",
-                pp_size=2,
-            )
+            with self.assertRaisesRegex(ValueError, "enable-unified-memory"):
+                self._construct(*qwen4, enable_unified_memory=True)
+            with self.assertRaisesRegex(ValueError, "MORI requires --pp-size 1"):
+                self._construct(
+                    *qwen4,
+                    disaggregation_mode="prefill",
+                    disaggregation_transfer_backend="mori",
+                    pp_size=2,
+                )
 
     def test_qwen4_ple_offload_default(self):
         qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -613,16 +613,21 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         # value: readers only ever read flags.
         self.assertEqual((self._publish(sa), self._leaf("dtype"))[1], "auto")
 
-    def test_qwen4_rejects_pd_and_unified_memory(self):
+    def test_qwen4_pd_support_and_remaining_limits(self):
         qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")
-        for kwargs, message in (
-            ({"disaggregation_mode": "prefill"}, "PD disaggregation"),
-            ({"disaggregation_mode": "decode"}, "PD disaggregation"),
-            ({"enable_unified_memory": True}, "enable-unified-memory"),
-        ):
-            with self.subTest(**kwargs):
-                with self.assertRaisesRegex(ValueError, message):
-                    self._construct(*qwen4, **kwargs)
+        for mode in ("prefill", "decode"):
+            with self.subTest(mode=mode):
+                self._construct(*qwen4, disaggregation_mode=mode)
+
+        with self.assertRaisesRegex(ValueError, "enable-unified-memory"):
+            self._construct(*qwen4, enable_unified_memory=True)
+        with self.assertRaisesRegex(ValueError, "MORI requires --pp-size 1"):
+            self._construct(
+                *qwen4,
+                disaggregation_mode="prefill",
+                disaggregation_transfer_backend="mori",
+                pp_size=2,
+            )
 
     def test_qwen4_ple_offload_default(self):
         qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable pipeline-parallel prefill for Qwen3.8-Flash-Next (`Qwen4Exp`) with PD disaggregation and native NEXTN/MTP.

This PR depends on #36651 for PD state transfer. It adds the missing model-level PP execution path and extends state transfer to include the MTP draft's QSA state.

The initial scope is PP-enabled prefill with PP=1 decode. Pipeline-parallel speculative decode is not enabled.

## Modifications

- Thread `PPProxyTensors` through the Qwen4Exp model wrappers. Run token embedding on the first stage, relay the full HyperConnection stream between stages, and apply final contraction on the last stage.
- Restrict PLE execution, request-state allocation, and weight loading to the owning stage.
- Enable CUDA PP + single-layer EAGLE/NEXTN on PD prefill nodes with overlap scheduling disabled.
- Add a PP-aware embedding/head accessor and handle non-last-stage workers without a local draft runner.
- Transfer draft QSA pending keys, RoPE state, and compressed keys through the existing state components, using reserved layer IDs to distinguish them from target state.
- Add regression tests for PP forwarding, stage ownership, MTP embedding loading, configuration validation, and draft QSA state metadata.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34368276373](https://github.com/sgl-project/sglang/actions/runs/34368276373)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34368271662](https://github.com/sgl-project/sglang/actions/runs/34368271662)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34368275874](https://github.com/sgl-project/sglang/actions/runs/34368275874)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->