### PR TITLE
feat(sgl-router): complete the DeepSeek-V4 chat encoder and forward input_ids for dsv4 traffic

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -37,7 +37,7 @@ sgl-kv-indexer = { path = "sgl-kv-indexer" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
 
 # Tokenizer auto-download from HuggingFace when --tokenizer-path is omitted.
 # Sync (`ureq`) API only — it runs once at startup; `ureq` is on rustls, so

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -58,9 +58,7 @@ pub fn request_tokens_for(
         && value.get("messages").is_some_and(|m| m.is_array())
     {
         // The full request goes down so the encoder can render `tools` and
-        // resolve thinking-mode / task / continue_final_message the way the
-        // engine does (see `dsv4::render_request`) — otherwise such traffic
-        // routes on a tokenization that never matches the engine's blocks.
+        // resolve thinking / task / continue_final_message the engine's way.
         if let Some(ids) = tokenizers.encode_chat(&model_id.0, value) {
             return Some(RequestTokens {
                 ids,

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -35,6 +35,9 @@ pub struct RequestTokens {
     pub ids: Vec<u32>,
     /// Whether the token ids are safe to forward as engine `input_ids`.
     pub engine_equivalent: bool,
+    /// Which forwarding predicate may gate these ids — stamped from the
+    /// encoder that produced them, so the provenance travels with the tokens.
+    pub parity: crate::tokenizer::ForwardParity,
 }
 
 /// External indexer answer prepared by the async ingress path for the
@@ -51,14 +54,19 @@ pub fn request_tokens_for(
     model_id: &ModelId,
     value: &serde_json::Value,
 ) -> Option<RequestTokens> {
-    if tokenizers.has_chat_encoder(&model_id.0) {
-        if let Some(messages) = value.get("messages").filter(|m| m.is_array()) {
-            if let Some(ids) = tokenizers.encode_chat(&model_id.0, messages) {
-                return Some(RequestTokens {
-                    ids,
-                    engine_equivalent: true,
-                });
-            }
+    if tokenizers.has_chat_encoder(&model_id.0)
+        && value.get("messages").is_some_and(|m| m.is_array())
+    {
+        // The full request goes down so the encoder can render `tools` and
+        // resolve thinking-mode / task / continue_final_message the way the
+        // engine does (see `dsv4::render_request`) — otherwise such traffic
+        // routes on a tokenization that never matches the engine's blocks.
+        if let Some(ids) = tokenizers.encode_chat(&model_id.0, value) {
+            return Some(RequestTokens {
+                ids,
+                engine_equivalent: true,
+                parity: tokenizers.forward_parity(&model_id.0),
+            });
         }
     }
     let text = extract_prompt_text_from_value(value)?;
@@ -66,6 +74,8 @@ pub fn request_tokens_for(
     Some(RequestTokens {
         ids,
         engine_equivalent: false,
+        // Raw fallback ids are never forwarded; the marker is inert.
+        parity: crate::tokenizer::ForwardParity::Conservative,
     })
 }
 

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -771,31 +771,30 @@ pub async fn chat_completions(
 
     // Forward the router-computed tokens to the engine as `input_ids` so it
     // skips re-tokenizing the same prompt — but only when they are
-    // engine-equivalent (chat-encoder path) AND the request contains nothing
-    // the router's encoder didn't replicate (see `input_ids_safe_to_forward`).
-    // Otherwise omit them and the engine tokenizes from `messages` as usual —
-    // a transparent, always-correct fallback (`messages` are always retained
-    // in the forwarded body). `forward_input_ids` is `Some` only when
-    // `request_value` is `Some` (a model the ingress tokenized for), so the
-    // predicate always has a parsed body to inspect.
-    let forward_input_ids: Option<&[u32]> = match (request_tokens.as_ref(), request_value.as_ref())
-    {
-        (Some(t), Some(v)) if t.engine_equivalent && input_ids_safe_to_forward(v) => {
-            Some(t.ids.as_slice())
-        }
-        _ => None,
-    };
+    // engine-equivalent (chat-encoder path) AND the request passes the
+    // predicate matching the encoder's stamped parity (see
+    // `select_forward_input_ids`). Otherwise omit them and the engine
+    // tokenizes from `messages` as usual — a transparent, always-correct
+    // fallback (`messages` are always retained in the forwarded body).
+    let forward_input_ids: Option<&[u32]> = select_forward_input_ids(
+        input_ids_offload_enabled(),
+        request_tokens.as_ref(),
+        request_value.as_ref(),
+    );
 
     // Surface a broken offload: when the encoder SHOULD have produced
     // engine-equivalent ids but didn't, the chat request silently fell back to
     // engine-side tokenization. Count only that case (see
     // `ingress_tokenize_offload_failed`); successful forwards and expected
-    // omissions are not problems.
+    // omissions are not problems. A render error from an encoder that MIRRORS
+    // the engine is a CLIENT error the engine rejects identically — never
+    // broken-offload signal (see `dsv4_render_rejects_request`).
     if ingress_tokenize_offload_failed(
         ctx.tokenizers.has_chat_encoder(&model_str),
         request_value.as_ref(),
         request_tokens.as_ref(),
-    ) {
+    ) && !dsv4_render_rejects_request(&ctx.tokenizers, &model_str, request_value.as_ref())
+    {
         ctx.metrics.record_ingress_tokenize_error(&metrics_model);
     }
 
@@ -1284,7 +1283,172 @@ fn build_outgoing_body(
     Ok(Bytes::from(bytes))
 }
 
-/// Whether the router's `input_ids` may be forwarded for this request.
+/// Whether the ingress tokenize offload is enabled — the
+/// `SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD` kill switch, read once. When
+/// disabled the router never injects `input_ids` into the forwarded body, so
+/// the engine always tokenizes from `messages` itself; ingress tokenization
+/// still runs for routing.
+fn input_ids_offload_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        let disabled = std::env::var("SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD")
+            .is_ok_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"));
+        if disabled {
+            tracing::info!(
+                "SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD set; ingress-computed input_ids \
+                 are never forwarded to engines (routing still uses them)"
+            );
+        }
+        !disabled
+    })
+}
+
+/// Select the ids to forward to the engine as `input_ids`, if any.
+///
+/// `Some` only when ALL of: the offload kill switch is off; the ids exist and
+/// are engine-equivalent (chat-encoder path); and the predicate matching the
+/// stamped [`crate::tokenizer::ForwardParity`] of the encoder that PRODUCED
+/// the ids holds — [`input_ids_safe_to_forward_dsv4`] for the built-in dsv4
+/// encoder, the conservative [`input_ids_safe_to_forward`] for everything
+/// else. The stamp travels with the tokens, so ids can never be gated by the
+/// wrong encoder's predicate.
+fn select_forward_input_ids<'a>(
+    offload_enabled: bool,
+    request_tokens: Option<&'a RequestTokens>,
+    request_value: Option<&serde_json::Value>,
+) -> Option<&'a [u32]> {
+    match (offload_enabled, request_tokens, request_value) {
+        (true, Some(t), Some(v)) if t.engine_equivalent => match t.parity {
+            crate::tokenizer::ForwardParity::Dsv4Full if input_ids_safe_to_forward_dsv4(v) => {
+                Some(t.ids.as_slice())
+            }
+            crate::tokenizer::ForwardParity::Conservative if input_ids_safe_to_forward(v) => {
+                Some(t.ids.as_slice())
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// The dsv4-encoder forwarding predicate. The built-in encoder mirrors the
+/// engine's FULL dsv4 request handling — tools and tool results, per-request
+/// thinking / reasoning-effort resolution, `task` attachment, and the
+/// trailing-assistant surgery behind `continue_final_message` (see
+/// `dsv4::render_request`) — so those are all forwardable. Withheld is exactly
+/// what the encoder cannot mirror faithfully:
+///
+///   * content parts that are not `type: "text"` — the surrounding mm-item
+///     plumbing on the engine side is unverified;
+///   * message-level `tools` — a declared protocol field the engine renders
+///     after that message's content (and it flips `drop_thinking` off);
+///   * any role outside the engine's dsv4 render set — `latest_reminder`
+///     renders a marker the encoder does not emit, and unknown roles are
+///     engine errors forwarding would convert into served prompts;
+///   * a `continue_final_message` value that isn't pydantic-coercible — the
+///     engine 422s; the router must not guess false;
+///   * a history tool call whose `arguments` is not a JSON object — the
+///     engine raises before a prompt exists.
+///
+/// NOTE (deploy): the router's `SGLANG_ROUTER_DSV4_*` env defaults must match
+/// the engine's `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` /
+/// checkpoint-resolved effort profile — a plain request carries no field the
+/// predicate could key a mismatch on, so wrong-mode ids would forward
+/// undetectably.
+fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
+    if let Some(v) = value.get("continue_final_message").filter(|v| !v.is_null()) {
+        if crate::tokenizer::openai_bool(v).is_none() {
+            return false;
+        }
+    }
+    let Some(msgs) = value.get("messages").and_then(|m| m.as_array()) else {
+        return true;
+    };
+    for m in msgs {
+        // Only message-level `tools` is a DECLARED protocol field; other
+        // extras are stripped by pydantic's `extra="ignore"` before the
+        // engine's encoder ever sees them.
+        if m.get("tools").is_some_and(|v| !v.is_null()) {
+            return false;
+        }
+        // The engine's dsv4 render set, compared case-insensitively to match
+        // `render_request`'s lowercasing.
+        let role_ok = m
+            .get("role")
+            .and_then(|r| r.as_str())
+            .map(|r| r.to_ascii_lowercase())
+            .is_none_or(|r| {
+                matches!(
+                    r.as_str(),
+                    "system" | "user" | "developer" | "assistant" | "tool"
+                )
+            });
+        if !role_ok {
+            return false;
+        }
+        if let Some(parts) = m.get("content").and_then(|c| c.as_array()) {
+            let has_non_text_part = parts
+                .iter()
+                .any(|p| p.get("type").and_then(|t| t.as_str()) != Some("text"));
+            if has_non_text_part {
+                return false;
+            }
+        }
+        // History tool calls: the engine requires `arguments` to BE a JSON
+        // object — inlined, or a string it can `json.loads` into one.
+        if let Some(calls) = m.get("tool_calls").and_then(|t| t.as_array()) {
+            let all_object_args = calls.iter().all(|c| {
+                match c.get("function").and_then(|f| f.get("arguments")) {
+                    Some(serde_json::Value::String(s)) => {
+                        serde_json::from_str::<serde_json::Value>(s).is_ok_and(|v| v.is_object())
+                    }
+                    Some(serde_json::Value::Object(_)) => true,
+                    // Absent / null / scalar validates, then fails the
+                    // engine's object check.
+                    _ => false,
+                }
+            });
+            if !all_object_args {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// True when the model's dsv4 encoder REFUSES the request — the cases
+/// `dsv4::render_request` errors on (invalid task, task without a
+/// user/developer message). The engine rejects such requests identically, so
+/// the ingress-encode fallback is the engine's own rejection, not offload
+/// breakage, and must not count in `sgl_router_ingress_tokenize_errors_total`
+/// (a client-controllable counter would hide real encoder regressions). Only
+/// invoked on the failure path, where the re-render cost is irrelevant.
+fn dsv4_render_rejects_request(
+    tokenizers: &crate::tokenizer::TokenizerRegistry,
+    model_id: &str,
+    value: Option<&serde_json::Value>,
+) -> bool {
+    if tokenizers.forward_parity(model_id) != crate::tokenizer::ForwardParity::Dsv4Full {
+        return false;
+    }
+    let Some(v) = value else { return false };
+    let Some(messages) = v.get("messages").filter(|m| m.is_array()) else {
+        return false;
+    };
+    crate::tokenizer::dsv4::render_request(
+        messages,
+        v.get("tools"),
+        crate::tokenizer::dsv4::resolve_render_opts(v),
+        crate::tokenizer::dsv4::RequestParts::resolve(v),
+    )
+    .is_err()
+}
+
+/// Whether the router's `input_ids` may be forwarded for this request — the
+/// predicate for NON-dsv4 chat encoders (today: the generic Jinja path). The
+/// dsv4 encoder has its own, far less conservative predicate
+/// [`input_ids_safe_to_forward_dsv4`]; selection happens in
+/// [`select_forward_input_ids`] via the ids' stamped parity.
 ///
 /// We forward only when the engine, fed `input_ids`, would have produced the
 /// SAME prompt the router tokenized. When `input_ids` is present the engine
@@ -1769,6 +1933,7 @@ mod tests {
         let tokens = RequestTokens {
             ids: vec![1, 2, 3],
             engine_equivalent: true,
+            parity: crate::tokenizer::ForwardParity::Conservative,
         };
         assert!(!ingress_tokenize_offload_failed(
             true,
@@ -1795,6 +1960,7 @@ mod tests {
         let tokens = RequestTokens {
             ids: vec![1, 2, 3],
             engine_equivalent: false,
+            parity: crate::tokenizer::ForwardParity::Conservative,
         };
         assert!(ingress_tokenize_offload_failed(
             true,
@@ -1818,6 +1984,176 @@ mod tests {
     fn offload_failed_false_for_non_messages_request() {
         let value = serde_json::json!({"prompt":"hi"});
         assert!(!ingress_tokenize_offload_failed(true, Some(&value), None));
+    }
+
+    /// The central kill switch: with the offload disabled, engine-equivalent
+    /// ids for a perfectly forwardable plain-text chat are still withheld, so
+    /// the engine always re-tokenizes from `messages`.
+    #[test]
+    fn select_forward_input_ids_disabled_gate_withholds_ids() {
+        let value = serde_json::json!({"messages":[{"role":"user","content":"hi"}]});
+        let tokens = RequestTokens {
+            ids: vec![1, 2, 3],
+            engine_equivalent: true,
+            parity: crate::tokenizer::ForwardParity::Conservative,
+        };
+        assert_eq!(
+            select_forward_input_ids(false, Some(&tokens), Some(&value)),
+            None
+        );
+        assert_eq!(
+            select_forward_input_ids(true, Some(&tokens), Some(&value)),
+            Some(&[1, 2, 3][..])
+        );
+    }
+
+    /// Non-engine-equivalent ids (the raw-prompt path) are withheld even with
+    /// the offload enabled and a plain body — the `engine_equivalent`
+    /// conjunct, so this gate can never forward ids the engine wouldn't have
+    /// produced itself.
+    #[test]
+    fn select_forward_input_ids_withholds_non_engine_equivalent_ids() {
+        let value = serde_json::json!({"messages":[{"role":"user","content":"hi"}]});
+        let tokens = RequestTokens {
+            ids: vec![1, 2, 3],
+            engine_equivalent: false,
+            parity: crate::tokenizer::ForwardParity::Conservative,
+        };
+        assert_eq!(
+            select_forward_input_ids(true, Some(&tokens), Some(&value)),
+            None
+        );
+    }
+
+    /// The stamped parity dispatches the predicate: the SAME tool-bearing
+    /// body is withheld for Conservative-stamped ids (Jinja renders no tool
+    /// schemas) but forwarded for Dsv4Full-stamped ids (the dsv4 encoder
+    /// mirrors tool rendering).
+    #[test]
+    fn select_forward_input_ids_dispatches_predicate_by_stamped_parity() {
+        let value = serde_json::json!({
+            "messages":[{"role":"user","content":"hi"}],
+            "tools":[{"type":"function","function":{"name":"f"}}]
+        });
+        let conservative = RequestTokens {
+            ids: vec![1, 2, 3],
+            engine_equivalent: true,
+            parity: crate::tokenizer::ForwardParity::Conservative,
+        };
+        assert_eq!(
+            select_forward_input_ids(true, Some(&conservative), Some(&value)),
+            None
+        );
+        let dsv4 = RequestTokens {
+            ids: vec![1, 2, 3],
+            engine_equivalent: true,
+            parity: crate::tokenizer::ForwardParity::Dsv4Full,
+        };
+        assert_eq!(
+            select_forward_input_ids(true, Some(&dsv4), Some(&value)),
+            Some(&[1, 2, 3][..])
+        );
+    }
+
+    /// The dsv4 predicate allows exactly the classes the dsv4 encoder mirrors
+    /// (or the engine ignores) — tools, thinking overrides, reasoning_effort,
+    /// task, trailing-assistant/continue-final-message — so a regression back
+    /// toward the conservative set would silently inert the offload for them.
+    #[test]
+    fn input_ids_safe_to_forward_dsv4_allows_mirrored_classes() {
+        for body in [
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "tools":[{"type":"function","function":{"name":"f"}}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "functions":[{"name":"f"}]}),
+            // BOTH `arguments` spellings the engine accepts and renders
+            // identically (JSON string, and the inlined object) forward.
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f","arguments":"{\"a\": 1}"}}]}]}),
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f","arguments":{"a":1}}}]}]}),
+            // The `reasoning` object (mirrored by `normalize_reasoning_inputs`)
+            // and the undeclared message keys pydantic strips.
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "reasoning":{"effort":"high"}}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "reasoning":{"enabled":true,"effort":"max"}}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi","wo_eos":true}]}),
+            serde_json::json!({"messages":[{"role":"system","content":"s",
+                               "response_format":{"type":"json_object"}}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "tools":[{"type":"function","defer_loading":true,
+                                         "function":{"name":"f"}}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "chat_template_kwargs":{"thinking":true}}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "reasoning_effort":"high"}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],"task":"query"}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"},
+                                           {"role":"assistant","content":"partial"}],
+                               "continue_final_message":true}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"},
+                                           {"role":"assistant","content":"partial"}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "chat_template":"custom"}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                               "continue_final_message":"true"}), // pydantic-coercible
+            // Numeric content and a case-varied `user` are 422s at the protocol
+            // boundary; the predicate need not withhold what can never reach
+            // the engine.
+            serde_json::json!({"messages":[{"role":"user","content":42}]}),
+            serde_json::json!({"messages":[{"role":"User","content":"hi"}]}),
+        ] {
+            assert!(
+                input_ids_safe_to_forward_dsv4(&body),
+                "dsv4 predicate must allow: {body}"
+            );
+        }
+    }
+
+    /// …and blocks exactly what the encoder cannot mirror: non-text content
+    /// parts, message-level `tools`, unmirrored roles, engine-rejected
+    /// tool-call `arguments`, and an uncoercible `continue_final_message`.
+    #[test]
+    fn input_ids_safe_to_forward_dsv4_blocks_unmirrored_classes() {
+        for body in [
+            serde_json::json!({"messages":[{"role":"user",
+                 "content":[{"type":"image_url","image_url":"x"}]}]}),
+            serde_json::json!({"messages":[{"role":"user",
+                 "content":[{"text":"no type key"}]}]}),
+            // `arguments` shapes the engine rejects before a prompt exists:
+            // unparsable, parsing to a non-object, a scalar, and absent.
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f","arguments":"not json"}}]}]}),
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f","arguments":"[1, 2]"}}]}]}),
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f","arguments":5}}]}]}),
+            serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
+                 {"function":{"name":"f"}}]}]}),
+            serde_json::json!({"messages":[{"role":"system","content":"hi",
+                 "tools":[{"type":"function","function":{"name":"f"}}]}]}),
+            serde_json::json!({"messages":[{"role":"latest_reminder","content":"hi"}]}),
+            serde_json::json!({"messages":[{"role":"function","content":"hi"}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                 "continue_final_message":"maybe"}),
+        ] {
+            assert!(
+                !input_ids_safe_to_forward_dsv4(&body),
+                "dsv4 predicate must block: {body}"
+            );
+        }
+        // null/absent forms are tolerated (treated as not-present).
+        for body in [
+            serde_json::json!({"messages":[{"role":"user","content":"hi","wo_eos":null}]}),
+            serde_json::json!({"messages":[{"role":"user","content":"hi"}],
+                 "continue_final_message":null}),
+        ] {
+            assert!(
+                input_ids_safe_to_forward_dsv4(&body),
+                "null forms must not block: {body}"
+            );
+        }
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -769,26 +769,18 @@ pub async fn chat_completions(
         start,
     };
 
-    // Forward the router-computed tokens to the engine as `input_ids` so it
-    // skips re-tokenizing the same prompt — but only when they are
-    // engine-equivalent (chat-encoder path) AND the request passes the
-    // predicate matching the encoder's stamped parity (see
-    // `select_forward_input_ids`). Otherwise omit them and the engine
-    // tokenizes from `messages` as usual — a transparent, always-correct
-    // fallback (`messages` are always retained in the forwarded body).
+    // Forward the router-computed tokens as `input_ids` so the engine skips
+    // re-tokenizing — gated by `select_forward_input_ids`. Otherwise the
+    // engine tokenizes from `messages` as usual (always retained in the body).
     let forward_input_ids: Option<&[u32]> = select_forward_input_ids(
         input_ids_offload_enabled(),
         request_tokens.as_ref(),
         request_value.as_ref(),
     );
 
-    // Surface a broken offload: when the encoder SHOULD have produced
-    // engine-equivalent ids but didn't, the chat request silently fell back to
-    // engine-side tokenization. Count only that case (see
-    // `ingress_tokenize_offload_failed`); successful forwards and expected
-    // omissions are not problems. A render error from an encoder that MIRRORS
-    // the engine is a CLIENT error the engine rejects identically — never
-    // broken-offload signal (see `dsv4_render_rejects_request`).
+    // Surface a broken offload: the encoder SHOULD have produced
+    // engine-equivalent ids but didn't. A dsv4 render error is a CLIENT error
+    // the engine rejects identically — never broken-offload signal.
     if ingress_tokenize_offload_failed(
         ctx.tokenizers.has_chat_encoder(&model_str),
         request_value.as_ref(),
@@ -1283,11 +1275,9 @@ fn build_outgoing_body(
     Ok(Bytes::from(bytes))
 }
 
-/// Whether the ingress tokenize offload is enabled — the
-/// `SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD` kill switch, read once. When
-/// disabled the router never injects `input_ids` into the forwarded body, so
-/// the engine always tokenizes from `messages` itself; ingress tokenization
-/// still runs for routing.
+/// The `SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD` kill switch, read once: when
+/// set, `input_ids` are never injected and engines re-tokenize from
+/// `messages`; ingress tokenization still runs for routing.
 fn input_ids_offload_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
@@ -1303,15 +1293,10 @@ fn input_ids_offload_enabled() -> bool {
     })
 }
 
-/// Select the ids to forward to the engine as `input_ids`, if any.
-///
-/// `Some` only when ALL of: the offload kill switch is off; the ids exist and
-/// are engine-equivalent (chat-encoder path); and the predicate matching the
-/// stamped [`crate::tokenizer::ForwardParity`] of the encoder that PRODUCED
-/// the ids holds — [`input_ids_safe_to_forward_dsv4`] for the built-in dsv4
-/// encoder, the conservative [`input_ids_safe_to_forward`] for everything
-/// else. The stamp travels with the tokens, so ids can never be gated by the
-/// wrong encoder's predicate.
+/// Select the ids to forward as engine `input_ids`: the kill switch is off,
+/// the ids are engine-equivalent, and the predicate matching their stamped
+/// [`crate::tokenizer::ForwardParity`] holds — so ids can never be gated by
+/// the wrong encoder's predicate.
 fn select_forward_input_ids<'a>(
     offload_enabled: bool,
     request_tokens: Option<&'a RequestTokens>,
@@ -1331,30 +1316,20 @@ fn select_forward_input_ids<'a>(
     }
 }
 
-/// The dsv4-encoder forwarding predicate. The built-in encoder mirrors the
-/// engine's FULL dsv4 request handling — tools and tool results, per-request
-/// thinking / reasoning-effort resolution, `task` attachment, and the
-/// trailing-assistant surgery behind `continue_final_message` (see
-/// `dsv4::render_request`) — so those are all forwardable. Withheld is exactly
-/// what the encoder cannot mirror faithfully:
+/// The dsv4-encoder forwarding predicate. The encoder mirrors the engine's
+/// full dsv4 request handling (tools, thinking, `task`,
+/// `continue_final_message`), so those all forward; withheld is exactly what
+/// it cannot mirror faithfully:
 ///
-///   * content parts that are not `type: "text"` — the surrounding mm-item
-///     plumbing on the engine side is unverified;
-///   * message-level `tools` — a declared protocol field the engine renders
-///     after that message's content (and it flips `drop_thinking` off);
-///   * any role outside the engine's dsv4 render set — `latest_reminder`
-///     renders a marker the encoder does not emit, and unknown roles are
-///     engine errors forwarding would convert into served prompts;
-///   * a `continue_final_message` value that isn't pydantic-coercible — the
-///     engine 422s; the router must not guess false;
-///   * a history tool call whose `arguments` is not a JSON object — the
-///     engine raises before a prompt exists.
+///   * non-`text` content parts (engine-side mm plumbing unverified);
+///   * message-level `tools` (a declared field the engine renders);
+///   * roles outside the engine's dsv4 render set;
+///   * a non-pydantic-coercible `continue_final_message` (an engine 422);
+///   * a tool call whose `arguments` is not a JSON object (an engine error).
 ///
-/// NOTE (deploy): the router's `SGLANG_ROUTER_DSV4_*` env defaults must match
-/// the engine's `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` /
-/// checkpoint-resolved effort profile — a plain request carries no field the
-/// predicate could key a mismatch on, so wrong-mode ids would forward
-/// undetectably.
+/// NOTE (deploy): the `SGLANG_ROUTER_DSV4_*` env defaults must match the
+/// engine's — a plain request carries no field to detect a mismatch on, so
+/// wrong-mode ids would forward undetectably.
 fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
     if let Some(v) = value.get("continue_final_message").filter(|v| !v.is_null()) {
         if crate::tokenizer::openai_bool(v).is_none() {
@@ -1366,12 +1341,11 @@ fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
     };
     for m in msgs {
         // Only message-level `tools` is a DECLARED protocol field; other
-        // extras are stripped by pydantic's `extra="ignore"` before the
-        // engine's encoder ever sees them.
+        // extras are stripped by pydantic before the engine's encoder.
         if m.get("tools").is_some_and(|v| !v.is_null()) {
             return false;
         }
-        // The engine's dsv4 render set, compared case-insensitively to match
+        // The engine's dsv4 render set, matched case-insensitively like
         // `render_request`'s lowercasing.
         let role_ok = m
             .get("role")
@@ -1394,8 +1368,8 @@ fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
                 return false;
             }
         }
-        // History tool calls: the engine requires `arguments` to BE a JSON
-        // object — inlined, or a string it can `json.loads` into one.
+        // The engine requires `arguments` to BE a JSON object — inlined, or
+        // a string it can `json.loads` into one.
         if let Some(calls) = m.get("tool_calls").and_then(|t| t.as_array()) {
             let all_object_args = calls.iter().all(|c| {
                 match c.get("function").and_then(|f| f.get("arguments")) {
@@ -1403,8 +1377,7 @@ fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
                         serde_json::from_str::<serde_json::Value>(s).is_ok_and(|v| v.is_object())
                     }
                     Some(serde_json::Value::Object(_)) => true,
-                    // Absent / null / scalar validates, then fails the
-                    // engine's object check.
+                    // Absent/null/scalar validates, then fails the object check.
                     _ => false,
                 }
             });
@@ -1416,13 +1389,11 @@ fn input_ids_safe_to_forward_dsv4(value: &serde_json::Value) -> bool {
     true
 }
 
-/// True when the model's dsv4 encoder REFUSES the request — the cases
-/// `dsv4::render_request` errors on (invalid task, task without a
-/// user/developer message). The engine rejects such requests identically, so
-/// the ingress-encode fallback is the engine's own rejection, not offload
-/// breakage, and must not count in `sgl_router_ingress_tokenize_errors_total`
-/// (a client-controllable counter would hide real encoder regressions). Only
-/// invoked on the failure path, where the re-render cost is irrelevant.
+/// True when the dsv4 encoder REFUSES the request (`dsv4::render_request`
+/// errors). The engine rejects such requests identically, so the fallback is
+/// not offload breakage and must not count in
+/// `sgl_router_ingress_tokenize_errors_total` — a client-controllable counter
+/// would hide real encoder regressions. Failure-path only.
 fn dsv4_render_rejects_request(
     tokenizers: &crate::tokenizer::TokenizerRegistry,
     model_id: &str,
@@ -1986,9 +1957,7 @@ mod tests {
         assert!(!ingress_tokenize_offload_failed(true, Some(&value), None));
     }
 
-    /// The central kill switch: with the offload disabled, engine-equivalent
-    /// ids for a perfectly forwardable plain-text chat are still withheld, so
-    /// the engine always re-tokenizes from `messages`.
+    /// The kill switch withholds even perfectly forwardable ids.
     #[test]
     fn select_forward_input_ids_disabled_gate_withholds_ids() {
         let value = serde_json::json!({"messages":[{"role":"user","content":"hi"}]});
@@ -2007,10 +1976,7 @@ mod tests {
         );
     }
 
-    /// Non-engine-equivalent ids (the raw-prompt path) are withheld even with
-    /// the offload enabled and a plain body — the `engine_equivalent`
-    /// conjunct, so this gate can never forward ids the engine wouldn't have
-    /// produced itself.
+    /// Non-engine-equivalent (raw-path) ids are never forwarded.
     #[test]
     fn select_forward_input_ids_withholds_non_engine_equivalent_ids() {
         let value = serde_json::json!({"messages":[{"role":"user","content":"hi"}]});
@@ -2025,10 +1991,8 @@ mod tests {
         );
     }
 
-    /// The stamped parity dispatches the predicate: the SAME tool-bearing
-    /// body is withheld for Conservative-stamped ids (Jinja renders no tool
-    /// schemas) but forwarded for Dsv4Full-stamped ids (the dsv4 encoder
-    /// mirrors tool rendering).
+    /// The stamped parity dispatches the predicate: the same tool-bearing body
+    /// is withheld for Conservative ids but forwarded for Dsv4Full ids.
     #[test]
     fn select_forward_input_ids_dispatches_predicate_by_stamped_parity() {
         let value = serde_json::json!({
@@ -2055,10 +2019,8 @@ mod tests {
         );
     }
 
-    /// The dsv4 predicate allows exactly the classes the dsv4 encoder mirrors
-    /// (or the engine ignores) — tools, thinking overrides, reasoning_effort,
-    /// task, trailing-assistant/continue-final-message — so a regression back
-    /// toward the conservative set would silently inert the offload for them.
+    /// The dsv4 predicate allows every class the encoder mirrors (or the
+    /// engine ignores); a regression here silently inerts the offload.
     #[test]
     fn input_ids_safe_to_forward_dsv4_allows_mirrored_classes() {
         for body in [
@@ -2072,8 +2034,6 @@ mod tests {
                  {"function":{"name":"f","arguments":"{\"a\": 1}"}}]}]}),
             serde_json::json!({"messages":[{"role":"assistant","tool_calls":[
                  {"function":{"name":"f","arguments":{"a":1}}}]}]}),
-            // The `reasoning` object (mirrored by `normalize_reasoning_inputs`)
-            // and the undeclared message keys pydantic strips.
             serde_json::json!({"messages":[{"role":"user","content":"hi"}],
                                "reasoning":{"effort":"high"}}),
             serde_json::json!({"messages":[{"role":"user","content":"hi"}],
@@ -2098,9 +2058,8 @@ mod tests {
                                "chat_template":"custom"}),
             serde_json::json!({"messages":[{"role":"user","content":"hi"}],
                                "continue_final_message":"true"}), // pydantic-coercible
-            // Numeric content and a case-varied `user` are 422s at the protocol
-            // boundary; the predicate need not withhold what can never reach
-            // the engine.
+            // 422s at the protocol boundary — no need to withhold what can
+            // never reach the engine.
             serde_json::json!({"messages":[{"role":"user","content":42}]}),
             serde_json::json!({"messages":[{"role":"User","content":"hi"}]}),
         ] {
@@ -2111,9 +2070,7 @@ mod tests {
         }
     }
 
-    /// …and blocks exactly what the encoder cannot mirror: non-text content
-    /// parts, message-level `tools`, unmirrored roles, engine-rejected
-    /// tool-call `arguments`, and an uncoercible `continue_final_message`.
+    /// …and blocks exactly what the encoder cannot mirror.
     #[test]
     fn input_ids_safe_to_forward_dsv4_blocks_unmirrored_classes() {
         for body in [

--- a/experimental/sgl-router/src/tokenizer/dsv4.rs
+++ b/experimental/sgl-router/src/tokenizer/dsv4.rs
@@ -4,23 +4,19 @@
 //! DeepSeek-V4 prompt encoder for cache-aware routing.
 //!
 //! DeepSeek-V4 ships no Jinja chat template; the engine builds the prompt in
-//! code (`python/sglang/srt/entrypoints/openai/encoding_dsv4.py`, selected for
-//! the `DeepseekV4` architecture). This reproduces that encoder byte-exactly
-//! for the routing-relevant subset, so the router's query tokens match the
-//! engine's cached blocks: chat AND thinking mode ([`resolve_render_opts`]
-//! mirrors the engine's per-request resolution), tools / tool calls / tool
-//! results, the `task` quick instructions, and the trailing-assistant surgery
-//! behind `continue_final_message` ([`render_request`]). Shapes this encoder
-//! does NOT mirror are withheld from `input_ids` forwarding by
-//! `input_ids_safe_to_forward_dsv4` (the single enumeration — not restated
-//! here); the render simply ignores them, degrading routing, never
-//! correctness.
+//! code (`python/sglang/srt/entrypoints/openai/encoding_dsv4.py`). This
+//! mirrors that encoder byte-exactly — chat and thinking mode, tools / tool
+//! calls / tool results, `task`, `continue_final_message` — so the router's
+//! query tokens match the engine's cached blocks. Shapes it does NOT mirror
+//! are withheld from `input_ids` forwarding by `input_ids_safe_to_forward_dsv4`
+//! (the single enumeration); the render just ignores them, degrading routing,
+//! never correctness.
 //!
-//! Tokenization does not auto-prepend special tokens (the `dynamo_tokenizers`
-//! HF wrapper defaults `add_special_tokens` to false; [`super::adapter::encode`]
-//! adds none), so the literal marker text below maps to the special token ids.
-//! Pinned byte-exact against the live engine's `/tokenize` (DeepSeek-V4-Flash,
-//! snapshot `6976c7ff`): `[{user:"ABCD"}]` → `[0, 128803, 51453, 128804, 128822]`.
+//! Tokenization adds no special tokens (the `dynamo_tokenizers` HF wrapper
+//! defaults `add_special_tokens` to false), so the literal marker text below
+//! maps to the special ids. Pinned against the live engine's `/tokenize`
+//! (DeepSeek-V4-Flash, snapshot `6976c7ff`):
+//! `[{user:"ABCD"}]` → `[0, 128803, 51453, 128804, 128822]`.
 
 use super::pyjson::py_json;
 
@@ -32,17 +28,15 @@ const EOS: &str = "<｜end▁of▁sentence｜>";
 const USER: &str = "<｜User｜>";
 /// Assistant-turn marker, opening the generation prompt (token id 128804).
 const ASSISTANT: &str = "<｜Assistant｜>";
-/// Thinking-start marker (`encoding_dsv4.thinking_start_token`); a thinking-mode
-/// generation prompt / historical assistant turn opens with it.
+/// Thinking-start marker; opens a thinking-mode assistant turn.
 const THINK_START: &str = "<think>";
 /// Thinking-end marker; the chat-mode generation prompt ends with it (128822).
 const THINK_END: &str = "</think>";
 /// DSML block token wrapping tool-call / tools markup (`encoding_dsv4.dsml_token`).
 const DSML: &str = "｜DSML｜";
 
-/// The `encoding_dsv4.DS_TASK_SP_TOKENS` map — special tokens appended after
-/// a task-carrying message. Valid task names are exactly these keys; anything
-/// else is an engine-side assertion failure (`VALID_TASKS`).
+/// The `encoding_dsv4.DS_TASK_SP_TOKENS` map; its keys are exactly the
+/// engine's `VALID_TASKS`.
 fn task_sp_token(task: &str) -> Option<&'static str> {
     match task {
         "action" => Some("<｜action｜>"),
@@ -56,17 +50,14 @@ fn task_sp_token(task: &str) -> Option<&'static str> {
 }
 
 /// Request-level fields beyond `messages`/`tools` that steer the engine's
-/// dsv4 encoding (`serving_chat` dsv4 branch) and which the router must
-/// mirror to remain engine-equivalent.
+/// dsv4 encoding (`serving_chat` dsv4 branch).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct RequestParts<'a> {
-    /// The request-level `task` (encoding_dsv4's quick-instruction tasks),
-    /// attached to the last user/developer message. A non-string `task` fails
-    /// engine-side pydantic validation, so it is treated as absent.
+    /// The quick-instruction `task`, attached to the last user/developer
+    /// message. A non-string `task` is an engine-side 422, treated as absent.
     pub task: Option<&'a str>,
-    /// OpenAI `continue_final_message` (default false): the engine extracts a
-    /// trailing assistant message and appends its text AFTER the generation
-    /// prompt. Coerced via [`openai_bool`], the way pydantic would.
+    /// OpenAI `continue_final_message`, coerced via [`openai_bool`] the way
+    /// pydantic would.
     pub continue_final_message: bool,
 }
 
@@ -81,27 +72,18 @@ impl<'a> RequestParts<'a> {
     }
 }
 
-/// Parse a JSON value as a coerced OpenAI boolean. Lives in
-/// [`crate::tokenizer::openai_bool`]; re-exported here so dsv4 call sites
-/// read naturally.
+/// Re-exported so dsv4 call sites read naturally.
 pub use crate::tokenizer::openai_bool;
 
-/// Errors from engine-mirroring pre-processing. Each corresponds to a request
-/// the ENGINE also rejects — at the protocol boundary or inside
-/// `serving_chat`/`encoding_dsv4` — so the caller treating it as "not
-/// engine-equivalent" reproduces the engine's own outcome. A future variant
-/// that is a ROUTER limitation rather than an engine rejection must not be
-/// added here: `dsv4_render_rejects_request` keys on this type to suppress the
-/// broken-offload metric.
+/// Request errors the ENGINE also rejects. Every variant must stay an engine
+/// rejection, never a router limitation: `dsv4_render_rejects_request` keys on
+/// this type to suppress the broken-offload metric.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RenderErr {
-    /// `task` present but no user/developer message —
-    /// `attach_task_to_last_user_message`'s `ValueError`.
+    /// `task` present but no user/developer message (the engine's ValueError).
     TaskWithoutUser,
-    /// A task name outside `encoding_dsv4.VALID_TASKS`. The request-level
-    /// field is `Optional[Literal[...]]`, so the engine rejects it as a 422
-    /// before rendering; this check exists because the router parses the raw
-    /// body, which has had no such validation.
+    /// A task name outside `encoding_dsv4.VALID_TASKS` (an engine-side 422;
+    /// the router parses the raw body, which had no such validation).
     InvalidTask,
 }
 
@@ -116,14 +98,10 @@ impl std::fmt::Display for RenderErr {
 
 impl std::error::Error for RenderErr {}
 
-/// Mirror `serving_chat._handle_last_assistant_message` on the dsv4 branch.
-/// The engine flattens content BEFORE the surgery ([`content_to_string`];
-/// `null`/absent → `""`), then for a trailing assistant turn:
-/// `continue_final_message = true` REMOVES it and hands back its flattened
-/// content as the prefix (the caller encodes and appends it after the
-/// generation prompt); `false` REPLACES it wholesale with
-/// `{"role": "user", "content": flattened}`, dropping every other key.
-/// Unflattenable content (a 422 at the protocol boundary) is left untouched.
+/// Mirror `serving_chat._handle_last_assistant_message`: content is flattened
+/// first, then a trailing assistant turn is REMOVED and returned as the prefix
+/// (`continue_final_message = true`) or REPLACED wholesale with
+/// `{"role": "user", "content": flattened}` (`false`), dropping every other key.
 fn handle_trailing_assistant(
     messages: &mut Vec<serde_json::Value>,
     continue_final_message: bool,
@@ -142,9 +120,7 @@ fn handle_trailing_assistant(
         Some(serde_json::Value::Array(_)) => {
             content_to_string(messages.last().and_then(|m| m.get("content")))
         }
-        // Non-string scalar: 422 at the protocol boundary, so unreachable —
-        // left untouched rather than guessing a flattening the engine
-        // never performs.
+        // Non-string scalar: 422 at the protocol boundary, so unreachable.
         Some(_) => return None,
     };
     if continue_final_message {
@@ -156,11 +132,9 @@ fn handle_trailing_assistant(
     }
 }
 
-/// Mirror `encoding_dsv4.find_last_user_index` + `attach_task_to_last_user_message`:
-/// set `task` on the most recent user/developer message. Errs when none
-/// exists (the engine's `ValueError`) and when the task name is invalid (the
-/// render-time `VALID_TASKS` assert — surfaced here so failure modes are
-/// uniform).
+/// Mirror `attach_task_to_last_user_message`: set `task` on the most recent
+/// user/developer message, erring like the engine when none exists or the
+/// task name is invalid.
 fn attach_task(messages: &mut [serde_json::Value], task: &str) -> Result<(), RenderErr> {
     if task_sp_token(task).is_none() {
         return Err(RenderErr::InvalidTask);
@@ -178,12 +152,10 @@ fn attach_task(messages: &mut [serde_json::Value], task: &str) -> Result<(), Ren
     Ok(())
 }
 
-/// Render a whole request the way the engine's dsv4 branch does
-/// (`serving_chat`): trailing-assistant surgery, then `task` attachment,
-/// then [`render_messages`]. Returns the rendered prompt and, when
-/// `continue_final_message` extracted a trailing assistant turn, its content
-/// — the caller encodes that text and appends the ids after the prompt ids
-/// (`_append_assistant_prefix_to_prompt_ids`).
+/// Render a whole request the way the engine's dsv4 branch does: trailing-
+/// assistant surgery, then `task` attachment, then [`render_messages`].
+/// Returns the prompt plus any extracted assistant prefix — the caller encodes
+/// it and appends the ids (`_append_assistant_prefix_to_prompt_ids`).
 pub fn render_request(
     messages: &serde_json::Value,
     tools: Option<&serde_json::Value>,
@@ -196,17 +168,13 @@ pub fn render_request(
         .unwrap_or(&[])
         .to_vec();
     for m in &mut raw {
-        // The generic-role model case-normalizes (`_normalize_role`); the
-        // user-role model is a bare `Literal["user"]`, so `"User"` is a 422
-        // rather than a normalized user turn. Lowercasing here is therefore
-        // harmless alignment, not a behavior the engine reproduces for `user`.
+        // Generic roles case-normalize engine-side (`_normalize_role`); a
+        // case-varied `user` is a 422 there, so lowercasing is harmless.
         if let Some(role) = m.get("role").and_then(|r| r.as_str()).map(str::to_owned) {
             m["role"] = serde_json::json!(role.to_ascii_lowercase());
         }
-        // Client-sent message-level `task` never reaches encoding_dsv4 (the
-        // message model has no such declared field), so it is stripped exactly
-        // where the engine strips it — the only task that renders is the
-        // request-level one attached below.
+        // Client-sent message-level `task` is undeclared on the message model
+        // and never reaches the engine's encoder; strip it the same way.
         if let serde_json::Value::Object(o) = m {
             o.remove("task");
         }
@@ -230,12 +198,9 @@ pub fn render_request(
     ))
 }
 
-/// Reasoning-effort level, mirroring `encoding_dsv4`'s `reasoning_effort`.
-/// Which levels prepend a preamble depends on the active
-/// [`ReasoningEffortProfile`] — see [`effort_preamble`]. `Low` (an accepted
-/// official-profile level, the checkpoint's `DEFAULT_REASONING_EFFORT`) and
-/// `None` ("filtered out engine-side, profile default substituted") both
-/// render no preamble but are kept distinct — the engine's own cardinality.
+/// Reasoning-effort level. `Low` (an accepted level, the checkpoint default)
+/// and `None` ("filtered out engine-side") both render no preamble but are
+/// kept distinct — the engine's own cardinality.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReasoningEffort {
     None,
@@ -245,11 +210,9 @@ pub enum ReasoningEffort {
 }
 
 /// Which `encoding_dsv4.REASONING_EFFORT_PROFILES` mapping the engine renders
-/// with. The engine resolves this per model at startup by AST-parsing
-/// `encoding/encoding_dsv4.py` INSIDE the checkpoint — a file the router never
-/// sees — so the router takes it from
-/// `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE` ([`resolve_effort_profile`]).
-/// A fleet serving a preview-era checkpoint MUST set it to `preview`.
+/// with. The engine AST-parses it out of the CHECKPOINT, which the router
+/// never sees, so it comes from `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE`;
+/// a preview-era checkpoint MUST set `preview`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ReasoningEffortProfile {
     /// `{"high": "", "max": PREVIEW_MAX}`.
@@ -259,30 +222,21 @@ pub enum ReasoningEffortProfile {
     Official,
 }
 
-/// How to render, mirroring the engine's per-request `thinking_mode` +
-/// `reasoning_effort`. The engine derives these from the request's
-/// `chat_template_kwargs.thinking` / `reasoning_effort` (falling back to its
-/// `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` defaults); the
-/// router mirrors that resolution in [`resolve_render_opts`] so its routing
-/// tokens match the engine's cached blocks even when the engine runs a
-/// non-default (e.g. thinking-on) mode. `RenderOpts::chat()` reproduces the
-/// chat-mode encoder output byte-for-byte.
+/// How to render — the engine's per-request `thinking_mode` +
+/// `reasoning_effort`, resolved the engine's way by [`resolve_render_opts`].
 #[derive(Clone, Copy, Debug)]
 pub struct RenderOpts {
     /// `true` = thinking mode (engine `thinking_mode == "thinking"`).
     pub thinking: bool,
     pub reasoning_effort: ReasoningEffort,
-    /// The engine's per-model effort mapping. Carried here (rather than read
-    /// from a global inside the renderer) so [`render_messages`] stays a pure
-    /// function of its inputs and parity fixtures can pin both profiles.
+    /// Carried here (not read from a global) so [`render_messages`] stays pure
+    /// and parity fixtures can pin both profiles.
     pub reasoning_effort_profile: ReasoningEffortProfile,
 }
 
 impl RenderOpts {
-    /// Chat / non-thinking mode with no effort preamble — the engine default,
-    /// byte-identical to the chat-mode encoder output. The profile is inert
-    /// here (no preamble renders outside thinking mode, and `None` maps to the
-    /// empty preamble under both profiles).
+    /// Chat / non-thinking mode with no effort preamble — the engine default.
+    /// The profile is inert here (no preamble renders outside thinking mode).
     pub const fn chat() -> Self {
         RenderOpts {
             thinking: false,
@@ -293,17 +247,11 @@ impl RenderOpts {
 }
 
 /// The `encoding_dsv4.REASONING_EFFORT_PROFILES[profile][effort]` lookup.
-///
-/// The engine filters a request's effort to the profile's accepted keys and
-/// substitutes the profile default (`"low"` official / `"high"` preview) when
-/// nothing survives — both of which map to the empty preamble, so every level
-/// the router collapses into [`ReasoningEffort::None`] renders `""` here too.
 fn effort_preamble(profile: ReasoningEffortProfile, effort: ReasoningEffort) -> &'static str {
     use ReasoningEffortProfile::*;
     match (profile, effort) {
-        // `None` = filtered out engine-side, so the engine substitutes the
-        // profile default (`"low"` official / `"high"` preview) — both of which
-        // map to the empty preamble, same as `Low`.
+        // `None` = filtered out engine-side; the engine substitutes the
+        // profile default, which renders the empty preamble, same as `Low`.
         (_, ReasoningEffort::None) | (_, ReasoningEffort::Low) => "",
         (Preview, ReasoningEffort::High) => "",
         (Preview, ReasoningEffort::Max) => REASONING_EFFORT_PREVIEW_MAX,
@@ -313,28 +261,17 @@ fn effort_preamble(profile: ReasoningEffortProfile, effort: ReasoningEffort) -> 
 }
 
 /// Resolve the render options for a request, mirroring the engine's dsv4
-/// normalization (`protocol.normalize_reasoning_inputs` + `serving_chat`'s
-/// dsv4 branch):
+/// normalization. Thinking: a PRESENT `chat_template_kwargs.thinking` wins by
+/// truthiness (explicit `null` counts as present, per `setdefault`), else the
+/// validator's effort-derived default, else env. Effort: ctk effort (present
+/// non-null; the engine pops it onto the top level) > top-level effort > env,
+/// env consulted only when both are absent/null. The asymmetry is the engine's:
+/// the thinking-setdefault runs at parse time, before the ctk pop, so ctk
+/// effort never defaults thinking.
 ///
-/// Thinking: a PRESENT `chat_template_kwargs.thinking` wins by truthiness
-/// (explicit `null` counts as present, per `setdefault`); else the validator's
-/// effort-derived default ([`normalize_reasoning_inputs`]); else the router's
-/// env default.
-///
-/// Effort: `_convert_to_internal_request` pops `chat_template_kwargs.
-/// reasoning_effort` ONTO the top-level field before the dsv4 branch reads it,
-/// so precedence is ctk effort (present non-null) > top-level effort > env —
-/// env consulted ONLY when both are absent/null; any other present value
-/// collapses to `None` without consulting env. Note the asymmetry: the
-/// thinking-setdefault runs at parse time, before the ctk pop, so ctk effort
-/// never defaults thinking — only a top-level one does.
-///
-/// The router cannot observe the engine's env defaults, so
-/// `SGLANG_ROUTER_DSV4_DEFAULT_THINKING` / `SGLANG_ROUTER_DSV4_REASONING_EFFORT`
-/// / `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE` (read once) MUST match the
-/// engine's `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` /
-/// checkpoint-resolved profile — a mismatch is undetectable from the request
-/// (see `input_ids_safe_to_forward_dsv4`'s deploy note).
+/// The `SGLANG_ROUTER_DSV4_*` env defaults MUST match the engine's — a
+/// mismatch is undetectable from the request (see
+/// `input_ids_safe_to_forward_dsv4`'s deploy note).
 pub fn resolve_render_opts(request: &serde_json::Value) -> RenderOpts {
     // The `reasoning` object + top-level effort, as the protocol validator
     // resolves them at parse time.
@@ -373,19 +310,12 @@ pub fn resolve_render_opts(request: &serde_json::Value) -> RenderOpts {
     }
 }
 
-/// Mirror `protocol.normalize_reasoning_inputs`, the `mode="before"` validator
-/// that runs at PARSE time — before `_convert_to_internal_request` pops
-/// `chat_template_kwargs.reasoning_effort`.
-///
-/// The top-level `reasoning` OBJECT can do two things: supply
-/// `reasoning_effort` (via its `effort` / `reasoning_effort` aliases) and turn
-/// thinking on (via `enabled` / `enable`). Returns the effective top-level
-/// effort and the thinking value the validator would `setdefault` into
-/// `chat_template_kwargs` — `None` meaning it set nothing, so the caller falls
-/// through to the env default.
-///
-/// Mirroring this is what lets `input_ids_safe_to_forward_dsv4` stop withholding
-/// `reasoning`-carrying requests.
+/// Mirror `protocol.normalize_reasoning_inputs` (the parse-time validator):
+/// the `reasoning` OBJECT supplies `reasoning_effort` (its `effort` /
+/// `reasoning_effort` aliases) and turns thinking on (`enabled` / `enable`).
+/// Returns the effective top-level effort and the thinking value the validator
+/// would `setdefault` — `None` meaning it set nothing. Mirroring this is what
+/// lets the forwarding predicate accept `reasoning`-carrying requests.
 fn normalize_reasoning_inputs(
     request: &serde_json::Value,
 ) -> (Option<serde_json::Value>, Option<bool>) {
@@ -404,10 +334,8 @@ fn normalize_reasoning_inputs(
             .filter(|v| !v.is_null())
             .or_else(|| r.get("reasoning_effort").filter(|v| !v.is_null()));
         match alias {
-            // A recognized level, a number, or a numeric string all become the
-            // top-level effort; only a recognized level can reach a preamble,
-            // so the numeric forms are kept verbatim (they map to `None` in
-            // `effort_from_str` exactly as the engine's filter drops them).
+            // Recognized levels, numbers, and numeric strings become the
+            // top-level effort; only a recognized level can reach a preamble.
             Some(Value::String(s)) if LEVELS.contains(&s.as_str()) => {
                 effort = Some(Value::String(s.clone()))
             }
@@ -415,8 +343,7 @@ fn normalize_reasoning_inputs(
             Some(Value::String(s)) if s.parse::<f64>().is_ok() => {
                 effort = Some(Value::String(s.clone()))
             }
-            // Anything else is a validator ValueError — the engine 422s the
-            // request, so leave the effort alone and let it fail there.
+            // Anything else 422s engine-side; leave the effort alone.
             _ => {}
         }
         // `enabled` wins over `enable`; a string is truthy by an explicit token
@@ -444,11 +371,9 @@ fn normalize_reasoning_inputs(
     (effort, thinking)
 }
 
-/// The engine's effort STRING → level. The single mapping used by the
-/// request path, the env default, and the fixture harness, so they cannot
-/// drift apart. Anything outside the profiles' keys becomes `None`: the
-/// engine's accepted-effort filter drops it and substitutes the profile
-/// default, which renders the same empty preamble as [`ReasoningEffort::Low`].
+/// The engine's effort STRING → level, shared by the request path and the env
+/// default. Anything outside the profiles' keys becomes `None` (the engine's
+/// filter drops it and substitutes the profile default).
 fn effort_from_str(s: &str) -> ReasoningEffort {
     match s {
         "max" => ReasoningEffort::Max,
@@ -458,11 +383,8 @@ fn effort_from_str(s: &str) -> ReasoningEffort {
     }
 }
 
-/// Python-truthiness of a JSON value, mirroring the engine's `if thinking_requested`
-/// test on the raw `chat_template_kwargs.thinking` value (`serving_chat.py`): a bool
-/// as-is, a string/array/object truthy iff non-empty, a number iff non-zero, null
-/// falsy. A conformant client sends a bool; this only matters for odd payloads, and
-/// keeps routing matching the engine on them.
+/// Python-truthiness of a JSON value — the engine's `if thinking_requested`
+/// test on the raw `chat_template_kwargs.thinking` value.
 fn json_truthy(v: &serde_json::Value) -> bool {
     match v {
         serde_json::Value::Bool(b) => *b,
@@ -474,11 +396,9 @@ fn json_truthy(v: &serde_json::Value) -> bool {
     }
 }
 
-/// Parse a boolean env value the way the engine's `EnvBool` does (`environ.py`):
-/// case-insensitive `true`/`1`/`yes`/`y` → `Some(true)`, `false`/`0`/`no`/`n` →
-/// `Some(false)`, anything else `None`. Matching the engine's exact token set is
-/// load-bearing: `y` is engine-true, so a set that omitted it would silently
-/// disagree with a `SGLANG_DEFAULT_THINKING=y` engine.
+/// Parse a boolean env value with the engine `EnvBool`'s exact token set —
+/// load-bearing: `y` is engine-true, so omitting it would silently disagree
+/// with a `SGLANG_DEFAULT_THINKING=y` engine.
 fn parse_env_bool(value: &str) -> Option<bool> {
     match value.to_ascii_lowercase().as_str() {
         "true" | "1" | "yes" | "y" => Some(true),
@@ -487,20 +407,16 @@ fn parse_env_bool(value: &str) -> Option<bool> {
     }
 }
 
-/// Resolve the thinking default from the env value (pure; the env read + one-time
-/// caching + logging live in [`router_defaults`]). Mirrors the engine's
-/// `EnvBool` + `EnvField.get`: a recognized token → that bool; a non-empty
-/// unrecognized value → WARN + `false` — the engine behaves identically (its
-/// `EnvField.get` catches `EnvBool.parse`'s `ValueError`, warns, and returns the
-/// `False` default; it does NOT surface a hard error). Unset/empty → `false`.
+/// Resolve the thinking default from the env value (pure; env read + caching
+/// live in [`router_defaults`]). An unrecognized value warns and falls back to
+/// `false`, exactly as the engine's `EnvField.get` does.
 fn resolve_default_thinking(env: Option<&str>) -> bool {
     match env {
         Some(s) if !s.is_empty() => parse_env_bool(s).unwrap_or_else(|| {
             tracing::warn!(
                 value = %s,
                 "SGLANG_ROUTER_DSV4_DEFAULT_THINKING is not a recognized boolean \
-                 (true/1/yes/y | false/0/no/n); using false (the engine warns + defaults \
-                 false the same way) — dsv4 routing renders chat mode, mismatching a thinking engine"
+                 (true/1/yes/y | false/0/no/n); using false, like the engine"
             );
             false
         }),
@@ -508,30 +424,22 @@ fn resolve_default_thinking(env: Option<&str>) -> bool {
     }
 }
 
-/// Resolve the reasoning-effort default from the env value (pure), mirroring
-/// the engine's `SGLANG_DSV4_REASONING_EFFORT` handling. Unset resolves to
-/// `low` — the checkpoint's `DEFAULT_REASONING_EFFORT`, rendering NO preamble,
-/// so an unset router env matches an unset engine env. Values the engine's
-/// accepted-effort filter drops (`medium` included) land on the same default.
-/// The engine always substitutes one, hence a level rather than an `Option`.
+/// Resolve the reasoning-effort default from the env value (pure). Unset — and
+/// any value the engine's filter drops, `medium` included — resolves to `low`,
+/// the checkpoint's `DEFAULT_REASONING_EFFORT`; it renders no preamble, so an
+/// unset router env matches an unset engine env.
 fn resolve_default_effort(env: Option<&str>) -> ReasoningEffort {
     match env.map(effort_from_str) {
-        // Absent, or a value outside the checkpoint's prompt keys: the engine's
-        // filter drops it and substitutes the profile default.
         None | Some(ReasoningEffort::None) => ReasoningEffort::Low,
         Some(level) => level,
     }
 }
 
-/// Resolve the effort profile from the env value (pure). Unset → `Official`,
-/// matching the current DeepSeek-V4 official API. An unrecognized value falls
-/// back to `Official` too — the router must not refuse to serve over a typo in
-/// a rendering hint — but WARNs, because a preview fleet that misspells this
-/// silently renders official preambles.
+/// Resolve the effort profile from the env value (pure). Unset → `Official`
+/// (the current DeepSeek-V4 official API). An unrecognized value WARNs and
+/// falls back too — a rendering hint must not refuse to serve.
 fn resolve_effort_profile(env: Option<&str>) -> ReasoningEffortProfile {
     match env {
-        // Single source of truth for "unconfigured" — the `#[default]` on the
-        // enum, so the two can't drift.
         None => ReasoningEffortProfile::default(),
         Some("official") => ReasoningEffortProfile::Official,
         Some("preview") => ReasoningEffortProfile::Preview,
@@ -573,10 +481,8 @@ fn router_defaults() -> &'static (bool, ReasoningEffort, ReasoningEffortProfile)
             default_thinking = thinking,
             default_reasoning_effort = ?effort,
             reasoning_effort_profile = ?profile,
-            "dsv4 router render defaults resolved; must match the engine's SGLANG_DEFAULT_THINKING \
-             / SGLANG_DSV4_REASONING_EFFORT — and, ahead of both, any \
-             --default-chat-template-kwargs the engine seeds ctk with — plus its \
-             checkpoint-resolved reasoning-effort profile for cache-aware routing to match"
+            "dsv4 router render defaults; must match the engine's SGLANG_DEFAULT_THINKING / \
+             SGLANG_DSV4_REASONING_EFFORT / checkpoint-resolved effort profile"
         );
         (thinking, effort, profile)
     })
@@ -591,19 +497,14 @@ fn default_effort() -> ReasoningEffort {
     router_defaults().1
 }
 
-/// The effort profile every render on this router uses. Fixed per process (the
-/// engine resolves it per model at startup, not per request), so probes that
-/// enumerate distinct render states must take it from here rather than assuming
-/// a profile.
+/// The effort profile every render on this router uses — fixed per process,
+/// like the engine's per-model startup resolution.
 pub fn active_effort_profile() -> ReasoningEffortProfile {
     router_defaults().2
 }
 
-/// `encoding_dsv4.REASONING_EFFORT_PREVIEW_MAX` — the preview profile's `max`
-/// preamble, and the official profile's `high` preamble. Emitted at the very
-/// front of the prompt (after BOS, before the system content) in thinking mode
-/// only, per `render_message`'s `index == 0` branch. Byte-identical to the
-/// engine.
+/// `encoding_dsv4.REASONING_EFFORT_PREVIEW_MAX` — preview `max` and official
+/// `high`. Byte-identical to the engine.
 const REASONING_EFFORT_PREVIEW_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
 
 /// `encoding_dsv4.REASONING_EFFORT_OFFICIAL_MAX` — the official profile's `max`
@@ -611,15 +512,9 @@ const REASONING_EFFORT_PREVIEW_MAX: &str = "Reasoning Effort: Absolute maximum w
 const REASONING_EFFORT_OFFICIAL_MAX: &str = "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
 
 /// Render `messages` (+ the request's top-level `tools`) into the DeepSeek-V4
-/// chat prompt, mirroring `encoding_dsv4.encode_messages` byte-exactly: tools
-/// render right after the system content ([`render_tools`]); a `tool` message
-/// folds into the preceding (or a fresh) user turn as a `<tool_result>` block
-/// ([`merge_tool_messages`]); an assistant turn's `tool_calls` render as a
-/// DSML block; multiple tool results in one turn are ordered by originating
-/// call ([`sort_tool_results_by_call_order`]); thinking mode follows the
-/// engine's `drop_thinking` rules ([`render_one`], [`drop_thinking_messages`]).
-/// Non-array `messages` renders to just BOS (the caller degrades to min-load).
-/// Request-level behaviors (`task`, trailing-assistant surgery) live in
+/// chat prompt, mirroring `encoding_dsv4.encode_messages` byte-exactly — see
+/// the helpers for each piece. Non-array `messages` renders to just BOS (the
+/// caller degrades to min-load); request-level behaviors live in
 /// [`render_request`].
 pub fn render_messages(
     messages: &serde_json::Value,
@@ -629,29 +524,21 @@ pub fn render_messages(
     let raw = messages.as_array().map(Vec::as_slice).unwrap_or(&[]);
     let mut msgs = merge_tool_messages(raw);
 
-    // The engine inserts an empty system message when the first message isn't a
-    // system message; it renders to nothing but keeps the index logic aligned
-    // (and is where tools attach). Doing it after the merge is equivalent — a
-    // system turn never joins a user run.
+    // The engine inserts an empty system message when the first message isn't
+    // one; it renders to nothing but anchors the tools block and index logic.
     if msgs.first().map(|m| m.role != "system").unwrap_or(true) {
         msgs.insert(0, MergedMsg::plain("system"));
     }
 
     sort_tool_results_by_call_order(&mut msgs);
 
-    // The engine attaches `request.tools` to `messages[0]` (the system message,
-    // always present after the insertion above) and renders them immediately
-    // after the system content. An empty `tools` array is falsy engine-side, so
-    // treat it as no tools.
+    // An empty `tools` array is falsy engine-side — no tools block.
     let tool_list = tools
         .and_then(|t| t.as_array())
         .filter(|arr| !arr.is_empty());
 
-    // Mirror `encode_messages`' drop resolution: the engine calls it with the
-    // default `drop_thinking = true`, then forces it OFF when any message carries
-    // tools (`effective_drop_thinking`). So: no tools → drop earlier turns'
-    // reasoning; tools present → keep it (DeepSeek requires prior reasoning in the
-    // context of a tool-calling multi-turn conversation).
+    // The engine's drop resolution: no tools → drop earlier turns' reasoning;
+    // tools present → keep it (`effective_drop_thinking` forced off).
     let effective_drop_thinking = tool_list.is_none();
     if opts.thinking && effective_drop_thinking {
         msgs = drop_thinking_messages(msgs);
@@ -659,9 +546,8 @@ pub fn render_messages(
     let last_user_idx = last_user_index(&msgs);
 
     let mut out = String::from(BOS);
-    // Reasoning-effort preamble sits at the very front (after BOS, before the
-    // system content), thinking mode only — `encoding_dsv4.render_message`
-    // index 0. WHICH levels emit one depends on the profile ([`effort_preamble`]).
+    // The effort preamble sits at the very front (after BOS), thinking mode
+    // only; which levels emit one depends on the profile.
     if opts.thinking {
         out.push_str(effort_preamble(
             opts.reasoning_effort_profile,
@@ -687,10 +573,8 @@ pub fn render_messages(
     out
 }
 
-/// Index of the last `user`/`developer` message (the engine's
-/// `find_last_user_index`), or `-1` when there is none. `i64` mirrors the
-/// engine's `-1` sentinel so the `index >= last_user_idx` transition comparisons
-/// are exact.
+/// The engine's `find_last_user_index`: last `user`/`developer` message, or
+/// `-1` (kept as `i64` so the transition comparisons mirror the engine's).
 fn last_user_index(msgs: &[MergedMsg]) -> i64 {
     for i in (0..msgs.len()).rev() {
         if matches!(msgs[i].role.as_str(), "user" | "developer") {
@@ -700,11 +584,9 @@ fn last_user_index(msgs: &[MergedMsg]) -> i64 {
     -1
 }
 
-/// Mirror `encoding_dsv4._drop_thinking_messages` (applied only in thinking mode
-/// when dropping is in effect, i.e. no tools): messages at/after the last user
-/// turn are kept verbatim; before it, `user`/`system`/`tool`/`latest_reminder`/
-/// `direct_search_results` pass through, an assistant turn keeps everything but its
-/// `reasoning_content`, and a `developer` (or any other) turn is dropped entirely.
+/// Mirror `encoding_dsv4._drop_thinking_messages`: before the last user turn,
+/// an assistant turn loses its `reasoning_content` and a `developer` (or other)
+/// turn is dropped entirely; everything else passes through.
 fn drop_thinking_messages(msgs: Vec<MergedMsg>) -> Vec<MergedMsg> {
     let last_user = last_user_index(&msgs);
     let mut out = Vec::with_capacity(msgs.len());
@@ -727,10 +609,8 @@ fn drop_thinking_messages(msgs: Vec<MergedMsg>) -> Vec<MergedMsg> {
 /// A tool call on an assistant turn, in the fields DSML rendering needs.
 struct ToolCall {
     name: String,
-    /// The OpenAI `arguments` — spec'd as a JSON string, but the type also
-    /// permits an inlined object — kept raw and decoded at render time by
-    /// [`encode_arguments_to_dsml`] (which mirrors the engine's `json.loads` +
-    /// wrap-on-failure).
+    /// Raw OpenAI `arguments` (a JSON string, or the inlined object the type
+    /// also permits); decoded at render time by [`encode_arguments_to_dsml`].
     arguments: serde_json::Value,
     /// OpenAI `id` (falling back to `function.id`); orders tool results.
     id: String,
@@ -745,13 +625,9 @@ enum Block {
     },
 }
 
-/// A message after `merge_tool_messages`. `blocks` is `Some` only for user turns
-/// (their text + folded-in tool results); `tool_calls` is non-empty only for
-/// assistant turns; `reasoning_content` is a prior assistant turn's thinking
-/// block, rendered only in thinking mode (see [`render_one`]). `task` is the
-/// engine's quick-instruction task key (request-attached or message-level),
-/// preserved through the merge the way `encoding_dsv4.merge_tool_messages`
-/// preserves it.
+/// A message after `merge_tool_messages`: `blocks` is `Some` only for user
+/// turns, `tool_calls` non-empty only for assistant turns, `reasoning_content`
+/// rendered only in thinking mode, `task` preserved through the merge.
 struct MergedMsg {
     role: String,
     content: String,
@@ -774,11 +650,8 @@ impl MergedMsg {
     }
 }
 
-/// Index of the trailing message iff it is a user turn a following USER
-/// message should merge into: carrying blocks and with NO task — the
-/// engine's user-merge guard (`merged[-1].get("task") is None`), which exists
-/// only on the user fold: a task-carrying user turn terminates the run so
-/// the following user message starts fresh (keeping its own keys).
+/// Trailing user turn a following USER message merges into: has blocks and NO
+/// task — the engine's user-merge guard (a task-carrying turn ends the run).
 fn open_user_idx(merged: &[MergedMsg]) -> Option<usize> {
     match merged.last() {
         Some(last) if last.role == "user" && last.blocks.is_some() && last.task.is_none() => {
@@ -788,10 +661,8 @@ fn open_user_idx(merged: &[MergedMsg]) -> Option<usize> {
     }
 }
 
-/// Index of the trailing message iff it is a user turn a TOOL message should
-/// fold into: carrying blocks — the engine's tool fold has NO task guard
-/// (`merged[-1].get("role") == "user" and "content_blocks" in merged[-1]`),
-/// so a tool result folds into a task-carrying run too.
+/// Trailing user turn a TOOL message folds into: has blocks. The engine's tool
+/// fold has NO task guard, so a result folds into a task-carrying run too.
 fn open_tool_fold_idx(merged: &[MergedMsg]) -> Option<usize> {
     match merged.last() {
         Some(last) if last.role == "user" && last.blocks.is_some() => Some(merged.len() - 1),
@@ -799,11 +670,9 @@ fn open_tool_fold_idx(merged: &[MergedMsg]) -> Option<usize> {
     }
 }
 
-/// Mirror `encoding_dsv4.merge_tool_messages`: DeepSeek-V4 has no standalone
-/// `tool` role, so a tool message folds into the preceding (or a fresh) user
-/// turn as a `tool_result` block, and consecutive user turns coalesce into one
-/// with a text block each. Other roles pass through unchanged. Message-level
-/// `task` keys are preserved the way the engine preserves extra fields.
+/// Mirror `encoding_dsv4.merge_tool_messages`: dsv4 has no standalone `tool`
+/// role, so a tool message folds into the preceding (or a fresh) user turn as
+/// a `tool_result` block, and consecutive user turns coalesce.
 fn merge_tool_messages(raw: &[serde_json::Value]) -> Vec<MergedMsg> {
     let mut merged: Vec<MergedMsg> = Vec::with_capacity(raw.len());
     for m in raw {
@@ -840,9 +709,7 @@ fn merge_tool_messages(raw: &[serde_json::Value]) -> Vec<MergedMsg> {
                 let mut am = MergedMsg::plain("assistant");
                 am.content = content_to_string(m.get("content"));
                 am.tool_calls = parse_tool_calls(m.get("tool_calls"));
-                // Prior-turn thinking block. The engine renders it verbatim as
-                // `reasoning_content or ""` (a plain string), so pass it through
-                // as-is; a missing/non-string value is treated as empty.
+                // Rendered verbatim (`reasoning_content or ""` engine-side).
                 am.reasoning_content = str_field(m, "reasoning_content");
                 am.task = str_field_opt(m, "task");
                 merged.push(am);
@@ -858,11 +725,9 @@ fn merge_tool_messages(raw: &[serde_json::Value]) -> Vec<MergedMsg> {
     merged
 }
 
-/// Extract an assistant turn's `tool_calls` into [`ToolCall`]s. Missing fields
-/// degrade to empty rather than dropping the call — a malformed call still
-/// contributes stable bytes to the hash. `id` falls back to `function.id` when
-/// absent at the top level, matching the engine's sort-key extraction
-/// (`tc.get("id") or tc.get("function",{}).get("id")`).
+/// Extract an assistant turn's `tool_calls`. Missing fields degrade to empty
+/// rather than dropping the call; `id` falls back to `function.id`, matching
+/// the engine's sort-key extraction.
 fn parse_tool_calls(v: Option<&serde_json::Value>) -> Vec<ToolCall> {
     let Some(arr) = v.and_then(|t| t.as_array()) else {
         return Vec::new();
@@ -879,18 +744,13 @@ fn parse_tool_calls(v: Option<&serde_json::Value>) -> Vec<ToolCall> {
                 }
             };
             ToolCall {
-                // `FunctionResponse.name` is `Optional[str] = None`, so a call
-                // without one VALIDATES engine-side and reaches
-                // `tool_call_template.format(name=None)`, which stringifies to
-                // the literal `None` — not an empty string.
+                // A nameless call validates engine-side and renders the
+                // stringified Python `None`, not an empty string.
                 name: func
                     .and_then(|f| f.get("name"))
                     .and_then(|n| n.as_str())
                     .map(str::to_owned)
                     .unwrap_or_else(|| "None".to_owned()),
-                // Keep the raw value (string or inlined object);
-                // `encode_arguments_to_dsml` reproduces the engine's handling of
-                // both.
                 arguments: func
                     .and_then(|f| f.get("arguments"))
                     .cloned()
@@ -901,11 +761,9 @@ fn parse_tool_calls(v: Option<&serde_json::Value>) -> Vec<ToolCall> {
         .collect()
 }
 
-/// Mirror `encoding_dsv4.sort_tool_results_by_call_order`: when a user turn
-/// carries more than one tool result, order them by the position of their
-/// originating call in the most recent assistant turn's `tool_calls`. Text
-/// blocks keep their slots; only the tool-result slots are reordered among
-/// themselves. A single tool result (or no preceding calls) is left untouched.
+/// Mirror `encoding_dsv4.sort_tool_results_by_call_order`: multiple tool
+/// results in one user turn are reordered to the most recent assistant turn's
+/// call order; text blocks keep their slots.
 fn sort_tool_results_by_call_order(merged: &mut [MergedMsg]) {
     let mut order: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     for m in merged.iter_mut() {
@@ -921,9 +779,7 @@ fn sort_tool_results_by_call_order(merged: &mut [MergedMsg]) {
         let Some(blocks) = m.blocks.as_mut() else {
             continue;
         };
-        // Capture the tool-result slot positions FIRST: the extraction below
-        // swaps a `Text` placeholder into each, so a later `matches!(ToolResult)`
-        // would no longer find them.
+        // Capture slot positions before the extraction swaps placeholders in.
         let slots: Vec<usize> = blocks
             .iter()
             .enumerate()
@@ -933,9 +789,8 @@ fn sort_tool_results_by_call_order(merged: &mut [MergedMsg]) {
         if slots.len() <= 1 || order.is_empty() {
             continue;
         }
-        // Pull the tool-result blocks out, stable-sort by call order (unknown
-        // ids sort to 0, matching the engine's `.get(id, 0)`), drop them back
-        // into the same slots — text blocks keep their positions.
+        // Stable-sort by call order (unknown ids sort to 0, the engine's
+        // `.get(id, 0)`) and drop the results back into the same slots.
         let mut results: Vec<Block> = slots
             .iter()
             .map(|&idx| std::mem::replace(&mut blocks[idx], Block::Text(String::new())))
@@ -976,13 +831,10 @@ fn render_one(
             }
         }
         "assistant" => {
-            // Thinking mode renders the turn's `reasoning_content` followed by
-            // `</think>` before its content; the opening `<think>` came from the
-            // preceding user turn's transition below. Kept when reasoning isn't
-            // being dropped (tools present) OR this turn is strictly after the last
-            // user turn — matching `encoding_dsv4.render_message`, including its
-            // `prev_has_task` rule: a task on the PRECEDING message marks this
-            // turn as a task output, whose thinking is never rendered.
+            // Thinking mode renders `reasoning_content</think>` before the
+            // content when reasoning is kept (tools present) or the turn is
+            // after the last user turn; a task on the PRECEDING message marks
+            // this turn as a task output, whose thinking is never rendered.
             let prev_has_task = i > 0 && msgs[i - 1].task.is_some();
             if opts.thinking
                 && !prev_has_task
@@ -998,11 +850,9 @@ fn render_one(
             }
             out.push_str(EOS);
         }
-        // Roles this encoder does not model — including `latest_reminder`,
-        // which IS protocol-declared and which the engine renders with a
-        // marker token this arm drops. `input_ids_safe_to_forward_dsv4`
-        // withholds every such role, so the cost is routing quality, never a
-        // served prompt; emit the content rather than vanishing it.
+        // Unmodeled roles (`latest_reminder` included): the forwarding
+        // predicate withholds them, so the cost is routing quality only; emit
+        // the content rather than vanishing it.
         _ => out.push_str(&m.content),
     }
 
@@ -1016,10 +866,8 @@ fn render_one(
         return;
     }
     if let Some(task) = m.task.as_deref() {
-        // Task transition (`encoding_dsv4.render_message`): any non-`action`
-        // task appends its special token directly — without the assistant
-        // opening — while `action` opens an assistant turn first. Task names
-        // are validated in `render_request`, the only non-test path here.
+        // A non-`action` task appends its special token bare; `action` opens
+        // an assistant turn first. Validated in `render_request`.
         let sp = task_sp_token(task).expect("task validated by the caller's gate");
         if task != "action" {
             out.push_str(sp);
@@ -1034,10 +882,8 @@ fn render_one(
         }
     } else if m.role == "user" || m.role == "developer" {
         out.push_str(ASSISTANT);
-        // Chat mode always closes with `</think>`. Thinking mode opens the next
-        // assistant turn with `<think>`: always when reasoning is kept (tools
-        // present), else only at/after the last user turn (the current
-        // generation) — mirroring `encoding_dsv4.render_message`.
+        // Chat mode closes with `</think>`; thinking mode opens `<think>` when
+        // reasoning is kept (tools) or at/after the last user turn.
         let token = if opts.thinking && (!effective_drop_thinking || i as i64 >= last_user_idx) {
             THINK_START
         } else {
@@ -1073,18 +919,14 @@ fn render_tool_calls(tool_calls: &[ToolCall]) -> String {
     format!("<{DSML}tool_calls>\n{invokes}\n</{DSML}tool_calls>")
 }
 
-/// Encode a tool call's `arguments` into DSML `<parameter>` lines, mirroring
-/// SGLANG's `encoding_dsv4.encode_arguments_to_dsml`: every key of the
-/// arguments OBJECT becomes one param — a string value raw with
-/// `string="true"`, anything else Python-`json.dumps`ed with `string="false"`.
-/// Both accepted spellings (a JSON string, or an inlined object — the engine's
-/// `json.loads` is guarded by `isinstance(raw, str)`) expand per key. Anything
-/// not an object is a request the ENGINE rejects; this renders empty and
-/// `input_ids_safe_to_forward_dsv4` withholds it, so the ids stay routing-only.
+/// Mirror SGLANG's `encode_arguments_to_dsml`: each key of the arguments
+/// OBJECT becomes one `<parameter>` — strings raw with `string="true"`, other
+/// values Python-serialized with `string="false"`. Both spellings (JSON string
+/// or inlined object) expand per key; a non-object is an ENGINE-rejected
+/// request, rendered empty here and withheld by the forwarding predicate.
 ///
 /// DELIBERATE FORK from the checkpoint's own `encoding_dsv4.py` (which wraps a
-/// dict into one `arguments` param): sglang rewrote the function to expand per
-/// key, and sglang renders the prompt the engine actually serves.
+/// dict into one param): sglang renders the prompt the engine actually serves.
 fn encode_arguments_to_dsml(arguments: &serde_json::Value) -> String {
     let parsed_from_str;
     let obj = match arguments {
@@ -1109,13 +951,9 @@ fn encode_arguments_to_dsml(arguments: &serde_json::Value) -> String {
         .join("\n")
 }
 
-/// Flatten a `tool` message's `content` for a `<tool_result>` body, mirroring
-/// the engine's pre-merge flatten on the dsv4 path
-/// (`process_content_for_template_format(_, "string")` runs over EVERY client
-/// message, tool messages included): a string as-is; an array to its text
-/// parts joined with a single space, non-text parts dropped. (The
-/// `[Unsupported <type>]` shape seen in `encoding_dsv4` only applies to
-/// engine-internal `content_blocks`, which clients cannot send.)
+/// Flatten a `tool` message's `content` for a `<tool_result>` body — the
+/// engine's pre-merge flatten runs over every client message, tool messages
+/// included: a string as-is, an array to its space-joined text parts.
 fn tool_result_content(content: Option<&serde_json::Value>) -> String {
     match content {
         Some(serde_json::Value::String(s)) => s.clone(),
@@ -1142,14 +980,10 @@ fn str_field(m: &serde_json::Value, key: &str) -> String {
         .to_string()
 }
 
-/// Flatten a message `content` field to a string: a plain string as-is; an
-/// OpenAI parts array to its `type == "text"` parts joined with a single space
-/// (mirroring `process_content_for_template_format(_, "string")`, which the
-/// engine applies to dsv4 before encoding and which ignores non-text parts);
-/// anything else to empty. NOTE: every non-string, non-array `content` — a
-/// number included — is a 422 at the protocol boundary (pydantic v2 does not
-/// coerce int/float to `str`), so those arms are unreachable defence, not a
-/// mirror of engine behavior.
+/// Flatten a message `content` to a string: a string as-is; a parts array to
+/// its `type == "text"` texts joined with one space (the engine's
+/// `process_content_for_template_format(_, "string")`). Other shapes are 422s
+/// at the protocol boundary — unreachable defence, not engine behavior.
 fn content_to_string(content: Option<&serde_json::Value>) -> String {
     match content {
         Some(serde_json::Value::String(s)) => s.clone(),
@@ -1164,19 +998,15 @@ fn content_to_string(content: Option<&serde_json::Value>) -> String {
     }
 }
 
-/// Fixed tools-section text from the engine's `encoding_dsv4.TOOLS_TEMPLATE`
-/// with the constant tokens (`dsml_token`, thinking start/end) already
-/// substituted; the tool schemas are the only variable part and slot between
-/// `TOOLS_PREFIX` and `TOOLS_SUFFIX`. Kept byte-identical to the engine so the
-/// router's block hashes match its cached blocks.
+/// The engine's `encoding_dsv4.TOOLS_TEMPLATE` with its constant tokens
+/// substituted; the tool schemas slot between prefix and suffix. Byte-identical
+/// to the engine.
 const TOOLS_PREFIX: &str = "## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n";
 const TOOLS_SUFFIX: &str =
     "\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n";
 
-/// Render the request's top-level OpenAI `tools` array into the DeepSeek-V4
-/// tools section, mirroring `encoding_dsv4.render_tools`: each tool's canonical
-/// `function` (see [`canonical_function`]) is serialized Python-style and the
-/// schemas are joined with `\n`, between the fixed preamble and trailer.
+/// Mirror `encoding_dsv4.render_tools`: each tool's [`canonical_function`],
+/// Python-serialized, newline-joined between the fixed prefix and suffix.
 fn render_tools(tools: &[serde_json::Value]) -> String {
     let schemas = tools
         .iter()
@@ -1186,35 +1016,27 @@ fn render_tools(tools: &[serde_json::Value]) -> String {
     format!("{TOOLS_PREFIX}{schemas}{TOOLS_SUFFIX}")
 }
 
-/// Reproduce the engine's `Function.model_dump()` (`serving_chat`) for one
-/// OpenAI tool: re-emit exactly `description, name, parameters, strict` (plus
-/// `defer_loading` only when set), injecting the pydantic defaults for omitted
-/// optionals and dropping unknown fields. `defer_loading` may be spelled on
-/// the FUNCTION or the TOOL (the engine's `Tool._propagate_defer_loading`
-/// copies a tool-level value onto a function that has none) — this canonical
-/// shape, not the raw client object, is what the engine serializes.
+/// Reproduce the engine's `Function.model_dump()` for one OpenAI tool: exactly
+/// `description, name, parameters, strict` with pydantic defaults injected and
+/// unknown fields dropped, plus `defer_loading` only when set — spelled on the
+/// FUNCTION or the TOOL (the engine's `Tool._propagate_defer_loading`). This
+/// canonical shape, not the raw client object, is what the engine serializes.
 fn canonical_function(tool: &serde_json::Value) -> serde_json::Value {
     let func = tool.get("function");
     let field = |k: &str| func.and_then(|f| f.get(k)).cloned();
     let mut m = serde_json::Map::new();
-    m.insert(
-        "description".to_string(),
-        field("description").unwrap_or(serde_json::Value::Null),
-    );
-    m.insert(
-        "name".to_string(),
-        field("name").unwrap_or(serde_json::Value::Null),
-    );
-    m.insert(
-        "parameters".to_string(),
-        field("parameters").unwrap_or(serde_json::Value::Null),
-    );
+    for key in ["description", "name", "parameters"] {
+        m.insert(
+            key.to_string(),
+            field(key).unwrap_or(serde_json::Value::Null),
+        );
+    }
     m.insert(
         "strict".to_string(),
         field("strict").unwrap_or(serde_json::Value::Bool(false)),
     );
-    // Function-level wins; a tool-level value propagates only when the function
-    // has none — the validator's `and self.function.defer_loading is None`.
+    // Function-level wins; a tool-level value propagates only when the
+    // function has none.
     let defer_loading = field("defer_loading")
         .filter(|v| !v.is_null())
         .or_else(|| tool.get("defer_loading").filter(|v| !v.is_null()).cloned());
@@ -1234,21 +1056,16 @@ mod tests {
         s.map_or(ReasoningEffort::None, effort_from_str)
     }
 
-    /// Byte-exact parity against the engine's `encoding_dsv4.encode_messages` in
-    /// BOTH chat and thinking mode, across fixtures generated from the engine
-    /// encoder itself (transition token `<think>`/`</think>`, prior reasoning
-    /// kept-with-tools vs dropped-without, the empty-reasoning `<think></think>`
-    /// block, and the `reasoning_effort=max` front preamble). A mismatch here is
-    /// exactly a router↔engine routing-tokenization divergence — the thing that
-    /// collapses cache-aware routing on a thinking-mode engine.
+    /// Byte-exact parity against engine-generated fixtures, chat AND thinking
+    /// mode. A mismatch is a router-engine tokenization divergence — the thing
+    /// that collapses cache-aware routing.
     #[test]
     fn thinking_and_chat_parity_fixtures() {
         let raw = include_str!("testdata/dsv4_thinking_cases.json");
         let cases: Vec<serde_json::Value> = serde_json::from_str(raw).expect("fixture json parses");
         assert!(!cases.is_empty(), "fixtures present");
-        // Both profiles must be represented, or a regenerate that silently fell
-        // back to the engine's `preview` default would drop half the coverage
-        // without failing anything.
+        // Both profiles must be represented, or a bad regenerate silently
+        // drops half the coverage.
         for want in ["preview", "official"] {
             assert!(
                 cases.iter().any(|c| c["reasoning_effort_profile"] == want),
@@ -1258,9 +1075,6 @@ mod tests {
         for c in &cases {
             let name = c["name"].as_str().unwrap();
             let tools = c.get("tools").filter(|t| !t.is_null());
-            // The profile the generator actually rendered under, replayed here
-            // — neither side may assume one (upstream's `encode_messages`
-            // defaults to `preview`, so an omitted argument is silent).
             let profile = match c["reasoning_effort_profile"].as_str() {
                 Some("official") => ReasoningEffortProfile::Official,
                 Some("preview") => ReasoningEffortProfile::Preview,
@@ -1404,10 +1218,8 @@ mod tests {
         );
     }
 
-    /// A `developer` turn renders identically to a user turn for text content
-    /// (the engine nests the same `<｜User｜>` marker) and takes the generation
-    /// prompt. Developer turns are not merged (only `user` runs merge), so two
-    /// developers emit two markers.
+    /// A `developer` turn renders like a user turn but never merges (only
+    /// `user` runs merge), so two developers emit two markers.
     #[test]
     fn developer_role_renders_like_user_without_merging() {
         assert_eq!(
@@ -1512,11 +1324,8 @@ mod tests {
         assert!(out.ends_with("<｜User｜>hi<｜Assistant｜></think>"));
     }
 
-    /// Byte-exact against the engine (`encode_messages`, chat mode): an assistant
-    /// `tool_calls` turn renders the DSML block — string args raw with
-    /// `string="true"`, others Python-serialized with `string="false"` — and a
-    /// following `tool` message folds into the next user turn as a
-    /// `<tool_result>` block.
+    /// Byte-exact: an assistant `tool_calls` turn renders the DSML block, and
+    /// a following `tool` message folds into the next user turn.
     #[test]
     fn renders_assistant_tool_calls_and_tool_result() {
         let messages = json!([
@@ -1574,13 +1383,9 @@ mod tests {
         );
     }
 
-    /// Byte-exact against the engine (expected string produced by running
-    /// `encoding_dsv4.encode_messages`): an inlined-object `arguments` — which
-    /// `FunctionResponse.arguments: Optional[str | Dict[str, Any]]` permits — is
-    /// expanded PER KEY, exactly like the equivalent JSON string. The engine's
-    /// `json.loads` is guarded by `isinstance(raw, str)`, so a dict reaches the
-    /// per-key loop untouched; wrapping it into one `arguments` param would
-    /// serve a tool-call history the engine never renders.
+    /// An inlined-object `arguments` (permitted by the engine's type) expands
+    /// PER KEY, exactly like the equivalent JSON string — wrapping it into one
+    /// param would render a history the engine never renders.
     #[test]
     fn inlined_object_arguments_expand_per_key_like_engine() {
         let expected = "<｜begin▁of▁sentence｜>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"f\">\n<｜DSML｜parameter name=\"x\" string=\"false\">1</｜DSML｜parameter>\n<｜DSML｜parameter name=\"y\" string=\"true\">z</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>R</tool_result><｜Assistant｜></think>";
@@ -1608,11 +1413,8 @@ mod tests {
         );
     }
 
-    /// `arguments` shapes the ENGINE rejects (`json.loads` raising, or its
-    /// `must be a JSON object` ValueError) render no params rather than an
-    /// invented wrapper — the ids stay routing-only, and
-    /// `input_ids_safe_to_forward_dsv4` withholds them so the engine produces
-    /// its own error instead of the router serving a made-up prompt.
+    /// `arguments` shapes the ENGINE rejects render no params rather than an
+    /// invented wrapper; the forwarding predicate withholds those ids.
     #[test]
     fn engine_rejected_arguments_render_no_params() {
         for args in [json!("not json"), json!("[1, 2]"), json!(5), json!(null)] {
@@ -1631,12 +1433,8 @@ mod tests {
         }
     }
 
-    /// `defer_loading` is accepted on the FUNCTION or on the TOOL, and the
-    /// engine's `Tool._propagate_defer_loading` copies a tool-level value onto
-    /// the function (only when the function has none) BEFORE
-    /// `Function.model_dump()` serializes it. Both spellings must therefore
-    /// produce the same canonical schema — this renders into the system turn, so
-    /// a dropped key shifts block 0 and every hash after it.
+    /// Both `defer_loading` spellings (function- or tool-level) produce the
+    /// same canonical schema; a dropped key would shift block 0's hash.
     #[test]
     fn tool_level_defer_loading_propagates_like_engine() {
         let want = json!({
@@ -1702,10 +1500,8 @@ mod tests {
         );
     }
 
-    /// `parse_env_bool` matches the engine's `EnvBool` token set exactly
-    /// (`true/1/yes/y` | `false/0/no/n`, case-insensitive), and returns `None`
-    /// for anything else — including `on`, which a hand-rolled set might wrongly
-    /// accept and thereby diverge from the engine.
+    /// Exactly the engine `EnvBool` token set — `None` for anything else,
+    /// including `on`, which a hand-rolled set might wrongly accept.
     #[test]
     fn parse_env_bool_matches_engine_token_set() {
         for t in ["true", "1", "yes", "y", "TRUE", "Yes", "Y"] {
@@ -1736,11 +1532,8 @@ mod tests {
         assert!(json_truthy(&json!({ "k": 1 })));
     }
 
-    /// `resolve_render_opts` honors per-request overrides (the paths that don't
-    /// depend on env): `chat_template_kwargs.thinking` truthiness; `reasoning_effort`
-    /// top-level ONLY (the engine's dsv4 branch never reads it from
-    /// chat_template_kwargs); and the protocol validator's thinking default
-    /// (effort present → `!= "none"`).
+    /// Per-request overrides: ctk thinking truthiness, the effort precedence
+    /// chain, and the validator's effort-derived thinking default.
     #[test]
     fn resolve_render_opts_request_overrides() {
         let opts = resolve_render_opts(&json!({"chat_template_kwargs": {"thinking": true}}));
@@ -1829,12 +1622,8 @@ mod tests {
         assert!(!resolve_default_thinking(Some("enabled"))); // unrecognized → false (WARNs)
     }
 
-    /// The default effort is `low` — the official checkpoint's
-    /// `DEFAULT_REASONING_EFFORT`, and what the engine substitutes when nothing
-    /// survives its accepted-effort filter. It renders NO preamble, so an
-    /// unset router env matches an unset engine env. Defaulting to `high` would
-    /// prepend the max-preview preamble to every plain thinking-mode request
-    /// under the official profile; `max` would prepend the heaviest one.
+    /// The default effort is `low` (the checkpoint's default, no preamble);
+    /// values the engine's filter drops land there too.
     #[test]
     fn resolve_default_effort_branches() {
         // NB: no `use ReasoningEffort::*` here — its `None` would shadow
@@ -1871,10 +1660,8 @@ mod tests {
         }
     }
 
-    /// The `reasoning` OBJECT is mirrored per `normalize_reasoning_inputs`: its
-    /// `effort`/`reasoning_effort` aliases supply the top-level effort, its
-    /// `enabled`/`enable` turns thinking on, an effort OVERRIDES `enabled`, and
-    /// a client-sent `chat_template_kwargs.thinking` beats both (`setdefault`).
+    /// The `reasoning` object: effort aliases, `enabled`/`enable`, effort
+    /// overriding `enabled`, and a client-sent ctk thinking beating both.
     #[test]
     fn reasoning_object_mirrors_the_protocol_validator() {
         use ReasoningEffort as E;
@@ -1942,10 +1729,8 @@ mod tests {
         }
     }
 
-    /// The profile defaults to `official` (the current DeepSeek-V4 official API
-    /// rendering) and only an explicit `preview` opts back into the older
-    /// mapping. An unrecognized value must not refuse to serve — it WARNs and
-    /// takes the default — because this is a rendering hint, not a safety gate.
+    /// Defaults to `official`; an unrecognized value WARNs and falls back
+    /// rather than refusing to serve.
     #[test]
     fn resolve_effort_profile_branches() {
         use ReasoningEffortProfile::*;
@@ -2156,10 +1941,8 @@ mod tests {
         );
     }
 
-    /// The flag-false rewrite REPLACES the message wholesale, like the engine
-    /// — a message-level `task` key on the trailing assistant must NOT
-    /// survive, or the render would emit a task transition the engine never
-    /// does.
+    /// The flag-false rewrite REPLACES the message wholesale: a `task` key on
+    /// the trailing assistant must not survive it.
     #[test]
     fn rewrite_drops_message_level_task_key() {
         let (text, _) = render_request(
@@ -2246,11 +2029,8 @@ mod tests {
         );
     }
 
-    /// Client-sent message-level `task` keys are stripped upstream (the
-    /// engine's message model has no such field — only the pydantic-declared
-    /// `request.task` path can ever produce a task transition). The strip
-    /// applies to invalid names too: no engine assert can be triggered by a
-    /// key the engine never sees.
+    /// Client-sent message-level `task` keys are stripped (undeclared on the
+    /// engine's message model) — only `request.task` renders a transition.
     #[test]
     fn client_message_level_task_is_stripped() {
         let rendered = render_request(
@@ -2321,14 +2101,9 @@ mod tests {
         assert!(thinking(true).contains("answer<｜end▁of▁sentence｜>"));
     }
 
-    /// Ordering: surgery first, then `task` attach (engine pipeline). With
-    /// `continue_final_message` unset the trailing assistant is rewritten to
-    /// user BEFORE the attach sees the list — and the preceding plain user
-    /// run then MERGES it in, which drops the incoming task key exactly like
-    /// `encoding_dsv4.merge_tool_messages` (its run-append guard only carries
-    /// blocks). So this shape emits the plain generation prompt, not a task
-    /// token — task-special-token rendering requires the task to land on a
-    /// run-terminating message.
+    /// Surgery runs before `task` attach: the rewritten-to-user trailing turn
+    /// merges into the preceding user run, dropping the incoming task exactly
+    /// as the engine's merge does — so no task token renders here.
     #[test]
     fn surgery_runs_before_task_attach_and_merge_is_engine_faithful() {
         let rendered = render_request(
@@ -2351,12 +2126,8 @@ mod tests {
         );
     }
 
-    /// Merge semantics with tasks: a task-carrying user turn TERMINATES a user
-    /// run (a following user starts fresh), but a following TOOL message still
-    /// folds INTO the task turn (the tool fold has no task guard engine-side).
-    /// Transitions (including a task token) render only when the NEXT message
-    /// is an assistant/reminder turn or the message is last — so a task on a
-    /// user turn followed by another user turn emits no task token at all.
+    /// A task-carrying user turn terminates a user run but still accepts a
+    /// tool fold; its task token renders only on a turn transition.
     #[test]
     fn task_merge_guard_and_tool_fold() {
         // {user(task), user}: no merge, and the first turn gets NO task

--- a/experimental/sgl-router/src/tokenizer/dsv4.rs
+++ b/experimental/sgl-router/src/tokenizer/dsv4.rs
@@ -5,30 +5,24 @@
 //!
 //! DeepSeek-V4 ships no Jinja chat template; the engine builds the prompt in
 //! code (`python/sglang/srt/entrypoints/openai/encoding_dsv4.py`, selected for
-//! the `DeepseekV4` architecture). So to make the router's query tokens match
-//! the engine's cached blocks, this reproduces that encoder's output for the
-//! routing-relevant subset.
-//!
-//! # Scope
-//!
-//! Text content, chat (non-thinking) mode — the engine default
-//! (`SGLANG_DEFAULT_THINKING=false`). For a user turn the engine emits
-//! `BOS <｜User｜> content <｜Assistant｜> </think>`. Two preprocessing steps mirror
-//! `serving_chat.py`/`encode_messages`: an empty system message is inserted when
-//! the first message isn't a system message, and consecutive user turns are
-//! merged into one (joined with `\n\n`). Tools, tasks, and per-turn reasoning
-//! content are out of scope: the engine renders tools immediately after the
-//! system content at the front of the prompt, so a tools-carrying request
-//! diverges from the first block and routes by min-load; tasks alter only the
-//! trailing turn transition; reasoning content is never emitted in chat mode,
-//! so it causes no divergence.
+//! the `DeepseekV4` architecture). This reproduces that encoder byte-exactly
+//! for the routing-relevant subset, so the router's query tokens match the
+//! engine's cached blocks: chat AND thinking mode ([`resolve_render_opts`]
+//! mirrors the engine's per-request resolution), tools / tool calls / tool
+//! results, the `task` quick instructions, and the trailing-assistant surgery
+//! behind `continue_final_message` ([`render_request`]). Shapes this encoder
+//! does NOT mirror are withheld from `input_ids` forwarding by
+//! `input_ids_safe_to_forward_dsv4` (the single enumeration — not restated
+//! here); the render simply ignores them, degrading routing, never
+//! correctness.
 //!
 //! Tokenization does not auto-prepend special tokens (the `dynamo_tokenizers`
-//! HF wrapper hardcodes `add_special_tokens = false`;
-//! [`super::adapter::encode`] adds none of its own), so the literal marker text
-//! below is what maps to the special token ids. Pinned byte-exact against the
-//! live engine's `/tokenize` (DeepSeek-V4-Flash, snapshot `6976c7ff`):
-//! `[{user:"ABCD"}]` → `[0, 128803, 51453, 128804, 128822]`.
+//! HF wrapper defaults `add_special_tokens` to false; [`super::adapter::encode`]
+//! adds none), so the literal marker text below maps to the special token ids.
+//! Pinned byte-exact against the live engine's `/tokenize` (DeepSeek-V4-Flash,
+//! snapshot `6976c7ff`): `[{user:"ABCD"}]` → `[0, 128803, 51453, 128804, 128822]`.
+
+use super::pyjson::py_json;
 
 /// Beginning-of-sequence marker (token id 0).
 const BOS: &str = "<｜begin▁of▁sentence｜>";
@@ -38,109 +32,1196 @@ const EOS: &str = "<｜end▁of▁sentence｜>";
 const USER: &str = "<｜User｜>";
 /// Assistant-turn marker, opening the generation prompt (token id 128804).
 const ASSISTANT: &str = "<｜Assistant｜>";
+/// Thinking-start marker (`encoding_dsv4.thinking_start_token`); a thinking-mode
+/// generation prompt / historical assistant turn opens with it.
+const THINK_START: &str = "<think>";
 /// Thinking-end marker; the chat-mode generation prompt ends with it (128822).
 const THINK_END: &str = "</think>";
+/// DSML block token wrapping tool-call / tools markup (`encoding_dsv4.dsml_token`).
+const DSML: &str = "｜DSML｜";
 
-/// Render `messages` into the DeepSeek-V4 chat prompt for routing.
-///
-/// Mirrors `encoding_dsv4.encode_messages` for the routing subset (chat mode,
-/// text content, no tools/tasks). `messages` is the request's `messages` array;
-/// non-array input renders to just the BOS marker (the caller then tokenizes it
-/// and, finding no useful prefix, degrades to min-load like any short prompt).
-pub fn render_messages(messages: &serde_json::Value) -> String {
-    let mut msgs: Vec<(String, String)> = messages
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .map(|m| {
-                    let role = m
-                        .get("role")
-                        .and_then(|r| r.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    (role, content_to_string(m.get("content")))
-                })
-                .collect()
+/// The `encoding_dsv4.DS_TASK_SP_TOKENS` map — special tokens appended after
+/// a task-carrying message. Valid task names are exactly these keys; anything
+/// else is an engine-side assertion failure (`VALID_TASKS`).
+fn task_sp_token(task: &str) -> Option<&'static str> {
+    match task {
+        "action" => Some("<｜action｜>"),
+        "query" => Some("<｜query｜>"),
+        "authority" => Some("<｜authority｜>"),
+        "domain" => Some("<｜domain｜>"),
+        "title" => Some("<｜title｜>"),
+        "read_url" => Some("<｜read_url｜>"),
+        _ => None,
+    }
+}
+
+/// Request-level fields beyond `messages`/`tools` that steer the engine's
+/// dsv4 encoding (`serving_chat` dsv4 branch) and which the router must
+/// mirror to remain engine-equivalent.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RequestParts<'a> {
+    /// The request-level `task` (encoding_dsv4's quick-instruction tasks),
+    /// attached to the last user/developer message. A non-string `task` fails
+    /// engine-side pydantic validation, so it is treated as absent.
+    pub task: Option<&'a str>,
+    /// OpenAI `continue_final_message` (default false): the engine extracts a
+    /// trailing assistant message and appends its text AFTER the generation
+    /// prompt. Coerced via [`openai_bool`], the way pydantic would.
+    pub continue_final_message: bool,
+}
+
+impl<'a> RequestParts<'a> {
+    /// Extract the dsv4 request-level steering from a parsed request body.
+    pub fn resolve(request: &'a serde_json::Value) -> Self {
+        RequestParts {
+            task: request.get("task").and_then(|t| t.as_str()),
+            continue_final_message: request.get("continue_final_message").and_then(openai_bool)
+                == Some(true),
+        }
+    }
+}
+
+/// Parse a JSON value as a coerced OpenAI boolean. Lives in
+/// [`crate::tokenizer::openai_bool`]; re-exported here so dsv4 call sites
+/// read naturally.
+pub use crate::tokenizer::openai_bool;
+
+/// Errors from engine-mirroring pre-processing. Each corresponds to a request
+/// the ENGINE also rejects — at the protocol boundary or inside
+/// `serving_chat`/`encoding_dsv4` — so the caller treating it as "not
+/// engine-equivalent" reproduces the engine's own outcome. A future variant
+/// that is a ROUTER limitation rather than an engine rejection must not be
+/// added here: `dsv4_render_rejects_request` keys on this type to suppress the
+/// broken-offload metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderErr {
+    /// `task` present but no user/developer message —
+    /// `attach_task_to_last_user_message`'s `ValueError`.
+    TaskWithoutUser,
+    /// A task name outside `encoding_dsv4.VALID_TASKS`. The request-level
+    /// field is `Optional[Literal[...]]`, so the engine rejects it as a 422
+    /// before rendering; this check exists because the router parses the raw
+    /// body, which has had no such validation.
+    InvalidTask,
+}
+
+impl std::fmt::Display for RenderErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RenderErr::TaskWithoutUser => write!(f, "`task` requires a user/developer message"),
+            RenderErr::InvalidTask => write!(f, "task outside encoding_dsv4.VALID_TASKS"),
+        }
+    }
+}
+
+impl std::error::Error for RenderErr {}
+
+/// Mirror `serving_chat._handle_last_assistant_message` on the dsv4 branch.
+/// The engine flattens content BEFORE the surgery ([`content_to_string`];
+/// `null`/absent → `""`), then for a trailing assistant turn:
+/// `continue_final_message = true` REMOVES it and hands back its flattened
+/// content as the prefix (the caller encodes and appends it after the
+/// generation prompt); `false` REPLACES it wholesale with
+/// `{"role": "user", "content": flattened}`, dropping every other key.
+/// Unflattenable content (a 422 at the protocol boundary) is left untouched.
+fn handle_trailing_assistant(
+    messages: &mut Vec<serde_json::Value>,
+    continue_final_message: bool,
+) -> Option<String> {
+    let trailing_role = messages
+        .last()
+        .and_then(|m| m.get("role"))
+        .and_then(|r| r.as_str());
+    if trailing_role != Some("assistant") {
+        return None;
+    }
+    let flattened = match messages.last().and_then(|m| m.get("content")) {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        // Flattened to "" by the engine before the surgery.
+        Some(serde_json::Value::Null) | None => String::new(),
+        Some(serde_json::Value::Array(_)) => {
+            content_to_string(messages.last().and_then(|m| m.get("content")))
+        }
+        // Non-string scalar: 422 at the protocol boundary, so unreachable —
+        // left untouched rather than guessing a flattening the engine
+        // never performs.
+        Some(_) => return None,
+    };
+    if continue_final_message {
+        messages.pop();
+        Some(flattened)
+    } else {
+        *messages.last_mut().unwrap() = serde_json::json!({"role": "user", "content": flattened});
+        None
+    }
+}
+
+/// Mirror `encoding_dsv4.find_last_user_index` + `attach_task_to_last_user_message`:
+/// set `task` on the most recent user/developer message. Errs when none
+/// exists (the engine's `ValueError`) and when the task name is invalid (the
+/// render-time `VALID_TASKS` assert — surfaced here so failure modes are
+/// uniform).
+fn attach_task(messages: &mut [serde_json::Value], task: &str) -> Result<(), RenderErr> {
+    if task_sp_token(task).is_none() {
+        return Err(RenderErr::InvalidTask);
+    }
+    let idx = messages
+        .iter()
+        .rposition(|m| {
+            matches!(
+                m.get("role").and_then(|r| r.as_str()),
+                Some("user") | Some("developer")
+            )
         })
-        .unwrap_or_default();
+        .ok_or(RenderErr::TaskWithoutUser)?;
+    messages[idx]["task"] = serde_json::json!(task);
+    Ok(())
+}
+
+/// Render a whole request the way the engine's dsv4 branch does
+/// (`serving_chat`): trailing-assistant surgery, then `task` attachment,
+/// then [`render_messages`]. Returns the rendered prompt and, when
+/// `continue_final_message` extracted a trailing assistant turn, its content
+/// — the caller encodes that text and appends the ids after the prompt ids
+/// (`_append_assistant_prefix_to_prompt_ids`).
+pub fn render_request(
+    messages: &serde_json::Value,
+    tools: Option<&serde_json::Value>,
+    opts: RenderOpts,
+    parts: RequestParts<'_>,
+) -> Result<(String, Option<String>), RenderErr> {
+    let mut raw = messages
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .to_vec();
+    for m in &mut raw {
+        // The generic-role model case-normalizes (`_normalize_role`); the
+        // user-role model is a bare `Literal["user"]`, so `"User"` is a 422
+        // rather than a normalized user turn. Lowercasing here is therefore
+        // harmless alignment, not a behavior the engine reproduces for `user`.
+        if let Some(role) = m.get("role").and_then(|r| r.as_str()).map(str::to_owned) {
+            m["role"] = serde_json::json!(role.to_ascii_lowercase());
+        }
+        // Client-sent message-level `task` never reaches encoding_dsv4 (the
+        // message model has no such declared field), so it is stripped exactly
+        // where the engine strips it — the only task that renders is the
+        // request-level one attached below.
+        if let serde_json::Value::Object(o) = m {
+            o.remove("task");
+        }
+    }
+    let prefix = handle_trailing_assistant(&mut raw, parts.continue_final_message);
+    if let Some(task) = parts.task {
+        attach_task(&mut raw, task)?;
+    }
+    // Validate the remaining (attach-set) task keys — the engine's
+    // render-time `VALID_TASKS` assert.
+    for m in &raw {
+        if let Some(t) = m.get("task").and_then(|t| t.as_str()) {
+            if task_sp_token(t).is_none() {
+                return Err(RenderErr::InvalidTask);
+            }
+        }
+    }
+    Ok((
+        render_messages(&serde_json::Value::Array(raw), tools, opts),
+        prefix,
+    ))
+}
+
+/// Reasoning-effort level, mirroring `encoding_dsv4`'s `reasoning_effort`.
+/// Which levels prepend a preamble depends on the active
+/// [`ReasoningEffortProfile`] — see [`effort_preamble`]. `Low` (an accepted
+/// official-profile level, the checkpoint's `DEFAULT_REASONING_EFFORT`) and
+/// `None` ("filtered out engine-side, profile default substituted") both
+/// render no preamble but are kept distinct — the engine's own cardinality.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    None,
+    Low,
+    High,
+    Max,
+}
+
+/// Which `encoding_dsv4.REASONING_EFFORT_PROFILES` mapping the engine renders
+/// with. The engine resolves this per model at startup by AST-parsing
+/// `encoding/encoding_dsv4.py` INSIDE the checkpoint — a file the router never
+/// sees — so the router takes it from
+/// `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE` ([`resolve_effort_profile`]).
+/// A fleet serving a preview-era checkpoint MUST set it to `preview`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ReasoningEffortProfile {
+    /// `{"high": "", "max": PREVIEW_MAX}`.
+    Preview,
+    /// `{"low": "", "high": PREVIEW_MAX, "max": OFFICIAL_MAX}`.
+    #[default]
+    Official,
+}
+
+/// How to render, mirroring the engine's per-request `thinking_mode` +
+/// `reasoning_effort`. The engine derives these from the request's
+/// `chat_template_kwargs.thinking` / `reasoning_effort` (falling back to its
+/// `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` defaults); the
+/// router mirrors that resolution in [`resolve_render_opts`] so its routing
+/// tokens match the engine's cached blocks even when the engine runs a
+/// non-default (e.g. thinking-on) mode. `RenderOpts::chat()` reproduces the
+/// chat-mode encoder output byte-for-byte.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderOpts {
+    /// `true` = thinking mode (engine `thinking_mode == "thinking"`).
+    pub thinking: bool,
+    pub reasoning_effort: ReasoningEffort,
+    /// The engine's per-model effort mapping. Carried here (rather than read
+    /// from a global inside the renderer) so [`render_messages`] stays a pure
+    /// function of its inputs and parity fixtures can pin both profiles.
+    pub reasoning_effort_profile: ReasoningEffortProfile,
+}
+
+impl RenderOpts {
+    /// Chat / non-thinking mode with no effort preamble — the engine default,
+    /// byte-identical to the chat-mode encoder output. The profile is inert
+    /// here (no preamble renders outside thinking mode, and `None` maps to the
+    /// empty preamble under both profiles).
+    pub const fn chat() -> Self {
+        RenderOpts {
+            thinking: false,
+            reasoning_effort: ReasoningEffort::None,
+            reasoning_effort_profile: ReasoningEffortProfile::Official,
+        }
+    }
+}
+
+/// The `encoding_dsv4.REASONING_EFFORT_PROFILES[profile][effort]` lookup.
+///
+/// The engine filters a request's effort to the profile's accepted keys and
+/// substitutes the profile default (`"low"` official / `"high"` preview) when
+/// nothing survives — both of which map to the empty preamble, so every level
+/// the router collapses into [`ReasoningEffort::None`] renders `""` here too.
+fn effort_preamble(profile: ReasoningEffortProfile, effort: ReasoningEffort) -> &'static str {
+    use ReasoningEffortProfile::*;
+    match (profile, effort) {
+        // `None` = filtered out engine-side, so the engine substitutes the
+        // profile default (`"low"` official / `"high"` preview) — both of which
+        // map to the empty preamble, same as `Low`.
+        (_, ReasoningEffort::None) | (_, ReasoningEffort::Low) => "",
+        (Preview, ReasoningEffort::High) => "",
+        (Preview, ReasoningEffort::Max) => REASONING_EFFORT_PREVIEW_MAX,
+        (Official, ReasoningEffort::High) => REASONING_EFFORT_PREVIEW_MAX,
+        (Official, ReasoningEffort::Max) => REASONING_EFFORT_OFFICIAL_MAX,
+    }
+}
+
+/// Resolve the render options for a request, mirroring the engine's dsv4
+/// normalization (`protocol.normalize_reasoning_inputs` + `serving_chat`'s
+/// dsv4 branch):
+///
+/// Thinking: a PRESENT `chat_template_kwargs.thinking` wins by truthiness
+/// (explicit `null` counts as present, per `setdefault`); else the validator's
+/// effort-derived default ([`normalize_reasoning_inputs`]); else the router's
+/// env default.
+///
+/// Effort: `_convert_to_internal_request` pops `chat_template_kwargs.
+/// reasoning_effort` ONTO the top-level field before the dsv4 branch reads it,
+/// so precedence is ctk effort (present non-null) > top-level effort > env —
+/// env consulted ONLY when both are absent/null; any other present value
+/// collapses to `None` without consulting env. Note the asymmetry: the
+/// thinking-setdefault runs at parse time, before the ctk pop, so ctk effort
+/// never defaults thinking — only a top-level one does.
+///
+/// The router cannot observe the engine's env defaults, so
+/// `SGLANG_ROUTER_DSV4_DEFAULT_THINKING` / `SGLANG_ROUTER_DSV4_REASONING_EFFORT`
+/// / `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE` (read once) MUST match the
+/// engine's `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` /
+/// checkpoint-resolved profile — a mismatch is undetectable from the request
+/// (see `input_ids_safe_to_forward_dsv4`'s deploy note).
+pub fn resolve_render_opts(request: &serde_json::Value) -> RenderOpts {
+    // The `reasoning` object + top-level effort, as the protocol validator
+    // resolves them at parse time.
+    let (validator_effort, validator_thinking) = normalize_reasoning_inputs(request);
+    let thinking = match request
+        .get("chat_template_kwargs")
+        .and_then(|k| k.as_object())
+        .and_then(|o| o.get("thinking"))
+    {
+        // A client-sent key wins: `setdefault` never overwrites it.
+        Some(v) => json_truthy(v),
+        None => validator_thinking.unwrap_or_else(default_thinking),
+    };
+
+    // Effective effort source, mirroring the engine's ctk-pop-with-precedence.
+    let effort_field = request
+        .get("chat_template_kwargs")
+        .and_then(|k| k.as_object())
+        .and_then(|o| o.get("reasoning_effort"))
+        .filter(|v| !v.is_null())
+        .cloned()
+        .or(validator_effort);
+    let reasoning_effort = match effort_field.as_ref() {
+        Some(serde_json::Value::String(s)) => effort_from_str(s),
+        // Absent or explicit null (both channels): the engine consults env.
+        Some(serde_json::Value::Null) | None => default_effort(),
+        // Any other present value (numeric, bool, …): never `max`/`high`, and
+        // the env default is NOT consulted.
+        Some(_) => ReasoningEffort::None,
+    };
+
+    RenderOpts {
+        thinking,
+        reasoning_effort,
+        reasoning_effort_profile: active_effort_profile(),
+    }
+}
+
+/// Mirror `protocol.normalize_reasoning_inputs`, the `mode="before"` validator
+/// that runs at PARSE time — before `_convert_to_internal_request` pops
+/// `chat_template_kwargs.reasoning_effort`.
+///
+/// The top-level `reasoning` OBJECT can do two things: supply
+/// `reasoning_effort` (via its `effort` / `reasoning_effort` aliases) and turn
+/// thinking on (via `enabled` / `enable`). Returns the effective top-level
+/// effort and the thinking value the validator would `setdefault` into
+/// `chat_template_kwargs` — `None` meaning it set nothing, so the caller falls
+/// through to the env default.
+///
+/// Mirroring this is what lets `input_ids_safe_to_forward_dsv4` stop withholding
+/// `reasoning`-carrying requests.
+fn normalize_reasoning_inputs(
+    request: &serde_json::Value,
+) -> (Option<serde_json::Value>, Option<bool>) {
+    use serde_json::Value;
+    // The validator's accepted string levels; anything else it coerces to a
+    // float (or 422s), and a non-string effort never maps to a preamble.
+    const LEVELS: [&str; 7] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+    let mut effort = request
+        .get("reasoning_effort")
+        .filter(|v| !v.is_null())
+        .cloned();
+    let mut thinking: Option<bool> = None;
+    if let Some(r) = request.get("reasoning").and_then(|v| v.as_object()) {
+        let alias = r
+            .get("effort")
+            .filter(|v| !v.is_null())
+            .or_else(|| r.get("reasoning_effort").filter(|v| !v.is_null()));
+        match alias {
+            // A recognized level, a number, or a numeric string all become the
+            // top-level effort; only a recognized level can reach a preamble,
+            // so the numeric forms are kept verbatim (they map to `None` in
+            // `effort_from_str` exactly as the engine's filter drops them).
+            Some(Value::String(s)) if LEVELS.contains(&s.as_str()) => {
+                effort = Some(Value::String(s.clone()))
+            }
+            Some(v @ Value::Number(_)) => effort = Some(v.clone()),
+            Some(Value::String(s)) if s.parse::<f64>().is_ok() => {
+                effort = Some(Value::String(s.clone()))
+            }
+            // Anything else is a validator ValueError — the engine 422s the
+            // request, so leave the effort alone and let it fail there.
+            _ => {}
+        }
+        // `enabled` wins over `enable`; a string is truthy by an explicit token
+        // set, not by Python truthiness.
+        let on = match r
+            .get("enabled")
+            .filter(|v| !v.is_null())
+            .or_else(|| r.get("enable"))
+        {
+            Some(Value::String(s)) => matches!(
+                s.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "y" | "on"
+            ),
+            Some(v) => json_truthy(v),
+            None => false,
+        };
+        if on {
+            thinking = Some(true);
+        }
+    }
+    // An effort — from either channel — OVERRIDES the `enabled`-derived value.
+    if let Some(e) = &effort {
+        thinking = Some(!matches!(e, Value::String(s) if s == "none"));
+    }
+    (effort, thinking)
+}
+
+/// The engine's effort STRING → level. The single mapping used by the
+/// request path, the env default, and the fixture harness, so they cannot
+/// drift apart. Anything outside the profiles' keys becomes `None`: the
+/// engine's accepted-effort filter drops it and substitutes the profile
+/// default, which renders the same empty preamble as [`ReasoningEffort::Low`].
+fn effort_from_str(s: &str) -> ReasoningEffort {
+    match s {
+        "max" => ReasoningEffort::Max,
+        "high" => ReasoningEffort::High,
+        "low" => ReasoningEffort::Low,
+        _ => ReasoningEffort::None,
+    }
+}
+
+/// Python-truthiness of a JSON value, mirroring the engine's `if thinking_requested`
+/// test on the raw `chat_template_kwargs.thinking` value (`serving_chat.py`): a bool
+/// as-is, a string/array/object truthy iff non-empty, a number iff non-zero, null
+/// falsy. A conformant client sends a bool; this only matters for odd payloads, and
+/// keeps routing matching the engine on them.
+fn json_truthy(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::String(s) => !s.is_empty(),
+        serde_json::Value::Number(n) => n.as_f64().is_none_or(|f| f != 0.0),
+        serde_json::Value::Array(a) => !a.is_empty(),
+        serde_json::Value::Object(o) => !o.is_empty(),
+        serde_json::Value::Null => false,
+    }
+}
+
+/// Parse a boolean env value the way the engine's `EnvBool` does (`environ.py`):
+/// case-insensitive `true`/`1`/`yes`/`y` → `Some(true)`, `false`/`0`/`no`/`n` →
+/// `Some(false)`, anything else `None`. Matching the engine's exact token set is
+/// load-bearing: `y` is engine-true, so a set that omitted it would silently
+/// disagree with a `SGLANG_DEFAULT_THINKING=y` engine.
+fn parse_env_bool(value: &str) -> Option<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "y" => Some(true),
+        "false" | "0" | "no" | "n" => Some(false),
+        _ => None,
+    }
+}
+
+/// Resolve the thinking default from the env value (pure; the env read + one-time
+/// caching + logging live in [`router_defaults`]). Mirrors the engine's
+/// `EnvBool` + `EnvField.get`: a recognized token → that bool; a non-empty
+/// unrecognized value → WARN + `false` — the engine behaves identically (its
+/// `EnvField.get` catches `EnvBool.parse`'s `ValueError`, warns, and returns the
+/// `False` default; it does NOT surface a hard error). Unset/empty → `false`.
+fn resolve_default_thinking(env: Option<&str>) -> bool {
+    match env {
+        Some(s) if !s.is_empty() => parse_env_bool(s).unwrap_or_else(|| {
+            tracing::warn!(
+                value = %s,
+                "SGLANG_ROUTER_DSV4_DEFAULT_THINKING is not a recognized boolean \
+                 (true/1/yes/y | false/0/no/n); using false (the engine warns + defaults \
+                 false the same way) — dsv4 routing renders chat mode, mismatching a thinking engine"
+            );
+            false
+        }),
+        _ => false,
+    }
+}
+
+/// Resolve the reasoning-effort default from the env value (pure), mirroring
+/// the engine's `SGLANG_DSV4_REASONING_EFFORT` handling. Unset resolves to
+/// `low` — the checkpoint's `DEFAULT_REASONING_EFFORT`, rendering NO preamble,
+/// so an unset router env matches an unset engine env. Values the engine's
+/// accepted-effort filter drops (`medium` included) land on the same default.
+/// The engine always substitutes one, hence a level rather than an `Option`.
+fn resolve_default_effort(env: Option<&str>) -> ReasoningEffort {
+    match env.map(effort_from_str) {
+        // Absent, or a value outside the checkpoint's prompt keys: the engine's
+        // filter drops it and substitutes the profile default.
+        None | Some(ReasoningEffort::None) => ReasoningEffort::Low,
+        Some(level) => level,
+    }
+}
+
+/// Resolve the effort profile from the env value (pure). Unset → `Official`,
+/// matching the current DeepSeek-V4 official API. An unrecognized value falls
+/// back to `Official` too — the router must not refuse to serve over a typo in
+/// a rendering hint — but WARNs, because a preview fleet that misspells this
+/// silently renders official preambles.
+fn resolve_effort_profile(env: Option<&str>) -> ReasoningEffortProfile {
+    match env {
+        // Single source of truth for "unconfigured" — the `#[default]` on the
+        // enum, so the two can't drift.
+        None => ReasoningEffortProfile::default(),
+        Some("official") => ReasoningEffortProfile::Official,
+        Some("preview") => ReasoningEffortProfile::Preview,
+        Some(other) => {
+            tracing::warn!(
+                value = other,
+                "unrecognized SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE; \
+                 expected `official` or `preview`, defaulting to `official`"
+            );
+            ReasoningEffortProfile::Official
+        }
+    }
+}
+
+/// The router's render defaults, resolved once from the
+/// `SGLANG_ROUTER_DSV4_*` env vars and logged once at INFO so an operator can
+/// confirm they match the engine's (an effort/profile mismatch sits at block 0
+/// and shifts every block hash, so it must be visible).
+fn router_defaults() -> &'static (bool, ReasoningEffort, ReasoningEffortProfile) {
+    static V: std::sync::OnceLock<(bool, ReasoningEffort, ReasoningEffortProfile)> =
+        std::sync::OnceLock::new();
+    V.get_or_init(|| {
+        let thinking = resolve_default_thinking(
+            std::env::var("SGLANG_ROUTER_DSV4_DEFAULT_THINKING")
+                .ok()
+                .as_deref(),
+        );
+        let effort = resolve_default_effort(
+            std::env::var("SGLANG_ROUTER_DSV4_REASONING_EFFORT")
+                .ok()
+                .as_deref(),
+        );
+        let profile = resolve_effort_profile(
+            std::env::var("SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE")
+                .ok()
+                .as_deref(),
+        );
+        tracing::info!(
+            default_thinking = thinking,
+            default_reasoning_effort = ?effort,
+            reasoning_effort_profile = ?profile,
+            "dsv4 router render defaults resolved; must match the engine's SGLANG_DEFAULT_THINKING \
+             / SGLANG_DSV4_REASONING_EFFORT — and, ahead of both, any \
+             --default-chat-template-kwargs the engine seeds ctk with — plus its \
+             checkpoint-resolved reasoning-effort profile for cache-aware routing to match"
+        );
+        (thinking, effort, profile)
+    })
+}
+
+fn default_thinking() -> bool {
+    router_defaults().0
+}
+
+/// The effort level a request that carries none renders at.
+fn default_effort() -> ReasoningEffort {
+    router_defaults().1
+}
+
+/// The effort profile every render on this router uses. Fixed per process (the
+/// engine resolves it per model at startup, not per request), so probes that
+/// enumerate distinct render states must take it from here rather than assuming
+/// a profile.
+pub fn active_effort_profile() -> ReasoningEffortProfile {
+    router_defaults().2
+}
+
+/// `encoding_dsv4.REASONING_EFFORT_PREVIEW_MAX` — the preview profile's `max`
+/// preamble, and the official profile's `high` preamble. Emitted at the very
+/// front of the prompt (after BOS, before the system content) in thinking mode
+/// only, per `render_message`'s `index == 0` branch. Byte-identical to the
+/// engine.
+const REASONING_EFFORT_PREVIEW_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+
+/// `encoding_dsv4.REASONING_EFFORT_OFFICIAL_MAX` — the official profile's `max`
+/// preamble. Byte-identical to the engine.
+const REASONING_EFFORT_OFFICIAL_MAX: &str = "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
+
+/// Render `messages` (+ the request's top-level `tools`) into the DeepSeek-V4
+/// chat prompt, mirroring `encoding_dsv4.encode_messages` byte-exactly: tools
+/// render right after the system content ([`render_tools`]); a `tool` message
+/// folds into the preceding (or a fresh) user turn as a `<tool_result>` block
+/// ([`merge_tool_messages`]); an assistant turn's `tool_calls` render as a
+/// DSML block; multiple tool results in one turn are ordered by originating
+/// call ([`sort_tool_results_by_call_order`]); thinking mode follows the
+/// engine's `drop_thinking` rules ([`render_one`], [`drop_thinking_messages`]).
+/// Non-array `messages` renders to just BOS (the caller degrades to min-load).
+/// Request-level behaviors (`task`, trailing-assistant surgery) live in
+/// [`render_request`].
+pub fn render_messages(
+    messages: &serde_json::Value,
+    tools: Option<&serde_json::Value>,
+    opts: RenderOpts,
+) -> String {
+    let raw = messages.as_array().map(Vec::as_slice).unwrap_or(&[]);
+    let mut msgs = merge_tool_messages(raw);
 
     // The engine inserts an empty system message when the first message isn't a
-    // system message; it renders to nothing but keeps the index logic aligned.
-    if msgs.first().map(|(r, _)| r != "system").unwrap_or(true) {
-        msgs.insert(0, ("system".to_string(), String::new()));
+    // system message; it renders to nothing but keeps the index logic aligned
+    // (and is where tools attach). Doing it after the merge is equivalent — a
+    // system turn never joins a user run.
+    if msgs.first().map(|m| m.role != "system").unwrap_or(true) {
+        msgs.insert(0, MergedMsg::plain("system"));
     }
 
-    merge_consecutive_user_turns(&mut msgs);
+    sort_tool_results_by_call_order(&mut msgs);
+
+    // The engine attaches `request.tools` to `messages[0]` (the system message,
+    // always present after the insertion above) and renders them immediately
+    // after the system content. An empty `tools` array is falsy engine-side, so
+    // treat it as no tools.
+    let tool_list = tools
+        .and_then(|t| t.as_array())
+        .filter(|arr| !arr.is_empty());
+
+    // Mirror `encode_messages`' drop resolution: the engine calls it with the
+    // default `drop_thinking = true`, then forces it OFF when any message carries
+    // tools (`effective_drop_thinking`). So: no tools → drop earlier turns'
+    // reasoning; tools present → keep it (DeepSeek requires prior reasoning in the
+    // context of a tool-calling multi-turn conversation).
+    let effective_drop_thinking = tool_list.is_none();
+    if opts.thinking && effective_drop_thinking {
+        msgs = drop_thinking_messages(msgs);
+    }
+    let last_user_idx = last_user_index(&msgs);
 
     let mut out = String::from(BOS);
+    // Reasoning-effort preamble sits at the very front (after BOS, before the
+    // system content), thinking mode only — `encoding_dsv4.render_message`
+    // index 0. WHICH levels emit one depends on the profile ([`effort_preamble`]).
+    if opts.thinking {
+        out.push_str(effort_preamble(
+            opts.reasoning_effort_profile,
+            opts.reasoning_effort,
+        ));
+    }
     for i in 0..msgs.len() {
-        render_one(i, &msgs, &mut out);
+        render_one(
+            i,
+            &msgs,
+            &mut out,
+            opts,
+            last_user_idx,
+            effective_drop_thinking,
+        );
+        if i == 0 {
+            if let Some(list) = tool_list {
+                out.push_str("\n\n");
+                out.push_str(&render_tools(list));
+            }
+        }
     }
     out
 }
 
-/// Collapse runs of consecutive `user` turns into one, joining their content
-/// with `\n\n` — the engine merges them (`merge_tool_messages`) before encoding,
-/// so back-to-back user messages must hash like the single turn it builds.
-/// `developer` and other roles break a run and are left as-is.
-fn merge_consecutive_user_turns(msgs: &mut Vec<(String, String)>) {
-    let mut merged: Vec<(String, String)> = Vec::with_capacity(msgs.len());
-    for (role, content) in msgs.drain(..) {
-        match merged.last_mut() {
-            Some((last_role, last_content)) if last_role == "user" && role == "user" => {
-                last_content.push_str("\n\n");
-                last_content.push_str(&content);
-            }
-            _ => merged.push((role, content)),
+/// Index of the last `user`/`developer` message (the engine's
+/// `find_last_user_index`), or `-1` when there is none. `i64` mirrors the
+/// engine's `-1` sentinel so the `index >= last_user_idx` transition comparisons
+/// are exact.
+fn last_user_index(msgs: &[MergedMsg]) -> i64 {
+    for i in (0..msgs.len()).rev() {
+        if matches!(msgs[i].role.as_str(), "user" | "developer") {
+            return i as i64;
         }
     }
-    *msgs = merged;
+    -1
 }
 
-/// Append message `i`'s encoded form to `out`.
-fn render_one(i: usize, msgs: &[(String, String)], out: &mut String) {
-    let (role, content) = &msgs[i];
-    match role.as_str() {
-        "system" => out.push_str(content),
+/// Mirror `encoding_dsv4._drop_thinking_messages` (applied only in thinking mode
+/// when dropping is in effect, i.e. no tools): messages at/after the last user
+/// turn are kept verbatim; before it, `user`/`system`/`tool`/`latest_reminder`/
+/// `direct_search_results` pass through, an assistant turn keeps everything but its
+/// `reasoning_content`, and a `developer` (or any other) turn is dropped entirely.
+fn drop_thinking_messages(msgs: Vec<MergedMsg>) -> Vec<MergedMsg> {
+    let last_user = last_user_index(&msgs);
+    let mut out = Vec::with_capacity(msgs.len());
+    for (idx, mut m) in msgs.into_iter().enumerate() {
+        let keep = matches!(
+            m.role.as_str(),
+            "user" | "system" | "tool" | "latest_reminder" | "direct_search_results"
+        );
+        if keep || idx as i64 >= last_user {
+            out.push(m);
+        } else if m.role == "assistant" {
+            m.reasoning_content.clear();
+            out.push(m);
+        }
+        // developer / other roles before the last user turn are dropped.
+    }
+    out
+}
+
+/// A tool call on an assistant turn, in the fields DSML rendering needs.
+struct ToolCall {
+    name: String,
+    /// The OpenAI `arguments` — spec'd as a JSON string, but the type also
+    /// permits an inlined object — kept raw and decoded at render time by
+    /// [`encode_arguments_to_dsml`] (which mirrors the engine's `json.loads` +
+    /// wrap-on-failure).
+    arguments: serde_json::Value,
+    /// OpenAI `id` (falling back to `function.id`); orders tool results.
+    id: String,
+}
+
+/// One piece of a merged user turn: literal text, or a folded-in tool result.
+enum Block {
+    Text(String),
+    ToolResult {
+        content: String,
+        tool_use_id: String,
+    },
+}
+
+/// A message after `merge_tool_messages`. `blocks` is `Some` only for user turns
+/// (their text + folded-in tool results); `tool_calls` is non-empty only for
+/// assistant turns; `reasoning_content` is a prior assistant turn's thinking
+/// block, rendered only in thinking mode (see [`render_one`]). `task` is the
+/// engine's quick-instruction task key (request-attached or message-level),
+/// preserved through the merge the way `encoding_dsv4.merge_tool_messages`
+/// preserves it.
+struct MergedMsg {
+    role: String,
+    content: String,
+    tool_calls: Vec<ToolCall>,
+    blocks: Option<Vec<Block>>,
+    reasoning_content: String,
+    task: Option<String>,
+}
+
+impl MergedMsg {
+    fn plain(role: &str) -> Self {
+        MergedMsg {
+            role: role.to_string(),
+            content: String::new(),
+            tool_calls: Vec::new(),
+            blocks: None,
+            reasoning_content: String::new(),
+            task: None,
+        }
+    }
+}
+
+/// Index of the trailing message iff it is a user turn a following USER
+/// message should merge into: carrying blocks and with NO task — the
+/// engine's user-merge guard (`merged[-1].get("task") is None`), which exists
+/// only on the user fold: a task-carrying user turn terminates the run so
+/// the following user message starts fresh (keeping its own keys).
+fn open_user_idx(merged: &[MergedMsg]) -> Option<usize> {
+    match merged.last() {
+        Some(last) if last.role == "user" && last.blocks.is_some() && last.task.is_none() => {
+            Some(merged.len() - 1)
+        }
+        _ => None,
+    }
+}
+
+/// Index of the trailing message iff it is a user turn a TOOL message should
+/// fold into: carrying blocks — the engine's tool fold has NO task guard
+/// (`merged[-1].get("role") == "user" and "content_blocks" in merged[-1]`),
+/// so a tool result folds into a task-carrying run too.
+fn open_tool_fold_idx(merged: &[MergedMsg]) -> Option<usize> {
+    match merged.last() {
+        Some(last) if last.role == "user" && last.blocks.is_some() => Some(merged.len() - 1),
+        _ => None,
+    }
+}
+
+/// Mirror `encoding_dsv4.merge_tool_messages`: DeepSeek-V4 has no standalone
+/// `tool` role, so a tool message folds into the preceding (or a fresh) user
+/// turn as a `tool_result` block, and consecutive user turns coalesce into one
+/// with a text block each. Other roles pass through unchanged. Message-level
+/// `task` keys are preserved the way the engine preserves extra fields.
+fn merge_tool_messages(raw: &[serde_json::Value]) -> Vec<MergedMsg> {
+    let mut merged: Vec<MergedMsg> = Vec::with_capacity(raw.len());
+    for m in raw {
+        let role = m.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        match role {
+            "tool" => {
+                let block = Block::ToolResult {
+                    content: tool_result_content(m.get("content")),
+                    tool_use_id: str_field(m, "tool_call_id"),
+                };
+                match open_tool_fold_idx(&merged) {
+                    Some(idx) => merged[idx].blocks.as_mut().unwrap().push(block),
+                    None => {
+                        let mut um = MergedMsg::plain("user");
+                        um.blocks = Some(vec![block]);
+                        merged.push(um);
+                    }
+                }
+            }
+            "user" => {
+                let text = content_to_string(m.get("content"));
+                match open_user_idx(&merged) {
+                    Some(idx) => merged[idx].blocks.as_mut().unwrap().push(Block::Text(text)),
+                    None => {
+                        let mut um = MergedMsg::plain("user");
+                        um.content = text.clone();
+                        um.blocks = Some(vec![Block::Text(text)]);
+                        um.task = str_field_opt(m, "task");
+                        merged.push(um);
+                    }
+                }
+            }
+            "assistant" => {
+                let mut am = MergedMsg::plain("assistant");
+                am.content = content_to_string(m.get("content"));
+                am.tool_calls = parse_tool_calls(m.get("tool_calls"));
+                // Prior-turn thinking block. The engine renders it verbatim as
+                // `reasoning_content or ""` (a plain string), so pass it through
+                // as-is; a missing/non-string value is treated as empty.
+                am.reasoning_content = str_field(m, "reasoning_content");
+                am.task = str_field_opt(m, "task");
+                merged.push(am);
+            }
+            other => {
+                let mut om = MergedMsg::plain(other);
+                om.content = content_to_string(m.get("content"));
+                om.task = str_field_opt(m, "task");
+                merged.push(om);
+            }
+        }
+    }
+    merged
+}
+
+/// Extract an assistant turn's `tool_calls` into [`ToolCall`]s. Missing fields
+/// degrade to empty rather than dropping the call — a malformed call still
+/// contributes stable bytes to the hash. `id` falls back to `function.id` when
+/// absent at the top level, matching the engine's sort-key extraction
+/// (`tc.get("id") or tc.get("function",{}).get("id")`).
+fn parse_tool_calls(v: Option<&serde_json::Value>) -> Vec<ToolCall> {
+    let Some(arr) = v.and_then(|t| t.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .map(|tc| {
+            let func = tc.get("function");
+            let id = {
+                let top = str_field(tc, "id");
+                if top.is_empty() {
+                    func.map(|f| str_field(f, "id")).unwrap_or_default()
+                } else {
+                    top
+                }
+            };
+            ToolCall {
+                // `FunctionResponse.name` is `Optional[str] = None`, so a call
+                // without one VALIDATES engine-side and reaches
+                // `tool_call_template.format(name=None)`, which stringifies to
+                // the literal `None` — not an empty string.
+                name: func
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| "None".to_owned()),
+                // Keep the raw value (string or inlined object);
+                // `encode_arguments_to_dsml` reproduces the engine's handling of
+                // both.
+                arguments: func
+                    .and_then(|f| f.get("arguments"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                id,
+            }
+        })
+        .collect()
+}
+
+/// Mirror `encoding_dsv4.sort_tool_results_by_call_order`: when a user turn
+/// carries more than one tool result, order them by the position of their
+/// originating call in the most recent assistant turn's `tool_calls`. Text
+/// blocks keep their slots; only the tool-result slots are reordered among
+/// themselves. A single tool result (or no preceding calls) is left untouched.
+fn sort_tool_results_by_call_order(merged: &mut [MergedMsg]) {
+    let mut order: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for m in merged.iter_mut() {
+        if m.role == "assistant" && !m.tool_calls.is_empty() {
+            order.clear();
+            for (idx, tc) in m.tool_calls.iter().enumerate() {
+                if !tc.id.is_empty() {
+                    order.insert(tc.id.clone(), idx);
+                }
+            }
+            continue;
+        }
+        let Some(blocks) = m.blocks.as_mut() else {
+            continue;
+        };
+        // Capture the tool-result slot positions FIRST: the extraction below
+        // swaps a `Text` placeholder into each, so a later `matches!(ToolResult)`
+        // would no longer find them.
+        let slots: Vec<usize> = blocks
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| matches!(b, Block::ToolResult { .. }))
+            .map(|(idx, _)| idx)
+            .collect();
+        if slots.len() <= 1 || order.is_empty() {
+            continue;
+        }
+        // Pull the tool-result blocks out, stable-sort by call order (unknown
+        // ids sort to 0, matching the engine's `.get(id, 0)`), drop them back
+        // into the same slots — text blocks keep their positions.
+        let mut results: Vec<Block> = slots
+            .iter()
+            .map(|&idx| std::mem::replace(&mut blocks[idx], Block::Text(String::new())))
+            .collect();
+        results.sort_by_key(|b| match b {
+            Block::ToolResult { tool_use_id, .. } => *order.get(tool_use_id).unwrap_or(&0),
+            Block::Text(_) => 0,
+        });
+        for (slot, b) in slots.into_iter().zip(results) {
+            blocks[slot] = b;
+        }
+    }
+}
+
+/// Append merged message `i`'s encoded form to `out`.
+fn render_one(
+    i: usize,
+    msgs: &[MergedMsg],
+    out: &mut String,
+    opts: RenderOpts,
+    last_user_idx: i64,
+    effective_drop_thinking: bool,
+) {
+    let m = &msgs[i];
+    match m.role.as_str() {
+        "system" => out.push_str(&m.content),
         "user" | "developer" => {
             out.push_str(USER);
-            out.push_str(content);
+            match &m.blocks {
+                // A merged user turn renders its blocks joined by `\n\n`.
+                Some(blocks) => {
+                    let parts: Vec<String> = blocks.iter().map(render_block).collect();
+                    out.push_str(&parts.join("\n\n"));
+                }
+                // `developer` (and any user that never went through the merge)
+                // renders its bare content.
+                None => out.push_str(&m.content),
+            }
         }
         "assistant" => {
-            // Chat mode emits no reasoning block, so a prior assistant turn is
-            // just its content closed by EOS.
-            out.push_str(content);
+            // Thinking mode renders the turn's `reasoning_content` followed by
+            // `</think>` before its content; the opening `<think>` came from the
+            // preceding user turn's transition below. Kept when reasoning isn't
+            // being dropped (tools present) OR this turn is strictly after the last
+            // user turn — matching `encoding_dsv4.render_message`, including its
+            // `prev_has_task` rule: a task on the PRECEDING message marks this
+            // turn as a task output, whose thinking is never rendered.
+            let prev_has_task = i > 0 && msgs[i - 1].task.is_some();
+            if opts.thinking
+                && !prev_has_task
+                && (!effective_drop_thinking || i as i64 > last_user_idx)
+            {
+                out.push_str(&m.reasoning_content);
+                out.push_str(THINK_END);
+            }
+            out.push_str(&m.content);
+            if !m.tool_calls.is_empty() {
+                out.push_str("\n\n");
+                out.push_str(&render_tool_calls(&m.tool_calls));
+            }
             out.push_str(EOS);
         }
-        // Unknown roles aren't part of routing traffic; emit the content so a
-        // stray role still contributes something rather than vanishing.
-        _ => out.push_str(content),
+        // Roles this encoder does not model — including `latest_reminder`,
+        // which IS protocol-declared and which the engine renders with a
+        // marker token this arm drops. `input_ids_safe_to_forward_dsv4`
+        // withholds every such role, so the cost is routing quality, never a
+        // served prompt; emit the content rather than vanishing it.
+        _ => out.push_str(&m.content),
     }
 
-    // Generation-prompt transition. The engine appends it only when this is the
-    // last message OR the next message is an assistant/reminder turn, and only
-    // for user/developer messages.
+    // Generation-prompt / task transition. The engine appends it only when this
+    // is the last message OR the next message is an assistant/reminder turn.
     let next_takes_transition = match msgs.get(i + 1) {
-        Some((next_role, _)) => next_role == "assistant" || next_role == "latest_reminder",
+        Some(next) => next.role == "assistant" || next.role == "latest_reminder",
         None => true,
     };
-    if next_takes_transition && (role == "user" || role == "developer") {
+    if !next_takes_transition {
+        return;
+    }
+    if let Some(task) = m.task.as_deref() {
+        // Task transition (`encoding_dsv4.render_message`): any non-`action`
+        // task appends its special token directly — without the assistant
+        // opening — while `action` opens an assistant turn first. Task names
+        // are validated in `render_request`, the only non-test path here.
+        let sp = task_sp_token(task).expect("task validated by the caller's gate");
+        if task != "action" {
+            out.push_str(sp);
+        } else {
+            out.push_str(ASSISTANT);
+            out.push_str(if opts.thinking {
+                THINK_START
+            } else {
+                THINK_END
+            });
+            out.push_str(sp);
+        }
+    } else if m.role == "user" || m.role == "developer" {
         out.push_str(ASSISTANT);
-        out.push_str(THINK_END);
+        // Chat mode always closes with `</think>`. Thinking mode opens the next
+        // assistant turn with `<think>`: always when reasoning is kept (tools
+        // present), else only at/after the last user turn (the current
+        // generation) — mirroring `encoding_dsv4.render_message`.
+        let token = if opts.thinking && (!effective_drop_thinking || i as i64 >= last_user_idx) {
+            THINK_START
+        } else {
+            THINK_END
+        };
+        out.push_str(token);
     }
 }
 
-/// Flatten a message `content` field to a string: a plain string as-is, an
-/// OpenAI parts array to its concatenated `text` parts, anything else to empty.
-fn content_to_string(content: Option<&serde_json::Value>) -> String {
+/// Render one merged-user block: text verbatim, a tool result wrapped in the
+/// engine's `<tool_result>…</tool_result>` (`tool_output_template`).
+fn render_block(b: &Block) -> String {
+    match b {
+        Block::Text(t) => t.clone(),
+        Block::ToolResult { content, .. } => format!("<tool_result>{content}</tool_result>"),
+    }
+}
+
+/// Render an assistant turn's tool calls as the engine's DSML block
+/// (`tool_calls_template` wrapping one `tool_call_template` per call).
+fn render_tool_calls(tool_calls: &[ToolCall]) -> String {
+    let invokes = tool_calls
+        .iter()
+        .map(|tc| {
+            format!(
+                "<{DSML}invoke name=\"{}\">\n{}\n</{DSML}invoke>",
+                tc.name,
+                encode_arguments_to_dsml(&tc.arguments)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("<{DSML}tool_calls>\n{invokes}\n</{DSML}tool_calls>")
+}
+
+/// Encode a tool call's `arguments` into DSML `<parameter>` lines, mirroring
+/// SGLANG's `encoding_dsv4.encode_arguments_to_dsml`: every key of the
+/// arguments OBJECT becomes one param — a string value raw with
+/// `string="true"`, anything else Python-`json.dumps`ed with `string="false"`.
+/// Both accepted spellings (a JSON string, or an inlined object — the engine's
+/// `json.loads` is guarded by `isinstance(raw, str)`) expand per key. Anything
+/// not an object is a request the ENGINE rejects; this renders empty and
+/// `input_ids_safe_to_forward_dsv4` withholds it, so the ids stay routing-only.
+///
+/// DELIBERATE FORK from the checkpoint's own `encoding_dsv4.py` (which wraps a
+/// dict into one `arguments` param): sglang rewrote the function to expand per
+/// key, and sglang renders the prompt the engine actually serves.
+fn encode_arguments_to_dsml(arguments: &serde_json::Value) -> String {
+    let parsed_from_str;
+    let obj = match arguments {
+        serde_json::Value::String(s) => {
+            parsed_from_str = serde_json::from_str::<serde_json::Value>(s).ok();
+            parsed_from_str.as_ref().and_then(|v| v.as_object())
+        }
+        other => other.as_object(),
+    };
+    let Some(obj) = obj else {
+        return String::new();
+    };
+    obj.iter()
+        .map(|(k, v)| {
+            let (is_str, value) = match v {
+                serde_json::Value::String(s) => ("true", s.clone()),
+                _ => ("false", py_json(v)),
+            };
+            format!("<{DSML}parameter name=\"{k}\" string=\"{is_str}\">{value}</{DSML}parameter>")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Flatten a `tool` message's `content` for a `<tool_result>` body, mirroring
+/// the engine's pre-merge flatten on the dsv4 path
+/// (`process_content_for_template_format(_, "string")` runs over EVERY client
+/// message, tool messages included): a string as-is; an array to its text
+/// parts joined with a single space, non-text parts dropped. (The
+/// `[Unsupported <type>]` shape seen in `encoding_dsv4` only applies to
+/// engine-internal `content_blocks`, which clients cannot send.)
+fn tool_result_content(content: Option<&serde_json::Value>) -> String {
     match content {
         Some(serde_json::Value::String(s)) => s.clone(),
         Some(serde_json::Value::Array(parts)) => parts
             .iter()
+            .filter(|p| p.get("type").and_then(|t| t.as_str()) == Some("text"))
             .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-            .collect(),
+            .collect::<Vec<_>>()
+            .join(" "),
         _ => String::new(),
     }
+}
+
+/// A message field as an optional owned string (`None` when absent/non-string).
+fn str_field_opt(m: &serde_json::Value, key: &str) -> Option<String> {
+    m.get(key).and_then(|v| v.as_str()).map(str::to_owned)
+}
+
+/// A message field as an owned string, empty when absent/non-string.
+fn str_field(m: &serde_json::Value, key: &str) -> String {
+    m.get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Flatten a message `content` field to a string: a plain string as-is; an
+/// OpenAI parts array to its `type == "text"` parts joined with a single space
+/// (mirroring `process_content_for_template_format(_, "string")`, which the
+/// engine applies to dsv4 before encoding and which ignores non-text parts);
+/// anything else to empty. NOTE: every non-string, non-array `content` — a
+/// number included — is a 422 at the protocol boundary (pydantic v2 does not
+/// coerce int/float to `str`), so those arms are unreachable defence, not a
+/// mirror of engine behavior.
+fn content_to_string(content: Option<&serde_json::Value>) -> String {
+    match content {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(serde_json::Value::Array(parts)) => parts
+            .iter()
+            .filter(|p| p.get("type").and_then(|t| t.as_str()) == Some("text"))
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    }
+}
+
+/// Fixed tools-section text from the engine's `encoding_dsv4.TOOLS_TEMPLATE`
+/// with the constant tokens (`dsml_token`, thinking start/end) already
+/// substituted; the tool schemas are the only variable part and slot between
+/// `TOOLS_PREFIX` and `TOOLS_SUFFIX`. Kept byte-identical to the engine so the
+/// router's block hashes match its cached blocks.
+const TOOLS_PREFIX: &str = "## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n";
+const TOOLS_SUFFIX: &str =
+    "\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n";
+
+/// Render the request's top-level OpenAI `tools` array into the DeepSeek-V4
+/// tools section, mirroring `encoding_dsv4.render_tools`: each tool's canonical
+/// `function` (see [`canonical_function`]) is serialized Python-style and the
+/// schemas are joined with `\n`, between the fixed preamble and trailer.
+fn render_tools(tools: &[serde_json::Value]) -> String {
+    let schemas = tools
+        .iter()
+        .map(|t| py_json(&canonical_function(t)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{TOOLS_PREFIX}{schemas}{TOOLS_SUFFIX}")
+}
+
+/// Reproduce the engine's `Function.model_dump()` (`serving_chat`) for one
+/// OpenAI tool: re-emit exactly `description, name, parameters, strict` (plus
+/// `defer_loading` only when set), injecting the pydantic defaults for omitted
+/// optionals and dropping unknown fields. `defer_loading` may be spelled on
+/// the FUNCTION or the TOOL (the engine's `Tool._propagate_defer_loading`
+/// copies a tool-level value onto a function that has none) — this canonical
+/// shape, not the raw client object, is what the engine serializes.
+fn canonical_function(tool: &serde_json::Value) -> serde_json::Value {
+    let func = tool.get("function");
+    let field = |k: &str| func.and_then(|f| f.get(k)).cloned();
+    let mut m = serde_json::Map::new();
+    m.insert(
+        "description".to_string(),
+        field("description").unwrap_or(serde_json::Value::Null),
+    );
+    m.insert(
+        "name".to_string(),
+        field("name").unwrap_or(serde_json::Value::Null),
+    );
+    m.insert(
+        "parameters".to_string(),
+        field("parameters").unwrap_or(serde_json::Value::Null),
+    );
+    m.insert(
+        "strict".to_string(),
+        field("strict").unwrap_or(serde_json::Value::Bool(false)),
+    );
+    // Function-level wins; a tool-level value propagates only when the function
+    // has none — the validator's `and self.function.defer_loading is None`.
+    let defer_loading = field("defer_loading")
+        .filter(|v| !v.is_null())
+        .or_else(|| tool.get("defer_loading").filter(|v| !v.is_null()).cloned());
+    if let Some(dl) = defer_loading {
+        m.insert("defer_loading".to_string(), dl);
+    }
+    serde_json::Value::Object(m)
 }
 
 #[cfg(test)]
@@ -148,11 +1229,62 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A fixture's `reasoning_effort` (JSON null = the engine passed `None`).
+    fn effort(s: Option<&str>) -> ReasoningEffort {
+        s.map_or(ReasoningEffort::None, effort_from_str)
+    }
+
+    /// Byte-exact parity against the engine's `encoding_dsv4.encode_messages` in
+    /// BOTH chat and thinking mode, across fixtures generated from the engine
+    /// encoder itself (transition token `<think>`/`</think>`, prior reasoning
+    /// kept-with-tools vs dropped-without, the empty-reasoning `<think></think>`
+    /// block, and the `reasoning_effort=max` front preamble). A mismatch here is
+    /// exactly a router↔engine routing-tokenization divergence — the thing that
+    /// collapses cache-aware routing on a thinking-mode engine.
+    #[test]
+    fn thinking_and_chat_parity_fixtures() {
+        let raw = include_str!("testdata/dsv4_thinking_cases.json");
+        let cases: Vec<serde_json::Value> = serde_json::from_str(raw).expect("fixture json parses");
+        assert!(!cases.is_empty(), "fixtures present");
+        // Both profiles must be represented, or a regenerate that silently fell
+        // back to the engine's `preview` default would drop half the coverage
+        // without failing anything.
+        for want in ["preview", "official"] {
+            assert!(
+                cases.iter().any(|c| c["reasoning_effort_profile"] == want),
+                "fixtures must cover the `{want}` profile"
+            );
+        }
+        for c in &cases {
+            let name = c["name"].as_str().unwrap();
+            let tools = c.get("tools").filter(|t| !t.is_null());
+            // The profile the generator actually rendered under, replayed here
+            // — neither side may assume one (upstream's `encode_messages`
+            // defaults to `preview`, so an omitted argument is silent).
+            let profile = match c["reasoning_effort_profile"].as_str() {
+                Some("official") => ReasoningEffortProfile::Official,
+                Some("preview") => ReasoningEffortProfile::Preview,
+                other => panic!("case `{name}` has unknown profile {other:?}"),
+            };
+            let opts = RenderOpts {
+                thinking: c["thinking"].as_bool().unwrap(),
+                reasoning_effort: effort(c["reasoning_effort"].as_str()),
+                reasoning_effort_profile: profile,
+            };
+            let got = render_messages(&c["messages"], tools, opts);
+            assert_eq!(got, c["expected"].as_str().unwrap(), "case `{name}`");
+        }
+    }
+
     /// Byte-exact against the engine's `/tokenize`: a single user turn renders
     /// `BOS <｜User｜> content <｜Assistant｜> </think>`.
     #[test]
     fn single_user_turn() {
-        let out = render_messages(&json!([{"role":"user","content":"ABCD"}]));
+        let out = render_messages(
+            &json!([{"role":"user","content":"ABCD"}]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜></think>"
@@ -163,10 +1295,14 @@ mod tests {
     /// user turn.
     #[test]
     fn system_then_user() {
-        let out = render_messages(&json!([
-            {"role":"system","content":"SYS"},
-            {"role":"user","content":"ABCD"}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"system","content":"SYS"},
+                {"role":"user","content":"ABCD"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜>SYS<｜User｜>ABCD<｜Assistant｜></think>"
@@ -178,11 +1314,15 @@ mod tests {
     /// `[0,128803,55,19,128804,128822,35,19,1,128803,55,20,128804,128822]`.
     #[test]
     fn multi_turn() {
-        let out = render_messages(&json!([
-            {"role":"user","content":"U1"},
-            {"role":"assistant","content":"A1"},
-            {"role":"user","content":"U2"}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":"A1"},
+                {"role":"user","content":"U2"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜></think>"
@@ -193,25 +1333,35 @@ mod tests {
     /// renders to nothing — same result as a bare user turn.
     #[test]
     fn explicit_empty_system_is_not_duplicated() {
-        let out = render_messages(&json!([
-            {"role":"system","content":""},
-            {"role":"user","content":"ABCD"}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"system","content":""},
+                {"role":"user","content":"ABCD"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜></think>"
         );
     }
 
-    /// Array (multimodal) content flattens to its text parts.
+    /// Multi-part text content flattens to its `type == "text"` parts joined
+    /// with a single space (mirroring the engine's
+    /// `process_content_for_template_format(_, "string")`), NOT concatenated.
     #[test]
     fn array_content_flattens_text_parts() {
-        let out = render_messages(&json!([
-            {"role":"user","content":[{"type":"text","text":"AB"},{"type":"text","text":"CD"}]}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"user","content":[{"type":"text","text":"AB"},{"type":"text","text":"CD"}]}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
-            "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜></think>"
+            "<｜begin▁of▁sentence｜><｜User｜>AB CD<｜Assistant｜></think>"
         );
     }
 
@@ -220,10 +1370,14 @@ mod tests {
     /// generation prompt are emitted — not a marker per message.
     #[test]
     fn consecutive_user_turns_merge() {
-        let out = render_messages(&json!([
-            {"role":"user","content":"U1"},
-            {"role":"user","content":"U2"}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"user","content":"U2"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜><｜User｜>U1\n\nU2<｜Assistant｜></think>"
@@ -234,12 +1388,16 @@ mod tests {
     /// assistant: each side is its own user turn.
     #[test]
     fn user_runs_do_not_merge_across_assistant() {
-        let out = render_messages(&json!([
-            {"role":"user","content":"U1"},
-            {"role":"user","content":"U2"},
-            {"role":"assistant","content":"A1"},
-            {"role":"user","content":"U3"}
-        ]));
+        let out = render_messages(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"user","content":"U2"},
+                {"role":"assistant","content":"A1"},
+                {"role":"user","content":"U3"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
         assert_eq!(
             out,
             "<｜begin▁of▁sentence｜><｜User｜>U1\n\nU2<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U3<｜Assistant｜></think>"
@@ -253,14 +1411,22 @@ mod tests {
     #[test]
     fn developer_role_renders_like_user_without_merging() {
         assert_eq!(
-            render_messages(&json!([{"role":"developer","content":"D1"}])),
+            render_messages(
+                &json!([{"role":"developer","content":"D1"}]),
+                None,
+                RenderOpts::chat()
+            ),
             "<｜begin▁of▁sentence｜><｜User｜>D1<｜Assistant｜></think>"
         );
         assert_eq!(
-            render_messages(&json!([
-                {"role":"developer","content":"D1"},
-                {"role":"developer","content":"D2"}
-            ])),
+            render_messages(
+                &json!([
+                    {"role":"developer","content":"D1"},
+                    {"role":"developer","content":"D2"}
+                ]),
+                None,
+                RenderOpts::chat()
+            ),
             "<｜begin▁of▁sentence｜><｜User｜>D1<｜User｜>D2<｜Assistant｜></think>"
         );
     }
@@ -269,6 +1435,972 @@ mod tests {
     /// degrade path (the caller then routes by min-load on the empty prefix).
     #[test]
     fn empty_messages_renders_bos_only() {
-        assert_eq!(render_messages(&json!([])), "<｜begin▁of▁sentence｜>");
+        assert_eq!(
+            render_messages(&json!([]), None, RenderOpts::chat()),
+            "<｜begin▁of▁sentence｜>"
+        );
+    }
+
+    /// `py_json` reproduces Python `json.dumps(v, ensure_ascii=False)` default
+    /// separators (`", "` / `": "`) and preserves key order — the exact bytes the
+    /// engine's `to_json` produces (serde's compact form would drop the spaces).
+    #[test]
+    fn py_json_uses_python_separators_and_preserves_order() {
+        let v = json!({"b": 1, "a": [1, 2], "c": {"x": true}});
+        assert_eq!(py_json(&v), r#"{"b": 1, "a": [1, 2], "c": {"x": true}}"#);
+    }
+
+    /// A tool's `function` is re-emitted as the engine's `Function.model_dump`:
+    /// fixed order (description, name, parameters, strict), pydantic defaults
+    /// injected for omitted fields, unknown fields dropped, then Python-serialized.
+    #[test]
+    fn canonical_function_reorders_and_injects_defaults() {
+        // Client sends keys out of order, omits description/strict, adds an extra.
+        let tool = json!({
+            "type": "function",
+            "function": {"name": "ping", "parameters": {"type": "object"}, "x-extra": 1}
+        });
+        assert_eq!(
+            py_json(&canonical_function(&tool)),
+            r#"{"description": null, "name": "ping", "parameters": {"type": "object"}, "strict": false}"#
+        );
+    }
+
+    /// Byte-exact against the engine (`encode_messages`, chat mode): tools render
+    /// right after the system content, each `function` canonicalized + serialized
+    /// Python-style. Pinned against `encoding_dsv4.encode_messages` output.
+    #[test]
+    fn renders_tools_after_system_content() {
+        let messages = json!([
+            {"role":"system","content":"SYS"},
+            {"role":"user","content":"hi"}
+        ]);
+        let tools = json!([
+            {"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}
+        ]);
+        let expected = "<｜begin▁of▁sentence｜>SYS\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Get weather\", \"name\": \"get_weather\", \"parameters\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>hi<｜Assistant｜></think>";
+        assert_eq!(
+            render_messages(&messages, Some(&tools), RenderOpts::chat()),
+            expected
+        );
+    }
+
+    /// An empty `tools` array is falsy engine-side — no tools block is rendered.
+    #[test]
+    fn empty_tools_array_renders_no_tools_block() {
+        let messages = json!([{"role":"user","content":"hi"}]);
+        assert_eq!(
+            render_messages(&messages, Some(&json!([])), RenderOpts::chat()),
+            "<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>"
+        );
+    }
+
+    /// With no system message the engine inserts an empty one and still renders
+    /// the tools block (right after the empty system content, i.e. after BOS).
+    #[test]
+    fn renders_tools_when_no_system_message_present() {
+        let messages = json!([{"role":"user","content":"hi"}]);
+        let tools = json!([{"type":"function","function":{"name":"ping","description":"p"}}]);
+        let out = render_messages(&messages, Some(&tools), RenderOpts::chat());
+        assert!(
+            out.starts_with("<｜begin▁of▁sentence｜>\n\n## Tools\n\n"),
+            "tools block should follow the inserted empty system; got: {out}"
+        );
+        assert!(out.contains(
+            r#"{"description": "p", "name": "ping", "parameters": null, "strict": false}"#
+        ));
+        assert!(out.ends_with("<｜User｜>hi<｜Assistant｜></think>"));
+    }
+
+    /// Byte-exact against the engine (`encode_messages`, chat mode): an assistant
+    /// `tool_calls` turn renders the DSML block — string args raw with
+    /// `string="true"`, others Python-serialized with `string="false"` — and a
+    /// following `tool` message folds into the next user turn as a
+    /// `<tool_result>` block.
+    #[test]
+    fn renders_assistant_tool_calls_and_tool_result() {
+        let messages = json!([
+            {"role":"user","content":"u1"},
+            {"role":"assistant","content":"reading","tool_calls":[
+                {"id":"c1","type":"function","function":{"name":"read","arguments":"{\"filePath\": \"/x\", \"limit\": 10, \"nested\": {\"a\": 1}}"}}
+            ]},
+            {"role":"tool","tool_call_id":"c1","content":"FILE"},
+            {"role":"user","content":"u2"}
+        ]);
+        let expected = "<｜begin▁of▁sentence｜><｜User｜>u1<｜Assistant｜></think>reading\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"filePath\" string=\"true\">/x</｜DSML｜parameter>\n<｜DSML｜parameter name=\"limit\" string=\"false\">10</｜DSML｜parameter>\n<｜DSML｜parameter name=\"nested\" string=\"false\">{\"a\": 1}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FILE</tool_result>\n\nu2<｜Assistant｜></think>";
+        assert_eq!(
+            render_messages(&messages, None, RenderOpts::chat()),
+            expected
+        );
+    }
+
+    /// Byte-exact against the engine: multiple tool results in one user turn are
+    /// reordered to the preceding assistant's `tool_calls` order. Results arrive
+    /// b,a; the calls were a,b → rendered a,b.
+    #[test]
+    fn tool_results_sorted_by_call_order() {
+        let messages = json!([
+            {"role":"assistant","content":"","tool_calls":[
+                {"id":"a","type":"function","function":{"name":"t1","arguments":"{}"}},
+                {"id":"b","type":"function","function":{"name":"t2","arguments":"{}"}}
+            ]},
+            {"role":"tool","tool_call_id":"b","content":"RB"},
+            {"role":"tool","tool_call_id":"a","content":"RA"}
+        ]);
+        let expected = "<｜begin▁of▁sentence｜>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"t1\">\n\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"t2\">\n\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>RA</tool_result>\n\n<tool_result>RB</tool_result><｜Assistant｜></think>";
+        assert_eq!(
+            render_messages(&messages, None, RenderOpts::chat()),
+            expected
+        );
+    }
+
+    /// Byte-exact against the engine: multiple tools render one canonical schema
+    /// per line (`\n`-joined). Tool `b` omits everything but `name` (defaults
+    /// injected: description/parameters → null) and sets `strict: true`.
+    #[test]
+    fn renders_multiple_tools() {
+        let messages = json!([
+            {"role":"system","content":"S"},
+            {"role":"user","content":"hi"}
+        ]);
+        let tools = json!([
+            {"type":"function","function":{"name":"a","description":"da","parameters":{"type":"object"}}},
+            {"type":"function","function":{"name":"b","strict":true}}
+        ]);
+        let expected = "<｜begin▁of▁sentence｜>S\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"da\", \"name\": \"a\", \"parameters\": {\"type\": \"object\"}, \"strict\": false}\n{\"description\": null, \"name\": \"b\", \"parameters\": null, \"strict\": true}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>hi<｜Assistant｜></think>";
+        assert_eq!(
+            render_messages(&messages, Some(&tools), RenderOpts::chat()),
+            expected
+        );
+    }
+
+    /// Byte-exact against the engine (expected string produced by running
+    /// `encoding_dsv4.encode_messages`): an inlined-object `arguments` — which
+    /// `FunctionResponse.arguments: Optional[str | Dict[str, Any]]` permits — is
+    /// expanded PER KEY, exactly like the equivalent JSON string. The engine's
+    /// `json.loads` is guarded by `isinstance(raw, str)`, so a dict reaches the
+    /// per-key loop untouched; wrapping it into one `arguments` param would
+    /// serve a tool-call history the engine never renders.
+    #[test]
+    fn inlined_object_arguments_expand_per_key_like_engine() {
+        let expected = "<｜begin▁of▁sentence｜>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"f\">\n<｜DSML｜parameter name=\"x\" string=\"false\">1</｜DSML｜parameter>\n<｜DSML｜parameter name=\"y\" string=\"true\">z</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>R</tool_result><｜Assistant｜></think>";
+        let inlined = json!([
+            {"role":"assistant","content":"","tool_calls":[
+                {"id":"c1","type":"function","function":{"name":"f","arguments":{"x":1,"y":"z"}}}
+            ]},
+            {"role":"tool","tool_call_id":"c1","content":"R"}
+        ]);
+        assert_eq!(
+            render_messages(&inlined, None, RenderOpts::chat()),
+            expected
+        );
+
+        // The engine renders both spellings identically; so must the router.
+        let as_string = json!([
+            {"role":"assistant","content":"","tool_calls":[
+                {"id":"c1","type":"function","function":{"name":"f","arguments":"{\"x\": 1, \"y\": \"z\"}"}}
+            ]},
+            {"role":"tool","tool_call_id":"c1","content":"R"}
+        ]);
+        assert_eq!(
+            render_messages(&as_string, None, RenderOpts::chat()),
+            expected
+        );
+    }
+
+    /// `arguments` shapes the ENGINE rejects (`json.loads` raising, or its
+    /// `must be a JSON object` ValueError) render no params rather than an
+    /// invented wrapper — the ids stay routing-only, and
+    /// `input_ids_safe_to_forward_dsv4` withholds them so the engine produces
+    /// its own error instead of the router serving a made-up prompt.
+    #[test]
+    fn engine_rejected_arguments_render_no_params() {
+        for args in [json!("not json"), json!("[1, 2]"), json!(5), json!(null)] {
+            let messages = json!([
+                {"role":"assistant","content":"","tool_calls":[
+                    {"id":"c1","type":"function","function":{"name":"f","arguments":args}}
+                ]},
+                {"role":"tool","tool_call_id":"c1","content":"R"}
+            ]);
+            let out = render_messages(&messages, None, RenderOpts::chat());
+            // Same shape the engine produces for a legitimately empty `{}`.
+            assert!(
+                out.contains("<｜DSML｜invoke name=\"f\">\n\n</｜DSML｜invoke>"),
+                "expected an empty invoke body for {args}; got: {out}"
+            );
+        }
+    }
+
+    /// `defer_loading` is accepted on the FUNCTION or on the TOOL, and the
+    /// engine's `Tool._propagate_defer_loading` copies a tool-level value onto
+    /// the function (only when the function has none) BEFORE
+    /// `Function.model_dump()` serializes it. Both spellings must therefore
+    /// produce the same canonical schema — this renders into the system turn, so
+    /// a dropped key shifts block 0 and every hash after it.
+    #[test]
+    fn tool_level_defer_loading_propagates_like_engine() {
+        let want = json!({
+            "description": null, "name": "f", "parameters": null,
+            "strict": false, "defer_loading": true
+        });
+        // Tool-level spelling — the one the engine propagates.
+        assert_eq!(
+            canonical_function(&json!({"type":"function","defer_loading":true,
+                                       "function":{"name":"f"}})),
+            want
+        );
+        // Function-level spelling.
+        assert_eq!(
+            canonical_function(&json!({"type":"function",
+                                       "function":{"name":"f","defer_loading":true}})),
+            want
+        );
+        // Function-level WINS: the validator only fills in when it is None.
+        assert_eq!(
+            canonical_function(&json!({"type":"function","defer_loading":true,
+                                       "function":{"name":"f","defer_loading":false}}))
+                ["defer_loading"],
+            json!(false)
+        );
+        // Absent on both → the key is popped by `Function._serialize`.
+        assert!(
+            canonical_function(&json!({"type":"function","function":{"name":"f"}}))
+                .get("defer_loading")
+                .is_none()
+        );
+    }
+
+    /// The two reported prompt-visible shapes, end to end through `py_json`:
+    /// a tool schema's numeric keyword, and a tool call's arguments.
+    #[test]
+    fn py_json_renders_small_floats_like_python() {
+        assert_eq!(
+            py_json(&json!({"multipleOf": 1e-6, "minimum": 2.5e-5})),
+            "{\"multipleOf\": 1e-06, \"minimum\": 2.5e-05}"
+        );
+        assert_eq!(
+            encode_arguments_to_dsml(&json!("{\"tol\": 1e-6}")),
+            "<｜DSML｜parameter name=\"tol\" string=\"false\">1e-06</｜DSML｜parameter>"
+        );
+    }
+
+    /// A tool call with no `function.name` validates engine-side
+    /// (`Optional[str] = None`) and renders the literal `None`, not `""`.
+    #[test]
+    fn missing_tool_call_name_renders_none_like_engine() {
+        let messages = json!([
+            {"role":"user","content":"U"},
+            {"role":"assistant","content":"","tool_calls":[
+                {"id":"c","type":"function","function":{"arguments":"{}"}}
+            ]},
+            {"role":"tool","tool_call_id":"c","content":"R"}
+        ]);
+        let out = render_messages(&messages, None, RenderOpts::chat());
+        assert!(
+            out.contains("<｜DSML｜invoke name=\"None\">"),
+            "expected the engine's stringified None; got: {out}"
+        );
+    }
+
+    /// `parse_env_bool` matches the engine's `EnvBool` token set exactly
+    /// (`true/1/yes/y` | `false/0/no/n`, case-insensitive), and returns `None`
+    /// for anything else — including `on`, which a hand-rolled set might wrongly
+    /// accept and thereby diverge from the engine.
+    #[test]
+    fn parse_env_bool_matches_engine_token_set() {
+        for t in ["true", "1", "yes", "y", "TRUE", "Yes", "Y"] {
+            assert_eq!(parse_env_bool(t), Some(true), "{t}");
+        }
+        for f in ["false", "0", "no", "n", "FALSE", "No"] {
+            assert_eq!(parse_env_bool(f), Some(false), "{f}");
+        }
+        for u in ["on", "off", "enabled", "t", "", "2"] {
+            assert_eq!(parse_env_bool(u), None, "{u}");
+        }
+    }
+
+    /// `json_truthy` mirrors Python truthiness on the raw `thinking` value.
+    #[test]
+    fn json_truthy_mirrors_python() {
+        assert!(json_truthy(&json!(true)));
+        assert!(!json_truthy(&json!(false)));
+        assert!(json_truthy(&json!("true"))); // non-empty string is truthy
+        assert!(json_truthy(&json!("false"))); // even "false" — non-empty
+        assert!(!json_truthy(&json!("")));
+        assert!(json_truthy(&json!(1)));
+        assert!(!json_truthy(&json!(0)));
+        assert!(!json_truthy(&serde_json::Value::Null));
+        assert!(!json_truthy(&json!([])));
+        assert!(json_truthy(&json!([1])));
+        assert!(!json_truthy(&json!({})));
+        assert!(json_truthy(&json!({ "k": 1 })));
+    }
+
+    /// `resolve_render_opts` honors per-request overrides (the paths that don't
+    /// depend on env): `chat_template_kwargs.thinking` truthiness; `reasoning_effort`
+    /// top-level ONLY (the engine's dsv4 branch never reads it from
+    /// chat_template_kwargs); and the protocol validator's thinking default
+    /// (effort present → `!= "none"`).
+    #[test]
+    fn resolve_render_opts_request_overrides() {
+        let opts = resolve_render_opts(&json!({"chat_template_kwargs": {"thinking": true}}));
+        assert!(opts.thinking);
+        // No effort on the request → the env default, which is `low` (the
+        // checkpoint's DEFAULT_REASONING_EFFORT — renders no preamble).
+        assert_eq!(opts.reasoning_effort, ReasoningEffort::Low);
+
+        assert!(
+            !resolve_render_opts(&json!({"chat_template_kwargs": {"thinking": false}})).thinking
+        );
+        // non-bool thinking follows truthiness (matches the engine), not `.as_bool()`.
+        assert!(
+            resolve_render_opts(&json!({"chat_template_kwargs": {"thinking": "true"}})).thinking
+        );
+        assert!(
+            !resolve_render_opts(&json!({"chat_template_kwargs": {"thinking": null}})).thinking
+        );
+
+        // chat_template_kwargs.reasoning_effort is popped ONTO the top-level
+        // field by `_convert_to_internal_request` before the dsv4 branch reads
+        // it — ctk wins over a set top-level.
+        assert_eq!(
+            resolve_render_opts(&json!({
+                "reasoning_effort": "high",
+                "chat_template_kwargs": {"reasoning_effort": "max"}
+            }))
+            .reasoning_effort,
+            ReasoningEffort::Max
+        );
+        // …but a present-null ctk value lets the top-level field through.
+        assert_eq!(
+            resolve_render_opts(&json!({
+                "reasoning_effort": "high",
+                "chat_template_kwargs": {"reasoning_effort": null}
+            }))
+            .reasoning_effort,
+            ReasoningEffort::High
+        );
+        assert_eq!(
+            resolve_render_opts(&json!({"reasoning_effort": "high"})).reasoning_effort,
+            ReasoningEffort::High
+        );
+        // `low` is accepted by the official profile (and is the checkpoint's
+        // DEFAULT_REASONING_EFFORT) — it renders no preamble but is NOT the same
+        // state as a filtered-out value, and it still switches thinking on.
+        let low = resolve_render_opts(&json!({"reasoning_effort": "low"}));
+        assert_eq!(low.reasoning_effort, ReasoningEffort::Low);
+        assert!(low.thinking);
+        // An effort outside the checkpoint's REASONING_EFFORT_PROMPTS collapses
+        // to None; the engine drops it and falls back to the profile default.
+        assert_eq!(
+            resolve_render_opts(&json!({"reasoning_effort": "medium"})).reasoning_effort,
+            ReasoningEffort::None
+        );
+        // and thinking still defaults from effort != "none".
+        assert!(resolve_render_opts(&json!({"reasoning_effort": "medium"})).thinking);
+        // a present-null effort falls to the (false) env default for thinking…
+        assert!(!resolve_render_opts(&json!({"reasoning_effort": null})).thinking);
+        // …while an explicit null THINKING key wins over the effort default
+        // (setdefault semantics: key presence, not truthiness).
+        assert!(
+            !resolve_render_opts(
+                &json!({"chat_template_kwargs": {"thinking": null}, "reasoning_effort": "high"})
+            )
+            .thinking
+        );
+        // "none" effort force-disables thinking (validator: thinking = effort != "none").
+        assert!(!resolve_render_opts(&json!({"reasoning_effort": "none"})).thinking);
+        // numeric (token-budget) effort: thinking on, effort None, env not consulted.
+        let o = resolve_render_opts(&json!({"reasoning_effort": 512}));
+        assert!(o.thinking);
+        assert_eq!(o.reasoning_effort, ReasoningEffort::None);
+    }
+
+    /// The env-default resolvers (the deploy-critical `SGLANG_ROUTER_DSV4_*` knobs):
+    /// pure over the env value so the empty / unrecognized / valid branches are
+    /// pinned without the process-global `OnceLock`.
+    #[test]
+    fn resolve_default_thinking_branches() {
+        assert!(!resolve_default_thinking(None)); // unset → false (engine default)
+        assert!(!resolve_default_thinking(Some(""))); // set-empty → false
+        assert!(resolve_default_thinking(Some("true")));
+        assert!(resolve_default_thinking(Some("y"))); // engine EnvBool token
+        assert!(!resolve_default_thinking(Some("false")));
+        assert!(!resolve_default_thinking(Some("enabled"))); // unrecognized → false (WARNs)
+    }
+
+    /// The default effort is `low` — the official checkpoint's
+    /// `DEFAULT_REASONING_EFFORT`, and what the engine substitutes when nothing
+    /// survives its accepted-effort filter. It renders NO preamble, so an
+    /// unset router env matches an unset engine env. Defaulting to `high` would
+    /// prepend the max-preview preamble to every plain thinking-mode request
+    /// under the official profile; `max` would prepend the heaviest one.
+    #[test]
+    fn resolve_default_effort_branches() {
+        // NB: no `use ReasoningEffort::*` here — its `None` would shadow
+        // `Option::None` and silently change what these calls pass.
+        use ReasoningEffort as E;
+        assert_eq!(resolve_default_effort(None), E::Low);
+        assert_eq!(resolve_default_effort(Some("max")), E::Max);
+        assert_eq!(resolve_default_effort(Some("high")), E::High);
+        assert_eq!(resolve_default_effort(Some("low")), E::Low);
+        // Values outside the checkpoint's REASONING_EFFORT_PROMPTS land on the
+        // same profile default the engine substitutes for them.
+        assert_eq!(resolve_default_effort(Some("medium")), E::Low);
+        assert_eq!(resolve_default_effort(Some("")), E::Low);
+        assert_eq!(resolve_default_effort(Some("none")), E::Low);
+    }
+
+    /// The resolved default reaches the level the renderer keys on, and that
+    /// level renders NO preamble under either profile — the property that keeps
+    /// a default-configured router matching a default-configured engine.
+    #[test]
+    fn default_effort_is_low_and_renders_no_preamble() {
+        // `default_effort()` reads the process-global env; the pure resolver is
+        // the testable seam, so drive the property through it.
+        let as_enum = resolve_default_effort;
+        for profile in [
+            ReasoningEffortProfile::Preview,
+            ReasoningEffortProfile::Official,
+        ] {
+            assert_eq!(
+                effort_preamble(profile, as_enum(None)),
+                "",
+                "the default effort must render no preamble under {profile:?}"
+            );
+        }
+    }
+
+    /// The `reasoning` OBJECT is mirrored per `normalize_reasoning_inputs`: its
+    /// `effort`/`reasoning_effort` aliases supply the top-level effort, its
+    /// `enabled`/`enable` turns thinking on, an effort OVERRIDES `enabled`, and
+    /// a client-sent `chat_template_kwargs.thinking` beats both (`setdefault`).
+    #[test]
+    fn reasoning_object_mirrors_the_protocol_validator() {
+        use ReasoningEffort as E;
+        let o = |v: serde_json::Value| resolve_render_opts(&v);
+        // `effort` alias -> effort + thinking on.
+        let r = o(json!({"reasoning": {"effort": "max"}}));
+        assert_eq!(r.reasoning_effort, E::Max);
+        assert!(r.thinking);
+        // the `reasoning_effort` spelling of the same alias
+        assert_eq!(
+            o(json!({"reasoning": {"reasoning_effort": "high"}})).reasoning_effort,
+            E::High
+        );
+        // `enabled` alone turns thinking on without setting an effort.
+        let r = o(json!({"reasoning": {"enabled": true}}));
+        assert!(r.thinking);
+        assert_eq!(r.reasoning_effort, default_effort());
+        // `enable` is the fallback spelling; a string uses the token set.
+        assert!(o(json!({"reasoning": {"enable": "yes"}})).thinking);
+        // effort OVERRIDES enabled: "none" forces thinking off despite enabled.
+        assert!(!o(json!({"reasoning": {"enabled": true, "effort": "none"}})).thinking);
+        // A non-dict `reasoning` is skipped entirely by the validator.
+        let r = o(json!({"reasoning": false}));
+        assert_eq!(r.thinking, default_thinking());
+        assert_eq!(r.reasoning_effort, default_effort());
+        // `enabled: false` sets nothing at all.
+        assert_eq!(
+            o(json!({"reasoning": {"enabled": false}})).thinking,
+            default_thinking()
+        );
+        // A client-sent ctk.thinking wins over the validator's setdefault.
+        assert!(
+            !o(json!({"reasoning": {"enabled": true},
+                          "chat_template_kwargs": {"thinking": false}}))
+            .thinking
+        );
+        // ctk effort still beats the reasoning object (the pop runs later).
+        assert_eq!(
+            o(json!({"reasoning": {"effort": "max"},
+                     "chat_template_kwargs": {"reasoning_effort": "high"}}))
+            .reasoning_effort,
+            E::High
+        );
+        // A numeric effort is kept but maps to no preamble, and turns thinking on.
+        let r = o(json!({"reasoning": {"effort": 0.5}}));
+        assert_eq!(r.reasoning_effort, E::None);
+        assert!(r.thinking);
+    }
+
+    /// `resolve_render_opts` is the ONLY place the env-resolved profile enters
+    /// a render, so a hardcoded profile there would be invisible to every other
+    /// test while silently rendering the wrong preamble in production.
+    #[test]
+    fn resolve_render_opts_carries_the_active_profile() {
+        for body in [
+            json!({"messages": [{"role":"user","content":"hi"}]}),
+            json!({"messages": [{"role":"user","content":"hi"}], "reasoning_effort": "max"}),
+            json!({"chat_template_kwargs": {"thinking": true}}),
+        ] {
+            assert_eq!(
+                resolve_render_opts(&body).reasoning_effort_profile,
+                active_effort_profile(),
+                "the profile is request-independent and must come from the env"
+            );
+        }
+    }
+
+    /// The profile defaults to `official` (the current DeepSeek-V4 official API
+    /// rendering) and only an explicit `preview` opts back into the older
+    /// mapping. An unrecognized value must not refuse to serve — it WARNs and
+    /// takes the default — because this is a rendering hint, not a safety gate.
+    #[test]
+    fn resolve_effort_profile_branches() {
+        use ReasoningEffortProfile::*;
+        assert_eq!(resolve_effort_profile(None), Official);
+        assert_eq!(resolve_effort_profile(Some("official")), Official);
+        assert_eq!(resolve_effort_profile(Some("preview")), Preview);
+        assert_eq!(resolve_effort_profile(Some("")), Official);
+        assert_eq!(resolve_effort_profile(Some("Preview")), Official); // case-sensitive, like the engine's key lookup
+        assert_eq!(resolve_effort_profile(Some("banana")), Official);
+    }
+
+    /// `encoding_dsv4.REASONING_EFFORT_PROFILES` as a table. Two cells differ
+    /// between the profiles: `high` gains a preamble under `official`, and
+    /// `max` switches to different text.
+    #[test]
+    fn effort_preamble_mirrors_engine_profiles() {
+        use ReasoningEffort as E;
+        use ReasoningEffortProfile::*;
+        // preview: {"high": "", "max": PREVIEW_MAX}; `low` is not an accepted
+        // key there, so the engine substitutes the profile default — also "".
+        assert_eq!(effort_preamble(Preview, E::None), "");
+        assert_eq!(effort_preamble(Preview, E::Low), "");
+        assert_eq!(effort_preamble(Preview, E::High), "");
+        assert_eq!(
+            effort_preamble(Preview, E::Max),
+            REASONING_EFFORT_PREVIEW_MAX
+        );
+        // official: {"low": "", "high": PREVIEW_MAX, "max": OFFICIAL_MAX} —
+        // byte-identical to the DeepSeek-V4-Flash-0731 checkpoint's
+        // `encoding/encoding_dsv4.py` REASONING_EFFORT_PROMPTS.
+        assert_eq!(effort_preamble(Official, E::None), "");
+        assert_eq!(effort_preamble(Official, E::Low), "");
+        assert_eq!(
+            effort_preamble(Official, E::High),
+            REASONING_EFFORT_PREVIEW_MAX
+        );
+        assert_eq!(
+            effort_preamble(Official, E::Max),
+            REASONING_EFFORT_OFFICIAL_MAX
+        );
+        // The two preambles are distinct text — a copy-paste regression that
+        // aliased them would make the official `max` render as preview `max`.
+        assert_ne!(REASONING_EFFORT_PREVIEW_MAX, REASONING_EFFORT_OFFICIAL_MAX);
+    }
+
+    /// End-to-end through the renderer: the preamble is emitted at the very
+    /// front (after BOS) in thinking mode only, and the profile picks which.
+    #[test]
+    fn render_emits_profile_specific_effort_preamble() {
+        let msgs = json!([{"role":"user","content":"hi"}]);
+        let render = |profile, effort, thinking| {
+            render_messages(
+                &msgs,
+                None,
+                RenderOpts {
+                    thinking,
+                    reasoning_effort: effort,
+                    reasoning_effort_profile: profile,
+                },
+            )
+        };
+        use ReasoningEffort as E;
+        use ReasoningEffortProfile::*;
+
+        let official_high = render(Official, E::High, true);
+        assert!(
+            official_high.starts_with(&format!("{BOS}{REASONING_EFFORT_PREVIEW_MAX}")),
+            "official `high` prepends the max-preview preamble right after BOS; got: {official_high}"
+        );
+        let official_max = render(Official, E::Max, true);
+        assert!(official_max.starts_with(&format!("{BOS}{REASONING_EFFORT_OFFICIAL_MAX}")));
+
+        // Same request under `preview` renders no preamble for `high` …
+        assert!(!render(Preview, E::High, true).contains("Reasoning Effort:"));
+        // … and the older text for `max`.
+        assert!(render(Preview, E::Max, true)
+            .starts_with(&format!("{BOS}{REASONING_EFFORT_PREVIEW_MAX}")));
+
+        // Chat mode never emits one, whatever the profile/effort.
+        for p in [Preview, Official] {
+            for e in [E::None, E::High, E::Max] {
+                assert!(
+                    !render(p, e, false).contains("Reasoning Effort:"),
+                    "chat mode must not emit an effort preamble ({p:?}/{e:?})"
+                );
+            }
+        }
+    }
+
+    // Mirrors of `normalize_reasoning_inputs` + `_handle_last_assistant_message`.
+
+    /// trailing assistant + continue_final_message=true: dropped; prefix back.
+    /// flag unset: role rewritten to user; prefix none; generation prompt follows.
+    /// engine bytes verified against serving_chat._handle_last_assistant_message.
+    #[test]
+    fn handle_trailing_assistant_both_flag_states() {
+        let (text, prefix) = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":"A-prefix"}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts {
+                task: None,
+                continue_final_message: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(prefix.as_deref(), Some("A-prefix"));
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>"
+        );
+        // The prefix lands AFTER that generation prompt at encode time
+        // (see TokenizerRegistry::encode_chat's append), not before.
+
+        // No surgery: trailing assistant rewritten to user, coalesced into the
+        // preceding user run, then the generation prompt.
+        let (text, prefix) = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":"A2"}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts::default(),
+        )
+        .unwrap();
+        assert_eq!(prefix, None);
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>U1\n\nA2<｜Assistant｜></think>"
+        );
+        assert_eq!(
+            text,
+            render_messages(
+                &json!([
+                    {"role":"user","content":"U1"},
+                    {"role":"user","content":"A2"}
+                ]),
+                None,
+                RenderOpts::chat()
+            ),
+            "the rewrite must behave exactly like a client-sent user role"
+        );
+    }
+
+    /// continue_final_message=true WITHOUT a trailing assistant is a no-op.
+    #[test]
+    fn continue_final_message_without_trailing_assistant_is_noop() {
+        let (text, prefix) = render_request(
+            &json!([{"role":"user","content":"hi"}]),
+            None,
+            RenderOpts::chat(),
+            RequestParts {
+                task: None,
+                continue_final_message: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(prefix, None);
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>"
+        );
+    }
+
+    /// The engine flattens content BEFORE the surgery, so array content with
+    /// only text parts and null content both see the surgery — the flattened
+    /// string is the prefix/rewrite content.
+    #[test]
+    fn trailing_assistant_flattened_content_shapes() {
+        // all-text parts array, continue_final_message=true
+        let (_, prefix) = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":[{"type":"text","text":"AB"},{"type":"text","text":"CD"}]}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts {
+                task: None,
+                continue_final_message: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(prefix.as_deref(), Some("AB CD"));
+
+        // null content: flattened to "" — surgery still runs.
+        let (text, prefix) = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":null}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts {
+                task: None,
+                continue_final_message: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(prefix.as_deref(), Some(""));
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>"
+        );
+    }
+
+    /// The flag-false rewrite REPLACES the message wholesale, like the engine
+    /// — a message-level `task` key on the trailing assistant must NOT
+    /// survive, or the render would emit a task transition the engine never
+    /// does.
+    #[test]
+    fn rewrite_drops_message_level_task_key() {
+        let (text, _) = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":"A2","task":"query"}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts::default(),
+        )
+        .unwrap();
+        assert!(
+            !text.contains("<｜query｜>"),
+            "task key must not survive; {text}"
+        );
+        assert!(text.contains("U1\n\nA2<｜Assistant｜></think>"), "{text}");
+    }
+
+    #[test]
+    fn attach_task_errors_and_last_user_targeting() {
+        assert_eq!(
+            attach_task(&mut [json!({"role":"system","content":"s"})], "query"),
+            Err(RenderErr::TaskWithoutUser)
+        );
+        assert_eq!(
+            attach_task(&mut [json!({"role":"user","content":"u"})], "bogus"),
+            Err(RenderErr::InvalidTask)
+        );
+        let mut msgs = vec![
+            json!({"role":"user","content":"first"}),
+            json!({"role":"assistant","content":"a"}),
+            json!({"role":"user","content":"last"}),
+        ];
+        attach_task(&mut msgs, "query").unwrap();
+        assert_eq!(msgs[0].get("task"), None);
+        assert_eq!(msgs[2]["task"], json!("query"));
+    }
+
+    /// Non-`action` tasks append their special token WITHOUT the assistant
+    /// opening; `action` opens an assistant turn first, with the think token
+    /// keyed purely on the mode (no drop_thinking dependence).
+    #[test]
+    fn task_transition_tokens() {
+        let user_task = |task: &str, thinking: bool| {
+            render_request(
+                &json!([{"role":"user","content":"do it"}]),
+                None,
+                RenderOpts {
+                    thinking,
+                    reasoning_effort: ReasoningEffort::None,
+                    reasoning_effort_profile: ReasoningEffortProfile::Official,
+                },
+                RequestParts {
+                    task: Some(task),
+                    continue_final_message: false,
+                },
+            )
+            .unwrap()
+            .0
+        };
+        assert_eq!(
+            user_task("query", false),
+            "<｜begin▁of▁sentence｜><｜User｜>do it<｜query｜>"
+        );
+        assert_eq!(
+            user_task("action", false),
+            "<｜begin▁of▁sentence｜><｜User｜>do it<｜Assistant｜></think><｜action｜>"
+        );
+        assert_eq!(
+            user_task("action", true),
+            "<｜begin▁of▁sentence｜><｜User｜>do it<｜Assistant｜><think><｜action｜>"
+        );
+        // message-level task key in the post-attach render layer (what the
+        // engine's merge/render sees after `attach_task_to_last_user_message`
+        // writes it onto a raw message).
+        assert_eq!(
+            render_messages(
+                &json!([{"role":"user","content":"do it","task":"query"}]),
+                None,
+                RenderOpts::chat(),
+            ),
+            "<｜begin▁of▁sentence｜><｜User｜>do it<｜query｜>"
+        );
+    }
+
+    /// Client-sent message-level `task` keys are stripped upstream (the
+    /// engine's message model has no such field — only the pydantic-declared
+    /// `request.task` path can ever produce a task transition). The strip
+    /// applies to invalid names too: no engine assert can be triggered by a
+    /// key the engine never sees.
+    #[test]
+    fn client_message_level_task_is_stripped() {
+        let rendered = render_request(
+            &json!([
+                {"role":"user","content":"do it","task":"query"},
+                {"role":"user","content":"do more","task":"bogus"}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts::default(),
+        )
+        .unwrap()
+        .0;
+        assert!(!rendered.contains("<｜query｜>"), "{rendered}");
+        assert_eq!(
+            rendered,
+            "<｜begin▁of▁sentence｜><｜User｜>do it\n\ndo more<｜Assistant｜></think>"
+        );
+        // roles normalize to lowercase the same way.
+        let rendered = render_request(
+            &json!([{"role":"User","content":"hi"}]),
+            None,
+            RenderOpts::chat(),
+            RequestParts::default(),
+        )
+        .unwrap()
+        .0;
+        assert_eq!(
+            rendered,
+            "<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>"
+        );
+    }
+
+    /// `prev_has_task`: the assistant turn directly after a task-carrying
+    /// message is a task OUTPUT — its thinking is never rendered, even in
+    /// thinking mode with tools (which normally KEEPS prior reasoning).
+    #[test]
+    fn prev_has_task_suppresses_thinking() {
+        let thinking = |with_task: bool| {
+            let mut msgs = vec![
+                json!({"role":"system","content":"s"}),
+                json!({"role":"user","content":"q"}),
+            ];
+            if with_task {
+                msgs[1]["task"] = json!("query");
+            }
+            msgs.push(
+                json!({"role":"assistant","content":"answer","reasoning_content":"my reasoning"}),
+            );
+            msgs.push(json!({"role":"user","content":"next"}));
+            let tools = json!([{"type":"function","function":{"name":"f"}}]);
+            render_messages(
+                &serde_json::Value::Array(msgs),
+                Some(&tools),
+                RenderOpts {
+                    thinking: true,
+                    reasoning_effort: ReasoningEffort::None,
+                    reasoning_effort_profile: ReasoningEffortProfile::Official,
+                },
+            )
+        };
+        assert!(thinking(false).contains("my reasoning</think>"));
+        assert!(
+            !thinking(true).contains("my reasoning"),
+            "task output must not render its reasoning"
+        );
+        // EOS/tool-calls still render around it.
+        assert!(thinking(true).contains("answer<｜end▁of▁sentence｜>"));
+    }
+
+    /// Ordering: surgery first, then `task` attach (engine pipeline). With
+    /// `continue_final_message` unset the trailing assistant is rewritten to
+    /// user BEFORE the attach sees the list — and the preceding plain user
+    /// run then MERGES it in, which drops the incoming task key exactly like
+    /// `encoding_dsv4.merge_tool_messages` (its run-append guard only carries
+    /// blocks). So this shape emits the plain generation prompt, not a task
+    /// token — task-special-token rendering requires the task to land on a
+    /// run-terminating message.
+    #[test]
+    fn surgery_runs_before_task_attach_and_merge_is_engine_faithful() {
+        let rendered = render_request(
+            &json!([
+                {"role":"user","content":"U1"},
+                {"role":"assistant","content":"A2"}
+            ]),
+            None,
+            RenderOpts::chat(),
+            RequestParts {
+                task: Some("query"),
+                continue_final_message: false,
+            },
+        )
+        .unwrap()
+        .0;
+        assert_eq!(
+            rendered, "<｜begin▁of▁sentence｜><｜User｜>U1\n\nA2<｜Assistant｜></think>",
+            "task dropped by the user-run merge guard, as engine-side; {rendered}"
+        );
+    }
+
+    /// Merge semantics with tasks: a task-carrying user turn TERMINATES a user
+    /// run (a following user starts fresh), but a following TOOL message still
+    /// folds INTO the task turn (the tool fold has no task guard engine-side).
+    /// Transitions (including a task token) render only when the NEXT message
+    /// is an assistant/reminder turn or the message is last — so a task on a
+    /// user turn followed by another user turn emits no task token at all.
+    #[test]
+    fn task_merge_guard_and_tool_fold() {
+        // {user(task), user}: no merge, and the first turn gets NO task
+        // transition (next is a user, not an assistant turn).
+        let text = render_messages(
+            &json!([
+                {"role":"user","content":"a","task":"query"},
+                {"role":"user","content":"b"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>a<｜User｜>b<｜Assistant｜></think>"
+        );
+
+        // task on a NON-final user followed by an assistant turn: the task
+        // token lands between the turns.
+        let text = render_messages(
+            &json!([
+                {"role":"user","content":"a","task":"query"},
+                {"role":"assistant","content":"b"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>a<｜query｜>b<｜end▁of▁sentence｜>"
+        );
+
+        // {user(task), tool}: the tool result folds into the task run's blocks.
+        let text = render_messages(
+            &json!([
+                {"role":"user","content":"q","task":"query"},
+                {"role":"tool","content":"result","tool_call_id":"c1"}
+            ]),
+            None,
+            RenderOpts::chat(),
+        );
+        assert_eq!(
+            text,
+            "<｜begin▁of▁sentence｜><｜User｜>q\n\n<tool_result>result</tool_result><｜query｜>",
+        );
     }
 }

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -4,6 +4,7 @@
 pub mod adapter;
 pub mod chat_template;
 pub mod dsv4;
+mod pyjson;
 
 use anyhow::Result;
 use chat_template::ChatTemplate;
@@ -25,12 +26,76 @@ pub enum ChatEncoder {
 }
 
 impl ChatEncoder {
-    /// Render `messages` into the engine-equivalent prompt text.
-    fn render(&self, messages: &serde_json::Value) -> Result<String> {
+    /// Render a parsed chat request into the engine-equivalent prompt text,
+    /// plus — when dsv4's `continue_final_message` surgery extracted a trailing
+    /// assistant turn — its content, for the caller to encode and append after
+    /// the prompt ids (the engine's `_append_assistant_prefix_to_prompt_ids`).
+    ///
+    /// The dsv4 encoder threads the request's `tools`, thinking mode, `task`,
+    /// and `continue_final_message`; the Jinja path renders only `messages`
+    /// with the model's default template (threading the rest is future work).
+    fn render(&self, request: &serde_json::Value) -> Result<(String, Option<String>)> {
+        static NO_MESSAGES: serde_json::Value = serde_json::Value::Null;
+        let messages = request.get("messages").unwrap_or(&NO_MESSAGES);
         match self {
-            ChatEncoder::Jinja(t) => t.render(messages),
-            ChatEncoder::DeepSeekV4 => Ok(dsv4::render_messages(messages)),
+            ChatEncoder::Jinja(t) => t.render(messages).map(|s| (s, None)),
+            ChatEncoder::DeepSeekV4 => dsv4::render_request(
+                messages,
+                request.get("tools"),
+                dsv4::resolve_render_opts(request),
+                dsv4::RequestParts::resolve(request),
+            )
+            .map_err(anyhow::Error::from),
         }
+    }
+
+    /// Which forwarding predicate this encoder's ids may pass through (see
+    /// [`ForwardParity`]). Stamped onto the ids at production time so the
+    /// provenance travels with the tokens.
+    fn forward_parity(&self) -> ForwardParity {
+        match self {
+            // The Jinja encoder renders no tools/thinking/task, so its ids
+            // need the conservative predicate.
+            ChatEncoder::Jinja(_) => ForwardParity::Conservative,
+            // The dsv4 encoder mirrors the engine's full dsv4 request handling
+            // (`input_ids_safe_to_forward_dsv4`).
+            ChatEncoder::DeepSeekV4 => ForwardParity::Dsv4Full,
+        }
+    }
+}
+
+/// Which `input_ids_safe_to_forward`-family predicate may gate a chat
+/// encoder's ids (see [`ChatEncoder::forward_parity`]). Exhaustive by
+/// construction: a new encoder variant forces a decision here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForwardParity {
+    /// `input_ids_safe_to_forward`: tools, thinking overrides, multimodal,
+    /// trailing assistant, … all withheld.
+    Conservative,
+    /// `input_ids_safe_to_forward_dsv4`: only genuinely unmirrored engine
+    /// internals withheld.
+    Dsv4Full,
+}
+
+/// Parse a JSON value the way pydantic v2 (lax mode) coerces an OpenAI boolean
+/// field: a bool as-is; numeric `1`/`0` and the strings `true/yes/on/y/t/1` /
+/// `false/no/off/n/f/0` (case-insensitive). Anything else is `None` — pydantic
+/// would 422 the request, so correctness-sensitive callers must treat it as
+/// unknown rather than defaulting it to `false`.
+pub fn openai_bool(v: &serde_json::Value) -> Option<bool> {
+    match v {
+        serde_json::Value::Bool(b) => Some(*b),
+        serde_json::Value::Number(n) => match n.as_f64() {
+            Some(1.0) => Some(true),
+            Some(0.0) => Some(false),
+            _ => None,
+        },
+        serde_json::Value::String(s) => match s.to_ascii_lowercase().as_str() {
+            "true" | "yes" | "on" | "y" | "t" | "1" => Some(true),
+            "false" | "no" | "off" | "n" | "f" | "0" => Some(false),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -141,37 +206,75 @@ impl TokenizerRegistry {
         self.encoders.contains_key(model_id)
     }
 
-    /// Render `messages` through the model's chat encoder, then tokenize the
-    /// result the same way the engine does (`add_special_tokens = false`, so the
-    /// encoder's literal `bos_token`/role markers carry the specials). Returns
-    /// `None` — caller falls back to raw routing — when the model has no
-    /// encoder, no tokenizer, or rendering/encoding fails or yields no tokens.
-    pub fn encode_chat(&self, model_id: &str, messages: &serde_json::Value) -> Option<Vec<u32>> {
+    /// This model's chat encoder's forwarding parity ([`ForwardParity`]);
+    /// `Conservative` when the model has no encoder at all (whose ids are
+    /// never engine-equivalent anyway).
+    pub fn forward_parity(&self, model_id: &str) -> ForwardParity {
+        self.encoders
+            .get(model_id)
+            .map(|e| e.encoder.forward_parity())
+            .unwrap_or(ForwardParity::Conservative)
+    }
+
+    /// Render the parsed chat `request` through the model's chat encoder, then
+    /// tokenize the result the same way the engine does (`add_special_tokens =
+    /// false`, so the encoder's literal `bos_token`/role markers carry the
+    /// specials). Returns `None` — caller falls back to raw routing — when the
+    /// model has no encoder, no tokenizer, or rendering/encoding fails or
+    /// yields no tokens.
+    pub fn encode_chat(&self, model_id: &str, request: &serde_json::Value) -> Option<Vec<u32>> {
         // Clone the Arc and drop the DashMap guard before the CPU-bound
         // render+encode (mirrors `get`), so no shard read-lock is held across it.
         let entry = Arc::clone(&*self.encoders.get(model_id)?);
         let tokenizer = self.get(model_id)?;
-        let rendered = entry
+        let (rendered, assistant_prefix) = entry
             .encoder
-            .render(messages)
+            .render(request)
             .inspect_err(|e| {
-                // `{e:#}` prints the full anyhow chain, so the underlying
-                // minijinja cause (e.g. a `raise_exception` message) is
-                // visible, not just the "render chat template" context.
-                entry.log_fallback(model_id, &format!("render failed: {e:#}"))
+                // A dsv4 RenderErr is a REQUEST error the engine also rejects
+                // (invalid task / task without user), not encoder breakage —
+                // it must not consume the model's one-shot WARN latch.
+                if e.downcast_ref::<dsv4::RenderErr>().is_some() {
+                    tracing::debug!(model = %model_id, error = %e,
+                        "dsv4 request-level render error (engine-invalid request)");
+                } else {
+                    // `{e:#}` prints the full anyhow chain, so the underlying
+                    // minijinja cause (e.g. a `raise_exception` message) is
+                    // visible, not just the "render chat template" context.
+                    entry.log_fallback(model_id, &format!("render failed: {e:#}"))
+                }
             })
             .ok()?;
-        match adapter::encode(&tokenizer, &rendered) {
-            Ok(ids) if !ids.is_empty() => Some(ids),
+        let mut ids = match adapter::encode(&tokenizer, &rendered) {
+            Ok(ids) if !ids.is_empty() => ids,
             Ok(_) => {
                 entry.log_fallback(model_id, "rendered prompt tokenized to zero tokens");
-                None
+                return None;
             }
             Err(e) => {
                 entry.log_fallback(model_id, &format!("tokenize failed: {e:#}"));
-                None
+                return None;
+            }
+        };
+        // Mirror `_append_assistant_prefix_to_prompt_ids`: the engine encodes
+        // the extracted prefix and appends it after the generation prompt. The
+        // router's encode never adds specials — and the pinned single-user-turn
+        // engine vector proves the V4 tokenizer adds none either — so this
+        // plain encode is exactly what the engine appends.
+        if let Some(prefix) = assistant_prefix.filter(|p| !p.is_empty()) {
+            match adapter::encode(&tokenizer, &prefix) {
+                Ok(pids) if !pids.is_empty() => ids.extend(pids),
+                Ok(_) => {
+                    entry.log_fallback(model_id, "assistant prefix tokenized to zero tokens");
+                    return None;
+                }
+                Err(e) => {
+                    entry.log_fallback(model_id, &format!("prefix tokenize failed: {e:#}"));
+                    return None;
+                }
             }
         }
+        Some(ids)
     }
 
     pub fn ids(&self) -> Vec<String> {
@@ -420,8 +523,8 @@ mod tests {
         reg.attach_chat_template_for_test("tiny", &cfg);
         assert!(reg.has_chat_encoder("tiny"));
 
-        let messages = serde_json::json!([{"role":"user","content":"hi"}]);
-        let chat_ids = reg.encode_chat("tiny", &messages).expect("encode_chat");
+        let request = serde_json::json!({"messages": [{"role":"user","content":"hi"}]});
+        let chat_ids = reg.encode_chat("tiny", &request).expect("encode_chat");
         assert!(!chat_ids.is_empty());
 
         let tok = reg.get("tiny").unwrap();
@@ -431,13 +534,13 @@ mod tests {
             "chat-templated tokens must differ from raw-content tokens"
         );
 
-        // encode_chat is exactly tokenize(render(messages)).
-        let rendered = reg
+        // encode_chat is exactly tokenize(render(request)).
+        let (rendered, _) = reg
             .encoders
             .get("tiny")
             .unwrap()
             .encoder
-            .render(&messages)
+            .render(&request)
             .unwrap();
         assert_eq!(chat_ids, adapter::encode(&tok, &rendered).unwrap());
     }
@@ -450,7 +553,7 @@ mod tests {
             adapter::load("tests/fixtures/tiny_tokenizer.json").unwrap(),
         );
         assert!(!reg.has_chat_encoder("tiny"));
-        let messages = serde_json::json!([{"role":"user","content":"hi"}]);
+        let messages = serde_json::json!({"messages": [{"role":"user","content":"hi"}]});
         assert!(reg.encode_chat("tiny", &messages).is_none());
     }
 
@@ -472,7 +575,7 @@ mod tests {
             }),
         );
         assert!(reg.has_chat_encoder("tiny"));
-        let messages = serde_json::json!([{"role":"user","content":"hi"}]);
+        let messages = serde_json::json!({"messages": [{"role":"user","content":"hi"}]});
         assert!(
             reg.encode_chat("tiny", &messages).is_none(),
             "a failing render must yield None so routing falls back to raw text"

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -27,13 +27,10 @@ pub enum ChatEncoder {
 
 impl ChatEncoder {
     /// Render a parsed chat request into the engine-equivalent prompt text,
-    /// plus — when dsv4's `continue_final_message` surgery extracted a trailing
-    /// assistant turn — its content, for the caller to encode and append after
-    /// the prompt ids (the engine's `_append_assistant_prefix_to_prompt_ids`).
-    ///
-    /// The dsv4 encoder threads the request's `tools`, thinking mode, `task`,
-    /// and `continue_final_message`; the Jinja path renders only `messages`
-    /// with the model's default template (threading the rest is future work).
+    /// plus any assistant prefix dsv4's `continue_final_message` surgery
+    /// extracted (the caller encodes and appends it after the prompt ids).
+    /// The Jinja path renders only `messages`; threading tools/mode through
+    /// it is future work.
     fn render(&self, request: &serde_json::Value) -> Result<(String, Option<String>)> {
         static NO_MESSAGES: serde_json::Value = serde_json::Value::Null;
         let messages = request.get("messages").unwrap_or(&NO_MESSAGES);
@@ -49,16 +46,13 @@ impl ChatEncoder {
         }
     }
 
-    /// Which forwarding predicate this encoder's ids may pass through (see
-    /// [`ForwardParity`]). Stamped onto the ids at production time so the
-    /// provenance travels with the tokens.
+    /// Which forwarding predicate this encoder's ids may pass through,
+    /// stamped onto the ids so the provenance travels with the tokens.
     fn forward_parity(&self) -> ForwardParity {
         match self {
-            // The Jinja encoder renders no tools/thinking/task, so its ids
-            // need the conservative predicate.
+            // Jinja renders no tools/thinking/task; dsv4 mirrors the engine's
+            // full request handling.
             ChatEncoder::Jinja(_) => ForwardParity::Conservative,
-            // The dsv4 encoder mirrors the engine's full dsv4 request handling
-            // (`input_ids_safe_to_forward_dsv4`).
             ChatEncoder::DeepSeekV4 => ForwardParity::Dsv4Full,
         }
     }
@@ -77,11 +71,9 @@ pub enum ForwardParity {
     Dsv4Full,
 }
 
-/// Parse a JSON value the way pydantic v2 (lax mode) coerces an OpenAI boolean
-/// field: a bool as-is; numeric `1`/`0` and the strings `true/yes/on/y/t/1` /
-/// `false/no/off/n/f/0` (case-insensitive). Anything else is `None` — pydantic
-/// would 422 the request, so correctness-sensitive callers must treat it as
-/// unknown rather than defaulting it to `false`.
+/// Parse a JSON value the way pydantic v2 (lax mode) coerces an OpenAI
+/// boolean. Anything else is `None` — pydantic would 422 the request, so
+/// callers must treat it as unknown, not `false`.
 pub fn openai_bool(v: &serde_json::Value) -> Option<bool> {
     match v {
         serde_json::Value::Bool(b) => Some(*b),
@@ -206,9 +198,8 @@ impl TokenizerRegistry {
         self.encoders.contains_key(model_id)
     }
 
-    /// This model's chat encoder's forwarding parity ([`ForwardParity`]);
-    /// `Conservative` when the model has no encoder at all (whose ids are
-    /// never engine-equivalent anyway).
+    /// The model's chat-encoder forwarding parity; `Conservative` when it has
+    /// no encoder at all (such ids are never engine-equivalent anyway).
     pub fn forward_parity(&self, model_id: &str) -> ForwardParity {
         self.encoders
             .get(model_id)
@@ -217,11 +208,10 @@ impl TokenizerRegistry {
     }
 
     /// Render the parsed chat `request` through the model's chat encoder, then
-    /// tokenize the result the same way the engine does (`add_special_tokens =
-    /// false`, so the encoder's literal `bos_token`/role markers carry the
-    /// specials). Returns `None` — caller falls back to raw routing — when the
-    /// model has no encoder, no tokenizer, or rendering/encoding fails or
-    /// yields no tokens.
+    /// tokenize it the way the engine does (`add_special_tokens = false`; the
+    /// rendered marker text carries the specials). `None` — the caller falls
+    /// back to raw routing — when there is no encoder/tokenizer or the
+    /// render/encode fails.
     pub fn encode_chat(&self, model_id: &str, request: &serde_json::Value) -> Option<Vec<u32>> {
         // Clone the Arc and drop the DashMap guard before the CPU-bound
         // render+encode (mirrors `get`), so no shard read-lock is held across it.
@@ -256,11 +246,9 @@ impl TokenizerRegistry {
                 return None;
             }
         };
-        // Mirror `_append_assistant_prefix_to_prompt_ids`: the engine encodes
-        // the extracted prefix and appends it after the generation prompt. The
-        // router's encode never adds specials — and the pinned single-user-turn
-        // engine vector proves the V4 tokenizer adds none either — so this
-        // plain encode is exactly what the engine appends.
+        // Mirror `_append_assistant_prefix_to_prompt_ids`: encode the prefix
+        // and append it after the generation prompt (neither side adds
+        // specials, so a plain encode is exactly what the engine appends).
         if let Some(prefix) = assistant_prefix.filter(|p| !p.is_empty()) {
             match adapter::encode(&tokenizer, &prefix) {
                 Ok(pids) if !pids.is_empty() => ids.extend(pids),

--- a/experimental/sgl-router/src/tokenizer/pyjson.rs
+++ b/experimental/sgl-router/src/tokenizer/pyjson.rs
@@ -1,23 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Python-`json.dumps`-compatible serialization for prompt encoders.
-//!
-//! Engine-side prompt encoders build their prompts in Python, so any JSON they
-//! embed (tool schemas, tool-call argument values) carries Python's byte-level
-//! formatting. A router encoder that emits serde's defaults instead produces a
-//! different prompt, different block hashes, and no cache-aware match.
+//! Python-`json.dumps`-compatible serialization for prompt encoders: the
+//! engine embeds JSON with Python's byte-level formatting, and serde's
+//! defaults would produce different block hashes and no cache-aware match.
 
 use serde::Serialize;
 
-/// Serialize `value` the way Python's `json.dumps(v, ensure_ascii=False)` does:
-/// `", "` / `": "` separators (serde's compact form omits the spaces), raw
-/// UTF-8, key order preserved (the crate's `preserve_order` feature), floats
-/// through [`py_float`].
-///
-/// RESIDUE: an integer literal outside `i64`/`u64` range is already an `f64`
-/// at parse time, so Python's exact-integer output cannot be recovered; such
-/// values are routing-quality only.
+/// Python's `json.dumps(v, ensure_ascii=False)`: `", "` / `": "` separators,
+/// raw UTF-8, key order preserved, floats through [`py_float`]. Residue: an
+/// integer outside `i64`/`u64` range is already an `f64` at parse time, so
+/// Python's exact-integer output cannot be recovered.
 pub(crate) fn py_json(value: &serde_json::Value) -> String {
     let mut buf = Vec::new();
     let mut serializer = serde_json::Serializer::with_formatter(&mut buf, PyJsonFormatter);
@@ -27,15 +20,11 @@ pub(crate) fn py_json(value: &serde_json::Value) -> String {
     String::from_utf8(buf).expect("serde_json emits valid UTF-8")
 }
 
-/// CPython's `repr(float)` — what `json.dumps` uses for floats.
-///
-/// CPython emits the shortest round-tripping digits, then lays them out
-/// scientific iff `exp < -4 || exp >= 16` with a signed, two-digit-padded
-/// exponent (`1e-06`, `1e+16`), else positional with a trailing `.0` when
-/// there is no fraction. Rust's `{}` never switches to scientific and `{:e}`
-/// always does, so neither matches alone: take the digits from `{:e}` and
-/// re-lay them out. Exact only because serde_json is built with
-/// `float_roundtrip`.
+/// CPython's `repr(float)`, which `json.dumps` uses: shortest round-tripping
+/// digits, scientific iff `exp < -4 || exp >= 16` with a signed two-digit
+/// exponent, else positional with a trailing `.0`. Neither Rust `{}` nor
+/// `{:e}` matches alone, so take `{:e}`'s digits and re-lay them out. Exact
+/// only because serde_json is built with `float_roundtrip`.
 fn py_float(v: f64) -> String {
     // Non-finite floats cannot appear: serde_json parses them to `Null`.
     if v == 0.0 {
@@ -114,9 +103,8 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    /// `py_float` reproduces CPython `repr` across the layout boundaries the
-    /// two writers disagree on. This text renders into the tools block at the
-    /// FRONT of the prompt, so one divergent byte shifts every block hash.
+    /// CPython-`repr` parity across the layout boundaries; one divergent byte
+    /// in the tools block shifts every block hash.
     #[test]
     fn py_float_matches_cpython_repr() {
         for (v, want) in [

--- a/experimental/sgl-router/src/tokenizer/pyjson.rs
+++ b/experimental/sgl-router/src/tokenizer/pyjson.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Python-`json.dumps`-compatible serialization for prompt encoders.
+//!
+//! Engine-side prompt encoders build their prompts in Python, so any JSON they
+//! embed (tool schemas, tool-call argument values) carries Python's byte-level
+//! formatting. A router encoder that emits serde's defaults instead produces a
+//! different prompt, different block hashes, and no cache-aware match.
+
+use serde::Serialize;
+
+/// Serialize `value` the way Python's `json.dumps(v, ensure_ascii=False)` does:
+/// `", "` / `": "` separators (serde's compact form omits the spaces), raw
+/// UTF-8, key order preserved (the crate's `preserve_order` feature), floats
+/// through [`py_float`].
+///
+/// RESIDUE: an integer literal outside `i64`/`u64` range is already an `f64`
+/// at parse time, so Python's exact-integer output cannot be recovered; such
+/// values are routing-quality only.
+pub(crate) fn py_json(value: &serde_json::Value) -> String {
+    let mut buf = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, PyJsonFormatter);
+    value
+        .serialize(&mut serializer)
+        .expect("serializing a serde_json::Value into a Vec is infallible");
+    String::from_utf8(buf).expect("serde_json emits valid UTF-8")
+}
+
+/// CPython's `repr(float)` — what `json.dumps` uses for floats.
+///
+/// CPython emits the shortest round-tripping digits, then lays them out
+/// scientific iff `exp < -4 || exp >= 16` with a signed, two-digit-padded
+/// exponent (`1e-06`, `1e+16`), else positional with a trailing `.0` when
+/// there is no fraction. Rust's `{}` never switches to scientific and `{:e}`
+/// always does, so neither matches alone: take the digits from `{:e}` and
+/// re-lay them out. Exact only because serde_json is built with
+/// `float_roundtrip`.
+fn py_float(v: f64) -> String {
+    // Non-finite floats cannot appear: serde_json parses them to `Null`.
+    if v == 0.0 {
+        return if v.is_sign_negative() { "-0.0" } else { "0.0" }.to_owned();
+    }
+    let sci = format!("{v:e}");
+    let (mantissa, exp) = sci.split_once('e').expect("{:e} always emits an exponent");
+    let exp: i32 = exp.parse().expect("{:e} exponent is an integer");
+    if !(-4..16).contains(&exp) {
+        let sign = if exp < 0 { '-' } else { '+' };
+        format!("{mantissa}e{sign}{:02}", exp.abs())
+    } else {
+        let positional = format!("{v}");
+        if positional.contains('.') {
+            positional
+        } else {
+            format!("{positional}.0")
+        }
+    }
+}
+
+/// serde_json formatter emitting Python `json.dumps` default separators.
+struct PyJsonFormatter;
+
+impl serde_json::ser::Formatter for PyJsonFormatter {
+    fn write_f64<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        value: f64,
+    ) -> std::io::Result<()> {
+        writer.write_all(py_float(value).as_bytes())
+    }
+
+    fn write_f32<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        value: f32,
+    ) -> std::io::Result<()> {
+        writer.write_all(py_float(value as f64).as_bytes())
+    }
+
+    fn begin_array_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_key<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+    ) -> std::io::Result<()> {
+        writer.write_all(b": ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `py_float` reproduces CPython `repr` across the layout boundaries the
+    /// two writers disagree on. This text renders into the tools block at the
+    /// FRONT of the prompt, so one divergent byte shifts every block hash.
+    #[test]
+    fn py_float_matches_cpython_repr() {
+        for (v, want) in [
+            (1e-6, "1e-06"),
+            (1e-5, "1e-05"),
+            (2.5e-5, "2.5e-05"),
+            (9.75e-5, "9.75e-05"),
+            (1e-4, "0.0001"),
+            (1e15, "1000000000000000.0"),
+            (1e16, "1e+16"),
+            (1e300, "1e+300"),
+            (5e-324, "5e-324"),
+            (1.7976931348623157e308, "1.7976931348623157e+308"),
+            (1.0, "1.0"),
+            (-1.5, "-1.5"),
+            (0.1, "0.1"),
+            (0.0, "0.0"),
+            (-0.0, "-0.0"),
+            // Full-precision doubles: exact only with `float_roundtrip`.
+            (-923807.2472198891, "-923807.2472198891"),
+            (1.602176634e-19, "1.602176634e-19"),
+        ] {
+            assert_eq!(py_float(v), want, "py_float({v:?})");
+        }
+    }
+
+    #[test]
+    fn py_json_uses_python_separators_and_preserves_order() {
+        let v = json!({"b": 1, "a": [1, 2], "c": {"x": true}});
+        assert_eq!(py_json(&v), r#"{"b": 1, "a": [1, 2], "c": {"x": true}}"#);
+    }
+
+    /// `ensure_ascii=False`: non-ASCII stays raw, never `\uXXXX`.
+    #[test]
+    fn non_ascii_is_not_escaped() {
+        assert_eq!(py_json(&json!({"k": "café 中文"})), r#"{"k": "café 中文"}"#);
+    }
+}

--- a/experimental/sgl-router/src/tokenizer/testdata/dsv4_thinking_cases.json
+++ b/experimental/sgl-router/src/tokenizer/testdata/dsv4_thinking_cases.json
@@ -1,0 +1,860 @@
+[
+  {
+    "name": "chat_single_user[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "ABCD"
+      }
+    ],
+    "tools": null,
+    "thinking": false,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜></think>"
+  },
+  {
+    "name": "chat_single_user[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "ABCD"
+      }
+    ],
+    "tools": null,
+    "thinking": false,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜></think>"
+  },
+  {
+    "name": "chat_with_tools[preview]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "S"
+      },
+      {
+        "role": "user",
+        "content": "hi"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": false,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>S\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>hi<｜Assistant｜></think>"
+  },
+  {
+    "name": "chat_with_tools[official]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "S"
+      },
+      {
+        "role": "user",
+        "content": "hi"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": false,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>S\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>hi<｜Assistant｜></think>"
+  },
+  {
+    "name": "chat_max_effort_suppresses_preamble[preview]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": false,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>SYS<｜User｜>U1<｜Assistant｜></think>"
+  },
+  {
+    "name": "chat_max_effort_suppresses_preamble[official]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": false,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>SYS<｜User｜>U1<｜Assistant｜></think>"
+  },
+  {
+    "name": "thinking_single_user[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "ABCD"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_single_user[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "ABCD"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>ABCD<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_multiturn_no_tools_drops_prior_reasoning[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_multiturn_no_tools_drops_prior_reasoning[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_assistant_after_last_user_keeps_reasoning_no_tools[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜><think>R1</think>A1<｜end▁of▁sentence｜>"
+  },
+  {
+    "name": "thinking_assistant_after_last_user_keeps_reasoning_no_tools[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜><think>R1</think>A1<｜end▁of▁sentence｜>"
+  },
+  {
+    "name": "thinking_multiple_prior_assistants_no_tools[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      },
+      {
+        "role": "assistant",
+        "content": "A2",
+        "reasoning_content": "R2"
+      },
+      {
+        "role": "user",
+        "content": "U3"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜></think>A2<｜end▁of▁sentence｜><｜User｜>U3<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_multiple_prior_assistants_no_tools[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      },
+      {
+        "role": "assistant",
+        "content": "A2",
+        "reasoning_content": "R2"
+      },
+      {
+        "role": "user",
+        "content": "U3"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U1<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜></think>A2<｜end▁of▁sentence｜><｜User｜>U3<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_developer_before_last_user_dropped_no_tools[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U0"
+      },
+      {
+        "role": "developer",
+        "content": "D1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U0<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_developer_before_last_user_dropped_no_tools[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U0"
+      },
+      {
+        "role": "developer",
+        "content": "D1"
+      },
+      {
+        "role": "assistant",
+        "content": "A1",
+        "reasoning_content": "R1"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜><｜User｜>U0<｜Assistant｜></think>A1<｜end▁of▁sentence｜><｜User｜>U2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_multiturn_with_tools_keeps_reasoning[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "Let me read",
+        "tool_calls": [
+          {
+            "id": "c1",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/x\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": "FILE"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>Let me read</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/x</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FILE</tool_result>\n\nU2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_multiturn_with_tools_keeps_reasoning[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "Let me read",
+        "tool_calls": [
+          {
+            "id": "c1",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/x\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": "FILE"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>Let me read</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/x</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FILE</tool_result>\n\nU2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_with_tools_two_tool_rounds_keeps_all_reasoning[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "r1",
+        "tool_calls": [
+          {
+            "id": "a",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/a\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "a",
+        "content": "FA"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "r2",
+        "tool_calls": [
+          {
+            "id": "b",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/b\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "b",
+        "content": "FB"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>r1</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/a</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FA</tool_result><｜Assistant｜><think>r2</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/b</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FB</tool_result>\n\nU2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_with_tools_two_tool_rounds_keeps_all_reasoning[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "r1",
+        "tool_calls": [
+          {
+            "id": "a",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/a\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "a",
+        "content": "FA"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "r2",
+        "tool_calls": [
+          {
+            "id": "b",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\": \"/b\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "b",
+        "content": "FB"
+      },
+      {
+        "role": "user",
+        "content": "U2"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>r1</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/a</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FA</tool_result><｜Assistant｜><think>r2</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n<｜DSML｜parameter name=\"path\" string=\"true\">/b</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>FB</tool_result>\n\nU2<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_empty_reasoning_still_emits_think_block[preview]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "",
+        "tool_calls": [
+          {
+            "id": "c1",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": "R"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think></think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>R</tool_result><｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_empty_reasoning_still_emits_think_block[official]",
+    "messages": [
+      {
+        "role": "user",
+        "content": "U1"
+      },
+      {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "",
+        "tool_calls": [
+          {
+            "id": "c1",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "content": "R"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": null,
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think></think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read\">\n\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>R</tool_result><｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_reasoning_effort_max_prefix[preview]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\nSYS<｜User｜>U1<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_reasoning_effort_max_prefix[official]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\nSYS<｜User｜>U1<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_reasoning_effort_high_no_prefix[preview]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": "high",
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>SYS<｜User｜>U1<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_reasoning_effort_high_no_prefix[official]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": null,
+    "thinking": true,
+    "reasoning_effort": "high",
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\nSYS<｜User｜>U1<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_max_effort_with_tools[preview]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "preview",
+    "expected": "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\nSYS\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>"
+  },
+  {
+    "name": "thinking_max_effort_with_tools[official]",
+    "messages": [
+      {
+        "role": "system",
+        "content": "SYS"
+      },
+      {
+        "role": "user",
+        "content": "U1"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "thinking": true,
+    "reasoning_effort": "max",
+    "reasoning_effort_profile": "official",
+    "expected": "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\nSYS\n\n## Tools\n\nYou have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<｜DSML｜tool_calls>\" block like the following:\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"$TOOL_NAME\">\n<｜DSML｜parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</｜DSML｜parameter>\n...\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"$TOOL_NAME2\">\n...\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n\nString parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.\n\nIf thinking_mode is enabled (triggered by <think>), you MUST output your complete reasoning inside <think>...</think> BEFORE any tool calls or final response.\n\nOtherwise, output directly after </think> with tool calls or final response.\n\n### Available Tool Schemas\n\n{\"description\": \"Read a file\", \"name\": \"read\", \"parameters\": {\"type\": \"object\", \"properties\": {\"path\": {\"type\": \"string\"}}}, \"strict\": false}\n\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n<｜User｜>U1<｜Assistant｜><think>"
+  }
+]

--- a/experimental/sgl-router/src/tokenizer/testdata/gen_dsv4_thinking_cases.py
+++ b/experimental/sgl-router/src/tokenizer/testdata/gen_dsv4_thinking_cases.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Generate dsv4_thinking_cases.json — the golden fixtures for the router's
+DeepSeek-V4 encoder parity test (`thinking_and_chat_parity_fixtures`).
+
+Each `expected` is produced by the ENGINE itself: the real `encoding_dsv4.py`
+encoder, fed the SAME preprocessing `serving_chat.py` applies before it
+(empty-system insertion + `tool.model_dump()` canonicalization). That pydantic
+canonicalization lives in serving_chat, NOT in encoding_dsv4 — running bare
+`encode_messages` on raw tools produces the WRONG field order, so this
+preprocessing MUST be replayed here. Re-run this whenever the engine encoder,
+`TOOLS_TEMPLATE`, the reasoning-effort profile prompts, or the `Function` field
+order changes:
+
+    python3 gen_dsv4_thinking_cases.py <path-to-encoding_dsv4.py>
+
+Each case is emitted for BOTH reasoning-effort profiles, with the profile
+recorded in the fixture and replayed by the Rust test — so neither side can
+silently assume one. Pass the encoder path EXPLICITLY when the checkout's own
+`python/` tree is older than the engine you actually deploy: the default ENC
+below points at this checkout, which on a long-lived branch can predate the
+feature under test. A pre-#33140 encoder is rejected outright rather than
+quietly emitting preview-only fixtures.
+
+The Rust consts + these fixtures drift together if the oracle changes but this
+isn't re-run — the test guards Rust-side regressions, and engine-side drift only
+once this is re-run against the deployed engine.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+# Default to the engine encoder shipping in THIS checkout (the router worktree is
+# inside the sglang repo, which also holds the Python engine). On a long-lived
+# branch that copy can lag the deployed engine badly enough that the guard below
+# rejects it — pass the encoder path explicitly when it does.
+# Repo root is five levels up: testdata/tokenizer/src/sgl-router/experimental/<root>.
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), *([os.pardir] * 5))
+)
+ENC = (
+    sys.argv[1]
+    if len(sys.argv) > 1
+    else os.path.join(
+        _REPO_ROOT,
+        "python",
+        "sglang",
+        "srt",
+        "entrypoints",
+        "openai",
+        "encoding_dsv4.py",
+    )
+)
+spec = importlib.util.spec_from_file_location("encoding_dsv4", ENC)
+enc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(enc)
+
+
+def fdump(f):
+    """Replicate pydantic Function.model_dump(): fixed field order, defaults
+    injected, extras dropped, defer_loading popped when None."""
+    out = {
+        "description": f.get("description"),
+        "name": f["name"],
+        "parameters": f.get("parameters"),
+        "strict": f.get("strict", False),
+    }
+    if f.get("defer_loading") is not None:
+        out["defer_loading"] = f["defer_loading"]
+    return out
+
+
+def tdump(ts):
+    return [
+        {"type": t.get("type", "function"), "function": fdump(t["function"])}
+        for t in ts
+    ]
+
+
+def prep(msgs, tools):
+    """Mirror serving_chat.py: flatten list content, None->'', insert empty
+    system if the first message isn't system, attach model_dump'd tools to [0]."""
+    msgs = [dict(m) for m in msgs]
+    for m in msgs:
+        if isinstance(m.get("content"), list):
+            # Match process_content_for_template_format(_, "string"): text parts are
+            # joined with a single space (jinja_template_utils), as the router's
+            # content_to_string does — NOT concatenated.
+            m["content"] = " ".join(
+                p.get("text", "") for p in m["content"] if isinstance(p, dict)
+            )
+        if m.get("content") is None:
+            m["content"] = ""
+    if not msgs or msgs[0].get("role") != "system":
+        msgs.insert(0, {"role": "system", "content": ""})
+    if tools:
+        msgs[0]["tools"] = tdump(tools)
+    return msgs
+
+
+PROFILES = getattr(enc, "REASONING_EFFORT_PROFILES", None)
+if PROFILES is None:
+    sys.exit(
+        f"{ENC} has no REASONING_EFFORT_PROFILES (it predates the profile split).\n"
+        "Regenerating against it would silently emit preview-only fixtures and\n"
+        "drop all `official` coverage. Point this at a newer encoder:\n"
+        "    python3 gen_dsv4_thinking_cases.py <newer>/encoding_dsv4.py"
+    )
+
+
+def render(msgs, tools, thinking, effort, profile):
+    mode = "thinking" if thinking else "chat"
+    # `reasoning_effort_profile` MUST be passed explicitly: upstream defaults it
+    # to "preview", so omitting it silently yields preview output regardless of
+    # which profile the fixture claims to cover.
+    return enc.encode_messages(
+        prep(msgs, tools),
+        thinking_mode=mode,
+        reasoning_effort=effort,
+        reasoning_effort_profile=profile,
+    )
+
+
+READ_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        },
+    }
+]
+
+cases = []
+
+# Every case is emitted once per profile: the two differ only in the block-0
+# effort preamble, but that is exactly the surface #33140 added, and `official`
+# is what the DeepSeek-V4-Flash-0731 checkpoint resolves to.
+_PROFILES = ("preview", "official")
+
+
+def add(name, msgs, tools, thinking, effort):
+    for profile in _PROFILES:
+        cases.append(
+            {
+                "name": f"{name}[{profile}]",
+                "messages": msgs,
+                "tools": tools,
+                "thinking": thinking,
+                "reasoning_effort": effort,
+                "reasoning_effort_profile": profile,
+                "expected": render(msgs, tools, thinking, effort, profile),
+            }
+        )
+
+
+# --- chat-mode regression guards (must equal the pre-thinking output) ---
+add("chat_single_user", [{"role": "user", "content": "ABCD"}], None, False, None)
+add(
+    "chat_with_tools",
+    [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}],
+    READ_TOOL,
+    False,
+    None,
+)
+# chat mode must SUPPRESS the max preamble (guarded on opts.thinking).
+add(
+    "chat_max_effort_suppresses_preamble",
+    [{"role": "system", "content": "SYS"}, {"role": "user", "content": "U1"}],
+    None,
+    False,
+    "max",
+)
+
+# --- thinking transitions ---
+add("thinking_single_user", [{"role": "user", "content": "ABCD"}], None, True, None)
+add(
+    "thinking_multiturn_no_tools_drops_prior_reasoning",
+    [
+        {"role": "user", "content": "U1"},
+        {"role": "assistant", "content": "A1", "reasoning_content": "R1"},
+        {"role": "user", "content": "U2"},
+    ],
+    None,
+    True,
+    None,
+)
+add(
+    "thinking_assistant_after_last_user_keeps_reasoning_no_tools",
+    [
+        {"role": "user", "content": "U1"},
+        {"role": "assistant", "content": "A1", "reasoning_content": "R1"},
+    ],
+    None,
+    True,
+    None,
+)
+# multiple prior assistant turns before last user: both reasonings dropped.
+add(
+    "thinking_multiple_prior_assistants_no_tools",
+    [
+        {"role": "user", "content": "U1"},
+        {"role": "assistant", "content": "A1", "reasoning_content": "R1"},
+        {"role": "user", "content": "U2"},
+        {"role": "assistant", "content": "A2", "reasoning_content": "R2"},
+        {"role": "user", "content": "U3"},
+    ],
+    None,
+    True,
+    None,
+)
+# developer turn before last user is dropped entirely (index-shift), R1 dropped.
+add(
+    "thinking_developer_before_last_user_dropped_no_tools",
+    [
+        {"role": "user", "content": "U0"},
+        {"role": "developer", "content": "D1"},
+        {"role": "assistant", "content": "A1", "reasoning_content": "R1"},
+        {"role": "user", "content": "U2"},
+    ],
+    None,
+    True,
+    None,
+)
+
+# --- thinking WITH tools keeps ALL prior reasoning (effective_drop_thinking=False) ---
+add(
+    "thinking_multiturn_with_tools_keeps_reasoning",
+    [
+        {"role": "user", "content": "U1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "Let me read",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": '{"path": "/x"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "FILE"},
+        {"role": "user", "content": "U2"},
+    ],
+    READ_TOOL,
+    True,
+    None,
+)
+# the real agentic shape: TWO interleaved assistant tool-call rounds, reasoning on each.
+add(
+    "thinking_with_tools_two_tool_rounds_keeps_all_reasoning",
+    [
+        {"role": "user", "content": "U1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "r1",
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": '{"path": "/a"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a", "content": "FA"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "r2",
+            "tool_calls": [
+                {
+                    "id": "b",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": '{"path": "/b"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "b", "content": "FB"},
+        {"role": "user", "content": "U2"},
+    ],
+    READ_TOOL,
+    True,
+    None,
+)
+add(
+    "thinking_empty_reasoning_still_emits_think_block",
+    [
+        {"role": "user", "content": "U1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "R"},
+    ],
+    READ_TOOL,
+    True,
+    None,
+)
+
+# --- reasoning-effort preamble (thinking + max only) ---
+add(
+    "thinking_reasoning_effort_max_prefix",
+    [{"role": "system", "content": "SYS"}, {"role": "user", "content": "U1"}],
+    None,
+    True,
+    "max",
+)
+add(
+    "thinking_reasoning_effort_high_no_prefix",
+    [{"role": "system", "content": "SYS"}, {"role": "user", "content": "U1"}],
+    None,
+    True,
+    "high",
+)
+# preamble + tools coexist: ordering is preamble < system < tools.
+add(
+    "thinking_max_effort_with_tools",
+    [{"role": "system", "content": "SYS"}, {"role": "user", "content": "U1"}],
+    READ_TOOL,
+    True,
+    "max",
+)
+
+out = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "dsv4_thinking_cases.json"
+)
+with open(out, "w") as f:
+    f.write(json.dumps(cases, ensure_ascii=False, indent=2) + "\n")
+print(f"wrote {len(cases)} cases -> {out}")

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -8,10 +8,11 @@
 //!
 //! * A plain text chat request on the engine-equivalent chat-encoder path →
 //!   the forwarded body carries `input_ids` AND retains `messages`.
-//! * A request carrying `tools` → `input_ids` omitted (the router's encoder
-//!   doesn't render tool schemas, so its ids would diverge from the engine).
-//! * A request with multimodal (array) content → `input_ids` omitted (a text
-//!   tokenizer can't represent image content).
+//! * Requests carrying `tools` or a thinking override → also forwarded (the
+//!   dsv4 encoder mirrors the engine's tool rendering and per-request
+//!   thinking resolution, so the ids are engine-equivalent).
+//! * A request with multimodal (non-text parts) content → `input_ids`
+//!   omitted (the engine-side mm-item plumbing is unverified).
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -102,7 +103,7 @@ async fn plain_chat_forwards_input_ids_and_keeps_messages() {
 }
 
 #[tokio::test]
-async fn tool_request_omits_input_ids() {
+async fn tool_request_forwards_input_ids() {
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(mock.url.clone());
     let status = send(
@@ -117,17 +118,18 @@ async fn tool_request_omits_input_ids() {
     assert_eq!(status, StatusCode::OK);
 
     let body = captured(&mock);
+    let ids = body.get("input_ids").and_then(|v| v.as_array());
     assert!(
-        body.get("input_ids").is_none(),
-        "tool requests must not forward input_ids; got {body}"
+        ids.is_some_and(|a| !a.is_empty()),
+        "tool requests on the dsv4 encoder must forward input_ids; got {body}"
     );
 }
 
 #[tokio::test]
-async fn thinking_request_omits_input_ids() {
-    // `chat_template_kwargs` steers engine-side thinking mode, which the
-    // router's encoder renders in the default mode only — forwarding ids would
-    // silently run the wrong mode, so the handler must omit them.
+async fn thinking_request_forwards_input_ids() {
+    // `chat_template_kwargs.thinking` steers engine-side thinking mode, and
+    // the dsv4 encoder resolves it the same way (`resolve_render_opts`), so
+    // the ids are engine-equivalent and forward.
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(mock.url.clone());
     let status = send(
@@ -135,16 +137,17 @@ async fn thinking_request_omits_input_ids() {
         json!({
             "model": MODEL,
             "messages": [{"role": "user", "content": "hi"}],
-            "chat_template_kwargs": {"enable_thinking": true},
+            "chat_template_kwargs": {"thinking": true},
         }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
 
     let body = captured(&mock);
+    let ids = body.get("input_ids").and_then(|v| v.as_array());
     assert!(
-        body.get("input_ids").is_none(),
-        "thinking-mode requests must not forward input_ids; got {body}"
+        ids.is_some_and(|a| !a.is_empty()),
+        "thinking-mode requests on the dsv4 encoder must forward input_ids; got {body}"
     );
 }
 

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -128,10 +128,10 @@ async fn round_robin_plain_chat_forwards_input_ids() {
     );
 }
 
-/// Even under round-robin, a tool request omits `input_ids` (the safe predicate
-/// is policy-independent too).
+/// Even under round-robin, a tool request forwards `input_ids` (the dsv4
+/// encoder mirrors tool rendering; the predicate is policy-independent too).
 #[tokio::test]
-async fn round_robin_tool_request_omits_input_ids() {
+async fn round_robin_tool_request_forwards_input_ids() {
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(mock.url.clone());
     let status = send(
@@ -146,9 +146,10 @@ async fn round_robin_tool_request_omits_input_ids() {
     assert_eq!(status, StatusCode::OK);
 
     let body = captured(&mock);
+    let ids = body.get("input_ids").and_then(|v| v.as_array());
     assert!(
-        body.get("input_ids").is_none(),
-        "tool requests must not forward input_ids under any policy; got {body}"
+        ids.is_some_and(|a| !a.is_empty()),
+        "tool requests on the dsv4 encoder must forward input_ids; got {body}"
     );
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -11,8 +11,10 @@
 //!
 //! * A plain text chat request forwards `input_ids` AND retains `messages`,
 //!   even though sticky never consults the tokens for routing.
-//! * A request carrying `tools` / multimodal content omits `input_ids` — the
-//!   same safe-to-forward predicate applies regardless of policy.
+//! * A request carrying `tools` or a thinking override forwards too (the dsv4
+//!   encoder mirrors the engine's tool/thinking rendering); multimodal
+//!   content omits `input_ids` — the same predicate applies regardless of
+//!   policy.
 //! * Same-session-header requests still pin to a single worker (O(1) sticky
 //!   routing is unchanged by the added tokenization).
 //!
@@ -157,7 +159,7 @@ async fn sticky_plain_chat_forwards_input_ids_and_keeps_messages() {
 }
 
 #[tokio::test]
-async fn sticky_tool_request_omits_input_ids() {
+async fn sticky_tool_request_forwards_input_ids() {
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(std::slice::from_ref(&mock.url));
     let status = send(
@@ -173,17 +175,18 @@ async fn sticky_tool_request_omits_input_ids() {
     assert_eq!(status, StatusCode::OK);
 
     let body = captured(&mock);
+    let ids = body.get("input_ids").and_then(|v| v.as_array());
     assert!(
-        body.get("input_ids").is_none(),
-        "tool requests must not forward input_ids even under sticky; got {body}"
+        ids.is_some_and(|a| !a.is_empty()),
+        "tool requests on the dsv4 encoder must forward input_ids under sticky; got {body}"
     );
 }
 
 #[tokio::test]
-async fn sticky_thinking_request_omits_input_ids() {
-    // `chat_template_kwargs` steers engine-side thinking mode the router's
-    // encoder renders in the default mode only — the safe-to-forward predicate
-    // is policy-independent, so sticky must omit ids here too.
+async fn sticky_thinking_request_forwards_input_ids() {
+    // `chat_template_kwargs.thinking` steers engine-side thinking mode, and
+    // the dsv4 encoder resolves it the same way — the predicate is
+    // policy-independent, so sticky forwards here too.
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(std::slice::from_ref(&mock.url));
     let status = send(
@@ -192,16 +195,17 @@ async fn sticky_thinking_request_omits_input_ids() {
         json!({
             "model": MODEL,
             "messages": [{"role": "user", "content": "hi"}],
-            "chat_template_kwargs": {"enable_thinking": true},
+            "chat_template_kwargs": {"thinking": true},
         }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
 
     let body = captured(&mock);
+    let ids = body.get("input_ids").and_then(|v| v.as_array());
     assert!(
-        body.get("input_ids").is_none(),
-        "thinking-mode requests must not forward input_ids under sticky; got {body}"
+        ids.is_some_and(|a| !a.is_empty()),
+        "thinking-mode requests on the dsv4 encoder must forward input_ids under sticky; got {body}"
     );
 }
 


### PR DESCRIPTION
## Motivation

Serving DeepSeek-V4-Flash through sgl-router today only works for plain, non-thinking, text-only chat: `dsv4.rs` on main renders that subset, and the conservative forwarding predicate withholds `input_ids` for anything carrying tools, thinking fields, `task`, or a trailing assistant turn. Real V4-Flash traffic is mostly thinking-mode and tool-calling, so cache-aware routing diverges at block 0 (tools render at the front of the prompt) and the ingress-tokenize offload never fires for it.

This ports the DeepSeek-V4-Flash support from `combine/router-admission-http2-loadaware` onto main — analyzed and re-scoped rather than copied wholesale (see *Not ported*).

## Modifications

**Full dsv4 encoder** (`src/tokenizer/dsv4.rs`, mirrors the engine's `encoding_dsv4.py` byte-exactly):
- Tools: canonical `Function.model_dump` schemas (incl. `defer_loading` propagation) rendered after the system content; assistant `tool_calls` as DSML blocks (both `arguments` spellings, per-key expansion); `tool` messages folded into user turns as `<tool_result>` blocks, ordered by originating call.
- Thinking mode: per-request resolution mirroring `normalize_reasoning_inputs` + the ctk pop (`chat_template_kwargs.thinking` / `reasoning_effort` / the `reasoning` object), reasoning-effort preambles under both `preview` and `official` profiles, and the engine's drop-thinking rules for prior-turn `reasoning_content`.
- Request-level behaviors: `task` quick instructions and the `continue_final_message` trailing-assistant surgery (`render_request`), with the extracted assistant prefix encoded and appended after the generation prompt.
- Parity pinned by engine-generated fixtures: `testdata/dsv4_thinking_cases.json` + its generator, replayed for both effort profiles.

**Python-faithful JSON** (`src/tokenizer/pyjson.rs`): `json.dumps` default separators and CPython float `repr` (serde_json gains `float_roundtrip`), since tool schemas land at the front of the prompt where one divergent byte shifts every block hash.

**Parity-gated `input_ids` forwarding** (`chat.rs`, `policies/mod.rs`, `tokenizer/mod.rs`):
- `encode_chat` now takes the full request (the encoder needs `tools` and the mode fields) and stamps a `ForwardParity` onto the produced tokens.
- `select_forward_input_ids` dispatches by that stamp: dsv4-encoder ids pass the new `input_ids_safe_to_forward_dsv4` (tools / thinking / task / continue-final-message traffic now forwards; withheld are only non-text content parts, message-level `tools`, unmirrored roles, engine-rejected tool-call `arguments`, and uncoercible `continue_final_message`); all other ids keep the conservative predicate unchanged.
- dsv4 request-level render errors (invalid task, task without user) are client errors the engine rejects identically: debug-logged, excluded from `sgl_router_ingress_tokenize_errors_total`, and they don't consume the broken-encoder WARN latch.
- `SGLANG_ROUTER_DISABLE_INPUT_IDS_OFFLOAD` is a central kill switch (read once): ingress tokenization still runs for routing, but engines always re-tokenize from `messages`.

**Deploy note**: `SGLANG_ROUTER_DSV4_DEFAULT_THINKING` / `SGLANG_ROUTER_DSV4_REASONING_EFFORT` / `SGLANG_ROUTER_DSV4_REASONING_EFFORT_PROFILE` must match the engine's `SGLANG_DEFAULT_THINKING` / `SGLANG_DSV4_REASONING_EFFORT` / checkpoint-resolved effort profile. The unset defaults (non-thinking, `low`, `official`) match a default-configured engine.

**Not ported** (branch-only concerns, deliberately out of scope): the Kimi-K3 encoder stack, cache-sim tees, dual-hash bimodal-fleet queries, and the `--disable-input-ids-offload` CLI flag — the kill switch here is env-only to avoid `ModelConfig` churn across ~23 construction sites; the env var name matches what the branch flag reads, so operator playbooks carry over.

## Test coverage

- 40+ dsv4 unit tests ported, incl. `thinking_and_chat_parity_fixtures` (engine-generated golden fixtures, both effort profiles) and byte-pinned tool/DSML render tests.
- New `select_forward_input_ids` / `input_ids_safe_to_forward_dsv4` unit tests (kill switch, parity dispatch, allow/block classes).
- The `*_input_ids` proxy integration tests flipped to the new contract: tools/thinking requests on the dsv4 model now must forward `input_ids`; multimodal must still omit.
- `cargo test` (588 lib + 58 component + 86 proxy, all green), `cargo clippy --all-targets` clean, `cargo fmt` applied.

## Checklist

- [x] Format your code with `cargo fmt` / pre-commit.
- [x] Add unit or integration tests for the changes.
- [ ] Update documentation as needed (router env vars are documented in the code; no docs page covers them yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34410199930](https://github.com/sgl-project/sglang/actions/runs/34410199930)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34410199663](https://github.com/sgl-project/sglang/actions/runs/34410199663)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->