### PR TITLE
[Fix] Ignore stream flag for tokenize requests

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -36,6 +36,18 @@ class OpenAIServingTokenize(OpenAIServingBase):
     ) -> tuple[TokenizeRequest, TokenizeRequest]:
         return request, request
 
+    async def _handle_streaming_request(
+        self,
+        adapted_request: TokenizeRequest,
+        request: TokenizeRequest,
+        raw_request: Request,
+    ) -> Union[TokenizeResponse, ErrorResponse]:
+        # Tokenization always returns one JSON response. Accept and ignore the
+        # stream flag when callers reuse a chat-completion request payload.
+        return await self._handle_non_streaming_request(
+            adapted_request, request, raw_request
+        )
+
     async def _handle_non_streaming_request(
         self,
         adapted_request: TokenizeRequest,

--- a/test/registered/core/test_srt_endpoint.py
+++ b/test/registered/core/test_srt_endpoint.py
@@ -852,6 +852,26 @@ class TestTokenizeDetokenize(CustomTestCase):
         self.assertEqual(no_tools_resp["tokens"], resp["tokens"])
         self.assertEqual(no_tools_resp["count"], resp["count"])
 
+    def test_tokenize_ignores_stream(self):
+        scenarios = [
+            (
+                self.tokenize_url,
+                {"model": self.model, "prompt": "Hello SGLang!"},
+            ),
+            (
+                self.openai_tokenize_url,
+                {
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": "Hello SGLang!"}],
+                },
+            ),
+        ]
+        for url, payload in scenarios:
+            with self.subTest(url=url):
+                expected = self._post_json(url, payload)
+                actual = self._post_json(url, {**payload, "stream": True})
+                self.assertEqual(actual, expected)
+
     def test_detokenize_roundtrip(self):
         text = "Verify detokenization round trip. यह डिटोकेनाइजेशन है"
         t0 = self._post_json(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

`/tokenize` and `/v1/tokenize` accept Chat Completions-style request payloads. Because the request model allows extra fields, including `stream`, passing `stream=true` caused the common serving handler to route the request to the unsupported streaming path and return HTTP 501.

Tokenization always produces a single JSON response, so callers should be able to reuse Chat Completions payloads without removing the `stream` field.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Handle `stream=true` in `OpenAIServingTokenize` by delegating to the existing non-streaming tokenization path.
- Keep the response format as the standard non-streaming JSON response; this change does not introduce SSE streaming for tokenization.
- Add regression coverage for both supported input forms:
  - `prompt` requests through `/tokenize`
  - Chat-style `messages` requests through `/v1/tokenize`
- Verify that requests with `stream=true` return the same result as requests without the field.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Not applicable. This change only affects HTTP request routing and does not modify tokenization or model output behavior.

Validation performed:

- The affected endpoint behavior was manually retested successfully.
- Added `TestTokenizeDetokenize.test_tokenize_ignores_stream`.
- Python syntax checks passed.
- Ruff lint and format checks passed.
- Registered-test validation scripts passed.
- Full Linux GPU E2E execution is left to CI because the local Windows environment does not provide the Unix `resource` module required to import SGLang.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not applicable. The change only redirects tokenize requests to the existing non-streaming handler.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34454089060](https://github.com/sgl-project/sglang/actions/runs/34454089060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34454088817](https://github.com/sgl-project/sglang/actions/runs/34454088817)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34454089062](https://github.com/sgl-project/sglang/actions/runs/34454089062)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->