### PR TITLE
[AMD][CI] Retire the ROCm 7.0 kernel wheel

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -17,7 +17,6 @@ on:
           - 'all'
           - 'cu129'
           - 'cu130'
-          - 'rocm700'
           - 'rocm720'
           - 'rocm1000'
           - 'musa43'
@@ -274,7 +273,7 @@ jobs:
   build-rocm-matrix:
     if: |
       github.repository == 'sgl-project/sglang' &&
-      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm700' || github.event.inputs.target == 'rocm720' || github.event.inputs.target == 'rocm1000')
+      (github.event_name == 'push' || github.event.inputs.target == 'all' || github.event.inputs.target == 'rocm720' || github.event.inputs.target == 'rocm1000')
     runs-on: amd-docker-scale
     strategy:
       matrix:
@@ -287,7 +286,7 @@ jobs:
         # leg is another image build on the shared AMD node, and its release job
         # appends the same wheel to the index a second time. `inputs` is empty
         # on push, which falls through to the full set.
-        rocm-version: ${{ fromJson(inputs.target == 'rocm700' && '["700"]' || inputs.target == 'rocm720' && '["720"]' || inputs.target == 'rocm1000' && '["1000"]' || '["700", "720", "1000"]') }}
+        rocm-version: ${{ fromJson(inputs.target == 'rocm720' && '["720"]' || inputs.target == 'rocm1000' && '["1000"]' || '["720", "1000"]') }}
     steps:
       # Self-hosted build nodes retain the workspace across jobs. Prior builds
       # leave root-owned artifacts under python/sglang/kernels/aot/build/ that actions/checkout
@@ -320,59 +319,6 @@ jobs:
         with:
           name: wheel-python${{ matrix.python-version }}-rocm${{ matrix.rocm-version }}
           path: python/sglang/kernels/aot/dist/*
-
-  release-rocm700:
-    needs: build-rocm-matrix
-    # Only publish the flavors this run built; see build-rocm-matrix.
-    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'rocm700' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: python/sglang/kernels/aot/dist/
-          merge-multiple: true
-          pattern: wheel-*-rocm700
-
-      - name: Set tag name
-        id: set_tag_name
-        run: |
-          if [ -z "${{ inputs.tag_name }}" ]; then
-            TAG_NAME="v$(cat python/sglang/kernels/aot/python/sgl_kernel/version.py | cut -d'"' -f2)"
-            echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          else
-            echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.set_tag_name.outputs.tag_name }}
-          repository: sgl-project/whl
-          token: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
-          files: |
-            python/sglang/kernels/aot/dist/*
-
-      - name: Clone wheel index
-        run: git clone https://oauth2:${WHL_TOKEN}@github.com/sgl-project/whl.git sgl-whl
-        env:
-          WHL_TOKEN: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
-
-      - name: Update wheel index
-        run: python3 scripts/update_kernel_whl_index.py --rocm 700
-
-      - name: Push wheel index
-        run: |
-          cd sgl-whl
-          git config --local user.name "sglang-bot"
-          git config --local user.email "sglangbot@gmail.com"
-          git add -A
-          git commit -m "update whl index"
-          git push
 
   release-rocm720:
     needs: build-rocm-matrix

--- a/3rdparty/amd/wheel/README.md
+++ b/3rdparty/amd/wheel/README.md
@@ -4,7 +4,7 @@ Building and releasing `sglang-kernel` as a wheel is a part of the release workf
 
 # sglang
 
-`3rdparty/amd/wheel/sglang/pyproject.toml` is the AMD-specific pyproject for building the `amd-sglang` wheel. It extends `python/pyproject_other.toml` with two ROCm-version extras (`rocm700`, `rocm720`) that pin the matching torch/triton/torchaudio/torchvision/`sglang-kernel` wheels, and renames the package to `amd-sglang`.
+`3rdparty/amd/wheel/sglang/pyproject.toml` is the AMD-specific pyproject for building the `amd-sglang` wheel. It extends `python/pyproject_other.toml` with a `rocm720` extra that pins the matching torch/triton/torchaudio/torchvision/`sglang-kernel` wheels, and renames the package to `amd-sglang`.
 
 ## Operation to build sglang wheel
 
@@ -17,12 +17,6 @@ $ cd python && python -m build
 ## Installation
 
 ### v0.5.9
-
-ROCm 7.0.0:
-```
-pip uninstall sglang-kernel sglang amd-sglang
-pip install "amd-sglang[all-hip,rocm700]" -i https://pypi.amd.com/rocm-7.0.0/simple --extra-index-url https://pypi.org/simple
-```
 
 ROCm 7.2.0:
 ```
@@ -39,13 +33,9 @@ Note: You must resolve the two dependencies, AITER and triton, below.  Others ar
 [AITER](https://github.com/ROCm/aiter) is a fundamental dependency. Wheel-izing it is ongoing.
 Until we can pin it reliably, install it manually (typically following the [ROCm docker recipe](https://github.com/sgl-project/sglang/blob/main/docker/rocm.Dockerfile#L106).
 
-### Revolving triton
+### Resolving triton
 
-To avoid known issues in triton 3.5.1 installed by default, we recommend upgrading triton after installation.  In ROCm 7.0.0 environment,
-```
-pip install triton==3.6.0
-```
-or ROCm 7.2.0,
+To avoid known issues in triton 3.5.1 installed by default, we recommend upgrading triton after installation in a ROCm 7.2.0 environment:
 ```
 pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.6.0%2Brocm7.2.0.gitba5c1517-cp310-cp310-linux_x86_64.whl
 ```

--- a/3rdparty/amd/wheel/sgl-kernel/build_rocm.sh
+++ b/3rdparty/amd/wheel/sgl-kernel/build_rocm.sh
@@ -3,9 +3,7 @@ set -euo pipefail
 
 ROCM_VERSION=${1:-}
 
-if [[ "${ROCM_VERSION}" == "700" ]]; then
-  IMAGE="lmsysorg/sglang:v0.5.8.post1-rocm700-mi35x"
-elif [[ "${ROCM_VERSION}" == "720" ]]; then
+if [[ "${ROCM_VERSION}" == "720" ]]; then
   IMAGE="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 elif [[ "${ROCM_VERSION}" == "1000" ]]; then
   # Ubuntu 24.04 / Python 3.12 / torch 2.11 matches the stack the released
@@ -13,7 +11,7 @@ elif [[ "${ROCM_VERSION}" == "1000" ]]; then
   # wheel can still cover both gfx942 and gfx950.
   IMAGE="rocm/pytorch:rocm10.0_ubuntu24.04_py3.12_pytorch_release_2.11.0"
 else
-  echo "ERROR: Unsupported ROCM_VERSION='${ROCM_VERSION}'. Only '700', '720' and '1000' are supported." >&2
+  echo "ERROR: Unsupported ROCM_VERSION='${ROCM_VERSION}'. Only '720' and '1000' are supported." >&2
   exit 1
 fi
 
@@ -69,9 +67,7 @@ docker run --rm \
   ${IMAGE} \
   bash -c "
   # Install torch, triton, and friends, depending on the ROCm version
-  if [[ "${ROCM_VERSION}" == "700" ]]; then
-    ${PYTHON_ROOT_PATH}/pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torch-2.9.1.dev20251204%2Brocm7.0.2.lw.git351ff442-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/triton-3.5.1%2Brocm7.0.2.gita272dfa8-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torchaudio-2.9.0%2Brocm7.0.2.gite3c6ee2b-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torchvision-0.24.0%2Brocm7.0.2.gitb919bd0c-cp310-cp310-linux_x86_64.whl
-  elif [[ "${ROCM_VERSION}" == "720" ]]; then
+  if [[ "${ROCM_VERSION}" == "720" ]]; then
     ${PYTHON_ROOT_PATH}/pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchaudio-2.9.0%2Brocm7.2.0.gite3c6ee2b-cp310-cp310-linux_x86_64.whl https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchvision-0.24.0%2Brocm7.2.0.gitb919bd0c-cp310-cp310-linux_x86_64.whl
   fi
 ${ROCM_SETUP}

--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -67,18 +67,6 @@ runtime_common = [
 ]
 
 # ROCm specific packages (https://repo.radeon.com/rocm/manylinux/)
-# Existing practice for daily rocm700 docker images relies on 700-rc
-# versions of software that are not public available. Here we pin some
-# from rocm702 as the closest set as daily rocm700 images.
-rocm700 = [
-  "torch @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torch-2.9.1.dev20251204%2Brocm7.0.2.lw.git351ff442-cp310-cp310-linux_x86_64.whl",
-  "triton @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/triton-3.5.1%2Brocm7.0.2.gita272dfa8-cp310-cp310-linux_x86_64.whl",
-  "torchaudio @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torchaudio-2.9.0%2Brocm7.0.2.gite3c6ee2b-cp310-cp310-linux_x86_64.whl",
-  "torchvision @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.0.2/torchvision-0.24.0%2Brocm7.0.2.gitb919bd0c-cp310-cp310-linux_x86_64.whl",
-  "mooncake-transfer-engine-non-cuda==0.3.8.post1",
-  "sglang-kernel @ https://github.com/sgl-project/whl/releases/download/v0.4.0/sglang_kernel-0.4.0+rocm700-cp310-abi3-manylinux2014_x86_64.whl",
-]
-
 rocm720 = [
   "torch @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl",
   "triton @ https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl",
@@ -89,8 +77,7 @@ rocm720 = [
 ]
 
 # HIP (Heterogeneous-computing Interface for Portability) for AMD
-# Install with one of:
-#   pip install "amd-sglang[srt_hip,rocm700]"
+# Install with:
 #   pip install "amd-sglang[srt_hip,rocm720]"
 srt_hip = [
   "amd-sglang[runtime_common]",


### PR DESCRIPTION
## Motivation

#38763 added a ROCm 10 kernel wheel, making the ROCm wheel matrix `["700", "720", "1000"]`. `rocm700` is now the only leg with no CI behind it, and it is the last ROCm 7.0 artifact SGLang still publishes on every kernel version bump.

Scope note: this PR was originally a broader ROCm 7.0 retirement (workflows, nightly image build, release image matrix). #38632 supersedes all of that with a better end state — it consolidates the AMD workflows back onto a single `pr-test-amd.yml` / `nightly-test-amd.yml` pair and retires ROCm 7.0 CI as a consequence. Rather than conflict with it on the same four workflow files, this PR is now reduced to the one ROCm 7.0 surface #38632 does not touch: the kernel wheel.

## Modifications

Retire the ROCm 7.0 kernel wheel end-to-end:

- `.github/workflows/release-whl-kernel.yml`: drop the `rocm700` dispatch option, the `rocm700` clause in the `build-rocm-matrix` guard, the `"700"` matrix entry, and the `release-rocm700` job (which published the artifact and ran `update_kernel_whl_index.py --rocm 700`). The ROCm wheel matrix becomes `["720", "1000"]`.
- `3rdparty/amd/wheel/sgl-kernel/build_rocm.sh`: drop the `700` build image (`lmsysorg/sglang:v0.5.8.post1-rocm700-mi35x`) and its pinned `rocm-rel-7.0.2` torch/triton/torchaudio/torchvision install branch. `720` and `1000` are unchanged, and an explicit `700` argument now fails with a clear message.
- `3rdparty/amd/wheel/sglang/pyproject.toml`: remove the `rocm700` optional-dependency extra (which pinned `sglang_kernel-0.4.0+rocm700`) and the stale install comment. `rocm720` is unchanged.
- `3rdparty/amd/wheel/README.md`: remove the ROCm 7.0.0 `pip install "amd-sglang[all-hip,rocm700]"` recipe and the ROCm 7.0.0 Triton upgrade note, and correct the extras description. Also fixes the section heading typo `Revolving triton` → `Resolving triton`.

`#38763`'s ROCm 10 wheel path is untouched.

## What this does not touch

The remaining ROCm 7.0 references are deliberately out of scope:

- The ROCm 7.0 workflows, nightly image build, and `release-docker-amd.yml` matrix leg — all handled by #38632.
- `scripts/ci/amd/amd_ci_start_container*.sh` still default to `ROCM_VERSION=rocm700`. This cannot change independently: all 58 container-launch sites in the current `pr-test-amd.yml` / `nightly-test-amd.yml` omit `--rocm-version` and rely on that default, so flipping it to `rocm10` before those workflows are deleted would silently repoint the ROCm 7.0 runs at ROCm 10 images. It belongs with #38632 or a follow-up.
- `docker/rocm.Dockerfile` retains the unsuffixed `gfx942` / `gfx950` ROCm 7.0 stages for local builds.
- `SGLANG_USE_ROCM700A` is misleadingly named but gates a workaround current ROCm 7.2 images still set.
- Cookbook pages pin historical `rocm700` image tags for reproducibility.

## Accuracy Tests

Not applicable — release-artifact configuration only; no runtime or kernel code changed.

## Speed Tests and Profiling

Not applicable. Removes one wheel build leg on the shared `amd-docker-scale` node plus its release job from every kernel version bump.

## Verification

- No `rocm700`, ROCm 7.0 dependency URL, `"700"` build input, or `--rocm 700` remains in `release-whl-kernel.yml` or `3rdparty/amd/wheel/`.
- `release-whl-kernel.yml` parses as YAML; the surviving legs are `rocm720` / `rocm1000` in the dispatch menu, the `["720", "1000"]` matrix, and the `release-rocm720` / `release-rocm1000` jobs.
- `build_rocm.sh` passes `bash -n`; `720` and `1000` still resolve their images, and `700` exits 1 with `Only '720' and '1000' are supported.`
- `pyproject.toml` parses with `tomllib`; the only remaining `rocm*` extra is `rocm720`.
- `python3 scripts/lint/check_workflow_job_names.py` passes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — n/a, release config only
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — n/a
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34489631801](https://github.com/sgl-project/sglang/actions/runs/34489631801)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34489631335](https://github.com/sgl-project/sglang/actions/runs/34489631335)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->