### PR TITLE
[Quant] ModelOpt mixed precision: dispatch block-FP8 MoE experts and derive the block size

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -779,9 +779,9 @@ class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
         return out.view(*index_shape, hidden).to(self.params_dtype)
 
 
-# ``FP8_PB_WO`` is ModelOpt's canonical 2D block-FP8 name. Early composed
-# Qwen3.8-Flash-Next checkpoints label the same tensor layout (fp8 weight +
-# per-block ``weight_scale_inv``) ``FP8_BLOCK_SCALES``; keep it as an alias.
+# FP8_PB_WO is ModelOpt's canonical 2D block-FP8 name.
+# Qwen3.8-Flash-Next-NVFP4 used FP8_BLOCK_SCALES for the same tensor layout.
+# Keep it as an alias.
 _BLOCK_FP8_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")
 
 
@@ -881,9 +881,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         if group_size is None:
             group_size = 16
 
-        # Block-FP8 layers carry their block size as ``group_size``
-        # (default 128). One Fp8Config serves every such layer, so they must
-        # all agree.
+        # Block-FP8 layers carry their block size as group_size
+        # (default 128). One Fp8Config serves every such layer.
         block_sizes = {
             int(layer_info.get("group_size", 128))
             for layer_info in quantized_layers.values()
@@ -1050,8 +1049,6 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             if quant_algo == "FP8":
                 return ModelOptFp8MoEMethod(self.fp8_config)
             if quant_algo in _BLOCK_FP8_ALGOS:
-                # Block-scaled fp8 experts with per-block weight_scale_inv
-                # (e.g. the MTP experts of Qwen3.8-Flash-Next-NVFP4).
                 return Fp8MoEMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -779,6 +779,12 @@ class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
         return out.view(*index_shape, hidden).to(self.params_dtype)
 
 
+# ``FP8_PB_WO`` is ModelOpt's canonical 2D block-FP8 name. Early composed
+# Qwen3.8-Flash-Next checkpoints label the same tensor layout (fp8 weight +
+# per-block ``weight_scale_inv``) ``FP8_BLOCK_SCALES``; keep it as an alias.
+_BLOCK_FP8_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")
+
+
 class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
     """Configuration for ModelOpt MIXED_PRECISION checkpoints."""
 
@@ -875,6 +881,21 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         if group_size is None:
             group_size = 16
 
+        # Block-FP8 layers carry their block size as ``group_size``
+        # (default 128). One Fp8Config serves every such layer, so they must
+        # all agree.
+        block_sizes = {
+            int(layer_info.get("group_size", 128))
+            for layer_info in quantized_layers.values()
+            if layer_info.get("quant_algo", "").upper() in _BLOCK_FP8_ALGOS
+        }
+        if len(block_sizes) > 1:
+            raise ValueError(
+                "MIXED_PRECISION currently requires all block-FP8 layers to "
+                f"use one group_size, got {sorted(block_sizes)}."
+            )
+        block_size = next(iter(block_sizes), 128)
+
         packed_modules_mapping = config.get("packed_modules_mapping")
         fp8_config = ModelOptFp8Config(
             is_checkpoint_fp8_serialized=True,
@@ -885,7 +906,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         fp8_pb_wo_config = Fp8Config(
             is_checkpoint_fp8_serialized=True,
             activation_scheme="dynamic",
-            weight_block_size=[128, 128],
+            weight_block_size=[block_size, block_size],
             packed_modules_mapping=packed_modules_mapping,
         )
         mxfp8_config = Fp8Config(
@@ -999,7 +1020,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
-            if quant_algo == "FP8_PB_WO":
+            if quant_algo in _BLOCK_FP8_ALGOS:
                 return Fp8LinearMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
@@ -1028,6 +1049,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return None
             if quant_algo == "FP8":
                 return ModelOptFp8MoEMethod(self.fp8_config)
+            if quant_algo in _BLOCK_FP8_ALGOS:
+                # Block-scaled fp8 experts with per-block weight_scale_inv
+                # (e.g. the MTP experts of Qwen3.8-Flash-Next-NVFP4).
+                return Fp8MoEMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)
             if quant_algo == "NVFP4":

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -22,7 +22,8 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod, Fp8MoEMethod
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -737,6 +738,61 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(method.quant_config.weight_block_size, [128, 128])
         self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
         self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+
+    def _block_fp8_moe_method(self, algo, group_size=128):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "mtp.layers.0.mlp.experts": {
+                        "quant_algo": algo,
+                        "group_size": group_size,
+                    },
+                },
+                "packed_modules_mapping": {},
+            }
+        )
+        # Type dispatch only needs a FusedMoE instance; skip GPU weight setup.
+        layer = FusedMoE.__new__(FusedMoE)
+        return quant_config.get_quant_method(layer, "mtp.layers.0.mlp.experts")
+
+    def test_block_fp8_moe_dispatches_under_both_algo_names(self):
+        """Regression: `nvidia/Qwen3.8-Flash-Next-NVFP4` lists its MTP experts as
+        block-FP8 (`FP8_BLOCK_SCALES` in hf_quant_config.json, the canonical
+        `FP8_PB_WO` in config.json). The FusedMoE branch had no entry for
+        either, so the experts were built unquantized: the fp8 values were
+        cast to bf16 without their scales and `weight_scale_inv` was dropped
+        by the loader, with no error."""
+        for algo in ("FP8_PB_WO", "FP8_BLOCK_SCALES"):
+            with self.subTest(algo=algo):
+                method = self._block_fp8_moe_method(algo)
+                self.assertIsInstance(method, Fp8MoEMethod)
+                self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+                self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+                self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+
+    def test_block_fp8_block_size_follows_checkpoint_group_size(self):
+        method = self._block_fp8_moe_method("FP8_BLOCK_SCALES", group_size=64)
+        self.assertEqual(method.quant_config.weight_block_size, [64, 64])
+
+    def test_block_fp8_conflicting_group_sizes_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "one group_size"):
+            ModelOptMixedPrecisionConfig.from_config(
+                {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "mtp.layers.0.mlp.experts": {
+                            "quant_algo": "FP8_BLOCK_SCALES",
+                            "group_size": 128,
+                        },
+                        "model.layers.0.self_attn.q_proj": {
+                            "quant_algo": "FP8_PB_WO",
+                            "group_size": 64,
+                        },
+                    },
+                    "packed_modules_mapping": {},
+                }
+            )
 
     def test_incomplete_inline_config_falls_back_to_hf_quant_config_file(self):
         packed_modules_mapping = {

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -757,12 +757,6 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         return quant_config.get_quant_method(layer, "mtp.layers.0.mlp.experts")
 
     def test_block_fp8_moe_dispatches_under_both_algo_names(self):
-        """Regression: `nvidia/Qwen3.8-Flash-Next-NVFP4` lists its MTP experts as
-        block-FP8 (`FP8_BLOCK_SCALES` in hf_quant_config.json, the canonical
-        `FP8_PB_WO` in config.json). The FusedMoE branch had no entry for
-        either, so the experts were built unquantized: the fp8 values were
-        cast to bf16 without their scales and `weight_scale_inv` was dropped
-        by the loader, with no error."""
         for algo in ("FP8_PB_WO", "FP8_BLOCK_SCALES"):
             with self.subTest(algo=algo):
                 method = self._block_fp8_moe_method(algo)


### PR DESCRIPTION
## Motivation

`ModelOptMixedPrecisionConfig` has a Linear entry for `FP8_PB_WO` but no FusedMoE entry for any block-FP8 algorithm, and it hard-codes the block-FP8 sub-config to `[128, 128]`.

`nvidia/Qwen3.8-Flash-Next-NVFP4` lists its MTP experts (`mtp.layers.0.mlp.experts`) as block-FP8: `FP8_BLOCK_SCALES` in `hf_quant_config.json`, the canonical `FP8_PB_WO` in the inline `config.json` copy (SGLang currently reads the file because the inline copy carries no KV-cache key, but either name can win). Both resolve to "no quant method" for FusedMoE, so the experts are built unquantized: the loader casts the fp8 values to bf16 without their block scales and silently skips `weight_scale_inv`. The server starts and target accuracy is unaffected, but the draft is numerically wrong (accept length ~1.6 instead of ~3).

Mirrors vllm-project/vllm#55513.

## Modifications

- `_BLOCK_FP8_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")`; Linear and FusedMoE both dispatch on it, FusedMoE to `Fp8MoEMethod(self.fp8_pb_wo_config)` (block scales via `weight_scale_inv`, dynamic activation).
- The block-FP8 sub-config's block size comes from the checkpoint's `group_size` (default 128); a MIXED_PRECISION map whose block-FP8 layers disagree raises.

## Test

- `test_modelopt_loader.py::TestModelOptMixedPrecisionConfig`: both names dispatch to `Fp8MoEMethod` with `[128,128]`; block size follows `group_size`; conflicting sizes raise. Verified red on the pre-change code.
- Existing mixed-precision tests in that class still pass.
- E2E together with the follow-up Qwen4-Exp PR: `nvidia/Qwen3.8-Flash-Next-NVFP4`, 4x B300, TP4, NEXTN 3/1/4: sgl-eval GSM8K (200, thinking) 0.97, accept length ~3.2-3.6.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel if you have any questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35454946958](https://github.com/sgl-project/sglang/actions/runs/35454946958)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35454946606](https://github.com/sgl-project/sglang/actions/runs/35454946606)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35454946870](https://github.com/sgl-project/sglang/actions/runs/35454946870)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->