### PR TITLE
Fix embedding overrides for single embedding inputs

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1218,6 +1218,8 @@ class EmbeddingReqInput:
             if self.sampling_params is None:
                 self.sampling_params = {}
             self.sampling_params["max_new_tokens"] = 0
+            if self.embed_overrides is not None:
+                self.embed_overrides = self.embed_overrides[0]
         else:
             if self.rid is None:
                 self.rid = [uuid.uuid4().hex for _ in range(self.batch_size)]

--- a/test/registered/unit/managers/test_embed_overrides.py
+++ b/test/registered/unit/managers/test_embed_overrides.py
@@ -14,6 +14,11 @@ from unittest.mock import AsyncMock, MagicMock
 import torch
 
 from sglang.srt.constants import MIS_DELIMITER_TOKEN_ID
+from sglang.srt.entrypoints.openai.protocol import (
+    EmbeddingRequest,
+    MultimodalEmbeddingInput,
+)
+from sglang.srt.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
 from sglang.srt.entrypoints.openai.utils import convert_embeds_to_tensors
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
@@ -207,6 +212,78 @@ class TestEmbeddingReqInputEmbedOverride(CustomTestCase):
         reset_context()
         self.addCleanup(reset_context)
         publish(ServerArgs(model_path="dummy"), role="tokenizer")
+
+    def test_single_override_normalization(self):
+        """Single requests must remove the per-input axis before resolution."""
+        for prompt in ({"input_ids": [50, 10, 50]}, {"text": "placeholder text"}):
+            for embeds in ([_vec(1), _vec(2)], None):
+                with self.subTest(prompt=prompt, skip=embeds is None):
+                    req = EmbeddingReqInput(
+                        **prompt,
+                        embed_override_token_id=50,
+                        embed_overrides=[embeds],
+                    )
+                    req.normalize_batch_and_arguments()
+                    self.assertTrue(req.is_single)
+                    self.assertIs(req.embed_overrides, embeds)
+                    if embeds is not None:
+                        resolved = TokenizerManager._resolve_embed_overrides(
+                            [50, 10, 50],
+                            req.embed_override_token_id,
+                            req.embed_overrides,
+                        )
+                        self.assertEqual(resolved.positions, [0, 2])
+                        torch.testing.assert_close(resolved.embeds, torch.stack(embeds))
+
+    def test_openai_override_normalization(self):
+        """The API's per-input overrides work for scalar and batched inputs."""
+        serving = OpenAIServingEmbedding(
+            MagicMock(tokenizer=None), MagicMock(chat_template_name=None)
+        )
+        for input_value in (
+            [50, 10, 50],
+            [[50, 10, 50]],
+            "placeholder text",
+            ["placeholder text"],
+            [MultimodalEmbeddingInput(text="placeholder text")],
+        ):
+            for overrides in ([[1.0] * HIDDEN_DIM, [2.0] * HIDDEN_DIM], None):
+                with self.subTest(input=input_value, skip=overrides is None):
+                    request = EmbeddingRequest(
+                        input=input_value,
+                        embed_override_token_id=50,
+                        embed_overrides=[overrides],
+                    )
+                    req, _ = serving._convert_to_internal_request(request)
+                    req.normalize_batch_and_arguments()
+                    item = req if req.is_single else req[0]
+                    if overrides is None:
+                        self.assertIsNone(item.embed_overrides)
+                    else:
+                        resolved = TokenizerManager._resolve_embed_overrides(
+                            [50, 10, 50],
+                            item.embed_override_token_id,
+                            item.embed_overrides,
+                        )
+                        self.assertEqual(resolved.positions, [0, 2])
+                        torch.testing.assert_close(
+                            resolved.embeds, torch.tensor(overrides)
+                        )
+
+    def test_batch_override_normalization_with_skip(self):
+        embeds = [_vec(1), _vec(2)]
+        req = EmbeddingReqInput(
+            input_ids=[[50, 10, 50], [20]],
+            embed_override_token_id=50,
+            embed_overrides=[embeds, None],
+        )
+        req.normalize_batch_and_arguments()
+        resolved = TokenizerManager._resolve_embed_overrides(
+            req[0].input_ids, req[0].embed_override_token_id, req[0].embed_overrides
+        )
+        self.assertEqual(resolved.positions, [0, 2])
+        torch.testing.assert_close(resolved.embeds, torch.stack(embeds))
+        self.assertIsNone(req[1].embed_overrides)
 
     def test_override_fields_in_getitem(self):
         """embed_override_token_id, embed_overrides, and positional_embed_overrides


### PR DESCRIPTION
## Motivation

Single embedding inputs keep the outer per-input override list, causing placeholder resolution to fail or treating a null override as a replacement.

## Modifications

Unwrap that list when normalizing a single request, matching the existing batch-item handling.

## Accuracy Tests

Embedding override and OpenAI embedding unit tests: 58 passed. Coverage includes token IDs, text, multimodal text, multiple placeholders, and null overrides.

## Speed Tests and Profiling

Not applicable to this request-normalization fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable; restores the documented input shape.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to request normalization.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34392030448](https://github.com/sgl-project/sglang/actions/runs/34392030448)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34392030204](https://github.com/sgl-project/sglang/actions/runs/34392030204)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34392030506](https://github.com/sgl-project/sglang/actions/runs/34392030506)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->