### PR TITLE
[Kimi-K3] O(1) expert weight lookup in load_weights

### DIFF
--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -8,6 +8,7 @@
 
 import logging
 import os
+import re
 from collections.abc import Iterable
 from functools import cached_property
 from types import SimpleNamespace
@@ -136,6 +137,10 @@ from sglang.srt.utils.common import (
 )
 
 logger = logging.getLogger(__name__)
+
+# `experts.<expert_id>.<w1|w2|w3>.` fragment of a checkpoint tensor name, the
+# key FusedMoE.make_expert_params_mapping entries match on.
+_EXPERT_WEIGHT_NAME = re.compile(r"experts\.\d+\.w[123]\.")
 _is_hip = is_hip()
 _is_npu = is_npu()
 _aiter_k3_opt = get_bool_env_var("SGLANG_AITER_K3_OPT")
@@ -3174,6 +3179,11 @@ class KimiK3LinearForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        # Scanning expert_params_mapping (num_experts * 3 entries) for every
+        # checkpoint tensor is O(num_experts) per tensor; with 896 experts and
+        # ~500k expert tensors that is a minute of pure string matching. Key
+        # the mapping by its `experts.<id>.<proj>.` fragment instead.
+        expert_params_lookup = {entry[1]: entry for entry in expert_params_mapping}
 
         num_hidden_layers = self.config.num_hidden_layers
         for args in weights:
@@ -3258,27 +3268,28 @@ class KimiK3LinearForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                for idx, (param_name, weight_name, expert_id, shard_id) in enumerate(
-                    expert_params_mapping
-                ):
-                    if weight_name not in name:
-                        continue
+                expert_match = _EXPERT_WEIGHT_NAME.search(name)
+                expert_entry = (
+                    expert_params_lookup.get(expert_match.group(0))
+                    if expert_match
+                    else None
+                )
+                if expert_entry is not None:
+                    param_name, weight_name, expert_id, shard_id = expert_entry
                     name = name.replace(weight_name, param_name)
                     # Skip experts of layers outside a truncated config (e.g.
                     # num_hidden_layers override), mirroring the non-expert
                     # `name not in params_dict` guard below.
-                    if name not in params_dict:
-                        break
-                    param = params_dict[name]
-                    weight_loader = param.weight_loader
-                    weight_loader(
-                        param,
-                        loaded_weight,
-                        name,
-                        expert_id=expert_id,
-                        shard_id=shard_id,
-                    )
-                    break
+                    if name in params_dict:
+                        param = params_dict[name]
+                        weight_loader = param.weight_loader
+                        weight_loader(
+                            param,
+                            loaded_weight,
+                            name,
+                            expert_id=expert_id,
+                            shard_id=shard_id,
+                        )
                 else:
                     if (
                         name.endswith(".bias")


### PR DESCRIPTION
## Motivation

`KimiK3LinearForCausalLM.load_weights` matches every checkpoint tensor against `expert_params_mapping` with a linear scan:

```python
for idx, (param_name, weight_name, expert_id, shard_id) in enumerate(expert_params_mapping):
    if weight_name not in name:
        continue
```

`make_expert_params_mapping` returns `num_experts * 3` entries. Kimi-K3 has 896 experts, so the list has 2688 entries, and the checkpoint has ~495k per-expert tensors (92 MoE layers × 896 experts × w1/w2/w3 × `weight_packed` + `weight_scale`). Every one of them walks on average half the list before it hits, which is pure Python string matching costing tens of seconds per rank on every load, in addition to the actual I/O and `weight_loader` work.

## Modifications

Build a dict keyed by the `experts.<id>.<proj>.` fragment once, extract that fragment from the tensor name with a regex, and look it up. The fallthrough for non-expert names and the truncated-config guard (`name not in params_dict`) behave exactly as before; the change is confined to `load_weights`.

## Benchmark

Name matching only, no weights involved. The script builds the Kimi-K3 tensor name list (494,868 names) and the real `FusedMoE.make_expert_params_mapping` output and times the old and the new matching strategy:

<details>
<summary>bench_expert_lookup.py</summary>

```python
import re
import time

from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE

LAYERS, EXPERTS = 92, 896
EXPERT_RE = re.compile(r"experts\.\d+\.w[123]\.")


def checkpoint_names():
    for layer in range(LAYERS):
        prefix = f"model.layers.{layer}"
        for suffix in ("input_layernorm.weight", "self_attn.o_proj.weight", "mlp.gate.weight"):
            yield f"{prefix}.{suffix}"
        for expert in range(EXPERTS):
            for proj in ("w1", "w2", "w3"):
                yield f"{prefix}.mlp.experts.{expert}.{proj}.weight_packed"
                yield f"{prefix}.mlp.experts.{expert}.{proj}.weight_scale"


def match_scan(names, mapping):
    hits = 0
    for name in names:
        for param_name, weight_name, expert_id, shard_id in mapping:
            if weight_name not in name:
                continue
            hits += 1
            break
    return hits


def match_lookup(names, mapping):
    lookup = {entry[1]: entry for entry in mapping}
    hits = 0
    for name in names:
        found = EXPERT_RE.search(name)
        entry = lookup.get(found.group(0)) if found else None
        if entry is not None:
            hits += 1
    return hits


def timed(fn, names, mapping):
    start = time.perf_counter()
    hits = fn(names, mapping)
    return hits, time.perf_counter() - start


def main():
    names = list(checkpoint_names())
    mapping = FusedMoE.make_expert_params_mapping(
        ckpt_gate_proj_name="w1",
        ckpt_down_proj_name="w2",
        ckpt_up_proj_name="w3",
        num_experts=EXPERTS,
    )
    print(f"{len(names)} tensor names, {len(mapping)} expert mapping entries")
    hits_scan, t_scan = timed(match_scan, names, mapping)
    hits_lookup, t_lookup = timed(match_lookup, names, mapping)
    assert hits_scan == hits_lookup, (hits_scan, hits_lookup)
    print(f"scan   : {t_scan:8.2f} s  ({t_scan / len(names) * 1e6:6.1f} us/tensor, {hits_scan} expert hits)")
    print(f"lookup : {t_lookup:8.2f} s  ({t_lookup / len(names) * 1e6:6.1f} us/tensor, {hits_lookup} expert hits)")
    print(f"speedup: {t_scan / t_lookup:.0f}x")


if __name__ == "__main__":
    main()
```

</details>

```
494868 tensor names, 2688 expert mapping entries
scan   :    21.45 s  (  43.3 us/tensor, 494592 expert hits)
lookup :     0.13 s  (   0.3 us/tensor, 494592 expert hits)
speedup: 161x
```

(Grace CPU; the per-tensor cost of the scan is higher inside a real load where the interpreter is also busy with the weight loaders.)

## End-to-end A/B

Kimi-K3 (MXFP4, 96 shards, 1.56 TB), TP8 across two 4×GB300 nodes, default safetensors loader from a shared filesystem, page cache dropped before each run so both are cold. Same flags, same greedy outputs on three prompts.

| | `Load weight end` per rank | launch → `/health` |
|---|---:|---:|
| main | 600–638 s | 763 s |
| this PR | 554–601 s | 707 s |

Within a run the two nodes differ by ~40 s because of I/O; the per-node improvement is 38–46 s on every rank.

With the weights already resident (an in-process loader that hands `load_weights` device tensors, no I/O), the same change takes the load from 75 s to 46 s per rank, and a cProfile of the remaining time shows no single hot spot beyond the per-expert `weight_loader` calls themselves.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UkHz3WSxr8svfKaHWZj6p

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35406441939](https://github.com/sgl-project/sglang/actions/runs/35406441939)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35406441784](https://github.com/sgl-project/sglang/actions/runs/35406441784)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35406442093](https://github.com/sgl-project/sglang/actions/runs/35406442093)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->