### PR TITLE
[Qwen3.8-Next] Fuse PLE hash and pinned-host embedding gather

### DIFF
--- a/python/sglang/kernels/ops/qwen4_ple.py
+++ b/python/sglang/kernels/ops/qwen4_ple.py
@@ -25,23 +25,18 @@ def _round_bf16_to_fp32(value):
 
 
 @triton.jit
-def _qwen4_ngram_hash_kernel(
+def _qwen4_ngram_id(
     contexts_ptr,
     multipliers_ptr,
     vocab_sizes_ptr,
     offsets_ptr,
-    output_ptr,
-    num_outputs,
+    token_idx,
+    head_idx,
+    mask,
     eos_token_id,
     NGRAM_SIZE: tl.constexpr,
     HEADS_PER_NGRAM: tl.constexpr,
-    NGRAM_HEADS: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
 ):
-    output_idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = output_idx < num_outputs
-    token_idx = output_idx // NGRAM_HEADS
-    head_idx = output_idx % NGRAM_HEADS
     context_base = token_idx * NGRAM_SIZE
 
     token_0 = tl.load(contexts_ptr + context_base, mask=mask, other=0)
@@ -64,7 +59,85 @@ def _qwen4_ngram_hash_kernel(
 
     vocab_size = tl.load(vocab_sizes_ptr + head_idx, mask=mask, other=1)
     offset = tl.load(offsets_ptr + head_idx, mask=mask, other=0)
-    tl.store(output_ptr + output_idx, mixed % vocab_size + offset, mask=mask)
+    return mixed % vocab_size + offset
+
+
+@triton.jit
+def _qwen4_ngram_hash_kernel(
+    contexts_ptr,
+    multipliers_ptr,
+    vocab_sizes_ptr,
+    offsets_ptr,
+    output_ptr,
+    num_outputs,
+    eos_token_id,
+    NGRAM_SIZE: tl.constexpr,
+    HEADS_PER_NGRAM: tl.constexpr,
+    NGRAM_HEADS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    output_idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = output_idx < num_outputs
+    ids = _qwen4_ngram_id(
+        contexts_ptr,
+        multipliers_ptr,
+        vocab_sizes_ptr,
+        offsets_ptr,
+        output_idx // NGRAM_HEADS,
+        output_idx % NGRAM_HEADS,
+        mask,
+        eos_token_id,
+        NGRAM_SIZE,
+        HEADS_PER_NGRAM,
+    )
+    tl.store(output_ptr + output_idx, ids, mask=mask)
+
+
+@triton.jit
+def _qwen4_ngram_gather_kernel(
+    contexts_ptr,
+    multipliers_ptr,
+    vocab_sizes_ptr,
+    offsets_ptr,
+    weight_ptr,
+    output_ptr,
+    eos_token_id,
+    embedding_dim,
+    tp_vocab_start,
+    tp_vocab_end,
+    IS_FP8: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    NGRAM_SIZE: tl.constexpr,
+    HEADS_PER_NGRAM: tl.constexpr,
+    NGRAM_HEADS: tl.constexpr,
+):
+    row_id = tl.program_id(0)
+    global_idx = _qwen4_ngram_id(
+        contexts_ptr,
+        multipliers_ptr,
+        vocab_sizes_ptr,
+        offsets_ptr,
+        row_id // NGRAM_HEADS,
+        row_id % NGRAM_HEADS,
+        True,
+        eos_token_id,
+        NGRAM_SIZE,
+        HEADS_PER_NGRAM,
+    )
+    in_range = (global_idx >= tp_vocab_start) & (global_idx < tp_vocab_end)
+    local_idx = tl.where(in_range, global_idx - tp_vocab_start, 0)
+    offsets = tl.arange(0, BLOCK_D)
+    mask = offsets < embedding_dim
+    if IS_FP8:
+        weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(tl.float8e4nv))
+    else:
+        weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(tl.bfloat16))
+    values = tl.load(
+        weight_ptr + local_idx * embedding_dim + offsets,
+        mask=mask & in_range,
+        other=0.0,
+    ).to(tl.bfloat16)
+    tl.store(output_ptr + row_id * embedding_dim + offsets, values, mask=mask)
 
 
 def can_fuse_qwen4_ngram_hash(
@@ -127,6 +200,54 @@ def fused_qwen4_ngram_hash(
             num_warps=4,
         )
     return output
+
+
+def fused_qwen4_ngram_gather(
+    contexts: torch.Tensor,
+    multipliers: torch.Tensor,
+    vocab_sizes: torch.Tensor,
+    offsets: torch.Tensor,
+    eos_token_id: int,
+    weight: torch.Tensor,
+    tp_vocab_start: int,
+    tp_vocab_end: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    if not can_fuse_qwen4_ngram_hash(contexts, multipliers, vocab_sizes, offsets):
+        raise ValueError("unsupported input for fused Qwen4 PLE N-gram gather")
+    if weight.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError("PLE gather requires bfloat16 or fp8 weights")
+    if weight.ndim != 2 or not weight.is_contiguous() or not weight.is_pinned():
+        raise ValueError("PLE gather requires a contiguous pinned host table")
+    if not 0 <= tp_vocab_start <= tp_vocab_end <= tp_vocab_start + weight.shape[0]:
+        raise ValueError("invalid vocabulary range for PLE gather")
+    embedding_dim = weight.shape[1]
+    if (
+        out.shape != (contexts.shape[0], _QWEN4_NGRAM_HEADS, embedding_dim)
+        or out.device != contexts.device
+        or out.dtype != torch.bfloat16
+        or not out.is_contiguous()
+    ):
+        raise ValueError("invalid output buffer for fused Qwen4 PLE N-gram gather")
+    if contexts.shape[0]:
+        _qwen4_ngram_gather_kernel[(contexts.shape[0] * _QWEN4_NGRAM_HEADS,)](
+            contexts,
+            multipliers,
+            vocab_sizes,
+            offsets,
+            weight.data_ptr(),
+            out,
+            eos_token_id,
+            embedding_dim,
+            tp_vocab_start,
+            tp_vocab_end,
+            IS_FP8=weight.dtype == torch.float8_e4m3fn,
+            BLOCK_D=triton.next_power_of_2(embedding_dim),
+            NGRAM_SIZE=_QWEN4_NGRAM_SIZE,
+            HEADS_PER_NGRAM=_QWEN4_HEADS_PER_NGRAM,
+            NGRAM_HEADS=_QWEN4_NGRAM_HEADS,
+        )
+    return out
 
 
 @triton.jit

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -685,6 +685,12 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         return embeddings.flatten(start_dim=-2)
 
     def compute_ngram_ids(self, batch: _PLEBatch) -> torch.Tensor:
+        return self._hash_contexts(
+            self.prepare_ngram_contexts(batch),
+            decode_sized=batch.mode.is_decode() or batch.mode.is_target_verify(),
+        )
+
+    def prepare_ngram_contexts(self, batch: _PLEBatch) -> torch.Tensor:
         assert batch.ngram_context is not None
         pool = get_req_to_token_pool()
         cached = pool.ple_window_cache
@@ -699,10 +705,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
                 ]
             contexts = contexts.to(torch.long)
             pool.ple_window_cache = (batch, contexts, None)
-        return self._hash_contexts(
-            contexts,
-            decode_sized=batch.mode.is_decode() or batch.mode.is_target_verify(),
-        )
+        return contexts
 
 
 @triton.jit
@@ -728,7 +731,7 @@ def _gather_ple_embedding_from_pinned_kernel(
         weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(tl.bfloat16))
     values = tl.load(
         weight_ptr + local_idx * embedding_dim + offsets,
-        mask=mask,
+        mask=mask & in_range,
         other=0.0,
     ).to(tl.bfloat16)
     tl.store(
@@ -1097,37 +1100,78 @@ class Qwen4ExpPLELayer(nn.Module):
         batch: Optional[_PLEBatch],
         forward_batch: ForwardBatch,
     ) -> None:
-        """Gather PLE rows via UVA while the preceding decoder layer runs."""
+        """Hash and gather PLE rows while the preceding decoder layer runs."""
         if self._prefetch_stream is None:
             return
         if self._prefetch_state is not None:
             raise RuntimeError("PLE prefetch state was not consumed before reuse")
-        if batch is None:
-            if not self.ple_embedding.gather_dp_tokens:
-                return
-            physical_tokens = forward_batch.input_ids.numel()
-            ngram_ids = forward_batch.input_ids.new_zeros(
-                (physical_tokens, self.ple_embedding.ngram_heads)
+        embedding = self.ple_embedding
+        contexts = None
+        if embedding.gather_dp_tokens:
+            # Keep cross-DP collectives on the main stream in their original order.
+            if batch is None:
+                physical_tokens = forward_batch.input_ids.numel()
+                ngram_ids = forward_batch.input_ids.new_zeros(
+                    (physical_tokens, embedding.ngram_heads)
+                )
+            else:
+                physical_tokens = batch.physical_tokens
+                ngram_ids = embedding.compute_ngram_ids(batch)
+            lookup_ids, semantic_tokens = embedding._prepare_embedding_lookup(
+                ngram_ids, forward_batch, physical_tokens
             )
+            prefetch_input = lookup_ids
         else:
+            if batch is None:
+                return
             physical_tokens = batch.physical_tokens
-            ngram_ids = self.ple_embedding.compute_ngram_ids(batch)
+            contexts = embedding.prepare_ngram_contexts(batch)
+            semantic_tokens = contexts.shape[0]
+            prefetch_input = contexts
 
-        lookup_ids, semantic_tokens = self.ple_embedding._prepare_embedding_lookup(
-            ngram_ids, forward_batch, physical_tokens
-        )
-        lookup_tokens = lookup_ids.shape[0]
+        lookup_tokens = prefetch_input.shape[0]
         if lookup_tokens == 0:
             return
-        prefetched = self._get_prefetch_buffer(lookup_tokens, lookup_ids)
-        output_view = prefetched.view(lookup_tokens, self.ple_embedding.ngram_heads, -1)
-        offloaded_embedding = self.ple_embedding.ngram_embedding
+        prefetched = self._get_prefetch_buffer(lookup_tokens, prefetch_input)
+        output_view = prefetched.view(lookup_tokens, embedding.ngram_heads, -1)
+        offloaded_embedding = embedding.ngram_embedding
 
         stream = self._prefetch_stream
         stream.wait_stream(torch.cuda.current_stream())
-        lookup_ids.record_stream(stream)
+        prefetch_input.record_stream(stream)
         with torch.cuda.stream(stream):
-            offloaded_embedding.gather(lookup_ids, out=output_view)
+            if contexts is None:
+                offloaded_embedding.gather(lookup_ids, out=output_view)
+            else:
+                from sglang.kernels.ops.qwen4_ple import (
+                    can_fuse_qwen4_ngram_hash,
+                    fused_qwen4_ngram_gather,
+                )
+
+                if embedding.enable_ple_fusion and can_fuse_qwen4_ngram_hash(
+                    contexts,
+                    embedding.layer_multipliers,
+                    embedding.ngram_heads_vocab_sizes,
+                    embedding.ngram_heads_offsets,
+                ):
+                    fused_qwen4_ngram_gather(
+                        contexts,
+                        embedding.layer_multipliers,
+                        embedding.ngram_heads_vocab_sizes,
+                        embedding.ngram_heads_offsets,
+                        embedding.eos_token_id,
+                        offloaded_embedding.weight,
+                        offloaded_embedding.shard_indices.org_vocab_start_index,
+                        offloaded_embedding.shard_indices.org_vocab_end_index,
+                        output_view,
+                    )
+                else:
+                    lookup_ids = embedding._hash_contexts(
+                        contexts,
+                        decode_sized=batch.mode.is_decode()
+                        or batch.mode.is_target_verify(),
+                    )
+                    offloaded_embedding.gather(lookup_ids, out=output_view)
         self._prefetch_state = prefetched, semantic_tokens, physical_tokens
 
     def _consume_prefetched_embeddings(

--- a/test/registered/kernel/embeddings/test_qwen4_ple_offload.py
+++ b/test/registered/kernel/embeddings/test_qwen4_ple_offload.py
@@ -4,15 +4,18 @@ import pytest
 import torch
 from torch import nn
 
+from sglang.kernels.ops.qwen4_ple import fused_qwen4_ngram_gather
 from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbeddingShardIndices,
 )
 from sglang.srt.models import qwen4_exp as qwen4_exp_module
 from sglang.srt.models.qwen4_exp import (
+    Qwen4ExpNGramEmbedding,
     Qwen4ExpPinnedHostEmbedding,
     Qwen4ExpPLELayer,
 )
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import set_weight_attrs
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -149,6 +152,24 @@ def test_qwen4_ple_pinned_gather_empty_input():
     assert actual.numel() == 0
 
 
+@pytest.mark.parametrize("is_fp8", [False, True])
+def test_qwen4_ple_nonowner_does_not_access_backing(is_fp8):
+    ids = torch.tensor([0, 3, 8, 99], dtype=torch.long, device="cuda")
+    output = torch.full((4, 160), torch.nan, dtype=torch.bfloat16, device="cuda")
+    # All IDs are outside [4, 8), so even an unmapped backing must not be read.
+    qwen4_exp_module._gather_ple_embedding_from_pinned_kernel[(4,)](
+        0,
+        ids,
+        output,
+        embedding_dim=160,
+        tp_vocab_start=4,
+        tp_vocab_end=8,
+        is_fp8=is_fp8,
+        BLOCK_D=256,
+    )
+    torch.testing.assert_close(output, torch.zeros_like(output), rtol=0, atol=0)
+
+
 def test_qwen4_ple_pinned_embedding_rejects_unsupported_weights():
     with pytest.raises(TypeError, match="requires bfloat16"):
         Qwen4ExpPinnedHostEmbedding(_make_source_embedding(dtype=torch.float16))
@@ -187,6 +208,184 @@ def test_qwen4_ple_prefetch_buffer_lifecycle(monkeypatch):
     assert graph_three_reused.data_ptr() == graph_three.data_ptr()
     assert graph_five.data_ptr() != graph_three.data_ptr()
     assert set(layer._graph_prefetch_buffers) == {3, 5}
+
+
+def _make_ngram_inputs(num_tokens):
+    contexts = (
+        torch.tensor(
+            [[1, 2, 3], [0, 2, 3], [1, 0, 3], [0, 0, 0], [3, 2, 1]],
+            dtype=torch.long,
+            device="cuda",
+        )
+        .repeat((num_tokens + 4) // 5, 1)[:num_tokens]
+        .contiguous()
+    )
+    multipliers = torch.tensor(
+        [190734863281251, 953674316406251, 4768371582031251],
+        dtype=torch.long,
+        device="cuda",
+    )
+    sizes = torch.tensor(
+        [17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79],
+        dtype=torch.long,
+        device="cuda",
+    )
+    offsets = sizes.cumsum(0) - sizes
+    return contexts, multipliers, sizes, offsets
+
+
+def _reference_ngram_ids(contexts, multipliers, sizes, offsets):
+    previous = torch.where(
+        (contexts[:, 0] == 0) | (contexts[:, 1] == 0), 0, contexts[:, 0]
+    )
+    mixed = (contexts[:, 2] * multipliers[0]) ^ (contexts[:, 1] * multipliers[1])
+    mixed_three = mixed ^ (previous * multipliers[2])
+    return torch.cat(
+        (
+            mixed[:, None].remainder(sizes[:8]) + offsets[:8],
+            mixed_three[:, None].remainder(sizes[8:]) + offsets[8:],
+        ),
+        dim=1,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("num_tokens", [0, 1, 5, 128])
+@pytest.mark.parametrize("vocab_start,vocab_end", [(0, 850), (100, 400)])
+def test_qwen4_fused_ngram_gather(dtype, num_tokens, vocab_start, vocab_end):
+    contexts, multipliers, sizes, offsets = _make_ngram_inputs(num_tokens)
+    weight = torch.empty((vocab_end - vocab_start, 160), dtype=dtype, pin_memory=True)
+    weight.copy_(
+        (torch.arange(weight.numel()).reshape(weight.shape) % 31 - 15).to(dtype)
+    )
+    output = torch.empty((num_tokens, 16, 160), dtype=torch.bfloat16, device="cuda")
+    actual = fused_qwen4_ngram_gather(
+        contexts, multipliers, sizes, offsets, 0, weight, vocab_start, vocab_end, output
+    )
+    ids = _reference_ngram_ids(contexts, multipliers, sizes, offsets)
+    in_range = (ids >= vocab_start) & (ids < vocab_end)
+    local_ids = torch.where(in_range, ids - vocab_start, 0)
+    rows = weight.to(device="cuda", dtype=torch.bfloat16)
+    expected = torch.where(in_range[..., None], rows[local_ids], 0)
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_qwen4_fused_ngram_gather_validates_output():
+    contexts, multipliers, sizes, offsets = _make_ngram_inputs(1)
+    weight = torch.empty((850, 160), dtype=torch.bfloat16, pin_memory=True)
+    out = torch.empty((1, 16, 159), dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(ValueError, match="invalid output buffer"):
+        fused_qwen4_ngram_gather(
+            contexts, multipliers, sizes, offsets, 0, weight, 0, 850, out
+        )
+
+
+@pytest.mark.parametrize("fusion", [False, True])
+@pytest.mark.parametrize("gather_dp_tokens", [False, True])
+@pytest.mark.parametrize(
+    "mode", [ForwardMode.DECODE, ForwardMode.TARGET_VERIFY, ForwardMode.EXTEND]
+)
+def test_qwen4_ple_prefetch_stream_and_graph(
+    monkeypatch, fusion, gather_dp_tokens, mode
+):
+    contexts, multipliers, sizes, offsets = _make_ngram_inputs(5)
+    offloaded = Qwen4ExpPinnedHostEmbedding(
+        _make_source_embedding(embedding_dim=160, vocab_end=850, org_vocab_size=850)
+    )
+    rows = (torch.arange(850 * 160).reshape(850, 160) % 31).to(
+        device="cuda", dtype=torch.bfloat16
+    )
+    _load_rows(offloaded, rows)
+    offloaded.weight_scale = torch.ones(1, device="cuda", dtype=torch.bfloat16)
+    embedding = Qwen4ExpNGramEmbedding.__new__(Qwen4ExpNGramEmbedding)
+    nn.Module.__init__(embedding)
+    embedding.ngram_embedding = offloaded
+    embedding.gather_dp_tokens = gather_dp_tokens
+    embedding.ngram_size = 3
+    embedding.ngram_heads = 16
+    embedding.heads_per_ngram = 8
+    embedding.eos_token_id = 0
+    embedding.enable_ple_fusion = fusion
+    embedding.layer_multipliers = multipliers
+    embedding.ngram_heads_vocab_sizes = sizes
+    embedding.ngram_heads_offsets = offsets
+    layer = Qwen4ExpPLELayer.__new__(Qwen4ExpPLELayer)
+    nn.Module.__init__(layer)
+    layer.ple_embedding = embedding
+    layer.ple_embed_dim = 2560
+    layer._prefetch_stream = torch.cuda.Stream()
+    layer._graph_prefetch_buffers = {}
+    layer._eager_prefetch_buffer = None
+    layer._prefetch_state = None
+    pool = SimpleNamespace(ple_window_cache=None)
+    monkeypatch.setattr(qwen4_exp_module, "get_req_to_token_pool", lambda: pool)
+    capturing = False
+    monkeypatch.setattr(qwen4_exp_module, "get_is_capture_mode", lambda: capturing)
+    forward_batch = SimpleNamespace(global_dp_buffer_len=5)
+    main_stream = torch.cuda.current_stream()
+    collectives = []
+
+    def gather(out, src, batch):
+        assert torch.cuda.current_stream() == main_stream
+        collectives.append("gather")
+        out.copy_(src)
+
+    def scatter(out, src, batch):
+        assert torch.cuda.current_stream() == main_stream
+        collectives.append("scatter")
+        out.copy_(src)
+
+    monkeypatch.setattr(qwen4_exp_module, "dp_gather_replicate", gather)
+    monkeypatch.setattr(qwen4_exp_module, "dp_scatter", scatter)
+    batch = SimpleNamespace(
+        ngram_context=contexts,
+        physical_tokens=5,
+        use_decode_fast_path=mode == ForwardMode.DECODE,
+        req_indices=torch.arange(5, device="cuda"),
+        token_offsets=torch.zeros(5, dtype=torch.long, device="cuda"),
+        mode=mode,
+    )
+
+    from sglang.kernels.ops import qwen4_ple
+
+    original = qwen4_ple.fused_qwen4_ngram_gather
+    streams = []
+
+    def checked_gather(*args, **kwargs):
+        streams.append(torch.cuda.current_stream())
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(qwen4_ple, "fused_qwen4_ngram_gather", checked_gather)
+
+    def run():
+        pool.ple_window_cache = None
+        layer.start_prefetch(batch, forward_batch)
+        return layer._consume_prefetched_embeddings(forward_batch)
+
+    actual = run()
+    expected_ids = _reference_ngram_ids(contexts, multipliers, sizes, offsets)
+    torch.testing.assert_close(actual, rows[expected_ids].flatten(1), rtol=0, atol=0)
+    if fusion and not gather_dp_tokens:
+        assert streams == [layer._prefetch_stream]
+    else:
+        assert streams == []
+    assert collectives == (["gather", "scatter"] if gather_dp_tokens else [])
+    assert layer._prefetch_state is None
+
+    capturing = True
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        main_stream = torch.cuda.current_stream()
+        graph_output = run()
+    contexts.copy_(contexts.flip(0).clone())
+    graph.replay()
+    expected_ids = _reference_ngram_ids(contexts, multipliers, sizes, offsets)
+    torch.testing.assert_close(
+        graph_output, rows[expected_ids].flatten(1), rtol=0, atol=0
+    )
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/benchmark/embeddings/bench_qwen4_ple_prefetch.py
+++ b/test/registered/kernels/benchmark/embeddings/bench_qwen4_ple_prefetch.py
@@ -1,0 +1,71 @@
+"""Single-rank, repeated-key PLE lookup benchmark; excludes TP communication."""
+
+import argparse
+
+import torch
+import triton.testing
+
+from sglang.kernels.ops.qwen4_ple import (
+    fused_qwen4_ngram_gather,
+    fused_qwen4_ngram_hash,
+)
+from sglang.srt.models.qwen4_exp import _gather_ple_embedding_from_pinned_kernel
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tp-size", type=int, choices=[1, 2, 4, 8], default=8)
+    parser.add_argument("--rows-per-head", type=int, default=65537)
+    parser.add_argument("--dtype", choices=["fp8", "bf16"], default="fp8")
+    parser.add_argument("--tokens", type=int, nargs="+", default=[1, 16, 64, 256, 4096])
+    args = parser.parse_args()
+    if args.rows_per_head <= 0 or any(n <= 0 for n in args.tokens):
+        parser.error("row and token counts must be positive")
+    dtype = torch.float8_e4m3fn if args.dtype == "fp8" else torch.bfloat16
+    local_rows = (16 * args.rows_per_head + args.tp_size - 1) // args.tp_size
+    weight = torch.empty((local_rows, 160), dtype=dtype, pin_memory=True)
+    weight.zero_()
+    sizes = torch.full((16,), args.rows_per_head, dtype=torch.long, device="cuda")
+    offsets = torch.arange(16, dtype=torch.long, device="cuda") * args.rows_per_head
+    multipliers = torch.tensor(
+        [190734863281251, 953674316406251, 4768371582031251],
+        dtype=torch.long,
+        device="cuda",
+    )
+    torch.manual_seed(42)
+    print("Single rank, repeated keys, CUDA Graph timing; no TP all-reduce.")
+    print("tokens,separate_us,fused_us")
+    for tokens in args.tokens:
+        contexts = torch.randint(
+            0, 151000, (tokens, 3), dtype=torch.long, device="cuda"
+        )
+        out = torch.empty((tokens, 16, 160), dtype=torch.bfloat16, device="cuda")
+
+        def separate():
+            ids = fused_qwen4_ngram_hash(contexts, multipliers, sizes, offsets, 0)
+            _gather_ple_embedding_from_pinned_kernel[(tokens * 16,)](
+                weight.data_ptr(),
+                ids,
+                out,
+                embedding_dim=160,
+                tp_vocab_start=0,
+                tp_vocab_end=local_rows,
+                is_fp8=dtype == torch.float8_e4m3fn,
+                BLOCK_D=256,
+            )
+            return out
+
+        def fused():
+            return fused_qwen4_ngram_gather(
+                contexts, multipliers, sizes, offsets, 0, weight, 0, local_rows, out
+            )
+
+        expected = separate().clone()
+        torch.testing.assert_close(fused(), expected, rtol=0, atol=0)
+        separate_ms = triton.testing.do_bench_cudagraph(separate)
+        fused_ms = triton.testing.do_bench_cudagraph(fused)
+        print(f"{tokens},{separate_ms * 1000:.3f},{fused_ms * 1000:.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Qwen3.8-Flash-Next PLE offload currently computes N-gram IDs and gathers the corresponding rows from pinned host memory in separate kernels.

In tensor-parallel deployments, the gather kernel also reads row 0 from pinned host memory for IDs owned by another TP rank before discarding the result. This creates unnecessary host-memory traffic.

This PR reduces kernel launch and host-memory overhead by fusing N-gram hashing with pinned-host row gathering and running the fused operation on the existing PLE prefetch stream.

## Modifications

- Mask pinned-host loads with the TP ownership predicate so non-owner ranks do not access the backing table.
- Extract the shared Qwen4 N-gram ID calculation into a reusable Triton helper.
- Add a fused Triton kernel that:
  - computes the 16 PLE N-gram IDs;
  - filters IDs by the local TP vocabulary range;
  - gathers local FP8/BF16 rows directly from pinned host memory;
  - writes BF16 output without materializing an intermediate ID tensor.
- Run the fused hash/gather operation on the PLE prefetch stream so it can overlap with the preceding decoder layer.
- Preserve the existing execution and collective ordering for attention-DP configurations that require cross-DP token gathering.
- Add CUDA coverage for:
  - FP8 and BF16 tables;
  - TP shard boundaries and non-owner IDs;
  - EOS-aware N-gram hashing;
  - decode, target-verify, and extend modes;
  - CUDA Graph capture and replay;
  - fused and fallback paths.
- Add a microbenchmark comparing separate hash + gather against the fused implementation.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34371182169](https://github.com/sgl-project/sglang/actions/runs/34371182169)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34371181801](https://github.com/sgl-project/sglang/actions/runs/34371181801)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34371181979](https://github.com/sgl-project/sglang/actions/runs/34371181979)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->