### PR TITLE
[Fix] Size routed expert capture buffers for speculative verification

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -215,6 +215,8 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     enable_show_time_cost,
     get_available_gpu_memory,
+    get_cuda_graph_max_batch_size,
+    get_eager_max_batch_size,
     is_host_cpu_arm64,
     is_npu,
     numa_utils,
@@ -1102,7 +1104,13 @@ class ModelRunner:
                 model=self.model,
                 model_config=self.model_config,
                 num_tokens=self.max_token_pool_size + self.page_size,
-                max_running_requests=self.max_running_requests,
+                max_decode_tokens=max(
+                    get_eager_max_batch_size(self.max_running_requests),
+                    get_cuda_graph_max_batch_size(self.req_to_token_pool.size),
+                )
+                * self.decode_num_tokens_per_req(
+                    num_draft_tokens=max_speculative_num_draft_tokens()
+                ),
                 device=self.device,
             )
         )

--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -43,7 +43,7 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         model: torch.nn.Module,
         model_config: ModelConfig,
         num_tokens: int,
-        max_running_requests: int,
+        max_decode_tokens: int,
         device: str,
     ) -> Optional["RoutedExpertsCapturer"]:
         if not get_exec().features.enable_return_routed_experts:
@@ -54,7 +54,7 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         return RoutedExpertsCapturer(
             model_config,
             num_tokens=num_tokens,
-            max_running_requests=max_running_requests,
+            max_decode_tokens=max_decode_tokens,
             num_fused_shared_experts=num_fused_shared_experts,
             device=device,
         )
@@ -63,7 +63,7 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         self,
         model_config: ModelConfig,
         num_tokens: int,
-        max_running_requests: int,
+        max_decode_tokens: int,
         num_fused_shared_experts: int,
         device: str,
     ):
@@ -71,14 +71,11 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         topk_size = model_config.hf_text_config.num_experts_per_tok
         num_layers = model_config.hf_text_config.num_hidden_layers
 
-        # Scale by dp_size so the buffer covers the full DP-concatenated batch.
-        # _get_local_slice indexes into [attention_dp_rank * cuda_graph_batch, ...)
-        # and otherwise overflows on dp_rank > 0 when max_running_requests >
-        # chunked_prefill_size.
-        # FIXME: spec decoding's num_verify_tokens is still not accounted for.
-        max_batch_size = max(
-            get_schedule().chunked_prefill_size * get_parallel().dp_size,
-            max_running_requests * get_parallel().dp_size,
+        # Verification contributes multiple token rows per request. Include all
+        # DP ranks because non-scattered MoE captures the concatenated batch.
+        max_batch_size = (
+            max(get_schedule().chunked_prefill_size, max_decode_tokens)
+            * get_parallel().dp_size
         )
 
         super().__init__(

--- a/test/registered/unit/model_executor/test_model_runner_decode_rows.py
+++ b/test/registered/unit/model_executor/test_model_runner_decode_rows.py
@@ -3,14 +3,21 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import torch
+
+from sglang.srt.model_executor import model_runner as mr_mod
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.state_capturer import base as capture_base
+from sglang.srt.state_capturer import routed_experts as capture_mod
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
 class _FakeModelRunner:
     max_decode_logits_rows = ModelRunner.max_decode_logits_rows
+    init_routed_experts_capturer = ModelRunner.init_routed_experts_capturer
 
     def __init__(self, *, initial_width: int, cuda_graph_bs: list[int]):
         self.initial_width = initial_width
@@ -24,7 +31,7 @@ def _alignment_8_capture_bs(runner, width):
     return ([bs for bs in runner.cuda_graph_bs if bs * width % 8 == 0], [])
 
 
-class TestModelRunnerDecodeRows(unittest.TestCase):
+class TestModelRunnerDecodeRows(CustomTestCase):
     def test_adaptive_sizing_covers_a_wider_candidate_width(self):
         """The shared logits buffer is sized for the widest adaptive candidate
         width: bs 12 at width 6 needs 72 rows."""
@@ -49,6 +56,65 @@ class TestModelRunnerDecodeRows(unittest.TestCase):
                 ),
             ):
                 self.assertEqual(runner.max_decode_logits_rows(), 72)
+
+    def test_routed_experts_buffer_fits_verification_tokens(self):
+        cases = [
+            # name, eager requests, graph requests, max width, prefill, DP, rows
+            ("ordinary_decode", 64, 64, 1, 128, 1, 128),
+            ("fixed_verify", 64, 64, 8, 128, 1, 512),
+            ("adaptive_verify", 64, 64, 16, 128, 1, 1024),
+            ("graph_padding", 3, 8, 8, 16, 1, 64),
+            ("eager_padding", 8, 4, 8, 16, 1, 64),
+            ("dp_verify", 64, 64, 8, 128, 2, 1024),
+        ]
+        for name, eager_bs, graph_bs, width, prefill, dp_size, rows in cases:
+            with self.subTest(name=name):
+                runner = _FakeModelRunner(
+                    initial_width=min(width, 4), cuda_graph_bs=[1]
+                )
+                runner.is_draft_worker = False
+                runner.max_running_requests = min(eager_bs, graph_bs)
+                runner.req_to_token_pool = SimpleNamespace(
+                    size=runner.max_running_requests
+                )
+                runner.max_token_pool_size = 4096
+                runner.page_size = 1
+                runner.device = "cpu"
+                runner.model = SimpleNamespace()
+                runner.model_config = SimpleNamespace(
+                    hf_text_config=SimpleNamespace(
+                        num_experts_per_tok=2, num_hidden_layers=2
+                    )
+                )
+                capturers = []
+                with (
+                    patch.multiple(
+                        mr_mod,
+                        get_eager_max_batch_size=lambda _: eager_bs,
+                        get_cuda_graph_max_batch_size=lambda _: graph_bs,
+                        max_speculative_num_draft_tokens=lambda: width,
+                        set_global_experts_capturer=capturers.append,
+                    ),
+                    patch.multiple(
+                        capture_mod,
+                        get_exec=lambda: SimpleNamespace(
+                            features=SimpleNamespace(enable_return_routed_experts=True)
+                        ),
+                        get_schedule=lambda: SimpleNamespace(
+                            chunked_prefill_size=prefill
+                        ),
+                        get_parallel=lambda: SimpleNamespace(dp_size=dp_size),
+                        _is_scattered_a2a_backend=lambda: False,
+                    ),
+                    patch.object(capture_base, "BaseHostCache"),
+                ):
+                    runner.init_routed_experts_capturer()
+                    routes = torch.arange(rows * 2, dtype=torch.int32).reshape(rows, 2)
+                    capturer = capturers[0]
+                    capturer.capture(1, routes)
+                    torch.testing.assert_close(
+                        capturer.device_cache.buffer[:, 1], routes
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Speculative verification produces multiple token rows per request. The routed-expert capture buffer was sized by request count, so verification batches larger than the prefill chunk could overflow it.

## Modifications

Size the buffer from the maximum aligned eager/graph request capacity and maximum verification width, including adaptive configurations. Apply DP scaling once when allocating the capture buffer.

Add a regression that writes the complete route tensor for ordinary decoding, fixed/adaptive verification, eager/graph padding, and DP concatenation.

## Accuracy Tests

```bash
PYTHONPATH=python python -m pytest \
  test/registered/unit/state_capturer/test_routed_experts_scattered_a2a.py \
  test/registered/unit/model_executor/test_model_runner_decode_rows.py -q
```
All applicable pre-commit checks passed.

## Speed Tests and Profiling

The change affects initialization-time allocation. It adds no operations to the forward path.

## Checklist

- [x] Follow SGLang code style and pass pre-commit checks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34389258617](https://github.com/sgl-project/sglang/actions/runs/34389258617)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34389258158](https://github.com/sgl-project/sglang/actions/runs/34389258158)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34389258530](https://github.com/sgl-project/sglang/actions/runs/34389258530)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->