### PR TITLE
[router] Raise chat body cap to 100 MiB for multimodal payloads

### DIFF
--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -107,14 +107,16 @@ fn prefill_policy_reason(
     }
 }
 
-/// Per-route body-size cap on `/v1/chat/completions`. 5 MiB accommodates a
-/// long context — a ~1 M-token context tokenized as JSON fits under this —
-/// while preventing a hostile client from forcing the router to
-/// heap-allocate hundreds of MiB before forwarding. The cap is wired in
-/// `crate::server::app::build_router` as a route-level `DefaultBodyLimit`
-/// layer; axum's `Bytes` extractor enforces it and returns 413
-/// PAYLOAD_TOO_LARGE before this handler runs.
-pub const MAX_CHAT_BODY_BYTES: usize = 5 << 20;
+/// Per-route body-size cap on `/v1/chat/completions`. 100 MiB accommodates a
+/// long text context AND multimodal requests, whose base64-encoded image or
+/// audio payloads dwarf any text body — a handful of high-resolution images
+/// alone runs to several MiB. It bounds a SINGLE request's body; the tokenize
+/// path holds roughly three copies of it, and nothing here bounds how many
+/// requests buffer concurrently, so this is not an aggregate memory bound.
+/// The cap is wired in `crate::server::app::build_router` as a route-level
+/// `DefaultBodyLimit` layer; axum's `Bytes` extractor enforces it and returns
+/// 413 PAYLOAD_TOO_LARGE before this handler runs.
+pub const MAX_CHAT_BODY_BYTES: usize = 100 << 20;
 
 /// Minimal probe over the request body — we only need the `stream` field
 /// and the `model` field to decide between buffered vs SSE forwarding and
@@ -253,10 +255,13 @@ pub async fn chat_completions(
     //   * Bucket routing also needs the prompt token count.
     //
     // When none holds, `parse_probe`'s minimal probe is enough, so we keep
-    // avoiding the full `serde_json::Value` allocation over a (up to 1 MiB)
-    // body. When parsed, this single value is reused for the routing
-    // tokenization and the outgoing-body injection below (and PD bootstrap
-    // injection). `parse_probe` already validated the object shape.
+    // avoiding the full `serde_json::Value` allocation over a body that may
+    // run to `MAX_CHAT_BODY_BYTES`. That parse is ADDITIVE with the buffered
+    // body and with the re-serialized outgoing body, so this path holds
+    // roughly three copies of a large request at once. When parsed, this
+    // single value is reused for the routing tokenization and the
+    // outgoing-body injection below (and PD bootstrap injection).
+    // `parse_probe` already validated the object shape.
     let want_tokens = should_tokenize_request(
         ctx.tokenizers.has_chat_encoder(&model_str),
         policy.needs_request_tokens(),

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -590,6 +590,64 @@ async fn oversized_request_body_returns_413() {
 }
 
 #[tokio::test]
+async fn multimodal_sized_body_reaches_the_worker() {
+    // Regression: multimodal requests carry base64-encoded image/audio
+    // payloads that dwarf any text body — a 3x1080p-image benchmark request
+    // runs to ~8.5 MiB. A cap sized for text context alone rejects every one
+    // of them with 413 at the `DefaultBodyLimit` layer, before the handler
+    // runs, so the router must admit a body of that magnitude.
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx);
+
+    // 8 MiB of base64, standing in for a handful of high-resolution images.
+    let image_b64 = "A".repeat(8 << 20);
+    let body = serde_json::to_vec(&serde_json::json!({
+        "model": "tiny",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is in this image?"},
+                {"type": "image_url", "image_url": {
+                    "url": format!("data:image/png;base64,{image_b64}"),
+                }},
+            ],
+        }],
+        "stream": false,
+    }))
+    .unwrap();
+    // Deliberately NOT asserting `body.len() <= MAX_CHAT_BODY_BYTES` first: at
+    // a too-small cap that fires before the request is sent, and reads as
+    // "shrink your test body" — pointing a bisecting reader at un-fixing the
+    // bug. Letting the request through makes `DefaultBodyLimit` produce the
+    // real 413 and the status assertion below report it.
+    let sent_len = body.len();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "multimodal-sized body must reach the handler; got: {}",
+        res.status(),
+    );
+    // Whole, not truncated — a cap that clips the payload is as broken as one
+    // that rejects it. Exact-length equality holds because this fixture takes
+    // the pass-through path (round-robin, no chat encoder, no buckets), so
+    // `build_outgoing_body` forwards the original bytes without re-serializing.
+    let captured = worker.captured.lock().unwrap();
+    assert_eq!(
+        captured.last_body.as_ref().map(|b| b.len()),
+        Some(sent_len),
+        "worker must receive the full multimodal body",
+    );
+}
+
+#[tokio::test]
 async fn chat_rejects_null_body_400() {
     // Regression: a JSON `null` body is syntactically valid JSON but is NOT
     // a chat-completions request shape. The router must reject it with 400

--- a/experimental/sgl-router/tests/proxy/common/mock_worker.rs
+++ b/experimental/sgl-router/tests/proxy/common/mock_worker.rs
@@ -4,7 +4,7 @@
 //! Minimal axum mock of an SGLang HTTP worker for routing tests.
 
 use axum::body::Body;
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -60,6 +60,12 @@ impl MockWorker {
         let app = axum::Router::new()
             .route("/v1/chat/completions", post(chat))
             .route("/server_info", get(serve_tiny_server_info))
+            // The router's own cap is what this suite exercises, so the mock
+            // must not impose a second one: axum's 2 MiB default would 413 a
+            // forwarded multimodal body here, before the assertion could see
+            // what the router did. Only `start` needs this today; the other
+            // constructors keep the default and serve small bodies.
+            .layer(DefaultBodyLimit::disable())
             .with_state(state);
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## Motivation

The 5 MiB `/v1/chat/completions` body cap introduced in #28742 was sized for
text context only — its rationale comment reads *"a ~1 M-token context
tokenized as JSON fits under this"*.

Multimodal requests break that assumption. They carry base64-encoded image and
audio payloads that dwarf any text body: a handful of high-resolution images
alone runs to several MiB, and an observed 3×1080p-image benchmark request is
~8.5 MiB. Those requests are rejected at axum's `DefaultBodyLimit` layer with
413 PAYLOAD_TOO_LARGE before `chat_completions` ever runs, so the router cannot
serve a multimodal model at realistic image resolutions at all.

## Modifications

- `MAX_CHAT_BODY_BYTES`: `5 << 20` → `100 << 20`.
- Update the rationale comment, which argued for the text-only sizing — and
  drop its claim that the cap bounds router heap, because it does not (see
  **Memory exposure** below).
- Correct a second, unrelated stale comment in the same handler describing the
  body as "up to 1 MiB" — a size the cap has not enforced since #28742. It now
  refers to `MAX_CHAT_BODY_BYTES` rather than restating a literal that drifts.

### Tests

New `multimodal_sized_body_reaches_the_worker` in
`tests/proxy/chat_routing.rs`: builds an ~8 MiB multimodal request (text part +
a base64 `image_url` data URL) and asserts it reaches the handler and arrives at
the worker **whole** — a cap that truncates would be as broken as one that
rejects. At the old cap it fails with `got: 413 Payload Too Large`.

It deliberately does *not* pre-assert that the body fits under the cap. Such a
check fires before the request is sent and reads as "shrink your test body",
pointing someone bisecting a revert at un-fixing the bug; letting the request
through makes the real `DefaultBodyLimit` produce the correct diagnosis.

The mock worker needed `DefaultBodyLimit::disable()`: it is a plain
`axum::Router`, so axum's own 2 MB default would have 413'd the forwarded body
at the *mock*, masking what the router's cap actually did. Verified across all
~100 `MockWorker::start` call sites that no existing test relies on a mock-side
413.

The existing `oversized_request_body_returns_413` is written against
`MAX_CHAT_BODY_BYTES + 1`, so it tracks the new cap without edits and still
passes.

## Memory exposure — please read before approving

The old comment claimed this constant "bound[s] the heap a hostile client can
force the router to allocate". That was already generous and is now wrong in
two ways, so the comment no longer says it:

- **It bounds one request, not the router.** On the tokenize path a single body
  is held roughly three times over — the buffered `Bytes`, the
  `serde_json::Value` parsed from it at `chat.rs:266`, and the re-serialized
  outgoing body at `chat.rs:1282`. The real per-request ceiling this authorizes
  is ~300 MiB, not 100 MiB.
- **Nothing bounds concurrency.** `build_router` installs no
  `ConcurrencyLimitLayer`, no load shed, and no body-read timeout, and
  `request_timeout_secs` is the *upstream* timeout, not a client-body deadline.
  N slow clients each holding a partial body is unbounded in N.

Landing it anyway, for two reasons: the cap is route-scoped — it is attached to
`/v1/chat/completions` only, and `/v1/tokenize`, `/v1/detokenize` and
`/flush_cache` keep axum's 2 MiB default — and the alternative is a total
outage for multimodal traffic. A bounded ingress (concurrency limit + body-read
timeout) is the actual fix and deserves its own PR rather than riding along
with a constant change.

Two adjacent pre-existing issues this makes more reachable, neither addressed
here: `estimate_prefill_tokens` uses `body.len() / 4`, so a large multimodal
body registers a phantom multi-million-token load; and on a chat-encoder model
a template that stringifies `content` would feed base64 image data to the
tokenizer synchronously on a runtime thread.

## Accuracy Tests

N/A — no model-output path is touched.

## Speed Tests and Profiling

N/A. The cap is a ceiling, not an allocation: axum allocates the actual body
size, so unchanged request shapes allocate exactly as before.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4BwRMwyC4FrVZva8f8iJ

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34395786108](https://github.com/sgl-project/sglang/actions/runs/34395786108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34395785787](https://github.com/sgl-project/sglang/actions/runs/34395785787)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->