### PR TITLE
[Config] Qwen3 MoE family: default modelopt_mixed to the flashinfer_trtllm MoE runner on SM100

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
@@ -38,12 +38,7 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["quantization"] = quant_method
             quantization = quant_method
-        # MIXED_PRECISION ModelOpt checkpoints resolve to modelopt_mixed
-        # (ModelConfig rewrites hf_config.quantization_config in place before
-        # this runs). Leaving it on the CUTLASS runner fails for gated experts
-        # whose w13 needs padding (Qwen4-Exp NVFP4, moe_intermediate_size 640).
-        # Do not add the raw "modelopt" here: it is also the online
-        # quantization request, which the trtllm MoE hook rejects.
+
         if (
             (
                 quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")

--- a/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
@@ -38,7 +38,6 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["quantization"] = quant_method
             quantization = quant_method
-
         if (
             (
                 quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")

--- a/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
+++ b/python/sglang/srt/arg_groups/model_overrides/qwen3_moe.py
@@ -38,8 +38,17 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["quantization"] = quant_method
             quantization = quant_method
+        # MIXED_PRECISION ModelOpt checkpoints resolve to modelopt_mixed
+        # (ModelConfig rewrites hf_config.quantization_config in place before
+        # this runs). Leaving it on the CUTLASS runner fails for gated experts
+        # whose w13 needs padding (Qwen4-Exp NVFP4, moe_intermediate_size 640).
+        # Do not add the raw "modelopt" here: it is also the online
+        # quantization request, which the trtllm MoE hook rejects.
         if (
-            (quantization in ("fp8", "modelopt_fp4") or quantization is None)
+            (
+                quantization in ("fp8", "modelopt_fp4", "modelopt_mixed")
+                or quantization is None
+            )
             and cfg.moe_a2a_backend == "none"
             and cfg.moe_runner_backend == "auto"
         ):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -648,6 +648,50 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 self._resolved(self._construct(*qwen4), "ple_offload_embedding")
             )
 
+    def test_qwen4_modelopt_config_json_selects_trtllm_moe_runner(self):
+        """`nvidia/Qwen3.8-Flash-Next-NVFP4` is a MIXED_PRECISION ModelOpt
+        checkpoint, which ModelConfig resolves to modelopt_mixed. The family
+        override used to whitelist only fp8 / modelopt_fp4 for
+        `moe_runner_backend=flashinfer_trtllm`, so the FP4 experts fell to the
+        CUTLASS runner, whose weight post-processing pads w13
+        (moe_intermediate_size 640) and asserts on gated activations.
+
+        The raw `--quantization modelopt` (online quantization of a bf16
+        checkpoint) must stay off that whitelist: the trtllm MoE hook rejects
+        it, so whitelisting it turns a working launch into an assertion."""
+        qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")
+        mixed_ckpt = {
+            "quantization_config": {
+                "quant_method": "modelopt",
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.language_model.layers.0.mlp.experts": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    }
+                },
+            }
+        }
+        with override_platform(is_sm100=True):
+            from_config_json = self._construct(*qwen4, config_extra=mixed_ckpt)
+            explicit_fp4 = self._construct(
+                *qwen4, config_extra=mixed_ckpt, quantization="modelopt_fp4"
+            )
+        self.assertEqual(
+            self._resolved(from_config_json, "quantization"), "modelopt_mixed"
+        )
+        for sa in (from_config_json, explicit_fp4):
+            self.assertEqual(
+                self._resolved(sa, "moe_runner_backend"), "flashinfer_trtllm"
+            )
+
+        with override_platform(is_sm100=True):
+            online = self._construct(
+                "Qwen3MoeForCausalLM", "qwen3_moe", quantization="modelopt"
+            )
+        self.assertEqual(self._resolved(online, "quantization"), "modelopt")
+        self.assertEqual(self._resolved(online, "moe_runner_backend"), "auto")
+
     def test_minimax_m2_enables_tf32_matmul(self):
         sa = self._construct("MiniMaxM2ForCausalLM", "llama")
         self.assertTrue(self._resolved(sa, "enable_tf32_matmul"))

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -649,16 +649,6 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )
 
     def test_qwen4_modelopt_config_json_selects_trtllm_moe_runner(self):
-        """`nvidia/Qwen3.8-Flash-Next-NVFP4` is a MIXED_PRECISION ModelOpt
-        checkpoint, which ModelConfig resolves to modelopt_mixed. The family
-        override used to whitelist only fp8 / modelopt_fp4 for
-        `moe_runner_backend=flashinfer_trtllm`, so the FP4 experts fell to the
-        CUTLASS runner, whose weight post-processing pads w13
-        (moe_intermediate_size 640) and asserts on gated activations.
-
-        The raw `--quantization modelopt` (online quantization of a bf16
-        checkpoint) must stay off that whitelist: the trtllm MoE hook rejects
-        it, so whitelisting it turns a working launch into an assertion."""
         qwen4 = ("Qwen4ExpForConditionalGeneration", "qwen4_exp")
         mixed_ckpt = {
             "quantization_config": {

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -662,7 +662,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 },
             }
         }
-        with override_platform(is_sm100=True):
+        with override_platform(is_cuda=True, is_sm100=True):
             from_config_json = self._construct(*qwen4, config_extra=mixed_ckpt)
             explicit_fp4 = self._construct(
                 *qwen4, config_extra=mixed_ckpt, quantization="modelopt_fp4"


### PR DESCRIPTION
## Motivation

`_qwen3_moe_family_overrides` picks `moe_runner_backend=flashinfer_trtllm` on SM100 for `fp8`, `modelopt_fp4` and unquantized models, but not for `modelopt_mixed`. That is what `ModelConfig` resolves a MIXED_PRECISION ModelOpt checkpoint to, and it rewrites `hf_config.quantization_config` in place before the overrides run, so the override sees `modelopt_mixed`, not the raw `modelopt`.

`nvidia/Qwen3.8-Flash-Next-NVFP4` therefore stayed on `auto`, its NVFP4 experts went through the CUTLASS weight post-processing, which pads `w13` to a 128-row multiple and asserts on gated activations for `moe_intermediate_size=640` at TP4:

```
AssertionError: The intermediate size required padding, but padding is also implemented for gated activations
```

Passing `--quantization modelopt_fp4` dodged it only because that name was whitelisted. The DeepSeek family override already lists `modelopt_mixed`.

## Modifications

- Add `modelopt_mixed` to the whitelist.
- The raw `modelopt` name is deliberately **not** added: it is also the online-quantization request for bf16 checkpoints, and the trtllm MoE hook rejects it (`Invalid quantization 'modelopt'`), so whitelisting it turns a working launch into an assertion. The test pins this.

## Test

- `test_model_overrides.py::test_qwen4_modelopt_config_json_selects_trtllm_moe_runner`: an inline MIXED_PRECISION config resolves to `modelopt_mixed` and gets `flashinfer_trtllm`; `--quantization modelopt` on a bf16 Qwen3-MoE keeps `auto`. Verified red on the pre-change code.
- E2E: `nvidia/Qwen3.8-Flash-Next-NVFP4` on 4x B300 without `--quantization` now starts (log: `Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen4ExpForConditionalGeneration`); with the two companion PRs, GSM8K 0.97.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel if you have any questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34420227508](https://github.com/sgl-project/sglang/actions/runs/34420227508)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34420227377](https://github.com/sgl-project/sglang/actions/runs/34420227377)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34420227455](https://github.com/sgl-project/sglang/actions/runs/34420227455)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->