### PR TITLE
Fix FlashInfer full-prefill SWA graph buffer lifetime

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -841,19 +841,25 @@ class FlashInferAttnBackend(AttentionBackend):
         # replay (bound onto the metadata at capture below).
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
-            self.cuda_graph_swa_out_cache_loc[n:].zero_()
+            swa_out_cache_loc = (
+                self.full_cg_prefill_swa_out_cache_loc
+                if forward_mode.is_extend_or_draft_extend_or_mixed()
+                else self.cuda_graph_swa_out_cache_loc
+            )
+            assert_buffer_fits(
+                n, swa_out_cache_loc.shape[0], "FlashInfer graph SWA write locations"
+            )
+            swa_out_cache_loc[n:].zero_()
             if in_capture:
-                self.cuda_graph_swa_out_cache_loc[:n].zero_()
+                swa_out_cache_loc[:n].zero_()
             else:
-                self.cuda_graph_swa_out_cache_loc[:n].copy_(
+                swa_out_cache_loc[:n].copy_(
                     self.kv_index_translator.sliding_window_write_loc_for(
                         forward_batch.out_cache_loc
                     )
                 )
             if in_capture:
-                self.forward_metadata.swa_out_cache_loc = (
-                    self.cuda_graph_swa_out_cache_loc[:n]
-                )
+                self.forward_metadata.swa_out_cache_loc = swa_out_cache_loc[:n]
 
     def _prepare_dequant_workspace_metadata_for_extend(
         self, forward_batch: ForwardBatch, use_ragged: bool = False
@@ -1194,6 +1200,13 @@ class FlashInferAttnBackend(AttentionBackend):
         """
         device = self.workspace_buffer.device
         self.full_cg_prefill_req_slots = num_slots
+        # Prefill captures before decode state is initialized. Its captured
+        # write targets must retain their address when decode allocates its own.
+        self.full_cg_prefill_swa_out_cache_loc = (
+            torch.zeros(max_num_tokens, dtype=torch.int64, device=device)
+            if self.use_sliding_window_kv_pool
+            else None
+        )
         upd = self.indices_updater_prefill
         workspace_bytes = self._full_cg_prefill_workspace_bytes(
             num_slots,

--- a/test/registered/unit/layers/attention/test_flashinfer_prefill_swa_graph.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_prefill_swa_graph.py
@@ -1,0 +1,124 @@
+"""SWA graph write-buffer lifetime, without model weights or GPU execution."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestFlashInferPrefillSWAGraph(CustomTestCase):
+    def make_backend(self, swa=True):
+        backend = FlashInferAttnBackend.__new__(FlashInferAttnBackend)
+        backend.use_sliding_window_kv_pool = swa
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend.num_wrappers = 1
+        backend.max_context_len = 16
+        backend.prefill_backend = "fa2"
+        backend.kv_last_page_len = torch.ones(2, dtype=torch.int32)
+        backend.indices_updater_prefill = SimpleNamespace(
+            num_qo_heads=4, num_kv_heads=1, head_dim=8, update=Mock()
+        )
+        backend.kv_index_translator = SimpleNamespace(
+            sliding_window_write_loc_for=lambda loc: loc + 100
+        )
+        with (
+            patch.object(backend, "_full_cg_prefill_workspace_bytes", return_value=64),
+            patch(
+                "sglang.srt.layers.attention.flashinfer_backend.BatchPrefillWithPagedKVCacheWrapper",
+                create=True,
+            ),
+        ):
+            backend.full_cg_prefill_wrappers = backend._create_full_cg_prefill_wrappers(
+                2, 8
+            )
+        return backend
+
+    def make_batch(self, mode=ForwardMode.EXTEND):
+        return SimpleNamespace(
+            batch_size=2,
+            req_pool_indices=torch.arange(2),
+            seq_lens=torch.tensor([4, 4]),
+            seq_lens_cpu=torch.tensor([4, 4]),
+            seq_lens_sum=8,
+            encoder_lens=None,
+            forward_mode=mode,
+            spec_info=None,
+            positions=torch.arange(8),
+            extend_prefix_lens=torch.zeros(2, dtype=torch.int32),
+            out_cache_loc=torch.arange(8),
+        )
+
+    def test_prefill_capture_before_decode_and_replay_keep_stable_storage(self):
+        backend = self.make_backend()
+        batch = self.make_batch()
+        backend.init_forward_metadata_out_graph(batch, in_capture=True)
+        captured = backend.forward_metadata.swa_out_cache_loc
+        address = captured.data_ptr()
+        self.assertEqual(captured.shape, (8,))
+        self.assertFalse(torch.any(captured))
+
+        # Decode capture happens later and must not replace prefill's write target.
+        backend.cuda_graph_swa_out_cache_loc = torch.full((2,), 99, dtype=torch.int64)
+        backend.forward_metadata = SimpleNamespace(
+            swa_out_cache_loc=backend.cuda_graph_swa_out_cache_loc
+        )
+        for locations in (torch.tensor([1, 2, 3, 4, 5]), torch.tensor([7, 8, 9])):
+            batch.out_cache_loc = locations
+            backend.init_forward_metadata_out_graph(batch)
+            self.assertEqual(captured.data_ptr(), address)
+            self.assertTrue(torch.equal(captured[: len(locations)], locations + 100))
+            self.assertFalse(torch.any(captured[len(locations) :]))
+            self.assertTrue(torch.all(backend.cuda_graph_swa_out_cache_loc == 99))
+
+        batch.out_cache_loc = torch.arange(9)
+        with self.assertRaisesRegex(AssertionError, "used 9 > capacity 8"):
+            backend.init_forward_metadata_out_graph(batch)
+
+    def test_decode_and_speculative_replay_keep_existing_buffer(self):
+        for mode in (
+            ForwardMode.DECODE,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND_V2,
+            ForwardMode.DLLM_EXTEND,
+        ):
+            with self.subTest(mode=mode):
+                backend = FlashInferAttnBackend.__new__(FlashInferAttnBackend)
+                backend.use_sliding_window_kv_pool = True
+                backend.cuda_graph_swa_out_cache_loc = torch.full((4,), 99)
+                backend.kv_index_translator = SimpleNamespace(
+                    sliding_window_write_loc_for=lambda loc: loc + 100
+                )
+                backend.indices_updater_decode = SimpleNamespace(update=Mock())
+                backend.indices_updater_prefill = SimpleNamespace(update=Mock())
+                backend.decode_cuda_graph_metadata = {2: [Mock()]}
+                backend.prefill_cuda_graph_metadata = {2: [Mock()]}
+                backend.draft_extend_cuda_graph_metadata = {2: [Mock()]}
+                backend.disable_cuda_graph_kv_split = False
+                backend.dllm_config = SimpleNamespace(block_size=2)
+                backend.use_paged = True
+                batch = self.make_batch(mode)
+                batch.out_cache_loc = torch.tensor([7, 8])
+                backend.init_forward_metadata_out_graph(batch)
+                self.assertTrue(
+                    torch.equal(
+                        backend.cuda_graph_swa_out_cache_loc,
+                        torch.tensor([107, 108, 0, 0]),
+                    )
+                )
+
+    def test_full_attention_does_not_allocate_swa_storage(self):
+        self.assertIsNone(
+            self.make_backend(swa=False).full_cg_prefill_swa_out_cache_loc
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Full-prefill CUDA graph capture can run before decode graph state is initialized. With a sliding-window KV pool, `init_forward_metadata_out_graph()` currently writes through `cuda_graph_swa_out_cache_loc`, which is only allocated by `init_cuda_graph_state()` for decode/verify. Prefill capture therefore raises:

```text
AttributeError: 'FlashInferAttnBackend' object has no attribute 'cuda_graph_swa_out_cache_loc'
```

Merely allocating the decode buffer earlier is not sufficient: later decode initialization may replace that tensor, while an already-captured prefill graph still references the old storage. Prefill token buckets can also be larger than decode buffers.

## Modifications

- Allocate a dedicated SWA write-location tensor with the full-prefill wrappers, sized to the largest prefill token bucket.
- Refresh/bind that tensor for plain extend/mixed/split-prefill modes; keep decode, target-verify, draft-extend-v2 and DLLM on their existing storage.
- Preserve zero padding and translated write locations; check buffer capacity before copying.
- Add a registered CPU component test without model weights or real FlashInfer execution.

No change to attention math, model loading, capture order, public configuration, dependencies or protocol parsers.

## Accuracy Tests

Base: `2092f6df05960c52d9df1994b0af812c2fc6544a`.

```bash
python test/registered/unit/layers/attention/test_flashinfer_prefill_swa_graph.py -v
```

Before the backend patch: 3 tests, 1 passes and 2 error; the prefill case reproduces the missing decode-owned buffer. After the patch: 3/3 pass. Coverage includes prefill-before-decode initialization, retained storage address after decode allocation, changing translated locations, clearing the unused tail, overflow rejection, non-SWA allocation, and unchanged decode/speculative buffer selection.

Local environment: Python3.12.13, Torch2.13.0+cu130; tensors in these tests are on CPU. GPUs were hidden for this run. `CUDA_VISIBLE_DEVICES=99` was used because the existing `test_utils` default-port calculation rejects an empty visibility string; this PR does not modify that unrelated test-infrastructure behavior.

The same backend fix was also exercised earlier in a local Muse-Glimmer-30B TP2 integration on two RTX5090s: successful full-prefill capture, 510 streaming requests without transport errors, and five cache/fact checks passed. That integration included a separate local checkpoint adapter on an older base; it is supporting evidence, **not** a model-wide accuracy evaluation or a fresh end-to-end test of this upstream branch. The new regression does not depend on that adapter or checkpoint.

## Speed Tests and Profiling

This is a correctness/lifetime fix, not a throughput claim. The original affected configuration fails during capture, so there is no valid before/after serving-speed comparison. The separate local full-prefill experiment did not outperform the selected eager-prefill configuration; no performance improvement is claimed here.

Additional persistent storage is one int64 per maximum captured prefill token when SWA is enabled (16KiB for a2048-token bucket), and none for non-SWA pools. Decode/verify allocation is unchanged.

## Checklist

- [x] Changed files pass the repository's pre-commit hooks, including pinned isort/Ruff, registered-test validation and private-key checks.
- [x] Focused registered component tests with fail-before/pass-after evidence.
- [x] No user-facing configuration/documentation change; buffer ownership and lifetime are documented at allocation.
- [x] Accuracy/profiling evidence and its limits are stated above; no speedup claim.
- [x] Followed the SGLang code-style and unit-test guidance.

Upstream CI/review remains to be run; local checks are not a substitute for maintainers' GPU CI. Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34416170685](https://github.com/sgl-project/sglang/actions/runs/34416170685)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34416170345](https://github.com/sgl-project/sglang/actions/runs/34416170345)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34416170572](https://github.com/sgl-project/sglang/actions/runs/34416170572)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->