### PR TITLE
[Bugfix] Preserve fp32 MoE router precision across model gates

### DIFF
--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -162,10 +162,7 @@ class BailingMoEGate(nn.Module):
             self.expert_bias = None
 
     def forward(self, hidden_states):
-        logits = F.linear(hidden_states.to(self.weight.dtype), self.weight, None).to(
-            hidden_states.dtype
-        )
-        return logits
+        return F.linear(hidden_states.to(self.weight.dtype), self.weight, None)
 
 
 class BailingMoESparseMoeBlock(nn.Module):

--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -225,10 +225,7 @@ class BailingMoEGate(nn.Module):
             self.expert_bias = None
 
     def forward(self, hidden_states):
-        logits = F.linear(hidden_states.to(self.weight.dtype), self.weight, None).to(
-            hidden_states.dtype
-        )
-        return logits
+        return F.linear(hidden_states.to(self.weight.dtype), self.weight, None)
 
 
 class BailingMoE(nn.Module):

--- a/python/sglang/srt/models/ernie4.py
+++ b/python/sglang/srt/models/ernie4.py
@@ -60,7 +60,7 @@ class MoEGate(nn.Module):
             torch.empty((config.moe_num_experts, config.hidden_size))
         )
         self.e_score_correction_bias = nn.Parameter(
-            torch.empty((1, config.moe_num_experts))
+            torch.empty((1, config.moe_num_experts), dtype=torch.float32)
         )
 
     def forward(self, hidden_states):

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -103,7 +103,9 @@ class KimiMoE(nn.Module):
             prefix=f"{prefix}.gate",
         )
 
-        self.gate.e_score_correction_bias = nn.Parameter(torch.empty(num_experts))
+        self.gate.e_score_correction_bias = nn.Parameter(
+            torch.empty(num_experts, dtype=torch.float32)
+        )
 
         self.experts = get_moe_impl_class(quant_config)(
             num_experts=config.n_routed_experts,

--- a/python/sglang/srt/models/llada2.py
+++ b/python/sglang/srt/models/llada2.py
@@ -179,10 +179,7 @@ class LLaDA2MoeGate(nn.Module):
             self.expert_bias = None
 
     def forward(self, hidden_states):
-        logits = F.linear(hidden_states.to(self.weight.dtype), self.weight, None).to(
-            hidden_states.dtype
-        )
-        return logits
+        return F.linear(hidden_states.to(self.weight.dtype), self.weight, None)
 
 
 class LLaDA2MoeSparseMoeBlock(nn.Module):

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -49,7 +49,6 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
-    get_moe_runner_backend,
     should_skip_post_experts_all_reduce,
 )
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
@@ -351,15 +350,8 @@ class MoEGate(nn.Module):
             torch.empty((config.n_routed_experts, config.hidden_size), dtype=self.dtype)
         )
         if config.topk_method == "noaux_tc":
-            correction_bias_dtype = (
-                torch.bfloat16
-                if quant_config is not None
-                and quant_config.get_name() == "modelopt_fp4"
-                and get_moe_runner_backend().is_flashinfer_trtllm()
-                else self.dtype
-            )
             self.e_score_correction_bias = nn.Parameter(
-                torch.empty((config.n_routed_experts), dtype=correction_bias_dtype)
+                torch.empty((config.n_routed_experts), dtype=torch.float32)
             )
         else:
             self.e_score_correction_bias = None

--- a/test/registered/unit/models/test_moe_router_fp32_contract.py
+++ b/test/registered/unit/models/test_moe_router_fp32_contract.py
@@ -1,0 +1,142 @@
+"""CPU tests for model-specific MoE router precision contracts."""
+
+import unittest
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+import sglang.srt.models.kimi_linear as kimi_linear
+import sglang.srt.models.mimo_v2 as mimo_v2
+from sglang.srt.models.bailing_moe import BailingMoEGate
+from sglang.srt.models.bailing_moe_linear import BailingMoEGate as BailingLinearMoEGate
+from sglang.srt.models.ernie4 import MoEGate as Ernie4MoEGate
+from sglang.srt.models.llada2 import LLaDA2MoeGate
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+@contextmanager
+def default_dtype(dtype: torch.dtype):
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous)
+
+
+class TestCorrectionBiasDtype(CustomTestCase):
+    def test_mimo_modelopt_flashinfer_keeps_fp32_bias(self):
+        config = SimpleNamespace(
+            n_routed_experts=8,
+            hidden_size=16,
+            topk_method="noaux_tc",
+        )
+        quant_config = SimpleNamespace(get_name=lambda: "modelopt_fp4")
+        backend = SimpleNamespace(is_flashinfer_trtllm=lambda: True)
+
+        # ``create=True`` keeps this test valid after the model-specific backend
+        # exception is removed from the production module.
+        with patch.object(
+            mimo_v2, "get_moe_runner_backend", return_value=backend, create=True
+        ):
+            gate = mimo_v2.MoEGate(config=config, quant_config=quant_config)
+
+        self.assertEqual(gate.e_score_correction_bias.dtype, torch.float32)
+
+    def test_ernie_keeps_fp32_bias_when_model_weights_are_bf16(self):
+        config = SimpleNamespace(moe_num_experts=8, hidden_size=16)
+        with default_dtype(torch.bfloat16):
+            gate = Ernie4MoEGate(config=config)
+
+        self.assertEqual(gate.weight.dtype, torch.bfloat16)
+        self.assertEqual(gate.e_score_correction_bias.dtype, torch.float32)
+
+    def test_kimi_linear_keeps_fp32_bias_when_model_weights_are_bf16(self):
+        class FakeGate(nn.Module):
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+
+        class FakeExperts(nn.Module):
+            should_fuse_routed_scaling_factor_in_topk = False
+
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+
+        class FakeTopK(nn.Module):
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+
+        config = SimpleNamespace(
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_experts=8,
+            n_routed_experts=8,
+            num_experts_per_token=2,
+            num_expert_group=2,
+            topk_group=1,
+            moe_renormalize=True,
+            routed_scaling_factor=1.0,
+            num_shared_experts=None,
+            hidden_act="silu",
+            activation_situ_beta=1.0,
+            activation_situ_linear_beta=0.0,
+        )
+
+        with (
+            default_dtype(torch.bfloat16),
+            patch.object(kimi_linear, "ReplicatedLinear", FakeGate),
+            patch.object(kimi_linear, "get_moe_impl_class", return_value=FakeExperts),
+            patch.object(kimi_linear, "TopK", FakeTopK),
+            patch.object(
+                kimi_linear,
+                "get_parallel",
+                return_value=SimpleNamespace(tp_size=1),
+            ),
+        ):
+            moe = kimi_linear.KimiMoE(config=config)
+
+        self.assertEqual(moe.gate.e_score_correction_bias.dtype, torch.float32)
+
+
+class TestRouterLogitsDtype(CustomTestCase):
+    def test_fp32_router_weights_produce_fp32_logits(self):
+        gate_types = (BailingMoEGate, BailingLinearMoEGate, LLaDA2MoeGate)
+        config = SimpleNamespace(
+            num_experts=8,
+            hidden_size=16,
+            moe_router_enable_expert_bias=False,
+        )
+        hidden_states = torch.randn(4, 16, dtype=torch.bfloat16)
+
+        for gate_type in gate_types:
+            with self.subTest(gate_type=gate_type.__name__):
+                gate = gate_type(config=config, params_dtype=torch.float32)
+                logits = gate(hidden_states)
+                self.assertEqual(logits.dtype, torch.float32)
+                self.assertEqual(logits.shape, (4, 8))
+
+    def test_bf16_router_weights_still_produce_bf16_logits(self):
+        gate_types = (BailingMoEGate, BailingLinearMoEGate, LLaDA2MoeGate)
+        config = SimpleNamespace(
+            num_experts=8,
+            hidden_size=16,
+            moe_router_enable_expert_bias=False,
+        )
+        hidden_states = torch.randn(4, 16, dtype=torch.bfloat16)
+
+        for gate_type in gate_types:
+            with self.subTest(gate_type=gate_type.__name__):
+                gate = gate_type(config=config, params_dtype=torch.bfloat16)
+                logits = gate(hidden_states)
+                self.assertEqual(logits.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Addresses the independent model fixes called out in #38695.

Several MoE models still discard router precision at model-specific boundaries:

- MiMo-V2, Ernie4, and Kimi Linear can construct the checkpoint correction bias in bf16, even though expert selection consumes it in fp32-sensitive score arithmetic.
- Bailing MoE, Bailing MoE Linear, and LLaDA2 compute with fp32 router weights when configured, then cast the logits back to the hidden-state dtype before top-k.

These paths either collapse checkpoint bias values or throw away the fp32 router output immediately before expert selection.

## Modifications

- Keep `e_score_correction_bias` parameters in fp32 for MiMo-V2, Ernie4, and Kimi Linear.
- Return the gate GEMM output at the router-weight dtype for Bailing MoE, Bailing MoE Linear, and LLaDA2.
- Add one registered CPU test file covering all six model-specific contracts, including the bf16-weight fallback.

The patch does not introduce a new kernel or change the MoE expert computation. It only removes model-local precision loss at the router/top-k boundary.

## Accuracy Tests

- Added `test/registered/unit/models/test_moe_router_fp32_contract.py`.
- The tests verify fp32 correction-bias storage and fp32 router logits for fp32 gate weights, while preserving bf16 logits for bf16 gate weights.
- Full model accuracy was not run locally; upstream model/CPU CI is requested.

## Speed Tests and Profiling

Not applicable. No additional kernel launch is introduced. The Bailing/LLaDA paths remove a dtype-conversion kernel when the router is configured for fp32.

## Test Plan

- [x] `pre-commit run --files <all changed files>`
- [x] Python bytecode compilation for all changed Python files
- [x] `git diff --check`
- [ ] Upstream `base-a-test-cpu` for the new registered test

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add focused unit tests.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34390766953](https://github.com/sgl-project/sglang/actions/runs/34390766953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34390766030](https://github.com/sgl-project/sglang/actions/runs/34390766030)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34390766682](https://github.com/sgl-project/sglang/actions/runs/34390766682)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->