### PR TITLE
[Feature] MXFP4 KV Cache for Qwen3.5/3.8 (MHA) on SM120

### DIFF
--- a/python/sglang/kernels/ops/attention/decode_attention_mxfp4_sm120.py
+++ b/python/sglang/kernels/ops/attention/decode_attention_mxfp4_sm120.py
@@ -1,0 +1,756 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MXFP4 native decode kernels.
+
+A standalone Triton kernel for the OCP MXFP4 KV cache (block-32 E2M1 data
++ per-block E8M0 scale), consumed directly from the packed pool buffers --
+no PLAIN materialization. ``mxfp4_decode_attention_fwd`` is a two-stage
+split-KV decode attention that mirrors the bf16/fp8 kernel structure in
+``decode_attention.py`` (``_fwd_kernel_stage1`` + ``_fwd_kernel_stage2``) but
+loads the packed bytes per token/head and dequantizes inline (fp32 math
+throughout).
+
+Codec semantics (must stay bit-compatible with the production codec and the
+oracle): low nibble of a packed byte = even-index element, high nibble =
+odd-index element; E2M1 code magnitude table (0, .5, 1, 1.5, 2, 3, 4, 6)
+with bit 3 = sign; E8M0 scale = 2^(byte - 127), applied by exact fp32 bit
+construction (``_e8m0_to_f32``). A NaN scale byte (0xFF) propagates NaN
+exactly like the oracle.
+
+Intentionally NOT implemented: lean attention, score_mod,
+DCP, sliding window, logit cap, xai temperature, MLA, extend/prefill.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.attention.decode_attention import _extract_kv_strides
+from sglang.kernels.ops.quantization.mxfp4_quant import e8m0_to_f32 as _e8m0_to_f32
+
+MXFP4_BLOCK_SIZE = 32
+# Kernel-side mirror of MXFP4_BLOCK_SIZE: @triton.jit functions may only read
+# tl.constexpr globals.
+_MXFP4_BLOCK = tl.constexpr(MXFP4_BLOCK_SIZE)
+_MIN_BLOCK_KV = 32
+_BLOCK_N = 64
+_GROUPED_BLOCK_H = 16
+
+
+@triton.jit
+def _e2m1_scale_to_bf16(code, sbytes):
+    """Bit-exact E2M1 code x E8M0 scale -> bf16 via pure integer ops.
+
+    value = mag(code) * 2^(b - 127). For normal E2M1 (e >= 1) the bf16 bit
+    pattern is exp field = e + b - 1, mantissa = m << 6; the E2M1 subnormal
+    (e == 0, m == 1) is 2^(b - 128), exp field b - 1, mantissa 0; e == 0 and
+    m == 0 is a signed zero. The product crosses bf16's normal/subnormal
+    boundary when the exponent field is 0 (value 2^-127) -> subnormal
+    encoding mant = 1 << (E + 6). Out-of-range scales encode inf; an E8M0
+    NaN byte (0xFF) encodes a quiet NaN (highest priority, matching the
+    oracle's all-NaN block). Verified against the OCP oracle over all
+    16 codes x 256 scale bytes: element-exact except scale byte 0 with
+    NONZERO codes (fp32-subnormal domain where the oracle's torch.exp2
+    carries a 1-ULP error; production pairs byte 0 only with all-zero
+    codes, where both sides give exact zeros). Pure int32 ALU: no SFU exp2,
+    no fp32 multiply in the dequant hot path.
+    """
+    e = (code >> 1) & 3
+    m = (code & 1).to(tl.int32)
+    sgn = (code & 8).to(tl.int32) << 12  # sign bit 3 -> bf16 bit 15
+    b = sbytes.to(tl.int32)
+
+    is_zero = (e == 0) & (m == 0)
+    E = tl.where(e == 0, b - 1, e + b - 1)
+    mant = tl.where(e == 0, 0, m << 6)
+
+    is_sub = E < 1  # value 2^(E-127) < 2^-126: bf16 subnormal encoding
+    sub_mant = tl.where(E >= -6, 1 << tl.minimum(E + 6, 31), 0)
+    is_inf = E >= 255
+    is_nan = b == 255
+
+    normal_bits = tl.where(E > 254, 0x7F80, (E << 7) | mant)
+    bits = tl.where(is_sub, sub_mant, normal_bits)
+    bits = tl.where(is_inf, 0x7F80, bits)
+    bits = tl.where(is_zero, 0, bits)
+    bits = tl.where(is_nan, 0x7FC0, bits)
+    bits = bits | sgn
+    return (bits & 0xFFFF).to(tl.uint16).to(tl.bfloat16, bitcast=True)
+
+
+# ---------------------------------------------------------------------------
+# Native MXFP4 decode attention (two-stage split-KV)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _mxfp4_decode_stage1_kernel(
+    Q,
+    K_Packed,
+    V_Packed,
+    K_Scales,
+    V_Scales,
+    sm_scale,
+    kv_indptr,
+    kv_indices,
+    Att_Out,
+    Att_Lse,
+    num_kv_splits,
+    stride_qbs,
+    stride_qh,
+    stride_kp_bs,
+    stride_kp_h,
+    stride_kp_page,
+    stride_kp_tok,
+    stride_vp_bs,
+    stride_vp_h,
+    stride_vp_page,
+    stride_vp_tok,
+    stride_ks_bs,
+    stride_ks_h,
+    stride_vs_bs,
+    stride_vs_h,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    kv_group_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    PACKED_K_DIM: tl.constexpr,
+    PACKED_V_DIM: tl.constexpr,
+    NUM_K_BLOCKS: tl.constexpr,
+    NUM_V_BLOCKS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    MIN_BLOCK_KV: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    # int64 to mirror the stock kernel's flat-offset overflow guard.
+    cur_batch = tl.program_id(0).to(tl.int64)
+    cur_head = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+
+    cur_kv_head = cur_head // kv_group_num
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_d = offs_d < Lk
+    mask_dv = offs_dv < Lv
+    byte_idx_k = offs_d // 2
+    byte_idx_v = offs_dv // 2
+    blk_idx_k = offs_d // _MXFP4_BLOCK
+    blk_idx_v = offs_dv // _MXFP4_BLOCK
+
+    cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
+    cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
+    kv_splits = tl.load(num_kv_splits + cur_batch)
+
+    off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
+
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = -float("inf")
+    e_sum = 0.0
+    acc = tl.zeros([BLOCK_DV], dtype=tl.float32)
+
+    if split_kv_end > split_kv_start:
+        q = tl.load(Q + off_q, mask=mask_d, other=0.0).to(tl.float32)
+        for start_n in range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            tok_mask = offs_n < split_kv_end
+            kv_loc = tl.load(
+                kv_indices + cur_batch_kv_start_idx + offs_n,
+                mask=tok_mask,
+                other=0,
+            )
+            # Page-aware address math, identical to the stock stage-1 kernel
+            # (for these buffers it reduces to kv_loc * slot_stride).
+            if PAGE_SIZE == 1:
+                k_row = kv_loc * stride_kp_bs + cur_kv_head * stride_kp_h
+                v_row = kv_loc * stride_vp_bs + cur_kv_head * stride_vp_h
+            else:
+                page_id = kv_loc // PAGE_SIZE
+                tok_in_p = kv_loc % PAGE_SIZE
+                k_row = (
+                    page_id * stride_kp_page
+                    + tok_in_p * stride_kp_tok
+                    + cur_kv_head * stride_kp_h
+                )
+                v_row = (
+                    page_id * stride_vp_page
+                    + tok_in_p * stride_vp_tok
+                    + cur_kv_head * stride_vp_h
+                )
+            ks_row = kv_loc * stride_ks_bs + cur_kv_head * stride_ks_h
+            vs_row = kv_loc * stride_vs_bs + cur_kv_head * stride_vs_h
+
+            # --- K tile: packed bytes -> E2M1 magnitudes -> E8M0 scale -> fp32
+            kbyte = tl.load(
+                K_Packed + k_row[:, None] + byte_idx_k[None, :],
+                mask=tok_mask[:, None] & (byte_idx_k[None, :] < PACKED_K_DIM),
+                other=0,
+            )
+            is_odd_k = (offs_d % 2) == 1
+            kcode = tl.where(is_odd_k[None, :], (kbyte >> 4) & 0x0F, kbyte & 0x0F)
+            kmant = (kcode & 0x1).to(tl.float32)
+            kexp = (kcode >> 1) & 0x3
+            knormal = tl.exp2(kexp.to(tl.float32) - 1.0) * (1.0 + 0.5 * kmant)
+            ksub = 0.5 * kmant
+            kmag = tl.where(kexp == 0, ksub, knormal)
+            k = tl.where((kcode & 0x8) != 0, -kmag, kmag)
+            k = tl.where(mask_d[None, :], k, 0.0)
+
+            ksbytes = tl.load(
+                K_Scales + ks_row[:, None] + blk_idx_k[None, :],
+                mask=tok_mask[:, None] & (blk_idx_k[None, :] < NUM_K_BLOCKS),
+                other=0,
+            )
+            ksf = _e8m0_to_f32(ksbytes)
+            k = k * ksf
+
+            qk = tl.sum(q[None, :] * k, 1)
+            qk *= sm_scale
+            qk = tl.where(tok_mask, qk, float("-inf"))
+
+            # --- V tile: same inline dequant
+            vbyte = tl.load(
+                V_Packed + v_row[:, None] + byte_idx_v[None, :],
+                mask=tok_mask[:, None] & (byte_idx_v[None, :] < PACKED_V_DIM),
+                other=0,
+            )
+            is_odd_v = (offs_dv % 2) == 1
+            vcode = tl.where(is_odd_v[None, :], (vbyte >> 4) & 0x0F, vbyte & 0x0F)
+            vmant = (vcode & 0x1).to(tl.float32)
+            vexp = (vcode >> 1) & 0x3
+            vnormal = tl.exp2(vexp.to(tl.float32) - 1.0) * (1.0 + 0.5 * vmant)
+            vsub = 0.5 * vmant
+            vmag = tl.where(vexp == 0, vsub, vnormal)
+            v = tl.where((vcode & 0x8) != 0, -vmag, vmag)
+            v = tl.where(mask_dv[None, :], v, 0.0)
+
+            vsbytes = tl.load(
+                V_Scales + vs_row[:, None] + blk_idx_v[None, :],
+                mask=tok_mask[:, None] & (blk_idx_v[None, :] < NUM_V_BLOCKS),
+                other=0,
+            )
+            vsf = _e8m0_to_f32(vsbytes)
+            v = v * vsf
+
+            # --- online softmax, fp32 (same recurrence as the stock kernel)
+            n_e_max = tl.maximum(tl.max(qk, 0), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max)
+            acc *= re_scale
+            acc += tl.sum(p[:, None] * v, 0)
+
+            e_sum = e_sum * re_scale + tl.sum(p, 0)
+            e_max = n_e_max
+
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_dv
+        )
+        tl.store(Att_Out + offs_mid_o, acc / e_sum, mask=mask_dv)
+
+        offs_mid_o_1 = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+        ) // Lv
+        tl.store(Att_Lse + offs_mid_o_1, e_max + tl.log(e_sum))
+
+
+@triton.jit
+def _mxfp4_grouped_decode_stage1_kernel(
+    Q,
+    K_Packed,
+    V_Packed,
+    K_Scales,
+    V_Scales,
+    sm_scale,
+    kv_indptr,
+    kv_indices,
+    Att_Out,
+    Att_Lse,
+    num_kv_splits,
+    stride_qbs,
+    stride_qh,
+    stride_kp_bs,
+    stride_kp_h,
+    stride_kp_page,
+    stride_kp_tok,
+    stride_vp_bs,
+    stride_vp_h,
+    stride_vp_page,
+    stride_vp_tok,
+    stride_ks_bs,
+    stride_ks_h,
+    stride_vs_bs,
+    stride_vs_h,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    q_head_num: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    PACKED_K_DIM: tl.constexpr,
+    PACKED_V_DIM: tl.constexpr,
+    NUM_K_BLOCKS: tl.constexpr,
+    NUM_V_BLOCKS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    MIN_BLOCK_KV: tl.constexpr,
+    Lk: tl.constexpr,
+    Lv: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    # Grouped-head variant of ``_mxfp4_decode_stage1_kernel`` (GQA/MQA): one
+    # program owns one kv head and serves its whole query group, so the
+    # packed K/V bytes are unpacked ONCE per (token, kv_head) instead of once
+    # per query head. The per-head grid above re-reads them kv_group_num
+    # times, which dominated TPOT at long context. Math follows the stock
+    # grouped kernel: Q/K/V tiles in bf16 (EXACT for dequantized E2M1 values:
+    # 2-bit mantissa x power-of-two scale always fits bf16's 8-bit
+    # significand), tl.dot with fp32 accumulation, online softmax in fp32.
+    cur_batch = tl.program_id(0).to(tl.int64)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+
+    heads_per_kv = tl.cdiv(kv_group_num, BLOCK_H)
+    cur_kv_head = cur_head_id // heads_per_kv
+    if BLOCK_H < kv_group_num:
+        VALID_BLOCK_H: tl.constexpr = BLOCK_H
+    else:
+        VALID_BLOCK_H: tl.constexpr = kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < (cur_head_id + 1) * VALID_BLOCK_H
+    mask_h = mask_h & (cur_head < q_head_num)
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_d = offs_d < Lk
+    mask_dv = offs_dv < Lv
+    byte_idx_k = offs_d // 2
+    byte_idx_v = offs_dv // 2
+    blk_idx_k = offs_d // _MXFP4_BLOCK
+    blk_idx_v = offs_dv // _MXFP4_BLOCK
+
+    cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
+    cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
+    kv_splits = tl.load(num_kv_splits + cur_batch)
+
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
+
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    if split_kv_end > split_kv_start:
+        q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
+
+        for start_n in range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            tok_mask = offs_n < split_kv_end
+            kv_loc = tl.load(
+                kv_indices + cur_batch_kv_start_idx + offs_n,
+                mask=tok_mask,
+                other=0,
+            )
+            if PAGE_SIZE == 1:
+                k_row = kv_loc * stride_kp_bs + cur_kv_head * stride_kp_h
+                v_row = kv_loc * stride_vp_bs + cur_kv_head * stride_vp_h
+            else:
+                page_id = kv_loc // PAGE_SIZE
+                tok_in_p = kv_loc % PAGE_SIZE
+                k_row = (
+                    page_id * stride_kp_page
+                    + tok_in_p * stride_kp_tok
+                    + cur_kv_head * stride_kp_h
+                )
+                v_row = (
+                    page_id * stride_vp_page
+                    + tok_in_p * stride_vp_tok
+                    + cur_kv_head * stride_vp_h
+                )
+            ks_row = kv_loc * stride_ks_bs + cur_kv_head * stride_ks_h
+            vs_row = kv_loc * stride_vs_bs + cur_kv_head * stride_vs_h
+
+            # --- K: integer bit-construct dequant straight to bf16 (no SFU
+            # exp2 / fp32 multiply; see _e2m1_scale_to_bf16), then a single
+            # bf16 dot shared by the whole query group
+            kbyte = tl.load(
+                K_Packed + k_row[:, None] + byte_idx_k[None, :],
+                mask=tok_mask[:, None] & (byte_idx_k[None, :] < PACKED_K_DIM),
+                other=0,
+            )
+            is_odd_k = (offs_d % 2) == 1
+            kcode = tl.where(is_odd_k[None, :], (kbyte >> 4) & 0x0F, kbyte & 0x0F)
+
+            ksbytes = tl.load(
+                K_Scales + ks_row[:, None] + blk_idx_k[None, :],
+                mask=tok_mask[:, None] & (blk_idx_k[None, :] < NUM_K_BLOCKS),
+                other=0,
+            )
+            k = _e2m1_scale_to_bf16(kcode, ksbytes)
+            k = tl.where(mask_d[None, :], k, 0.0)
+
+            qk = tl.dot(q, tl.trans(k))
+            qk *= sm_scale
+            qk = tl.where(
+                mask_h[:, None] & (offs_n[None, :] < split_kv_end),
+                qk,
+                float("-inf"),
+            )
+
+            # --- V: integer bit-construct dequant to bf16; p goes to bf16
+            # for the dot (stock semantics)
+            vbyte = tl.load(
+                V_Packed + v_row[:, None] + byte_idx_v[None, :],
+                mask=tok_mask[:, None] & (byte_idx_v[None, :] < PACKED_V_DIM),
+                other=0,
+            )
+            is_odd_v = (offs_dv % 2) == 1
+            vcode = tl.where(is_odd_v[None, :], (vbyte >> 4) & 0x0F, vbyte & 0x0F)
+
+            vsbytes = tl.load(
+                V_Scales + vs_row[:, None] + blk_idx_v[None, :],
+                mask=tok_mask[:, None] & (blk_idx_v[None, :] < NUM_V_BLOCKS),
+                other=0,
+            )
+            v = _e2m1_scale_to_bf16(vcode, vsbytes)
+            v = tl.where(mask_dv[None, :], v, 0.0)
+
+            # --- online softmax (fp32), same recurrence as the stock kernel
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            acc += tl.dot(p.to(v.dtype), v)
+
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_dv[None, :]
+        )
+        tl.store(
+            Att_Out + offs_mid_o,
+            acc / e_sum[:, None],
+            mask=(mask_h[:, None]) & (mask_dv[None, :]),
+        )
+
+        offs_mid_o_1 = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+        ) // Lv
+        tl.store(Att_Lse + offs_mid_o_1, e_max + tl.log(e_sum), mask=mask_h)
+
+
+@triton.jit
+def _mxfp4_decode_stage2_kernel(
+    Mid_O,
+    Mid_O_1,
+    O,
+    kv_indptr,
+    num_kv_splits,
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    stride_obs,
+    stride_oh,
+    MAX_KV_SPLITS: tl.constexpr,
+    MIN_BLOCK_KV: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    Lv: tl.constexpr,
+):
+    # Codec-agnostic split merge; mirrors the stock ``_fwd_kernel_stage2``
+    # (v_scale fixed at 1.0: MXFP4 scales are applied inline in stage 1).
+    cur_batch = tl.program_id(0).to(tl.int64)
+    cur_head = tl.program_id(1)
+
+    cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - tl.load(
+        kv_indptr + cur_batch
+    )
+    kv_splits = tl.load(num_kv_splits + cur_batch)
+
+    offs_d = tl.arange(0, BLOCK_DV)
+    mask_d = offs_d < Lv
+
+    e_sum = 0.0
+    e_max = -float("inf")
+    acc = tl.zeros([BLOCK_DV], dtype=tl.float32)
+
+    offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
+    offs_logic = (cur_batch * stride_mid_ob + cur_head * stride_mid_oh) // Lv
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
+
+    for split_kv_id in tl.range(0, MAX_KV_SPLITS, num_stages=2):
+        split_kv_start = kv_len_per_split * split_kv_id
+        split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+        if split_kv_end > split_kv_start:
+            tv = tl.load(
+                Mid_O + offs_v + split_kv_id * stride_mid_os, mask=mask_d, other=0.0
+            )
+            tlogic = tl.load(Mid_O_1 + offs_logic + split_kv_id * stride_mid_os // Lv)
+            n_e_max = tl.maximum(tlogic, e_max)
+
+            old_scale = tl.exp(e_max - n_e_max)
+            acc *= old_scale
+            exp_logic = tl.exp(tlogic - n_e_max)
+            acc += exp_logic * tv
+
+            e_sum = e_sum * old_scale + exp_logic
+            e_max = n_e_max
+
+    tl.store(
+        O + cur_batch * stride_obs + cur_head * stride_oh + offs_d,
+        acc / e_sum,
+        mask=mask_d,
+    )
+
+
+def _host_num_kv_splits(seq_lens_cpu, max_kv_splits):
+    """Test/prototype split schedule: fill up to max_kv_splits with at least
+    MIN_BLOCK_KV tokens per split. The production backend brings its own
+    on-device schedule (Phase 2); correctness holds for any split count."""
+    splits = []
+    for seq_len in seq_lens_cpu:
+        seq_len = int(seq_len)
+        splits.append(max(1, min(max_kv_splits, triton.cdiv(seq_len, _MIN_BLOCK_KV))))
+    return splits
+
+
+def mxfp4_decode_attention_fwd(
+    q: torch.Tensor,
+    k_packed: torch.Tensor,
+    v_packed: torch.Tensor,
+    k_scales: torch.Tensor,
+    v_scales: torch.Tensor,
+    o: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    sm_scale: float,
+    page_size: int = 1,
+    max_kv_splits: int = 8,
+    attn_logits: torch.Tensor | None = None,
+    attn_lse: torch.Tensor | None = None,
+    num_kv_splits: torch.Tensor | None = None,
+    block_n: int = _BLOCK_N,
+    num_warps: int = 4,
+):
+    """Native MXFP4 decode attention over packed paged KV.
+
+    Args:
+        q: (batch, q_heads, head_dim), bf16/fp16/fp32.
+        k_packed / v_packed: (slots, kv_heads, ceil(head_dim/2)) uint8.
+        k_scales / v_scales: (slots, kv_heads, head_dim//32) E8M0 bytes.
+        o: (batch, q_heads, v_head_dim) output buffer; written in its dtype
+            (fp32 for oracle comparison).
+        kv_indptr / kv_indices: standard ragged page-table metadata (indices
+            are physical slot ids; page_size > 1 uses the same page/tok
+            address math as the stock triton decode kernel).
+        attn_logits / attn_lse / num_kv_splits: optional preallocated
+            split-KV scratch (CUDA-graph reuse in the backend integration).
+
+    Note: ``num_kv_splits=None`` derives the schedule on the host (prototype
+    convenience; involves a device->host sync). The backend passes its
+    on-device schedule instead.
+    """
+    batch, head_num, head_dim = q.shape
+    kv_head_num = k_packed.shape[1]
+    if head_num % kv_head_num != 0:
+        raise ValueError(
+            f"GQA requires q_heads % kv_heads == 0, got {head_num} % {kv_head_num}"
+        )
+    kv_group_num = head_num // kv_head_num
+    logical_k = head_dim
+    logical_v = o.shape[-1]
+    packed_k_dim = k_packed.shape[-1]
+    packed_v_dim = v_packed.shape[-1]
+    if packed_k_dim != (logical_k + 1) // 2 or packed_v_dim != (logical_v + 1) // 2:
+        raise ValueError(
+            f"packed dims {packed_k_dim}/{packed_v_dim} do not match logical "
+            f"dims {logical_k}/{logical_v}"
+        )
+    if q.shape[0] != kv_indptr.shape[0] - 1:
+        raise ValueError("kv_indptr must have batch + 1 entries")
+
+    k_packed = k_packed.view(torch.uint8).contiguous()
+    v_packed = v_packed.view(torch.uint8).contiguous()
+    k_scales = k_scales.view(torch.uint8).contiguous()
+    v_scales = v_scales.view(torch.uint8).contiguous()
+    num_k_blocks = k_scales.shape[-1]
+    num_v_blocks = v_scales.shape[-1]
+
+    if num_kv_splits is None:
+        seq_lens_cpu = (kv_indptr[1:] - kv_indptr[:-1]).cpu().tolist()
+        splits = _host_num_kv_splits(seq_lens_cpu, max_kv_splits)
+        num_kv_splits = torch.tensor(splits, dtype=torch.int32, device=q.device)
+    if attn_logits is None:
+        attn_logits = torch.empty(
+            (batch, head_num, max_kv_splits, logical_v),
+            dtype=torch.float32,
+            device=q.device,
+        )
+    if attn_lse is None:
+        attn_lse = torch.empty(
+            (batch, head_num, max_kv_splits), dtype=torch.float32, device=q.device
+        )
+    if attn_logits.shape[-1] != logical_v:
+        raise ValueError("attn_logits last dim must equal the V head dim")
+
+    BLOCK_DMODEL = triton.next_power_of_2(logical_k)
+    BLOCK_DV = triton.next_power_of_2(logical_v)
+
+    (
+        kp_slot_stride,
+        kp_head_stride,
+        kp_page_stride,
+        kp_tok_stride,
+    ) = _extract_kv_strides(k_packed, page_size)
+    (
+        vp_slot_stride,
+        vp_head_stride,
+        vp_page_stride,
+        vp_tok_stride,
+    ) = _extract_kv_strides(v_packed, page_size)
+    ks_slot_stride, ks_head_stride, _, _ = _extract_kv_strides(k_scales, 1)
+    vs_slot_stride, vs_head_stride, _, _ = _extract_kv_strides(v_scales, 1)
+
+    if kv_group_num == 1:
+        # MHA: one query head per kv head -> no redundant K/V reads; the
+        # per-head kernel keeps exact element-wise fp32 math.
+        grid = (batch, head_num, max_kv_splits)
+        _mxfp4_decode_stage1_kernel[grid](
+            q,
+            k_packed,
+            v_packed,
+            k_scales,
+            v_scales,
+            sm_scale,
+            kv_indptr,
+            kv_indices,
+            attn_logits,
+            attn_lse,
+            num_kv_splits,
+            q.stride(0),
+            q.stride(1),
+            kp_slot_stride,
+            kp_head_stride,
+            kp_page_stride,
+            kp_tok_stride,
+            vp_slot_stride,
+            vp_head_stride,
+            vp_page_stride,
+            vp_tok_stride,
+            ks_slot_stride,
+            ks_head_stride,
+            vs_slot_stride,
+            vs_head_stride,
+            attn_logits.stride(0),
+            attn_logits.stride(1),
+            attn_logits.stride(2),
+            kv_group_num=kv_group_num,
+            BLOCK_DMODEL=BLOCK_DMODEL,
+            BLOCK_DV=BLOCK_DV,
+            PACKED_K_DIM=packed_k_dim,
+            PACKED_V_DIM=packed_v_dim,
+            NUM_K_BLOCKS=num_k_blocks,
+            NUM_V_BLOCKS=num_v_blocks,
+            BLOCK_N=block_n,
+            MIN_BLOCK_KV=_MIN_BLOCK_KV,
+            Lk=logical_k,
+            Lv=logical_v,
+            PAGE_SIZE=page_size,
+            num_warps=num_warps,
+            num_stages=2,
+        )
+    else:
+        # GQA/MQA: grouped kernel unpacks the packed K/V once per kv head and
+        # serves the whole query group with tl.dot (see kernel docstring).
+        valid_block_h = min(_GROUPED_BLOCK_H, kv_group_num)
+        head_tiles = triton.cdiv(head_num, valid_block_h)
+        grid = (batch, head_tiles, max_kv_splits)
+        _mxfp4_grouped_decode_stage1_kernel[grid](
+            q,
+            k_packed,
+            v_packed,
+            k_scales,
+            v_scales,
+            sm_scale,
+            kv_indptr,
+            kv_indices,
+            attn_logits,
+            attn_lse,
+            num_kv_splits,
+            q.stride(0),
+            q.stride(1),
+            kp_slot_stride,
+            kp_head_stride,
+            kp_page_stride,
+            kp_tok_stride,
+            vp_slot_stride,
+            vp_head_stride,
+            vp_page_stride,
+            vp_tok_stride,
+            ks_slot_stride,
+            ks_head_stride,
+            vs_slot_stride,
+            vs_head_stride,
+            attn_logits.stride(0),
+            attn_logits.stride(1),
+            attn_logits.stride(2),
+            q_head_num=head_num,
+            kv_group_num=kv_group_num,
+            BLOCK_H=_GROUPED_BLOCK_H,
+            BLOCK_DMODEL=BLOCK_DMODEL,
+            BLOCK_DV=BLOCK_DV,
+            PACKED_K_DIM=packed_k_dim,
+            PACKED_V_DIM=packed_v_dim,
+            NUM_K_BLOCKS=num_k_blocks,
+            NUM_V_BLOCKS=num_v_blocks,
+            BLOCK_N=block_n,
+            MIN_BLOCK_KV=_MIN_BLOCK_KV,
+            Lk=logical_k,
+            Lv=logical_v,
+            PAGE_SIZE=page_size,
+            num_warps=num_warps,
+            num_stages=2,
+        )
+
+    _mxfp4_decode_stage2_kernel[(batch, head_num)](
+        attn_logits,
+        attn_lse,
+        o,
+        kv_indptr,
+        num_kv_splits,
+        attn_logits.stride(0),
+        attn_logits.stride(1),
+        attn_logits.stride(2),
+        o.stride(0),
+        o.stride(1),
+        MAX_KV_SPLITS=max_kv_splits,
+        MIN_BLOCK_KV=_MIN_BLOCK_KV,
+        BLOCK_DV=BLOCK_DV,
+        Lv=logical_v,
+    )

--- a/python/sglang/kernels/ops/quantization/mxfp4_quant.py
+++ b/python/sglang/kernels/ops/quantization/mxfp4_quant.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused MXFP4 quantize + scatter-store kernel for the KV cache.
+
+One triton kernel replaces the eager ``MXFP4KVQuantizeUtil.batched_quantize``
++ indexed-scatter write path: per 32-element block it computes amax -> E8M0
+scale -> saturating ties-to-even E2M1 codes -> nibble pack, then scatters the
+packed bytes and scale bytes into the paged pool at ``loc`` (data + scale move
+together). Slot 0 stays reserved (CUDA-graph padding contract, mirrored from
+``reserved_skip_index=0``). No host sync: CUDA-graph safe.
+
+Bit-exactness scope: for bf16/fp16 inputs the kernel is bit-exact with the
+eager OCP codec (``MXFP4KVQuantizeUtil``) and the independent oracle
+(``mxfp4_quantize_reference``). The scale exponent is extracted from the fp32
+amax bit pattern instead of ``floor(log2(amax))``; the two agree for
+bf16/fp16-derived amax because the smallest relative mantissa gap (2^-11 for
+fp16) is orders of magnitude larger than log2f's ~2^-22 relative error, so
+the floor can never flip. fp32 inputs (gap 2^-23) are NOT covered and must
+keep using the eager codec -- ``mxfp4_fused_store_supported`` gates this.
+
+NaN/Inf semantics follow OCP MX v1.0 §6.3 exactly like the eager codec:
+NaN in block -> scale byte 0xFF and all-zero codes; Inf in block (no NaN) ->
+scale byte 254 (2^127) with sign-saturated elements; all-zero block -> scale
+byte 0 (2^-127).
+"""
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+MXFP4_BLOCK_SIZE = 32
+# Kernel-side mirrors: @triton.jit functions may only read tl.constexpr globals.
+_MXFP4_BLOCK = tl.constexpr(MXFP4_BLOCK_SIZE)
+_E8M0_NAN_BYTE = tl.constexpr(255)
+_E2M1_MAX = tl.constexpr(6.0)
+
+
+@triton.jit
+def e8m0_to_f32(sbytes):
+    """Bit-exact E8M0 byte -> fp32 scale factor 2^(byte - 127).
+
+    Bit construction instead of ``tl.exp2``: the fp32 pattern ``byte << 23``
+    is exact for bytes 1..254, byte 0 (2^-127) needs the subnormal pattern
+    0x00400000, and byte 255 (E8M0 NaN) maps to a quiet NaN. The approximate
+    ex2 instruction flushes subnormal results (FTZ), which silently zeroed
+    the 2^-127 scale; plain fp32 multiplies downstream do not flush.
+    """
+    b = sbytes.to(tl.int32)
+    bits = b << 23
+    bits = tl.where(b == 0, 0x00400000, bits)
+    bits = tl.where(b == 255, 0x7FC00000, bits)
+    return bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _mxfp4_quant_store_kernel(
+    K,
+    V,
+    Loc,
+    KC,
+    VC,
+    KSF,
+    VSF,
+    stride_kt,
+    stride_kh,
+    stride_vt,
+    stride_vh,
+    stride_kc_slot,
+    stride_kc_h,
+    stride_vc_slot,
+    stride_vc_h,
+    stride_ksf_slot,
+    stride_ksf_h,
+    stride_vsf_slot,
+    stride_vsf_h,
+    NKV: tl.constexpr,
+    D: tl.constexpr,
+    SF_ACTUAL: tl.constexpr,
+    SF: tl.constexpr,
+    PADDED: tl.constexpr,
+    PACKED_STORE: tl.constexpr,
+):
+    t = tl.program_id(0)
+    is_v = tl.program_id(1)
+    h = tl.program_id(2)
+
+    loc = tl.load(Loc + t).to(tl.int64)
+
+    blk = tl.arange(0, SF)
+    offs = blk[:, None] * _MXFP4_BLOCK + tl.arange(0, _MXFP4_BLOCK)[None, :]
+    load_mask = offs < D
+
+    if is_v == 0:
+        x = tl.load(
+            K + t * stride_kt + h * stride_kh + offs, mask=load_mask, other=0.0
+        ).to(tl.float32)
+    else:
+        x = tl.load(
+            V + t * stride_vt + h * stride_vh + offs, mask=load_mask, other=0.0
+        ).to(tl.float32)
+
+    # --- block amax with OCP NaN/Inf classification (bit patterns)
+    xb = x.to(tl.int32, bitcast=True)
+    abs_bits = xb & 0x7FFFFFFF
+    is_nan = abs_bits > 0x7F800000
+    is_inf = abs_bits == 0x7F800000
+    finite_abs = tl.where(is_nan | is_inf, 0.0, tl.abs(x))
+    amax = tl.max(finite_abs, axis=1)
+    any_nan = tl.max(is_nan.to(tl.int32), axis=1) != 0
+    any_inf = tl.max(is_inf.to(tl.int32), axis=1) != 0
+
+    # scale_exp = floor(log2(amax)) - 2, exact via the fp32 exponent field
+    # (see module docstring); zero/subnormal amax -> E8M0 min; inf blocks ->
+    # E8M0 max; clamp to [-127, 127].
+    amax_bits = amax.to(tl.int32, bitcast=True)
+    amax_exp = (amax_bits >> 23) & 0xFF
+    scale_exp = tl.where(amax_exp == 0, -127, amax_exp - 129)
+    scale_exp = tl.maximum(scale_exp, -127)
+    scale_exp = tl.where(any_inf, 127, scale_exp)
+    scale_bytes = tl.where(any_nan, _E8M0_NAN_BYTE, scale_exp + 127)
+
+    # scaled = x * 2^-scale_exp. Multiplying by the exact power of two equals
+    # the eager codec's division bit-for-bit (both correctly rounded, power-of-
+    # two operand), then OCP nan_to_num + saturate to the E2M1 max.
+    inv_scale = e8m0_to_f32(127 - scale_exp)
+    prod = x * inv_scale[:, None]
+    prod = tl.where(prod != prod, 0.0, prod)
+    prod = tl.where(prod == float("inf"), _E2M1_MAX, prod)
+    prod = tl.where(prod == float("-inf"), -_E2M1_MAX, prod)
+    abs_p = tl.minimum(tl.abs(prod), _E2M1_MAX)
+
+    # Saturating round-to-nearest ties-to-even onto (0,.5,1,1.5,2,3,4,6):
+    # each branch has uniform value spacing, so rint() on the normalized
+    # coordinate reproduces the eager distance-table tie rules exactly
+    # (0.25->0, 0.75->2, 1.25->2, 1.75->4, 2.5->4, 3.5->6, 5->6).
+    mag_lo = libdevice.rint(abs_p * 2.0)
+    mag_mid = 4.0 + libdevice.rint(abs_p - 2.0)
+    mag_hi = 6.0 + libdevice.rint((abs_p - 4.0) * 0.5)
+    mag = tl.where(abs_p < 2.0, mag_lo, tl.where(abs_p < 4.0, mag_mid, mag_hi))
+
+    sign = (prod.to(tl.int32, bitcast=True) >> 31) & 1
+    code = mag.to(tl.int32) | (sign << 3)
+    code = tl.where(any_nan[:, None], 0, code)
+    code = tl.where(load_mask, code, 0)
+
+    # Nibble pack: low = even-index element, high = odd-index element.
+    pairs = tl.reshape(code, (PADDED // 2, 2))
+    weights = 1 + 15 * tl.arange(0, 2)
+    packed = tl.sum(pairs * weights[None, :], axis=1).to(tl.uint8)
+
+    # Slot 0 is reserved for CUDA-graph padding writes: keep its bytes.
+    if loc != 0:
+        offs_p = tl.arange(0, PADDED // 2)
+        store_mask_p = offs_p < PACKED_STORE
+        store_mask_s = blk < SF_ACTUAL
+        if is_v == 0:
+            tl.store(
+                KC + loc * stride_kc_slot + h * stride_kc_h + offs_p,
+                packed,
+                mask=store_mask_p,
+            )
+            tl.store(
+                KSF + loc * stride_ksf_slot + h * stride_ksf_h + blk,
+                scale_bytes.to(tl.uint8),
+                mask=store_mask_s,
+            )
+        else:
+            tl.store(
+                VC + loc * stride_vc_slot + h * stride_vc_h + offs_p,
+                packed,
+                mask=store_mask_p,
+            )
+            tl.store(
+                VSF + loc * stride_vsf_slot + h * stride_vsf_h + blk,
+                scale_bytes.to(tl.uint8),
+                mask=store_mask_s,
+            )
+
+
+_FUSED_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def mxfp4_fused_store_supported(k, v, loc) -> bool:
+    """Whether (k, v, loc) can go through the fused kernel bit-exactly.
+
+    Gate: CUDA, bf16/fp16 K/V of identical shape, contiguous last dim, and a
+    matching per-token loc vector. Everything else (CPU tests, fp32 inputs,
+    exotic strides) falls back to the eager OCP codec.
+    """
+    return (
+        k.is_cuda
+        and v.is_cuda
+        and loc.is_cuda
+        and k.ndim == 3
+        and v.shape == k.shape
+        and k.dtype in _FUSED_SUPPORTED_DTYPES
+        and v.dtype == k.dtype
+        and k.stride(2) == 1
+        and v.stride(2) == 1
+        and loc.ndim == 1
+        and loc.shape[0] == k.shape[0]
+    )
+
+
+def quant_store_kv_mxfp4(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    loc: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    k_sf: torch.Tensor,
+    v_sf: torch.Tensor,
+) -> None:
+    """Fused quantize + scatter for MXFP4 KV pools.
+
+    Args:
+        k / v: (num_tokens, kv_heads, head_dim) bf16/fp16 projections.
+        loc: (num_tokens,) physical slot ids (int32/int64); slot 0 is skipped.
+        k_cache / v_cache: (slots, kv_heads, ceil(head_dim/2)) uint8 pools.
+        k_sf / v_sf: (slots, kv_heads, ceil(head_dim/32)) uint8 (or
+            float8_e8m0fnu-viewed) scale pools.
+    """
+    if not mxfp4_fused_store_supported(k, v, loc):
+        raise ValueError("quant_store_kv_mxfp4 called with unsupported inputs")
+    num_tokens, nkv, d = k.shape
+    if num_tokens == 0:
+        return
+    sf_actual = (d + MXFP4_BLOCK_SIZE - 1) // MXFP4_BLOCK_SIZE
+    sf = triton.next_power_of_2(sf_actual)
+    packed_store = (d + 1) // 2
+
+    k_cache = k_cache.view(torch.uint8)
+    v_cache = v_cache.view(torch.uint8)
+    k_sf = k_sf.view(torch.uint8)
+    v_sf = v_sf.view(torch.uint8)
+
+    _mxfp4_quant_store_kernel[(num_tokens, 2, nkv)](
+        k,
+        v,
+        loc,
+        k_cache,
+        v_cache,
+        k_sf,
+        v_sf,
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        k_sf.stride(0),
+        k_sf.stride(1),
+        v_sf.stride(0),
+        v_sf.stride(1),
+        NKV=nkv,
+        D=d,
+        SF_ACTUAL=sf_actual,
+        SF=sf,
+        PADDED=sf * MXFP4_BLOCK_SIZE,
+        PACKED_STORE=packed_store,
+    )

--- a/python/sglang/srt/arg_groups/fields/model.py
+++ b/python/sglang/srt/arg_groups/fields/model.py
@@ -202,8 +202,10 @@ class Model:
                 '"fp8_e4m3" are supported for CUDA 11.8+. "mxfp8" is supported '
                 'by the FA4 backend. "nvfp4" selects '
                 'the NVFP4 FP4 E2M1 KV cache recipe; "fp4_mx_block16" '
-                "selects the MX-style block-size-16 FP4 E2M1 KV cache "
-                "recipe. Both require CUDA 12.8+ and PyTorch 2.8.0+"
+                "selects the MX-style block-size-16 FP4 E2M1 KV cache recipe; "
+                '"mxfp4" selects strict OCP block-size-32 E2M1 + E8M0 storage '
+                "with a validation-only FlashInfer BF16 PLAIN path. FP4 recipes "
+                "require CUDA 12.8+ and PyTorch 2.8.0+"
             ),
             choices=[
                 "auto",
@@ -214,6 +216,7 @@ class Model:
                 "bfloat16",
                 "nvfp4",
                 "fp4_mx_block16",
+                "mxfp4",
                 "fp4_e2m1",
             ],
             resolvable=True,

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -39,12 +39,43 @@ def handle_kv4_compatibility(server_args: Any) -> None:
 
     cfg = resolving_view(server_args)
 
-    if cfg.kv_cache_dtype not in ("nvfp4", "fp4_mx_block16"):
+    if cfg.kv_cache_dtype not in ("nvfp4", "fp4_mx_block16", "mxfp4"):
         return
 
     uses_mla = use_mla_backend(server_args)
     prefill_backend, decode_backend = attention_backends_of(resolved_view(server_args))
     attention_backend = resolved_view(server_args).attention_backend
+
+    if cfg.kv_cache_dtype == "mxfp4":
+        if not get_platform().is_cuda:
+            raise RuntimeError("--kv-cache-dtype=mxfp4 is currently CUDA-only.")
+        if uses_mla:
+            raise ValueError(
+                "--kv-cache-dtype=mxfp4 currently supports MHA only, not MLA."
+            )
+        # Prefill/extend always runs on FlashInfer (BF16 PLAIN read). Decode may
+        # stay on FlashInfer (PLAIN, validation path) or use triton (native MXFP4
+        # kernel reading packed data + scales inline).
+        allowed_backend_pairs = (("flashinfer", "flashinfer"), ("flashinfer", "triton"))
+        if (prefill_backend, decode_backend) not in allowed_backend_pairs:
+            raise ValueError(
+                "--kv-cache-dtype=mxfp4 requires prefill=flashinfer with decode "
+                "flashinfer (BF16 PLAIN read) or triton (native MXFP4 kernel), "
+                f"got {prefill_backend!r}/{decode_backend!r}."
+            )
+        # CUDA graph capture is graph-safe only with the native triton decode
+        # (fused write kernel + native decode kernel, no host sync, verified by
+        # capture/replay tests). The flashinfer PLAIN decode materializes a
+        # full-layer BF16 temporary per step and stays validation-only.
+        if decode_backend == "flashinfer" and not cfg.disable_cuda_graph:
+            raise ValueError(
+                "--kv-cache-dtype=mxfp4 with the flashinfer PLAIN decode path "
+                "requires --disable-cuda-graph (it materializes a full-layer "
+                "BF16 temporary per decode step); use "
+                "--decode-attention-backend triton (native kernel, "
+                "graph-safe) to run with CUDA graphs."
+            )
+        return
 
     if get_platform().is_cuda:
         if cfg.kv_cache_dtype == "nvfp4" and not (
@@ -462,11 +493,12 @@ def validate_prefill_only_disable_kv_cache_args(server_args: Any):
             "Other prefill-only workloads may be supported in a future change once "
             "their attention paths stop reading or writing the paged KV cache."
         )
-    if cfg.kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+    if cfg.kv_cache_dtype in ("nvfp4", "fp4_mx_block16", "mxfp4"):
         raise ValueError(
             "--prefill-only-disable-kv-cache does not currently support "
-            "--kv-cache-dtype=nvfp4 or --kv-cache-dtype=fp4_mx_block16 because "
-            "the FP4 pool uses a separate allocation path."
+            "--kv-cache-dtype=nvfp4, --kv-cache-dtype=fp4_mx_block16, or "
+            "--kv-cache-dtype=mxfp4 because the FP4 pool uses a separate "
+            "allocation path."
         )
     if cfg.kv_cache_dtype == "mxfp8":
         raise ValueError(

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -352,13 +352,30 @@ class FlashInferAttnBackend(AttentionBackend):
         self.dq_page_table = None
         self.dq_paged_kernel_lens = None
         self.cpu_req_pool_indices = None
-        # FP4 fake-quant prefill/decode exposes an FP8 workspace to FlashInfer.
-        self.flashinfer_kv_cache_dtype = (
-            torch.float8_e4m3fn
-            if (
-                self.prefill_uses_dequant_workspace
-                or self.decode_uses_dequant_workspace
+        # Resolve the dtype actually presented to FlashInfer, rather than the
+        # pool's storage tag. Quantized PLAIN reads (MXFP4) materialize BF16,
+        # while DEQUANT_WORKSPACE reads (NVFP4) materialize FP8.
+        active_flashinfer_accesses = [
+            access
+            for backend, access in (
+                (prefill_backend, self.prefill_kv_access),
+                (decode_backend, self.decode_kv_access),
             )
+            if backend == "flashinfer" and access is not None
+        ]
+        effective_kv_dtypes = {
+            access.attention_kv_dtype
+            for access in active_flashinfer_accesses
+            if access.attention_kv_dtype is not None
+        }
+        if len(effective_kv_dtypes) > 1:
+            raise ValueError(
+                "FlashInfer prefill/decode resolved different attention KV dtypes: "
+                f"{sorted(str(dtype) for dtype in effective_kv_dtypes)}."
+            )
+        self.flashinfer_kv_cache_dtype = (
+            next(iter(effective_kv_dtypes))
+            if effective_kv_dtypes
             else model_runner.kv_cache_dtype
         )
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -28,6 +28,9 @@ from sglang.srt.layers.dcp import (
     create_triton_kv_indices_for_dcp_triton,
     get_dcp_lens,
 )
+from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+    KVCacheAttentionAccessKind,
+)
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
@@ -281,6 +284,29 @@ class TritonAttnBackend(AttentionBackend):
             self.swa_v_head_dim = None
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device
+        # Native MXFP4 decode: the quantized pool keeps packed E2M1 data +
+        # E8M0 scales and this backend consumes them inline through the
+        # dedicated triton kernel (no PLAIN BF16 materialization). Prefill must
+        # stay on flashinfer in production; that pairing is enforced by the
+        # server-arg hook (kv_cache_hook.py). forward_extend here would still
+        # work through the generic PLAIN BF16 read, but it is out of the
+        # validated scope.
+        self.kv_cache_quant_method = self.token_to_kv_pool.get_kv_cache_quant_method()
+        self.mxfp4_native_decode = False
+        if getattr(self.kv_cache_quant_method, "name", None) == "mxfp4":
+            decode_access = self.kv_cache_quant_method.resolve_attention_access(
+                "decode", "triton"
+            )
+            self.mxfp4_native_decode = (
+                decode_access is not None
+                and decode_access.kind == KVCacheAttentionAccessKind.NATIVE_FP4
+            )
+            if not self.mxfp4_native_decode:
+                raise ValueError(
+                    "mxfp4 KV cache has no NATIVE decode access for the triton "
+                    "backend; available: "
+                    + self.kv_cache_quant_method.describe_attention_accesses("decode")
+                )
         self.device_core_count = get_device_core_count(model_runner.gpu_id)
         # Lean decode persistent-grid size (depends only on head architecture).
         kv_group_num = self.num_head // self.num_kv_head
@@ -305,6 +331,13 @@ class TritonAttnBackend(AttentionBackend):
                 # fp32 attn_logits buffer to ~4 GiB on Kimi-K2.6 and faulting in
                 # ROCm graph replay; pin to 256 to match validated gfx950 behavior.
                 self.max_kv_splits = min(self.max_kv_splits, 256)
+        if self.mxfp4_native_decode:
+            # The native kernel is latency-bound at the default 8 splits:
+            # bs=1 long-context grid is only kv_heads * splits CTAs (4*8=32
+            # vs 170 SMs on SM120), and the stage-1 kernel drops from ~155us
+            # to ~67us at 4096 seq when raising splits to 32. Raise the
+            # floor; an explicit larger --triton-attention-num-kv-splits wins.
+            self.max_kv_splits = max(self.max_kv_splits, 32)
         if _is_cuda:
             self.use_pdl = is_arch_support_pdl()
         else:
@@ -2198,6 +2231,54 @@ class TritonAttnBackend(AttentionBackend):
             and layer.v_head_dim == self.swa_v_head_dim
         ):
             attn_logits = self.forward_metadata.swa_attn_logits
+
+        # Native MXFP4 decode: read packed E2M1 + E8M0 scales straight from the
+        # pool and dequantize inline in the kernel. Narrow scope for now -- the
+        # unsupported branches fail fast instead of silently falling back.
+        if self.mxfp4_native_decode:
+            if self.dcp_size > 1:
+                raise NotImplementedError(
+                    "mxfp4 native decode does not support DCP (--dcp-size > 1)."
+                )
+            if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
+                raise NotImplementedError(
+                    "mxfp4 native decode does not support sliding window attention."
+                )
+            if (
+                (logits_soft_cap or 0.0) > 0
+                or sinks is not None
+                or score_mod is not None
+                or (layer.xai_temperature_len or 0) > 0
+            ):
+                raise NotImplementedError(
+                    "mxfp4 native decode does not support logit capping, "
+                    "attention sinks, score_mod or xai temperature."
+                )
+            from sglang.kernels.ops.attention.decode_attention_mxfp4_sm120 import (
+                mxfp4_decode_attention_fwd,
+            )
+
+            k_packed, v_packed, k_scales, v_scales = (
+                self.token_to_kv_pool.get_raw_kv_buffer(layer.layer_id)
+            )
+            mxfp4_decode_attention_fwd(
+                q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                k_packed,
+                v_packed,
+                k_scales,
+                v_scales,
+                o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                kv_indptr,
+                kv_indices,
+                layer.scaling,
+                page_size=self.page_size,
+                max_kv_splits=self.max_kv_splits,
+                num_warps=8,
+                attn_logits=attn_logits,
+                attn_lse=self.forward_metadata.attn_lse,
+                num_kv_splits=self.forward_metadata.num_kv_splits,
+            )
+            return o
 
         # Resolve Work-Centric (Lean) Attention activation. In auto mode (None) the decision
         # depends on whether this forward is a CUDA-graph capture: during capture seq_lens are

--- a/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
+++ b/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
@@ -751,6 +751,166 @@ class FP4MXBlock16KVCacheMethod(KVCacheQuantMethodBase):
         return fp4_size + scale_size + dq_size
 
 
+class MXFP4KVCacheMethod(KVCacheQuantMethodBase):
+    """OCP MXFP4 block-32 E2M1 + E8M0 with a BF16 PLAIN read path."""
+
+    name = "mxfp4"
+    SCALE_BLOCK_SIZE = 32
+
+    def __init__(
+        self,
+        num_layers: Optional[int] = None,
+        device: Optional[str] = None,
+    ):
+        self.head_dim: Optional[int] = None
+
+    def scale_buffer_view_dtype(self) -> Optional[torch.dtype]:
+        return torch.float8_e8m0fnu
+
+    def create_buffers(
+        self, size: int, head_num: int, head_dim: int, layer_num: int, device: str
+    ) -> dict:
+        if head_dim <= 0:
+            raise ValueError(f"MXFP4 head_dim must be positive, got {head_dim}")
+        self.head_dim = head_dim
+        packed_dim = (head_dim + 1) // 2
+        scale_blocks = (head_dim + self.SCALE_BLOCK_SIZE - 1) // self.SCALE_BLOCK_SIZE
+        store_dtype = self.kv_storage_dtype()
+        k_buffer = [
+            torch.zeros((size, head_num, packed_dim), dtype=store_dtype, device=device)
+            for _ in range(layer_num)
+        ]
+        v_buffer = [
+            torch.zeros((size, head_num, packed_dim), dtype=store_dtype, device=device)
+            for _ in range(layer_num)
+        ]
+        k_scale_buffer = [
+            torch.zeros(
+                (size, head_num, scale_blocks), dtype=store_dtype, device=device
+            )
+            for _ in range(layer_num)
+        ]
+        v_scale_buffer = [
+            torch.zeros(
+                (size, head_num, scale_blocks), dtype=store_dtype, device=device
+            )
+            for _ in range(layer_num)
+        ]
+        return {
+            "k_buffer": k_buffer,
+            "v_buffer": v_buffer,
+            "k_scale_buffer": k_scale_buffer,
+            "v_scale_buffer": v_scale_buffer,
+            "dq_k_buffer": None,
+            "dq_v_buffer": None,
+            "store_dtype": store_dtype,
+        }
+
+    def quantize_and_store(
+        self,
+        k_buffer,
+        v_buffer,
+        k_scale_buffer,
+        v_scale_buffer,
+        loc,
+        cache_k,
+        cache_v,
+        k_scale=None,
+        v_scale=None,
+    ) -> None:
+        from sglang.kernels.ops.quantization.mxfp4_quant import (
+            mxfp4_fused_store_supported,
+            quant_store_kv_mxfp4,
+        )
+
+        if mxfp4_fused_store_supported(cache_k, cache_v, loc):
+            # Fused write path: one triton kernel does block amax -> E8M0
+            # scale -> E2M1 saturating RNE pack -> scatter of data + scale,
+            # preserving the reserved-slot-0 contract inside the kernel. No
+            # host sync, CUDA-graph safe. Bit-exact with the eager codec for
+            # bf16/fp16 inputs (see mxfp4_quant module docstring).
+            quant_store_kv_mxfp4(
+                cache_k,
+                cache_v,
+                loc,
+                k_buffer,
+                v_buffer,
+                k_scale_buffer,
+                v_scale_buffer,
+            )
+            return
+
+        # Eager OCP codec fallback (CPU tests, fp32/exotic dtypes,
+        # non-contiguous K/V). This remains the bit-exact reference.
+        from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+
+        cache_k_fp4, cache_k_sf = MXFP4KVQuantizeUtil.batched_quantize(cache_k)
+        cache_v_fp4, cache_v_sf = MXFP4KVQuantizeUtil.batched_quantize(cache_v)
+
+        # Slot 0 is the reserved CUDA-graph padding slot. Quantized writes bypass
+        # _store_kv_layer(), so preserve its reserved_skip_index=0 contract here.
+        valid = (loc != 0).view(-1, 1, 1)
+        k_buffer[loc] = torch.where(valid, cache_k_fp4, k_buffer[loc])
+        v_buffer[loc] = torch.where(valid, cache_v_fp4, v_buffer[loc])
+        k_scale_buffer[loc] = torch.where(valid, cache_k_sf, k_scale_buffer[loc])
+        v_scale_buffer[loc] = torch.where(valid, cache_v_sf, v_scale_buffer[loc])
+
+    def dequantize_kv_tensor(
+        self,
+        fp4_tensor: Tensor,
+        scales: Tensor,
+        layer_id: int,
+        dtype: Optional[torch.dtype] = None,
+    ) -> Tensor:
+        from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+
+        if self.head_dim is None:
+            raise RuntimeError("MXFP4 buffers must be created before dequantization.")
+        target_dtype = dtype or self.plain_attention_kv_dtype() or torch.bfloat16
+        return MXFP4KVQuantizeUtil.batched_dequantize(
+            fp4_tensor,
+            scales,
+            logical_dim=self.head_dim,
+            dtype=target_dtype,
+        )
+
+    def dequantize_prev_kv(
+        self,
+        k_fp4: Tensor,
+        k_scales: Tensor,
+        v_fp4: Tensor,
+        v_scales: Tensor,
+        layer_id: int,
+    ) -> tuple[Tensor, Tensor]:
+        return (
+            self.dequantize_kv_tensor(k_fp4, k_scales, layer_id),
+            self.dequantize_kv_tensor(v_fp4, v_scales, layer_id),
+        )
+
+    def compute_cell_size(
+        self, head_num: int, head_dim: int, num_layers: int, kv_size: int
+    ) -> int:
+        packed_size = head_num * ((head_dim + 1) // 2) * num_layers * 2 * kv_size
+        scale_size = (
+            head_num
+            * ((head_dim + self.SCALE_BLOCK_SIZE - 1) // self.SCALE_BLOCK_SIZE)
+            * num_layers
+            * 2
+            * kv_size
+        )
+        # PLAIN materializes one layer's K and V as BF16 simultaneously. Reserve
+        # that transient footprint during capacity sizing even though it is not a
+        # persistent pool allocation.
+        plain_scratch_size = (
+            head_num
+            * head_dim
+            * 2
+            * torch.empty((), dtype=torch.bfloat16).element_size()
+            * kv_size
+        )
+        return packed_size + scale_size + plain_scratch_size
+
+
 # Registry: method name -> attention access rules.
 _PREFILL = KVCacheAttentionPhase.PREFILL
 _DECODE = KVCacheAttentionPhase.DECODE
@@ -760,6 +920,7 @@ _NATIVE_FP4_KIND = KVCacheAttentionAccessKind.NATIVE_FP4
 _ANY_BACKEND = KVCacheBackendMatcher(any_backend=True)
 _NVFP4_SCALE = "nvfp4"
 _FP4_MX_SCALE = "fp4_mx_block16"
+_MXFP4_SCALE = "mxfp4"
 _FP8_E4M3 = torch.float8_e4m3fn
 _TORCH_FP4 = getattr(torch, "float4_e2m1fn_x2", None)
 _BF16 = torch.bfloat16
@@ -770,6 +931,8 @@ _FP4_MX_MHA_BACKENDS = frozenset(
 )
 _FP4_MX_PREFILL_BACKENDS = _FP4_MX_MHA_BACKENDS | frozenset({"fa4"})
 _CPU_FP8_BACKENDS = frozenset({"intel_amx"})
+_MXFP4_FLASHINFER_BACKENDS = frozenset({"flashinfer"})
+_MXFP4_TRITON_DECODE_BACKENDS = frozenset({"triton"})
 
 
 def _backend_matcher(backends) -> KVCacheBackendMatcher:
@@ -844,6 +1007,14 @@ KV_CACHE_ATTENTION_ACCESS_REGISTRY: dict[str, tuple[KVCacheAttentionAccess, ...]
         _plain(_PREFILL, _FP4_MX_PREFILL_BACKENDS, _FP4_MX_SCALE, _BF16),
         _plain(_DECODE, _FP4_MX_MHA_BACKENDS, _FP4_MX_SCALE, _BF16),
     ),
+    MXFP4KVCacheMethod.name: (
+        _plain(_PREFILL, _MXFP4_FLASHINFER_BACKENDS, _MXFP4_SCALE, _BF16),
+        _plain(_DECODE, _MXFP4_FLASHINFER_BACKENDS, _MXFP4_SCALE, _BF16),
+        # Native decode: the triton kernel in
+        # sglang/kernels/ops/attention/decode_attention_mxfp4_sm120.py reads the
+        # packed E2M1 data + E8M0 scales inline (no PLAIN materialization).
+        _native_fp4(_DECODE, _MXFP4_TRITON_DECODE_BACKENDS, _MXFP4_SCALE, _TORCH_FP4),
+    ),
 }
 
 
@@ -852,6 +1023,7 @@ KV_CACHE_QUANT_REGISTRY: dict[str, type[KVCacheQuantMethodBase]] = {
     "cpu_fp8_e4m3": CPUFP8KVCacheMethod,
     "nvfp4": NVFP4KVCacheMethod,
     "fp4_mx_block16": FP4MXBlock16KVCacheMethod,
+    "mxfp4": MXFP4KVCacheMethod,
 }
 
 
@@ -865,7 +1037,8 @@ def resolve_kv_cache_quant(kv_cache_dtype) -> Optional[str]:
         ):
             raise ValueError(
                 "FP4 KV cache storage dtype does not identify the recipe. "
-                "Pass the explicit --kv-cache-dtype value: 'nvfp4' or 'fp4_mx_block16'."
+                "Pass an explicit --kv-cache-dtype value: 'nvfp4', "
+                "'fp4_mx_block16', or 'mxfp4'."
             )
         return None
 
@@ -873,12 +1046,6 @@ def resolve_kv_cache_quant(kv_cache_dtype) -> Optional[str]:
         raise ValueError(
             "--kv-cache-dtype=fp4_e2m1 is deprecated. "
             "Use --kv-cache-dtype=fp4_mx_block16."
-        )
-    if kv_cache_dtype == "mxfp4":
-        raise ValueError(
-            "--kv-cache-dtype=mxfp4 is reserved for true MXFP4 block-size-32 "
-            "semantics. Use --kv-cache-dtype=fp4_mx_block16 for the current "
-            "block-size-16 FP4 KV recipe."
         )
     if kv_cache_dtype in KV_CACHE_QUANT_REGISTRY:
         return kv_cache_dtype

--- a/python/sglang/srt/layers/quantization/kv_cache.py
+++ b/python/sglang/srt/layers/quantization/kv_cache.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from sglang.srt.runtime_context import get_model
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,19 @@ class BaseKVCacheMethod(QuantizeMethodBase):
 
     def __init__(self, quant_config: QuantizationConfig):
         self.quant_config = quant_config
+
+    def _checkpoint_kv_scales_apply(self, kv_cache_dtype) -> bool:
+        """Whether --kv-cache-dtype is a per-tensor FP8 cache that consumes this
+        checkpoint's external k_scale/v_scale: fp8_e4m3/fp8_e5m2, or "auto" under an
+        FP8 KV scheme. bf16 and block-scaled formats (mxfp8/mxfp4/nvfp4/...) carry
+        their own/no scales; keys on the raw string, not the shared torch dtype.
+        """
+        if kv_cache_dtype in ("fp8_e4m3", "fp8_e5m2"):
+            return True
+        if kv_cache_dtype == "auto":
+            algo = getattr(self.quant_config, "kv_cache_quant_algo", None)
+            return isinstance(algo, str) and algo.upper() == "FP8"
+        return False
 
     def create_weights(self, layer: torch.nn.Module):
         """
@@ -75,6 +89,14 @@ class BaseKVCacheMethod(QuantizeMethodBase):
 
         if not isinstance(k_scale, float) or not isinstance(v_scale, float):
             raise ValueError("Only support per-tensor scaling factor for fp8 KV cache")
+
+        # Apply the checkpoint's FP8-KV scales only when the runtime KV cache
+        # actually is that FP8 cache; otherwise fall back to unit scales so every
+        # backend reads an identity descale with no per-backend guard. Mirrors
+        # load_kv_cache_scales(), which only loads scales for fp8_e4m3.
+        if not self._checkpoint_kv_scales_apply(get_model().kv_cache_dtype):
+            k_scale = 1.0
+            v_scale = 1.0
 
         # These are used in the final Attention.forward()
         layer.k_scale.copy_(k_scale)

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -140,6 +140,156 @@ class FP4MXBlock16KVQuantizeUtil:
         return scaled.view(b, m, n).to(dtype)
 
 
+class MXFP4KVQuantizeUtil:
+    """OCP MXFP4: block-32 E2M1 values with one E8M0 scale per head block.
+
+    The scale follows OCP MX v1.0 section 6.3: the largest power of two not
+    greater than the block amax, divided by the largest power of two
+    representable by E2M1 (4). E2M1 conversion is saturating round-to-nearest,
+    ties-to-even. Scale tensors contain raw E8M0 bytes.
+    """
+
+    BLOCK_SIZE = 32
+    E8M0_MIN_EXP = -127
+    E8M0_MAX_EXP = 127
+    E8M0_NAN_BYTE = 0xFF
+
+    @staticmethod
+    def batched_quantize(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # NOTE: deliberately eager, unlike FP4MXBlock16KVQuantizeUtil. Under
+        # torch 2.11 inductor, the compiled slice[...,:n] + pad-to-even +
+        # nibble-pack graph skipped the final output byte, so callers observed
+        # stale buffer contents that varied per process. The golden contract is
+        # bit-exactness, so this util stays on eager pure-tensor ops (still
+        # CUDA-graph capturable).
+        if tensor.ndim != 3:
+            raise ValueError(
+                f"MXFP4 expects a 3-D [tokens, heads, dim] tensor, got {tensor.shape}"
+            )
+        b, h, n = tensor.shape
+        if n <= 0:
+            raise ValueError("MXFP4 head_dim must be positive")
+
+        num_blocks = (
+            n + MXFP4KVQuantizeUtil.BLOCK_SIZE - 1
+        ) // MXFP4KVQuantizeUtil.BLOCK_SIZE
+        padded_n = num_blocks * MXFP4KVQuantizeUtil.BLOCK_SIZE
+        values = tensor.to(torch.float32)
+        if padded_n != n:
+            values = torch.nn.functional.pad(values, (0, padded_n - n))
+        blocks = values.reshape(b, h, num_blocks, MXFP4KVQuantizeUtil.BLOCK_SIZE)
+
+        nan_blocks = torch.isnan(blocks).any(dim=-1)
+        inf_blocks = torch.isinf(blocks).any(dim=-1) & ~nan_blocks
+        finite_abs = torch.nan_to_num(blocks.abs(), nan=0.0, posinf=0.0, neginf=0.0)
+        amax = finite_abs.amax(dim=-1)
+        scale_exp = torch.floor(torch.log2(amax)) - 2.0
+        scale_exp = torch.where(
+            amax == 0,
+            scale_exp.new_full((), MXFP4KVQuantizeUtil.E8M0_MIN_EXP),
+            scale_exp,
+        )
+        scale_exp = torch.where(
+            inf_blocks,
+            scale_exp.new_full((), MXFP4KVQuantizeUtil.E8M0_MAX_EXP),
+            scale_exp,
+        ).clamp(
+            MXFP4KVQuantizeUtil.E8M0_MIN_EXP,
+            MXFP4KVQuantizeUtil.E8M0_MAX_EXP,
+        )
+        scale_bytes = (scale_exp.to(torch.int32) + 127).to(torch.uint8)
+        scale_bytes = torch.where(
+            nan_blocks,
+            scale_bytes.new_full((), MXFP4KVQuantizeUtil.E8M0_NAN_BYTE),
+            scale_bytes,
+        )
+
+        scaled = blocks / torch.exp2(scale_exp).unsqueeze(-1)
+        scaled = torch.nan_to_num(scaled, nan=0.0, posinf=6.0, neginf=-6.0)
+        abs_vals = scaled.abs().clamp(max=E2M1_MAX)
+        e2m1_values = tensor.new_tensor(E2M1_VALUES[:8], dtype=torch.float32)
+        distances = (abs_vals.unsqueeze(-1) - e2m1_values).abs()
+        min_distances = distances.amin(dim=-1, keepdim=True)
+        tied = distances == min_distances
+        code_ids = torch.arange(8, dtype=torch.int64, device=tensor.device)
+        even_tied = tied & ((code_ids & 1) == 0)
+        magnitude_bits = torch.where(
+            even_tied.any(dim=-1),
+            even_tied.to(torch.uint8).argmax(dim=-1).to(torch.uint8),
+            tied.to(torch.uint8).argmax(dim=-1).to(torch.uint8),
+        )
+        fp4_vals = magnitude_bits | (torch.signbit(scaled).to(torch.uint8) << 3)
+        fp4_vals = torch.where(
+            nan_blocks.unsqueeze(-1), torch.zeros_like(fp4_vals), fp4_vals
+        )
+        fp4_vals = fp4_vals.reshape(b, h, padded_n)[..., :n]
+        if n % 2:
+            fp4_vals = torch.nn.functional.pad(fp4_vals, (0, 1))
+        packed = fp4_vals[..., 0::2] | (fp4_vals[..., 1::2] << 4)
+        return packed.contiguous(), scale_bytes.contiguous()
+
+    @staticmethod
+    def batched_dequantize(
+        quant_tensor: torch.Tensor,
+        scale_factors: torch.Tensor,
+        *,
+        logical_dim: int,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> torch.Tensor:
+        # See the note on batched_quantize: kept eager for bit-exactness.
+        if quant_tensor.ndim != 3 or scale_factors.ndim != 3:
+            raise ValueError("MXFP4 packed data and scales must both be 3-D")
+        if logical_dim <= 0 or quant_tensor.shape[-1] != (logical_dim + 1) // 2:
+            raise ValueError(
+                f"packed last dim {quant_tensor.shape[-1]} does not match "
+                f"logical_dim {logical_dim}"
+            )
+        num_blocks = (
+            logical_dim + MXFP4KVQuantizeUtil.BLOCK_SIZE - 1
+        ) // MXFP4KVQuantizeUtil.BLOCK_SIZE
+        if (
+            scale_factors.shape[:-1] != quant_tensor.shape[:-1]
+            or scale_factors.shape[-1] != num_blocks
+        ):
+            raise ValueError(
+                f"scale shape {scale_factors.shape} does not match packed shape "
+                f"{quant_tensor.shape} and logical_dim {logical_dim}"
+            )
+
+        quant_bytes = quant_tensor.view(torch.uint8)
+        fp4_vals = torch.empty(
+            *quant_bytes.shape[:-1],
+            quant_bytes.shape[-1] * 2,
+            dtype=torch.uint8,
+            device=quant_tensor.device,
+        )
+        fp4_vals[..., 0::2] = quant_bytes & 0x0F
+        fp4_vals[..., 1::2] = (quant_bytes >> 4) & 0x0F
+        fp4_vals = fp4_vals[..., :logical_dim]
+
+        magnitude_idx = fp4_vals & 0x07
+        values = quant_tensor.new_tensor(E2M1_VALUES[:8], dtype=torch.float32)
+        float_vals = values[magnitude_idx.long()]
+        float_vals = torch.where((fp4_vals & 0x08) != 0, -float_vals, float_vals)
+
+        padded_n = num_blocks * MXFP4KVQuantizeUtil.BLOCK_SIZE
+        if padded_n != logical_dim:
+            float_vals = torch.nn.functional.pad(
+                float_vals, (0, padded_n - logical_dim)
+            )
+        blocks = float_vals.reshape(
+            *float_vals.shape[:-1], num_blocks, MXFP4KVQuantizeUtil.BLOCK_SIZE
+        )
+
+        scale_bytes = scale_factors.view(torch.uint8)
+        nan_blocks = scale_bytes == MXFP4KVQuantizeUtil.E8M0_NAN_BYTE
+        scale_exp = scale_bytes.to(torch.int16) - 127
+        scales = torch.exp2(scale_exp.to(torch.float32))
+        scales = torch.where(nan_blocks, scales.new_full((), float("nan")), scales)
+        output = (blocks * scales.unsqueeze(-1)).flatten(-2)[..., :logical_dim]
+        return output.to(dtype)
+
+
 class NVFP4KVQuantizeUtil:
     """Utility class for NVFP4 quantization and dequantization with two-level scaling
     (global FP32 + block FP8 E4M3).

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -633,7 +633,7 @@ class KVCacheConfigurator:
                 "Supported configurations today: plain MHA models on CUDA with the FA "
                 "(fa3/fa4) prefill backend, --is-embedding, --chunked-prefill-size=-1, "
                 "--disable-radix-cache, no context-parallel attention, no HiSparse, "
-                "and --kv-cache-dtype not in {nvfp4, fp4_mx_block16}."
+                "and --kv-cache-dtype not in {nvfp4, fp4_mx_block16, mxfp4}."
             )
         return _InitializedPools(
             req_to_token_pool=req_to_token_pool,
@@ -979,7 +979,7 @@ class KVCacheConfigurator:
                 f"{unsupported_pool_family}. Supported configurations today: plain MHA "
                 "models on CUDA with the FA (fa3/fa4) prefill backend, --is-embedding, "
                 "--chunked-prefill-size=-1, --disable-radix-cache, no context-parallel "
-                "attention, no HiSparse, and --kv-cache-dtype not in {nvfp4, fp4_mx_block16}."
+                "attention, no HiSparse, and --kv-cache-dtype not in {nvfp4, fp4_mx_block16, mxfp4}."
             )
 
     def _build_req_to_token_pool(self, *, max_num_reqs: int) -> ReqToTokenPool:

--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -67,7 +67,7 @@ def configure_kv_cache_dtype(
             "--kv-cache-dtype=fp4_e2m1 is deprecated. "
             "Use --kv-cache-dtype=fp4_mx_block16."
         )
-    elif server_args_kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+    elif server_args_kv_cache_dtype in ("nvfp4", "fp4_mx_block16", "mxfp4"):
         if hasattr(torch, "float4_e2m1fn_x2"):
             kv_cache_dtype = torch.float4_e2m1fn_x2
             logger.warning(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2137,6 +2137,11 @@ class MHATokenToKVPool(KVCache):
         self._init_data_ptrs_and_strides()
 
     def _create_quantized_buffers(self):
+        if self.quant_method.name == "mxfp4" and self.v_head_dim != self.head_dim:
+            raise ValueError(
+                "MXFP4 KV cache currently requires v_head_dim == head_dim, got "
+                f"{self.v_head_dim} != {self.head_dim}."
+            )
         # Quantized recipes own packed-data, scale, and workspace shapes.
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
             with (

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -407,14 +407,40 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             )
 
             if is_float4_e2m1fn_x2(kv_cache_dtype):
-                # kv_scale_buffer
-                scale_block_size = 16
-                k = model_config.head_dim
-                cell_size = (cell_size // 2) + (
-                    (n * k * effective_num_layers * 2 * kv_size) // scale_block_size
-                )
-                # FP4 prefill uses one shared FP8 dequant workspace across layers.
-                cell_size += n * k * 2 * kv_size
+                if kvc.kv_cache_dtype_str == "mxfp4":
+                    k_dim = model_config.head_dim
+                    v_dim = model_config.v_head_dim
+                    # OCP MXFP4 physical storage: packed E2M1 data plus one
+                    # E8M0 byte per 32 values, independently for every head.
+                    cell_size = (
+                        n
+                        * (ceil_div(k_dim, 2) + ceil_div(v_dim, 2))
+                        * effective_num_layers
+                        * kv_size
+                    )
+                    cell_size += (
+                        n
+                        * (ceil_div(k_dim, 32) + ceil_div(v_dim, 32))
+                        * effective_num_layers
+                        * kv_size
+                    )
+                    # The validation-only PLAIN path materializes one layer's
+                    # full K and V pools as BF16 at the same time. Account for
+                    # that transient allocation so sizing leaves enough headroom.
+                    cell_size += (
+                        n
+                        * (k_dim + v_dim)
+                        * torch.empty((), dtype=torch.bfloat16).element_size()
+                    )
+                else:
+                    # Existing block-16 recipes: packed FP4 + uint8 scales and
+                    # one shared FP8 dequant-workspace reserve.
+                    scale_block_size = 16
+                    k = model_config.head_dim
+                    cell_size = (cell_size // 2) + (
+                        (n * k * effective_num_layers * 2 * kv_size) // scale_block_size
+                    )
+                    cell_size += n * k * 2 * kv_size
             elif self.kv_cache_dtype_str == "mxfp8":
                 scale_block_size = 32
                 cell_size += (

--- a/test/registered/e2e/models/test_qwen35_mxfp4_kv_cache_sm120.py
+++ b/test/registered/e2e/models/test_qwen35_mxfp4_kv_cache_sm120.py
@@ -1,0 +1,41 @@
+"""End-to-end MXFP4 KV cache serving test on SM120.
+
+Boots Llama-3.1-8B-Instruct with --kv-cache-dtype mxfp4 (FlashInfer BF16 PLAIN
+prefill + native triton MXFP4 decode, CUDA graph enabled) and runs the shared
+basic-decode-correctness probes, which target exactly the KV/attention
+corruption and cuda-graph edge cases this serving path could introduce. Codec
+and kernel bit-exactness are covered by their own tests; this exercises the
+full wiring (CLI -> hook -> configurator -> pool -> backend -> kernel).
+"""
+
+import unittest
+
+from sglang.srt.utils.common import is_sm120_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST
+
+register_cuda_ci(est_time=200, stage="extra-a", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(
+    is_sm120_supported(), "MXFP4 native decode requires an SM120 GPU (CUDA 12.8+)"
+)
+class TestLlama8BMxfp4KVCacheSM120(BasicDecodeCorrectnessMixin, DefaultServerBase):
+    """Llama-3.1-8B-Instruct with MXFP4 KV cache: FlashInfer PLAIN prefill +
+    native triton MXFP4 decode on SM120."""
+
+    model = DEFAULT_MODEL_NAME_FOR_TEST
+    other_args = [
+        "--kv-cache-dtype",
+        "mxfp4",
+        "--prefill-attention-backend",
+        "flashinfer",
+        "--decode-attention-backend",
+        "triton",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernel/attention/test_decode_attention_mxfp4_sm120.py
+++ b/test/registered/kernel/attention/test_decode_attention_mxfp4_sm120.py
@@ -24,7 +24,7 @@ from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 
 _HAS_REQUIREMENTS = torch.cuda.is_available()
 _DEVICE = "cuda"

--- a/test/registered/kernels/ops/attention/test_decode_attention_mxfp4_sm120.py
+++ b/test/registered/kernels/ops/attention/test_decode_attention_mxfp4_sm120.py
@@ -1,0 +1,621 @@
+"""Native MXFP4 Triton decode kernel vs a pure-Torch golden.
+
+``mxfp4_decode_attention_fwd`` reads the packed E2M1 + E8M0 pool buffers and
+dequantizes inline; the golden (``torch_mxfp4_radix_decode_reference``) reads the
+SAME packed bytes, dequantizes with the production eager codec (independently
+validated bit-exact against an OCP reference in the codec test), and runs explicit
+fp32 GQA decode attention. Both sides therefore consume identical dequantized
+values, so the residual is kernel accumulation order only.
+
+Also checks the MXFP4 Triton kernels capture into a CUDA graph and replay
+byte-deterministically (the kernel-level half of CUDA-graph support).
+"""
+
+import unittest
+from dataclasses import dataclass
+from itertools import accumulate
+
+import torch
+
+from sglang.kernels.ops.attention.decode_attention_mxfp4_sm120 import (
+    mxfp4_decode_attention_fwd,
+)
+from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+_HAS_REQUIREMENTS = torch.cuda.is_available()
+_DEVICE = "cuda"
+
+
+def decode_output_metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict:
+    """Comparable metrics for decode outputs: max abs, mean abs, relative L2,
+    cosine, norm ratio. Both inputs flattened in fp32 (device-agnostic)."""
+    e = expected.detach().float().reshape(-1)
+    a = actual.detach().float().reshape(-1).to(e.device)
+    assert a.shape == e.shape, f"shape mismatch: {a.shape} vs {e.shape}"
+    diff = a - e
+    norm_a = a.norm().item()
+    norm_e = e.norm().item()
+    cos = torch.nn.functional.cosine_similarity(a, e, dim=0).item()
+    return {
+        "max_abs": diff.abs().max().item(),
+        "mean_abs": diff.abs().mean().item(),
+        "rel_l2": (diff.norm() / (e.norm() + 1e-12)).item(),
+        "cosine": cos,
+        "norm_ratio": norm_a / (norm_e + 1e-12),
+    }
+
+
+def format_metrics(metrics: dict) -> str:
+    return (
+        f"max_abs={metrics['max_abs']:.3e} mean_abs={metrics['mean_abs']:.3e} "
+        f"rel_l2={metrics['rel_l2']:.3e} cos={metrics['cosine']:.6f} "
+        f"norm_ratio={metrics['norm_ratio']:.5f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-Torch decode golden (dsv4_attention.py style): dequantize the same packed
+# bytes with the production eager codec, then run explicit fp32 GQA attention.
+# Never calls the Triton kernel, so a mismatch localizes to the kernel.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DecodeMathDiagnostics:
+    """Codec-independent fp32 decode-attention intermediates."""
+
+    k_dequant: torch.Tensor  # (q_heads, seq, dim) fp32
+    v_dequant: torch.Tensor  # (q_heads, seq, dim) fp32
+    scores: torch.Tensor  # (q_heads, seq) fp32
+    probs: torch.Tensor  # (q_heads, seq) fp32
+    output: torch.Tensor  # (q_heads, head_dim) fp32
+
+
+def torch_radix_decode_from_effective_kv(
+    q: torch.Tensor,
+    k_effective: torch.Tensor,
+    v_effective: torch.Tensor,
+    *,
+    scaling: float,
+    return_diagnostics: bool = False,
+):
+    """Run the shared decode math on already dequantized logical K/V.
+
+    ``k_effective`` and ``v_effective`` are logical sequences shaped
+    ``(seq_len, num_kv_heads, head_dim)``. This owns all codec-independent
+    behavior: GQA head expansion, fp32 QK, softmax, and fp32 PV.
+    """
+    q32 = q.to(torch.float32)
+    k32 = k_effective.to(torch.float32).transpose(0, 1)
+    v32 = v_effective.to(torch.float32).transpose(0, 1)
+
+    num_q_heads = q32.shape[0]
+    num_kv_heads = k32.shape[0]
+    assert num_q_heads % num_kv_heads == 0, "GQA requires q % kv == 0"
+    group = num_q_heads // num_kv_heads
+    if group > 1:
+        k32 = k32.repeat_interleave(group, dim=0)
+        v32 = v32.repeat_interleave(group, dim=0)
+
+    scores = torch.einsum("hd,hsd->hs", q32, k32) * scaling
+    probs = torch.softmax(scores, dim=-1)
+    out = torch.einsum("hs,hsd->hd", probs, v32)
+
+    if not return_diagnostics:
+        return out
+    return out, DecodeMathDiagnostics(
+        k_dequant=k32,
+        v_dequant=v32,
+        scores=scores,
+        probs=probs,
+        output=out,
+    )
+
+
+@dataclass
+class Mxfp4DecodeDiagnostics:
+    k_packed: torch.Tensor
+    v_packed: torch.Tensor
+    k_scales: torch.Tensor
+    v_scales: torch.Tensor
+    k_dequant: torch.Tensor
+    v_dequant: torch.Tensor
+    scores: torch.Tensor
+    probs: torch.Tensor
+    output: torch.Tensor
+
+
+def torch_mxfp4_radix_decode_reference(
+    q: torch.Tensor,
+    k_packed_cache: torch.Tensor,
+    v_packed_cache: torch.Tensor,
+    k_scale_cache: torch.Tensor,
+    v_scale_cache: torch.Tensor,
+    req_to_token: torch.Tensor,
+    req_pool_indices,
+    seq_lens,
+    *,
+    scaling: float,
+    logical_dim: int | None = None,
+    return_diagnostics: bool = False,
+):
+    """Decode one request from a paged MXFP4 cache with shared Torch math."""
+    logical_dim = q.shape[-1] if logical_dim is None else logical_dim
+    seq_len = int(seq_lens)
+    locs = req_to_token[int(req_pool_indices), :seq_len].long()
+    k_packed = k_packed_cache[locs]
+    v_packed = v_packed_cache[locs]
+    k_scales = k_scale_cache[locs]
+    v_scales = v_scale_cache[locs]
+    k_effective = MXFP4KVQuantizeUtil.batched_dequantize(
+        k_packed, k_scales, logical_dim=logical_dim, dtype=torch.float32
+    )
+    v_effective = MXFP4KVQuantizeUtil.batched_dequantize(
+        v_packed, v_scales, logical_dim=logical_dim, dtype=torch.float32
+    )
+    out, math_diag = torch_radix_decode_from_effective_kv(
+        q,
+        k_effective,
+        v_effective,
+        scaling=scaling,
+        return_diagnostics=True,
+    )
+    if not return_diagnostics:
+        return out
+    assert isinstance(math_diag, DecodeMathDiagnostics)
+    return out, Mxfp4DecodeDiagnostics(
+        k_packed=k_packed,
+        v_packed=v_packed,
+        k_scales=k_scales,
+        v_scales=v_scales,
+        k_dequant=math_diag.k_dequant,
+        v_dequant=math_diag.v_dequant,
+        scores=math_diag.scores,
+        probs=math_diag.probs,
+        output=math_diag.output,
+    )
+
+
+# Hard caps bounding IMPLEMENTATION equivalence (Triton native vs the Torch
+# golden on the SAME packed cache); never relaxed to mask a scale/page/pack bug.
+REL_L2_CAP = 2e-2
+COSINE_CAP = 0.999
+NORM_RATIO_RANGE = (0.98, 1.02)
+
+# Frozen per-path thresholds (worst * 1.25 from an offline 20-seed sweep on
+# SM120 / torch 2.13.0+cu130). MHA (per-head kernel, fp32 elementwise): the
+# native kernel dequantizes inline in fp32, so both sides consume numerically
+# identical values and the residual is fp32 accumulation order only -- four
+# orders of magnitude tighter than a BF16-materializing (PLAIN) path.
+MXFP4_TRITON_FROZEN_REL_L2 = 3.5e-7
+MXFP4_TRITON_FROZEN_COSINE = 0.9999997
+MXFP4_TRITON_FROZEN_NORM_RATIO = (0.9999998, 1.0000002)
+
+# GQA/MQA (grouped kernel): serves the whole query group with tl.dot over bf16
+# tiles (stock-kernel semantics; the K/V unpack is shared across the group
+# instead of re-read per query head). The bf16 cast is lossless for dequantized
+# E2M1 values; the residual comes from p->bf16 rounding before the PV dot plus
+# the tensor-core accumulation order.
+MXFP4_TRITON_GROUPED_FROZEN_REL_L2 = 1.85e-3
+MXFP4_TRITON_GROUPED_FROZEN_COSINE = 0.9999986
+MXFP4_TRITON_GROUPED_FROZEN_NORM_RATIO = (0.9994, 1.0006)
+
+
+def _assert_caps(testcase, metrics, context):
+    testcase.assertLessEqual(
+        metrics["rel_l2"],
+        REL_L2_CAP,
+        f"[{context}] rel_l2 {metrics['rel_l2']:.3e} > cap {REL_L2_CAP} "
+        f"({format_metrics(metrics)})",
+    )
+    testcase.assertGreaterEqual(
+        metrics["cosine"],
+        COSINE_CAP,
+        f"[{context}] cosine {metrics['cosine']:.6f} < cap {COSINE_CAP} "
+        f"({format_metrics(metrics)})",
+    )
+    lo, hi = NORM_RATIO_RANGE
+    testcase.assertTrue(
+        lo <= metrics["norm_ratio"] <= hi,
+        f"[{context}] norm_ratio {metrics['norm_ratio']:.5f} outside "
+        f"[{lo}, {hi}] ({format_metrics(metrics)})",
+    )
+
+
+def _assert_frozen(testcase, metrics, context, grouped=False):
+    rel_cap = (
+        MXFP4_TRITON_GROUPED_FROZEN_REL_L2 if grouped else MXFP4_TRITON_FROZEN_REL_L2
+    )
+    cos_cap = (
+        MXFP4_TRITON_GROUPED_FROZEN_COSINE if grouped else MXFP4_TRITON_FROZEN_COSINE
+    )
+    lo, hi = (
+        MXFP4_TRITON_GROUPED_FROZEN_NORM_RATIO
+        if grouped
+        else MXFP4_TRITON_FROZEN_NORM_RATIO
+    )
+    testcase.assertLessEqual(
+        metrics["rel_l2"],
+        rel_cap,
+        f"[{context}] rel_l2 {metrics['rel_l2']:.3e} > frozen {rel_cap} "
+        f"({format_metrics(metrics)})",
+    )
+    testcase.assertGreaterEqual(
+        metrics["cosine"],
+        cos_cap,
+        f"[{context}] cosine {metrics['cosine']:.6f} < frozen {cos_cap} "
+        f"({format_metrics(metrics)})",
+    )
+    testcase.assertTrue(
+        lo <= metrics["norm_ratio"] <= hi,
+        f"[{context}] norm_ratio {metrics['norm_ratio']:.5f} outside frozen "
+        f"[{lo}, {hi}] ({format_metrics(metrics)})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Decode differential harness
+# ---------------------------------------------------------------------------
+
+
+def _build_req_locs(layout, seq_lens, num_slots, seed):
+    """Physical slot lists per request. Slot 0 stays reserved (production
+    contract). Page-size > 1 does not constrain the layouts: the kernel's
+    page/tok address math is an identity for these buffers, which is exactly
+    what the page_size cases below exercise."""
+    total = sum(seq_lens)
+    if num_slots < total + 2:
+        raise ValueError("slot pool too small")
+    g = torch.Generator().manual_seed(seed)
+
+    def _split(pool):
+        reqs, cur = [], 0
+        for s in seq_lens:
+            reqs.append(pool[cur : cur + s])
+            cur += s
+        return reqs
+
+    if layout == "contiguous":
+        return _split(list(range(1, 1 + total)))
+    if layout == "shuffled_pages":
+        perm = torch.randperm(num_slots - 1, generator=g).tolist()
+        return _split([i + 1 for i in perm[:total]])
+    if layout == "interleaved_pages":
+        perm = torch.randperm(num_slots - 1, generator=g).tolist()
+        pool = [i + 1 for i in perm]
+        reqs = [[] for _ in seq_lens]
+        idx = 0
+        for slot in pool:
+            while idx < len(reqs) and len(reqs[idx]) >= seq_lens[idx]:
+                idx += 1
+            if idx >= len(reqs):
+                break
+            reqs[idx].append(slot)
+        if any(len(r) != s for r, s in zip(reqs, seq_lens)):
+            raise ValueError("interleaved layout ran out of slots")
+        return reqs
+    if layout == "non_monotonic":
+        reqs = _split(list(range(1, 1 + total)))
+        return [list(reversed(r)) for r in reqs]
+    raise ValueError(f"unknown loc layout {layout!r}")
+
+
+def _run_decode_case(
+    testcase,
+    *,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    prefix_lens,
+    layout="shuffled_pages",
+    seed=20260903,
+    zero_first_request=False,
+    max_kv_splits=8,
+    assert_level="frozen",
+):
+    torch.manual_seed(seed)
+    seq_lens = [p + 1 for p in prefix_lens]  # decode: current token included
+    batch = len(seq_lens)
+    total = sum(seq_lens)
+    num_slots = total + page_size + 16
+
+    packed_dim = head_dim // 2
+    num_blocks = head_dim // 32
+    scaling = head_dim**-0.5
+
+    k_pool = torch.zeros(
+        (num_slots, num_kv_heads, packed_dim), dtype=torch.uint8, device=_DEVICE
+    )
+    v_pool = torch.zeros(
+        (num_slots, num_kv_heads, packed_dim), dtype=torch.uint8, device=_DEVICE
+    )
+    ks_pool = torch.zeros(
+        (num_slots, num_kv_heads, num_blocks), dtype=torch.uint8, device=_DEVICE
+    )
+    vs_pool = torch.zeros(
+        (num_slots, num_kv_heads, num_blocks), dtype=torch.uint8, device=_DEVICE
+    )
+
+    req_locs = _build_req_locs(layout, seq_lens, num_slots, seed)
+    req_to_token = torch.zeros(
+        (batch, max(seq_lens)), dtype=torch.int64, device=_DEVICE
+    )
+    for i, locs in enumerate(req_locs):
+        locs_t = torch.tensor(locs, dtype=torch.int64, device=_DEVICE)
+        req_to_token[i, : len(locs)] = locs_t
+        k_logical = torch.randn((len(locs), num_kv_heads, head_dim), device=_DEVICE).to(
+            torch.bfloat16
+        )
+        v_logical = torch.randn((len(locs), num_kv_heads, head_dim), device=_DEVICE).to(
+            torch.bfloat16
+        )
+        if zero_first_request and i == 0:
+            # amax == 0 blocks: scale byte 0 (2^-127), all-zero E2M1 data.
+            k_logical = torch.zeros_like(k_logical)
+            v_logical = torch.zeros_like(v_logical)
+        k_packed, k_scales = MXFP4KVQuantizeUtil.batched_quantize(k_logical)
+        v_packed, v_scales = MXFP4KVQuantizeUtil.batched_quantize(v_logical)
+        k_pool[locs_t] = k_packed
+        ks_pool[locs_t] = k_scales
+        v_pool[locs_t] = v_packed
+        vs_pool[locs_t] = v_scales
+
+    q = torch.randn((batch, num_q_heads, head_dim), device=_DEVICE).to(torch.bfloat16)
+    o = torch.zeros((batch, num_q_heads, head_dim), dtype=torch.float32, device=_DEVICE)
+
+    kv_indptr = torch.tensor(
+        [0] + list(accumulate(seq_lens)), dtype=torch.int32, device=_DEVICE
+    )
+    kv_indices = torch.tensor(
+        [loc for locs in req_locs for loc in locs], dtype=torch.int32, device=_DEVICE
+    )
+    mxfp4_decode_attention_fwd(
+        q,
+        k_pool,
+        v_pool,
+        ks_pool,
+        vs_pool,
+        o,
+        kv_indptr,
+        kv_indices,
+        scaling,
+        page_size=page_size,
+        max_kv_splits=max_kv_splits,
+    )
+
+    refs = [
+        torch_mxfp4_radix_decode_reference(
+            q[i],
+            k_pool,
+            v_pool,
+            ks_pool,
+            vs_pool,
+            req_to_token,
+            i,
+            seq_lens[i],
+            scaling=scaling,
+            logical_dim=head_dim,
+        )
+        for i in range(batch)
+    ]
+    ref = torch.stack(refs, dim=0)
+
+    metrics = decode_output_metrics(o, ref)
+    grouped = num_q_heads != num_kv_heads
+    if assert_level == "frozen":
+        _assert_frozen(
+            testcase, metrics, f"{layout}_p{page_size}_hd{head_dim}", grouped
+        )
+    else:
+        _assert_caps(testcase, metrics, f"{layout}_p{page_size}_hd{head_dim}")
+    return metrics
+
+
+# (name, q_heads, kv_heads, head_dim, page_size, prefix_lens, layout, kwargs).
+# Representative coverage: MHA per-head path, GQA/MQA grouped path, the Qwen
+# 24q/4kv/256 shape, page-size and physical-layout variants, a long multi-split
+# sequence, and an all-zero (amax==0) request.
+_DECODE_CASES = (
+    ("mha_hd64_p1_contiguous", 4, 4, 64, 1, (31,), "contiguous", {}),
+    ("gqa_hd64_p16_boundary", 4, 2, 64, 16, (14, 15, 16), "shuffled_pages", {}),
+    ("mqa_hd64_p16_bsz1", 4, 1, 64, 16, (7,), "shuffled_pages", {}),
+    ("qwen_24_4_256_p16", 24, 4, 256, 16, (31,), "shuffled_pages", {}),
+    ("qwen_24_4_256_multisplit_long", 24, 4, 256, 16, (255,), "shuffled_pages", {}),
+    (
+        "qwen_24_4_256_zero_req",
+        24,
+        4,
+        256,
+        16,
+        (15, 16),
+        "shuffled_pages",
+        {"zero_first_request": True},
+    ),
+)
+
+
+@unittest.skipUnless(_HAS_REQUIREMENTS, "CUDA is required")
+class TestTritonMxfp4NativeDecode(CustomTestCase):
+    def test_triton_mxfp4_native_decode_cases(self):
+        for (
+            name,
+            q_heads,
+            kv_heads,
+            head_dim,
+            page_size,
+            prefix_lens,
+            layout,
+            kwargs,
+        ) in _DECODE_CASES:
+            with self.subTest(case=name):
+                metrics = _run_decode_case(
+                    self,
+                    num_q_heads=q_heads,
+                    num_kv_heads=kv_heads,
+                    head_dim=head_dim,
+                    page_size=page_size,
+                    prefix_lens=prefix_lens,
+                    layout=layout,
+                    **kwargs,
+                )
+                print(f"[mxfp4-triton-decode] {name}: {format_metrics(metrics)}")
+
+
+@unittest.skipUnless(_HAS_REQUIREMENTS, "CUDA is required")
+class TestMxfp4TritonCudaGraphSafety(CustomTestCase):
+    """Both MXFP4 Triton kernels must capture into a CUDA graph and replay
+    deterministically: outputs byte-identical across replays AND identical to the
+    eager run (same deterministic kernel, same static buffers). This is the
+    kernel-level half of CUDA-graph support; the service-level half is the
+    end-to-end server test."""
+
+    def _capture(self, fn):
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            fn()  # warmup: triton JIT must not compile during capture
+        torch.cuda.current_stream().wait_stream(s)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            fn()
+        return g
+
+    def test_decode_kernel_capture_replay(self):
+        torch.manual_seed(20260905)
+        batch, q_heads, kv_heads, head_dim, page_size = 2, 8, 4, 64, 16
+        seq_lens = (37, 96)
+        slots = sum(seq_lens) + page_size + 8
+        scaling = head_dim**-0.5
+
+        packed_dim, num_blocks = head_dim // 2, head_dim // 32
+        k_pool = torch.randint(
+            0, 256, (slots, kv_heads, packed_dim), dtype=torch.uint8, device=_DEVICE
+        )
+        v_pool = torch.randint(
+            0, 256, (slots, kv_heads, packed_dim), dtype=torch.uint8, device=_DEVICE
+        )
+        ks_pool = torch.randint(
+            120, 135, (slots, kv_heads, num_blocks), dtype=torch.uint8, device=_DEVICE
+        )
+        vs_pool = torch.randint(
+            120, 135, (slots, kv_heads, num_blocks), dtype=torch.uint8, device=_DEVICE
+        )
+        q = torch.randn((batch, q_heads, head_dim), device=_DEVICE).to(torch.bfloat16)
+
+        max_kv_splits = 8
+        splits = [max(1, min(max_kv_splits, (s + 31) // 32)) for s in seq_lens]
+        num_kv_splits = torch.tensor(splits, dtype=torch.int32, device=_DEVICE)
+        attn_logits = torch.empty(
+            (batch, q_heads, max_kv_splits, head_dim),
+            dtype=torch.float32,
+            device=_DEVICE,
+        )
+        attn_lse = torch.empty(
+            (batch, q_heads, max_kv_splits), dtype=torch.float32, device=_DEVICE
+        )
+
+        kv_indptr = torch.tensor(
+            [0] + list(accumulate(seq_lens)), dtype=torch.int32, device=_DEVICE
+        )
+        total = sum(seq_lens)
+        kv_indices = torch.tensor(
+            list(range(1, 1 + total)), dtype=torch.int32, device=_DEVICE
+        )
+
+        def run(out):
+            mxfp4_decode_attention_fwd(
+                q,
+                k_pool,
+                v_pool,
+                ks_pool,
+                vs_pool,
+                out,
+                kv_indptr,
+                kv_indices,
+                scaling,
+                page_size=page_size,
+                max_kv_splits=max_kv_splits,
+                attn_logits=attn_logits,
+                attn_lse=attn_lse,
+                num_kv_splits=num_kv_splits,
+            )
+
+        o_eager = torch.zeros(
+            (batch, q_heads, head_dim), dtype=torch.float32, device=_DEVICE
+        )
+        run(o_eager)
+
+        o_graph = torch.zeros_like(o_eager)
+        graph = self._capture(lambda: run(o_graph))
+        graph.replay()
+        out1 = o_graph.clone()
+        graph.replay()
+        out2 = o_graph.clone()
+
+        self.assertTrue(torch.equal(out1, out2), "replay is not deterministic")
+        self.assertTrue(
+            torch.equal(out1, o_eager),
+            f"graph output differs from eager: max diff "
+            f"{(out1 - o_eager).abs().max().item()}",
+        )
+
+    def test_fused_write_kernel_capture_replay(self):
+        from sglang.kernels.ops.quantization.mxfp4_quant import quant_store_kv_mxfp4
+
+        torch.manual_seed(20260906)
+        tokens, kv_heads, head_dim = 5, 4, 128
+        slots = tokens + 8
+        k = (torch.randn((tokens, kv_heads, head_dim), device=_DEVICE) * 1.5).to(
+            torch.bfloat16
+        )
+        v = (torch.randn((tokens, kv_heads, head_dim), device=_DEVICE) * 1.5).to(
+            torch.bfloat16
+        )
+        loc = torch.arange(1, tokens + 1, dtype=torch.int64, device=_DEVICE)
+
+        def fresh_pools():
+            return (
+                torch.zeros(
+                    (slots, kv_heads, head_dim // 2), dtype=torch.uint8, device=_DEVICE
+                ),
+                torch.zeros(
+                    (slots, kv_heads, head_dim // 2), dtype=torch.uint8, device=_DEVICE
+                ),
+                torch.zeros(
+                    (slots, kv_heads, head_dim // 32), dtype=torch.uint8, device=_DEVICE
+                ),
+                torch.zeros(
+                    (slots, kv_heads, head_dim // 32), dtype=torch.uint8, device=_DEVICE
+                ),
+            )
+
+        kd_e, vd_e, ks_e, vs_e = fresh_pools()
+        quant_store_kv_mxfp4(k, v, loc, kd_e, vd_e, ks_e, vs_e)
+
+        kd_g, vd_g, ks_g, vs_g = fresh_pools()
+        graph = self._capture(
+            lambda: quant_store_kv_mxfp4(k, v, loc, kd_g, vd_g, ks_g, vs_g)
+        )
+        graph.replay()
+        snap1 = (kd_g.clone(), vd_g.clone(), ks_g.clone(), vs_g.clone())
+        graph.replay()
+        snap2 = (kd_g.clone(), vd_g.clone(), ks_g.clone(), vs_g.clone())
+
+        for a, b in zip(snap1, snap2):
+            self.assertTrue(
+                torch.equal(a, b), "fused write replay is not deterministic"
+            )
+        for got, want in zip(snap1, (kd_e, vd_e, ks_e, vs_e)):
+            self.assertTrue(
+                torch.equal(got, want),
+                "fused write graph output differs from eager bytes",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/quantization/test_mxfp4_kv_codec.py
+++ b/test/registered/kernels/ops/quantization/test_mxfp4_kv_codec.py
@@ -1,0 +1,473 @@
+"""MXFP4 KV-cache codec conformance.
+
+Two implementations are locked against the independent OCP oracle
+(``mxfp4_quantize_reference``):
+
+1. the eager ``MXFP4KVQuantizeUtil`` -- OCP MX v1.0 §6.3 surface: all E2M1 codes
+   and nibble order, saturating round-to-nearest-even, E8M0 scale exponent
+   boundaries, all-zero / NaN / +-Inf blocks, per-head block isolation,
+   partial-block padding, random parity, CPU/CUDA byte determinism;
+2. the fused Triton write kernel ``quant_store_kv_mxfp4`` -- bit-exactness vs the
+   eager codec and the oracle (bf16/fp16, special values, ties), the reserved
+   slot-0 contract, and the support gate that falls back to the eager codec for
+   fp32 / CPU / non-contiguous / shape-mismatched inputs.
+"""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.quantization.mxfp4_quant import (
+    mxfp4_fused_store_supported,
+    quant_store_kv_mxfp4,
+)
+from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+_HAS_CUDA = torch.cuda.is_available()
+_DEVICE = "cuda"
+
+
+# ---------------------------------------------------------------------------
+# Independent OCP MXFP4 reference (test-only). Shares no code with the runtime
+# MXFP4KVQuantizeUtil, so the bit-exactness assertions below are not circular.
+# OCP MX v1.0 6.3: block-32, E2M1 saturating round-to-nearest-even, one E8M0
+# scale per head block = 2^(floor(log2(amax)) - 2).
+# ---------------------------------------------------------------------------
+MXFP4_BLOCK_SIZE = 32
+E8M0_MIN_EXP = -127
+E8M0_MAX_EXP = 127
+E8M0_NAN_BYTE = 0xFF
+
+_E2M1_POSITIVE_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def _round_e2m1_rne_reference(values: torch.Tensor) -> torch.Tensor:
+    """Return positive E2M1 codes using round-to-nearest, ties-to-even."""
+    values = values.to(torch.float32).abs().clamp(max=6.0)
+    table = values.new_tensor(_E2M1_POSITIVE_VALUES)
+    distance = (values.unsqueeze(-1) - table).abs()
+    minimum = distance.amin(dim=-1, keepdim=True)
+    tied = distance == minimum
+    code_ids = torch.arange(8, dtype=torch.int64, device=values.device)
+    even_tied = tied & ((code_ids & 1) == 0)
+    has_even = even_tied.any(dim=-1)
+    even_code = even_tied.to(torch.uint8).argmax(dim=-1).to(torch.uint8)
+    first_code = tied.to(torch.uint8).argmax(dim=-1).to(torch.uint8)
+    return torch.where(has_even, even_code, first_code)
+
+
+def mxfp4_quantize_reference(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize ``[tokens, heads, dim]`` to OCP MXFP4 bytes.
+
+    Blocks are independent along each head's final dimension. The final partial
+    block and an odd high nibble are padded with positive zero.
+    """
+    if tensor.ndim != 3:
+        raise ValueError(
+            f"MXFP4 expects a 3-D [tokens, heads, dim] tensor, got {tensor.shape}"
+        )
+    tokens, heads, logical_dim = tensor.shape
+    if logical_dim <= 0:
+        raise ValueError("MXFP4 logical_dim must be positive")
+
+    num_blocks = (logical_dim + MXFP4_BLOCK_SIZE - 1) // MXFP4_BLOCK_SIZE
+    padded_dim = num_blocks * MXFP4_BLOCK_SIZE
+    values = tensor.to(torch.float32)
+    if padded_dim != logical_dim:
+        values = torch.nn.functional.pad(values, (0, padded_dim - logical_dim))
+    blocks = values.reshape(tokens, heads, num_blocks, MXFP4_BLOCK_SIZE)
+
+    nan_blocks = torch.isnan(blocks).any(dim=-1)
+    inf_blocks = torch.isinf(blocks).any(dim=-1) & ~nan_blocks
+    finite_abs = torch.nan_to_num(blocks.abs(), nan=0.0, posinf=0.0, neginf=0.0)
+    amax = finite_abs.amax(dim=-1)
+
+    scale_exp = torch.floor(torch.log2(amax)) - 2.0
+    scale_exp = torch.where(amax == 0, scale_exp.new_full((), E8M0_MIN_EXP), scale_exp)
+    scale_exp = torch.where(inf_blocks, scale_exp.new_full((), E8M0_MAX_EXP), scale_exp)
+    scale_exp = scale_exp.clamp(E8M0_MIN_EXP, E8M0_MAX_EXP)
+    scale_bytes = (scale_exp.to(torch.int32) + 127).to(torch.uint8)
+    scale_bytes = torch.where(
+        nan_blocks,
+        scale_bytes.new_full((), E8M0_NAN_BYTE),
+        scale_bytes,
+    )
+
+    scale = torch.exp2(scale_exp).unsqueeze(-1)
+    scaled = blocks / scale
+    scaled = torch.nan_to_num(scaled, nan=0.0, posinf=6.0, neginf=-6.0)
+    magnitude = _round_e2m1_rne_reference(scaled)
+    codes = magnitude | (torch.signbit(scaled).to(torch.uint8) << 3)
+    codes = torch.where(nan_blocks.unsqueeze(-1), torch.zeros_like(codes), codes)
+    codes = codes.reshape(tokens, heads, padded_dim)[..., :logical_dim]
+
+    if logical_dim % 2:
+        codes = torch.nn.functional.pad(codes, (0, 1))
+    packed = codes[..., 0::2] | (codes[..., 1::2] << 4)
+    return packed.contiguous(), scale_bytes.contiguous()
+
+
+def mxfp4_dequantize_reference(
+    packed: torch.Tensor,
+    scale_bytes: torch.Tensor,
+    *,
+    logical_dim: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize raw packed E2M1 and E8M0 bytes to ``dtype``."""
+    if packed.ndim != 3 or scale_bytes.ndim != 3:
+        raise ValueError("MXFP4 packed data and scales must both be 3-D")
+    if logical_dim <= 0 or packed.shape[-1] != (logical_dim + 1) // 2:
+        raise ValueError(
+            f"packed last dim {packed.shape[-1]} does not match logical_dim {logical_dim}"
+        )
+    expected_blocks = (logical_dim + MXFP4_BLOCK_SIZE - 1) // MXFP4_BLOCK_SIZE
+    if (
+        scale_bytes.shape[:-1] != packed.shape[:-1]
+        or scale_bytes.shape[-1] != expected_blocks
+    ):
+        raise ValueError(
+            f"scale shape {scale_bytes.shape} does not match packed shape {packed.shape} "
+            f"and logical_dim {logical_dim}"
+        )
+
+    packed_bytes = packed.view(torch.uint8)
+    raw_codes = torch.empty(
+        *packed_bytes.shape[:-1],
+        packed_bytes.shape[-1] * 2,
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    raw_codes[..., 0::2] = packed_bytes & 0x0F
+    raw_codes[..., 1::2] = (packed_bytes >> 4) & 0x0F
+    raw_codes = raw_codes[..., :logical_dim]
+
+    table = packed_bytes.new_tensor(_E2M1_POSITIVE_VALUES, dtype=torch.float32)
+    magnitude = table[(raw_codes & 0x07).long()]
+    elements = torch.where((raw_codes & 0x08) != 0, -magnitude, magnitude)
+
+    num_blocks = scale_bytes.shape[-1]
+    padded_dim = num_blocks * MXFP4_BLOCK_SIZE
+    if padded_dim != logical_dim:
+        elements = torch.nn.functional.pad(elements, (0, padded_dim - logical_dim))
+    elements = elements.reshape(*elements.shape[:-1], num_blocks, MXFP4_BLOCK_SIZE)
+
+    raw_scales = scale_bytes.view(torch.uint8)
+    nan_blocks = raw_scales == E8M0_NAN_BYTE
+    scale_exp = raw_scales.to(torch.int16) - 127
+    scales = torch.exp2(scale_exp.to(torch.float32))
+    scales = torch.where(nan_blocks, scales.new_full((), float("nan")), scales)
+    output = (elements * scales.unsqueeze(-1)).flatten(-2)[..., :logical_dim]
+    return output.to(dtype)
+
+
+class TestMXFP4CodecConformance(CustomTestCase):
+    def _assert_production_matches_oracle(self, x):
+        actual_data, actual_scales = MXFP4KVQuantizeUtil.batched_quantize(x)
+        expected_data, expected_scales = mxfp4_quantize_reference(x)
+        self.assertTrue(torch.equal(actual_data, expected_data))
+        self.assertTrue(torch.equal(actual_scales, expected_scales))
+
+        actual_dq = MXFP4KVQuantizeUtil.batched_dequantize(
+            actual_data,
+            actual_scales,
+            logical_dim=x.shape[-1],
+            dtype=torch.float32,
+        )
+        expected_dq = mxfp4_dequantize_reference(
+            expected_data,
+            expected_scales,
+            logical_dim=x.shape[-1],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(
+            actual_dq, expected_dq, rtol=0, atol=0, equal_nan=True
+        )
+        return actual_data, actual_scales, actual_dq
+
+    def test_all_e2m1_codes_and_nibble_order(self):
+        values = (
+            torch.tensor(
+                [
+                    0.0,
+                    0.5,
+                    1.0,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    6.0,
+                    -0.0,
+                    -0.5,
+                    -1.0,
+                    -1.5,
+                    -2.0,
+                    -3.0,
+                    -4.0,
+                    -6.0,
+                ],
+                dtype=torch.float32,
+            )
+            .repeat(2)
+            .view(1, 1, 32)
+        )
+        packed, scales, reconstructed = self._assert_production_matches_oracle(values)
+        expected_codes = torch.arange(16, dtype=torch.uint8).repeat(2)
+        expected_packed = expected_codes[0::2] | (expected_codes[1::2] << 4)
+        self.assertTrue(torch.equal(packed.flatten(), expected_packed))
+        self.assertEqual(scales.item(), 127)  # scale = 1.0
+        torch.testing.assert_close(reconstructed, values, rtol=0, atol=0)
+
+    def test_round_ties_to_even_and_saturation(self):
+        values = torch.tensor(
+            [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0, 7.0],
+            dtype=torch.float32,
+        )
+        values = torch.cat([values, -values, torch.tensor([6.0] * 16)]).view(1, 1, 32)
+        packed, scales, reconstructed = self._assert_production_matches_oracle(values)
+        self.assertEqual(scales.item(), 127)
+        expected = torch.tensor(
+            [0.0, 1.0, 1.0, 2.0, 2.0, 4.0, 4.0, 6.0],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(reconstructed[0, 0, :8], expected, rtol=0, atol=0)
+        torch.testing.assert_close(reconstructed[0, 0, 8:16], -expected, rtol=0, atol=0)
+        self.assertEqual(packed.dtype, torch.uint8)
+
+    def test_scale_exponent_boundaries_and_zero_block(self):
+        x = torch.zeros(1, 3, 32, dtype=torch.float32)
+        x[0, 0, 0] = 3.9  # floor_pow2=2, scale=0.5, byte=126
+        x[0, 1, 0] = 8.0  # floor_pow2=8, scale=2, byte=128
+        _, scales, reconstructed = self._assert_production_matches_oracle(x)
+        self.assertEqual(scales.flatten().tolist(), [126, 128, 0])
+        self.assertEqual(reconstructed[0, 2].abs().sum().item(), 0.0)
+
+    def test_nan_and_infinity_policy(self):
+        x = torch.zeros(1, 2, 32, dtype=torch.float32)
+        x[0, 0, 3] = float("nan")
+        x[0, 1, 4] = float("inf")
+        x[0, 1, 5] = -float("inf")
+        _, scales, reconstructed = self._assert_production_matches_oracle(x)
+        self.assertEqual(scales[0, 0, 0].item(), E8M0_NAN_BYTE)
+        self.assertTrue(torch.isnan(reconstructed[0, 0]).all())
+        self.assertEqual(scales[0, 1, 0].item(), 254)
+        self.assertTrue(torch.isinf(reconstructed[0, 1, 4]))
+        self.assertTrue(torch.isinf(reconstructed[0, 1, 5]))
+
+    def test_head_isolation_and_partial_block(self):
+        x = torch.zeros(2, 2, 33, dtype=torch.float32)
+        x[0, 0, 0] = 4.0
+        x[0, 0, 32] = 0.5
+        x[0, 1, 0] = 16.0
+        packed, scales, reconstructed = self._assert_production_matches_oracle(x)
+        self.assertEqual(packed.shape, (2, 2, 17))
+        self.assertEqual(scales.shape, (2, 2, 2))
+        self.assertEqual(scales[0, 0].tolist(), [127, 124])
+        self.assertEqual(scales[0, 1].tolist(), [129, 0])
+        self.assertEqual(reconstructed.shape, x.shape)
+
+    def test_random_cpu_parity(self):
+        torch.manual_seed(20260831)
+        for head_dim in (1, 2, 31, 32, 33, 64, 256):
+            with self.subTest(head_dim=head_dim):
+                x = torch.randn(3, 4, head_dim, dtype=torch.bfloat16)
+                self._assert_production_matches_oracle(x)
+
+    @unittest.skipUnless(_HAS_CUDA, "CUDA is required")
+    def test_fixed_vector_cpu_cuda_byte_parity(self):
+        torch.manual_seed(20260901)
+        x_cpu = torch.randn(3, 4, 65, dtype=torch.bfloat16)
+        cpu_data, cpu_scales = MXFP4KVQuantizeUtil.batched_quantize(x_cpu)
+        cuda_data, cuda_scales = MXFP4KVQuantizeUtil.batched_quantize(x_cpu.cuda())
+        self.assertTrue(torch.equal(cpu_data, cuda_data.cpu()))
+        self.assertTrue(torch.equal(cpu_scales, cuda_scales.cpu()))
+
+
+def _make_buffers(slots, heads, dim, device=_DEVICE):
+    packed_dim = (dim + 1) // 2
+    num_blocks = (dim + 31) // 32
+    data = torch.zeros((slots, heads, packed_dim), dtype=torch.uint8, device=device)
+    scales = torch.zeros((slots, heads, num_blocks), dtype=torch.uint8, device=device)
+    return data, scales
+
+
+def _fused_write(k, v, loc):
+    """Run the fused kernel into fresh pool-shaped buffers; returns
+    (k_data, v_data, k_sf, v_sf) at the written slots."""
+    slots = int(loc.max().item()) + 2
+    heads, dim = k.shape[1], k.shape[2]
+    kd, ks = _make_buffers(slots, heads, dim, device=k.device)
+    vd, vs = _make_buffers(slots, heads, dim, device=v.device)
+    quant_store_kv_mxfp4(k, v, loc, kd, vd, ks, vs)
+    return kd, vd, ks, vs
+
+
+@unittest.skipUnless(_HAS_CUDA, "CUDA is required")
+class TestMxfp4FusedStore(CustomTestCase):
+    def _check_bit_exact(self, k, v, loc, context):
+        kd, vd, ks, vs = _fused_write(k, v, loc)
+        valid = loc != 0
+        locs_valid = loc[valid]
+
+        eager_k, eager_ks = MXFP4KVQuantizeUtil.batched_quantize(k)
+        eager_v, eager_vs = MXFP4KVQuantizeUtil.batched_quantize(v)
+        oracle_k, oracle_ks = mxfp4_quantize_reference(k)
+        oracle_v, oracle_vs = mxfp4_quantize_reference(v)
+
+        # The eager codec and the oracle must agree first; otherwise this test
+        # would chase a moving target.
+        self.assertTrue(
+            torch.equal(eager_k, oracle_k) and torch.equal(eager_ks, oracle_ks),
+            f"[{context}] eager codec drifted from the OCP oracle (K scales)",
+        )
+        self.assertTrue(
+            torch.equal(eager_v, oracle_v) and torch.equal(eager_vs, oracle_vs),
+            f"[{context}] eager codec drifted from the OCP oracle (V scales)",
+        )
+
+        self.assertTrue(
+            torch.equal(kd[locs_valid], eager_k[valid]),
+            f"[{context}] fused K packed bytes differ from eager codec",
+        )
+        self.assertTrue(
+            torch.equal(ks[locs_valid], eager_ks[valid]),
+            f"[{context}] fused K E8M0 bytes differ from eager codec",
+        )
+        self.assertTrue(
+            torch.equal(vd[locs_valid], eager_v[valid]),
+            f"[{context}] fused V packed bytes differ from eager codec",
+        )
+        self.assertTrue(
+            torch.equal(vs[locs_valid], eager_vs[valid]),
+            f"[{context}] fused V E8M0 bytes differ from eager codec",
+        )
+
+    def test_random_bf16_dims(self):
+        g = torch.Generator(device=_DEVICE).manual_seed(20260903)
+        for dim in (32, 48, 64, 128, 256):
+            for heads in (1, 4):
+                with self.subTest(dim=dim, heads=heads):
+                    k = (
+                        torch.randn((7, heads, dim), generator=g, device=_DEVICE) * 2
+                    ).to(torch.bfloat16)
+                    v = (
+                        torch.randn((7, heads, dim), generator=g, device=_DEVICE) * 2
+                    ).to(torch.bfloat16)
+                    loc = torch.arange(1, 8, dtype=torch.int64, device=_DEVICE)
+                    self._check_bit_exact(k, v, loc, f"random_bf16_d{dim}_h{heads}")
+
+    def test_random_fp16(self):
+        g = torch.Generator(device=_DEVICE).manual_seed(5)
+        k = torch.randn((5, 2, 128), generator=g, device=_DEVICE).to(torch.float16)
+        v = torch.randn((5, 2, 128), generator=g, device=_DEVICE).to(torch.float16)
+        loc = torch.arange(1, 6, dtype=torch.int64, device=_DEVICE)
+        self._check_bit_exact(k, v, loc, "random_fp16")
+
+    def test_special_values(self):
+        # NaN blocks, +-Inf blocks, signed zeros, bf16 subnormals and
+        # extremes; one (heads=4, dim=64) row per scenario so each 32-block
+        # isolates a case.
+        row = torch.zeros((4, 64), dtype=torch.float32)
+        row[0] = float("nan")  # NaN block -> scale 0xFF, zero codes
+        row[1, :16] = float("inf")
+        row[1, 16:] = -float("inf")  # mixed +-Inf block -> scale 2^127
+        row[2, ::2] = 0.0
+        row[2, 1::2] = -0.0  # signed zeros -> codes 0x0 / 0x8
+        row[3, 0] = 3.3895e38  # bf16 max
+        row[3, 1] = -3.3895e38
+        row[3, 2] = 1e-40  # fp32 subnormal -> rounds to 0 in bf16
+        row[3, 3] = 2.0**-130  # bf16 subnormal
+        k = (
+            row.unsqueeze(0)
+            .to(torch.bfloat16)
+            .expand(3, 4, 64)
+            .contiguous()
+            .to(_DEVICE)
+        )
+        v = (-k).clone()
+        loc = torch.arange(1, 4, dtype=torch.int64, device=_DEVICE)
+        self._check_bit_exact(k, v, loc, "special_values")
+
+    def test_all_zero_block(self):
+        k = torch.zeros((2, 2, 64), dtype=torch.bfloat16, device=_DEVICE)
+        v = torch.zeros((2, 2, 64), dtype=torch.bfloat16, device=_DEVICE)
+        loc = torch.arange(1, 3, dtype=torch.int64, device=_DEVICE)
+        self._check_bit_exact(k, v, loc, "all_zero")
+        # amax == 0 -> scale byte 0 (2^-127) with zero codes.
+        _, _, ks, _ = _fused_write(k, v, loc)
+        self.assertTrue((ks[loc] == 0).all())
+
+    def test_tie_midpoints(self):
+        # Exact RNE midpoints after scaling. amax = 6.0 pins the block scale
+        # to 2^(floor(log2(6))-2) = 1, so the bf16-exact tie values below hit
+        # the distance-table midpoints (.25/.75/1.25/1.75/2.5/3.5/5) bit for
+        # bit; ties-to-even must pick codes 0/2/2/4/4/6/6.
+        base = torch.tensor(
+            [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0, 6.0], dtype=torch.float32
+        )
+        row = base.repeat(8)[:64]  # dim 64 = two 32-blocks, amax 6.0
+        k = row.unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+        v = (-row).unsqueeze(0).unsqueeze(0).to(torch.bfloat16)
+        loc = torch.tensor([1], dtype=torch.int64, device=_DEVICE)
+        self._check_bit_exact(
+            k.contiguous().to(_DEVICE), v.contiguous().to(_DEVICE), loc, "ties"
+        )
+
+    def test_slot0_untouched(self):
+        g = torch.Generator(device=_DEVICE).manual_seed(9)
+        k = torch.randn((4, 2, 64), generator=g, device=_DEVICE).to(torch.bfloat16)
+        v = torch.randn((4, 2, 64), generator=g, device=_DEVICE).to(torch.bfloat16)
+        # Token 1 targets the reserved slot 0; its bytes must not change.
+        loc = torch.tensor([1, 0, 2, 3], dtype=torch.int64, device=_DEVICE)
+
+        kd, ks = _make_buffers(8, 2, 64)
+        vd, vs = _make_buffers(8, 2, 64)
+        sentinel = torch.tensor(0xA5, dtype=torch.uint8, device=_DEVICE)
+        kd[0].fill_(sentinel)
+        ks[0].fill_(sentinel)
+        vd[0].fill_(sentinel)
+        vs[0].fill_(sentinel)
+        quant_store_kv_mxfp4(k, v, loc, kd, vd, ks, vs)
+
+        self.assertTrue((kd[0] == sentinel).all(), "slot 0 K data was written")
+        self.assertTrue((ks[0] == sentinel).all(), "slot 0 K scale was written")
+        self.assertTrue((vd[0] == sentinel).all(), "slot 0 V data was written")
+        self.assertTrue((vs[0] == sentinel).all(), "slot 0 V scale was written")
+
+        # The non-reserved rows must match the eager codec byte-for-byte:
+        # token 0 -> slot 1, token 1 -> slot 0 (skipped), token 2 -> slot 2,
+        # token 3 -> slot 3.
+        eager_k, eager_ks = MXFP4KVQuantizeUtil.batched_quantize(k)
+        for token, slot in ((0, 1), (2, 2), (3, 3)):
+            self.assertTrue(torch.equal(kd[slot], eager_k[token]))
+            self.assertTrue(torch.equal(ks[slot], eager_ks[token]))
+
+    def test_gate(self):
+        loc = torch.arange(1, 4, dtype=torch.int64, device=_DEVICE)
+        with self.subTest(supported_bf16=True):
+            k = torch.randn((3, 2, 64), device=_DEVICE).to(torch.bfloat16)
+            self.assertTrue(mxfp4_fused_store_supported(k, k.clone(), loc))
+        with self.subTest(rejects_fp32=True):
+            k = torch.randn((3, 2, 64), device=_DEVICE)
+            self.assertFalse(mxfp4_fused_store_supported(k, k.clone(), loc))
+        with self.subTest(rejects_non_contiguous_last_dim=True):
+            base = torch.randn((3, 2, 128), device=_DEVICE).to(torch.bfloat16)
+            k = base[..., ::2]  # last-dim stride 2
+            self.assertFalse(mxfp4_fused_store_supported(k, k.clone(), loc))
+        with self.subTest(rejects_cpu=True):
+            k = torch.randn((3, 2, 64)).to(torch.bfloat16)
+            cpu_loc = torch.arange(1, 4, dtype=torch.int64)
+            self.assertFalse(mxfp4_fused_store_supported(k, k.clone(), cpu_loc))
+        with self.subTest(rejects_shape_mismatch=True):
+            k = torch.randn((3, 2, 64), device=_DEVICE).to(torch.bfloat16)
+            v = torch.randn((3, 2, 32), device=_DEVICE).to(torch.bfloat16)
+            self.assertFalse(mxfp4_fused_store_supported(k, v, loc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
@@ -80,6 +80,37 @@ class TestCompressedTensorsKVCacheMethod(CustomTestCase):
             _config(dict(_FP8_TENSOR_KV_SCHEME, dynamic=True)).kv_cache_quant_algo
         )
 
+    def test_checkpoint_scales_gated_by_kv_cache_dtype(self):
+        """process_weights_after_loading applies the calibrated per-tensor
+        k_scale/v_scale only when --kv-cache-dtype is that FP8 cache: a bf16 or
+        block-scaled (mxfp4) cache carries its own or no scales, so the
+        checkpoint FP8 scales fall back to unit. One gate at load time replaces
+        any per-backend scale-validity guard."""
+        from types import SimpleNamespace
+
+        import torch
+
+        from sglang.srt.runtime_context import get_context
+
+        method = _config(_FP8_TENSOR_KV_SCHEME).get_quant_method(
+            _attn(), "model.layers.0.attn"
+        )
+        for kv_cache_dtype, exp_k, exp_v in (
+            ("fp8_e4m3", 0.5, 0.25),
+            ("mxfp4", 1.0, 1.0),
+            ("bfloat16", 1.0, 1.0),
+        ):
+            with self.subTest(kv_cache_dtype=kv_cache_dtype):
+                # A layer whose calibrated per-tensor scales were loaded from
+                # the checkpoint (both k_scale and v_scale positive).
+                layer = SimpleNamespace(
+                    k_scale=torch.tensor(0.5), v_scale=torch.tensor(0.25)
+                )
+                with get_context().override_server_args(kv_cache_dtype=kv_cache_dtype):
+                    method.process_weights_after_loading(layer)
+                self.assertEqual(layer.k_scale_float, exp_k)
+                self.assertEqual(layer.v_scale_float, exp_v)
+
     def test_unsupported_scheme_degrades_to_none(self):
         """Unsupported declared schemes must skip the method, not fail
         the boot: such checkpoints serve with an unquantized-scale cache."""

--- a/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
+++ b/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
@@ -31,6 +31,7 @@ class TestKVCacheQuantRegistry(CustomTestCase):
         self.assertIn("nvfp4", KV_CACHE_QUANT_REGISTRY)
         self.assertIn("fp4_mx_block16", KV_CACHE_QUANT_REGISTRY)
         self.assertIn("cpu_fp8_e4m3", KV_CACHE_QUANT_REGISTRY)
+        self.assertIn("mxfp4", KV_CACHE_QUANT_REGISTRY)
 
     def test_factory_nvfp4(self):
         from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
@@ -59,6 +60,7 @@ class TestKVCacheQuantRegistry(CustomTestCase):
 
         self.assertEqual(resolve_kv_cache_quant("nvfp4"), "nvfp4")
         self.assertEqual(resolve_kv_cache_quant("fp4_mx_block16"), "fp4_mx_block16")
+        self.assertEqual(resolve_kv_cache_quant("mxfp4"), "mxfp4")
         self.assertIsNone(resolve_kv_cache_quant("fp8_e4m3"))
 
     def test_resolve_legacy_fp4_alias_raises(self):
@@ -86,13 +88,14 @@ class TestKVCacheQuantRegistry(CustomTestCase):
         with self.assertRaisesRegex(ValueError, "fp4_mx_block16"):
             runner.configure_kv_cache_dtype()
 
-    def test_resolve_mxfp4_name_raises(self):
+    def test_factory_mxfp4(self):
         from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
-            resolve_kv_cache_quant,
+            MXFP4KVCacheMethod,
+            get_kv_cache_quant_method,
         )
 
-        with self.assertRaises(ValueError):
-            resolve_kv_cache_quant("mxfp4")
+        method = get_kv_cache_quant_method("mxfp4")
+        self.assertIsInstance(method, MXFP4KVCacheMethod)
 
     def test_factory_unknown_raises(self):
         from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
@@ -349,6 +352,92 @@ class TestFP4MXBlock16KVCacheMethod(CustomTestCase):
         self.assertEqual(v_out.shape, (4, heads, dim))
         self.assertEqual(k_out.dtype, torch.bfloat16)
         self.assertEqual(v_out.dtype, torch.bfloat16)
+
+
+class TestMXFP4KVCacheMethod(CustomTestCase):
+    """Test strict OCP MXFP4 buffer, access, and PLAIN-read contracts."""
+
+    def test_properties_and_qwen_capacity(self):
+        from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+            KVCacheAttentionAccessKind,
+            MXFP4KVCacheMethod,
+        )
+
+        method = MXFP4KVCacheMethod()
+        self.assertEqual(method.name, "mxfp4")
+        self.assertEqual(method.SCALE_BLOCK_SIZE, 32)
+        self.assertFalse(method.needs_dequant_workspace())
+        self.assertTrue(method.needs_plain_kv_dequant_read())
+        self.assertFalse(method.needs_global_scale())
+        self.assertEqual(method.plain_attention_kv_dtype(), torch.bfloat16)
+        self.assertEqual(method.scale_buffer_view_dtype(), torch.float8_e8m0fnu)
+        self.assertEqual(
+            method.resolve_attention_access("prefill", "flashinfer").kind,
+            KVCacheAttentionAccessKind.PLAIN,
+        )
+        self.assertEqual(
+            method.resolve_attention_access("decode", "flashinfer").kind,
+            KVCacheAttentionAccessKind.PLAIN,
+        )
+        # Native decode for the triton backend (kernel reads packed E2M1 +
+        # E8M0 scales inline); triton prefill stays unsupported (PLAIN reads
+        # are flashinfer-only).
+        self.assertEqual(
+            method.resolve_attention_access("decode", "triton").kind,
+            KVCacheAttentionAccessKind.NATIVE_FP4,
+        )
+        self.assertIsNone(method.resolve_attention_access("prefill", "triton"))
+        # 16 layers: 16 KiB packed + 1 KiB E8M0 scales + 4 KiB
+        # one-layer BF16 PLAIN scratch reserve.
+        self.assertEqual(method.compute_cell_size(4, 256, 16, 1), 21 * 1024)
+
+    def test_buffer_shapes_and_plain_roundtrip(self):
+        from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+            MXFP4KVCacheMethod,
+        )
+        from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+
+        method = MXFP4KVCacheMethod()
+        buffers = method.create_buffers(12, 4, 33, 2, "cpu")
+        self.assertEqual(buffers["k_buffer"][0].shape, (12, 4, 17))
+        self.assertEqual(buffers["k_scale_buffer"][0].shape, (12, 4, 2))
+        self.assertIsNone(buffers["dq_k_buffer"])
+        self.assertIsNone(buffers["dq_v_buffer"])
+
+        torch.manual_seed(20260902)
+        k = torch.randn(3, 4, 33, dtype=torch.bfloat16)
+        v = torch.randn_like(k)
+        loc = torch.tensor([0, 3, 9])
+        k0, v0 = k.clone(), v.clone()
+        method.quantize_and_store(
+            buffers["k_buffer"][0],
+            buffers["v_buffer"][0],
+            buffers["k_scale_buffer"][0],
+            buffers["v_scale_buffer"][0],
+            loc,
+            k,
+            v,
+        )
+        expected_k, expected_ks = MXFP4KVQuantizeUtil.batched_quantize(k0[1:])
+        expected_v, expected_vs = MXFP4KVQuantizeUtil.batched_quantize(v0[1:])
+        self.assertTrue(torch.equal(buffers["k_buffer"][0][loc[1:]], expected_k))
+        self.assertTrue(torch.equal(buffers["v_buffer"][0][loc[1:]], expected_v))
+        self.assertTrue(torch.equal(buffers["k_scale_buffer"][0][loc[1:]], expected_ks))
+        self.assertTrue(torch.equal(buffers["v_scale_buffer"][0][loc[1:]], expected_vs))
+        self.assertEqual(buffers["k_buffer"][0][0].sum().item(), 0)
+        self.assertEqual(buffers["k_scale_buffer"][0][0].sum().item(), 0)
+        self.assertTrue(torch.equal(k, k0))
+        self.assertTrue(torch.equal(v, v0))
+
+        actual = method.dequantize_kv_tensor(
+            buffers["k_buffer"][0][loc[1:]],
+            buffers["k_scale_buffer"][0][loc[1:]],
+            0,
+        )
+        expected = MXFP4KVQuantizeUtil.batched_dequantize(
+            expected_k, expected_ks, logical_dim=33, dtype=torch.bfloat16
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 class TestFP4MXBlock16KVQuantizeUtil(CustomTestCase):

--- a/test/registered/unit/layers/quantization/test_mxfp4_kv_codec.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_kv_codec.py
@@ -22,11 +22,10 @@ from sglang.kernels.ops.quantization.mxfp4_quant import (
     quant_store_kv_mxfp4,
 )
 from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
-from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
-register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
 
 _HAS_CUDA = torch.cuda.is_available()
 _DEVICE = "cuda"

--- a/test/registered/unit/mem_cache/test_mxfp4_kv_pool.py
+++ b/test/registered/unit/mem_cache/test_mxfp4_kv_pool.py
@@ -1,0 +1,163 @@
+"""CUDA pool-level tests for the MXFP4 KV cache: real MHATokenToKVPool.
+
+Covers the production write path (`set_kv_buffer` -> `quantize_and_store`),
+the reserved padding slot, the PLAIN BF16 read (`get_kv_buffer`), and slot
+moves that must carry packed data AND E8M0 scales together.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.quantization.kvfp4_tensor import MXFP4KVQuantizeUtil
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_HAS_CUDA = torch.cuda.is_available()
+
+
+def _make_pool(num_slots, heads, head_dim, layers=1):
+    from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+        MXFP4KVCacheMethod,
+    )
+
+    return MHATokenToKVPool(
+        size=num_slots,
+        page_size=1,
+        dtype=torch.float4_e2m1fn_x2,
+        head_num=heads,
+        head_dim=head_dim,
+        layer_num=layers,
+        device="cuda",
+        enable_memory_saver=False,
+        enable_alt_stream=False,
+        enable_kv_cache_copy=True,
+        quant_method=MXFP4KVCacheMethod(),
+    )
+
+
+@unittest.skipUnless(_HAS_CUDA, "CUDA is required")
+class TestMxfp4PoolWriteReadMove(CustomTestCase):
+    HEADS = 4
+    HEAD_DIM = 64
+    SLOTS = 64
+
+    def _pool(self):
+        return _make_pool(self.SLOTS, self.HEADS, self.HEAD_DIM)
+
+    def _locs(self, n, seed):
+        gen = torch.Generator(device="cuda").manual_seed(seed)
+        return torch.randperm(self.SLOTS - 1, device="cuda", generator=gen)[:n] + 1
+
+    def test_set_kv_buffer_bit_exact_and_slot0_reserved(self):
+        torch.manual_seed(20260903)
+        pool = self._pool()
+        layer = SimpleNamespace(layer_id=0)
+        k = torch.randn(
+            6, self.HEADS, self.HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+        )
+        v = torch.randn_like(k)
+        loc = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device="cuda"), self._locs(5, 7)]
+        )
+        k0, v0 = k.clone(), v.clone()
+        # Checkpoint FP8 scales must be ignored by the MXFP4 recipe.
+        pool.set_kv_buffer(layer, loc, k, v, 0.0275, 0.0245)
+
+        exp_k, exp_ks = MXFP4KVQuantizeUtil.batched_quantize(k0[1:])
+        exp_v, exp_vs = MXFP4KVQuantizeUtil.batched_quantize(v0[1:])
+        self.assertTrue(torch.equal(pool.k_buffer[0][loc[1:]], exp_k))
+        self.assertTrue(torch.equal(pool.k_scale_buffer[0][loc[1:]], exp_ks))
+        self.assertTrue(torch.equal(pool.v_buffer[0][loc[1:]], exp_v))
+        self.assertTrue(torch.equal(pool.v_scale_buffer[0][loc[1:]], exp_vs))
+        # Slot 0 stays untouched (reserved CUDA-graph padding slot).
+        self.assertEqual(pool.k_buffer[0][0].sum().item(), 0)
+        self.assertEqual(pool.k_scale_buffer[0][0].sum().item(), 0)
+        self.assertEqual(pool.v_buffer[0][0].sum().item(), 0)
+        self.assertEqual(pool.v_scale_buffer[0][0].sum().item(), 0)
+        self.assertTrue(torch.equal(k, k0), "MXFP4 write must not mutate inputs")
+        self.assertTrue(torch.equal(v, v0))
+
+    def test_plain_read_matches_codec(self):
+        torch.manual_seed(20260904)
+        pool = self._pool()
+        layer = SimpleNamespace(layer_id=0)
+        k = torch.randn(
+            8, self.HEADS, self.HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+        )
+        v = torch.randn_like(k)
+        loc = self._locs(8, 11)
+        k0, v0 = k.clone(), v.clone()
+        pool.set_kv_buffer(layer, loc, k, v)
+
+        k_plain, v_plain = pool.get_kv_buffer(0)
+        self.assertEqual(k_plain.dtype, torch.bfloat16)
+        self.assertEqual(k_plain.shape, (self.SLOTS + 1, self.HEADS, self.HEAD_DIM))
+        exp_k = MXFP4KVQuantizeUtil.batched_dequantize(
+            pool.k_buffer[0][loc],
+            pool.k_scale_buffer[0][loc],
+            logical_dim=self.HEAD_DIM,
+        )
+        exp_v = MXFP4KVQuantizeUtil.batched_dequantize(
+            pool.v_buffer[0][loc],
+            pool.v_scale_buffer[0][loc],
+            logical_dim=self.HEAD_DIM,
+        )
+        torch.testing.assert_close(k_plain[loc], exp_k, rtol=0, atol=0)
+        torch.testing.assert_close(v_plain[loc], exp_v, rtol=0, atol=0)
+        self.assertTrue(torch.equal(k, k0))
+        self.assertTrue(torch.equal(v, v0))
+
+    def test_slot_move_carries_data_and_scales(self):
+        torch.manual_seed(20260905)
+        pool = self._pool()
+        layer = SimpleNamespace(layer_id=0)
+        k = torch.randn(
+            8, self.HEADS, self.HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+        )
+        v = torch.randn_like(k)
+        src = self._locs(8, 13)
+        pool.set_kv_buffer(layer, src, k, v)
+
+        dst = self._locs(8, 17)
+        self.assertFalse(torch.equal(src, dst))
+        pool.move_kv_cache(dst, src)
+
+        exp_k, exp_ks = MXFP4KVQuantizeUtil.batched_quantize(k)
+        exp_v, exp_vs = MXFP4KVQuantizeUtil.batched_quantize(v)
+        self.assertTrue(torch.equal(pool.k_buffer[0][dst], exp_k))
+        self.assertTrue(torch.equal(pool.k_scale_buffer[0][dst], exp_ks))
+        self.assertTrue(torch.equal(pool.v_buffer[0][dst], exp_v))
+        self.assertTrue(torch.equal(pool.v_scale_buffer[0][dst], exp_vs))
+        # The tiled copy duplicates rows; the source slots keep their payload
+        # (same semantics as the block16/mxfp8 pools).
+        self.assertTrue(torch.equal(pool.k_buffer[0][src], exp_k))
+        self.assertTrue(torch.equal(pool.k_scale_buffer[0][src], exp_ks))
+
+    def test_v_head_dim_mismatch_fails_fast(self):
+        from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+            MXFP4KVCacheMethod,
+        )
+
+        with self.assertRaisesRegex(ValueError, "v_head_dim"):
+            MHATokenToKVPool(
+                size=16,
+                page_size=1,
+                dtype=torch.float4_e2m1fn_x2,
+                head_num=2,
+                head_dim=64,
+                layer_num=1,
+                device="cuda",
+                enable_memory_saver=False,
+                enable_alt_stream=False,
+                v_head_dim=32,
+                quant_method=MXFP4KVCacheMethod(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1751,9 +1751,9 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
             self._validate_prefill_only_args(enable_hisparse=True)
 
     def test_rejects_fp4_kv_cache(self):
-        for kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+        for kv_cache_dtype in ("nvfp4", "fp4_mx_block16", "mxfp4"):
             with self.subTest(kv_cache_dtype=kv_cache_dtype):
-                with self.assertRaisesRegex(ValueError, "nvfp4.*fp4_mx_block16"):
+                with self.assertRaisesRegex(ValueError, "FP4 pool"):
                     self._validate_prefill_only_args(kv_cache_dtype=kv_cache_dtype)
 
 


### PR DESCRIPTION
## Motivation

Add an OCP **MXFP4** KV-cache recipe (`--kv-cache-dtype mxfp4`, block-32, E2M1 data + E8M0 scale) for dense **MHA** models on **SM120** (RTX 5090 class), validated on Qwen3.5/3.8-27B. It stores KV in ~1.9× fewer bytes than FP8, for a measured **+52% KV capacity (1.52×) at equal memory**. End to end and self-contained in pure Triton (no sgl-kernel wheel change): codec + memory pool + a native Triton split-KV decode kernel + backend integration (FlashInfer PLAIN prefill, Triton native decode).

It also carries one general fix: checkpoint FP8 `k_scale`/`v_scale` are now applied through a single load-time gate keyed on `--kv-cache-dtype`, replacing scattered per-backend `kv_cache_scales_valid` guards.

## Modifications

Standard **MXFP4 layout** — block-32, E2M1 packed (uint8) + one E8M0 byte (`float8_e8m0fnu`) per 32 values, blocked **per head** (never across heads); no global scale (unlike NVFP4). Per token per layer (K or V) on Qwen3.8 (4 KV heads, head_dim 256): 4×(128 packed + 8 scale) = **544 B**, vs FP8 1024 B and BF16 2048 B.

**Components** (4 commits):
- **Scale gate** (`kv_cache.py`): `_checkpoint_kv_scales_apply` decides whether the checkpoint's per-tensor FP8 scales apply, keyed on the raw `--kv-cache-dtype` string (fp8_e4m3/e5m2 → yes; `auto` → via `kv_cache_quant_algo`; bf16/mxfp4/nvfp4/mxfp8 → unit). One point covers compressed-tensors + ModelOpt + every backend.
- **Codec** (`kvfp4_tensor.py`, `mxfp4_quant.py`): OCP quantize/dequant (saturating RNE, NaN/±Inf/zero-block policy) + a fused write kernel `quant_store_kv_mxfp4` (amax → E8M0 → E2M1 pack → scatter, CUDA-graph safe); `e8m0_to_f32` is built by bit-shift (avoids `tl.exp2` FTZ flushing 2^-127).
- **Decode kernel** (`decode_attention_mxfp4_sm120.py`): native Triton split-KV — per-head stage1 (MHA, fp32), grouped stage1 (GQA/MQA), stage2 split-combine; `num_warps=8` / `BLOCK_N=64`; head_dim-agnostic (`next_power_of_2`, `//32`).
- **Serving**: `MXFP4KVCacheMethod` + an access registry (`PLAIN` FlashInfer BF16 read / `NATIVE_FP4` Triton inline), pool buffers + cell sizing, backend wiring, and a startup hook.

**Startup guards** (fail fast at arg parse): CUDA-only; MHA-only (no MLA); prefill=flashinfer with decode ∈ {flashinfer, triton}; the PLAIN decode path requires `--disable-cuda-graph`; the pool requires `v_head_dim == head_dim`. 21 files, +3097 / −36.

## Validation

Checkpoint using unsloth/Qwen3.8-27B-NVFP4, FP8 (`fp8_e4m3` + flashinfer) vs MXFP4 (mxfp4 + flashinfer prefill + triton decode), Qwen3.8-27B-NVFP4 on single RTX 5090, identical flags otherwise. Capacity/throughput are single-request at `--mem-fraction-static 0.80` (a clean-capacity baseline, no mamba-state tuning); accuracy is the paired, truncation-excluded metric.

| Metric | FP8 | MXFP4 | Δ |
|---|---|---|---|
| **KV capacity** (`max_total_num_tokens`) | 53503 | 81529 | **+52% (1.52×)** |
| Decode throughput (single-req, 4k×128) | 37.9 tok/s | 35.4 tok/s | −6.7% |
| GSM8K (1319, greedy, 4k) | 98.19% | 97.95% | −0.24pt (McNemar p=0.450) |
| AIME25 (30×avg@8, T=0.6, 16k) | 95.56% | 96.30% | +0.74pt (p=1.000) |

Accuracy is statistically indistinguishable from FP8. MXFP4 inflates generation length (GSM8K mean +43%, AIME median +61% — KV noise flattens softmax concentration), raising the truncated rate (AIME 30%→40%).

## Known Limitations / Follow-ups

- SM120-only; MHA-only (no MLA); `v_head_dim == head_dim` required.
- Prefill must be FlashInfer; the PLAIN decode path is validation-only (needs `--disable-cuda-graph`), while production decode uses the graph-safe Triton native kernel. A native Triton prefill is out of scope.
- Decode −6.7% vs FP8 (single-request): the SM120 Triton kernel and PLAIN prefill are less optimized than the FlashInfer FP8 path.
- **The +52% capacity shrinks under concurrency**: serving conc > 1 on this hybrid (GDN) model needs a mamba-state cache (`--max-mamba-cache-size`) that eats ~2.9 GB of the KV budget, pulling the gain down toward ~+20%.
- Length inflation (+43–67%) discounts the effective capacity gain to roughly 1.06–1.3× for long-CoT workloads.

## References

- OCP Microscaling (MX) Formats v1.0, §6.3 — MXFP4 (E2M1 + E8M0, block-32)
- #32741 — MXFP4 KV cache decode for DSV4 on Hopper (SM90 / MLA sibling)
- #31269 — NVFP4 KV cache for DSV4 (reference); #37135–#37138 — DSV4 MXFP4 series

## Checklist

- [x] Format code with pre-commit (isort clean; the black diffs on 5 files are pre-existing upstream style under a newer black — left untouched to avoid polluting this diff)
- [x] Add unit tests (codec / decode kernel / method + pool + scale gate; 237 CPU + 21 GPU pass)
- [x] Update documentation — N/A: no KV-cache-recipe doc precedent (nvfp4 / fp4_mx_block16 are undocumented), matching #32741
- [x] Accuracy and speed benchmark (Validation above; FP8 vs MXFP4, single-request capacity/throughput + paired truncation-excluded accuracy)
- [x] Follow the SGLang code style guidance


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34397606320](https://github.com/sgl-project/sglang/actions/runs/34397606320)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34397606012](https://github.com/sgl-project/sglang/actions/runs/34397606012)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34397606527](https://github.com/sgl-project/sglang/actions/runs/34397606527)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->