### PR TITLE
Fix per-token top logprobs in multi-token chat streaming chunks

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2224,8 +2224,7 @@ class OpenAIServingChat(OpenAIServingBase):
     def _process_logprobs_tokens(
         self, logprobs: LogProbs
     ) -> List[ChatCompletionTokenLogprob]:
-        """Common helper to process logprobs tokens for both streaming and non-streaming
-        """
+        """Common helper to process logprobs tokens for both streaming and non-streaming"""
         token_logprobs = []
 
         for token_idx, (token, logprob) in enumerate(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2222,13 +2222,9 @@ class OpenAIServingChat(OpenAIServingBase):
         )
 
     def _process_logprobs_tokens(
-        self, logprobs: LogProbs, use_token_index: bool = False
+        self, logprobs: LogProbs
     ) -> List[ChatCompletionTokenLogprob]:
         """Common helper to process logprobs tokens for both streaming and non-streaming
-
-        Args:
-            logprobs: LogProbs data from model
-            use_token_index: True for non-streaming (use token_idx), False for streaming (use index 0)
         """
         token_logprobs = []
 
@@ -2238,12 +2234,7 @@ class OpenAIServingChat(OpenAIServingBase):
             token_bytes = list(token.encode("utf-8"))
             top_logprobs = []
             if logprobs.top_logprobs:
-                # - Non-streaming (use_token_index=True): uses token_idx for full data
-                # - Streaming (use_token_index=False): uses index 0 for pre-sliced data
-                top_logprobs_idx = token_idx if use_token_index else 0
-                for top_token, top_logprob in logprobs.top_logprobs[
-                    top_logprobs_idx
-                ].items():
+                for top_token, top_logprob in logprobs.top_logprobs[token_idx].items():
                     top_token_bytes = list(top_token.encode("utf-8"))
                     top_logprobs.append(
                         TopLogprob(
@@ -2270,7 +2261,7 @@ class OpenAIServingChat(OpenAIServingBase):
             output_top_logprobs=ret_item["meta_info"].get("output_top_logprobs", None),
         )
 
-        token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=True)
+        token_logprobs = self._process_logprobs_tokens(logprobs)
         return ChoiceLogprobs(content=token_logprobs)
 
     def _process_tool_call_id(
@@ -2440,7 +2431,7 @@ class OpenAIServingChat(OpenAIServingBase):
             output_top_logprobs=output_top_logprobs,
         )
 
-        token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=False)
+        token_logprobs = self._process_logprobs_tokens(logprobs)
         return ChoiceLogprobs(content=token_logprobs)
 
     def _process_reasoning_stream(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2821,6 +2821,37 @@ class ServingChatTestCase(unittest.TestCase):
             chunks.append(chunk)
         return chunks
 
+    def test_multitoken_stream_preserves_top_logprob_rows(self):
+        content = {
+            "meta_info": {
+                "output_token_logprobs": [
+                    (-0.1, 10, "answer"),
+                    (-0.2, 11, '":'),
+                    (-0.3, 12, "42"),
+                ],
+                "output_top_logprobs": [
+                    [(-0.1, 10, "answer"), (-1.1, 20, "réponse")],
+                    [(-0.2, 11, '":'), (-1.2, 21, "=")],
+                    [(-0.3, 12, "42"), (-1.3, 22, "43")],
+                ],
+            },
+        }
+        streamed = self.chat._process_streaming_logprobs(content, 0, 3)
+        nonstreamed = self.chat._process_response_logprobs(content)
+
+        self.assertEqual(streamed, nonstreamed)
+        self.assertEqual(
+            [
+                [(top.token, top.logprob) for top in row.top_logprobs]
+                for row in streamed.content
+            ],
+            [
+                [("answer", -0.1), ("réponse", -1.1)],
+                [('":', -0.2), ("=", -1.2)],
+                [("42", -0.3), ("43", -1.3)],
+            ],
+        )
+
     def test_streaming_logprobs_attached_with_reasoning_parser(self):
         """Logprobs must ride on the reasoning chunk when a reasoning parser is active."""
         self.chat.reasoning_parser = "qwen3"


### PR DESCRIPTION
## Why is this change needed?

When one chat-completion streaming chunk contains multiple tokens, each token receives the first token's `top_logprobs`. For example, a chunk with `answer`, `":`, and `42` repeats the alternatives for `answer` on all three rows, even though the sampled token and its own logprob are correct.

The streaming handler already slices both token logprobs and top-logprob rows to the same chunk. Index the latter by the token's position within that chunk, just as the non-streaming handler does. Remove the now-unnecessary `use_token_index` parameter and update its two callers.

## Test Plan

Adds one CPU unit test to `ServingChatTestCase` with three distinct token rows and two alternatives per row. It checks streaming/non-streaming parity and the exact expected alternatives.

The added test fails against the formatter methods from upstream `2092f6df05960c52d9df1994b0af812c2fc6544a` and passes with this patch. This local check executed the exact upstream handler methods and test in isolation, using the installed shared protocol/format utility; it was not a run of the full upstream unit suite.

Full upstream test target, pending CI:

```bash
python -m unittest discover -s test/registered/unit/entrypoints/openai -p test_serving_chat.py
```

A live DSV4 comparison with this repair also matched complete text, all ten token/logprob rows (including terminal EOS), every top-logprob row, and the finish reason between streaming and non-streaming responses. The maximum absolute token-logprob difference was zero.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34418565481](https://github.com/sgl-project/sglang/actions/runs/34418565481)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34418565392](https://github.com/sgl-project/sglang/actions/runs/34418565392)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34418566050](https://github.com/sgl-project/sglang/actions/runs/34418566050)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->