### PR TITLE
Pin remaining unpinned H2D copies in ForwardBatch init hot paths

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -727,11 +727,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         self.original_global_num_tokens_cpu = batch.global_num_tokens
         self.global_num_tokens_cpu = global_num_tokens
         self.global_num_tokens_gpu = torch.tensor(
-            global_num_tokens, dtype=torch.int64
+            global_num_tokens,
+            dtype=torch.int64,
+            pin_memory=is_pin_memory_available(device),
         ).to(device, non_blocking=True)
         self.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
         self.global_num_tokens_for_logprob_gpu = torch.tensor(
-            global_num_tokens_for_logprob, dtype=torch.int64
+            global_num_tokens_for_logprob,
+            dtype=torch.int64,
+            pin_memory=is_pin_memory_available(device),
         ).to(device, non_blocking=True)
         self.can_run_dp_cuda_graph = batch.can_run_dp_cuda_graph
 
@@ -869,9 +873,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         num_tokens = len(batch.input_ids) if batch.input_ids is not None else 0
         if enable_num_token_non_padded():
-            ret.num_token_non_padded = torch.tensor(num_tokens, dtype=torch.int32).to(
-                device, non_blocking=True
-            )
+            ret.num_token_non_padded = torch.tensor(
+                num_tokens,
+                dtype=torch.int32,
+                pin_memory=is_pin_memory_available(device),
+            ).to(device, non_blocking=True)
         ret.num_token_non_padded_cpu = num_tokens
 
         ret.init_mlp_sync_metadata(batch, device)
@@ -894,6 +900,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     for i in range(block_offset, block_offset + block_size)
                 ],
                 dtype=positions_dtype,
+                pin_memory=is_pin_memory_available(device),
             ).to(device, non_blocking=True)
         elif (
             ret.spec_info is not None
@@ -910,10 +917,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
                 assert isinstance(extend_prefix_lens, list)
                 ret.extend_seq_lens = torch.tensor(
-                    extend_seq_lens, dtype=torch.int32
+                    extend_seq_lens,
+                    dtype=torch.int32,
+                    pin_memory=is_pin_memory_available(device),
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens = torch.tensor(
-                    extend_prefix_lens, dtype=torch.int32
+                    extend_prefix_lens,
+                    dtype=torch.int32,
+                    pin_memory=is_pin_memory_available(device),
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens_cpu = extend_prefix_lens
                 ret.extend_seq_lens_cpu = extend_seq_lens


### PR DESCRIPTION
## Motivation

`torch.tensor(host_list).to(device, non_blocking=True)` without a pinned staging buffer is effectively a **host-synchronous** copy: per CUDA semantics, `cudaMemcpyAsync` to/from pageable host memory blocks the caller until the copy completes, so `non_blocking=True` is a no-op there and the calling thread (the scheduler, in this case) stalls on every such copy in the per-batch critical path.

The tree already pins these staging tensors in most places — `schedule_batch.py` (`input_ids` / `seq_lens` / `orig_seq_lens`) and `token_type_ids` in `forward_batch_info.py` all use `pin_memory=is_pin_memory_available(...)` — but five H2D sites in `forward_batch_info.py` were still left unpinned. One of them, `extend_seq_lens` / `extend_prefix_lens`, is on the main extend/prefill path and fires on **every** batch.

## Modifications

Pin the five remaining unpinned H2D staging tensors in `forward_batch_info.py`, following the existing in-tree pattern exactly:

- `extend_seq_lens` / `extend_prefix_lens` — main extend/prefill path, every batch
- dLLM `positions` — `dllm_config` path
- `num_token_non_padded` — DP-attention padding metadata
- `global_num_tokens_gpu` / `global_num_tokens_for_logprob_gpu` — `init_mlp_sync_metadata` (DP attention)

No behavior change beyond pinning: values, dtypes, and copy ordering are unchanged. Pinned allocations go through PyTorch's caching host allocator, so the per-batch cost is a cache hit rather than a raw `cudaHostAlloc`.

## Accuracy Tests

Metadata-only change (sequence-length bookkeeping and DP sync counters); no effect on model outputs. `py_compile`, `black` (26.1.0), `isort` (7.0.0), and `ruff` (0.15.1) pass on the touched file.

## Speed Tests and Profiling

Not benchmarked here (no GPU on the dev machine used for this change). Each of these copies is a small host-synchronous stall of the scheduler thread inside `ForwardBatch.init_new`; this PR removes the stalls without changing the copies themselves. Can add numbers on an H100 with a preferred bench setup if maintainers want them.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->