### PR TITLE
Keep VMM capability votes on CPU

### DIFF
--- a/python/sglang/srt/utils/cuda_vmm_utils.py
+++ b/python/sglang/srt/utils/cuda_vmm_utils.py
@@ -667,7 +667,7 @@ class VmmReservation:
 
 def all_ranks_ok(group: ProcessGroup, ok: bool) -> bool:
     """True iff ``ok`` holds on every rank in ``group`` (BAND all-reduce)."""
-    flag = torch.tensor([1 if ok else 0], dtype=torch.int32)
+    flag = torch.tensor([1 if ok else 0], dtype=torch.int32, device="cpu")
     dist.all_reduce(flag, op=dist.ReduceOp.BAND, group=group)
     return flag.item() == 1
 


### PR DESCRIPTION
## Summary

`all_ranks_ok()` in `cuda_vmm_utils.py` votes over a CPU/Gloo group, but `torch.tensor(...)` inherits the enclosing CUDA default device. Handing Gloo a CUDA tensor routes the all-reduce through its CUDA-host path, and the Gloo worker thread ends up initializing a CUDA context on GPU 0 — wasting device memory that would otherwise back the KV cache. Pin the 1-element vote tensor to CPU.

## Original commits

- `fcc39d9f2c`

## Test plan

- `git diff --check`: clean; `python3 -m py_compile` on the touched file: passes.
- Pre-commit hooks on the OSS commit: passed.
- No GPU/runtime test run from this host (no CUDA here); the change is a one-line device pin on a 1-element int32 vote tensor consumed only by a Gloo `BAND` all-reduce.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34391605109](https://github.com/sgl-project/sglang/actions/runs/34391605109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34391604704](https://github.com/sgl-project/sglang/actions/runs/34391604704)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34391604883](https://github.com/sgl-project/sglang/actions/runs/34391604883)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->