### PR TITLE
[Router] Honor KV-event storage tiers in the cache-aware tree

### DIFF
--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -16,7 +16,8 @@ on `/metrics` (text/plain, version 0.0.4) on the router's serving port
 
 ## Metrics covered
 
-The dashboard graphs every family the router emits:
+Families the router emits. The dashboard graphs all of them except the
+`sgl_router_kv_*` series, whose panels ship separately:
 
 | Metric | Type | What it shows |
 |---|---|---|
@@ -33,6 +34,13 @@ The dashboard graphs every family the router emits:
 | `sgl_router_stale_requests_total` | Counter | Stale-request cancellations |
 | `sgl_router_decode_affinity_total` | Counter | PD decode-affinity outcomes |
 | `sgl_router_sticky_total` | Counter | Sticky-session selection outcomes |
+| `sgl_router_kv_events_total` | Counter | KV-cache events applied to the tree, by `event` and storage `medium` |
+| `sgl_router_kv_event_blocks_total` | Counter | Block hashes those events carried, by `event` and `medium` |
+| `sgl_router_kv_tree_blocks` | Gauge | Blocks the tree attributes to a `worker_url` / `dp_rank`, by storage `tier` |
+| `sgl_router_kv_block_size` | Gauge | Tokens per block hash, as established from the fleet (0 until a worker reports) |
+| `sgl_router_kv_event_batches_lost_total` | Counter | KV-event batches dropped in transit, from gaps in each publisher's sequence |
+| `sgl_router_kv_tree_accounting_errors_total` | Counter | Occupancy-bookkeeping contradictions, by `reason`. Always 0 on a correct tree |
+| `sgl_router_kv_tree_maintained` | Gauge | 1 when this router maintains its own KV tree, 0 under an external Indexer |
 
 The legacy `sgl_router_overlap_blocks` metric was removed with the
 `cache_aware_zmq` policy and has no direct replacement. Remove queries, alerts,
@@ -40,7 +48,28 @@ and dashboard panels that depend on this metric before upgrading.
 
 The `sgl_router_workers` / `sgl_router_worker_*` gauges are sampled from the
 live worker registry on every scrape, so a removed worker stops emitting
-series immediately rather than leaving a stale value.
+series immediately rather than leaving a stale value. The `sgl_router_kv_*`
+series are pulled from the KV-event index the same way.
+
+`sgl_router_kv_tree_blocks * sgl_router_kv_block_size` for one worker and
+tier, divided by that pod's own occupancy of the tier (device:
+`sglang_kv_used_tokens + sglang_kv_evictable_tokens`; host:
+`sglang_hicache_host_used_tokens`; `tp_rank="0"`), is the tree's coverage of
+that tier. Scope both sides to the same deployment before dividing — block
+size and fleet membership both vary between them, and an unscoped ratio
+divides one fleet's tree by another's occupancy.
+
+Read it as: about 1, the tree mirrors the engine; about 0, the engine holds a
+tier routing cannot see; **above 1, the tree holds tiers a worker has already
+released** — check `sgl_router_kv_event_batches_lost_total`, because a tagged
+removal clears only its own tier and a lost batch strands the rest.
+
+`sgl_router_kv_events_total` renders every `(event, medium)` cell including
+zeros, so a `CPU_PINNED` row pinned at 0 on a hierarchical-cache fleet is
+visible rather than absent. Comparing `sgl_router_kv_event_blocks_total` for
+`block_stored/CPU_PINNED` against the engine's `sglang_hicache_backup_tokens_total`
+needs `sum without(pool)` on the engine side, and the two are not equal
+anyway: the engine also evicts device blocks it never backed up.
 
 ## Prometheus scrape config
 

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -210,6 +210,7 @@ async fn main() -> Result<()> {
     });
     app_ctx.block_size_oracle = block_size_oracle;
     app_ctx.engine_load = kv_index.engine_load();
+    app_ctx.kv_metrics = kv_index.metrics_source();
     let ctx = Arc::new(app_ctx);
     ctx.mark_ready();
 

--- a/experimental/sgl-router/src/policies/kv_events/index.rs
+++ b/experimental/sgl-router/src/policies/kv_events/index.rs
@@ -38,7 +38,8 @@ use tracing::{debug, info, warn};
 use super::block_size_oracle::BlockSizeOracle;
 use super::discovery::{fetch_event_config, EventConfig};
 use super::subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
-use super::tree::{HashTree, KvWorkerId};
+use super::tally::{EventKind, EventTally};
+use super::tree::{HashTree, KvWorkerId, Tiers};
 use super::wire::KvCacheEvent;
 use crate::policies::engine_load::EngineLoadTable;
 
@@ -68,6 +69,21 @@ fn subscribable_ranks(port_base: u16, dp_size: u32) -> Vec<u32> {
     (0..dp_size)
         .filter(|rank| port_base.saturating_add(*rank) <= u32::from(u16::MAX))
         .collect()
+}
+
+/// The read-only handles the `/metrics` scrape pulls the KV storage-tier
+/// series from. Narrower than an [`KvEventIndex`] handle on purpose: a route
+/// has no business calling `add_worker` / `remove_worker` / `shutdown`.
+#[derive(Clone)]
+pub struct KvIndexMetrics {
+    pub(crate) tree: Arc<HashTree>,
+    pub(crate) tally: Arc<EventTally>,
+}
+
+impl KvIndexMetrics {
+    pub fn new(tree: Arc<HashTree>, tally: Arc<EventTally>) -> Self {
+        Self { tree, tally }
+    }
 }
 
 /// Bundle of `HashTree` + `KvEventSubscriberRegistry` + pump task.
@@ -103,6 +119,9 @@ pub struct KvEventIndex {
     /// may legitimately have a fresh publisher whose sequence numbers
     /// restart from 1.
     cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
+    /// Applied events by kind and storage medium, for the `/metrics` scrape.
+    /// Written only by the pump.
+    tally: Arc<EventTally>,
     /// Worker-sourced `page_size` shared with prefix providers.
     /// `add_worker` calls `try_set(cfg.block_size)` so the first worker
     /// establishes the value; subsequent workers that disagree are
@@ -162,11 +181,13 @@ impl KvEventIndex {
         let cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>> = Arc::new(Mutex::new(HashMap::new()));
         let live_workers: Arc<Mutex<HashSet<KvWorkerId>>> = Arc::new(Mutex::new(HashSet::new()));
         let pump_cancel = CancellationToken::new();
+        let tally = Arc::new(EventTally::new());
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
             engine_load.clone(),
             cursors.clone(),
             live_workers.clone(),
+            Arc::clone(&tally),
             pump_cancel.clone(),
             rx,
         ));
@@ -182,6 +203,7 @@ impl KvEventIndex {
             http,
             live_workers,
             cursors,
+            tally,
             block_size_oracle,
         })
     }
@@ -196,6 +218,22 @@ impl KvEventIndex {
     /// returned handle as read-only.
     pub fn tree(&self) -> Arc<HashTree> {
         self.tree.clone()
+    }
+
+    /// Handles for the `/metrics` storage-tier series, or `None` when this
+    /// router does not maintain a local tree.
+    ///
+    /// In metadata-only mode (an external Indexer is the routing signal) no KV
+    /// subscription is opened, so every tier series would be a structural
+    /// zero — while their own HELP text tells the operator to read a zero
+    /// `CPU_PINNED` row as "the tier stream is not reaching the router". That
+    /// is a different fault with a different fix, so emit nothing rather than
+    /// a confidently wrong zero.
+    pub fn metrics_source(&self) -> Option<KvIndexMetrics> {
+        self.maintain_tree.then(|| KvIndexMetrics {
+            tree: Arc::clone(&self.tree),
+            tally: Arc::clone(&self.tally),
+        })
     }
 
     /// Shared accessor for the engine-load table. Load values are written solely by the pump
@@ -422,6 +460,7 @@ async fn pump_loop(
     engine_load: Arc<EngineLoadTable>,
     cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
     live_workers: Arc<Mutex<HashSet<KvWorkerId>>>,
+    tally: Arc<EventTally>,
     cancel: CancellationToken,
     mut rx: mpsc::Receiver<WorkerEvent>,
 ) {
@@ -480,16 +519,59 @@ async fn pump_loop(
                         );
                         continue;
                     }
+                    // The publisher's seq is dense, so a jump is exactly the
+                    // batches ZMQ dropped at its high-water mark. This became
+                    // worth counting with tier-tagged removals: a removal now
+                    // clears only its own tier, so losing the batch carrying a
+                    // block's LAST removal leaves the worker owning it until
+                    // the next AllBlocksCleared or teardown. The tree cannot
+                    // see that happened — only the sequence can. The
+                    // operator-visible signature is tree coverage above 1.
+                    let lost = (seq - p - 1) as u64;
+                    if lost > 0 {
+                        tally.record_lost_batches(lost);
+                        warn!(
+                            worker = ?worker,
+                            seq,
+                            last_applied = p,
+                            lost,
+                            "kv-events pump: sequence gap; batches were dropped in transit and the tree may hold stale tiers for this worker",
+                        );
+                    }
                 }
                 for event in &batch.events {
+                    // The `medium` tag decides which tier a store lands on and
+                    // which tier a removal clears, so a device eviction leaves
+                    // a worker that still holds the block on host as an owner
+                    // — see the tree's "Storage tiers" docs.
                     match event {
                         KvCacheEvent::BlockStored(b) => {
-                            tree.insert(&worker, b.parent_block_hash, &b.block_hashes);
+                            tally.record(
+                                EventKind::BlockStored,
+                                b.medium.as_deref(),
+                                b.block_hashes.len(),
+                            );
+                            tree.insert_tiered(
+                                &worker,
+                                b.parent_block_hash,
+                                &b.block_hashes,
+                                Tiers::for_store(b.medium.as_deref()),
+                            );
                         }
                         KvCacheEvent::BlockRemoved(b) => {
-                            tree.remove(&worker, &b.block_hashes);
+                            tally.record(
+                                EventKind::BlockRemoved,
+                                b.medium.as_deref(),
+                                b.block_hashes.len(),
+                            );
+                            tree.remove_tiered(
+                                &worker,
+                                &b.block_hashes,
+                                Tiers::for_remove(b.medium.as_deref()),
+                            );
                         }
                         KvCacheEvent::AllBlocksCleared => {
+                            tally.record(EventKind::AllBlocksCleared, None, 0);
                             tree.clear_worker(&worker);
                         }
                     }
@@ -527,6 +609,7 @@ mod tests {
         tree: Arc<HashTree>,
         engine_load: Arc<EngineLoadTable>,
         cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
+        tally: Arc<EventTally>,
         #[allow(dead_code)]
         live_set: Arc<Mutex<HashSet<KvWorkerId>>>,
         #[allow(dead_code)]
@@ -544,12 +627,14 @@ mod tests {
         let live_set: Arc<Mutex<HashSet<KvWorkerId>>> =
             Arc::new(Mutex::new(live.iter().cloned().collect()));
         let cancel = CancellationToken::new();
+        let tally = Arc::new(EventTally::new());
         let (tx, rx) = mpsc::channel(4);
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
             engine_load.clone(),
             cursors.clone(),
             live_set.clone(),
+            Arc::clone(&tally),
             cancel.clone(),
             rx,
         ));
@@ -557,6 +642,7 @@ mod tests {
             tree,
             engine_load,
             cursors,
+            tally,
             live_set,
             cancel,
             tx,
@@ -593,7 +679,152 @@ mod tests {
 
         let m = tree.match_prefix(None, &[10, 20, 30]);
         assert_eq!(m.matched_blocks, 3);
-        assert!(m.workers.contains(&id), "tree must hold the worker");
+        assert!(m.workers().contains(&id), "tree must hold the worker");
+    }
+
+    /// The pump must carry each event's `medium` into the tree. The engine's
+    /// write-back sequence for a backed-up block is a host-tagged store
+    /// followed by a device-tagged removal; applied tier-blind, the removal
+    /// erased the worker and every repeat of that prefix routed cold for the
+    /// whole host retention horizon.
+    #[tokio::test]
+    async fn pump_keeps_host_backed_block_owned_across_device_eviction() {
+        let id = worker_id("http://w1", 0);
+        let h = spawn_pump(std::slice::from_ref(&id));
+        let (tree, tx, pump) = (h.tree, h.tx, h.pump);
+
+        let stored = |medium: Option<&str>| {
+            KvCacheEvent::BlockStored(BlockStored {
+                parent_block_hash: None,
+                block_hashes: vec![10, 20],
+                token_ids: vec![],
+                block_size: 64,
+                lora_id: None,
+                medium: medium.map(str::to_owned),
+            })
+        };
+        let removed = |medium: Option<&str>| {
+            KvCacheEvent::BlockRemoved(BlockRemoved {
+                block_hashes: vec![20],
+                medium: medium.map(str::to_owned),
+            })
+        };
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 1,
+            batch: batch(vec![
+                stored(Some("GPU")),
+                stored(Some("CPU_PINNED")),
+                removed(Some("GPU")),
+            ]),
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+
+        let m = tree.match_prefix(None, &[10, 20]);
+        assert_eq!(m.matched_blocks, 2, "host copy keeps the block routable");
+        assert!(m.workers().contains(&id));
+        assert!(!m.device_workers().contains(&id), "device copy is gone");
+    }
+
+    /// The metadata-only gate. Its whole justification is that a structural
+    /// zero would be read as "the tier stream is not reaching the router" — a
+    /// different fault with a different fix — so the gate itself needs pinning:
+    /// inverting it leaves every test green while `/metrics` starts lying.
+    #[tokio::test]
+    async fn metrics_source_is_none_only_without_a_local_tree() {
+        let http = reqwest::Client::builder().build().unwrap();
+        let with_tree =
+            KvEventIndex::new_with_http_and_oracle(http.clone(), BlockSizeOracle::new());
+        assert!(
+            with_tree.metrics_source().is_some(),
+            "a router maintaining its own tree must publish the tier series",
+        );
+        let metadata_only =
+            KvEventIndex::new_metadata_only_with_http_and_oracle(http, BlockSizeOracle::new());
+        assert!(
+            metadata_only.metrics_source().is_none(),
+            "an external-Indexer router must emit nothing rather than a structural zero",
+        );
+    }
+
+    /// Every applied event is tallied by kind and medium, blocks included, so
+    /// the scrape can show the tier stream the tree is consuming. An
+    /// out-of-order batch is filtered before the tally and must not count.
+    #[tokio::test]
+    async fn pump_tallies_applied_events_by_medium() {
+        let id = worker_id("http://w1", 0);
+        let h = spawn_pump(std::slice::from_ref(&id));
+        let (tally, tx, pump) = (h.tally, h.tx, h.pump);
+
+        let stored = |medium: Option<&str>, hashes: Vec<i64>| {
+            KvCacheEvent::BlockStored(BlockStored {
+                parent_block_hash: None,
+                block_hashes: hashes,
+                token_ids: vec![],
+                block_size: 64,
+                lora_id: None,
+                medium: medium.map(str::to_owned),
+            })
+        };
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 2,
+            batch: batch(vec![
+                stored(Some("GPU"), vec![10, 20, 30]),
+                stored(Some("CPU_PINNED"), vec![10, 20, 30]),
+                KvCacheEvent::BlockRemoved(BlockRemoved {
+                    block_hashes: vec![30],
+                    medium: Some("GPU".into()),
+                }),
+            ]),
+        })
+        .await
+        .unwrap();
+        // Out of order: filtered, must not be tallied.
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 1,
+            batch: batch(vec![stored(None, vec![99])]),
+        })
+        .await
+        .unwrap();
+        // A gap: seq 3 and 4 were dropped in transit. Counted, because a
+        // tagged removal now clears only its own tier, so a lost batch can
+        // strand a tier the tree will never clear on its own.
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 5,
+            batch: batch(vec![KvCacheEvent::AllBlocksCleared]),
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+
+        assert_eq!(tally.batches_lost(), 2, "seq 3 and 4 never arrived");
+        let rows = tally.snapshot();
+        let cell = |event: &str, medium: &str| {
+            rows.iter()
+                .find(|r| r.event == event && r.medium == medium)
+                .cloned()
+                .expect("cell rendered")
+        };
+        assert_eq!(cell("block_stored", "GPU").blocks, 3);
+        assert_eq!(cell("block_stored", "CPU_PINNED").blocks, 3);
+        assert_eq!(cell("block_removed", "GPU").events, 1);
+        assert_eq!(
+            cell("block_stored", "untagged").events,
+            0,
+            "the out-of-order batch was filtered before the tally",
+        );
+        assert_eq!(
+            cell("all_blocks_cleared", "untagged").events,
+            1,
+            "a clear carries no medium and lands on the untagged row",
+        );
     }
 
     /// A `WorkerEvent::Load` lands in the engine-load table (gauge, no

--- a/experimental/sgl-router/src/policies/kv_events/mod.rs
+++ b/experimental/sgl-router/src/policies/kv_events/mod.rs
@@ -10,7 +10,9 @@
 //! - [`wire`] — msgpack types and [`decode_event_batch`]; the contract
 //!   with the SGLang publisher. Pure decoding; no I/O.
 //! - [`hash`] — block-hash compute mirroring SGLang `RadixKey.hash_page`.
-//! - [`tree`] — hash-keyed radix tree consumed by the routing path.
+//! - [`tree`] — hash-keyed radix tree consumed by the routing path,
+//!   tracking the storage tier each worker holds a block on.
+//! - [`tally`] — per-(kind, medium) counters of the events the pump applied.
 //! - [`subscriber`] — per-worker ZMQ SUB tasks.
 //! - [`discovery`] — `/server_info` parse → publisher endpoint.
 //! - [`index`] — public façade bundling the tree + subscribers + pump.
@@ -20,6 +22,7 @@ pub mod discovery;
 pub mod hash;
 pub mod index;
 pub mod subscriber;
+pub mod tally;
 pub mod tree;
 pub mod wire;
 
@@ -27,9 +30,12 @@ pub use block_size_oracle::BlockSizeOracle;
 pub(crate) use discovery::classify_bigram;
 pub use discovery::{fetch_event_config, EventConfig};
 pub use hash::{compute_block_hashes, compute_block_hashes_bigram, sha256_to_i64};
-pub use index::KvEventIndex;
+pub use index::{KvEventIndex, KvIndexMetrics};
 pub use subscriber::{KvEventSubscriberRegistry, SubKind, WorkerEvent};
-pub use tree::{HashTree, KvWorkerId, MatchResult};
+pub use tally::{EventKind, EventTally, TallyRow};
+pub use tree::{
+    HashTree, KvWorkerId, MatchResult, TierCounts, Tiers, ACCOUNTING_REASONS, TIER_SLOT_COUNT,
+};
 pub use wire::{
     decode_event_batch, BlockRemoved, BlockStored, DecodeError, KvCacheEvent, KvEventBatch,
 };

--- a/experimental/sgl-router/src/policies/kv_events/tally.rs
+++ b/experimental/sgl-router/src/policies/kv_events/tally.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Counters for the KV-cache event stream the pump consumes: events by kind
+//! and by the storage `medium` tag each carried, plus the batches the
+//! transport lost. Rendered as `sgl_router_kv_events_total`,
+//! `sgl_router_kv_event_blocks_total` and `sgl_router_kv_event_batches_lost_total`.
+//!
+//! WHY this exists: an engine running a hierarchical cache publishes a
+//! host-tier store for every block it backs up and a device-tier removal when
+//! the device copy goes. Whether those tagged events reach the router, and at
+//! what volume, was not observable anywhere — the tree consumed them and
+//! nothing counted them — so a router discarding the tag looked identical to
+//! an engine never sending it. Counting by medium makes the tier stream a
+//! time series: `block_stored/CPU_PINNED` tracks the engine's D2H backup
+//! volume and `block_removed/GPU` its device eviction volume. The two are NOT
+//! equal — the engine also evicts device blocks that were never backed up,
+//! and counts those itself as `sglang_hicache_dropped_tokens_total` — but a
+//! `CPU_PINNED` row pinned at zero with hicache enabled points at the
+//! publisher or the subscription, not the tree.
+//!
+//! Every cell is rendered, zeros included: the zero IS the finding.
+//!
+//! Label cardinality is fixed: the medium label is folded to the values the
+//! tree can rank plus `untagged` (no `medium` field) and `unknown` (a string
+//! this build does not recognise), so a misbehaving publisher cannot mint
+//! series.
+//!
+//! WHY lost batches are counted here rather than left to the tree: ZMQ drops
+//! at the publisher's high-water mark, and since a tagged removal now clears
+//! only its own tier, losing the batch that carried a block's LAST removal
+//! leaves the worker owning that block until the next `AllBlocksCleared` or
+//! worker teardown. The tree cannot see that it happened; only the sequence
+//! numbers can.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+use tracing::warn;
+
+use super::tree::Tiers;
+
+/// Medium labels, in the order [`EventTally`] stores them: the wire strings
+/// the tree ranks, read off [`Tiers::WIRE_MEDIA`] so the two can never
+/// disagree, then the two folds.
+pub const MEDIUM_LABELS: [&str; 6] = [
+    Tiers::WIRE_MEDIA[0].0,
+    Tiers::WIRE_MEDIA[1].0,
+    Tiers::WIRE_MEDIA[2].0,
+    Tiers::WIRE_MEDIA[3].0,
+    "untagged",
+    "unknown",
+];
+const UNTAGGED: usize = 4;
+const UNKNOWN: usize = 5;
+const _: () = assert!(
+    Tiers::WIRE_MEDIA.len() == UNTAGGED,
+    "MEDIUM_LABELS lists every WIRE_MEDIA entry before the folds",
+);
+
+/// Cap on the distinct unrecognised `medium` strings remembered for
+/// warn-once. A publisher cannot grow router memory by inventing media; past
+/// the cap the warning simply repeats.
+const MAX_REMEMBERED_UNKNOWN_MEDIA: usize = 16;
+
+/// Which event a tally entry describes.
+///
+/// [`Self::slot`] and [`Self::label`] are exhaustive matches rather than a
+/// discriminant cast into a parallel `&[&str]` table: a cast plus a
+/// length assertion still lets an APPENDED variant compile and then panic on
+/// an out-of-range index inside the pump task, which would take the whole
+/// cache-aware path down with no restart. A new variant here is two compile
+/// errors instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventKind {
+    BlockStored,
+    BlockRemoved,
+    AllBlocksCleared,
+}
+
+impl EventKind {
+    /// Every kind, in storage order.
+    pub const ALL: [EventKind; 3] = [
+        Self::BlockStored,
+        Self::BlockRemoved,
+        Self::AllBlocksCleared,
+    ];
+
+    const fn slot(self) -> usize {
+        match self {
+            Self::BlockStored => 0,
+            Self::BlockRemoved => 1,
+            Self::AllBlocksCleared => 2,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::BlockStored => "block_stored",
+            Self::BlockRemoved => "block_removed",
+            Self::AllBlocksCleared => "all_blocks_cleared",
+        }
+    }
+}
+
+// `slot()` indexes the counter arrays, so it must be a permutation of
+// `0..ALL.len()`. Pinned here rather than trusted.
+const _: () = {
+    let mut i = 0;
+    while i < EventKind::ALL.len() {
+        assert!(
+            EventKind::ALL[i].slot() == i,
+            "EventKind::slot must match position in EventKind::ALL",
+        );
+        i += 1;
+    }
+};
+
+/// One rendered cell of the tally.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TallyRow {
+    pub event: &'static str,
+    pub medium: &'static str,
+    /// Events applied.
+    pub events: u64,
+    /// Block hashes those events carried (0 for `all_blocks_cleared`, whose
+    /// wire type carries no hashes).
+    pub blocks: u64,
+}
+
+/// Lock-free counters, written by the single pump task and read on scrape.
+#[derive(Debug, Default)]
+pub struct EventTally {
+    events: [[AtomicU64; MEDIUM_LABELS.len()]; EventKind::ALL.len()],
+    blocks: [[AtomicU64; MEDIUM_LABELS.len()]; EventKind::ALL.len()],
+    /// Batches the transport lost, inferred from gaps in the publisher's
+    /// dense sequence.
+    batches_lost: AtomicU64,
+    /// Unrecognised `medium` strings already warned about, so an engine that
+    /// adds a tier logs once per string rather than once per event.
+    warned_unknown_media: Mutex<HashSet<String>>,
+}
+
+impl EventTally {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn medium_slot(&self, medium: Option<&str>) -> usize {
+        let Some(m) = medium else {
+            return UNTAGGED;
+        };
+        match MEDIUM_LABELS[..UNTAGGED]
+            .iter()
+            .position(|known| *known == m)
+        {
+            Some(slot) => slot,
+            None => {
+                // Only an unrecognised medium takes the lock, so the common
+                // path stays allocation- and lock-free.
+                self.warn_unknown_medium(m);
+                UNKNOWN
+            }
+        }
+    }
+
+    /// Log the first sighting of each unrecognised `medium`. This is the
+    /// "the engine added a storage tier, upgrade the router" line: without
+    /// it the fold to `unknown` / [`Tiers::OTHER`] is completely silent, and
+    /// silence about a discarded tag is the bug this module exists to
+    /// prevent recurring.
+    fn warn_unknown_medium(&self, medium: &str) {
+        let mut seen = self.warned_unknown_media.lock();
+        if seen.contains(medium) {
+            return;
+        }
+        if seen.len() < MAX_REMEMBERED_UNKNOWN_MEDIA {
+            seen.insert(medium.to_owned());
+        }
+        drop(seen);
+        warn!(
+            medium,
+            known = ?MEDIUM_LABELS[..UNTAGGED],
+            "kv-events: unrecognised storage medium; blocks stored on it are routable but rank below every known tier, and a removal tagged with it clears every tier",
+        );
+    }
+
+    /// Book one applied event carrying `blocks` block hashes.
+    pub fn record(&self, event: EventKind, medium: Option<&str>, blocks: usize) {
+        let (e, m) = (event.slot(), self.medium_slot(medium));
+        self.events[e][m].fetch_add(1, Ordering::Relaxed);
+        self.blocks[e][m].fetch_add(blocks as u64, Ordering::Relaxed);
+    }
+
+    /// Book `count` batches the transport dropped between two applied
+    /// sequence numbers.
+    pub fn record_lost_batches(&self, count: u64) {
+        self.batches_lost.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn batches_lost(&self) -> u64 {
+        self.batches_lost.load(Ordering::Relaxed)
+    }
+
+    /// Every cell in (event, medium) order, zeros included.
+    pub fn snapshot(&self) -> Vec<TallyRow> {
+        let mut rows = Vec::with_capacity(EventKind::ALL.len() * MEDIUM_LABELS.len());
+        for event in EventKind::ALL {
+            for (m, medium) in MEDIUM_LABELS.iter().enumerate() {
+                rows.push(TallyRow {
+                    event: event.label(),
+                    medium,
+                    events: self.events[event.slot()][m].load(Ordering::Relaxed),
+                    blocks: self.blocks[event.slot()][m].load(Ordering::Relaxed),
+                });
+            }
+        }
+        rows
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell<'a>(rows: &'a [TallyRow], event: &str, medium: &str) -> &'a TallyRow {
+        rows.iter()
+            .find(|r| r.event == event && r.medium == medium)
+            .expect("every (event, medium) cell is rendered")
+    }
+
+    #[test]
+    fn records_by_kind_and_medium_and_folds_the_rest() {
+        let t = EventTally::new();
+        t.record(EventKind::BlockStored, Some("GPU"), 3);
+        t.record(EventKind::BlockStored, Some("CPU_PINNED"), 3);
+        t.record(EventKind::BlockRemoved, Some("GPU"), 1);
+        t.record(EventKind::BlockRemoved, None, 2);
+        t.record(EventKind::BlockStored, Some("NVLINK_PEER"), 5);
+        t.record(EventKind::AllBlocksCleared, None, 0);
+
+        let rows = t.snapshot();
+        assert_eq!(rows.len(), EventKind::ALL.len() * MEDIUM_LABELS.len());
+        assert_eq!(cell(&rows, "block_stored", "GPU").blocks, 3);
+        assert_eq!(cell(&rows, "block_stored", "CPU_PINNED").events, 1);
+        assert_eq!(cell(&rows, "block_removed", "GPU").blocks, 1);
+        assert_eq!(cell(&rows, "block_removed", "untagged").blocks, 2);
+        assert_eq!(cell(&rows, "block_stored", "unknown").blocks, 5);
+        assert_eq!(cell(&rows, "all_blocks_cleared", "untagged").events, 1);
+        // Zero cells are present, not omitted.
+        assert_eq!(cell(&rows, "block_removed", "CPU_PINNED").events, 0);
+    }
+
+    /// A publisher inventing media must not grow router memory without bound;
+    /// past the cap the warning repeats instead.
+    #[test]
+    fn remembered_unknown_media_are_bounded() {
+        let t = EventTally::new();
+        for i in 0..MAX_REMEMBERED_UNKNOWN_MEDIA * 3 {
+            t.record(EventKind::BlockStored, Some(&format!("MEDIUM_{i}")), 1);
+        }
+        assert_eq!(
+            t.warned_unknown_media.lock().len(),
+            MAX_REMEMBERED_UNKNOWN_MEDIA,
+        );
+        assert_eq!(
+            cell(&t.snapshot(), "block_stored", "unknown").events,
+            (MAX_REMEMBERED_UNKNOWN_MEDIA * 3) as u64,
+            "every unknown medium is still counted, only the warning is capped",
+        );
+    }
+
+    #[test]
+    fn lost_batches_accumulate() {
+        let t = EventTally::new();
+        assert_eq!(t.batches_lost(), 0);
+        t.record_lost_batches(3);
+        t.record_lost_batches(1);
+        assert_eq!(t.batches_lost(), 4);
+    }
+}

--- a/experimental/sgl-router/src/policies/kv_events/tree.rs
+++ b/experimental/sgl-router/src/policies/kv_events/tree.rs
@@ -3,8 +3,8 @@
 //! Each non-root node represents one block hash (`i64`). A node's children
 //! are keyed by the *next* block hash in a chain, so a path from the root
 //! down to depth `n` represents a chain of `n` block hashes. Every node
-//! tracks the set of [`KvWorkerId`]s that hold the chain ending at that
-//! node.
+//! tracks the [`KvWorkerId`]s that hold the chain ending at that node, and
+//! on which storage [`Tiers`] each of them holds it.
 //!
 //! The tree is fed by `BlockStored` / `BlockRemoved` / `AllBlocksCleared`
 //! events from SGLang workers (decoded by [`super::wire`]) and is queried
@@ -39,6 +39,39 @@
 //! from the reverse index. Pruning cascades upward iteratively (chains
 //! can be deep — the recursive form would risk stack-overflow for
 //! pathological inputs).
+//!
+//! # Storage tiers
+//!
+//! An engine running a hierarchical cache holds a block on device and, once
+//! it has been backed up, on host pinned memory (or a storage backend) as
+//! well. It publishes every tier transition as its own event, tagged with a
+//! `medium`: a host-tier `BlockStored` when the backup lands, a device-tier
+//! `BlockRemoved` when the device copy is evicted, a host-tier `BlockRemoved`
+//! when the host copy goes.
+//!
+//! The two orderings differ by write policy, and neither may be assumed.
+//! Under write-through the pending D2H copy holds a lock ref, so the host
+//! store is published before the device eviction. Under write-back
+//! `_detach_backuped` publishes the device removal as soon as host slots are
+//! reserved and the host store follows only when the copy lands — the
+//! inverse. The tree therefore has to converge either way, and it does: a
+//! removal clears only its own tier, and a later store re-adds the chain.
+//!
+//! WHY the tree keeps the tiers apart instead of treating any `BlockRemoved`
+//! as "the worker lost the block": a device eviction that leaves a host copy
+//! behind does not end the worker's ability to serve the prefix — it loads
+//! the copy back at memory speed instead of recomputing it. Dropping the
+//! worker on that event makes every prefix unroutable after one device
+//! turnover, even though the fleet still holds it for the whole host
+//! retention horizon, and the repeat request lands on a random worker that
+//! then prefills it cold. Ownership here is "any tier", which is what makes
+//! the prefix routable again. [`MatchResult::tiers`] reports which tier each
+//! owner holds it on so a policy can price a load-back against an in-place
+//! hit; no policy consumes it yet — the routing path reads
+//! [`HashTree::prefix_depths`], which is tier-blind by design.
+//!
+//! Untagged events keep their pre-tiering meaning: an untagged store is a
+//! device store, an untagged remove clears every tier. See [`Tiers`].
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -96,15 +129,249 @@ impl KvWorkerId {
     }
 }
 
-/// Result of [`HashTree::match_prefix`].
-#[derive(Debug, Clone)]
+/// The storage tiers on which one worker holds one block — a bitset, because
+/// a backed-up block sits on device AND host at once (module docs, "Storage
+/// tiers").
+///
+/// A worker owns a block, and is a routing candidate for it, while ANY bit is
+/// set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Tiers(u8);
+
+impl Tiers {
+    /// Device HBM: `medium = "GPU"`, or an untagged event from a publisher
+    /// that predates tiering.
+    pub const DEVICE: Tiers = Tiers(1);
+    /// Host pinned memory: `medium = "CPU_PINNED"`.
+    pub const HOST: Tiers = Tiers(1 << 1);
+    /// L3 local SSD / NVMe: `medium = "DISK"`.
+    pub const DISK: Tiers = Tiers(1 << 2);
+    /// L4 shared / remote pool, e.g. Mooncake: `medium = "EXTERNAL"`.
+    ///
+    /// Separate from [`Self::DISK`] rather than folded into one "storage" bit
+    /// because the engine treats them as distinct tiers
+    /// (`StorageMedium` in `python/sglang/srt/disaggregation/kv_events.py`).
+    /// Sharing a bit would make an L3 eviction erase the router's knowledge of
+    /// an L4 copy on a fleet running both.
+    pub const EXTERNAL: Tiers = Tiers(1 << 3);
+    /// A tier this build cannot rank: a `medium` string [`Self::known`] does
+    /// not recognise. The worker is an owner (it can serve the prefix
+    /// somehow) but is never preferred as a device owner for it. Surfaced on
+    /// the wire side as the tally's `unknown` medium row.
+    pub const OTHER: Tiers = Tiers(1 << 4);
+    /// Every tier — what an untagged `BlockRemoved` clears.
+    pub const ALL: Tiers = Self::DEVICE
+        .union(Self::HOST)
+        .union(Self::DISK)
+        .union(Self::EXTERNAL)
+        .union(Self::OTHER);
+    /// Every tier with its metric label, in bit order. [`TierCounts`] is
+    /// indexed by position in this table, and the order is preference order:
+    /// a device copy is served in place, a host copy by load-back from host
+    /// memory, local disk slower still, a remote pool slower again, `other`
+    /// unranked.
+    pub const SLOTS: [(Tiers, &'static str); TIER_SLOT_COUNT] = [
+        (Self::DEVICE, "device"),
+        (Self::HOST, "host"),
+        (Self::DISK, "disk"),
+        (Self::EXTERNAL, "external"),
+        (Self::OTHER, "other"),
+    ];
+
+    /// The `StorageMedium` strings SGLang puts on the wire
+    /// (`python/sglang/srt/disaggregation/kv_events.py`) and the tier each
+    /// lands on. The single source for both the tree's ranking and the event
+    /// tally's medium labels, so a medium the tree ranks can never be one the
+    /// tally reports as unknown.
+    pub const WIRE_MEDIA: [(&'static str, Tiers); 4] = [
+        ("GPU", Self::DEVICE),
+        ("CPU_PINNED", Self::HOST),
+        ("DISK", Self::DISK),
+        ("EXTERNAL", Self::EXTERNAL),
+    ];
+
+    /// The tier a `BlockStored` tagged `medium` lands on. Untagged reads as
+    /// device, which is what the event meant before tiers existed. An unknown
+    /// tag reads as [`Self::OTHER`]: the store still makes the worker an
+    /// owner, but a tier this tree cannot rank must not be the one a policy
+    /// prefers — an engine adding a medium would otherwise turn every store
+    /// on it into a device hit.
+    pub fn for_store(medium: Option<&str>) -> Tiers {
+        match medium {
+            None => Self::DEVICE,
+            Some(m) => Self::known(m).unwrap_or(Self::OTHER),
+        }
+    }
+
+    /// The tiers a `BlockRemoved` tagged `medium` clears. Untagged clears
+    /// everything — the pre-tiering meaning. An unknown tag ALSO clears
+    /// everything, deliberately asymmetric with [`Self::for_store`]: clearing
+    /// only a bit this tree never set would leave the worker owning the block
+    /// for good, and a permanently stale owner is the one failure a routing
+    /// index must never manufacture. Over-removal costs at most one cold
+    /// prefill.
+    ///
+    /// A KNOWN tag clears its own tier and [`Self::OTHER`] with it, for the
+    /// same reason. No removal for a recognised medium would otherwise touch
+    /// `OTHER`, so an engine that adds a tier — publishing stores under a
+    /// `medium` this build folds to `OTHER` — but freeing the block on a path
+    /// that emits a tag this build DOES know would strand that bit until the
+    /// worker is dropped entirely. `hiradix_cache.py` has such paths: a
+    /// device-tagged teardown is emitted without consulting which media the
+    /// node was actually published under. On today's engine every `medium` is
+    /// known, so this clears a bit that is never set.
+    pub fn for_remove(medium: Option<&str>) -> Tiers {
+        match medium.and_then(Self::known) {
+            Some(known) => known.union(Self::OTHER),
+            None => Self::ALL,
+        }
+    }
+
+    fn known(medium: &str) -> Option<Tiers> {
+        Self::WIRE_MEDIA
+            .iter()
+            .find(|(name, _)| *name == medium)
+            .map(|(_, tier)| *tier)
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Whether every bit of `other` is set here.
+    pub const fn contains(self, other: Tiers) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    pub fn insert(&mut self, other: Tiers) {
+        self.0 |= other.0;
+    }
+
+    pub fn remove(&mut self, other: Tiers) {
+        self.0 &= !other.0;
+    }
+
+    /// The bits set in both.
+    pub const fn intersection(self, other: Tiers) -> Tiers {
+        Tiers(self.0 & other.0)
+    }
+
+    /// The bits set here and not in `other`.
+    pub const fn difference(self, other: Tiers) -> Tiers {
+        Tiers(self.0 & !other.0)
+    }
+
+    /// The bits set in either. `const` so the tier tables can be built from
+    /// the individual tiers rather than from raw bit arithmetic.
+    pub const fn union(self, other: Tiers) -> Tiers {
+        Tiers(self.0 | other.0)
+    }
+}
+
+/// Number of entries in [`Tiers::SLOTS`].
+pub const TIER_SLOT_COUNT: usize = 5;
+
+// The three tier tables have to stay in step, and nothing about adding a
+// `pub const` tier would otherwise force it:
+//
+// * a bit missing from `ALL` is a bit an untagged `BlockRemoved` never
+//   clears — a permanently stale owner, the one failure `for_remove` exists
+//   to prevent;
+// * a bit missing from `SLOTS` is never counted by `tally_tiers` nor
+//   decremented by `account_remove`, so the tier is invisible in
+//   `sgl_router_kv_tree_blocks` — this bug class, one tier later. The
+//   `debug_recount_occupancy` oracle cannot catch it either, because it
+//   walks the same `SLOTS`.
+const _: () = {
+    let mut union = Tiers(0);
+    let mut i = 0;
+    while i < TIER_SLOT_COUNT {
+        union = union.union(Tiers::SLOTS[i].0);
+        i += 1;
+    }
+    assert!(
+        union.0 == Tiers::ALL.0,
+        "Tiers::ALL must be exactly the union of Tiers::SLOTS",
+    );
+    let mut i = 0;
+    while i < Tiers::WIRE_MEDIA.len() {
+        assert!(
+            Tiers::ALL.contains(Tiers::WIRE_MEDIA[i].1),
+            "every wire medium must map to a tier that SLOTS ranks",
+        );
+        i += 1;
+    }
+};
+
+/// How many nodes one carrier holds on each tier, indexed like
+/// [`Tiers::SLOTS`]. A node held on device and host counts under both.
+pub type TierCounts = [u64; TIER_SLOT_COUNT];
+
+/// Count one node's worth of `bits` into `counts`.
+fn tally_tiers(counts: &mut TierCounts, bits: Tiers) {
+    for (slot, (tier, _)) in Tiers::SLOTS.iter().enumerate() {
+        if bits.contains(*tier) {
+            counts[slot] += 1;
+        }
+    }
+}
+
+/// Add `tiers` to `worker`'s hold in `carriers`, creating the entry on first
+/// sight, and return the bits that were newly set. One lookup on the re-store
+/// path — under a hierarchical cache the host backup of a chain the worker
+/// already holds on device, the common case — and two on first sight. Never
+/// leaves an entry with no bits, which [`TreeState::remove`] relies on.
+fn add_tiers(
+    carriers: &mut HashMap<KvWorkerId, Tiers>,
+    worker: &KvWorkerId,
+    tiers: Tiers,
+) -> Tiers {
+    match carriers.get_mut(worker) {
+        Some(held) => {
+            let added = tiers.difference(*held);
+            held.insert(tiers);
+            added
+        }
+        None => {
+            carriers.insert(worker.clone(), tiers);
+            tiers
+        }
+    }
+}
+
+/// Result of [`HashTree::match_prefix`]. `Default` is the no-match result:
+/// zero depth, no carriers on any tier.
+#[derive(Debug, Clone, Default)]
 pub struct MatchResult {
     /// Number of leading block hashes from the input slice that matched a
     /// path from the root.
     pub matched_blocks: usize,
-    /// Workers holding the deepest matched node. Empty when
-    /// `matched_blocks == 0`.
-    pub workers: HashSet<KvWorkerId>,
+    /// Every worker holding the deepest matched node, and the tiers it holds
+    /// it on. A worker without the device bit serves the prefix by loading it
+    /// back from a lower tier — cheaper than a cold prefill, dearer than
+    /// serving in place — which is the ordering a policy would prefer on.
+    /// Empty when `matched_blocks == 0`.
+    ///
+    /// The single carrier list: [`Self::workers`] and [`Self::device_workers`]
+    /// are derived from it, so no two views of one match can disagree.
+    pub tiers: HashMap<KvWorkerId, Tiers>,
+}
+
+impl MatchResult {
+    /// Workers holding the deepest matched node on ANY tier.
+    pub fn workers(&self) -> HashSet<KvWorkerId> {
+        self.tiers.keys().cloned().collect()
+    }
+
+    /// The subset of [`Self::workers`] holding the deepest matched node on
+    /// device.
+    pub fn device_workers(&self) -> HashSet<KvWorkerId> {
+        self.tiers
+            .iter()
+            .filter(|(_, tiers)| tiers.contains(Tiers::DEVICE))
+            .map(|(w, _)| w.clone())
+            .collect()
+    }
 }
 
 /// Internal stable handle to a tree node.
@@ -140,7 +407,10 @@ struct Node {
     parent_block_hash: Option<i64>,
     /// `None` only for the root sentinel.
     parent: Option<NodeId>,
-    workers: HashSet<KvWorkerId>,
+    /// Carriers of the chain ending here, each with the tiers it holds the
+    /// block on. A carrier is dropped the moment its last tier bit clears;
+    /// an entry with empty tiers never exists (see [`TreeState::insert`]).
+    workers: HashMap<KvWorkerId, Tiers>,
     /// Children keyed by next-block hash.
     children: HashMap<i64, NodeId>,
     last_used: AtomicU64,
@@ -152,7 +422,7 @@ impl Node {
             block_hash,
             parent_block_hash,
             parent: Some(parent),
-            workers: HashSet::new(),
+            workers: HashMap::new(),
             children: HashMap::new(),
             last_used: AtomicU64::new(now_millis()),
         }
@@ -175,7 +445,24 @@ struct TreeState {
     nodes: HashMap<NodeId, Node>,
     by_hash: HashMap<i64, HashSet<NodeId>>,
     next_id: NodeId,
+    /// Nodes each carrier holds, per tier. Booked at every site where a
+    /// carrier's tier bits on a node change (`account_add` /
+    /// `account_remove`), so a scrape reads it without walking the tree. A
+    /// carrier holding nothing has no row.
+    occupancy: HashMap<KvWorkerId, TierCounts>,
+    /// Times the occupancy bookkeeping contradicted itself, by reason. Both
+    /// reasons mean the same class of bug — bits added without being booked —
+    /// but the symptom the operator sees is a worker's
+    /// `sgl_router_kv_tree_blocks` rows vanishing while it still holds nodes,
+    /// which the metric's own HELP text says means "this worker publishes
+    /// nothing". A counter is the only thing separating those.
+    accounting_errors: [u64; ACCOUNTING_REASONS.len()],
 }
+
+/// Reasons in [`TreeState::accounting_errors`] order.
+pub const ACCOUNTING_REASONS: [&str; 2] = ["missing_row", "underflow"];
+const REASON_MISSING_ROW: usize = 0;
+const REASON_UNDERFLOW: usize = 1;
 
 const ROOT_ID: NodeId = 0;
 /// Sentinel block_hash for the root. Real workers can in principle emit
@@ -192,7 +479,7 @@ impl TreeState {
                 block_hash: ROOT_HASH_SENTINEL,
                 parent_block_hash: None,
                 parent: None,
-                workers: HashSet::new(),
+                workers: HashMap::new(),
                 children: HashMap::new(),
                 last_used: AtomicU64::new(now_millis()),
             },
@@ -201,6 +488,8 @@ impl TreeState {
             nodes,
             by_hash: HashMap::new(),
             next_id: 1,
+            occupancy: HashMap::new(),
+            accounting_errors: [0; ACCOUNTING_REASONS.len()],
         }
     }
 
@@ -208,6 +497,74 @@ impl TreeState {
         let id = self.next_id;
         self.next_id += 1;
         id
+    }
+
+    /// Book `delta` nodes-per-tier newly held by `worker` — one row lookup
+    /// for a whole chain, which is how `insert` uses it.
+    fn account_add(&mut self, worker: &KvWorkerId, delta: TierCounts) {
+        if delta.iter().all(|&c| c == 0) {
+            return;
+        }
+        match self.occupancy.get_mut(worker) {
+            Some(counts) => {
+                for (acc, d) in counts.iter_mut().zip(delta) {
+                    *acc += d;
+                }
+            }
+            None => {
+                self.occupancy.insert(worker.clone(), delta);
+            }
+        }
+    }
+
+    /// Book one node's worth of `removed` tier bits `worker` no longer holds.
+    fn account_remove(&mut self, worker: &KvWorkerId, removed: Tiers) {
+        let mut delta = TierCounts::default();
+        tally_tiers(&mut delta, removed);
+        self.account_remove_counts(worker, delta);
+    }
+
+    /// Book `delta` nodes-per-tier `worker` no longer holds, dropping the
+    /// carrier's row once it holds nothing.
+    ///
+    /// Takes a whole-carrier delta rather than one node's bits so
+    /// `clear_worker` can book a fleet-sized tree in ONE call: booking per
+    /// node would emit one `error!` per node on the failure path below, which
+    /// is hundreds of thousands of lines written while holding the tree's
+    /// write lock — every routing decision blocked behind a log flood.
+    fn account_remove_counts(&mut self, worker: &KvWorkerId, delta: TierCounts) {
+        if delta.iter().all(|&c| c == 0) {
+            return;
+        }
+        let Some(counts) = self.occupancy.get_mut(worker) else {
+            self.accounting_errors[REASON_MISSING_ROW] += 1;
+            error!(
+                worker = %worker.url,
+                dp_rank = worker.dp_rank,
+                "tree invariant violation: releasing tiers for a carrier with no occupancy row",
+            );
+            return;
+        };
+        let mut underflowed = false;
+        for (acc, d) in counts.iter_mut().zip(delta) {
+            underflowed |= *acc < d;
+            *acc = acc.saturating_sub(d);
+        }
+        if underflowed {
+            // Saturating so a release can never wrap the gauge — but then the
+            // all-zero test below would drop a row for a carrier that still
+            // holds nodes, and a missing series reads as "this worker
+            // publishes nothing". Count it so a release build is not blind;
+            // assert so a debug run stops at the release that exposed it.
+            self.accounting_errors[REASON_UNDERFLOW] += 1;
+            debug_assert!(
+                false,
+                "occupancy underflow: a tier was released that was never booked",
+            );
+        }
+        if counts.iter().all(|&c| c == 0) {
+            self.occupancy.remove(worker);
+        }
     }
 
     /// Insert a brand-new child under `parent_id` and wire up the reverse
@@ -273,7 +630,7 @@ impl TreeState {
             if self
                 .nodes
                 .get(&cand)
-                .is_some_and(|n| n.workers.contains(worker))
+                .is_some_and(|n| n.workers.contains_key(worker))
             {
                 return cand;
             }
@@ -288,13 +645,25 @@ impl TreeState {
         ROOT_ID
     }
 
-    fn insert(&mut self, worker: &KvWorkerId, parent_hash: Option<i64>, block_hashes: &[i64]) {
-        if block_hashes.is_empty() {
+    /// Mark every node along `block_hashes` as held by `worker` on `tiers`,
+    /// adding to whatever tiers it already holds there. Empty `tiers` is a
+    /// no-op: a carrier entry with no tier would be an owner of nothing, and
+    /// `remove` relies on "no bits ⇒ no entry" to know when to prune.
+    fn insert(
+        &mut self,
+        worker: &KvWorkerId,
+        parent_hash: Option<i64>,
+        block_hashes: &[i64],
+        tiers: Tiers,
+    ) {
+        if block_hashes.is_empty() || tiers.is_empty() {
             return;
         }
         let mut current = self.resolve_parent(worker, parent_hash);
         let mut prev_hash = parent_hash;
         let now = now_millis();
+        // Occupancy is booked once for the whole chain, not per block.
+        let mut delta = TierCounts::default();
         for &h in block_hashes {
             let child_id = match self
                 .nodes
@@ -302,9 +671,13 @@ impl TreeState {
                 .and_then(|n| n.children.get(&h).copied())
             {
                 Some(id) => id,
+                // `break`, not `return`: the tier bits are already written
+                // into the nodes visited so far, so bailing without reaching
+                // `account_add` below would leave the occupancy gauge
+                // permanently short by exactly those blocks.
                 None => match self.create_child(current, h, prev_hash) {
                     Some(id) => id,
-                    None => return,
+                    None => break,
                 },
             };
             let Some(child) = self.nodes.get_mut(&child_id) else {
@@ -313,16 +686,21 @@ impl TreeState {
                     block_hash = h,
                     "tree invariant violation: child node missing immediately after fetch/create; aborting chain",
                 );
-                return;
+                break;
             };
-            child.workers.insert(worker.clone());
+            let added = add_tiers(&mut child.workers, worker, tiers);
             child.last_used.store(now, Ordering::Relaxed);
+            tally_tiers(&mut delta, added);
             current = child_id;
             prev_hash = Some(h);
         }
+        self.account_add(worker, delta);
     }
 
-    fn remove(&mut self, worker: &KvWorkerId, block_hashes: &[i64]) {
+    /// Clear `tiers` from `worker`'s hold on every node carrying any hash in
+    /// `block_hashes`. The worker leaves a node once no tier bit remains, and
+    /// a node that becomes empty + childless is pruned.
+    fn remove(&mut self, worker: &KvWorkerId, block_hashes: &[i64], tiers: Tiers) {
         // Collect all node ids to touch (fixed snapshot — avoids iterator
         // invalidation when pruning mutates `by_hash`).
         let mut targets: Vec<NodeId> = Vec::new();
@@ -334,14 +712,25 @@ impl TreeState {
         for id in targets {
             // Node may already be gone if a previous prune in this batch
             // cascaded through it — skip silently.
-            let still_present = match self.nodes.get_mut(&id) {
+            let (prunable, released) = match self.nodes.get_mut(&id) {
                 Some(node) => {
-                    node.workers.remove(worker);
-                    node.workers.is_empty() && node.children.is_empty()
+                    let mut released = Tiers::default();
+                    if let Some(held) = node.workers.get_mut(worker) {
+                        released = held.intersection(tiers);
+                        held.remove(tiers);
+                        if held.is_empty() {
+                            node.workers.remove(worker);
+                        }
+                    }
+                    (
+                        node.workers.is_empty() && node.children.is_empty(),
+                        released,
+                    )
                 }
-                None => false,
+                None => (false, Tiers::default()),
             };
-            if still_present {
+            self.account_remove(worker, released);
+            if prunable {
                 self.prune_cascade(id);
             }
         }
@@ -356,16 +745,23 @@ impl TreeState {
             .filter(|&id| id != ROOT_ID)
             .collect();
         let mut prune_candidates: Vec<NodeId> = Vec::new();
+        // Accumulated over every node, then booked once — see
+        // `account_remove_counts`.
+        let mut delta = TierCounts::default();
         for id in ids {
-            if let Some(node) = self.nodes.get_mut(&id) {
-                if node.workers.remove(worker)
-                    && node.workers.is_empty()
-                    && node.children.is_empty()
-                {
+            let removed = self.nodes.get_mut(&id).and_then(|node| {
+                node.workers
+                    .remove(worker)
+                    .map(|held| (held, node.workers.is_empty() && node.children.is_empty()))
+            });
+            if let Some((held, prunable)) = removed {
+                tally_tiers(&mut delta, held);
+                if prunable {
                     prune_candidates.push(id);
                 }
             }
         }
+        self.account_remove_counts(worker, delta);
         for id in prune_candidates {
             // Re-check: cascading prune from a sibling may have already
             // removed this id.
@@ -448,10 +844,7 @@ impl TreeState {
     /// [`HashTree::match_prefix`] documents the policy for callers.
     fn match_prefix(&self, parent_hash: Option<i64>, block_hashes: &[i64]) -> MatchResult {
         if block_hashes.is_empty() {
-            return MatchResult {
-                matched_blocks: 0,
-                workers: HashSet::new(),
-            };
+            return MatchResult::default();
         }
         // Determine starting node: root, or the unique node carrying
         // `parent_hash`. Multiple matches: bail to root (caller should
@@ -487,17 +880,13 @@ impl TreeState {
                 None => break,
             }
         }
-        let workers = match last_match_node {
-            Some(id) => self
-                .nodes
-                .get(&id)
-                .map(|n| n.workers.clone())
-                .unwrap_or_default(),
-            None => HashSet::new(),
-        };
+        let tiers: HashMap<KvWorkerId, Tiers> = last_match_node
+            .and_then(|id| self.nodes.get(&id))
+            .map(|n| n.workers.clone())
+            .unwrap_or_default();
         MatchResult {
             matched_blocks: matched,
-            workers,
+            tiers,
         }
     }
 
@@ -545,12 +934,14 @@ impl TreeState {
             reached += 1;
             if reached == 1 {
                 // Absent here means never in `alive`: a tail held without
-                // block 0 is reported as holding nothing.
-                alive = child.workers.iter().collect();
+                // block 0 is reported as holding nothing. Presence is "on any
+                // tier" — a worker whose device copy was evicted but whose
+                // host backup remains still holds the level.
+                alive = child.workers.keys().collect();
             } else {
                 let mut still = Vec::with_capacity(alive.len());
                 for w in alive {
-                    if child.workers.contains(w) {
+                    if child.workers.contains_key(w) {
                         still.push(w);
                     } else {
                         depths.insert(w, reached - 1);
@@ -635,9 +1026,14 @@ impl TreeState {
             };
             // Force-prune even if the leaf still holds workers — eviction
             // intentionally evicts. We clear workers first so the cascade
-            // precondition holds.
-            if let Some(node) = self.nodes.get_mut(&victim) {
-                node.workers.clear();
+            // precondition holds, releasing each carrier's tiers as we go so
+            // the occupancy counters stay in step.
+            let carriers: Vec<(KvWorkerId, Tiers)> = match self.nodes.get_mut(&victim) {
+                Some(node) => node.workers.drain().collect(),
+                None => Vec::new(),
+            };
+            for (worker, held) in &carriers {
+                self.account_remove(worker, *held);
             }
             self.prune_cascade(victim);
         }
@@ -665,27 +1061,51 @@ impl HashTree {
         }
     }
 
-    /// Apply a `BlockStored` event.
-    ///
-    /// Walks from `parent_hash`'s node (or root) and descends along
-    /// `block_hashes`, marking every visited node as held by `worker`.
-    /// Empty `block_hashes` is a no-op.
+    /// Apply an untagged `BlockStored` event: a device store. See
+    /// [`Self::insert_tiered`].
     pub fn insert(&self, worker: &KvWorkerId, parent_hash: Option<i64>, block_hashes: &[i64]) {
-        let mut state = self.state.write();
-        state.insert(worker, parent_hash, block_hashes);
+        self.insert_tiered(worker, parent_hash, block_hashes, Tiers::DEVICE);
     }
 
-    /// Apply a `BlockRemoved` event.
+    /// Apply a `BlockStored` event on `tiers` (from its `medium`, via
+    /// [`Tiers::for_store`]).
     ///
-    /// For every node carrying any hash in `block_hashes`, drop `worker`
-    /// from that node's worker set. Nodes that become empty AND childless
-    /// are pruned (cascading upward).
+    /// Walks from `parent_hash`'s node (or root) and descends along
+    /// `block_hashes`, marking every visited node as held by `worker` on
+    /// `tiers` in addition to any tier it already holds there. Empty
+    /// `block_hashes` or empty `tiers` is a no-op.
+    pub fn insert_tiered(
+        &self,
+        worker: &KvWorkerId,
+        parent_hash: Option<i64>,
+        block_hashes: &[i64],
+        tiers: Tiers,
+    ) {
+        let mut state = self.state.write();
+        state.insert(worker, parent_hash, block_hashes, tiers);
+    }
+
+    /// Apply an untagged `BlockRemoved` event: the worker loses the blocks on
+    /// every tier. See [`Self::remove_tiered`].
+    pub fn remove(&self, worker: &KvWorkerId, block_hashes: &[i64]) {
+        self.remove_tiered(worker, block_hashes, Tiers::ALL);
+    }
+
+    /// Apply a `BlockRemoved` event for `tiers` (from its `medium`, via
+    /// [`Tiers::for_remove`]).
+    ///
+    /// For every node carrying any hash in `block_hashes`, clear `tiers`
+    /// from `worker`'s hold on it. The worker stays an owner of the node
+    /// while it holds the block on any other tier — a device eviction after a
+    /// host backup leaves the worker a host-tier owner. Once no tier remains
+    /// the worker is dropped, and nodes that become empty AND childless are
+    /// pruned (cascading upward).
     ///
     /// Removing the worker from a node does NOT remove the node if other
     /// workers still hold it.
-    pub fn remove(&self, worker: &KvWorkerId, block_hashes: &[i64]) {
+    pub fn remove_tiered(&self, worker: &KvWorkerId, block_hashes: &[i64], tiers: Tiers) {
         let mut state = self.state.write();
-        state.remove(worker, block_hashes);
+        state.remove(worker, block_hashes, tiers);
     }
 
     /// Apply an `AllBlocksCleared` event for `worker`.
@@ -747,6 +1167,33 @@ impl HashTree {
         self.state.read().by_hash.len()
     }
 
+    /// Times the occupancy bookkeeping contradicted itself, by
+    /// [`ACCOUNTING_REASONS`]. Always zero on a correct tree; rendered so a
+    /// release build, where the debug assertion is compiled out, still says
+    /// so out loud.
+    pub fn accounting_errors(&self) -> [u64; ACCOUNTING_REASONS.len()] {
+        self.state.read().accounting_errors
+    }
+
+    /// Nodes each carrier holds on each tier, sorted by carrier. Rendered as
+    /// `sgl_router_kv_tree_blocks`; against the engine's own per-tier
+    /// occupancy for the same pod it is the tree's coverage of that tier —
+    /// the number that says whether a tier the engine holds is visible to
+    /// routing at all (module docs, "Storage tiers").
+    ///
+    /// Read off the incrementally maintained accounting rather than walked,
+    /// so a scrape costs one read lock. A carrier holding nothing has no row.
+    pub fn tier_occupancy(&self) -> Vec<(KvWorkerId, TierCounts)> {
+        let state = self.state.read();
+        let mut rows: Vec<(KvWorkerId, TierCounts)> = state
+            .occupancy
+            .iter()
+            .map(|(w, counts)| (w.clone(), *counts))
+            .collect();
+        rows.sort_by(|a, b| (&a.0.url, a.0.dp_rank).cmp(&(&b.0.url, b.0.dp_rank)));
+        rows
+    }
+
     /// Evict least-recently-used nodes until `node_count() <= max_size`.
     ///
     /// Strategy:
@@ -766,6 +1213,46 @@ impl HashTree {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+impl HashTree {
+    /// Whether every carrier on every node holds at least one tier. `remove`
+    /// and `prune_cascade` rely on "no bits ⇒ no entry"; a violation means a
+    /// node can never be pruned and a worker never dropped.
+    fn debug_no_empty_carrier(&self) -> bool {
+        let state = self.state.read();
+        state
+            .nodes
+            .values()
+            .all(|n| n.workers.values().all(|t| !t.is_empty()))
+    }
+
+    /// Recompute [`Self::tier_occupancy`] by walking every node — the oracle
+    /// the incrementally maintained counters are checked against.
+    ///
+    /// Its ceiling: it shares `tally_tiers` and [`Tiers::SLOTS`] with the code
+    /// it checks, so it proves only that incremental booking agrees with a
+    /// full walk. It is blind by construction to WHICH tier is right — a
+    /// SLOTS/bit mismatch would mis-tally identically on both sides. The
+    /// example-based tier tests and the compile-time coupling asserts own
+    /// that half.
+    fn debug_recount_occupancy(&self) -> Vec<(KvWorkerId, TierCounts)> {
+        let state = self.state.read();
+        let mut total: HashMap<KvWorkerId, TierCounts> = HashMap::new();
+        for (&id, node) in &state.nodes {
+            if id == ROOT_ID {
+                continue;
+            }
+            for (worker, held) in &node.workers {
+                let acc = total.entry(worker.clone()).or_default();
+                tally_tiers(acc, *held);
+            }
+        }
+        let mut rows: Vec<(KvWorkerId, TierCounts)> = total.into_iter().collect();
+        rows.sort_by(|a, b| (&a.0.url, a.0.dp_rank).cmp(&(&b.0.url, b.0.dp_rank)));
+        rows
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -809,7 +1296,7 @@ mod tests {
         // so `match_prefix` credits it with the full chain scored here at 1.
         let m = tree.match_prefix(None, &chain);
         assert_eq!(m.matched_blocks, 4);
-        assert_eq!(m.workers, workers(&[&deep, &holed]));
+        assert_eq!(m.workers(), workers(&[&deep, &holed]));
     }
 
     #[test]
@@ -817,11 +1304,388 @@ mod tests {
         let tree = HashTree::new();
         let m = tree.match_prefix(None, &[]);
         assert_eq!(m.matched_blocks, 0);
-        assert!(m.workers.is_empty());
+        assert!(m.workers().is_empty());
 
         let m2 = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m2.matched_blocks, 0);
-        assert!(m2.workers.is_empty());
+        assert!(m2.workers().is_empty());
+    }
+
+    /// The write-back sequence the engine publishes for a backed-up block:
+    /// device store, host store once the D2H copy lands, then a DEVICE-tagged
+    /// removal when the device copy is evicted. The worker still holds the
+    /// block on host, so it must stay an owner — just no longer a device one.
+    /// Only the host-tagged removal ends ownership.
+    #[test]
+    fn device_eviction_after_host_backup_keeps_the_worker_as_host_owner() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert_tiered(&a, None, &[1, 2, 3], Tiers::for_store(Some("GPU")));
+        tree.insert_tiered(&a, None, &[1, 2, 3], Tiers::for_store(Some("CPU_PINNED")));
+
+        let m = tree.match_prefix(None, &[1, 2, 3]);
+        assert_eq!(m.matched_blocks, 3);
+        assert_eq!(m.workers(), workers(&[&a]));
+        assert_eq!(m.device_workers(), workers(&[&a]), "held on device too");
+
+        tree.remove_tiered(&a, &[3], Tiers::for_remove(Some("GPU")));
+        let m = tree.match_prefix(None, &[1, 2, 3]);
+        assert_eq!(m.matched_blocks, 3, "host copy keeps the chain matchable");
+        assert_eq!(
+            m.workers(),
+            workers(&[&a]),
+            "host-only holder is still an owner"
+        );
+        assert!(
+            m.device_workers().is_empty(),
+            "but no longer a device owner"
+        );
+
+        tree.remove_tiered(&a, &[3], Tiers::for_remove(Some("CPU_PINNED")));
+        let m = tree.match_prefix(None, &[1, 2, 3]);
+        assert_eq!(m.matched_blocks, 2, "last tier gone: node pruned");
+    }
+
+    /// The routing path reads `prefix_depths`, not `match_prefix`, so the
+    /// tier fix has to show up there: a chain whose device copy was evicted
+    /// after a host backup still scores at its full depth. The untagged
+    /// removal is the control — it clears every tier and the depth collapses,
+    /// which is what the tier-blind tree did for the tagged case too.
+    #[test]
+    fn prefix_depths_survive_a_device_eviction_with_a_host_backup() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert_tiered(&a, None, &[1, 2, 3], Tiers::for_store(Some("GPU")));
+        tree.insert_tiered(&a, None, &[1, 2, 3], Tiers::for_store(Some("CPU_PINNED")));
+
+        // Block 1 included on purpose. `prefix_depths` SEEDS its live set from
+        // level 1 and narrows from there, so evicting only from block 2 onward
+        // would leave that seed exercised against device-held state alone — and
+        // a seed narrowed to device owners would send every host-only worker to
+        // depth 0, restoring this bug with the suite still green.
+        tree.remove_tiered(&a, &[1, 2, 3], Tiers::for_remove(Some("GPU")));
+        assert_eq!(
+            tree.prefix_depths(None, &[1, 2, 3]).get(&a).copied(),
+            Some(3),
+            "host backup keeps every level attributed to the worker",
+        );
+
+        tree.remove_tiered(&a, &[1, 2, 3], Tiers::for_remove(None));
+        assert_eq!(
+            tree.prefix_depths(None, &[1, 2, 3]).get(&a).copied(),
+            None,
+            "an untagged removal still clears every tier, host backup included",
+        );
+    }
+
+    /// Untagged events keep the pre-tiering contract: a bare `BlockStored` is
+    /// a device store, a bare `BlockRemoved` clears every tier at once. A
+    /// publisher that never tags must see exactly the behaviour it always had.
+    #[test]
+    fn untagged_events_keep_the_legacy_meaning() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert(&a, None, &[1, 2]);
+        let m = tree.match_prefix(None, &[1, 2]);
+        assert_eq!(
+            m.device_workers(),
+            workers(&[&a]),
+            "untagged store is device"
+        );
+
+        // Add a host copy, then an UNTAGGED removal: must clear both.
+        tree.insert_tiered(&a, None, &[1, 2], Tiers::HOST);
+        tree.remove(&a, &[2]);
+        assert_eq!(tree.match_prefix(None, &[1, 2]).matched_blocks, 1);
+    }
+
+    /// An unknown medium is asymmetric on purpose: a store on it makes the
+    /// worker an owner on the unranked `OTHER` tier — never a device owner —
+    /// while a removal tagged with it clears everything. The alternative for
+    /// removal — clearing only a bit that was never set — leaves a stale
+    /// owner forever.
+    #[test]
+    fn unknown_medium_stores_as_owner_and_removes_everything() {
+        assert_eq!(Tiers::for_store(Some("NVLINK_PEER")), Tiers::OTHER);
+        assert_eq!(Tiers::for_remove(Some("NVLINK_PEER")), Tiers::ALL);
+        assert_eq!(Tiers::for_store(None), Tiers::DEVICE);
+        assert_eq!(Tiers::for_remove(None), Tiers::ALL);
+        assert_eq!(Tiers::for_store(Some("CPU_PINNED")), Tiers::HOST);
+        assert_eq!(Tiers::for_store(Some("DISK")), Tiers::DISK);
+        assert_eq!(Tiers::for_store(Some("EXTERNAL")), Tiers::EXTERNAL);
+        // A known tag clears its own tier AND the unranked one.
+        assert_eq!(
+            Tiers::for_remove(Some("DISK")),
+            Tiers::DISK.union(Tiers::OTHER)
+        );
+        assert_eq!(
+            Tiers::for_remove(Some("EXTERNAL")),
+            Tiers::EXTERNAL.union(Tiers::OTHER)
+        );
+
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        let b = worker("http://b", 0);
+        tree.insert_tiered(&a, None, &[1], Tiers::DEVICE);
+        tree.insert_tiered(&a, None, &[1], Tiers::HOST);
+        tree.insert_tiered(&b, None, &[1], Tiers::for_store(Some("NVLINK_PEER")));
+        let m = tree.match_prefix(None, &[1]);
+        assert_eq!(
+            m.workers(),
+            workers(&[&a, &b]),
+            "unknown-tier holder is an owner"
+        );
+        assert_eq!(m.device_workers(), workers(&[&a]), "but not a device owner");
+        tree.remove_tiered(&a, &[1], Tiers::for_remove(Some("NVLINK_PEER")));
+        tree.remove_tiered(&b, &[1], Tiers::for_remove(Some("NVLINK_PEER")));
+        assert_eq!(tree.match_prefix(None, &[1]).matched_blocks, 0);
+    }
+
+    /// Tiers are per (node, worker): a device removal by one worker must not
+    /// touch another worker's hold on the same node, and a node whose
+    /// carriers differ by tier reports the device subset exactly.
+    #[test]
+    fn tiers_are_tracked_per_worker() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        let b = worker("http://b", 0);
+        tree.insert_tiered(&a, None, &[1, 2], Tiers::DEVICE);
+        tree.insert_tiered(&b, None, &[1, 2], Tiers::HOST);
+
+        let m = tree.match_prefix(None, &[1, 2]);
+        assert_eq!(m.workers(), workers(&[&a, &b]));
+        assert_eq!(m.device_workers(), workers(&[&a]));
+
+        tree.remove_tiered(&a, &[2], Tiers::DEVICE);
+        let m = tree.match_prefix(None, &[1, 2]);
+        assert_eq!(m.workers(), workers(&[&b]), "a dropped, b untouched");
+        assert!(m.device_workers().is_empty());
+    }
+
+    /// A store on no tier must not create a carrier: `remove` relies on
+    /// "no bits ⇒ no entry" to know when a node is prunable.
+    #[test]
+    fn empty_tier_insert_is_noop() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert_tiered(&a, None, &[1], Tiers::default());
+        assert_eq!(tree.node_count(), 0);
+    }
+
+    /// The per-tier occupancy is maintained incrementally at every mutation
+    /// site, so it is checked against a full recount after a sequence that
+    /// exercises all of them: tiered stores, partial and full removals,
+    /// `clear_worker`, and LRU eviction.
+    #[test]
+    fn tier_occupancy_matches_a_full_recount_after_mixed_mutations() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        let b = worker("http://b", 1);
+        let c = worker("http://c", 0);
+
+        tree.insert_tiered(&a, None, &[1, 2, 3, 4], Tiers::DEVICE);
+        tree.insert_tiered(&a, None, &[1, 2], Tiers::HOST);
+        tree.insert_tiered(&b, None, &[1, 2, 3], Tiers::HOST);
+        tree.insert_tiered(&b, None, &[1, 2, 5, 6], Tiers::DEVICE);
+        tree.insert_tiered(&c, None, &[7], Tiers::for_store(Some("NVLINK_PEER")));
+        for r in 0..40i64 {
+            tree.insert(&c, None, &[r * 4096 + 11, r * 4096 + 12]);
+        }
+        assert_eq!(tree.tier_occupancy(), tree.debug_recount_occupancy());
+
+        // Spot-check the shape: a holds 4 device nodes and 2 host nodes.
+        let rows = tree.tier_occupancy();
+        let (_, a_counts) = rows.iter().find(|(w, _)| *w == a).unwrap();
+        assert_eq!(a_counts[0], 4, "device");
+        assert_eq!(a_counts[1], 2, "host");
+        assert_eq!(a_counts[2], 0, "disk");
+        let (_, c_counts) = rows.iter().find(|(w, _)| *w == c).unwrap();
+        assert_eq!(c_counts[4], 1, "unknown medium lands on other");
+
+        // Partial removal (device only) on a node held on both tiers, then a
+        // removal that clears the last tier and prunes.
+        tree.remove_tiered(&a, &[2], Tiers::DEVICE);
+        tree.remove_tiered(&a, &[4], Tiers::ALL);
+        assert_eq!(tree.tier_occupancy(), tree.debug_recount_occupancy());
+
+        // Whole-worker clear, then LRU eviction down to a small cap.
+        tree.clear_worker(&b);
+        assert_eq!(tree.tier_occupancy(), tree.debug_recount_occupancy());
+        assert!(tree.evict_lru(10) > 0);
+        assert_eq!(tree.tier_occupancy(), tree.debug_recount_occupancy());
+        assert!(
+            tree.tier_occupancy().iter().all(|(w, _)| *w != b),
+            "a cleared worker must leave no occupancy row",
+        );
+    }
+
+    /// Nothing but a known-medium removal ever clears `OTHER`, so without that
+    /// rule a store on a medium this build does not recognise would leave the
+    /// worker an owner for good once the engine frees the block on a path that
+    /// tags the removal with a medium the build DOES know — which
+    /// `_evict_regular` in `hiradix_cache.py` does, tagging a whole-node
+    /// teardown `GPU`.
+    #[test]
+    fn a_known_medium_removal_also_clears_the_unranked_tier() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert_tiered(&a, None, &[1], Tiers::for_store(Some("NVLINK_PEER")));
+        assert_eq!(tree.match_prefix(None, &[1]).workers(), workers(&[&a]));
+
+        tree.remove_tiered(&a, &[1], Tiers::for_remove(Some("GPU")));
+        assert_eq!(
+            tree.match_prefix(None, &[1]).matched_blocks,
+            0,
+            "an unrankable hold must not outlive a removal the engine did emit",
+        );
+    }
+
+    /// `DISK` (L3) and `EXTERNAL` (L4) are distinct tiers in the engine's own
+    /// `StorageMedium`, so they must not share a bit: on a fleet running both,
+    /// folding them would make an L3 eviction erase the router's knowledge of
+    /// the L4 copy.
+    #[test]
+    fn disk_and_external_are_independent_tiers() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        tree.insert_tiered(&a, None, &[1], Tiers::for_store(Some("EXTERNAL")));
+        tree.insert_tiered(&a, None, &[1], Tiers::for_store(Some("DISK")));
+
+        tree.remove_tiered(&a, &[1], Tiers::for_remove(Some("DISK")));
+        assert_eq!(
+            tree.match_prefix(None, &[1]).workers(),
+            workers(&[&a]),
+            "an L3 eviction must not take the L4 copy with it",
+        );
+
+        tree.remove_tiered(&a, &[1], Tiers::for_remove(Some("EXTERNAL")));
+        assert_eq!(tree.match_prefix(None, &[1]).matched_blocks, 0);
+    }
+
+    /// The occupancy counters are maintained incrementally at four mutation
+    /// sites, which is exactly the shape that rots under a later refactor. A
+    /// deterministic random walk over every operation and every medium, with
+    /// both invariants asserted after EVERY step:
+    ///
+    /// * `tier_occupancy()` equals a full node-walk recount, and
+    /// * no carrier entry with empty tiers exists (`remove` relies on
+    ///   "no bits ⇒ no entry" to know when a node is prunable).
+    #[test]
+    fn occupancy_and_carrier_invariants_hold_under_a_random_walk() {
+        // xorshift64*, so the walk is reproducible without a dev-dependency.
+        struct Rng(u64);
+        impl Rng {
+            fn next(&mut self) -> u64 {
+                self.0 ^= self.0 >> 12;
+                self.0 ^= self.0 << 25;
+                self.0 ^= self.0 >> 27;
+                self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+            }
+            fn below(&mut self, n: u64) -> u64 {
+                self.next() % n
+            }
+        }
+
+        const MEDIA: [Option<&str>; 6] = [
+            Some("GPU"),
+            Some("CPU_PINNED"),
+            Some("DISK"),
+            Some("EXTERNAL"),
+            Some("NVLINK_PEER"),
+            None,
+        ];
+
+        for seed in 1..=16u64 {
+            let tree = HashTree::new();
+            let ws: Vec<KvWorkerId> = (0..4)
+                .map(|i| worker(&format!("http://w{i}"), i % 2))
+                .collect();
+            let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+
+            for step in 0..400 {
+                let w = &ws[rng.below(ws.len() as u64) as usize];
+                let medium = MEDIA[rng.below(MEDIA.len() as u64) as usize];
+                // A small hash space so chains collide and share nodes.
+                let hashes: Vec<i64> = (0..1 + rng.below(4))
+                    .map(|_| rng.below(12) as i64)
+                    .collect();
+                // Sometimes anchor to a hash that may or may not be in the
+                // tree, to exercise `resolve_parent`'s fallbacks.
+                let parent = (rng.below(4) == 0).then(|| rng.below(12) as i64);
+
+                match rng.below(16) {
+                    0 => tree.clear_worker(w),
+                    1 => {
+                        tree.evict_lru(rng.below(20) as usize);
+                    }
+                    2..=6 => tree.remove_tiered(w, &hashes, Tiers::for_remove(medium)),
+                    _ => tree.insert_tiered(w, parent, &hashes, Tiers::for_store(medium)),
+                }
+
+                assert_eq!(
+                    tree.tier_occupancy(),
+                    tree.debug_recount_occupancy(),
+                    "seed {seed} step {step}: incremental occupancy diverged from a full recount",
+                );
+                assert!(
+                    tree.debug_no_empty_carrier(),
+                    "seed {seed} step {step}: a carrier is present holding no tier",
+                );
+            }
+        }
+    }
+
+    /// `AllBlocksCleared` is the pod-restart / scale-down path
+    /// (`remove_worker` clears every rank), so it must drop a carrier
+    /// regardless of which tiers it held — a host-only or unranked hold is
+    /// still a hold. Asserted at the tree, not only through the rendered
+    /// metric, so a metrics refactor cannot take the coverage with it.
+    #[test]
+    fn clear_worker_drops_carriers_on_every_tier() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        let b = worker("http://b", 0);
+        tree.insert_tiered(&a, None, &[1, 2], Tiers::HOST);
+        tree.insert_tiered(&a, None, &[3], Tiers::for_store(Some("NVLINK_PEER")));
+        tree.insert_tiered(&b, None, &[1, 2], Tiers::DEVICE);
+
+        tree.clear_worker(&a);
+        assert_eq!(
+            tree.match_prefix(None, &[1, 2]).workers(),
+            workers(&[&b]),
+            "a host-only carrier must be cleared like any other",
+        );
+        assert_eq!(tree.match_prefix(None, &[3]).matched_blocks, 0);
+        assert!(
+            tree.tier_occupancy().iter().all(|(w, _)| *w != a),
+            "a cleared worker must leave no occupancy row on any tier",
+        );
+        assert_eq!(tree.tier_occupancy(), tree.debug_recount_occupancy());
+    }
+
+    /// `resolve_parent` disambiguates a shared hash by preferring a candidate
+    /// the worker already holds — on ANY tier. Narrowing that to device owners
+    /// would re-anchor a continuation at the root once the worker's device
+    /// copy was evicted, fragmenting the very prefix the host tier still
+    /// serves. The shape is a shared system prompt whose block hash also
+    /// appears in another chain.
+    #[test]
+    fn ambiguous_parent_resolves_through_a_host_only_hold() {
+        let tree = HashTree::new();
+        let a = worker("http://a", 0);
+        let b = worker("http://b", 0);
+        tree.insert_tiered(&a, None, &[5, 7], Tiers::DEVICE);
+        tree.insert_tiered(&a, None, &[5, 7], Tiers::HOST);
+        tree.remove_tiered(&a, &[5, 7], Tiers::for_remove(Some("GPU")));
+        // A second chain carrying hash 7, so `parent_hash = 7` is ambiguous.
+        tree.insert_tiered(&b, None, &[6, 7], Tiers::DEVICE);
+
+        tree.insert_tiered(&a, Some(7), &[8], Tiers::DEVICE);
+        assert_eq!(
+            tree.prefix_depths(None, &[5, 7, 8]).get(&a).copied(),
+            Some(3),
+            "the continuation must attach under the host-only hold, not at root",
+        );
     }
 
     #[test]
@@ -832,21 +1696,21 @@ mod tests {
 
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         let m = tree.match_prefix(None, &[1, 2]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // Diverges at depth 3 (input asks for 4, tree has 3).
         let m = tree.match_prefix(None, &[1, 2, 4]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // No match at root.
         let m = tree.match_prefix(None, &[9, 9]);
         assert_eq!(m.matched_blocks, 0);
-        assert!(m.workers.is_empty());
+        assert!(m.workers().is_empty());
     }
 
     #[test]
@@ -860,16 +1724,16 @@ mod tests {
         // Common prefix node carries both.
         let m = tree.match_prefix(None, &[1, 2]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&a, &b]));
+        assert_eq!(m.workers(), workers(&[&a, &b]));
 
         // Divergent leaf carries only the matching worker.
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         let m = tree.match_prefix(None, &[1, 2, 4]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&b]));
+        assert_eq!(m.workers(), workers(&[&b]));
     }
 
     #[test]
@@ -881,7 +1745,7 @@ mod tests {
 
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
     }
 
     #[test]
@@ -902,12 +1766,12 @@ mod tests {
         // Match length 2 lands on node 2 (workers empty), so workers={}.
         let m = tree.match_prefix(None, &[1, 2]);
         assert_eq!(m.matched_blocks, 2);
-        assert!(m.workers.is_empty());
+        assert!(m.workers().is_empty());
 
         // Match length 3 lands on node 3 (workers still has A).
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // Reverse-index sanity for hash 2: still present (node holds it).
         {
@@ -932,13 +1796,13 @@ mod tests {
         let m = tree.match_prefix(None, &[1, 2, 3]);
         // Node 3 was pruned, so only 2 levels match.
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&b]));
+        assert_eq!(m.workers(), workers(&[&b]));
 
         // [1,2] now has only B (A was the only other holder of node 2;
         // wait — actually A held 1 and 2 too. But B also holds 1 and 2.)
         let m = tree.match_prefix(None, &[1, 2]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&b]));
+        assert_eq!(m.workers(), workers(&[&b]));
 
         // Node count: root + 1 + 2 + 4 (no 3) = 3 non-root nodes.
         assert_eq!(tree.node_count(), 3);
@@ -986,11 +1850,11 @@ mod tests {
         // Both chains exist independently.
         let m = tree.match_prefix(None, &[1, 5]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         let m = tree.match_prefix(None, &[2, 5]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // Reverse index for hash 5 has 2 distinct nodes.
         {
@@ -1005,10 +1869,10 @@ mod tests {
         assert_eq!(tree.node_count(), 2);
         let m = tree.match_prefix(None, &[1, 5]);
         assert_eq!(m.matched_blocks, 1);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
         let m = tree.match_prefix(None, &[2, 5]);
         assert_eq!(m.matched_blocks, 1);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
     }
 
     #[test]
@@ -1022,16 +1886,16 @@ mod tests {
         // Common prefix has both ranks.
         let m = tree.match_prefix(None, &[1, 2]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&w0, &w1]));
+        assert_eq!(m.workers(), workers(&[&w0, &w1]));
 
         // Divergent leaves: each rank on its own.
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&w0]));
+        assert_eq!(m.workers(), workers(&[&w0]));
 
         let m = tree.match_prefix(None, &[1, 2, 4]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&w1]));
+        assert_eq!(m.workers(), workers(&[&w1]));
     }
 
     #[test]
@@ -1049,12 +1913,12 @@ mod tests {
         // The chain 1->5->7 must exist with A.
         let m = tree.match_prefix(None, &[1, 5, 7]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // The chain 2->5 should NOT have a 7-child (we routed to A's branch).
         let m = tree.match_prefix(None, &[2, 5, 7]);
         assert_eq!(m.matched_blocks, 2);
-        assert_eq!(m.workers, workers(&[&b]));
+        assert_eq!(m.workers(), workers(&[&b]));
     }
 
     #[test]
@@ -1073,7 +1937,7 @@ mod tests {
         // C is reachable as a fresh root child at hash=9.
         let m = tree.match_prefix(None, &[9]);
         assert_eq!(m.matched_blocks, 1);
-        assert_eq!(m.workers, workers(&[&c]));
+        assert_eq!(m.workers(), workers(&[&c]));
     }
 
     #[test]
@@ -1086,7 +1950,7 @@ mod tests {
         assert_eq!(tree.node_count(), 3);
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
     }
 
     #[test]
@@ -1158,7 +2022,7 @@ mod tests {
         // The newer chain should still match fully.
         let m = tree.match_prefix(None, &[200, 201, 202]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
     }
 
     #[test]
@@ -1171,7 +2035,7 @@ mod tests {
 
         let m = tree.match_prefix(None, &[10, 20, 30]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&a]));
+        assert_eq!(m.workers(), workers(&[&a]));
 
         // Confirm parent_block_hash chain: node carrying 30 should record
         // parent_block_hash = Some(20).
@@ -1199,6 +2063,6 @@ mod tests {
 
         let m = tree.match_prefix(None, &[1, 2, 3]);
         assert_eq!(m.matched_blocks, 3);
-        assert_eq!(m.workers, workers(&[&b]));
+        assert_eq!(m.workers(), workers(&[&b]));
     }
 }

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -6,7 +6,7 @@ use crate::config::Config;
 use crate::policies::active_load::ActiveLoadRegistry;
 use crate::policies::buckets::BucketSelector;
 use crate::policies::engine_load::EngineLoadTable;
-use crate::policies::kv_events::BlockSizeOracle;
+use crate::policies::kv_events::{BlockSizeOracle, KvIndexMetrics};
 use crate::policies::prefix_provider::RadixTreePrefixProvider;
 use crate::policies::PolicyRegistry;
 use crate::proxy::Proxy;
@@ -36,6 +36,11 @@ pub struct AppContext {
     pub prefix_index: Option<Arc<dyn sgl_kv_indexer::PrefixIndex>>,
     pub radix_tree_prefix_provider: Option<RadixTreePrefixProvider>,
     pub block_size_oracle: Arc<BlockSizeOracle>,
+    /// Read-only handles `/metrics` pulls the KV storage-tier series from on
+    /// scrape. `None` when this router maintains no local tree (external
+    /// Indexer), where those series would all be a structural zero — see
+    /// [`crate::policies::kv_events::KvEventIndex::metrics_source`].
+    pub kv_metrics: Option<KvIndexMetrics>,
     ready: AtomicBool,
 }
 
@@ -91,6 +96,7 @@ impl AppContext {
             prefix_index: None,
             radix_tree_prefix_provider: None,
             block_size_oracle: BlockSizeOracle::new(),
+            kv_metrics: None,
             engine_load: EngineLoadTable::new(),
             ready: AtomicBool::new(false),
         }
@@ -146,6 +152,7 @@ impl AppContext {
             prefix_index: None,
             radix_tree_prefix_provider: None,
             block_size_oracle: BlockSizeOracle::new(),
+            kv_metrics: None,
             engine_load: EngineLoadTable::new(),
             ready: AtomicBool::new(false),
         }

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -994,7 +994,7 @@ fn render_histogram(out: &mut String, name: &str, label_body: &str, hist: &Histo
 /// https://prometheus.io/docs/instrumenting/exposition_formats/.
 /// We only escape `\`, `"`, and newline — the three characters the
 /// reference parser rejects unescaped.
-fn escape_label(s: &str) -> String {
+pub(crate) fn escape_label(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {

--- a/experimental/sgl-router/src/server/routes/metrics.rs
+++ b/experimental/sgl-router/src/server/routes/metrics.rs
@@ -10,8 +10,9 @@
 //! discovered" failure mode is observable.
 
 use crate::discovery::WorkerMode;
+use crate::policies::kv_events::{KvIndexMetrics, Tiers, ACCOUNTING_REASONS};
 use crate::server::app_context::AppContext;
-use crate::server::metrics::WorkerSnapshot;
+use crate::server::metrics::{escape_label, WorkerSnapshot};
 use axum::extract::State;
 use axum::http::header::CONTENT_TYPE;
 use axum::http::StatusCode;
@@ -49,12 +50,127 @@ pub async fn metrics(State(ctx): State<Arc<AppContext>>) -> impl IntoResponse {
             }
         })
         .collect();
-    let body = ctx.metrics.render_with_workers(&workers);
+    let mut body = ctx.metrics.render_with_workers(&workers);
+    // Pull-on-scrape, like the worker gauges above: the tree and the tally
+    // own the numbers, so a worker that goes away stops emitting series
+    // without anything having to reset a pushed counter.
+    // Emitted unconditionally: without it, "no kv series" is indistinguishable
+    // between the intended metadata-only mode, a broken `kv_metrics` wiring,
+    // and a regressed endpoint.
+    body.push_str(
+        "# HELP sgl_router_kv_tree_maintained 1 when this router maintains its own cache-aware KV tree and therefore emits the sgl_router_kv_* series; 0 when placement comes from an external Indexer, where those series would be a structural zero and are omitted rather than reported as an empty tier stream.\n",
+    );
+    body.push_str("# TYPE sgl_router_kv_tree_maintained gauge\n");
+    body.push_str(&format!(
+        "sgl_router_kv_tree_maintained {}\n",
+        u8::from(ctx.kv_metrics.is_some()),
+    ));
+    if let Some(kv) = ctx.kv_metrics.as_ref() {
+        body.push_str(&render_kv_tiers(
+            kv,
+            ctx.block_size_oracle.get().unwrap_or(0),
+        ));
+    }
     (
         StatusCode::OK,
         [(CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)],
         body,
     )
+}
+
+/// Render the storage-tier series: what the tree holds per worker and tier,
+/// the block size to convert it to tokens, and the tagged event stream it
+/// consumed.
+///
+/// These exist to make a router-vs-engine tier mismatch a number instead of
+/// an inference. `sgl_router_kv_tree_blocks * sgl_router_kv_block_size`
+/// for a worker and tier, divided by that pod's own occupancy of the tier
+/// (device: `sglang_kv_used_tokens + sglang_kv_evictable_tokens`; host:
+/// `sglang_hicache_host_used_tokens`; `tp_rank="0"`), is the tree's coverage
+/// of the tier. About 1 means the tree mirrors the engine; about 0 means the
+/// engine holds a tier that routing cannot see; a missing series means the
+/// worker publishes nothing. The event counters show whether the tagged
+/// stream that should feed the tree is arriving at all.
+/// Emitted only when the router maintains a local tree; in metadata-only mode
+/// (external Indexer) the tier and event series here would be a structural
+/// zero, which the HELP text below would have the operator read as a missing
+/// tier stream. See `KvEventIndex::metrics_source`.
+///
+/// `block_size` is 0 until the first worker reports, and a coverage panel
+/// multiplies by it, so such a panel reads 0 rather than NaN on a fleet that
+/// has not registered yet.
+fn render_kv_tiers(kv: &KvIndexMetrics, block_size: u32) -> String {
+    let mut out = String::new();
+
+    out.push_str(
+        "# HELP sgl_router_kv_block_size Tokens per KV block hash, as established from the fleet (0 until a worker reports). Multiply sgl_router_kv_tree_blocks by this to compare with the engine's token gauges.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_block_size gauge\n");
+    out.push_str(&format!("sgl_router_kv_block_size {block_size}\n"));
+
+    // Every tier is emitted per carrier, zeros included: a host row at 0 next
+    // to a device row in the millions is the mismatch signature, and an
+    // absent series cannot be told from a tier the tree never tracked.
+    out.push_str(
+        "# HELP sgl_router_kv_tree_blocks Blocks the cache-aware tree attributes to a worker rank, by the storage tier the worker holds them on (a block held on device and host counts under both). Times sgl_router_kv_block_size, and divided by the engine's own occupancy of that tier for the same pod (device: sglang_kv_used_tokens + sglang_kv_evictable_tokens; host: sglang_hicache_host_used_tokens; tp_rank=\"0\"), this is the tree's coverage of the tier: ~1 mirrors the engine, ~0 means the engine holds a tier routing cannot see.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_tree_blocks gauge\n");
+    for (id, counts) in kv.tree.tier_occupancy() {
+        for (slot, (_, tier)) in Tiers::SLOTS.iter().enumerate() {
+            out.push_str(&format!(
+                "sgl_router_kv_tree_blocks{{worker_url=\"{}\",dp_rank=\"{}\",tier=\"{}\"}} {}\n",
+                escape_label(&id.url),
+                id.dp_rank,
+                tier,
+                counts[slot],
+            ));
+        }
+    }
+
+    let rows = kv.tally.snapshot();
+    out.push_str(
+        "# HELP sgl_router_kv_events_total KV-cache events applied to the tree, by kind and the storage medium tag they carried (untagged = no medium field; unknown = a medium this build does not recognise). On a hierarchical-cache fleet block_stored/CPU_PINNED runs at about the block_removed/GPU rate; a CPU_PINNED row pinned at 0 with hicache enabled means the tier stream is not reaching the router.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_events_total counter\n");
+    for r in &rows {
+        out.push_str(&format!(
+            "sgl_router_kv_events_total{{event=\"{}\",medium=\"{}\"}} {}\n",
+            r.event, r.medium, r.events,
+        ));
+    }
+    out.push_str(
+        "# HELP sgl_router_kv_event_blocks_total Block hashes carried by the KV-cache events applied to the tree, by kind and storage medium tag. Times sgl_router_kv_block_size this is comparable to the engine's device eviction volume (block_removed/GPU) and, summed without its pool label, to sglang_hicache_backup_tokens_total (block_stored/CPU_PINNED). The two are not equal: the engine also evicts device blocks it never backed up.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_event_blocks_total counter\n");
+    for r in &rows {
+        out.push_str(&format!(
+            "sgl_router_kv_event_blocks_total{{event=\"{}\",medium=\"{}\"}} {}\n",
+            r.event, r.medium, r.blocks,
+        ));
+    }
+
+    // A tagged removal clears only its own tier, so a batch lost in transit
+    // can strand a tier bit the tree will never clear on its own. Nonzero
+    // here is the explanation for tree coverage drifting above 1.
+    out.push_str(
+        "# HELP sgl_router_kv_event_batches_lost_total KV-event batches dropped in transit, inferred from gaps in each publisher's dense sequence number (ZMQ drops at the publisher's high-water mark). Nonzero means the tree may hold tiers a worker has already released, which shows up as sgl_router_kv_tree_blocks exceeding the engine's own occupancy of that tier.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_event_batches_lost_total counter\n");
+    out.push_str(&format!(
+        "sgl_router_kv_event_batches_lost_total {}\n",
+        kv.tally.batches_lost(),
+    ));
+
+    out.push_str(
+        "# HELP sgl_router_kv_tree_accounting_errors_total Times the tree's per-tier occupancy bookkeeping contradicted itself. Always 0 on a correct tree. Nonzero means sgl_router_kv_tree_blocks understates what the tree holds, and can drop a worker's series entirely — which the gauge's own HELP would have you read as a worker that publishes nothing.\n",
+    );
+    out.push_str("# TYPE sgl_router_kv_tree_accounting_errors_total counter\n");
+    for (reason, count) in ACCOUNTING_REASONS.iter().zip(kv.tree.accounting_errors()) {
+        out.push_str(&format!(
+            "sgl_router_kv_tree_accounting_errors_total{{reason=\"{reason}\"}} {count}\n",
+        ));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -65,6 +181,146 @@ mod tests {
     use axum::http::Request;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
+
+    /// The tier series are what a coverage dashboard joins on, so their names
+    /// and label keys are contract: per-worker blocks by tier with zeros
+    /// emitted, the block size to convert them, and every (event, medium)
+    /// cell of the tally.
+    #[tokio::test]
+    async fn kv_tier_series_render_per_worker_and_per_medium() {
+        use crate::policies::kv_events::{EventKind, EventTally, HashTree, KvWorkerId};
+
+        let kv = KvIndexMetrics::new(Arc::new(HashTree::new()), Arc::new(EventTally::new()));
+        let w = KvWorkerId::new("http://w0:30000".into(), 0);
+        kv.tree.insert_tiered(&w, None, &[1, 2, 3], Tiers::DEVICE);
+        kv.tree.insert_tiered(&w, None, &[1, 2], Tiers::HOST);
+        kv.tree.insert_tiered(&w, None, &[1], Tiers::OTHER);
+        kv.tally
+            .record(EventKind::BlockStored, Some("CPU_PINNED"), 2);
+
+        let out = render_kv_tiers(&kv, 64);
+        let blocks = |tier: &str, n: u32| {
+            format!(
+                r#"sgl_router_kv_tree_blocks{{worker_url="http://w0:30000",dp_rank="0",tier="{tier}"}} {n}"#
+            )
+        };
+        // Every tier is asserted, `other` and `external` included: those are
+        // the rows a later edit to `Tiers::SLOTS` would silently drop, and
+        // `other` is where an unrecognised medium lands.
+        let mut want: Vec<String> = [
+            ("device", 3),
+            ("host", 2),
+            ("disk", 0),
+            ("external", 0),
+            ("other", 1),
+        ]
+        .iter()
+        .map(|(t, n)| blocks(t, *n))
+        .collect();
+        want.extend(
+            [
+                "sgl_router_kv_block_size 64\n",
+                r#"sgl_router_kv_events_total{event="block_stored",medium="CPU_PINNED"} 1"#,
+                r#"sgl_router_kv_event_blocks_total{event="block_stored",medium="CPU_PINNED"} 2"#,
+                r#"sgl_router_kv_events_total{event="block_removed",medium="GPU"} 0"#,
+            ]
+            .iter()
+            .map(|s| (*s).to_owned()),
+        );
+        for w in want {
+            assert!(out.contains(&w), "missing {w:?}; got:\n{out}");
+        }
+    }
+
+    /// The series are pulled from the tree on every scrape, so dropping a
+    /// worker must make its rows disappear rather than freeze at their last
+    /// value. This is what `KvEventIndex::remove_worker` relies on when it
+    /// calls `clear_worker`.
+    #[tokio::test]
+    async fn kv_tree_blocks_drop_with_the_worker() {
+        use crate::policies::kv_events::{EventTally, HashTree, KvWorkerId};
+
+        let kv = KvIndexMetrics::new(Arc::new(HashTree::new()), Arc::new(EventTally::new()));
+        let w = KvWorkerId::new("http://w0:30000".into(), 0);
+        kv.tree.insert_tiered(&w, None, &[1, 2], Tiers::HOST);
+        assert!(render_kv_tiers(&kv, 64).contains("http://w0:30000"));
+
+        kv.tree.clear_worker(&w);
+        let out = render_kv_tiers(&kv, 64);
+        assert!(
+            !out.contains("http://w0:30000"),
+            "a cleared worker must stop emitting series; got:\n{out}"
+        );
+        // The family itself stays declared so the scrape shape is stable.
+        assert!(out.contains("# TYPE sgl_router_kv_tree_blocks gauge"));
+    }
+
+    /// The route wiring itself: `render_kv_tiers` had two direct unit tests
+    /// but nothing exercised `ctx.kv_metrics`, so deleting the `if let` in the
+    /// handler left the suite green while `/metrics` silently stopped emitting
+    /// all four families.
+    #[tokio::test]
+    async fn metrics_endpoint_emits_kv_series_when_a_tree_is_maintained() {
+        use crate::policies::kv_events::{EventTally, HashTree, KvWorkerId};
+
+        let mut ctx = AppContext::stub();
+        let tree = Arc::new(HashTree::new());
+        tree.insert_tiered(
+            &KvWorkerId::new("http://w0:30000".into(), 0),
+            None,
+            &[1, 2],
+            Tiers::HOST,
+        );
+        ctx.kv_metrics = Some(KvIndexMetrics::new(tree, Arc::new(EventTally::new())));
+        let ctx = Arc::new(ctx);
+
+        let app = crate::server::app::build_router(ctx.clone());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert!(body.contains("sgl_router_kv_tree_maintained 1"));
+        assert!(body.contains(
+            r#"sgl_router_kv_tree_blocks{worker_url="http://w0:30000",dp_rank="0",tier="host"} 2"#
+        ));
+        assert!(body.contains("sgl_router_kv_event_batches_lost_total 0"));
+        assert!(
+            body.contains(r#"sgl_router_kv_tree_accounting_errors_total{reason="underflow"} 0"#)
+        );
+    }
+
+    /// The other half of the gate: with no local tree the families are absent,
+    /// but the mode gauge still says so rather than leaving the operator to
+    /// guess whether the endpoint regressed.
+    #[tokio::test]
+    async fn metrics_endpoint_reports_the_mode_when_no_tree_is_maintained() {
+        let ctx = Arc::new(AppContext::stub());
+        assert!(ctx.kv_metrics.is_none());
+        let app = crate::server::app::build_router(ctx.clone());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert!(body.contains("sgl_router_kv_tree_maintained 0"));
+        assert!(
+            !body.contains("sgl_router_kv_tree_blocks{"),
+            "a structural zero must not be emitted as if it were a reading",
+        );
+    }
 
     #[tokio::test]
     async fn metrics_endpoint_returns_prometheus_text() {

--- a/experimental/sgl-router/tests/component/policies/kv_events_tree_concurrent.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_tree_concurrent.rs
@@ -155,9 +155,9 @@ fn match_prefix_is_consistent_with_concurrent_clear() {
         // consistent.
         if m.matched_blocks == chain.len() {
             assert!(
-                m.workers.contains(&w),
+                m.workers().contains(&w),
                 "full match must include worker; got {:?}",
-                m.workers,
+                m.workers(),
             );
         }
     }

--- a/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
@@ -84,8 +84,8 @@ async fn two_independent_subscribers_converge_to_same_tree_state() {
         let mb = router_b.tree().match_prefix(None, &hashes);
         let converged = ma.matched_blocks == target
             && mb.matched_blocks == target
-            && ma.workers.contains(&key)
-            && mb.workers.contains(&key);
+            && ma.workers().contains(&key)
+            && mb.workers().contains(&key);
         if converged {
             // Both trees agree on count AND on the worker that holds the
             // prefix. This is what the Radix Tree provider reads to
@@ -96,7 +96,8 @@ async fn two_independent_subscribers_converge_to_same_tree_state() {
                 "subscribers disagreed on matched_blocks",
             );
             assert_eq!(
-                ma.workers, mb.workers,
+                ma.workers(),
+                mb.workers(),
                 "subscribers disagreed on worker set",
             );
             break;
@@ -106,7 +107,10 @@ async fn two_independent_subscribers_converge_to_same_tree_state() {
                 "subscribers did not converge within 3s: \
                  router_a={{matched={}, workers={:?}}}, \
                  router_b={{matched={}, workers={:?}}}, target={target}",
-                ma.matched_blocks, ma.workers, mb.matched_blocks, mb.workers,
+                ma.matched_blocks,
+                ma.workers(),
+                mb.matched_blocks,
+                mb.workers(),
             );
         }
         sequence += 1;
@@ -249,34 +253,34 @@ async fn two_subscribers_merge_events_from_two_publishers() {
             && ay.matched_blocks == target_y
             && bx.matched_blocks == target_x
             && by.matched_blocks == target_y
-            && ax.workers.contains(&key_x)
-            && ay.workers.contains(&key_y)
-            && bx.workers.contains(&key_x)
-            && by.workers.contains(&key_y);
+            && ax.workers().contains(&key_x)
+            && ay.workers().contains(&key_y)
+            && bx.workers().contains(&key_x)
+            && by.workers().contains(&key_y);
         if converged {
             // Negative attribution: prefix X must not be attributed to
             // worker_y in either tree, and vice versa. A regression that
             // keyed events by arriving socket rather than announced
             // worker URL would set BOTH worker keys on each prefix.
             assert!(
-                !ax.workers.contains(&key_y),
+                !ax.workers().contains(&key_y),
                 "router_a cross-attributed worker_y to prefix X: {:?}",
-                ax.workers,
+                ax.workers(),
             );
             assert!(
-                !ay.workers.contains(&key_x),
+                !ay.workers().contains(&key_x),
                 "router_a cross-attributed worker_x to prefix Y: {:?}",
-                ay.workers,
+                ay.workers(),
             );
             assert!(
-                !bx.workers.contains(&key_y),
+                !bx.workers().contains(&key_y),
                 "router_b cross-attributed worker_y to prefix X: {:?}",
-                bx.workers,
+                bx.workers(),
             );
             assert!(
-                !by.workers.contains(&key_x),
+                !by.workers().contains(&key_x),
                 "router_b cross-attributed worker_x to prefix Y: {:?}",
-                by.workers,
+                by.workers(),
             );
             break;
         }
@@ -287,13 +291,13 @@ async fn two_subscribers_merge_events_from_two_publishers() {
                  router_b: X={{matched={}, workers={:?}}}, Y={{matched={}, workers={:?}}}\n  \
                  targets: X={target_x}, Y={target_y}",
                 ax.matched_blocks,
-                ax.workers,
+                ax.workers(),
                 ay.matched_blocks,
-                ay.workers,
+                ay.workers(),
                 bx.matched_blocks,
-                bx.workers,
+                bx.workers(),
                 by.matched_blocks,
-                by.workers,
+                by.workers(),
             );
         }
         sequence += 1;

--- a/experimental/sgl-router/tests/e2e/chat_completions/test_hicache_storage_tiers.py
+++ b/experimental/sgl-router/tests/e2e/chat_completions/test_hicache_storage_tiers.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-GPU coverage for storage-tier-aware cache routing (hicache L2).
+
+An engine running ``--enable-hierarchical-cache`` publishes each KV-cache
+tier transition as its own event, tagged with a ``medium``: a ``CPU_PINNED``
+``BlockStored`` when a block's host backup lands, a ``GPU`` ``BlockRemoved``
+when its device copy is evicted. The router's radix tree used to apply every
+``BlockRemoved`` as a full removal, so a worker lost ownership of a prefix the
+instant its device copy went — even though the host tier still held it and
+could load it back at memory speed.
+
+This is the end-to-end half of that fix. Every other test of the tier logic
+synthesises the event sequence; here a real engine produces it, which is the
+only way to catch the tag going missing anywhere along
+``hiradix_cache -> kv_events -> ZMQ -> subscriber -> pump -> tree``, and the
+only way to check the payoff — that a repeat still routes to the worker
+holding the prefix — rather than just the tree state behind it.
+
+Two workers, so the routing assertion has somewhere else to go wrong: with a
+tier-blind tree the owner is forgotten the moment its device copy is evicted
+and the repeat falls through to min-load, a coin flip. Asserting the tree
+state alone would need only one worker, but it is a strictly weaker claim and
+this test establishes it on the way (see the ``_drive_until`` predicate).
+
+The engine is launched with a deliberately tiny device KV pool
+(``--max-total-tokens``) so a handful of requests forces real device eviction
+in seconds, while ``--hicache-ratio`` keeps the host pool large enough that
+those blocks are retained on L2 rather than dropped outright. That is the
+whole point: the device tier must turn over while the host tier does not.
+
+Both write policies are covered, because they publish the SAME two events in
+OPPOSITE orders and the tree has to converge either way:
+
+* ``write_through`` — the pending D2H copy holds a lock ref that blocks
+  eviction, so the ``CPU_PINNED`` store is published first and the ``GPU``
+  removal second. The worker is never not-an-owner.
+* ``write_back`` — ``_detach_backuped`` publishes the ``GPU`` removal as soon
+  as host slots are reserved, and the ``CPU_PINNED`` store follows only when
+  the copy actually lands. The worker is briefly dropped from the chain (the
+  node may even be pruned) and the later store re-adds it.
+
+A tree that only handled the write_through order would look correct in every
+steady-state check and still lose the prefix on a write_back fleet.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import httpx
+import pytest
+from infra.gateway import Gateway
+from infra.model_pool import spawn_worker
+from infra.model_specs import get_model_spec
+
+# Device KV pool, in tokens. Small enough that the filler prompts below evict
+# the primed prefix within seconds, large enough to hold several requests at
+# once so nothing wedges on admission.
+DEVICE_KV_TOKENS = 8192
+# Tokens per block hash. The router keys its tree on page-sized blocks, so a
+# page of 1 would make the tree one node per token.
+PAGE_SIZE = 64
+# Host pool as a multiple of the device pool. Everything evicted from device
+# during a test must still fit on host, or the engine drops it and there is no
+# host tier left to observe.
+HICACHE_RATIO = 4
+
+_METRIC_RE = re.compile(r"^(\w+)\{([^}]*)\}\s+(-?\d+(?:\.\d+)?)\s*$")
+_BARE_METRIC_RE = re.compile(r"^(\w+)\s+(-?\d+(?:\.\d+)?)\s*$")
+_LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
+
+# The two orders in which an engine can publish a backup + eviction pair.
+WRITE_POLICIES = ["write_through", "write_back"]
+
+
+def worker_args(write_policy: str) -> list[str]:
+    return [
+        "--enable-hierarchical-cache",
+        "--hicache-ratio",
+        str(HICACHE_RATIO),
+        "--hicache-write-policy",
+        write_policy,
+        "--max-total-tokens",
+        str(DEVICE_KV_TOKENS),
+        "--page-size",
+        str(PAGE_SIZE),
+    ]
+
+
+def _scrape(router_url: str) -> str:
+    resp = httpx.get(f"{router_url}/metrics", timeout=10.0)
+    resp.raise_for_status()
+    return resp.text
+
+
+def _samples(text: str, name: str) -> list[tuple[dict[str, str], float]]:
+    """Every sample of `name`, as (labels, value)."""
+    out: list[tuple[dict[str, str], float]] = []
+    for line in text.splitlines():
+        if not line.startswith(name) or line.startswith("#"):
+            continue
+        match = _METRIC_RE.match(line)
+        if match and match.group(1) == name:
+            out.append((dict(_LABEL_RE.findall(match.group(2))), float(match.group(3))))
+            continue
+        bare = _BARE_METRIC_RE.match(line)
+        if bare and bare.group(1) == name:
+            out.append(({}, float(bare.group(2))))
+    return out
+
+
+def _sum_where(text: str, name: str, **labels: str) -> float:
+    total = 0.0
+    for got, value in _samples(text, name):
+        if all(got.get(k) == v for k, v in labels.items()):
+            total += value
+    return total
+
+
+def _events(text: str, event: str, medium: str) -> float:
+    return _sum_where(text, "sgl_router_kv_events_total", event=event, medium=medium)
+
+
+def _tree_blocks(text: str, tier: str, worker_url: str | None = None) -> float:
+    labels = {"tier": tier}
+    if worker_url is not None:
+        labels["worker_url"] = worker_url
+    return _sum_where(text, "sgl_router_kv_tree_blocks", **labels)
+
+
+def _success_counts(text: str) -> dict[str, int]:
+    """Successful dispatches per worker, from one already-fetched scrape."""
+    counts: dict[str, int] = {}
+    for labels, value in _samples(text, "sgl_router_worker_requests_total"):
+        if labels.get("outcome") != "success":
+            continue
+        url = labels.get("worker_url")
+        if url:
+            counts[url] = counts.get(url, 0) + int(value)
+    return counts
+
+
+def _tier_summary(text: str) -> str:
+    """One-line view of the tier state, logged before each assertion so a
+    failure (and a pass) shows the numbers it was judged on rather than only
+    the predicate that tripped."""
+    tiers = {
+        tier: _tree_blocks(text, tier)
+        for tier in ("device", "host", "disk", "external", "other")
+    }
+    events = {
+        f"{ev}/{med}": _events(text, ev, med)
+        for ev in ("block_stored", "block_removed")
+        for med in ("GPU", "CPU_PINNED")
+    }
+    lost = _sum_where(text, "sgl_router_kv_event_batches_lost_total")
+    errs = _sum_where(text, "sgl_router_kv_tree_accounting_errors_total")
+    return (
+        f"tree_blocks={tiers} events={events} "
+        f"batches_lost={lost} accounting_errors={errs}"
+    )
+
+
+def _chat(router_url: str, model_id: str, prompt: str, max_tokens: int = 8) -> None:
+    resp = httpx.post(
+        f"{router_url}/v1/chat/completions",
+        json={
+            "model": model_id,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": False,
+        },
+        timeout=240.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# Words per prompt. Each `tag<i>` word costs several tokens, so this lands
+# around 2k tokens: comfortably under the context ceiling that
+# --max-total-tokens implies (the engine rejects anything longer), and small
+# enough that a handful of prompts turns the device pool over in stages rather
+# than in one step.
+PROMPT_WORDS = 300
+
+
+def _long_prompt(tag: str) -> str:
+    """A prompt with a distinct leading token, so two prompts built with
+    different tags share no block hash and cannot be confused for cache hits
+    of one another."""
+    filler = " ".join(f"{tag}{i}" for i in range(PROMPT_WORDS))
+    return f"Context {tag}: {filler}\nReply with one word."
+
+
+def _wait_until(predicate, *, timeout: float, what: str):
+    """Poll `predicate` until it returns a truthy value. KV events are
+    asynchronous (engine -> ZMQ -> pump), so every assertion about them has to
+    tolerate a lag rather than read once and hope."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(0.5)
+    raise AssertionError(f"timed out waiting for {what}; last observed: {last}")
+
+
+def _drive_until(
+    router_url: str,
+    model_id: str,
+    predicate,
+    *,
+    prefix: str,
+    max_requests: int = 40,
+    what: str,
+):
+    """Push distinct long prompts through the tiny device pool until
+    `predicate(scrape_text)` holds.
+
+    Driven by the observed effect rather than a fixed request count: how many
+    requests it takes to turn the device tier over depends on the tokenizer,
+    the page size and how the scheduler batches, none of which this test
+    should be asserting. A fixed count is either flaky or needlessly slow.
+    """
+    for i in range(max_requests):
+        text = _scrape(router_url)
+        if predicate(text):
+            return text
+        _chat(router_url, model_id, _long_prompt(f"{prefix}{i}"))
+    # The events are asynchronous, so give the pump a moment after the last
+    # request before declaring failure.
+    return _wait_until(
+        lambda: (lambda t: t if predicate(t) else None)(_scrape(router_url)),
+        timeout=60.0,
+        what=what,
+    )
+
+
+@pytest.mark.real_gpu
+@pytest.mark.slow
+@pytest.mark.parametrize("write_policy", WRITE_POLICIES)
+def test_repeat_returns_to_the_host_tier_owner(
+    router_binary,  # noqa: ARG001 - fixture forces release-binary presence
+    gpu_allocator,
+    write_policy: str,
+) -> None:
+    """The routing payoff: after a device eviction, a repeat of the evicted
+    prefix still goes back to the worker holding it on host.
+
+    This is what the tier split buys. With two workers and a tier-blind tree
+    the owner is forgotten the moment its device copy goes, and the repeat
+    falls through to min-load — a coin flip that prefills the whole prompt
+    cold half the time.
+    """
+    spec = get_model_spec("qwen3-0.6b")
+    gpus = gpu_allocator.acquire(2)
+    try:
+        with (
+            spawn_worker(
+                "qwen3-0.6b",
+                gpu_ids=[gpus[0]],
+                enable_kv_events=True,
+                extra_args=worker_args(write_policy),
+            ) as worker_a,
+            spawn_worker(
+                "qwen3-0.6b",
+                gpu_ids=[gpus[1]],
+                enable_kv_events=True,
+                extra_args=worker_args(write_policy),
+            ) as worker_b,
+            Gateway() as router,
+        ):
+            worker_urls = [worker_a.url, worker_b.url]
+            router.start_regular(
+                model_id=spec["model"],
+                tokenizer_path=spec["model"],
+                worker_urls=worker_urls,
+                policy="cache_aware",
+                timeout=120.0,
+            )
+
+            primed = _long_prompt("owner")
+            # The first request lands by min-load (the tree is empty); the
+            # second should hit the prefix and settle a single owner.
+            _chat(router.base_url, spec["model"], primed)
+            _chat(router.base_url, spec["model"], primed)
+
+            def _sole_device_owner() -> str | None:
+                text = _scrape(router.base_url)
+                owners = [
+                    url
+                    for url in worker_urls
+                    if _tree_blocks(text, "device", worker_url=url) > 0
+                ]
+                return owners[0] if len(owners) == 1 else None
+
+            owner = _wait_until(
+                _sole_device_owner,
+                timeout=120.0,
+                what="exactly one worker to own the primed prefix on device",
+            )
+
+            # Turn the device tier over until the owner's copy is demoted:
+            # gone from device, still held on host.
+            _drive_until(
+                router.base_url,
+                spec["model"],
+                lambda t: (
+                    _events(t, "block_removed", "GPU") > 0
+                    and _tree_blocks(t, "host", worker_url=owner)
+                    > _tree_blocks(t, "device", worker_url=owner)
+                ),
+                prefix="evict",
+                what=(
+                    "the owner to hold more host-tier than device-tier blocks. "
+                    "Not `device == 0`: the owner keeps taking a share of the "
+                    "filler traffic, so its device set never empties"
+                ),
+            )
+
+            text = _scrape(router.base_url)
+            print(f"[{write_policy}] after eviction: {_tier_summary(text)}")
+
+            # The engine really did back blocks up to host. Without this the
+            # test proves nothing: a fleet with no L2 traffic cannot exercise
+            # the tier split at all, and the assertions below would hold
+            # trivially on a device-only cache.
+            assert _events(text, "block_stored", "CPU_PINNED") > 0, (
+                "engine published no CPU_PINNED stores; hierarchical cache is "
+                "not backing blocks up to host and this test is vacuous"
+            )
+            # The occupancy counters are booked at four mutation sites, all of
+            # which the eviction churn above exercised.
+            assert (
+                _sum_where(text, "sgl_router_kv_tree_accounting_errors_total") == 0
+            ), "tree occupancy accounting contradicted itself"
+
+            before = _success_counts(text)
+            _chat(router.base_url, spec["model"], primed)
+            after = _success_counts(_scrape(router.base_url))
+
+            deltas = {
+                url: after.get(url, 0) - before.get(url, 0) for url in worker_urls
+            }
+            assert deltas.get(owner, 0) == 1, (
+                "repeat of a host-resident prefix did not return to its owner "
+                f"{owner}; per-worker deltas={deltas}"
+            )
+    finally:
+        gpu_allocator.release(gpus)


### PR DESCRIPTION
> **Superseded — split into a stacked series and closed.** The same change,
> byte-for-byte, now lands as #39108 (the tier-aware tree), #39109 (the
> `sgl_router_kv_*` `/metrics` series) and #39110 (the real-GPU e2e proof), all
> with their heads on `sgl-project/sglang` so they can chain base-to-head.
> Review there; this branch is gone.

---

## Motivation

An engine running a hierarchical cache publishes tier-tagged KV events: a
`CPU_PINNED` `BlockStored` when a block's host backup lands, a `GPU`
`BlockRemoved` when its device copy is demoted, a `CPU_PINNED` `BlockRemoved`
when the host copy goes. The router's in-process radix tree applies **every**
`BlockRemoved` as a full removal:

> For every node carrying any hash in `block_hashes`, drop `worker` from that
> node's worker set.
> — `src/policies/kv_events/tree.rs`, `HashTree::remove`

So a pod loses ownership of a prefix the moment its *device* copy is evicted,
even though its host tier still holds the block and can load it back at memory
speed. The tag is decoded off the wire and then discarded: `medium` appears 35
times in `wire.rs` and 6 in `index.rs` — and **zero times in `tree.rs`**.

Observed consequence on a hierarchical-cache fleet: every prefix became
unroutable after one device turnover (~15 min) while the host tier retained it
for ~2 h. Repeats fell through to min-load and landed on a random pod, which
prefilled them cold. The 2.4% host-hit share that remained was the 1-in-61 luck
of picking the right pod.

Worth noting for reviewers: **the Indexer path already solves this.**
`sgl-kv-indexer/src/memory_backend.rs` carries `TierType`, per-`(worker, tier)`
holdings and `revoke_one(&mut state, &worker_id, &hash, action.tier)`. Tiers
were designed for the new crate and the in-process tree was left blind — which
matters because `--cache-prefix-provider radix_tree` is the `#[default]`
(`src/config/types.rs:376`).

## Modifications

**Tree** (`kv_events/tree.rs`). Each `(node, worker)` carries a tier bitset
over the engine's own `StorageMedium` ladder — device (L1) / host (L2) / disk
(L3) / external (L4) — plus an unranked `other`, instead of bare membership:

- a tagged store sets one bit; a tagged removal clears only that bit; a worker
  stays an owner while any bit remains;
- untagged events keep their pre-tiering meaning — an untagged store is a
  device store, an untagged removal clears every tier;
- an unknown medium on a **store** lands on the unranked `other` tier, so an
  engine adding a medium cannot silently turn every store on it into a device
  hit.

Removal is deliberately asymmetric with storing, because a permanently stale
owner is the one failure a routing index must never manufacture while
over-removal costs at most one cold prefill:

- an untagged **or unrecognised** medium on a removal clears every tier;
- a **recognised** medium clears its own tier *and the unranked `other` with
  it*. Nothing else clears `other`, so a future engine publishing stores under
  a medium this build folds there — but freeing them on a path that emits a tag
  this build does know (`_evict_regular` in `hiradix_cache.py` tags a
  whole-node teardown `GPU`) — would otherwise strand that bit until the worker
  is dropped entirely. On today's engine every medium is known, so this clears
  a bit that is never set.

`DISK` and `EXTERNAL` get their own bits rather than one shared "storage" bit:
the engine treats them as distinct tiers, so sharing one would make an L3
eviction erase the router's knowledge of an L4 copy on a fleet running both.

`prefix_depths` — which is what the routing path actually reads
(`policies/prefix_provider.rs`) — needs no signature change: presence is now
"on any tier", so a host-backed chain keeps its full depth.

`MatchResult` now carries a per-worker `tiers` map as its single carrier list,
with `workers()` derived from it — so the two can never disagree and the match
path clones each `KvWorkerId` once instead of twice. Nothing selects on tier
yet; that is left to the policy layer.

**Event tally** (`kv_events/tally.rs`, new). Fixed-cardinality counters of the
events the pump applied, by kind and medium. Without it a router discarding the
tag is indistinguishable from an engine never sending it — which is exactly why
this survived. Every `(event, medium)` cell renders, zeros included: the zero
is the finding.

**Metrics** (`/metrics`, pulled on scrape like the worker gauges):

| series | what it says |
|---|---|
| `sgl_router_kv_events_total{event,medium}` | the tier-tagged stream the tree applied |
| `sgl_router_kv_event_blocks_total{event,medium}` | block hashes those events carried |
| `sgl_router_kv_tree_blocks{worker_url,dp_rank,tier}` | what the tree attributes per worker and tier |
| `sgl_router_kv_block_size` | tokens per block hash, to convert the above |
| `sgl_router_kv_event_batches_lost_total` | batches dropped in transit, from gaps in the publisher's sequence |
| `sgl_router_kv_tree_accounting_errors_total{reason}` | occupancy bookkeeping contradicting itself; always 0 on a correct tree |
| `sgl_router_kv_tree_maintained` | 1 when this router maintains a tree, 0 under an external Indexer |

`kv_tree_blocks * kv_block_size`, divided by the pod's own occupancy of the
tier (device: `sglang_kv_used_tokens + sglang_kv_evictable_tokens`; host:
`sglang_hicache_host_used_tokens`; `tp_rank="0"`), is the tree's coverage of
that tier: ~1 mirrors the engine, ~0 means the engine holds a tier routing
cannot see. The occupancy is maintained incrementally at each mutation site, so
a scrape costs one read lock rather than a tree walk.

**Coverage above 1 is a third reading, and it is new.** A tagged removal now
clears only its own tier, so a batch lost in transit (ZMQ drops at the
publisher's high-water mark) can strand a tier bit the tree will never clear on
its own — where previously the earlier device removal had already evicted the
worker outright and losing the later batch was harmless. The pump therefore
counts sequence gaps: `sgl_router_kv_event_batches_lost_total` is the
explanation for a coverage ratio drifting above 1, and the gap is logged at
`warn` naming the worker.

The three health series above exist because the failure modes of this
accounting are otherwise silent: an occupancy underflow would clamp to zero and
then drop a worker's row entirely, which the gauge's own HELP text tells the
operator means "this worker publishes nothing", and the metadata-only mode
emits no tier series at all — indistinguishable from broken wiring without
`kv_tree_maintained`.

`AppContext` gains `kv_metrics`, a read-only pair of handles (tree + tally) so
`/metrics` can reach them without a route being able to call `add_worker` /
`remove_worker` / `shutdown`.

It is `None` — and the whole block is omitted from the scrape — when the router
does **not** maintain a local tree. In metadata-only mode (an external Indexer
is the routing signal) no KV subscription is opened, so every series here would
be a structural zero, which their own HELP text would have the operator read as
"the tier stream is not reaching the router": a different fault with a
different fix.

## Not in this PR

- **Tier-ranked *selection*.** Owners on any tier are routable, which is the
  fix; preferring the device owner among them is a policy change and belongs
  with the scoring layer.
- `sgl_router_selected_owner_tier_total` and
  `sgl_router_zero_match_block0_total` — their call sites are at the selection
  point, so they land with the policy work rather than as counters nothing
  increments.
- The Grafana row that reads these series (follow-up PR; the four expressions
  are already validated against a live Prometheus).

## Accuracy Tests

N/A — router-side routing metadata, no model forward path touched.

## Speed Tests and Profiling

No new work on the hot path. `match_prefix` and `prefix_depths` do the same
descent; the node's carrier set changed from `HashSet<KvWorkerId>` to
`HashMap<KvWorkerId, Tiers>`, i.e. one extra `u8` per (node, carrier).
Occupancy is booked once per inserted chain, not per block, and the scrape
reads the counters instead of walking the tree.

## Tests

### End-to-end, on real GPUs

`tests/e2e/chat_completions/test_hicache_storage_tiers.py` — two workers, a
real engine with `--enable-hierarchical-cache`, a deliberately tiny device
pool (`--max-total-tokens 8192`, `--page-size 64`) so a handful of ~2k-token
prompts turns it over in seconds, and `--hicache-ratio 4` so what leaves
device is retained on host. Every other test of this logic synthesises the
event sequence; this is the only one that catches the tag going missing
anywhere along `hiradix_cache -> kv_events -> ZMQ -> subscriber -> pump ->
tree`, and the only one that asserts the payoff rather than the tree state
behind it: **a repeat of an evicted prefix must return to the worker holding
it on host.**

Parametrized over both write policies, because they publish the same two
events in OPPOSITE orders and the tree has to converge either way —
`write_through` orders the host store first (the pending D2H copy holds a lock
ref that blocks eviction), `write_back` publishes the device removal as soon
as host slots are reserved and the store only once the copy lands. A tree that
handled one order would look correct in every steady-state check and still
lose the prefix on the other. Measured, they do drive different paths:
`block_removed/GPU` = 1 under `write_through` vs 9 under `write_back`.

Verified on 2x H200:

| | result |
|---|---|
| against this branch | **2 passed** in 2:44 |
| against a tier-blind build of the same source (`for_store`→`DEVICE`, `for_remove`→`ALL`) | **2 failed** — "timed out waiting for the owner to hold more host-tier than device-tier blocks" |

The assertion is `host > device` on the owning worker, not `host > 0`: under
`write_through` every stored block is host-backed immediately, so `host > 0`
is true before anything is ever evicted and would pass on a tree that had
never seen a removal. An earlier draft made exactly that mistake.

### Unit and integration

`cargo test -p sgl-router`: 715 passed, 0 failed (567 lib + 148 integration).

New tests, and each of the seven marked ★ fails against the pre-fix
(tier-blind) behaviour — verified by neutralising `Tiers::for_store` /
`Tiers::for_remove` to their old constants and re-running:

- ★ `device_eviction_after_host_backup_keeps_the_worker_as_host_owner` — the
  engine's real write-back sequence; only the host-tagged removal ends
  ownership.
- ★ `prefix_depths_survive_a_device_eviction_with_a_host_backup` — the same
  through the accessor the routing path uses, with an untagged removal as the
  control.
- ★ `unknown_medium_stores_as_owner_and_removes_everything` and
  `a_known_medium_removal_also_clears_the_unranked_tier` — pin the asymmetry in
  both directions, including the forward-compat hole.
- ★ `disk_and_external_are_independent_tiers` — an L3 eviction must not take
  the L4 copy with it.
- ★ `ambiguous_parent_resolves_through_a_host_only_hold` — a continuation whose
  parent hash is shared must attach under the worker's host-only hold, not
  re-anchor at the root.
- `clear_worker_drops_carriers_on_every_tier` — the pod-restart path, asserted
  at the tree rather than only through the rendered metric.
- `metrics_source_is_none_only_without_a_local_tree` and two route-level tests
  — the metadata-only gate and the `/metrics` wiring. Both were previously
  unpinned: inverting the gate, or deleting the handler's `if let`, left the
  whole suite green while the endpoint started lying.
- ★ `tier_occupancy_matches_a_full_recount_after_mixed_mutations` — the
  incremental counters against a full recount after stores, partial and full
  removals, `clear_worker` and LRU eviction.
- ★ `pump_keeps_host_backed_block_owned_across_device_eviction` — the same
  sequence end-to-end through the pump.
- `occupancy_and_carrier_invariants_hold_under_a_random_walk` — 16 seeds x 400
  mixed ops over every operation and every medium, asserting after **every**
  step that the incremental occupancy equals a full node-walk recount and that
  no carrier is present holding no tier. Incremental accounting is exactly what
  rots under a later refactor.
- `untagged_events_keep_the_legacy_meaning`, `tiers_are_tracked_per_worker`,
  `empty_tier_insert_is_noop`, `records_by_kind_and_medium_and_folds_the_rest`,
  `pump_tallies_applied_events_by_medium`,
  `kv_tier_series_render_per_worker_and_per_medium`,
  `kv_tree_blocks_drop_with_the_worker`.

`prefix_depths_survive_a_device_eviction_with_a_host_backup` deliberately
evicts **block 1** as well: that method seeds its live set from level 1 and
narrows from there, so evicting only from block 2 onward would leave the seed
exercised against device-held state alone — and a seed narrowed to device
owners would send every host-only worker to depth 0, restoring this exact bug
with the suite still green.

Also hardened while here:

- `TreeState::insert`'s two invariant-violation exits now book the occupancy
  delta they had already written (they returned past it, leaving the gauge
  permanently short).
- `EventKind` gained exhaustive `slot()` / `label()` matches. A discriminant
  cast plus a length assertion still lets an *appended* variant compile and
  then panic on an out-of-range index inside the long-lived pump task, taking
  the cache-aware path down with no restart; a new variant is now two compile
  errors.
- Compile-time assertions pin `Tiers::ALL` to the union of `Tiers::SLOTS` and
  every `WIRE_MEDIA` entry to a ranked tier. A bit missing from `ALL` is one an
  untagged removal never clears — a permanently stale owner; a bit missing from
  `SLOTS` is a tier invisible in the coverage gauge, i.e. this bug class one
  tier later. The `debug_recount_occupancy` oracle cannot catch either, because
  it walks the same table.
- `clear_worker` books its accounting once per worker instead of once per node:
  on the failure path the per-node form emitted one `error!` per node while
  holding the tree's write lock, blocking every routing decision behind a log
  flood.
- An unrecognised `medium` now logs once per distinct string. The fold to
  `unknown` / `OTHER` was completely silent, and silence about a discarded tag
  is precisely the bug this PR fixes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011odv4mFVztjuMpkyuBeasC
