### PR TITLE
Fix: post-load staging regression breaks offload meta/sharded_gpu modes

### DIFF
--- a/python/sglang/srt/model_loader/post_load.py
+++ b/python/sglang/srt/model_loader/post_load.py
@@ -134,13 +134,16 @@ def stage_module_for_post_load(
     owner_origins: dict[int, set[torch.device]] = {}
     module_origins: set[torch.device] = set()
     tensor_states: dict[int, _TensorState] = {}
+    # Offloader-parked parameters (see sglang.srt.utils.offloader) live on the
+    # meta device through post-load processing; kernels are expected to skip
+    # them. Pass them through untouched, matching the pre-staging behaviour.
+    meta_tensor_ids: set[int] = set()
 
     # snapshot and validate all state before moving any tensor
     for owner, registry_name, name, tensor in _iter_registered_tensors(module):
         if tensor.is_meta:
-            raise RuntimeError(
-                f"Cannot post-process meta tensor {type(owner).__name__}.{name}"
-            )
+            meta_tensor_ids.add(id(tensor))
+            continue
         state = tensor_states.get(id(tensor))
         if state is None:
             state = _TensorState(tensor, tensor.data, tensor.device)
@@ -167,6 +170,9 @@ def stage_module_for_post_load(
             next(iter(module_origins)) if len(module_origins) == 1 else None
         )
         for owner, registry_name, name, tensor in _iter_registered_tensors(module):
+            if id(tensor) in meta_tensor_ids:
+                # Parked by the offloader before staging; leave it as-is.
+                continue
             key = _slot_key(owner, registry_name, name)
             original_state = original_slots.get(key)
             if original_state is None:

--- a/test/registered/unit/test_quantization_post_load.py
+++ b/test/registered/unit/test_quantization_post_load.py
@@ -140,18 +140,31 @@ class TestModulePostLoadValidation(unittest.TestCase):
 
         self.assertEqual(module.weight.device, PROCESS_DEVICE)
 
-    def test_rejects_meta_before_moving_other_state(self):
+    def test_parks_existing_meta_tensor_and_stages_the_rest(self):
         module = nn.Module()
         module.meta_weight = nn.Parameter(torch.empty(1, device="meta"))
         module.register_buffer("scale", torch.ones(1))
         scale_ptr = module.scale.data_ptr()
+        meta_weight = module.meta_weight
+
+        with stage_module_for_post_load(module, torch.device("cpu")):
+            # offloader-parked meta state passes through untouched
+            self.assertTrue(module.meta_weight.is_meta)
+            module.scale.add_(1)
+
+        self.assertIs(module.meta_weight, meta_weight)
+        self.assertTrue(module.meta_weight.is_meta)
+        self.assertEqual(module.scale.device.type, "cpu")
+        self.assertEqual(module.scale.data_ptr(), scale_ptr)
+        torch.testing.assert_close(module.scale, torch.full((1,), 2.0))
+
+    def test_rejects_meta_produced_by_post_load_processing(self):
+        module = nn.Module()
+        module.register_buffer("scale", torch.ones(1))
 
         with self.assertRaisesRegex(RuntimeError, "meta tensor"):
             with stage_module_for_post_load(module, torch.device("cpu")):
-                self.fail("context should not be entered")
-
-        self.assertEqual(module.scale.device.type, "cpu")
-        self.assertEqual(module.scale.data_ptr(), scale_ptr)
+                module.new_weight = nn.Parameter(torch.empty(1, device="meta"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The offloader (V2, `--offload-group-size`) intentionally parks offloaded parameters on the meta device through weight post-processing:

- `--offload-mode=meta`: all offloaded params become meta at build time (weight loading is a no-op via a replaced `weight_loader`).
- `--offload-mode=sharded_gpu` / `shm_cpu`: non-rank-0 DP ranks park params on meta during loading (rank 0 owns the real data).

This is by design: device kernels skip meta params (e.g. `npu_format_cast` has an explicit meta skip), and the old `device_loading_context` passed meta tensors through untouched. Since #35180, `process_weights_after_loading` hits the new upfront check and the scheduler dies during startup:
  RuntimeError: Cannot post-process meta tensor FusedMoE.w13_weight

The bug is device-agnostic (same code path on CUDA/NPU); it was caught by the NPU offload CI suites (`test_npu_offload_modes.py`, `test_npu_offload_group_size.py`).
## Modifications

<!-- Detail the changes made in this pull request. -->
In `stage_module_for_post_load()`, record tensors that are already meta at context entry and pass them through untouched — no staging, no restore — restoring the pre-#35180 behavior for offloader-parked params.

The original guard is preserved: tensors that *become* meta during post-load processing still raise, so genuine kernel bugs keep failing fast.

for test_npu_offload_modes.py
before
<img width="1062" height="685" alt="image" src="https://github.com/user-attachments/assets/6014c1b8-4540-457d-829e-771d1498b586" />
 after
<img width="602" height="103" alt="image" src="https://github.com/user-attachments/assets/b65a3059-0c32-4b87-a831-5f652a3762b0" />

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35295705325](https://github.com/sgl-project/sglang/actions/runs/35295705325)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35295705264](https://github.com/sgl-project/sglang/actions/runs/35295705264)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35295705315](https://github.com/sgl-project/sglang/actions/runs/35295705315)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->