### PR TITLE
[AMD][DSA] Extend Triton sparse-MLA prefill to gfx942 (MI308X) via 2-query merged programs

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -1,10 +1,22 @@
-"""Triton sparse-MLA forward for the DSA fp8 prefill path.
+"""Triton sparse-MLA forward for the DSA fp8 prefill path — gfx942 (MI308X) port.
 
-A per-query flash-attention kernel over the indexer-selected topk KV. On
-gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
-prefill regime (n_groups=1): the attention tile is tiny (M=16 heads = one
-16x16 MFMA), so a small-warp per-program kernel avoids the intra-block
-coordination overhead of the 256-thread TileLang block.
+A per-(merged)query flash-attention kernel over the indexer-selected topk KV.
+On gfx950 this is ~1.6x faster than the TileLang partial+combine kernel for the
+prefill regime (n_groups=1): the attention tile is tiny (one 16x16 MFMA), so a
+small-warp per-program kernel avoids the intra-block coordination overhead of
+the 256-thread TileLang block.
+
+gfx942 port note (v2 — 2-query merged program)
+------------------------------------------------
+The per-query kernel computes tl.dot([H, D_V], [D_V, BLOCK_N]), placing the
+head count H on the MFMA **M** dimension. CDNA3 matrix cores require M >= 16,
+but with 8 heads/card on MI308X (TP8) H=8 < 16 — pad-to-16 head duplication
+(v1) satisfied the constraint but wasted 2x FLOPs.
+
+v2 instead merges **2 query tokens** into one program. 2 tokens x 8 heads = 16
+rows, so M = 16 is legal with *zero* wasted compute (each row is a distinct
+real (token, head) and the two tokens' KV sets are kept disjoint via a
+structured (row_tok == tok2) block-diagonal mask). grid = ceil(seq/2).
 """
 
 import torch
@@ -15,6 +27,10 @@ from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 
 _IS_FNUZ = is_fp8_fnuz()
 _FP8_MAX = 240.0 if _IS_FNUZ else 448.0
+
+# Number of query tokens fused into a single program. 2 tokens * 8 heads = 16
+# rows -> tl.dot M = 16 (legal on CDNA3), with no duplicate work.
+_NTOK = 2
 
 
 def _prune_configs(configs, named_args, **kwargs):
@@ -50,69 +66,94 @@ def _sparse_mla_fwd_kernel(
     sm_scale,
     fp8_max,
     topk,
+    seq,
     H: tl.constexpr,
     DIM: tl.constexpr,
     D_V: tl.constexpr,
     D_TAIL: tl.constexpr,
+    NTOK: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
     s_i = tl.program_id(0)
 
-    h = tl.arange(0, H)
+    ROWS: tl.constexpr = NTOK * H
+    row_tok = tl.arange(0, ROWS) // H   # [rows] which token within this program
+    row_h = tl.arange(0, ROWS) % H      # [rows] which head within the token
     dv = tl.arange(0, D_V)
     dt = tl.arange(0, D_TAIL)
-    # q is read as two separate tensors (q_nope width D_V, q_rope width D_TAIL):
-    # the upstream concat into a single [.., DIM] tensor is skipped since this
-    # kernel splits q into main/tail anyway.
-    q_main = tl.load(q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :]).to(
-        q_nope_ptr.dtype.element_ty
-    )  # [H, D_V]
-    q_tail = tl.load(
-        q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :]
-    ).to(q_nope_ptr.dtype.element_ty)  # [H, D_TAIL]
 
-    m_i = tl.full([H], -float("inf"), tl.float32)
-    l_i = tl.zeros([H], tl.float32)
-    acc = tl.zeros([H, D_V], tl.float32)
+    # ---- load q for all NTOK tokens of this program ----------------------
+    # Row layout: [tok0 h0..h_{H-1}, tok1 h0..h_{H-1}, ...]; M = rows = 16.
+    tok_idx = s_i * NTOK + row_tok                 # [rows] global token index
+    q_off_nope = tok_idx[:, None] * H * D_V + row_h[:, None] * D_V + dv[None, :]
+    q_off_rope = tok_idx[:, None] * H * D_TAIL + row_h[:, None] * D_TAIL + dt[None, :]
+    q_mask = tok_idx[:, None] < seq                # mask odd-boundary token out
+
+    q_main = tl.load(
+        q_nope_ptr + q_off_nope, mask=q_mask, other=0.0
+    ).to(q_nope_ptr.dtype.element_ty)              # [rows, D_V]
+    q_tail = tl.load(
+        q_rope_ptr + q_off_rope, mask=q_mask, other=0.0
+    ).to(q_nope_ptr.dtype.element_ty)              # [rows, D_TAIL]
+
+    m_i = tl.full([ROWS], -float("inf"), tl.float32)
+    l_i = tl.zeros([ROWS], tl.float32)
+    acc = tl.zeros([ROWS, D_V], tl.float32)
+
+    # ---- gather KV for all NTOK tokens, laid out as NTOK * BLOCK_N cols ---
+    col = tl.arange(0, NTOK * BLOCK_N)             # [NTOK*BLOCK_N]
+    tok2 = col // BLOCK_N                          # which token each column feeds
+    within2 = col % BLOCK_N                         # index within that token's topk
 
     n = tl.arange(0, BLOCK_N)
     for k0 in range(0, topk, BLOCK_N):
-        kmask = (k0 + n) < topk
-        idx = tl.load(idx_ptr + s_i * topk + k0 + n, mask=kmask, other=-1)
-        valid = (idx >= 0) & kmask
-        page = tl.where(valid, idx, 0)
-        kbase = kv_ptr + page[:, None] * DIM
-        kv_main = tl.load(kbase + dv[None, :], mask=valid[:, None], other=0.0).to(
-            q_nope_ptr.dtype.element_ty
-        )  # [BLOCK_N, D_V] -- reused as V
-        kv_tail = tl.load(
-            kbase + (D_V + dt)[None, :], mask=valid[:, None], other=0.0
-        ).to(q_nope_ptr.dtype.element_ty)  # [BLOCK_N, D_TAIL]
+        kmask = (k0 + within2) < topk
+        base = s_i * NTOK + tok2                   # global token for this column
+        idx_off = base * topk + k0 + within2
+        idx_mask = kmask & (base < seq)
+        idx_cat = tl.load(
+            idx_ptr + idx_off, mask=idx_mask, other=-1
+        )                                          # [NTOK*BLOCK_N]
+        valid_page = idx_cat >= 0                  # [NTOK*BLOCK_N]
+        kbase = kv_ptr + idx_cat[:, None] * DIM
+        kv_main_cat = tl.load(
+            kbase + dv[None, :], mask=valid_page[:, None], other=0.0
+        ).to(q_nope_ptr.dtype.element_ty)          # [NTOK*BLOCK_N, D_V]
+        kv_tail_cat = tl.load(
+            kbase + (D_V + dt)[None, :], mask=valid_page[:, None], other=0.0
+        ).to(q_nope_ptr.dtype.element_ty)          # [NTOK*BLOCK_N, D_TAIL]
 
-        qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
-        qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
-        qk = qk * sm_scale
-        qk = tl.where(valid[None, :], qk, -float("inf"))
+        # qk: [rows, NTOK*BLOCK_N]. dot M = rows = NTOK*H = 16 (legal).
+        qk = tl.dot(q_main, tl.trans(kv_main_cat)).to(tl.float32)
+        qk += tl.dot(q_tail, tl.trans(kv_tail_cat)).to(tl.float32)
+
+        # Block-diagonal mask: token t's rows only attend its own BLOCK_N cols.
+        valid_2d = (
+            (row_tok[:, None] == tok2[None, :])
+            & valid_page[None, :]
+            & kmask[None, :]
+        )                                          # [rows, NTOK*BLOCK_N]
+        qk = tl.where(valid_2d, qk * sm_scale, -float("inf"))
 
         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
-        # Guard an all-masked row (m_new == -inf): shift by 0 instead so that
-        # exp(-inf - 0) = 0 rather than exp(-inf + inf) = NaN. Identical to
-        # m_new whenever the row has >=1 valid key.
+        # Guard an all-masked row (m_new == -inf): shift by 0 rather than
+        # exp(-inf + inf) = NaN. Identical to m_new whenever the row has a key.
         m_safe = tl.where(m_new == -float("inf"), 0.0, m_new)
         alpha = tl.exp(m_i - m_safe)
-        p = tl.exp(qk - m_safe[:, None])  # [H, BLOCK_N]
+        p = tl.exp(qk - m_safe[:, None])           # [rows, NTOK*BLOCK_N]
         l_i = l_i * alpha + tl.sum(p, axis=1)
 
         p_fp8 = (p * fp8_max).to(q_nope_ptr.dtype.element_ty)
-        pv = tl.dot(p_fp8, kv_main).to(tl.float32) * (1.0 / fp8_max)
+        pv = tl.dot(p_fp8, kv_main_cat).to(tl.float32) * (1.0 / fp8_max)
         acc = acc * alpha[:, None] + pv
         m_i = m_new
 
     l_safe = tl.where(l_i == 0.0, 1.0, l_i)
     acc = acc / l_safe[:, None]
     tl.store(
-        o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :],
+        o_ptr + q_off_nope,
         acc.to(o_ptr.dtype.element_ty),
+        mask=q_mask,
     )
 
 
@@ -127,19 +168,24 @@ def triton_sparse_mla_fwd(
     """q_nope: [seq, H, d_v] fp8, q_rope: [seq, H, dim-d_v] fp8,
     kv: [num_pages, 1, dim] fp8, indices: [seq, 1, topk].
 
-    Reads q from the two un-concatenated tensors directly (no q_nope/q_rope
-    concat). Returns [1, seq, H, d_v] bf16 to match tilelang_sparse_fwd.
+    Fuses NTOK=2 query tokens per program so the MFMA M dimension is
+    NTOK*H = 16 (>= 16, legal on CDNA3) with no duplicate compute (v2).
+    Returns [1, seq, H, d_v] bf16 to match tilelang_sparse_fwd.
     """
     seq, H, d_v_in = q_nope.shape
     assert d_v_in == d_v
+    # v2 needs NTOK*H >= 16 for the tl.dot M dimension; with NTOK=2 that means
+    # H >= 8. The MI308X TP8 target has H=8 (8 heads/card) -> M = 16 exactly.
+    assert 2 * H >= 16, "gfx942 v2 kernel needs NTOK*H >= 16 (H >= 8 for NTOK=2)"
     d_tail = q_rope.shape[-1]
     dim = kv.shape[-1]
     topk = indices.shape[-1]
+
     q_nope = q_nope.contiguous()
     q_rope = q_rope.contiguous()
     out = torch.empty(seq, H, d_v, device=q_nope.device, dtype=torch.bfloat16)
-    # BLOCK_N / num_warps / num_stages are chosen by @triton.autotune.
-    _sparse_mla_fwd_kernel[(seq,)](
+    # grid: one program per NTOK tokens; BLOCK_N/warps/stages via autotune.
+    _sparse_mla_fwd_kernel[((seq + _NTOK - 1) // _NTOK,)](
         q_nope,
         q_rope,
         kv,
@@ -148,9 +194,11 @@ def triton_sparse_mla_fwd(
         sm_scale,
         _FP8_MAX,
         topk,
+        seq,
         H=H,
         DIM=dim,
         D_V=d_v,
         D_TAIL=d_tail,
+        NTOK=_NTOK,
     )
     return out.unsqueeze(0)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2125,13 +2125,17 @@ class DeepseekSparseAttnBackend(
             if q_rope is not None:
                 # Triton prefill kernel reads q_nope/q_rope directly, skipping
                 # the concat (it splits q into main/tail internally anyway).
-                # Gated to gfx950 + the validated shape (16 heads, d_v=512,
-                # tail=64, topk=2048); everything else uses TileLang.
+                # Gated to gfx950/gfx942 + the validated shape (8/16 heads,
+                # d_v=512, tail=64, topk=2048); everything else uses TileLang.
+                # 2026-09-10: gfx942 (MI308X) port from the MI350X TP4 validated
+                # config — the 8-heads case (TP8: 64 heads / 8 = 8 per card)
+                # merges 2 query tokens per program in the kernel wrapper so
+                # the MFMA M dimension stays 16 with zero wasted compute.
                 if (
                     _DSA_TRITON_PREFILL
-                    and _IS_GFX95
+                    and _is_hip
                     and kv_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
-                    and layer.tp_q_head_num == 16
+                    and layer.tp_q_head_num in (8, 16)
                     and layer.v_head_dim == 512
                     and (layer.head_dim - layer.v_head_dim) == 64
                     and page_table_1.shape[-1] == 2048


### PR DESCRIPTION
## Motivation

The Triton per-query sparse-MLA prefill kernel (`SGLANG_DSA_TRITON_PREFILL=1`) is gated to **gfx950 + exactly 16 q-heads per card**: the per-query program places the head count `H` on the MFMA **M** dimension, and CDNA matrix cores require `M >= 16`. On **gfx942 (MI308X)** with GLM-5.3-class models at **TP8** there are only **8 heads per card**, so the fast path was unreachable and DSA prefill always fell back to TileLang (~3200 tok/s ceiling measured on this shape).

## Modifications

**`triton_sparse_mla.py`** — merge **2 query tokens per program**: `2 tokens × 8 heads = 16 rows`, so `M = 16` is legal with **zero wasted compute** (no head padding/duplication, which was tried first and measured 2× FLOP waste → −5.7% at C=64). The two tokens' topk KV sets are gathered into a single `NTOK*BLOCK_N` column block and kept disjoint via a structured **block-diagonal mask** (`row_tok == tok2`), so tokens never attend each other's KV. Odd `seq_len` boundaries are handled by load/store masks on the trailing token. The fp8 numerics (QK in fp8, `p` quantized to fp8 for the PV dot) are unchanged.

**`dsa_backend.py`** — gate changes:
- `_IS_GFX95` → `_is_hip` (gfx942 is also a HIP arch; the kernel itself remains shape-gated)
- `tp_q_head_num == 16` → `in (8, 16)`

## Validation

Hardware: **8× MI308X (gfx942, ROCm 7.2.0)**, GLM-5.3 (`GlmMoeDsaForCausalLM`, FP8 block 128×128), TP8, EAGLE 5/1/6, `fp8_e4m3` KV, random ISL 8192 / OSL 1024, `n = CON × 10`.

**Correctness (three layers):**
1. Kernel-level deterministic comparison vs `tilelang_sparse_fwd` on fixed fp8 tensors (seq=512, H=8, d_v=512, tail=64, topk=2048, fnuz): **max_abs_diff 0.001984**, `allclose(atol=0.03) = True` — bf16-output-level equivalent.
2. Standalone unit test (even `seq=128` and odd `seq=127` boundary cases) vs a dense softmax-over-topk reference with identical fp8 numerics: max_abs_err **0.02474 / 0.01365**, both PASS at `atol=rtol=0.03`.
3. End-to-end EAGLE accept length stays **6.00 / rate 1.00** (greedy), same as the TileLang path.

**Throughput vs the TileLang prefill baseline** (identical server config, only `SGLANG_DSA_TRITON_PREFILL=1` differs):

| Point | Metric | TileLang | Triton 2-query | Δ |
|---|---|---|---|---|
| C=64 | Output tok/s | 283.45 | **365.03** | **+28.8%** |
| C=64 | Total tok/s | 2551 | **3285** | **+28.8%** |
| C=64 | TPOT ms | 160.4 | **123.7** | **−22.9%** |
| C=64 | TTFT ms | 63902 | **50079** | −21.6% |
| C=1 | TTFT ms | 3626 | **2266** | **−37.5%** |
| C=1 | Output tok/s | 87.5 | **118.9** | +35.9% |

## Notes for reviewers

- The 2-query merge also **unblocks the 8-heads-per-card shape on gfx950** (e.g. TP8 on MI350X), which the old `== 16` gate excluded.
- Serving-time autotune compilation of the merged kernel takes **~213 s** on first use (18 configs); pre-compile it during engine init or raise `--watchdog-timeout` for the first request. After the first compile the Triton cache hits and there is no recurring cost.
- A head-padding variant (pad 8→16 by row duplication) was built and measured first: correct but **−5.7%** at C=64 (50% wasted FLOPs) — the 2-query merge is the design that actually wins on this shape.

## Test plan

- [x] Standalone kernel unit test (even/odd seq, fp8-numerics-aligned reference) — PASS
- [x] Kernel-level deterministic diff vs `tilelang_sparse_fwd` — max_abs_diff 0.002
- [x] End-to-end EAGLE accept 6.00/rate 1.00 + exact output token counts
- [x] Full 7-point concurrency sweep (C=1..64) vs TileLang baseline
- [ ] gfx950 (MI350X) regression on the 16-heads path (TP4) — needs a gfx950 box
- [ ] Pre-compile / warmup integration so the 213 s autotune doesn't hit the watchdog on first request

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34443710894](https://github.com/sgl-project/sglang/actions/runs/34443710894)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34443710475](https://github.com/sgl-project/sglang/actions/runs/34443710475)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34443710549](https://github.com/sgl-project/sglang/actions/runs/34443710549)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->