### PR TITLE
[Model] Qwen4-Exp: honour per-layer FP8 for the PLE table and the MTP experts in ModelOpt mixed checkpoints

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -779,9 +779,9 @@ class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
         return out.view(*index_shape, hidden).to(self.params_dtype)
 
 
-# ``FP8_PB_WO`` is ModelOpt's canonical 2D block-FP8 name. Early composed
-# Qwen3.8-Flash-Next checkpoints label the same tensor layout (fp8 weight +
-# per-block ``weight_scale_inv``) ``FP8_BLOCK_SCALES``; keep it as an alias.
+# FP8_PB_WO is ModelOpt's canonical 2D block-FP8 name.
+# Qwen3.8-Flash-Next-NVFP4 used FP8_BLOCK_SCALES for the same tensor layout.
+# Keep it as an alias.
 _BLOCK_FP8_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")
 
 
@@ -881,9 +881,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         if group_size is None:
             group_size = 16
 
-        # Block-FP8 layers carry their block size as ``group_size``
-        # (default 128). One Fp8Config serves every such layer, so they must
-        # all agree.
+        # Block-FP8 layers carry their block size as group_size
+        # (default 128). One Fp8Config serves every such layer.
         block_sizes = {
             int(layer_info.get("group_size", 128))
             for layer_info in quantized_layers.values()
@@ -1050,8 +1049,6 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             if quant_algo == "FP8":
                 return ModelOptFp8MoEMethod(self.fp8_config)
             if quant_algo in _BLOCK_FP8_ALGOS:
-                # Block-scaled fp8 experts with per-block weight_scale_inv
-                # (e.g. the MTP experts of Qwen3.8-Flash-Next-NVFP4).
                 return Fp8MoEMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -779,6 +779,12 @@ class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
         return out.view(*index_shape, hidden).to(self.params_dtype)
 
 
+# ``FP8_PB_WO`` is ModelOpt's canonical 2D block-FP8 name. Early composed
+# Qwen3.8-Flash-Next checkpoints label the same tensor layout (fp8 weight +
+# per-block ``weight_scale_inv``) ``FP8_BLOCK_SCALES``; keep it as an alias.
+_BLOCK_FP8_ALGOS = ("FP8_PB_WO", "FP8_BLOCK_SCALES")
+
+
 class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
     """Configuration for ModelOpt MIXED_PRECISION checkpoints."""
 
@@ -875,6 +881,21 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         if group_size is None:
             group_size = 16
 
+        # Block-FP8 layers carry their block size as ``group_size``
+        # (default 128). One Fp8Config serves every such layer, so they must
+        # all agree.
+        block_sizes = {
+            int(layer_info.get("group_size", 128))
+            for layer_info in quantized_layers.values()
+            if layer_info.get("quant_algo", "").upper() in _BLOCK_FP8_ALGOS
+        }
+        if len(block_sizes) > 1:
+            raise ValueError(
+                "MIXED_PRECISION currently requires all block-FP8 layers to "
+                f"use one group_size, got {sorted(block_sizes)}."
+            )
+        block_size = next(iter(block_sizes), 128)
+
         packed_modules_mapping = config.get("packed_modules_mapping")
         fp8_config = ModelOptFp8Config(
             is_checkpoint_fp8_serialized=True,
@@ -885,7 +906,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         fp8_pb_wo_config = Fp8Config(
             is_checkpoint_fp8_serialized=True,
             activation_scheme="dynamic",
-            weight_block_size=[128, 128],
+            weight_block_size=[block_size, block_size],
             packed_modules_mapping=packed_modules_mapping,
         )
         mxfp8_config = Fp8Config(
@@ -999,7 +1020,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
-            if quant_algo == "FP8_PB_WO":
+            if quant_algo in _BLOCK_FP8_ALGOS:
                 return Fp8LinearMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
@@ -1028,6 +1049,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return None
             if quant_algo == "FP8":
                 return ModelOptFp8MoEMethod(self.fp8_config)
+            if quant_algo in _BLOCK_FP8_ALGOS:
+                # Block-scaled fp8 experts with per-block weight_scale_inv
+                # (e.g. the MTP experts of Qwen3.8-Flash-Next-NVFP4).
+                return Fp8MoEMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8MoEMethod(self.mxfp8_config)
             if quant_algo == "NVFP4":

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -58,12 +58,23 @@ def _mtp_quant_config(quant_config):
     # Serialized Qwen3.5 ModelOpt checkpoints keep embedded MTP weights in
     # BF16. Disable quantization for those checkpoints; non-serialized
     # modelopt_fp4 still converts MoE expert weights on load.
+    if quant_config and quant_config.get_name() == "modelopt_mixed":
+        # A MIXED_PRECISION checkpoint may still quantize the MTP module
+        # (Qwen3.8-Flash-Next-NVFP4 ships `mtp.*.experts` as block-FP8).
+        # Building the draft unquantized would cast the fp8 expert values to
+        # bf16 without their block scales (weight_scale_inv is silently
+        # skipped by the loader), leaving the draft numerically wrong but
+        # the server running.
+        quantized_layers = getattr(quant_config, "quantized_layers", {}) or {}
+        if any(
+            isinstance(layer, str) and layer.startswith("mtp.")
+            for layer in quantized_layers
+        ):
+            return quant_config
+        return None
     if quant_config and (
-        quant_config.get_name() == "modelopt_mixed"
-        or (
-            quant_config.get_name() == "modelopt_fp4"
-            and quant_config.is_checkpoint_nvfp4_serialized
-        )
+        quant_config.get_name() == "modelopt_fp4"
+        and quant_config.is_checkpoint_nvfp4_serialized
     ):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -59,12 +59,7 @@ def _mtp_quant_config(quant_config):
     # BF16. Disable quantization for those checkpoints; non-serialized
     # modelopt_fp4 still converts MoE expert weights on load.
     if quant_config and quant_config.get_name() == "modelopt_mixed":
-        # A MIXED_PRECISION checkpoint may still quantize the MTP module
-        # (Qwen3.8-Flash-Next-NVFP4 ships `mtp.*.experts` as block-FP8).
-        # Building the draft unquantized would cast the fp8 expert values to
-        # bf16 without their block scales (weight_scale_inv is silently
-        # skipped by the loader), leaving the draft numerically wrong but
-        # the server running.
+        # Qwen3.8-Flash-Next-NVFP4 ships `mtp.*.experts` as block-FP8
         quantized_layers = getattr(quant_config, "quantized_layers", {}) or {}
         if any(
             isinstance(layer, str) and layer.startswith("mtp.")

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -410,6 +410,34 @@ class Qwen4ExpPLEGroupedNorm(nn.Module):
         return (x_norm * weight).to(compute_dtype)
 
 
+def _ple_table_is_fp8(
+    config: Qwen4ExpTextConfig,
+    quant_config: Optional[QuantizationConfig],
+    ngram_prefix: str,
+) -> bool:
+    """Whether the PLE n-gram table should be stored as fp8.
+
+    True when the config pins it (``ple_embedding_dtype``), when the whole
+    checkpoint is fp8, or when a mixed-precision (ModelOpt) checkpoint lists
+    the table itself as FP8. The last case matters because the storage dtype
+    is fixed at construction: with ``ple_offload_embedding`` the pinned host
+    table cannot be swapped to fp8 later in ``load_weights``.
+    """
+    if getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn":
+        return True
+    if quant_config is None:
+        return False
+    if quant_config.get_name() == "fp8":
+        return True
+    resolve = getattr(quant_config, "_resolve_quant_algo", None)
+    if resolve is None:
+        return False
+    try:
+        return resolve(ngram_prefix) == "FP8"
+    except ValueError:
+        return False
+
+
 class Qwen4ExpNGramEmbedding(nn.Module):
     _MASK64 = (1 << 64) - 1
     _SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
@@ -423,6 +451,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         embedding_dim: int,
         ple_layer_index: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.config = config
@@ -484,8 +513,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             self.head_dim_per_ngram,
             params_dtype=(
                 torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                if _ple_table_is_fp8(config, quant_config, f"{prefix}.ngram_embedding")
                 else torch.bfloat16
             ),
             output_dtype=torch.bfloat16,
@@ -881,6 +909,7 @@ class Qwen4ExpPLELayer(nn.Module):
             self.ple_embed_dim,
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
+            prefix=f"{prefix}.ple_embedding" if prefix else "ple_embedding",
         )
         if config.ple_offload_embedding:
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -417,11 +417,9 @@ def _ple_table_is_fp8(
 ) -> bool:
     """Whether the PLE n-gram table should be stored as fp8.
 
-    True when the config pins it (``ple_embedding_dtype``), when the whole
-    checkpoint is fp8, or when a mixed-precision (ModelOpt) checkpoint lists
-    the table itself as FP8. The last case matters because the storage dtype
-    is fixed at construction: with ``ple_offload_embedding`` the pinned host
-    table cannot be swapped to fp8 later in ``load_weights``.
+    True when the config pins it, or when the whole checkpoint
+    is fp8, or when a mixed-precision checkpoint lists the table
+    itself as FP8.
     """
     if getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn":
         return True

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -22,7 +22,8 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod, Fp8MoEMethod
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -737,6 +738,61 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(method.quant_config.weight_block_size, [128, 128])
         self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
         self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+
+    def _block_fp8_moe_method(self, algo, group_size=128):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "mtp.layers.0.mlp.experts": {
+                        "quant_algo": algo,
+                        "group_size": group_size,
+                    },
+                },
+                "packed_modules_mapping": {},
+            }
+        )
+        # Type dispatch only needs a FusedMoE instance; skip GPU weight setup.
+        layer = FusedMoE.__new__(FusedMoE)
+        return quant_config.get_quant_method(layer, "mtp.layers.0.mlp.experts")
+
+    def test_block_fp8_moe_dispatches_under_both_algo_names(self):
+        """Regression: `nvidia/Qwen3.8-Flash-Next-NVFP4` lists its MTP experts as
+        block-FP8 (`FP8_BLOCK_SCALES` in hf_quant_config.json, the canonical
+        `FP8_PB_WO` in config.json). The FusedMoE branch had no entry for
+        either, so the experts were built unquantized: the fp8 values were
+        cast to bf16 without their scales and `weight_scale_inv` was dropped
+        by the loader, with no error."""
+        for algo in ("FP8_PB_WO", "FP8_BLOCK_SCALES"):
+            with self.subTest(algo=algo):
+                method = self._block_fp8_moe_method(algo)
+                self.assertIsInstance(method, Fp8MoEMethod)
+                self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+                self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+                self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+
+    def test_block_fp8_block_size_follows_checkpoint_group_size(self):
+        method = self._block_fp8_moe_method("FP8_BLOCK_SCALES", group_size=64)
+        self.assertEqual(method.quant_config.weight_block_size, [64, 64])
+
+    def test_block_fp8_conflicting_group_sizes_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "one group_size"):
+            ModelOptMixedPrecisionConfig.from_config(
+                {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "mtp.layers.0.mlp.experts": {
+                            "quant_algo": "FP8_BLOCK_SCALES",
+                            "group_size": 128,
+                        },
+                        "model.layers.0.self_attn.q_proj": {
+                            "quant_algo": "FP8_PB_WO",
+                            "group_size": 64,
+                        },
+                    },
+                    "packed_modules_mapping": {},
+                }
+            )
 
     def test_incomplete_inline_config_falls_back_to_hf_quant_config_file(self):
         packed_modules_mapping = {

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -757,12 +757,6 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         return quant_config.get_quant_method(layer, "mtp.layers.0.mlp.experts")
 
     def test_block_fp8_moe_dispatches_under_both_algo_names(self):
-        """Regression: `nvidia/Qwen3.8-Flash-Next-NVFP4` lists its MTP experts as
-        block-FP8 (`FP8_BLOCK_SCALES` in hf_quant_config.json, the canonical
-        `FP8_PB_WO` in config.json). The FusedMoE branch had no entry for
-        either, so the experts were built unquantized: the fp8 values were
-        cast to bf16 without their scales and `weight_scale_inv` was dropped
-        by the loader, with no error."""
         for algo in ("FP8_PB_WO", "FP8_BLOCK_SCALES"):
             with self.subTest(algo=algo):
                 method = self._block_fp8_moe_method(algo)

--- a/test/registered/unit/models/test_qwen4_exp_mixed_precision.py
+++ b/test/registered/unit/models/test_qwen4_exp_mixed_precision.py
@@ -1,0 +1,100 @@
+"""Regression tests for Qwen4-Exp on three-precision ModelOpt MIXED_PRECISION
+checkpoints (`nvidia/Qwen3.8-Flash-Next-NVFP4`: NVFP4 experts + FP8 PLE table
++ block-FP8 MTP experts).
+
+Each case guards a decision that used to be made before consulting the
+per-layer `quantized_layers` map:
+  1. The PLE n-gram table's storage dtype is fixed at construction. Building it
+     bf16 and switching to fp8 in load_weights is impossible once the table
+     sits in pinned host memory (`--ple-offload-embedding`, default on), so
+     the FP8 entry in `quantized_layers` must be honoured at construction.
+  2. The draft (MTP) module dropped its quant config for every modelopt_mixed
+     checkpoint. With `mtp.*.experts` listed as block-FP8 that cast the fp8
+     expert values to bf16 without their scales and silently discarded
+     `weight_scale_inv` (accept length fell from ~3.0 to ~1.6 with no error).
+"""
+
+import unittest
+
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptMixedPrecisionConfig,
+)
+from sglang.srt.models.qwen3_5_mtp import _mtp_quant_config
+from sglang.srt.models.qwen4_exp import _ple_table_is_fp8
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+PLE_PREFIX = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+MTP_EXPERTS = "mtp.layers.0.mlp.experts"
+
+
+def _mixed_config(quantized_layers):
+    return ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quantization": {
+                "quant_algo": "MIXED_PRECISION",
+                "exclude_modules": [],
+                "group_size": 16,
+                "quantized_layers": quantized_layers,
+            }
+        }
+    )
+
+
+class _Cfg:
+    ple_embedding_dtype = None
+
+
+class TestPLETableDtype(CustomTestCase):
+    def test_mixed_precision_fp8_ple_entry_selects_fp8_storage(self):
+        quant_config = _mixed_config(
+            {
+                PLE_PREFIX: {"quant_algo": "FP8"},
+                "model.language_model.layers.0.mlp.experts": {"quant_algo": "NVFP4"},
+            }
+        )
+        self.assertTrue(_ple_table_is_fp8(_Cfg(), quant_config, PLE_PREFIX))
+        # A checkpoint that quantizes only the experts keeps the table bf16.
+        self.assertFalse(
+            _ple_table_is_fp8(
+                _Cfg(),
+                _mixed_config(
+                    {
+                        "model.language_model.layers.0.mlp.experts": {
+                            "quant_algo": "NVFP4"
+                        }
+                    }
+                ),
+                PLE_PREFIX,
+            )
+        )
+
+    def test_hf_style_prefix_resolves_the_same_entry(self):
+        # Multimodal prefixes drift between `model.language_model.` and
+        # `language_model.model.`; both must find the FP8 entry.
+        quant_config = _mixed_config({PLE_PREFIX: {"quant_algo": "FP8"}})
+        drifted = PLE_PREFIX.replace("model.language_model.", "language_model.model.")
+        self.assertTrue(_ple_table_is_fp8(_Cfg(), quant_config, drifted))
+
+
+class TestMTPQuantConfig(CustomTestCase):
+    def test_mixed_precision_keeps_config_when_mtp_layers_are_quantized(self):
+        quant_config = _mixed_config(
+            {
+                "model.language_model.layers.0.mlp.experts": {"quant_algo": "NVFP4"},
+                MTP_EXPERTS: {"quant_algo": "FP8_BLOCK_SCALES", "group_size": 128},
+            }
+        )
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_mixed_precision_drops_config_when_mtp_ships_bf16(self):
+        quant_config = _mixed_config(
+            {"model.language_model.layers.0.mlp.experts": {"quant_algo": "NVFP4"}}
+        )
+        self.assertIsNone(_mtp_quant_config(quant_config))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`nvidia/Qwen3.8-Flash-Next-NVFP4` is a three-precision ModelOpt MIXED_PRECISION checkpoint: NVFP4 routed experts, an FP8 PLE n-gram table (128 F8_E4M3 shards + a scalar `weight_scale`), and block-FP8 MTP experts. Two decisions in the Qwen4-Exp model code were made before consulting the checkpoint's per-layer `quantized_layers` map, and both break on it. `RadixArk/Qwen3.8-Flash-Next-NVFP4` (plain NVFP4, PLE declared via `text_config.ple_embedding_dtype`, bf16 MTP) and `Qwen/Qwen3.8-Flash-Next-FP8` (`fp8`) are on other code paths and are not affected.

**1. Startup failure.** The PLE table's storage dtype is fixed at construction and only became fp8 for a whole-checkpoint `fp8` quant name or an explicit `text_config.ple_embedding_dtype`. This checkpoint sets neither, so the table was built bf16, moved into pinned host memory by the default `--ple-offload-embedding`, and `load_weights` then hit

```
ValueError: fp8 PLE auto-switch is unsupported with ple_offload_embedding; set text_config.ple_embedding_dtype="float8_e4m3fn" instead
```

**2. Silent draft corruption.** `_mtp_quant_config` dropped the quant config for every `modelopt_mixed` checkpoint, assuming embedded MTP weights are bf16. Here `mtp.layers.0.mlp.experts` is block-FP8, so the draft's FusedMoE was built unquantized: fp8 expert values were cast to bf16 without their scales and `weight_scale_inv` was skipped by the loader's ignore list. The server ran and target accuracy was fine, but MTP accept length fell to ~1.6.

Mirrors vllm-project/vllm#54882 (PLE) and #55513 (MTP).

## Modifications

- `models/qwen4_exp.py`: `_ple_table_is_fp8()` additionally asks the mixed config's `_resolve_quant_algo()` for the embedding's own prefix (`...ple.ple_embedding.ngram_embedding`), so the table is fp8 from construction; the prefix is threaded through `Qwen4ExpPLELayer` → `Qwen4ExpNGramEmbedding`.
- `models/qwen3_5_mtp.py`: for `modelopt_mixed`, keep the quant config when `quantized_layers` lists any `mtp.` layer. Every other draft module still resolves to bf16 through the same per-layer lookup (verified: qkv_proj, shared_expert, gate, lm_head all resolve to None).

Depends on #38726 (block-FP8 FusedMoE dispatch in `ModelOptMixedPrecisionConfig`). This branch is stacked on that one, so its diff also shows #38726's commit until it merges; please review only the second commit here.

## Test

- New `test/registered/unit/models/test_qwen4_exp_mixed_precision.py` (cpu): PLE fp8 detection from the per-layer map incl. the `language_model.model.` prefix drift; draft keeps / drops the quant config depending on `mtp.` entries. Verified red on the pre-change code.
- E2E on 4x B300, user launch command (TP4, NEXTN steps 3 / topk 1 / draft 4, no `--quantization` flag): loads; sgl-eval GSM8K 200 examples, thinking, max_tokens 16384: **0.97** (CI threshold 0.94), stop_rate 1.0; accept length **3.2–3.6** (was 1.6); draft weights 1.53 GB (was 2.47 GB bf16).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel if you have any questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34413177538](https://github.com/sgl-project/sglang/actions/runs/34413177538)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34413177514](https://github.com/sgl-project/sglang/actions/runs/34413177514)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34413177487](https://github.com/sgl-project/sglang/actions/runs/34413177487)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->