### PR TITLE
[Docs] Add Qwen3-Next Ascend NPU deployment to the Cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3-Next.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3-Next.mdx
@@ -5,6 +5,9 @@ metatags:
 ---
 
 import { Qwen3NextDeployment } from '/src/snippets/autoregressive/qwen3-next-deployment.jsx';
+import { Deployment } from '/src/snippets/_deployment.jsx';
+import { config as ascendConfig } from '/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct.jsx';
+import { benchmarks as ascendBenchmarks } from '/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct-benchmarks.jsx';
 
 ## 1. Model Introduction
 
@@ -46,7 +49,21 @@ The Qwen3-Next series comes in only one size but offers different thinking modes
 
 <Qwen3NextDeployment />
 
-### 3.2 Configuration Tips
+<a id="ascend-npu-deployment" />
+
+### 3.2 Ascend NPU deployment
+
+The Cookbook also includes a deployment path based on the validated **Atlas 800I A3** best-practice configuration.
+The selector below currently exposes the supported **1-card PD co-located** scenario: prefill and decode run in the same process, and one A3 card contributes two dies, so the command uses `--tp-size 2`.
+
+Before you run the command, complete the [Ascend NPU quickstart](/docs/hardware-platforms/ascend-npus/getting-started/quick_start) or the [full installation guide](/docs/hardware-platforms/ascend-npus/getting-started/installation).
+Use the W8A8 main checkpoint and the BF16 checkpoint as the NEXTN draft model. The selector's **Env** control lets you set both local paths and the HCCL/Gloo interface. This is the only A3 launch recipe on this page. The pre-existing GPU examples below retain their stated platform scope and are not NPU launch recipes; do not use them as a substitute for the 1-card A3 command.
+
+<Deployment config={ascendConfig} benchmarks={ascendBenchmarks} />
+
+For model conversion, environment versions, and the reasoning behind each performance setting, see the [Qwen3-Next Ascend NPU tutorial](/docs/hardware-platforms/ascend-npus/model-deployment/tutorials/qwen3_next_80b_a3b_instruct) and [best-practice configuration](/docs/hardware-platforms/ascend-npus/model-deployment/best-practices/qwen3_next_80b_a3b_instruct).
+
+### 3.3 Configuration Tips
 
 - `--max-mamba-cache-size`: Adjust `--max-mamba-cache-size` to increase mamba cache space and max running requests capability. It will decrease KV cache space as a trade-off. You can adjust it according to workload.
 

--- a/docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct-benchmarks.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct-benchmarks.jsx
@@ -1,0 +1,32 @@
+export const benchmarks = [
+  {
+    match: {
+      hw: "a3",
+      variant: "instruct",
+      quant: "w8a8",
+      deployment: "pd-colocated",
+      nodes: "single",
+    },
+    sglang_version: "v0.5.16 Ascend NPU run (2026-09-08)",
+    latencyPercentile: "Mean",
+    accuracy: {
+      gsm8k_pct: 97.0,
+    },
+    speed: [
+      {
+        workload: {
+          dataset: "random",
+          isl: 3500,
+          osl: 1500,
+          max_concurrency: 1,
+          num_prompts: 1,
+        },
+        ttft_ms: 563.17,
+        tpot_ms: 11.84,
+        // The run used TP=2, so this is total throughput divided by two dies.
+        tokens_per_sec_per_gpu: 136.18,
+      },
+    ],
+    notes: "One-request random run at 3.5k input / 1.5k output. Total throughput was 272.35 tok/s across two NPU dies; output throughput was 81.71 tok/s and mean speculative accept length was 3.93. The 11.84 ms mean TPOT is below the 20 ms best-practice target. Re-run on your target host before comparing results.",
+  },
+];

--- a/docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct.jsx
@@ -1,0 +1,173 @@
+// Ascend NPU cookbook configuration for Qwen3-Next-80B-A3B-Instruct.
+// The deployment recipe follows the validated 1-card A3 PD mixed reference.
+
+export const config = {
+  modelName: "Qwen3-Next-80B-A3B-Instruct",
+
+  // One A3 card contains two dies, so the recipe uses TP=2.
+  supportedHardware: ["a3"],
+  hardware: [
+    { id: "a3", label: "Atlas 800I A3 (1 card)", vram: "64GB/die", vendor: "npu" },
+  ],
+
+  matchDims: [
+    {
+      id: "variant",
+      title: "Model variant",
+      options: [{ id: "instruct", label: "Instruct" }],
+    },
+    {
+      id: "quant",
+      title: "Quantization",
+      options: [{ id: "w8a8", label: "W8A8 INT8" }],
+    },
+    {
+      id: "deployment",
+      title: "Deployment mode",
+      options: [
+        { id: "pd-colocated", label: "PD co-located", subtitle: "Prefill + decode" },
+      ],
+    },
+    {
+      id: "nodes",
+      title: "Nodes",
+      options: [{ id: "single", label: "Single node" }],
+    },
+  ],
+
+  modelNames: {
+    "instruct|w8a8": "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8",
+  },
+
+  placeholders: {
+    MODEL_PATH: {
+      target: "command",
+      label: "Main model path",
+      default: "/path/to/Qwen3-Next-80B-A3B-Instruct-W8A8",
+    },
+    DRAFT_MODEL_PATH: {
+      target: "command",
+      label: "Draft model path",
+      default: "/path/to/Qwen3-Next-80B-A3B-Instruct",
+    },
+    NETWORK_IFACE: {
+      target: "command",
+      label: "HCCL/Gloo interface",
+      default: "<network-interface>",
+    },
+    HOST_IP: { target: "command", label: "Bind host", default: "127.0.0.1" },
+    PORT: { target: "command", label: "Bind port", default: "6688" },
+    CURL_HOST: { target: "curl", label: "Server host", default: "127.0.0.1" },
+    CURL_PORT: { target: "curl", label: "Server port", default: "6688" },
+  },
+
+  curl: `curl http://{{CURL_HOST}}:{{CURL_PORT}}/generate \\
+  -H 'Content-Type: application/json' \\
+  -d '{"text":"What is the capital of France?","sampling_params":{"temperature":0,"max_new_tokens":64}}'`,
+
+  benchmarkCommands: {
+    speed:
+`python3 -m sglang.benchmark.serving \\
+  --dataset-name random \\
+  --backend sglang \\
+  --host {{CURL_HOST}} --port {{CURL_PORT}} \\
+  --max-concurrency {{MAX_CONCURRENCY}} \\
+  --num-prompts {{NUM_PROMPTS}} \\
+  --random-input-len {{ISL}} \\
+  --random-output-len {{OSL}} \\
+  --random-range-ratio 1 \\
+  --seed 1`,
+    numPromptsByConc: { 1: 1 },
+    accuracy: {
+      gsm8k_pct:
+`python3 -m sglang.test.run_eval \\
+  --eval-name gsm8k \\
+  --api generate \\
+  --host {{CURL_HOST}} --port {{CURL_PORT}} \\
+  --num-examples 100 \\
+  --num-shots 5 \\
+  --num-threads 1 \\
+  --max-tokens 512 \\
+  --temperature 0`,
+    },
+  },
+
+  // This recipe is validated as a host Python launch. Do not present a Docker
+  // command until its image, device mapping, and host mounts are verified.
+  runModes: ["python"],
+  showPlaygroundLink: false,
+
+  accuracyLabels: [
+    ["gsm8k_pct", "GSM8K (100, 5-shot)", "%"],
+  ],
+
+  github: {
+    cookbookModel: "vllm-ascend/Qwen3-Next-80B-A3B-Instruct-W8A8",
+  },
+
+  cells: [
+    {
+      match: {
+        hw: "a3",
+        variant: "instruct",
+        quant: "w8a8",
+        deployment: "pd-colocated",
+        nodes: "single",
+      },
+      verified: true,
+      env: [
+        "ASCEND_USE_FIA=1",
+        "DEEPEP_HCCL_BUFFSIZE=2000",
+        "DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=2048",
+        "DEEPEP_NORMAL_LONG_SEQ_ROUND=10",
+        "FORCE_DRAFT_MODEL_NON_QUANT=1",
+        "GLOO_SOCKET_IFNAME={{NETWORK_IFACE}}",
+        "HCCL_OP_EXPANSION_MODE=AIV",
+        "HCCL_SOCKET_IFNAME={{NETWORK_IFACE}}",
+        "PYTORCH_NPU_ALLOC_CONF=expandable_segments:True",
+        "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=400",
+        "SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1",
+        "SGLANG_ENABLE_SPEC_V2=1",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
+        "SGLANG_NPU_USE_MULTI_STREAM=0",
+        "SGLANG_SET_CPU_AFFINITY=1",
+        "SGLANG_WARMUP_TIMEOUT=3600",
+        "STREAMS_PER_DEVICE=32",
+        "TASK_QUEUE_ENABLE=1",
+        "ZBCCL_BOOTSTRAP_URL=tcp://127.0.0.1:24669",
+        "ZBCCL_ENABLE_GRAPH=1",
+        "ZBCCL_LOCAL_MEM_SIZE=60416",
+        "ZBCCL_NPU_ALLOC_CONF=use_vmm_for_static_memory:True",
+      ],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_PATH}}",
+        "--attention-backend ascend",
+        "--device npu",
+        "--quantization modelslim",
+        "--page-size 128",
+        "--tp-size 2",
+        "--watchdog-timeout 9000",
+        "--mem-fraction-static 0.85",
+        "--disable-radix-cache",
+        "--max-prefill-tokens 28672",
+        "--context-length 26384",
+        "--max-total-tokens 122304",
+        "--speculative-algorithm NEXTN",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--speculative-draft-model-quantization unquant",
+        "--speculative-draft-model-path {{DRAFT_MODEL_PATH}}",
+        "--chunked-prefill-size -1",
+        "--max-running-requests 2",
+        "--cuda-graph-bs-decode 2",
+        "--mamba-ssm-dtype bfloat16",
+        "--reasoning-parser qwen3",
+        "--tool-call-parser qwen3_coder",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
# Add Qwen3-Next 1-card Ascend NPU deployment to the Cookbook

## Motivation

Related issue: https://github.com/Ascend/sglang/issues/1217

The existing Ascend documentation already contains the validated `Qwen3-Next-80B-A3B-Instruct` best-practice command, but the Qwen3-Next Cookbook page does not expose an Ascend NPU scenario. Users therefore have to translate a platform-specific command into the model Cookbook by hand. This change adds the verified one-card Atlas 800I A3 deployment as a selectable Cookbook scenario while keeping the existing GPU examples unchanged.

## Modifications

- Add an Ascend NPU deployment section to `docs/cookbook/autoregressive/Qwen/Qwen3-Next.mdx`.
- Add a data-driven selector for one Atlas 800I A3 card (two dies), single-node PD co-located serving, W8A8 main weights, BF16 NEXTN draft weights, and `--tp-size 2` in `docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct.jsx`.
- Add the measured A3 accuracy and speed cell in `docs/src/snippets/configs/Qwen/qwen3-next-80b-a3b-instruct-benchmarks.jsx`.

## Accuracy Tests

The exact one-card A3 command was run with two logical NPU ranks, the W8A8 main checkpoint, the BF16 NEXTN draft checkpoint, and the validated Ascend environment. The server reached the ready state and returned HTTP 200 for the `/generate` smoke request; the capital-of-France prompt returned `Paris`.

GSM8K was run serially with 100 examples, 5 shots, temperature 0, and a maximum of 512 generated tokens:

- Accuracy: **0.970**
- Invalid responses: **0.000**

After evaluation, `/health` continued to return HTTP 200 and both A3 dies remained healthy.

## Speed Tests and Profiling

The reference random workload used input length 3500, output length 1500, concurrency 1, one prompt, range ratio 1, and seed 1. The measured results were:

| Measurement | Result |
| --- | ---: |
| TTFT | 563.17 ms |
| TPOT | 11.84 ms |
| Output throughput | 81.71 tokens/s |
| Total throughput across two dies | 272.35 tokens/s |
| Throughput per logical die | 136.18 tokens/s |
| Mean speculative acceptance length | 3.93 |

The measured TPOT is below the 20 ms target reported by the referenced Ascend best-practice configuration. 

## Documentation Checks

- `node docs/scripts/check_cookbook_configs.mjs`
- `mint validate` from `docs/`
- `mint broken-links --check-anchors --check-redirects` from `docs/`
- Local Mint preview: the page and the Ascend deployment anchor returned HTTP 200 and rendered the A3/PD content.
- File-scoped pre-commit hooks and `git diff --check`.

## Checklist

- [x] Add the Ascend NPU Cookbook scenario and measured benchmark cell.
- [x] Verify the generated one-card A3 service command, request, accuracy, and speed workload.
- [x] Validate Cookbook configuration, links, preview, formatting, and hooks.
- [x] Provide the separately applicable CANN 9.1 `sgl-kernel-npu` patch and reproducible application steps.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34444443171](https://github.com/sgl-project/sglang/actions/runs/34444443171)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34444442989](https://github.com/sgl-project/sglang/actions/runs/34444442989)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->