### PR TITLE
[Perf] Consume linear NVFP4 scales in FlashInfer CUTLASS A2A MoE

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -194,6 +194,7 @@ def _run_flashinfer_cutlass(
     runner_config: MoeRunnerConfig,
     output: Optional[torch.Tensor] = None,
     enable_alltoall: bool = False,
+    swizzled_input_sf: bool = True,
 ) -> torch.Tensor:
     flashinfer_cutlass_fused_moe, _ = _flashinfer_cutlass_fused_moe()
 
@@ -240,6 +241,7 @@ def _run_flashinfer_cutlass(
         fc2_expert_weights=w2_weight,
         output_dtype=output_dtype,
         input_sf=x_sf,
+        swizzled_input_sf=swizzled_input_sf,
         quant_scales=quant_scales,
         ep_size=quant_info.moe_ep_size,
         ep_rank=quant_info.moe_ep_rank,
@@ -281,13 +283,22 @@ def fused_experts_none_to_flashinfer_cutlass(
 
 @register_fused_func("flashinfer", "flashinfer_cutlass")
 def fused_experts_flashinfer_to_flashinfer_cutlass(
-    dispatch_output: FlashinferDispatchOutput,
+    dispatch_output: FlashinferDispatchOutput | StandardDispatchOutput,
     quant_info: MoeQuantInfo,
     runner_config: MoeRunnerConfig,
-) -> FlashinferCombineInput:
+) -> FlashinferCombineInput | StandardCombineInput:
     from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
         FlashinferCombineInput,
     )
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+
+    # Prefill/mixed extend uses all-gather and the Standard combine path.
+    if isinstance(dispatch_output, StandardDispatchOutput):
+        return fused_experts_none_to_flashinfer_cutlass(
+            dispatch_output=dispatch_output,
+            quant_info=quant_info,
+            runner_config=runner_config,
+        )
 
     assert isinstance(quant_info, FlashInferCutlassMoeQuantInfo), (
         f"Unexpected quant_info type for flashinfer_cutlass: {type(quant_info)}"
@@ -296,12 +307,34 @@ def fused_experts_flashinfer_to_flashinfer_cutlass(
         "apply_router_weight_on_input is not supported for FlashInfer CUTLASS"
     )
 
+    swizzled_input_sf = True
+    x_sf = dispatch_output.hidden_states_scale
+    if quant_info.quant_type == "fp4" and x_sf is not None:
+        x = dispatch_output.hidden_states
+        hidden_size = quant_info.w2_weight.shape[1]
+        assert x.shape[1] * 2 == hidden_size, (
+            "FlashInfer A2A NVFP4 packed input must match the expert hidden size."
+        )
+        assert x_sf.shape == (x.shape[0], hidden_size // 16) and x_sf.is_contiguous(), (
+            "FlashInfer A2A NVFP4 scales must be contiguous linear [M, H / 16]."
+        )
+        # FlashInfer 0.6.18 expand reads linear scales with round_up(H, 64) / 16
+        # row stride. Preserve the old conversion for unaligned hidden sizes.
+        swizzled_input_sf = hidden_size % 64 != 0
+        if swizzled_input_sf:
+            from flashinfer import nvfp4_block_scale_interleave
+
+            dispatch_output = dispatch_output._replace(
+                hidden_states_scale=nvfp4_block_scale_interleave(x_sf)
+            )
+
     output = _run_flashinfer_cutlass(
         dispatch_output=dispatch_output,
         quant_info=quant_info,
         runner_config=runner_config,
         output=dispatch_output.moe_output,
         enable_alltoall=True,
+        swizzled_input_sf=swizzled_input_sf,
     )
     return FlashinferCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -37,7 +37,6 @@ from sglang.srt.runtime_context import get_flags, get_parallel, get_schedule, ge
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 try:
-    from flashinfer import nvfp4_block_scale_interleave
     from flashinfer.comm import MoeAlltoAll, moe_a2a_get_workspace_size_per_rank
     from flashinfer.comm.mapping import Mapping
     from flashinfer.comm.mnnvl import MnnvlConfig
@@ -422,10 +421,8 @@ class FlashinferDispatcher(BaseDispatcher):
         )
         if x_sf is not None:
             x_recv, x_sf_recv, topk_ids_recv, topk_weights_recv = recv_tensors
+            # Keep the linear receive view; each MoE runner owns its scale layout.
             x_sf = x_sf_recv.view(-1, x_sf_recv.shape[-1])
-            # TODO: fuse interleave into cutlass moe
-            if get_moe_runner_backend().is_flashinfer_cutlass():
-                x_sf = nvfp4_block_scale_interleave(x_sf)
         else:
             x_recv, topk_ids_recv, topk_weights_recv = recv_tensors
         x = x_recv.view(-1, x_recv.shape[-1])

--- a/test/registered/kernel/moe/test_flashinfer_cutlass_nvfp4_scales.py
+++ b/test/registered/kernel/moe/test_flashinfer_cutlass_nvfp4_scales.py
@@ -1,0 +1,187 @@
+"""NVFP4 scale-layout and Standard-input regressions for the CUTLASS Adapter."""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0),
+    "Requires an SM100 GPU",
+)
+class TestFlashinferCutlassNvfp4Scales(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        from sglang.srt.distributed.parallel_state import (
+            destroy_distributed_environment,
+            destroy_model_parallel,
+            model_parallel_is_initialized,
+        )
+        from sglang.test.layer_ut_utils import init_single_process_dist
+
+        if not torch.distributed.is_initialized():
+            cls.addClassCleanup(destroy_distributed_environment)
+        if not model_parallel_is_initialized():
+            cls.addClassCleanup(destroy_model_parallel)
+        init_single_process_dist()
+
+    def _prepare_inputs(self, hidden_size):
+        from flashinfer import fp4_quantize
+
+        from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+        from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+            FlashInferCutlassMoeQuantInfo,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardDispatchOutput,
+        )
+        from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+        from sglang.test.quant_ref_utils import FLOAT4_E2M1_MAX, FLOAT8_E4M3_MAX
+
+        torch.manual_seed(42)
+        num_tokens, intermediate_size = 32, 128
+        num_experts, top_k = 4, 2
+        self.config = MoeRunnerConfig(
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size,
+            top_k=top_k,
+        )
+
+        def quantize_weights(rows, cols):
+            weights = (
+                torch.randn(
+                    num_experts, rows, cols, device="cuda", dtype=torch.bfloat16
+                )
+                / 10
+            )
+            scales = (
+                FLOAT8_E4M3_MAX
+                * FLOAT4_E2M1_MAX
+                / weights.float().abs().amax(dim=(1, 2))
+            )
+            packed, block_scales = zip(
+                *(fp4_quantize(w, gs) for w, gs in zip(weights, scales))
+            )
+            return torch.stack(packed), torch.stack(block_scales), scales
+
+        w13, w13_sf, w13_gs = quantize_weights(2 * intermediate_size, hidden_size)
+        w2, w2_sf, w2_gs = quantize_weights(hidden_size, intermediate_size)
+        activation_scale = torch.ones((), device="cuda", dtype=torch.float32)
+        self.quant_info = FlashInferCutlassMoeQuantInfo(
+            quant_type="fp4",
+            w13_weight=w13,
+            w2_weight=w2,
+            output_dtype=torch.bfloat16,
+            quant_scales=[
+                activation_scale,
+                w13_sf,
+                1 / (activation_scale * w13_gs),
+                activation_scale,
+                w2_sf,
+                1 / (activation_scale * w2_gs),
+            ],
+        )
+        x = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+        topk_output = select_experts(
+            hidden_states=x,
+            router_logits=torch.randn(num_tokens, num_experts, device="cuda"),
+            topk_config=TopKConfig(top_k=top_k, renormalize=True),
+        )
+        self.standard = StandardDispatchOutput(x, None, topk_output)
+
+    def test_linear_scales(self):
+        from flashinfer import fp4_quantize, nvfp4_block_scale_interleave
+        from flashinfer.fused_moe import cutlass_fused_moe
+
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+            fused_experts_flashinfer_to_flashinfer_cutlass,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+            FlashinferCombineInput,
+            FlashinferDispatchOutput,
+        )
+
+        # H=288 exercises the unaligned interleave fallback.
+        for hidden_size in (128, 288):
+            with self.subTest(hidden_size=hidden_size):
+                self._prepare_inputs(hidden_size=hidden_size)
+                quant_info = self.quant_info
+                scales = quant_info.quant_scales
+                x, linear_sf = fp4_quantize(
+                    self.standard.hidden_states, scales[0], is_sf_swizzled_layout=False
+                )
+                output = torch.empty_like(self.standard.hidden_states)
+                dispatch = FlashinferDispatchOutput(
+                    x, linear_sf, self.standard.topk_output, output
+                )
+                expected = torch.empty_like(output)
+                # Independent swizzled baseline with the same packed input and routing.
+                cutlass_fused_moe(
+                    input=x,
+                    input_sf=nvfp4_block_scale_interleave(linear_sf),
+                    swizzled_input_sf=True,
+                    token_selected_experts=dispatch.topk_output.topk_ids.to(
+                        torch.int32
+                    ),
+                    token_final_scales=dispatch.topk_output.topk_weights,
+                    fc1_expert_weights=quant_info.w13_weight.view(torch.int64),
+                    fc2_expert_weights=quant_info.w2_weight.view(torch.int64),
+                    quant_scales=[
+                        scales[0],
+                        scales[1].view(torch.int32),
+                        scales[2],
+                        scales[3],
+                        scales[4].view(torch.int32),
+                        scales[5],
+                    ],
+                    output_dtype=output.dtype,
+                    output=expected,
+                    tune_max_num_tokens=x.shape[0],
+                    enable_alltoall=True,
+                    use_fused_finalize=envs.SGLANG_FLASHINFER_MOE_FUSED_FINALIZE.get(),
+                )
+                actual = fused_experts_flashinfer_to_flashinfer_cutlass(
+                    dispatch_output=dispatch,
+                    quant_info=quant_info,
+                    runner_config=self.config,
+                )
+                self.assertIsInstance(actual, FlashinferCombineInput)
+                self.assertEqual(actual.hidden_states.data_ptr(), output.data_ptr())
+                torch.testing.assert_close(
+                    actual.hidden_states, expected, rtol=1e-3, atol=1e-3
+                )
+
+    def test_standard_dispatch(self):
+        from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+            fused_experts_flashinfer_to_flashinfer_cutlass,
+            fused_experts_none_to_flashinfer_cutlass,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+        self._prepare_inputs(hidden_size=128)
+        expected = fused_experts_none_to_flashinfer_cutlass(
+            dispatch_output=self.standard,
+            quant_info=self.quant_info,
+            runner_config=self.config,
+        )
+        actual = fused_experts_flashinfer_to_flashinfer_cutlass(
+            dispatch_output=self.standard,
+            quant_info=self.quant_info,
+            runner_config=self.config,
+        )
+        self.assertIsInstance(actual, StandardCombineInput)
+        torch.testing.assert_close(
+            actual.hidden_states, expected.hidden_states, rtol=1e-3, atol=1e-3
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Consume FlashInfer A2A's linear NVFP4 scales directly in CUTLASS input expansion, removing the intermediate interleave using [FlashInfer #2330](https://github.com/flashinfer-ai/flashinfer/pull/2330) ([#2200](https://github.com/flashinfer-ai/flashinfer/issues/2200)).

## Modifications

- Pass `swizzled_input_sf=False` for `H % 64 == 0`; validate layout and retain the unaligned fallback.
- Delegate Standard prefill/extend inputs to the existing wrapper.

## Accuracy Tests

Passed on **1×B200**: linear-scale and unaligned fallback parity against explicit interleave (`H=128/288`, `rtol=atol=1e-3`), output buffer reuse, and Standard dispatch parity (output type and numerics).

```bash
python3 test/registered/kernel/moe/test_flashinfer_cutlass_nvfp4_scales.py -v
```

Tested on **4×B200**, TP=EP=DP=4, with `nvidia/Qwen3-30B-A3B-NVFP4`, FlashInfer 0.6.18 and PyTorch 2.13.0+cu130. GSM8K: 200 questions, 5-shot, 128 threads, temperature 0, max 512 output tokens.

<details>
<summary>Server and evaluation commands</summary>

```bash
SGLANG_MOE_NVFP4_DISPATCH=1 \
SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION=0 \
SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK=4096 \
sglang serve --model-path nvidia/Qwen3-30B-A3B-NVFP4 \
  --revision 2538ded2a4edb247b4d2b4a8ba24e44bd4c017c3 \
  --quantization modelopt_fp4 --tp 4 --ep-size 4 --dp 4 \
  --enable-dp-attention --enable-dp-lm-head \
  --moe-runner-backend flashinfer_cutlass --moe-a2a-backend flashinfer \
  --max-prefill-tokens 4096 --chunked-prefill-size 4096 \
  --max-running-requests 64 --cuda-graph-max-bs-decode 64 \
  --disable-radix-cache --disable-flashinfer-autotune \
  --random-seed 42 --watchdog-timeout 300 --port 30000
```

```bash
python3 -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --model nvidia/Qwen3-30B-A3B-NVFP4 --eval-name gsm8k --api completion \
  --num-examples 200 --num-threads 128 --max-tokens 512 \
  --num-shots 5 --temperature 0
```

</details>

| Configuration | GSM8K run 1 | GSM8K run 2 |
| --- | ---: | ---: |
| Swizzled control | 90.5% | 92.5% |
| This PR (linear) | 91.5% | 91.5% |

Control uses the same implementation with `swizzled_input_sf=True`. The runs are independent; an earlier 64-thread paired evaluation scored 92.5% versus 91.5%, so accuracy equivalence remains unverified.

## Speed Tests and Profiling

- Profiling on 4×B200 with Qwen3-30B-A3B-NVFP4: across 20 matched rank/step pairs (4 ranks × 5 CUDA Graph decode steps, batch size 8 per rank), interleave launches decrease from 48 to 0 per rank and step, with unchanged copy counts and no added in-step synchronization/allocation.
- Serving on 4×B200 with the same model, TP=EP=DP=4: 128 requests, max concurrency 64, input/output lengths sampled from 1–1024/1–128 tokens. Mean TPOT (control → linear) is 53.36 → 46.69 ms and 51.92 → 44.14 ms in two paired runs. Separate control runs reach 41.51–46.81 ms, so a stable serving speedup remains unverified.

Historical full synthetic `dispatch → MoE → combine`: **H=2048, I=1024, E=32, K=2**, BF16 output, balanced `R` tokens/source, TP=EP=DP. Both variants use B200 GPUs, FlashInfer 0.6.18, torch 2.13.0+cu130 and CUDA 13.0. Baseline includes interleave; linear consumes scales directly. Correctness gates exercise the production wrapper; timing uses the shared CUTLASS helper and real communication.

| EP | Tokens/source | Run 02: baseline → linear (µs) | Run 03: baseline → linear (µs) | Paired latency reduction |
| ---: | ---: | ---: | ---: | ---: |
| 4 | 2048 | 146.898 → 139.771 | 140.770 → 134.910 | 3.749%–4.233% |
| 4 | 4096 | 226.051 → 218.708 | 222.081 → 214.454 | 3.636%–4.412% |
| 4 | 8192 | 386.008 → 373.136 | 382.333 → 368.862 | 3.522%–3.526% |
| 8 | 2048 | 152.819 → 146.606 | 151.825 → 142.594 | 5.567%–7.174% |
| 8 | 4096 | 236.530 → 225.151 | 240.221 → 226.164 | 5.388%–6.061% |
| 8 | 8192 | 416.683 → 390.500 | 412.721 → 390.890 | 5.589%–6.261% |

Warm-cache CUDA Graph timing: 20 warmups, 10 alternating AB/BA rounds, 20 replays/sample, 10 chains/Graph; PDL and fused finalize enabled, online autotuning disabled, A/A controls at R=64/8192. Latencies are medians of per-round maximum-rank times. Reductions are medians of paired per-round percentages; ranges span two independent runs, not confidence intervals, and need not match ratios of displayed medians.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no user-facing API or configuration changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34425151590](https://github.com/sgl-project/sglang/actions/runs/34425151590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34425150956](https://github.com/sgl-project/sglang/actions/runs/34425150956)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34425151299](https://github.com/sgl-project/sglang/actions/runs/34425151299)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->