### PR TITLE
[Router] Drain readiness before SIGTERM shutdown so k8s deregisters the pod first

### DIFF
--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -10,12 +10,13 @@ use clap::Parser;
 use std::num::NonZeroU32;
 
 use crate::config::{
-    default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
-    resolve_mode, ActiveLoadConfig, AffinityConfig, AffinityMode, CacheAwareConfig,
-    CachePrefixProvider, CircuitBreakerConfig, Config, DecodePolicyKind, DiscoveryBackend,
-    EligibilityConfig, FilterKind, FusedTerm, K8sDiscoveryConfig, KvIndexerEndpointConfig,
-    LogFormat, ModelConfig, ObservabilityConfig, PolicyKind, ProxyConfig, ServerConfig,
-    SessionAffinityMode, StaticUrlsDiscoveryConfig, StickyConfig, StickyFallbackKind, DEFAULT_FUSE,
+    default_cb_cool_down, default_host, default_port, default_proxy_request_timeout_secs,
+    default_shutdown_drain_secs, default_stale_request_timeout_secs, resolve_mode,
+    ActiveLoadConfig, AffinityConfig, AffinityMode, CacheAwareConfig, CachePrefixProvider,
+    CircuitBreakerConfig, Config, DecodePolicyKind, DiscoveryBackend, EligibilityConfig,
+    FilterKind, FusedTerm, K8sDiscoveryConfig, KvIndexerEndpointConfig, LogFormat, ModelConfig,
+    ObservabilityConfig, PolicyKind, ProxyConfig, ServerConfig, SessionAffinityMode,
+    StaticUrlsDiscoveryConfig, StickyConfig, StickyFallbackKind, DEFAULT_FUSE,
 };
 
 const DEFAULT_KV_INDEXER_QUERY_TIMEOUT_MS: u64 = 100;
@@ -35,11 +36,19 @@ const DEFAULT_KV_INDEXER_QUERY_MAX_INFLIGHT: usize = sgl_kv_indexer::DEFAULT_QUE
 pub struct Cli {
     // ---- server ----
     /// Address to bind the HTTP server to.
-    #[arg(long, default_value = "127.0.0.1")]
+    #[arg(long, default_value_t = default_host())]
     pub host: String,
     /// Port to bind the HTTP server to.
-    #[arg(long, default_value_t = 30000)]
+    #[arg(long, default_value_t = default_port())]
     pub port: u16,
+    /// Seconds to keep serving after SIGTERM, with `/readyz` returning 503,
+    /// before the server stops accepting — so the endpoint removal reaches
+    /// kube-proxy first. Leave room under terminationGracePeriodSeconds for the
+    /// in-flight drain that follows. If you rely on a readiness probe (rather
+    /// than pod deletion) to deregister, size this above your
+    /// failureThreshold * periodSeconds. 0 disables the pause.
+    #[arg(long, default_value_t = default_shutdown_drain_secs())]
+    pub shutdown_drain_secs: u64,
 
     // ---- model (exactly one) ----
     /// Model id this router serves (the OpenAI `model` field).
@@ -581,6 +590,7 @@ impl Cli {
             server: ServerConfig {
                 host: self.host,
                 port: self.port,
+                shutdown_drain_secs: self.shutdown_drain_secs,
             },
             observability: ObservabilityConfig {
                 log_level: self.log_level,
@@ -731,6 +741,32 @@ mod tests {
         assert_eq!(c.model.id, "qwen3-0.6b");
         assert_eq!(c.proxy.request_timeout_secs, 300);
         assert_eq!(c.active_load.stale_request_timeout_secs, 600);
+        assert_eq!(c.server.shutdown_drain_secs, 5);
+    }
+
+    /// Several values, not just the default: a clamp or a rescale in the
+    /// mapping satisfies any single-value assertion.
+    #[test]
+    fn shutdown_drain_secs_maps_into_config() {
+        for secs in ["0", "17", "600"] {
+            let c = into_config_owned(with_model(&[
+                "--worker-urls",
+                "http://10.0.0.1:30000",
+                "--shutdown-drain-secs",
+                secs,
+            ]))
+            .unwrap();
+            let expected: u64 = secs.parse().unwrap();
+            assert_eq!(
+                c.server.shutdown_drain_secs, expected,
+                "--shutdown-drain-secs {secs} must map through unchanged",
+            );
+            assert_eq!(
+                c.server.shutdown_drain(),
+                std::time::Duration::from_secs(expected),
+                "the Duration accessor must agree with the configured seconds",
+            );
+        }
     }
 
     /// With `--tokenizer-path` omitted, the tokenizer source defaults to the

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -5,6 +5,29 @@ pub use types::*;
 
 use anyhow::{anyhow, Result};
 
+/// The k8s default `terminationGracePeriodSeconds`. A `shutdown_drain_secs` at
+/// or above this leaves no time for the in-flight drain, so the pod is
+/// SIGKILLed before it finishes, unless the operator has raised the grace
+/// period — the opposite of what the drain is for.
+const K8S_DEFAULT_GRACE_SECS: u64 = 30;
+
+/// Advisory (not a hard error: the router can't read the pod's actual
+/// `terminationGracePeriodSeconds`) for a `shutdown_drain_secs` that leaves no
+/// room under the grace period for the in-flight drain that follows the pause.
+/// The bound is `>=`, not `>`: a drain of exactly the grace period already
+/// consumes all of it. Returns `Some(message)` to warn, `None` if safe.
+pub fn shutdown_drain_advisory(shutdown_drain_secs: u64) -> Option<String> {
+    (shutdown_drain_secs >= K8S_DEFAULT_GRACE_SECS).then(|| {
+        format!(
+            "shutdown_drain_secs={shutdown_drain_secs} leaves no room under the k8s default \
+             terminationGracePeriodSeconds ({K8S_DEFAULT_GRACE_SECS}s); under k8s the pod \
+             will be SIGKILLed during the in-flight drain unless \
+             terminationGracePeriodSeconds is raised to at least the drain plus in-flight \
+             request time"
+        )
+    })
+}
+
 impl Config {
     /// Check invariants the type system and `clap` don't already enforce.
     /// Called by [`cli::Cli::into_config`] after assembling the `Config`
@@ -206,10 +229,7 @@ mod tests {
     /// the `cli` module tests; the k8s selector grammar in `types`.
     fn cfg(model_id: &str, urls: &[&str]) -> Config {
         Config {
-            server: ServerConfig {
-                host: "127.0.0.1".into(),
-                port: 30000,
-            },
+            server: ServerConfig::default(),
             observability: ObservabilityConfig::default(),
             model: ModelConfig {
                 id: model_id.into(),
@@ -478,5 +498,30 @@ mod tests {
             .expect_err("a misspelled capacity profile must fail startup")
             .to_string();
         assert!(error.contains("ttft_p95_at_capcity_ms"), "got: {error}");
+    }
+
+    #[test]
+    fn shutdown_drain_advisory_is_silent_below_the_k8s_default_grace() {
+        // The default drain (5 s) and anything strictly under the k8s default
+        // terminationGracePeriodSeconds (30 s) still leaves room for the
+        // in-flight drain, so it is safe without operator action.
+        assert!(shutdown_drain_advisory(default_shutdown_drain_secs()).is_none());
+        assert!(shutdown_drain_advisory(29).is_none());
+        assert!(shutdown_drain_advisory(0).is_none());
+    }
+
+    #[test]
+    fn shutdown_drain_advisory_warns_once_the_drain_consumes_the_whole_grace() {
+        // A drain of exactly the 30 s k8s default leaves zero seconds for the
+        // in-flight drain, so the pod is SIGKILLed mid-drain — the boundary
+        // itself must warn, not just values past it.
+        for drain in [K8S_DEFAULT_GRACE_SECS, 120] {
+            let msg =
+                shutdown_drain_advisory(drain).unwrap_or_else(|| panic!("{drain} s must warn"));
+            assert!(
+                msg.contains("terminationGracePeriodSeconds"),
+                "advisory must name the k8s knob to raise: {msg}"
+            );
+        }
     }
 }

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -247,6 +247,51 @@ impl std::fmt::Display for StickyFallbackKind {
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
+    /// Seconds to keep serving after SIGTERM — with `/readyz` flipped to 503 —
+    /// before the HTTP server stops accepting. The default (5 s) is sized for
+    /// the endpoint removal reaching kube-proxy after the pod's
+    /// `deletionTimestamp` is stamped; it is not sized for probe-driven
+    /// deregistration, which needs `failureThreshold * periodSeconds` first —
+    /// raise this if you rely on that path. Must leave room under
+    /// `terminationGracePeriodSeconds` for the in-flight drain that follows.
+    /// 0 disables the pause.
+    pub shutdown_drain_secs: u64,
+}
+
+impl ServerConfig {
+    /// [`Self::shutdown_drain_secs`] as a `Duration`. Keeps the seconds-to-
+    /// `Duration` conversion in the library, where a test can pin it, rather
+    /// than in `main.rs` where a `from_secs`/`from_millis` slip would silently
+    /// shorten every drain by a factor of 1000.
+    pub fn shutdown_drain(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.shutdown_drain_secs)
+    }
+}
+
+pub fn default_host() -> String {
+    "127.0.0.1".into()
+}
+
+pub fn default_port() -> u16 {
+    30000
+}
+
+pub fn default_shutdown_drain_secs() -> u64 {
+    5
+}
+
+/// Exists so test fixtures can spell out only the fields they care about
+/// (`tests/` is a separate crate, so a `#[cfg(test)]` constructor cannot reach
+/// the integration fixtures). Keep `Cli::into_config` exhaustive so adding a
+/// field still forces a decision on the production path.
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+            shutdown_drain_secs: default_shutdown_drain_secs(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -62,6 +62,11 @@ fn install_bootstrap_subscriber() {
         .try_init();
 }
 
+/// How often to report progress while axum drains in-flight requests. That
+/// phase is unbounded, so without a heartbeat a pod SIGKILLed at
+/// `terminationGracePeriodSeconds` leaves no evidence of what it was waiting on.
+const DRAIN_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Install SIGTERM and SIGINT handlers up front so a failure here surfaces
 /// before `axum::serve` starts. If installation fails (rare: container
 /// without signal capability, seccomp policy), we return an error and the
@@ -84,6 +89,18 @@ async fn main() -> Result<()> {
         .context("resolve configuration from CLI flags")?;
 
     init_tracing(&cfg.observability.log_level, cfg.observability.log_format)?;
+
+    // Emitted here rather than from `Config::validate`: this is startup advice
+    // about the deployment, not a validation failure, and keeping it out of
+    // `validate` leaves that function free of side effects. It also runs after
+    // the configured subscriber is installed, and carries the value as a
+    // structured field rather than only inside the message text.
+    if let Some(msg) = sgl_router::config::shutdown_drain_advisory(cfg.server.shutdown_drain_secs) {
+        tracing::warn!(
+            shutdown_drain_secs = cfg.server.shutdown_drain_secs,
+            "{msg}"
+        );
+    }
 
     tracing::info!(
         configured_decode_policy = ?cfg.model.decode_policy,
@@ -223,16 +240,85 @@ async fn main() -> Result<()> {
 
     let (sigterm, sigint) = install_signal_handlers()?;
 
-    let serve = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal(sigterm, sigint));
+    // Published the moment the readiness drain finishes, i.e. when axum starts
+    // its in-flight drain. That phase — not the pause, and not the uptime
+    // before it — is what the heartbeat below reports on.
+    let (inflight_drain_tx, inflight_drain_rx) =
+        tokio::sync::watch::channel(None::<std::time::Instant>);
+    let shutdown_ctx = ctx.clone();
+    let drain = cfg.server.shutdown_drain();
+    let serve = axum::serve(listener, app).with_graceful_shutdown(async move {
+        shutdown_signal(sigterm, sigint, shutdown_ctx, drain).await;
+        let _ = inflight_drain_tx.send(Some(std::time::Instant::now()));
+    });
+
+    let heartbeat_ctx = ctx.clone();
+    let mut heartbeat_rx = inflight_drain_rx.clone();
+    let heartbeat = tokio::spawn(async move {
+        // Stay silent until the in-flight drain actually begins; an `Err` here
+        // means the sender went away without one, so there is nothing to report.
+        let Ok(started) = heartbeat_rx
+            .wait_for(Option::is_some)
+            .await
+            .map(|at| at.expect("wait_for only resolves once the instant is published"))
+        else {
+            return;
+        };
+        let mut ticker = tokio::time::interval(DRAIN_HEARTBEAT_INTERVAL);
+        // Delay, not the default Burst: the runtime stalling is exactly the
+        // condition this heartbeat exists to report, and Burst would answer it
+        // with a clump of back-dated ticks instead of one line per interval.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await; // the first tick completes immediately
+        loop {
+            ticker.tick().await;
+            tracing::warn!(
+                elapsed_secs = started.elapsed().as_secs(),
+                // Proxied requests only: a connection axum is still holding for
+                // another reason does not appear here, so 0 means "not waiting
+                // on a worker", not "not waiting".
+                inflight_proxied = heartbeat_ctx.active_load.inflight_count(),
+                "still draining in-flight requests; this phase is unbounded and ends at \
+                 SIGKILL when terminationGracePeriodSeconds expires",
+            );
+        }
+    });
     let server_result = serve.await.context("axum serve");
+    heartbeat.abort();
+    let inflight_drain_secs = inflight_drain_rx.borrow().map(|at| at.elapsed().as_secs());
 
     // Best-effort: cancel discovery + manager + janitor on shutdown.
     // The janitor handle's drop signals cancellation; we additionally
     // await `shutdown` so the task joins cleanly before the process
-    // exits — useful for tracing tail logs.
+    // exits — useful for tracing tail logs. `JanitorHandle::shutdown` caps its
+    // own join at 2 s, so it cannot hang the exit — though those 2 s are still
+    // charged to terminationGracePeriodSeconds.
     discovery_handle.abort();
     manager_handle.abort();
     janitor_handle.shutdown().await;
+    // The ERROR arms exist because otherwise the log says "shutdown complete"
+    // at INFO and the error leaves the process through `Termination`, never
+    // through `tracing` — so a severity-based alert sees nothing wrong with a
+    // crashed router. `None` means the server stopped without ever reaching the
+    // drain, which is not the same as draining instantly, so it gets its own
+    // message rather than `inflight_drain_secs = 0`.
+    match (&server_result, inflight_drain_secs) {
+        (Ok(()), Some(inflight_drain_secs)) => {
+            tracing::info!(inflight_drain_secs, "shutdown complete")
+        }
+        (Ok(()), None) => {
+            tracing::info!("shutdown complete; the server stopped without a termination signal")
+        }
+        (Err(e), Some(inflight_drain_secs)) => tracing::error!(
+            error = %e,
+            inflight_drain_secs,
+            "shutdown complete, but the server exited with an error",
+        ),
+        (Err(e), None) => tracing::error!(
+            error = %e,
+            "the server exited with an error before any termination signal",
+        ),
+    }
     server_result
 }
 
@@ -247,11 +333,77 @@ fn prefix_index_config(
     }
 }
 
-/// Waits for either Unix termination signal and logs the selected cause.
-async fn shutdown_signal(mut sigterm: Signal, mut sigint: Signal) {
-    tokio::select! {
-        _ = sigterm.recv() => tracing::info!("got SIGTERM, shutting down"),
-        _ = sigint.recv()  => tracing::info!("got SIGINT, shutting down"),
+/// Resolve when a termination signal arrives, then hand control to axum's
+/// graceful drain. On SIGTERM (k8s pod termination) first run the readiness
+/// drain — flip `/readyz` to 503 and keep serving for `drain` so the endpoint
+/// removal reaches kube-proxy before we stop accepting, closing the
+/// rolling-update race. SIGINT (local Ctrl-C) skips the readiness drain
+/// entirely — no 503 flip, no pause — so dev iteration does not pay it.
+///
+/// Either way axum's own in-flight drain runs afterwards and is unbounded: a
+/// long streaming completion still holds the process until it finishes or
+/// `terminationGracePeriodSeconds` expires. A further termination signal cuts
+/// the pause short but cannot reach that phase; it is logged instead.
+async fn shutdown_signal(
+    mut sigterm: Signal,
+    mut sigint: Signal,
+    ctx: Arc<sgl_router::server::app_context::AppContext>,
+    drain: std::time::Duration,
+) {
+    let sigterm_first = tokio::select! {
+        _ = sigterm.recv() => {
+            tracing::info!("got SIGTERM, shutting down");
+            true
+        }
+        _ = sigint.recv() => {
+            tracing::info!("got SIGINT, shutting down without the readiness drain");
+            false
+        }
+    };
+
+    let (expedite_tx, expedite_rx) = tokio::sync::oneshot::channel::<()>();
+    // Only the SIGTERM path runs a pause, so only it has something to cut
+    // short; on the SIGINT path the first further signal goes straight to the
+    // warning below.
+    let mut expedite_tx = sigterm_first.then_some(expedite_tx);
+    // Hand both streams to a task that outlives this future, on EITHER branch.
+    // Dropping them here would make every later signal vanish: tokio never
+    // restores the default disposition, so the process would neither expedite
+    // nor die, and nothing would be logged.
+    tokio::spawn(async move {
+        loop {
+            let delivered = tokio::select! {
+                delivered = sigterm.recv() => delivered,
+                delivered = sigint.recv() => delivered,
+            };
+            if delivered.is_none() {
+                // The signal driver is gone (runtime shutting down). Looping
+                // would spin without ever receiving again.
+                return;
+            }
+            match expedite_tx.take() {
+                // The first further signal cuts the readiness pause short, so
+                // an operator watching a stuck rollout is not held for a window
+                // that has stopped being useful.
+                Some(tx) => {
+                    let _ = tx.send(());
+                }
+                // Past the pause there is nothing left to cut short — say so
+                // rather than swallowing the signal silently.
+                None => tracing::warn!(
+                    "further termination signal ignored: the readiness pause is over \
+                     and the in-flight drain cannot be cut short; send SIGKILL to \
+                     force an immediate exit",
+                ),
+            }
+        }
+    });
+
+    if sigterm_first {
+        let expedite = async move {
+            let _ = expedite_rx.await;
+        };
+        sgl_router::server::shutdown::drain_for_termination(&ctx, drain, expedite).await;
     }
 }
 

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -331,6 +331,7 @@ mod tests {
             server: ServerConfig {
                 host: "0".into(),
                 port: 0,
+                ..Default::default()
             },
             observability: Default::default(),
             model: ModelConfig {

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -102,6 +102,21 @@ impl AppContext {
         self.ready.store(true, Ordering::Relaxed);
     }
 
+    /// Inverse of [`mark_ready`](Self::mark_ready): flip `/readyz` to 503.
+    /// Called at the start of the SIGTERM drain so probes and any probe-driven
+    /// load balancer see this pod as not-ready while the endpoint removal
+    /// (triggered by the pod's `deletionTimestamp`, not by this flip)
+    /// propagates. See [`crate::server::shutdown::drain_for_termination`] for
+    /// which mechanism the pause is sized for.
+    pub fn mark_not_ready(&self) {
+        self.ready.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether bootstrap finished — only ONE term of the `/readyz` predicate,
+    /// which also requires a non-empty worker registry (see
+    /// `server::routes::health::readyz`). Expected to be monotonic once
+    /// [`mark_not_ready`](Self::mark_not_ready) has run: nothing re-readies a
+    /// pod that has begun draining.
     pub fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Relaxed)
     }
@@ -113,6 +128,7 @@ impl AppContext {
                 server: crate::config::ServerConfig {
                     host: "x".into(),
                     port: 0,
+                    ..Default::default()
                 },
                 observability: Default::default(),
                 model: crate::config::ModelConfig {
@@ -149,5 +165,25 @@ impl AppContext {
             engine_load: EngineLoadTable::new(),
             ready: AtomicBool::new(false),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_not_ready_flips_readiness_back_off() {
+        let ctx = AppContext::stub();
+        // stub starts not-ready; mark_ready is the readiness on-switch.
+        ctx.mark_ready();
+        assert!(ctx.is_ready(), "mark_ready must report ready");
+        // The SIGTERM drain path needs the inverse so /readyz can flip to 503
+        // before the server stops accepting.
+        ctx.mark_not_ready();
+        assert!(
+            !ctx.is_ready(),
+            "mark_not_ready must flip readiness back off",
+        );
     }
 }

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -7,3 +7,4 @@ pub mod error;
 pub mod header_utils;
 pub mod metrics;
 pub mod routes;
+pub mod shutdown;

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -112,6 +112,7 @@ mod tests {
             server: crate::config::ServerConfig {
                 host: "x".into(),
                 port: 0,
+                ..Default::default()
             },
             observability: Default::default(),
             model: crate::config::ModelConfig {

--- a/experimental/sgl-router/src/server/shutdown.rs
+++ b/experimental/sgl-router/src/server/shutdown.rs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Graceful-termination helpers.
+//!
+//! On SIGTERM the pod is on its way out, but the data plane does not know it
+//! yet: kube-proxy keeps routing here until the endpoint removal propagates to
+//! it (an external load balancer deregisters on its own probe cadence
+//! instead — see [`drain_for_termination`]). Requests sent in that window
+//! reach a socket that is about to stop accepting and fail at the client. The
+//! drain below holds the listener open for a fixed, operator-set window sized
+//! to cover that propagation, with `/readyz` already reporting 503.
+
+use crate::server::app_context::AppContext;
+use std::future::Future;
+use std::time::Duration;
+
+/// Begin a graceful-termination drain: flip `/readyz` to 503, then keep
+/// serving for `drain` before the caller stops accepting connections. A zero
+/// `drain` flips readiness and returns at once. This composes with axum's
+/// `with_graceful_shutdown`: once this future resolves, axum stops accepting
+/// and drains the already-in-flight requests.
+///
+/// The two deregistration mechanisms, and which one the pause is sized for:
+///
+/// 1. **Endpoint removal.** For a pod deletion or rolling update the
+///    EndpointSlice controller marks this pod's endpoint not-ready the moment
+///    the `deletionTimestamp` is stamped — it does not wait on a probe. The
+///    pause covers the propagation of that to kube-proxy on every node. This
+///    is the mechanism the default drain is sized for.
+/// 2. **The `/readyz` flip.** Probe-driven deregistration (an external load
+///    balancer, or a kubelet readiness probe on a pod that is not being
+///    deleted) needs `failureThreshold` consecutive failures at
+///    `periodSeconds` apart before it acts. A drain shorter than that product
+///    never gets observed, so operators relying on this path must raise the
+///    drain to match their own probe cadence — the default does not do it for
+///    them.
+///
+/// `expedite` cuts the *pause* short: if it resolves first (a further
+/// termination signal), the drain returns early so the process is not held for
+/// a window that has stopped being useful. It does not reach the axum
+/// in-flight drain that runs afterwards, which is unbounded. Pass
+/// [`std::future::pending`] to never expedite. Note that two signals delivered
+/// close enough together coalesce into one notification, so a drain already
+/// running takes one *further* signal to expedite.
+pub async fn drain_for_termination(
+    ctx: &AppContext,
+    drain: Duration,
+    expedite: impl Future<Output = ()>,
+) {
+    ctx.mark_not_ready();
+    if drain.is_zero() {
+        // Still say so: without this line `--shutdown-drain-secs 0` produces a
+        // shutdown log indistinguishable from an image that predates the drain.
+        tracing::info!("/readyz now 503; drain pause disabled (shutdown_drain_secs=0)");
+        return;
+    }
+    tracing::info!(
+        drain_secs = drain.as_secs(),
+        "draining: /readyz now 503, waiting before the server stops accepting"
+    );
+    tokio::select! {
+        _ = tokio::time::sleep(drain) => {
+            tracing::info!(
+                drain_secs = drain.as_secs(),
+                "drain pause elapsed; the server now stops accepting",
+            );
+        }
+        _ = expedite => {
+            tracing::info!("drain pause expedited by a further termination signal");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn drain_zero_flips_readiness_without_pausing() {
+        let ctx = AppContext::stub();
+        ctx.mark_ready();
+        // Real time, and an elapsed-time assertion rather than a `timeout`: a
+        // "minimum safe drain" floor added to the production path would still
+        // fit inside any timeout generous enough not to be flaky, so only
+        // measuring the elapsed time actually pins "0 means no pause".
+        let started = std::time::Instant::now();
+        drain_for_termination(&ctx, Duration::ZERO, std::future::pending::<()>()).await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "zero drain must not pause, slept {elapsed:?}",
+        );
+        assert!(!ctx.is_ready(), "zero drain still flips readiness off");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_holds_for_the_delay_after_flipping_readiness() {
+        let ctx = AppContext::stub();
+        ctx.mark_ready();
+        // A 30 s drain must not have returned within a 10 ms window...
+        let returned = tokio::time::timeout(
+            Duration::from_millis(10),
+            drain_for_termination(&ctx, Duration::from_secs(30), std::future::pending::<()>()),
+        )
+        .await;
+        assert!(
+            returned.is_err(),
+            "drain must still be sleeping out the configured delay",
+        );
+        // ...but readiness flipped off on entry, before the sleep.
+        assert!(
+            !ctx.is_ready(),
+            "readiness must flip off before the drain delay elapses",
+        );
+    }
+
+    /// The pause must last *the configured* time — not merely "some time".
+    /// Two distinct values, because a hardcoded constant substituted for
+    /// `drain` satisfies any single-value test.
+    #[tokio::test(start_paused = true)]
+    async fn drain_holds_for_exactly_the_configured_delay() {
+        for secs in [5_u64, 30] {
+            let ctx = Arc::new(AppContext::stub());
+            ctx.mark_ready();
+            let drain_ctx = Arc::clone(&ctx);
+            let handle = tokio::spawn(async move {
+                drain_for_termination(
+                    &drain_ctx,
+                    Duration::from_secs(secs),
+                    std::future::pending::<()>(),
+                )
+                .await;
+            });
+            // Let the task register its sleep before advancing: a timer that
+            // has not been created yet cannot be advanced past.
+            tokio::task::yield_now().await;
+
+            // One millisecond shy of the deadline the drain must still be held.
+            tokio::time::advance(Duration::from_millis(secs * 1000 - 1)).await;
+            tokio::task::yield_now().await;
+            assert!(
+                !handle.is_finished(),
+                "a {secs} s drain returned before its configured delay elapsed",
+            );
+
+            // Past it, it must return promptly.
+            tokio::time::advance(Duration::from_millis(2)).await;
+            tokio::time::timeout(Duration::from_secs(1), handle)
+                .await
+                .unwrap_or_else(|_| panic!("a {secs} s drain must return once its delay elapses"))
+                .expect("drain task joined cleanly");
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_is_cut_short_when_expedite_resolves() {
+        let ctx = AppContext::stub();
+        ctx.mark_ready();
+        // A further termination signal (here: an already-resolved expedite
+        // future) must cut the pause short so an operator re-sending SIGTERM
+        // is not held for the full window.
+        let done = tokio::time::timeout(
+            Duration::from_millis(10),
+            drain_for_termination(&ctx, Duration::from_secs(3600), std::future::ready(())),
+        )
+        .await;
+        assert!(
+            done.is_ok(),
+            "an expedite signal must cut the drain short, not wait out 3600 s"
+        );
+        assert!(!ctx.is_ready(), "readiness still flipped off");
+    }
+}

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -226,6 +226,7 @@ mod tests {
             server: crate::config::ServerConfig {
                 host: "0".into(),
                 port: 0,
+                ..Default::default()
             },
             observability: Default::default(),
             model: crate::config::ModelConfig {

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -468,6 +468,7 @@ mod tests {
             server: ServerConfig {
                 host: "0".into(),
                 port: 0,
+                ..Default::default()
             },
             observability: Default::default(),
             model: ModelConfig {

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -124,6 +124,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
         server: ServerConfig {
             host: "127.0.0.1".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: sgl_router::config::ModelConfig {

--- a/experimental/sgl-router/tests/e2e/k8s_integration/conftest.py
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/conftest.py
@@ -172,14 +172,20 @@ def _port_forward_start(
     service: str,
     local_port: int,
     remote_port: int,
+    resource: str = "svc",
 ) -> subprocess.Popen:
-    """Start kubectl port-forward and wait until the port is reachable."""
+    """Start kubectl port-forward and wait until the port is reachable.
+
+    `resource="pod"` binds one specific pod instead of the Service. A draining
+    pod is removed from the Service's ready endpoints, so a test that needs to
+    keep talking to it through the drain must address the pod directly.
+    """
     cmd = [
         "kubectl",
         "--context",
         KUBECTL_CONTEXT,
         "port-forward",
-        f"svc/{service}",
+        f"{resource}/{service}",
         f"{local_port}:{remote_port}",
         "-n",
         namespace,
@@ -213,6 +219,47 @@ def _cleanup_port_forward(name: str, pf: subprocess.Popen) -> None:
         logger.warning("Port-forward %s exited rc=%s%s", name, rc, suffix)
     else:
         logger.debug("Port-forward %s exited cleanly (rc=%s)", name, rc)
+
+
+def _pod_json(pod: str, namespace: str = NAMESPACE) -> dict:
+    """One pod's full object. The `or "{}"` mirrors
+    `_wait_for_replacement_pod_ready`: kubectl can hand back empty stdout, and a
+    JSONDecodeError there says nothing about what went wrong."""
+    result = _kubectl("get", "pod", pod, "-n", namespace, "-o", "json")
+    return json.loads(result.stdout or "{}")
+
+
+def _pod_names(selector: str, namespace: str = NAMESPACE) -> list[str]:
+    """Names of pods matching `selector`, excluding any already terminating."""
+    result = _kubectl("get", "pods", "-n", namespace, "-l", selector, "-o", "json")
+    pods = json.loads(result.stdout or "{}").get("items", [])
+    return [
+        p["metadata"]["name"]
+        for p in pods
+        if not p["metadata"].get("deletionTimestamp")
+    ]
+
+
+def _container_restart_count(
+    pod: str,
+    container: str,
+    namespace: str = NAMESPACE,
+) -> int:
+    """`restartCount` for one container — how a test observes that the process
+    exited and kubelet restarted it in place (no new pod, same name)."""
+    statuses = _pod_json(pod, namespace).get("status", {}).get("containerStatuses", [])
+    for status in statuses:
+        if status["name"] == container:
+            return int(status["restartCount"])
+    raise AssertionError(f"container {container!r} not found on pod {pod!r}")
+
+
+def _pod_ready_condition(pod: str, namespace: str = NAMESPACE) -> str:
+    """The pod's `Ready` condition as k8s currently sees it ("True"/"False")."""
+    for cond in _pod_json(pod, namespace).get("status", {}).get("conditions", []):
+        if cond["type"] == "Ready":
+            return cond["status"]
+    return "Unknown"
 
 
 def _poll_until(

--- a/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router-cluster-scoped.yaml
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router-cluster-scoped.yaml
@@ -16,6 +16,9 @@ spec:
         app: sgl-router-cluster
     spec:
       serviceAccountName: sgl-router-cluster
+      # Must exceed --shutdown-drain-secs plus the time in-flight requests need
+      # after the pause, or the pod is SIGKILLed mid-drain.
+      terminationGracePeriodSeconds: 40
       containers:
         - name: router
           image: sgl-router:e2e
@@ -37,6 +40,10 @@ spec:
             - "--service-discovery"
             - "--selector"
             - "app=sglang,cross-ns-test=true"
+            # Parity with router.yaml so the cross-namespace router exercises
+            # the same shutdown path; no test asserts on it here.
+            - "--shutdown-drain-secs"
+            - "8"
           ports:
             - containerPort: 8091
               name: http

--- a/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router.yaml
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/manifests/router.yaml
@@ -14,6 +14,10 @@ spec:
         app: sgl-router
     spec:
       serviceAccountName: sgl-router
+      # Must exceed --shutdown-drain-secs plus the time in-flight requests
+      # need after the pause, or the pod is SIGKILLed mid-drain and the drain
+      # has bought nothing.
+      terminationGracePeriodSeconds: 40
       containers:
         - name: router
           image: sgl-router:e2e
@@ -44,6 +48,14 @@ spec:
             - "sgl-router-test"
             - "--selector"
             - "app=sglang"
+            # On SIGTERM, keep serving with /readyz at 503 so the endpoint
+            # removal reaches kube-proxy before the listener closes. Sized for
+            # the deletionTimestamp path, which does not wait on a probe.
+            # Probe-driven deregistration would instead need this above the
+            # readinessProbe's failureThreshold * periodSeconds below.
+            # test_shutdown_drain.py reads this value; do not restate it there.
+            - "--shutdown-drain-secs"
+            - "8"
           ports:
             - containerPort: 8090
               name: http

--- a/experimental/sgl-router/tests/e2e/k8s_integration/test_shutdown_drain.py
+++ b/experimental/sgl-router/tests/e2e/k8s_integration/test_shutdown_drain.py
@@ -1,0 +1,173 @@
+"""SIGTERM readiness-drain integration tests.
+
+The drain exists to produce a *Kubernetes* behaviour, and the Rust tests can
+only argue it: they substitute a channel for the real `Signal` and an
+in-process `AppContext` for a real pod. These run the shipped container, so
+they cover `main.rs::shutdown_signal` — the signal handler, the SIGTERM/SIGINT
+branch, and the `ctx` wiring — which no in-process test reaches.
+
+Why `kill -TERM 1` rather than `kubectl delete pod`: deleting a pod stamps a
+`deletionTimestamp`, and the endpoints controller marks the endpoint not-ready
+on that alone, without ever consulting `/readyz`. A delete-based test would
+therefore pass identically with the drain removed — it would look like
+coverage while pinning nothing. Signalling the process directly leaves the pod
+undeleted, so a `/readyz` 503 can only have come from the drain calling
+`AppContext::mark_not_ready`.
+
+The router image is `debian:bookworm-slim` with an exec-form ENTRYPOINT, so
+the binary is PID 1 and `kill -TERM 1` reaches it exactly as kubelet's SIGTERM
+would.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from pathlib import Path
+
+import httpx
+from conftest import (
+    NAMESPACE,
+    _cleanup_port_forward,
+    _container_restart_count,
+    _kubectl,
+    _pod_names,
+    _pod_ready_condition,
+    _poll_until,
+    _port_forward_start,
+    _wait_for_deployment_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+# Distinct from the shared 8090 forward so this test's pod-scoped forward
+# cannot collide with a leaked service-scoped one from another test.
+DRAIN_PORT = 8094
+
+_ROUTER_MANIFEST = Path(__file__).parent / "manifests" / "router.yaml"
+
+
+def _manifest_drain_secs() -> int:
+    """Read `--shutdown-drain-secs` out of the manifest the pod is started
+    from. Read rather than restated, because every assertion below is scaled to
+    the drain window: a manifest edit that this file did not track would leave
+    the test green while measuring the wrong window."""
+    args = _ROUTER_MANIFEST.read_text()
+    match = re.search(
+        r'"--shutdown-drain-secs"\s*\n\s*-\s*"(\d+)"',
+        args,
+    )
+    assert match, f"--shutdown-drain-secs not found in {_ROUTER_MANIFEST}"
+    return int(match.group(1))
+
+
+CONFIGURED_DRAIN_SECS = _manifest_drain_secs()
+
+# Budget for observing the /readyz flip, deliberately a fraction of the drain:
+# the assertions that follow it must still land inside the window, so the poll
+# cannot be allowed to consume the whole thing.
+FLIP_OBSERVATION_SECS = max(2, CONFIGURED_DRAIN_SECS // 2)
+
+
+def _router_pod() -> str:
+    pods = _pod_names("app=sgl-router")
+    assert len(pods) == 1, f"expected exactly one live router pod, got {pods}"
+    return pods[0]
+
+
+class TestReadinessDrain:
+    """SIGTERM must flip /readyz to 503 while the pod keeps serving."""
+
+    def test_sigterm_flips_readyz_while_the_pod_keeps_serving(self, k8s_cluster):
+        _wait_for_deployment_ready("sgl-router")
+        pod = _router_pod()
+        restarts_before = _container_restart_count(pod, "router")
+
+        # Bind the pod, not the Service: a draining pod leaves the Service's
+        # ready endpoints, and the point of this test is to keep talking to it
+        # after that happens.
+        pf = _port_forward_start(NAMESPACE, pod, DRAIN_PORT, 8090, resource="pod")
+        base = f"http://127.0.0.1:{DRAIN_PORT}"
+        try:
+            assert httpx.get(f"{base}/readyz", timeout=5.0).status_code == 200, (
+                "router must be ready before SIGTERM"
+            )
+
+            # Through `sh -c`: the slim image ships no `kill` binary, and
+            # `kubectl exec` execs directly rather than through a shell, so the
+            # builtin is the only way to signal PID 1 from outside.
+            sigterm_at = time.monotonic()
+            _kubectl("exec", "-n", NAMESPACE, pod, "--", "sh", "-c", "kill -TERM 1")
+
+            # The flip is observable from outside the pod.
+            _poll_until(
+                lambda: httpx.get(f"{base}/readyz", timeout=3.0).status_code == 503,
+                "/readyz returns 503 after SIGTERM",
+                timeout=FLIP_OBSERVATION_SECS,
+                interval=0.2,
+            )
+
+            # ...and the pod is still serving while it reports not-ready.
+            # `/healthz` staying 200 is what stops the liveness probe
+            # restarting a pod that is draining on purpose.
+            assert httpx.get(f"{base}/healthz", timeout=5.0).status_code == 200, (
+                "liveness must stay green while the pod drains"
+            )
+
+            # A proxied completion still succeeding does double duty: it is the
+            # request k8s may still route during the window, AND it proves the
+            # worker registry is non-empty — so the 503 above can only be the
+            # readiness flip, not `/readyz`'s other term.
+            chat = httpx.post(
+                f"{base}/v1/chat/completions",
+                json={
+                    "model": "tiny",
+                    "messages": [{"role": "user", "content": "drain"}],
+                },
+                timeout=10.0,
+            )
+            assert chat.status_code == 200, (
+                f"a proxied request must still succeed mid-drain, got {chat.status_code}"
+            )
+
+            # Everything above claims to have run *inside* the window. Say so,
+            # so an overrun reads as "the window closed" and not as whichever
+            # transport error the closed listener happened to raise next.
+            mid_drain_elapsed = time.monotonic() - sigterm_at
+            assert mid_drain_elapsed < CONFIGURED_DRAIN_SECS, (
+                f"the mid-drain assertions took {mid_drain_elapsed:.1f}s, past the "
+                f"{CONFIGURED_DRAIN_SECS}s window they claim to observe"
+            )
+
+            # Recorded, not asserted: k8s needs failureThreshold consecutive
+            # failing probes, periodSeconds apart, to mark the pod not-ready —
+            # longer than the drain at the values in router.yaml. That is
+            # exactly why the default is sized for the deletionTimestamp path
+            # instead, and why probe-driven setups must raise it.
+            logger.info("pod Ready condition mid-drain: %s", _pod_ready_condition(pod))
+
+        finally:
+            _cleanup_port_forward(f"pod/{pod}", pf)
+
+        # The drain must END in an exit, and must have lasted roughly the
+        # configured window. Both are read off `restartCount`: the process
+        # exits when the drain elapses and kubelet restarts the container in
+        # place, same pod. Timing it this way rather than by watching the
+        # listener close is deliberate — the restart is fast enough that a
+        # port-forward probe can miss the closed window entirely and hang,
+        # whereas `restartCount` is monotonic and cannot be missed. Kubelet's
+        # own latency only ever makes this longer, so the lower bound is safe.
+        _poll_until(
+            lambda: _container_restart_count(pod, "router") > restarts_before,
+            "router container restarts once the drain elapses",
+            timeout=CONFIGURED_DRAIN_SECS + 90,
+            interval=0.5,
+        )
+        held_open_for = time.monotonic() - sigterm_at
+        # One second of slack for signal delivery and poll granularity.
+        assert held_open_for >= CONFIGURED_DRAIN_SECS - 1, (
+            f"the router exited {held_open_for:.1f}s after SIGTERM, short of the "
+            f"configured {CONFIGURED_DRAIN_SECS}s drain"
+        )
+        _wait_for_deployment_ready("sgl-router")

--- a/experimental/sgl-router/tests/proxy/bucket_routing.rs
+++ b/experimental/sgl-router/tests/proxy/bucket_routing.rs
@@ -55,6 +55,7 @@ fn build_app_context(
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -28,6 +28,7 @@ fn config_for(_worker_url: &str) -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/common/cache_aware_fixture.rs
+++ b/experimental/sgl-router/tests/proxy/common/cache_aware_fixture.rs
@@ -20,6 +20,7 @@ pub fn config() -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -29,6 +29,7 @@ async fn failover_when_one_worker_dies() {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: Default::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Pins the contract that `axum::serve(...).with_graceful_shutdown(...)` —
-//! exactly as wired in `src/main.rs` — drains every in-flight streaming
+//! the same combinator `src/main.rs` uses — drains every in-flight streaming
 //! request through the **real** `build_router(ctx)` stack before the
 //! server future resolves. A k8s SIGTERM must not truncate streaming
-//! completions.
+//! completions. (`main.rs` additionally runs the readiness drain first; the
+//! later tests cover that.)
 //!
 //! Why route the test through the real router (chat handler + proxy +
 //! SSE pump) rather than a synthetic `Router::new().route(...)`: a
@@ -13,6 +14,14 @@
 //! `bytes_stream_to_body` completion hook, in `chat::chat_completions`'
 //! guards, or in the SSE pump's `tx.send().await` race — all of which
 //! would be silently skipped by a synthetic-handler test.
+//!
+//! The later tests pin the readiness drain that runs *before* that axum
+//! drain: `server::shutdown::drain_for_termination` flips `/readyz` to 503
+//! and holds the listener open for `--shutdown-drain-secs` so the endpoint
+//! removal reaches kube-proxy first. They substitute a channel for the real
+//! `Signal`, so `main.rs`'s `shutdown_signal` is not exercised here; the k8s
+//! integration suite (`tests/e2e/k8s_integration/test_shutdown_drain.py`)
+//! signals the shipped binary and covers that wiring.
 
 use futures::future::join_all;
 use sgl_router::config::{
@@ -38,6 +47,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
         server: ServerConfig {
             host: "127.0.0.1".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {
@@ -231,4 +241,291 @@ async fn shutdown_with_no_inflight_returns_promptly() {
         elapsed < Duration::from_secs(1),
         "idle shutdown took too long: {elapsed:?}"
     );
+}
+
+/// The readiness-drain contract: on SIGTERM the drain flips `/readyz` to 503
+/// *while the server keeps accepting* (`/healthz` stays 200, a brand-new
+/// connection is still served), so the endpoint removal reaches kube-proxy
+/// before the listener closes. Mirrors `src/main.rs`'s SIGTERM arm by driving
+/// the shutdown future as "await the signal, then `drain_for_termination`"
+/// against the real `build_router(ctx)` stack.
+///
+/// The drain window is ended by the `expedite` channel rather than by wall
+/// clock, so the mid-drain assertions cannot lose a race with a sleeping
+/// timer on a loaded runner — and the expedite path itself gets covered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn readyz_flips_to_503_during_drain_while_still_serving() {
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        SLOW_CHUNKS.to_vec(),
+        Duration::from_millis(20),
+    )
+    .await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    assert!(ctx.is_ready(), "ctx starts ready");
+
+    let app = build_router(ctx.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // `sigterm_tx` stands in for SIGTERM delivery; `expedite_tx` stands in for
+    // the further termination signal that cuts the pause short. The drain is
+    // an hour so only `expedite_tx` can end it.
+    let ctx_for_shutdown = ctx.clone();
+    let (sigterm_tx, sigterm_rx) = oneshot::channel::<()>();
+    let (expedite_tx, expedite_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = sigterm_rx.await;
+                sgl_router::server::shutdown::drain_for_termination(
+                    &ctx_for_shutdown,
+                    Duration::from_secs(3600),
+                    async {
+                        let _ = expedite_rx.await;
+                    },
+                )
+                .await;
+            })
+            .await
+            .unwrap();
+    });
+
+    // Every probe opens its own connection: a pooled client would ride the
+    // pre-SIGTERM connection and keep passing even if the listener had already
+    // closed, which is exactly the regression this test exists to catch.
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .unwrap();
+    let readyz = format!("http://{addr}/readyz");
+    let healthz = format!("http://{addr}/healthz");
+
+    // Before SIGTERM: ready + worker registered ⇒ /readyz 200.
+    let pre = client.get(&readyz).send().await.unwrap();
+    assert_eq!(
+        pre.status(),
+        reqwest::StatusCode::OK,
+        "ready before SIGTERM"
+    );
+
+    sigterm_tx.send(()).unwrap();
+    // The drain flips readiness before its first await, but the flip and this
+    // observation are on different tasks — wait for it rather than sleeping.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while ctx.is_ready() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the drain must flip readiness off promptly after SIGTERM");
+
+    let mid_ready = client.get(&readyz).send().await.unwrap();
+    assert_eq!(
+        mid_ready.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "/readyz must flip to 503 during the drain so probes and load balancers see this pod as not-ready before the listener closes",
+    );
+
+    // State the accept explicitly rather than inferring it from a 200: this is
+    // the half of the contract that a pooled client would silently satisfy.
+    tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("the listener must still accept new connections during the drain");
+    let mid_health = client.get(&healthz).send().await.unwrap();
+    assert_eq!(
+        mid_health.status(),
+        reqwest::StatusCode::OK,
+        "the server must still be serving during the drain window",
+    );
+
+    // A *real proxied* request (not just the local health handlers) must still
+    // be accepted and served during the drain window — this is the request k8s
+    // may still route before the endpoint removal reaches kube-proxy.
+    let chat = format!("http://{addr}/v1/chat/completions");
+    let body = serde_json::json!({
+        "model": "tiny",
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    let mid_chat = client.post(&chat).json(&body).send().await.unwrap();
+    assert_eq!(
+        mid_chat.status(),
+        reqwest::StatusCode::OK,
+        "a proxied chat request must still succeed during the drain window",
+    );
+
+    // The request the drain actually exists for: it ARRIVES during the pause
+    // (kube-proxy has not observed the removal yet) and is still streaming when
+    // the pause ends. It must survive the handover into axum's in-flight drain,
+    // not just the window it started in.
+    //
+    // Await the response headers here rather than inside the spawned task: that
+    // is the point at which the request is provably in flight, so cutting the
+    // pause short below cannot race the client's connect on a loaded runner.
+    let stream_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let late_request = serde_json::json!({
+        "model": "tiny",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": true,
+    });
+    let late_resp = stream_client
+        .post(&chat)
+        .json(&late_request)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        late_resp.status().is_success(),
+        "a stream started during the drain must be accepted: {}",
+        late_resp.status(),
+    );
+    let late = tokio::spawn(async move { late_resp.bytes().await.unwrap() });
+
+    // Cut the pause short while that stream is still mid-flight; the server
+    // resolves without waiting out the hour.
+    expedite_tx.send(()).unwrap();
+
+    let late_body = late.await.expect("late client task joined");
+    assert!(
+        String::from_utf8_lossy(&late_body).contains("data: [DONE]"),
+        "a request that arrived during the drain must still complete after the pause ends",
+    );
+    tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("an expedite signal must end the drain instead of sleeping an hour")
+        .expect("server task joined cleanly");
+}
+
+/// After the drain elapses and the server future resolves, axum must have
+/// stopped accepting: a *new* connection is refused. This is the other half of
+/// the contract — the drain has to actually END in a closed listener, or the
+/// pause merely postpones shutdown without ever handing traffic off. (What
+/// closes the rolling-update race is the pause itself, covered by
+/// `readyz_flips_to_503_during_drain_while_still_serving`.) Asserted on a raw
+/// TCP connect so the failure has to be `ConnectionRefused`; a `reqwest` error
+/// would also cover a timeout, which is a different (and on a loaded runner,
+/// plausible) outcome.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn new_connections_refused_after_drain_completes() {
+    let worker = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Short drain so the test is fast; the point is the post-resolve state.
+    let drain = Duration::from_millis(100);
+    let ctx_for_shutdown = ctx.clone();
+    let (sigterm_tx, sigterm_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = sigterm_rx.await;
+                sgl_router::server::shutdown::drain_for_termination(
+                    &ctx_for_shutdown,
+                    drain,
+                    std::future::pending::<()>(),
+                )
+                .await;
+            })
+            .await
+            .unwrap();
+    });
+
+    // Server accepts before shutdown.
+    tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("listener accepts before SIGTERM");
+
+    // Fire SIGTERM and wait for the drain + server future to fully resolve.
+    sigterm_tx.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("server resolves after the drain elapses")
+        .expect("server task joined cleanly");
+
+    // A fresh connection must now be refused — the listener is closed.
+    let err = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect_err("a new connection must be refused after the drain completes");
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused,
+        "expected the closed listener to refuse, got {err:?}",
+    );
+}
+
+/// End-to-end composition: SIGTERM → `drain_for_termination` (flip 503, pause)
+/// → axum drains the already-attached streaming request to `[DONE]`.
+/// `shutdown_drains_100_inflight_streaming_chat_completions` drives a bare
+/// oneshot shutdown future; this one composes the readiness drain with the axum
+/// drain, so a regression that truncates in-flight streams once the drain
+/// begins is caught. It does NOT assert the flip/pause ordering —
+/// `readyz_flips_to_503_during_drain_while_still_serving` covers that.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn inflight_stream_completes_through_drain_for_termination() {
+    let worker = crate::common::mock_worker::MockWorker::start_slow_stream(
+        SLOW_CHUNKS.to_vec(),
+        Duration::from_millis(60),
+    )
+    .await;
+    let ctx = build_ctx_with_worker(&worker.url);
+    let app = build_router(ctx.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://{addr}/v1/chat/completions");
+
+    let drain = Duration::from_millis(50);
+    let ctx_for_shutdown = ctx.clone();
+    let (sigterm_tx, sigterm_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = sigterm_rx.await;
+                sgl_router::server::shutdown::drain_for_termination(
+                    &ctx_for_shutdown,
+                    drain,
+                    std::future::pending::<()>(),
+                )
+                .await;
+            })
+            .await
+            .unwrap();
+    });
+
+    // Start one slow stream and hand back the response only once its headers
+    // have arrived — that is the point at which the request is provably
+    // in-flight, so SIGTERM below cannot race the client's connect.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let body = serde_json::json!({
+        "model": "tiny",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": true,
+    });
+    let resp = client.post(&url).json(&body).send().await.unwrap();
+    assert!(
+        resp.status().is_success(),
+        "stream started: {}",
+        resp.status()
+    );
+    let inflight = tokio::spawn(async move { resp.bytes().await.unwrap() });
+
+    // Fire SIGTERM mid-stream: the drain must NOT truncate the in-flight stream.
+    sigterm_tx.send(()).unwrap();
+
+    let received = inflight.await.expect("client task joined");
+    let body_str = String::from_utf8_lossy(&received);
+    assert!(
+        body_str.contains("data: [DONE]"),
+        "the in-flight stream must terminate with `data: [DONE]` through the drain path, got: {body_str}",
+    );
+    tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("server resolves after in-flight stream drains")
+        .expect("server task joined cleanly");
 }

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -25,6 +25,7 @@ async fn forwards_whitelisted_headers_strips_others() {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -40,6 +40,7 @@ fn config() -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -39,6 +39,7 @@ fn config() -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -36,6 +36,7 @@ fn config() -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/shared_prefill_admission.rs
+++ b/experimental/sgl-router/tests/proxy/shared_prefill_admission.rs
@@ -142,6 +142,7 @@ fn config(policy: PolicyKind) -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -48,6 +48,7 @@ fn config() -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -36,6 +36,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -32,6 +32,7 @@ fn config(_worker_url: &str) -> Config {
         server: ServerConfig {
             host: "0".into(),
             port: 0,
+            ..Default::default()
         },
         observability: ObservabilityConfig::default(),
         model: ModelConfig {


### PR DESCRIPTION
## Motivation

On SIGTERM the router hands straight to axum's `with_graceful_shutdown`: already-in-flight requests drain, but `/readyz` keeps returning 200 until the listener closes.

The pod is on its way out and the data plane does not know it yet. `kubelet` sends SIGTERM while the endpoint removal is still propagating — kube-proxy on every node keeps routing here until it lands. Those requests arrive at a socket that is about to stop accepting, so they fail at the client. On every rolling update this shows up as a burst of connection errors that has nothing to do with the workload.

The fix is the standard one: stop advertising readiness *before* you stop accepting, and hold the listener open long enough for the removal to converge.

## Modifications

**Readiness drain ahead of the axum drain** (`src/server/shutdown.rs`, `src/main.rs`). On SIGTERM:

1. `AppContext::mark_not_ready()` — `/readyz` flips to 503.
2. Keep serving for `--shutdown-drain-secs` (new flag, default `5`, `0` disables the pause).
3. The drain future resolves, axum stops accepting and drains whatever is already in flight — unchanged behaviour from here on.

`/healthz` stays 200 for the whole drain, so the liveness probe does not restart a pod that is deliberately draining. SIGINT (local Ctrl-C) skips the readiness drain entirely so dev iteration does not pay it, and a further termination signal cuts the pause short.

**What the pause is actually covering.** Worth being precise, because the two deregistration mechanisms have very different latencies:

- *Endpoint removal.* For a pod deletion or rolling update the EndpointSlice controller marks this pod's endpoint not-ready the moment the `deletionTimestamp` is stamped — it does not wait on a probe. The pause covers propagating that to kube-proxy. **This is what the 5 s default is sized for.**
- *The `/readyz` flip.* Probe-driven deregistration — an external LB, or a kubelet readiness probe on a pod that is not being deleted — needs `failureThreshold` consecutive failures at `periodSeconds` apart before it acts. This repo's own manifests use `periodSeconds: 3` with the default `failureThreshold: 3`, i.e. 9-12 s. A 5 s drain is never observed on that path. The flag help and the field doc say so, so nobody sizes a drain against a probe cadence the default does not cover.

**Startup advisory** (`src/config/mod.rs`). Warns when `--shutdown-drain-secs` leaves no room under the k8s default `terminationGracePeriodSeconds` (30 s). The bound is `>=`, not `>`: a drain of exactly the grace period already consumes all of it, so the in-flight drain that follows is guaranteed to be SIGKILLed. Advisory rather than fatal — the router cannot read the pod's actual grace period. Emitted from `main` after the subscriber is installed, with the value as a structured field, so `Config::validate` stays free of side effects.

**Observability, because this path is now load-bearing for the grace period.** Each of these was a way for the shutdown to fail with nothing in the log to explain it:

- **Both termination branches hand the `Signal` streams to a task that outlives the shutdown future.** Dropping them made every later signal vanish — tokio never restores the default disposition, so the process neither expedited nor died, and nothing was logged. (Pre-existing: `main`'s `shutdown_signal` drops both on return too.) Signals arriving past the pause are now logged and point the operator at SIGKILL, and the watcher returns on `recv() == None` rather than spinning.
- **axum's in-flight drain is heartbeated** every 5 s with the in-flight count. It is unbounded, so without this a pod SIGKILLed at the grace period leaves a log whose last line is the drain *starting* — one long stream is indistinguishable from a wedged upstream.
- **`--shutdown-drain-secs 0` logs the readiness flip.** It previously logged nothing at all, producing a shutdown log byte-identical to an image that predates the drain.
- **A failed `axum serve` logs at ERROR** instead of reporting "shutdown complete" at INFO while the actual error left the process through `Termination`, never through `tracing` — invisible to severity-based alerting.

**Types.** `ServerConfig` gains a `Default` impl so the new field need not be spelled out in the ~20 fixture literals, plus `shutdown_drain()` so the seconds-to-`Duration` conversion lives where a test can pin it rather than in `main.rs`, where a `from_secs`/`from_millis` slip would shorten every drain by 1000×. `Cli::into_config` still constructs exhaustively, so a future field cannot silently default on the production path. `--host`/`--port` now route their clap defaults through the same `default_host()`/`default_port()` the impl uses, so the two cannot drift.

### Known limitations, not addressed here

- **axum's in-flight drain is unbounded**, and the expedite signal cannot reach that phase. A long streaming completion can still run the pod into `terminationGracePeriodSeconds`. Bounding it means choosing to truncate streams, which the pre-existing `shutdown_drains_100_inflight_streaming_chat_completions` test deliberately forbids. That tradeoff deserves its own PR; the heartbeat above at least makes the phase visible.
- **The SIGINT branch is not covered in-process.** The Rust tests substitute a channel for the real `Signal`; the k8s test covers the SIGTERM path end-to-end against the shipped container. Isolating SIGINT would need the signal source behind a trait — a separate change.
- **Adjacent defect found while reviewing this, not fixed here:** `--log-format json` is inert. `install_bootstrap_subscriber` wins the `try_init` race and `init_tracing` silently loses, reporting it only at DEBUG. Measured 0/23 parseable lines under `--log-format json`. Unrelated to the drain; belongs in its own PR.

### Compatibility

The 5 s default changes shutdown timing for every deployment, not just k8s ones. It sits well inside the k8s default 30 s grace period. Under a bare `docker stop` (10 s default grace) the pause consumes 5 s of that window before in-flight requests get their turn — pass `--shutdown-drain-secs 0` to restore the previous behaviour exactly, or raise `--time`/`--stop-timeout`. Happy to flip the default to `0` and set it explicitly in the manifests instead if reviewers prefer opt-in.

## Accuracy Tests

Not applicable — no model or numerical path is touched.

## Speed Tests and Profiling

Not applicable — shutdown path only; the steady-state request path is unchanged.

## Test Coverage

**The drain length is pinned at two distinct values** (`src/server/shutdown.rs`) via `tokio::time::advance`, asserting the drain is still held 1 ms before its deadline and returns 1 ms after. Two values because a hardcoded constant satisfies any single-value assertion — and did: replacing `sleep(drain)` with `sleep(2s)`, severing the flag from the pause entirely, previously left all 13 tests green. **Zero-drain is pinned on elapsed time**, not a timeout, so a "minimum safe drain" floor cannot slip underneath a bound generous enough not to flake.

Other unit coverage: readiness flips *before* the pause; expedite cuts a 3600 s drain short; `mark_not_ready`; the advisory boundary at 29/30/120; and the CLI mapping at 0/17/600 (several values, so a clamp cannot escape) including the `Duration` accessor.

**Integration, over the real `build_router` stack** (`tests/proxy/graceful_shutdown.rs`):
- mid-drain: `/readyz` is 503, a **fresh TCP connect still succeeds**, and a proxied chat completion still returns 200. Probes use a non-pooling client — a pooled one rides the pre-SIGTERM connection and passes even if the listener has already closed, which is the ordering regression this test exists to catch.
- a request that **arrives during the drain** and is still streaming when the pause ends still reaches `data: [DONE]` — the request the drain actually exists to protect.
- a new connect is refused with `io::ErrorKind::ConnectionRefused` once the drain completes, asserted on raw TCP so a timeout on a loaded runner cannot be mistaken for a refusal.
- an in-flight SSE stream reaches `data: [DONE]` through the drain path.
- the mid-drain window is ended by an expedite channel rather than a wall-clock sleep, so assertions cannot lose a race — and the expedite path gets covered as a side effect.

**Kubernetes** (`tests/e2e/k8s_integration/test_shutdown_drain.py`), because the drain exists to produce a k8s behaviour that no in-process test can do more than argue. It runs the shipped container on kind, so it covers `main.rs::shutdown_signal` — real signal handler, real branch, real `ctx` wiring.

The test signals the process with `kill -TERM 1` rather than deleting the pod, and that choice is the whole point. `kubectl delete pod` stamps a `deletionTimestamp`, and the endpoints controller marks the endpoint not-ready on that alone, without consulting `/readyz` — so a delete-based test passes identically with the drain removed. Signalling PID 1 leaves the pod undeleted, so a `/readyz` 503 can only have come from `mark_not_ready`. Observed against the real cluster:

```
GET  /readyz            200        <- before SIGTERM
                                   <- sh -c 'kill -TERM 1'
GET  /readyz            503        <- flip, first poll
GET  /healthz           200        <- liveness stays green while draining
POST /v1/chat/...       200        <- still serving; also proves the registry
                                      is non-empty, so the 503 is the flip
pod Ready condition mid-drain: True
```

That last line is the two-mechanism argument turned into a measurement: the flip is visible at the endpoint immediately, while k8s itself has not reacted — it needs `failureThreshold * periodSeconds`, longer than the configured drain. Exactly why the default is sized for the `deletionTimestamp` path.

The test also pins the pause *length*, read off `restartCount` rather than by watching the listener close — kubelet restarts the container fast enough that a port-forward probe can miss the closed window entirely, while `restartCount` is monotonic and cannot be missed. The drain value is parsed out of the manifest, so the test and the deployment cannot drift apart.

The manifests now set `--shutdown-drain-secs 8` and `terminationGracePeriodSeconds: 40`, so the shipped example demonstrates the contract instead of relying on defaults.

Verified non-vacuous by mutation at every level: stubbing `mark_not_ready` to a no-op, hardcoding the sleep, and adding a 900 ms drain floor each fail a specific Rust test; and a container image rebuilt with the readiness flip removed fails the k8s test (38 polls across the full window, never 503). The shutdown log timeline was also checked against a real binary, which is how the heartbeat's original phase mislabelling and the `--log-format json` defect above were caught.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — the new flag is documented in `--help` and on `ServerConfig::shutdown_drain_secs`; the router has no separate flag reference page.
- [x] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Gates run locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (also clean on `main` beforehand, so no pre-existing lint debt is folded in), and `cargo test --release --workspace -- --skip parity_matrix` — 826 tests, 0 failures. `pre-commit` clean on the changed files.

The k8s integration test was run against a real kind cluster (`tests/e2e/k8s_integration/setup.sh`), passing on a clean build and failing on the mutated one. The rest of that suite was also run: 9 pass, and 3 in `test_discovery.py` fail on my machine only because an unrelated local process holds port 8090 and the fixture's port-forward collides with it — the 401 they report comes from that process, and its error code appears nowhere in the router source at any revision. Unrelated to this change; they pass where 8090 is free. The chat-completions e2e suite under `tests/e2e/chat_completions/` needs GPU workers and was not run.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132uxdbtdCKr2TbtiTcJ1Fe

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34417665587](https://github.com/sgl-project/sglang/actions/runs/34417665587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34417665342](https://github.com/sgl-project/sglang/actions/runs/34417665342)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->