### PR TITLE
fix(sampling): reject empty stop strings in normalize()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -296,6 +296,11 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
         else:
             if isinstance(self.stop_strs, str):
                 self.stop_strs = [self.stop_strs]
+            if "" in self.stop_strs:
+                # An empty stop string matches every position ("x" in any
+                # tail is True), causing generation to stop after one token
+                # and the detokenizer to return an empty string.
+                raise ValueError("stop cannot contain an empty string.")
             if len(self.stop_strs) > MAX_STOP_COUNT:
                 raise ValueError(
                     f"at most {MAX_STOP_COUNT} stop strings are allowed, "


### PR DESCRIPTION
## Summary

An empty string in `stop` was never validated. Python's `in` operator returns `True` for `'' in any_string`, so generation stopped after **one token** (matched empty stop), and the detokenizer returned an **empty string** (`output.find('')` = 0 → `output[:0]`). Streaming was similarly suppressed.

vLLM rejects the same input with `raise ValueError('stop cannot contain an empty string.')` — this PR brings SGLang to parity.

## Repro

```python
tail_str = 'Hello'; stop_str = ''
print(stop_str in tail_str)        # True → finishes on first token
print('Hello'[:'Hello'.find('')])  # '' → empty output
```

Docs-only fix (validation added at normalization time; no behavior change for valid inputs).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34386768569](https://github.com/sgl-project/sglang/actions/runs/34386768569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34386768281](https://github.com/sgl-project/sglang/actions/runs/34386768281)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34386768521](https://github.com/sgl-project/sglang/actions/runs/34386768521)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->