### PR TITLE
[Lint] Reject methods shadowed by a later def in the same class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,23 @@ repos:
         entry: python3 scripts/lint/check_no_bare_pytest_main.py
         language: system
         files: ^(python|test)/.*\.py$
+      - id: check-no-shadowed-defs
+        name: reject methods shadowed by a later def in the same class
+        # Pre-existing offenders, excluded while they are handled separately:
+        #   qwen3_5_text.py            -> #38096
+        #   hybrid_attn_backend.py     -> history in #20812 and #34303
+        #   test_scripted_runtime_core -> the shadowed script is a coverage gap
+        #     rather than dead code, and confirming the fix needs a GPU run
+        # Drop each exclusion as it is resolved.
+        entry: python3 scripts/lint/check_no_shadowed_defs.py
+        language: system
+        files: ^(python|test|scripts)/.*\.py$
+        exclude: |
+          (?x)^(
+          python/sglang/srt/models/qwen3_5_text\.py|
+          python/sglang/srt/layers/attention/hybrid_attn_backend\.py|
+          test/registered/scripted_runtime/test_scripted_runtime_core\.py
+          )$
       - id: check-lint-script-tests
         name: unit tests for lint checkers
         entry: python3 -m unittest discover -s scripts/lint -p 'test_check_*.py'

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1148,11 +1148,6 @@ class HybridLinearAttnBackend(AttentionBackend):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_metadata_in_graph(forward_batch)
 
-    def get_indexer_metadata(self, layer_id: int, forward_batch: ForwardBatch):
-        if layer_id in self.full_attn_layers:
-            return self.full_attn_backend.get_indexer_metadata(layer_id, forward_batch)
-        return None
-
     def on_after_cuda_graph_warmup(self):
         for attn_backend in self.attn_backend_list:
             attn_backend.on_after_cuda_graph_warmup()

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -650,22 +650,6 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
     uses_own_vocab_modules = _is_npu
 
     @classmethod
-    def shared_experts_fusion_disable_reason(
-        cls,
-        hf_config,
-        quant_config,
-    ):
-        if _is_npu:
-            return (
-                "NPU DSpark ModelSlim weight loading does not support mapping "
-                "shared experts into fused expert slots."
-            )
-
-        return DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
-            hf_config, quant_config
-        )
-
-    @classmethod
     def shared_experts_fusion_disable_reason(cls, hf_config, quant_config):
         return DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
             hf_config, quant_config

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -1133,9 +1133,6 @@ class Gemma4ForCausalLM(PreTrainedModel):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.model.embed_tokens
 
-    def get_embed_and_head(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self.model.embed_tokens.weight, self.lm_head.weight
-
     def get_attention_sliding_window_size(self):
         return get_attention_sliding_window_size(self.config)
 

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -306,11 +306,6 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.language_model.get_input_embeddings()
 
-    def get_embed_and_head(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Gemma 4 multimodal ties its LM head to the text embed_tokens
-        embed = self.language_model.embed_tokens.weight
-        return embed, embed
-
     def get_attention_sliding_window_size(self):
         return getattr(self.config.text_config, "sliding_window", -1) - 1
 

--- a/scripts/lint/check_no_shadowed_defs.py
+++ b/scripts/lint/check_no_shadowed_defs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Reject a method defined twice in one class body.
+
+Python binds the last definition, so the earlier one never runs. That is
+usually a merge artifact: two branches each added the method, and the survivor
+silently drops whatever the other one did. `HybridAttnBackend.forward` sat like
+that for months, and the shadowed copy still read as live code.
+
+Only same-class collisions count. Overloads, property accessors, and
+`typing.overload` stubs are legitimate repeats and are skipped.
+"""
+
+import ast
+import pathlib
+import sys
+
+_ALLOWED_DECORATORS = ("overload", "setter", "getter", "deleter", "register")
+
+
+def _is_intentional_repeat(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Property accessors and dispatch registrations reuse a name on purpose."""
+    for decorator in node.decorator_list:
+        text = ast.unparse(decorator)
+        if any(marker in text for marker in _ALLOWED_DECORATORS):
+            return True
+    return False
+
+
+def find_shadowed_defs(path: pathlib.Path) -> list[tuple[str, str, int, int]]:
+    """Return (class, method, shadowed_line, winning_line) for each collision."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    shadowed = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        # Direct children only: a nested class keeps its own namespace.
+        seen: dict[str, int] = {}
+        for item in node.body:
+            if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if _is_intentional_repeat(item):
+                continue
+            if item.name in seen:
+                shadowed.append((node.name, item.name, seen[item.name], item.lineno))
+            seen[item.name] = item.lineno
+    return shadowed
+
+
+def main(paths: list[str]) -> int:
+    offenders = []
+    for path_string in paths:
+        path = pathlib.Path(path_string)
+        for class_name, method, shadowed_line, winning_line in find_shadowed_defs(path):
+            offenders.append(
+                f"  {path}:{shadowed_line}: {class_name}.{method}() is shadowed "
+                f"by the definition on line {winning_line}"
+            )
+
+    if not offenders:
+        return 0
+
+    print(
+        "ERROR: a method defined twice in one class body only runs the last "
+        "definition. Delete the dead one, or merge what it does into the "
+        "survivor:"
+    )
+    for offender in offenders:
+        print(offender)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/lint/test_check_no_shadowed_defs.py
+++ b/scripts/lint/test_check_no_shadowed_defs.py
@@ -1,0 +1,130 @@
+import pathlib
+import tempfile
+import unittest
+
+from check_no_shadowed_defs import find_shadowed_defs
+
+
+class TestFindShadowedDefs(unittest.TestCase):
+    def check_source(self, source: str):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "example.py"
+            path.write_text(source, encoding="utf-8")
+            return find_shadowed_defs(path)
+
+    def test_reports_shadowed_method(self):
+        source = """
+class Backend:
+    def forward(self):
+        return "dead"
+
+    def forward(self):
+        return "live"
+"""
+        self.assertEqual(self.check_source(source), [("Backend", "forward", 3, 6)])
+
+    def test_accepts_single_definition(self):
+        source = """
+class Backend:
+    def forward(self):
+        return 1
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_accepts_same_name_in_different_classes(self):
+        source = """
+class A:
+    def forward(self):
+        return 1
+
+
+class B:
+    def forward(self):
+        return 2
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_accepts_same_name_in_a_nested_class(self):
+        source = """
+class Outer:
+    def forward(self):
+        return 1
+
+    class Inner:
+        def forward(self):
+            return 2
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_accepts_property_accessors(self):
+        source = """
+class Config:
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self._value = new_value
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_accepts_typing_overloads(self):
+        source = """
+class Loader:
+    @overload
+    def load(self, name: str) -> str: ...
+
+    @typing.overload
+    def load(self, name: int) -> int: ...
+
+    def load(self, name):
+        return name
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_reports_async_method(self):
+        source = """
+class Client:
+    async def send(self):
+        return "dead"
+
+    async def send(self):
+        return "live"
+"""
+        self.assertEqual(self.check_source(source), [("Client", "send", 3, 6)])
+
+    def test_reports_every_extra_definition(self):
+        source = """
+class Backend:
+    def forward(self):
+        return 1
+
+    def forward(self):
+        return 2
+
+    def forward(self):
+        return 3
+"""
+        self.assertEqual(
+            self.check_source(source),
+            [("Backend", "forward", 3, 6), ("Backend", "forward", 6, 9)],
+        )
+
+    def test_ignores_module_level_redefinition(self):
+        source = """
+def helper():
+    return 1
+
+
+def helper():
+    return 2
+"""
+        self.assertEqual(self.check_source(source), [])
+
+    def test_ignores_unparsable_file(self):
+        self.assertEqual(self.check_source("class Backend\n"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/manual/lang_frontend/test_separate_reasoning_execution.py
+++ b/test/manual/lang_frontend/test_separate_reasoning_execution.py
@@ -56,12 +56,6 @@ class TestSeparateReasoningExecution(CustomTestCase):
         for event in self.events:
             event.set()
 
-    def tearDown(self):
-        super().tearDown()
-        # wake up all threads
-        for ev in self.events:
-            ev.set()
-
     @patch("sglang.srt.parser.reasoning_parser.ReasoningParser")
     def test_execute_separate_reasoning(self, mock_parser_class):
         """Test that _execute_separate_reasoning correctly calls the ReasoningParser."""


### PR DESCRIPTION
## Motivation

Python binds the last definition in a class body, so an earlier method with the same name never runs. It is usually a merge artifact — two branches each add the method, both land, and the survivor silently drops whatever the other one did. Nothing flags it, and the dead copy still reads as live code.

`HybridAttnBackend.forward` is the clearest example: #20812 proposed reverting #19369 in March 2026 precisely because it left a duplicate `forward`, that revert was auto-closed after 158 days, #32541 later added a third variant, and #34303 tried again in August and was closed unreviewed. Six months, three attempts, still there.

It also does not stay fixed. Scanning a week apart, `UnifiedMambaTokenToKVPoolAllocator.clear` had been repaired and `HybridLinearAttnBackend.get_indexer_metadata` had appeared. That is what makes this a gate rather than a one-off cleanup.

## Modifications

`scripts/lint/check_no_shadowed_defs.py`, wired into pre-commit next to the other AST checks. Only same-class collisions count, so a nested class keeps its own namespace; `@overload`, property accessors and dispatch registrations legitimately repeat a name and are skipped.

Removed the five shadowed definitions it finds. All are unreachable today, so behaviour is unchanged:

| class | method |
|---|---|
| `HybridLinearAttnBackend` | `get_indexer_metadata` |
| `DeepseekV4ForCausalLMDSpark` | `shared_experts_fusion_disable_reason` |
| `Gemma4ForCausalLM` | `get_embed_and_head` |
| `Gemma4ForConditionalGeneration` | `get_embed_and_head` |
| `TestSeparateReasoningExecution` | `tearDown` |

The first four keep the definition Python already bound, byte for byte — `ast.unparse` of the surviving def equals `ast.unparse` of the last def on `main`. The two `tearDown` bodies are the same three statements written twice, so that one keeps the documented copy rather than the terser one.

## Two things worth a maintainer's eye

**The dspark one had an NPU guard that was never running.** The shadowed copy returned a disable reason under `_is_npu`, saying ModelSlim weight loading cannot map shared experts into fused expert slots. The bound copy has no such branch, so on NPU that fusion is currently *not* disabled. Restoring it is a behaviour change, so it is not in this PR — but if that guard was meant to be live, it needs its own fix.

**A test is not testing what it names.** In `test_scripted_runtime_core.py`, `test_get_all_node_lock_refs_held_during_run_released_after` and `test_lock_refs_held_during_run_released_after` both call `self._script_lock_refs_held_then_released`, and that name is defined twice. The first script — the one that exercises `get_all_node_lock_refs()` — is the shadowed one, so it never runs and both tests execute the same script. Fixing that means renaming rather than deleting, and confirming it needs a GPU run, so I left the file excluded and flagged it here instead.

## Exclusions

Three pre-existing offenders are excluded, each with a note in the config so they are easy to retire:

- `qwen3_5_text.py` — being fixed in #38096
- `hybrid_attn_backend.py` — the history above; worth its own PR
- `test_scripted_runtime_core.py` — the coverage gap described above

## Test Plan

`scripts/lint/test_check_no_shadowed_defs.py`, 10 cases: shadowing detected for sync and async methods, every extra definition reported, and no false positives for a single def, same name in sibling classes, same name in a nested class, property setters, `typing.overload` stubs, module-level redefinition, or an unparsable file. The existing `check-lint-script-tests` hook picks it up automatically.

```
$ pre-commit run check-no-shadowed-defs --all-files
reject methods shadowed by a later def in the same class...............Passed

$ pre-commit run check-lint-script-tests --all-files
unit tests for lint checkers...........................................Passed
```

Full pre-commit chain is green on every changed file. Verified on macOS/arm64, Python 3.12; nothing here needs a GPU.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34445759299](https://github.com/sgl-project/sglang/actions/runs/34445759299)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34445759078](https://github.com/sgl-project/sglang/actions/runs/34445759078)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34445759318](https://github.com/sgl-project/sglang/actions/runs/34445759318)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->