### PR TITLE
fix(gemma4): set lm_head_is_tied in the unified model

### DIFF
--- a/python/sglang/srt/models/gemma4_unified.py
+++ b/python/sglang/srt/models/gemma4_unified.py
@@ -52,7 +52,11 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.gemma4_causal import Gemma4TextModel, pp_filter_load_weight
-from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
+from sglang.srt.models.gemma4_mm import (
+    Gemma4ForConditionalGeneration,
+    _is_cpu,
+    _is_cpu_amx_available,
+)
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -189,8 +193,17 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
             prefix=add_prefix("language_model", add_prefix("model", prefix)),
         )
 
+        # __init__ above deliberately skips Gemma4ForConditionalGeneration's, so
+        # the lm_head_is_tied contract has to be reproduced here: forward() and
+        # load_weights() both read the attribute, and the CPU/AMX path must not
+        # tie because the packed head weights cannot alias the embedding table.
         text_tie = getattr(text_config, "tie_word_embeddings", True)
-        if self.pp_group.world_size == 1 and text_tie:
+        self.lm_head_is_tied = (
+            self.pp_group.world_size == 1
+            and text_tie
+            and not (_is_cpu and _is_cpu_amx_available)
+        )
+        if self.lm_head_is_tied:
             self.lm_head = self.language_model.embed_tokens
         elif self.pp_group.is_last_rank:
             self.lm_head = ParallelLMHead(


### PR DESCRIPTION
## Motivation

`Gemma4UnifiedForConditionalGeneration` deliberately skips
`Gemma4ForConditionalGeneration.__init__` — it builds the SigLIP/conformer towers
that the encoder-free unified variant does not have — and re-implements the
`lm_head` setup itself. It evaluates the tie condition but never assigns
`self.lm_head_is_tied`, so the attribute the parent class relies on does not
exist on this subclass.

The parent reads it in two places:

- `forward()` selects the head with
  `self.language_model.embed_tokens if self.lm_head_is_tied else self.lm_head`
- `load_weights()` gates the tied-head copy on `not self.lm_head_is_tied`

Both raise `AttributeError`, so the first request against a unified Gemma4
checkpoint fails.

The re-implemented condition also dropped the parent's CPU/AMX term. The parent
excludes that case on purpose — with AMX the packed head weights cannot alias
the embedding table — so the unified path would tie the head where it must not.

## Modifications

`python/sglang/srt/models/gemma4_unified.py`: store `self.lm_head_is_tied` using
the same condition as the parent, including the `_is_cpu and
_is_cpu_amx_available` term, and branch on the stored flag.

15 insertions, 2 deletions, one file.

## Checklist

Reproduce the missing attribute without a checkpoint or a GPU, on `main`:

```python
import ast, pathlib

src = pathlib.Path("python/sglang/srt/models/gemma4_unified.py").read_text()
cls = next(
    n for n in ast.walk(ast.parse(src))
    if isinstance(n, ast.ClassDef)
    and n.name == "Gemma4UnifiedForConditionalGeneration"
)
init = next(
    n for n in cls.body
    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
)
assigned = [
    t.attr
    for st in ast.walk(init)
    if isinstance(st, ast.Assign)
    for t in st.targets
    if isinstance(t, ast.Attribute)
]
print("lm_head_is_tied assigned:", "lm_head_is_tied" in assigned)
print("lm_head assigned:        ", "lm_head" in assigned)
```

On `main` this prints `False` / `True`; with this change it prints `True` /
`True`. `grep -n lm_head_is_tied python/sglang/srt/models/gemma4_mm.py` shows the
three parent sites that expect the attribute (definition, `forward`,
`load_weights`).

- [x] Format with `pre-commit` (isort 7.0.0, black, ruff `F401,F821,UP037`)
- [x] `python -m py_compile` on the changed file
- [x] No behaviour change for the non-unified Gemma4 path

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34451791717](https://github.com/sgl-project/sglang/actions/runs/34451791717)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34451791396](https://github.com/sgl-project/sglang/actions/runs/34451791396)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34451791808](https://github.com/sgl-project/sglang/actions/runs/34451791808)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->