### PR TITLE
[Bug] Guard FlashInfer CUTLASS MoE against 0-token inputs

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -346,9 +346,12 @@ def _fused_experts_flashinfer_mxfp4_cutlass(
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
     from sglang.srt.layers.moe.topk import TopKOutputChecker
 
+    x = dispatch_output.hidden_states
+    if x.shape[0] == 0:
+        return StandardCombineInput(hidden_states=x)
+
     flashinfer_cutlass_fused_moe, ActivationType = _flashinfer_cutlass_fused_moe()
 
-    x = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
 
     # Under ``--moe-runner-backend flashinfer_mxfp4`` topk may be in bypassed

--- a/test/registered/unit/layers/moe/test_flashinfer_mxfp4_empty_tokens.py
+++ b/test/registered/unit/layers/moe/test_flashinfer_mxfp4_empty_tokens.py
@@ -1,0 +1,70 @@
+"""CPU tests for FlashInfer MXFP4 CUTLASS 0-token early return."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+    FlashInferCutlassMxfp4MoeQuantInfo,
+    _fused_experts_flashinfer_mxfp4_cutlass,
+)
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+_KERNEL = (
+    "sglang.srt.layers.moe.moe_runner.flashinfer_cutlass._flashinfer_cutlass_fused_moe"
+)
+
+
+def _dispatch(num_tokens: int, hidden: int = 256) -> StandardDispatchOutput:
+    return StandardDispatchOutput(
+        hidden_states=torch.empty(num_tokens, hidden, dtype=torch.bfloat16),
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=torch.empty(num_tokens, 4),
+            topk_ids=torch.empty(num_tokens, 4, dtype=torch.int32),
+            router_logits=torch.empty(num_tokens, 8),
+        ),
+    )
+
+
+def _quant_info() -> FlashInferCutlassMxfp4MoeQuantInfo:
+    return FlashInferCutlassMxfp4MoeQuantInfo(
+        w13_weight=torch.empty(0),
+        w2_weight=torch.empty(0),
+        w13_weight_scale=torch.empty(0),
+        w2_weight_scale=torch.empty(0),
+    )
+
+
+class TestFlashInferMxfp4EmptyTokens(CustomTestCase):
+    def test_empty_tokens_skip_kernel(self):
+        dispatch = _dispatch(0)
+        with patch(_KERNEL) as mock_kernel:
+            mock_kernel.side_effect = RuntimeError("kernel should not be called")
+            result = _fused_experts_flashinfer_mxfp4_cutlass(
+                dispatch, _quant_info(), MoeRunnerConfig()
+            )
+        mock_kernel.assert_not_called()
+        self.assertIs(result.hidden_states, dispatch.hidden_states)
+
+    def test_nonzero_tokens_reach_kernel(self):
+        with patch(_KERNEL) as mock_kernel:
+            mock_kernel.side_effect = RuntimeError("kernel reached")
+            with self.assertRaisesRegex(RuntimeError, "kernel reached"):
+                _fused_experts_flashinfer_mxfp4_cutlass(
+                    _dispatch(1), _quant_info(), MoeRunnerConfig()
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TBO + DP attention can produce empty child batches. CUTLASS fused MoE asserts a non-null input_activations pointer, and PyTorch 0-row tensors have data_ptr()==0, which crashes flashinfer_mxfp4.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #38773.

FlashInfer CUTLASS flashinfer_mxfp4 asserts on 0-token MoE batches because empty PyTorch tensors have data_ptr() == 0. DP attention + TBO hits this on idle ranks / bs=1 decode (child_a or idle hidden states are [0, H]). TBO is especially important on communication-bound GPUs such as L20N; this crash currently blocks enabling it together with flashinfer_mxfp4.

## Modifications

<!-- Detail the changes made in this pull request. -->

In `_fused_experts_flashinfer_mxfp4_cutlass`, return `StandardCombineInput(hidden_states=x)` when `x.shape[0] == 0`, before pad / CUTLASS. Same identity early-return as `moe_runner/aiter.py` and `moe_runner/humming.py`.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A. 0-token path is identity; no change to non-empty batches.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35075254113](https://github.com/sgl-project/sglang/actions/runs/35075254113)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35075253797](https://github.com/sgl-project/sglang/actions/runs/35075253797)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35075254187](https://github.com/sgl-project/sglang/actions/runs/35075254187)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->