### PR TITLE
[Disaggregation] Honor admission aborts before KV handoff

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -193,6 +193,10 @@ class BaseKVSender(ABC):
         """
         pass
 
+    def abort_before_send(self) -> None:
+        """Abort a bootstrap request that has never submitted a send."""
+        self.abort()
+
 
 class BaseKVReceiver(ABC):
     @abstractmethod

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -383,6 +383,10 @@ class CommonKVManager(BaseKVManager):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
 
+    def notify_bootstrap_failure(self, bootstrap_room: int) -> None:
+        """Best-effort peer notification before any KV send was submitted."""
+        pass
+
     def register_deferred_abort_room(self, bootstrap_room: int) -> None:
         """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
         from a prior request that reused this bootstrap_room."""
@@ -1217,6 +1221,7 @@ class CommonKVSender(BaseKVSender):
         self._transfer_num_state_indices = 0
         # inner state
         self.curr_idx = 0
+        self._send_started = False
         self.init_time: Optional[float] = None
         if self.kv_mgr.is_dummy_cp_rank:
             # Non-authoritative CP ranks are dummy participants.
@@ -1307,6 +1312,7 @@ class CommonKVSender(BaseKVSender):
             (kv_indices, index_slice, is_last_chunk, should_skip)
             If should_skip is True, the caller should return immediately.
         """
+        self._send_started = True
         index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
         self.curr_idx += len(kv_indices)
         is_last_chunk = self.curr_idx == self.num_kv_indices
@@ -1375,6 +1381,12 @@ class CommonKVSender(BaseKVSender):
         )
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
+
+    def abort_before_send(self) -> None:
+        if self._send_started:
+            raise RuntimeError("Cannot notify bootstrap failure after a KV send")
+        self.abort()
+        self.kv_mgr.notify_bootstrap_failure(self.bootstrap_room)
 
 
 class CommonKVReceiver(BaseKVReceiver):

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -51,6 +51,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    _all_reduce_polls,
     _is_fake_transfer,
     build_kv_layer_ids,
     build_staging_slot_metadata,
@@ -2137,6 +2138,36 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             output_dsa_topk_indices,
             output_bootstrap_room,
         ) = self.metadata_buffers.get_buf(idx)
+
+        transferred_seq_len = cached_tokens[7].item()
+        expected_seq_len = decode_req.req.kv.kv_committed_len
+        # Zero is unknown for older prefill workers and intentionally fails open.
+        length_valid = _is_fake_transfer(decode_req.req) or transferred_seq_len in (
+            0,
+            expected_seq_len,
+        )
+        # Readiness consensus has completed; agree on length before any TP rank
+        # commits, without freeing pages while another rank is still transferring.
+        length_poll = _all_reduce_polls(
+            [KVPoll.Success if length_valid else KVPoll.Failed], self.gloo_group
+        )[0]
+        if length_poll == KVPoll.Failed:
+            logger.error(
+                "KV transfer sequence length mismatch on at least one TP rank: "
+                "request=%s bootstrap_room=%s received=%s expected=%s",
+                decode_req.req.rid,
+                decode_req.req.bootstrap_room,
+                transferred_seq_len,
+                expected_seq_len,
+            )
+            prepare_abort(
+                decode_req.req,
+                "KV transfer sequence length mismatch",
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+            decode_req.kv_receiver.clear()
+            decode_req.kv_receiver = None
+            return
 
         # Validate bootstrap_room to detect context corruption
         actual_room = output_bootstrap_room[0].item()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -57,6 +57,7 @@ from sglang.srt.disaggregation.utils import (
     get_dsa_tail_state_indices,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -638,6 +639,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         dispatch happens later, after preallocation and ``send_metadata`` (see
         ``pop_preallocated``).
         """
+        if is_aborted(req):
+            if self.pp_size > 1:
+                self._create_receiver_and_enqueue(req, is_rebootstrap=is_rebootstrap)
+            else:
+                req.update_finish_state()
+                if not req.finished_output:
+                    self.scheduler.output_streamer.stream_output(
+                        [req], req.return_logprob
+                    )
+            return
         if self._check_if_req_exceed_kv_capacity(req):
             return
 
@@ -900,6 +911,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
 
+            if is_aborted(decode_req.req):
+                poll = KVPoll.Failed
             if poll == KVPoll.Bootstrapping:
                 pass
             elif poll == KVPoll.WaitingForInput:
@@ -918,11 +931,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     logger.debug(error_message)
                 else:
                     logger.error(error_message)
-                prepare_abort(
-                    decode_req.req,
-                    error_message,
-                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                )
+                if not is_aborted(decode_req.req):
+                    prepare_abort(
+                        decode_req.req,
+                        error_message,
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
             else:
@@ -981,6 +995,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         addr_to_reqs: Dict[str, List[DecodeRequest]] = {}
         for decode_req in self.pending_reqs:
+            if is_aborted(decode_req.req):
+                continue
             addr = _bootstrap_addr(decode_req.req)
             addr_to_reqs.setdefault(addr, []).append(decode_req)
 
@@ -1022,7 +1038,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         # Group pending requests by bootstrap_addr
         addr_to_reqs: Dict[str, List[DecodeRequest]] = {}
+        aborted_reqs = []
         for decode_req in self.pending_reqs:
+            if is_aborted(decode_req.req):
+                aborted_reqs.append(decode_req)
+                continue
             addr = _bootstrap_addr(decode_req.req)
             addr_to_reqs.setdefault(addr, []).append(decode_req)
 
@@ -1075,7 +1095,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 if prefetched is not None:
                     prefetched[1].cancel()
 
-        self.pending_reqs = remaining
+        self.pending_reqs = remaining + aborted_reqs
 
         for decode_req, prefill_dp_rank in resolved:
             decode_req.kv_receiver.init(prefill_dp_rank)
@@ -1093,10 +1113,20 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if is_pp_mode and rids_to_check is not None:
             raise ValueError("rids_to_check cannot be used in PP mode")
 
-        self._resolve_pending_reqs()
-        self._update_handshake_waiters(rids_to_check, pp_good_rids, pp_bad_rids)
         if is_pp_mode:
             rids_to_check = set(pp_good_rids) | set(pp_bad_rids)
+
+        for decode_req in self.queue:
+            req = decode_req.req
+            if rids_to_check is not None and req.rid not in rids_to_check:
+                continue
+            if isinstance(req.to_finish, FINISH_ABORT):
+                req.update_finish_state()
+                # Preallocation has not published destination pages yet.
+                decode_req.kv_receiver.abort()
+
+        self._resolve_pending_reqs()
+        self._update_handshake_waiters(rids_to_check, pp_good_rids, pp_bad_rids)
 
         failed_reqs = []
         preallocated_reqs = []

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2377,11 +2377,26 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
 
-            hicache_restore_status = decode_req.hicache_restore_status
-            if (
-                poll == KVPoll.Failed
-                or hicache_restore_status == HiCacheRestoreResult.FAILED
+            if self.scheduler.enable_decode_hicache and poll in (
+                KVPoll.Success,
+                KVPoll.Failed,
             ):
+                # PENDING must block even a peer's FAILED restore until H2D is done.
+                # A restore failure alone must not bypass network/scatter readiness.
+                restore_status = decode_req.hicache_restore_status
+                restore_done, restore_valid = _all_reduce_polls(
+                    [
+                        int(restore_status != HiCacheRestoreResult.PENDING),
+                        int(restore_status != HiCacheRestoreResult.FAILED),
+                    ],
+                    self.gloo_group,
+                )
+                if not restore_done:
+                    continue
+                if not restore_valid:
+                    poll = KVPoll.Failed
+
+            if poll == KVPoll.Failed:
                 error_message = (
                     f"Decode transfer failed for request rank={self.tp_rank} "
                     f"{decode_req.req.rid=} {decode_req.req.bootstrap_room=}"
@@ -2432,11 +2447,6 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     self.scheduler.metrics_collector.increment_transfer_failed_reqs()
                 continue
             elif poll == KVPoll.Success:
-                if (
-                    self.scheduler.enable_decode_hicache
-                    and hicache_restore_status == HiCacheRestoreResult.PENDING
-                ):
-                    continue
                 self._commit_transfer_to_req(decode_req)
                 indices_to_remove.add(i)
                 # Check if request was aborted due to corruption

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1756,6 +1756,25 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
+    def notify_bootstrap_failure(self, bootstrap_room: int) -> None:
+        for info in list(self.transfer_infos.get(bootstrap_room, {}).values()):
+            if info.is_dummy:
+                continue
+            try:
+                self.sync_status_to_decode_endpoint(
+                    info.endpoint,
+                    info.dst_port,
+                    bootstrap_room,
+                    KVPoll.Failed,
+                    self._prefill_unique_rank(),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to notify decode of bootstrap rejection for room %s",
+                    bootstrap_room,
+                    exc_info=True,
+                )
+
     def transfer_worker(
         self,
         queue: FastQueue,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -473,6 +473,11 @@ class PrefillBootstrapQueue:
 
             if is_aborted(req):
                 if poll == KVPoll.Bootstrapping:
+                    if self.pp_size == 1 and not req.finished_output:
+                        req.update_finish_state()
+                        self.scheduler.output_streamer.stream_output(
+                            [req], req.return_logprob
+                        )
                     # Keep the bounded bootstrap wait to learn decode destinations,
                     # but never admit the rejected request to optimistic prefill.
                     continue

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -471,6 +471,15 @@ class PrefillBootstrapQueue:
             if poll is None:
                 continue
 
+            if is_aborted(req):
+                if poll == KVPoll.Bootstrapping:
+                    # Keep the bounded bootstrap wait to learn decode destinations,
+                    # but never admit the rejected request to optimistic prefill.
+                    continue
+                assert req.disagg_kv_sender is not None
+                req.disagg_kv_sender.abort_before_send()
+                poll = KVPoll.Failed
+
             if poll == KVPoll.Failed:
                 self.scheduler.handle_bootstrap_failure(req)
                 indices_to_remove.add(i)
@@ -1111,8 +1120,14 @@ class SchedulerDisaggregationPrefillMixin:
             release_kv_cache(req, self.tree_cache)
         maybe_release_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
         req.pending_bootstrap = False
-        prepare_abort(req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
-        self.output_streamer.stream_output([req], req.return_logprob)
+        if is_aborted(req):
+            req.update_finish_state()
+        else:
+            prepare_abort(
+                req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+        if not req.finished_output:
+            self.output_streamer.stream_output([req], req.return_logprob)
         if self.metrics_reporter.enable_metrics:
             self.metrics_collector.increment_bootstrap_failed_reqs()
         if self.enable_hicache_storage:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -479,10 +479,8 @@ class MetadataBuffers:
     def set_buf(self, req: Req):
 
         self.output_ids[req.metadata_buffer_index][0] = req.output_ids[0]
-        # The cached_tokens buffer is (size, 16); slots 0-3 hold cached token
-        # counts and slots 4-6 are reused for multimodal prompt token counts
-        # (slots 7-15 remain spare). This avoids adding new RDMA buffers.
-        # Slot map: 0=cached 1=device 2=host 3=storage 4=image 5=audio 6=video.
+        # cached_tokens slots: 0=cached 1=device 2=host 3=storage 4=image
+        # 5=audio 6=video 7=logical KV sequence length. Slots 8-15 remain spare.
         self.cached_tokens[req.metadata_buffer_index][0] = req.cached_tokens
         self.cached_tokens[req.metadata_buffer_index][1] = req.cached_tokens_device
         self.cached_tokens[req.metadata_buffer_index][2] = req.cached_tokens_host
@@ -497,6 +495,10 @@ class MetadataBuffers:
         self.cached_tokens[req.metadata_buffer_index][4] = image_t
         self.cached_tokens[req.metadata_buffer_index][5] = audio_t
         self.cached_tokens[req.metadata_buffer_index][6] = video_t
+        # Total coverage includes the decode cached prefix, not just the sent delta.
+        self.cached_tokens[req.metadata_buffer_index][7] = min(
+            req.extend_range.end, len(req.origin_input_ids)
+        )
         if req.return_logprob:
             if req.logprob.output_token_logprobs_val:  # not none or empty list
                 self.output_token_logprobs_val[req.metadata_buffer_index][0] = (

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -18,7 +18,7 @@ from sglang.srt.distributed.parallel_state import P2PWork
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.overlap_utils import RelayPayload
-from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sglang.srt.managers.utils import (
     GenerationBatchResult,
     get_logprob_dict_from_result,
@@ -619,14 +619,13 @@ class SchedulerPPMixin:
             bad_bootstrapped_rids = list(
                 set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
             )
-        # Route locally-aborted reqs through the bad-union consensus so every PP
-        # rank flushes them in the same consensus round, regardless of when the
-        # AbortReq reaches each rank and regardless of whether
-        # disagg_kv_sender.abort() drives the poll to Failed (it is optional).
+        # Completed AbortReqs bypass readiness even if sender.abort() is a no-op.
+        # Pending admission aborts wait for the ready intersection; each stage
+        # retires its rejected request in pop_bootstrapped.
         aborted_rids = {
             req.rid
             for req in self.disagg_prefill_bootstrap_queue.queue
-            if is_aborted(req)
+            if isinstance(req.finished_reason, FINISH_ABORT)
         }
         good_bootstrapped_rids, bad_bootstrapped_rids = self._route_aborts_to_bad(
             good_bootstrapped_rids, bad_bootstrapped_rids, aborted_rids

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -9,13 +9,16 @@ import torch
 import torch.distributed
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.utils import poll_and_all_reduce_attn_cp_tp_group
+from sglang.srt.disaggregation.utils import (
+    is_aborted,
+    poll_and_all_reduce_attn_cp_tp_group,
+)
 from sglang.srt.distributed.communication_op import attn_cp_tp_broadcast_pyobj
 from sglang.srt.distributed.parallel_state import P2PWork
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.overlap_utils import RelayPayload
-from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.utils import (
     GenerationBatchResult,
     get_logprob_dict_from_result,
@@ -623,7 +626,7 @@ class SchedulerPPMixin:
         aborted_rids = {
             req.rid
             for req in self.disagg_prefill_bootstrap_queue.queue
-            if isinstance(req.finished_reason, FINISH_ABORT)
+            if is_aborted(req)
         }
         good_bootstrapped_rids, bad_bootstrapped_rids = self._route_aborts_to_bad(
             good_bootstrapped_rids, bad_bootstrapped_rids, aborted_rids
@@ -1186,7 +1189,7 @@ class SchedulerPPMixin:
         aborted_rids = {
             decode_req.req.rid
             for decode_req in self.disagg_decode_prealloc_queue.queue
-            if isinstance(decode_req.req.finished_reason, FINISH_ABORT)
+            if is_aborted(decode_req.req)
         }
         good_prealloc_rids, bad_prealloc_rids = self._route_aborts_to_bad(
             good_prealloc_rids, bad_prealloc_rids, aborted_rids

--- a/test/registered/unit/disaggregation/test_admission_abort.py
+++ b/test/registered/unit/disaggregation/test_admission_abort.py
@@ -141,7 +141,7 @@ def code():
         ns,
         "disaggregation/mooncake/conn.py",
         {
-            "MooncakeKVManager": {"notify_bootstrap_failure"},
+            "MooncakeKVManager": {"notify_bootstrap_failure", "start_prefill_thread"},
             "MooncakeFailureExceptionMixin": {"failure_exception"},
             "MooncakeKVSender": {"abort", "poll"},
             "MooncakeKVReceiver": {"poll"},
@@ -181,6 +181,7 @@ def code():
                 "_pp_pd_get_bootstrapped_ids",
                 "_pp_pd_get_prealloc_ids",
                 "_route_aborts_to_bad",
+                "get_rids",
             },
         },
     )
@@ -368,7 +369,7 @@ def test_decode_abort_respects_queue_filter(code, pp):
 
 
 @pytest.mark.parametrize("role", ["prefill", "decode"])
-def test_pp_consensus_routes_pending_abort_to_bad(code, role):
+def test_pp_consensus_keeps_ready_prefill_admission_abort_in_ready_set(code, role):
     req = _req(code)
     scheduler = code.SchedulerPPMixin()
     scheduler.pp_group = SimpleNamespace(is_first_rank=True)
@@ -382,7 +383,8 @@ def test_pp_consensus_routes_pending_abort_to_bad(code, role):
         if role == "prefill"
         else scheduler._pp_pd_get_prealloc_ids
     )
-    assert method() == [[], [req.rid]]
+    expected = [[req.rid], []] if role == "prefill" else [[], [req.rid]]
+    assert method() == expected
 
 
 @pytest.mark.parametrize("status", [0, 2])
@@ -454,7 +456,7 @@ def test_general_sender_abort_does_not_notify_or_clear_inflight_room(code):
     assert sender.kv_mgr._staging_outstanding[42] == 1
 
 
-def test_prefill_timeout_retires_unknown_room_without_leaking_state(code, monkeypatch):
+def test_prefill_timeout_cleans_current_room_state(code, monkeypatch):
     req = _req(code)
     original = req.to_finish
     queue, sender = _prefill_queue(code, req, code.KVPoll.Bootstrapping)
@@ -529,6 +531,153 @@ def test_decode_abort_does_not_repeat_finished_output(code):
     assert req.finished_reason.status_code == 400
     queue.scheduler.output_streamer.stream_output.assert_not_called()
     receiver._send_abort_notification.assert_called_once_with()
+
+
+def _pp_prefill_queues(code):
+    queues = []
+    for rank in range(3):
+        queue, sender = _prefill_queue(code, _req(code), code.KVPoll.Bootstrapping)
+        queue.pp_size = 3
+        sender.kv_mgr.pp_rank = rank
+        sender.kv_mgr.pp_size = 3
+        sender.kv_mgr.transfer_infos.clear()
+        sender.kv_mgr.req_to_decode_prefix_len.clear()
+        queues.append(queue)
+    return queues
+
+
+def _pp_prefill_round(code, queues):
+    consensus = None
+    for rank, queue in enumerate(queues):
+        scheduler = code.SchedulerPPMixin()
+        scheduler.pp_group = SimpleNamespace(is_first_rank=rank == 0)
+        scheduler.attn_cp_cpu_group = None
+        scheduler.attn_tp_cpu_group = None
+        scheduler.disagg_prefill_bootstrap_queue = queue
+        scheduler._pp_recv_pyobj_from_prev_stage = Mock(return_value=consensus)
+        consensus = scheduler._pp_pd_get_bootstrapped_ids()
+    results = [
+        queue.pop_bootstrapped(
+            return_failed_reqs=True,
+            pp_good_rids=consensus[0],
+            pp_bad_rids=consensus[1],
+        )
+        for queue in queues
+    ]
+    return consensus, results
+
+
+def _deliver_prefill_metadata(manager, monkeypatch):
+    # Run the actual registration loop once; only transport and parsing are mocked.
+    namespace = manager.start_prefill_thread.__globals__
+    monkeypatch.setitem(
+        namespace,
+        "threading",
+        SimpleNamespace(Thread=lambda target: SimpleNamespace(start=target)),
+    )
+    info = SimpleNamespace(
+        endpoint="decode", dst_port=8001, is_dummy=False, decode_prefix_len=64
+    )
+    monkeypatch.setitem(
+        namespace, "TransferInfo", SimpleNamespace(from_zmq=Mock(return_value=info))
+    )
+    manager.resolve_kv_replica_factor = Mock()
+    manager.server_socket = SimpleNamespace(
+        recv_multipart=Mock(
+            side_effect=[
+                [b"42", b"decode", b"8001", b"session", b"", b"", b"", b"1"],
+                StopIteration,
+            ]
+        )
+    )
+    with pytest.raises(StopIteration):
+        manager.start_prefill_thread()
+
+
+@pytest.mark.parametrize("arrival_order", [(0, 1, 2), (2, 1, 0)])
+def test_pp_admission_abort_waits_for_metadata_on_every_stage(
+    code, monkeypatch, arrival_order
+):
+    queues = _pp_prefill_queues(code)
+    reqs = [queue.queue[0] for queue in queues]
+    original_errors = [req.to_finish for req in reqs]
+    senders = [req.disagg_kv_sender for req in reqs]
+
+    for rank in arrival_order:
+        assert _pp_prefill_round(code, queues) == ([[], []], [([], [])] * 3)
+        for queue, req in zip(queues, reqs):
+            assert queue.queue == [req]
+            assert req.finished_reason is None
+            assert req.prefill_attempt_count == 0
+            queue.ensure_metadata_buffer.assert_not_called()
+            queue.finalize_bootstrap.assert_not_called()
+            queue.scheduler.output_streamer.stream_output.assert_not_called()
+            req.disagg_kv_sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+        _deliver_prefill_metadata(senders[rank].kv_mgr, monkeypatch)
+
+    consensus, results = _pp_prefill_round(code, queues)
+    assert consensus == [[reqs[0].rid], []]
+    assert results == [([], [req]) for req in reqs]
+    for queue, req, error, sender in zip(queues, reqs, original_errors, senders):
+        assert req.finished_reason is error
+        assert error.status_code == 400
+        assert not sender._send_started
+        assert not req.pending_bootstrap
+        manager = sender.kv_mgr
+        manager.sync_status_to_decode_endpoint.assert_called_once_with(
+            "decode", 8001, 42, code.KVPoll.Failed, manager._prefill_unique_rank()
+        )
+        assert manager.request_status == manager.transfer_infos == {}
+        assert manager.req_to_decode_prefix_len == manager.failure_records == {}
+    assert _pp_prefill_round(code, queues) == ([[], []], [([], [])] * 3)
+    for queue, req in zip(queues, reqs):
+        queue.scheduler.output_streamer.stream_output.assert_called_once_with(
+            [req], False
+        )
+    code.release_kv_cache.assert_not_called()
+
+
+@pytest.mark.parametrize("completed_rank", [0, 1, 2])
+def test_pp_completed_abort_keeps_immediate_bad_union(code, completed_rank):
+    queues = _pp_prefill_queues(code)
+    reqs = [queue.queue[0] for queue in queues]
+    reqs[completed_rank].update_finish_state()
+    consensus, results = _pp_prefill_round(code, queues)
+    assert consensus == [[], [reqs[0].rid]]
+    assert results == [([], [req]) for req in reqs]
+    assert all(not queue.queue for queue in queues)
+
+
+def test_pp_admission_timeout_cleans_known_state_but_late_metadata_can_recreate_room(
+    code, monkeypatch
+):
+    queues = _pp_prefill_queues(code)
+    reqs = [queue.queue[0] for queue in queues]
+    senders = [req.disagg_kv_sender for req in reqs]
+    _deliver_prefill_metadata(senders[0].kv_mgr, monkeypatch)
+    assert _pp_prefill_round(code, queues) == ([[], []], [([], [])] * 3)
+
+    monkeypatch.setattr(code.logger, "warning_once", code.logger.warning, raising=False)
+    senders[1].init_time -= senders[1].kv_mgr.bootstrap_timeout + 1
+    consensus, results = _pp_prefill_round(code, queues)
+    assert consensus == [[], [reqs[0].rid]]
+    assert results == [([], [req]) for req in reqs]
+    senders[0].kv_mgr.sync_status_to_decode_endpoint.assert_called_once()
+    for sender in senders:
+        manager = sender.kv_mgr
+        assert manager.request_status == manager.transfer_infos == {}
+        assert manager.req_to_decode_prefix_len == manager.failure_records == {}
+    for sender in senders[1:]:
+        sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+
+    late_manager = senders[2].kv_mgr
+    _deliver_prefill_metadata(late_manager, monkeypatch)
+    assert _pp_prefill_round(code, queues) == ([[], []], [([], [])] * 3)
+    # Existing timeout behavior: late metadata has no scheduler owner to retire it.
+    assert late_manager.request_status[42] == code.KVPoll.WaitingForInput
+    assert 42 in late_manager.transfer_infos
+    assert late_manager.req_to_decode_prefix_len == {42: 64}
+    late_manager.sync_status_to_decode_endpoint.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_admission_abort.py
+++ b/test/registered/unit/disaggregation/test_admission_abort.py
@@ -8,11 +8,14 @@ import time
 from abc import ABC
 from array import array
 from collections import defaultdict
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import Mock
 
+import msgspec
 import pytest
 
 ROOT = Path(__file__).resolve().parents[4]
@@ -43,7 +46,7 @@ def _load(namespace, path, selections):
                 child.decorator_list = [
                     d
                     for d in child.decorator_list
-                    if isinstance(d, ast.Name) and d.id == "staticmethod"
+                    if isinstance(d, ast.Name) and d.id in ("staticmethod", "property")
                 ]
                 # FINISH_ABORT is supplied from the real schedule_batch AST.
                 child.body = [
@@ -91,7 +94,13 @@ def code():
         {
             "BaseFinishReason": None,
             "FINISH_ABORT": None,
-            "Req": {"set_finish_with_abort", "update_finish_state", "finished"},
+            "Req": {
+                "set_finish_with_abort",
+                "update_finish_state",
+                "finished",
+                "output_ids_through_stop",
+                "init_incremental_detokenize",
+            },
         },
     )
     _load(
@@ -418,6 +427,137 @@ def test_prefill_pending_abort_does_not_enter_optimistic_prefill(code):
     assert queue.queue == [req]
     queue.ensure_metadata_buffer.assert_not_called()
     sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+
+
+@pytest.fixture
+def real_streamer(code):
+    ns = code.Req.finished.__globals__
+    ns.update(
+        __name__=__name__,
+        dataclass=dataclass,
+        field=field,
+        ClassVar=ClassVar,
+        msgspec=msgspec,
+        wrap_as_pickle=lambda value: value,
+        INIT_INCREMENTAL_DETOKENIZATION_OFFSET=5,
+        DEFAULT_FORCE_STREAM_INTERVAL=50,
+        get_serving=lambda: SimpleNamespace(stream_interval=1, weight_version="test"),
+        get_observability=lambda: SimpleNamespace(
+            enable_request_time_stats_logging=False
+        ),
+        envs=SimpleNamespace(
+            SGLANG_TEST_CRASH_AFTER_STREAM_OUTPUTS=SimpleNamespace(get=lambda: 0)
+        ),
+    )
+    _load(
+        ns, "managers/io_struct.py", {"BaseBatchReq": None, "BatchTokenIDOutput": None}
+    )
+    _load(
+        ns,
+        "utils/weight_versions.py",
+        {"WeightVersionSpan": None, "compute_weight_version_spans": None},
+    )
+    _load(
+        ns,
+        "managers/scheduler_components/output_streamer.py",
+        {"SchedulerOutputStreamer": None, "_GenerationStreamAccumulator": None},
+    )
+    payloads = []
+    streamer = ns["SchedulerOutputStreamer"](
+        send_to_detokenizer=SimpleNamespace(send_output=payloads.append),
+        tree_cache=None,
+        ps=SimpleNamespace(dp_rank=0, attn_tp_rank=0),
+        server_args=SimpleNamespace(),
+        is_generation=True,
+        spec_algorithm=SimpleNamespace(is_none=lambda: True),
+        disaggregation_mode="prefill",
+        enable_hicache_storage=lambda: False,
+    )
+    return streamer, payloads
+
+
+@pytest.mark.parametrize("pp_size", [1, 2])
+@pytest.mark.parametrize("cleanup", ["metadata", "timeout"])
+def test_prefill_admission_response_precedes_cleanup(
+    code, real_streamer, monkeypatch, pp_size, cleanup
+):
+    req = _req(code)
+    original = req.to_finish
+    req.output_ids = array("q")
+    req.origin_input_ids_unpadded = array("q", [1, 2, 3])
+    req.finished_len = req.surr_offset = req.read_offset = None
+    req.beam_group = req.http_worker_ipc = req.customized_info = None
+    req.decoded_text = ""
+    req.weight_version_events = []
+    req.sampling_params = SimpleNamespace(
+        skip_special_tokens=True, spaces_between_special_tokens=True, no_stop_trim=False
+    )
+    req.return_hidden_states = req.return_routed_experts = False
+    req.return_indexer_topk = req.return_sampling_mask = False
+    req.send_token_offset = req.send_output_token_logprobs_offset = 0
+    req.send_decode_id_offset = req.reasoning_tokens = req.retraction_count = 0
+    req.cached_tokens = req.cached_tokens_device = 0
+    req.cached_tokens_host = req.cached_tokens_storage = 0
+    req.mm_image_tokens = req.mm_audio_tokens = req.mm_video_tokens = 0
+    queue, sender = _prefill_queue(code, req, code.KVPoll.Bootstrapping)
+    queue.pp_size = pp_size
+    queue.scheduler.output_streamer, payloads = real_streamer
+    sender.kv_mgr.transfer_infos.clear()
+    sender.kv_mgr.req_to_decode_prefix_len.clear()
+
+    waiting = {"pp_good_rids": [], "pp_bad_rids": []} if pp_size > 1 else {}
+    for _ in range(2):
+        assert queue.pop_bootstrapped(**waiting) == []
+        assert queue.queue == [req]
+        assert req.pending_bootstrap
+        assert req.finished_output is (pp_size == 1)
+        assert req.finished_reason is (original if pp_size == 1 else None)
+        assert req.to_finish is (None if pp_size == 1 else original)
+        assert len(payloads) == (1 if pp_size == 1 else 0)
+        sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+        queue.scheduler.tree_cache.release_aborted_request.assert_not_called()
+        assert 42 in sender.kv_mgr.request_status
+
+    if cleanup == "metadata":
+        _deliver_prefill_metadata(sender.kv_mgr, monkeypatch)
+    else:
+        sender.init_time -= sender.kv_mgr.bootstrap_timeout + 1
+        monkeypatch.setattr(
+            code.logger, "warning_once", code.logger.warning, raising=False
+        )
+    kwargs = (
+        {
+            "pp_good_rids": [req.rid] if cleanup == "metadata" else [],
+            "pp_bad_rids": [req.rid] if cleanup == "timeout" else [],
+        }
+        if pp_size > 1
+        else {}
+    )
+    assert queue.pop_bootstrapped(return_failed_reqs=True, **kwargs) == ([], [req])
+    assert queue.pop_bootstrapped(**kwargs) == []
+    assert queue.queue == []
+    assert not req.pending_bootstrap
+    assert req.finished_reason is original
+    assert req.finished_output
+    assert len(req.output_ids) == 0
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.rids == [req.rid]
+    assert payload.finished_reasons == [original.to_json()]
+    assert payload.finished_reasons[0]["status_code"] == 400
+    assert payload.output_ids == [array("q")]
+    assert payload.completion_tokens == [0]
+    assert payload.decode_ids == [req.origin_input_ids_unpadded]
+    assert not sender._send_started
+    queue.ensure_metadata_buffer.assert_not_called()
+    queue.finalize_bootstrap.assert_not_called()
+    queue.scheduler.tree_cache.release_aborted_request.assert_called_once_with(req.rid)
+    code.release_kv_cache.assert_not_called()
+    assert sender.kv_mgr.request_status == sender.kv_mgr.transfer_infos == {}
+    assert sender.kv_mgr.failure_records == sender.kv_mgr.req_to_decode_prefix_len == {}
+    assert sender.kv_mgr.sync_status_to_decode_endpoint.call_count == (
+        cleanup == "metadata"
+    )
 
 
 def test_prefill_notification_failure_still_cleans_up(code):

--- a/test/registered/unit/disaggregation/test_admission_abort.py
+++ b/test/registered/unit/disaggregation/test_admission_abort.py
@@ -1,0 +1,535 @@
+"""CPU admission tests, loading production methods without GPU runtime imports."""
+
+import ast
+import logging
+import runpy
+import threading
+import time
+from abc import ABC
+from array import array
+from collections import defaultdict
+from http import HTTPStatus
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+SRT = ROOT / "python/sglang/srt"
+register_cpu_ci = runpy.run_path(str(ROOT / "python/sglang/test/ci/ci_register.py"))[
+    "register_cpu_ci"
+]
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _load(namespace, path, selections):
+    tree = ast.parse((SRT / path).read_text())
+    nodes = []
+    for node in tree.body:
+        if not isinstance(node, (ast.ClassDef, ast.FunctionDef)):
+            continue
+        if node.name not in selections:
+            continue
+        if isinstance(node, ast.ClassDef) and selections[node.name] is not None:
+            node.body = [
+                method
+                for method in node.body
+                if isinstance(method, ast.FunctionDef)
+                and method.name in selections[node.name]
+            ] or [ast.Pass()]
+        for child in ast.walk(node):
+            if isinstance(child, ast.FunctionDef):
+                child.decorator_list = [
+                    d
+                    for d in child.decorator_list
+                    if isinstance(d, ast.Name) and d.id == "staticmethod"
+                ]
+                # FINISH_ABORT is supplied from the real schedule_batch AST.
+                child.body = [
+                    statement
+                    for statement in child.body
+                    if not isinstance(statement, ast.ImportFrom)
+                ]
+        nodes.append(node)
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias("annotations")], level=0
+            )
+        ]
+        + nodes,
+        type_ignores=[],
+    )
+    exec(compile(ast.fix_missing_locations(module), str(SRT / path), "exec"), namespace)
+
+
+@pytest.fixture
+def code():
+    ns = {
+        "ABC": ABC,
+        "HTTPStatus": HTTPStatus,
+        "array": array,
+        "logger": logging.getLogger(__name__),
+        "time": time,
+        "get_parallel": lambda: SimpleNamespace(tp_rank=0, dp_size=1),
+        "get_disagg": lambda: SimpleNamespace(optimistic_prefill_attempts=2),
+        "should_force_retry": lambda req: False,
+        "release_kv_cache": Mock(),
+        "StagingManagerMixin": type("StagingManagerMixin", (), {}),
+        "ReqDllmMixin": type("ReqDllmMixin", (), {}),
+        "DecodeHiCachePreallocMixin": type("DecodeHiCachePreallocMixin", (), {}),
+        "_is_fake_transfer": lambda req: False,
+        "KVTransferMetric": SimpleNamespace,
+        "NetworkAddress": lambda host, port: SimpleNamespace(
+            to_host_port_str=lambda: f"{host}:{port}"
+        ),
+    }
+    _load(
+        ns,
+        "managers/schedule_batch.py",
+        {
+            "BaseFinishReason": None,
+            "FINISH_ABORT": None,
+            "Req": {"set_finish_with_abort", "update_finish_state", "finished"},
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/base/conn.py",
+        {
+            "KVPoll": None,
+            "BaseKVManager": set(),
+            "BaseKVSender": {"abort", "clear", "abort_before_send"},
+            "BaseKVReceiver": set(),
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/utils.py",
+        {
+            "is_aborted": None,
+            "prepare_abort": None,
+            "poll_and_all_reduce_pp": None,
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/common/conn.py",
+        {
+            "KVTransferError": None,
+            "CommonKVManager": {
+                "check_status",
+                "update_status",
+                "record_failure",
+                "_prefill_unique_rank",
+                "notify_bootstrap_failure",
+            },
+            "CommonKVSender": {
+                "__init__",
+                "init",
+                "_prepare_send_indices",
+                "abort",
+                "clear",
+                "abort_before_send",
+                "_check_bootstrap_timeout",
+            },
+            "CommonKVReceiver": {"abort", "clear", "_check_waiting_timeout"},
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/mooncake/conn.py",
+        {
+            "MooncakeKVManager": {"notify_bootstrap_failure"},
+            "MooncakeFailureExceptionMixin": {"failure_exception"},
+            "MooncakeKVSender": {"abort", "poll"},
+            "MooncakeKVReceiver": {"poll"},
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/prefill.py",
+        {
+            "maybe_release_metadata_buffer": None,
+            "PrefillBootstrapQueue": {"pop_bootstrapped"},
+            "SchedulerDisaggregationPrefillMixin": {
+                "clear_pending_chunk_send",
+                "handle_bootstrap_failure",
+            },
+        },
+    )
+    _load(
+        ns,
+        "disaggregation/decode.py",
+        {
+            "DecodePreallocQueue": {
+                "add",
+                "pop_preallocated",
+                "_update_handshake_waiters",
+                "_resolve_pending_reqs",
+                "prefetch_prefill_dp_rank_queries",
+            },
+            "_bootstrap_addr": None,
+        },
+    )
+    _load(
+        ns,
+        "managers/scheduler_pp_mixin.py",
+        {
+            "SchedulerPPMixin": {
+                "_pp_pd_get_bootstrapped_ids",
+                "_pp_pd_get_prealloc_ids",
+                "_route_aborts_to_bad",
+            },
+        },
+    )
+    ns["poll_and_all_reduce"] = lambda pollers, *args: [p.poll() for p in pollers]
+    ns["poll_and_all_reduce_attn_cp_tp_group"] = ns["poll_and_all_reduce"]
+    return SimpleNamespace(**ns)
+
+
+def _req(code, rid="rejected"):
+    req = code.Req.__new__(code.Req)
+    req.rid = rid
+    req.bootstrap_room = 42
+    req.bootstrap_host = "prefill"
+    req.bootstrap_port = 8000
+    req.finished_reason = None
+    req.finished_output = False
+    req.to_finish = None
+    req.multimodal_inputs = None
+    req.session = None
+    req.output_ids = []
+    req.origin_input_ids = [1, 2, 3]
+    req.time_stats = Mock()
+    req.kv = SimpleNamespace(holds_kv=False, holds_mamba=False)
+    req.metadata_buffer_index = -1
+    req.prefill_attempt_count = 0
+    req.pending_bootstrap = True
+    req.is_retracted = False
+    req.set_finish_with_abort("original admission error")
+    assert req.finished_reason is None
+    assert list(req.origin_input_ids) == [0]
+    assert req.to_finish.status_code == 400
+    return req
+
+
+def _manager(code):
+    manager = code.MooncakeKVManager.__new__(code.MooncakeKVManager)
+    manager.request_status = {42: code.KVPoll.WaitingForInput}
+    manager.failure_records = {}
+    manager.failure_lock = threading.Lock()
+    manager.req_to_decode_prefix_len = {42: 64}
+    manager.transfer_infos = {
+        42: {
+            "a": SimpleNamespace(endpoint="decode-a", dst_port=8001, is_dummy=False),
+            "dummy": SimpleNamespace(endpoint="dummy", dst_port=8002, is_dummy=True),
+            "b": SimpleNamespace(endpoint="decode-b", dst_port=8003, is_dummy=False),
+        }
+    }
+    manager._deferred_ack_targets = {}
+    manager._staging_outstanding = defaultdict(int)
+    manager.attn_tp_rank = 1
+    manager.attn_cp_rank = 1
+    manager.attn_cp_size = 2
+    manager.pp_rank = 1
+    manager.pp_size = 2
+    manager.bootstrap_timeout = 10
+    manager.sync_status_to_decode_endpoint = Mock()
+    return manager
+
+
+def _decode_queue(code, req):
+    manager = _manager(code)
+    manager.required_prefill_response_num_table = {42: 1}
+    manager.prefill_response_tracker = {42: set()}
+    receiver = code.MooncakeKVReceiver.__new__(code.MooncakeKVReceiver)
+    receiver.kv_mgr = manager
+    receiver.bootstrap_room = 42
+    receiver.conclude_state = None
+    receiver.init_time = None
+    receiver.abort_notified = False
+    receiver.bootstrap_infos = [{}]
+    receiver._send_abort_notification = Mock()
+    receiver.init = Mock()
+    receiver.send_metadata = Mock()
+    decode_req = SimpleNamespace(req=req, kv_receiver=receiver, waiting_for_input=False)
+    queue = code.DecodePreallocQueue.__new__(code.DecodePreallocQueue)
+    queue.queue = [decode_req]
+    queue.pending_reqs = [decode_req]
+    queue._prefill_dp_rank_queries = {}
+    queue._cancel_prefill_dp_rank_queries = Mock()
+    queue._ensure_prefill_info = Mock(side_effect=lambda groups: (groups, []))
+    queue._resolve_prefill_dp_rank = Mock(return_value=0)
+    queue._check_if_req_exceed_kv_capacity = Mock(return_value=False)
+    queue._create_receiver_and_enqueue = Mock(return_value=decode_req)
+    queue._uses_swa_tail_prealloc = Mock(return_value=False)
+    queue._allocatable_token_budgets = Mock(return_value=0)
+    queue._hicache_pending_restore_tokens = Mock(return_value=0)
+    queue._pre_alloc = Mock()
+    queue.req_to_token_pool = SimpleNamespace(available_size=lambda: 0)
+    queue.pp_size = 1
+    queue.tp_rank = 0
+    queue.gloo_group = None
+    queue.scheduler = SimpleNamespace(
+        running_batch=SimpleNamespace(reqs=[]),
+        enable_priority_scheduling=False,
+        enable_hisparse=False,
+        metrics_reporter=SimpleNamespace(enable_metrics=False),
+        output_streamer=Mock(),
+    )
+    return queue, decode_req, receiver
+
+
+def _prefill_queue(code, req, poll):
+    sender = code.MooncakeKVSender.__new__(code.MooncakeKVSender)
+    manager = _manager(code)
+    manager.enable_all_cp_ranks_for_transfer = False
+    manager.is_dummy_cp_rank = False
+    code.CommonKVSender.__init__(sender, manager, "prefill:8000", 42, [0], 0)
+    sender.kv_mgr.request_status[42] = poll
+    sender.init_time = time.time()
+    sender.trace_ctx = Mock()
+    req.disagg_kv_sender = sender
+    scheduler = code.SchedulerDisaggregationPrefillMixin()
+    scheduler.ps = SimpleNamespace(tp_rank=0)
+    scheduler.disagg_prefill_pending_chunk_rids = set()
+    scheduler.tree_cache = Mock()
+    scheduler.req_to_metadata_buffer_idx_allocator = Mock()
+    scheduler.output_streamer = Mock()
+    scheduler.metrics_reporter = SimpleNamespace(enable_metrics=False)
+    scheduler.enable_hicache_storage = True
+    scheduler.attn_cp_cpu_group = None
+    scheduler.attn_tp_cpu_group = None
+    scheduler.processed_tokens_counter = 0
+    queue = code.PrefillBootstrapQueue.__new__(code.PrefillBootstrapQueue)
+    queue.queue = [req]
+    queue.scheduler = scheduler
+    queue.pp_size = 1
+    queue.ensure_metadata_buffer = Mock(return_value=True)
+    queue.finalize_bootstrap = Mock(return_value=True)
+    return queue, sender
+
+
+@pytest.mark.parametrize("status", [0, 1, 2])
+def test_decode_pending_admission_abort_preserves_error_and_cleans_once(code, status):
+    req = _req(code)
+    original = req.to_finish
+    queue, decode_req, receiver = _decode_queue(code, req)
+    receiver.kv_mgr.request_status[42] = status
+
+    assert queue.pop_preallocated() == ([], [decode_req])
+    assert req.finished_reason is original
+    assert req.to_finish is None
+    assert queue.queue == queue.pending_reqs == []
+    assert decode_req.kv_receiver is None
+    receiver.init.assert_not_called()
+    receiver.send_metadata.assert_not_called()
+    receiver._send_abort_notification.assert_called_once_with()
+    queue._pre_alloc.assert_not_called()
+    code.release_kv_cache.assert_not_called()
+    assert receiver.kv_mgr.request_status == receiver.kv_mgr.failure_records == {}
+    assert queue.pop_preallocated() == ([], [])
+    queue.scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+
+def test_decode_add_rejects_without_receiver_or_capacity_check(code):
+    req = _req(code)
+    original = req.to_finish
+    queue, _, _ = _decode_queue(code, req)
+    queue.queue = []
+    queue.pending_reqs = []
+    queue.add(req)
+    assert req.finished_reason is original
+    queue._check_if_req_exceed_kv_capacity.assert_not_called()
+    queue._create_receiver_and_enqueue.assert_not_called()
+    queue.scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+
+@pytest.mark.parametrize("pp", [False, True])
+def test_decode_abort_respects_queue_filter(code, pp):
+    req = _req(code)
+    queue, decode_req, receiver = _decode_queue(code, req)
+    queue.pp_size = 2 if pp else 1
+    kwargs = {"pp_good_rids": [], "pp_bad_rids": []} if pp else {"rids_to_check": []}
+    assert queue.pop_preallocated(**kwargs) == ([], [])
+    assert queue.queue == queue.pending_reqs == [decode_req]
+    assert req.finished_reason is None
+    receiver.init.assert_not_called()
+    receiver._send_abort_notification.assert_not_called()
+    kwargs = (
+        {"pp_good_rids": [], "pp_bad_rids": [req.rid]}
+        if pp
+        else {"rids_to_check": [req.rid]}
+    )
+    assert queue.pop_preallocated(**kwargs) == ([], [decode_req])
+    assert req.finished_reason.status_code == 400
+
+
+@pytest.mark.parametrize("role", ["prefill", "decode"])
+def test_pp_consensus_routes_pending_abort_to_bad(code, role):
+    req = _req(code)
+    scheduler = code.SchedulerPPMixin()
+    scheduler.pp_group = SimpleNamespace(is_first_rank=True)
+    scheduler.get_rids = Mock(return_value=([req.rid], []))
+    scheduler.disagg_prefill_bootstrap_queue = SimpleNamespace(queue=[req])
+    scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
+        queue=[SimpleNamespace(req=req)]
+    )
+    method = (
+        scheduler._pp_pd_get_bootstrapped_ids
+        if role == "prefill"
+        else scheduler._pp_pd_get_prealloc_ids
+    )
+    assert method() == [[], [req.rid]]
+
+
+@pytest.mark.parametrize("status", [0, 2])
+def test_prefill_admission_abort_notifies_known_peers_without_forward(code, status):
+    req = _req(code)
+    original = req.to_finish
+    queue, sender = _prefill_queue(code, req, status)
+    assert queue.pop_bootstrapped(return_failed_reqs=True) == ([], [req])
+    assert req.finished_reason is original
+    assert not req.pending_bootstrap
+    queue.ensure_metadata_buffer.assert_not_called()
+    queue.finalize_bootstrap.assert_not_called()
+    code.release_kv_cache.assert_not_called()
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_any_call(
+        "decode-a", 8001, 42, code.KVPoll.Failed, 7
+    )
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_any_call(
+        "decode-b", 8003, 42, code.KVPoll.Failed, 7
+    )
+    assert sender.kv_mgr.sync_status_to_decode_endpoint.call_count == 2
+    assert sender.kv_mgr.request_status == sender.kv_mgr.transfer_infos == {}
+    assert sender.kv_mgr.failure_records == sender.kv_mgr.req_to_decode_prefix_len == {}
+    assert queue.pop_bootstrapped() == []
+    queue.scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+
+def test_prefill_pending_abort_does_not_enter_optimistic_prefill(code):
+    req = _req(code)
+    queue, sender = _prefill_queue(code, req, code.KVPoll.Bootstrapping)
+    assert queue.pop_bootstrapped() == []
+    assert queue.queue == [req]
+    queue.ensure_metadata_buffer.assert_not_called()
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+
+
+def test_prefill_notification_failure_still_cleans_up(code):
+    req = _req(code)
+    queue, sender = _prefill_queue(code, req, code.KVPoll.WaitingForInput)
+    sender.kv_mgr.sync_status_to_decode_endpoint.side_effect = RuntimeError("peer down")
+    assert queue.pop_bootstrapped() == []
+    assert req.finished_reason.status_code == 400
+    assert sender.kv_mgr.sync_status_to_decode_endpoint.call_count == 2
+    assert (
+        sender.kv_mgr.request_status
+        == sender.kv_mgr.transfer_infos
+        == sender.kv_mgr.failure_records
+        == {}
+    )
+
+
+@pytest.mark.parametrize("pages", [[], [1]])
+def test_before_send_abort_refuses_even_metadata_only_send(code, pages):
+    queue, sender = _prefill_queue(code, _req(code), code.KVPoll.WaitingForInput)
+    sender.init(len(pages), 3)
+    sender._prepare_send_indices(pages)
+    with pytest.raises(RuntimeError, match="send"):
+        sender.abort_before_send()
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+    assert 42 in sender.kv_mgr.request_status
+
+
+def test_general_sender_abort_does_not_notify_or_clear_inflight_room(code):
+    queue, sender = _prefill_queue(code, _req(code), code.KVPoll.Transferring)
+    sender._send_started = True
+    sender.kv_mgr._staging_outstanding[42] = 1
+    sender.abort()
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+    assert 42 in sender.kv_mgr.transfer_infos
+    assert sender.kv_mgr._staging_outstanding[42] == 1
+
+
+def test_prefill_timeout_retires_unknown_room_without_leaking_state(code, monkeypatch):
+    req = _req(code)
+    original = req.to_finish
+    queue, sender = _prefill_queue(code, req, code.KVPoll.Bootstrapping)
+    sender.kv_mgr.transfer_infos.clear()
+    sender.init_time -= sender.kv_mgr.bootstrap_timeout + 1
+    monkeypatch.setattr(code.logger, "warning_once", code.logger.warning, raising=False)
+
+    assert queue.pop_bootstrapped(return_failed_reqs=True) == ([], [req])
+    assert req.finished_reason is original
+    assert sender.kv_mgr.request_status == sender.kv_mgr.failure_records == {}
+    assert sender.kv_mgr.transfer_infos == sender.kv_mgr.req_to_decode_prefix_len == {}
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+
+
+def test_prefill_abort_waits_for_pp_consensus_and_frees_reserved_metadata_once(code):
+    req = _req(code)
+    req.metadata_buffer_index = 7
+    queue, sender = _prefill_queue(code, req, code.KVPoll.WaitingForInput)
+    queue.pp_size = 2
+    assert queue.pop_bootstrapped(pp_good_rids=[], pp_bad_rids=[]) == []
+    assert queue.queue == [req]
+    sender.kv_mgr.sync_status_to_decode_endpoint.assert_not_called()
+    assert queue.pop_bootstrapped(pp_good_rids=[], pp_bad_rids=[req.rid]) == []
+    assert queue.queue == []
+    assert req.metadata_buffer_index == -1
+    assert queue.pop_bootstrapped(pp_good_rids=[], pp_bad_rids=[]) == []
+    queue.scheduler.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(7)
+    queue.scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+
+def test_decode_add_in_pp_enqueues_without_initializing_receiver(code):
+    req = _req(code)
+    queue, _, receiver = _decode_queue(code, req)
+    queue.pp_size = 2
+    queue.add(req)
+    queue._create_receiver_and_enqueue.assert_called_once_with(
+        req, is_rebootstrap=False
+    )
+    receiver.init.assert_not_called()
+    queue._check_if_req_exceed_kv_capacity.assert_not_called()
+    queue.scheduler.output_streamer.stream_output.assert_not_called()
+    assert req.finished_reason is None
+
+
+def test_decode_pending_abort_cancels_prefetched_query(code):
+    queue, _, receiver = _decode_queue(code, _req(code))
+    future = Mock()
+    queue._prefill_dp_rank_queries = {"prefill:8000": ((42,), future)}
+    queue.prefetch_prefill_dp_rank_queries()
+    future.cancel.assert_called_once_with()
+    assert queue._prefill_dp_rank_queries == {}
+    receiver.init.assert_not_called()
+
+
+def test_decode_valid_request_still_initializes_receiver(code):
+    req = _req(code)
+    req.to_finish = None
+    queue, decode_req, receiver = _decode_queue(code, req)
+    assert queue.pop_preallocated() == ([], [])
+    assert queue.queue == [decode_req]
+    assert queue.pending_reqs == []
+    receiver.init.assert_called_once_with(0)
+    receiver._send_abort_notification.assert_not_called()
+    assert req.finished_reason is None
+
+
+def test_decode_abort_does_not_repeat_finished_output(code):
+    req = _req(code)
+    queue, decode_req, receiver = _decode_queue(code, req)
+    req.finished_output = True
+    assert queue.pop_preallocated() == ([], [decode_req])
+    assert req.finished_reason.status_code == 400
+    queue.scheduler.output_streamer.stream_output.assert_not_called()
+    receiver._send_abort_notification.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -105,6 +105,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             rid="abort-prealloc",
             bootstrap_room=42,
             finished_reason=None,
+            to_finish=None,
             return_logprob=False,
         )
         decode_req = SimpleNamespace(
@@ -162,6 +163,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         req = SimpleNamespace(
             rid="abort-shared",
             finished_reason=FINISH_ABORT("aborted"),
+            to_finish=None,
             return_logprob=False,
         )
         decode_req = SimpleNamespace(req=req, kv_receiver=receiver)
@@ -200,6 +202,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             origin_input_ids=[1, 2, 3],
             output_ids=[],
             finished_reason=None,
+            to_finish=None,
             return_logprob=False,
             sampling_params=SimpleNamespace(max_new_tokens=1),
         )
@@ -292,6 +295,8 @@ class TestDecodeQueueCleanup(CustomTestCase):
                     bootstrap_host="127.0.0.1",
                     bootstrap_port=11500,
                     bootstrap_room=room,
+                    finished_reason=None,
+                    to_finish=None,
                 ),
                 kv_receiver=MagicMock(),
             )

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -340,6 +340,8 @@ class TestEagleDsaSeedTransfer(unittest.TestCase):
     def _make_req(seed, metadata_buffer_index=0):
         return SimpleNamespace(
             metadata_buffer_index=metadata_buffer_index,
+            origin_input_ids=[1, 2, 3],
+            extend_range=SimpleNamespace(end=3),
             output_ids=[101],
             cached_tokens=0,
             cached_tokens_device=0,

--- a/test/registered/unit/disaggregation/test_transfer_sequence_length.py
+++ b/test/registered/unit/disaggregation/test_transfer_sequence_length.py
@@ -1,0 +1,425 @@
+"""CPU-only coverage of PD length validation without importing GPU backends."""
+
+from __future__ import annotations
+
+import ast
+import enum
+import hashlib
+import logging
+import random
+import sys
+import unittest
+from collections import deque
+from contextlib import nullcontext
+from http import HTTPStatus
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+import torch.distributed as dist
+
+ROOT = Path(__file__).resolve().parents[4]
+SRT = ROOT / "python/sglang/srt"
+
+
+def load_definitions(path, names, namespace, class_name=None):
+    tree = ast.parse(path.read_text())
+    body = tree.body
+    if class_name is not None:
+        body = next(n for n in body if getattr(n, "name", None) == class_name).body
+    selected = [n for n in body if getattr(n, "name", None) in names]
+    assert {n.name for n in selected} == set(names)
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias("annotations")], level=0
+            )
+        ]
+        + selected,
+        type_ignores=[],
+    )
+    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+
+
+# Load the CI marker without importing the public API and its GPU dependencies.
+_ci = {}
+load_definitions(
+    ROOT / "python/sglang/test/ci/ci_register.py", ["register_cpu_ci"], _ci
+)
+register_cpu_ci = _ci["register_cpu_ci"]
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTransferSequenceLength(unittest.TestCase):
+    def setUp(self):
+        self.config = SimpleNamespace(disaggregation_transfer_backend="mooncake")
+        self.ns = dict(
+            torch=torch,
+            enum=enum,
+            dist=dist,
+            random=random,
+            hashlib=hashlib,
+            deque=deque,
+            nullcontext=nullcontext,
+            HTTPStatus=HTTPStatus,
+            logger=logging.getLogger(__name__),
+            is_npu=lambda: False,
+            _is_npu=False,
+            get_disagg=lambda: self.config,
+            FAKE_BOOTSTRAP_HOST="2.2.2.2",
+            envs=SimpleNamespace(
+                SGLANG_MOONCAKE_CUSTOM_MEM_POOL=Mock(get=lambda: None),
+                SGLANG_TEST_DISAGG_FAILURE_PROB=Mock(get=lambda: 0),
+            ),
+            release_kv_cache=Mock(),
+            HiCacheRestoreResult=SimpleNamespace(READY=0, PENDING=1, FAILED=2),
+        )
+        load_definitions(
+            SRT / "disaggregation/base/conn.py", ["KVPoll", "StateType"], self.ns
+        )
+        load_definitions(
+            SRT / "managers/schedule_batch.py",
+            ["BaseFinishReason", "FINISH_ABORT"],
+            self.ns,
+        )
+        schedule_batch = patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.managers.schedule_batch": SimpleNamespace(
+                    FINISH_ABORT=self.ns["FINISH_ABORT"]
+                )
+            },
+        )
+        schedule_batch.start()
+        self.addCleanup(schedule_batch.stop)
+        load_definitions(
+            SRT / "disaggregation/utils.py",
+            [
+                "MetadataBuffers",
+                "ReqToMetadataIdxAllocator",
+                "_is_fake_transfer",
+                "_poll_with_failure_injection",
+                "_apply_metadata_gate",
+                "_all_reduce_polls",
+                "poll_and_all_reduce",
+                "poll_and_all_reduce_with_staging",
+                "prepare_abort",
+            ],
+            self.ns,
+        )
+        load_definitions(
+            SRT / "disaggregation/decode.py",
+            ["_generate_fake_prefill_handoff_output_id"],
+            self.ns,
+        )
+        load_definitions(
+            SRT / "disaggregation/prefill.py",
+            ["send_kv_chunk"],
+            self.ns,
+            class_name="SchedulerDisaggregationPrefillMixin",
+        )
+        load_definitions(SRT / "mem_cache/common.py", ["kv_to_page_indices"], self.ns)
+        load_definitions(
+            SRT / "disaggregation/decode.py",
+            ["_pre_alloc_fill_len"],
+            self.ns,
+            class_name="DecodePreallocQueue",
+        )
+        methods = {}
+        load_definitions(
+            SRT / "disaggregation/decode.py",
+            [
+                "_commit_transfer_to_req",
+                "_poll_with_metadata_gate",
+                "_poll_with_staging",
+                "pop_transferred",
+            ],
+            self.ns,
+            class_name="DecodeTransferQueue",
+        )
+        for name in (
+            "_commit_transfer_to_req",
+            "_poll_with_metadata_gate",
+            "_poll_with_staging",
+            "pop_transferred",
+        ):
+            methods[name] = self.ns[name]
+        self.queue_type = type("DecodeTransferQueue", (), methods)
+        self.poll = self.ns["KVPoll"]
+        self.all_reduce = patch.object(
+            dist, "all_reduce", side_effect=lambda *a, **kw: None
+        )
+        self.reduce = self.all_reduce.start()
+        self.addCleanup(self.all_reduce.stop)
+
+    def make_buffers(self):
+        return self.ns["MetadataBuffers"](
+            size=1,
+            hidden_size=2,
+            hidden_states_dtype=torch.float32,
+            max_sampling_mask_tokens=0,
+        )
+
+    def make_req(self, prompt_len=9, prefix_len=0, outputs=(), rebootstrap=False):
+        req = SimpleNamespace(
+            rid="length-test",
+            origin_input_ids=list(range(prompt_len)),
+            output_ids=list(outputs),
+            bootstrap_host="127.0.0.1",
+            bootstrap_room=42,
+            vocab_size=100,
+            metadata_buffer_index=0,
+            cached_tokens=prefix_len,
+            cached_tokens_device=prefix_len,
+            cached_tokens_host=0,
+            cached_tokens_storage=0,
+            multimodal_inputs=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            hidden_states_tensor=None,
+            pd_rebootstrap_in_progress=rebootstrap,
+            pd_rebootstrap_forced_output_id=99 if rebootstrap else None,
+            time_stats=Mock(),
+            finished_reason=None,
+        )
+        fill_len = self.ns["_pre_alloc_fill_len"](req)
+        req.kv = SimpleNamespace(kv_committed_len=fill_len)
+        req.extend_range = SimpleNamespace(start=prefix_len, end=fill_len)
+        return req
+
+    def make_queue(self, req, transferred_len, staging=False):
+        buffers = self.make_buffers()
+        buffers.output_ids[0, 0] = 17
+        buffers.bootstrap_room[0, 0] = req.bootstrap_room
+        buffers.cached_tokens[0, 0] = req.cached_tokens
+        buffers.cached_tokens[0, 7] = transferred_len
+        receiver = Mock(require_staging=staging, abort_notified=False)
+        receiver.poll.return_value = self.poll.Success
+        dr = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            metadata_buffer_index=0,
+            is_rebootstrap=req.pd_rebootstrap_in_progress,
+            hicache_restore_status=0,
+        )
+        queue = self.queue_type()
+        queue.queue = [dr]
+        queue.gloo_group = object()
+        queue.tp_rank = 0
+        queue.metadata_buffers = buffers
+        queue.enable_staging = staging
+        queue.staging_handler = Mock()
+        queue.staging_handler.is_done.return_value = True
+        queue.staging_handler.is_failed.return_value = False
+        queue.staging_handler.is_staging_room.return_value = staging
+        queue.enable_deferred_kv_release = False
+        queue.tree_cache = object()
+        queue.req_to_metadata_buffer_idx_allocator = self.ns[
+            "ReqToMetadataIdxAllocator"
+        ](1)
+        self.assertEqual(queue.req_to_metadata_buffer_idx_allocator.alloc(), 0)
+        queue.spec_algorithm = SimpleNamespace(is_none=lambda: True)
+        queue.scheduler = SimpleNamespace(
+            enable_decode_hicache=False,
+            enable_hisparse=False,
+            metrics_reporter=SimpleNamespace(enable_metrics=False),
+            batch_result_processor=Mock(),
+            output_streamer=Mock(),
+        )
+        queue._commit_hicache_local_restore_to_req = Mock()
+        queue._clean_hicache_prefetch_resources = Mock()
+        return queue, dr, receiver
+
+    def assert_rejected(self, queue, dr, receiver, outputs=()):
+        self.assertEqual(queue.pop_transferred(), [])
+        self.assertEqual(dr.req.output_ids, list(outputs))
+        self.assertIsInstance(dr.req.finished_reason, self.ns["FINISH_ABORT"])
+        self.assertEqual(
+            dr.req.finished_reason.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+        queue._commit_hicache_local_restore_to_req.assert_not_called()
+        queue.scheduler.batch_result_processor._maybe_update_reasoning_tokens.assert_not_called()
+        queue.scheduler.output_streamer.stream_output.assert_called_once_with(
+            [dr.req], False
+        )
+        self.ns["release_kv_cache"].assert_called_once_with(
+            dr.req, queue.tree_cache, is_insert=False
+        )
+        receiver.clear.assert_called_once()
+        self.assertIsNone(dr.kv_receiver)
+        self.assertEqual(queue.queue, [])
+        self.assertEqual(queue.metadata_buffers.bootstrap_room[0, 0].item(), 0)
+        self.assertEqual(queue.req_to_metadata_buffer_idx_allocator.available_size(), 1)
+        self.assertEqual(queue.pop_transferred(), [])
+        receiver.clear.assert_called_once()
+
+    def test_metadata_publishes_logical_coverage_and_overwrites_reused_slot(self):
+        buffers = self.make_buffers()
+        ptrs, sizes, item_sizes = buffers.get_buf_infos()
+        self.assertEqual(buffers.cached_tokens.shape, (1, 16))
+        self.assertEqual(buffers.cached_tokens.dtype, torch.int32)
+        self.assertEqual(ptrs[1], buffers.cached_tokens.data_ptr())
+        self.assertEqual(item_sizes[1], 64)
+        req = self.make_req(prompt_len=9, prefix_len=4, outputs=[17])
+        for end, expected in ((9, 9), (12, 9), (5, 5)):
+            with self.subTest(end=end):
+                req.extend_range.end = end
+                buffers.set_buf(req)
+                self.assertEqual(buffers.get_buf(0)[1][7].item(), expected)
+                self.assertEqual(
+                    buffers.cached_tokens[0, :7].tolist(), [4, 4, 0, 0, 0, 0, 0]
+                )
+                self.assertEqual(buffers.get_buf_infos(), (ptrs, sizes, item_sizes))
+
+    def test_correct_length_includes_cached_prefix_and_excludes_handoff(self):
+        req = self.make_req(prefix_len=4)
+        queue, dr, receiver = self.make_queue(req, 9)
+        self.assertEqual(queue.pop_transferred(), [req])
+        self.assertEqual(req.output_ids, [17])
+        self.assertIsNone(req.finished_reason)
+        self.ns["release_kv_cache"].assert_not_called()
+        receiver.clear.assert_called_once()
+
+    def test_only_final_chunk_publishes_total_coverage_before_send(self):
+        buffers = self.make_buffers()
+        req = self.make_req(prefix_len=4, outputs=[17])
+        req.kv.req_pool_idx = 0
+        req.start_send_idx = 4
+        req.disagg_decode_prefix_len = 4
+        req.disagg_kv_sender = Mock()
+        req.disagg_kv_sender.should_send_kv_chunk.return_value = True
+        prefill = SimpleNamespace(
+            enable_staging=False,
+            token_to_kv_pool_allocator=SimpleNamespace(
+                page_size=4,
+                translate_kv_indices_for_transfer=lambda indices: indices,
+            ),
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.arange(12).reshape(1, 12)
+            ),
+            disagg_metadata_buffers=buffers,
+            disagg_prefill_bootstrap_queue=SimpleNamespace(
+                kv_manager=SimpleNamespace(kv_args=SimpleNamespace(state_types=[]))
+            ),
+            disagg_prefill_pending_chunk_rids=set(),
+        )
+        sends = []
+        req.disagg_kv_sender.send.side_effect = lambda *a, **kw: sends.append(
+            (buffers.cached_tokens[0, 7].item(), kw["num_kv_tokens"])
+        )
+        self.ns["send_kv_chunk"](prefill, req, last_chunk=False)
+        self.ns["send_kv_chunk"](prefill, req, last_chunk=True)
+        self.assertEqual(sends, [(0, 4), (9, 1)])
+        self.assertEqual(req.start_send_idx, 9)
+
+    def test_stale_length_is_not_read_before_metadata_arrives(self):
+        queue, dr, receiver = self.make_queue(self.make_req(), 1)
+        queue.metadata_buffers.bootstrap_room[0, 0] = 0
+        self.assertEqual(queue.pop_transferred(), [])
+        self.assertIsNone(dr.req.finished_reason)
+        receiver.clear.assert_not_called()
+        self.ns["release_kv_cache"].assert_not_called()
+        self.assertEqual(queue.req_to_metadata_buffer_idx_allocator.available_size(), 0)
+
+    def test_rejects_short_long_delta_and_page_rounded_lengths(self):
+        for length in (1, 5, 10, 16, -1):
+            with self.subTest(length=length):
+                self.ns["release_kv_cache"].reset_mock()
+                self.assert_rejected(
+                    *self.make_queue(self.make_req(prefix_len=4), length)
+                )
+
+    def test_rebootstrap_validates_preallocated_prompt_plus_existing_outputs(self):
+        req = self.make_req(outputs=[31, 32], rebootstrap=True)
+        queue, dr, receiver = self.make_queue(req, 11)
+        self.assertEqual(queue.pop_transferred(), [req])
+        self.assertEqual(req.output_ids, [31, 32, 99])
+        self.assertIsNone(req.finished_reason)
+        req = self.make_req(outputs=[31, 32], rebootstrap=True)
+        self.assert_rejected(*self.make_queue(req, 9), outputs=[31, 32])
+        self.assertEqual(req.pd_rebootstrap_forced_output_id, 99)
+
+    def test_zero_legacy_length_fails_open_after_slot_reuse(self):
+        req = self.make_req()
+        queue, dr, receiver = self.make_queue(req, 9)
+        self.assertEqual(queue.pop_transferred(), [req])
+        # Older prefill sends the entire 16-int row, with spare slots zeroed.
+        legacy = self.make_buffers()
+        legacy.output_ids[0, 0] = 18
+        legacy.bootstrap_room[0, 0] = 43
+        for dst, src in (
+            (queue.metadata_buffers.cached_tokens, legacy.cached_tokens),
+            (queue.metadata_buffers.output_ids, legacy.output_ids),
+            (queue.metadata_buffers.bootstrap_room, legacy.bootstrap_room),
+        ):
+            dst.copy_(src)
+        self.assertEqual(queue.req_to_metadata_buffer_idx_allocator.alloc(), 0)
+        req = self.make_req(prompt_len=20)
+        req.bootstrap_room = 43
+        dr.req = req
+        dr.kv_receiver = receiver
+        queue.queue = [dr]
+        self.assertEqual(queue.pop_transferred(), [req])
+        self.assertEqual(req.output_ids, [18])
+        self.assertEqual(queue.metadata_buffers.cached_tokens[0, 7].item(), 0)
+
+    def test_fake_host_and_fake_backend_bypass_length_validation(self):
+        for host in ("2.2.2.2", None):
+            with self.subTest(host=host):
+                self.config.disaggregation_transfer_backend = "fake"
+                req = self.make_req()
+                req.bootstrap_host = host
+                queue, dr, receiver = self.make_queue(req, 1)
+                queue.metadata_buffers.bootstrap_room[0, 0] = 0
+                self.assertEqual(queue.pop_transferred(), [req])
+                self.assertIsNone(req.finished_reason)
+                self.assertEqual(len(req.output_ids), 1)
+
+    def test_length_validation_waits_for_all_ranks_to_finish_transfer(self):
+        queue, dr, receiver = self.make_queue(self.make_req(), 1)
+
+        def peer_still_transferring(tensor, op, group):
+            self.assertEqual(op, dist.ReduceOp.MIN)
+            tensor.fill_(self.poll.Transferring)
+
+        self.reduce.side_effect = peer_still_transferring
+        self.assertEqual(queue.pop_transferred(), [])
+        self.assertIsNone(dr.req.finished_reason)
+        receiver.clear.assert_not_called()
+        self.ns["release_kv_cache"].assert_not_called()
+        self.assertEqual(len(queue.queue), 1)
+
+    def test_each_rank_rejects_if_any_rank_has_wrong_length(self):
+        for staging in (False, True):
+            for local_length in (1, 9):
+                with self.subTest(staging=staging, local_length=local_length):
+                    self.ns["release_kv_cache"].reset_mock()
+                    queue, dr, receiver = self.make_queue(
+                        self.make_req(), local_length, staging
+                    )
+                    calls = []
+
+                    def consensus(tensor, op, group):
+                        self.assertEqual(op, dist.ReduceOp.MIN)
+                        self.assertIs(group, queue.gloo_group)
+                        calls.append(tensor.tolist())
+                        if len(calls) == 2:
+                            self.assertEqual(dr.req.output_ids, [])
+                            self.assertEqual(
+                                tensor.tolist(),
+                                [
+                                    self.poll.Success
+                                    if local_length == 9
+                                    else self.poll.Failed
+                                ],
+                            )
+                            tensor.fill_(self.poll.Failed)
+
+                    self.reduce.side_effect = consensus
+                    self.assert_rejected(queue, dr, receiver)
+                    self.assertEqual(len(calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_transfer_sequence_length.py
+++ b/test/registered/unit/disaggregation/test_transfer_sequence_length.py
@@ -6,11 +6,16 @@ import ast
 import enum
 import hashlib
 import logging
+import multiprocessing
 import random
 import sys
+import tempfile
+import time
+import traceback
 import unittest
 from collections import deque
 from contextlib import nullcontext
+from datetime import timedelta
 from http import HTTPStatus
 from pathlib import Path
 from types import SimpleNamespace
@@ -48,7 +53,205 @@ load_definitions(
     ROOT / "python/sglang/test/ci/ci_register.py", ["register_cpu_ci"], _ci
 )
 register_cpu_ci = _ci["register_cpu_ci"]
-register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+def run_hicache_rank(rank, init_method, results, step_barrier):
+    case = TestTransferSequenceLength()
+    phase = "initialization"
+    calls = []
+    try:
+        dist.init_process_group(
+            "gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=2,
+            timeout=timedelta(seconds=5),
+        )
+        case.setUp()
+        case.all_reduce.stop()
+        all_reduce = dist.all_reduce
+
+        def tracked_reduce(tensor, op, group):
+            calls.append(tensor.tolist())
+            return all_reduce(tensor, op=op, group=group)
+
+        restore = case.ns["HiCacheRestoreResult"]
+        scenarios = [
+            ("pending", restore.READY, restore.PENDING, "success", 9, False, False),
+            ("failed", restore.READY, restore.FAILED, "success", 9, False, True),
+            (
+                "failed_pending",
+                restore.FAILED,
+                restore.PENDING,
+                "success",
+                9,
+                False,
+                True,
+            ),
+            (
+                "failed_rdma",
+                restore.FAILED,
+                restore.READY,
+                "transferring",
+                9,
+                False,
+                True,
+            ),
+            ("failed_scatter", restore.FAILED, restore.READY, "success", 9, True, True),
+            (
+                "network_failed_pending",
+                restore.READY,
+                restore.PENDING,
+                "failed",
+                9,
+                False,
+                True,
+            ),
+            (
+                "length_pending",
+                restore.READY,
+                restore.PENDING,
+                "success",
+                1,
+                False,
+                True,
+            ),
+        ]
+        observations = []
+        with patch.object(dist, "all_reduce", side_effect=tracked_reduce):
+            for staging in (False, True):
+                for (
+                    name,
+                    left,
+                    right,
+                    network,
+                    length,
+                    scatter_pending,
+                    fails,
+                ) in scenarios:
+                    if scatter_pending and not staging:
+                        continue
+                    case.ns["release_kv_cache"].reset_mock()
+                    queue, dr, receiver = case.make_queue(
+                        case.make_req(), length if rank == 0 else 9, staging
+                    )
+                    queue.gloo_group = dist.group.WORLD
+                    queue.tp_rank = rank
+                    queue.metadata_buffers.get_buf = Mock(
+                        wraps=queue.metadata_buffers.get_buf
+                    )
+                    queue.scheduler.enable_decode_hicache = True
+                    dr.hicache_restore_status = (left, right)[rank]
+                    dr.prefix_match = SimpleNamespace(needs_local_restore=True)
+                    dr.hicache_restored_node = object()
+                    dr.hicache_load_consumer_index = 0
+                    queue.tree_cache = SimpleNamespace(
+                        is_load_back_event_done=Mock(return_value=False),
+                        cache_controller=SimpleNamespace(
+                            layer_done_counter=SimpleNamespace(
+                                producer_index=0, num_counters=2
+                            )
+                        ),
+                    )
+                    network_rank = 1 if network == "transferring" else 0
+                    receiver.poll.return_value = (
+                        {
+                            "success": case.poll.Success,
+                            "transferring": case.poll.Transferring,
+                            "failed": case.poll.Failed,
+                        }[network]
+                        if rank == network_rank
+                        else case.poll.Success
+                    )
+                    queue.staging_handler.is_done.return_value = not (
+                        scatter_pending and rank == 1
+                    )
+                    waits = (
+                        restore.PENDING in (left, right)
+                        or network == "transferring"
+                        or scatter_pending
+                    )
+                    for tick in range(2 if waits else 1):
+                        phase = (name, staging, tick)
+                        calls.clear()
+                        if tick:
+                            queue.tree_cache.is_load_back_event_done.return_value = True
+                            if network != "failed":
+                                receiver.poll.return_value = case.poll.Success
+                            queue.staging_handler.is_done.return_value = True
+                        transferred = queue.pop_transferred()
+                        waiting = waits and tick == 0
+                        expected_outcome = (
+                            "waiting" if waiting else "failed" if fails else "committed"
+                        )
+                        outcome = (
+                            "waiting"
+                            if queue.queue
+                            else "failed"
+                            if dr.req.finished_reason is not None
+                            else "committed"
+                        )
+                        state = (name, staging, tick, outcome, len(calls))
+                        # Keep the next tick from matching an omitted collective.
+                        step_barrier.wait(timeout=10)
+                        case.assertEqual(outcome, expected_outcome)
+                        if waiting:
+                            restore_gate = network == "failed" or (
+                                staging and network == "success" and not scatter_pending
+                            )
+                            expected_shapes = [1, 2] if restore_gate else [1]
+                        else:
+                            expected_shapes = (
+                                [1, 2, 1]
+                                if not fails or name == "length_pending"
+                                else [1, 2]
+                            )
+                        case.assertEqual([len(call) for call in calls], expected_shapes)
+                        if waiting:
+                            case.assertEqual(transferred, [])
+                            case.assertEqual(dr.req.output_ids, [])
+                            case.assertIsNone(dr.req.finished_reason)
+                            receiver.clear.assert_not_called()
+                            case.ns["release_kv_cache"].assert_not_called()
+                            queue._commit_hicache_local_restore_to_req.assert_not_called()
+                            queue.metadata_buffers.get_buf.assert_not_called()
+                            case.assertEqual(
+                                queue.req_to_metadata_buffer_idx_allocator.available_size(),
+                                0,
+                            )
+                        else:
+                            receiver.clear.assert_called_once()
+                            case.assertIsNone(dr.kv_receiver)
+                            case.assertEqual(
+                                queue.req_to_metadata_buffer_idx_allocator.available_size(),
+                                1,
+                            )
+                            if fails:
+                                case.assertEqual(transferred, [])
+                                case.assertEqual(dr.req.output_ids, [])
+                                case.assertEqual(
+                                    dr.req.finished_reason.status_code,
+                                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                                )
+                                case.ns["release_kv_cache"].assert_called_once_with(
+                                    dr.req, queue.tree_cache, is_insert=False
+                                )
+                                queue._commit_hicache_local_restore_to_req.assert_not_called()
+                            else:
+                                case.assertEqual(transferred, [dr.req])
+                                case.assertEqual(dr.req.output_ids, [17])
+                                case.ns["release_kv_cache"].assert_not_called()
+                        observations.append(state)
+        results.put((rank, observations, None))
+    except Exception:
+        results.put(
+            (rank, None, f"{phase=}, collectives={calls}\n{traceback.format_exc()}")
+        )
+    finally:
+        case.doCleanups()
+        if dist.is_initialized():
+            dist.destroy_process_group()
 
 
 class TestTransferSequenceLength(unittest.TestCase):
@@ -73,10 +276,15 @@ class TestTransferSequenceLength(unittest.TestCase):
                 SGLANG_TEST_DISAGG_FAILURE_PROB=Mock(get=lambda: 0),
             ),
             release_kv_cache=Mock(),
-            HiCacheRestoreResult=SimpleNamespace(READY=0, PENDING=1, FAILED=2),
+            Enum=enum.Enum,
         )
         load_definitions(
             SRT / "disaggregation/base/conn.py", ["KVPoll", "StateType"], self.ns
+        )
+        load_definitions(
+            SRT / "disaggregation/decode_hicache_mixin.py",
+            ["HiCacheRestoreResult", "HiCacheRestoreGatedKVReceiver"],
+            self.ns,
         )
         load_definitions(
             SRT / "managers/schedule_batch.py",
@@ -145,6 +353,15 @@ class TestTransferSequenceLength(unittest.TestCase):
             "pop_transferred",
         ):
             methods[name] = self.ns[name]
+        load_definitions(
+            SRT / "disaggregation/decode_hicache_mixin.py",
+            ["_process_hicache_local_restores"],
+            self.ns,
+            class_name="DecodeHiCacheTransferMixin",
+        )
+        methods["_process_hicache_local_restores"] = self.ns[
+            "_process_hicache_local_restores"
+        ]
         self.queue_type = type("DecodeTransferQueue", (), methods)
         self.poll = self.ns["KVPoll"]
         self.all_reduce = patch.object(
@@ -201,7 +418,7 @@ class TestTransferSequenceLength(unittest.TestCase):
             kv_receiver=receiver,
             metadata_buffer_index=0,
             is_rebootstrap=req.pd_rebootstrap_in_progress,
-            hicache_restore_status=0,
+            hicache_restore_status=self.ns["HiCacheRestoreResult"].READY,
         )
         queue = self.queue_type()
         queue.queue = [dr]
@@ -419,6 +636,44 @@ class TestTransferSequenceLength(unittest.TestCase):
                     self.reduce.side_effect = consensus
                     self.assert_rejected(queue, dr, receiver)
                     self.assertEqual(len(calls), 2)
+
+    @unittest.skipUnless(dist.is_gloo_available(), "requires CPU Gloo")
+    def test_two_rank_hicache_collective_order(self):
+        ctx = multiprocessing.get_context("spawn")
+        results = ctx.Queue()
+        step_barrier = ctx.Barrier(2)
+        with tempfile.TemporaryDirectory() as directory:
+            init_method = f"file://{directory}/gloo"
+            processes = [
+                ctx.Process(
+                    target=run_hicache_rank,
+                    args=(rank, init_method, results, step_barrier),
+                )
+                for rank in range(2)
+            ]
+            try:
+                for process in processes:
+                    process.start()
+                deadline = time.monotonic() + 45
+                reports = [
+                    results.get(timeout=max(0.1, deadline - time.monotonic()))
+                    for _ in processes
+                ]
+                for process in processes:
+                    process.join(timeout=5)
+                    self.assertEqual(process.exitcode, 0)
+                self.assertEqual({rank for rank, _, _ in reports}, {0, 1})
+                for _, _, error in reports:
+                    self.assertIsNone(error, error)
+                self.assertEqual(reports[0][1], reports[1][1])
+                self.assertEqual(len(reports[0][1]), 24)
+            finally:
+                for process in processes:
+                    if process.is_alive():
+                        process.kill()
+                    process.join(timeout=5)
+                results.close()
+                results.join_thread()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -6,6 +6,7 @@ token, so the over-drafted suffix is never committed to KV nor emitted.
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
@@ -117,12 +118,13 @@ def _commit_disagg_handoff(
     replayed_boundary: bool = False,
 ) -> None:
     queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    queue.gloo_group = None
     queue.scheduler = SimpleNamespace(batch_result_processor=processor)
     queue.spec_algorithm = SimpleNamespace(is_none=lambda: True)
     queue.metadata_buffers = SimpleNamespace(
         get_buf=lambda _: (
             torch.tensor([token_id], dtype=torch.long),
-            torch.zeros(7, dtype=torch.long),
+            torch.zeros(16, dtype=torch.int32),
             torch.zeros(1),
             torch.zeros(1, dtype=torch.long),
             torch.zeros(1),
@@ -148,7 +150,11 @@ def _commit_disagg_handoff(
         is_rebootstrap=replayed_boundary,
     )
 
-    queue._commit_transfer_to_req(decode_req)
+    with patch(
+        "sglang.srt.disaggregation.decode._all_reduce_polls",
+        side_effect=lambda polls, group: polls,
+    ):
+        queue._commit_transfer_to_req(decode_req)
 
 
 class TestSpecV2GrammarTruncation(CustomTestCase):

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -111,6 +111,7 @@ class TestDecodePreallocQueuePriority(unittest.TestCase):
             origin_input_ids=[1, 2, 3],
             output_ids=[],
             finished_reason=FINISH_ABORT("failed") if failed else None,
+            to_finish=None,
             return_logprob=False,
             sampling_params=SimpleNamespace(max_new_tokens=8),
             kv=ReqKvInfo(req_pool_idx=int(priority) % 8, cache_protected_len=0),


### PR DESCRIPTION
## Motivation

`Req.set_finish_with_abort()` records a pending error in `to_finish` and replaces the input with a one-token placeholder. Disaggregated admission queues must treat that request as rejected rather than continue bootstrap, allocation, or optimistic prefill as though it were valid.

This builds on #36988, which already retires aborted post-forward prefill results. It addresses remaining admission handling and adds an independent transferred-length check before decode commits a handoff.

## Modifications

- Preserve pending admission errors on decode, skip allocation and metadata publication, and reuse cleanup of the request and pending-bootstrap queues.
- Keep rejected prefill requests out of optimistic execution. Wait for bounded bootstrap readiness to discover destinations, then retire with the original error.
- Add a guarded Mooncake before-send failure notification, including protection against metadata-only sends. General sender abort behavior and in-flight transfer lifetime handling remain unchanged.
- Publish logical KV sequence coverage in spare metadata slot 7, without changing buffer layout. Validate against the preallocated decode length, including cached prefixes and rebootstrap output tokens.
- Agree on HiCache restore state and transferred-length validity across attention-TP ranks before commit or cleanup, avoiding rank-local branches that skip the new collective.
- Keep functional changes and regression tests in separate commits.

## Validation

Validated head `d1843270b8`:

```bash
uv run --python 3.12 --with torch --with numpy --with pytest --with pytest-asyncio --no-project python -m pytest \
  test/registered/unit/disaggregation/test_admission_abort.py \
  test/registered/unit/disaggregation/test_transfer_sequence_length.py \
  -q --tb=short
```

Result: **38 passed, 14 subtests passed**. Coverage includes actual `set_finish_with_abort` methods, pending admission errors, PP bootstrap ordering, metadata-only sends, legacy/fake metadata behavior, cached prefixes, rebootstrap, and resource cleanup.

The collective regression uses two real Gloo processes with bounded timeouts, covering 13 scenarios and 24 steps per rank. Other runtime components are mocked, and the focused tests load production definitions through AST extraction to avoid GPU backend imports.

File-scoped `pre-commit` and `git diff --check` passed. Broader runtime-importing suites could not collect in the local environment because dependency setup remained incomplete, ending at a missing `gguf` import. No broad-suite pass is claimed.

## Accuracy Tests

No model accuracy or live GPU/RDMA tests were run. The intended behavior for valid handoffs is unchanged; rejected admission requests retain their original error, and inconsistent handoff lengths fail before decode commit.

## Speed Tests and Profiling

Not benchmarked. The length guard adds a CPU attention-TP reduction per completed handoff. Decode HiCache adds a restore-state reduction when the transport poll is terminal. No performance improvement claim is made.

## Scope and Remaining Limits

- Metadata length zero remains unknown and intentionally fails open for compatibility with older prefill workers. Fake transfers remain exempt.
- Metadata arriving after the existing bootstrap timeout can still recreate orphaned room state. This PR does not redesign room lifetime or late-message handling.
- Separate RDMA drain/quiescence races, inherited HiCache helper ordering, and cross-PP terminal-result consensus remain outside this change.
- This is a draft pending full runtime, GPU/transport, and performance validation.

## Checklist

- [x] Format changed files with pre-commit.
- [x] Add focused regression tests and CPU CI registration.
- [x] Follow SGLang code style.
- [ ] Run broader runtime and GPU/transport tests.
- [ ] Provide accuracy and performance benchmark results.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34387680907](https://github.com/sgl-project/sglang/actions/runs/34387680907)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34387680619](https://github.com/sgl-project/sglang/actions/runs/34387680619)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34387680833](https://github.com/sgl-project/sglang/actions/runs/34387680833)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->