### PR TITLE
fix(modelopt): expand exclusions nested under model.language_model.*

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -354,6 +354,15 @@ class ModelOptQuantConfig(QuantizationConfig):
                 expanded.append(name)
                 if name.startswith("language_model."):
                     expanded.append(name.removeprefix("language_model."))
+                # ModelOpt writes some vision-language checkpoints with the decoder
+                # nested under "model.language_model.*" while sglang builds it as
+                # "model.*". The segment is interior, so the prefix strip above never
+                # fires for it. Ref: hf_quant_config.json for
+                # https://huggingface.co/nvidia/GLM-5.3-Flash-NVFP4
+                if name.startswith("model.language_model."):
+                    expanded.append(
+                        "model." + name.removeprefix("model.language_model.")
+                    )
             # Preserve order, drop duplicates.
             self.exclude_modules = list(dict.fromkeys(expanded))
 

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
@@ -17,6 +17,52 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
+class TestModelOptExcludeModuleMapping(CustomTestCase):
+    """apply_weight_name_mapper expands exclusion patterns to the names sglang builds."""
+
+    class _IdentityMapper:
+        def apply_list(self, names):
+            return list(names)
+
+    def _mapped(self, exclude_modules):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            group_size=16,
+            exclude_modules=list(exclude_modules),
+        )
+        config.apply_weight_name_mapper(self._IdentityMapper())
+        return config
+
+    def test_interior_language_model_segment_is_expanded(self):
+        """nvidia/GLM-5.3-Flash-NVFP4 nests the decoder under model.language_model.*
+        while sglang builds it as model.*, leaving every excluded attention, gate and
+        shared-expert layer quantized and crashing the load on a shape mismatch."""
+        config = self._mapped(["model.language_model.layers.0.self_attn*"])
+        self.assertTrue(config.is_layer_excluded("model.layers.0.self_attn.kv_b_proj"))
+        self.assertTrue(config.is_layer_excluded("model.layers.0.self_attn.q_b_proj"))
+        # the checkpoint's own spelling keeps matching
+        self.assertTrue(
+            config.is_layer_excluded(
+                "model.language_model.layers.0.self_attn.kv_b_proj"
+            )
+        )
+
+    def test_interior_expansion_does_not_widen_the_match(self):
+        config = self._mapped(["model.language_model.layers.10.mlp.gate"])
+        self.assertTrue(config.is_layer_excluded("model.layers.10.mlp.gate"))
+        self.assertFalse(config.is_layer_excluded("model.layers.11.mlp.gate"))
+        self.assertFalse(config.is_layer_excluded("model.layers.10.mlp.experts"))
+
+    def test_leading_language_model_strip_is_unchanged(self):
+        config = self._mapped(["language_model.model.layers.0.self_attn.q_proj"])
+        self.assertTrue(config.is_layer_excluded("model.layers.0.self_attn.q_proj"))
+
+    def test_names_without_the_segment_are_untouched(self):
+        config = self._mapped(["lm_head", "model.visual*"])
+        self.assertEqual(config.exclude_modules, ["lm_head", "model.visual*"])
+
+
 class TestModelOptNvfp4(CustomTestCase):
     def _make_layer(self):
         return MergedColumnParallelLinear(


### PR DESCRIPTION
## Motivation

Follow-up to #36596. #36761 fixes the fused-module and `model.`-prefixed vision-tower halves; this fixes the third naming form, which neither the shipped matcher nor that PR handles: exclusions nested under `model.language_model.*`.

`apply_weight_name_mapper` strips `language_model.` only when it is the *leading* segment. ModelOpt writes some vision-language checkpoints with the decoder nested one level in — `model.language_model.layers.N.*` — while sglang builds it as `model.layers.N.*`. The strip never fires, every layer the checkpoint keeps in BF16 is built as an FP4 module, and the load dies on a packed-versus-unpacked shape mismatch.

Hit on [`nvidia/GLM-5.3-Flash-NVFP4`](https://huggingface.co/nvidia/GLM-5.3-Flash-NVFP4) (the official NVIDIA checkpoint; #36596 was filed against LibertAIDAI's, which is spelled differently) at TP8 on 8xB200, FlashInfer 0.6.17:

```
AssertionError: target.shape=torch.Size([4096, 256]),
                loaded_weight.shape=torch.Size([4096, 512])
```

the FP4-packed parameter against the BF16 tensor the checkpoint actually ships.

Its exclusion list uses this form throughout — `model.language_model.layers.N.self_attn*`, `...mlp.gate`, `...mlp.shared_experts*` — so on this checkpoint the two PRs are both required and neither is sufficient. Measured against that exclusion list with the matcher's shipped behaviour, #36761's logic, and this change:

| built prefix | shipped | #36761 | this PR |
|---|---|---|---|
| `visual.blocks.10.attn.proj` | miss | fixed | miss |
| `model.layers.0.self_attn.kv_b_proj` | miss | miss | fixed |
| `model.layers.10.mlp.gate` | miss | miss | fixed |
| `model.layers.10.mlp.shared_experts.gate_up_proj` | miss | miss | fixed |

## Modifications

`python/sglang/srt/layers/quantization/modelopt_quant.py`: in `apply_weight_name_mapper`, expand `model.language_model.<rest>` to `model.<rest>` alongside the existing leading-segment strip. Same place, same shape, and the expansion is exact rather than a wildcard, so it cannot widen a match.

## Accuracy

No numerical change. This only affects which modules are *built* quantized; it restores the checkpoint's own intent, which is that these layers stay BF16.

## Checklist

- [x] Unit tests in `test/registered/unit/layers/quantization/test_modelopt_nvfp4.py`: the interior form matches, the checkpoint's own spelling still matches, a neighbouring layer index does **not** match, the leading strip is unchanged, and names without the segment are left untouched.
- [x] Verified against the unmodified `hf_quant_config.json` from `nvidia/GLM-5.3-Flash-NVFP4`, in the sglang image, on 8xB200.
- [x] With this and #36761 applied, the checkpoint loads and serves.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34433045876](https://github.com/sgl-project/sglang/actions/runs/34433045876)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34433045790](https://github.com/sgl-project/sglang/actions/runs/34433045790)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34433045968](https://github.com/sgl-project/sglang/actions/runs/34433045968)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->