### PR TITLE
[Router] Preserve global cache affinity with bucket routing

### DIFF
--- a/experimental/sgl-router/src/policies/buckets.rs
+++ b/experimental/sgl-router/src/policies/buckets.rs
@@ -118,36 +118,6 @@ impl BucketSelector {
         .collect()
     }
 
-    /// Maps global Indexer candidates to prefill buckets using `E` as the workload.
-    pub fn bind_prefill_cache_candidate(
-        &self,
-        mut candidate: CacheCandidate,
-        request: BucketRequest,
-    ) -> Option<CacheCandidate> {
-        let Some(config) = &self.config else {
-            candidate.candidate_range_id = "global".to_string();
-            candidate.max_pending_prefill_tokens = None;
-            return Some(candidate);
-        };
-        let spec = config.buckets.iter().find(|spec| {
-            spec.stage == BucketStage::Prefill
-                && self.contains(spec, &candidate.worker.id.0)
-                && within(
-                    candidate.uncached_tokens,
-                    spec.min_extend_tokens,
-                    spec.max_extend_tokens,
-                )
-                && spec
-                    .max_context_tokens
-                    .is_none_or(|max_context| request.input_tokens <= max_context)
-                && (config.ttft_slo_policy != SloBucketPolicy::SloFirst
-                    || ttft_eligible(spec, request.ttft_slo_ms))
-        })?;
-        candidate.candidate_range_id = spec.id.clone();
-        candidate.max_pending_prefill_tokens = spec.max_pending_prefill_tokens;
-        Some(candidate)
-    }
-
     /// Finds the prefill bucket containing a global session primary.
     pub fn prefill_affinity_domain(
         &self,
@@ -176,6 +146,35 @@ impl BucketSelector {
                     spec.max_pending_prefill_tokens,
                 )
             })
+    }
+
+    /// Applies a cache candidate's Bucket metadata and hard limits.
+    /// Unbucketed candidates remain globally eligible, and extend ranges do not
+    /// constrain global cache affinity.
+    pub fn prepare_prefill_cache_candidate(
+        &self,
+        mut candidate: CacheCandidate,
+        request: BucketRequest,
+    ) -> Option<CacheCandidate> {
+        let Some(config) = &self.config else {
+            return Some(candidate);
+        };
+        let Some(spec) = config.buckets.iter().find(|spec| {
+            spec.stage == BucketStage::Prefill && self.contains(spec, &candidate.worker.id.0)
+        }) else {
+            return Some(candidate);
+        };
+        if !spec
+            .max_context_tokens
+            .is_none_or(|max_context| request.input_tokens <= max_context)
+            || (config.ttft_slo_policy == SloBucketPolicy::SloFirst
+                && !ttft_eligible(spec, request.ttft_slo_ms))
+        {
+            return None;
+        }
+        candidate.candidate_range_id = spec.id.clone();
+        candidate.max_pending_prefill_tokens = spec.max_pending_prefill_tokens;
+        Some(candidate)
     }
 
     fn contains(&self, spec: &BucketSpec, worker_id: &str) -> bool {

--- a/experimental/sgl-router/src/policies/cache_aware.rs
+++ b/experimental/sgl-router/src/policies/cache_aware.rs
@@ -75,7 +75,9 @@ impl CacheAwarePolicy {
         if let Some((selector, request)) = ctx.prefill_cache_bucket() {
             candidates = candidates
                 .into_iter()
-                .filter_map(|candidate| selector.bind_prefill_cache_candidate(candidate, request))
+                .filter_map(|candidate| {
+                    selector.prepare_prefill_cache_candidate(candidate, request)
+                })
                 .collect();
         }
 

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -239,7 +239,7 @@ impl<'a> SelectionContext<'a> {
         self
     }
 
-    /// Cache-Aware uses this binding before Top-K truncation so an
+    /// Cache-Aware applies Bucket constraints before Top-K truncation so an
     /// incompatible cache holder cannot displace a lower-ranked usable one.
     pub fn with_prefill_cache_bucket(
         mut self,

--- a/experimental/sgl-router/tests/component/policies/bucket_domains.rs
+++ b/experimental/sgl-router/tests/component/policies/bucket_domains.rs
@@ -107,91 +107,71 @@ fn prefill_best_effort_tries_non_slo_bucket_before_reserved_slo_capacity() {
 }
 
 #[test]
-fn cache_candidate_uses_uncached_work_range_but_full_context_and_own_ttft_profile() {
+fn prefill_domain_uses_full_input_as_extend_work_without_cache() {
     let short = worker("short", WorkerMode::Prefill);
     let long = worker("long", WorkerMode::Prefill);
     let mut short_bucket = bucket("p-short", BucketStage::Prefill, 10, &["short"]);
     short_bucket.max_extend_tokens = Some(64);
-    short_bucket.max_context_tokens = Some(4_096);
-    short_bucket.ttft_p95_at_capacity_ms = Some(80);
     let mut long_bucket = bucket("p-long", BucketStage::Prefill, 20, &["long"]);
     long_bucket.min_extend_tokens = Some(65);
-    long_bucket.max_context_tokens = Some(4_096);
-    long_bucket.ttft_p95_at_capacity_ms = Some(300);
     let selector = BucketSelector::new(Some(BucketConfig {
         buckets: vec![short_bucket, long_bucket],
-        ttft_slo_policy: SloBucketPolicy::SloFirst,
+        ttft_slo_policy: SloBucketPolicy::Disabled,
         tps_slo_policy: SloBucketPolicy::Disabled,
     }));
-    let workers = vec![Arc::clone(&short), Arc::clone(&long)];
-    let request = BucketRequest {
-        input_tokens: 256,
-        expected_peak_sequence_tokens: None,
-        ttft_slo_ms: Some(100),
-        tps_slo: None,
-    };
+
+    let domains = selector.prefill_domains(
+        &[short, long],
+        BucketRequest {
+            input_tokens: 256,
+            expected_peak_sequence_tokens: None,
+            ttft_slo_ms: None,
+            tps_slo: None,
+        },
+    );
 
     assert_eq!(
-        selector
-            .prefill_domains(&workers, request)
+        domains
             .iter()
             .map(|domain| domain.id.as_str())
             .collect::<Vec<_>>(),
-        ["p-long"],
-        "no-hit target selection uses E=L for extend-work compatibility"
-    );
-    let short_hit = CacheCandidate {
-        worker: Arc::clone(&short),
-        matched_prefix_tokens: 224,
-        uncached_tokens: 32,
-        candidate_range_id: "global".into(),
-        max_pending_prefill_tokens: None,
-    };
-    let bound = selector
-        .bind_prefill_cache_candidate(short_hit, request)
-        .expect("E=32 fits short work range and the full L=256 fits max context");
-    assert_eq!(bound.candidate_range_id, "p-short");
-
-    let long_hit = CacheCandidate {
-        worker: Arc::clone(&long),
-        matched_prefix_tokens: 0,
-        uncached_tokens: 256,
-        candidate_range_id: "global".into(),
-        max_pending_prefill_tokens: None,
-    };
-    assert!(
-        selector
-            .bind_prefill_cache_candidate(long_hit, request)
-            .is_none(),
-        "a cache candidate whose own Hard TTFT profile misses the request SLO is rejected"
+        ["p-long"]
     );
 }
 
 #[test]
-fn cache_candidate_without_bucket_configuration_keeps_global_metadata() {
-    let p = worker("p", WorkerMode::Prefill);
-    let selector = BucketSelector::new(None);
+fn cache_candidate_uses_bucket_metadata_without_extend_range_filtering() {
+    let cached = worker("cached", WorkerMode::Prefill);
+    let mut cached_bucket = bucket("p-cached", BucketStage::Prefill, 10, &["cached"]);
+    cached_bucket.max_extend_tokens = Some(8);
+    cached_bucket.max_pending_prefill_tokens = Some(64);
+    let selector = BucketSelector::new(Some(BucketConfig {
+        buckets: vec![cached_bucket],
+        ttft_slo_policy: SloBucketPolicy::Disabled,
+        tps_slo_policy: SloBucketPolicy::Disabled,
+    }));
     let candidate = CacheCandidate {
-        worker: p,
-        matched_prefix_tokens: 64,
-        uncached_tokens: 64,
-        candidate_range_id: "probe".into(),
-        max_pending_prefill_tokens: Some(1),
+        worker: cached,
+        matched_prefix_tokens: 128,
+        uncached_tokens: 128,
+        candidate_range_id: "global".into(),
+        max_pending_prefill_tokens: None,
     };
-    let bound = selector
-        .bind_prefill_cache_candidate(
+
+    let prepared = selector
+        .prepare_prefill_cache_candidate(
             candidate,
             BucketRequest {
-                input_tokens: 128,
+                input_tokens: 256,
                 expected_peak_sequence_tokens: None,
                 ttft_slo_ms: None,
                 tps_slo: None,
             },
         )
-        .expect("Step 1 always has a catch-all domain");
+        .expect("extend range does not constrain global cache affinity");
 
-    assert_eq!(bound.candidate_range_id, "global");
-    assert_eq!(bound.max_pending_prefill_tokens, None);
+    assert_eq!(prepared.candidate_range_id, "p-cached");
+    assert_eq!(prepared.max_pending_prefill_tokens, Some(64));
 }
 
 #[test]
@@ -332,20 +312,6 @@ fn membership_index_preserves_exact_matching_and_fleet_order() {
     assert_eq!(ids(0), ["w1", "w3"]);
     assert_eq!(ids(1), ["w1", "w3", "w9"]);
 
-    let candidate = CacheCandidate {
-        worker: Arc::clone(&workers[9]),
-        matched_prefix_tokens: 0,
-        uncached_tokens: 128,
-        candidate_range_id: "global".into(),
-        max_pending_prefill_tokens: None,
-    };
-    assert_eq!(
-        selector
-            .bind_prefill_cache_candidate(candidate, request)
-            .expect("w9 belongs to the hash-indexed bucket")
-            .candidate_range_id,
-        "set"
-    );
     assert_eq!(
         selector
             .prefill_affinity_domain(&workers, &workers[9], request)

--- a/experimental/sgl-router/tests/proxy/bucket_routing.rs
+++ b/experimental/sgl-router/tests/proxy/bucket_routing.rs
@@ -223,6 +223,16 @@ fn set_native_load(
     num_total_tokens: u64,
     max_total_num_tokens: u64,
 ) {
+    set_native_load_with_waiting(ctx, worker_url, num_total_tokens, max_total_num_tokens, 0);
+}
+
+fn set_native_load_with_waiting(
+    ctx: &AppContext,
+    worker_url: &str,
+    num_total_tokens: u64,
+    max_total_num_tokens: u64,
+    num_waiting_uncached_tokens: u64,
+) {
     ctx.engine_load.set(
         worker_url,
         0,
@@ -232,7 +242,7 @@ fn set_native_load(
             num_tokens: num_total_tokens,
             max_total_num_tokens,
             native_cache: Some(NativeCacheRankLoad {
-                num_waiting_uncached_tokens: 0,
+                num_waiting_uncached_tokens,
                 num_total_tokens,
                 max_running_requests: 64,
                 total_prefill_uncached_tokens: 1,
@@ -694,17 +704,14 @@ async fn cache_winner_uses_target_uncached_work_before_prompt_length_bucket() {
 }
 
 #[tokio::test]
-async fn cache_candidate_bucket_binding_happens_before_candidate_limit() {
+async fn unbucketed_global_cache_winner_remains_eligible() {
     let best = crate::common::mock_worker::MockWorker::start(vec![]).await;
     let lower_ranked = crate::common::mock_worker::MockWorker::start(vec![]).await;
     let decode = crate::common::mock_worker::MockWorker::start(vec![]).await;
-    let mut best_bucket = bucket("p-best", BucketStage::Prefill, 10, "p-best");
-    best_bucket.min_extend_tokens = Some(32);
     let mut lower_ranked_bucket = bucket("p-lower", BucketStage::Prefill, 20, "p-lower");
     lower_ranked_bucket.min_extend_tokens = Some(32);
     let bucket_config = BucketConfig {
         buckets: vec![
-            best_bucket,
             lower_ranked_bucket,
             bucket("d-catch-all", BucketStage::Decode, 30, "d"),
         ],
@@ -736,16 +743,203 @@ async fn cache_candidate_bucket_binding_happens_before_candidate_limit() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    wait_for_prefill(&lower_ranked).await;
+    wait_for_prefill(&best).await;
     assert!(
-        best.captured.lock().unwrap().last_body.is_none(),
-        "the top Indexer hit is Bucket-incompatible and must not consume K=1"
+        lower_ranked.captured.lock().unwrap().last_body.is_none(),
+        "an admitted unbucketed cache holder must remain globally eligible"
     );
     assert!(
         ctx.metrics.render().contains(
             r#"sgl_router_policy_decisions_total{policy="cache_aware",reason="cache_candidate"} 1"#
         ),
-        "the compatible lower-ranked cache holder must remain a cache candidate"
+        "the global cache winner must remain a cache candidate"
+    );
+}
+
+#[tokio::test]
+async fn cache_candidate_over_context_limit_falls_back_to_compatible_bucket() {
+    let cached = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let fallback = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let decode = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let mut short_bucket = bucket("p-short", BucketStage::Prefill, 10, "p-cached");
+    short_bucket.max_context_tokens = Some(32);
+    let bucket_config = BucketConfig {
+        buckets: vec![
+            short_bucket,
+            bucket("p-long", BucketStage::Prefill, 20, "p-fallback"),
+            bucket("d-catch-all", BucketStage::Decode, 30, "d"),
+        ],
+        ttft_slo_policy: SloBucketPolicy::Disabled,
+        tps_slo_policy: SloBucketPolicy::Disabled,
+    };
+    let prefix_index: Arc<dyn PrefixIndex> = FakePrefixIndex::matched(cached.url.clone());
+    let ctx = build_cache_ctx(
+        vec![
+            worker_spec("p-cached", cached.url.clone(), WorkerMode::Prefill),
+            worker_spec("p-fallback", fallback.url.clone(), WorkerMode::Prefill),
+            worker_spec("d", decode.url.clone(), WorkerMode::Decode),
+        ],
+        bucket_config,
+        prefix_index,
+    );
+
+    let content = "context limit ".repeat(128);
+    let response = build_router(ctx)
+        .oneshot(chat_request_with_content(&content, None, Some(8), None))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    wait_for_prefill(&fallback).await;
+    assert!(
+        cached.captured.lock().unwrap().last_body.is_none(),
+        "a cache holder that cannot serve the full context must not receive the request"
+    );
+}
+
+#[tokio::test]
+async fn cache_candidate_outside_slo_first_tier_falls_back_to_eligible_bucket() {
+    let cached = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let fallback = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let decode = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let mut slow_bucket = bucket("p-slow", BucketStage::Prefill, 10, "p-cached");
+    slow_bucket.ttft_p95_at_capacity_ms = Some(400);
+    let mut fast_bucket = bucket("p-fast", BucketStage::Prefill, 20, "p-fallback");
+    fast_bucket.ttft_p95_at_capacity_ms = Some(100);
+    let bucket_config = BucketConfig {
+        buckets: vec![
+            slow_bucket,
+            fast_bucket,
+            bucket("d-catch-all", BucketStage::Decode, 30, "d"),
+        ],
+        ttft_slo_policy: SloBucketPolicy::SloFirst,
+        tps_slo_policy: SloBucketPolicy::Disabled,
+    };
+    let prefix_index: Arc<dyn PrefixIndex> = FakePrefixIndex::matched(cached.url.clone());
+    let ctx = build_cache_ctx(
+        vec![
+            worker_spec("p-cached", cached.url.clone(), WorkerMode::Prefill),
+            worker_spec("p-fallback", fallback.url.clone(), WorkerMode::Prefill),
+            worker_spec("d", decode.url.clone(), WorkerMode::Decode),
+        ],
+        bucket_config,
+        prefix_index,
+    );
+
+    let content = "ttft tier ".repeat(128);
+    let response = build_router(ctx)
+        .oneshot(chat_request_with_content(
+            &content,
+            Some(200),
+            Some(8),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    wait_for_prefill(&fallback).await;
+    assert!(
+        cached.captured.lock().unwrap().last_body.is_none(),
+        "SloFirst must exclude a cache holder outside the request's TTFT tier"
+    );
+}
+
+#[tokio::test]
+async fn cache_candidate_respects_its_bucket_pending_prefill_budget() {
+    let cached = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let fallback = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let decode = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let mut limited_bucket = bucket("p-limited", BucketStage::Prefill, 10, "p-cached");
+    limited_bucket.max_pending_prefill_tokens = Some(64);
+    let bucket_config = BucketConfig {
+        buckets: vec![
+            limited_bucket,
+            bucket("p-fallback", BucketStage::Prefill, 20, "p-fallback"),
+            bucket("d-catch-all", BucketStage::Decode, 30, "d"),
+        ],
+        ttft_slo_policy: SloBucketPolicy::Disabled,
+        tps_slo_policy: SloBucketPolicy::Disabled,
+    };
+    let prefix_index: Arc<dyn PrefixIndex> = FakePrefixIndex::matched(cached.url.clone());
+    let ctx = build_cache_ctx(
+        vec![
+            worker_spec("p-cached", cached.url.clone(), WorkerMode::Prefill),
+            worker_spec("p-fallback", fallback.url.clone(), WorkerMode::Prefill),
+            worker_spec("d", decode.url.clone(), WorkerMode::Decode),
+        ],
+        bucket_config,
+        prefix_index,
+    );
+    set_native_load_with_waiting(&ctx, &cached.url, 0, 100_000, 64);
+
+    let content = "pending budget ".repeat(128);
+    let response = build_router(Arc::clone(&ctx))
+        .oneshot(chat_request_with_content(&content, None, Some(8), None))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    wait_for_prefill(&fallback).await;
+    assert!(
+        cached.captured.lock().unwrap().last_body.is_none(),
+        "a cache holder beyond its Bucket pending-prefill budget must not receive the request"
+    );
+    assert!(ctx
+        .metrics
+        .render()
+        .contains("sgl_router_cache_admission_rejected_total 1"));
+}
+
+#[tokio::test]
+async fn rejected_global_cache_candidate_falls_back_to_prompt_length_bucket() {
+    let cached = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let fallback = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let decode = crate::common::mock_worker::MockWorker::start(vec![]).await;
+    let mut short_bucket = bucket("p-short", BucketStage::Prefill, 10, "p-cached");
+    short_bucket.max_extend_tokens = Some(8);
+    let mut long_bucket = bucket("p-long", BucketStage::Prefill, 20, "p-fallback");
+    long_bucket.min_extend_tokens = Some(9);
+    let bucket_config = BucketConfig {
+        buckets: vec![
+            short_bucket,
+            long_bucket,
+            bucket("d-catch-all", BucketStage::Decode, 30, "d"),
+        ],
+        ttft_slo_policy: SloBucketPolicy::Disabled,
+        tps_slo_policy: SloBucketPolicy::Disabled,
+    };
+    let prefix_index: Arc<dyn PrefixIndex> = FakePrefixIndex::matched(cached.url.clone());
+    let ctx = build_cache_ctx(
+        vec![
+            worker_spec("p-cached", cached.url.clone(), WorkerMode::Prefill),
+            worker_spec("p-fallback", fallback.url.clone(), WorkerMode::Prefill),
+            worker_spec("d", decode.url.clone(), WorkerMode::Decode),
+        ],
+        bucket_config,
+        prefix_index,
+    );
+    set_native_load(&ctx, &cached.url, 1, 1);
+
+    let content = "admission fallback ".repeat(128);
+    let response = build_router(Arc::clone(&ctx))
+        .oneshot(chat_request_with_content(&content, None, Some(8), None))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    wait_for_prefill(&fallback).await;
+    assert!(
+        cached.captured.lock().unwrap().last_body.is_none(),
+        "an admission-rejected cache holder must not receive the request"
+    );
+    let metrics = ctx.metrics.render();
+    assert!(metrics.contains("sgl_router_cache_admission_rejected_total 1"));
+    assert!(
+        !metrics.contains(
+            r#"sgl_router_policy_decisions_total{policy="cache_aware",reason="cache_candidate"} 1"#
+        ),
+        "Bucket fallback must not be reported as a cache-candidate decision"
     );
 }
 


### PR DESCRIPTION
## Motivation

This is a corrective follow-up to [#38108](https://github.com/sgl-project/sglang/pull/38108) and the bucket-based PD routing roadmap in [#25760](https://github.com/sgl-project/sglang/issues/25760).

Cache-Aware routing is a global affinity decision. When a cache candidate is admitted, the Router should select it directly regardless of Bucket membership. Bucket domains should only constrain the Power-of-Two fallback when no usable cache candidate exists.

The previous flow rebound global cache candidates to Bucket domains, which could discard the best cache holder and change the intended policy semantics.

## Modifications

- Select Cache-Aware candidates from the complete Prefill worker pool before constructing Bucket domains.
- Route an admitted global cache winner directly, regardless of Bucket membership.
- Fall back to prompt-length Bucket selection and Power-of-Two when:
  - no cache candidate is available; or
  - the global cache candidate is rejected by admission control.
- Remove the obsolete cache-candidate Bucket binding API and associated selection context.
- Add regression coverage for:
  - global cache winners outside the prompt-length Bucket;
  - admission-rejected candidates falling back to the correct Bucket;
  - missing cache signals using normal Bucket fallback;
  - unchanged non-cache Bucket and Decode routing behavior.

## Accuracy Tests

This PR only changes Router worker selection. It does not modify model execution, kernels, tokenization, or generated outputs.

Validated at `332db6375c71f7431a604885d0f2608835f51df8`:

- `cargo test --test proxy bucket_routing`: 11 passed
- `cargo test --test component bucket_domains`: 8 passed
- `cargo test -p sgl-router --lib`: 545 passed
- `cargo check --workspace --all-targets`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

The existing `workers::manager::mode_changed_preserves_active_requests_and_breaker` test remains sensitive to parallel execution. It passed 10/10 isolated runs and 3/3 single-threaded component-suite runs. This PR does not modify that path.

## Speed Tests and Profiling

A 256-worker Simulator comparison was run on TraceLab and standard SWE-bench:

- No-Bucket CA
- Bucket PO2
- Bucket CA
- Two 128-worker Buckets with a 4,096-token boundary
- Three qualified repeats per arm
- 27,558 measurement requests, 0 errors
- Values below are three-repeat medians

These are `simulator_predicted_relative` results and do not represent real GPU or PD KV-transfer performance.

### TraceLab

| Metric | No-Bucket CA | Bucket PO2 | Bucket CA |
|---|---:|---:|---:|
| TTFT p50 (ms) | 25.662 | 31.121 | 25.364 |
| Completion TPS | 8,675.652 | 8,669.650 | 8,658.285 |
| Request RPS | 41.888 | 41.859 | 41.805 |
| TTFT p95 (ms) | 58.296 | 73.159 | 59.964 |
| TTFT p99 (ms) | 65.427 | 93.351 | 76.399 |
| E2E p95 (ms) | 1,238.766 | 1,274.054 | 1,224.407 |
| E2E p99 (ms) | 2,514.146 | 2,487.160 | 2,503.132 |
| TPOT p95 (ms) | 1.909 | 1.933 | 1.912 |
| Work CV | 90.76% | 93.17% | 94.23% |
| Hit rate | 76.02% | 0.17% | 72.12% |

Bucket CA improves TTFT p50 by 18.50% relative to Bucket PO2 and remains within 1.16% of No-Bucket CA.

### SWE-bench

| Metric | No-Bucket CA | Bucket PO2 | Bucket CA |
|---|---:|---:|---:|
| TTFT p50 (ms) | 3,801.111 | 167.932 | 3,762.825 |
| Completion TPS | 2,931.700 | 4,020.010 | 3,032.568 |
| Request RPS | 45.808 | 62.813 | 47.384 |
| TTFT p95 (ms) | 5,076.069 | 263.548 | 5,543.949 |
| TTFT p99 (ms) | 5,757.420 | 335.063 | 6,500.456 |
| E2E p95 (ms) | 7,488.399 | 967.655 | 7,415.101 |
| E2E p99 (ms) | 8,566.866 | 1,224.074 | 8,746.336 |
| TPOT p95 (ms) | 55.592 | 11.988 | 49.519 |
| Work CV | 265.25% | 101.08% | 337.39% |
| Hit rate | 65.88% | 41.29% | 66.14% |

Bucket CA closely matches No-Bucket CA in TTFT p50, confirming that Bucket configuration no longer changes an admitted global CA decision. Both global CA arms show workload concentration on this SWE-bench configuration, so this correctness fix should not be interpreted as a universal performance improvement over Bucket PO2.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing API or configuration documentation changes are required.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34565713574](https://github.com/sgl-project/sglang/actions/runs/34565713574)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34565713444](https://github.com/sgl-project/sglang/actions/runs/34565713444)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->