### PR TITLE
[Core] Use indexed operations for Mamba state slots

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -378,6 +378,35 @@ class ReqToTokenPool:
             )
 
 
+def _clear_state_slots(state: torch.Tensor, indices: torch.Tensor) -> None:
+    if _is_npu:
+        state[:, indices] = 0
+    else:
+        state.index_fill_(1, indices, 0)
+
+
+def _state_slot_indices(indices: torch.Tensor) -> torch.Tensor:
+    return indices if _is_npu else indices.to(dtype=torch.long)
+
+
+def _store_state_slots(
+    state: torch.Tensor, indices: torch.Tensor, values: torch.Tensor
+) -> None:
+    if _is_npu:
+        state[:, indices] = values
+    else:
+        state.index_copy_(1, indices, values)
+
+
+def _copy_state_slots(
+    state: torch.Tensor, src_indices: torch.Tensor, dst_indices: torch.Tensor
+) -> None:
+    if _is_npu:
+        state[:, dst_indices] = state[:, src_indices]
+    else:
+        _store_state_slots(state, dst_indices, state.index_select(1, src_indices))
+
+
 class MambaPool:
     # Axis of each two-dimensional conv state that represents the sliding window.
     # Upstream states use (dim, K-1); subclasses may preserve another layout.
@@ -988,36 +1017,22 @@ class MambaPool:
         """Zero out mamba state at the given pool indices. Must run on forward stream."""
         for sibling in self._slot_siblings:
             sibling.reset_slots(indices)
+        indexed_indices = _state_slot_indices(indices)
         if self._should_fuse_slot_ops():
             from sglang.srt.mem_cache.mamba_slot_fused import fused_clear_conv_slots
 
             fused_clear_conv_slots(self._conv_slot_desc, indices)
-            temporal = self.mamba_cache.temporal
-            if temporal.numel() > 0:
-                temporal[:, indices] = 0
-            return
-        if not _is_npu:
-            need_size = len(indices)
-            for i in range(len(self.mamba_cache.conv)):
-                t = self.mamba_cache.conv[i]
-                z = torch.zeros(1, dtype=t.dtype, device=t.device).expand(
-                    t.shape[0], need_size, *t.shape[2:]
-                )
-                t[:, indices] = z
-            t = self.mamba_cache.temporal
-            z = torch.zeros(1, dtype=t.dtype, device=t.device).expand(
-                t.shape[0], need_size, *t.shape[2:]
-            )
-            t[:, indices] = z
         else:
             for i in range(len(self.mamba_cache.conv)):
-                t = self.mamba_cache.conv[i]
-                t[:, indices] = 0
-            t = self.mamba_cache.temporal
-            t[:, indices] = 0
+                _clear_state_slots(self.mamba_cache.conv[i], indexed_indices)
+        temporal = self.mamba_cache.temporal
+        if temporal.numel() > 0:
+            _clear_state_slots(temporal, indexed_indices)
 
     def copy_from(self, src_indices: torch.Tensor, dst_indices: torch.Tensor):
         """Clone mamba state (conv + temporal) from src slots into dst slots.
+
+        Destination indices must be unique.
 
         ReplaySSM invariant: the SOURCE must be a fully-flushed checkpoint
         (``write_pos[src] == 0``). Only ``temporal`` is copied, not the ring, so
@@ -1027,6 +1042,15 @@ class MambaPool:
         caps the donate to the last flush boundary. The dst cursor is reset to 0
         (the copied checkpoint has no pending ring entries).
         """
+        indexed_src_indices = _state_slot_indices(src_indices)
+        indexed_dst_indices = _state_slot_indices(dst_indices)
+        dst_slots = (
+            dst_indices.tolist() if envs.SGLANG_DEBUG_MEMORY_POOL.get() else None
+        )
+        if dst_slots is not None:
+            assert len(dst_slots) == len(set(dst_slots)), (
+                f"copy_from requires unique destination slots, got {dst_slots}"
+            )
         if self.replayssm_write_pos is not None and self.debug_memory_pool:
             # Debug-only (syncs): catch any copy of an active, un-flushed slot.
             src_wp = self.replayssm_write_pos[src_indices]
@@ -1038,26 +1062,26 @@ class MambaPool:
         if self._should_fuse_slot_ops():
             from sglang.srt.mem_cache.mamba_slot_fused import fused_copy_conv_slots
 
-            if envs.SGLANG_DEBUG_MEMORY_POOL.get():
-                overlap = set(src_indices.tolist()) & set(dst_indices.tolist())
+            if dst_slots is not None:
+                overlap = set(src_indices.tolist()) & set(dst_slots)
                 assert not overlap, (
                     "fused copy_from requires disjoint src/dst slots; "
                     f"overlap={sorted(overlap)}"
                 )
             fused_copy_conv_slots(self._conv_slot_desc, src_indices, dst_indices)
-            temporal = self.mamba_cache.temporal
-            if temporal.numel() > 0:
-                temporal[:, dst_indices] = temporal[:, src_indices]
         else:
             for i in range(len(self.mamba_cache.conv)):
-                self.mamba_cache.conv[i][:, dst_indices] = self.mamba_cache.conv[i][
-                    :, src_indices
-                ]
-            self.mamba_cache.temporal[:, dst_indices] = self.mamba_cache.temporal[
-                :, src_indices
-            ]
+                _copy_state_slots(
+                    self.mamba_cache.conv[i], indexed_src_indices, indexed_dst_indices
+                )
+        temporal = self.mamba_cache.temporal
+        if temporal.numel() > 0:
+            _copy_state_slots(temporal, indexed_src_indices, indexed_dst_indices)
         if self.replayssm_write_pos is not None:
-            self.replayssm_write_pos[dst_indices] = 0
+            if _is_npu:
+                self.replayssm_write_pos[dst_indices] = 0
+            else:
+                self.replayssm_write_pos.index_fill_(0, indexed_dst_indices, 0)
         for sibling in self._slot_siblings:
             sibling.copy_slots(src_indices, dst_indices)
 
@@ -1090,11 +1114,20 @@ class MambaPool:
         else:
             conv_cpu, temporal_cpu = mamba_cache_cpu
         current_platform.synchronize()
+        indexed_indices = _state_slot_indices(indices)
         for i, conv in enumerate(self.mamba_cache.conv):
-            conv[:, indices] = conv_cpu[i].to(conv.device, non_blocking=True)
-        self.mamba_cache.temporal[:, indices] = temporal_cpu.to(
-            self.mamba_cache.temporal.device, non_blocking=True
-        )
+            _store_state_slots(
+                conv,
+                indexed_indices,
+                conv_cpu[i].to(conv.device, non_blocking=True),
+            )
+        temporal = self.mamba_cache.temporal
+        if temporal.numel() > 0:
+            _store_state_slots(
+                temporal,
+                indexed_indices,
+                temporal_cpu.to(temporal.device, non_blocking=True),
+            )
         if siblings_cpu is not None:
             for sibling, data in zip(self._slot_siblings, siblings_cpu):
                 sibling.load_cpu_slots(data, indices)

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -871,14 +871,41 @@ class UnifiedMambaPool(MambaPool):
             self.num_mamba_layers,
         )
 
-    # Inherited MambaPool state ops (copy_from/clear_slots/get_cpu_copy/load_cpu_copy)
-    # take PHYSICAL slot ids; callers translate via the slot allocator first.
+    def _slot_envelopes(self) -> torch.Tensor:
+        spec = self._unified_buffer.mamba_spec(self._sub_pool_name)
+        max_slots = self._unified_buffer.max_slots(self._sub_pool_name)
+        entry_bytes = spec.entry_bytes()
+        return self._unified_buffer._raw[: max_slots * entry_bytes].view(
+            max_slots, entry_bytes
+        )
+
+    def clear_slots(self, indices: torch.Tensor):
+        for sibling in self._slot_siblings:
+            sibling.reset_slots(indices)
+        spec = self._unified_buffer.mamba_spec(self._sub_pool_name)
+        zero_pages(
+            self._unified_buffer._raw,
+            indices,
+            self._unified_buffer.max_slots(self._sub_pool_name),
+            spec.entry_bytes(),
+        )
+
+    def copy_from(self, src_indices: torch.Tensor, dst_indices: torch.Tensor):
+        src_indices = src_indices.to(dtype=torch.long)
+        dst_indices = dst_indices.to(dtype=torch.long)
+        if envs.SGLANG_DEBUG_MEMORY_POOL.get():
+            dst_slots = dst_indices.tolist()
+            assert len(dst_slots) == len(set(dst_slots)), (
+                f"copy_from requires unique destination slots, got {dst_slots}"
+            )
+        envelopes = self._slot_envelopes()
+        envelopes.index_copy_(0, dst_indices, envelopes.index_select(0, src_indices))
+        for sibling in self._slot_siblings:
+            sibling.copy_slots(src_indices, dst_indices)
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
-        # Cross-pool physical-move contract, implemented by every pool the
-        # MultiEndedAllocator wraps. Ids are PHYSICAL slots; `MambaPool.copy_from`
-        # takes (src, dst), hence the swap.
-        MambaPool.copy_from(self, src_loc, tgt_loc)
+        # Compaction passes physical ids; copy_from takes (src, dst).
+        self.copy_from(src_loc, tgt_loc)
 
     # -- PD state transfer (StateType.MAMBA) --
     # The transfer item is the whole per-slot envelope, addressed as

--- a/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -20,10 +21,58 @@ def _pool(temporal: torch.Tensor, num_conv: int = 2) -> MambaPool:
         conv=[torch.zeros(NUM_LAYERS, NUM_SLOTS, 4, 5) for _ in range(num_conv)],
         temporal=temporal,
     )
+    pool.debug_memory_pool = False
+    pool.replayssm_write_pos = None
     return pool
 
 
 class TestMambaStateTransferBuffers(unittest.TestCase):
+    def test_slot_lifecycle_accepts_int32_indices(self):
+        pool = _pool(torch.ones(NUM_LAYERS, NUM_SLOTS, 6, 7, 8), num_conv=1)
+        pool.mamba_cache.conv[0].fill_(1)
+        indices = torch.tensor([0, 2], dtype=torch.int32)
+
+        pool.clear_slots(indices)
+        torch.testing.assert_close(
+            pool.mamba_cache.conv[0][:, indices.long()],
+            torch.zeros(NUM_LAYERS, 2, 4, 5),
+        )
+        torch.testing.assert_close(
+            pool.mamba_cache.temporal[:, indices.long()],
+            torch.zeros(NUM_LAYERS, 2, 6, 7, 8),
+        )
+
+        pool.copy_from(
+            torch.tensor([1], dtype=torch.int32),
+            torch.tensor([0], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            pool.mamba_cache.conv[0][:, 0], pool.mamba_cache.conv[0][:, 1]
+        )
+        torch.testing.assert_close(
+            pool.mamba_cache.temporal[:, 0], pool.mamba_cache.temporal[:, 1]
+        )
+
+    def test_load_cpu_copy_skips_empty_temporal_state(self):
+        pool = _pool(torch.empty(NUM_LAYERS, NUM_SLOTS, 0, 0, 0), num_conv=1)
+        indices = torch.tensor([0, 2], dtype=torch.int32)
+        conv_cpu = [torch.ones(NUM_LAYERS, 2, 4, 5)]
+        temporal_cpu = torch.empty(NUM_LAYERS, 2, 0, 0, 0)
+
+        pool.load_cpu_copy((conv_cpu, temporal_cpu), indices)
+
+        torch.testing.assert_close(
+            pool.mamba_cache.conv[0][:, indices.long()], conv_cpu[0]
+        )
+
+    def test_copy_rejects_duplicate_destinations_in_debug_mode(self):
+        pool = _pool(torch.zeros(NUM_LAYERS, NUM_SLOTS, 6, 7, 8), num_conv=1)
+        with (
+            envs.SGLANG_DEBUG_MEMORY_POOL.override(True),
+            self.assertRaisesRegex(AssertionError, "unique destination slots"),
+        ):
+            pool.copy_from(torch.tensor([0, 1]), torch.tensor([2, 2]))
+
     def test_conv_only_state_advertises_no_empty_buffer(self):
         """A ShortConv layer declares a degenerate temporal shape, so the pool
         allocates an empty tensor for it. The RDMA engine rejects a zero-length

--- a/test/registered/unit/mem_cache/test_unified_mamba_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mamba_views.py
@@ -26,6 +26,7 @@ be a multiple of the temporal itemsize -- an alignment hazard that
 """
 
 import unittest
+from unittest.mock import MagicMock
 
 import torch
 
@@ -191,6 +192,38 @@ class TestUnifiedMambaViews(unittest.TestCase):
                     f"writing {names[target]} CORRUPTED {names[other]} "
                     f"(envelope regions overlap)",
                 )
+
+    def test_slot_lifecycle_updates_whole_envelopes(self):
+        from sglang.srt.mem_cache.unified_memory_pool import UnifiedMambaPool
+
+        pool, spec = _make_pool(**self.FALCON_KW)
+        mamba_pool = UnifiedMambaPool(
+            unified_buffer=pool,
+            sub_pool_name="mamba",
+            spec_state_size=0,
+            mamba_layer_ids=list(range(spec.layer_num)),
+        )
+        sibling = MagicMock()
+        mamba_pool.register_slot_state(sibling)
+        envelopes = mamba_pool._slot_envelopes()
+        values = torch.arange(
+            envelopes.numel(), dtype=torch.int64, device=envelopes.device
+        ).view_as(envelopes)
+        envelopes.copy_(values.to(torch.uint8))
+        before = envelopes.clone()
+
+        mamba_pool.clear_slots(torch.tensor([2, 5], device=envelopes.device))
+        self.assertTrue(bool((envelopes[[2, 5]] == 0).all().item()))
+        self.assertTrue(torch.equal(envelopes[1], before[1]))
+        sibling.reset_slots.assert_called_once()
+
+        mamba_pool.copy_from(
+            torch.tensor([1, 3], dtype=torch.int32, device=envelopes.device),
+            torch.tensor([4, 6], dtype=torch.int32, device=envelopes.device),
+        )
+        self.assertTrue(torch.equal(envelopes[4], before[1]))
+        self.assertTrue(torch.equal(envelopes[6], before[3]))
+        sibling.copy_slots.assert_called_once()
 
     def test_alignment_guard_fires_on_misaligned_spec(self):
         """A per-slot entry that is not a multiple of the temporal itemsize would


### PR DESCRIPTION
Use index_fill_, index_select, and index_copy_ for Mamba slot lifecycle operations instead of advanced-index assignment. Non-NPU indices are normalized to int64, while the existing NPU and fused CUDA paths remain intact. Unified Mamba pools update complete slot envelopes so strided state views stay coherent, and both pool paths preserve registered sibling state. Focused CPU tests cover int32 indices, empty temporal state, duplicate destinations, sibling propagation, and unified-envelope clear/copy behavior.