### PR TITLE
[router] Raise chat body cap to 32 MB for multimodal payloads

### DIFF
--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -107,13 +107,9 @@ fn prefill_policy_reason(
     }
 }
 
-/// Per-route body-size cap on `/v1/chat/completions`, wired in
-/// `crate::server::app::build_router` as a route-level `DefaultBodyLimit`;
-/// axum's `Bytes` extractor enforces it and returns 413 PAYLOAD_TOO_LARGE
-/// before this handler runs. 100 MiB admits multimodal bodies, whose base64
-/// image/audio payloads dwarf any text context, while still bounding the
-/// heap a hostile client can force the router to allocate.
-pub const MAX_CHAT_BODY_BYTES: usize = 100 << 20;
+/// Maximum buffered chat-completions body (32MiB). Sized for base64 multimodal inputs;
+/// enforced by the `DefaultBodyLimit`, and returns 413 PAYLOAD_TOO_LARGE.
+pub const MAX_CHAT_BODY_BYTES: usize = 32 << 20;
 
 /// Minimal probe over the request body — we only need the `stream` field
 /// and the `model` field to decide between buffered vs SSE forwarding and

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -107,14 +107,13 @@ fn prefill_policy_reason(
     }
 }
 
-/// Per-route body-size cap on `/v1/chat/completions`. 5 MiB accommodates a
-/// long context — a ~1 M-token context tokenized as JSON fits under this —
-/// while preventing a hostile client from forcing the router to
-/// heap-allocate hundreds of MiB before forwarding. The cap is wired in
-/// `crate::server::app::build_router` as a route-level `DefaultBodyLimit`
-/// layer; axum's `Bytes` extractor enforces it and returns 413
-/// PAYLOAD_TOO_LARGE before this handler runs.
-pub const MAX_CHAT_BODY_BYTES: usize = 5 << 20;
+/// Per-route body-size cap on `/v1/chat/completions`, wired in
+/// `crate::server::app::build_router` as a route-level `DefaultBodyLimit`;
+/// axum's `Bytes` extractor enforces it and returns 413 PAYLOAD_TOO_LARGE
+/// before this handler runs. 100 MiB admits multimodal bodies, whose base64
+/// image/audio payloads dwarf any text context, while still bounding the
+/// heap a hostile client can force the router to allocate.
+pub const MAX_CHAT_BODY_BYTES: usize = 100 << 20;
 
 /// Minimal probe over the request body — we only need the `stream` field
 /// and the `model` field to decide between buffered vs SSE forwarding and


### PR DESCRIPTION
## Motivation

The 5 MiB `/v1/chat/completions` body cap was sized for text context only. Multimodal requests carry base64-encoded image/audio payloads that dwarf any text body — a 3×1080p-image request runs ~8.5 MiB — so they are rejected at axum's `DefaultBodyLimit` layer with `413 PAYLOAD_TOO_LARGE` before ever reaching the handler.

## Modifications

- `MAX_CHAT_BODY_BYTES`: `5 << 20` → `32 << 20`. 32 MiB admits realistic multimodal bodies while still bounding the heap a hostile client can force the router to allocate before forwarding. Ported from `combine/router-admission-http2-loadaware` (but downsized from 100 to 32 MB).

## Test

- `cargo check` clean.
- `cargo test --test proxy oversized_request_body_returns_413` passes (413 still enforced at the new cap, oversized body not forwarded upstream).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34408050988](https://github.com/sgl-project/sglang/actions/runs/34408050988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34408341439](https://github.com/sgl-project/sglang/actions/runs/34408341439)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->