### PR TITLE
[Feature] Add Prometheus metrics for multimodal preprocessing latency

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -5,6 +5,7 @@ import dataclasses
 import multiprocessing as mp
 import os
 import re
+import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -18,6 +19,11 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputFormat,
     MultimodalProcessorOutput,
+)
+from sglang.srt.observability.mm_preprocessing_metrics import (
+    observe_mm_load_data,
+    observe_mm_media_load,
+    observe_mm_processor,
 )
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import (
@@ -491,12 +497,16 @@ class BaseMultimodalProcessor(ABC):
             if bos and input_text.startswith(bos):
                 kwargs.setdefault("add_special_tokens", False)
 
-        result = processor.__call__(
-            text=[input_text],
-            padding=True,
-            return_tensors="pt",
-            **kwargs,
-        )
+        processor_start = time.perf_counter()
+        try:
+            result = processor.__call__(
+                text=[input_text],
+                padding=True,
+                return_tensors="pt",
+                **kwargs,
+            )
+        finally:
+            observe_mm_processor(time.perf_counter() - processor_start)
         if not self.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:
@@ -561,6 +571,7 @@ class BaseMultimodalProcessor(ABC):
         """
         if cls._is_preprocessed_input(data):
             return data
+        load_start = time.perf_counter()
         try:
             if modality == Modality.IMAGE:
                 img, _ = load_image(data, cls.gpu_image_decode)
@@ -588,6 +599,10 @@ class BaseMultimodalProcessor(ABC):
             if len(data_str) > 100:
                 data_str = data_str[:100] + "..."
             raise RuntimeError(f"Error while loading data {data_str}: {e}") from e
+        finally:
+            observe_mm_media_load(
+                modality.name.lower(), time.perf_counter() - load_start
+            )
 
     @staticmethod
     def _get_preprocessed_input_format(data):
@@ -810,6 +825,35 @@ class BaseMultimodalProcessor(ABC):
         return is_precomputed, images, videos, audios
 
     async def load_mm_data(
+        self,
+        prompt: str,
+        multimodal_tokens: MultimodalSpecialTokens,
+        image_data: Optional[list] = None,
+        video_data: Optional[list] = None,
+        audio_data: Optional[list] = None,
+        return_text: Optional[bool] = True,
+        discard_alpha_channel: bool = True,
+        audio_sample_rate: Optional[int] = None,
+    ) -> BaseMultiModalProcessorOutput:
+        # Timed wrapper around _load_mm_data_impl. Requests whose mm inputs
+        # are all precomputed embeddings / processor outputs take a
+        # near-instant fast path and are still observed (lowest bucket).
+        load_start = time.perf_counter()
+        try:
+            return await self._load_mm_data_impl(
+                prompt=prompt,
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                return_text=return_text,
+                discard_alpha_channel=discard_alpha_channel,
+                audio_sample_rate=audio_sample_rate,
+            )
+        finally:
+            observe_mm_load_data(time.perf_counter() - load_start)
+
+    async def _load_mm_data_impl(
         self,
         prompt: str,
         multimodal_tokens: MultimodalSpecialTokens,

--- a/python/sglang/srt/observability/mm_preprocessing_metrics.py
+++ b/python/sglang/srt/observability/mm_preprocessing_metrics.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prometheus metrics for multimodal preprocessing in the tokenizer manager.
+
+In the default (co-located) deployment, all multimodal input handling --
+downloading media from URLs, base64/PIL/video/audio decoding, and the HF
+processor call -- happens in the tokenizer manager process *before* the
+request reaches the scheduler. Scheduler-side latency metrics (TTFT, e2e,
+queue wait) only start counting afterwards, so without the metrics in this
+module the multimodal preprocessing time is invisible and shows up only as
+inflated perceived queueing / TTFT.
+
+SGLang serves /metrics via prometheus_client multiprocess mode
+(``PROMETHEUS_MULTIPROC_DIR`` + ``MultiProcessCollector``), so Histograms
+registered in the default registry of this process are exported
+automatically.
+
+All metrics are lazily initialized on the first observation and only when
+the server is started with ``--enable-metrics`` -- there are no import-time
+side effects and no overhead when metrics are disabled.
+"""
+
+import threading
+
+_metrics_lock = threading.Lock()
+_metrics_initialized = False
+_metrics_enabled = False
+
+_media_download_seconds = None
+_media_download_bytes = None
+_media_load_seconds = None
+_load_data_seconds = None
+_processor_seconds = None
+
+# Per-item latencies: an item is usually fetched+decoded in tens of
+# milliseconds, but large videos over slow links can take tens of seconds.
+_ITEM_LATENCY_BUCKETS = [
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+]
+
+# Per-request stage latencies (all items of one request, or the HF processor
+# call for one request).
+_STAGE_LATENCY_BUCKETS = [
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+]
+
+_SIZE_BUCKETS = [
+    1024,
+    10240,
+    102400,
+    524288,
+    1048576,
+    5242880,
+    10485760,
+    52428800,
+    104857600,
+]
+
+
+def _metrics_turned_on() -> bool:
+    """Return True iff the server was started with --enable-metrics.
+
+    Returns False (instead of raising) when the global server args have not
+    been published in this process (unit tests, offline tools).
+    """
+    try:
+        from sglang.srt.runtime_context import get_server_args
+
+        return bool(get_server_args().enable_metrics)
+    except Exception:
+        return False
+
+
+def _init_metrics(enabled: bool, registry=None) -> None:
+    """(Re)initialize the metric objects. Holds no lock; callers synchronize."""
+    global _media_download_seconds, _media_download_bytes, _media_load_seconds
+    global _load_data_seconds, _processor_seconds
+    global _metrics_initialized, _metrics_enabled
+
+    _media_download_seconds = None
+    _media_download_bytes = None
+    _media_load_seconds = None
+    _load_data_seconds = None
+    _processor_seconds = None
+
+    if enabled:
+        from prometheus_client import Histogram
+
+        _media_download_seconds = Histogram(
+            name="sglang:mm_media_download_seconds",
+            documentation=(
+                "Histogram of HTTP(S) media download latency in seconds "
+                "(per media item)."
+            ),
+            buckets=_ITEM_LATENCY_BUCKETS,
+            labelnames=["modality"],
+            registry=registry,
+        )
+        _media_download_bytes = Histogram(
+            name="sglang:mm_media_download_bytes",
+            documentation=(
+                "Histogram of downloaded media size in bytes (per media item)."
+            ),
+            buckets=_SIZE_BUCKETS,
+            labelnames=["modality"],
+            registry=registry,
+        )
+        _media_load_seconds = Histogram(
+            name="sglang:mm_media_load_seconds",
+            documentation=(
+                "Histogram of the full load latency of one media item in "
+                "seconds (download + decode). Subtract "
+                "sglang:mm_media_download_seconds to isolate decode time."
+            ),
+            buckets=_ITEM_LATENCY_BUCKETS,
+            labelnames=["modality"],
+            registry=registry,
+        )
+        _load_data_seconds = Histogram(
+            name="sglang:mm_load_data_seconds",
+            documentation=(
+                "Histogram of the media loading stage latency in seconds "
+                "(all items of one request, loaded concurrently)."
+            ),
+            buckets=_STAGE_LATENCY_BUCKETS,
+            labelnames=[],
+            registry=registry,
+        )
+        _processor_seconds = Histogram(
+            name="sglang:mm_processor_seconds",
+            documentation=(
+                "Histogram of the HF multimodal processor call latency in "
+                "seconds (per request)."
+            ),
+            buckets=_STAGE_LATENCY_BUCKETS,
+            labelnames=[],
+            registry=registry,
+        )
+
+    _metrics_enabled = enabled
+    _metrics_initialized = True
+
+
+def _ensure_metrics() -> bool:
+    """Initialize metrics on first call; return True iff they are enabled."""
+    global _metrics_initialized, _metrics_enabled
+    if _metrics_initialized:
+        return _metrics_enabled
+    with _metrics_lock:
+        if _metrics_initialized:
+            return _metrics_enabled
+        try:
+            _init_metrics(enabled=_metrics_turned_on())
+        except Exception:
+            # Never let metrics break request serving.
+            _metrics_initialized = True
+            _metrics_enabled = False
+    return _metrics_enabled
+
+
+def _reset_for_test(enabled: bool = True, registry=None) -> None:
+    """Reinitialize metrics with an explicit state. For unit tests only."""
+    with _metrics_lock:
+        _init_metrics(enabled=enabled, registry=registry)
+
+
+def observe_mm_media_download(
+    modality: str, elapsed_seconds: float, num_bytes: int
+) -> None:
+    """Record the HTTP(S) download latency and size of one media item."""
+    if not _ensure_metrics():
+        return
+    _media_download_seconds.labels(modality=modality).observe(elapsed_seconds)
+    _media_download_bytes.labels(modality=modality).observe(num_bytes)
+
+
+def observe_mm_media_load(modality: str, elapsed_seconds: float) -> None:
+    """Record the full load (download + decode) latency of one media item."""
+    if not _ensure_metrics():
+        return
+    _media_load_seconds.labels(modality=modality).observe(elapsed_seconds)
+
+
+def observe_mm_load_data(elapsed_seconds: float) -> None:
+    """Record the media loading stage latency of one request (all items)."""
+    if not _ensure_metrics():
+        return
+    _load_data_seconds.observe(elapsed_seconds)
+
+
+def observe_mm_processor(elapsed_seconds: float) -> None:
+    """Record the HF multimodal processor call latency of one request."""
+    if not _ensure_metrics():
+        return
+    _processor_seconds.observe(elapsed_seconds)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -96,6 +96,9 @@ from typing_extensions import Literal
 
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
+from sglang.srt.observability.mm_preprocessing_metrics import (
+    observe_mm_media_download,
+)
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
@@ -1522,9 +1525,13 @@ def load_audio(
         audio_file.startswith("http://") or audio_file.startswith("https://")
     ):
         timeout = int(os.getenv("REQUEST_TIMEOUT", "5"))
+        download_start = time.perf_counter()
         with get_mm_http_session().get(audio_file, timeout=timeout) as response:
             response.raise_for_status()
             source = response.content
+        observe_mm_media_download(
+            "audio", time.perf_counter() - download_start, len(source)
+        )
     elif isinstance(audio_file, str) and audio_file.startswith("file://"):
         source = unquote(urlparse(audio_file).path)
     elif isinstance(audio_file, str):
@@ -1683,12 +1690,16 @@ def get_image_bytes(image_file: Union[str, bytes]) -> bytes:
         return image_file
     if image_file.startswith(("http://", "https://")):
         timeout = int(os.getenv("REQUEST_TIMEOUT", "3"))
+        download_start = time.perf_counter()
         response = get_mm_http_session().get(image_file, timeout=timeout)
         try:
             response.raise_for_status()
             result = response.content
         finally:
             response.close()
+        observe_mm_media_download(
+            "image", time.perf_counter() - download_start, len(result)
+        )
         return result
     if image_file.startswith(("file://", "/")):
         with open(image_file, "rb") as f:
@@ -1715,11 +1726,16 @@ def _normalize_video_input(
     elif isinstance(video_file, str):
         if video_file.startswith(("http://", "https://")):
             timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
+            download_start = time.perf_counter()
             with get_mm_http_session().get(
                 video_file, stream=True, timeout=timeout
             ) as response:
                 response.raise_for_status()
-                return response.content
+                content = response.content
+            observe_mm_media_download(
+                "video", time.perf_counter() - download_start, len(content)
+            )
+            return content
         elif video_file.startswith("data:"):
             _, encoded = video_file.split(",", 1)
             return pybase64.b64decode(encoded, validate=True)

--- a/test/registered/unit/observability/test_mm_preprocessing_metrics.py
+++ b/test/registered/unit/observability/test_mm_preprocessing_metrics.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+import threading
+import unittest
+from unittest import mock
+
+from prometheus_client import CollectorRegistry
+
+from sglang.srt.observability import mm_preprocessing_metrics as mpm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMMPreprocessingMetrics(unittest.TestCase):
+    """Unit tests for the multimodal preprocessing Prometheus metrics."""
+
+    def setUp(self):
+        self.registry = CollectorRegistry()
+        mpm._reset_for_test(enabled=True, registry=self.registry)
+
+    def tearDown(self):
+        mpm._reset_for_test(enabled=False)
+
+    def test_observe_media_download_records_latency_and_bytes(self):
+        mpm.observe_mm_media_download("image", 0.5, 2048)
+        mpm.observe_mm_media_download("image", 1.5, 4096)
+
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "sglang:mm_media_download_seconds_count", {"modality": "image"}
+            ),
+            2.0,
+        )
+        self.assertAlmostEqual(
+            self.registry.get_sample_value(
+                "sglang:mm_media_download_seconds_sum", {"modality": "image"}
+            ),
+            2.0,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "sglang:mm_media_download_bytes_count", {"modality": "image"}
+            ),
+            2.0,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "sglang:mm_media_download_bytes_sum", {"modality": "image"}
+            ),
+            6144.0,
+        )
+
+    def test_observe_media_load_per_modality_labels(self):
+        mpm.observe_mm_media_load("image", 0.1)
+        mpm.observe_mm_media_load("video", 2.0)
+        mpm.observe_mm_media_load("audio", 0.05)
+
+        for modality, expected_sum in (
+            ("image", 0.1),
+            ("video", 2.0),
+            ("audio", 0.05),
+        ):
+            self.assertEqual(
+                self.registry.get_sample_value(
+                    "sglang:mm_media_load_seconds_count", {"modality": modality}
+                ),
+                1.0,
+            )
+            self.assertAlmostEqual(
+                self.registry.get_sample_value(
+                    "sglang:mm_media_load_seconds_sum", {"modality": modality}
+                ),
+                expected_sum,
+            )
+        # No cross-label contamination.
+        self.assertIsNone(
+            self.registry.get_sample_value(
+                "sglang:mm_media_load_seconds_count", {"modality": "text"}
+            )
+        )
+
+    def test_observe_load_data_and_processor(self):
+        mpm.observe_mm_load_data(0.25)
+        mpm.observe_mm_load_data(0.75)
+        mpm.observe_mm_processor(1.25)
+
+        self.assertEqual(
+            self.registry.get_sample_value("sglang:mm_load_data_seconds_count"), 2.0
+        )
+        self.assertAlmostEqual(
+            self.registry.get_sample_value("sglang:mm_load_data_seconds_sum"), 1.0
+        )
+        self.assertEqual(
+            self.registry.get_sample_value("sglang:mm_processor_seconds_count"), 1.0
+        )
+        self.assertAlmostEqual(
+            self.registry.get_sample_value("sglang:mm_processor_seconds_sum"), 1.25
+        )
+
+    def test_disabled_metrics_are_noop(self):
+        mpm._reset_for_test(enabled=False)
+
+        # Must not raise, and must not touch the registry.
+        mpm.observe_mm_media_download("image", 1.0, 10)
+        mpm.observe_mm_media_load("image", 1.0)
+        mpm.observe_mm_load_data(1.0)
+        mpm.observe_mm_processor(1.0)
+
+        self.assertIsNone(
+            self.registry.get_sample_value(
+                "sglang:mm_media_load_seconds_count", {"modality": "image"}
+            )
+        )
+        # Label-less histograms create their timeseries at construction time
+        # (during setUp), so the count exists but must stay at 0.
+        self.assertEqual(
+            self.registry.get_sample_value("sglang:mm_processor_seconds_count"), 0.0
+        )
+
+    def test_concurrent_observations_are_thread_safe(self):
+        n_threads, n_obs = 8, 50
+
+        def worker():
+            for _ in range(n_obs):
+                mpm.observe_mm_media_load("image", 0.01)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "sglang:mm_media_load_seconds_count", {"modality": "image"}
+            ),
+            float(n_threads * n_obs),
+        )
+
+    def test_metrics_turned_on_reflects_server_args(self):
+        fake_args = mock.Mock(enable_metrics=True)
+        with mock.patch(
+            "sglang.srt.runtime_context.get_server_args", return_value=fake_args
+        ):
+            self.assertTrue(mpm._metrics_turned_on())
+
+        fake_args.enable_metrics = False
+        with mock.patch(
+            "sglang.srt.runtime_context.get_server_args", return_value=fake_args
+        ):
+            self.assertFalse(mpm._metrics_turned_on())
+
+        # Server args not published (unit tests, offline tools) -> disabled,
+        # no exception.
+        with mock.patch(
+            "sglang.srt.runtime_context.get_server_args",
+            side_effect=ValueError("Global server args is not set yet!"),
+        ):
+            self.assertFalse(mpm._metrics_turned_on())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes #38676.

In the default (co-located) deployment, all multimodal input handling — downloading media from URLs, base64/PIL/video/audio decoding, and the HF processor call — happens in the tokenizer manager process **before** the request reaches the scheduler. Scheduler-side latency metrics (`sglang:time_to_first_token_seconds`, `sglang:e2e_request_latency_seconds`, queue stats) only start counting afterwards, so multimodal preprocessing time is invisible and shows up only as inflated perceived queueing / TTFT. The existing `sglang:encoder_preprocess_seconds` covers only the disaggregated encoder service, not this standard path.

When a multimodal request is slow, operators currently cannot tell whether the time went to (a) network download of media, (b) CPU-bound media decode, or (c) the HF processor. This is the same gap that vLLM addressed in https://github.com/vllm-project/vllm/pull/50875.

## Modifications

New module `python/sglang/srt/observability/mm_preprocessing_metrics.py` with five lazily-initialized histograms, recorded in the tokenizer manager process and exported through the existing prometheus multiprocess `/metrics` endpoint; initialized on first observation and only when `--enable-metrics` is set, so there is no import-time side effect and no overhead when disabled. Observation helpers never raise into the request path.

| Metric | Labels | Instrumentation point |
| --- | --- | --- |
| `sglang:mm_media_download_seconds` | `modality` | HTTP(S) branches of `get_image_bytes` / `_normalize_video_input` / `load_audio` (`utils/common.py`) |
| `sglang:mm_media_download_bytes` | `modality` | same |
| `sglang:mm_media_load_seconds` | `modality` | `BaseMultimodalProcessor._load_single_item` (full per-item load = fetch + decode; covers both the fast and legacy loading paths) |
| `sglang:mm_load_data_seconds` | — | `BaseMultimodalProcessor.load_mm_data` (whole media-loading stage of one request) |
| `sglang:mm_processor_seconds` | — | HF `processor.__call__` in `BaseMultimodalProcessor.process_mm_data` |

Decode time can be isolated via `mm_media_load_seconds - mm_media_download_seconds`; `mm_load_data_seconds` / `mm_processor_seconds` give the request-level stage breakdown.

Coverage notes:
- `load_mm_data` is split into a timed public wrapper + `_load_mm_data_impl`; no signature or behavior change for the 40+ subclass processors that call it.
- A few processors overriding `process_mm_data` entirely (`gemma4`, `mimo_v2`, `mimo_v2_asr`, `midashenglm`, `ernie45_vl`) bypass the processor metric; their media downloads/loads are still covered.

## Tests

- Added `test/registered/unit/observability/test_mm_preprocessing_metrics.py` (registered to `base-a-test-cpu`): per-metric observation correctness, per-modality label isolation, disabled-mode no-op behavior, thread safety of concurrent observations, and the `--enable-metrics` gate. All 6 tests pass locally.
- `isort` / `black` / `ruff --select=F401,F821,UP037` pass on all touched files.
- Not run: GPU e2e serving test (no GPU available locally); the change is observation-only and gated behind `--enable-metrics`.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations. (N/A — no behavior change; happy to add a docs note if reviewers want one)
- [ ] Provide accuracy and speed benchmark results. (N/A — no model output or hot-path impact; metrics path is a no-op unless `--enable-metrics` is set)
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->