### PR TITLE
[Fix] Only log "Enable Aiter AllReduce Fusion" when the flag is actually set

### DIFF
--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -360,7 +360,13 @@ def handle_model_specific_adjustments(server_args: Any):
             if not resolved_view(server_args).enable_dp_attention and cfg.nnodes == 1:
                 # TODO (Hubert): Put this back later
                 # server_args.enable_aiter_allreduce_fusion = True
-                logger.info("Enable Aiter AllReduce Fusion for DeepseekV3ForCausalLM")
+                # Only report the fusion as enabled when it actually is
+                # (auto-enable is disabled above; the flag may still be set
+                # explicitly). An unconditional log here misled profiling.
+                if server_args.enable_aiter_allreduce_fusion:
+                    logger.info(
+                        "Enable Aiter AllReduce Fusion for DeepseekV3ForCausalLM"
+                    )
 
             # The fp4-checkpoint draft spec-MoE resolution moved to the
             # resolution pipeline (arg_groups/overrides.py:
@@ -454,7 +460,9 @@ def handle_model_specific_adjustments(server_args: Any):
         ):
             # TODO (Hubert): Put this back later
             # server_args.enable_aiter_allreduce_fusion = True
-            logger.info("Enable Aiter AllReduce Fusion for GptOssForCausalLM")
+            # See the DeepseekV3 branch above: log only when the flag is set.
+            if server_args.enable_aiter_allreduce_fusion:
+                logger.info("Enable Aiter AllReduce Fusion for GptOssForCausalLM")
         quantization_config = getattr(hf_config, "quantization_config", None)
         is_mxfp4_quant_format = (
             quantization_config is not None


### PR DESCRIPTION
## Motivation

Fixes #38710. In `arg_groups/model_hook.py` the auto-enable of `enable_aiter_allreduce_fusion` for `DeepseekV3ForCausalLM` (and `GptOssForCausalLM`) on single-node ROCm is commented out with a TODO, but the `logger.info("Enable Aiter AllReduce Fusion for ...")` next to it still fires unconditionally. The boot log therefore claims the fusion is enabled while `server_args` reports `enable_aiter_allreduce_fusion: False`, which misleads anyone profiling ROCm TP decode.

## Modifications

Guard both log lines on the flag's actual value, so the message only appears when the fusion is really on (i.e. set explicitly by the user). The commented-out assignments and the TODO are left as they are; restoring the auto-enable is a separate decision.

## Accuracy Tests

Not applicable (logging only, no change to model execution).

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`ruff format`, `ruff check`, `isort --check-only` on the changed file)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (log-only change)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (not needed)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (not applicable)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34401636337](https://github.com/sgl-project/sglang/actions/runs/34401636337)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34401636052](https://github.com/sgl-project/sglang/actions/runs/34401636052)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34401636358](https://github.com/sgl-project/sglang/actions/runs/34401636358)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->