### PR TITLE
[Hardening] Log why the fused all-reduce + RMSNorm path falls back instead of discarding it

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -236,6 +236,28 @@ def reg_all_to_all_single(
     group._all_to_all_single(output, input)
 
 
+#: The fused all-reduce + RMSNorm paths fall back when the communicator cannot express an
+#: operand's layout, and the exception they catch is the diagnostic: it names which operand
+#: and which layout. Discarding it makes a run that is permanently on the unfused path
+#: indistinguishable from one where the fusion was never requested, so someone measuring
+#: the fusion's benefit can measure zero and conclude it does not help. Warned once per
+#: process, because these sit on the per-layer forward path.
+_fused_ar_rms_fallback_warned = False
+
+
+def _warn_fused_ar_rms_fallback(api: str, err: Exception) -> None:
+    global _fused_ar_rms_fallback_warned
+    if _fused_ar_rms_fallback_warned:
+        return
+    logger.warning(
+        "Fused all-reduce + RMSNorm via %s is unavailable (%s); falling back. "
+        "Reported once per process.",
+        api,
+        err,
+    )
+    _fused_ar_rms_fallback_warned = True
+
+
 class GroupCoordinator:
     """
     PyTorch ProcessGroup wrapper for a group of processes.
@@ -791,9 +813,9 @@ class GroupCoordinator:
                 return ca_comm.fused_allreduce_rmsnorm(
                     input_, residual_inp_, weight_, eps
                 )
-            except Exception:
-                # Fall back to custom_fused_ar_rms path below.
-                pass
+            except Exception as e:
+                # Fall back to custom_fused_ar_rms path below, saying why.
+                _warn_fused_ar_rms_fallback("fused_allreduce_rmsnorm", e)
 
         if not hasattr(ca_comm, "custom_fused_ar_rms"):
             return None
@@ -908,7 +930,8 @@ class GroupCoordinator:
                 emit_bf16=emit_bf16,
                 transpose_scale=transpose_scale,
             )
-        except Exception:
+        except Exception as e:
+            _warn_fused_ar_rms_fallback("custom_fused_ar_rms_per_group_quant", e)
             return None
 
     def _resolve_outplace_all_reduce_method(


### PR DESCRIPTION
Two handlers on the fused all-reduce path catch `Exception` and drop it, so a permanent
fallback to a slower path — or a silent `None` — is indistinguishable from the fast path
having been chosen. `python/sglang/srt/distributed/parallel_state.py`:

```python
if hasattr(ca_comm, "fused_allreduce_rmsnorm"):
    try:
        return ca_comm.fused_allreduce_rmsnorm(input_, residual_inp_, weight_, eps)
    except Exception:
        # Fall back to custom_fused_ar_rms path below.
        pass
```

and, a few hundred lines later:

```python
try:
    return ca_comm.custom_fused_ar_rms_per_group_quant(...)
except Exception:
    return None
```

Why this matters in practice: the communicator behind these calls validates operand
layout and raises when it cannot express one. That exception is the diagnostic — it names
which operand and which layout — and both handlers throw it away. The result is a run
that is quietly on the unfused path for every layer of every forward, with nothing in the
log to say so and no way to tell it apart from a configuration where the fusion was never
requested. Someone measuring the fusion's benefit can then measure zero and conclude the
fusion does not help, when in fact it never ran.

The change keeps the fallback behaviour exactly as it is — this is not a behaviour change
and not a bid to make these paths fatal — and only stops the reason being lost: warned once
per process with the exception attached, so a fallback is visible in the log while
remaining a fallback.

It follows the pattern already in the tree for this exact situation rather than adding a
helper: a module-level `_..._warned` flag with a small `_warn_*` function, as
`layers/attention/minimax_sparse_ops/minimax_sparse.py` does for its own backend fallback.

Two notes for reviewers:

- Warning once per process rather than per call is deliberate: these sit on the per-layer
  forward path and a per-call log would be unusable.
- Narrowing `except Exception` to the specific exception types worth falling back on would
  be better still, but that needs a decision about which are expected; the log is the part
  that is safe to do now, and it makes the narrowing decidable later from real logs.

## Test plan, and what has not been exercised

Both handlers are reached only when a ROCm custom all-reduce communicator is present *and*
raises, so there is no unit test that meaningfully covers them and no existing test that
this change can be shown to affect.

What has been checked: the module parses, the diff is confined to the two handlers plus the
warn helper, and the fallback control flow is byte-for-byte the same paths as before — the
first still falls through to `custom_fused_ar_rms`, the second still returns `None`.

**What has not:** the warning has not been triggered on hardware. Doing so needs a
communicator that rejects an operand layout, which our own runs do not produce while the
fusion is working, and provoking one would test the harness rather than this change. If
maintainers would like it exercised on MI355X before merge, say so and we will construct
the rejecting case and report both branches.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34409002650](https://github.com/sgl-project/sglang/actions/runs/34409002650)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34409002260](https://github.com/sgl-project/sglang/actions/runs/34409002260)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34409002528](https://github.com/sgl-project/sglang/actions/runs/34409002528)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->