### PR TITLE
[Router] Add --override-sampling-params fleet-wide sampling contract

### DIFF
--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -68,6 +68,97 @@ The Indexer replaces the Router-local radix tree as the native Cache-Aware
 signal. Query timeouts and local concurrency are bounded by the two Indexer
 options, which default to 100 ms and 32 respectively.
 
+### Fleet-wide sampling contract
+
+`--override-sampling-params` fixes the sampling configuration for every client
+of this router, independently of what the engine's own defaults happen to be:
+
+```bash
+sgl-router \
+  --model-id qwen3 \
+  --tokenizer-path /models/qwen3/tokenizer.json \
+  --worker-urls http://10.0.0.1:30000 \
+  --override-sampling-params '{"temperature": 1, "top_p": 0.95, "n": 1}' \
+  --sampling-param-conflict reject
+```
+
+It takes one JSON object keyed by the request-body field names
+(`temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`,
+`frequency_penalty`, `presence_penalty`, `n`). A configured value is injected
+whenever the request omits that field, so the engine's defaults cannot drift
+from what the operator declared. `temperature`, `top_p`, `top_k`, `min_p` and
+`repetition_penalty` are the five the engine resolves from the model's own
+`generation_config`, which is what makes them drift when a deployed image
+changes; the rest have fixed API defaults.
+
+An explicit `null` counts as omitting the field, not as a client-supplied
+value: the OpenAI API types these parameters as nullable with a documented
+default, so `null` asks for the default — and on a governed fleet the
+configured value is what the default is.
+
+For a request that does send a value, `--sampling-param-conflict` decides:
+`reject` (the default) 400s a differing value before admission, while `allow`
+forwards the client's value untouched — the router never silently rewrites what
+a client sent. A `reject` response carries
+`x-router-error-code: sampling_contract_violation` and is counted in
+`sgl_router_sampling_contract_rejections_total{param}`, so a rollout's blast
+radius is visible per parameter rather than folded into `bad_request`.
+
+A value may also be an inclusive band, `{"min": LO, "max": HI}`, for a
+parameter that stays tunable inside a range. A band names no value to inject,
+so it constrains only the requests that name the parameter; one that omits it
+gets the model's own `generation_config` default, which the router cannot see.
+Because a band can only ever reject, combining one with `allow` is a startup
+error.
+
+Values are range-checked at startup, so a misconfiguration fails the launch
+instead of 400ing every request at the engine. Repeating a key in the flag is
+also a startup error, rather than silently enforcing whichever copy came last.
+
+| parameter | accepted | notes |
+| --- | --- | --- |
+| `temperature` | `[0, 2]` | |
+| `top_p` | `(0, 1]` | |
+| `top_k` | `>= 1`, or exactly `-1` | `-1` is the engine's "whole vocabulary" spelling and its default. Being non-contiguous it cannot bound a band. Note `top_k: 1` is greedy decoding, not "disabled". |
+| `min_p` | `[0, 1]` | not an OpenAI parameter; the engine's domain |
+| `repetition_penalty` | `(0, 2]` | not an OpenAI parameter; the engine's domain |
+| `frequency_penalty` | `[-2, 2]` | |
+| `presence_penalty` | `[-2, 2]` | |
+| `n` | `[1, 128]` | |
+
+The OpenAI domains are deliberately narrower than what the engine itself
+accepts (`SamplingParams.verify` would take `temperature: 5`): these values are
+injected into request bodies, and a fleet contract outside the range every
+OpenAI client library validates against is far more likely a typo than an
+intent.
+
+Cost: a request that named every configured field forwards its original bytes
+untouched. One that omits a field has the scalars spliced directly into the
+body bytes — no parse, no re-serialize — which on a 16 MiB body is ~0.24 ms
+against ~5.7 ms for a `serde_json` round-trip. Only `input_ids` and PD
+bootstrap injection still parse and re-serialize, because those may have to
+overwrite a key the client sent.
+
+### Relationship to the engine's own `--preferred-sampling-params`
+
+The engine has an inject-when-absent flag of its own,
+`--preferred-sampling-params`, merged in
+`python/sglang/srt/managers/tokenizer_manager.py` as
+`{**preferred, **obj.sampling_params}`. On `/v1/chat/completions` it is
+currently a no-op: `ChatCompletionRequest.to_sampling_params`
+(`python/sglang/srt/entrypoints/openai/protocol.py`) resolves every sampling
+key eagerly through `generation_config` and then its own defaults, so the
+right-hand side of that merge is always fully populated and always wins.
+(`/v1/responses`, in the same file, already omits `None` entries for exactly
+this reason.) If that is fixed engine-side, `--preferred-sampling-params`
+covers the inject-when-absent half for a single engine.
+
+What stays the router's to own either way is the enforcement half: the
+`reject` immutability contract with its 400 before admission — costing no
+queue slot and no engine round-trip — the `sampling_contract_violation` code
+and per-parameter counter, bands, and one contract applied at a shared ingress
+across engines whose own flags the router operator may not control.
+
 ## Upgrading from `cache_aware_zmq`
 
 The `cache_aware_zmq` policy has been removed. Configurations using it should

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::num::NonZeroU32;
 
+use crate::config::sampling::{parse_sampling_overrides, ConflictPolicy, SamplingOverrides};
 use crate::config::{
     default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
     resolve_mode, ActiveLoadConfig, AffinityConfig, AffinityMode, CacheAwareConfig,
@@ -59,6 +60,33 @@ pub struct Cli {
     /// Static P/D bucket configuration. Omit to use the global candidate domain.
     #[arg(long)]
     pub bucket_config: Option<String>,
+
+    // ---- fleet-wide sampling contract (opt-in) ----
+    /// Sampling parameters fixed fleet-wide, as one JSON object keyed by the
+    /// request-body field names — e.g. `{"temperature": 1, "top_p": 0.95}`.
+    /// Keys: temperature, top_p, top_k, min_p, repetition_penalty,
+    /// frequency_penalty, presence_penalty, n. Each value is a number, or an
+    /// inclusive band `{"min": LO, "max": HI}`.
+    ///
+    /// A configured value is injected whenever the request omits that field;
+    /// `--sampling-param-conflict` decides what a request that sends one gets.
+    /// Unknown or repeated keys, out-of-domain values and a band under `allow`
+    /// all fail the launch, naming the offending key. Full contract — domains,
+    /// `null` handling, cost — in the router README.
+    #[arg(long, value_name = "JSON")]
+    pub override_sampling_params: Option<String>,
+    /// What a request that sends a value differing from
+    /// `--override-sampling-params` gets: `reject` (the default) 400s it
+    /// before admission, quoting the configured value; `allow` forwards the
+    /// client's value untouched. Only accepted alongside
+    /// `--override-sampling-params`.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "MODE",
+        requires = "override_sampling_params"
+    )]
+    pub sampling_param_conflict: Option<ConflictPolicy>,
 
     // ---- circuit breaker (opt-in via --cb-threshold) ----
     /// Consecutive upstream failures before the circuit breaker opens.
@@ -577,6 +605,13 @@ impl Cli {
             None
         };
 
+        let sampling_overrides = match &self.override_sampling_params {
+            None => SamplingOverrides::default(),
+            Some(raw) => {
+                parse_sampling_overrides(raw, self.sampling_param_conflict.unwrap_or_default())?
+            }
+        };
+
         let config = Config {
             server: ServerConfig {
                 host: self.host,
@@ -600,6 +635,7 @@ impl Cli {
                 affinity,
                 fused,
                 eligibility,
+                sampling_overrides,
             },
             discovery,
             proxy: ProxyConfig {
@@ -1884,5 +1920,65 @@ mod tests {
             buckets.tps_slo_policy,
             crate::config::SloBucketPolicy::BestEffort
         );
+    }
+
+    /// The flag reaches `ModelConfig`, and is opt-in: unset leaves the model
+    /// with an empty sampling contract, so no request is ever checked.
+    #[test]
+    fn override_sampling_params_reaches_the_model_config() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--override-sampling-params",
+            r#"{"temperature": 1, "top_p": 0.95}"#,
+        ]))
+        .unwrap();
+        assert_eq!(c.model.sampling_overrides.params.len(), 2);
+        // `reject` is the default mode: declaring a contract is the usual
+        // reason to declare one.
+        assert_eq!(c.model.sampling_overrides.conflict, ConflictPolicy::Reject);
+
+        let c = into_config_owned(with_model(&["--worker-urls", "http://x:30000"])).unwrap();
+        assert!(c.model.sampling_overrides.params.is_empty());
+    }
+
+    #[test]
+    fn sampling_param_conflict_selects_the_mode() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--override-sampling-params",
+            r#"{"temperature": 1}"#,
+            "--sampling-param-conflict",
+            "allow",
+        ]))
+        .unwrap();
+        assert_eq!(c.model.sampling_overrides.conflict, ConflictPolicy::Allow);
+
+        // The mode alone governs nothing, so clap rejects it (`requires`).
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--sampling-param-conflict",
+            "reject",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--override-sampling-params"), "got: {err}");
+    }
+
+    /// A malformed contract fails the launch with the parser's own message,
+    /// rather than starting a router that 400s every request at the engine.
+    #[test]
+    fn malformed_override_sampling_params_fails_the_launch() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--override-sampling-params",
+            r#"{"temp": 1}"#,
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unknown parameter"), "got: {err}");
     }
 }

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -1,6 +1,8 @@
 pub mod cli;
+pub mod sampling;
 pub mod types;
 pub use cli::Cli;
+pub use sampling::*;
 pub use types::*;
 
 use anyhow::{anyhow, Result};
@@ -18,6 +20,7 @@ impl Config {
         if let Some(bucket_config) = self.model.bucket_config.as_ref() {
             validate_bucket_config(bucket_config)?;
         }
+        self.model.sampling_overrides.validate()?;
         match &self.discovery {
             DiscoveryBackend::StaticUrls(s) => {
                 if s.urls.is_empty() {
@@ -223,6 +226,7 @@ mod tests {
                 affinity: None,
                 fused: None,
                 eligibility: None,
+                sampling_overrides: Default::default(),
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: urls.iter().map(|s| s.to_string()).collect(),

--- a/experimental/sgl-router/src/config/sampling.rs
+++ b/experimental/sgl-router/src/config/sampling.rs
@@ -1,0 +1,812 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fleet-wide sampling contract (`--override-sampling-params` /
+//! `--sampling-param-conflict`): the parameters an operator fixes for every
+//! request this router serves, and what a request that disagrees gets.
+//!
+//! WHY this is parsed by hand rather than with `serde(deny_unknown_fields)`:
+//! the flag is read once, at startup, on a router that crash-loops if it is
+//! wrong, so the message an operator reads out of `kubectl logs` is the whole
+//! debugging session. Every rejection here names the offending key, the value
+//! it saw, and the domain it violated. The same reasoning is why both the
+//! outer object and a band are decoded as ordered ENTRIES instead of a
+//! `serde_json::Map`: a map keeps only the last of a repeated key, so
+//! `{"temperature": 0, "temperature": 1}` would start cleanly and enforce a
+//! value the operator did not write.
+
+use anyhow::{anyhow, Result};
+use std::collections::BTreeMap;
+
+/// Sampling parameters fixed fleet-wide, and what to do with a request that
+/// disagrees.
+///
+/// A configured parameter is always injected into the forwarded body when the
+/// request OMITS it, so the engine's own defaults cannot drift from what the
+/// operator declared. What differs between the two [`ConflictPolicy`] modes is
+/// only the request that DOES send the field: `Reject` makes the value an
+/// immutability contract (400 before admission — never a silent rewrite),
+/// while `Allow` lets the client value through untouched, degrading the
+/// configured value to a fleet-wide default.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SamplingOverrides {
+    /// Configured parameters, keyed so enforcement and injection are one loop
+    /// over whatever the operator set instead of a per-field ladder repeated
+    /// at each site. Iterating a `BTreeMap` keyed by the field enum is what
+    /// fixes the order values are injected in, so a forwarded body is
+    /// byte-identical across runs.
+    pub params: BTreeMap<SamplingField, ParamSpec>,
+    /// Applies to every configured parameter: there is deliberately no
+    /// per-parameter mode, so an operator reads one knob off one manifest.
+    pub conflict: ConflictPolicy,
+}
+
+impl SamplingOverrides {
+    /// Re-check every invariant [`parse_sampling_overrides`] enforces, on an
+    /// already-built value.
+    ///
+    /// WHY this is separate from the parser: the parser turns a raw JSON
+    /// string into this struct and is reachable only from the CLI, but the
+    /// struct itself is reachable from anywhere — a test fixture, a future
+    /// config file, an admin API. [`crate::config::Config::validate`] calls
+    /// this so no such path can hold a spec the flag would have refused to
+    /// start with (an out-of-domain exact value, an inverted band whose
+    /// `contains` rejects every value, or a band under `allow`, which names
+    /// nothing to inject and rejects nothing).
+    pub(crate) fn validate(&self) -> Result<()> {
+        for (&field, spec) in &self.params {
+            validate_spec(field, spec, self.conflict)?;
+        }
+        Ok(())
+    }
+}
+
+/// What a request sending a value that differs from the configured one gets
+/// (`--sampling-param-conflict`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum ConflictPolicy {
+    /// 400 before admission, quoting the configured value. The default: the
+    /// point of declaring a fleet-wide sampling contract is usually that it
+    /// holds, and silently serving something other than what the client asked
+    /// for is the one behavior no client can detect.
+    #[default]
+    Reject,
+    /// Forward the client's value to the engine untouched. The configured
+    /// value degrades to a fill-when-absent default.
+    Allow,
+}
+
+/// One configured parameter's value: a single value, or an inclusive band of
+/// accepted ones.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParamSpec {
+    /// A single value: injected when the request omits the field, and under
+    /// [`ConflictPolicy::Reject`] the only value a request may send.
+    ///
+    /// Held as the parsed JSON number rather than an `f64` so injection
+    /// re-emits the operator's literal — `"n": 1` stays `1` and does not
+    /// become `1.0` on the wire for the integer-typed fields.
+    Exact(serde_json::Number),
+    /// An inclusive `[lo, hi]` band of accepted values, for a contract that
+    /// fixes most sampling knobs but leaves one tunable inside a range. A band
+    /// names no single value, so it never injects; it only rejects
+    /// out-of-band values, which is why a band under [`ConflictPolicy::Allow`]
+    /// is a startup error rather than a no-op.
+    ///
+    /// A band therefore constrains only the requests that NAME the parameter.
+    /// A request that omits it gets the model's own default (the engine reads
+    /// `generation_config`), which the router cannot see and which may itself
+    /// lie outside the band. An operator who needs the omitting majority
+    /// pinned too wants an exact value, not a band.
+    Range { lo: f64, hi: f64 },
+}
+
+/// A sampling parameter that can be fixed fleet-wide. The enum is what makes a
+/// typo in the `--override-sampling-params` JSON a startup error instead of a
+/// key that silently never matches a request field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SamplingField {
+    Temperature,
+    TopP,
+    TopK,
+    MinP,
+    RepetitionPenalty,
+    FrequencyPenalty,
+    PresencePenalty,
+    N,
+}
+
+impl SamplingField {
+    /// Every field, in the order they are written into the forwarded body.
+    pub const ALL: [Self; 8] = [
+        Self::Temperature,
+        Self::TopP,
+        Self::TopK,
+        Self::MinP,
+        Self::RepetitionPenalty,
+        Self::FrequencyPenalty,
+        Self::PresencePenalty,
+        Self::N,
+    ];
+
+    /// This field's slot in [`Self::ALL`], and in the request probe's
+    /// fixed-size array of probed values.
+    ///
+    /// Declaration order IS the slot order, so this cannot assign a wrong
+    /// one. What still needs checking is that [`Self::ALL`] agrees — see the
+    /// assertion below; `from_wire_name` and `supported_fields` both iterate
+    /// `ALL`, so a field missing from it is rejected at startup as an unknown
+    /// key, the failure that is invisible to any test that also iterates
+    /// `ALL`.
+    pub const fn index(self) -> usize {
+        self as usize
+    }
+
+    /// The request-body key, identical on the wire in and out: the JSON config
+    /// names the parameter exactly as a client sends it.
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            Self::Temperature => "temperature",
+            Self::TopP => "top_p",
+            Self::TopK => "top_k",
+            Self::MinP => "min_p",
+            Self::RepetitionPenalty => "repetition_penalty",
+            Self::FrequencyPenalty => "frequency_penalty",
+            Self::PresencePenalty => "presence_penalty",
+            Self::N => "n",
+        }
+    }
+
+    /// Parse a key from the `--override-sampling-params` JSON object.
+    pub fn from_wire_name(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|f| f.wire_name() == key)
+    }
+
+    /// True for the fields the engine types as `int`, which a configured value
+    /// must therefore be integral for.
+    pub const fn is_integral(self) -> bool {
+        matches!(self, Self::TopK | Self::N)
+    }
+}
+
+/// [`SamplingField::ALL`] agrees with [`SamplingField::index`] — see that
+/// method for why a disagreement is a silent startup rejection.
+const _: () = {
+    let mut i = 0;
+    while i < SamplingField::ALL.len() {
+        assert!(SamplingField::ALL[i].index() == i);
+        i += 1;
+    }
+};
+
+/// Parse `--override-sampling-params` into a [`SamplingOverrides`].
+pub(crate) fn parse_sampling_overrides(
+    raw: &str,
+    conflict: ConflictPolicy,
+) -> Result<SamplingOverrides> {
+    let ObjectEntries(entries) = serde_json::from_str(raw).map_err(|e| {
+        anyhow!(
+            "--override-sampling-params must be a JSON object like \
+             '{{\"temperature\": 1, \"top_p\": 0.95}}': {e}"
+        )
+    })?;
+    if entries.is_empty() {
+        return Err(anyhow!(
+            "--override-sampling-params is empty: pass at least one of {}, or omit the flag",
+            supported_fields()
+        ));
+    }
+    let mut params = BTreeMap::new();
+    for (key, value) in entries {
+        let field = SamplingField::from_wire_name(&key).ok_or_else(|| {
+            anyhow!(
+                "--override-sampling-params: unknown parameter \"{key}\" (supported: {})",
+                supported_fields()
+            )
+        })?;
+        let spec = match value {
+            ParamValue::Number(n) => {
+                ParamSpec::Exact(canonical_number(field, checked_value(field, &n)?, n))
+            }
+            ParamValue::Band(entries) => parse_band(field, entries)?,
+            ParamValue::Other(other) => {
+                return Err(anyhow!(
+                    "--override-sampling-params: {key} must be a number or a \
+                     {{\"min\": LO, \"max\": HI}} band, got {other}"
+                ))
+            }
+        };
+        if params.insert(field, spec).is_some() {
+            return Err(anyhow!(
+                "--override-sampling-params: {} is set more than once",
+                field.wire_name()
+            ));
+        }
+    }
+    let overrides = SamplingOverrides { params, conflict };
+    // Re-checks the domains `checked_value` already covered above. That first
+    // pass is not redundant: it is what quotes the operator's own literal
+    // (`1e2`, not `100`) and what guards `canonical_number`'s saturating
+    // `as i64` cast before it runs. This pass is what a hand-built
+    // `SamplingOverrides` gets, and is the only check a band's bounds see.
+    overrides.validate()?;
+    Ok(overrides)
+}
+
+/// Check one already-built spec. Shared by [`parse_sampling_overrides`] and
+/// [`SamplingOverrides::validate`] so a hand-built `SamplingOverrides` is held
+/// to exactly the domain the flag is.
+fn validate_spec(field: SamplingField, spec: &ParamSpec, conflict: ConflictPolicy) -> Result<()> {
+    let key = field.wire_name();
+    match spec {
+        ParamSpec::Exact(n) => {
+            checked_value(field, n)?;
+        }
+        &ParamSpec::Range { lo, hi } => {
+            check_domain(field, lo, &lo.to_string())?;
+            check_domain(field, hi, &hi.to_string())?;
+            if lo > hi {
+                return Err(anyhow!(
+                    "--override-sampling-params: {key} band needs min <= max, got min {lo} > max {hi}"
+                ));
+            }
+            // Bounds are checked one at a time, which is only sufficient for a
+            // contiguous domain. `top_k`'s is not ({-1} U [1, inf)): `{"min": -1,
+            // "max": 100}` has two individually legal bounds and would admit
+            // `top_k: 0`, which is rejected as an exact value. -1 is a sentinel,
+            // not a range endpoint.
+            if field == SamplingField::TopK && lo < 1.0 {
+                return Err(anyhow!(
+                    "--override-sampling-params: top_k band bounds must both be >= 1 \
+                     (-1 disables top_k entirely and cannot bound a range)"
+                ));
+            }
+            // A band only ever rejects, so under `allow` it would be dead config
+            // that silently accepts everything.
+            if conflict == ConflictPolicy::Allow {
+                return Err(anyhow!(
+                    "--override-sampling-params: the {key} band requires \
+                     --sampling-param-conflict reject — under `allow` nothing is rejected \
+                     and a band names no value to inject"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Turn one parameter's `{"min": LO, "max": HI}` entries into a
+/// [`ParamSpec::Range`].
+fn parse_band(
+    field: SamplingField,
+    entries: Vec<(String, serde_json::Value)>,
+) -> Result<ParamSpec> {
+    let key = field.wire_name();
+    let (mut min, mut max) = (None, None);
+    for (bound, v) in entries {
+        let slot = match bound.as_str() {
+            "min" => &mut min,
+            "max" => &mut max,
+            _ => {
+                return Err(anyhow!(
+                    "--override-sampling-params: {key} band must be exactly \
+                     {{\"min\": LO, \"max\": HI}}, got an unexpected \"{bound}\""
+                ))
+            }
+        };
+        if slot.is_some() {
+            return Err(anyhow!(
+                "--override-sampling-params: {key} band sets \"{bound}\" more than once"
+            ));
+        }
+        let serde_json::Value::Number(n) = v else {
+            return Err(anyhow!(
+                "--override-sampling-params: {key} band needs numeric bounds, got {bound}: {v}"
+            ));
+        };
+        *slot = Some(checked_value(field, &n)?);
+    }
+    let (Some(lo), Some(hi)) = (min, max) else {
+        return Err(anyhow!(
+            "--override-sampling-params: {key} band must be exactly \
+             {{\"min\": LO, \"max\": HI}} with numeric bounds"
+        ));
+    };
+    // `lo <= hi`, `top_k`'s discontiguous domain and the band-under-`allow`
+    // rule are all properties of the finished spec, so they live in
+    // `validate_spec` and hold for a hand-built `SamplingOverrides` too.
+    Ok(ParamSpec::Range { lo, hi })
+}
+
+/// Check one configured value against its parameter's domain, at startup
+/// instead of per request. Written as positive containment so a NaN bound
+/// fails too.
+///
+/// These are the OpenAI API's domains, which are NARROWER than what the engine
+/// itself accepts (`SamplingParams.verify` requires only that `temperature` be
+/// non-negative and finite, so it would take `temperature: 5`). Narrower is
+/// deliberate: the values here are injected into request bodies, and a fleet
+/// contract outside the range every OpenAI client library validates against is
+/// far more likely a typo than an intent. The one exception is `top_k`, where
+/// `-1` is the engine's own "disable / whole vocabulary" spelling and its
+/// default — a legitimate thing to fix fleet-wide. Note `top_k: 1` is greedy
+/// decoding, NOT "disabled".
+fn checked_value(field: SamplingField, n: &serde_json::Number) -> Result<f64> {
+    let name = field.wire_name();
+    // `as_f64` is infallible for a JSON number unless serde_json's
+    // `arbitrary_precision` is on (it is not); kept total rather than
+    // `expect`-ing, so enabling that feature can't turn config into a panic.
+    let v = n.as_f64().ok_or_else(|| {
+        anyhow!("--override-sampling-params: {name} ({n}) is not a finite number")
+    })?;
+    // The operator's own literal is what the message quotes, not the parsed
+    // f64: `1e2` should read back as `1e2`.
+    check_domain(field, v, &n.to_string())?;
+    Ok(v)
+}
+
+/// The domain half of [`checked_value`], over an f64 that may not have come
+/// from a literal (a band's bounds are stored as f64). `shown` is what the
+/// error quotes back to the operator.
+fn check_domain(field: SamplingField, v: f64, shown: &str) -> Result<()> {
+    let name = field.wire_name();
+    let (ok, domain) = match field {
+        SamplingField::Temperature => ((0.0..=2.0).contains(&v), "in [0, 2]"),
+        SamplingField::TopP => (v > 0.0 && v <= 1.0, "in (0, 1]"),
+        SamplingField::TopK => (v >= 1.0 || v == -1.0, ">= 1, or -1 to disable"),
+        // Not an OpenAI parameter: `min_p` is the engine's own nucleus floor,
+        // and 0 is its default (disabled), so the whole [0, 1] range is
+        // legitimate to fix fleet-wide.
+        SamplingField::MinP => ((0.0..=1.0).contains(&v), "in [0, 1]"),
+        // Also engine-only. 1.0 is "no penalty"; the engine requires > 0, and
+        // values above ~2 degrade output badly enough that a fleet-wide pin
+        // there is far more likely a typo than an intent.
+        SamplingField::RepetitionPenalty => (v > 0.0 && v <= 2.0, "in (0, 2]"),
+        SamplingField::FrequencyPenalty | SamplingField::PresencePenalty => {
+            ((-2.0..=2.0).contains(&v), "in [-2, 2]")
+        }
+        // OpenAI caps `n` at 128. Unbounded here, a typo'd digit would be
+        // injected into every request that omits `n` and fan each one out to
+        // that many sequences at the engine — the exact per-request failure
+        // this startup check exists to convert into a launch failure.
+        SamplingField::N => ((1.0..=128.0).contains(&v), "in [1, 128]"),
+    };
+    if !ok {
+        return Err(anyhow!(
+            "--override-sampling-params: {name} ({shown}) must be {domain}"
+        ));
+    }
+    if field.is_integral() {
+        if v.fract() != 0.0 {
+            return Err(anyhow!(
+                "--override-sampling-params: {name} ({shown}) must be a whole number"
+            ));
+        }
+        // `canonical_number` casts to `i64`, and a Rust float-to-int cast
+        // SATURATES rather than failing, so a literal past the i64 range would
+        // silently become `i64::MAX` in every forwarded body. The exactly
+        // convertible f64s are [-2^63, 2^63), which is this half-open range
+        // written as positive containment — `i64::MAX as f64` rounds UP to
+        // 2^63, so an inclusive `<=` against it would admit 2^63 itself and
+        // saturate exactly as described.
+        if !(i64::MIN as f64..i64::MAX as f64).contains(&v) {
+            return Err(anyhow!(
+                "--override-sampling-params: {name} ({shown}) is too large to forward"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Normalize an integer-typed parameter's literal so injection writes `1`
+/// rather than `1.0` for a config that spelled it `1.0` — the engine types
+/// these fields as `int`, and the forwarded body should look like what a
+/// client would have sent. Non-integral fields keep the operator's literal.
+fn canonical_number(
+    field: SamplingField,
+    value: f64,
+    literal: serde_json::Number,
+) -> serde_json::Number {
+    if field.is_integral() {
+        serde_json::Number::from(value as i64)
+    } else {
+        literal
+    }
+}
+
+/// The supported `--override-sampling-params` keys, for error messages.
+fn supported_fields() -> String {
+    SamplingField::ALL
+        .iter()
+        .map(|f| f.wire_name())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// A JSON object decoded to its entries IN ORDER, keeping a repeated key
+/// instead of collapsing it. See the module WHY note.
+struct ObjectEntries(Vec<(String, ParamValue)>);
+
+impl<'de> serde::Deserialize<'de> for ObjectEntries {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct EntryVisitor;
+        impl<'de> serde::de::Visitor<'de> for EntryVisitor {
+            type Value = ObjectEntries;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a JSON object")
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<ObjectEntries, M::Error> {
+                let mut entries = Vec::new();
+                while let Some(entry) = map.next_entry::<String, ParamValue>()? {
+                    entries.push(entry);
+                }
+                Ok(ObjectEntries(entries))
+            }
+        }
+        // `deserialize_map` rejects a non-object with the type error the
+        // caller wraps into the flag's own message.
+        d.deserialize_map(EntryVisitor)
+    }
+}
+
+/// One parameter's raw value: a number, a band's entries, or anything else.
+/// `Other` keeps the offending value so the caller can name it, rather than
+/// degrading a wrong-type message into a serde type error behind the outer
+/// object's context.
+enum ParamValue {
+    Number(serde_json::Number),
+    Band(Vec<(String, serde_json::Value)>),
+    Other(serde_json::Value),
+}
+
+impl<'de> serde::Deserialize<'de> for ParamValue {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct ValueVisitor;
+        impl<'de> serde::de::Visitor<'de> for ValueVisitor {
+            type Value = ParamValue;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a number or a {\"min\": LO, \"max\": HI} band")
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<ParamValue, E> {
+                Ok(ParamValue::Number(v.into()))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<ParamValue, E> {
+                Ok(ParamValue::Number(v.into()))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<ParamValue, E> {
+                // `from_f64` is None only for NaN/inf, which JSON cannot
+                // express; `checked_value` rejects the null either way.
+                Ok(match serde_json::Number::from_f64(v) {
+                    Some(n) => ParamValue::Number(n),
+                    None => ParamValue::Other(serde_json::Value::Null),
+                })
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<ParamValue, M::Error> {
+                let mut entries = Vec::new();
+                while let Some(entry) = map.next_entry::<String, serde_json::Value>()? {
+                    entries.push(entry);
+                }
+                Ok(ParamValue::Band(entries))
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<ParamValue, E> {
+                Ok(ParamValue::Other(v.into()))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<ParamValue, E> {
+                Ok(ParamValue::Other(v.into()))
+            }
+
+            /// JSON `null`. There is deliberately no `visit_none`: this type
+            /// is only ever reached through `deserialize_any`, which routes
+            /// null here and never to the `Option` hook.
+            fn visit_unit<E>(self) -> Result<ParamValue, E> {
+                Ok(ParamValue::Other(serde_json::Value::Null))
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<ParamValue, A::Error> {
+                let mut items = Vec::new();
+                while let Some(v) = seq.next_element::<serde_json::Value>()? {
+                    items.push(v);
+                }
+                Ok(ParamValue::Other(serde_json::Value::Array(items)))
+            }
+        }
+        d.deserialize_any(ValueVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: &str) -> Result<SamplingOverrides> {
+        parse_sampling_overrides(raw, ConflictPolicy::Reject)
+    }
+
+    /// The exact value configured for one parameter, as an f64.
+    fn exact_of(o: &SamplingOverrides, field: SamplingField) -> Option<f64> {
+        match o.params.get(&field) {
+            Some(ParamSpec::Exact(n)) => n.as_f64(),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn parses_every_supported_parameter() {
+        let o = parse(
+            r#"{"temperature": 1, "top_p": 1.0, "top_k": 20,
+                "frequency_penalty": 0, "presence_penalty": -0.5, "n": 1}"#,
+        )
+        .unwrap();
+        assert_eq!(exact_of(&o, SamplingField::Temperature), Some(1.0));
+        assert_eq!(exact_of(&o, SamplingField::TopP), Some(1.0));
+        assert_eq!(exact_of(&o, SamplingField::TopK), Some(20.0));
+        assert_eq!(exact_of(&o, SamplingField::FrequencyPenalty), Some(0.0));
+        assert_eq!(exact_of(&o, SamplingField::PresencePenalty), Some(-0.5));
+        assert_eq!(exact_of(&o, SamplingField::N), Some(1.0));
+        assert_eq!(o.conflict, ConflictPolicy::Reject);
+    }
+
+    #[test]
+    fn parses_a_band() {
+        let o = parse(r#"{"temperature": {"min": 0, "max": 1}}"#).unwrap();
+        assert_eq!(
+            o.params.get(&SamplingField::Temperature),
+            Some(&ParamSpec::Range { lo: 0.0, hi: 1.0 })
+        );
+    }
+
+    /// A band can only ever reject, so under `allow` it would be dead config.
+    #[test]
+    fn a_band_under_allow_is_a_startup_error() {
+        let err = parse_sampling_overrides(
+            r#"{"temperature": {"min": 0, "max": 1}}"#,
+            ConflictPolicy::Allow,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("requires --sampling-param-conflict reject"),
+            "got: {err}"
+        );
+    }
+
+    /// Every malformed spelling fails the launch, naming the offending key and
+    /// its domain.
+    #[test]
+    fn rejects_malformed_input() {
+        for (json, needle) in [
+            ("not json", "must be a JSON object"),
+            ("[1, 2]", "must be a JSON object"),
+            (r#"[["temperature", 1]]"#, "must be a JSON object"),
+            ("{}", "is empty"),
+            (r#"{"temp": 1}"#, "unknown parameter"),
+            (r#"{"max_tokens": 100}"#, "unknown parameter"),
+            (r#"{"temperature": 2.5}"#, "in [0, 2]"),
+            (r#"{"temperature": -0.1}"#, "in [0, 2]"),
+            (r#"{"top_p": 0}"#, "in (0, 1]"),
+            (r#"{"top_p": 1.5}"#, "in (0, 1]"),
+            (r#"{"top_k": 0}"#, ">= 1"),
+            (r#"{"top_k": -2}"#, ">= 1"),
+            (r#"{"top_k": 1.5}"#, "whole number"),
+            (r#"{"frequency_penalty": 2.1}"#, "in [-2, 2]"),
+            (r#"{"presence_penalty": -2.1}"#, "in [-2, 2]"),
+            (r#"{"n": 0}"#, "in [1, 128]"),
+            (r#"{"n": 129}"#, "in [1, 128]"),
+            (r#"{"n": 1.5}"#, "whole number"),
+            (r#"{"n": 1e20}"#, "in [1, 128]"),
+            (r#"{"temperature": "1"}"#, "must be a number"),
+            (r#"{"temperature": true}"#, "must be a number"),
+            (r#"{"temperature": null}"#, "must be a number"),
+            (r#"{"temperature": [1]}"#, "must be a number"),
+            (
+                r#"{"temperature": 0, "temperature": 1}"#,
+                "temperature is set more than once",
+            ),
+            (r#"{"temperature": {"min": 1, "max": 0}}"#, "min <= max"),
+            (r#"{"temperature": {"min": 0, "max": 2.5}}"#, "in [0, 2]"),
+            (r#"{"temperature": {"min": 0}}"#, "band must be exactly"),
+            (
+                r#"{"temperature": {"min": 0, "max": 1, "typo": 2}}"#,
+                "unexpected \"typo\"",
+            ),
+            (
+                r#"{"temperature": {"min": 0, "max": 1, "max": 0.5}}"#,
+                "band sets \"max\" more than once",
+            ),
+            (
+                r#"{"temperature": {"min": "0", "max": "1"}}"#,
+                "needs numeric bounds",
+            ),
+            (
+                r#"{"top_k": {"min": -1, "max": 100}}"#,
+                "band bounds must both be >= 1",
+            ),
+        ] {
+            let err = parse(json).unwrap_err().to_string();
+            assert!(err.contains(needle), "{json}: got {err}");
+        }
+    }
+
+    /// `top_p`'s domain is (0, 1] — the inclusive upper bound is valid — and
+    /// `top_k` has no upper bound, so a wide sample width parses.
+    #[test]
+    fn top_p_upper_bound_and_wide_top_k_are_accepted() {
+        let o = parse(r#"{"top_p": 1, "top_k": 1000}"#).unwrap();
+        assert_eq!(exact_of(&o, SamplingField::TopP), Some(1.0));
+        assert_eq!(exact_of(&o, SamplingField::TopK), Some(1000.0));
+    }
+
+    /// `top_k: -1` is the engine's own "disable / whole vocabulary" spelling
+    /// (and its default), so a fleet may legitimately fix `top_k` to it —
+    /// unlike every other parameter, whose domain is the OpenAI one.
+    #[test]
+    fn top_k_accepts_the_engines_disable_sentinel() {
+        let o = parse(r#"{"top_k": -1}"#).unwrap();
+        assert_eq!(exact_of(&o, SamplingField::TopK), Some(-1.0));
+    }
+
+    /// An integer-typed parameter spelled as a float is normalized, so the
+    /// forwarded body carries `1` and not `1.0` for a field the engine types
+    /// as `int`.
+    #[test]
+    fn integral_params_are_normalized_to_integers() {
+        let o = parse(r#"{"n": 1.0, "top_k": 20.0}"#).unwrap();
+        for field in [SamplingField::N, SamplingField::TopK] {
+            let Some(ParamSpec::Exact(n)) = o.params.get(&field) else {
+                panic!("{field:?} must be an exact value");
+            };
+            assert!(n.is_i64(), "{field:?} kept a float literal: {n}");
+        }
+    }
+
+    /// The wire name is the request-body key in both directions, so a
+    /// configured key round-trips back to its field.
+    #[test]
+    fn every_field_round_trips_through_its_wire_name() {
+        for field in SamplingField::ALL {
+            assert_eq!(
+                SamplingField::from_wire_name(field.wire_name()),
+                Some(field)
+            );
+        }
+        assert_eq!(SamplingField::from_wire_name("max_tokens"), None);
+    }
+    /// `canonical_number` casts to `i64` and a Rust float-to-int cast
+    /// SATURATES, so a literal past the i64 range must fail the launch rather
+    /// than be injected as `i64::MAX`. The boundary case is the trap: `i64::MAX
+    /// as f64` rounds UP to 2^63, so a `>` comparison against it admits 2^63
+    /// itself.
+    #[test]
+    fn integral_literals_beyond_i64_fail_the_launch() {
+        for raw in [
+            // 2^63 exactly — equal to `i64::MAX as f64`, not greater than it.
+            r#"{"top_k": 9223372036854775808}"#,
+            // i64::MAX, which also rounds to 2^63 as an f64.
+            r#"{"top_k": 9223372036854775807}"#,
+            r#"{"top_k": 1e30}"#,
+        ] {
+            let err = parse(raw).unwrap_err().to_string();
+            assert!(err.contains("too large to forward"), "{raw}: got {err}");
+        }
+        // Nothing in range regressed.
+        assert_eq!(
+            exact_of(
+                &parse(r#"{"top_k": 1000000}"#).unwrap(),
+                SamplingField::TopK
+            ),
+            Some(1_000_000.0)
+        );
+    }
+
+    /// `min_p` and `repetition_penalty` are the only two parameters besides
+    /// `temperature`/`top_p`/`top_k` that the engine resolves from the model's
+    /// own `generation_config`, so they are exactly the ones a fleet-wide pin
+    /// exists to stop drifting when an image is swapped. Rejecting them as
+    /// unknown keys would crash-loop the router for the operator who needs the
+    /// flag most.
+    #[test]
+    fn governs_the_engine_defaulted_parameters() {
+        let o = parse(r#"{"min_p": 0.05, "repetition_penalty": 1.1}"#).unwrap();
+        assert_eq!(exact_of(&o, SamplingField::MinP), Some(0.05));
+        assert_eq!(exact_of(&o, SamplingField::RepetitionPenalty), Some(1.1));
+
+        // Both defaults are legitimate fleet-wide pins.
+        let o = parse(r#"{"min_p": 0, "repetition_penalty": 1}"#).unwrap();
+        assert_eq!(exact_of(&o, SamplingField::MinP), Some(0.0));
+        assert_eq!(exact_of(&o, SamplingField::RepetitionPenalty), Some(1.0));
+
+        for (raw, needle) in [
+            (r#"{"min_p": -0.1}"#, "in [0, 1]"),
+            (r#"{"min_p": 1.1}"#, "in [0, 1]"),
+            (r#"{"repetition_penalty": 0}"#, "in (0, 2]"),
+            (r#"{"repetition_penalty": 2.5}"#, "in (0, 2]"),
+        ] {
+            let err = parse(raw).unwrap_err().to_string();
+            assert!(err.contains(needle), "{raw}: got {err}");
+        }
+    }
+
+    /// `ALL` is what `from_wire_name` and `supported_fields` iterate, so a
+    /// field missing from it is silently rejected at startup as an unknown
+    /// key — invisible to any test that also iterates `ALL`. Pin the length
+    /// and the slot mapping against the wire names instead.
+    #[test]
+    fn all_covers_every_field_exactly_once() {
+        // The slot mapping itself is asserted at compile time (see the
+        // `const _` block above `parse_sampling_overrides`); what only a test
+        // can catch is a field missing from `ALL` entirely, which is why the
+        // names below are written out rather than derived from it.
+        let names: std::collections::BTreeSet<_> =
+            SamplingField::ALL.iter().map(|f| f.wire_name()).collect();
+        assert_eq!(names.len(), SamplingField::ALL.len(), "duplicate wire name");
+        for name in [
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "repetition_penalty",
+            "frequency_penalty",
+            "presence_penalty",
+            "n",
+        ] {
+            assert!(names.contains(name), "{name} is not governed");
+        }
+    }
+
+    /// The struct-level invariants must hold for a `SamplingOverrides` that
+    /// never went through the parser — a test fixture, a future config file or
+    /// admin API. An inverted band is the nastiest of these: `(lo..=hi)`
+    /// contains nothing, so it would 400 every request naming the parameter.
+    #[test]
+    fn validate_rejects_hand_built_specs_the_parser_would_refuse() {
+        let bad = [
+            (
+                ParamSpec::Exact(serde_json::Number::from_f64(50.0).unwrap()),
+                ConflictPolicy::Reject,
+                "in [0, 2]",
+            ),
+            (
+                ParamSpec::Range { lo: 1.0, hi: 0.0 },
+                ConflictPolicy::Reject,
+                "min <= max",
+            ),
+            (
+                ParamSpec::Range { lo: 0.0, hi: 1.0 },
+                ConflictPolicy::Allow,
+                "requires --sampling-param-conflict reject",
+            ),
+        ];
+        for (spec, conflict, needle) in bad {
+            let o = SamplingOverrides {
+                params: [(SamplingField::Temperature, spec)].into_iter().collect(),
+                conflict,
+            };
+            let err = o.validate().unwrap_err().to_string();
+            assert!(err.contains(needle), "got {err}");
+        }
+
+        // A well-formed contract still validates.
+        parse(r#"{"temperature": 1, "min_p": 0.05}"#)
+            .unwrap()
+            .validate()
+            .unwrap();
+    }
+}

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -1,3 +1,4 @@
+use crate::config::sampling::SamplingOverrides;
 use serde::Deserialize;
 use std::num::NonZeroU32;
 
@@ -312,6 +313,12 @@ pub struct ModelConfig {
     pub fused: Option<Vec<FusedTerm>>,
     /// Hard constraints applied before policy selection.
     pub eligibility: Option<EligibilityConfig>,
+    /// Sampling parameters fixed fleet-wide for this model, and what happens
+    /// to a request that sends a different value: a 400 before admission, or
+    /// the client value forwarded untouched. Either way the configured value
+    /// is injected when the request omits the field — see
+    /// [`SamplingOverrides`]. Empty (default) preserves today's behavior.
+    pub sampling_overrides: SamplingOverrides,
 }
 
 /// External KV Indexer client settings.

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -345,6 +345,7 @@ mod tests {
                 affinity: None,
                 fused: None,
                 eligibility: None,
+                sampling_overrides: Default::default(),
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -127,6 +127,7 @@ impl AppContext {
                     affinity: None,
                     fused: None,
                     eligibility: None,
+                    sampling_overrides: Default::default(),
                 },
                 discovery: crate::config::DiscoveryBackend::StaticUrls(
                     crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -17,6 +17,21 @@ pub enum ApiError {
     #[error("model not found: {0}")]
     ModelNotFound(String),
 
+    /// A request refused by the fleet-wide sampling contract
+    /// (`--override-sampling-params` under `--sampling-param-conflict
+    /// reject`).
+    ///
+    /// Distinct from [`Self::BadRequest`] on purpose: rolling a contract out
+    /// across a fleet turns previously-served client traffic into 400s, and
+    /// the operator's first question is how much and on which parameter.
+    /// Folded into `bad_request` that is unanswerable — the code would be the
+    /// same one malformed JSON and a missing `model` field already emit.
+    /// `param` is a `&'static str` from
+    /// [`crate::config::SamplingField::wire_name`], which keeps it usable as a
+    /// bounded metric label.
+    #[error("{param} is fixed by this deployment: {detail}")]
+    SamplingContract { param: &'static str, detail: String },
+
     /// Could not reach the upstream worker (connect refused, DNS, TLS, request
     /// build error). `source` captures the full anyhow chain for server-side
     /// logging; clients see a generic message.
@@ -114,6 +129,9 @@ impl ApiError {
     fn status_and_code(&self) -> (StatusCode, &'static str) {
         match self {
             ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
+            ApiError::SamplingContract { .. } => {
+                (StatusCode::BAD_REQUEST, "sampling_contract_violation")
+            }
             ApiError::ModelNotFound(_) => (StatusCode::NOT_FOUND, "model_not_found"),
             ApiError::UpstreamUnreachable { .. } => {
                 (StatusCode::BAD_GATEWAY, "upstream_unreachable")
@@ -242,7 +260,9 @@ impl IntoResponse for ApiError {
                 );
                 "service unavailable".to_string()
             }
-            ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
+            ApiError::BadRequest(_)
+            | ApiError::ModelNotFound(_)
+            | ApiError::SamplingContract { .. } => self.to_string(),
         };
         let mut resp = (
             status,
@@ -440,6 +460,29 @@ mod tests {
         assert!(
             !body_str.contains(secret_msg),
             "ApiError::Internal must not leak anyhow chain to client; got: {body_str}"
+        );
+    }
+    /// A sampling-contract rejection must not be filed under `bad_request`:
+    /// an operator rolling `--sampling-param-conflict reject` across a fleet
+    /// has to be able to alert on contract rejections without them being
+    /// indistinguishable from clients sending malformed JSON.
+    #[test]
+    fn sampling_contract_has_a_distinct_code_from_other_bad_requests() {
+        let err = ApiError::SamplingContract {
+            param: "temperature",
+            detail: "got 0.5, expected 1 (or omit the field)".into(),
+        };
+        let (status, code_header, env) = parse_envelope(err.into_response());
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(code_header.as_deref(), Some("sampling_contract_violation"));
+        assert_eq!(env.error.code, "sampling_contract_violation");
+        assert_ne!(env.error.code, "bad_request");
+        // The parameter and both values reach the client: a 400 here is
+        // actionable without an operator explaining it.
+        assert!(
+            env.error.message.contains("temperature") && env.error.message.contains("0.5"),
+            "got: {}",
+            env.error.message
         );
     }
 }

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -39,6 +39,7 @@
 //! | `sgl_router_cache_pressure_guard_override_total` | Counter | — |
 //! | `sgl_router_cache_monitor_decisions_total` | Counter | `source` |
 //! | `sgl_router_ingress_tokenize_errors_total` | Counter | `model_id` |
+//! | `sgl_router_sampling_contract_rejections_total` | Counter | `param` |
 //!
 //! The four `sgl_router_worker*` gauges and `sgl_router_workers` are sampled
 //! at scrape time from the live [`crate::workers::WorkerRegistry`] (passed to
@@ -245,6 +246,7 @@ pub struct MetricsRegistry {
     cache_pressure_guard_override_total: AtomicU64,
     cache_monitor_decisions_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     ingress_tokenize_errors_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    sampling_contract_rejections_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -576,6 +578,24 @@ impl MetricsRegistry {
         let mut guard = self.ingress_tokenize_errors_total.lock();
         let counter = guard
             .entry(model_id.to_owned())
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_sampling_contract_rejections_total{param}`.
+    ///
+    /// Recorded when the fleet-wide sampling contract refuses a request under
+    /// `--sampling-param-conflict reject`. This is the rollout gauge for the
+    /// flag: it answers "how much client traffic is the contract turning away,
+    /// and on which parameter" — which is otherwise unanswerable, because the
+    /// rejection reaches the client as a 400 like any other. `param` is a
+    /// wire name from a fixed enum, so the label set is bounded.
+    pub fn record_sampling_contract_rejection(&self, param: &'static str) {
+        let mut guard = self.sampling_contract_rejections_total.lock();
+        let counter = guard
+            .entry(param)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .clone();
         drop(guard);
@@ -959,6 +979,26 @@ impl MetricsRegistry {
             out.push_str(&format!(
                 "sgl_router_ingress_tokenize_errors_total{{model_id=\"{}\"}} {}\n",
                 escape_label(model_id),
+                value,
+            ));
+        }
+        drop(guard);
+
+        // sampling_contract_rejections_total
+        out.push_str(
+            "# HELP sgl_router_sampling_contract_rejections_total Requests refused by the fleet-wide sampling contract (--override-sampling-params under --sampling-param-conflict reject), by parameter.\n",
+        );
+        out.push_str("# TYPE sgl_router_sampling_contract_rejections_total counter\n");
+        let guard = self.sampling_contract_rejections_total.lock();
+        let mut entries: Vec<(&str, u64)> = guard
+            .iter()
+            .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by_key(|entry| entry.0);
+        for (param, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_sampling_contract_rejections_total{{param=\"{}\"}} {}\n",
+                escape_label(param),
                 value,
             ));
         }
@@ -1418,6 +1458,31 @@ mod tests {
         assert!(
             out.contains(r#"model_id="back\\slash""#),
             "render did not escape backslash; got:\n{out}",
+        );
+    }
+    /// The contract's rollout gauge: absent until a request is actually
+    /// refused, then keyed by the parameter that refused it.
+    #[test]
+    fn sampling_contract_rejections_are_keyed_by_param() {
+        let reg = MetricsRegistry::new();
+        let out = reg.render();
+        assert!(out.contains("# TYPE sgl_router_sampling_contract_rejections_total counter"));
+        assert!(
+            !out.contains("sgl_router_sampling_contract_rejections_total{"),
+            "must emit no series before the first rejection"
+        );
+
+        reg.record_sampling_contract_rejection("temperature");
+        reg.record_sampling_contract_rejection("temperature");
+        reg.record_sampling_contract_rejection("top_p");
+        let out = reg.render();
+        assert!(
+            out.contains(r#"sgl_router_sampling_contract_rejections_total{param="temperature"} 2"#),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains(r#"sgl_router_sampling_contract_rejections_total{param="top_p"} 1"#),
+            "got:\n{out}"
         );
     }
 }

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::{PolicyKind, SessionAffinityMode};
+use crate::config::{
+    ConflictPolicy, ParamSpec, PolicyKind, SamplingField, SamplingOverrides, SessionAffinityMode,
+};
 use crate::discovery::{ModelId, WorkerMode};
 use crate::policies::admission::{
     resolve_cache_candidates, resolve_decode, resolve_prefill, resolve_prefill_admitted,
@@ -31,7 +33,6 @@ use bytes::Bytes;
 use serde::de::IgnoredAny;
 use serde::Deserialize;
 use std::cell::Cell;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Observability header carrying the final decode-pool URL for a
@@ -111,34 +112,255 @@ fn prefill_policy_reason(
 /// enforced by the `DefaultBodyLimit`, and returns 413 PAYLOAD_TOO_LARGE.
 pub const MAX_CHAT_BODY_BYTES: usize = 32 << 20;
 
-/// Minimal probe over the request body — we only need the `stream` field
-/// and the `model` field to decide between buffered vs SSE forwarding and
-/// to select a worker. Deserializing into this struct (vs `serde_json::Value`)
-/// does two things:
+/// Minimal probe over the request body — the fields the ROUTER itself acts on,
+/// plus the sampling parameters the fleet-wide contract governs.
+/// Deserializing into this struct (vs `serde_json::Value`) does two things:
 ///
-/// 1. Avoids the per-field heap allocation of `Value` for a multi-MiB body.
+/// 1. Avoids building a `Value` tree over a multi-MiB body. NOTHING here
+///    retains client-sized data: an unrecognized key is skipped through
+///    `IgnoredAny`, and a sampling value that is not a number is drained the
+///    same way (see [`ProbedValue`]).
 /// 2. Pins the contract: the body MUST be a JSON object. Degenerate
 ///    shapes (`null`, `[]`, `"hi"`) fail at this step rather than being
 ///    silently forwarded with `stream=false`.
 ///
 /// All other fields are ignored — the worker is authoritative for the
 /// full request schema.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default)]
 struct RequestProbe {
-    #[serde(default)]
     stream: Option<bool>,
-    #[serde(default)]
     model: Option<String>,
     /// Explicit output budget used by Decode Bucket routing.
-    #[serde(default)]
     max_tokens: Option<u64>,
-    #[serde(default)]
     max_completion_tokens: Option<u64>,
+    /// What the request said about each governed sampling parameter, indexed
+    /// by [`SamplingField::index`] so governing another needs no change here.
+    /// Read by [`apply_sampling_overrides`]; see [`ProbedValue`].
+    sampling: [ProbedValue; SamplingField::ALL.len()],
+}
+
+/// What the request said about one governed sampling parameter.
+///
+/// WHY not `Option<serde_json::Value>`: these keys carry client-controlled
+/// JSON of arbitrary size and the probe runs on every request whether or not a
+/// contract is configured, so holding a `Value` would let
+/// `{"temperature": [1, 1, ...]}` allocate a tree proportional to a
+/// [`MAX_CHAT_BODY_BYTES`] body for a field nothing then reads. Each variant is
+/// resolved during deserialization; nothing client-sized is retained.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+enum ProbedValue {
+    /// Omitted, or an explicit `null`. The OpenAI API types these parameters
+    /// as nullable with a documented default, so `null` asks for the default —
+    /// and on a governed fleet the configured value IS the default. Both mean
+    /// the configured value is injected.
+    #[default]
+    Absent,
+    /// A JSON number, or a string the engine's pydantic lax mode reads as one.
+    Number(f64),
+    /// Present but not numeric. Nobody's business but the engine's, which owns
+    /// the request schema and gives the better message — so the contract
+    /// neither compares it nor overwrites it.
+    Unusable,
+}
+
+impl<'de> Deserialize<'de> for ProbedValue {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct ValueVisitor;
+        impl<'de> serde::de::Visitor<'de> for ValueVisitor {
+            type Value = ProbedValue;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a sampling parameter value")
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<ProbedValue, E> {
+                Ok(ProbedValue::Number(v as f64))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<ProbedValue, E> {
+                Ok(ProbedValue::Number(v as f64))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<ProbedValue, E> {
+                Ok(ProbedValue::Number(v))
+            }
+
+            /// Parsed, not retained: the engine reads a numeric string as a
+            /// number, so a `reject` contract must too or `"1.5"` slips past
+            /// a pin of 1.
+            fn visit_str<E>(self, v: &str) -> Result<ProbedValue, E> {
+                Ok(v.trim()
+                    .parse::<f64>()
+                    .map_or(ProbedValue::Unusable, ProbedValue::Number))
+            }
+
+            fn visit_unit<E>(self) -> Result<ProbedValue, E> {
+                Ok(ProbedValue::Absent)
+            }
+
+            fn visit_bool<E>(self, _: bool) -> Result<ProbedValue, E> {
+                Ok(ProbedValue::Unusable)
+            }
+
+            /// Drained, never collected — the allocation this type exists to
+            /// avoid.
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<ProbedValue, A::Error> {
+                while seq.next_element::<IgnoredAny>()?.is_some() {}
+                Ok(ProbedValue::Unusable)
+            }
+
+            /// Drained, never collected — as [`Self::visit_seq`].
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<ProbedValue, M::Error> {
+                while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+                Ok(ProbedValue::Unusable)
+            }
+        }
+        d.deserialize_any(ValueVisitor)
+    }
+}
+
+/// A field the ROUTER acts on, as opposed to one it only forwards. A repeated
+/// occurrence of one of these is a 400: a body that says two different things
+/// about how to route itself is ambiguous at the edge, and the router must not
+/// decide on one copy while the engine serves the other.
+#[derive(Debug, Clone, Copy)]
+enum RoutingKey {
+    Stream,
+    Model,
+    MaxTokens,
+    MaxCompletionTokens,
+}
+
+impl RoutingKey {
+    /// Bit position in the visitor's occurrence mask. Unlike
+    /// [`SamplingField::index`] this indexes no array, so it needs no
+    /// agreement with a separate length constant.
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Stream => 1 << 0,
+            Self::Model => 1 << 1,
+            Self::MaxTokens => 1 << 2,
+            Self::MaxCompletionTokens => 1 << 3,
+        }
+    }
+
+    const fn wire_name(self) -> &'static str {
+        match self {
+            Self::Stream => "stream",
+            Self::Model => "model",
+            Self::MaxTokens => "max_tokens",
+            Self::MaxCompletionTokens => "max_completion_tokens",
+        }
+    }
+}
+
+/// One key of the request object, resolved WITHOUT allocating: the visitor
+/// matches a borrowed `&str` and keeps only a discriminant, so a body's
+/// unrecognized majority costs no `String` per key.
+enum ProbeKey {
+    Routing(RoutingKey),
+    /// A governed sampling parameter. A repeat LAST-WINS, matching the
+    /// engine's own `json.loads` — so the value the contract compares against
+    /// and the value the engine actually samples with are the same one.
+    Sampling(SamplingField),
+    Other,
+}
+
+impl<'de> Deserialize<'de> for ProbeKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct KeyVisitor;
+        impl serde::de::Visitor<'_> for KeyVisitor {
+            type Value = ProbeKey;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a request field name")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<ProbeKey, E> {
+                Ok(match v {
+                    "stream" => ProbeKey::Routing(RoutingKey::Stream),
+                    "model" => ProbeKey::Routing(RoutingKey::Model),
+                    "max_tokens" => ProbeKey::Routing(RoutingKey::MaxTokens),
+                    "max_completion_tokens" => ProbeKey::Routing(RoutingKey::MaxCompletionTokens),
+                    other => match SamplingField::from_wire_name(other) {
+                        Some(field) => ProbeKey::Sampling(field),
+                        None => ProbeKey::Other,
+                    },
+                })
+            }
+        }
+        d.deserialize_str(KeyVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestProbe {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct ProbeVisitor;
+        impl<'de> serde::de::Visitor<'de> for ProbeVisitor {
+            type Value = RequestProbe;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a JSON object")
+            }
+
+            fn visit_map<M: serde::de::MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> Result<RequestProbe, M::Error> {
+                let mut probe = RequestProbe::default();
+                let mut seen = 0u8;
+                while let Some(key) = map.next_key::<ProbeKey>()? {
+                    match key {
+                        ProbeKey::Routing(r) => {
+                            if seen & r.bit() != 0 {
+                                return Err(serde::de::Error::custom(format_args!(
+                                    "duplicate field `{}`",
+                                    r.wire_name()
+                                )));
+                            }
+                            seen |= r.bit();
+                            match r {
+                                RoutingKey::Stream => probe.stream = map.next_value()?,
+                                RoutingKey::Model => probe.model = map.next_value()?,
+                                RoutingKey::MaxTokens => probe.max_tokens = map.next_value()?,
+                                RoutingKey::MaxCompletionTokens => {
+                                    probe.max_completion_tokens = map.next_value()?
+                                }
+                            }
+                        }
+                        ProbeKey::Sampling(field) => {
+                            probe.sampling[field.index()] = map.next_value()?;
+                        }
+                        ProbeKey::Other => {
+                            map.next_value::<IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(probe)
+            }
+        }
+        // `deserialize_map` is what pins the body to a JSON object: `null`,
+        // `[]` and `"hi"` are all rejected here, so no separate shape-anchoring
+        // pass is needed.
+        d.deserialize_map(ProbeVisitor)
+    }
 }
 
 impl RequestProbe {
     fn requested_max_output_tokens(&self) -> Option<u64> {
         self.max_completion_tokens.or(self.max_tokens)
+    }
+
+    /// Lets [`apply_sampling_overrides`] loop over whatever the operator
+    /// configured instead of repeating a per-field ladder.
+    fn sampling_field(&self, field: SamplingField) -> ProbedValue {
+        self.sampling[field.index()]
     }
 }
 
@@ -198,11 +420,15 @@ pub async fn chat_completions(
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
     let start = std::time::Instant::now();
-    let probe = parse_probe(&body)?;
+    let mut probe = parse_probe(&body)?;
     let streaming = probe.stream.unwrap_or(false);
     let requested_max_output_tokens = probe.requested_max_output_tokens();
+    // `take`n rather than borrowed: the sampling contract further down reads
+    // the rest of `probe`, but nothing reads `model` again, so the `String`
+    // moves out instead of being cloned on every request.
     let model_str = probe
         .model
+        .take()
         .ok_or_else(|| ApiError::BadRequest("missing `model` field".into()))?;
     let model_id = ModelId(model_str.clone());
 
@@ -230,6 +456,16 @@ pub async fn chat_completions(
         .policies
         .get(&model_id)
         .ok_or_else(|| ApiError::ModelNotFound(model_str.clone()))?;
+
+    // Fleet-wide sampling contract (`--override-sampling-params`), applied
+    // once the model is known to be served (so a request naming an unknown
+    // model still gets that answer) and before anything is admitted: under
+    // `reject` a numeric value differing from the configured one is a 400
+    // here, costing no queue slot and no engine round-trip. Either way the
+    // configured values for fields the request omitted come back as the
+    // inject-set for the forwarded body.
+    let inject_sampling =
+        apply_sampling_overrides(&ctx.config.model.sampling_overrides, &probe, &ctx.metrics)?;
 
     // Tokenize once at ingress whenever it can pay off — decoupled from the
     // routing policy, because forwarding `input_ids` is a property of the
@@ -804,10 +1040,15 @@ pub async fn chat_completions(
     let bootstrap_room = bootstrap.as_ref().map(|b| b.room);
 
     // Build the body forwarded to the engine(s) exactly once — injecting the
-    // `input_ids` and/or bootstrap fields, or forwarding the original bytes
-    // untouched when neither applies.
-    let outgoing_body =
-        build_outgoing_body(&body, request_value, forward_input_ids, bootstrap.as_ref())?;
+    // `input_ids`, bootstrap fields and sampling values, or forwarding the
+    // original bytes untouched when none applies.
+    let outgoing_body = build_outgoing_body(
+        &body,
+        request_value,
+        forward_input_ids,
+        bootstrap.as_ref(),
+        &inject_sampling,
+    )?;
 
     let result = if let Some(decode_worker) = decode_peer {
         // PD-disagg dispatch (Pattern B — spawn prefill, await decode).
@@ -1202,38 +1443,102 @@ struct BootstrapFields {
     room: u64,
 }
 
+/// Write `members` in as top-level keys of the JSON object in `body`, without
+/// parsing it.
+///
+/// WHY: going through `serde_json` costs a full parse into a `Value` plus a
+/// full re-serialize, over a body that runs to [`MAX_CHAT_BODY_BYTES`].
+///
+/// Members go in before the CLOSING brace so they win the last-wins reading
+/// every JSON parser performs — the authority `obj.insert` has on the parse
+/// path. Inserting after the opening brace would lose to a client's own later
+/// copy of the key, which a request sending an explicit `null` for a governed
+/// parameter has: the probe reads `null` as absent, so the value IS injected.
+/// The last `}` is the object's closing brace, since `parse_probe` proved the
+/// body is an object and only whitespace may follow it.
+///
+/// `None` (braces not located) falls back to the parse path rather than
+/// panicking on a shape `parse_probe` should already have rejected.
+fn splice_top_level(
+    body: &Bytes,
+    members: &[(SamplingField, serde_json::Number)],
+) -> Option<Bytes> {
+    use std::io::Write as _;
+
+    let open = body.iter().position(|&b| b == b'{')?;
+    let close = body.iter().rposition(|&b| b == b'}')?;
+    if close <= open {
+        return None;
+    }
+    // An empty object takes no separating comma: `{"temperature":1}`, not
+    // `{,"temperature":1}`.
+    let has_members = body[open + 1..close]
+        .iter()
+        .any(|b| !b.is_ascii_whitespace());
+    // 24 bytes per member covers `"repetition_penalty":` plus a short number;
+    // an over-run just costs one realloc, never correctness.
+    let mut out = Vec::with_capacity(body.len() + 24 * members.len() + 1);
+    out.extend_from_slice(&body[..close]);
+    for (i, (field, value)) in members.iter().enumerate() {
+        if has_members || i > 0 {
+            out.push(b',');
+        }
+        // Wire names are a fixed set of JSON-safe identifiers and a
+        // `serde_json::Number` renders as valid JSON, so neither needs
+        // escaping. Written straight into `out` — no intermediate `String`.
+        write!(out, "\"{}\":{}", field.wire_name(), value).ok()?;
+    }
+    out.extend_from_slice(&body[close..]);
+    Some(Bytes::from(out))
+}
+
 /// Build the body forwarded to the engine, injecting (when present) the
-/// precomputed `input_ids` and/or the PD `bootstrap_*` fields into the
-/// already-parsed request object and serializing once. When neither is
-/// needed, returns the original bytes unchanged (no re-serialize).
+/// precomputed `input_ids`, the PD `bootstrap_*` fields and the fleet-wide
+/// sampling values into the already-parsed request object and serializing
+/// once. When none is needed, returns the original bytes unchanged (no
+/// re-serialize).
 ///
-/// `input_ids`: the router-computed prompt tokens. When set, the engine skips
-/// its own chat-template tokenization; `messages` are retained in the body so
-/// the engine still derives stop tokens / tool-call constraint and the OpenAI
-/// response shape. The caller sets this only when the tokens are
-/// engine-equivalent and `input_ids_safe_to_forward` held.
+/// `input_ids`: the router-computed prompt tokens. When set the engine skips
+/// its own chat-template tokenization, so `messages` are retained for the stop
+/// tokens, tool-call constraint and response shape it still derives from them.
+/// Set only when `input_ids_safe_to_forward` held.
 ///
-/// `value` is the already-parsed request body when one is on hand (the
-/// cache-aware path parses once at ingress); it is consumed so the mutation
-/// reuses that parse. It is `None` only for a load-only policy in PD mode — a
-/// path that never parses at ingress — so the bootstrap injection re-parses
-/// the bytes here (matching the pre-refactor behavior). The body shape was
-/// validated by `parse_probe`; the non-object arm defends against a TOCTOU
+/// `value` is the ingress parse when one is on hand, reused rather than
+/// repeated — and dropped unused when splicing makes it unnecessary. Sampling
+/// alone never reaches `serde_json`: only `input_ids` and bootstrap injection
+/// do, because those may have to OVERWRITE a key the client sent, which
+/// [`splice_top_level`] cannot. The non-object arm defends against a TOCTOU
 /// regression rather than panicking.
 fn build_outgoing_body(
     body: &Bytes,
     value: Option<serde_json::Value>,
     input_ids: Option<&[u32]>,
     bootstrap: Option<&BootstrapFields>,
+    sampling: &[(SamplingField, serde_json::Number)],
 ) -> Result<Bytes, ApiError> {
-    if input_ids.is_none() && bootstrap.is_none() {
+    // `input_ids` and bootstrap injection may have to OVERWRITE a key the
+    // client sent, which only the parse path can do; sampling injection never
+    // does, because the inject-set holds only keys the request omitted.
+    let only_sampling = input_ids.is_none() && bootstrap.is_none();
+    if only_sampling && sampling.is_empty() {
         // Nothing to inject — forward the original bytes (cheap Arc clone).
         return Ok(body.clone());
     }
+    // Splice regardless of whether a parse is already on hand: `value` is
+    // read-only up to this point, so having one does not make splicing wrong
+    // — it only means the parse was already paid for elsewhere. Gating on
+    // `value.is_none()` would have skipped the splice on exactly the
+    // configurations that parse at ingress (a chat encoder, the cache-aware
+    // policy, bucket routing), i.e. most governed fleets.
+    if only_sampling {
+        if let Some(spliced) = splice_top_level(body, sampling) {
+            return Ok(spliced);
+        }
+    }
     let parsed = match value {
         Some(v) => v,
-        // Load-only + PD: the ingress skipped the parse, so re-parse for the
-        // bootstrap injection (input_ids is never set on this path).
+        // The ingress skipped the parse, so re-parse. Reached for bootstrap
+        // injection, and as the fallback if `splice_top_level` declined.
         None => serde_json::from_slice(body).map_err(|_| {
             ApiError::BadRequest("invalid request: body must be a JSON object".to_string())
         })?,
@@ -1246,6 +1551,15 @@ fn build_outgoing_body(
             ));
         }
     };
+    // The caller passes the inject-set from `apply_sampling_overrides` —
+    // configured values for fields the request omitted — so writing them here
+    // never masks a client value, in either conflict mode.
+    for (field, value) in sampling {
+        obj.insert(
+            field.wire_name().to_string(),
+            serde_json::Value::Number(value.clone()),
+        );
+    }
     if let Some(ids) = input_ids {
         obj.insert(
             "input_ids".to_string(),
@@ -1416,6 +1730,78 @@ fn request_is_multimodal(value: &serde_json::Value) -> bool {
         })
 }
 
+/// Apply the fleet-wide sampling contract (`--override-sampling-params` /
+/// `--sampling-param-conflict`) to one request, before admission.
+///
+/// Returns the inject-set: the configured value for every exact-valued
+/// parameter the request OMITTED, which [`build_outgoing_body`] writes into
+/// the forwarded body so the engine's own defaults can't drift from what the
+/// operator declared. A band ([`ParamSpec::Range`]) names no single value, so
+/// it never injects.
+///
+/// For a parameter the request DID send:
+///   * [`ConflictPolicy::Allow`] forwards the client value untouched, which
+///     is why the mode check comes before any comparison;
+///   * [`ConflictPolicy::Reject`] 400s a numeric value that differs from the
+///     configured one (or falls outside the band) — never a silent rewrite,
+///     which is the one behavior no client can detect;
+///   * a value that is not a number ([`ProbedValue::Unusable`]) is nobody's
+///     business but the engine's, which is authoritative for the request
+///     schema and produces the better message.
+///
+/// A rejection is counted per parameter before it is returned, because a
+/// contract rollout turns served traffic into 400s and the operator needs to
+/// see how much and where.
+fn apply_sampling_overrides(
+    overrides: &SamplingOverrides,
+    probe: &RequestProbe,
+    metrics: &MetricsRegistry,
+) -> Result<Vec<(SamplingField, serde_json::Number)>, ApiError> {
+    // Length is a startup constant, and `Vec::with_capacity(0)` does not
+    // allocate — so an unconfigured contract still costs nothing.
+    let mut inject = Vec::with_capacity(overrides.params.len());
+    for (&field, spec) in &overrides.params {
+        let name = field.wire_name();
+        let reject = |detail: String| {
+            metrics.record_sampling_contract_rejection(name);
+            ApiError::SamplingContract {
+                param: name,
+                detail,
+            }
+        };
+        let got = match probe.sampling_field(field) {
+            // A band names no single value, so it never injects — a request
+            // that omits the parameter gets the engine's own default.
+            ProbedValue::Absent => {
+                if let ParamSpec::Exact(v) = spec {
+                    inject.push((field, v.clone()));
+                }
+                continue;
+            }
+            ProbedValue::Unusable => continue,
+            // `allow` forwards a client value untouched, so the comparison
+            // below is `reject`-only.
+            ProbedValue::Number(_) if overrides.conflict == ConflictPolicy::Allow => continue,
+            ProbedValue::Number(got) => got,
+        };
+        match spec {
+            ParamSpec::Exact(want) => {
+                if Some(got) != want.as_f64() {
+                    return Err(reject(format!(
+                        "got {got}, expected {want} (or omit the field)"
+                    )));
+                }
+            }
+            &ParamSpec::Range { lo, hi } => {
+                if !(lo..=hi).contains(&got) {
+                    return Err(reject(format!("must be between {lo} and {hi}, got {got}")));
+                }
+            }
+        }
+    }
+    Ok(inject)
+}
+
 fn parse_probe(body: &Bytes) -> Result<RequestProbe, ApiError> {
     // We deliberately do NOT echo the serde error into the client-visible
     // message — that risks leaking field-level detail and is also of little
@@ -1423,24 +1809,16 @@ fn parse_probe(body: &Bytes) -> Result<RequestProbe, ApiError> {
     // Server-side, the full error is logged with `tracing::debug!` for
     // operator triage.
     //
-    // Two-step deserialize:
-    //   1. `Map<String, IgnoredAny>` *anchors* the shape to a JSON object.
-    //      This rejects `null` / `[]` / `"hi"` (all valid JSON but not
-    //      request shape) without walking the full value into a
-    //      `serde_json::Value` per field.
-    //   2. `RequestProbe` (struct of `Option<bool>` + `Option<String>`)
-    //      lifts out only the fields we care about — `stream` and `model`.
-    //      Other fields are ignored; the worker is authoritative for the
-    //      rest of the schema.
-    let _: HashMap<String, IgnoredAny> = serde_json::from_slice(body).map_err(|e| {
-        tracing::debug!(error = %e, "chat-completions body rejected as non-object JSON");
-        ApiError::BadRequest("invalid request: body must be a JSON object".to_string())
-    })?;
-    let probe: RequestProbe = serde_json::from_slice(body).map_err(|e| {
+    // ONE deserialize. [`RequestProbe`]'s hand-written `visit_map` both
+    // anchors the shape (its `deserialize_map` rejects `null` / `[]` / `"hi"`
+    // — valid JSON, not request shape) and lifts out the probed fields,
+    // skipping the unknown majority through `IgnoredAny`. It never builds a
+    // `serde_json::Value` and allocates nothing per unrecognized key, so the
+    // shape check costs no separate pass over a multi-MiB body.
+    serde_json::from_slice(body).map_err(|e| {
         tracing::debug!(error = %e, "chat-completions request-probe deserialize failed");
         ApiError::BadRequest("invalid request: body must be a JSON object".to_string())
-    })?;
-    Ok(probe)
+    })
 }
 
 #[cfg(test)]
@@ -1596,7 +1974,8 @@ mod tests {
             port: None,
             room: 42,
         };
-        let injected = build_outgoing_body(&body, Some(value), None, Some(&bootstrap)).unwrap();
+        let injected =
+            build_outgoing_body(&body, Some(value), None, Some(&bootstrap), &[]).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&injected).unwrap();
         assert_eq!(parsed.get("bootstrap_port"), Some(&serde_json::Value::Null));
         assert_eq!(
@@ -1617,7 +1996,7 @@ mod tests {
             Bytes::from_static(br#"{"model":"x","messages":[{"role":"user","content":"hi"}]}"#);
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         let ids = [1u32, 2, 3];
-        let out = build_outgoing_body(&body, Some(value), Some(&ids), None).unwrap();
+        let out = build_outgoing_body(&body, Some(value), Some(&ids), None, &[]).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(parsed.get("input_ids"), Some(&serde_json::json!([1, 2, 3])));
         assert!(
@@ -1632,7 +2011,7 @@ mod tests {
     fn build_outgoing_body_no_injection_returns_original_bytes() {
         let body = Bytes::from_static(br#"{"model":"x","messages":[]}"#);
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let out = build_outgoing_body(&body, Some(value), None, None).unwrap();
+        let out = build_outgoing_body(&body, Some(value), None, None, &[]).unwrap();
         assert_eq!(
             out, body,
             "no injection must forward the original bytes unchanged"
@@ -1652,7 +2031,8 @@ mod tests {
             port: Some(9),
             room: 5,
         };
-        let out = build_outgoing_body(&body, Some(value), Some(&ids), Some(&bootstrap)).unwrap();
+        let out =
+            build_outgoing_body(&body, Some(value), Some(&ids), Some(&bootstrap), &[]).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(parsed.get("input_ids"), Some(&serde_json::json!([7, 8])));
         assert_eq!(
@@ -1747,7 +2127,7 @@ mod tests {
             port: Some(1),
             room: 2,
         };
-        let out = build_outgoing_body(&body, None, None, Some(&bootstrap)).unwrap();
+        let out = build_outgoing_body(&body, None, None, Some(&bootstrap), &[]).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(
             parsed.get("bootstrap_room"),
@@ -1944,5 +2324,465 @@ mod tests {
             ),
             other => panic!("expected BadRequest, got {other:?}"),
         }
+    }
+
+    fn probe_of(body: &str) -> RequestProbe {
+        parse_probe(&Bytes::copy_from_slice(body.as_bytes())).unwrap()
+    }
+
+    /// Build a [`SamplingOverrides`] the only way production does — through
+    /// the flag parser.
+    ///
+    /// Hand-building the struct here would re-implement `canonical_number`'s
+    /// integral normalization in the test, so a regression in the parser would
+    /// leave these assertions green while the forwarded body changed.
+    fn overrides_of(conflict: ConflictPolicy, json: &str) -> SamplingOverrides {
+        crate::config::parse_sampling_overrides(json, conflict).expect("test config must parse")
+    }
+
+    /// A throwaway registry, so the contract's rejection counter has somewhere
+    /// to land.
+    fn metrics() -> Arc<MetricsRegistry> {
+        MetricsRegistry::new()
+    }
+
+    /// With nothing configured the sampling contract is inert: no request is
+    /// ever inspected, and nothing is injected.
+    #[test]
+    fn unconfigured_sampling_overrides_inject_nothing() {
+        let overrides = SamplingOverrides::default();
+        let p = probe_of(r#"{"model":"x","temperature":0.7,"n":4}"#);
+        assert_eq!(
+            apply_sampling_overrides(&overrides, &p, &metrics()).unwrap(),
+            vec![]
+        );
+    }
+
+    /// The `reject` contract at the decision level: omitted -> inject the
+    /// configured value; equal to it -> pass untouched; any other numeric
+    /// value -> 400; non-numeric garbage -> forwarded for the engine's own
+    /// schema error. A band admits its range, 400s outside it, and injects
+    /// nothing.
+    #[test]
+    fn reject_mode_pins_configured_values_and_admits_a_band() {
+        let overrides = overrides_of(
+            ConflictPolicy::Reject,
+            r#"{"top_p": 0.95, "frequency_penalty": 0.0, "presence_penalty": 0.0,
+                "n": 1, "temperature": {"min": 0, "max": 1}}"#,
+        );
+
+        // Omitted params: accepted, exact values injected, band injects nothing.
+        let p = probe_of(r#"{"model":"x","messages":[]}"#);
+        let inject = apply_sampling_overrides(&overrides, &p, &metrics()).unwrap();
+        assert_eq!(
+            inject
+                .iter()
+                .map(|(f, v)| (f.wire_name(), v.to_string()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("top_p", "0.95".to_string()),
+                ("frequency_penalty", "0.0".to_string()),
+                ("presence_penalty", "0.0".to_string()),
+                ("n", "1".to_string()),
+            ]
+        );
+
+        for accepted in [
+            r#"{"model":"x","temperature":0.0}"#,
+            r#"{"model":"x","temperature":0.6}"#,
+            r#"{"model":"x","temperature":1.0}"#,
+            r#"{"model":"x","top_p":0.95}"#,
+            r#"{"model":"x","presence_penalty":0}"#,
+            r#"{"model":"x","frequency_penalty":0}"#,
+            r#"{"model":"x","n":1}"#,
+        ] {
+            let p = probe_of(accepted);
+            apply_sampling_overrides(&overrides, &p, &metrics())
+                .unwrap_or_else(|e| panic!("{accepted} must be accepted: {e:?}"));
+        }
+
+        // Nothing is injected over a field the client already sent.
+        let p = probe_of(r#"{"model":"x","top_p":0.95}"#);
+        let inject = apply_sampling_overrides(&overrides, &p, &metrics()).unwrap();
+        assert!(!inject.iter().any(|(f, _)| *f == SamplingField::TopP));
+
+        for rejected in [
+            r#"{"model":"x","temperature":1.1}"#,
+            r#"{"model":"x","temperature":2.0}"#,
+            r#"{"model":"x","temperature":-0.1}"#,
+            r#"{"model":"x","top_p":0.8}"#,
+            r#"{"model":"x","presence_penalty":0.5}"#,
+            r#"{"model":"x","frequency_penalty":0.5}"#,
+            r#"{"model":"x","n":2}"#,
+        ] {
+            let p = probe_of(rejected);
+            let err = apply_sampling_overrides(&overrides, &p, &metrics())
+                .expect_err(&format!("{rejected} must be rejected"));
+            assert!(
+                matches!(err, ApiError::SamplingContract { .. }),
+                "{rejected}: got {err:?}"
+            );
+        }
+
+        // Non-numeric garbage is not ours to judge: forwarded untouched (and
+        // not injected over), the engine's schema validation owns the 400.
+        let p = probe_of(r#"{"model":"x","top_p":"hot","n":true}"#);
+        let inject = apply_sampling_overrides(&overrides, &p, &metrics()).unwrap();
+        assert!(inject
+            .iter()
+            .all(|(f, _)| !matches!(f, SamplingField::TopP | SamplingField::N)));
+
+        // Numeric strings coerce the way the engine's pydantic lax mode does:
+        // "0.95" equals the configured value, "0.8" differs and 400s here.
+        let p = probe_of(r#"{"model":"x","top_p":"0.95"}"#);
+        assert!(apply_sampling_overrides(&overrides, &p, &metrics()).is_ok());
+        let p = probe_of(r#"{"model":"x","top_p":"0.8"}"#);
+        assert!(apply_sampling_overrides(&overrides, &p, &metrics()).is_err());
+
+        // An exact temperature (no band) rejects differing values and injects
+        // when absent, like every other parameter.
+        let exact = overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1.0}"#);
+        let p = probe_of(r#"{"model":"x","temperature":0.6}"#);
+        assert!(apply_sampling_overrides(&exact, &p, &metrics()).is_err());
+        let p = probe_of(r#"{"model":"x"}"#);
+        assert_eq!(
+            apply_sampling_overrides(&exact, &p, &metrics()).unwrap(),
+            vec![(
+                SamplingField::Temperature,
+                serde_json::Number::from_f64(1.0).unwrap()
+            )]
+        );
+    }
+
+    /// `allow` keeps the fill-when-absent half of the contract and drops the
+    /// rejection half: a client value — right, wrong or garbage — is forwarded
+    /// untouched, so the configured values are fleet-wide defaults.
+    #[test]
+    fn allow_mode_never_rejects_and_never_masks_a_client_value() {
+        let overrides = overrides_of(
+            ConflictPolicy::Allow,
+            r#"{"temperature": 1, "top_p": 0.95, "n": 1}"#,
+        );
+
+        // Omitted -> injected, exactly as under `reject`.
+        let p = probe_of(r#"{"model":"x"}"#);
+        assert_eq!(
+            apply_sampling_overrides(&overrides, &p, &metrics())
+                .unwrap()
+                .iter()
+                .map(|(f, _)| f.wire_name())
+                .collect::<Vec<_>>(),
+            vec!["temperature", "top_p", "n"]
+        );
+
+        // Every value `reject` would 400 is accepted here, and nothing is
+        // injected over it — the client's value reaches the engine.
+        let p = probe_of(r#"{"model":"x","temperature":0.6,"top_p":0.8,"n":4}"#);
+        assert_eq!(
+            apply_sampling_overrides(&overrides, &p, &metrics()).unwrap(),
+            vec![]
+        );
+
+        // Partial overlap: the client set temperature, so only the untouched
+        // parameters are filled in.
+        let p = probe_of(r#"{"model":"x","temperature":0.6}"#);
+        assert_eq!(
+            apply_sampling_overrides(&overrides, &p, &metrics())
+                .unwrap()
+                .iter()
+                .map(|(f, _)| f.wire_name())
+                .collect::<Vec<_>>(),
+            vec!["top_p", "n"]
+        );
+    }
+
+    /// An explicit `null` is absent for the engine, so it is absent here too:
+    /// the configured value is injected rather than the field being read as a
+    /// client-supplied conflict.
+    #[test]
+    fn explicit_null_sampling_value_counts_as_omitted() {
+        let overrides = overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1}"#);
+        let p = probe_of(r#"{"model":"x","temperature":null}"#);
+        assert_eq!(
+            apply_sampling_overrides(&overrides, &p, &metrics())
+                .unwrap()
+                .iter()
+                .map(|(f, _)| f.wire_name())
+                .collect::<Vec<_>>(),
+            vec!["temperature"]
+        );
+    }
+
+    /// The inject-set lands in the forwarded body, and rides the same
+    /// `build_outgoing_body` serialize as the forwarded `input_ids` — so
+    /// chat-encoder traffic gets the contract too, not just the raw-prompt
+    /// path.
+    #[test]
+    fn build_outgoing_body_injects_sampling_overrides_alongside_input_ids() {
+        let body =
+            Bytes::from_static(br#"{"model":"x","messages":[{"role":"user","content":"hi"}]}"#);
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let ids = [1u32, 2, 3];
+        let overrides = overrides_of(
+            ConflictPolicy::Reject,
+            r#"{"top_p": 0.95, "top_k": 1000, "frequency_penalty": 0.0,
+                "presence_penalty": 0.0, "n": 1}"#,
+        );
+        let inject = apply_sampling_overrides(
+            &overrides,
+            &probe_of(r#"{"model":"x","messages":[{"role":"user","content":"hi"}]}"#),
+            &metrics(),
+        )
+        .unwrap();
+        let out = build_outgoing_body(&body, Some(value), Some(&ids), None, &inject).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed.get("top_p"), Some(&serde_json::json!(0.95)));
+        // `top_k` and `n` are engine-typed `int`: the injected literals must
+        // not be `1000.0` / `1.0`.
+        assert_eq!(parsed.get("top_k"), Some(&serde_json::json!(1000)));
+        assert_eq!(parsed.get("n"), Some(&serde_json::json!(1)));
+        assert_eq!(
+            parsed.get("frequency_penalty"),
+            Some(&serde_json::json!(0.0))
+        );
+        assert_eq!(
+            parsed.get("presence_penalty"),
+            Some(&serde_json::json!(0.0))
+        );
+        assert_eq!(parsed.get("input_ids"), Some(&serde_json::json!([1, 2, 3])));
+        assert!(parsed.get("messages").is_some());
+    }
+    /// A repeated sampling key LAST-WINS instead of 400ing, matching the
+    /// engine's own `json.loads`: the value the contract compares against must
+    /// be the value the engine will actually sample with. Probing these fields
+    /// must not turn a body the router used to forward into a rejection.
+    #[test]
+    fn duplicate_sampling_key_takes_the_last_value_like_the_engine() {
+        let overrides = overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1}"#);
+
+        // Last value matches the contract -> accepted.
+        let p = probe_of(r#"{"model":"x","temperature":0.5,"temperature":1}"#);
+        assert!(apply_sampling_overrides(&overrides, &p, &metrics()).is_ok());
+
+        // Last value differs -> rejected on THAT value, not the first one.
+        let p = probe_of(r#"{"model":"x","temperature":1,"temperature":0.5}"#);
+        let err = apply_sampling_overrides(&overrides, &p, &metrics()).unwrap_err();
+        assert!(
+            format!("{err}").contains("got 0.5"),
+            "must judge the last value; got {err}"
+        );
+    }
+
+    /// The router-actionable fields keep the stricter pre-existing contract:
+    /// a body that says two different things about how to route itself is
+    /// ambiguous at the edge. See
+    /// `parse_probe_handles_duplicate_stream_keys`.
+    #[test]
+    fn duplicate_routing_key_still_rejects() {
+        for body in [
+            r#"{"model":"a","model":"b"}"#,
+            r#"{"stream":true,"stream":false}"#,
+            r#"{"max_tokens":1,"max_tokens":2}"#,
+            r#"{"max_completion_tokens":1,"max_completion_tokens":2}"#,
+            // An explicit null still counts as an occurrence, so this is a
+            // duplicate even though the first value reads as `None`.
+            r#"{"stream":null,"stream":true}"#,
+        ] {
+            let b = Bytes::copy_from_slice(body.as_bytes());
+            assert!(
+                parse_probe(&b).is_err(),
+                "{body} must be rejected as ambiguous"
+            );
+        }
+    }
+
+    /// A sampling key carrying a huge non-numeric value must cost nothing: it
+    /// is drained, not materialized, and it does not fail the probe. Before
+    /// these fields were probed the value was skipped by `IgnoredAny`, and
+    /// probing them must not put a client-sized allocation back on the path
+    /// nor start rejecting bodies that used to be forwarded.
+    #[test]
+    fn oversized_non_numeric_sampling_value_is_drained_not_materialized() {
+        let big_array = format!("[{}]", "1,".repeat(50_000) + "1");
+        let big_string = format!("\"{}\"", "x".repeat(200_000));
+        let big_object = format!("{{{}\"k\":1}}", "\"j\":[[[1]]],".repeat(10_000));
+        for value in [&big_array, &big_string, &big_object] {
+            let body = format!(r#"{{"model":"x","temperature":{value}}}"#);
+            let probe = probe_of(&body);
+            assert_eq!(
+                probe.sampling_field(SamplingField::Temperature),
+                ProbedValue::Unusable,
+                "a non-numeric value must collapse to Unusable"
+            );
+            // ...and it stays the engine's business: neither compared nor
+            // injected over.
+            let overrides = overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1}"#);
+            let inject = apply_sampling_overrides(&overrides, &probe, &metrics()).unwrap();
+            assert!(inject.is_empty(), "must not inject over a client value");
+        }
+    }
+
+    /// A numeric string is read the way the engine's pydantic lax mode reads
+    /// it, but is not retained as a string.
+    #[test]
+    fn probed_sampling_values_normalize_to_numbers() {
+        let p = probe_of(r#"{"model":"x","temperature":" 0.7 ","top_k":40,"min_p":0.05}"#);
+        assert_eq!(
+            p.sampling_field(SamplingField::Temperature),
+            ProbedValue::Number(0.7)
+        );
+        assert_eq!(
+            p.sampling_field(SamplingField::TopK),
+            ProbedValue::Number(40.0)
+        );
+        assert_eq!(
+            p.sampling_field(SamplingField::MinP),
+            ProbedValue::Number(0.05)
+        );
+        assert_eq!(p.sampling_field(SamplingField::N), ProbedValue::Absent);
+    }
+
+    /// A contract rejection must be distinguishable from every other 400 —
+    /// malformed JSON, a missing `model`, a bad SLO header — and must name the
+    /// parameter, since that is what an operator rolling the flag out needs.
+    #[test]
+    fn contract_rejection_has_its_own_error_code_and_counter() {
+        let overrides = overrides_of(ConflictPolicy::Reject, r#"{"top_p": 0.95}"#);
+        let metrics = metrics();
+        let p = probe_of(r#"{"model":"x","top_p":0.5}"#);
+
+        let err = apply_sampling_overrides(&overrides, &p, &metrics).unwrap_err();
+        let ApiError::SamplingContract { param, .. } = &err else {
+            panic!("expected SamplingContract, got {err:?}");
+        };
+        assert_eq!(*param, "top_p");
+        // The parameter and the offending value both reach the client, so a
+        // 400 is self-explanatory without an operator in the loop. The
+        // distinct `x-router-error-code` is pinned in `server::error`.
+        let msg = format!("{err}");
+        assert!(msg.contains("top_p") && msg.contains("0.5"), "got {msg}");
+
+        apply_sampling_overrides(&overrides, &p, &metrics).unwrap_err();
+        assert!(
+            metrics
+                .render()
+                .contains(r#"sgl_router_sampling_contract_rejections_total{param="top_p"} 2"#),
+            "rejections must be counted per parameter:\n{}",
+            metrics.render()
+        );
+    }
+
+    /// The steady state of a governed fleet: a load-only policy on a model
+    /// with no chat encoder, so the ingress never parsed, and only sampling
+    /// scalars to add. This must NOT re-parse and re-serialize the body —
+    /// proven by the original bytes surviving verbatim, which a
+    /// `serde_json::Value` round-trip would have normalized away.
+    #[test]
+    fn build_outgoing_body_splices_sampling_without_reparsing() {
+        let body = Bytes::from_static(br#"{ "model" : "x" ,  "messages" : [ ] }"#);
+        let inject = apply_sampling_overrides(
+            &overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1.0, "n": 1}"#),
+            &probe_of(r#"{"model":"x"}"#),
+            &metrics(),
+        )
+        .unwrap();
+
+        let out = build_outgoing_body(&body, None, None, None, &inject).unwrap();
+        assert_eq!(
+            std::str::from_utf8(&out).unwrap(),
+            r#"{ "model" : "x" ,  "messages" : [ ] ,"temperature":1.0,"n":1}"#
+        );
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed.get("temperature"), Some(&serde_json::json!(1.0)));
+        assert_eq!(parsed.get("n"), Some(&serde_json::json!(1)));
+        assert_eq!(parsed.get("model"), Some(&serde_json::json!("x")));
+    }
+
+    /// Splice edge cases: an empty object must not gain a trailing comma, and
+    /// leading whitespace before the root brace must not shift the insert.
+    #[test]
+    fn splice_top_level_handles_empty_objects_and_leading_whitespace() {
+        let inject = apply_sampling_overrides(
+            &overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1.0}"#),
+            &probe_of(r#"{"model":"x"}"#),
+            &metrics(),
+        )
+        .unwrap();
+
+        for (raw, want) in [
+            (r#"{}"#, r#"{"temperature":1.0}"#),
+            (r#"{ }"#, r#"{ "temperature":1.0}"#),
+            ("\n\t {\"a\":1}", "\n\t {\"a\":1,\"temperature\":1.0}"),
+            // A `}` inside a string literal is not the closing brace.
+            (r#"{"a":"}"}"#, r#"{"a":"}","temperature":1.0}"#),
+            // Trailing whitespace stays outside the object.
+            ("{\"a\":1} \n", "{\"a\":1,\"temperature\":1.0} \n"),
+        ] {
+            let out = splice_top_level(&Bytes::copy_from_slice(raw.as_bytes()), &inject).unwrap();
+            assert_eq!(std::str::from_utf8(&out).unwrap(), want, "input {raw:?}");
+            serde_json::from_slice::<serde_json::Value>(&out)
+                .unwrap_or_else(|e| panic!("{raw:?} spliced to invalid JSON: {e}"));
+        }
+    }
+
+    /// Nothing configured -> the body is forwarded as the same `Bytes`, with
+    /// neither a parse nor a copy.
+    #[test]
+    fn build_outgoing_body_without_injection_forwards_the_same_allocation() {
+        let body = Bytes::from_static(br#"{"model":"x"}"#);
+        let out = build_outgoing_body(&body, None, None, None, &[]).unwrap();
+        assert_eq!(
+            out.as_ptr(),
+            body.as_ptr(),
+            "must be an Arc clone, not a copy"
+        );
+    }
+    /// A request sending an explicit `null` for a governed parameter is the
+    /// one case where the inject-set and a key PRESENT in the body overlap:
+    /// the probe reads `null` as absent (the OpenAI contract), so the value is
+    /// injected even though the key is there. The injected value therefore has
+    /// to win the engine's last-wins parse — which is why members are spliced
+    /// in before the CLOSING brace. Inserting after the opening brace would
+    /// leave the client's trailing `null` authoritative and silently defeat
+    /// the contract.
+    #[test]
+    fn spliced_value_outranks_an_explicit_null_the_client_sent() {
+        let overrides = overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1.0}"#);
+        let raw = r#"{"model":"x","temperature":null}"#;
+        let body = Bytes::copy_from_slice(raw.as_bytes());
+        let inject = apply_sampling_overrides(&overrides, &probe_of(raw), &metrics()).unwrap();
+        assert_eq!(inject.len(), 1, "null must be treated as omitted");
+
+        let out = build_outgoing_body(&body, None, None, None, &inject).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(
+            parsed.get("temperature"),
+            Some(&serde_json::json!(1.0)),
+            "the engine must read the configured value, not the client's null: {}",
+            std::str::from_utf8(&out).unwrap()
+        );
+    }
+
+    /// The splice must also fire when the ingress ALREADY parsed the body — a
+    /// chat-encoder model, the cache-aware policy or bucket routing — as long
+    /// as nothing needs overwriting. Gating on `value.is_none()` skipped
+    /// exactly those configurations, i.e. most governed fleets.
+    #[test]
+    fn splice_fires_even_when_a_parse_is_already_on_hand() {
+        let body = Bytes::from_static(br#"{ "model" : "x" }"#);
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let inject = apply_sampling_overrides(
+            &overrides_of(ConflictPolicy::Reject, r#"{"temperature": 1.0}"#),
+            &probe_of(r#"{"model":"x"}"#),
+            &metrics(),
+        )
+        .unwrap();
+
+        let out = build_outgoing_body(&body, Some(value), None, None, &inject).unwrap();
+        // Byte-identical to the no-parse case: the parse was dropped unused.
+        assert_eq!(
+            std::str::from_utf8(&out).unwrap(),
+            r#"{ "model" : "x" ,"temperature":1.0}"#
+        );
     }
 }

--- a/experimental/sgl-router/src/server/routes/models.rs
+++ b/experimental/sgl-router/src/server/routes/models.rs
@@ -59,6 +59,7 @@ mod tests {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         };
         let app = crate::server::app::build_router(std::sync::Arc::new(ctx));
         let res = app

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -126,6 +126,7 @@ mod tests {
                 affinity: None,
                 fused: None,
                 eligibility: None,
+                sampling_overrides: Default::default(),
             },
             discovery: crate::config::DiscoveryBackend::StaticUrls(
                 crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -240,6 +240,7 @@ mod tests {
                 affinity: None,
                 fused: None,
                 eligibility: None,
+                sampling_overrides: Default::default(),
             },
             discovery: crate::config::DiscoveryBackend::StaticUrls(
                 crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -485,6 +485,7 @@ mod tests {
                 affinity: None,
                 fused: None,
                 eligibility: None,
+                sampling_overrides: Default::default(),
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: vec!["http://test:30000".into()],

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -138,6 +138,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec![url.clone()],

--- a/experimental/sgl-router/tests/proxy/bucket_routing.rs
+++ b/experimental/sgl-router/tests/proxy/bucket_routing.rs
@@ -69,6 +69,7 @@ fn build_app_context(
             affinity,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -42,6 +42,7 @@ fn config_for(_worker_url: &str) -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/common/cache_aware_fixture.rs
+++ b/experimental/sgl-router/tests/proxy/common/cache_aware_fixture.rs
@@ -34,6 +34,7 @@ pub fn config() -> Config {
             sticky: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -46,6 +46,7 @@ async fn failover_when_one_worker_dies() {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec![w1.url.clone(), w2.url.clone(), w3.url.clone()],

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -52,6 +52,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -39,6 +39,7 @@ async fn forwards_whitelisted_headers_strips_others() {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/main.rs
+++ b/experimental/sgl-router/tests/proxy/main.rs
@@ -21,6 +21,7 @@ mod pd_bootstrap_injection;
 mod pd_pool_isolation;
 mod radix_tree_routing;
 mod roundrobin_input_ids;
+mod sampling_overrides;
 mod shared_prefill_admission;
 mod sticky_input_ids;
 mod sticky_routing;

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -54,6 +54,7 @@ fn config() -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -53,6 +53,7 @@ fn config() -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -50,6 +50,7 @@ fn config() -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/sampling_overrides.rs
+++ b/experimental/sgl-router/tests/proxy/sampling_overrides.rs
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `--override-sampling-params` end to end: from the CLI flag an operator
+//! writes in a manifest to the JSON body the engine actually receives.
+//!
+//! The unit tests in `config::sampling` and `server::routes::chat` cover
+//! parsing and the per-parameter decision; these drive the whole path, because
+//! the failure this flag exists to prevent (an engine serving sampling
+//! parameters the operator did not declare) is only observable on the wire.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use sgl_router::config::{Cli, Config};
+use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+use sgl_router::policies::factory::build_registry_with_defaults;
+use sgl_router::proxy::Proxy;
+use sgl_router::server::app::build_router;
+use sgl_router::server::app_context::AppContext;
+use sgl_router::tokenizer::TokenizerRegistry;
+use sgl_router::workers::WorkerRegistry;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+use crate::common::mock_worker::MockWorker;
+
+const MODEL: &str = "tiny";
+
+const OVERRIDES: &str = r#"{"temperature": 1, "top_p": 0.95, "top_k": 1000,
+                            "frequency_penalty": 0, "presence_penalty": 0, "n": 1}"#;
+
+/// Build the config the way a deployment does — through `Cli`, so what these
+/// tests pin is the flag spelling in a manifest, not a hand-built struct that
+/// could drift from what the parser produces.
+fn config(flags: &[&str]) -> Config {
+    let mut argv = vec![
+        "sgl-router",
+        "--model-id",
+        MODEL,
+        "--tokenizer-path",
+        "tests/fixtures/tiny_tokenizer.json",
+        "--worker-urls",
+        "http://placeholder:0",
+    ];
+    argv.extend_from_slice(flags);
+    <Cli as clap::Parser>::parse_from(argv)
+        .into_config()
+        .expect("flags must parse")
+}
+
+fn build_ctx(url: String, flags: &[&str]) -> Arc<AppContext> {
+    let cfg = config(flags);
+    let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
+    let registry = Arc::new(WorkerRegistry::default());
+    let _ = registry.add(WorkerSpec {
+        id: WorkerId(url.clone()),
+        url,
+        mode: WorkerMode::Plain,
+        model_ids: vec![ModelId(MODEL.into())],
+        bootstrap_port: None,
+    });
+    let policies = Arc::new(build_registry_with_defaults(&cfg).unwrap());
+    let proxy = Arc::new(Proxy::new(Duration::from_secs(5)).unwrap());
+    Arc::new(AppContext::new(cfg, tokenizers, proxy, registry, policies))
+}
+
+async fn send(ctx: Arc<AppContext>, body: Value) -> StatusCode {
+    send_raw(ctx, serde_json::to_vec(&body).unwrap()).await.0
+}
+
+/// Send a body verbatim, so a test can express what `serde_json::Value`
+/// cannot — a repeated key. Returns the status and the router's own error
+/// code header.
+async fn send_raw(ctx: Arc<AppContext>, body: Vec<u8>) -> (StatusCode, Option<String>) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = build_router(ctx).oneshot(req).await.unwrap();
+    let code = resp
+        .headers()
+        .get("x-router-error-code")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    (resp.status(), code)
+}
+
+fn captured(mock: &MockWorker) -> Option<Value> {
+    let b = mock.captured.lock().unwrap().last_body.clone()?;
+    Some(serde_json::from_slice(&b).expect("captured body is valid JSON"))
+}
+
+/// The values an operator configures replace the engine's own defaults: a
+/// request that names no sampling parameter reaches the engine carrying every
+/// configured one.
+#[tokio::test]
+async fn configured_values_reach_the_engine_when_the_request_omits_them() {
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &["--override-sampling-params", OVERRIDES]);
+    let status = send(
+        ctx,
+        json!({"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let body = captured(&mock).expect("worker received a request");
+    assert_eq!(body.get("temperature"), Some(&json!(1)));
+    assert_eq!(body.get("top_p"), Some(&json!(0.95)));
+    assert_eq!(body.get("top_k"), Some(&json!(1000)));
+    assert_eq!(body.get("frequency_penalty"), Some(&json!(0)));
+    assert_eq!(body.get("presence_penalty"), Some(&json!(0)));
+    assert_eq!(body.get("n"), Some(&json!(1)));
+}
+
+/// Under the default `reject` mode a conflicting request is a 400 that never
+/// reaches a worker — the contract costs no engine round-trip and no
+/// admission slot.
+#[tokio::test]
+async fn reject_mode_400s_a_conflicting_request_without_touching_the_engine() {
+    // Covers the whole rejection contract: status, wire error code, and that
+    // the engine is never reached.
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &["--override-sampling-params", OVERRIDES]);
+    let body = json!({
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "temperature": 0.7,
+    });
+    let (status, code) = send_raw(ctx, serde_json::to_vec(&body).unwrap()).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    // Its own error code, so an operator rolling `reject` across a fleet can
+    // alert on contract rejections without them being buried among the
+    // `bad_request`s from clients sending malformed JSON.
+    assert_eq!(code.as_deref(), Some("sampling_contract_violation"));
+    assert!(
+        captured(&mock).is_none(),
+        "a rejected request must not reach the engine"
+    );
+}
+
+/// A repeated sampling key must not become a router-side 400: it is legal JSON
+/// that every engine reads last-wins, and the router forwarded it before these
+/// fields were probed. The contract judges the value the engine will use.
+#[tokio::test]
+async fn duplicate_sampling_key_is_judged_on_its_last_value() {
+    // Last value agrees with the contract -> served.
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &["--override-sampling-params", OVERRIDES]);
+    let (status, _) = send_raw(
+        ctx,
+        br#"{"model":"tiny","messages":[{"role":"user","content":"hi"}],
+             "temperature":0.7,"temperature":1}"#
+            .to_vec(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        captured(&mock).and_then(|b| b.get("temperature").cloned()),
+        Some(json!(1)),
+        "the engine must see the last value"
+    );
+
+    // Last value disagrees -> rejected, even though the first one matched.
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &["--override-sampling-params", OVERRIDES]);
+    let (status, _) = send_raw(
+        ctx,
+        br#"{"model":"tiny","messages":[{"role":"user","content":"hi"}],
+             "temperature":1,"temperature":0.7}"#
+            .to_vec(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// `min_p` and `repetition_penalty` are the parameters the engine resolves
+/// from the model's own `generation_config`, so they are the ones a fleet-wide
+/// pin exists for. Drive them the whole way to the engine.
+#[tokio::test]
+async fn engine_defaulted_parameters_reach_the_engine() {
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(
+        mock.url.clone(),
+        &[
+            "--override-sampling-params",
+            r#"{"min_p": 0.05, "repetition_penalty": 1.1}"#,
+        ],
+    );
+    let status = send(
+        ctx,
+        json!({"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let body = captured(&mock).expect("engine must receive a body");
+    assert_eq!(body.get("min_p"), Some(&json!(0.05)));
+    assert_eq!(body.get("repetition_penalty"), Some(&json!(1.1)));
+}
+
+/// The same request under `allow` is forwarded with the client's value intact,
+/// and the parameters it did not name still get the configured ones.
+#[tokio::test]
+async fn allow_mode_forwards_the_client_value_and_fills_the_rest() {
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(
+        mock.url.clone(),
+        &[
+            "--override-sampling-params",
+            OVERRIDES,
+            "--sampling-param-conflict",
+            "allow",
+        ],
+    );
+    let status = send(
+        ctx,
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.7,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let body = captured(&mock).expect("worker received a request");
+    assert_eq!(body.get("temperature"), Some(&json!(0.7)));
+    assert_eq!(body.get("top_p"), Some(&json!(0.95)));
+    assert_eq!(body.get("top_k"), Some(&json!(1000)));
+    assert_eq!(body.get("n"), Some(&json!(1)));
+}
+
+/// A band accepts anything inside it, 400s outside, and injects nothing:
+/// temperature tunable in [0, 1], everything else fixed.
+#[tokio::test]
+async fn a_temperature_band_admits_in_range_values_and_injects_nothing() {
+    let flags = [
+        "--override-sampling-params",
+        r#"{"temperature": {"min": 0, "max": 1}, "top_p": 0.95}"#,
+    ];
+
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &flags);
+    let status = send(
+        ctx,
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.6,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let body = captured(&mock).expect("worker received a request");
+    assert_eq!(body.get("temperature"), Some(&json!(0.6)));
+    assert_eq!(body.get("top_p"), Some(&json!(0.95)));
+
+    // Omitted: the band names no value, so the engine's own default applies.
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &flags);
+    let status = send(
+        ctx,
+        json!({"model": MODEL, "messages": [{"role": "user", "content": "hi"}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let body = captured(&mock).expect("worker received a request");
+    assert_eq!(body.get("temperature"), None);
+
+    // Outside the band: 400.
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &flags);
+    let status = send(
+        ctx,
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 1.5,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(captured(&mock).is_none());
+}
+
+/// With the flag unset the router touches nothing: the body the client sent
+/// is the body the engine sees, including a sampling parameter the operator
+/// could have fixed.
+#[tokio::test]
+async fn unset_flag_forwards_the_body_untouched() {
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone(), &[]);
+    let status = send(
+        ctx,
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.7,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let body = captured(&mock).expect("worker received a request");
+    assert_eq!(body.get("temperature"), Some(&json!(0.7)));
+    assert_eq!(body.get("top_p"), None);
+    assert_eq!(body.get("top_k"), None);
+    assert_eq!(body.get("n"), None);
+}

--- a/experimental/sgl-router/tests/proxy/shared_prefill_admission.rs
+++ b/experimental/sgl-router/tests/proxy/shared_prefill_admission.rs
@@ -156,6 +156,7 @@ fn config(policy: PolicyKind) -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -69,6 +69,7 @@ fn config() -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -55,6 +55,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -46,6 +46,7 @@ fn config(_worker_url: &str) -> Config {
             affinity: None,
             fused: None,
             eligibility: None,
+            sampling_overrides: Default::default(),
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],


### PR DESCRIPTION
## Motivation

An operator running a hosted endpoint often needs the sampling contract to be
theirs, not the engine's: one fixed configuration for every client of a
router, independent of what the deployed image's defaults happen to be. Today
that is not expressible at the router.

The concrete case is serving Kimi models the way Moonshot's own API serves
them, which is what the
[Kimi-Vendor-Verifier](https://github.com/MoonshotAI/K2-Vendor-Verifier)
`tests/params` suite checks: for a governed parameter a client may omit it, or
send exactly the configured value, or get a 400. Without that framing `reject`
reads as gratuitously strict — it is worth stating up front that it is the
behavior the reference vendor implements.

## What

Two flags, opt-in. Unset preserves today's behavior exactly, including the
no-injection fast path that forwards the original request bytes with no
re-serialize.

```bash
sgl-router ... \
  --override-sampling-params '{"temperature": 1, "top_p": 0.95, "n": 1}' \
  --sampling-param-conflict reject      # the default
```

**`--override-sampling-params <JSON>`** — one object keyed by the request-body
field names (`temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`,
`frequency_penalty`, `presence_penalty`, `n`), so the config reads like the
traffic it governs and a typo'd key is a startup error rather than a silently
dead entry. Each value is either a number (an exact value) or an inclusive
band `{"min": LO, "max": HI}`.

The first five are the parameters the engine resolves from the model's own
`generation_config` (`_DEFAULT_SAMPLING_PARAMS` in
`python/sglang/srt/entrypoints/openai/protocol.py`), which is exactly what
makes them drift when a deployed image changes — the drift this flag exists
to stop. The remaining three have fixed API defaults (0.0 / 0.0 / 1) and
cannot drift; they are supported because pinning them is still a legitimate
fleet contract, not because they are at risk.

A configured value is injected into the forwarded body whenever the request
**omits** the field — in *both* modes — so the engine's own defaults cannot
drift from what the operator declared.

**`--sampling-param-conflict <reject|allow>`** decides only the request that
**does** send the field. `reject` (default) 400s a differing value before
admission, quoting the configured value; `allow` forwards the client's value
untouched, degrading the configured values to fleet-wide defaults. It
`requires = override_sampling_params` — there is nothing for it to govern
otherwise.

**The router never silently rewrites a value a client sent.** Rewriting
misrepresents what the engine actually ran, and it is the one behavior no
client can detect. An explicit `null` is *not* such a value: the OpenAI API
types every one of these parameters as nullable with a documented default
(`temperature: number or null`, default 1), so `null` asks for the default —
and on a governed fleet the configured value is what the default is. It is
therefore treated as omitting the field, in both modes. A band names no value, so it never injects — which is why
a band combined with `allow` is a **startup error** rather than a no-op: a
band can only ever reject. A band also constrains only the requests that name
the parameter; one that omits it gets the model's own `generation_config`
default, which the router cannot see and which may itself lie outside the
band. That is documented on the flag; pin an exact value when the omitting
majority has to be constrained too.

**Everything an operator can get wrong fails the launch**, naming the key and
its domain: unknown key, wrong value type, out-of-domain value, non-integral
`top_k`/`n`, inverted or partial band, a band under `allow`, and a duplicated
key at either level. Both the outer object and a band are parsed as ordered
*entries* rather than a `serde_json::Map`, because a map keeps only the last
of a repeated key — `{"min": 0, "max": 1, "max": 0.5}` would quietly narrow
the accepted band and 400 requests the operator meant to admit.

Those domain and cross-field checks also run from `Config::validate`, not
only at the flag parse site, so a `SamplingOverrides` reached by any other
path (a test fixture, a future config file or admin API) cannot hold a spec
the flag would have refused to start with. An inverted band is the one that
matters: `(lo..=hi)` contains nothing, so it would 400 every request naming
the parameter.

A duplicated key in a **request** body is a different question, and gets a
different answer. For a governed sampling parameter a repeat last-wins,
matching the engine's own `json.loads`, so the value the contract judges is
the value the engine will actually sample with — probing these fields must
not turn a body the router used to forward into a rejection. The stricter
pre-existing rule stays for the fields the *router* acts on (`stream`,
`model`, `max_tokens`, `max_completion_tokens`): a body that says two
different things about how to route itself is ambiguous at the edge, and the
router must not decide on one copy while the engine serves the other.

Startup range checks use the **OpenAI API's** domains, deliberately narrower
than the engine's own (`SamplingParams.verify` would take `temperature: 5`):
`temperature` [0, 2], `top_p` (0, 1], `frequency_penalty` /
`presence_penalty` [-2, 2], `n` [1, 128], `top_k` >= 1 or exactly -1. The
`top_k` exception is deliberate: `-1` is the engine's own "disable / whole
vocabulary" spelling *and* its default, so a fleet may legitimately fix it
there. Being non-contiguous it cannot bound a band (`{"min": -1, "max": 100}`
has two individually legal bounds and would admit `top_k: 0`, which is
rejected as an exact value). Note `top_k: 1` is greedy decoding, **not**
"disabled".

`min_p` [0, 1] and `repetition_penalty` (0, 2] are not OpenAI parameters and
take the engine's domain. Both defaults (0 and 1 respectively) are legitimate
fleet-wide pins.

The integral guard is checked as containment in the exactly-i64-representable
range rather than against `i64::MAX as f64` — that cast rounds *up* to 2^63,
so a `>` test admits 2^63 itself, and the float-to-int cast then saturates
into every forwarded body.

## Where it runs

The contract is applied after the model is known to be served and before
anything is admitted, so a rejection costs no queue slot and no engine
round-trip, and a request naming a model this router does not serve still
gets that answer rather than a sampling 400.

Injection rides the existing single `build_outgoing_body` serialize, so
chat-encoder traffic — whose prompt is forwarded to the engine as `input_ids`
— is governed too, not just the raw-prompt path. An integer-typed parameter's
literal is normalized, so a config that spells `"n": 1.0` still puts `1` on
the wire for a field the engine types as `int`.

A rejection answers with `x-router-error-code:
sampling_contract_violation` — not the `bad_request` that malformed JSON, a
missing `model` field and a bad SLO header already emit — and increments
`sgl_router_sampling_contract_rejections_total{param}`. Rolling `reject`
across a fleet turns previously-served client traffic into 400s, and "how
much, and on which parameter" has to be answerable without reading logs.

Cost on a 16 MiB body (the shape the 32 MiB multimodal cap exists for), warmed,
best-of-5 — an unwarmed single shot is dominated by first-touch page faults on
the output buffer and is not a usable measurement:

| path | cost/req |
| --- | --- |
| request named every configured field | zero-copy forward, unchanged |
| injection, ingress had not parsed | **0.24 ms** |
| injection, ingress had already parsed | **1.69 ms** (of which ~1.45 ms is that parse) |
| the `serde_json` round-trip it replaces | 5.73 ms |

Injecting a handful of top-level scalars does not need a `serde_json::Value`
round-trip, so `splice_top_level` writes them straight into the bytes. They go
in before the CLOSING brace, so they win the last-wins reading every JSON
parser performs — the same authority `obj.insert` has on the parse path, and
what makes the injected value outrank an explicit `null` the client sent (the
probe reads `null` as absent, so the value is injected while the key is also
present in the body). For a document `parse_probe` has proved to be an object,
the last `}` is that object's closing brace.

Splicing does not require the ingress parse to be absent — `value` is
read-only up to that point, so it is simply dropped. That matters because the
configurations that parse at ingress (a chat encoder, the cache-aware policy,
bucket routing) are most governed fleets, and gating the fast path on
"no parse on hand" would have excluded exactly them. Only `input_ids` and PD
bootstrap injection still parse and re-serialize, because those may have to
OVERWRITE a key the client sent, which splicing cannot.

`parse_probe` also drops from two deserializes to one. The separate
`HashMap<String, IgnoredAny>` pass existed to anchor the body to a JSON
object — a derived struct would also accept a JSON array — which the probe's
hand-written `deserialize_map` now does directly, while allocating nothing
per unrecognized key.

Each probed sampling key is reduced at deserialize time to `ProbedValue` —
`Absent` / `Number` / `Unusable` — rather than held as a `serde_json::Value`.
These keys carry client-controlled JSON of arbitrary size and the probe runs on
every request whether or not a contract is configured, so a `Value` would let
`{"temperature": [1, 1, ...]}` build a tree proportional to the body for a
field nothing then reads; anything non-numeric drains through `IgnoredAny`.

Those three states are irreducible. Folding `Unusable` into `Absent` would have
the router inject over a value the client sent — and since members splice in
last, ours would win, which is the silent rewrite this flag promises never to
do. A numeric string is read as a number (`Number`, not `Unusable`) because the
engine's pydantic lax mode does, and otherwise `{"temperature": "1.5"}` slips
past a `reject` contract pinning 1.

## Tests

`cargo test` (732 tests, all five suites) and `cargo clippy --all-targets --
-D warnings` are green, both verified by exit code. The Python e2e suite under
`tests/e2e/` needs a real SGLang worker and was not run locally (no GPU on
this host).

* `config::sampling` — 12 unit tests on the parser: every supported
  parameter, bands, integral normalization, the `top_k: -1` sentinel, the
  `top_p` inclusive upper bound, the two engine-defaulted parameters and
  their domains, integral literals past the i64 range (including the 2^63
  boundary that a `>` guard admits), `ALL` covering every field exactly once,
  `validate` refusing hand-built specs the parser would have refused, a band
  under `allow`, and a 31-case table of malformed input each asserting the
  message names the offending key and its domain.
* `server::routes::chat` — 13 unit tests on the per-request decision and the
  injection path: the `reject` contract (inject-when-omitted / pass-when-equal
  / 400-when-different / forward-when-non-numeric, including the
  numeric-string coercion the engine's pydantic lax mode performs), band
  admission, `allow` never rejecting and never masking a client value,
  explicit `null` counting as omitted, an unconfigured contract being inert,
  the inject-set landing in the body alongside forwarded `input_ids`, a
  repeated sampling key judged on its last value while a repeated routing key
  still rejects, an oversized non-numeric value draining rather than
  materializing, and the splice path — asserted by the original bytes
  surviving verbatim, which a `serde_json::Value` round-trip would have
  normalized away — plus its empty-object and leading-whitespace edges.
* `server::error` / `server::metrics` — the rejection's distinct error code
  and envelope, and the per-parameter counter being absent until the first
  rejection.
* `tests/proxy/sampling_overrides.rs` — 8 integration tests driving the whole
  path, built through `Cli` so what is pinned is the flag spelling in a
  manifest rather than a hand-built struct. They assert on the body the mock
  worker actually received — the failure this flag exists to prevent is only
  observable on the wire — that a rejected request never reaches a worker at
  all, that the rejection carries its error code, that a repeated key is
  judged on its last value, and that the two engine-defaulted parameters
  arrive.

## Not in this PR

A companion `--max-output-tokens` per-model output cap was split out. A cap
enforced by *injecting* `max_tokens` collides with the engine's unconditional
`input + max_new_tokens <= context_len` check
(`python/sglang/srt/managers/tokenizer_manager.py`, where
`validate_total_tokens` is hard-coded `True` and `allow_auto_truncate`
defaults to `False`): a prompt longer than `context_len - cap` would then be
rejected where it previously served. The safe form is
`min(cap, context_len - input_tokens)`, and the router does not currently know
the engine's context length — so that flag needs `/server_info` context-length
introspection first, and gets its own PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nSt4cKMpjM5D7E4cUMzG9

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34554127902](https://github.com/sgl-project/sglang/actions/runs/34554127902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34554127700](https://github.com/sgl-project/sglang/actions/runs/34554127700)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

