### PR TITLE
[sglang-miles] Pass Nemotron-H layer ID to routing replay

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -215,6 +215,7 @@ class NemotronHMoE(nn.Module):
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok,
+            layer_id=layer_idx,
             use_grouped_topk=True,
             topk_group=config.topk_group,
             num_expert_group=config.n_group,


### PR DESCRIPTION
## Motivation

Nemotron-H constructs `TopK` without a layer ID. With routed-expert capture enabled, `layer_id=None` reaches `BaseDeviceCache.capture`, where indexing inserts an extra dimension instead of selecting a layer. CUDA graph capture then fails with a shape mismatch, for example a `[76, 6]` tensor targeting `[76, 1, 52, 6]`.

## Modifications

Pass the existing `layer_idx` to `TopK`, matching the layer ID already supplied to the expert implementation. This is a one-line change against **sglang-miles**.

## Accuracy Tests

CI currently stops in the shared maintenance check before model tests: it requires upstream main commit `a5f07b1241fc`, which is not in the current `sglang-miles` base. This PR targets `sglang-miles` as intended. [CI failure](https://github.com/sgl-project/sglang/actions/runs/34389901581/job/102595349414).

- This exact one-line patch was previously exercised with NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 on 8 H200 GPUs and routing replay enabled: CUDA graph capture and engine startup completed. [Bring-up run](https://wandb.ai/radixarkai/nemotron3-nano-agentic/runs/can3tmvh).
- All applicable pre-commit hooks pass on this PR.
- Full training/convergence validation remains pending; no new training run was launched for this PR.

## Speed Tests and Profiling

No speed benchmark was performed. The change supplies the model's existing layer index to the routing recorder.

## Checklist

- [x] Format code with pre-commit and follow existing code style.
- [x] Document the failure trigger and previous engine-level validation.
- [ ] Add a new unit test (none added for this one-line argument propagation).
- [ ] Provide accuracy and speed benchmark results beyond the startup validation above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34389901581](https://github.com/sgl-project/sglang/actions/runs/34389901581)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34389901069](https://github.com/sgl-project/sglang/actions/runs/34389901069)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34389901588](https://github.com/sgl-project/sglang/actions/runs/34389901588)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->