### PR TITLE
[Benchmark] Fix generated-prefix cache reuse across orderings

### DIFF
--- a/docs/docs/developer_guide/bench_serving.mdx
+++ b/docs/docs/developer_guide/bench_serving.mdx
@@ -117,6 +117,7 @@ Generated Shared Prefix flags (for `generated-shared-prefix`):
 - `--gsp-system-prompt-len`
 - `--gsp-question-len`
 - `--gsp-output-len`
+- `--gsp-ordered`: keep requests in generation order instead of shuffling them.
 - `--gsp-group-distribution {uniform,zipf}`: per-request prefix-group sampling distribution (default: `uniform`). With `zipf`, each request's group is sampled by rank with `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)`; rank starts at 1 and group index 0 is the hottest. The on-disk dataset cache uses a distinct key per `(group_distribution, zipf_alpha)`, so uniform-mode caches are never mixed with zipf-mode caches.
 - `--gsp-zipf-alpha FLOAT`: Zipf exponent for `--gsp-group-distribution=zipf`. Must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups. Required when the distribution is `zipf`; must be omitted otherwise.
 
@@ -377,7 +378,7 @@ python3 -m sglang.bench_serving \
 
 `zipf` mode samples each request's prefix group from the rank-based distribution `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)` with rank starting at 1, so group index 0 is the hottest. The total request count stays `num_groups * prompts_per_group` — identical to `uniform` mode — and only the per-request group assignment changes. `alpha` must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups.
 
-The on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` includes `group_distribution` and `zipf_alpha` in its key, so uniform-mode and zipf-mode runs (or two zipf runs with different alpha) never share a cache file. Uniform-mode filenames are unchanged from the legacy format, so existing caches remain valid.
+The on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` includes request ordering, `group_distribution`, and `zipf_alpha` in its key. Ordered and shuffled runs, uniform and zipf runs, and different Zipf exponents use separate files. Legacy files without an ordering marker are not reused; the dataset is regenerated for each ordering mode.
 
 This flag controls prefix-popularity shape only. It does not by itself reproduce any production trace or guarantee an observed cache-hit rate for a given engine.
 

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -130,18 +130,21 @@ def get_gen_prefix_cache_path(
     tokenizer,
     group_distribution: str = "uniform",
     zipf_alpha: Optional[float] = None,
+    ordered: Optional[bool] = None,
 ):
-    """Create cache directory under ~/.cache/sglang/benchmark.
+    """Build a cache path under ~/.cache/sglang/benchmark.
 
-    The uniform-mode filename is preserved exactly as before so existing
-    on-disk caches remain valid. Non-default sampling modes get an extra
-    suffix encoding the parameters that affect the cached payload.
+    Ordered and shuffled variants do not reuse legacy caches whose ordering
+    is unknown. Leaving ordered unset preserves the legacy path used by the
+    HiCache benchmark.
     """
     cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
 
     suffix = ""
     if group_distribution != "uniform":
         suffix = f"_{group_distribution}_{zipf_alpha}"
+    if ordered is not None:
+        suffix += "_ordered" if ordered else "_shuffled"
 
     cache_key = (
         f"gen_shared_prefix_{seed}_{num_groups}_{prompts_per_group}_"
@@ -190,6 +193,7 @@ def sample_generated_shared_prefix_requests(
         tokenizer,
         group_distribution=group_distribution,
         zipf_alpha=zipf_alpha,
+        ordered=ordered,
     )
     # range_ratio != 1 / num_turns > 1 perturb the payload but are not in the
     # cache key; send_routing_key embeds a per-run uuid + timestamp that is

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -1116,6 +1116,35 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         self.assertTrue(path.name.endswith(".pkl"))
         self.assertEqual(path.parent, Path.home() / ".cache" / "sglang" / "benchmark")
 
+    def test_gsp_cache_respects_ordering(self):
+        shuffled_rows = self._run_gsp(ordered=False)
+        rows = self._run_gsp(ordered=True)
+
+        with patch(
+            "sglang.benchmark.datasets.generated_shared_prefix.Path.home",
+            return_value=self.tmpdir_path / "fresh",
+        ):
+            expected = self._run_gsp(ordered=True)
+
+        self.assertEqual(self._row_fields(rows), self._row_fields(expected))
+
+        # Pre-upgrade ordered caches must not contaminate shuffled runs either.
+        legacy_path = get_gen_prefix_cache_path(
+            seed=42,
+            num_groups=4,
+            prompts_per_group=5,
+            system_prompt_len=4,
+            question_len=3,
+            output_len=2,
+            tokenizer=self.tokenizer,
+        )
+        with open(legacy_path, "wb") as f:
+            pickle.dump(expected, f)
+        self.assertEqual(
+            self._row_fields(self._run_gsp(ordered=False)),
+            self._row_fields(shuffled_rows),
+        )
+
     def test_zipf_group_probs_helper(self):
         # Rank-based probability vector: weight(rank) = 1 / rank ** alpha,
         # normalized to sum to 1, with rank starting at 1.
@@ -1275,6 +1304,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 question_len=common["question_len"],
                 output_len=common["output_len"],
                 tokenizer=self.tokenizer,
+                ordered=common["ordered"],
             )
             zipf_path_a = get_gen_prefix_cache_path(
                 seed=common["seed"],
@@ -1286,6 +1316,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 tokenizer=self.tokenizer,
                 group_distribution="zipf",
                 zipf_alpha=1.5,
+                ordered=common["ordered"],
             )
             zipf_path_b = get_gen_prefix_cache_path(
                 seed=common["seed"],
@@ -1297,6 +1328,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 tokenizer=self.tokenizer,
                 group_distribution="zipf",
                 zipf_alpha=2.0,
+                ordered=common["ordered"],
             )
             self.assertNotEqual(uniform_path, zipf_path_a)
             self.assertNotEqual(zipf_path_a, zipf_path_b)


### PR DESCRIPTION
## Motivation

I fixed a `generated-shared-prefix` cache collision: the key omitted `--gsp-ordered`, so an ordered run could reuse shuffled rows, or a shuffled run could reuse ordered rows.

## Modifications

I separated the dataset cache files by ordering mode and excluded legacy entries whose ordering is unknown. I left the HiCache benchmark's legacy cache path unchanged, added a regression test for both directions, and updated the benchmark documentation.

I checked #37359. It adds prefix metadata and prewarming, but does not distinguish ordered and shuffled cache files. These fixes are complementary, though they touch the same generator, tests, and documentation.

## Tests

- `python test/registered/bench_fn/test_benchmark_datasets_api.py`: 46 CPU tests passed.
- The public `get_dataset` path passed cold-cache and opposite-order warm-cache checks for both orderings and uniform/Zipf distributions.
- `pre-commit run --all-files`: passed.
- From `docs/`, `npx --yes mint validate` and `npx --yes mint broken-links`: passed.
- Accuracy and inference-speed benchmarks are not applicable; this changes dataset cache selection, not model or kernel execution.

Could an authorized maintainer start CI with `/tag-and-rerun-ci`?

I used OpenAI Codex for AI assistance; this has been manually reviewed. I reviewed every changed line and understand the change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34379925845](https://github.com/sgl-project/sglang/actions/runs/34379925845)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34379925180](https://github.com/sgl-project/sglang/actions/runs/34379925180)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34379925525](https://github.com/sgl-project/sglang/actions/runs/34379925525)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->