### PR TITLE
pyproject(xpu): drop human-eval git dep to unblock image build

### DIFF
--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -103,7 +103,6 @@ test = [
   "bitsandbytes",
   "pymupdf",
   "expecttest",
-  "human-eval @ git+https://github.com/merrymercy/human-eval.git",
   "jsonlines",
   "lm-eval[api]>=0.4.9.2",
   "matplotlib",


### PR DESCRIPTION
## Motivation

The XPU nightly Docker image build (`intel/sglang-dev:latest`) is failing at the `pip install .[dev,diffusion]` step in `docker/xpu.Dockerfile:78-85` because pip cannot build `human-eval @ git+https://github.com/merrymercy/human-eval.git`:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

Example failing run: https://github.com/sgl-project/sglang/actions/runs/34447556590/job/102775601484

Root cause: `merrymercy/human-eval` ships no `pyproject.toml`, and its `setup.py` does `import pkg_resources` at module load. `setuptools >= 81` dropped `pkg_resources` from the default install, so pip's PEP 517 isolated build environment grabs a newer setuptools and blows up before it can even read `requirements.txt`. The same failure hits any local `pip install .[test]` against `pyproject_xpu.toml`.

## Modifications

- Drop `"human-eval @ git+https://github.com/merrymercy/human-eval.git"` from the `test` extra in `python/pyproject_xpu.toml`. It can be reintroduced once `merrymercy/human-eval` grows a `pyproject.toml` (or is swapped for a modern packaging fork).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34454632258](https://github.com/sgl-project/sglang/actions/runs/34454632258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34454631964](https://github.com/sgl-project/sglang/actions/runs/34454631964)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34454632548](https://github.com/sgl-project/sglang/actions/runs/34454632548)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->