### PR TITLE
[1/N] [AMD] Fix HiSparse slot translation in the fused MLA KV writer

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -42,6 +42,7 @@ from sglang.srt.lora.deepseek_mla_correction import (
 from sglang.srt.lora.deepseek_mla_correction import (
     is_kv_b_lora_active,
 )
+from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
@@ -350,12 +351,18 @@ def _fused_rope_cat_and_cache(
         and attn.current_attention_backend == "aiter"
         else kv_cache_dtype
     )
+    kv_pool = get_token_to_kv_pool()
+    if isinstance(kv_pool, HiSparseDSATokenToKVPool):
+        # The fused write bypasses set_mla_kv_buffer()'s logical-to-device mapping.
+        out_cache_loc = kv_pool.translate_loc_to_hisparse_device(out_cache_loc)
+    # AITER reads slot_mapping with stride 1, including on the resident path.
+    out_cache_loc = out_cache_loc.contiguous()
     return fused_qk_rope_cat_and_cache_mla(
         q_nope_out,
         q_pe,
         k_nope,
         k_pe,
-        get_token_to_kv_pool().get_key_buffer(attn.attn_mqa.layer_id),
+        kv_pool.get_key_buffer(attn.attn_mqa.layer_id),
         out_cache_loc,
         positions,
         attn.rotary_emb.cos_cache,

--- a/test/registered/e2e/mla/test_rocm_hisparse_fused_kv_gpu.py
+++ b/test/registered/e2e/mla/test_rocm_hisparse_fused_kv_gpu.py
@@ -1,0 +1,136 @@
+"""Model-free AITER KV-write regression for MI35x, including graph replay."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+class TestRocmHiSparseFusedKVKernel(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not torch.version.hip or not torch.cuda.is_available():
+            raise AssertionError("The MI35x regression requires ROCm and an AMD GPU")
+        arch = torch.cuda.get_device_properties(0).gcnArchName
+        if not arch.startswith("gfx95"):
+            raise AssertionError("The MI35x regression requires gfx95 hardware")
+
+        from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
+        from sglang.srt.models.deepseek_common.attention_forward_methods import (
+            forward_mla_rocm,
+        )
+
+        if not forward_mla_rocm._use_aiter_gfx95:
+            raise AssertionError(
+                "This gfx95 regression must run with the fused MLA path; "
+                "set SGLANG_USE_AITER=1 before starting Python"
+            )
+
+        cls.forward = forward_mla_rocm
+        cls.pool_type = HiSparseDSATokenToKVPool
+
+    def setUp(self):
+        super().setUp()
+        # The owned guard catches out-of-range writes without corrupting other tensors.
+        self.backing = torch.full(
+            (24, 1, 576), -99.0, dtype=torch.bfloat16, device="cuda"
+        )
+        mapping = torch.zeros(65, dtype=torch.int64, device="cuda")
+        mapping[17], mapping[18] = 3, 5
+        mapping[-1] = -1
+        self.pool = self.pool_type.__new__(self.pool_type)
+        self.pool.register_mapping(mapping)
+        self.pool.kv_buffer = [self.backing[:8]]
+        self.pool.start_layer = 7
+        self.pool.layer_transfer_counter = None
+        self.pool.dtype = self.pool.store_dtype = torch.bfloat16
+        self.attn = SimpleNamespace(
+            kv_cache_dtype="bfloat16",
+            current_attention_backend="dsa",
+            attn_mqa=SimpleNamespace(layer_id=7, k_scale=torch.ones(1, device="cuda")),
+            rotary_emb=SimpleNamespace(
+                cos_cache=torch.ones((8, 64), dtype=torch.bfloat16, device="cuda"),
+                sin_cache=torch.zeros((8, 64), dtype=torch.bfloat16, device="cuda"),
+                is_neox_style=False,
+            ),
+        )
+        self.qn = torch.ones((3, 8, 512), dtype=torch.bfloat16, device="cuda")
+        self.qr = torch.ones((3, 8, 64), dtype=torch.bfloat16, device="cuda")
+        self.kn = (
+            torch.arange(1, 4, dtype=torch.bfloat16, device="cuda")[:, None, None]
+            .expand(3, 1, 512)
+            .contiguous()
+        )
+        self.kr = torch.full((3, 1, 64), 2.5, dtype=torch.bfloat16, device="cuda")
+        self.positions = torch.zeros(3, dtype=torch.int64, device="cuda")
+        self.locations = torch.tensor([17, 18, -1], device="cuda")
+        self.expected_rows = torch.cat((self.kn, self.kr), dim=-1)
+
+    def write(self):
+        return self.forward._fused_rope_cat_and_cache(
+            self.attn,
+            self.qn,
+            self.qr,
+            self.kn,
+            self.kr,
+            self.positions,
+            self.locations,
+        )
+
+    def check_cache(self, row_to_slot):
+        torch.cuda.synchronize()
+        expected = torch.full_like(self.backing, -99.0)
+        for row, slot in row_to_slot.items():
+            expected[slot] = self.expected_rows[row]
+        torch.testing.assert_close(self.backing, expected, rtol=0, atol=0)
+
+    def test_eager_and_graph_writes_use_physical_slots(self):
+        with patch.object(self.forward, "get_token_to_kv_pool", return_value=self.pool):
+            # The helper calls the real AITER kernel with the pool's device buffer.
+            self.write()
+            with self.subTest(mode="eager"):
+                self.check_cache({0: 3, 1: 5})
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                self.write()
+            self.backing.fill_(-99.0)
+            graph.replay()
+            with self.subTest(mode="graph"):
+                self.check_cache({0: 3, 1: 5})
+
+            # Inputs are mutable between graph replays, including padding.
+            self.locations.copy_(torch.tensor([18, -1, 17], device="cuda"))
+            self.backing.fill_(-99.0)
+            graph.replay()
+            with self.subTest(mode="graph-updated-inputs"):
+                self.check_cache({0: 5, 2: 3})
+
+            self.locations.copy_(torch.tensor([19, -1, 17], device="cuda"))
+            self.backing.fill_(-99.0)
+            graph.replay()
+            with self.subTest(mode="graph-unmapped-dummy-slot"):
+                self.check_cache({0: 0, 2: 3})
+
+    def test_resident_strided_locations(self):
+        """AITER must write selected slots rather than interleaved storage values."""
+        from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+        resident = DSATokenToKVPool.__new__(DSATokenToKVPool)
+        resident.__dict__.update(self.pool.__dict__)
+        self.pool = resident
+        self.locations = torch.tensor([3, 21, 5, 22, -1, 23], device="cuda")[::2]
+        with patch.object(self.forward, "get_token_to_kv_pool", return_value=self.pool):
+            self.write()
+        with self.subTest(layout="strided"):
+            self.check_cache({0: 3, 1: 5})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_rocm_hisparse_fused_kv.py
+++ b/test/registered/unit/models/test_rocm_hisparse_fused_kv.py
@@ -1,0 +1,97 @@
+"""Exercise the ROCm writer's slot contract with a CPU kernel boundary."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
+from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+from sglang.srt.models.deepseek_common.attention_forward_methods import forward_mla_rocm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestRocmHiSparseFusedKV(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.cache = object()
+        self.pool = self.make_pool(DSATokenToKVPool)
+        self.attn = SimpleNamespace(
+            kv_cache_dtype="bfloat16",
+            current_attention_backend="dsa",
+            attn_mqa=SimpleNamespace(layer_id=7, k_scale=1.0),
+            rotary_emb=SimpleNamespace(
+                cos_cache=None, sin_cache=None, is_neox_style=False
+            ),
+        )
+
+    def make_pool(self, pool_type):
+        # Supply storage without allocating a model's cache; keep real accessors.
+        pool = pool_type.__new__(pool_type)
+        pool.kv_buffer = [self.cache]
+        pool.start_layer = 7
+        pool.layer_transfer_counter = None
+        pool.dtype = pool.store_dtype = torch.bfloat16
+        return pool
+
+    def use_hisparse(self):
+        self.pool = self.make_pool(HiSparseDSATokenToKVPool)
+        mapping = torch.zeros(65, dtype=torch.int64)
+        mapping[17], mapping[18], mapping[-1] = 3, 5, -1
+        self.pool.register_mapping(mapping)
+        return mapping
+
+    def invoke(self, locations):
+        with (
+            patch.object(forward_mla_rocm, "get_token_to_kv_pool", lambda: self.pool),
+            patch.object(
+                forward_mla_rocm,
+                "fused_qk_rope_cat_and_cache_mla",
+                lambda *args, **kwargs: args,
+                create=True,
+            ),
+        ):
+            args = forward_mla_rocm._fused_rope_cat_and_cache(
+                self.attn, torch.empty(0), None, None, None, None, locations
+            )
+        self.assertIs(args[4], self.cache)
+        return args[5]
+
+    def test_resident_locations_are_unchanged(self):
+        locations = torch.tensor([17, 0, -1], dtype=torch.int64)
+        self.assertIs(self.invoke(locations), locations)
+
+    def test_resident_strided_locations(self):
+        """Strided locations must not send interleaved storage values to AITER."""
+        storage = torch.tensor([3, 21, 5, 22, -1, 23])
+        locations = storage[::2]
+        actual = self.invoke(locations)
+        with self.subTest(layout="strided"):
+            self.assertTrue(actual.is_contiguous())
+            torch.testing.assert_close(actual, torch.tensor([3, 5, -1]))
+            torch.testing.assert_close(storage, torch.tensor([3, 21, 5, 22, -1, 23]))
+
+    def test_hisparse_maps_logical_slots(self):
+        """Logical slots beyond device capacity must write their physical rows."""
+        self.use_hisparse()
+        locations = torch.tensor([17, 18], dtype=torch.int64)
+        with self.subTest(logical_slots=[17, 18]):
+            torch.testing.assert_close(self.invoke(locations), torch.tensor([3, 5]))
+            torch.testing.assert_close(locations, torch.tensor([17, 18]))
+
+    def test_hisparse_padding_and_unmapped_slots(self):
+        self.use_hisparse()
+        locations = torch.tensor([17, -1, 19, 0])
+        with self.subTest(padding=-1, unmapped=19):
+            torch.testing.assert_close(
+                self.invoke(locations), torch.tensor([3, -1, 0, 0])
+            )
+            torch.testing.assert_close(locations, torch.tensor([17, -1, 19, 0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR stack

Merge in order:

1. [[1/N] [AMD] Fix HiSparse slot translation in the fused MLA KV writer](https://github.com/sgl-project/sglang/pull/38776)
2. [[2/N] [Kernel] Fuse padding-preserving HiSparse slot translation](https://github.com/sgl-project/sglang/pull/39837)

This is the correctness fix that the following optimization builds on.

## What this fixes

On the ROCm gfx95 fused MLA path, we were passing logical cache locations directly to AITER's KV-cache writer. HiSparse normally translates those locations to physical device slots, but this particular path uses `save_kv_cache=False`, so it skips the normal translation.

That means a logical slot such as 17 could be used where the physical slot should be 3, which can write to the wrong KV entry or outside the device cache allocation.

This change translates the locations before the fused write when the token pool is a `HiSparseDSATokenToKVPool`. It also makes the locations contiguous before calling AITER, since the kernel expects stride-one slot indices.

The translation is local to the fused writer: `forward_batch.out_cache_loc` stays in logical space, as does the index-K buffer.

## Testing

- CPU regression: `test/registered/unit/models/test_rocm_hisparse_fused_kv.py` exercises the production helper and real pool classes with the AITER call mocked. It covers logical-to-physical translation, padding and unmapped slots, resident-cache locations, and non-contiguous resident inputs. It requires no AMD hardware and remains registered in `base-a-test-cpu`.
- GPU regression: `test/registered/amd/test_rocm_hisparse_fused_kv_gpu.py` exercises the real AITER writer on gfx95, including eager writes, graph replay with changed inputs, padding/unmapped slots, and strided resident locations. It remains registered in `stage-b-test-1-gpu-small-amd-mi35x` and requires `SGLANG_USE_AITER=1`.

[Independent MI355X validation by @amd-danli103](https://github.com/sgl-project/sglang/pull/38776#issuecomment-5678337574), with `SGLANG_USE_AITER=1`, reported **4 passed + 3 subtests** for the CPU file and **2 passed + 5 subtests** for the GPU file. This validation preceded the GPU file's move from `e2e/mla/` to `amd/`; the move preserves its contents byte-for-byte.

For the test-placement follow-up, verified the exact rename, both CI registrations and executable entry points using the repository's registration collector, and `git diff --check`. No hardware tests were rerun for the rename.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35287725497](https://github.com/sgl-project/sglang/actions/runs/35287725497)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35287725205](https://github.com/sgl-project/sglang/actions/runs/35287725205)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35287725516](https://github.com/sgl-project/sglang/actions/runs/35287725516)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
