### PR TITLE
fix: zero the default Qwen3 classification bias

### DIFF
--- a/python/sglang/srt/models/qwen3_classification.py
+++ b/python/sglang/srt/models/qwen3_classification.py
@@ -134,6 +134,9 @@ class Qwen3ForSequenceClassification(Qwen3ForPooledOutput):
     ) -> None:
         super().__init__(config, quant_config, prefix)
         self.score = nn.Linear(config.hidden_size, config.num_labels)
+        # Standard Qwen3 checkpoints have no score.bias. Keep it neutral unless
+        # an explicit bias is supplied by the checkpoint.
+        nn.init.zeros_(self.score.bias)
         # Use normalize=True for qwen3 embedding based on official implementation
         # Reference: https://github.com/QwenLM/Qwen3-Embedding/blob/main/examples/qwen3_embedding_transformers.py#L55
         # Official code: output = F.normalize(output, p=2, dim=1)

--- a/test/registered/unit/models/test_qwen3_classification_bias.py
+++ b/test/registered/unit/models/test_qwen3_classification_bias.py
@@ -1,0 +1,44 @@
+"""Checkpoint parity for the Qwen3 sequence-classification head."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from sglang.srt.models.qwen3_classification import Qwen3ForSequenceClassification
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestQwen3ClassificationBias(CustomTestCase):
+    def test_checkpoint_bias(self):
+        """Missing bias must be neutral; an explicit checkpoint bias must survive."""
+        config = Qwen3Config(hidden_size=8, num_labels=3)
+        weight = torch.arange(24, dtype=torch.float32).reshape(3, 8) / 10
+        hidden_states = torch.arange(16, dtype=torch.float32).reshape(2, 8) / 10
+        for bias in (None, torch.tensor([0.1, -0.2, 0.3])):
+            with self.subTest(bias=bias):
+                # The backbone is unrelated to head initialization and loading.
+                with patch(
+                    "sglang.srt.models.qwen3_classification.Qwen3Model",
+                    return_value=nn.Identity(),
+                ):
+                    model = Qwen3ForSequenceClassification(config)
+                checkpoint = [("score.weight", weight)]
+                if bias is not None:
+                    checkpoint.append(("score.bias", bias))
+                model.load_weights(iter(checkpoint))
+                torch.testing.assert_close(
+                    model.score(hidden_states),
+                    nn.functional.linear(hidden_states, weight, bias),
+                    rtol=0,
+                    atol=0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #38768. Standard Transformers Qwen3 sequence-classification checkpoints have `score.weight` but no `score.bias`. SGLang currently keeps the randomly initialized bias, so these checkpoints silently produce `W @ h + b_init` instead of `W @ h`.

## Modifications

Initialize the existing classifier bias to zero. Checkpoints that explicitly provide `score.bias` still overwrite it through the existing weight loader. Add a CPU CI regression exercising both checkpoint shapes through the real classification constructor and `load_weights`; the unit test isolates the unrelated backbone with `nn.Identity`.

## Accuracy Tests

- `PYTHONPATH=python python3 test/registered/unit/models/test_qwen3_classification_bias.py`: passed (missing-bias and explicit-bias subcases). The missing-bias case fails on upstream.
- Also instantiated the complete native one-layer Qwen3 model with a tiny config (`hidden_size=8`, `num_labels=3`) and a real single-rank Gloo process group, without mocking the backbone. Loaded `score.weight`, then compared classifier outputs on fixed hidden states with `torch.nn.functional.linear(..., bias=None)`. Maximum absolute logit error: **0.320134 before, 0.0 after**. The fixed model's classifier also passes on an RTX 5060 Ti (PyTorch 2.13.0+cu130).
- This validates head initialization/loading and head-output parity; it is not a full transformer-forward or model-server accuracy benchmark.
- Pre-commit checks passed for both changed files, including registered-test validation.

## Speed Tests and Profiling

The change only zeroes a small bias once during construction; the forward path is unchanged.

## Checklist

- [x] Format checks passed for changed files.
- [x] Added a registered CPU regression test using `CustomTestCase`.
- [x] Verified bias-free output parity and explicit checkpoint-bias compatibility.
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34429353832](https://github.com/sgl-project/sglang/actions/runs/34429353832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34429353650](https://github.com/sgl-project/sglang/actions/runs/34429353650)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34429353756](https://github.com/sgl-project/sglang/actions/runs/34429353756)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->