### PR TITLE
Relax GSM8K thresholds for the GLM-5.2 DSA-MTP variants

### DIFF
--- a/python/sglang/test/server_fixtures/dsa_mtp_fixture.py
+++ b/python/sglang/test/server_fixtures/dsa_mtp_fixture.py
@@ -32,8 +32,9 @@ from sglang.test.test_utils import (
 class DsaMtpEvalConfigDefaults:
     """Eval thresholds & params shared across DSA-MTP regression variants."""
 
-    # GSM8KMixin defaults.
-    gsm8k_accuracy_thres = 0.935
+    # GSM8KMixin defaults. `gsm8k_accuracy_thres` is measured on the FP8
+    # variants; lower-scoring quantizations override it per variant.
+    gsm8k_accuracy_thres = 0.925
     gsm8k_accept_length_thres = 3.7
     gsm8k_num_questions = 500
     gsm8k_num_threads = 500

--- a/test/registered/e2e/models/test_dsa_glm52_nvfp4_dp_mtp.py
+++ b/test/registered/e2e/models/test_dsa_glm52_nvfp4_dp_mtp.py
@@ -24,6 +24,7 @@ class TestGLM52NVFP4DPMTP(
     mem_fraction_static = 0.88
     enable_dp_attention = True
     bs_1_speed_thres = 180
+    gsm8k_accuracy_thres = 0.92
     extra_server_args = [
         "--moe-runner-backend",
         "flashinfer_trtllm",

--- a/test/registered/e2e/models/test_dsa_glm52_nvfp4_tp_mtp.py
+++ b/test/registered/e2e/models/test_dsa_glm52_nvfp4_tp_mtp.py
@@ -22,6 +22,7 @@ class TestGLM52NVFP4TPMTP(
     tp_size = 4
     mem_fraction_static = 0.8
     bs_1_speed_thres = 280
+    gsm8k_accuracy_thres = 0.92
     extra_server_args = [
         "--moe-runner-backend",
         "flashinfer_trtllm",


### PR DESCRIPTION
`test_dsa_glm52_nvfp4_dp_mtp.py` fails gsm8k about twice a week with scores of 0.926–0.934 against a 0.935 threshold — 13 of its 19 recorded failures since July are this one assert, spread across every B200 host and unrelated commits.

Nothing is regressing. The 0.935 default was calibrated on DeepSeek-V3.2, which scores 0.960, and has been inherited unchanged through two model swaps. On GLM-5.2 NVFP4 it lands 1.3σ below the mean.

Measured from CI job logs, 08-30 → 09-09:

| test | n | mean | sd | min | headroom at 0.935 |
|---|---|---|---|---|---|
| `test_dsa_glm52_dp_mtp` (FP8) | 95 | 0.9495 | 0.0058 | 0.930 | 2.5σ |
| `test_dsa_glm52_tp_mtp` (FP8) | 90 | 0.9492 | 0.0058 | 0.932 | 2.4σ |
| `test_dsa_glm52_nvfp4_dp_mtp` | 61 | 0.9439 | 0.0069 | 0.928 | 1.3σ |
| `test_dsa_glm52_nvfp4_tp_mtp` | 55 | 0.9477 | 0.0066 | 0.934 | 1.9σ |

All four minima are already below 0.935.

The distribution has not drifted since the NVFP4 tests were added on 07-03 — it has been landing under 0.935 since its first full week:

| week | n | mean | min | attempts <0.935 |
|---|---|---|---|---|
| 07-06 (first full week) | 13 | 0.9462 | 0.930 | 2 |
| 07-13 | 14 | 0.9459 | 0.940 | 0 |
| 07-20 | 14 | 0.9461 | 0.932 | 1 |
| 07-27 | 13 | 0.9477 | 0.940 | 0 |
| 08-03 | 13 | 0.9443 | 0.930 | 2 |
| 08-17 | 8 | 0.9472 | 0.940 | 0 |

First week (n=18) mean 0.9457 / sd 0.0087 vs recent (n=61) mean 0.9439 / sd 0.0069; Welch t=0.79, variance ratio F=1.62, neither significant. The threshold never had adequate headroom rather than losing it.

Currently 9.0% of eval attempts (6/67 over the last 10 days) land under 0.935; the `retry()` wrapper rescues most of them, which is why this surfaces as an occasional red job rather than a constant failure.

Fix: shared default 0.935 → 0.925, which gives the FP8 pair 4.2σ, plus 0.92 overrides on the two NVFP4 variants for 3.5σ and 4.2σ. Every value sits below all ~300 observed scores and still catches a real break — the one genuine accuracy failure on this fixture scored 0.046.
