### PR TITLE
[Unified Cache] Dedup replicated MLA/DSA KV in the UMBP direct linker

### DIFF
--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_direct_linker.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_direct_linker.py
@@ -47,6 +47,8 @@ def _storage_suffix(
 ) -> str:
     # A rank-replicated group (MLA / DSA) holds byte-identical pages on every
     # attention TP rank, so a tp term stores tp_size copies of the same page.
+    # Only the key collapses -- every rank still writes, because a Local-mode
+    # tier is private to its rank and a standalone server is per node.
     parts = []
     if not rank_replicated:
         parts.append(f"tp{tp_rank}")
@@ -227,9 +229,6 @@ class UMBPDirectLinker(UnifiedCacheLinker):
             components=components,
         )
         rank_replicated = self.pool_group.rank_replicated
-        # One rank writes a replicated page; the others must still post a result
-        # or the attention group's MIN over finish counts never advances.
-        self.offload_owner = not rank_replicated or tp_rank == 0
         self.pools = self.pool_group.entry_map
         self.num_layers = self.pool_group.num_layers
         if self.num_layers <= 0:
@@ -377,11 +376,10 @@ class UMBPDirectLinker(UnifiedCacheLinker):
             # it could not have shown an embedded run for what it was.
             logger.info(
                 "UMBPDirectLinker topology=%s+%s ranged_io=yes "
-                "rank_replicated=%s offload_owner=%s suffix=%s",
+                "rank_replicated=%s suffix=%s",
                 mode.name,
                 self.backend_mode.name if self.backend_mode is not None else None,
                 rank_replicated,
-                self.offload_owner,
                 rank_suffix,
             )
         except BaseException:
@@ -907,11 +905,6 @@ class UMBPDirectLinker(UnifiedCacheLinker):
         if not expanded:
             return False
         self._freeze_gc_once()
-        if not self.offload_owner:
-            # The owner writes these exact bytes under the key this rank reads;
-            # still post the result the tree pairs positionally with the task.
-            self._offload_results.put(True)
-            return True
         ready_event = device_module.Event()
         ready_event.record()
         self._offload_queue.put((expanded, ready_event))

--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_direct_linker.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_direct_linker.py
@@ -42,6 +42,18 @@ CHUNK_PAGES = 64
 RANGES_PER_CALL = int(os.getenv("UMBP_RANGES_PER_CALL", "8192"))
 
 
+def _storage_suffix(
+    *, rank_replicated: bool, tp_rank: int, attn_cp_rank: int, pp_rank: int
+) -> str:
+    # A rank-replicated group (MLA / DSA) holds byte-identical pages on every
+    # attention TP rank, so a tp term stores tp_size copies of the same page.
+    parts = []
+    if not rank_replicated:
+        parts.append(f"tp{tp_rank}")
+    parts.extend((f"cp{attn_cp_rank}", f"pp{pp_rank}"))
+    return "_".join(parts)
+
+
 def _ordered_layers(entry) -> list[int]:
     component_lengths = {len(component) for component in entry.components}
     if len(component_lengths) != 1:
@@ -214,6 +226,10 @@ class UMBPDirectLinker(UnifiedCacheLinker):
             params=params,
             components=components,
         )
+        rank_replicated = self.pool_group.rank_replicated
+        # One rank writes a replicated page; the others must still post a result
+        # or the attention group's MIN over finish counts never advances.
+        self.offload_owner = not rank_replicated or tp_rank == 0
         self.pools = self.pool_group.entry_map
         self.num_layers = self.pool_group.num_layers
         if self.num_layers <= 0:
@@ -346,7 +362,12 @@ class UMBPDirectLinker(UnifiedCacheLinker):
             self.storage.mem_pool_host = self.pool_group
             self.storage._kv_anchor_is_logical = True
             self.storage.registered_pools = self.pools
-            rank_suffix = f"tp{tp_rank}_cp{params.attn_cp_rank}_pp{params.pp_rank}"
+            rank_suffix = _storage_suffix(
+                rank_replicated=rank_replicated,
+                tp_rank=tp_rank,
+                attn_cp_rank=params.attn_cp_rank,
+                pp_rank=params.pp_rank,
+            )
             self.storage.mla_suffix = rank_suffix
             self.storage.mha_suffix = rank_suffix
             self._register_buffers()
@@ -355,9 +376,13 @@ class UMBPDirectLinker(UnifiedCacheLinker):
             # all, and it used to say "standalone_process" unconditionally, so
             # it could not have shown an embedded run for what it was.
             logger.info(
-                "UMBPDirectLinker topology=%s+%s ranged_io=yes",
+                "UMBPDirectLinker topology=%s+%s ranged_io=yes "
+                "rank_replicated=%s offload_owner=%s suffix=%s",
                 mode.name,
                 self.backend_mode.name if self.backend_mode is not None else None,
+                rank_replicated,
+                self.offload_owner,
+                rank_suffix,
             )
         except BaseException:
             self.storage.close()
@@ -882,6 +907,11 @@ class UMBPDirectLinker(UnifiedCacheLinker):
         if not expanded:
             return False
         self._freeze_gc_once()
+        if not self.offload_owner:
+            # The owner writes these exact bytes under the key this rank reads;
+            # still post the result the tree pairs positionally with the task.
+            self._offload_results.put(True)
+            return True
         ready_event = device_module.Event()
         ready_event.record()
         self._offload_queue.put((expanded, ready_event))

--- a/test/registered/unit/mem_cache/test_umbp_direct_linker_rank_keys.py
+++ b/test/registered/unit/mem_cache/test_umbp_direct_linker_rank_keys.py
@@ -1,0 +1,93 @@
+"""Unit tests for the UMBP direct linker's rank-replicated key handling."""
+
+import unittest
+from queue import Queue
+from types import SimpleNamespace
+from unittest import mock
+
+import sglang.srt.mem_cache.storage.umbp.umbp_direct_linker as umbp_direct_linker
+from sglang.srt.mem_cache.storage.umbp.umbp_direct_linker import (
+    UMBPDirectLinker,
+    _storage_suffix,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestStorageSuffix(CustomTestCase):
+    def test_replicated_group_drops_the_tp_term(self):
+        # MLA/DSA pages are byte-identical on every attention TP rank, so every
+        # rank has to name the same object or the store holds tp_size copies.
+        suffixes = {
+            _storage_suffix(
+                rank_replicated=True, tp_rank=rank, attn_cp_rank=0, pp_rank=0
+            )
+            for rank in range(8)
+        }
+        self.assertEqual(suffixes, {"cp0_pp0"})
+
+    def test_sharded_group_keeps_one_keyspace_per_rank(self):
+        suffixes = [
+            _storage_suffix(
+                rank_replicated=False, tp_rank=rank, attn_cp_rank=0, pp_rank=0
+            )
+            for rank in range(8)
+        ]
+        self.assertEqual(len(set(suffixes)), 8)
+        self.assertEqual(suffixes[3], "tp3_cp0_pp0")
+
+    def test_cp_and_pp_shard_even_when_replicated(self):
+        # CP shards the sequence and PP shards layers, so neither may collapse.
+        self.assertEqual(
+            _storage_suffix(rank_replicated=True, tp_rank=0, attn_cp_rank=1, pp_rank=2),
+            "cp1_pp2",
+        )
+        self.assertNotEqual(
+            _storage_suffix(rank_replicated=True, tp_rank=0, attn_cp_rank=0, pp_rank=0),
+            _storage_suffix(rank_replicated=True, tp_rank=0, attn_cp_rank=1, pp_rank=0),
+        )
+
+
+class TestOffloadOwnership(CustomTestCase):
+    @staticmethod
+    def _linker(*, offload_owner: bool, transfers=("transfer",)) -> UMBPDirectLinker:
+        linker = UMBPDirectLinker.__new__(UMBPDirectLinker)
+        linker.offload_owner = offload_owner
+        linker._offload_results = Queue()
+        linker._offload_queue = Queue()
+        linker._gc_frozen = True  # short-circuits _freeze_gc_once
+        linker.pool_group = SimpleNamespace(
+            resolve_transfers=lambda _transfers, allow_partial: list(transfers)
+        )
+        return linker
+
+    def test_non_owner_reports_completion_without_queueing_io(self):
+        linker = self._linker(offload_owner=False)
+        self.assertTrue(linker.offload(["t"]))
+        # The tree pairs one result per submitted offload, so a rank that skips
+        # the write still has to produce one or the group's MIN never advances.
+        self.assertEqual(linker._offload_results.qsize(), 1)
+        self.assertTrue(linker._offload_results.get_nowait())
+        self.assertEqual(linker._offload_queue.qsize(), 0)
+
+    def test_owner_queues_the_write(self):
+        linker = self._linker(offload_owner=True)
+        fake_device = SimpleNamespace(
+            Event=lambda: SimpleNamespace(record=lambda: None)
+        )
+        with mock.patch.object(umbp_direct_linker, "device_module", fake_device):
+            self.assertTrue(linker.offload(["t"]))
+        self.assertEqual(linker._offload_queue.qsize(), 1)
+        self.assertEqual(linker._offload_results.qsize(), 0)
+
+    def test_empty_transfer_set_produces_no_result(self):
+        linker = self._linker(offload_owner=False, transfers=())
+        self.assertFalse(linker.offload([]))
+        self.assertEqual(linker._offload_results.qsize(), 0)
+        self.assertEqual(linker._offload_queue.qsize(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_umbp_direct_linker_rank_keys.py
+++ b/test/registered/unit/mem_cache/test_umbp_direct_linker_rank_keys.py
@@ -50,40 +50,42 @@ class TestStorageSuffix(CustomTestCase):
         )
 
 
-class TestOffloadOwnership(CustomTestCase):
-    @staticmethod
-    def _linker(*, offload_owner: bool, transfers=("transfer",)) -> UMBPDirectLinker:
+class TestEveryRankWrites(CustomTestCase):
+    """Collapsing the key must not also elide the write on non-zero ranks.
+
+    A Local-mode UMBP tier is in-process and private to its rank, and a
+    standalone server is per node, so a page written only by rank 0 is not
+    reachable from the other ranks' stores. They then miss on a key nobody
+    wrote for them, and the attention group's MIN over the restorable mask
+    drives the hit to zero.
+    """
+
+    def test_offload_queues_the_write_on_every_rank(self):
         linker = UMBPDirectLinker.__new__(UMBPDirectLinker)
-        linker.offload_owner = offload_owner
         linker._offload_results = Queue()
         linker._offload_queue = Queue()
         linker._gc_frozen = True  # short-circuits _freeze_gc_once
         linker.pool_group = SimpleNamespace(
-            resolve_transfers=lambda _transfers, allow_partial: list(transfers)
+            resolve_transfers=lambda _transfers, allow_partial: ["transfer"]
         )
-        return linker
-
-    def test_non_owner_reports_completion_without_queueing_io(self):
-        linker = self._linker(offload_owner=False)
-        self.assertTrue(linker.offload(["t"]))
-        # The tree pairs one result per submitted offload, so a rank that skips
-        # the write still has to produce one or the group's MIN never advances.
-        self.assertEqual(linker._offload_results.qsize(), 1)
-        self.assertTrue(linker._offload_results.get_nowait())
-        self.assertEqual(linker._offload_queue.qsize(), 0)
-
-    def test_owner_queues_the_write(self):
-        linker = self._linker(offload_owner=True)
         fake_device = SimpleNamespace(
             Event=lambda: SimpleNamespace(record=lambda: None)
         )
         with mock.patch.object(umbp_direct_linker, "device_module", fake_device):
             self.assertTrue(linker.offload(["t"]))
         self.assertEqual(linker._offload_queue.qsize(), 1)
+        # The result comes from the offload thread once the write lands, so
+        # nothing may pre-post one here.
         self.assertEqual(linker._offload_results.qsize(), 0)
 
     def test_empty_transfer_set_produces_no_result(self):
-        linker = self._linker(offload_owner=False, transfers=())
+        linker = UMBPDirectLinker.__new__(UMBPDirectLinker)
+        linker._offload_results = Queue()
+        linker._offload_queue = Queue()
+        linker._gc_frozen = True
+        linker.pool_group = SimpleNamespace(
+            resolve_transfers=lambda _transfers, allow_partial: []
+        )
         self.assertFalse(linker.offload([]))
         self.assertEqual(linker._offload_results.qsize(), 0)
         self.assertEqual(linker._offload_queue.qsize(), 0)


### PR DESCRIPTION
## Motivation

The UMBP direct external linker suffixes every stored object key with `tp{rank}`:

```python
rank_suffix = f"tp{tp_rank}_cp{params.attn_cp_rank}_pp{params.pp_rank}"
self.storage.mla_suffix = rank_suffix
self.storage.mha_suffix = rank_suffix
```

For DeepSeek-V4 that stores `tp_size` byte-identical copies of every page. The DSv4/DSA device pools carry no `tp_size` term (`deepseek_v4_memory_pool.py` has no `tp_size`/`tp_rank` anywhere — per-token bytes are fixed, and MLA latent plus the DSA indexer are *replicated* across attention TP ranks rather than sharded), so all eight ranks in a TP8 run hold the same bytes and write them under eight different keys into one shared tier.

Nothing collapses them today:

- `offload()` -> `_run_offload()` calls `batch_put_ranges_from_ptr` with no pre-put existence check (`_page_exists` is wired only into the load path).
- `BackupKV` is dispatched from the replicated radix tree on every rank, so all ranks issue the write.
- The one dedup mechanism built for this case — the SharedSSDLeader/Follower scheme in `umbp_store.py`, gated on `is_mla_backend and tp_size > 1` — is deliberately disabled here via `per_rank_keyspace=True`, because a follower would look for keys the leader never wrote under the follower's own suffix.
- UMBP's own dedup is keyed on the key *string* (`RoutePutOutcome::kAlreadyExists`), so eight distinct keys never collide.

The per-rank suffix also makes the keyspace asymmetric against DP attention. `tp_cache_group` is the attention-TP group when DP attention is on (`kv_cache_builder.py`), which is size 1 for `tp8dp8`, so every DP rank already writes `tp0`. A DP-attention engine can therefore read what a plain-TP engine wrote, but not the reverse: ranks 1..7 look for `tp1..tp7`, which nobody wrote, and the MIN reduction in `UnifiedCacheLinkerWrapper._sync_restorable_prefix` (a 0/1 mask under MIN is an AND) then intersects the hit down to zero.

## Modifications

Add `_storage_suffix()`, mirroring the helper `MooncakeDirectLinker` already has: drop the `tp` term when `pool_group.rank_replicated`, so every rank names the same object. `cp` and `pp` always stay — CP shards the sequence and PP shards layers, so neither may be collapsed. The topology log line gains `rank_replicated` / `suffix`; its existing prefix is unchanged, since acceptance checks grep it.

**Only the key collapses — the write path is untouched, and every rank still writes.** `MooncakeDirectLinker` pairs its suffix helper with `offload_owner = not rank_replicated or tp_rank == 0`, which is safe there because MooncakeStore is always a shared external store. UMBP has deployment forms whose tier is *not* shared by the ranks that read it: a Local/embedded tier is in-process and private to its rank, and a standalone server is per node. Electing a single writer in those forms leaves the other ranks looking up a key that only exists in the owner's store, so they miss and the MIN reduction drives the hit to zero. Eliding the redundant writes needs a predicate for "this store is shared by exactly these ranks", which the linker cannot currently answer; that is left for a follow-up.

Ranks writing one key concurrently is not a new code path — DP attention already has every rank writing the `tp0` keyspace today.

Scope: `_build_deepseek_v4_device_pool_group` and `_build_dsa_device_pool_group` set `rank_replicated=True`, so this activates on the DSv4/DSA paths. Every other pool group keeps the default `rank_replicated=False` and is untouched — mamba/hybrid state *is* sharded per rank and keeps its per-rank key.

## Accuracy Tests

E2E A/B on MI355X (8x gfx950), DeepSeek-V4-Pro FP4, **TP8 with DP attention off** — the topology this patch actually changes, since `tp_cache_group` collapses to a size-1 attention-TP group under DP attention and every rank already writes `tp0`. `--attention-backend dsv4`, `--page-size 256`, `--max-total-tokens 524288`, UMBP standalone tier (128 GiB DRAM, no master), one 256K prompt at 100% hit, 5 reps. Both arms ran back to back on one node in one session; the two checkouts differ by exactly one file (`diff -rq` over the trees reports only `umbp_direct_linker.py`).

| | base (unpatched) | this PR |
|---|---:|---:|
| linker attach | `topology=StandaloneProcess+Distributed` x8 | same, x8 |
| `UMBPStore` ranks seen | `rank=0` .. `rank=7` | `rank=0` .. `rank=7` |
| object-key suffix | `tp0_cp0_pp0` .. `tp7_cp0_pp0` — **8 keyspaces** | `cp0_pp0` on all 8 — **1 keyspace** |
| `achieved_hit` | **99.9%** | **99.9%** |
| cached_tokens | 261888 / 262144 | 261888 / 262144 |

The functional result: collapsing the key does not break readback. All eight ranks attach, and all eight resolve their pages out of the single shared keyspace at the same 99.9% hit the per-rank layout gets (the missing 0.1% is the request's own last partial page, which is never cached). The 8-vs-1 keyspace split is visible directly in the server log via the `suffix=` field on the linker's attach line.

No task-accuracy benchmark (gsm8k or similar) was run — the change renames an object, it does not alter KV bytes, and UMBP returns a miss rather than copying when a stored object's size disagrees with the request.

## Speed Tests and Profiling

Same runs as above.

| | base (unpatched) | this PR |
|---|---:|---:|
| ttft (median of 5) | 260.2 ms | 260.3 ms |
| `dev_ms` (device-tree floor) | 161.5 ms | 167.7 ms |
| **`load_ms` = ttft - dev** | **98.6 ms** | **92.6 ms** |
| ttft spread | 1.3% | 33.2% |
| `warm_ms` (comparability gate) | 62040.0 ms | 61948.2 ms |

`warm_ms` is the arms-are-comparable gate — it is machine state, not arm state — and the two agree to **0.15%**, so the cells are comparable.

**Read this as "no regression", not as a speedup.** The 6 ms lower `load_ms` is well inside the patched arm's 33.2% spread, which comes from a single stalled rep (`[242.6, 252.8, 260.3, 261.9, 323.2]` vs the base arm's tight `[258.9 .. 262.3]`). Intermittent admission stalls are a known property of this cell. The honest conclusion is that load cost is unchanged.

The saving this patch targets is storage, not latency: for a rank-replicated pool group on a shared tier, the distinct objects stored per page drop from `tp_size` to 1. Read traffic is unchanged — each rank still needs its own copy delivered into its own device buffer — and a per-rank-private tier (Local mode) keeps one copy per rank, so it neither gains nor regresses.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (full `pre-commit run --files ...` clean, including the registered-test CI registry validators)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test/registered/unit/mem_cache/test_umbp_direct_linker_rank_keys.py`, registered `register_cpu_ci`)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (no user-facing surface changes)
- [x] Provide accuracy and speed benchmark results — E2E A/B on MI355X in the two sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35727522370](https://github.com/sgl-project/sglang/actions/runs/35727522370)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35727522318](https://github.com/sgl-project/sglang/actions/runs/35727522318)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:hourglass_flowing_sand: [Run #35727522712](https://github.com/sgl-project/sglang/actions/runs/35727522712)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->