### PR TITLE
[Router] Add a KV storage-tier coverage row to the Grafana dashboard

### DIFF
--- a/experimental/sgl-router/monitoring/grafana-dashboard.json
+++ b/experimental/sgl-router/monitoring/grafana-dashboard.json
@@ -1896,6 +1896,311 @@
           "format": "time_series"
         }
       ]
+    },
+    {
+      "type": "row",
+      "title": "KV tree vs engine (storage-tier coverage)",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 24,
+        "h": 1
+      },
+      "id": 28,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "KV event blocks by medium",
+      "description": "Blocks/s the router tree consumes, by event kind and the storage-medium tag the engine put on the event, per deployment. On a hierarchical-cache fleet block_stored/CPU_PINNED runs at roughly the block_removed/GPU rate; they are not equal, because the engine also evicts device blocks it never backed up. A CPU_PINNED line at 0 while the engines report hicache backups means the tier stream is not reaching the router. Both the busiest and the quietest replica are plotted: every replica receives the full stream, so a quietest-replica line at 0 while the busiest is healthy means one replica has lost its subscription and is routing blind.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 12,
+        "h": 8
+      },
+      "id": 29,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (namespace, event, medium) (rate(sgl_router_kv_event_blocks_total[$__rate_interval]))",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "{{namespace}} {{event}}/{{medium}}",
+          "format": "time_series"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "min by (namespace, event, medium) (rate(sgl_router_kv_event_blocks_total[$__rate_interval]))",
+          "range": true,
+          "refId": "B",
+          "legendFormat": "{{namespace}} {{event}}/{{medium}} (quietest replica)",
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "KV tree blocks by tier (fleet)",
+      "description": "Blocks the router tree attributes to the fleet, by the tier the worker holds them on (a block held on device and host counts under both). Absolute counts, so summing across workers is valid. host should sit at roughly hicache-ratio times device on a fleet with a full host tier; host at 0 means routing cannot see the L2 tier at all. max per worker across replicas, then summed.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 59,
+        "w": 12,
+        "h": 8
+      },
+      "id": 30,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (tier) (max by (worker_url, dp_rank, tier) (sgl_router_kv_tree_blocks))",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "{{tier}}",
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tree coverage of engine host tier",
+      "description": "Router-attributed host-tier tokens / engine hicache host tokens in use, per deployment. ~1: every block the engines hold on host is routable. ~0 with a full host tier: the L2 tier is invisible to routing and repeats of anything evicted from device land on random pods -- this is the ratio that separates a retention problem (the engines really evicted it) from a visibility problem (the engines still hold it, the router forgot). Above 1: the tree holds tiers a worker already released, so check sgl_router_kv_event_batches_lost_total -- a tagged removal clears only its own tier, and a batch lost in transit strands the rest. Both sides are grouped by namespace because the ratio is not additive across deployments.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 67,
+        "w": 24,
+        "h": 8
+      },
+      "id": 31,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (namespace) (max by (namespace, worker_url, dp_rank) (sgl_router_kv_tree_blocks{tier=\"host\"})) * on(namespace) group_left() max by (namespace) (sgl_router_kv_block_size)) / sum by (namespace) (sglang_hicache_host_used_tokens{tp_rank=\"0\"})",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "{{namespace}}",
+          "format": "time_series"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
> **Superseded — closed in favour of #39111**, which is this same dashboard row
> re-based onto the split stack (#39108 → #39109 → #39110) with its head on
> `sgl-project/sglang`. Review there; this branch is gone.

---

## Motivation

> Stacked on **#38720**, which adds the `sgl_router_kv_*` series these panels
> read. Merge that first — on its own this row renders "No data".

The dashboard has no way to answer the one question that matters when
cache-aware routing degrades: **does the router's view of the fleet's KV cache
match what the engines actually hold, tier by tier?**

That gap is not academic. It hid a real defect for months — the tree was
discarding the storage-`medium` tag on KV events, so a pod's host-tier copy of
a prefix was invisible to routing. From the board the symptom (a low cache-hit
rate) was indistinguishable from ordinary engine-side eviction, because nothing
plotted what the router believed against what the engines held.

## Modifications

One row, **KV tree vs engine (storage-tier coverage)**, three panels. Pure
addition: 305 lines, no existing panel or variable touched, no new template
variable.

Everything is grouped by `namespace` on **both sides of every ratio**. That is
not tidiness. Measured on two live deployments: block size is not uniform
(64 on one, 512 on the other), and the router series and the engine gauges do
not span the same set of namespaces. A fleet-global expression therefore
divides one deployment's tree by another's occupancy and scales it by a third's
block size. On a fleet that is actually at parity, the unscoped form of the
coverage panel reads **0.54** and the scoped form reads **1.00** — the unscoped
version ships a permanent, plausible-looking P1.

- **KV event blocks by medium** — blocks/s the tree consumes by event kind and
  `medium`, per deployment. On a hierarchical-cache fleet
  `block_stored/CPU_PINNED` runs at roughly the `block_removed/GPU` rate
  (measured 29.7 vs 29.7 blocks/s), though not equal in general: the engine
  also evicts device blocks it never backed up. Plots the busiest **and the
  quietest** replica — every replica receives the full stream, so a
  quietest-replica line at 0 while the busiest is healthy is one replica that
  lost its subscription and is routing blind. A `max` alone hides exactly that.
- **KV tree blocks by tier (fleet)** — `max` per worker across replicas, then
  summed by tier. Absolute counts, so summing across workers is valid (unlike
  the ratios).
- **Tree coverage of engine host tier** — against
  `sglang_hicache_host_used_tokens`. ~1: every block the engines hold on host
  is routable. ~0 with a full host tier: repeats of anything evicted from
  device land on random pods. **Above 1**: the tree holds tiers a worker has
  already released — the description points at
  `sgl_router_kv_event_batches_lost_total`, since a tagged removal clears only
  its own tier and a batch lost in transit strands the rest.

## Not in this PR

**Device-tier coverage.** It needs `sglang_kv_evictable_tokens` carrying a
per-rank label to build a pod-level denominator, and engines predating that
gauge need a `--dcp-size` factor supplied out of band. A manual dashboard
variable is the wrong mechanism for that: it is one global value on an
otherwise multi-deployment board, so it cannot describe a mixed fleet and is
silently wrong for any deployment that does not match it — at its default of 1
against an 8-way DCP fleet the panel reads 10.6 and accuses the router of a 10x
over-count. Worth adding once the denominator can be derived rather than
configured.

## Accuracy Tests

N/A — dashboard JSON only.

## Speed Tests and Profiling

N/A.

## Tests

Every expression was substituted (`$vars` → `.*`, `$__rate_interval` → `5m`)
and POSTed to a live Prometheus holding these series, then checked **for its
value, not merely for returning rows** — a returning-rows check is what let the
unscoped 0.54 look healthy in the first place:

| panel | result |
|---|---|
| KV event blocks by medium (max / min) | 36 series each, per namespace |
| KV tree blocks by tier | 4 series (device, host, other, storage) |
| Tree coverage of engine host tier | **1.0000** on both deployments at parity |

The file re-serialises to valid JSON with unique panel ids, correct `gridPos`
stacking after the last existing row, and a zero-deletion diff.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests — N/A, dashboard JSON; queries value-checked against a live Prometheus instead.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results — N/A.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011odv4mFVztjuMpkyuBeasC
