### PR TITLE
[CP] Remove stale DSA prefill CP model overrides

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
@@ -92,19 +92,9 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
                 logger.warning(
                     "Context parallel feature is still under experiment. It has only been verified on Hopper platform."
                 )
-                overrides["enable_dp_attention"] = True
-                overrides["moe_dense_tp_size"] = 1
-                if cfg.cp_strategy == "zigzag":
-                    overrides["moe_a2a_backend"] = "deepep"
-                    overrides["ep_size"] = cfg.tp_size
-                    logger.warning(
-                        "zigzag DSA CP requires moe_dense_tp_size=1, "
-                        "moe_a2a_backend=deepep, ep_size=tp_size, batch_size=1."
-                    )
-                else:
-                    assert cfg.dp_size == 1, (
-                        "interleave DSA CP does not support DP attention."
-                    )
+                assert cfg.dp_size == 1, (
+                    "interleave DSA CP does not support DP attention."
+                )
                 assert cfg.tp_size <= 8, (
                     "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
                 )
@@ -116,11 +106,11 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
                 logger.warning(
                     "Enabled DSA context parallel: "
                     f"strategy={cfg.cp_strategy}, dp_size={cfg.dp_size}, "
-                    f"moe_dense_tp_size={overrides['moe_dense_tp_size']}, "
-                    f"ep_size={overrides.get('ep_size', cfg.ep_size)}, tp_size={cfg.tp_size}, "
+                    f"moe_dense_tp_size={cfg.moe_dense_tp_size}, "
+                    f"ep_size={cfg.ep_size}, tp_size={cfg.tp_size}, "
                     f"attn_cp_size={attn_cp_size}, "
                     f"kv_cache_dtype={cfg.kv_cache_dtype}, "
-                    f"moe_a2a_backend={overrides.get('moe_a2a_backend', cfg.moe_a2a_backend)}, "
+                    f"moe_a2a_backend={cfg.moe_a2a_backend}, "
                     f"cuda_graph_config[prefill].backend=disabled"
                 )
 

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2944,7 +2944,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                                 _deepseek_family_overrides(_args(), None),
                                 {"attention_backend": "dsa", "page_size": 1},
                             )
-        # DSA CP (zigzag): the coupled parallel-field declaration
+        # DSA CP derives attention CP size without overriding DP/MoE settings.
         with patch(
             "sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True
         ):
@@ -2954,10 +2954,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                         result = _deepseek_family_overrides(
                             _args(
                                 enable_prefill_cp=True,
-                                cp_strategy="zigzag",
+                                cp_strategy="interleave",
                                 tp_size=8,
                                 dp_size=1,
-                                ep_size=1,
+                                enable_dp_attention=False,
+                                moe_dense_tp_size=2,
+                                ep_size=2,
                                 moe_a2a_backend="none",
                                 kv_cache_dtype="auto",
                             ),
@@ -2968,10 +2970,6 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                             {
                                 "attention_backend": "dsa",
                                 "page_size": 64,
-                                "enable_dp_attention": True,
-                                "moe_dense_tp_size": 1,
-                                "moe_a2a_backend": "deepep",
-                                "ep_size": 8,
                                 "attn_cp_size": 8,
                             },
                         )


### PR DESCRIPTION
## Motivation

DSA prefill CP still declares DP-attention and dense-MLP TP overrides and carries legacy zigzag settings. Remove these overrides so the supported interleave path preserves the configured DP/MoE settings.

## Modifications

- Remove the DSA CP `enable_dp_attention` and `moe_dense_tp_size` overrides and the zigzag-specific DeepEP/EP settings.
- Retain the DP1 validation and attention CP-size derivation; log the configured MoE values.
- Update the existing override regression case to use interleave and verify that custom DP/MoE settings do not receive model overrides.

## Accuracy Tests

- Passed all applicable pre-commit hooks on both changed files.
- Executed `test_deepseek_family_order_safe_declarations` in an isolated harness using the actual override module and config-view/registry implementation, with platform and unrelated import dependencies stubbed. The updated case failed against the original override values and passes with this change.
- Direct execution of the unit-test file is blocked on this macOS host by a missing `orjson` dependency at import time. The isolated check does not replace the normal CPU CI test. No GPU inference was run.

## Speed Tests and Profiling

Not run; this PR changes configuration declarations and logging.

## Checklist

- [x] Format code with pre-commit.
- [x] Update the existing unit test.
- [ ] Update documentation (no public documentation changes needed).
- [ ] Provide accuracy and speed benchmark results (not run; see validation above).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34422541837](https://github.com/sgl-project/sglang/actions/runs/34422541837)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34422541232](https://github.com/sgl-project/sglang/actions/runs/34422541232)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34422541829](https://github.com/sgl-project/sglang/actions/runs/34422541829)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->