### PR TITLE
[router] Honor HF_TOKEN when downloading a gated tokenizer repo

### DIFF
--- a/experimental/sgl-router/src/tokenizer/adapter.rs
+++ b/experimental/sgl-router/src/tokenizer/adapter.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use dynamo_tokenizers::{traits::DecodeResult, Tokenizer};
+use std::env::VarError;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -12,9 +13,11 @@ use std::sync::Arc;
 /// An existing local file (or anything with a filesystem-path shape) is
 /// loaded directly via `Tokenizer::from_file`. Otherwise `source` is treated
 /// as a HuggingFace repo id and its `tokenizer.json` is downloaded (once, at
-/// startup) into the HF cache, honoring `HF_TOKEN` / `HF_HOME` /
-/// `HF_HUB_OFFLINE`. `dynamo_tokenizers` itself has no HF-download path, so
-/// the fetch is done here via `hf-hub`.
+/// startup) into the HF cache, honoring `HF_HOME`, `HF_ENDPOINT` and
+/// `HF_TOKEN` — `hf-hub` reads the first two, `hf_token_override` below reads
+/// the third. `hf-hub` 0.4 has no offline mode, so `HF_HUB_OFFLINE` is NOT
+/// honored. `dynamo_tokenizers` itself has no HF-download path, so the
+/// fetch is done here via `hf-hub`.
 pub fn load(source: &str) -> Result<Arc<Tokenizer>> {
     if Path::new(source).is_file() || looks_like_path(source) {
         return Tokenizer::from_file(source)
@@ -45,14 +48,15 @@ fn looks_like_path(source: &str) -> bool {
 
 /// Download `tokenizer.json` for a HuggingFace repo id and return the cached
 /// local path, adding an actionable error context. The actual fetch (blocking
-/// `ureq`, `from_env` so `HF_TOKEN` / `HF_HOME` / endpoint overrides apply)
-/// lives in [`download_repo_file`].
+/// `ureq`, `from_env` for the `HF_HOME` / `HF_ENDPOINT` overrides plus an
+/// explicit `HF_TOKEN` read) lives in [`download_repo_file`].
 fn download_tokenizer_json(repo_id: &str) -> Result<std::path::PathBuf> {
     download_repo_file(repo_id, "tokenizer.json").with_context(|| {
         format!(
             "download tokenizer.json for HuggingFace repo {repo_id:?} \
              (pass --tokenizer-path with a local tokenizer.json, or set HF_TOKEN \
-             for a gated/private repo)"
+             to a valid token for a gated/private repo — a blank or malformed \
+             HF_TOKEN is ignored with a startup warning)"
         )
     })
 }
@@ -61,12 +65,60 @@ fn download_tokenizer_json(repo_id: &str) -> Result<std::path::PathBuf> {
 /// Shared by `tokenizer.json` (required) and `tokenizer_config.json` (optional).
 fn download_repo_file(repo_id: &str, file: &str) -> Result<std::path::PathBuf> {
     use hf_hub::api::sync::ApiBuilder;
-    let api = ApiBuilder::from_env()
+    let mut builder = ApiBuilder::from_env();
+    if let Some(token) = hf_token_override(std::env::var("HF_TOKEN")) {
+        builder = builder.with_token(Some(token));
+    }
+    let api = builder
         .build()
         .context("initialize HuggingFace Hub client")?;
     api.model(repo_id.to_string())
         .get(file)
         .with_context(|| format!("download {file} for HuggingFace repo {repo_id:?}"))
+}
+
+/// Resolve `HF_TOKEN` into a token override, or `None` to leave alone whatever
+/// token `hf-hub` already resolved.
+///
+/// hf-hub 0.4's `ApiBuilder::from_env()` reads `HF_HOME` and `HF_ENDPOINT` but
+/// NOT `HF_TOKEN`; its only token source is the `$HF_HOME/token` file written
+/// by `huggingface-cli login`, so a gated repo 401s with `HF_TOKEN` exported.
+///
+/// `None` means "leave the existing token alone", never "no token".
+/// `with_token` OVERWRITES, so passing `None` through to it would clobber the
+/// file-based token — which is why the caller must keep the `if let`.
+fn hf_token_override(var: Result<String, VarError>) -> Option<String> {
+    let ignored = |reason: &str| {
+        tracing::warn!(
+            "HF_TOKEN is set but {reason}; ignoring it and falling back to $HF_HOME/token \
+             or anonymous access (gated/private repos will 401)"
+        );
+        None
+    };
+    match var {
+        // Trimmed: a surrounding space rides through ureq's header validation
+        // and 401s at HF indistinguishably from sending no token at all.
+        Ok(token) => match token.trim() {
+            "" => ignored("empty or whitespace-only"),
+            // ureq validates header values before sending and puts the WHOLE
+            // offending line — token included — in the error it returns, which
+            // reaches stderr. Reject here so a malformed token can never be
+            // echoed. Legal header bytes are ' ', '\t' and 0x21..=0x7E; after
+            // trimming, anything outside 0x21..=0x7E is a broken secret mount.
+            t => match t.bytes().position(|b| !(0x21..=0x7E).contains(&b)) {
+                // Never interpolate the token itself: offset and byte value
+                // are enough to find an embedded newline or a stray CR.
+                Some(i) => ignored(&format!(
+                    "not a valid HTTP header value (byte {:#04x} at offset {i})",
+                    t.as_bytes()[i]
+                )),
+                None => Some(t.to_string()),
+            },
+        },
+        Err(VarError::NotUnicode(_)) => ignored("not valid UTF-8"),
+        // Genuinely unset is the legitimate token-file / public-repo path.
+        Err(VarError::NotPresent) => None,
+    }
 }
 
 /// Load the `tokenizer_config.json` co-located with the tokenizer named by
@@ -136,4 +188,68 @@ pub fn decode_complete(t: &Tokenizer, ids: &[u32], skip_special: bool) -> Result
             s
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hf_token_override;
+    use std::env::VarError;
+
+    #[test]
+    fn unset_hf_token_yields_no_override() {
+        // Load-bearing: `with_token` OVERWRITES, so an unset HF_TOKEN must
+        // produce no override at all. Passing `None` through would clobber the
+        // $HF_HOME/token value `from_env` already resolved.
+        assert_eq!(hf_token_override(Err(VarError::NotPresent)), None);
+    }
+
+    #[test]
+    fn set_hf_token_overrides() {
+        assert_eq!(
+            hf_token_override(Ok("hf_abc123".into())),
+            Some("hf_abc123".to_string()),
+        );
+    }
+
+    #[test]
+    fn hf_token_is_trimmed() {
+        // Secret mounts can leave trailing whitespace on the value. A trailing
+        // space or tab is a LEGAL header byte, so untrimmed it rides through
+        // ureq's validation and HF rejects it with the same 401 a missing
+        // token gives. A trailing newline would instead trip ureq's local
+        // header validation — see token_with_invalid_header_byte_yields_no_override.
+        assert_eq!(
+            hf_token_override(Ok("  hf_abc123\n".into())),
+            Some("hf_abc123".to_string()),
+        );
+    }
+
+    #[test]
+    fn blank_hf_token_yields_no_override() {
+        assert_eq!(hf_token_override(Ok(String::new())), None);
+        assert_eq!(hf_token_override(Ok("  \n\t ".into())), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_hf_token_yields_no_override() {
+        use std::os::unix::ffi::OsStringExt;
+        let bad = std::ffi::OsString::from_vec(vec![0xff, 0xfe]);
+        assert_eq!(hf_token_override(Err(VarError::NotUnicode(bad))), None);
+    }
+
+    #[test]
+    fn token_with_invalid_header_byte_yields_no_override() {
+        // A newline INSIDE the value survives trimming and would reach ureq,
+        // which rejects it and quotes the whole `authorization: Bearer <tok>`
+        // line into an error that lands on stderr. Rejecting here is what
+        // keeps the credential out of the logs.
+        for bad in ["hf_abc\ndef", "hf_abc\rdef", "hf_abc\u{7f}def", "hf_é_abc"] {
+            assert_eq!(
+                hf_token_override(Ok(bad.to_string())),
+                None,
+                "must reject a token carrying a byte illegal in a header value: {bad:?}",
+            );
+        }
+    }
 }

--- a/experimental/sgl-router/tests/hf_token_download.rs
+++ b/experimental/sgl-router/tests/hf_token_download.rs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end checks that the right token reaches the HuggingFace request.
+//!
+//! Own test binary, and deliberately ONE `#[test]`: these mutate process-wide
+//! environment (`HF_HOME`, `HF_ENDPOINT`, `HF_TOKEN`). A second `#[test]` here
+//! would run on another thread of the SAME process and race them. Keep the
+//! assertions sequential inside this one test.
+//!
+//! The hub is mocked on loopback via `HF_ENDPOINT`, so no network and no
+//! credentials are needed.
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, Uri};
+use std::net::SocketAddr;
+use std::sync::{mpsc, Arc, Mutex};
+
+/// Every request the mock hub saw, as `(uri, authorization header)`.
+type SeenRequests = Arc<Mutex<Vec<(String, Option<String>)>>>;
+
+async fn capture(State(seen): State<SeenRequests>, uri: Uri, headers: HeaderMap) -> StatusCode {
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    seen.lock().unwrap().push((uri.to_string(), auth));
+    // 404 every path: we assert on what went out, not on a successful
+    // download, so the mock never has to serve a real tokenizer blob.
+    StatusCode::NOT_FOUND
+}
+
+/// Start a loopback stand-in for huggingface.co and return its base URL.
+/// The server thread is detached; it dies with the test process.
+fn start_mock_hub(seen: SeenRequests) -> String {
+    let (tx, rx) = mpsc::channel::<SocketAddr>();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            tx.send(listener.local_addr().unwrap()).unwrap();
+            let app = axum::Router::new().fallback(capture).with_state(seen);
+            axum::serve(listener, app).await.unwrap();
+        });
+    });
+    format!("http://{}", rx.recv().unwrap())
+}
+
+fn auths(seen: &SeenRequests) -> Vec<Option<String>> {
+    seen.lock()
+        .unwrap()
+        .iter()
+        .map(|(_, a)| a.clone())
+        .collect()
+}
+
+#[test]
+fn hf_token_reaches_the_hub_without_clobbering_the_token_file() {
+    // hf-hub's agent honors ALL_PROXY / HTTPS_PROXY / HTTP_PROXY
+    // (`try_proxy_from_env(true)`). An ambient proxy would divert the loopback
+    // request and fail this test with a misleading "endpoint not honored".
+    for proxy in [
+        "ALL_PROXY",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "all_proxy",
+        "https_proxy",
+        "http_proxy",
+    ] {
+        std::env::remove_var(proxy);
+    }
+
+    // Empty HF_HOME: no `$HF_HOME/token` file yet, so a token on the wire in
+    // part 1 can ONLY have come from HF_TOKEN. Set before the server thread
+    // starts — `setenv` is not thread-safe, so keep the window narrow.
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("HF_HOME", home.path());
+    // Surrounding whitespace is what a secret mount can leave behind; it must
+    // be trimmed off before it reaches the header.
+    std::env::set_var("HF_TOKEN", "  hf_test_token\n");
+
+    let seen: SeenRequests = Arc::new(Mutex::new(Vec::new()));
+    let endpoint = start_mock_hub(Arc::clone(&seen));
+    std::env::set_var("HF_ENDPOINT", &endpoint);
+
+    // --- Part 1: HF_TOKEN is honored at all. -----------------------------
+    // Regression: hf-hub 0.4's `ApiBuilder::from_env()` reads HF_HOME and
+    // HF_ENDPOINT but NOT HF_TOKEN, so without an explicit read a gated repo
+    // 401s with the token correctly exported.
+    //
+    // The mock 404s, so the load fails; the assertion is on the request.
+    let _ = sgl_router::tokenizer::adapter::load("fake-org/fake-repo");
+
+    let got = auths(&seen);
+    assert!(
+        !got.is_empty(),
+        "no request reached the mock hub — either HF_ENDPOINT was not honored, \
+         or the Authorization value was rejected locally by ureq's header validation",
+    );
+    // Every request, not just the first: hf-hub may issue metadata and blob
+    // requests, and all of them must be authenticated.
+    assert!(
+        got.iter()
+            .all(|a| a.as_deref() == Some("Bearer hf_test_token")),
+        "HF_TOKEN must be sent as a trimmed bearer token on every hub request; got: {got:?}",
+    );
+
+    // --- Part 2: an unset HF_TOKEN must NOT clobber the token file. ------
+    // This is the load-bearing half. `with_token` OVERWRITES, so collapsing
+    // the caller's `if let` into `with_token(hf_token_override(..))` type-checks,
+    // reads cleaner, and silently drops the file-based token on every
+    // `huggingface-cli login` deployment. Every unit test still passes under
+    // that refactor; only this assertion catches it.
+    std::fs::write(home.path().join("token"), "hf_file_token\n").unwrap();
+    std::env::remove_var("HF_TOKEN");
+    seen.lock().unwrap().clear();
+
+    let _ = sgl_router::tokenizer::adapter::load("fake-org/fake-repo-two");
+
+    let got = auths(&seen);
+    assert!(!got.is_empty(), "no request reached the mock hub in part 2");
+    assert!(
+        got.iter()
+            .all(|a| a.as_deref() == Some("Bearer hf_file_token")),
+        "with HF_TOKEN unset, hf-hub's $HF_HOME/token value must survive; got: {got:?}",
+    );
+}


### PR DESCRIPTION
## Motivation

`--model-id` pointing at a gated or private HuggingFace tokenizer repo 401s at
router startup even when `HF_TOKEN` is correctly exported.

`src/tokenizer/adapter.rs` builds its client with
`ApiBuilder::from_env().build()`. In `hf-hub` 0.4, `from_env()` reads **only**
`HF_HOME` (via `Cache::from_env`) and `HF_ENDPOINT` — it never looks at
`HF_TOKEN`. Its only token source is `Cache::token()`, which reads the
`$HF_HOME/token` file written by `huggingface-cli login`:

```rust
// hf-hub-0.4.3/src/api/sync.rs
pub fn from_env() -> Self {
    let cache = Cache::from_env();          // HF_HOME only
    let mut builder = Self::from_cache(cache);
    if let Ok(endpoint) = std::env::var(HF_ENDPOINT) { … }
    builder
}
```

Environment is how a token is supplied in every containerized deployment, where
nobody has run the CLI, so this is the common path rather than an edge case.
The existing error text already tells operators to *"set `HF_TOKEN` for a
gated/private repo"* — advice the code does not honor.

## Modifications

`download_repo_file` now reads `HF_TOKEN` itself and passes it via
`with_token`. Two details are load-bearing and are why this is not a one-liner:

- **Override only when the variable holds a value.** `with_token` overwrites
  unconditionally (`self.token = token`), so calling it with `None` would
  clobber the file-based token `from_env` already resolved — turning a working
  `huggingface-cli login` setup into an anonymous one. The resolution returns
  `None` to mean "leave hf-hub's token alone", never "no token".
- **Reject a token carrying a byte illegal in an HTTP header value.** ureq
  validates header values before sending and puts the *whole* offending line —
  token included — into the error it returns (`ureq-2.12.1/src/header.rs:141-147`
  formats `"invalid header '{}'"` from the full `authorization: Bearer <tok>`
  line). That propagates through hf-hub → anyhow → `main` → **stderr**, so a
  secret mounted with an embedded newline would print the credential straight
  into startup logs. The warning names the offending byte and its offset and
  never echoes the value.
- **Trim.** A surrounding space rides through ureq's validation and 401s at HF
  indistinguishably from sending no token at all.

A set-but-blank or non-UTF-8 value warns rather than silently falling back to
anonymous: both are almost always a broken interpolation the operator intended
as auth, and a silent fallback reappears as a confusing 401. A genuinely unset
variable stays silent — that is the legitimate token-file / public-repo path.

`README.md` and `--model-id`'s own help text already told operators the
download honors `HF_TOKEN`. This PR makes two pre-existing documentation
claims true, rather than only fixing its own comments.

Also corrects two doc comments that described the behavior this PR is adding:
both claimed `from_env` applies `HF_TOKEN`, and the `load` doc additionally
claimed `HF_HUB_OFFLINE` is honored. `hf-hub` 0.4 has no offline mode at all
(the string appears nowhere in the crate), so that claim is now stated as a
non-feature rather than silently dropped.

### Tests

`tests/hf_token_download.rs` points `HF_ENDPOINT` at a loopback mock hub (no
network, no credentials) and asserts both halves of the contract in a single
process-env-mutating test:

1. A whitespace-padded `HF_TOKEN` arrives trimmed as `Authorization: Bearer` on
   **every** hub request. Against the current code this fails with `got: None` —
   no Authorization header at all.
2. With `HF_TOKEN` unset, an `$HF_HOME/token` value still survives.

Part 2 is the load-bearing one. Collapsing the caller's `if let` into
`builder.with_token(hf_token_override(std::env::var("HF_TOKEN")))` type-checks,
reads cleaner, is exactly what a simplification pass would propose — and
silently drops the file-based token on every `huggingface-cli login`
deployment. Verified: under that refactor part 2 fails with
`got: [None]` while all six unit tests stay green.

Unit tests cover the resolution contract directly, including rejection of
tokens carrying bytes illegal in a header value.

## Accuracy Tests

N/A — startup-time tokenizer download only; no model-output path is touched.

## Speed Tests and Profiling

N/A — one `std::env::var` read per repo file at startup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM4BwRMwyC4FrVZva8f8iJ

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34651276604](https://github.com/sgl-project/sglang/actions/runs/34651276604)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34651276456](https://github.com/sgl-project/sglang/actions/runs/34651276456)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->