### PR TITLE
[Bugfix] Preserve PP token shards with MoE A2A

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -14,6 +14,7 @@ from sglang.srt.distributed.communication_op import attn_cp_tp_broadcast_pyobj
 from sglang.srt.distributed.parallel_state import P2PWork
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req, ScheduleBatch
 from sglang.srt.managers.utils import (
@@ -550,6 +551,14 @@ class SchedulerPPMixin:
 
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.ps.pp_size + get_parallel().pp_async_batch_depth
+        # MoE A2A can leave hidden_states/residual token-sharded across TP ranks.
+        # Send-slice/all-gather assumes replicated tensors and corrupts those
+        # shards. Preserve each TP rank's complete local tensor instead.
+        # Proxy and output messages must use the same protocol: the typed
+        # receiver can consume and stash either kind before finding its target.
+        self.pp_all_gather_group = (
+            self.attn_tp_group if get_moe_a2a_backend().is_none() else None
+        )
         self.mbs = [None] * self.pp_loop_size
         self.last_mbs = [None] * self.pp_loop_size
         self.running_mbs = [
@@ -810,7 +819,7 @@ class SchedulerPPMixin:
         p2p_work.extend(
             self.pp_group.send_tensor_dict(
                 tensor_dict=tensor_dict,
-                all_gather_group=(self.attn_tp_group),
+                all_gather_group=self.pp_all_gather_group,
                 async_send=async_send,
             )
         )
@@ -855,7 +864,7 @@ class SchedulerPPMixin:
             pp_proxy_tensors = PPProxyTensors(
                 self._pp_recv_typed_dict(
                     expected_kind="proxy",
-                    all_gather_group=(self.attn_tp_group),
+                    all_gather_group=self.pp_all_gather_group,
                 )
             )
         return pp_proxy_tensors
@@ -865,7 +874,7 @@ class SchedulerPPMixin:
     ) -> Dict[str, torch.Tensor]:
         return self._pp_recv_typed_dict(
             expected_kind="output",
-            all_gather_group=(self.attn_tp_group),
+            all_gather_group=self.pp_all_gather_group,
         )
 
     def _pp_make_skip_output_result(


### PR DESCRIPTION
## Motivation

Pipeline parallelism with MoE A2A can silently corrupt token-sharded proxy tensors. The PP send-allgather optimization assumes identical tensors on all attention TP ranks, but sparse A2A layers can leave `hidden_states` and `residual` in `SCATTERED` layout at a PP boundary.

For example, TP-local tensors `[0, 1, 2, 3]` and `[4, 5, 6, 7]` become `[0, 1, 6, 7]` on both receiving ranks. The original local shape is preserved, so shape checks do not catch the corruption.

Related: #20834 (closed without merging), #33280 (open MiniMax-specific proposal).

## Modifications

Select one PP transport group when initializing the pipeline loop. With a MoE A2A backend, disable send-slice/allgather and transmit each TP rank's complete local tensor to the corresponding rank in the next PP stage. Keep the optimization for the `none` backend.

Apply the same selection to sends, proxy receives, and output receives: the typed receiver can consume and stash either message kind before finding the requested kind, so their wire protocols must agree.

Only `scheduler_pp_mixin.py` is changed. This does not change model math, MoE dispatch/combine, PP/TP/EP sizes, KV precision, or graph buffer sizing. The backend-wide guard is conservative: replicated tensors from an A2A model are still transferred correctly, at the cost of the optimization.

## Accuracy Tests

- On a SGLang 0.5.19 deployment, GLM-5.3 prefill used PP2/TP8/EP8/DP1, DeepEP normal, FP8 KV, and static memory fraction 0.85. The original image's DeepEP reproduced corrupt first tokens before any P-to-D KV transfer (`The capital of France is` -> `ModelState`).
- Disabling only the PP send-allgather optimization restored the first token to ` Paris`. Keeping the same prefill configuration and unchanged decode deployment (TP32/EP32/DP16, DeepEP low_latency), official 5-shot GSM8K with 64 questions, temperature 0, max 2048 output tokens, and concurrency 16 achieved **60/64 (93.75%), Invalid 0**.
- This GPU result validates the transport change on 0.5.19, not a full GPU run of current main. Both A/B runs disabled eager DeepGEMM precompilation.
- A private CPU harness executed the current main scheduler and GroupCoordinator serialization/send/receive methods extracted from source, replacing only network I/O and server initialization dependencies. All 48 protocol cases passed, covering every backend enum, synchronous/asynchronous sends, proxy/output ordering, empty tensors, and tensors not divisible by TP size. Re-enabling the original protocol failed exact tensor equality for distinct DeepEP token shards. The full server import was not exercised by this harness.
- All applicable pre-commit hooks passed. No test files are included in this PR.

## Speed Tests and Profiling

Not measured. MoE A2A now transfers full local tensors rather than slices and avoids the receiver TP all-gather. Replicated output messages also use full local transfer because they share the typed receive path. Ordinary TP without A2A retains its optimization. GSM8K timings included cold compilation and are not a throughput comparison.

## Checklist

- [x] Format code with the repository's pre-commit hooks.
- [ ] Add registered unit tests (local validation only; no test files in this change).
- [x] Documentation: no user-facing interface changes.
- [x] Provide accuracy validation with version and sample-size limits stated.
- [ ] Provide speed benchmark results.
- [x] Follow SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34436823480](https://github.com/sgl-project/sglang/actions/runs/34436823480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34436823348](https://github.com/sgl-project/sglang/actions/runs/34436823348)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34436823401](https://github.com/sgl-project/sglang/actions/runs/34436823401)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->