### PR TITLE
fix(metrics): gate scheduler stats logging on attn_cp_rank == 0

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1111,7 +1111,11 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         enable_hierarchical_cache: bool,
     ) -> SchedulerMetricsCollectorContext:
         enable_metrics = get_observability().enable_metrics
-        is_stats_logging_rank = ps.attn_tp_rank == 0
+        # Under attention CP every CP rank runs a scheduler over the same global
+        # requests. Gate on the CP rank as well, otherwise every CP rank exports
+        # the same request gauges and Prometheus sums inflate by attn_cp_size
+        # (issue #31896), matching the kv-cache event gate below.
+        is_stats_logging_rank = ps.attn_tp_rank == 0 and ps.attn_cp_rank == 0
         current_scheduler_metrics_enabled = enable_metrics and (
             is_stats_logging_rank
             or get_observability().enable_metrics_for_all_schedulers

--- a/test/registered/unit/observability/test_metrics_collector_rank_gate.py
+++ b/test/registered/unit/observability/test_metrics_collector_rank_gate.py
@@ -1,0 +1,96 @@
+"""Rank-gate tests for ``SchedulerMetricsCollector.init_new`` (issue #31896).
+
+Under attention context parallelism every CP rank runs its own scheduler over
+the same global requests, and with ``attn_tp_size == 1`` every CP rank has
+``attn_tp_rank == 0``. Gating stats logging on ``attn_tp_rank`` alone therefore
+made every CP rank export the same request gauges (``sglang:num_running_reqs``
+and friends), inflating Prometheus sums by ``attn_cp_size``. The KV-cache event
+export already gates on ``attn_cp_rank == 0``; these tests lock the same
+predicate for request stats.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.observability.metrics_collector import SchedulerMetricsCollector
+from sglang.srt.runtime_context import get_context
+from sglang.test.test_utils import CustomTestCase
+
+
+class _DummyCollector:
+    """Stand-in so ``init_new`` runs without registering prometheus metrics."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_ps(**overrides) -> ParallelState:
+    defaults = dict(dp_rank=None, moe_dp_rank=None)
+    defaults.update(overrides)
+    return ParallelState.trivial(**defaults)
+
+
+class TestStatsLoggingRankGate(CustomTestCase):
+    def _init_ctx(self, *, ps, enable_metrics=True, all_schedulers=False):
+        override = get_context().override_server_args(
+            enable_metrics=enable_metrics,
+            enable_metrics_for_all_schedulers=all_schedulers,
+            kv_events_config=None,
+        )
+        server_args = override.install()
+        self.addCleanup(override.restore)
+        with patch(
+            "sglang.srt.observability.metrics_collector.resolve_collector_class",
+            return_value=_DummyCollector,
+        ):
+            return SchedulerMetricsCollector.init_new(
+                server_args=server_args,
+                ps=ps,
+                tp_rank=ps.tp_rank,
+                pp_rank=ps.pp_rank,
+                dp_rank=None,
+                enable_priority_scheduling=False,
+                enable_lora=False,
+                enable_hierarchical_cache=False,
+            )
+
+    def test_cp_rank_zero_logs_and_exports(self):
+        ctx = self._init_ctx(ps=_make_ps(attn_tp_rank=0, attn_cp_rank=0))
+        self.assertTrue(ctx.is_stats_logging_rank)
+        self.assertTrue(ctx.current_scheduler_metrics_enabled)
+
+    def test_cp_nonzero_rank_does_not_log_or_export(self):
+        # cp=8 with attn_tp_size == 1: tp_rank differs per CP rank while
+        # attn_tp_rank == 0 on every one of them (issue #31896).
+        ctx = self._init_ctx(
+            ps=_make_ps(
+                tp_rank=3, tp_size=8, attn_tp_rank=0, attn_cp_rank=3, attn_cp_size=8
+            )
+        )
+        self.assertFalse(ctx.is_stats_logging_rank)
+        self.assertFalse(ctx.current_scheduler_metrics_enabled)
+
+    def test_enable_metrics_for_all_schedulers_still_exports_on_cp_ranks(self):
+        ctx = self._init_ctx(
+            ps=_make_ps(
+                tp_rank=3, tp_size=8, attn_tp_rank=0, attn_cp_rank=3, attn_cp_size=8
+            ),
+            all_schedulers=True,
+        )
+        self.assertFalse(ctx.is_stats_logging_rank)
+        self.assertTrue(ctx.current_scheduler_metrics_enabled)
+
+    def test_metrics_disabled_never_exports(self):
+        ctx = self._init_ctx(ps=_make_ps(), enable_metrics=False)
+        self.assertTrue(ctx.is_stats_logging_rank)
+        self.assertFalse(ctx.current_scheduler_metrics_enabled)
+        self.assertIsNone(ctx.collector)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #31896. With `--cp 8` (`attn_cp_size=8`), Prometheus gauges such as `sglang:num_running_reqs` are inflated by roughly the CP size.

Root cause: under attention CP every CP rank runs its own scheduler over the **same** global requests, and with `attn_tp_size == 1` the rank arithmetic in `dp_attention.py` makes `attn_tp_rank == 0` on every CP rank while `tp_rank` runs 0..7. `SchedulerMetricsCollector.init_new` gated `is_stats_logging_rank` on `attn_tp_rank == 0` alone, so all `attn_cp_size` schedulers exported the same request gauges and Prometheus sums inflated by the CP size.

The KV-cache event export one block below already gates on `attn_cp_rank == 0`; request stats now use the same predicate.

## Modifications

- `metrics_collector.py`: `is_stats_logging_rank` now requires `ps.attn_tp_rank == 0 and ps.attn_cp_rank == 0`. `enable_metrics_for_all_schedulers` remains as the explicit opt-in to export from every rank.
- New CPU unit test `test_metrics_collector_rank_gate.py` locking the predicate: cp rank 0 logs/exports, nonzero cp rank does not, `enable_metrics_for_all_schedulers` still exports from every rank, and metrics-disabled never exports.

Note: an earlier attempt (#31909) with the same one-line guard was closed by its author before review; this picks it back up with focused tests on current main.

## Accuracy Test

Pure CPU unit tests (`test/registered/unit/observability/test_metrics_collector_rank_gate.py`) covering the rank predicate through the real `init_new`; no model/GPU surface is touched.

## Benchmark & Profiling

N/A — one boolean predicate on the metrics init path; no hot-path or numeric behavior change. Nonzero CP ranks simply stop emitting duplicate log lines and duplicate gauge series.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34454699956](https://github.com/sgl-project/sglang/actions/runs/34454699956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34454699689](https://github.com/sgl-project/sglang/actions/runs/34454699689)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34454699884](https://github.com/sgl-project/sglang/actions/runs/34454699884)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->