### PR TITLE
Fix MLX shutdown test mock after request-ingestion refactor

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
+++ b/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
@@ -260,7 +260,7 @@ class TestOverlapLoopGracefulExit(unittest.TestCase):
     never get their user-space release.
     """
 
-    def _make_scheduler(self, *, recv_side_effect):
+    def _make_scheduler(self):
         from collections import deque
 
         scheduler = MagicMock()
@@ -269,13 +269,14 @@ class TestOverlapLoopGracefulExit(unittest.TestCase):
         scheduler._engine_paused = False
         scheduler.waiting_queue = []
         scheduler.result_queue = deque()
-        scheduler.ingest_requests.side_effect = recv_side_effect
-        # Model handle_shutdown: processing a non-empty recv batch (the
-        # ShutdownReq) flips the flag; the loop must notice at the top of the
-        # next iteration instead of polling forever.
-        scheduler.process_input_requests.side_effect = lambda reqs: (
-            setattr(scheduler, "gracefully_exit", True) if reqs else None
-        )
+
+        # ingest_requests now receives and processes ShutdownReq in one call.
+        def ingest_shutdown():
+            if scheduler.gracefully_exit:
+                raise _StopLoop()
+            scheduler.gracefully_exit = True
+
+        scheduler.ingest_requests.side_effect = ingest_shutdown
         plan = MagicMock()
         plan.batch_to_run = None
         scheduler.get_next_batch_to_run.return_value = plan
@@ -286,10 +287,9 @@ class TestOverlapLoopGracefulExit(unittest.TestCase):
             SchedulerMlxOverlapMixin,
         )
 
-        # Iteration 1: recv the ShutdownReq stand-in (flag flips inside
-        # process_input_requests).  Iteration 2 must break before polling
-        # again; the sentinel raising instead means the loop never exits.
-        scheduler = self._make_scheduler(recv_side_effect=[[MagicMock()], _StopLoop()])
+        # Ingest shutdown once. A second poll raises instead of hanging if
+        # the loop fails to exit.
+        scheduler = self._make_scheduler()
 
         with patch(
             "sglang.srt.hardware_backend.mlx.scheduler_mixin.mx.synchronize"
@@ -309,7 +309,7 @@ class TestOverlapLoopGracefulExit(unittest.TestCase):
         # the body.  The flag check must sit above the paused-continue, like in
         # event_loop_normal/event_loop_overlap, or shutdown during a pause
         # spins forever.
-        scheduler = self._make_scheduler(recv_side_effect=[[MagicMock()], _StopLoop()])
+        scheduler = self._make_scheduler()
         scheduler._engine_paused = True
 
         with patch(


### PR DESCRIPTION
## Summary
The MLX graceful-shutdown tests still mock request ingestion as receive-only, but `ingest_requests()` now receives and processes shutdown requests together. The stale mock leaves `gracefully_exit` false and raises `_StopLoop` on the next iteration.

Update the mock to deliver shutdown through `ingest_requests()` and raise if the scheduler polls again. Both normal and paused shutdown cases now exercise the actual ingestion contract. This separates the unrelated test repair from #36631; production code is unchanged.

## Validation
On Apple Silicon, using current main `a84ffd1326`:
- Before: 2 shutdown tests failed, 5 other tests passed.
- After: all 7 tests in `test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py` passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829740978](https://github.com/sgl-project/sglang/actions/runs/34829740978)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829740001](https://github.com/sgl-project/sglang/actions/runs/34829740001)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829740663](https://github.com/sgl-project/sglang/actions/runs/34829740663)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->