### PR TITLE
[router] Stream outcome observability for 2xx SSE streams

### DIFF
--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -25,7 +25,7 @@ The dashboard graphs every family the router emits:
 | `sgl_router_worker_requests_total` | Counter | Per-worker **dispatches** by `worker_url`, `model_id`, `mode`, `outcome` (recorded after dispatch; blind to pre-dispatch drops) |
 | `sgl_router_request_duration_seconds` | Histogram | End-to-end request latency by `model_id` |
 | `sgl_router_ttft_seconds` | Histogram | Time to first token (streaming) by `model_id` |
-| `sgl_router_stream_outcome_total` | Counter | Streaming outcomes by `worker_url`, `model_id`, and `outcome` (`ok`, `stream_error_event`, `upstream_error`, or `client_disconnect`) |
+| `sgl_router_stream_outcome_total` | Counter | Streaming outcomes by `worker_url`, `model_id`, and `outcome` (`ok`, `stream_error_event`, `upstream_error`, or `client_disconnect`). Counts committed 2xx streams only — non-2xx responses are counted by status in `responses_total` |
 | `sgl_router_active_load` | Gauge | Per-worker prefill-token / decode-block load |
 | `sgl_router_workers` | Gauge | Registered worker count by `mode` |
 | `sgl_router_worker_health` | Gauge | Per-worker health (1=breaker admits, 0=open) |

--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -25,6 +25,8 @@ The dashboard graphs every family the router emits:
 | `sgl_router_worker_requests_total` | Counter | Per-worker **dispatches** by `worker_url`, `model_id`, `mode`, `outcome` (recorded after dispatch; blind to pre-dispatch drops) |
 | `sgl_router_request_duration_seconds` | Histogram | End-to-end request latency by `model_id` |
 | `sgl_router_ttft_seconds` | Histogram | Time to first token (streaming) by `model_id` |
+| `sgl_router_itl_seconds` | Histogram | Time between consecutive chunks of a successful (200) streaming response — roughly the time between generated tokens — by `model_id`. Uses the same buckets as the engine's ITL histogram, so router and engine percentiles compare directly |
+| `sgl_router_stream_outcome_total` | Counter | How each successful (200) streaming response actually ended, by `worker_url`, `model_id`, `outcome`: `ok` = finished normally, `inband_error` = the engine answered 200 but then reported an error inside the stream, `upstream_error` = the connection to the worker broke mid-stream, `client_disconnect` = the client left early. Status-code metrics count all of these as 200s; this counter is the only place the failure shows |
 | `sgl_router_active_load` | Gauge | Per-worker prefill-token / decode-block load |
 | `sgl_router_workers` | Gauge | Registered worker count by `mode` |
 | `sgl_router_worker_health` | Gauge | Per-worker health (1=breaker admits, 0=open) |

--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -25,8 +25,7 @@ The dashboard graphs every family the router emits:
 | `sgl_router_worker_requests_total` | Counter | Per-worker **dispatches** by `worker_url`, `model_id`, `mode`, `outcome` (recorded after dispatch; blind to pre-dispatch drops) |
 | `sgl_router_request_duration_seconds` | Histogram | End-to-end request latency by `model_id` |
 | `sgl_router_ttft_seconds` | Histogram | Time to first token (streaming) by `model_id` |
-| `sgl_router_itl_seconds` | Histogram | Time between streaming chunks by `model_id`, using engine-compatible buckets |
-| `sgl_router_stream_outcome_total` | Counter | Streaming outcomes by `worker_url`, `model_id`, and `outcome` (`ok`, `inband_error`, `upstream_error`, or `client_disconnect`) |
+| `sgl_router_stream_outcome_total` | Counter | Streaming outcomes by `worker_url`, `model_id`, and `outcome` (`ok`, `stream_error_event`, `upstream_error`, or `client_disconnect`) |
 | `sgl_router_active_load` | Gauge | Per-worker prefill-token / decode-block load |
 | `sgl_router_workers` | Gauge | Registered worker count by `mode` |
 | `sgl_router_worker_health` | Gauge | Per-worker health (1=breaker admits, 0=open) |

--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -25,8 +25,8 @@ The dashboard graphs every family the router emits:
 | `sgl_router_worker_requests_total` | Counter | Per-worker **dispatches** by `worker_url`, `model_id`, `mode`, `outcome` (recorded after dispatch; blind to pre-dispatch drops) |
 | `sgl_router_request_duration_seconds` | Histogram | End-to-end request latency by `model_id` |
 | `sgl_router_ttft_seconds` | Histogram | Time to first token (streaming) by `model_id` |
-| `sgl_router_itl_seconds` | Histogram | Time between consecutive chunks of a successful (200) streaming response — roughly the time between generated tokens — by `model_id`. Uses the same buckets as the engine's ITL histogram, so router and engine percentiles compare directly |
-| `sgl_router_stream_outcome_total` | Counter | How each successful (200) streaming response actually ended, by `worker_url`, `model_id`, `outcome`: `ok` = finished normally, `inband_error` = the engine answered 200 but then reported an error inside the stream, `upstream_error` = the connection to the worker broke mid-stream, `client_disconnect` = the client left early. Status-code metrics count all of these as 200s; this counter is the only place the failure shows |
+| `sgl_router_itl_seconds` | Histogram | Time between streaming chunks by `model_id`, using engine-compatible buckets |
+| `sgl_router_stream_outcome_total` | Counter | Streaming outcomes by `worker_url`, `model_id`, and `outcome` (`ok`, `inband_error`, `upstream_error`, or `client_disconnect`) |
 | `sgl_router_active_load` | Gauge | Per-worker prefill-token / decode-block load |
 | `sgl_router_workers` | Gauge | Registered worker count by `mode` |
 | `sgl_router_worker_health` | Gauge | Per-worker health (1=breaker admits, 0=open) |

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -163,8 +163,17 @@ impl Proxy {
     /// `active_requests` counter and the per-request active-load entry alive
     /// for the full streaming lifetime — without which a long-running SSE
     /// response would under-report load.
+    ///
+    /// `on_stream_end` — fires once at pump completion with the
+    /// [`sse::StreamEnd`] verdict; 2xx-only, since it classifies what
+    /// happened after a committed 200. Breaker recording is separate and
+    /// judges transport health only.
+    ///
+    /// `on_inter_chunk` — fires per non-empty chunk after the first with the
+    /// gap (seconds) since the previous; 2xx-only (an error body's pacing is
+    /// not inter-token latency). Feeds `sgl_router_itl_seconds`.
     // Each parameter is a distinct, required input to a single upstream
-    // forward (target, breaker, path, headers, body, plus the two
+    // forward (target, breaker, path, headers, body, plus the
     // streaming-lifetime callbacks). Bundling them into a struct purely to
     // satisfy the arg-count heuristic would add indirection without clarity.
     #[allow(clippy::too_many_arguments)]
@@ -177,6 +186,8 @@ impl Proxy {
         body: Bytes,
         stream_guards: Option<Box<dyn Send + 'static>>,
         on_first_byte: Option<Box<dyn FnOnce() + Send + 'static>>,
+        on_stream_end: Option<Box<dyn FnOnce(sse::StreamEnd) + Send + 'static>>,
+        on_inter_chunk: Option<Box<dyn Fn(f64) + Send + 'static>>,
     ) -> Result<Response<Body>, ApiError> {
         if !breaker.allow() {
             return Err(ApiError::BreakerOpen {
@@ -217,17 +228,27 @@ impl Proxy {
         // is recorded as a failure. For 5xx headers we record_failure
         // up front and skip the pump hook (the body we surface is the
         // error response — its stream completing is not a worker win).
-        let on_complete: Option<Box<dyn FnOnce(bool) + Send + 'static>> =
+        let caller_end_hook = if status.is_success() {
+            on_stream_end
+        } else {
+            None
+        };
+        let on_complete: Option<Box<dyn FnOnce(sse::StreamEnd) + Send + 'static>> =
             if status.is_server_error() {
                 breaker.record_failure();
                 None
             } else {
                 let breaker_for_hook = Arc::clone(breaker);
-                Some(Box::new(move |ok| {
-                    if ok {
+                Some(Box::new(move |end: sse::StreamEnd| {
+                    // Breaker judges transport only; the in-band verdict
+                    // deliberately stays out of routing.
+                    if end.transport_ok {
                         breaker_for_hook.record_success();
                     } else {
                         breaker_for_hook.record_failure();
+                    }
+                    if let Some(hook) = caller_end_hook {
+                        hook(end);
                     }
                 }))
             };
@@ -239,11 +260,18 @@ impl Proxy {
         } else {
             None
         };
+        // Same 2xx gate: an error body's chunk pacing is not a token cadence.
+        let inter_chunk_hook = if status.is_success() {
+            on_inter_chunk
+        } else {
+            None
+        };
         let body = sse::bytes_stream_to_body(
             resp.bytes_stream(),
             stream_guards,
             on_complete,
             first_byte_hook,
+            inter_chunk_hook,
         );
         let mut out = Response::new(body);
         *out.status_mut() = status;

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -178,7 +178,6 @@ impl Proxy {
         stream_guards: Option<Box<dyn Send + 'static>>,
         on_first_byte: Option<Box<dyn FnOnce() + Send + 'static>>,
         on_stream_end: Option<Box<dyn FnOnce(sse::StreamEnd) + Send + 'static>>,
-        on_inter_chunk: Option<Box<dyn Fn(f64) + Send + 'static>>,
     ) -> Result<Response<Body>, ApiError> {
         if !breaker.allow() {
             return Err(ApiError::BreakerOpen {
@@ -231,7 +230,7 @@ impl Proxy {
             } else {
                 let breaker_for_hook = Arc::clone(breaker);
                 Some(Box::new(move |end: sse::StreamEnd| {
-                    // Breaker judges transport only; the in-band verdict
+                    // Breaker judges transport only; the SSE error event
                     // deliberately stays out of routing.
                     if end.transport_ok {
                         breaker_for_hook.record_success();
@@ -243,19 +242,18 @@ impl Proxy {
                     }
                 }))
             };
-        // Only record TTFT and ITL for successful streams; error-body chunks
-        // are not generated tokens.
-        let (first_byte_hook, inter_chunk_hook) = if status.is_success() {
-            (on_first_byte, on_inter_chunk)
+        // Only record TTFT for successful streams; error-body chunks are not
+        // generated tokens.
+        let first_byte_hook = if status.is_success() {
+            on_first_byte
         } else {
-            (None, None)
+            None
         };
         let body = sse::bytes_stream_to_body(
             resp.bytes_stream(),
             stream_guards,
             on_complete,
             first_byte_hook,
-            inter_chunk_hook,
         );
         let mut out = Response::new(body);
         *out.status_mut() = status;

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -218,7 +218,11 @@ impl Proxy {
         // is recorded as a failure. For 5xx headers we record_failure
         // up front and skip the pump hook (the body we surface is the
         // error response — its stream completing is not a worker win).
-        let caller_end_hook = status.is_success().then_some(on_stream_end).flatten();
+        let caller_end_hook = if status.is_success() {
+            on_stream_end
+        } else {
+            None
+        };
         let on_complete: Option<Box<dyn FnOnce(sse::StreamEnd) + Send + 'static>> =
             if status.is_server_error() {
                 breaker.record_failure();

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -163,15 +163,6 @@ impl Proxy {
     /// `active_requests` counter and the per-request active-load entry alive
     /// for the full streaming lifetime — without which a long-running SSE
     /// response would under-report load.
-    ///
-    /// `on_stream_end` — fires once at pump completion with the
-    /// [`sse::StreamEnd`] verdict; 2xx-only, since it classifies what
-    /// happened after a committed 200. Breaker recording is separate and
-    /// judges transport health only.
-    ///
-    /// `on_inter_chunk` — fires per non-empty chunk after the first with the
-    /// gap (seconds) since the previous; 2xx-only (an error body's pacing is
-    /// not inter-token latency). Feeds `sgl_router_itl_seconds`.
     // Each parameter is a distinct, required input to a single upstream
     // forward (target, breaker, path, headers, body, plus the
     // streaming-lifetime callbacks). Bundling them into a struct purely to
@@ -252,19 +243,12 @@ impl Proxy {
                     }
                 }))
             };
-        // Only record TTFT for successful streams — a 4xx/5xx error body
-        // streaming back is not a generated token, so drop the hook for
-        // non-2xx responses.
-        let first_byte_hook = if status.is_success() {
-            on_first_byte
+        // Only record TTFT and ITL for successful streams; error-body chunks
+        // are not generated tokens.
+        let (first_byte_hook, inter_chunk_hook) = if status.is_success() {
+            (on_first_byte, on_inter_chunk)
         } else {
-            None
-        };
-        // Same 2xx gate: an error body's chunk pacing is not a token cadence.
-        let inter_chunk_hook = if status.is_success() {
-            on_inter_chunk
-        } else {
-            None
+            (None, None)
         };
         let body = sse::bytes_stream_to_body(
             resp.bytes_stream(),

--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -218,20 +218,14 @@ impl Proxy {
         // is recorded as a failure. For 5xx headers we record_failure
         // up front and skip the pump hook (the body we surface is the
         // error response — its stream completing is not a worker win).
-        let caller_end_hook = if status.is_success() {
-            on_stream_end
-        } else {
-            None
-        };
+        let caller_end_hook = status.is_success().then_some(on_stream_end).flatten();
         let on_complete: Option<Box<dyn FnOnce(sse::StreamEnd) + Send + 'static>> =
             if status.is_server_error() {
                 breaker.record_failure();
                 None
             } else {
                 let breaker_for_hook = Arc::clone(breaker);
-                Some(Box::new(move |end: sse::StreamEnd| {
-                    // Breaker judges transport only; the SSE error event
-                    // deliberately stays out of routing.
+                Some(Box::new(move |end| {
                     if end.transport_ok {
                         breaker_for_hook.record_success();
                     } else {

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -22,61 +22,42 @@ pub struct StreamEnd {
     pub client_disconnect: bool,
 }
 
-/// Maximum buffered length of an SSE line split across chunks.
-const INBAND_SCAN_CARRYOVER_CAP: usize = 1 << 20; // 1 MiB
+const ERROR_EVENT_PREFIX: &[u8] = b"data: {\"error\"";
 
 /// Finds error events emitted after an SSE response commits a 200.
 #[derive(Default)]
 struct ErrorEventScanner {
-    carry: Vec<u8>,
+    overlap: Vec<u8>,
 }
 
 impl ErrorEventScanner {
-    fn feed(&mut self, mut chunk: &[u8]) -> bool {
-        // Complete a line carried over from the previous chunk.
-        if !self.carry.is_empty() {
-            let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') else {
-                self.extend_carry(chunk);
-                return false;
-            };
-            self.extend_carry(&chunk[..newline]);
-            let found = Self::line_is_error_event(&self.carry);
-            self.carry.clear();
-            if found {
-                return true;
-            }
-            chunk = &chunk[newline + 1..];
+    fn feed(&mut self, chunk: &[u8]) -> bool {
+        if chunk
+            .windows(ERROR_EVENT_PREFIX.len())
+            .any(|window| window == ERROR_EVENT_PREFIX)
+        {
+            return true;
         }
 
-        // Scan complete lines in place and retain the trailing partial line.
-        while let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') {
-            if Self::line_is_error_event(&chunk[..newline]) {
-                return true;
-            }
-            chunk = &chunk[newline + 1..];
+        let overlap_len = ERROR_EVENT_PREFIX.len() - 1;
+        self.overlap
+            .extend_from_slice(&chunk[..chunk.len().min(overlap_len)]);
+        if self
+            .overlap
+            .windows(ERROR_EVENT_PREFIX.len())
+            .any(|window| window == ERROR_EVENT_PREFIX)
+        {
+            return true;
         }
-        self.extend_carry(chunk);
+
+        if chunk.len() >= overlap_len {
+            self.overlap.clear();
+            self.overlap
+                .extend_from_slice(&chunk[chunk.len() - overlap_len..]);
+        } else if self.overlap.len() > overlap_len {
+            self.overlap.drain(..self.overlap.len() - overlap_len);
+        }
         false
-    }
-
-    fn extend_carry(&mut self, bytes: &[u8]) {
-        if bytes.len() <= INBAND_SCAN_CARRYOVER_CAP.saturating_sub(self.carry.len()) {
-            self.carry.extend_from_slice(bytes);
-        } else {
-            self.carry.clear();
-        }
-    }
-
-    fn line_is_error_event(line: &[u8]) -> bool {
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let Some(payload) = line.strip_prefix(b"data:") else {
-            return false;
-        };
-        let first_non_space = payload
-            .iter()
-            .position(|&byte| byte != b' ')
-            .unwrap_or(payload.len());
-        payload[first_non_space..].starts_with(b"{\"error\"")
     }
 }
 
@@ -117,10 +98,7 @@ impl ErrorEventScanner {
 ///
 /// # Completion hook
 /// When `on_complete` is `Some`, it runs exactly once when the pump task
-/// finishes, receiving a [`StreamEnd`]. `forward_streaming_to` records the
-/// worker's circuit-breaker outcome from `transport_ok` alone — an SSE error
-/// event is an application-level verdict, not a transport fault. The event
-/// scan runs only when `on_complete` is installed.
+/// finishes with the transport, SSE error-event, and client-disconnect state.
 ///
 /// # First-byte hook
 /// When `on_first_byte` is `Some`, the closure runs exactly once, the moment
@@ -141,15 +119,12 @@ where
     let (tx, rx) = tokio::sync::mpsc::channel(64);
     tokio::spawn(async move {
         let tx_for_panic = tx.clone();
-        // Capture the pump's outcome so we can report it through `on_complete`
-        // AFTER `pump.catch_unwind()` settles. The closure inside owns
-        // `outcome_setter`; the outer scope reads `outcome_holder` once.
-        let outcome_holder = Arc::new(parking_lot::Mutex::new(StreamEnd {
+        let outcome = Arc::new(parking_lot::Mutex::new(StreamEnd {
             transport_ok: true,
             saw_error_event: false,
             client_disconnect: false,
         }));
-        let outcome_setter = Arc::clone(&outcome_holder);
+        let outcome_setter = Arc::clone(&outcome);
         // The error-event scan exists solely to inform `on_complete`; skip the
         // per-chunk work entirely when nobody is listening.
         let mut scanner = on_complete.is_some().then(ErrorEventScanner::default);
@@ -215,8 +190,8 @@ where
                 .await;
         }
         if let Some(hook) = on_complete {
-            let mut end = *outcome_holder.lock();
-            end.transport_ok = end.transport_ok && !panicked;
+            let mut end = *outcome.lock();
+            end.transport_ok &= !panicked;
             hook(end);
         }
     });
@@ -489,12 +464,6 @@ mod tests {
     }
 
     #[test]
-    fn error_event_scanner_tolerates_no_space_and_crlf() {
-        let mut scanner = ErrorEventScanner::default();
-        assert!(scanner.feed(b"data:{\"error\": {\"code\": 500}}\r\n"));
-    }
-
-    #[test]
     fn error_event_scanner_ignores_error_text_inside_content() {
         let mut scanner = ErrorEventScanner::default();
         assert!(!scanner.feed(
@@ -504,12 +473,11 @@ mod tests {
     }
 
     #[test]
-    fn error_event_scanner_bounds_carryover_and_recovers() {
+    fn error_event_scanner_bounds_overlap() {
         let mut scanner = ErrorEventScanner::default();
-        let big = vec![b'x'; INBAND_SCAN_CARRYOVER_CAP + 1024];
+        let big = vec![b'x'; 1 << 20];
         assert!(!scanner.feed(&big));
-        assert!(scanner.carry.len() <= INBAND_SCAN_CARRYOVER_CAP);
-        assert!(scanner.feed(b"\ndata: {\"error\": {\"code\": 503}}\n"));
+        assert_eq!(scanner.overlap.len(), ERROR_EVENT_PREFIX.len() - 1);
     }
 
     fn body_with_completion(
@@ -527,60 +495,61 @@ mod tests {
         (body, rx)
     }
 
-    async fn wait_for_stream_end(rx: tokio::sync::oneshot::Receiver<StreamEnd>) -> StreamEnd {
-        tokio::time::timeout(std::time::Duration::from_secs(1), rx)
-            .await
-            .expect("on_complete timed out")
-            .expect("on_complete dropped")
+    async fn stream_end(rx: tokio::sync::oneshot::Receiver<StreamEnd>) -> StreamEnd {
+        rx.await.expect("completion hook dropped")
     }
 
     #[tokio::test]
-    async fn on_complete_reports_error_event_with_clean_transport() {
+    async fn completion_reports_error_event() {
         let chunks = vec![
-            Ok::<Bytes, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\": [{\"delta\": {\"content\": \"partial\"}}]}\n\n",
-            )),
-            Ok(Bytes::from_static(
-                b"data: {\"error\": {\"message\": \"aborted\", \"code\": 503}}\n\n",
-            )),
-            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: {\"err")),
+            Ok(Bytes::from_static(b"or\": {\"code\": 503}}\n\n")),
         ];
         let (body, completion) = body_with_completion(chunks);
         let _ = body.collect().await.unwrap();
-        let end = wait_for_stream_end(completion).await;
-        assert!(end.transport_ok, "clean close: transport is fine");
-        assert!(end.saw_error_event, "SSE error event must be reported");
+        let end = stream_end(completion).await;
+        assert!(end.transport_ok);
+        assert!(end.saw_error_event);
         assert!(!end.client_disconnect);
     }
 
     #[tokio::test]
-    async fn on_complete_reports_clean_success() {
-        let chunks = vec![
-            Ok::<Bytes, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\": [{\"delta\": {\"content\": \"hello\"}}]}\n\n",
-            )),
-            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
-        ];
+    async fn completion_reports_upstream_error() {
+        let chunks = vec![Err(std::io::Error::other("upstream failed"))];
+        let (body, completion) = body_with_completion(chunks);
+        let _ = body.collect().await;
+        let end = stream_end(completion).await;
+        assert!(!end.transport_ok);
+        assert!(!end.saw_error_event);
+        assert!(!end.client_disconnect);
+    }
+
+    #[tokio::test]
+    async fn completion_reports_clean_end() {
+        let chunks = vec![Ok::<Bytes, std::io::Error>(Bytes::from_static(
+            b"data: [DONE]\n\n",
+        ))];
         let (body, completion) = body_with_completion(chunks);
         let _ = body.collect().await.unwrap();
-        let end = wait_for_stream_end(completion).await;
+        let end = stream_end(completion).await;
         assert!(end.transport_ok);
         assert!(!end.saw_error_event);
         assert!(!end.client_disconnect);
     }
 
     #[tokio::test]
-    async fn on_complete_reports_client_disconnect() {
-        let chunks: Vec<Result<Bytes, std::io::Error>> =
-            std::iter::repeat_with(|| Ok(Bytes::from_static(b"data: x\n\n")))
-                .take(1000)
-                .collect();
+    async fn completion_reports_client_disconnect() {
+        let chunks = std::iter::repeat_with(|| {
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: x\n\n"))
+        })
+        .take(1000)
+        .collect();
         let (body, completion) = body_with_completion(chunks);
-        let mut data_stream = body.into_data_stream();
-        let _ = data_stream.next().await;
-        drop(data_stream);
-        let end = wait_for_stream_end(completion).await;
-        assert!(end.transport_ok, "a walk-away client is not a worker fault");
-        assert!(end.client_disconnect, "disconnect must be reported");
+        let mut stream = body.into_data_stream();
+        let _ = stream.next().await;
+        drop(stream);
+        let end = stream_end(completion).await;
+        assert!(end.transport_ok);
+        assert!(end.client_disconnect);
     }
 }

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -11,10 +11,7 @@ use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
-/// How the SSE pump ended, reported to the `on_complete` hook. The fields
-/// beyond `transport_ok` separate outcomes that are byte-level identical to
-/// success: an in-band engine error under a committed 200, and a client that
-/// walked away mid-generation.
+/// How the SSE pump ended, reported to the `on_complete` hook.
 #[derive(Debug, Clone, Copy)]
 pub struct StreamEnd {
     /// No upstream stream error and no pump panic.
@@ -25,15 +22,10 @@ pub struct StreamEnd {
     pub client_disconnect: bool,
 }
 
-/// Carryover cap for the in-band scanner: a single longer line resets the
-/// buffer — its detection is forfeited, but memory stays bounded.
+/// Maximum buffered length of an SSE line split across chunks.
 const INBAND_SCAN_CARRYOVER_CAP: usize = 1 << 20; // 1 MiB
 
-/// Incremental scanner for in-band SSE error envelopes — the shape sglang's
-/// `create_streaming_error_response` emits after a committed 200. Complete
-/// lines are scanned in place; only a trailing partial line is carried over.
-/// The `{"error"` prefix check is parity-safe: inside a JSON string every
-/// quote is escaped, so it cannot start a well-formed content payload.
+/// Finds in-band error envelopes emitted after an SSE response commits a 200.
 #[derive(Default)]
 struct InbandErrorScanner {
     carry: Vec<u8>,
@@ -41,55 +33,59 @@ struct InbandErrorScanner {
 }
 
 impl InbandErrorScanner {
-    fn feed(&mut self, chunk: &[u8]) {
+    /// Returns whether an error has been seen so callers can stop scanning.
+    fn feed(&mut self, mut chunk: &[u8]) -> bool {
         if self.found {
-            return;
+            return true;
         }
-        let mut rest = chunk;
-        // Finish the carried-over partial line first.
+
+        // Complete a line carried over from the previous chunk.
         if !self.carry.is_empty() {
-            match rest.iter().position(|&b| b == b'\n') {
-                Some(i) => {
-                    self.carry.extend_from_slice(&rest[..i]);
-                    if Self::line_is_inband_error(&self.carry) {
-                        self.found = true;
-                        self.carry = Vec::new();
-                        return;
-                    }
-                    self.carry.clear();
-                    rest = &rest[i + 1..];
-                }
-                None => {
-                    self.carry.extend_from_slice(rest);
-                    if self.carry.len() > INBAND_SCAN_CARRYOVER_CAP {
-                        self.carry.clear();
-                    }
-                    return;
-                }
+            let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') else {
+                self.extend_carry(chunk);
+                return false;
+            };
+            self.extend_carry(&chunk[..newline]);
+            self.found = Self::line_is_inband_error(&self.carry);
+            self.carry.clear();
+            if self.found {
+                return true;
             }
+            chunk = &chunk[newline + 1..];
         }
-        // Scan complete lines in place; keep only the trailing partial.
-        while let Some(i) = rest.iter().position(|&b| b == b'\n') {
-            if Self::line_is_inband_error(&rest[..i]) {
+
+        // Scan complete lines in place and retain the trailing partial line.
+        while let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') {
+            if Self::line_is_inband_error(&chunk[..newline]) {
                 self.found = true;
-                return;
+                return true;
             }
-            rest = &rest[i + 1..];
+            chunk = &chunk[newline + 1..];
         }
-        if rest.len() <= INBAND_SCAN_CARRYOVER_CAP {
-            self.carry.extend_from_slice(rest);
+        self.extend_carry(chunk);
+        false
+    }
+
+    fn extend_carry(&mut self, bytes: &[u8]) {
+        if bytes.len()
+            <= INBAND_SCAN_CARRYOVER_CAP.saturating_sub(self.carry.len())
+        {
+            self.carry.extend_from_slice(bytes);
+        } else {
+            self.carry.clear();
         }
     }
 
     fn line_is_inband_error(line: &[u8]) -> bool {
         let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let Some(mut payload) = line.strip_prefix(b"data:") else {
+        let Some(payload) = line.strip_prefix(b"data:") else {
             return false;
         };
-        while let Some(p) = payload.strip_prefix(b" ") {
-            payload = p;
-        }
-        payload.starts_with(b"{\"error\"")
+        let first_non_space = payload
+            .iter()
+            .position(|&byte| byte != b' ')
+            .unwrap_or(payload.len());
+        payload[first_non_space..].starts_with(b"{\"error\"")
     }
 }
 
@@ -173,7 +169,7 @@ where
         let outcome_setter = Arc::clone(&outcome_holder);
         // The in-band scan exists solely to inform `on_complete`; skip the
         // per-chunk work entirely when nobody is listening.
-        let mut scanner = on_complete.as_ref().map(|_| InbandErrorScanner::default());
+        let mut scanner = on_complete.is_some().then(InbandErrorScanner::default);
         let pump = AssertUnwindSafe(async move {
             // Hold the guards for the task's lifetime — dropped when this
             // block exits (stream done or client disconnect).  Leading
@@ -202,19 +198,18 @@ where
                         if !bytes.is_empty() {
                             if let Some(hook) = on_inter_chunk.as_ref() {
                                 let now = std::time::Instant::now();
-                                if let Some(prev) = prev_chunk_at {
+                                if let Some(prev) = prev_chunk_at.replace(now) {
                                     hook(now.duration_since(prev).as_secs_f64());
                                 }
-                                prev_chunk_at = Some(now);
                             }
                         }
-                        if let Some(scan) = scanner.as_mut() {
-                            scan.feed(bytes);
-                            if scan.found {
-                                outcome_setter.lock().saw_inband_error = true;
-                                // Verdict is sticky; stop scanning.
-                                scanner = None;
-                            }
+                        if scanner
+                            .as_mut()
+                            .is_some_and(|scanner| scanner.feed(bytes))
+                        {
+                            outcome_setter.lock().saw_inband_error = true;
+                            // Verdict is sticky; stop scanning.
+                            scanner = None;
                         }
                     }
                     Err(_) => outcome_setter.lock().transport_ok = false,
@@ -513,78 +508,73 @@ mod tests {
 
     #[test]
     fn inband_scanner_detects_engine_error_event() {
-        // Exact shape sglang's create_streaming_error_response emits.
-        let mut s = InbandErrorScanner::default();
-        s.feed(b"data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\n");
-        assert!(!s.found);
-        s.feed(b"data: {\"error\": {\"message\": \"queue is full\", \"code\": 503}}\n\n");
-        assert!(s.found, "must detect a well-formed in-band error event");
+        let mut scanner = InbandErrorScanner::default();
+        assert!(!scanner.feed(
+            b"data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\n"
+        ));
+        assert!(scanner.feed(
+            b"data: {\"error\": {\"message\": \"queue is full\", \"code\": 503}}\n\n"
+        ));
     }
 
     #[test]
     fn inband_scanner_detects_error_split_across_chunks() {
-        // Network chunking can split an SSE event anywhere — including inside
-        // the `data: {"error"` prefix itself.
-        let mut s = InbandErrorScanner::default();
-        s.feed(b"data: {\"err");
-        assert!(!s.found);
-        s.feed(b"or\": {\"code\": 503}}\n\n");
-        assert!(s.found, "must detect an error event split across chunks");
+        let mut scanner = InbandErrorScanner::default();
+        assert!(!scanner.feed(b"data: {\"err"));
+        assert!(scanner.feed(b"or\": {\"code\": 503}}\n\n"));
     }
 
     #[test]
     fn inband_scanner_tolerates_no_space_and_crlf() {
-        // SSE permits `data:` with no space; proxies may normalize to CRLF.
-        let mut s = InbandErrorScanner::default();
-        s.feed(b"data:{\"error\": {\"code\": 500}}\r\n");
-        assert!(s.found, "must handle data: without space and CRLF endings");
+        let mut scanner = InbandErrorScanner::default();
+        assert!(scanner.feed(b"data:{\"error\": {\"code\": 500}}\r\n"));
     }
 
     #[test]
     fn inband_scanner_ignores_error_text_inside_content() {
-        // A model that TALKS about errors must not trip the scanner — escaped
-        // quotes mean `{"error"` cannot start a content payload.
-        let mut s = InbandErrorScanner::default();
-        s.feed(
+        let mut scanner = InbandErrorScanner::default();
+        assert!(!scanner.feed(
             b"data: {\"choices\": [{\"delta\": {\"content\": \"data: {\\\"error\\\" is how it looks\"}}]}\n\n",
-        );
-        assert!(
-            !s.found,
-            "escaped quotes in content must not false-positive"
-        );
-        s.feed(b"data: [DONE]\n\n");
-        assert!(!s.found);
+        ));
+        assert!(!scanner.feed(b"data: [DONE]\n\n"));
     }
 
     #[test]
     fn inband_scanner_bounds_carryover_on_pathological_line() {
-        // A single line longer than the cap resets the buffer (detection of
-        // that one line is forfeited by design), and scanning recovers after.
-        let mut s = InbandErrorScanner::default();
+        let mut scanner = InbandErrorScanner::default();
         let big = vec![b'x'; INBAND_SCAN_CARRYOVER_CAP + 1024];
-        s.feed(&big);
-        assert!(s.carry.len() <= INBAND_SCAN_CARRYOVER_CAP);
-        assert!(!s.found);
-        s.feed(b"\ndata: {\"error\": {\"code\": 503}}\n");
-        assert!(s.found, "scanner must recover after a pathological line");
+        assert!(!scanner.feed(&big));
+        assert!(scanner.carry.len() <= INBAND_SCAN_CARRYOVER_CAP);
+        assert!(scanner.feed(b"\ndata: {\"error\": {\"code\": 503}}\n"));
     }
 
-    /// Poll until the completion hook has fired (it runs on the spawned pump
-    /// task, after the body is fully collected).
-    async fn wait_for_stream_end(seen: &Arc<std::sync::Mutex<Option<StreamEnd>>>) -> StreamEnd {
-        for _ in 0..200 {
-            if let Some(end) = *seen.lock().unwrap() {
-                return end;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
-        panic!("on_complete never fired");
+    fn body_with_completion(
+        chunks: Vec<Result<Bytes, std::io::Error>>,
+    ) -> (Body, tokio::sync::oneshot::Receiver<StreamEnd>) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let body = bytes_stream_to_body(
+            stream::iter(chunks),
+            None,
+            Some(Box::new(move |end| {
+                let _ = tx.send(end);
+            })),
+            None,
+            None,
+        );
+        (body, rx)
+    }
+
+    async fn wait_for_stream_end(
+        rx: tokio::sync::oneshot::Receiver<StreamEnd>,
+    ) -> StreamEnd {
+        tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("on_complete timed out")
+            .expect("on_complete dropped")
     }
 
     #[tokio::test]
     async fn on_complete_reports_inband_error_with_clean_transport() {
-        let seen = Arc::new(std::sync::Mutex::new(None));
-        let seen_c = Arc::clone(&seen);
         let chunks = vec![
             Ok::<Bytes, std::io::Error>(Bytes::from_static(
                 b"data: {\"choices\": [{\"delta\": {\"content\": \"partial\"}}]}\n\n",
@@ -594,17 +584,9 @@ mod tests {
             )),
             Ok(Bytes::from_static(b"data: [DONE]\n\n")),
         ];
-        let body = bytes_stream_to_body(
-            stream::iter(chunks),
-            None,
-            Some(Box::new(move |end| {
-                *seen_c.lock().unwrap() = Some(end);
-            })),
-            None,
-            None,
-        );
+        let (body, completion) = body_with_completion(chunks);
         let _ = body.collect().await.unwrap();
-        let end = wait_for_stream_end(&seen).await;
+        let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok, "clean close: transport is fine");
         assert!(end.saw_inband_error, "in-band error must be reported");
         assert!(!end.client_disconnect);
@@ -612,25 +594,15 @@ mod tests {
 
     #[tokio::test]
     async fn on_complete_reports_clean_success() {
-        let seen = Arc::new(std::sync::Mutex::new(None));
-        let seen_c = Arc::clone(&seen);
         let chunks = vec![
             Ok::<Bytes, std::io::Error>(Bytes::from_static(
                 b"data: {\"choices\": [{\"delta\": {\"content\": \"hello\"}}]}\n\n",
             )),
             Ok(Bytes::from_static(b"data: [DONE]\n\n")),
         ];
-        let body = bytes_stream_to_body(
-            stream::iter(chunks),
-            None,
-            Some(Box::new(move |end| {
-                *seen_c.lock().unwrap() = Some(end);
-            })),
-            None,
-            None,
-        );
+        let (body, completion) = body_with_completion(chunks);
         let _ = body.collect().await.unwrap();
-        let end = wait_for_stream_end(&seen).await;
+        let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok);
         assert!(!end.saw_inband_error);
         assert!(!end.client_disconnect);
@@ -638,27 +610,15 @@ mod tests {
 
     #[tokio::test]
     async fn on_complete_reports_client_disconnect() {
-        let seen = Arc::new(std::sync::Mutex::new(None));
-        let seen_c = Arc::clone(&seen);
-        // Enough chunks to outlast the 64-slot channel, so the pump is still
-        // sending when the receiver is dropped.
         let chunks: Vec<Result<Bytes, std::io::Error>> =
             std::iter::repeat_with(|| Ok(Bytes::from_static(b"data: x\n\n")))
                 .take(1000)
                 .collect();
-        let body = bytes_stream_to_body(
-            stream::iter(chunks),
-            None,
-            Some(Box::new(move |end| {
-                *seen_c.lock().unwrap() = Some(end);
-            })),
-            None,
-            None,
-        );
+        let (body, completion) = body_with_completion(chunks);
         let mut data_stream = body.into_data_stream();
         let _ = data_stream.next().await;
         drop(data_stream);
-        let end = wait_for_stream_end(&seen).await;
+        let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok, "a walk-away client is not a worker fault");
         assert!(end.client_disconnect, "disconnect must be reported");
     }
@@ -683,13 +643,6 @@ mod tests {
             })),
         );
         let _ = body.collect().await.unwrap();
-        // The hook fires from the spawned pump task; poll briefly.
-        for _ in 0..200 {
-            if gaps.lock().unwrap().len() == 2 {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
         let gaps = gaps.lock().unwrap();
         assert_eq!(
             gaps.len(),

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -11,6 +11,88 @@ use bytes::Bytes;
 use futures::{FutureExt, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
 
+/// How the SSE pump ended, reported to the `on_complete` hook. The fields
+/// beyond `transport_ok` separate outcomes that are byte-level identical to
+/// success: an in-band engine error under a committed 200, and a client that
+/// walked away mid-generation.
+#[derive(Debug, Clone, Copy)]
+pub struct StreamEnd {
+    /// No upstream stream error and no pump panic.
+    pub transport_ok: bool,
+    /// An in-band SSE error envelope (`data: {"error"...}`) rode the stream.
+    pub saw_inband_error: bool,
+    /// The client dropped the response body before upstream finished.
+    pub client_disconnect: bool,
+}
+
+/// Carryover cap for the in-band scanner: a single longer line resets the
+/// buffer — its detection is forfeited, but memory stays bounded.
+const INBAND_SCAN_CARRYOVER_CAP: usize = 1 << 20; // 1 MiB
+
+/// Incremental scanner for in-band SSE error envelopes — the shape sglang's
+/// `create_streaming_error_response` emits after a committed 200. Complete
+/// lines are scanned in place; only a trailing partial line is carried over.
+/// The `{"error"` prefix check is parity-safe: inside a JSON string every
+/// quote is escaped, so it cannot start a well-formed content payload.
+#[derive(Default)]
+struct InbandErrorScanner {
+    carry: Vec<u8>,
+    found: bool,
+}
+
+impl InbandErrorScanner {
+    fn feed(&mut self, chunk: &[u8]) {
+        if self.found {
+            return;
+        }
+        let mut rest = chunk;
+        // Finish the carried-over partial line first.
+        if !self.carry.is_empty() {
+            match rest.iter().position(|&b| b == b'\n') {
+                Some(i) => {
+                    self.carry.extend_from_slice(&rest[..i]);
+                    if Self::line_is_inband_error(&self.carry) {
+                        self.found = true;
+                        self.carry = Vec::new();
+                        return;
+                    }
+                    self.carry.clear();
+                    rest = &rest[i + 1..];
+                }
+                None => {
+                    self.carry.extend_from_slice(rest);
+                    if self.carry.len() > INBAND_SCAN_CARRYOVER_CAP {
+                        self.carry.clear();
+                    }
+                    return;
+                }
+            }
+        }
+        // Scan complete lines in place; keep only the trailing partial.
+        while let Some(i) = rest.iter().position(|&b| b == b'\n') {
+            if Self::line_is_inband_error(&rest[..i]) {
+                self.found = true;
+                return;
+            }
+            rest = &rest[i + 1..];
+        }
+        if rest.len() <= INBAND_SCAN_CARRYOVER_CAP {
+            self.carry.extend_from_slice(rest);
+        }
+    }
+
+    fn line_is_inband_error(line: &[u8]) -> bool {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some(mut payload) = line.strip_prefix(b"data:") else {
+            return false;
+        };
+        while let Some(p) = payload.strip_prefix(b" ") {
+            payload = p;
+        }
+        payload.starts_with(b"{\"error\"")
+    }
+}
+
 /// Bridge a byte stream into an axum Body that streams chunks unchanged.
 ///
 /// Spawns one tokio task per stream so the handler can return immediately.
@@ -47,14 +129,11 @@ use tokio_stream::wrappers::ReceiverStream;
 /// guard scope).
 ///
 /// # Completion hook
-/// When `on_complete` is `Some`, the closure runs exactly once when the
-/// pump task finishes. The bool argument is `true` on clean stream end
-/// (including a clean client disconnect after at least the headers
-/// landed cleanly), `false` on upstream stream error or pump panic.
-/// `forward_streaming_to` passes a closure that records the worker's
-/// circuit-breaker outcome — without this hook, a worker that returns
-/// 2xx headers and then drops the stream mid-flight would stay credited
-/// as healthy.
+/// When `on_complete` is `Some`, it runs exactly once when the pump task
+/// finishes, receiving a [`StreamEnd`]. `forward_streaming_to` records the
+/// worker's circuit-breaker outcome from `transport_ok` alone — an in-band
+/// error is an application-level verdict, not a transport fault. The in-band
+/// scan runs only when `on_complete` is installed.
 ///
 /// # First-byte hook
 /// When `on_first_byte` is `Some`, the closure runs exactly once, the moment
@@ -62,11 +141,19 @@ use tokio_stream::wrappers::ReceiverStream;
 /// token. It does NOT fire if the stream ends or errors before any `Ok` chunk
 /// arrives. `forward_streaming_to` passes a closure that records
 /// `sgl_router_ttft_seconds` for successful streaming responses.
+///
+/// # Inter-chunk hook
+/// When `on_inter_chunk` is `Some`, it runs once per non-empty `Ok` chunk
+/// after the first with the gap (seconds) since the previous one — inter-token
+/// latency as seen at the router. Gaps are between upstream ARRIVALS, so the
+/// reading is engine pacing, not client drain speed, while the 64-slot
+/// channel has room. Feeds `sgl_router_itl_seconds`.
 pub fn bytes_stream_to_body<S, E>(
     stream: S,
     stream_guards: Option<Box<dyn Send + 'static>>,
-    on_complete: Option<Box<dyn FnOnce(bool) + Send + 'static>>,
+    on_complete: Option<Box<dyn FnOnce(StreamEnd) + Send + 'static>>,
     on_first_byte: Option<Box<dyn FnOnce() + Send + 'static>>,
+    on_inter_chunk: Option<Box<dyn Fn(f64) + Send + 'static>>,
 ) -> Body
 where
     S: futures::Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
@@ -78,8 +165,15 @@ where
         // Capture the pump's outcome so we can report it through `on_complete`
         // AFTER `pump.catch_unwind()` settles. The closure inside owns
         // `outcome_setter`; the outer scope reads `outcome_holder` once.
-        let outcome_holder = Arc::new(parking_lot::Mutex::new(true));
+        let outcome_holder = Arc::new(parking_lot::Mutex::new(StreamEnd {
+            transport_ok: true,
+            saw_inband_error: false,
+            client_disconnect: false,
+        }));
         let outcome_setter = Arc::clone(&outcome_holder);
+        // The in-band scan exists solely to inform `on_complete`; skip the
+        // per-chunk work entirely when nobody is listening.
+        let mut scanner = on_complete.as_ref().map(|_| InbandErrorScanner::default());
         let pump = AssertUnwindSafe(async move {
             // Hold the guards for the task's lifetime — dropped when this
             // block exits (stream done or client disconnect).  Leading
@@ -87,6 +181,7 @@ where
             // keeping intent explicit.
             let _hold = stream_guards;
             let mut on_first_byte = on_first_byte;
+            let mut prev_chunk_at: Option<std::time::Instant> = None;
             let mut s = stream;
             while let Some(chunk) = s.next().await {
                 let item: Result<Bytes, std::io::Error> = chunk.map_err(|e| {
@@ -95,17 +190,34 @@ where
                     std::io::Error::other(msg)
                 });
                 let is_err_chunk = item.is_err();
-                // Fire the time-to-first-token hook on the first successful
-                // chunk from upstream. `take()` makes it fire at most once;
-                // an error-first stream never produced a token, so it's left
-                // unfired (and dropped on task end).
-                if !is_err_chunk {
-                    if let Some(hook) = on_first_byte.take() {
-                        hook();
+                match &item {
+                    Ok(bytes) => {
+                        // TTFT hook: at most once (`take()`); an error-first
+                        // stream never produced a token, so it stays unfired.
+                        if let Some(hook) = on_first_byte.take() {
+                            hook();
+                        }
+                        // ITL: gap between non-empty Ok-chunk arrivals; the
+                        // first chunk seeds the clock (its latency is TTFT).
+                        if !bytes.is_empty() {
+                            if let Some(hook) = on_inter_chunk.as_ref() {
+                                let now = std::time::Instant::now();
+                                if let Some(prev) = prev_chunk_at {
+                                    hook(now.duration_since(prev).as_secs_f64());
+                                }
+                                prev_chunk_at = Some(now);
+                            }
+                        }
+                        if let Some(scan) = scanner.as_mut() {
+                            scan.feed(bytes);
+                            if scan.found {
+                                outcome_setter.lock().saw_inband_error = true;
+                                // Verdict is sticky; stop scanning.
+                                scanner = None;
+                            }
+                        }
                     }
-                }
-                if is_err_chunk {
-                    *outcome_setter.lock() = false;
+                    Err(_) => outcome_setter.lock().transport_ok = false,
                 }
                 if tx.send(item).await.is_err() {
                     // Receiver dropped. If we were about to ship an upstream
@@ -114,6 +226,7 @@ where
                     // not a router-side fault.
                     if !is_err_chunk {
                         tracing::debug!("SSE client disconnected mid-stream");
+                        outcome_setter.lock().client_disconnect = true;
                     }
                     break;
                 }
@@ -139,8 +252,9 @@ where
                 .await;
         }
         if let Some(hook) = on_complete {
-            let ok = !panicked && *outcome_holder.lock();
-            hook(ok);
+            let mut end = *outcome_holder.lock();
+            end.transport_ok = end.transport_ok && !panicked;
+            hook(end);
         }
     });
     Body::from_stream(ReceiverStream::new(rx))
@@ -160,7 +274,7 @@ mod tests {
             Ok(Bytes::from_static(b"world")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let bytes = body.collect().await.unwrap().to_bytes();
         assert_eq!(&bytes[..], b"hello world");
     }
@@ -184,6 +298,7 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
+            None,
         );
         let _ = body.collect().await.unwrap();
         assert_eq!(
@@ -211,6 +326,7 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
+            None,
         );
         let _ = body.collect().await;
         assert_eq!(
@@ -227,7 +343,7 @@ mod tests {
             Err(std::io::Error::other("upstream blew up mid-stream")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         // Collecting a body that terminates with an error must return Err.
         let result = body.collect().await;
         assert!(
@@ -289,7 +405,7 @@ mod tests {
         // that arm, the closure unwrap-or-elses would panic itself or
         // produce an empty message, which this test catches.
         let s = PanicAnyOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -312,7 +428,7 @@ mod tests {
         // The pump task panics mid-stream. The client must see a loud Err,
         // NOT a silently-truncated success.
         let s = PanicOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -371,7 +487,7 @@ mod tests {
             yielded: 0,
             max: 1000, // way more than we'll let it consume
         };
-        let body = bytes_stream_to_body(stream, None, None, None);
+        let body = bytes_stream_to_body(stream, None, None, None, None);
 
         // Read exactly one frame, then drop the body to simulate client disconnect.
         let mut data_stream = body.into_data_stream();
@@ -393,5 +509,193 @@ mod tests {
             final_polls < 1000,
             "pump drained the entire upstream after client disconnect ({final_polls} polls); the break-on-tx.send-err path is dead"
         );
+    }
+
+    #[test]
+    fn inband_scanner_detects_engine_error_event() {
+        // Exact shape sglang's create_streaming_error_response emits.
+        let mut s = InbandErrorScanner::default();
+        s.feed(b"data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\n");
+        assert!(!s.found);
+        s.feed(b"data: {\"error\": {\"message\": \"queue is full\", \"code\": 503}}\n\n");
+        assert!(s.found, "must detect a well-formed in-band error event");
+    }
+
+    #[test]
+    fn inband_scanner_detects_error_split_across_chunks() {
+        // Network chunking can split an SSE event anywhere — including inside
+        // the `data: {"error"` prefix itself.
+        let mut s = InbandErrorScanner::default();
+        s.feed(b"data: {\"err");
+        assert!(!s.found);
+        s.feed(b"or\": {\"code\": 503}}\n\n");
+        assert!(s.found, "must detect an error event split across chunks");
+    }
+
+    #[test]
+    fn inband_scanner_tolerates_no_space_and_crlf() {
+        // SSE permits `data:` with no space; proxies may normalize to CRLF.
+        let mut s = InbandErrorScanner::default();
+        s.feed(b"data:{\"error\": {\"code\": 500}}\r\n");
+        assert!(s.found, "must handle data: without space and CRLF endings");
+    }
+
+    #[test]
+    fn inband_scanner_ignores_error_text_inside_content() {
+        // A model that TALKS about errors must not trip the scanner — escaped
+        // quotes mean `{"error"` cannot start a content payload.
+        let mut s = InbandErrorScanner::default();
+        s.feed(
+            b"data: {\"choices\": [{\"delta\": {\"content\": \"data: {\\\"error\\\" is how it looks\"}}]}\n\n",
+        );
+        assert!(
+            !s.found,
+            "escaped quotes in content must not false-positive"
+        );
+        s.feed(b"data: [DONE]\n\n");
+        assert!(!s.found);
+    }
+
+    #[test]
+    fn inband_scanner_bounds_carryover_on_pathological_line() {
+        // A single line longer than the cap resets the buffer (detection of
+        // that one line is forfeited by design), and scanning recovers after.
+        let mut s = InbandErrorScanner::default();
+        let big = vec![b'x'; INBAND_SCAN_CARRYOVER_CAP + 1024];
+        s.feed(&big);
+        assert!(s.carry.len() <= INBAND_SCAN_CARRYOVER_CAP);
+        assert!(!s.found);
+        s.feed(b"\ndata: {\"error\": {\"code\": 503}}\n");
+        assert!(s.found, "scanner must recover after a pathological line");
+    }
+
+    /// Poll until the completion hook has fired (it runs on the spawned pump
+    /// task, after the body is fully collected).
+    async fn wait_for_stream_end(seen: &Arc<std::sync::Mutex<Option<StreamEnd>>>) -> StreamEnd {
+        for _ in 0..200 {
+            if let Some(end) = *seen.lock().unwrap() {
+                return end;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        panic!("on_complete never fired");
+    }
+
+    #[tokio::test]
+    async fn on_complete_reports_inband_error_with_clean_transport() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let seen_c = Arc::clone(&seen);
+        let chunks = vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"data: {\"choices\": [{\"delta\": {\"content\": \"partial\"}}]}\n\n",
+            )),
+            Ok(Bytes::from_static(
+                b"data: {\"error\": {\"message\": \"aborted\", \"code\": 503}}\n\n",
+            )),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+        ];
+        let body = bytes_stream_to_body(
+            stream::iter(chunks),
+            None,
+            Some(Box::new(move |end| {
+                *seen_c.lock().unwrap() = Some(end);
+            })),
+            None,
+            None,
+        );
+        let _ = body.collect().await.unwrap();
+        let end = wait_for_stream_end(&seen).await;
+        assert!(end.transport_ok, "clean close: transport is fine");
+        assert!(end.saw_inband_error, "in-band error must be reported");
+        assert!(!end.client_disconnect);
+    }
+
+    #[tokio::test]
+    async fn on_complete_reports_clean_success() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let seen_c = Arc::clone(&seen);
+        let chunks = vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"data: {\"choices\": [{\"delta\": {\"content\": \"hello\"}}]}\n\n",
+            )),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+        ];
+        let body = bytes_stream_to_body(
+            stream::iter(chunks),
+            None,
+            Some(Box::new(move |end| {
+                *seen_c.lock().unwrap() = Some(end);
+            })),
+            None,
+            None,
+        );
+        let _ = body.collect().await.unwrap();
+        let end = wait_for_stream_end(&seen).await;
+        assert!(end.transport_ok);
+        assert!(!end.saw_inband_error);
+        assert!(!end.client_disconnect);
+    }
+
+    #[tokio::test]
+    async fn on_complete_reports_client_disconnect() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let seen_c = Arc::clone(&seen);
+        // Enough chunks to outlast the 64-slot channel, so the pump is still
+        // sending when the receiver is dropped.
+        let chunks: Vec<Result<Bytes, std::io::Error>> =
+            std::iter::repeat_with(|| Ok(Bytes::from_static(b"data: x\n\n")))
+                .take(1000)
+                .collect();
+        let body = bytes_stream_to_body(
+            stream::iter(chunks),
+            None,
+            Some(Box::new(move |end| {
+                *seen_c.lock().unwrap() = Some(end);
+            })),
+            None,
+            None,
+        );
+        let mut data_stream = body.into_data_stream();
+        let _ = data_stream.next().await;
+        drop(data_stream);
+        let end = wait_for_stream_end(&seen).await;
+        assert!(end.transport_ok, "a walk-away client is not a worker fault");
+        assert!(end.client_disconnect, "disconnect must be reported");
+    }
+
+    #[tokio::test]
+    async fn on_inter_chunk_reports_one_gap_per_nonempty_chunk_after_first() {
+        let gaps: Arc<std::sync::Mutex<Vec<f64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let gaps_c = Arc::clone(&gaps);
+        let chunks = vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: a\n\n")),
+            Ok(Bytes::new()), // empty: no token, must not report or reset the clock
+            Ok(Bytes::from_static(b"data: b\n\n")),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+        ];
+        let body = bytes_stream_to_body(
+            stream::iter(chunks),
+            None,
+            None,
+            None,
+            Some(Box::new(move |gap| {
+                gaps_c.lock().unwrap().push(gap);
+            })),
+        );
+        let _ = body.collect().await.unwrap();
+        // The hook fires from the spawned pump task; poll briefly.
+        for _ in 0..200 {
+            if gaps.lock().unwrap().len() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let gaps = gaps.lock().unwrap();
+        assert_eq!(
+            gaps.len(),
+            2,
+            "3 non-empty chunks must report exactly 2 gaps; got {gaps:?}",
+        );
+        assert!(gaps.iter().all(|g| g.is_finite() && *g >= 0.0));
     }
 }

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -16,8 +16,8 @@ use tokio_stream::wrappers::ReceiverStream;
 pub struct StreamEnd {
     /// No upstream stream error and no pump panic.
     pub transport_ok: bool,
-    /// An in-band SSE error envelope (`data: {"error"...}`) rode the stream.
-    pub saw_inband_error: bool,
+    /// An SSE error event (`data: {"error"...}`) rode the stream.
+    pub saw_error_event: bool,
     /// The client dropped the response body before upstream finished.
     pub client_disconnect: bool,
 }
@@ -25,20 +25,14 @@ pub struct StreamEnd {
 /// Maximum buffered length of an SSE line split across chunks.
 const INBAND_SCAN_CARRYOVER_CAP: usize = 1 << 20; // 1 MiB
 
-/// Finds in-band error envelopes emitted after an SSE response commits a 200.
+/// Finds error events emitted after an SSE response commits a 200.
 #[derive(Default)]
-struct InbandErrorScanner {
+struct ErrorEventScanner {
     carry: Vec<u8>,
-    found: bool,
 }
 
-impl InbandErrorScanner {
-    /// Returns whether an error has been seen so callers can stop scanning.
+impl ErrorEventScanner {
     fn feed(&mut self, mut chunk: &[u8]) -> bool {
-        if self.found {
-            return true;
-        }
-
         // Complete a line carried over from the previous chunk.
         if !self.carry.is_empty() {
             let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') else {
@@ -46,9 +40,9 @@ impl InbandErrorScanner {
                 return false;
             };
             self.extend_carry(&chunk[..newline]);
-            self.found = Self::line_is_inband_error(&self.carry);
+            let found = Self::line_is_error_event(&self.carry);
             self.carry.clear();
-            if self.found {
+            if found {
                 return true;
             }
             chunk = &chunk[newline + 1..];
@@ -56,8 +50,7 @@ impl InbandErrorScanner {
 
         // Scan complete lines in place and retain the trailing partial line.
         while let Some(newline) = chunk.iter().position(|&byte| byte == b'\n') {
-            if Self::line_is_inband_error(&chunk[..newline]) {
-                self.found = true;
+            if Self::line_is_error_event(&chunk[..newline]) {
                 return true;
             }
             chunk = &chunk[newline + 1..];
@@ -67,16 +60,14 @@ impl InbandErrorScanner {
     }
 
     fn extend_carry(&mut self, bytes: &[u8]) {
-        if bytes.len()
-            <= INBAND_SCAN_CARRYOVER_CAP.saturating_sub(self.carry.len())
-        {
+        if bytes.len() <= INBAND_SCAN_CARRYOVER_CAP.saturating_sub(self.carry.len()) {
             self.carry.extend_from_slice(bytes);
         } else {
             self.carry.clear();
         }
     }
 
-    fn line_is_inband_error(line: &[u8]) -> bool {
+    fn line_is_error_event(line: &[u8]) -> bool {
         let line = line.strip_suffix(b"\r").unwrap_or(line);
         let Some(payload) = line.strip_prefix(b"data:") else {
             return false;
@@ -127,8 +118,8 @@ impl InbandErrorScanner {
 /// # Completion hook
 /// When `on_complete` is `Some`, it runs exactly once when the pump task
 /// finishes, receiving a [`StreamEnd`]. `forward_streaming_to` records the
-/// worker's circuit-breaker outcome from `transport_ok` alone — an in-band
-/// error is an application-level verdict, not a transport fault. The in-band
+/// worker's circuit-breaker outcome from `transport_ok` alone — an SSE error
+/// event is an application-level verdict, not a transport fault. The event
 /// scan runs only when `on_complete` is installed.
 ///
 /// # First-byte hook
@@ -137,19 +128,11 @@ impl InbandErrorScanner {
 /// token. It does NOT fire if the stream ends or errors before any `Ok` chunk
 /// arrives. `forward_streaming_to` passes a closure that records
 /// `sgl_router_ttft_seconds` for successful streaming responses.
-///
-/// # Inter-chunk hook
-/// When `on_inter_chunk` is `Some`, it runs once per non-empty `Ok` chunk
-/// after the first with the gap (seconds) since the previous one — inter-token
-/// latency as seen at the router. Gaps are between upstream ARRIVALS, so the
-/// reading is engine pacing, not client drain speed, while the 64-slot
-/// channel has room. Feeds `sgl_router_itl_seconds`.
 pub fn bytes_stream_to_body<S, E>(
     stream: S,
     stream_guards: Option<Box<dyn Send + 'static>>,
     on_complete: Option<Box<dyn FnOnce(StreamEnd) + Send + 'static>>,
     on_first_byte: Option<Box<dyn FnOnce() + Send + 'static>>,
-    on_inter_chunk: Option<Box<dyn Fn(f64) + Send + 'static>>,
 ) -> Body
 where
     S: futures::Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
@@ -163,13 +146,13 @@ where
         // `outcome_setter`; the outer scope reads `outcome_holder` once.
         let outcome_holder = Arc::new(parking_lot::Mutex::new(StreamEnd {
             transport_ok: true,
-            saw_inband_error: false,
+            saw_error_event: false,
             client_disconnect: false,
         }));
         let outcome_setter = Arc::clone(&outcome_holder);
-        // The in-band scan exists solely to inform `on_complete`; skip the
+        // The error-event scan exists solely to inform `on_complete`; skip the
         // per-chunk work entirely when nobody is listening.
-        let mut scanner = on_complete.is_some().then(InbandErrorScanner::default);
+        let mut scanner = on_complete.is_some().then(ErrorEventScanner::default);
         let pump = AssertUnwindSafe(async move {
             // Hold the guards for the task's lifetime — dropped when this
             // block exits (stream done or client disconnect).  Leading
@@ -177,7 +160,6 @@ where
             // keeping intent explicit.
             let _hold = stream_guards;
             let mut on_first_byte = on_first_byte;
-            let mut prev_chunk_at: Option<std::time::Instant> = None;
             let mut s = stream;
             while let Some(chunk) = s.next().await {
                 let item: Result<Bytes, std::io::Error> = chunk.map_err(|e| {
@@ -193,22 +175,8 @@ where
                         if let Some(hook) = on_first_byte.take() {
                             hook();
                         }
-                        // ITL: gap between non-empty Ok-chunk arrivals; the
-                        // first chunk seeds the clock (its latency is TTFT).
-                        if !bytes.is_empty() {
-                            if let Some(hook) = on_inter_chunk.as_ref() {
-                                let now = std::time::Instant::now();
-                                if let Some(prev) = prev_chunk_at.replace(now) {
-                                    hook(now.duration_since(prev).as_secs_f64());
-                                }
-                            }
-                        }
-                        if scanner
-                            .as_mut()
-                            .is_some_and(|scanner| scanner.feed(bytes))
-                        {
-                            outcome_setter.lock().saw_inband_error = true;
-                            // Verdict is sticky; stop scanning.
+                        if scanner.as_mut().is_some_and(|scanner| scanner.feed(bytes)) {
+                            outcome_setter.lock().saw_error_event = true;
                             scanner = None;
                         }
                     }
@@ -269,7 +237,7 @@ mod tests {
             Ok(Bytes::from_static(b"world")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None);
         let bytes = body.collect().await.unwrap().to_bytes();
         assert_eq!(&bytes[..], b"hello world");
     }
@@ -293,7 +261,6 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
-            None,
         );
         let _ = body.collect().await.unwrap();
         assert_eq!(
@@ -321,7 +288,6 @@ mod tests {
             Some(Box::new(move || {
                 fired_c.fetch_add(1, Ordering::SeqCst);
             })),
-            None,
         );
         let _ = body.collect().await;
         assert_eq!(
@@ -338,7 +304,7 @@ mod tests {
             Err(std::io::Error::other("upstream blew up mid-stream")),
         ];
         let s = stream::iter(chunks);
-        let body = bytes_stream_to_body(s, None, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None);
         // Collecting a body that terminates with an error must return Err.
         let result = body.collect().await;
         assert!(
@@ -400,7 +366,7 @@ mod tests {
         // that arm, the closure unwrap-or-elses would panic itself or
         // produce an empty message, which this test catches.
         let s = PanicAnyOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -423,7 +389,7 @@ mod tests {
         // The pump task panics mid-stream. The client must see a loud Err,
         // NOT a silently-truncated success.
         let s = PanicOnSecondPoll { polls: 0 };
-        let body = bytes_stream_to_body(s, None, None, None, None);
+        let body = bytes_stream_to_body(s, None, None, None);
         let result = body.collect().await;
         assert!(
             result.is_err(),
@@ -482,7 +448,7 @@ mod tests {
             yielded: 0,
             max: 1000, // way more than we'll let it consume
         };
-        let body = bytes_stream_to_body(stream, None, None, None, None);
+        let body = bytes_stream_to_body(stream, None, None, None);
 
         // Read exactly one frame, then drop the body to simulate client disconnect.
         let mut data_stream = body.into_data_stream();
@@ -507,32 +473,30 @@ mod tests {
     }
 
     #[test]
-    fn inband_scanner_detects_engine_error_event() {
-        let mut scanner = InbandErrorScanner::default();
-        assert!(!scanner.feed(
-            b"data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\n"
-        ));
-        assert!(scanner.feed(
-            b"data: {\"error\": {\"message\": \"queue is full\", \"code\": 503}}\n\n"
-        ));
+    fn error_event_scanner_detects_engine_error_event() {
+        let mut scanner = ErrorEventScanner::default();
+        assert!(!scanner.feed(b"data: {\"choices\": [{\"delta\": {\"content\": \"hi\"}}]}\n\n"));
+        assert!(
+            scanner.feed(b"data: {\"error\": {\"message\": \"queue is full\", \"code\": 503}}\n\n")
+        );
     }
 
     #[test]
-    fn inband_scanner_detects_error_split_across_chunks() {
-        let mut scanner = InbandErrorScanner::default();
+    fn error_event_scanner_detects_error_split_across_chunks() {
+        let mut scanner = ErrorEventScanner::default();
         assert!(!scanner.feed(b"data: {\"err"));
         assert!(scanner.feed(b"or\": {\"code\": 503}}\n\n"));
     }
 
     #[test]
-    fn inband_scanner_tolerates_no_space_and_crlf() {
-        let mut scanner = InbandErrorScanner::default();
+    fn error_event_scanner_tolerates_no_space_and_crlf() {
+        let mut scanner = ErrorEventScanner::default();
         assert!(scanner.feed(b"data:{\"error\": {\"code\": 500}}\r\n"));
     }
 
     #[test]
-    fn inband_scanner_ignores_error_text_inside_content() {
-        let mut scanner = InbandErrorScanner::default();
+    fn error_event_scanner_ignores_error_text_inside_content() {
+        let mut scanner = ErrorEventScanner::default();
         assert!(!scanner.feed(
             b"data: {\"choices\": [{\"delta\": {\"content\": \"data: {\\\"error\\\" is how it looks\"}}]}\n\n",
         ));
@@ -540,8 +504,8 @@ mod tests {
     }
 
     #[test]
-    fn inband_scanner_bounds_carryover_on_pathological_line() {
-        let mut scanner = InbandErrorScanner::default();
+    fn error_event_scanner_bounds_carryover_and_recovers() {
+        let mut scanner = ErrorEventScanner::default();
         let big = vec![b'x'; INBAND_SCAN_CARRYOVER_CAP + 1024];
         assert!(!scanner.feed(&big));
         assert!(scanner.carry.len() <= INBAND_SCAN_CARRYOVER_CAP);
@@ -559,14 +523,11 @@ mod tests {
                 let _ = tx.send(end);
             })),
             None,
-            None,
         );
         (body, rx)
     }
 
-    async fn wait_for_stream_end(
-        rx: tokio::sync::oneshot::Receiver<StreamEnd>,
-    ) -> StreamEnd {
+    async fn wait_for_stream_end(rx: tokio::sync::oneshot::Receiver<StreamEnd>) -> StreamEnd {
         tokio::time::timeout(std::time::Duration::from_secs(1), rx)
             .await
             .expect("on_complete timed out")
@@ -574,7 +535,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn on_complete_reports_inband_error_with_clean_transport() {
+    async fn on_complete_reports_error_event_with_clean_transport() {
         let chunks = vec![
             Ok::<Bytes, std::io::Error>(Bytes::from_static(
                 b"data: {\"choices\": [{\"delta\": {\"content\": \"partial\"}}]}\n\n",
@@ -588,7 +549,7 @@ mod tests {
         let _ = body.collect().await.unwrap();
         let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok, "clean close: transport is fine");
-        assert!(end.saw_inband_error, "in-band error must be reported");
+        assert!(end.saw_error_event, "SSE error event must be reported");
         assert!(!end.client_disconnect);
     }
 
@@ -604,7 +565,7 @@ mod tests {
         let _ = body.collect().await.unwrap();
         let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok);
-        assert!(!end.saw_inband_error);
+        assert!(!end.saw_error_event);
         assert!(!end.client_disconnect);
     }
 
@@ -621,34 +582,5 @@ mod tests {
         let end = wait_for_stream_end(completion).await;
         assert!(end.transport_ok, "a walk-away client is not a worker fault");
         assert!(end.client_disconnect, "disconnect must be reported");
-    }
-
-    #[tokio::test]
-    async fn on_inter_chunk_reports_one_gap_per_nonempty_chunk_after_first() {
-        let gaps: Arc<std::sync::Mutex<Vec<f64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let gaps_c = Arc::clone(&gaps);
-        let chunks = vec![
-            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: a\n\n")),
-            Ok(Bytes::new()), // empty: no token, must not report or reset the clock
-            Ok(Bytes::from_static(b"data: b\n\n")),
-            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
-        ];
-        let body = bytes_stream_to_body(
-            stream::iter(chunks),
-            None,
-            None,
-            None,
-            Some(Box::new(move |gap| {
-                gaps_c.lock().unwrap().push(gap);
-            })),
-        );
-        let _ = body.collect().await.unwrap();
-        let gaps = gaps.lock().unwrap();
-        assert_eq!(
-            gaps.len(),
-            2,
-            "3 non-empty chunks must report exactly 2 gaps; got {gaps:?}",
-        );
-        assert!(gaps.iter().all(|g| g.is_finite() && *g >= 0.0));
     }
 }

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -22,42 +22,40 @@ pub struct StreamEnd {
     pub client_disconnect: bool,
 }
 
-const ERROR_EVENT_PREFIX: &[u8] = b"data: {\"error\"";
+/// A `data:` line whose payload's first JSON key is `error` — tolerant of
+/// SSE-legal framing variants (no space after `data:`, whitespace after `{`),
+/// so the match is anchored to the spec rather than one serializer's bytes.
+fn is_error_event_line(line: &[u8]) -> bool {
+    line.strip_prefix(b"data:")
+        .map(|p| p.trim_ascii_start())
+        .and_then(|p| p.strip_prefix(b"{"))
+        .map(|p| p.trim_ascii_start())
+        .is_some_and(|p| p.starts_with(b"\"error\""))
+}
+
+/// Line-start bytes that suffice to decide `is_error_event_line`.
+const LINE_PROBE: usize = 32;
 
 /// Finds error events emitted after an SSE response commits a 200.
+/// Line-anchored, so lookalike text inside event payloads cannot match.
 #[derive(Default)]
 struct ErrorEventScanner {
-    overlap: Vec<u8>,
+    line_start: Vec<u8>,
 }
 
 impl ErrorEventScanner {
     fn feed(&mut self, chunk: &[u8]) -> bool {
-        if chunk
-            .windows(ERROR_EVENT_PREFIX.len())
-            .any(|window| window == ERROR_EVENT_PREFIX)
-        {
-            return true;
+        let mut hit = false;
+        for (i, segment) in chunk.split(|&b| b == b'\n').enumerate() {
+            if i > 0 {
+                hit |= is_error_event_line(&self.line_start);
+                self.line_start.clear();
+            }
+            let room = LINE_PROBE - self.line_start.len();
+            self.line_start
+                .extend_from_slice(&segment[..segment.len().min(room)]);
         }
-
-        let overlap_len = ERROR_EVENT_PREFIX.len() - 1;
-        self.overlap
-            .extend_from_slice(&chunk[..chunk.len().min(overlap_len)]);
-        if self
-            .overlap
-            .windows(ERROR_EVENT_PREFIX.len())
-            .any(|window| window == ERROR_EVENT_PREFIX)
-        {
-            return true;
-        }
-
-        if chunk.len() >= overlap_len {
-            self.overlap.clear();
-            self.overlap
-                .extend_from_slice(&chunk[chunk.len() - overlap_len..]);
-        } else if self.overlap.len() > overlap_len {
-            self.overlap.drain(..self.overlap.len() - overlap_len);
-        }
-        false
+        hit
     }
 }
 
@@ -125,9 +123,8 @@ where
             client_disconnect: false,
         }));
         let outcome_setter = Arc::clone(&outcome);
-        // The error-event scan exists solely to inform `on_complete`; skip the
-        // per-chunk work entirely when nobody is listening.
-        let mut scanner = on_complete.is_some().then(ErrorEventScanner::default);
+        // `None` once an error event is found — the scan is done for good.
+        let mut scanner = Some(ErrorEventScanner::default());
         let pump = AssertUnwindSafe(async move {
             // Hold the guards for the task's lifetime — dropped when this
             // block exits (stream done or client disconnect).  Leading
@@ -473,11 +470,26 @@ mod tests {
     }
 
     #[test]
-    fn error_event_scanner_bounds_overlap() {
+    fn error_event_scanner_accepts_sse_framing_variants() {
+        for event in [
+            &b"data:{\"error\": {\"code\": 503}}\n\n"[..],
+            b"data: { \"error\": {\"code\": 503}}\n\n",
+            b"data:  {\"error\": \"queue full\"}\n\n",
+        ] {
+            assert!(
+                ErrorEventScanner::default().feed(event),
+                "missed variant: {}",
+                String::from_utf8_lossy(event)
+            );
+        }
+    }
+
+    #[test]
+    fn error_event_scanner_bounds_line_buffer() {
         let mut scanner = ErrorEventScanner::default();
         let big = vec![b'x'; 1 << 20];
         assert!(!scanner.feed(&big));
-        assert_eq!(scanner.overlap.len(), ERROR_EVENT_PREFIX.len() - 1);
+        assert_eq!(scanner.line_start.len(), LINE_PROBE);
     }
 
     fn body_with_completion(
@@ -511,6 +523,21 @@ mod tests {
         assert!(end.transport_ok);
         assert!(end.saw_error_event);
         assert!(!end.client_disconnect);
+    }
+
+    #[tokio::test]
+    async fn completion_reports_error_event_then_transport_error() {
+        let chunks = vec![
+            Ok(Bytes::from_static(
+                b"data: {\"error\": {\"code\": 503}}\n\n",
+            )),
+            Err(std::io::Error::other("connection reset")),
+        ];
+        let (body, completion) = body_with_completion(chunks);
+        let _ = body.collect().await;
+        let end = stream_end(completion).await;
+        assert!(!end.transport_ok);
+        assert!(end.saw_error_event);
     }
 
     #[tokio::test]

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -11,22 +11,40 @@ use axum::routing::{get, post};
 use axum::Router;
 use std::sync::Arc;
 
+/// Endpoints polled constantly (Prometheus scrape, kubelet probes) — logged
+/// at DEBUG so they don't bury API traffic.
+fn is_infra_path(path: &str) -> bool {
+    matches!(path, "/healthz" | "/readyz" | "/metrics")
+}
+
 /// Edge counters: `requests_total{route,method}` at entry (true intake, incl.
 /// requests parked/shed/cancelled before dispatch), `responses_total{...,
 /// status_code}` on exit (incl. early-exit 400/413/503). Their difference =
 /// received-but-not-answered, invisible to post-dispatch `worker_requests_total`.
 /// `route` is the matched template (not raw URI) to bound label cardinality.
+///
+/// Also the single access-log site: one `http_request` line per request with
+/// the final status, including responses no handler sees (e.g. a 413 from the
+/// body-limit layer). For streams, `duration_ms` is time to response headers.
 async fn count_requests(State(ctx): State<Arc<AppContext>>, req: Request, next: Next) -> Response {
     let method = req.method().as_str().to_owned();
+    let path = req.uri().path().to_owned();
     let route = req
         .extensions()
         .get::<MatchedPath>()
         .map(|m| m.as_str().to_owned())
         .unwrap_or_else(|| "unmatched".to_owned());
     ctx.metrics.record_ingress(&route, &method);
+    let start = std::time::Instant::now();
     let resp = next.run(req).await;
-    ctx.metrics
-        .record_response(&route, &method, resp.status().as_u16());
+    let status = resp.status().as_u16();
+    ctx.metrics.record_response(&route, &method, status);
+    let duration_ms = start.elapsed().as_millis() as u64;
+    if is_infra_path(&path) {
+        tracing::debug!(target: "http_request", %method, %path, status, duration_ms);
+    } else {
+        tracing::info!(target: "http_request", %method, %path, status, duration_ms);
+    }
     resp
 }
 

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -22,10 +22,6 @@ fn is_infra_path(path: &str) -> bool {
 /// status_code}` on exit (incl. early-exit 400/413/503). Their difference =
 /// received-but-not-answered, invisible to post-dispatch `worker_requests_total`.
 /// `route` is the matched template (not raw URI) to bound label cardinality.
-///
-/// Also the single access-log site: one `http_request` line per request with
-/// the final status, including responses no handler sees (e.g. a 413 from the
-/// body-limit layer). For streams, `duration_ms` is time to response headers.
 async fn count_requests(State(ctx): State<Arc<AppContext>>, req: Request, next: Next) -> Response {
     let method = req.method().as_str().to_owned();
     let path = req.uri().path().to_owned();

--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -11,12 +11,6 @@ use axum::routing::{get, post};
 use axum::Router;
 use std::sync::Arc;
 
-/// Endpoints polled constantly (Prometheus scrape, kubelet probes) — logged
-/// at DEBUG so they don't bury API traffic.
-fn is_infra_path(path: &str) -> bool {
-    matches!(path, "/healthz" | "/readyz" | "/metrics")
-}
-
 /// Edge counters: `requests_total{route,method}` at entry (true intake, incl.
 /// requests parked/shed/cancelled before dispatch), `responses_total{...,
 /// status_code}` on exit (incl. early-exit 400/413/503). Their difference =
@@ -24,23 +18,15 @@ fn is_infra_path(path: &str) -> bool {
 /// `route` is the matched template (not raw URI) to bound label cardinality.
 async fn count_requests(State(ctx): State<Arc<AppContext>>, req: Request, next: Next) -> Response {
     let method = req.method().as_str().to_owned();
-    let path = req.uri().path().to_owned();
     let route = req
         .extensions()
         .get::<MatchedPath>()
         .map(|m| m.as_str().to_owned())
         .unwrap_or_else(|| "unmatched".to_owned());
     ctx.metrics.record_ingress(&route, &method);
-    let start = std::time::Instant::now();
     let resp = next.run(req).await;
-    let status = resp.status().as_u16();
-    ctx.metrics.record_response(&route, &method, status);
-    let duration_ms = start.elapsed().as_millis() as u64;
-    if is_infra_path(&path) {
-        tracing::debug!(target: "http_request", %method, %path, status, duration_ms);
-    } else {
-        tracing::info!(target: "http_request", %method, %path, status, duration_ms);
-    }
+    ctx.metrics
+        .record_response(&route, &method, resp.status().as_u16());
     resp
 }
 

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -23,7 +23,6 @@
 //! | `sgl_router_worker_requests_total` | Counter | `worker_url`, `model_id`, `mode`, `outcome` |
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
-//! | `sgl_router_itl_seconds` | Histogram | `model_id` |
 //! | `sgl_router_stream_outcome_total` | Counter | `worker_url`, `model_id`, `outcome` |
 //! | `sgl_router_active_load` | Gauge | `worker_url`, `kind` |
 //! | `sgl_router_workers` | Gauge | `mode` |
@@ -87,12 +86,6 @@ const TTFT_BUCKETS: &[f64] = &[
     400.0,
 ];
 
-/// Bucket bounds (seconds) for `sgl_router_itl_seconds`.
-const ITL_BUCKETS: &[f64] = &[
-    0.002, 0.004, 0.006, 0.008, 0.010, 0.015, 0.020, 0.025, 0.030, 0.035, 0.040, 0.060, 0.080,
-    0.100, 0.200, 0.400, 0.600, 0.800, 1.0, 2.0, 4.0, 6.0, 8.0,
-];
-
 /// Recordable outcome for a request — narrowed to a handful of variants so
 /// the label cardinality stays bounded.
 #[derive(Debug, Clone, Copy)]
@@ -117,8 +110,8 @@ impl RequestOutcome {
 pub enum StreamOutcome {
     /// Stream ended without errors.
     Ok,
-    /// The engine sent an in-band `data: {"error"...}` event.
-    InbandError,
+    /// The engine sent a `data: {"error"...}` SSE event.
+    StreamErrorEvent,
     /// The upstream byte stream failed.
     UpstreamError,
     /// The client disconnected before the stream finished.
@@ -129,7 +122,7 @@ impl StreamOutcome {
     fn as_str(self) -> &'static str {
         match self {
             Self::Ok => "ok",
-            Self::InbandError => "inband_error",
+            Self::StreamErrorEvent => "stream_error_event",
             Self::UpstreamError => "upstream_error",
             Self::ClientDisconnect => "client_disconnect",
         }
@@ -265,7 +258,6 @@ pub struct MetricsRegistry {
     // on `worker_requests_total` / the worker gauges instead.
     request_duration: Mutex<HashMap<String, Histogram>>,
     ttft_seconds: Mutex<HashMap<String, Histogram>>,
-    itl_seconds: Mutex<HashMap<String, Histogram>>,
     stream_outcome_total: Mutex<HashMap<StreamOutcomeKey, Arc<AtomicU64>>>,
     active_load: Mutex<HashMap<ActiveLoadKey, Arc<AtomicI64>>>,
     stale_requests_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
@@ -306,7 +298,7 @@ struct EdgeResponseKey {
 }
 
 /// Labels for `sgl_router_stream_outcome_total`. Per-worker so a single pod
-/// stuck in an accept-then-in-band-reject loop stands out.
+/// stuck in an accept-then-error-event loop stands out.
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 struct StreamOutcomeKey {
     worker_url: String,
@@ -470,18 +462,6 @@ impl MetricsRegistry {
             .entry(model_id.to_owned())
             .or_insert_with(|| Histogram::new(TTFT_BUCKETS));
         hist.observe(seconds);
-    }
-
-    /// Record an inter-chunk latency sample in seconds.
-    pub fn observe_itl(&self, model_id: &str, seconds: f64) {
-        if !seconds.is_finite() {
-            return;
-        }
-        self.itl_seconds
-            .lock()
-            .entry(model_id.to_owned())
-            .or_insert_with(|| Histogram::new(ITL_BUCKETS))
-            .observe(seconds);
     }
 
     /// Record the final outcome of a 2xx stream.
@@ -755,25 +735,8 @@ impl MetricsRegistry {
         }
         drop(guard);
 
-        // itl histogram
-        out.push_str(
-            "# HELP sgl_router_itl_seconds Gap between successive chunks of a 2xx stream, in seconds.\n",
-        );
-        out.push_str("# TYPE sgl_router_itl_seconds histogram\n");
-        let guard = self.itl_seconds.lock();
-        let mut models: Vec<&String> = guard.keys().collect();
-        models.sort();
-        for model_id in models {
-            let hist = guard.get(model_id).unwrap();
-            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
-            render_histogram(&mut out, "sgl_router_itl_seconds", &label_body, hist);
-        }
-        drop(guard);
-
         // stream_outcome_total — end-of-stream truth for 2xx streaming responses
-        out.push_str(
-            "# HELP sgl_router_stream_outcome_total Final outcome of a 2xx stream.\n",
-        );
+        out.push_str("# HELP sgl_router_stream_outcome_total Final outcome of a 2xx stream.\n");
         out.push_str("# TYPE sgl_router_stream_outcome_total counter\n");
         let guard = self.stream_outcome_total.lock();
         let mut entries: Vec<(&StreamOutcomeKey, u64)> = guard
@@ -1267,52 +1230,17 @@ mod tests {
     }
 
     #[test]
-    fn observe_itl_writes_buckets_sum_and_count() {
-        let reg = MetricsRegistry::new();
-        reg.observe_itl("tiny", 0.009);
-        reg.observe_itl("tiny", 0.05);
-        let out = reg.render();
-        for expected in [
-            r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#,
-            r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.01"} 1"#,
-            r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.06"} 2"#,
-        ] {
-            assert_metric_line(&out, expected);
-        }
-    }
-
-    #[test]
-    fn itl_buckets_align_with_engine_grid() {
-        // Every engine ITL edge must appear verbatim, else a router-vs-engine
-        // `histogram_quantile` comparison interpolates on mismatched grids.
-        let reg = MetricsRegistry::new();
-        reg.observe_itl("m", 0.05);
-        let out = reg.render();
-        for le in [
-            "0.002", "0.004", "0.006", "0.008", "0.01", "0.015", "0.02", "0.025", "0.03", "0.035",
-            "0.04", "0.06", "0.08", "0.1", "0.2", "0.4", "0.6", "0.8", "1", "2", "4", "6", "8",
-        ] {
-            assert!(
-                out.contains(&format!(
-                    r#"sgl_router_itl_seconds_bucket{{model_id="m",le="{le}"}}"#
-                )),
-                "missing engine-aligned ITL bucket le={le}; got:\n{out}",
-            );
-        }
-    }
-
-    #[test]
     fn record_stream_outcome_emits_labelled_counter_lines() {
         let reg = MetricsRegistry::new();
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::Ok);
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::Ok);
-        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::InbandError);
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::StreamErrorEvent);
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::UpstreamError);
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::ClientDisconnect);
         let out = reg.render();
         for expected in [
             r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="ok"} 2"#,
-            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="inband_error"} 1"#,
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="stream_error_event"} 1"#,
             r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="upstream_error"} 1"#,
             r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="client_disconnect"} 1"#,
         ] {

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -23,6 +23,8 @@
 //! | `sgl_router_worker_requests_total` | Counter | `worker_url`, `model_id`, `mode`, `outcome` |
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
+//! | `sgl_router_itl_seconds` | Histogram | `model_id` |
+//! | `sgl_router_stream_outcome_total` | Counter | `worker_url`, `model_id`, `outcome` |
 //! | `sgl_router_active_load` | Gauge | `worker_url`, `kind` |
 //! | `sgl_router_workers` | Gauge | `mode` |
 //! | `sgl_router_worker_health` | Gauge | `worker_url` |
@@ -85,6 +87,15 @@ const TTFT_BUCKETS: &[f64] = &[
     400.0,
 ];
 
+/// Bucket bounds (seconds) for `sgl_router_itl_seconds`. Edges are IDENTICAL
+/// to the engine's `sglang:inter_token_latency_seconds` grid
+/// (`python/sglang/srt/observability/metrics_collector.py`) — same rationale
+/// as [`TTFT_BUCKETS`]: mismatched grids skew `histogram_quantile` deltas.
+const ITL_BUCKETS: &[f64] = &[
+    0.002, 0.004, 0.006, 0.008, 0.010, 0.015, 0.020, 0.025, 0.030, 0.035, 0.040, 0.060, 0.080,
+    0.100, 0.200, 0.400, 0.600, 0.800, 1.0, 2.0, 4.0, 6.0, 8.0,
+];
+
 /// Recordable outcome for a request — narrowed to a handful of variants so
 /// the label cardinality stays bounded.
 #[derive(Debug, Clone, Copy)]
@@ -100,6 +111,32 @@ impl RequestOutcome {
             Self::Success => "success",
             Self::Error => "error",
             Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// True outcome of a 2xx-committed SSE stream, observed at stream END — the
+/// one vantage the headers-time counters lack once the 200 is on the wire.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamOutcome {
+    /// Stream ended cleanly with no in-band error — a real success.
+    Ok,
+    /// The engine reported failure via an in-band `data: {"error"...}` event
+    /// under an already-committed 200.
+    InbandError,
+    /// The byte stream itself broke (connection reset, truncated body).
+    UpstreamError,
+    /// The client dropped the response body before the stream finished.
+    ClientDisconnect,
+}
+
+impl StreamOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::InbandError => "inband_error",
+            Self::UpstreamError => "upstream_error",
+            Self::ClientDisconnect => "client_disconnect",
         }
     }
 }
@@ -233,6 +270,10 @@ pub struct MetricsRegistry {
     // on `worker_requests_total` / the worker gauges instead.
     request_duration: Mutex<HashMap<String, Histogram>>,
     ttft_seconds: Mutex<HashMap<String, Histogram>>,
+    itl_seconds: Mutex<HashMap<String, Histogram>>,
+    // End-of-stream outcomes for 2xx streams, from the SSE pump's completion
+    // hook — in-band errors, mid-stream drops, client disconnects.
+    stream_outcome_total: Mutex<HashMap<StreamOutcomeKey, Arc<AtomicU64>>>,
     active_load: Mutex<HashMap<ActiveLoadKey, Arc<AtomicI64>>>,
     stale_requests_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     decode_affinity_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
@@ -269,6 +310,15 @@ struct EdgeResponseKey {
     route: String,
     method: String,
     status_code: u16,
+}
+
+/// Labels for `sgl_router_stream_outcome_total`. Per-worker so a single pod
+/// stuck in an accept-then-in-band-reject loop stands out.
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+struct StreamOutcomeKey {
+    worker_url: String,
+    model_id: String,
+    outcome: &'static str,
 }
 
 /// Per-worker state sampled from the [`crate::workers::WorkerRegistry`] at
@@ -427,6 +477,38 @@ impl MetricsRegistry {
             .entry(model_id.to_owned())
             .or_insert_with(|| Histogram::new(TTFT_BUCKETS));
         hist.observe(seconds);
+    }
+
+    /// Observe one inter-token gap (seconds) for `sgl_router_itl_seconds`.
+    /// Strictly inter-CHUNK latency (the router does not tokenize output);
+    /// with the engine's one-event-per-token streaming the two coincide.
+    pub fn observe_itl(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.itl_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(ITL_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Bump `sgl_router_stream_outcome_total{worker_url,model_id,outcome}`.
+    /// Recorded at SSE-pump completion, 2xx streams only.
+    pub fn record_stream_outcome(&self, worker_url: &str, model_id: &str, outcome: StreamOutcome) {
+        let key = StreamOutcomeKey {
+            worker_url: worker_url.to_owned(),
+            model_id: model_id.to_owned(),
+            outcome: outcome.as_str(),
+        };
+        let mut guard = self.stream_outcome_total.lock();
+        let counter = guard
+            .entry(key)
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Bump the edge counter `responses_total{route,method,status_code}`. Called
@@ -681,6 +763,49 @@ impl MetricsRegistry {
             let hist = guard.get(model_id).unwrap();
             let label_body = format!("model_id=\"{}\"", escape_label(model_id));
             render_histogram(&mut out, "sgl_router_ttft_seconds", &label_body, hist);
+        }
+        drop(guard);
+
+        // itl histogram
+        out.push_str(
+            "# HELP sgl_router_itl_seconds Inter-token latency (gap between successive upstream response chunks) for 2xx streaming requests, in seconds.\n",
+        );
+        out.push_str("# TYPE sgl_router_itl_seconds histogram\n");
+        let guard = self.itl_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(&mut out, "sgl_router_itl_seconds", &label_body, hist);
+        }
+        drop(guard);
+
+        // stream_outcome_total — end-of-stream truth for 2xx streaming responses
+        out.push_str(
+            "# HELP sgl_router_stream_outcome_total End-of-stream outcome of 2xx streaming responses: ok, inband_error (engine reported failure via an in-band SSE error event after committing 200), upstream_error (transport broke mid-stream), or client_disconnect.\n",
+        );
+        out.push_str("# TYPE sgl_router_stream_outcome_total counter\n");
+        let guard = self.stream_outcome_total.lock();
+        let mut entries: Vec<(&StreamOutcomeKey, u64)> = guard
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by(|a, b| {
+            (&a.0.worker_url, &a.0.model_id, a.0.outcome).cmp(&(
+                &b.0.worker_url,
+                &b.0.model_id,
+                b.0.outcome,
+            ))
+        });
+        for (key, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_stream_outcome_total{{worker_url=\"{}\",model_id=\"{}\",outcome=\"{}\"}} {}\n",
+                escape_label(&key.worker_url),
+                escape_label(&key.model_id),
+                key.outcome,
+                value,
+            ));
         }
         drop(guard);
 
@@ -1149,6 +1274,78 @@ mod tests {
                 "missing engine-aligned TTFT bucket le={le}; got:\n{out}",
             );
         }
+    }
+
+    #[test]
+    fn observe_itl_writes_buckets_sum_and_count() {
+        let reg = MetricsRegistry::new();
+        reg.observe_itl("tiny", 0.009);
+        reg.observe_itl("tiny", 0.05);
+        let out = reg.render();
+        assert!(
+            out.contains(r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#),
+            "expected itl count=2; got:\n{out}",
+        );
+        // 0.009 <= 0.01, so the le=0.01 bucket is 1 (cumulative).
+        assert!(
+            out.contains(r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.01"} 1"#),
+            "expected le=0.01 bucket = 1; got:\n{out}",
+        );
+        assert!(out.contains(r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.06"} 2"#));
+    }
+
+    #[test]
+    fn itl_buckets_align_with_engine_grid() {
+        // Every engine ITL edge must appear verbatim, else a router-vs-engine
+        // `histogram_quantile` comparison interpolates on mismatched grids.
+        let reg = MetricsRegistry::new();
+        reg.observe_itl("m", 0.05);
+        let out = reg.render();
+        for le in [
+            "0.002", "0.004", "0.006", "0.008", "0.01", "0.015", "0.02", "0.025", "0.03", "0.035",
+            "0.04", "0.06", "0.08", "0.1", "0.2", "0.4", "0.6", "0.8", "1", "2", "4", "6", "8",
+        ] {
+            assert!(
+                out.contains(&format!(
+                    r#"sgl_router_itl_seconds_bucket{{model_id="m",le="{le}"}}"#
+                )),
+                "missing engine-aligned ITL bucket le={le}; got:\n{out}",
+            );
+        }
+    }
+
+    #[test]
+    fn record_stream_outcome_emits_labelled_counter_lines() {
+        let reg = MetricsRegistry::new();
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::Ok);
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::Ok);
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::InbandError);
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::UpstreamError);
+        reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::ClientDisconnect);
+        let out = reg.render();
+        assert!(out.contains(
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="ok"} 2"#
+        ));
+        assert!(out.contains(
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="inband_error"} 1"#
+        ));
+        assert!(out.contains(
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="upstream_error"} 1"#
+        ));
+        assert!(out.contains(
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="client_disconnect"} 1"#
+        ));
+    }
+
+    #[test]
+    fn stream_outcome_absent_until_recorded() {
+        let reg = MetricsRegistry::new();
+        let out = reg.render();
+        assert!(out.contains("# TYPE sgl_router_stream_outcome_total counter"));
+        assert!(
+            !out.contains("sgl_router_stream_outcome_total{"),
+            "no series until an outcome is recorded; got:\n{out}",
+        );
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -87,10 +87,7 @@ const TTFT_BUCKETS: &[f64] = &[
     400.0,
 ];
 
-/// Bucket bounds (seconds) for `sgl_router_itl_seconds`. Edges are IDENTICAL
-/// to the engine's `sglang:inter_token_latency_seconds` grid
-/// (`python/sglang/srt/observability/metrics_collector.py`) — same rationale
-/// as [`TTFT_BUCKETS`]: mismatched grids skew `histogram_quantile` deltas.
+/// Bucket bounds (seconds) for `sgl_router_itl_seconds`.
 const ITL_BUCKETS: &[f64] = &[
     0.002, 0.004, 0.006, 0.008, 0.010, 0.015, 0.020, 0.025, 0.030, 0.035, 0.040, 0.060, 0.080,
     0.100, 0.200, 0.400, 0.600, 0.800, 1.0, 2.0, 4.0, 6.0, 8.0,
@@ -115,18 +112,16 @@ impl RequestOutcome {
     }
 }
 
-/// True outcome of a 2xx-committed SSE stream, observed at stream END — the
-/// one vantage the headers-time counters lack once the 200 is on the wire.
+/// Final outcome of a 2xx SSE stream, observed after headers are committed.
 #[derive(Debug, Clone, Copy)]
 pub enum StreamOutcome {
-    /// Stream ended cleanly with no in-band error — a real success.
+    /// Stream ended without errors.
     Ok,
-    /// The engine reported failure via an in-band `data: {"error"...}` event
-    /// under an already-committed 200.
+    /// The engine sent an in-band `data: {"error"...}` event.
     InbandError,
-    /// The byte stream itself broke (connection reset, truncated body).
+    /// The upstream byte stream failed.
     UpstreamError,
-    /// The client dropped the response body before the stream finished.
+    /// The client disconnected before the stream finished.
     ClientDisconnect,
 }
 
@@ -271,8 +266,6 @@ pub struct MetricsRegistry {
     request_duration: Mutex<HashMap<String, Histogram>>,
     ttft_seconds: Mutex<HashMap<String, Histogram>>,
     itl_seconds: Mutex<HashMap<String, Histogram>>,
-    // End-of-stream outcomes for 2xx streams, from the SSE pump's completion
-    // hook — in-band errors, mid-stream drops, client disconnects.
     stream_outcome_total: Mutex<HashMap<StreamOutcomeKey, Arc<AtomicU64>>>,
     active_load: Mutex<HashMap<ActiveLoadKey, Arc<AtomicI64>>>,
     stale_requests_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
@@ -314,7 +307,7 @@ struct EdgeResponseKey {
 
 /// Labels for `sgl_router_stream_outcome_total`. Per-worker so a single pod
 /// stuck in an accept-then-in-band-reject loop stands out.
-#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 struct StreamOutcomeKey {
     worker_url: String,
     model_id: String,
@@ -479,35 +472,31 @@ impl MetricsRegistry {
         hist.observe(seconds);
     }
 
-    /// Observe one inter-token gap (seconds) for `sgl_router_itl_seconds`.
-    /// Strictly inter-CHUNK latency (the router does not tokenize output);
-    /// with the engine's one-event-per-token streaming the two coincide.
+    /// Record an inter-chunk latency sample in seconds.
     pub fn observe_itl(&self, model_id: &str, seconds: f64) {
-        // See `observe_request_duration` — drop non-finite before the map.
         if !seconds.is_finite() {
             return;
         }
-        let mut guard = self.itl_seconds.lock();
-        let hist = guard
+        self.itl_seconds
+            .lock()
             .entry(model_id.to_owned())
-            .or_insert_with(|| Histogram::new(ITL_BUCKETS));
-        hist.observe(seconds);
+            .or_insert_with(|| Histogram::new(ITL_BUCKETS))
+            .observe(seconds);
     }
 
-    /// Bump `sgl_router_stream_outcome_total{worker_url,model_id,outcome}`.
-    /// Recorded at SSE-pump completion, 2xx streams only.
+    /// Record the final outcome of a 2xx stream.
     pub fn record_stream_outcome(&self, worker_url: &str, model_id: &str, outcome: StreamOutcome) {
         let key = StreamOutcomeKey {
             worker_url: worker_url.to_owned(),
             model_id: model_id.to_owned(),
             outcome: outcome.as_str(),
         };
-        let mut guard = self.stream_outcome_total.lock();
-        let counter = guard
+        let counter = self
+            .stream_outcome_total
+            .lock()
             .entry(key)
-            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .or_default()
             .clone();
-        drop(guard);
         counter.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -768,7 +757,7 @@ impl MetricsRegistry {
 
         // itl histogram
         out.push_str(
-            "# HELP sgl_router_itl_seconds Inter-token latency (gap between successive upstream response chunks) for 2xx streaming requests, in seconds.\n",
+            "# HELP sgl_router_itl_seconds Gap between successive chunks of a 2xx stream, in seconds.\n",
         );
         out.push_str("# TYPE sgl_router_itl_seconds histogram\n");
         let guard = self.itl_seconds.lock();
@@ -783,7 +772,7 @@ impl MetricsRegistry {
 
         // stream_outcome_total — end-of-stream truth for 2xx streaming responses
         out.push_str(
-            "# HELP sgl_router_stream_outcome_total End-of-stream outcome of 2xx streaming responses: ok, inband_error (engine reported failure via an in-band SSE error event after committing 200), upstream_error (transport broke mid-stream), or client_disconnect.\n",
+            "# HELP sgl_router_stream_outcome_total Final outcome of a 2xx stream.\n",
         );
         out.push_str("# TYPE sgl_router_stream_outcome_total counter\n");
         let guard = self.stream_outcome_total.lock();
@@ -791,13 +780,7 @@ impl MetricsRegistry {
             .iter()
             .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
             .collect();
-        entries.sort_by(|a, b| {
-            (&a.0.worker_url, &a.0.model_id, a.0.outcome).cmp(&(
-                &b.0.worker_url,
-                &b.0.model_id,
-                b.0.outcome,
-            ))
-        });
+        entries.sort();
         for (key, value) in entries {
             out.push_str(&format!(
                 "sgl_router_stream_outcome_total{{worker_url=\"{}\",model_id=\"{}\",outcome=\"{}\"}} {}\n",
@@ -1136,6 +1119,13 @@ fn escape_label(s: &str) -> String {
 mod tests {
     use super::*;
 
+    fn assert_metric_line(output: &str, expected: &str) {
+        assert!(
+            output.lines().any(|line| line == expected),
+            "missing metric line `{expected}`; got:\n{output}"
+        );
+    }
+
     #[test]
     fn empty_registry_renders_only_help_lines() {
         let reg = MetricsRegistry::new();
@@ -1282,16 +1272,13 @@ mod tests {
         reg.observe_itl("tiny", 0.009);
         reg.observe_itl("tiny", 0.05);
         let out = reg.render();
-        assert!(
-            out.contains(r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#),
-            "expected itl count=2; got:\n{out}",
-        );
-        // 0.009 <= 0.01, so the le=0.01 bucket is 1 (cumulative).
-        assert!(
-            out.contains(r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.01"} 1"#),
-            "expected le=0.01 bucket = 1; got:\n{out}",
-        );
-        assert!(out.contains(r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.06"} 2"#));
+        for expected in [
+            r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#,
+            r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.01"} 1"#,
+            r#"sgl_router_itl_seconds_bucket{model_id="tiny",le="0.06"} 2"#,
+        ] {
+            assert_metric_line(&out, expected);
+        }
     }
 
     #[test]
@@ -1323,18 +1310,14 @@ mod tests {
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::UpstreamError);
         reg.record_stream_outcome("http://w:30000", "tiny", StreamOutcome::ClientDisconnect);
         let out = reg.render();
-        assert!(out.contains(
-            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="ok"} 2"#
-        ));
-        assert!(out.contains(
-            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="inband_error"} 1"#
-        ));
-        assert!(out.contains(
-            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="upstream_error"} 1"#
-        ));
-        assert!(out.contains(
-            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="client_disconnect"} 1"#
-        ));
+        for expected in [
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="ok"} 2"#,
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="inband_error"} 1"#,
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="upstream_error"} 1"#,
+            r#"sgl_router_stream_outcome_total{worker_url="http://w:30000",model_id="tiny",outcome="client_disconnect"} 1"#,
+        ] {
+            assert_metric_line(&out, expected);
+        }
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -50,6 +50,7 @@
 //! The exposition is text/plain; version=0.0.4 per the Prometheus spec.
 
 use crate::config::PolicyKind;
+use crate::proxy::sse::StreamEnd;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -106,7 +107,7 @@ impl RequestOutcome {
 }
 
 /// Final outcome of a 2xx SSE stream.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamOutcome {
     /// Stream ended without errors.
     Ok,
@@ -116,6 +117,15 @@ pub enum StreamOutcome {
     UpstreamError,
     /// The client disconnected before the stream finished.
     ClientDisconnect,
+}
+
+pub(crate) fn classify_stream_end(end: StreamEnd) -> StreamOutcome {
+    match (end.transport_ok, end.saw_error_event, end.client_disconnect) {
+        (false, _, _) => StreamOutcome::UpstreamError,
+        (_, true, _) => StreamOutcome::StreamErrorEvent,
+        (_, _, true) => StreamOutcome::ClientDisconnect,
+        _ => StreamOutcome::Ok,
+    }
 }
 
 impl StreamOutcome {
@@ -1225,6 +1235,29 @@ mod tests {
                 )),
                 "missing engine-aligned TTFT bucket le={le}; got:\n{out}",
             );
+        }
+    }
+
+    #[test]
+    fn stream_outcome_precedence() {
+        use StreamOutcome::*;
+
+        for (transport_ok, saw_error_event, client_disconnect, expected) in [
+            (false, false, false, UpstreamError),
+            (false, false, true, UpstreamError),
+            (false, true, false, UpstreamError),
+            (false, true, true, UpstreamError),
+            (true, false, false, Ok),
+            (true, false, true, ClientDisconnect),
+            (true, true, false, StreamErrorEvent),
+            (true, true, true, StreamErrorEvent),
+        ] {
+            let end = StreamEnd {
+                transport_ok,
+                saw_error_event,
+                client_disconnect,
+            };
+            assert_eq!(classify_stream_end(end), expected, "{end:?}");
         }
     }
 

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -105,7 +105,7 @@ impl RequestOutcome {
     }
 }
 
-/// Final outcome of a 2xx SSE stream, observed after headers are committed.
+/// Final outcome of a 2xx SSE stream.
 #[derive(Debug, Clone, Copy)]
 pub enum StreamOutcome {
     /// Stream ended without errors.
@@ -297,8 +297,7 @@ struct EdgeResponseKey {
     status_code: u16,
 }
 
-/// Labels for `sgl_router_stream_outcome_total`. Per-worker so a single pod
-/// stuck in an accept-then-error-event loop stands out.
+/// Labels for `sgl_router_stream_outcome_total`.
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Clone)]
 struct StreamOutcomeKey {
     worker_url: String,
@@ -735,7 +734,7 @@ impl MetricsRegistry {
         }
         drop(guard);
 
-        // stream_outcome_total — end-of-stream truth for 2xx streaming responses
+        // Final outcomes observed after a 2xx stream's headers are committed.
         out.push_str("# HELP sgl_router_stream_outcome_total Final outcome of a 2xx stream.\n");
         out.push_str("# TYPE sgl_router_stream_outcome_total counter\n");
         let guard = self.stream_outcome_total.lock();

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -765,13 +765,12 @@ pub async fn chat_completions(
         start,
     };
 
-    // Builds the end-of-stream hook classifying a 2xx stream after the 200
-    // was committed. Takes the streaming worker's URL (Final D in PD mode).
+    // Classifies a 2xx stream after its headers are committed. Takes the
+    // streaming worker's URL (Final D in PD mode).
     let make_stream_end_hook = |worker_url: String| -> Box<dyn FnOnce(StreamEnd) + Send + 'static> {
         let metrics = Arc::clone(&ctx.metrics);
         let model = metrics_model.clone();
-        Box::new(move |end: StreamEnd| {
-            // Precedence: error event > transport fault > disconnect.
+        Box::new(move |end| {
             let outcome = if end.saw_error_event {
                 StreamOutcome::StreamErrorEvent
             } else if !end.transport_ok {

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -771,9 +771,9 @@ pub async fn chat_completions(
         let metrics = Arc::clone(&ctx.metrics);
         let model = metrics_model.clone();
         Box::new(move |end: StreamEnd| {
-            // Precedence: in-band verdict > transport fault > disconnect.
-            let outcome = if end.saw_inband_error {
-                StreamOutcome::InbandError
+            // Precedence: error event > transport fault > disconnect.
+            let outcome = if end.saw_error_event {
+                StreamOutcome::StreamErrorEvent
             } else if !end.transport_ok {
                 StreamOutcome::UpstreamError
             } else if end.client_disconnect {
@@ -783,13 +783,6 @@ pub async fn chat_completions(
             };
             metrics.record_stream_outcome(&worker_url, &model, outcome);
         })
-    };
-
-    // Builds the inter-chunk hook recording `sgl_router_itl_seconds`.
-    let make_itl_hook = || -> Box<dyn Fn(f64) + Send + 'static> {
-        let metrics = Arc::clone(&ctx.metrics);
-        let model = metrics_model.clone();
-        Box::new(move |gap| metrics.observe_itl(&model, gap))
     };
 
     // Forward the router-computed tokens to the engine as `input_ids` so it
@@ -933,7 +926,6 @@ pub async fn chat_completions(
                 Some(stream_guards),
                 Some(make_ttft_hook()),
                 Some(make_stream_end_hook(decode_worker.url.clone())),
-                Some(make_itl_hook()),
             );
             tokio::select! {
                 biased;
@@ -970,7 +962,6 @@ pub async fn chat_completions(
             Some(stream_guards),
             Some(make_ttft_hook()),
             Some(make_stream_end_hook(worker.url.clone())),
-            Some(make_itl_hook()),
         );
         // Bias `fetch` over the cancellation branch: a successful
         // response that completes in the same poll as the token firing

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -21,8 +21,8 @@ use crate::proxy::sse::StreamEnd;
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
 use crate::server::metrics::{
-    MetricsRegistry, PolicySelectionFailureReason, RequestOutcome, StaleRequestOutcome,
-    StreamOutcome, WorkerModeLabel,
+    classify_stream_end, MetricsRegistry, PolicySelectionFailureReason, RequestOutcome,
+    StaleRequestOutcome, WorkerModeLabel,
 };
 use crate::workers::{LoadGuard, Worker};
 use axum::body::Body;
@@ -771,18 +771,7 @@ pub async fn chat_completions(
         let metrics = Arc::clone(&ctx.metrics);
         let model = metrics_model.clone();
         Box::new(move |end| {
-            // Transport truth first, so the label agrees with the breaker
-            // (proxy/mod.rs records failure from `transport_ok` alone).
-            let outcome = if !end.transport_ok {
-                StreamOutcome::UpstreamError
-            } else if end.saw_error_event {
-                StreamOutcome::StreamErrorEvent
-            } else if end.client_disconnect {
-                StreamOutcome::ClientDisconnect
-            } else {
-                StreamOutcome::Ok
-            };
-            metrics.record_stream_outcome(&worker_url, &model, outcome);
+            metrics.record_stream_outcome(&worker_url, &model, classify_stream_end(end));
         })
     };
 

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -17,11 +17,12 @@ use crate::policies::{
     request_tokens_for, ExternalPrefixSignal, PrefillProposal, ProposalKind, RequestTokens,
     SelectionContext,
 };
+use crate::proxy::sse::StreamEnd;
 use crate::server::app_context::AppContext;
 use crate::server::error::ApiError;
 use crate::server::metrics::{
     MetricsRegistry, PolicySelectionFailureReason, RequestOutcome, StaleRequestOutcome,
-    WorkerModeLabel,
+    StreamOutcome, WorkerModeLabel,
 };
 use crate::workers::{LoadGuard, Worker};
 use axum::body::Body;
@@ -764,6 +765,33 @@ pub async fn chat_completions(
         start,
     };
 
+    // Builds the end-of-stream hook classifying a 2xx stream after the 200
+    // was committed. Takes the streaming worker's URL (Final D in PD mode).
+    let make_stream_end_hook = |worker_url: String| -> Box<dyn FnOnce(StreamEnd) + Send + 'static> {
+        let metrics = Arc::clone(&ctx.metrics);
+        let model = metrics_model.clone();
+        Box::new(move |end: StreamEnd| {
+            // Precedence: in-band verdict > transport fault > disconnect.
+            let outcome = if end.saw_inband_error {
+                StreamOutcome::InbandError
+            } else if !end.transport_ok {
+                StreamOutcome::UpstreamError
+            } else if end.client_disconnect {
+                StreamOutcome::ClientDisconnect
+            } else {
+                StreamOutcome::Ok
+            };
+            metrics.record_stream_outcome(&worker_url, &model, outcome);
+        })
+    };
+
+    // Builds the inter-chunk hook recording `sgl_router_itl_seconds`.
+    let make_itl_hook = || -> Box<dyn Fn(f64) + Send + 'static> {
+        let metrics = Arc::clone(&ctx.metrics);
+        let model = metrics_model.clone();
+        Box::new(move |gap| metrics.observe_itl(&model, gap))
+    };
+
     // Forward the router-computed tokens to the engine as `input_ids` so it
     // skips re-tokenizing the same prompt — but only when they are
     // engine-equivalent (chat-encoder path) AND the request contains nothing
@@ -904,6 +932,8 @@ pub async fn chat_completions(
                 outgoing_body,
                 Some(stream_guards),
                 Some(make_ttft_hook()),
+                Some(make_stream_end_hook(decode_worker.url.clone())),
+                Some(make_itl_hook()),
             );
             tokio::select! {
                 biased;
@@ -939,6 +969,8 @@ pub async fn chat_completions(
             outgoing_body,
             Some(stream_guards),
             Some(make_ttft_hook()),
+            Some(make_stream_end_hook(worker.url.clone())),
+            Some(make_itl_hook()),
         );
         // Bias `fetch` over the cancellation branch: a successful
         // response that completes in the same poll as the token firing

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -771,10 +771,12 @@ pub async fn chat_completions(
         let metrics = Arc::clone(&ctx.metrics);
         let model = metrics_model.clone();
         Box::new(move |end| {
-            let outcome = if end.saw_error_event {
-                StreamOutcome::StreamErrorEvent
-            } else if !end.transport_ok {
+            // Transport truth first, so the label agrees with the breaker
+            // (proxy/mod.rs records failure from `transport_ok` alone).
+            let outcome = if !end.transport_ok {
                 StreamOutcome::UpstreamError
+            } else if end.saw_error_event {
+                StreamOutcome::StreamErrorEvent
             } else if end.client_disconnect {
                 StreamOutcome::ClientDisconnect
             } else {

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -951,7 +951,6 @@ async fn forward_streaming_to_records_failure_on_mid_stream_drop() {
             None,
             None,
             None,
-            None,
         )
         .await;
 
@@ -1522,9 +1521,9 @@ async fn stream_chat_and_render(
     }
 }
 
-/// A clean transport carrying an in-band error records only the stream failure.
+/// A clean transport carrying an SSE error event records only the stream failure.
 #[tokio::test]
-async fn streaming_inband_error_records_stream_outcome_without_tripping_breaker() {
+async fn streaming_error_event_records_stream_outcome_without_tripping_breaker() {
     let worker = crate::common::mock_worker::MockWorker::start(vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
         "data: {\"error\": {\"message\": \"The request queue is full.\", \"code\": 503}}\n\n",
@@ -1532,7 +1531,7 @@ async fn streaming_inband_error_records_stream_outcome_without_tripping_breaker(
     ])
     .await;
     let expected = format!(
-        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="inband_error"}} 1"#,
+        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="stream_error_event"}} 1"#,
         worker.url,
     );
     let (ctx, metrics) = stream_chat_and_render(&worker.url, &expected).await;
@@ -1545,7 +1544,7 @@ async fn streaming_inband_error_records_stream_outcome_without_tripping_breaker(
             .all()
             .iter()
             .all(|worker| worker.breaker.would_allow()),
-        "in-band error must not trip the circuit breaker",
+        "SSE error event must not trip the circuit breaker",
     );
 }
 
@@ -1563,23 +1562,7 @@ async fn streaming_clean_completion_records_stream_outcome_ok() {
     );
     let (_, metrics) = stream_chat_and_render(&worker.url, &expected).await;
     assert!(
-        !metrics.contains(r#"outcome="inband_error""#),
-        "clean stream recorded an in-band error; got:\n{metrics}",
+        !metrics.contains(r#"outcome="stream_error_event""#),
+        "clean stream recorded an SSE error event; got:\n{metrics}",
     );
-}
-
-/// N chunks record N-1 inter-chunk gaps; the first chunk is TTFT.
-#[tokio::test]
-async fn streaming_2xx_request_records_itl_per_chunk_gap() {
-    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
-        vec![
-            "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
-            "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
-            "data: [DONE]\n\n",
-        ],
-        Duration::from_millis(20),
-    )
-    .await;
-    let expected = r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#;
-    stream_chat_and_render(&worker.url, expected).await;
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1521,9 +1521,9 @@ async fn stream_chat_and_render(
     }
 }
 
-/// A clean transport carrying an SSE error event records only the stream failure.
+/// A post-200 SSE error event is classified without affecting routing health.
 #[tokio::test]
-async fn streaming_error_event_records_stream_outcome_without_tripping_breaker() {
+async fn streaming_error_event_records_outcome_without_tripping_breaker() {
     let worker = crate::common::mock_worker::MockWorker::start(vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
         "data: {\"error\": {\"message\": \"The request queue is full.\", \"code\": 503}}\n\n",
@@ -1548,9 +1548,8 @@ async fn streaming_error_event_records_stream_outcome_without_tripping_breaker()
     );
 }
 
-/// A clean stream records one successful outcome.
 #[tokio::test]
-async fn streaming_clean_completion_records_stream_outcome_ok() {
+async fn streaming_clean_completion_records_ok() {
     let worker = crate::common::mock_worker::MockWorker::start(vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
         "data: [DONE]\n\n",
@@ -1560,9 +1559,5 @@ async fn streaming_clean_completion_records_stream_outcome_ok() {
         r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="ok"}} 1"#,
         worker.url,
     );
-    let (_, metrics) = stream_chat_and_render(&worker.url, &expected).await;
-    assert!(
-        !metrics.contains(r#"outcome="stream_error_event""#),
-        "clean stream recorded an SSE error event; got:\n{metrics}",
-    );
+    stream_chat_and_render(&worker.url, &expected).await;
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -950,6 +950,8 @@ async fn forward_streaming_to_records_failure_on_mid_stream_drop() {
             body,
             None,
             None,
+            None,
+            None,
         )
         .await;
 
@@ -1475,5 +1477,121 @@ async fn non_streaming_error_path_drops_active_load_guard() {
         active_load.inflight_count(),
         0,
         "error path must drop the active-load guard",
+    );
+}
+
+/// Send one streaming chat request through the real router and return the
+/// rendered metrics once `predicate` matches (or the deadline passes).
+async fn stream_chat_and_render(worker_url: &str, predicate: &str) -> (Arc<AppContext>, String) {
+    let ctx = build_ctx_with_worker(worker_url);
+    let app = build_router(ctx.clone());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "tiny",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": true
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let _ = res.into_body().collect().await.unwrap().to_bytes();
+    // The hooks record from the SSE pump's spawned task — poll briefly.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let m = loop {
+        let m = ctx.metrics.render();
+        if m.contains(predicate) || std::time::Instant::now() > deadline {
+            break m;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+    (ctx, m)
+}
+
+/// An engine that commits 200, streams an in-band `data: {"error"...}` event,
+/// and closes cleanly must be classified `inband_error` — without tripping
+/// the circuit breaker (the transport was healthy).
+#[tokio::test]
+async fn streaming_inband_error_records_stream_outcome_without_tripping_breaker() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+        "data: {\"error\": {\"message\": \"The request queue is full.\", \"code\": 503}}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start(chunks).await;
+    let expected = format!(
+        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="inband_error"}} 1"#,
+        worker.url,
+    );
+    let (ctx, m) = stream_chat_and_render(&worker.url, &expected).await;
+    assert!(
+        m.contains(&expected),
+        "in-band error must be classified at stream end; got:\n{m}",
+    );
+    // Headers-time counters still (correctly) say 200 — the new metric is
+    // the only place the in-band failure is visible.
+    assert!(m.contains(
+        r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="200"} 1"#
+    ));
+    // Transport was clean: the breaker must still admit requests.
+    for w in ctx.registry.all() {
+        assert!(
+            w.breaker.would_allow(),
+            "in-band error must not trip the circuit breaker",
+        );
+    }
+}
+
+/// The `ok` leg of the stream-outcome classification: a clean streaming
+/// completion records exactly one `outcome="ok"` sample and nothing else.
+#[tokio::test]
+async fn streaming_clean_completion_records_stream_outcome_ok() {
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start(chunks).await;
+    let expected = format!(
+        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="ok"}} 1"#,
+        worker.url,
+    );
+    let (_ctx, m) = stream_chat_and_render(&worker.url, &expected).await;
+    assert!(
+        m.contains(&expected),
+        "clean stream must record outcome=ok; got:\n{m}",
+    );
+    assert!(
+        !m.contains(r#"outcome="inband_error""#),
+        "no in-band error on a clean stream; got:\n{m}",
+    );
+}
+
+/// N streamed chunks record exactly N-1 gaps in `sgl_router_itl_seconds`
+/// (the first chunk is TTFT). End-to-end proof the chat handler installs the
+/// ITL hook; the sse unit tests cover the pump primitive.
+#[tokio::test]
+async fn streaming_2xx_request_records_itl_per_chunk_gap() {
+    // Paced chunks: back-to-back writes can coalesce into one TCP segment
+    // and undercount the gaps.
+    let chunks: Vec<&'static str> = vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    ];
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        chunks,
+        Duration::from_millis(20),
+    )
+    .await;
+    let expected = r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#;
+    let (_ctx, m) = stream_chat_and_render(&worker.url, expected).await;
+    assert!(
+        m.contains(expected),
+        "3 upstream chunks must record exactly 2 inter-token gaps; got:\n{m}",
     );
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1320,35 +1320,20 @@ async fn streaming_active_load_drops_on_client_disconnect() {
         Duration::from_millis(100),
     )
     .await;
-    let ctx = build_ctx_with_worker(&worker.url);
+    let (ctx, body) = stream_chat(&worker.url).await;
     let active_load = Arc::clone(&ctx.active_load);
-    let app = build_router(ctx);
-
-    let req = Request::builder()
-        .method("POST")
-        .uri("/v1/chat/completions")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            serde_json::to_vec(&serde_json::json!({
-                "model": "tiny",
-                "messages": [{"role": "user", "content": "hi"}],
-                "stream": true,
-            }))
-            .unwrap(),
-        ))
-        .unwrap();
-    let res = app.oneshot(req).await.unwrap();
 
     // Read one chunk to confirm the stream is live, then drop the body.
     use futures::StreamExt;
-    let mut data_stream = res.into_body().into_data_stream();
+    let mut data_stream = body.into_data_stream();
     let _first = data_stream.next().await;
     drop(data_stream);
 
-    // Wait long enough for the SSE pump to notice the receiver-drop and
-    // exit (per `bytes_stream_to_body_breaks_on_client_disconnect` test
-    // in sse.rs, that takes well under 200 ms).
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    let expected = format!(
+        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="client_disconnect"}} 1"#,
+        worker.url,
+    );
+    wait_for_metric(&ctx, &expected).await;
 
     assert_eq!(
         active_load.inflight_count(),
@@ -1488,6 +1473,13 @@ async fn stream_chat_and_render(
     worker_url: &str,
     expected_metric: &str,
 ) -> (Arc<AppContext>, String) {
+    let (ctx, body) = stream_chat(worker_url).await;
+    body.collect().await.unwrap();
+    let metrics = wait_for_metric(&ctx, expected_metric).await;
+    (ctx, metrics)
+}
+
+async fn stream_chat(worker_url: &str) -> (Arc<AppContext>, Body) {
     let ctx = build_ctx_with_worker(worker_url);
     let app = build_router(ctx.clone());
     let req = Request::builder()
@@ -1505,13 +1497,15 @@ async fn stream_chat_and_render(
         .unwrap();
     let res = app.oneshot(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::OK);
-    let _ = res.into_body().collect().await.unwrap().to_bytes();
+    (ctx, res.into_body())
+}
 
+async fn wait_for_metric(ctx: &AppContext, expected_metric: &str) -> String {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
         let metrics = ctx.metrics.render();
         if has_metric_line(&metrics, expected_metric) {
-            return (ctx, metrics);
+            return metrics;
         }
         assert!(
             std::time::Instant::now() < deadline,
@@ -1560,4 +1554,20 @@ async fn streaming_clean_completion_records_ok() {
         worker.url,
     );
     stream_chat_and_render(&worker.url, &expected).await;
+}
+
+#[tokio::test]
+async fn streaming_error_event_then_transport_failure_records_upstream_error() {
+    let worker = crate::common::mock_worker::MockWorker::start_returning_partial_body(
+        StatusCode::OK,
+        b"data: {\"error\": {\"code\": 503}}\n\n",
+    )
+    .await;
+    let (ctx, body) = stream_chat(&worker.url).await;
+    assert!(body.collect().await.is_err());
+    let expected = format!(
+        r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="upstream_error"}} 1"#,
+        worker.url,
+    );
+    wait_for_metric(&ctx, &expected).await;
 }

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -1480,9 +1480,15 @@ async fn non_streaming_error_path_drops_active_load_guard() {
     );
 }
 
-/// Send one streaming chat request through the real router and return the
-/// rendered metrics once `predicate` matches (or the deadline passes).
-async fn stream_chat_and_render(worker_url: &str, predicate: &str) -> (Arc<AppContext>, String) {
+fn has_metric_line(metrics: &str, expected: &str) -> bool {
+    metrics.lines().any(|line| line == expected)
+}
+
+/// Send a streaming request and wait for the expected metric.
+async fn stream_chat_and_render(
+    worker_url: &str,
+    expected_metric: &str,
+) -> (Arc<AppContext>, String) {
     let ctx = build_ctx_with_worker(worker_url);
     let app = build_router(ctx.clone());
     let req = Request::builder()
@@ -1490,108 +1496,90 @@ async fn stream_chat_and_render(worker_url: &str, predicate: &str) -> (Arc<AppCo
         .uri("/v1/chat/completions")
         .header("content-type", "application/json")
         .body(Body::from(
-            serde_json::to_vec(&serde_json::json!({
+            serde_json::json!({
                 "model": "tiny",
                 "messages": [{"role": "user", "content": "hi"}],
                 "stream": true
-            }))
-            .unwrap(),
+            })
+            .to_string(),
         ))
         .unwrap();
     let res = app.oneshot(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::OK);
     let _ = res.into_body().collect().await.unwrap().to_bytes();
-    // The hooks record from the SSE pump's spawned task — poll briefly.
+
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    let m = loop {
-        let m = ctx.metrics.render();
-        if m.contains(predicate) || std::time::Instant::now() > deadline {
-            break m;
+    loop {
+        let metrics = ctx.metrics.render();
+        if has_metric_line(&metrics, expected_metric) {
+            return (ctx, metrics);
         }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for `{expected_metric}`; got:\n{metrics}"
+        );
         tokio::time::sleep(Duration::from_millis(10)).await;
-    };
-    (ctx, m)
+    }
 }
 
-/// An engine that commits 200, streams an in-band `data: {"error"...}` event,
-/// and closes cleanly must be classified `inband_error` — without tripping
-/// the circuit breaker (the transport was healthy).
+/// A clean transport carrying an in-band error records only the stream failure.
 #[tokio::test]
 async fn streaming_inband_error_records_stream_outcome_without_tripping_breaker() {
-    let chunks: Vec<&'static str> = vec![
+    let worker = crate::common::mock_worker::MockWorker::start(vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
         "data: {\"error\": {\"message\": \"The request queue is full.\", \"code\": 503}}\n\n",
         "data: [DONE]\n\n",
-    ];
-    let worker = crate::common::mock_worker::MockWorker::start(chunks).await;
+    ])
+    .await;
     let expected = format!(
         r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="inband_error"}} 1"#,
         worker.url,
     );
-    let (ctx, m) = stream_chat_and_render(&worker.url, &expected).await;
-    assert!(
-        m.contains(&expected),
-        "in-band error must be classified at stream end; got:\n{m}",
-    );
-    // Headers-time counters still (correctly) say 200 — the new metric is
-    // the only place the in-band failure is visible.
-    assert!(m.contains(
+    let (ctx, metrics) = stream_chat_and_render(&worker.url, &expected).await;
+    assert!(has_metric_line(
+        &metrics,
         r#"sgl_router_responses_total{route="/v1/chat/completions",method="POST",status_code="200"} 1"#
     ));
-    // Transport was clean: the breaker must still admit requests.
-    for w in ctx.registry.all() {
-        assert!(
-            w.breaker.would_allow(),
-            "in-band error must not trip the circuit breaker",
-        );
-    }
+    assert!(
+        ctx.registry
+            .all()
+            .iter()
+            .all(|worker| worker.breaker.would_allow()),
+        "in-band error must not trip the circuit breaker",
+    );
 }
 
-/// The `ok` leg of the stream-outcome classification: a clean streaming
-/// completion records exactly one `outcome="ok"` sample and nothing else.
+/// A clean stream records one successful outcome.
 #[tokio::test]
 async fn streaming_clean_completion_records_stream_outcome_ok() {
-    let chunks: Vec<&'static str> = vec![
+    let worker = crate::common::mock_worker::MockWorker::start(vec![
         "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
         "data: [DONE]\n\n",
-    ];
-    let worker = crate::common::mock_worker::MockWorker::start(chunks).await;
+    ])
+    .await;
     let expected = format!(
         r#"sgl_router_stream_outcome_total{{worker_url="{}",model_id="tiny",outcome="ok"}} 1"#,
         worker.url,
     );
-    let (_ctx, m) = stream_chat_and_render(&worker.url, &expected).await;
+    let (_, metrics) = stream_chat_and_render(&worker.url, &expected).await;
     assert!(
-        m.contains(&expected),
-        "clean stream must record outcome=ok; got:\n{m}",
-    );
-    assert!(
-        !m.contains(r#"outcome="inband_error""#),
-        "no in-band error on a clean stream; got:\n{m}",
+        !metrics.contains(r#"outcome="inband_error""#),
+        "clean stream recorded an in-band error; got:\n{metrics}",
     );
 }
 
-/// N streamed chunks record exactly N-1 gaps in `sgl_router_itl_seconds`
-/// (the first chunk is TTFT). End-to-end proof the chat handler installs the
-/// ITL hook; the sse unit tests cover the pump primitive.
+/// N chunks record N-1 inter-chunk gaps; the first chunk is TTFT.
 #[tokio::test]
 async fn streaming_2xx_request_records_itl_per_chunk_gap() {
-    // Paced chunks: back-to-back writes can coalesce into one TCP segment
-    // and undercount the gaps.
-    let chunks: Vec<&'static str> = vec![
-        "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
-        "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
-        "data: [DONE]\n\n",
-    ];
     let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
-        chunks,
+        vec![
+            "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n",
+            "data: [DONE]\n\n",
+        ],
         Duration::from_millis(20),
     )
     .await;
     let expected = r#"sgl_router_itl_seconds_count{model_id="tiny"} 2"#;
-    let (_ctx, m) = stream_chat_and_render(&worker.url, expected).await;
-    assert!(
-        m.contains(expected),
-        "3 upstream chunks must record exactly 2 inter-token gaps; got:\n{m}",
-    );
+    stream_chat_and_render(&worker.url, expected).await;
 }


### PR DESCRIPTION
## Summary

- Add `sgl_router_stream_outcome_total{worker_url, model_id, outcome}` classifying every committed 2xx SSE stream as `ok`, `stream_error_event`, `upstream_error`, or `client_disconnect`. Non-2xx responses remain covered by `responses_total`; scope is documented in `monitoring/README.md`.
- Detect in-band engine error events line-anchored per the SSE spec: a `data:` line whose payload's first JSON key is `error`. This tolerates framing variants (`data:` with no space, whitespace after `{`) and cannot match lookalike text inside event payloads. The scanner is a single pass per chunk with a bounded line buffer.
- Keep the metric consistent with the circuit breaker: a transport failure outranks an in-band error event when labeling, and only transport failures affect the breaker. Routing behavior is unchanged.

## Testing

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (557 passed) and `cargo test --test proxy` (88 passed), including new tests for SSE framing variants, scanner buffer bounds, and error-event-then-transport-failure classification.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34547251154](https://github.com/sgl-project/sglang/actions/runs/34547251154)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34547250800](https://github.com/sgl-project/sglang/actions/runs/34547250800)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
