### PR TITLE
[AMD] ci: port the AgentX GLM-5.2-MXFP4 agentic-coding MTP benchmark to MI35x nightly

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -2079,6 +2079,16 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
+      # amd/GLM-5.2-MXFP4 is 408 GiB and is not used by any other suite, so it
+      # is the fleet-shared cache's worst case: a checkpoint nothing has seeded.
+      # Run 34446866991 spent five minutes downloading it before dying on
+      # ENOSPC with 853 MB free. Report the shortfall up front instead.
+      - name: Check model cache space
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout \
+            bash scripts/ci/amd/check_hf_cache_space.sh \
+            amd/GLM-5.2-MXFP4 408
+
       # Two arms (TP4/EP4 with HiCache, then TP8/EP1 GPU-resident), each
       # sweeping concurrency over a multi-turn agentic-coding replay. Both load
       # the same checkpoint, so they share one job and one MI35x slot.

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -2095,6 +2095,12 @@ jobs:
       # Two arms (TP4/EP4 with HiCache, then TP8/EP1 GPU-resident), each
       # sweeping concurrency over a multi-turn agentic-coding replay. Both load
       # the same checkpoint, so they share one job and one MI35x slot.
+      #
+      # The trace is one of the corpora staged on the MI35x runners: 64
+      # conversations over 584 turns, averaging 86K prompt tokens per turn and
+      # peaking at 231K, against a server that serves 1M context. Without it the
+      # test synthesizes a lighter corpus, which keeps it runnable off these
+      # runners but is not the workload the recipe is about.
       - name: Performance Test MI35x ROCm 7.2 (8-GPU GLM-5.2-MXFP4 agentic MTP)
         timeout-minutes: 300
         continue-on-error: true
@@ -2103,6 +2109,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_USE_AITER=1 \
             -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e SGLANG_AGENTIC_TRACE_PATH="/sgl-data/agentic-traces/agentic_trace_b76deeeacbf0839e.json" \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -2081,13 +2081,16 @@ jobs:
 
       # amd/GLM-5.2-MXFP4 is 408 GiB and is not used by any other suite, so it
       # is the fleet-shared cache's worst case: a checkpoint nothing has seeded.
-      # Run 34446866991 spent five minutes downloading it before dying on
-      # ENOSPC with 853 MB free. Report the shortfall up front instead.
+      # Runs 34446866991, 34448628528 and 34487053976 all died downloading it,
+      # the last of them after consuming the volume's remaining 120 GiB. The
+      # checkpoint is useless until every shard is present, so --strict stops at
+      # the check rather than spending the rest of the fleet's headroom to reach
+      # the same ENOSPC.
       - name: Check model cache space
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout \
             bash scripts/ci/amd/check_hf_cache_space.sh \
-            amd/GLM-5.2-MXFP4 408
+            amd/GLM-5.2-MXFP4 408 --strict
 
       # Two arms (TP4/EP4 with HiCache, then TP8/EP1 GPU-resident), each
       # sweeping concurrency over a multi-turn agentic-coding replay. Both load

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -93,6 +93,8 @@ on:
           - nightly-8-gpu-glm51-rocm720
           # 8-GPU GLM-5.2-FP8 (MI35x accuracy + performance)
           - nightly-8-gpu-mi35x-glm52-fp8-rocm720
+          # 8-GPU GLM-5.2-MXFP4 agentic-coding + MTP (MI35x only)
+          - nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp-rocm720
           # 8-GPU GLM-5-MXFP4 (MI35x only)
           - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
           # 4-GPU MiniMax-M2.5 (MI35x)
@@ -2044,6 +2046,56 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
+  # 8-GPU GLM-5.2-MXFP4 agentic-coding + MTP (MI35x only)
+  # ==============================================================================
+
+  nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp-rocm720:
+    name: ${{ format('nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm10", "rocm724", "rocm720"]') }}
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp-rocm720,'))
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (${{ matrix.rocm_version }})
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      # Two arms (TP4/EP4 with HiCache, then TP8/EP1 GPU-resident), each
+      # sweeping concurrency over a multi-turn agentic-coding replay. Both load
+      # the same checkpoint, so they share one job and one MI35x slot.
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU GLM-5.2-MXFP4 agentic MTP)
+        timeout-minutes: 300
+        continue-on-error: true
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ==============================================================================
   # 8-GPU GLM-5-MXFP4 (MI35x only)
   # ==============================================================================
 
@@ -2367,6 +2419,8 @@ jobs:
       - nightly-8-gpu-glm51-rocm720
       # 8-GPU GLM-5.2-FP8 (MI35x accuracy + performance)
       - nightly-8-gpu-mi35x-glm52-fp8-rocm720
+      # 8-GPU GLM-5.2-MXFP4 agentic-coding + MTP (MI35x only)
+      - nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp-rocm720
       # 8-GPU GLM-5-MXFP4 (MI35x only)
       - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
       # 4-GPU MiniMax-M2.5 (MI35x)

--- a/python/sglang/test/agentic_bench_utils.py
+++ b/python/sglang/test/agentic_bench_utils.py
@@ -1,0 +1,462 @@
+"""Utilities for running agentic multi-turn serving benchmarks.
+
+Nightly perf tests in :mod:`test.registered` use these helpers to drive
+``sglang.benchmark.serving --dataset-name agentic-trace`` over a concurrency
+sweep and turn the resulting JSONL into a markdown report.
+
+Agentic coding replay differs from the fixed-shape ``bench_one_batch_server``
+sweeps the other nightly perf tests run: each conversation is a session whose
+history grows turn by turn, so the interesting numbers are inter-token latency
+under a growing context and how much of each turn's prompt the prefix cache
+serves. ``NightlyBenchmarkRunner`` only drives ``bench_one_batch_server``
+(batch size x input len x output len), which cannot express that, hence this
+module.
+"""
+
+import json
+import os
+import random
+import subprocess
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+# Env var pointing at a pre-built agentic trace JSON. When unset the caller
+# falls back to `write_agentic_coding_trace`, so CI has a workload without
+# depending on a corpus it cannot download.
+AGENTIC_TRACE_PATH_ENV = "SGLANG_AGENTIC_TRACE_PATH"
+
+# Rough BPE tokens-per-word for the code-and-prose mix below. Only used to
+# turn the token budgets in `AgenticTraceSpec` into word counts; the replay
+# itself never depends on hitting the budget exactly (`AgenticTraceDataset`
+# treats each conversation's `prompt_tokens` as informational).
+_TOKENS_PER_WORD = 1.3
+
+_MODULES = (
+    "scheduler",
+    "tokenizer_manager",
+    "radix_cache",
+    "hicache_storage",
+    "attention_backend",
+    "moe_runner",
+    "speculative_worker",
+    "memory_pool",
+    "model_runner",
+    "server_args",
+)
+
+_SYMBOLS = (
+    "allocate_token_slots",
+    "match_prefix",
+    "evict_host_pages",
+    "prepare_for_decode",
+    "resolve_future_tokens",
+    "build_forward_batch",
+    "capture_cuda_graph",
+    "flush_write_queue",
+    "select_experts",
+    "verify_draft_tokens",
+)
+
+_TOOL_NAMES = ("read_file", "grep", "edit_file", "run_tests", "bash", "list_dir")
+
+
+def _lorem_words(rng: random.Random, num_words: int) -> str:
+    """Deterministic filler that tokenizes like source code and tracebacks.
+
+    Realistic token shapes matter here: the replay measures prefill cost, and a
+    stream of identical short words would compress into far fewer tokens per
+    word than a real agent transcript.
+    """
+    parts = []
+    while len(parts) < num_words:
+        parts.extend(
+            (
+                f"{rng.choice(_MODULES)}.{rng.choice(_SYMBOLS)}",
+                f"line={rng.randint(10, 4000)}",
+                rng.choice(
+                    (
+                        "returns",
+                        "expects",
+                        "raises",
+                        "asserts",
+                        "wraps",
+                        "reuses",
+                        "invalidates",
+                    )
+                ),
+                rng.choice(
+                    (
+                        "the page-aligned KV block",
+                        "a host-tier prefetch",
+                        "the draft token budget",
+                        "an evicted radix node",
+                        "the chunked prefill window",
+                    )
+                ),
+            )
+        )
+    return " ".join(parts[:num_words])
+
+
+def _block(rng: random.Random, num_tokens: int) -> str:
+    return _lorem_words(rng, max(1, int(num_tokens / _TOKENS_PER_WORD)))
+
+
+@dataclass(frozen=True)
+class AgenticTraceSpec:
+    """Shape of a synthesized agentic-coding corpus.
+
+    Defaults approximate a mid-sized coding-agent session: a shared agent
+    scaffold, a per-session repository context that dominates the first turn,
+    and tool-output deltas that grow the history every turn.
+    """
+
+    num_conversations: int = 24
+    turns_per_conversation: int = 8
+    # Identical across conversations, so it models the cross-session prefix
+    # every coding agent re-sends.
+    system_prompt_tokens: int = 2048
+    # Unique per conversation: the bulk of turn 1, and the prefix that every
+    # later turn in the same session should hit in cache.
+    repo_context_tokens: int = 32768
+    # Tool output appended each turn.
+    turn_tokens: int = 4096
+
+    def first_turn_tokens(self) -> int:
+        return self.system_prompt_tokens + self.repo_context_tokens + self.turn_tokens
+
+
+def _system_prompt(spec: AgenticTraceSpec) -> str:
+    rng = random.Random(0)
+    tools = ", ".join(_TOOL_NAMES)
+    head = (
+        "You are a coding agent working inside a large Python and C++ "
+        f"repository. You have these tools available: {tools}. Investigate "
+        "before editing, keep patches minimal, and run the tests you touch. "
+        "Reference implementation notes follow.\n"
+    )
+    return head + _block(rng, spec.system_prompt_tokens)
+
+
+def write_agentic_coding_trace(
+    path: str,
+    spec: AgenticTraceSpec = AgenticTraceSpec(),
+    seed: int = 42,
+) -> str:
+    """Write a synthetic agentic-coding trace in ``agentic-trace`` JSON form.
+
+    The real SemiAnalysis/OpenHands corpora these benchmarks were built against
+    are gated, so CI synthesizes a corpus with the same structure instead: a
+    long shared scaffold, a long per-session context, and short tool-output
+    deltas. Absolute throughput is therefore not comparable to a run over a
+    real corpus, but the run-to-run comparison a nightly regression check needs
+    holds, because the corpus is a deterministic function of ``spec`` and
+    ``seed``.
+
+    Returns the path written.
+    """
+    system_prompt = _system_prompt(spec)
+    conversations = []
+
+    for conv_index in range(spec.num_conversations):
+        rng = random.Random(seed + conv_index)
+        repo_context = _block(rng, spec.repo_context_tokens)
+        turns = [
+            {
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Task {conv_index}: a regression landed in "
+                            f"{rng.choice(_MODULES)}. Repository context "
+                            f"follows.\n{repo_context}\n"
+                            f"{_block(rng, spec.turn_tokens)}"
+                        ),
+                    },
+                ],
+                "prompt_tokens": spec.first_turn_tokens(),
+            }
+        ]
+
+        for turn_index in range(1, spec.turns_per_conversation):
+            tool = rng.choice(_TOOL_NAMES)
+            turns.append(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": (
+                                f"Output of {tool} (call {turn_index}):\n"
+                                f"{_block(rng, spec.turn_tokens)}"
+                            ),
+                        }
+                    ],
+                    "prompt_tokens": spec.first_turn_tokens()
+                    + turn_index * spec.turn_tokens,
+                }
+            )
+
+        conversations.append(turns)
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "metadata": {
+                    "source": "sglang-synthetic-agentic-coding",
+                    "seed": seed,
+                    **{k: getattr(spec, k) for k in spec.__dataclass_fields__},
+                },
+                "conversations": conversations,
+            },
+            f,
+        )
+    return path
+
+
+def resolve_agentic_trace(
+    result_dir: str,
+    spec: AgenticTraceSpec = AgenticTraceSpec(),
+    seed: int = 42,
+) -> str:
+    """Return a trace path, preferring a real corpus over the synthetic one."""
+    override = os.environ.get(AGENTIC_TRACE_PATH_ENV)
+    if override:
+        if not os.path.isfile(override):
+            raise FileNotFoundError(
+                f"{AGENTIC_TRACE_PATH_ENV}={override} does not point to a file"
+            )
+        print(f"Using agentic trace from {AGENTIC_TRACE_PATH_ENV}: {override}")
+        return override
+
+    path = os.path.join(result_dir, "agentic_coding_trace.json")
+    write_agentic_coding_trace(path, spec=spec, seed=seed)
+    print(
+        f"Synthesized agentic trace at {path} "
+        f"({spec.num_conversations} conversations x "
+        f"{spec.turns_per_conversation} turns, "
+        f"~{spec.first_turn_tokens()} tokens on turn 1). "
+        f"Set {AGENTIC_TRACE_PATH_ENV} to replay a real corpus instead."
+    )
+    return path
+
+
+@dataclass
+class AgenticBenchPoint:
+    """One concurrency point of an agentic sweep.
+
+    ``bench_serving`` reports no input throughput for multi-turn replay (it
+    cannot attribute a prompt length to a turn it did not construct), so the
+    prefill side shows up as cache hit rate rather than input tok/s.
+    """
+
+    concurrency: int
+    conversations: int
+    completed_turns: int
+    duration_s: float
+    output_throughput: float
+    mean_ttft_ms: float
+    p99_ttft_ms: float
+    mean_itl_ms: float
+    p99_itl_ms: float
+    mean_e2e_latency_ms: float
+    achieved_concurrency: float
+    accept_length: Optional[float] = None
+    cache_hit_rate_pct: Optional[float] = None
+    host_cached_tokens: Optional[int] = None
+    raw: Dict = field(default_factory=dict, repr=False)
+
+
+def _parse_bench_record(record: Dict, concurrency: int, conversations: int):
+    cache_report = record.get("cache_report") or {}
+    return AgenticBenchPoint(
+        concurrency=concurrency,
+        conversations=conversations,
+        completed_turns=record.get("completed", 0),
+        duration_s=record.get("duration", 0.0),
+        output_throughput=record.get("output_throughput", 0.0),
+        mean_ttft_ms=record.get("mean_ttft_ms", 0.0),
+        p99_ttft_ms=record.get("p99_ttft_ms", 0.0),
+        mean_itl_ms=record.get("mean_itl_ms", 0.0),
+        p99_itl_ms=record.get("p99_itl_ms", 0.0),
+        mean_e2e_latency_ms=record.get("mean_e2e_latency_ms", 0.0),
+        achieved_concurrency=record.get("concurrency", 0.0),
+        accept_length=record.get("accept_length"),
+        cache_hit_rate_pct=cache_report.get("cache_hit_rate_pct"),
+        host_cached_tokens=cache_report.get("host_cached_tokens"),
+        raw=record,
+    )
+
+
+def run_agentic_concurrency_sweep(
+    base_url: str,
+    model_path: str,
+    trace_path: str,
+    result_dir: str,
+    concurrencies: Sequence[int],
+    conversations_per_slot: int = 2,
+    max_turns: Optional[int] = None,
+    output_len: Optional[int] = None,
+    timeout: int = 3600,
+    extra_bench_args: Optional[List[str]] = None,
+) -> List[AgenticBenchPoint]:
+    """Replay the trace once per concurrency level against a running server.
+
+    ``conversations_per_slot`` scales the conversation count with concurrency so
+    every point replays the same number of sequential waves; a fixed count would
+    make low-concurrency points many times longer than high-concurrency ones.
+
+    In CI ``bench_serving`` flushes the server cache before each measured run
+    (see ``should_flush_cache`` in ``sglang.benchmark.serving``), so each point
+    starts cold and measures only the prefix reuse it generates itself.
+    """
+    os.makedirs(result_dir, exist_ok=True)
+    points: List[AgenticBenchPoint] = []
+
+    for concurrency in concurrencies:
+        conversations = concurrency * conversations_per_slot
+        output_file = os.path.join(result_dir, f"agentic_conc{concurrency}.jsonl")
+        if os.path.exists(output_file):
+            os.remove(output_file)
+
+        command = [
+            "python3",
+            "-m",
+            "sglang.benchmark.serving",
+            "--backend",
+            "sglang-oai-chat",
+            "--base-url",
+            base_url,
+            "--model",
+            model_path,
+            "--tokenizer",
+            model_path,
+            "--dataset-name",
+            "agentic-trace",
+            "--dataset-path",
+            trace_path,
+            "--num-prompts",
+            str(conversations),
+            "--max-concurrency",
+            str(concurrency),
+            "--warmup-requests",
+            "1",
+            "--cache-report",
+            "--output-file",
+            output_file,
+            "--trust-remote-code",
+        ]
+        if max_turns is not None:
+            command += ["--agentic-max-turns", str(max_turns)]
+        if output_len is not None:
+            command += ["--sharegpt-output-len", str(output_len)]
+        if extra_bench_args:
+            command += list(extra_bench_args)
+
+        print(f"Running agentic replay at concurrency {concurrency}: {command}")
+        result = subprocess.run(command, text=True, timeout=timeout)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Agentic replay failed at concurrency {concurrency} "
+                f"(exit code {result.returncode})"
+            )
+        if not os.path.exists(output_file):
+            raise RuntimeError(
+                f"Agentic replay at concurrency {concurrency} wrote no results "
+                f"to {output_file}"
+            )
+
+        with open(output_file, "r", encoding="utf-8") as f:
+            records = [json.loads(line) for line in f if line.strip()]
+        if not records:
+            raise RuntimeError(f"{output_file} contains no benchmark records")
+
+        point = _parse_bench_record(records[-1], concurrency, conversations)
+        if point.completed_turns == 0:
+            raise RuntimeError(
+                f"Agentic replay at concurrency {concurrency} completed no turns"
+            )
+        points.append(point)
+
+    return points
+
+
+def run_agentic_benchmark(
+    model_path: str,
+    base_url: str,
+    server_args: List[str],
+    result_dir: str,
+    concurrencies: Sequence[int],
+    trace_spec: AgenticTraceSpec = AgenticTraceSpec(),
+    conversations_per_slot: int = 2,
+    max_turns: Optional[int] = None,
+    output_len: Optional[int] = None,
+    server_launch_timeout: int = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    bench_timeout: int = 3600,
+    env: Optional[dict] = None,
+) -> List[AgenticBenchPoint]:
+    """Launch a server, run the concurrency sweep against it, then tear it down."""
+    trace_path = resolve_agentic_trace(result_dir, spec=trace_spec)
+
+    process = popen_launch_server(
+        model=model_path,
+        base_url=base_url,
+        other_args=server_args,
+        timeout=server_launch_timeout,
+        env=env,
+    )
+    try:
+        return run_agentic_concurrency_sweep(
+            base_url=base_url,
+            model_path=model_path,
+            trace_path=trace_path,
+            result_dir=result_dir,
+            concurrencies=concurrencies,
+            conversations_per_slot=conversations_per_slot,
+            max_turns=max_turns,
+            output_len=output_len,
+            timeout=bench_timeout,
+        )
+    finally:
+        kill_process_tree(process.pid)
+
+
+def generate_agentic_markdown_report(
+    points: Sequence[AgenticBenchPoint], header: str
+) -> str:
+    """Render a sweep as a markdown table for the GitHub step summary."""
+    summary = f"### {header}\n"
+    summary += (
+        "| concurrency | conversations | turns | duration (s) | "
+        "output throughput (tok/s) | mean TTFT (ms) | p99 TTFT (ms) | "
+        "mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | cache hit (%) | "
+        "accept len |\n"
+    )
+    summary += (
+        "| ----------- | ------------- | ----- | ------------ | "
+        "------------------------- | -------------- | ------------- | "
+        "------------- | ------------ | ------------- | ------------- | "
+        "---------- |\n"
+    )
+
+    for p in points:
+        cache_hit = (
+            f"{p.cache_hit_rate_pct:.1f}" if p.cache_hit_rate_pct is not None else "n/a"
+        )
+        accept = f"{p.accept_length:.2f}" if p.accept_length else "n/a"
+        summary += (
+            f"| {p.concurrency} | {p.conversations} | {p.completed_turns} | "
+            f"{p.duration_s:.1f} | {p.output_throughput:.2f} | "
+            f"{p.mean_ttft_ms:.2f} | {p.p99_ttft_ms:.2f} | "
+            f"{p.mean_itl_ms:.2f} | {p.p99_itl_ms:.2f} | "
+            f"{p.mean_e2e_latency_ms:.2f} | {cache_hit} | {accept} |\n"
+        )
+
+    return summary

--- a/python/sglang/test/agentic_bench_utils.py
+++ b/python/sglang/test/agentic_bench_utils.py
@@ -17,7 +17,7 @@ import json
 import os
 import random
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Sequence
 
 from sglang.srt.utils import kill_process_tree
@@ -31,11 +31,16 @@ from sglang.test.test_utils import (
 # depending on a corpus it cannot download.
 AGENTIC_TRACE_PATH_ENV = "SGLANG_AGENTIC_TRACE_PATH"
 
-# Rough BPE tokens-per-word for the code-and-prose mix below. Only used to
-# turn the token budgets in `AgenticTraceSpec` into word counts; the replay
-# itself never depends on hitting the budget exactly (`AgenticTraceDataset`
-# treats each conversation's `prompt_tokens` as informational).
-_TOKENS_PER_WORD = 1.3
+# Tokens produced per filler fragment emitted by `_lorem_words`, used to turn
+# the token budgets in `AgenticTraceSpec` into fragment counts. Measured at
+# 5.34 (gpt2) and 5.30 (bert-base-uncased) over the fragments below; dotted
+# identifiers and `key=value` pairs split densely, which is the point. Pass a
+# tokenizer to `write_agentic_coding_trace` to calibrate this exactly instead.
+_TOKENS_PER_PART = 5.3
+
+# Fragments to encode when calibrating against a real tokenizer. Large enough
+# that the ratio settles, small enough to encode in well under a second.
+_CALIBRATION_PARTS = 2000
 
 _MODULES = (
     "scheduler",
@@ -66,7 +71,7 @@ _SYMBOLS = (
 _TOOL_NAMES = ("read_file", "grep", "edit_file", "run_tests", "bash", "list_dir")
 
 
-def _lorem_words(rng: random.Random, num_words: int) -> str:
+def _lorem_words(rng: random.Random, num_parts: int) -> str:
     """Deterministic filler that tokenizes like source code and tracebacks.
 
     Realistic token shapes matter here: the replay measures prefill cost, and a
@@ -74,7 +79,7 @@ def _lorem_words(rng: random.Random, num_words: int) -> str:
     word than a real agent transcript.
     """
     parts = []
-    while len(parts) < num_words:
+    while len(parts) < num_parts:
         parts.extend(
             (
                 f"{rng.choice(_MODULES)}.{rng.choice(_SYMBOLS)}",
@@ -101,11 +106,23 @@ def _lorem_words(rng: random.Random, num_words: int) -> str:
                 ),
             )
         )
-    return " ".join(parts[:num_words])
+    return " ".join(parts[:num_parts])
 
 
-def _block(rng: random.Random, num_tokens: int) -> str:
-    return _lorem_words(rng, max(1, int(num_tokens / _TOKENS_PER_WORD)))
+def calibrate_tokens_per_part(tokenizer) -> float:
+    """Measure how many tokens one filler fragment costs under ``tokenizer``.
+
+    The filler is statistically homogeneous, so one sample is enough to scale
+    the whole corpus; encoding every block to hit its budget exactly would cost
+    far more than the accuracy is worth.
+    """
+    sample = _lorem_words(random.Random(0), _CALIBRATION_PARTS)
+    num_tokens = len(tokenizer.encode(sample, add_special_tokens=False))
+    return num_tokens / _CALIBRATION_PARTS
+
+
+def _block(rng: random.Random, num_tokens: int, tokens_per_part: float) -> str:
+    return _lorem_words(rng, max(1, int(num_tokens / tokens_per_part)))
 
 
 @dataclass(frozen=True)
@@ -132,7 +149,7 @@ class AgenticTraceSpec:
         return self.system_prompt_tokens + self.repo_context_tokens + self.turn_tokens
 
 
-def _system_prompt(spec: AgenticTraceSpec) -> str:
+def _system_prompt(spec: AgenticTraceSpec, tokens_per_part: float) -> str:
     rng = random.Random(0)
     tools = ", ".join(_TOOL_NAMES)
     head = (
@@ -141,13 +158,14 @@ def _system_prompt(spec: AgenticTraceSpec) -> str:
         "before editing, keep patches minimal, and run the tests you touch. "
         "Reference implementation notes follow.\n"
     )
-    return head + _block(rng, spec.system_prompt_tokens)
+    return head + _block(rng, spec.system_prompt_tokens, tokens_per_part)
 
 
 def write_agentic_coding_trace(
     path: str,
     spec: AgenticTraceSpec = AgenticTraceSpec(),
     seed: int = 42,
+    tokenizer=None,
 ) -> str:
     """Write a synthetic agentic-coding trace in ``agentic-trace`` JSON form.
 
@@ -156,17 +174,27 @@ def write_agentic_coding_trace(
     long shared scaffold, a long per-session context, and short tool-output
     deltas. Absolute throughput is therefore not comparable to a run over a
     real corpus, but the run-to-run comparison a nightly regression check needs
-    holds, because the corpus is a deterministic function of ``spec`` and
-    ``seed``.
+    holds, because the corpus is a deterministic function of its inputs.
+
+    Passing ``tokenizer`` makes the token budgets in ``spec`` land on the model
+    actually under test; without one they fall back to a measured constant that
+    is accurate to a few percent for BPE and WordPiece vocabularies. Sizes have
+    to be roughly right either way, since they decide how much context each
+    session carries and therefore what the run costs.
 
     Returns the path written.
     """
-    system_prompt = _system_prompt(spec)
+    tokens_per_part = _TOKENS_PER_PART
+    if tokenizer is not None:
+        tokens_per_part = calibrate_tokens_per_part(tokenizer)
+        print(f"Calibrated agentic filler at {tokens_per_part:.2f} tokens/fragment")
+
+    system_prompt = _system_prompt(spec, tokens_per_part)
     conversations = []
 
     for conv_index in range(spec.num_conversations):
         rng = random.Random(seed + conv_index)
-        repo_context = _block(rng, spec.repo_context_tokens)
+        repo_context = _block(rng, spec.repo_context_tokens, tokens_per_part)
         turns = [
             {
                 "messages": [
@@ -177,7 +205,7 @@ def write_agentic_coding_trace(
                             f"Task {conv_index}: a regression landed in "
                             f"{rng.choice(_MODULES)}. Repository context "
                             f"follows.\n{repo_context}\n"
-                            f"{_block(rng, spec.turn_tokens)}"
+                            f"{_block(rng, spec.turn_tokens, tokens_per_part)}"
                         ),
                     },
                 ],
@@ -194,7 +222,7 @@ def write_agentic_coding_trace(
                             "role": "user",
                             "content": (
                                 f"Output of {tool} (call {turn_index}):\n"
-                                f"{_block(rng, spec.turn_tokens)}"
+                                f"{_block(rng, spec.turn_tokens, tokens_per_part)}"
                             ),
                         }
                     ],
@@ -212,6 +240,7 @@ def write_agentic_coding_trace(
                 "metadata": {
                     "source": "sglang-synthetic-agentic-coding",
                     "seed": seed,
+                    "tokens_per_part": tokens_per_part,
                     **{k: getattr(spec, k) for k in spec.__dataclass_fields__},
                 },
                 "conversations": conversations,
@@ -221,10 +250,43 @@ def write_agentic_coding_trace(
     return path
 
 
+def _resolve_local_tokenizer(model_path: str) -> str:
+    """Prefer an on-disk snapshot so the client skips the HF Hub API.
+
+    ``AutoTokenizer.from_pretrained`` on a repo id can stall for minutes in CI;
+    ``run_bench_serving`` resolves the same way.
+    """
+    try:
+        from sglang.srt.utils import find_local_repo_dir
+
+        local_dir = find_local_repo_dir(model_path, revision=None)
+        if local_dir and os.path.isdir(local_dir):
+            return local_dir
+    except Exception as e:
+        print(f"Could not resolve a local snapshot for {model_path}: {e}")
+    return model_path
+
+
+def _load_tokenizer_for_calibration(model_path: str):
+    """Load the model's tokenizer, or return None if it cannot be loaded.
+
+    Only used to size the synthetic corpus, so a failure here should downgrade
+    to the fallback ratio rather than take down the benchmark.
+    """
+    try:
+        from sglang.benchmark.utils import get_tokenizer
+
+        return get_tokenizer(_resolve_local_tokenizer(model_path))
+    except Exception as e:
+        print(f"Falling back to the default filler ratio; no tokenizer for {e}")
+        return None
+
+
 def resolve_agentic_trace(
     result_dir: str,
     spec: AgenticTraceSpec = AgenticTraceSpec(),
     seed: int = 42,
+    tokenizer=None,
 ) -> str:
     """Return a trace path, preferring a real corpus over the synthetic one."""
     override = os.environ.get(AGENTIC_TRACE_PATH_ENV)
@@ -237,7 +299,7 @@ def resolve_agentic_trace(
         return override
 
     path = os.path.join(result_dir, "agentic_coding_trace.json")
-    write_agentic_coding_trace(path, spec=spec, seed=seed)
+    write_agentic_coding_trace(path, spec=spec, seed=seed, tokenizer=tokenizer)
     print(
         f"Synthesized agentic trace at {path} "
         f"({spec.num_conversations} conversations x "
@@ -259,6 +321,7 @@ class AgenticBenchPoint:
 
     concurrency: int
     conversations: int
+    total_turns: int
     completed_turns: int
     duration_s: float
     output_throughput: float
@@ -273,12 +336,36 @@ class AgenticBenchPoint:
     host_cached_tokens: Optional[int] = None
     raw: Dict = field(default_factory=dict, repr=False)
 
+    @property
+    def failed_turns(self) -> int:
+        return self.total_turns - self.completed_turns
+
+
+# Per-turn arrays that `--output-details` adds. Only the errors list is read;
+# the rest would carry megabytes of generated text through the sweep.
+_DETAIL_KEYS = (
+    "input_lens",
+    "output_lens",
+    "ttfts",
+    "itls",
+    "generated_texts",
+    "errors",
+    "cached_tokens",
+    "cached_tokens_details",
+)
+
 
 def _parse_bench_record(record: Dict, concurrency: int, conversations: int):
     cache_report = record.get("cache_report") or {}
+    # One entry per replayed turn, which is the only corpus-agnostic way to
+    # learn how many turns the run actually attempted: a real trace has a
+    # different turn count in every conversation.
+    errors = record.get("errors") or []
+    summary = {k: v for k, v in record.items() if k not in _DETAIL_KEYS}
     return AgenticBenchPoint(
         concurrency=concurrency,
         conversations=conversations,
+        total_turns=len(errors),
         completed_turns=record.get("completed", 0),
         duration_s=record.get("duration", 0.0),
         output_throughput=record.get("output_throughput", 0.0),
@@ -291,8 +378,61 @@ def _parse_bench_record(record: Dict, concurrency: int, conversations: int):
         accept_length=record.get("accept_length"),
         cache_hit_rate_pct=cache_report.get("cache_hit_rate_pct"),
         host_cached_tokens=cache_report.get("host_cached_tokens"),
-        raw=record,
+        raw=summary,
     )
+
+
+def build_agentic_bench_command(
+    base_url: str,
+    model_path: str,
+    tokenizer: str,
+    trace_path: str,
+    conversations: int,
+    concurrency: int,
+    output_file: str,
+    max_turns: Optional[int] = None,
+    output_len: Optional[int] = None,
+    extra_bench_args: Optional[List[str]] = None,
+) -> List[str]:
+    """Build one ``sglang.benchmark.serving`` invocation for the sweep."""
+    command = [
+        "python3",
+        "-m",
+        "sglang.benchmark.serving",
+        # Multi-turn replay is only wired up for the chat backends.
+        "--backend",
+        "sglang-oai-chat",
+        "--base-url",
+        base_url,
+        "--model",
+        model_path,
+        "--tokenizer",
+        tokenizer,
+        "--dataset-name",
+        "agentic-trace",
+        "--dataset-path",
+        trace_path,
+        # For this dataset one "prompt" is one conversation.
+        "--num-prompts",
+        str(conversations),
+        "--max-concurrency",
+        str(concurrency),
+        "--warmup-requests",
+        "1",
+        "--cache-report",
+        # Carries the per-turn errors list, which is how the caller tells a
+        # clean run from one that reported throughput for turns that 5xx'd.
+        "--output-details",
+        "--output-file",
+        output_file,
+    ]
+    if max_turns is not None:
+        command += ["--agentic-max-turns", str(max_turns)]
+    if output_len is not None:
+        command += ["--sharegpt-output-len", str(output_len)]
+    if extra_bench_args:
+        command += list(extra_bench_args)
+    return command
 
 
 def run_agentic_concurrency_sweep(
@@ -304,7 +444,7 @@ def run_agentic_concurrency_sweep(
     conversations_per_slot: int = 2,
     max_turns: Optional[int] = None,
     output_len: Optional[int] = None,
-    timeout: int = 3600,
+    timeout_per_point: int = 1800,
     extra_bench_args: Optional[List[str]] = None,
 ) -> List[AgenticBenchPoint]:
     """Replay the trace once per concurrency level against a running server.
@@ -319,6 +459,7 @@ def run_agentic_concurrency_sweep(
     """
     os.makedirs(result_dir, exist_ok=True)
     points: List[AgenticBenchPoint] = []
+    tokenizer = _resolve_local_tokenizer(model_path)
 
     for concurrency in concurrencies:
         conversations = concurrency * conversations_per_slot
@@ -326,42 +467,21 @@ def run_agentic_concurrency_sweep(
         if os.path.exists(output_file):
             os.remove(output_file)
 
-        command = [
-            "python3",
-            "-m",
-            "sglang.benchmark.serving",
-            "--backend",
-            "sglang-oai-chat",
-            "--base-url",
-            base_url,
-            "--model",
-            model_path,
-            "--tokenizer",
-            model_path,
-            "--dataset-name",
-            "agentic-trace",
-            "--dataset-path",
-            trace_path,
-            "--num-prompts",
-            str(conversations),
-            "--max-concurrency",
-            str(concurrency),
-            "--warmup-requests",
-            "1",
-            "--cache-report",
-            "--output-file",
-            output_file,
-            "--trust-remote-code",
-        ]
-        if max_turns is not None:
-            command += ["--agentic-max-turns", str(max_turns)]
-        if output_len is not None:
-            command += ["--sharegpt-output-len", str(output_len)]
-        if extra_bench_args:
-            command += list(extra_bench_args)
+        command = build_agentic_bench_command(
+            base_url=base_url,
+            model_path=model_path,
+            tokenizer=tokenizer,
+            trace_path=trace_path,
+            conversations=conversations,
+            concurrency=concurrency,
+            output_file=output_file,
+            max_turns=max_turns,
+            output_len=output_len,
+            extra_bench_args=extra_bench_args,
+        )
 
         print(f"Running agentic replay at concurrency {concurrency}: {command}")
-        result = subprocess.run(command, text=True, timeout=timeout)
+        result = subprocess.run(command, text=True, timeout=timeout_per_point)
         if result.returncode != 0:
             raise RuntimeError(
                 f"Agentic replay failed at concurrency {concurrency} "
@@ -379,9 +499,9 @@ def run_agentic_concurrency_sweep(
             raise RuntimeError(f"{output_file} contains no benchmark records")
 
         point = _parse_bench_record(records[-1], concurrency, conversations)
-        if point.completed_turns == 0:
+        if point.total_turns == 0:
             raise RuntimeError(
-                f"Agentic replay at concurrency {concurrency} completed no turns"
+                f"Agentic replay at concurrency {concurrency} replayed no turns"
             )
         points.append(point)
 
@@ -399,11 +519,23 @@ def run_agentic_benchmark(
     max_turns: Optional[int] = None,
     output_len: Optional[int] = None,
     server_launch_timeout: int = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-    bench_timeout: int = 3600,
+    bench_timeout_per_point: int = 1800,
     env: Optional[dict] = None,
 ) -> List[AgenticBenchPoint]:
     """Launch a server, run the concurrency sweep against it, then tear it down."""
-    trace_path = resolve_agentic_trace(result_dir, spec=trace_spec)
+    # The largest point needs this many distinct conversations; the loader
+    # silently returns fewer rows than asked for if the corpus is smaller, so
+    # grow the synthesized one rather than measure a shorter workload than the
+    # sweep describes. A caller-supplied corpus is taken as-is.
+    needed = max(concurrencies) * conversations_per_slot
+    if trace_spec.num_conversations < needed:
+        trace_spec = replace(trace_spec, num_conversations=needed)
+
+    trace_path = resolve_agentic_trace(
+        result_dir,
+        spec=trace_spec,
+        tokenizer=_load_tokenizer_for_calibration(model_path),
+    )
 
     process = popen_launch_server(
         model=model_path,
@@ -422,7 +554,7 @@ def run_agentic_benchmark(
             conversations_per_slot=conversations_per_slot,
             max_turns=max_turns,
             output_len=output_len,
-            timeout=bench_timeout,
+            timeout_per_point=bench_timeout_per_point,
         )
     finally:
         kill_process_tree(process.pid)
@@ -434,13 +566,13 @@ def generate_agentic_markdown_report(
     """Render a sweep as a markdown table for the GitHub step summary."""
     summary = f"### {header}\n"
     summary += (
-        "| concurrency | conversations | turns | duration (s) | "
+        "| concurrency | conversations | turns (ok/total) | duration (s) | "
         "output throughput (tok/s) | mean TTFT (ms) | p99 TTFT (ms) | "
         "mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | cache hit (%) | "
         "accept len |\n"
     )
     summary += (
-        "| ----------- | ------------- | ----- | ------------ | "
+        "| ----------- | ------------- | ---------------- | ------------ | "
         "------------------------- | -------------- | ------------- | "
         "------------- | ------------ | ------------- | ------------- | "
         "---------- |\n"
@@ -452,7 +584,8 @@ def generate_agentic_markdown_report(
         )
         accept = f"{p.accept_length:.2f}" if p.accept_length else "n/a"
         summary += (
-            f"| {p.concurrency} | {p.conversations} | {p.completed_turns} | "
+            f"| {p.concurrency} | {p.conversations} | "
+            f"{p.completed_turns}/{p.total_turns} | "
             f"{p.duration_s:.1f} | {p.output_throughput:.2f} | "
             f"{p.mean_ttft_ms:.2f} | {p.p99_ttft_ms:.2f} | "
             f"{p.mean_itl_ms:.2f} | {p.p99_itl_ms:.2f} | "

--- a/python/sglang/test/agentic_bench_utils.py
+++ b/python/sglang/test/agentic_bench_utils.py
@@ -316,7 +316,17 @@ class AgenticBenchPoint:
 
     ``bench_serving`` reports no input throughput for multi-turn replay (it
     cannot attribute a prompt length to a turn it did not construct), so the
-    prefill side shows up as cache hit rate rather than input tok/s.
+    prefill side shows up as reused prompt tokens rather than input tok/s.
+
+    Those are absolute token counts, not a hit rate, because a rate needs a
+    prompt length the two sides agree on and here they do not.
+    ``cache_report.cache_hit_rate_pct`` divides the server's ``cached_tokens``
+    by the client's ``len(tokenizer.encode(prompt_text))``, and on a chat
+    backend the server additionally tokenizes the chat template the client
+    never saw. Run 34551237847 reported 117% on every point of both arms.
+    ``host_share_pct`` below is a ratio of two server-side numbers, so it is
+    sound, and it is the one this recipe is about: how much of the reuse came
+    from the DRAM tier rather than from GPU memory.
     """
 
     concurrency: int
@@ -332,13 +342,25 @@ class AgenticBenchPoint:
     mean_e2e_latency_ms: float
     achieved_concurrency: float
     accept_length: Optional[float] = None
-    cache_hit_rate_pct: Optional[float] = None
+    cached_tokens: Optional[int] = None
     host_cached_tokens: Optional[int] = None
     raw: Dict = field(default_factory=dict, repr=False)
 
     @property
     def failed_turns(self) -> int:
         return self.total_turns - self.completed_turns
+
+    @property
+    def reused_tokens_per_turn(self) -> Optional[float]:
+        if self.cached_tokens is None or not self.completed_turns:
+            return None
+        return self.cached_tokens / self.completed_turns
+
+    @property
+    def host_share_pct(self) -> Optional[float]:
+        if not self.cached_tokens or self.host_cached_tokens is None:
+            return None
+        return 100.0 * self.host_cached_tokens / self.cached_tokens
 
 
 # Per-turn arrays that `--output-details` adds. Only the errors list is read;
@@ -376,7 +398,7 @@ def _parse_bench_record(record: Dict, concurrency: int, conversations: int):
         mean_e2e_latency_ms=record.get("mean_e2e_latency_ms", 0.0),
         achieved_concurrency=record.get("concurrency", 0.0),
         accept_length=record.get("accept_length"),
-        cache_hit_rate_pct=cache_report.get("cache_hit_rate_pct"),
+        cached_tokens=cache_report.get("total_cached_tokens"),
         host_cached_tokens=cache_report.get("host_cached_tokens"),
         raw=summary,
     )
@@ -568,20 +590,21 @@ def generate_agentic_markdown_report(
     summary += (
         "| concurrency | conversations | turns (ok/total) | duration (s) | "
         "output throughput (tok/s) | mean TTFT (ms) | p99 TTFT (ms) | "
-        "mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | cache hit (%) | "
-        "accept len |\n"
+        "mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | reused tok/turn | "
+        "host tier (%) | accept len |\n"
     )
     summary += (
         "| ----------- | ------------- | ---------------- | ------------ | "
         "------------------------- | -------------- | ------------- | "
-        "------------- | ------------ | ------------- | ------------- | "
-        "---------- |\n"
+        "------------- | ------------ | ------------- | --------------- | "
+        "------------- | ---------- |\n"
     )
 
     for p in points:
-        cache_hit = (
-            f"{p.cache_hit_rate_pct:.1f}" if p.cache_hit_rate_pct is not None else "n/a"
-        )
+        reused = p.reused_tokens_per_turn
+        reused_cell = f"{reused:,.0f}" if reused is not None else "n/a"
+        host = p.host_share_pct
+        host_cell = f"{host:.1f}" if host is not None else "n/a"
         accept = f"{p.accept_length:.2f}" if p.accept_length else "n/a"
         summary += (
             f"| {p.concurrency} | {p.conversations} | "
@@ -589,7 +612,8 @@ def generate_agentic_markdown_report(
             f"{p.duration_s:.1f} | {p.output_throughput:.2f} | "
             f"{p.mean_ttft_ms:.2f} | {p.p99_ttft_ms:.2f} | "
             f"{p.mean_itl_ms:.2f} | {p.p99_itl_ms:.2f} | "
-            f"{p.mean_e2e_latency_ms:.2f} | {cache_hit} | {accept} |\n"
+            f"{p.mean_e2e_latency_ms:.2f} | {reused_cell} | {host_cell} | "
+            f"{accept} |\n"
         )
 
     return summary

--- a/scripts/ci/amd/check_hf_cache_space.sh
+++ b/scripts/ci/amd/check_hf_cache_space.sh
@@ -3,7 +3,7 @@
 # clear stale download artifacts.
 #
 # Usage (inside the ci_sglang container, where /sgl-data is the cache mount):
-#   check_hf_cache_space.sh <model_repo_id> [required_gib]
+#   check_hf_cache_space.sh <model_repo_id> [required_gib] [--strict]
 #
 # Why this exists: run 32196787596 died 40 minutes into a 1.2 TB download with
 # "OSError: [Errno 28] No space left on device", and the only way to find that
@@ -22,9 +22,20 @@
 # infrastructure problem and a per-job script cannot fix it by deleting things
 # other jobs still need.
 #
-# Never fails the job: a full cache is not necessarily fatal (the checkpoint may
+# Warn-only by default: a full cache is not necessarily fatal (the checkpoint may
 # already be cached, which is the common case), and when it is fatal the
 # download says so itself -- now against a log that already explained why.
+#
+# `--strict` makes a predicted shortfall fail the job instead. Warning and
+# proceeding is only harmless when the download's failure is confined to this
+# job, and for a checkpoint far larger than the free space it is not: run
+# 34487053976 warned that amd/GLM-5.2-MXFP4 needed 314 GiB against 120 GiB free,
+# proceeded anyway, and spent eleven minutes turning that 120 GiB into a
+# checkpoint that was still incomplete -- ending with 832 MB free on a volume the
+# whole AMD fleet shares. Every byte it consumed came out of some other job's
+# headroom, and it could not have finished no matter how long it ran. Pass
+# --strict when the caller knows the download is all-or-nothing, so the job stops
+# at the check instead of draining the volume on the way to the same failure.
 #
 # "Cached" is decided by bytes on disk, not by the model directory existing. An
 # ENOSPC failure leaves a partial checkpoint behind, so the directory test alone
@@ -35,8 +46,27 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-MODEL_REPO_ID="${1:?model repo id, e.g. amd/Qwen3.8-2.4T-A95B-Quark-MXFP4}"
-REQUIRED_GIB="${2:-0}"
+STRICT=0
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        # An empty positional is how a caller says "no expected size".
+        "") ;;
+        -*)
+            echo "Unknown argument: $arg (expected --strict)" >&2
+            exit 2
+            ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
+
+MODEL_REPO_ID="${ARGS[0]:?model repo id, e.g. amd/Qwen3.8-2.4T-A95B-Quark-MXFP4}"
+REQUIRED_GIB="${ARGS[1]:-0}"
+if [[ ! "$REQUIRED_GIB" =~ ^[0-9]+$ ]]; then
+    echo "Expected size in GiB to be a whole number, got: $REQUIRED_GIB" >&2
+    exit 2
+fi
 
 HF_CACHE="${HF_HOME:-/sgl-data/hf-cache}/hub"
 # HuggingFace stores `org/name` as `models--org--name`.
@@ -124,6 +154,14 @@ check_hf_cache_space() {
     echo "         failure onto whichever job needed them next. Raising it"
     echo "         needs the runner owners."
     echo "=============================================================="
+
+    if (( STRICT )); then
+        echo "Stopping here (--strict). Starting the download would spend the"
+        echo "remaining ${avail} GiB on a checkpoint that would still be"
+        echo "incomplete, leaving the shared volume with nothing for any other"
+        echo "job and failing anyway."
+        return 1
+    fi
     return 0
 }
 

--- a/scripts/ci/amd/check_hf_cache_space.sh
+++ b/scripts/ci/amd/check_hf_cache_space.sh
@@ -25,6 +25,11 @@
 # Never fails the job: a full cache is not necessarily fatal (the checkpoint may
 # already be cached, which is the common case), and when it is fatal the
 # download says so itself -- now against a log that already explained why.
+#
+# "Cached" is decided by bytes on disk, not by the model directory existing. An
+# ENOSPC failure leaves a partial checkpoint behind, so the directory test alone
+# reports the next run's 300 GiB shortfall as "already cached, no download
+# needed" and suppresses the one warning that run needs.
 
 set -uo pipefail
 
@@ -41,6 +46,13 @@ avail_gib() {
     df -BG --output=avail "$1" 2>/dev/null | tail -1 | tr -dc '0-9'
 }
 
+# Only the blobs hold real data -- snapshot entries are symlinks into them, and
+# du counts a symlink's target once -- so this is the checkpoint's true
+# footprint. Timed out because it walks a fleet-shared network volume.
+cached_gib() {
+    timeout 300 du -sBG "$1" 2>/dev/null | cut -f1 | tr -dc '0-9'
+}
+
 report() {
     echo "=== HF cache space ($1) ==="
     df -h "$HF_CACHE" 2>/dev/null || df -h /sgl-data 2>/dev/null || true
@@ -54,13 +66,6 @@ check_hf_cache_space() {
     fi
 
     report "before"
-
-    if [[ -d "$MODEL_DIR" ]]; then
-        echo "✓ ${MODEL_REPO_ID} is already cached at ${MODEL_DIR};" \
-             "no download needed regardless of free space."
-    else
-        echo "${MODEL_REPO_ID} is NOT cached; it must be downloaded."
-    fi
 
     # Abandoned partial downloads are pure waste and safe to drop. This is the
     # shared helper the CUDA runner prep already uses; it only touches
@@ -78,14 +83,40 @@ check_hf_cache_space() {
     fi
     echo "Free space: ${avail} GiB."
 
-    if [[ -d "$MODEL_DIR" ]] || (( REQUIRED_GIB == 0 )) || (( avail >= REQUIRED_GIB )); then
+    local cached=0
+    if [[ -d "$MODEL_DIR" ]]; then
+        cached=$(cached_gib "$MODEL_DIR")
+        # A size we cannot read is indistinguishable from a complete download,
+        # so assume the common case rather than warn about a download that may
+        # never be attempted.
+        if [[ -z "$cached" ]]; then
+            echo "✓ ${MODEL_REPO_ID} is cached at ${MODEL_DIR}, size unreadable;" \
+                 "assuming it is complete."
+            return 0
+        fi
+    fi
+
+    local remaining=$(( REQUIRED_GIB > cached ? REQUIRED_GIB - cached : 0 ))
+
+    if (( cached == 0 )); then
+        echo "${MODEL_REPO_ID} is NOT cached; it must be downloaded."
+    elif (( remaining == 0 )); then
+        echo "✓ ${MODEL_REPO_ID} is already cached at ${MODEL_DIR} (${cached} GiB);" \
+             "no download needed regardless of free space."
+    else
+        echo "${MODEL_REPO_ID} is only PARTIALLY cached at ${MODEL_DIR}:" \
+             "${cached} GiB of roughly ${REQUIRED_GIB} GiB, so about ${remaining} GiB" \
+             "still has to be downloaded."
+    fi
+
+    if (( remaining == 0 )) || (( avail >= remaining )); then
         return 0
     fi
 
     echo "=============================================================="
-    echo "WARNING: ${MODEL_REPO_ID} is not cached and only ${avail} GiB is"
-    echo "         free, against roughly ${REQUIRED_GIB} GiB of weights. The"
-    echo "         download will likely fail with ENOSPC partway through."
+    echo "WARNING: ${MODEL_REPO_ID} still needs roughly ${remaining} GiB against"
+    echo "         only ${avail} GiB free. The download will likely fail with"
+    echo "         ENOSPC partway through."
     echo ""
     echo "         /sgl-data is shared by the whole AMD fleet, so this is a"
     echo "         capacity problem rather than something this job can clear:"

--- a/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
+++ b/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
@@ -1,0 +1,224 @@
+"""MI35x nightly agentic-coding performance benchmark for GLM-5.2-MXFP4 with MTP.
+
+Ported from the AgentX recipe
+``benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh`` and its
+``glm5.2-fp4-mi355x-sglang-agentic-mtp`` config entry in
+``SemiAnalysisAI/InferenceX``. That recipe measures ``amd/GLM-5.2-MXFP4`` on
+MI355X under a multi-turn coding-agent workload with EAGLE/MTP speculative
+decoding, over two arms:
+
+1. TP4 / EP4 with HiCache offloading the KV overflow to host DRAM, swept over
+   concurrency 1-12. This is the throughput arm.
+2. TP8 / EP1 fully GPU-resident, swept over concurrency 1-10. EP=1 drops the
+   MoE all-to-all, which wins on ITL at low concurrency.
+
+What this port keeps and what it changes:
+
+- The server configuration is reproduced flag for flag, because that is what a
+  nightly regression check is for. The one restructuring is that the recipe
+  launches a server per concurrency point and sizes ``--max-running-requests``
+  and the decode CUDA-graph batch list from that point's concurrency, whereas
+  here one server serves the whole sweep and both are sized from the largest
+  concurrency in it.
+- The workload is synthesized rather than replayed from the SemiAnalysis
+  ``cc-traces-weka`` corpus, which is gated and reachable only through AIPerf's
+  loader. ``sglang.test.agentic_bench_utils`` builds a corpus with the same
+  structure instead, and ``SGLANG_AGENTIC_TRACE_PATH`` replays a real one when
+  a runner has it. Absolute numbers therefore are not comparable against
+  AgentX's published results; run-over-run numbers here are.
+- The recipe pins ``SGLANG_SIMULATE_ACC_LEN=3.61``, which makes the server
+  report a fixed acceptance length instead of running draft verification. That
+  suits AgentX's projections and defeats a regression check, so this test runs
+  real MTP and reports the measured acceptance length per point.
+- The recipe also sets ``SGLANG_OPT_USE_TOPK_V2=false`` for gfx950. Upstream
+  now decides that per architecture and deliberately turns the fused top-k v2
+  kernel back on for the GLM-5.x DSA family on ROCm (see
+  ``arg_groups/model_hook.py``), so the override is not carried over.
+
+Registry: nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp suite
+"""
+
+import os
+import unittest
+
+from sglang.test.agentic_bench_utils import (
+    AgenticTraceSpec,
+    generate_agentic_markdown_report,
+    run_agentic_benchmark,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    _parse_int_list_env,
+    is_in_ci,
+    write_github_step_summary,
+)
+
+register_amd_ci(
+    est_time=10800,
+    suite="nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp",
+    nightly=True,
+)
+
+GLM_52_MXFP4_MODEL_PATH = os.environ.get("GLM52_MXFP4_MODEL_PATH", "amd/GLM-5.2-MXFP4")
+RESULT_DIR = "performance_results_glm52_fp4_agentic_mtp_mi35x"
+SERVER_LAUNCH_TIMEOUT = 7200
+BENCH_TIMEOUT = 5400
+
+# The recipe sweeps [1, 2, 4, 8, 10, 12] and [1, 2, 4, 10]. Both are trimmed to
+# the endpoints and midpoints that carry the regression signal, since each
+# extra point costs a full replay of the corpus.
+HICACHE_CONCURRENCIES = _parse_int_list_env("AGENTIC_HICACHE_CONCURRENCIES", "1,4,8,12")
+GPU_RESIDENT_CONCURRENCIES = _parse_int_list_env("AGENTIC_TP8_CONCURRENCIES", "1,4,10")
+
+TRACE_SPEC = AgenticTraceSpec()
+
+# Common to both arms, straight from the recipe.
+BASE_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--kv-cache-dtype",
+    "fp8_e4m3",
+    "--dsa-prefill-backend",
+    "tilelang",
+    "--dsa-decode-backend",
+    "tilelang",
+    # GLM-5.2 emits GLM-4.7-style tool calls, so glm47 is what populates
+    # structured message.tool_calls; glm45 keeps hybrid thinking in
+    # reasoning_content.
+    "--tool-call-parser",
+    "glm47",
+    "--reasoning-parser",
+    "glm45",
+    # 32k chunks let the scheduler interleave decode between prefill chunks,
+    # which is what keeps TPOT bounded once several long agent sessions are
+    # prefilling at once.
+    "--chunked-prefill-size",
+    "32768",
+    "--mem-fraction-static",
+    "0.85",
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    "5",
+    "--speculative-eagle-topk",
+    "1",
+    "--speculative-num-draft-tokens",
+    "6",
+    "--model-loader-extra-config",
+    '{"enable_multithread_load": true}',
+    "--watchdog-timeout",
+    "1800",
+    "--enable-metrics",
+]
+
+SERVER_ENV = {
+    # A conversation waiting on the concurrency semaphore holds an idle pooled
+    # connection, and the 5s default closes it out from under the client right
+    # as its first turn is admitted.
+    "SGLANG_TIMEOUT_KEEP_ALIVE": "900",
+}
+
+
+def _concurrency_args(concurrencies):
+    """Size the in-flight slots and decode graph list for the whole sweep.
+
+    2x the largest concurrency, per the recipe: MTP draft+verify transiently
+    batches more than one request per session, and without the headroom the
+    scheduler stalls on burst.
+    """
+    max_running_requests = min(2 * max(concurrencies), 256)
+    cuda_graph_max_bs = min(max_running_requests, 64)
+    return [
+        "--max-running-requests",
+        str(max_running_requests),
+        "--cuda-graph-max-bs-decode",
+        str(cuda_graph_max_bs),
+    ]
+
+
+class TestGLM52FP4AgenticMTPMI35x(unittest.TestCase):
+    """GLM-5.2-MXFP4 agentic-coding replay with MTP on AMD MI35x."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.full_report = f"## {cls.__name__}\n"
+
+    @classmethod
+    def tearDownClass(cls):
+        if is_in_ci():
+            write_github_step_summary(cls.full_report)
+        print(cls.full_report)
+
+    def _run_arm(self, variant, parallel_args, cache_args, concurrencies):
+        server_args = (
+            BASE_SERVER_ARGS
+            + parallel_args
+            + cache_args
+            + _concurrency_args(concurrencies)
+        )
+        points = run_agentic_benchmark(
+            model_path=GLM_52_MXFP4_MODEL_PATH,
+            base_url=self.base_url,
+            server_args=server_args,
+            result_dir=os.path.join(RESULT_DIR, variant),
+            concurrencies=concurrencies,
+            trace_spec=TRACE_SPEC,
+            server_launch_timeout=SERVER_LAUNCH_TIMEOUT,
+            bench_timeout=BENCH_TIMEOUT,
+            env={**os.environ, **SERVER_ENV},
+        )
+
+        type(self).full_report += (
+            generate_agentic_markdown_report(
+                points, f"{GLM_52_MXFP4_MODEL_PATH} ({variant}) [MI35x]"
+            )
+            + "\n"
+        )
+
+        # A replay that dropped turns produces throughput numbers for a
+        # workload nobody ran, so treat any dropped turn as a failure rather
+        # than reporting the partial result.
+        for point in points:
+            expected_turns = point.conversations * TRACE_SPEC.turns_per_conversation
+            self.assertEqual(
+                point.completed_turns,
+                expected_turns,
+                f"{variant} concurrency {point.concurrency}: completed "
+                f"{point.completed_turns}/{expected_turns} turns",
+            )
+
+    def test_agentic_tp4_ep4_hicache(self):
+        """Throughput arm: TP4/EP4 with the KV overflow offloaded to host DRAM."""
+        self._run_arm(
+            variant="tp4-ep4-hicache",
+            parallel_args=["--tp", "4", "--ep-size", "4"],
+            cache_args=[
+                "--enable-hierarchical-cache",
+                # ~2.9 TB pinned at TP4, within the ~3.0 TB these nodes carry.
+                "--hicache-ratio",
+                "1.5",
+                # Skips host writes for KV blocks that cannot be reused, which
+                # takes load off the host bus without costing hit rate.
+                "--hicache-write-policy",
+                "write_through_selective",
+                "--hicache-io-backend",
+                "direct",
+                "--hicache-mem-layout",
+                "page_first_direct",
+            ],
+            concurrencies=HICACHE_CONCURRENCIES,
+        )
+
+    def test_agentic_tp8_ep1_gpu_resident(self):
+        """Latency arm: TP8/EP1, GPU-resident KV, no MoE all-to-all."""
+        self._run_arm(
+            variant="tp8-ep1-gpu-resident",
+            parallel_args=["--tp", "8", "--ep-size", "1"],
+            cache_args=[],
+            concurrencies=GPU_RESIDENT_CONCURRENCIES,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
+++ b/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
@@ -61,8 +61,12 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
+# Measured 2309 s over both arms on the staged corpus (run 34554491724), and
+# 1409 s on the synthesized one (run 34551237847). The budget keeps enough room
+# for a heavier corpus without claiming the three hours this was guessed at
+# before either number existed.
 register_amd_ci(
-    est_time=10800,
+    est_time=3600,
     suite="nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp",
     nightly=True,
 )

--- a/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
+++ b/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
@@ -20,14 +20,19 @@ What this port keeps and what it changes:
   and the decode CUDA-graph batch list from that point's concurrency, whereas
   here one server serves the whole sweep and both are sized from the largest
   concurrency in it.
-- The workload is synthesized rather than replayed from the SemiAnalysis
-  ``cc-traces-weka`` corpus, which is gated and reachable only through AIPerf's
-  loader. ``sglang.test.agentic_bench_utils`` builds a corpus with the same
-  structure instead -- a shared agent scaffold, a per-session repository
-  context, and per-turn tool output, sized so a session opens at ~39K tokens
-  and reaches ~68K by its eighth turn -- and ``SGLANG_AGENTIC_TRACE_PATH``
-  replays a real one when a runner has it. Absolute numbers therefore are not
-  comparable against AgentX's published results; run-over-run numbers here are.
+- The workload is a real multi-turn corpus where the runner has one and a
+  synthesized one otherwise. The SemiAnalysis ``cc-traces-weka`` corpus the
+  recipe names is gated and reachable only through AIPerf's loader, but the
+  MI35x runners carry staged traces under ``/sgl-data/agentic-traces`` (64
+  conversations over 584 turns, averaging 86K prompt tokens per turn and
+  peaking at 231K), and the nightly points ``SGLANG_AGENTIC_TRACE_PATH`` at
+  one. Without that variable ``sglang.test.agentic_bench_utils`` builds a
+  corpus with the same shape -- a shared agent scaffold, a per-session
+  repository context, and per-turn tool output, sized so a session opens at
+  ~39K tokens and reaches ~68K by its eighth turn -- which is lighter, so the
+  two are not comparable with each other. Neither is comparable against
+  AgentX's published numbers, which measure a fixed duration rather than fixed
+  work; run-over-run numbers here are.
 - The recipe pins ``SGLANG_SIMULATE_ACC_LEN=3.61``, which makes the server
   report a fixed acceptance length instead of running draft verification. That
   suits AgentX's projections and defeats a regression check, so this test runs

--- a/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
+++ b/test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py
@@ -23,9 +23,11 @@ What this port keeps and what it changes:
 - The workload is synthesized rather than replayed from the SemiAnalysis
   ``cc-traces-weka`` corpus, which is gated and reachable only through AIPerf's
   loader. ``sglang.test.agentic_bench_utils`` builds a corpus with the same
-  structure instead, and ``SGLANG_AGENTIC_TRACE_PATH`` replays a real one when
-  a runner has it. Absolute numbers therefore are not comparable against
-  AgentX's published results; run-over-run numbers here are.
+  structure instead -- a shared agent scaffold, a per-session repository
+  context, and per-turn tool output, sized so a session opens at ~39K tokens
+  and reaches ~68K by its eighth turn -- and ``SGLANG_AGENTIC_TRACE_PATH``
+  replays a real one when a runner has it. Absolute numbers therefore are not
+  comparable against AgentX's published results; run-over-run numbers here are.
 - The recipe pins ``SGLANG_SIMULATE_ACC_LEN=3.61``, which makes the server
   report a fixed acceptance length instead of running draft verification. That
   suits AgentX's projections and defeats a regression check, so this test runs
@@ -62,8 +64,12 @@ register_amd_ci(
 
 GLM_52_MXFP4_MODEL_PATH = os.environ.get("GLM52_MXFP4_MODEL_PATH", "amd/GLM-5.2-MXFP4")
 RESULT_DIR = "performance_results_glm52_fp4_agentic_mtp_mi35x"
-SERVER_LAUNCH_TIMEOUT = 7200
-BENCH_TIMEOUT = 5400
+# Generous enough to absorb a cold weight cache on the first run of a new
+# checkpoint; the job's own timeout is the real backstop.
+SERVER_LAUNCH_TIMEOUT = 5400
+# Each point replays two waves of conversations, so this is a hang detector
+# rather than a budget.
+BENCH_TIMEOUT_PER_POINT = 1800
 
 # The recipe sweeps [1, 2, 4, 8, 10, 12] and [1, 2, 4, 10]. Both are trimmed to
 # the endpoints and midpoints that carry the regression signal, since each
@@ -71,6 +77,9 @@ BENCH_TIMEOUT = 5400
 HICACHE_CONCURRENCIES = _parse_int_list_env("AGENTIC_HICACHE_CONCURRENCIES", "1,4,8,12")
 GPU_RESIDENT_CONCURRENCIES = _parse_int_list_env("AGENTIC_TP8_CONCURRENCIES", "1,4,10")
 
+# Defaults put ~39K tokens in each session's first turn and grow it to ~68K by
+# the eighth, which is the range where prefix reuse and the host tier decide
+# the result.
 TRACE_SPEC = AgenticTraceSpec()
 
 # Common to both arms, straight from the recipe.
@@ -165,8 +174,8 @@ class TestGLM52FP4AgenticMTPMI35x(unittest.TestCase):
             concurrencies=concurrencies,
             trace_spec=TRACE_SPEC,
             server_launch_timeout=SERVER_LAUNCH_TIMEOUT,
-            bench_timeout=BENCH_TIMEOUT,
-            env={**os.environ, **SERVER_ENV},
+            bench_timeout_per_point=BENCH_TIMEOUT_PER_POINT,
+            env=SERVER_ENV,
         )
 
         type(self).full_report += (
@@ -177,15 +186,13 @@ class TestGLM52FP4AgenticMTPMI35x(unittest.TestCase):
         )
 
         # A replay that dropped turns produces throughput numbers for a
-        # workload nobody ran, so treat any dropped turn as a failure rather
-        # than reporting the partial result.
+        # workload nobody ran, so fail rather than publish the partial result.
         for point in points:
-            expected_turns = point.conversations * TRACE_SPEC.turns_per_conversation
             self.assertEqual(
-                point.completed_turns,
-                expected_turns,
-                f"{variant} concurrency {point.concurrency}: completed "
-                f"{point.completed_turns}/{expected_turns} turns",
+                point.failed_turns,
+                0,
+                f"{variant} concurrency {point.concurrency}: "
+                f"{point.failed_turns} of {point.total_turns} turns failed",
             )
 
     def test_agentic_tp4_ep4_hicache(self):

--- a/test/registered/unit/bench/test_agentic_bench_utils.py
+++ b/test/registered/unit/bench/test_agentic_bench_utils.py
@@ -68,7 +68,11 @@ def _bench_record(**overrides):
         "mean_e2e_latency_ms": 6000.0,
         "concurrency": 3.9,
         "accept_length": 3.42,
-        "cache_report": {"cache_hit_rate_pct": 71.25, "host_cached_tokens": 120345},
+        "cache_report": {
+            "cache_hit_rate_pct": 117.2,
+            "total_cached_tokens": 1200000,
+            "host_cached_tokens": 300000,
+        },
         "errors": [None] * 24,
     }
     record.update(overrides)
@@ -291,8 +295,20 @@ class TestParseBenchRecord(CustomTestCase):
         self.assertEqual(point.failed_turns, 0)
         self.assertEqual(point.output_throughput, 512.0)
         self.assertEqual(point.accept_length, 3.42)
-        self.assertEqual(point.cache_hit_rate_pct, 71.25)
-        self.assertEqual(point.host_cached_tokens, 120345)
+        self.assertEqual(point.cached_tokens, 1200000)
+        self.assertEqual(point.host_cached_tokens, 300000)
+        self.assertEqual(point.reused_tokens_per_turn, 50000)
+        self.assertEqual(point.host_share_pct, 25.0)
+
+    def test_ignores_the_hit_rate_bench_serving_reports(self):
+        # It divides the server's cached_tokens by the client's tokenization of
+        # the prompt, and on a chat backend the server also tokenizes a chat
+        # template the client never saw. Run 34551237847 reported 117% on every
+        # point of both arms, so the reported ratio must not reach the table.
+        point = _parse_bench_record(_bench_record(), concurrency=4, conversations=8)
+        report = generate_agentic_markdown_report([point], "hit-rate")
+        self.assertNotIn("117", report)
+        self.assertNotIn("cache hit", report)
 
     def test_counts_dropped_turns(self):
         record = _bench_record(completed=20, errors=[None] * 20 + ["boom"] * 4)
@@ -312,7 +328,9 @@ class TestParseBenchRecord(CustomTestCase):
         del record["cache_report"]
         del record["accept_length"]
         point = _parse_bench_record(record, concurrency=1, conversations=2)
-        self.assertIsNone(point.cache_hit_rate_pct)
+        self.assertIsNone(point.cached_tokens)
+        self.assertIsNone(point.reused_tokens_per_turn)
+        self.assertIsNone(point.host_share_pct)
         self.assertIsNone(point.accept_length)
 
 

--- a/test/registered/unit/bench/test_agentic_bench_utils.py
+++ b/test/registered/unit/bench/test_agentic_bench_utils.py
@@ -1,0 +1,414 @@
+"""Unit tests for the agentic multi-turn benchmark helpers.
+
+The nightly perf tests that use these helpers need an MI35x node and a
+multi-hundred-GB checkpoint, so the parts that can go wrong quietly -- the
+shape of the synthesized corpus and the parsing of a bench_serving record --
+are pinned here instead.
+"""
+
+import argparse
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from argparse import Namespace
+
+from sglang.benchmark import serving as bench_serving
+from sglang.benchmark.datasets.agentic_trace import (
+    DEFAULT_AGENTIC_OUTPUT_LEN,
+    AgenticTraceDataset,
+)
+from sglang.benchmark.serving import MULTI_TURN_BACKENDS, _normalize_round_messages
+from sglang.test.agentic_bench_utils import (
+    AGENTIC_TRACE_PATH_ENV,
+    AgenticTraceSpec,
+    _parse_bench_record,
+    build_agentic_bench_command,
+    calibrate_tokens_per_part,
+    generate_agentic_markdown_report,
+    resolve_agentic_trace,
+    write_agentic_coding_trace,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+SMALL_SPEC = AgenticTraceSpec(
+    num_conversations=5,
+    turns_per_conversation=4,
+    system_prompt_tokens=64,
+    repo_context_tokens=256,
+    turn_tokens=32,
+)
+
+
+class _StubTokenizer:
+    """Splits on a fixed rule so calibration is testable without the Hub."""
+
+    def __init__(self, tokens_per_char_group=4):
+        self.tokens_per_char_group = tokens_per_char_group
+
+    def encode(self, text, add_special_tokens=False):
+        # One token per fixed-size chunk: a stand-in for subword splitting that
+        # stays proportional to text length, which is all calibration needs.
+        return [0] * (len(text) // self.tokens_per_char_group + 1)
+
+
+def _bench_record(**overrides):
+    record = {
+        "completed": 24,
+        "duration": 100.0,
+        "output_throughput": 512.0,
+        "mean_ttft_ms": 900.0,
+        "p99_ttft_ms": 1800.0,
+        "mean_itl_ms": 22.0,
+        "p99_itl_ms": 40.0,
+        "mean_e2e_latency_ms": 6000.0,
+        "concurrency": 3.9,
+        "accept_length": 3.42,
+        "cache_report": {"cache_hit_rate_pct": 71.25, "host_cached_tokens": 120345},
+        "errors": [None] * 24,
+    }
+    record.update(overrides)
+    return record
+
+
+class TestAgenticTraceSynthesis(CustomTestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write(self, name="trace.json", spec=SMALL_SPEC, seed=42):
+        path = write_agentic_coding_trace(
+            os.path.join(self.tmpdir.name, name), spec=spec, seed=seed
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            return path, json.load(f)
+
+    def test_trace_has_requested_shape(self):
+        _, data = self._write()
+        conversations = data["conversations"]
+        self.assertEqual(len(conversations), SMALL_SPEC.num_conversations)
+        for conversation in conversations:
+            self.assertEqual(len(conversation), SMALL_SPEC.turns_per_conversation)
+
+        first_turn, second_turn = conversations[0][0], conversations[0][1]
+        self.assertEqual(
+            [m["role"] for m in first_turn["messages"]], ["system", "user"]
+        )
+        # Later turns carry only the new delta; the replay rebuilds the rest.
+        self.assertEqual([m["role"] for m in second_turn["messages"]], ["user"])
+        self.assertEqual(first_turn["prompt_tokens"], SMALL_SPEC.first_turn_tokens())
+        self.assertGreater(
+            conversations[0][-1]["prompt_tokens"], first_turn["prompt_tokens"]
+        )
+
+    def test_prefix_structure(self):
+        """The scaffold is shared; the repository context is not.
+
+        Both halves matter: the shared scaffold is the cross-session prefix a
+        coding agent re-sends, and the unique context is what each session's
+        own later turns hit in cache.
+        """
+        _, data = self._write()
+        systems = {c[0]["messages"][0]["content"] for c in data["conversations"]}
+        self.assertEqual(len(systems), 1)
+
+        contexts = {c[0]["messages"][1]["content"] for c in data["conversations"]}
+        self.assertEqual(len(contexts), SMALL_SPEC.num_conversations)
+
+    def test_deterministic_for_a_fixed_seed(self):
+        path_a, _ = self._write("a.json", seed=7)
+        path_b, _ = self._write("b.json", seed=7)
+        path_c, _ = self._write("c.json", seed=8)
+        with open(path_a) as a, open(path_b) as b, open(path_c) as c:
+            text_a, text_b, text_c = a.read(), b.read(), c.read()
+        self.assertEqual(text_a, text_b)
+        self.assertNotEqual(text_a, text_c)
+
+    def test_longer_context_spec_produces_longer_prompts(self):
+        _, small = self._write("small.json")
+        _, large = self._write(
+            "large.json",
+            spec=AgenticTraceSpec(
+                num_conversations=2,
+                turns_per_conversation=2,
+                system_prompt_tokens=64,
+                repo_context_tokens=4096,
+                turn_tokens=32,
+            ),
+        )
+        small_len = len(small["conversations"][0][0]["messages"][1]["content"])
+        large_len = len(large["conversations"][0][0]["messages"][1]["content"])
+        self.assertGreater(large_len, small_len * 4)
+
+
+class TestTokenBudgetCalibration(CustomTestCase):
+    """The declared budgets decide how much context each session carries, so
+    they have to land near the truth, not just be documented."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _turn_one_tokens(self, tokenizer, spec, calibrate):
+        path = write_agentic_coding_trace(
+            os.path.join(self.tmpdir.name, "trace.json"),
+            spec=spec,
+            tokenizer=tokenizer if calibrate else None,
+        )
+        with open(path, "r", encoding="utf-8") as f:
+            first_turn = json.load(f)["conversations"][0][0]
+        return sum(
+            len(tokenizer.encode(m["content"], add_special_tokens=False))
+            for m in first_turn["messages"]
+        )
+
+    def test_calibration_reports_tokens_per_fragment(self):
+        dense, sparse = _StubTokenizer(2), _StubTokenizer(8)
+        self.assertGreater(
+            calibrate_tokens_per_part(dense), calibrate_tokens_per_part(sparse)
+        )
+
+    def test_calibrated_budget_is_close_to_declared(self):
+        spec = AgenticTraceSpec(
+            num_conversations=1,
+            turns_per_conversation=2,
+            system_prompt_tokens=512,
+            repo_context_tokens=4096,
+            turn_tokens=256,
+        )
+        tokenizer = _StubTokenizer(3)
+        measured = self._turn_one_tokens(tokenizer, spec, calibrate=True)
+        declared = spec.first_turn_tokens()
+        self.assertAlmostEqual(measured / declared, 1.0, delta=0.1)
+
+    def test_calibration_adapts_to_the_tokenizer(self):
+        """A tokenizer that splits twice as finely must yield half the text, so
+        both land on the same budget."""
+        spec = AgenticTraceSpec(
+            num_conversations=1,
+            turns_per_conversation=1,
+            system_prompt_tokens=256,
+            repo_context_tokens=2048,
+            turn_tokens=128,
+        )
+        for chunk in (2, 6):
+            tokenizer = _StubTokenizer(chunk)
+            ratio = self._turn_one_tokens(tokenizer, spec, calibrate=True) / (
+                spec.first_turn_tokens()
+            )
+            self.assertAlmostEqual(ratio, 1.0, delta=0.1, msg=f"chunk={chunk}")
+
+
+class TestAgenticTraceLoads(CustomTestCase):
+    """The synthesized corpus has to satisfy the loader it was written for."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.path = write_agentic_coding_trace(
+            os.path.join(self.tmpdir.name, "trace.json"), spec=SMALL_SPEC
+        )
+
+    def _load(self, **overrides):
+        args = Namespace(
+            dataset_path=self.path,
+            num_prompts=3,
+            sharegpt_output_len=None,
+            dataset_offset=0,
+            agentic_max_turns=None,
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return AgenticTraceDataset.from_args(args).load(tokenizer=None)
+
+    def test_rows_are_multi_turn(self):
+        rows = self._load()
+        self.assertEqual(len(rows), 3)
+        for row in rows:
+            self.assertEqual(len(row.prompt), SMALL_SPEC.turns_per_conversation)
+            self.assertEqual(row.output_len, DEFAULT_AGENTIC_OUTPUT_LEN)
+
+    def test_turns_satisfy_the_multi_turn_detector(self):
+        """`benchmark()` routes on this predicate; a shape it rejects would
+        silently replay the corpus as single-shot prompts."""
+        rows = self._load()
+        for turn in rows[0].prompt:
+            normalized = _normalize_round_messages(turn)
+            self.assertIsNotNone(normalized)
+            for message in normalized:
+                self.assertIn(message["role"], ("system", "user"))
+                self.assertTrue(message["content"])
+
+    def test_sweep_knobs_are_honored(self):
+        rows = self._load(agentic_max_turns=2, sharegpt_output_len=220, num_prompts=2)
+        self.assertEqual([len(row.prompt) for row in rows], [2, 2])
+        self.assertEqual({row.output_len for row in rows}, {220})
+
+        rotated = self._load(dataset_offset=1, num_prompts=1)
+        unrotated = self._load(dataset_offset=0, num_prompts=1)
+        self.assertNotEqual(rotated[0].prompt[0], unrotated[0].prompt[0])
+
+
+class TestResolveAgenticTrace(CustomTestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self._saved = os.environ.pop(AGENTIC_TRACE_PATH_ENV, None)
+        if self._saved is not None:
+            self.addCleanup(os.environ.__setitem__, AGENTIC_TRACE_PATH_ENV, self._saved)
+
+    def test_synthesizes_when_unset(self):
+        path = resolve_agentic_trace(self.tmpdir.name, spec=SMALL_SPEC)
+        self.assertTrue(os.path.isfile(path))
+        self.assertEqual(os.path.dirname(path), self.tmpdir.name)
+
+    def test_prefers_the_override(self):
+        real = write_agentic_coding_trace(
+            os.path.join(self.tmpdir.name, "real.json"), spec=SMALL_SPEC
+        )
+        os.environ[AGENTIC_TRACE_PATH_ENV] = real
+        self.addCleanup(os.environ.pop, AGENTIC_TRACE_PATH_ENV, None)
+        self.assertEqual(resolve_agentic_trace(self.tmpdir.name), real)
+
+    def test_rejects_a_missing_override(self):
+        os.environ[AGENTIC_TRACE_PATH_ENV] = os.path.join(self.tmpdir.name, "nope.json")
+        self.addCleanup(os.environ.pop, AGENTIC_TRACE_PATH_ENV, None)
+        with self.assertRaises(FileNotFoundError):
+            resolve_agentic_trace(self.tmpdir.name)
+
+
+class TestParseBenchRecord(CustomTestCase):
+    def test_maps_a_clean_record(self):
+        point = _parse_bench_record(_bench_record(), concurrency=4, conversations=8)
+        self.assertEqual(point.concurrency, 4)
+        self.assertEqual(point.conversations, 8)
+        self.assertEqual(point.total_turns, 24)
+        self.assertEqual(point.completed_turns, 24)
+        self.assertEqual(point.failed_turns, 0)
+        self.assertEqual(point.output_throughput, 512.0)
+        self.assertEqual(point.accept_length, 3.42)
+        self.assertEqual(point.cache_hit_rate_pct, 71.25)
+        self.assertEqual(point.host_cached_tokens, 120345)
+
+    def test_counts_dropped_turns(self):
+        record = _bench_record(completed=20, errors=[None] * 20 + ["boom"] * 4)
+        point = _parse_bench_record(record, concurrency=4, conversations=8)
+        self.assertEqual(point.total_turns, 24)
+        self.assertEqual(point.failed_turns, 4)
+
+    def test_drops_per_turn_arrays_from_raw(self):
+        record = _bench_record(generated_texts=["x"] * 24, itls=[[1.0]] * 24)
+        point = _parse_bench_record(record, concurrency=4, conversations=8)
+        self.assertNotIn("generated_texts", point.raw)
+        self.assertNotIn("errors", point.raw)
+        self.assertIn("output_throughput", point.raw)
+
+    def test_tolerates_a_record_without_cache_or_spec_fields(self):
+        record = _bench_record()
+        del record["cache_report"]
+        del record["accept_length"]
+        point = _parse_bench_record(record, concurrency=1, conversations=2)
+        self.assertIsNone(point.cache_hit_rate_pct)
+        self.assertIsNone(point.accept_length)
+
+
+def _bench_serving_parser():
+    """Rebuild bench_serving's parser without running a benchmark.
+
+    ``cli_main`` constructs the parser and immediately parses and runs, so the
+    parser is only reachable by replaying the construction up to that point.
+    """
+    lines = inspect.getsource(bench_serving.cli_main).splitlines()
+    body = []
+    for line in lines[1:]:
+        if "args = parser.parse_args()" in line:
+            break
+        body.append(line[4:])
+    namespace = {}
+    exec("\n".join(body), {"argparse": argparse, **vars(bench_serving)}, namespace)
+    return namespace["parser"]
+
+
+class TestBuildAgenticBenchCommand(CustomTestCase):
+    """The sweep shells out, so a renamed flag surfaces as a nightly failure a
+    day later unless the command is parsed against the real CLI here."""
+
+    def setUp(self):
+        self.parser = _bench_serving_parser()
+
+    def _parse(self, **overrides):
+        kwargs = dict(
+            base_url="http://127.0.0.1:30000",
+            model_path="amd/GLM-5.2-MXFP4",
+            tokenizer="/models/glm52",
+            trace_path="/tmp/trace.json",
+            conversations=24,
+            concurrency=12,
+            output_file="/tmp/out.jsonl",
+        )
+        kwargs.update(overrides)
+        command = build_agentic_bench_command(**kwargs)
+        self.assertEqual(command[:3], ["python3", "-m", "sglang.benchmark.serving"])
+        return self.parser.parse_args(command[3:])
+
+    def test_required_flags_parse(self):
+        args = self._parse()
+        self.assertIn(args.backend, MULTI_TURN_BACKENDS)
+        self.assertEqual(args.dataset_name, "agentic-trace")
+        self.assertEqual(args.dataset_path, "/tmp/trace.json")
+        self.assertEqual(args.tokenizer, "/models/glm52")
+        # For this dataset --num-prompts counts conversations, not turns.
+        self.assertEqual(args.num_prompts, 24)
+        self.assertEqual(args.max_concurrency, 12)
+        self.assertTrue(args.cache_report)
+        self.assertTrue(args.output_details)
+
+    def test_optional_flags_are_omitted_when_unset(self):
+        args = self._parse()
+        self.assertIsNone(args.agentic_max_turns)
+        self.assertIsNone(args.sharegpt_output_len)
+
+    def test_optional_flags_parse_when_set(self):
+        args = self._parse(
+            max_turns=6, output_len=220, extra_bench_args=["--seed", "7"]
+        )
+        self.assertEqual(args.agentic_max_turns, 6)
+        self.assertEqual(args.sharegpt_output_len, 220)
+        self.assertEqual(args.seed, 7)
+
+
+class TestAgenticMarkdownReport(CustomTestCase):
+    def test_renders_a_row_per_point(self):
+        points = [
+            _parse_bench_record(_bench_record(), concurrency=c, conversations=c * 2)
+            for c in (1, 4, 12)
+        ]
+        report = generate_agentic_markdown_report(points, "model (arm) [MI35x]")
+
+        self.assertIn("### model (arm) [MI35x]", report)
+        rows = [line for line in report.splitlines() if line.startswith("| ")]
+        header, separator, *body = rows
+        self.assertEqual(len(body), 3)
+        self.assertEqual(header.count("|"), separator.count("|"))
+        for row in body:
+            self.assertEqual(row.count("|"), header.count("|"))
+        self.assertIn("24/24", body[0])
+        # Input throughput is meaningless for multi-turn replay, so it must not
+        # appear as a column that readers would compare against other runs.
+        self.assertNotIn("input throughput", header)
+
+    def test_renders_missing_values_as_na(self):
+        record = _bench_record()
+        del record["cache_report"]
+        record["accept_length"] = None
+        point = _parse_bench_record(record, concurrency=1, conversations=2)
+        report = generate_agentic_markdown_report([point], "no-extras")
+        self.assertIn("n/a", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

AgentX benchmarks SGLang on MI355X under an agentic-coding workload via [`benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh) and its `glm5.2-fp4-mi355x-sglang-agentic-mtp` config entry. That configuration — `amd/GLM-5.2-MXFP4`, EAGLE/MTP speculative decoding, DSA tilelang backends, FP8 KV cache, and HiCache offloading KV overflow to host DRAM — is not covered by any test here, so a regression in it is invisible to SGLang CI until AgentX notices.

The existing MI35x GLM-5.2 coverage (`test_glm52_fp8_perf_mi35x.py`) is a different checkpoint and a different workload: fixed 8K-in/1K-out batch sweeps, which exercise neither multi-turn prefix reuse nor the host-DRAM tier the agentic recipe is built around.

## Modifications

**`python/sglang/test/agentic_bench_utils.py` (new).** Nightly perf tests drive `bench_one_batch_server` through `NightlyBenchmarkRunner`, which is keyed on batch size × input len × output len and cannot express a multi-turn replay. These helpers drive `sglang.benchmark.serving --dataset-name agentic-trace` over a concurrency sweep instead, parse the JSONL, and render a markdown table.

- `resolve_agentic_trace` replays a real corpus when `SGLANG_AGENTIC_TRACE_PATH` names one, and otherwise synthesizes one in `agentic-trace` JSON form: a shared agent scaffold, a per-session repository context, and per-turn tool output, deterministic given its spec and seed. The nightly points that variable at a corpus staged on the MI35x runners; the fallback is what keeps the test runnable elsewhere.
- `run_agentic_benchmark` launches a server, replays the trace once per concurrency level, and tears the server down. Conversation count scales with concurrency so every point replays the same number of sequential waves; a fixed count would make low-concurrency points many times longer.
- The report omits input throughput, which `bench_serving` reports as zero for multi-turn replay, and reports reused prompt tokens, the host-tier share of that reuse, and measured MTP acceptance length instead.

**`test/registered/amd/agentic/test_glm52_fp4_agentic_mtp_mi35x.py` (new).** Both arms of the recipe, registered to the `nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp` suite:

| Arm | Parallelism | KV | Concurrency |
| --- | --- | --- | --- |
| Throughput | TP4 / EP4 | HiCache → host DRAM, ratio 1.5, `write_through_selective`, `page_first_direct` | 1, 4, 8, 12 |
| Latency | TP8 / EP1 | GPU-resident | 1, 4, 10 |

**`test/registered/unit/bench/test_agentic_bench_utils.py` (new).** 23 CPU tests, 26 ms. Without these nothing about the helpers is exercised until a nightly run on scarce hardware.

**`.github/workflows/nightly-test-amd-rocm720.yml`.** New `nightly-8-gpu-mi35x-glm52-fp4-agentic-mtp-rocm720` job on `linux-mi35x-gpu-8`, added to the dispatch dropdown and the `check-all-jobs` gate. Both arms share one job so they share one checkpoint load and one scarce MI35x slot. The job runs `check_hf_cache_space.sh` in `--strict` mode and points `SGLANG_AGENTIC_TRACE_PATH` at the staged corpus.

**`scripts/ci/amd/check_hf_cache_space.sh`.** Decide cache residency by bytes on disk rather than by the model directory existing, since an ENOSPC leaves a partial checkpoint behind that the directory test reports as complete. And add an opt-in `--strict` that fails at the check when the predicted shortfall is real, instead of warning and letting the download consume a fleet-shared volume on its way to the ENOSPC the warning predicted. The existing Qwen3.8 caller is unchanged.

### Deliberate departures from the recipe

The server configuration is reproduced flag for flag. Four things could not or should not carry over, each noted in the test docstring:

1. **The corpus is not the recipe's.** The recipe replays the SemiAnalysis `cc-traces-weka` corpus, which is gated and reachable only through AIPerf's loader. The MI35x runners do carry staged multi-turn traces under `/sgl-data/agentic-traces` that nothing in this repo creates or reads — 64 conversations over 584 turns, averaging 86K prompt tokens per turn and peaking at 231K against a server that serves 1M context — and the nightly replays one of those. It is a real agentic workload, but not the one AgentX publishes against, so absolute numbers are still not comparable with theirs; run-over-run numbers here are.
2. **One server serves the whole sweep.** The recipe launches a server per concurrency point and sizes `--max-running-requests` and the decode CUDA-graph batch list from that point. Here both are sized from the largest concurrency in the sweep, since reloading a 408 GiB checkpoint per point is not affordable in CI.
3. **MTP acceptance is measured, not asserted.** The recipe pins `SGLANG_SIMULATE_ACC_LEN=3.61`, which makes the server report a fixed acceptance length instead of running draft verification. That suits AgentX's projections and defeats a regression check, so this test runs real MTP and reports measured acceptance per point.
4. **`SGLANG_OPT_USE_TOPK_V2=false` is dropped.** The recipe disables the fused top-k v2 kernel for gfx950. Upstream now decides this per architecture and deliberately turns that kernel back on for the GLM-5.x DSA family on ROCm (`arg_groups/model_hook.py`), so carrying the override would test a configuration SGLang does not ship.

## Accuracy Tests

N/A — this adds a benchmark and its CI wiring; no model output path changes.

## Speed Tests and Profiling

[Run 34554491724](https://github.com/sgl-project/sglang/actions/runs/34554491724), `rocm10`, `linux-mi35x-gpu-8`, replaying the staged corpus. Both arms green, all 431 turns completed, no failures.

### TP4 / EP4, HiCache → host DRAM

| concurrency | conversations | turns | duration (s) | output tok/s | mean TTFT (ms) | p99 TTFT (ms) | mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | reused tok/turn | host tier (%) | accept len |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 2 | 32/32 | 60.2 | 117.02 | 900.15 | 6571.62 | 4.51 | 16.76 | 1879.30 | 93,868 | 0.0 | 4.28 |
| 4 | 8 | 80/80 | 205.4 | 85.69 | 3250.65 | 35128.53 | 27.64 | 257.23 | 9267.17 | 113,639 | 0.0 | 3.87 |
| 8 | 16 | 153/153 | 303.9 | 110.77 | 3324.55 | 39034.44 | 52.46 | 737.02 | 14746.30 | 100,924 | 0.0 | 4.05 |
| 12 | 24 | 232/232 | 419.6 | 121.65 | 3505.43 | 42333.60 | 78.26 | 1295.12 | 20510.15 | 100,742 | 0.0 | 4.01 |

### TP8 / EP1, GPU-resident

| concurrency | conversations | turns | duration (s) | output tok/s | mean TTFT (ms) | p99 TTFT (ms) | mean ITL (ms) | p99 ITL (ms) | mean E2E (ms) | reused tok/turn | host tier (%) | accept len |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 2 | 32/32 | 47.9 | 147.02 | 756.48 | 5642.23 | 3.41 | 14.17 | 1495.39 | 93,878 | 0.0 | 4.20 |
| 4 | 8 | 80/80 | 153.3 | 114.81 | 3073.19 | 31299.01 | 17.99 | 129.68 | 6985.71 | 113,695 | 0.0 | 4.06 |
| 10 | 20 | 199/199 | 270.5 | 161.85 | 3595.70 | 48223.29 | 40.34 | 617.43 | 12356.88 | 94,552 | 0.0 | 4.06 |

Four things worth reading out of these:

- **MTP acceptance is 3.87–4.28 measured**, against the 3.61 the recipe pins with `SGLANG_SIMULATE_ACC_LEN`. Real draft verification on this workload does better than the simulated constant, which is the whole reason for not carrying that override over.
- **The host tier served 0% of the reuse on every point.** GPU KV usage peaked at 0.76 of the pool, so `write_through_selective` wrote to DRAM but nothing was ever read back — the reused prefixes were still resident on device. So this arm currently regression-tests that the HiCache configuration is accepted and does not perturb results, not that the host-hit path works. Exercising the latter needs more pressure than concurrency 12 puts on a 4M-token pool; that is a follow-up, and worth raising with AMD since it applies to the recipe as written, not just to this port.
- **TP8/EP1 wins on every metric at every shared concurrency**, which is the direction the recipe implies by calling it the latency arm, but here it also wins on throughput. Dropping the MoE all-to-all is worth more than the extra expert parallelism at these concurrencies.
- **Throughput dips at concurrency 4 and recovers.** Both arms show it. It is reproducible across the two arms, and it is the kind of thing this benchmark exists to notice.

### Cost

**2309 s for both arms**, and 44 min for the whole job including container setup and two loads of a 408 GiB checkpoint. Against the 300-minute step budget that leaves a wide margin, and it settles the question this PR could not answer before: seven points cost well under an hour, not the tens of minutes per point that AgentX's own runs take. The comparison was never like-for-like — AgentX measures a fixed duration (a 900 s floor on the window, 1800–3600 s of warmup grace, up to 1800 s of corpus configuration), whereas this measures fixed work — and the measurement now bears that out. `est_time` drops from the guessed 10800 to 3600 accordingly.

For reference, [run 34551237847](https://github.com/sgl-project/sglang/actions/runs/34551237847) is the same sweep on the synthesized corpus: 1409 s, and materially different numbers (260 tok/s at concurrency 12 versus 122 here). The synthesized corpus is lighter, which is exactly why the nightly uses the staged one.

### A reporting bug this surfaced

The first green run reported a **117% cache hit rate** on every point of both arms. `bench_serving`'s `cache_hit_rate_pct` divides the server's `cached_tokens` by the client's `len(tokenizer.encode(prompt_text))`, and on a chat backend the server additionally tokenizes the chat template the client never constructed, so the two sides do not share a denominator and the ratio has no upper bound. The table now reports reused prompt tokens per turn and the host-tier share of that reuse, both derived from `cache_report` alone. A unit test asserts the reported ratio never reaches the table. The underlying `bench_serving` metric is still wrong for every chat-backend caller and is left alone here.

### Getting the checkpoint onto the runners

`amd/GLM-5.2-MXFP4` is 408 GiB and no other suite uses it, so it was the one checkpoint on this fleet that nothing had seeded. Three dispatches ([34446866991](https://github.com/sgl-project/sglang/actions/runs/34446866991), [34448628528](https://github.com/sgl-project/sglang/actions/runs/34448628528), [34487053976](https://github.com/sgl-project/sglang/actions/runs/34487053976)) each took an 8-GPU MI35x slot and died with `[Errno 28] No space left on device`, the last of them after converting the fleet's remaining 120 GiB into a checkpoint that was still incomplete. `--strict` in this PR is what stops that: the job now fails at the pre-flight in under a second rather than draining a volume the whole AMD fleet shares.

Seeding it is [#38966](https://github.com/sgl-project/sglang/pull/38966), which reclaims space and downloads in the same job because freeing space and then queueing for a scarce runner does not work here — a 1.42 TB reclaim had 120 GiB left by the time this job got a runner seven hours later. It also found the staged corpora this PR now replays.

The checkpoint has held: [run 34842611921](https://github.com/sgl-project/sglang/actions/runs/34842611921), three days after the seed, revalidated `amd/GLM-5.2-MXFP4` at 408 GiB and downloaded nothing, and the corpus this PR replays is still in place. Free space on the volume fell from 176 GiB to 57 GiB over those three days, so the `--strict` pre-flight remains the thing standing between this job and another drained volume if the checkpoint is ever evicted. One of the two checkpoints #38966 reclaimed to make room turned out to be in use by InferenceX rather than dead; that is written up there and does not affect this benchmark.

### What the earlier dispatches established, and what is still open

Confirmed on gfx950 against the real ROCm build: every server arg in both arms resolves to the recipe's values, MTP resolves the nextn head from the same checkpoint without a separate draft model, `--max-running-requests`/`--cuda-graph-max-bs-decode` size from the largest concurrency, and the DSA path is the one the recipe assumes (page size 64, `index_topk=2048`, FP8 KV, tilelang prefill and decode).

Two log lines are worth pre-empting, since neither is caused by this PR:

- `Warning: Unknown suite nightly-perf-8-gpu-mi35x-glm52-fp4-agentic-mtp for backend AMD` is cosmetic. `run_suite.py`'s `NIGHTLY_SUITES` list covers 12 of the 58 AMD suites the nightly dispatches, and AMD is deliberately outside `_SUITE_CHECKED_BACKENDS`.
- `Tokenizer for amd/GLM-5.2-MXFP4 is still TokenizersBackend after retries with --trust-remote-code`. Chat templating resolved correctly regardless, and the sweeps above ran to completion through it.

Still open: a failure in the first arm tears down the process tree via sglang's SIGQUIT handler, so the second arm does not run. Splitting them into two files would make them independent, since `run_suite.py` schedules per file. Not done here — with the job green it is a resilience improvement rather than a blocker.

### Verified without a GPU

Two real bugs came out of the GPU-free checks, before any dispatch:

- **Parsing the generated command against `bench_serving`'s real CLI** rejected `--trust-remote-code`. That flag belongs to `bench_one_batch_server`; `bench_serving` has none and needs none, since its tokenizer loader already passes `trust_remote_code=True`. A unit test now parses the command so this cannot regress.
- **Measuring the synthesized corpus with a real tokenizer** showed every block coming out ~4x its declared budget: the filler emits multi-word fragments and the tokens-per-word constant was applied per fragment. Turn 1 now lands within 1% of its budget under gpt2 (BPE), bert-base-uncased (WordPiece), and GLM-5.2's own tokenizer on the runner.

Also checked: the corpus round-trips through the real `AgenticTraceDataset` and satisfies `_normalize_round_messages`; both arms' server args parse through `ServerArgs.add_cli_args` (the recipe's `--cuda-graph-max-bs` no longer exists and was mapped to `--cuda-graph-max-bs-decode`); the suite is claimed uniquely across all registrations and excluded without `--nightly`; and `check_registered_tests.py`, `check_no_registered_tests_in_package.py`, `check_workflow_job_names.py`, `check_no_bare_pytest_main.py`, `isort`, `ruff`, and `codespell` all pass.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829752358](https://github.com/sgl-project/sglang/actions/runs/34829752358)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829751994](https://github.com/sgl-project/sglang/actions/runs/34829751994)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829752248](https://github.com/sgl-project/sglang/actions/runs/34829752248)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
