### PR TITLE
[AMD][CI] Publish ROCm 10 release images and kernel wheel

### DIFF
--- a/.github/workflows/release-docker-amd.yml
+++ b/.github/workflows/release-docker-amd.yml
@@ -15,6 +15,7 @@ on:
         default: 'all'
         options:
           - 'all'
+          - rocm10
           - rocm724
           - rocm720
           - rocm700
@@ -25,11 +26,11 @@ jobs:
     runs-on: amd-docker-scale
     environment: 'prod'
     strategy:
-      # Six flavors publish independently: a failure in one must not cancel the
-      # others mid-push and leave the release tag with a partial image set.
+      # Eight flavors publish independently: a failure in one must not cancel
+      # the others mid-push and leave the release tag with a partial image set.
       fail-fast: false
       matrix:
-        rocm_version: ${{ fromJson((github.event_name == 'workflow_dispatch' && inputs.rocm_version != 'all' && inputs.rocm_version != '') && format('["{0}"]', inputs.rocm_version) || '["rocm700", "rocm720", "rocm724"]') }}
+        rocm_version: ${{ fromJson((github.event_name == 'workflow_dispatch' && inputs.rocm_version != 'all' && inputs.rocm_version != '') && format('["{0}"]', inputs.rocm_version) || '["rocm700", "rocm720", "rocm724", "rocm10"]') }}
         gpu_arch: ['gfx942', 'gfx950']
         build_type: ['all']
     steps:
@@ -85,6 +86,19 @@ jobs:
               rocm_tag="${{ matrix.rocm_version }}-mi30x"
             elif [ "${{ matrix.gpu_arch }}" = "gfx950" ]; then
               rocm_tag="${{ matrix.rocm_version }}-mi35x"
+            else
+              echo "Unsupported gfx arch"
+              exit 1
+            fi
+          elif [ "${{ matrix.rocm_version }}" = "rocm10" ]; then
+            # The Dockerfile stages carry the full SDK version (gfx942-rocm1000)
+            # while the published tag keeps the rocm10 flavor name that CI and
+            # the nightly images already use.
+            gpu_arch_suffix="-rocm1000"
+            if [ "${{ matrix.gpu_arch }}" = "gfx942" ]; then
+              rocm_tag="rocm10-mi30x"
+            elif [ "${{ matrix.gpu_arch }}" = "gfx950" ]; then
+              rocm_tag="rocm10-mi35x"
             else
               echo "Unsupported gfx arch"
               exit 1

--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -19,6 +19,7 @@ on:
           - 'cu130'
           - 'rocm700'
           - 'rocm720'
+          - 'rocm1000'
           - 'musa43'
       tag_name:
         description: "Version number, must be in the form of vX.Y.Z (e.g. v0.4.0)"
@@ -273,12 +274,15 @@ jobs:
   build-rocm-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm700' || github.event.inputs.target == 'rocm720')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm700' || github.event.inputs.target == 'rocm720' || github.event.inputs.target == 'rocm1000')
     runs-on: amd-docker-scale
     strategy:
       matrix:
         python-version: ["3.10"]
-        rocm-version: ["700", "720"]
+        # ROCm 10.0.0 builds inside a Python 3.12 container; the wheel is still
+        # tagged cp310-abi3 (wheel.py-api in pyproject.toml), so it stays under
+        # the same python-version leg as the 7.x wheels.
+        rocm-version: ["700", "720", "1000"]
     steps:
       # Self-hosted build nodes retain the workspace across jobs. Prior builds
       # leave root-owned artifacts under python/sglang/kernels/aot/build/ that actions/checkout
@@ -404,6 +408,57 @@ jobs:
 
       - name: Update wheel index
         run: python3 scripts/update_kernel_whl_index.py --rocm 720
+
+      - name: Push wheel index
+        run: |
+          cd sgl-whl
+          git config --local user.name "sglang-bot"
+          git config --local user.email "sglangbot@gmail.com"
+          git add -A
+          git commit -m "update whl index"
+          git push
+
+  release-rocm1000:
+    needs: build-rocm-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: python/sglang/kernels/aot/dist/
+          merge-multiple: true
+          pattern: wheel-*-rocm1000
+
+      - name: Set tag name
+        id: set_tag_name
+        run: |
+          if [ -z "${{ inputs.tag_name }}" ]; then
+            TAG_NAME="v$(cat python/sglang/kernels/aot/python/sgl_kernel/version.py | cut -d'"' -f2)"
+            echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          else
+            echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.set_tag_name.outputs.tag_name }}
+          repository: sgl-project/whl
+          token: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+          files: |
+            python/sglang/kernels/aot/dist/*
+
+      - name: Clone wheel index
+        run: git clone https://oauth2:${WHL_TOKEN}@github.com/sgl-project/whl.git sgl-whl
+        env:
+          WHL_TOKEN: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+
+      - name: Update wheel index
+        run: python3 scripts/update_kernel_whl_index.py --rocm 1000
 
       - name: Push wheel index
         run: |

--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -282,7 +282,12 @@ jobs:
         # ROCm 10.0.0 builds inside a Python 3.12 container; the wheel is still
         # tagged cp310-abi3 (wheel.py-api in pyproject.toml), so it stays under
         # the same python-version leg as the 7.x wheels.
-        rocm-version: ["700", "720", "1000"]
+        #
+        # A dispatch that names one flavor builds only that flavor. Every extra
+        # leg is another image build on the shared AMD node, and its release job
+        # appends the same wheel to the index a second time. `inputs` is empty
+        # on push, which falls through to the full set.
+        rocm-version: ${{ fromJson(inputs.target == 'rocm700' && '["700"]' || inputs.target == 'rocm720' && '["720"]' || inputs.target == 'rocm1000' && '["1000"]' || '["700", "720", "1000"]') }}
     steps:
       # Self-hosted build nodes retain the workspace across jobs. Prior builds
       # leave root-owned artifacts under python/sglang/kernels/aot/build/ that actions/checkout
@@ -318,6 +323,8 @@ jobs:
 
   release-rocm700:
     needs: build-rocm-matrix
+    # Only publish the flavors this run built; see build-rocm-matrix.
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'rocm700' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -369,6 +376,7 @@ jobs:
 
   release-rocm720:
     needs: build-rocm-matrix
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'rocm720' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -420,6 +428,7 @@ jobs:
 
   release-rocm1000:
     needs: build-rocm-matrix
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'rocm1000' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/3rdparty/amd/wheel/sgl-kernel/build_rocm.sh
+++ b/3rdparty/amd/wheel/sgl-kernel/build_rocm.sh
@@ -7,13 +7,56 @@ if [[ "${ROCM_VERSION}" == "700" ]]; then
   IMAGE="lmsysorg/sglang:v0.5.8.post1-rocm700-mi35x"
 elif [[ "${ROCM_VERSION}" == "720" ]]; then
   IMAGE="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+elif [[ "${ROCM_VERSION}" == "1000" ]]; then
+  # Ubuntu 24.04 / Python 3.12 / torch 2.11 matches the stack the released
+  # ROCm 10 images carry, and this image is built for every device arch, so one
+  # wheel can still cover both gfx942 and gfx950.
+  IMAGE="rocm/pytorch:rocm10.0_ubuntu24.04_py3.12_pytorch_release_2.11.0"
 else
-  echo "ERROR: Unsupported ROCM_VERSION='${ROCM_VERSION}'. Only '700' and '720' are supported." >&2
+  echo "ERROR: Unsupported ROCM_VERSION='${ROCM_VERSION}'. Only '700', '720' and '1000' are supported." >&2
   exit 1
 fi
 
 PYTHON_ROOT_PATH="/opt/venv/bin"
 AMDGPU_TARGET="gfx942;gfx950"
+
+# ROCm 10.0.0 is distributed as pip packages that unpack into site-packages, so
+# the image has neither the /opt/rocm tree CMakeLists_rocm.txt looks for
+# hip-lang under nor, being a runtime image, a devel tree to compile against.
+# These are the same fixups docker/rocm.Dockerfile's rocm1000-base stage makes
+# for the released images.
+ROCM_SETUP=""
+if [[ "${ROCM_VERSION}" == "1000" ]]; then
+  ROCM_SETUP=$(cat <<'ROCM1000_SETUP'
+  set -e
+  apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates wget
+  rocm_sdk_version=$(pip show rocm-sdk-core | awk '/^Version:/ {print $2}')
+  test -n "${rocm_sdk_version}"
+  pip install --no-cache-dir --index-url https://stable.repo.amd.com/rocm/whl-next/ "rocm-sdk-devel==${rocm_sdk_version}"
+  rocm-sdk init
+  export ROCM_HOME=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')/_rocm_sdk_devel
+  export ROCM_PATH="${ROCM_HOME}"
+  export CPATH="${ROCM_HOME}/include"
+  export LIBRARY_PATH="${ROCM_HOME}/lib"
+  export LD_LIBRARY_PATH="${ROCM_HOME}/lib"
+  export PATH="${ROCM_HOME}/llvm/bin:${ROCM_HOME}/bin:${PATH}"
+  ln -sfn "${ROCM_HOME}" /opt/rocm
+  # The SDK's hsakmtTargets.cmake hardcodes /usr/lib64/libc.so from its own
+  # build host; Ubuntu keeps libc in /lib/x86_64-linux-gnu.
+  mkdir -p /usr/lib64 && ln -sf /lib/x86_64-linux-gnu/libc.so /usr/lib64/libc.so
+ROCM1000_SETUP
+)
+fi
+
+# ROCm 10 has no /opt/rocm-<version> directory for rename_wheels_rocm.sh to read
+# the local version tag from, so name it here instead. Keeping it in step with
+# the `--rocm` argument release-whl-kernel.yml passes to
+# scripts/update_kernel_whl_index.py is what puts the wheel in the index it
+# gets published under.
+WHEEL_ROCM_VERSION=""
+if [[ "${ROCM_VERSION}" == "1000" ]]; then
+  WHEEL_ROCM_VERSION="1000"
+fi
 
 # Pull and run the latest image
 echo "Pulling Docker image: ${IMAGE}"
@@ -31,6 +74,7 @@ docker run --rm \
   elif [[ "${ROCM_VERSION}" == "720" ]]; then
     ${PYTHON_ROOT_PATH}/pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchaudio-2.9.0%2Brocm7.2.0.gite3c6ee2b-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchvision-0.24.0%2Brocm7.2.0.gitb919bd0c-cp310-cp310-linux_x86_64.whl
   fi
+${ROCM_SETUP}
   # Install CMake (version >= 3.26) - Robust Installation
   export CMAKE_VERSION_MAJOR=3.31
   export CMAKE_VERSION_MINOR=1
@@ -46,5 +90,5 @@ docker run --rm \
   rm -rf CMakeLists.txt && mv CMakeLists_rocm.txt CMakeLists.txt && \
   ${PYTHON_ROOT_PATH}/python rocm_hipify.py && \
   ${PYTHON_ROOT_PATH}/python -m uv build --wheel -Cbuild-dir=build . --color=always --no-build-isolation && \
-  ./rename_wheels_rocm.sh
+  ./rename_wheels_rocm.sh ${WHEEL_ROCM_VERSION}
 "

--- a/3rdparty/amd/wheel/sgl-kernel/rename_wheels_rocm.sh
+++ b/3rdparty/amd/wheel/sgl-kernel/rename_wheels_rocm.sh
@@ -3,6 +3,11 @@ set -ex
 
 WHEEL_DIR="dist"
 
+# ROCm version for the wheel's local version tag (e.g. 720 -> +rocm720). It is
+# read from the /opt/rocm-<version> tree when the caller does not name one; the
+# pip-installed ROCm 10 SDK has no such tree, so that flavor passes it in.
+ROCM_WHEEL_VERSION="${1:-}"
+
 wheel_files=($WHEEL_DIR/*.whl)
 for wheel in "${wheel_files[@]}"; do
     intermediate_wheel="${wheel/linux/manylinux2014}"
@@ -17,7 +22,10 @@ for wheel in "${wheel_files[@]}"; do
     fi
 
     # Detect ROCm version and add appropriate suffix
-    ver_abrv=$(realpath /opt/rocm-* | sed -e 's/.*-//' -e 's/\.//g')
+    ver_abrv="${ROCM_WHEEL_VERSION}"
+    if [[ -z "$ver_abrv" ]]; then
+        ver_abrv=$(realpath /opt/rocm-* | sed -e 's/.*-//' -e 's/\.//g')
+    fi
     new_wheel=${intermediate_wheel/-cp${cp_version}/+rocm${ver_abrv}-cp${cp_version}}
 
     if [[ "$wheel" != "$new_wheel" ]]; then


### PR DESCRIPTION
## Motivation

Follow-up to #38659, which made ROCm 10 the default flavor for AMD PR and nightly tests. The release side was left behind: the two release workflows called out there still produce 7.x artifacts only.

- `release-docker-amd.yml` builds `rocm700`, `rocm720` and `rocm724` on a version tag, so `lmsysorg/sglang` has no `v<version>-rocm10-mi30x` / `-mi35x` tag even though `release-docker-amd-rocm10.yml` publishes the same images nightly to `rocm/sgl-dev` and `lmsysorg/sglang-rocm`.
- `release-whl-kernel.yml` builds `sglang-kernel` wheels for ROCm 7.0 and 7.2 only, so the flavor AMD CI now gates on has no published wheel and no `rocm1000` wheel index.

## Modifications

**`release-docker-amd.yml`** — add `rocm10` to the release matrix and to the manual flavor selector, mapping it to the `gfx942-rocm1000` / `gfx950-rocm1000` Dockerfile stages and the `rocm10-mi30x` / `rocm10-mi35x` tags the nightly images already use. gfx1250 (mi45x) is deliberately left out: it is bring-up only, which is why the nightly keeps it in its own job.

**`release-whl-kernel.yml`** — add a `1000` leg to the ROCm build matrix, a `rocm1000` option to the dispatch target selector, and a `release-rocm1000` job that publishes the wheel and updates the `rocm1000` index (`scripts/update_kernel_whl_index.py --rocm 1000`, no change needed there). A dispatch that names one ROCm flavor now builds and publishes only that flavor: each leg is an image build on the shared AMD node, and each release job appends its wheel to the index again, so pulling all three along was both expensive and a source of duplicate index lines. A push still runs the full set.

**`3rdparty/amd/wheel/sgl-kernel/build_rocm.sh`** — teach it ROCm 10, building against `rocm/pytorch:rocm10.0_ubuntu24.04_py3.12_pytorch_release_2.11.0`. That image matches the Ubuntu 24.04 / Python 3.12 / torch 2.11 stack the released ROCm 10 images carry and is built with `AMDGPU_FAMILY=device-all`, so a single wheel still covers gfx942 and gfx950. ROCm 10 ships as pip packages that unpack into site-packages, so the container has no `/opt/rocm` tree for `CMakeLists_rocm.txt` to find hip-lang under and, being a runtime image, no devel tree to compile against; the new setup block applies the same fixups `docker/rocm.Dockerfile`'s `rocm1000-base` stage makes for the images.

**`3rdparty/amd/wheel/sgl-kernel/rename_wheels_rocm.sh`** — accept the ROCm version for the wheel's local version tag from the caller, since the pip-installed SDK leaves no `/opt/rocm-<version>` directory to read it from. The 7.x flavors pass nothing and keep the existing probe.

## Compatibility

- Existing flavors are untouched. The generated in-container build script for `700` and `720` is byte-identical to today's apart from one blank line and a trailing space, and `rename_wheels_rocm.sh` falls back to the same `/opt/rocm-*` probe when no version is passed.
- Workflow names, job IDs, and the tag scheme for existing images are unchanged. `rocm700` / `rocm720` / `rocm724` still publish on every version tag.

## Validation

**ROCm 10 kernel wheel — dispatched and green.** [Run #34422339330](https://github.com/sgl-project/sglang/actions/runs/34422339330) on this branch with `target: rocm1000`. Only the `1000` leg was created, confirming the new flavor scoping, and both `build-rocm-matrix (3.10, 1000)` and `release-rocm1000` passed. The build log confirms each piece of the ROCm 10 path:

- `rocm-sdk-devel==10.0.0` installed, so the runtime image did need the devel tree added.
- CMake resolved hip-lang through the `/opt/rocm` symlink: `Found HIP: /opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel`.
- `Using AMDGPU_TARGET from environment: gfx942;gfx950` / `Multi-arch build: Enabling both HIP_FP8_TYPE_FNUZ (gfx942) and HIP_FP8_TYPE_E4M3 (gfx950)`, so one wheel covers both archs despite the Python 3.12 container.
- Renamed to `sglang_kernel-0.4.6.post1+rocm1000-cp310-abi3-manylinux2014_x86_64.whl`.

The artifact is live: it is attached to the `v0.4.6.post1` release in `sgl-project/whl` next to the `+rocm700` and `+rocm720` wheels, `rocm1000/sglang-kernel/index.html` on `gh-pages` has the matching entry, and the wheel contains the built `sgl_kernel/common_ops.abi3.so`.

**ROCm 10 release image — dispatched and green.** [Run #34422374614](https://github.com/sgl-project/sglang/actions/runs/34422374614) on this branch with `rocm_version: rocm10`, `version: 0.5.19`. The flavor selector expanded to exactly `publish (rocm10, gfx942, all)` and `publish (rocm10, gfx950, all)` and both passed, publishing `lmsysorg/sglang:v0.5.19-rocm10-mi30x` and `-mi35x` (new tags, colliding with nothing). Inspecting the published image configs confirms the flavor-to-stage mapping: the mi30x image carries `GPU_ARCH=gfx942-rocm1000` and the mi35x image `GPU_ARCH=gfx950-rocm1000`, both with `ROCM_HOME` under `site-packages/_rocm_sdk_devel` as the ROCm 10 stack expects.

**Local:** captured the in-container script `build_rocm.sh` generates for `700`, `720` and `1000`, syntax-checked each, and diffed the `700` / `720` output against the pre-change script to confirm ROCm 10 support does not alter them. `pre-commit run --files` over the changed files passes.

## Follow-ups

`3rdparty/amd/wheel/sglang/pyproject.toml` carries `rocm700` and `rocm720` extras that pin a published `sglang-kernel` wheel URL. Now that a `+rocm1000` wheel exists, a `rocm1000` extra can be added in a follow-up.

## Accuracy Tests

N/A — release workflow change; model outputs are unaffected.

## Speed Tests and Profiling

N/A — this changes which release artifacts are built.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
