### PR TITLE
[kernel] DSA top-k v2: long-context cluster rework, and NaN padding for the lanes outside a row

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -190,9 +190,20 @@ SGL_DEVICE void problem_transform(TopKProblem& problem, int32_t* output_ptr) {
  * the cluster path (which exists to split ONE row across blocks) is never worth
  * it here.
  *
- * Round the input down for aligned vector loads, then exclude the preceding
- * columns from both histogram and candidate collection. A score sentinel cannot
- * mask them: valid scores may also be negative infinity.
+ * The window start is an arbitrary token offset, so the 16-byte vectorized load
+ * needs the row pointer rounded down to a 4-float boundary. The <= 3 elements
+ * that pulls in are columns of a preceding request -- real finite scores that
+ * would otherwise win the selection -- so they are masked in place first. That
+ * write races with nothing and needs no barrier of its own:
+ *   - one block owns the row, and a column of row `b` is read by no other row;
+ *   - the score buffer is dead once the top-k has run;
+ *   - every forward() below opens with its smem init and a `__syncthreads()`
+ *     before it reads any score. That barrier both publishes the mask to
+ *     whichever thread loads the head vector and keeps the compiler from
+ *     hoisting those loads above the store -- store and loads reach the same row
+ *     through two `__restrict__` pointers, which otherwise licenses exactly that
+ *     reordering.
+ * It must however land after the PDL wait, or the indexer overwrites it.
  */
 template <bool kPDL>
 TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams params) {
@@ -216,6 +227,15 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
 
   const auto rem = row_start % kVecSize;
   const auto score = params.scores + bx * params.score_stride;
+  if (rem != 0) {
+    // The mask has to land after the indexer has retired
+    // Otherwise it may be accidentally overwritten by DG upstream
+    device::PDLWaitPrimary<kPDL>();
+    static_assert(kVecSize <= kBlockSize, "not enough threads ");
+    if (const auto tx = threadIdx.x; tx < rem) {
+      score[row_start - rem + tx] = -std::numeric_limits<float>::max();
+    }
+  }
 
   const auto problem = TopKProblem{
       .in = score + (row_start - rem),
@@ -225,15 +245,14 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
       .seq_len = seq_len + rem,
       .page_bits = 1,  // unused
       .bias = offset - static_cast<int32_t>(rem),
-      .input_start = rem,
   };
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
   if (problem.seq_len <= Register2::kMaxSeqLen) {
-    Register2::forward<kPDL, true>(problem, &smem);
+    Register2::forward<kPDL>(problem, &smem);
   } else if (problem.seq_len <= Register4::kMaxSeqLen) {
-    Register4::forward<kPDL, true>(problem, &smem);
+    Register4::forward<kPDL>(problem, &smem);
   } else {
-    Streaming::forward<kPDL, true>(problem, &smem);
+    Streaming::forward<kPDL>(problem, &smem);
   }
   // PDL trigger secondary at the end the block typically has no use, so ignore it
 }
@@ -595,6 +614,11 @@ struct TopKKernel {
   /**
    * \brief Ragged (prefill) variant of `transform`: per-row window, additive
    * output transform, no page table and no plan.
+   *
+   * `scores` is written in place: the <= 3 columns the 16-byte-aligned read base
+   * pulls in ahead of each row's window are masked out (see
+   * `topk_ragged_kernel`). They are invalid for that row, and the buffer has no
+   * consumer after this call.
    *
    * `row_starts` absent means every window starts at column 0, which is the
    * single-request case; `out_offsets` is added to every selected position and

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <iterator>
 #include <limits>
+#include <mutex>
 
 namespace sglang {
 
@@ -321,7 +322,6 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
 
 constexpr uint32_t kNumPersistentClusters = SGL_TOPK_V2_MAX_C8_OCC2;
 constexpr uint32_t kMaxCluster16BatchSize = SGL_TOPK_V2_MAX_C16_OCC1;
-static_assert(kNumPersistentClusters > 0 && kMaxCluster16BatchSize > 0);
 constexpr uint32_t kClusterMaxBatch = 512;
 #define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
 
@@ -633,37 +633,41 @@ struct TopKKernel {
 #if SUPPORT_CLUSTER
       const bool use_cluster = (max_seq_len > params.static_cluster_floor) && (batch_size <= kClusterMaxBatch);
       if (use_cluster) {
-        if (batch_size <= kMaxCluster16BatchSize) {
-          constexpr uint32_t kClusterSize = 16;
-          // Widths above 8 are non-portable; the launch is rejected without this.
-          static const bool once = [] {
-            RuntimeDeviceCheck(
-                ::cudaFuncSetAttribute(
-                    reinterpret_cast<const void*>(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>),
-                    ::cudaFuncAttributeNonPortableClusterSizeAllowed,
-                    1));
-            return true;
-          }();
-          static_cast<void>(once);
-          LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
-              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>, params);
-        } else if (batch_size <= kNumPersistentClusters) {
-          constexpr uint32_t kClusterSize = 8;
-          LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
-              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 2>, params);
-        } else {
-          constexpr uint32_t kClusterSize = 8;
-          const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
-          LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)
-              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_persistent_cluster_kernel<kUsePDL, kClusterSize>, params);
-          LaunchKernel(batch_size, kBlockSize, device)
-              .config({.use_pdl = kUsePDL})
-              .launch(topk_main_kernel<kUsePDL, /*kLevel=*/3, kMode>, params);
+        if constexpr (kMaxCluster16BatchSize > 0) {
+          if (batch_size <= kMaxCluster16BatchSize) {
+            constexpr uint32_t kClusterSize = 16;
+            // Widths above 8 are non-portable; the launch is rejected without this.
+            const auto kernel = topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>;
+            [[maybe_unused]]
+            static const bool _ = [&kernel] {
+              const auto kernel_ptr = reinterpret_cast<const void*>(kernel);
+              CHECK_CUDA(::cudaFuncSetAttribute(kernel_ptr, ::cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+              return true;
+            }();
+            return LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(kernel, params);
+          }
         }
-        return;
+
+        if constexpr (kNumPersistentClusters > 0) {
+          if (batch_size <= kNumPersistentClusters) {
+            constexpr uint32_t kClusterSize = 8;
+            return LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 2>, params);
+          } else {
+            constexpr uint32_t kClusterSize = 8;
+            const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
+            LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(topk_persistent_cluster_kernel<kUsePDL, kClusterSize>, params);
+            LaunchKernel(batch_size, kBlockSize, device)
+                .config({.use_pdl = kUsePDL})
+                .launch(topk_main_kernel<kUsePDL, /*kLevel=*/3, kMode>, params);
+            return void();
+          }
+        }
       }
 #endif
       if (max_seq_len <= kReg2MaxSeqLen) {

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -20,6 +20,7 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <bit>
+#include <climits>
 #include <cstdint>
 #include <iterator>
 #include <limits>
@@ -37,27 +38,14 @@ enum class TopKMode {
 using Register2 = impl::TopKRegister<2>;  // <= 8192, register-resident, 1 read
 using Register4 = impl::TopKRegister<4>;  // <= 16384, register-resident, 1 read
 using Streaming = impl::TopKStreaming;
-#ifndef USE_ROCM
-using Cluster = impl::TopKCluster<8>;
-#endif
 
 constexpr uint32_t kBlockSize = impl::TopKConfig::kBlockSize;
 constexpr uint32_t kOccupancy = impl::TopKConfig::kOccupancy;
 constexpr uint32_t kMaxTopK = impl::TopKConfig::kMaxTopK;
-#ifndef USE_ROCM
-constexpr uint32_t kClusterSize = Cluster::kClusterSize;
-#endif
 constexpr uint32_t kReg2MaxSeqLen = Register2::kMaxSeqLen;  // 8192
 constexpr uint32_t kReg4MaxSeqLen = Register4::kMaxSeqLen;  // 16384
 
 #define TOPK_KERNEL __global__ __launch_bounds__(kBlockSize, kOccupancy)
-#ifndef USE_ROCM
-#define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
-#endif
-
-constexpr uint32_t kClusterFloor = 65536;
-constexpr uint32_t kClusterMaxBatch = 512;
-constexpr uint32_t kNumPersistentClusters = 15 * kOccupancy;
 
 /// Metadata tensor rows (each 8 B / 2 int32). Row 0 is the global plan result;
 /// rows 1..N are the (batch_id, seq_len) of items routed to the cluster pool.
@@ -71,6 +59,16 @@ struct alignas(8) PlanItem {
 };
 static_assert(sizeof(GlobalMetadata) == 2 * sizeof(int32_t) && sizeof(PlanItem) == sizeof(GlobalMetadata));
 
+struct PageTransform {
+  const int32_t* __restrict__ page_table;
+  uint32_t page_bits;
+
+  SGL_DEVICE int32_t page_to_indices(uint32_t i) const {
+    const uint32_t mask = (1u << page_bits) - 1u;
+    return (page_table[i >> page_bits] << page_bits) | (i & mask);
+  }
+};
+
 struct TopKPagedParams {
   const float* __restrict__ scores;
   const int32_t* __restrict__ seq_lens;
@@ -81,7 +79,8 @@ struct TopKPagedParams {
   int64_t page_table_stride;
   uint32_t topk;
   uint32_t page_bits;
-  uint32_t cluster_floor;  // seq_len > this routes to the cluster path (batch-aware, host-set)
+  uint32_t static_cluster_floor;  // only used in small batch variant
+  uint32_t batch_size;
 
   SGL_DEVICE const GlobalMetadata& global() const {
     return *reinterpret_cast<const GlobalMetadata*>(metadata);
@@ -95,15 +94,16 @@ struct TopKPagedParams {
   SGL_DEVICE int32_t* get_output_ptr(uint32_t batch_id) const {
     return page_indices + batch_id * static_cast<int64_t>(topk);
   }
+  SGL_DEVICE PageTransform get_transform(uint32_t batch_id) const {
+    return {page_table + batch_id * page_table_stride, page_bits};
+  }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id, uint32_t seq_len) const {
     const auto k = static_cast<int64_t>(topk);
     return TopKProblem{
         .in = scores + batch_id * score_stride,
         .out = page_indices + batch_id * k,
-        .page_table = page_table + batch_id * page_table_stride,
         .topk = topk,
         .seq_len = seq_len,
-        .page_bits = page_bits,
     };
   }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id) const {
@@ -121,30 +121,9 @@ struct TopKRaggedParams {
   uint32_t topk;
 };
 
-#ifndef USE_ROCM
-/**
- * \brief Persistent cluster kernel for the long items. It will handle long inputs.
- * The short items are handled by the separate topk_kernel.
- */
-template <bool kPDL>
-CLUSTER_TOPK_KERNEL void topk_persistent_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
-  device::enable_smem_spilling();
-  __shared__ impl::MaxSmem<Cluster::Smem> smem;
-  const uint32_t num_cluster_items = params.global().num_cluster_items;
-  device::PDLWaitPrimary<kPDL>();
-  device::PDLTriggerSecondary<kPDL>();
-#pragma unroll 1
-  for (uint32_t w = blockIdx.x; w < num_cluster_items; w += kNumPersistentClusters) {
-    const auto it = params.item(w);
-    const auto problem = params.problem(it.batch_id, it.seq_len);
-    Cluster::forward<false>(problem, &smem);
-    __syncthreads();
-  }
-}
-#endif  // !USE_ROCM
-
 template <typename F>
 SGL_DEVICE void for_each_item(uint32_t topk, const F& f) {
+  static_assert(kMaxTopK % kBlockSize == 0);
   constexpr uint32_t kNumElems = kMaxTopK / kBlockSize;
 #pragma unroll
   for (uint32_t i = 0; i < kNumElems; ++i) {
@@ -156,26 +135,30 @@ SGL_DEVICE void for_each_item(uint32_t topk, const F& f) {
 }
 
 template <bool kPDL, TopKMode kMode>
-SGL_DEVICE void trivial_transform(const TopKProblem& problem) {
+SGL_DEVICE void trivial_transform(const TopKProblem& problem, const PageTransform& transform) {
   device::PDLWaitPrimary<kPDL>();
   device::PDLTriggerSecondary<kPDL>();
   for_each_item(problem.topk, [&](uint32_t tx, uint32_t) {
-    const auto idx = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
     if constexpr (kMode == TopKMode::INDICES) {
-      problem.emit(tx, idx);
+      problem.out[tx] = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
     } else {
-      problem.transform_output(tx, idx);
+      problem.out[tx] = tx < problem.seq_len ? transform.page_to_indices(tx) : -1;
     }
   });
 }
 
-SGL_DEVICE void problem_transform(TopKProblem& problem, int32_t* output_ptr) {
+SGL_DEVICE void paged_transform(const TopKProblem& problem, int32_t* out, const PageTransform& transform) {
   static_assert(kMaxTopK % kBlockSize == 0);
   constexpr uint32_t kNumElems = kMaxTopK / kBlockSize;
-  int32_t source_index[kNumElems];
-  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) { source_index[i] = problem.out[tx]; });
-  problem.out = output_ptr;
-  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) { problem.transform_output(tx, source_index[i]); });
+  int32_t indices[kNumElems];
+  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) {
+    // load into register at once
+    indices[i] = problem.out[tx];
+  });
+  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) {
+    // safe write to output
+    out[tx] = indices[i] >= 0 ? transform.page_to_indices(indices[i]) : -1;
+  });
 }
 
 /**
@@ -240,10 +223,8 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
   const auto problem = TopKProblem{
       .in = score + (row_start - rem),
       .out = out,
-      .page_table = nullptr,  // unused
       .topk = topk,
       .seq_len = seq_len + rem,
-      .page_bits = 1,  // unused
       .bias = offset - static_cast<int32_t>(rem),
   };
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
@@ -269,8 +250,7 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
 template <bool kPDL, int kLevel, TopKMode kMode>
 TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params) {
   device::enable_smem_spilling();
-  auto problem = params.problem(blockIdx.x);
-  constexpr uint32_t kU32Max = std::numeric_limits<uint32_t>::max();
+  constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
   constexpr bool kHandleCluster = (kLevel == 3);
   // Only the cluster path consumes the cluster kernel's output, so only it waits
   // on that kernel (kPDLFinal). Every other path waits at most on the indexer
@@ -279,14 +259,18 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
   constexpr bool kPDLEarly = kPDL && !kHandleCluster;
   constexpr bool kPDLFinal = kPDL && kHandleCluster;
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDLEarly, kMode>(problem);
+  __shared__ int32_t s_topk_indices[kMaxTopK];
 
-  constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
-  __shared__ int32_t s_topk_indices[kNeedStaging ? kMaxTopK : 1];
-  if constexpr (kNeedStaging) problem.out = s_topk_indices;
+  const auto bx = blockIdx.x;
+  auto problem = params.problem(bx);
+  if (problem.seq_len <= problem.topk) {
+    return trivial_transform<kPDLEarly, kMode>(problem, params.get_transform(bx));
+  }
+  if constexpr (kNeedStaging) {
+    problem.out = s_topk_indices;  // write into stage buffer in smem first
+  }
 
   // non-trivial path: dispatch based on level and seq_len
-  const auto cluster_threshold = kHandleCluster ? params.cluster_threshold() : kU32Max;
   if constexpr (kLevel == 0) {
     __builtin_assume(problem.seq_len <= kReg2MaxSeqLen);
     Register2::forward<kPDL>(problem, &smem);
@@ -294,82 +278,135 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
     __builtin_assume(problem.seq_len <= kReg4MaxSeqLen);
     Register4::forward<kPDL>(problem, &smem);  // max_seq_len <= 16384 guarantees seq <= 16384
   } else {
+    const auto cluster_threshold = kHandleCluster ? params.cluster_threshold() : UINT_MAX;
     static_assert(kLevel == 2 || kLevel == 3, "we only support level = 0,1,2,3 now");
     if (problem.seq_len <= kReg4MaxSeqLen) {
       Register4::forward<kPDLEarly>(problem, &smem);
     } else if (problem.seq_len <= cluster_threshold) {
       Streaming::forward<kPDLEarly>(problem, &smem);
-    } else {
+    } else [[unlikely]] {
       // Cluster path: the pool already selected into our output row; the only
       // work left is the epilogue, so this is the one path that waits for it.
-      problem.out = params.get_output_ptr(blockIdx.x);
-      device::PDLWaitPrimary<kPDLFinal>();
+      if constexpr (kNeedStaging) {
+        device::PDLWaitPrimary<kPDLFinal>();
+        problem.out = params.get_output_ptr(bx);  // in-place transform
+        device::PDLTriggerSecondary<kPDL>();
+        return paged_transform(problem, problem.out, params.get_transform(bx));
+      } else {
+        return device::PDLTriggerSecondary<kPDL>();
+      }
     }
   }
 
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
     __syncthreads();
-    problem_transform(problem, params.get_output_ptr(blockIdx.x));
+    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
 
-#ifndef USE_ROCM
-template <bool kPDL, TopKMode kMode>
-CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKPagedParams params) {
-  device::enable_smem_spilling();
-  auto problem = params.problem(blockIdx.x);
-  __shared__ impl::MaxSmem<Streaming::Smem, Cluster::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDL, kMode>(problem);
+#if SUPPORT_CLUSTER
 
+#ifndef SGL_TOPK_V2_MAX_C8_OCC2
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+#define SGL_TOPK_V2_MAX_C8_OCC2 33  // NOTE: B200
+#else
+#define SGL_TOPK_V2_MAX_C8_OCC2 30  // NOTE: H200
+#endif
+#endif
+
+#ifndef SGL_TOPK_V2_MAX_C16_OCC1
+#define SGL_TOPK_V2_MAX_C16_OCC1 7
+#endif
+
+constexpr uint32_t kNumPersistentClusters = SGL_TOPK_V2_MAX_C8_OCC2;
+constexpr uint32_t kMaxCluster16BatchSize = SGL_TOPK_V2_MAX_C16_OCC1;
+constexpr uint32_t kClusterMaxBatch = 512;
+#define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
+
+/**
+ * \brief Persistent cluster kernel for the long items. It will handle long inputs.
+ * The short items are handled by the separate topk_kernel.
+ */
+template <bool kPDL, uint32_t kClusterSize>
+CLUSTER_TOPK_KERNEL void topk_persistent_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
+  device::enable_smem_spilling();
+  using ClusterN = impl::TopKCluster<kClusterSize>;
+  __shared__ impl::MaxSmem<typename ClusterN::Smem> smem;
+  const auto bx = blockIdx.x;
+  const auto num_cluster_items = params.global().num_cluster_items;
+  device::PDLWaitPrimary<kPDL>();
+  if (bx >= params.batch_size) return;
+  device::PDLTriggerSecondary<kPDL>();
+  auto idx = static_cast<int32_t>(num_cluster_items - 1 - bx);
+#pragma unroll 1
+  while (idx >= 0) {
+    const auto it = params.item(idx);
+    const auto problem = params.problem(it.batch_id, it.seq_len);
+    ClusterN::template forward<false>(problem, &smem);
+    idx -= kNumPersistentClusters;
+    if (idx >= 0) __syncthreads();
+  }
+}
+
+template <bool kPDL, TopKMode kMode, uint32_t kClusterSize, uint32_t kOccupancy>
+CLUSTER_TOPK_KERNEL void topk_small_batch_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
+  device::enable_smem_spilling();
   constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
-  __shared__ int32_t s_topk_indices[kNeedStaging ? kMaxTopK : 1];
-  if constexpr (kNeedStaging) problem.out = s_topk_indices;
+  const auto bx = blockIdx.x;
+  const auto by = blockIdx.y;
+  auto problem = params.problem(bx);
+  __shared__ int32_t s_topk_indices[kMaxTopK];
+  using ClusterN = impl::TopKCluster<kClusterSize>;
+  __shared__ impl::MaxSmem<Register4::Smem, Streaming::Smem, typename ClusterN::Smem> smem;
 
   // randomly elect one worker rank to avoid workload imbalance
-  const auto worker_rank = blockIdx.x % kClusterSize;
+  const auto worker_rank = bx % kClusterSize;
+  if (problem.seq_len <= problem.topk) {
+    if (by != worker_rank) return;
+    return trivial_transform<kPDL, kMode>(problem, params.get_transform(bx));
+  }
 
+  if constexpr (kNeedStaging) {
+    problem.out = s_topk_indices;  // write into stage buffer in smem first
+  }
   // for small batch, we will fuse in the cluster case
   if (problem.seq_len <= kReg4MaxSeqLen) {
-    if (blockIdx.y != worker_rank) return;
+    if (by != worker_rank) return;
     Register4::forward<kPDL>(problem, &smem);
-    __syncthreads();
-  } else if (problem.seq_len <= params.cluster_floor) {
-    if (blockIdx.y != worker_rank) return;
+  } else if (problem.seq_len <= params.static_cluster_floor) {
+    if (by != worker_rank) return;
     Streaming::forward<kPDL>(problem, &smem);
-    __syncthreads();
   } else {
     auto cluster = cooperative_groups::this_cluster();
     if constexpr (kNeedStaging) {
-      problem.out = cluster.map_shared_rank(s_topk_indices, worker_rank);
+      problem.out = cluster.map_shared_rank(s_topk_indices, 0);
     }
-    Cluster::forward<kPDL>(problem, &smem);
+    ClusterN::forward<kPDL>(problem, &smem);
     if constexpr (kNeedStaging) {
+      device::PDLTriggerSecondary<kPDL>();
       cluster.sync();
-      if (blockIdx.y != worker_rank) return;
+      if (by != 0) return;
+      problem.out = s_topk_indices;
+      return paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
+    } else {
+      return device::PDLTriggerSecondary<kPDL>();
     }
   }
 
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
-    // Only the elected worker reaches here, and it mapped `topk_indices` to
-    // itself, so `problem.out` is this block's own buffer. Stating that keeps the
-    // shared::cluster address out of the load problem_transform issues -- which is
-    // load-bearing, not an optimization: without it cicc segfaults on CUDA 13.1+
-    // for sm_90a (issue #32830, previously worked around by copying `problem` in
-    // #32910). Verified: dropping this line reproduces the crash on 13.1/13.2/13.3.
-    __builtin_assume(problem.out == s_topk_indices);
-    problem_transform(problem, params.get_output_ptr(blockIdx.x));
+    __syncthreads();
+    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
-#endif  // !USE_ROCM
 
 // --- Plan: choose cluster_threshold from the seq_len distribution -----------
-__global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
+__global__ __launch_bounds__(kBlockSize, 1) void topk_plan_cluster(
     const uint32_t* __restrict__ seq_lens,
     PlanItem* __restrict__ metadata,  // [0]=GlobalMetadata, [1+i]=PlanItem
     const uint32_t batch_size,
-    const uint32_t static_cluster_threshold) {
+    const int32_t static_cluster_threshold) {
   // Candidate (threshold T_j, cap_j) pairs, T strictly increasing. The plan lowers
   // cluster_threshold to T_j while #(items with seq_len > T_j) <= cap_j, so cap_j
   // bounds how many long items go to the persistent pool. The pool runs N items in
@@ -382,16 +419,24 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
     uint32_t max_batch_size;
   };
   constexpr Pair kCandidates[] = {
-      {65536, 30},    // (65536,98304]:    ~1 pool wave, streams beyond 30
-      {98304, 48},    // (98304,131072]
-      {131072, 60},   // (131072,196608]
-      {196608, 80},   // (196608,262144]
-      {262144, 112},  // (262144,393216]
-      {393216, 128},  // (393216,inf):     longest -- worth many pool waves; a top
-                      // threshold here lets overloaded ~280-393K batches still stream
+#if SGL_ARCH_BLACKWELL_OR_GREATER  // tuned on B200
+      {32768, 48},
+      {131072, 66},
+      {163840, 99},
+      {196608, 132},
+      {262144, 198},
+      {393216, 231},
+      {524288, 264},
+#else  // tuned on H200
+      {65536, 30},
+      {98304, 45},
+      {131072, 60},
+      {196608, 80},
+      {262144, 112},
+      {393216, 128},
+#endif
   };
   constexpr uint32_t kNumCandidates = std::size(kCandidates);
-  static_assert(kCandidates[0].threshold == kClusterFloor);
 
   __shared__ uint32_t s_counts[kNumCandidates];
   __shared__ uint32_t s_threshold;
@@ -402,15 +447,15 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
   if (tx == 0) s_count = 0;
   __syncthreads();
 
-  if (static_cluster_threshold > 0) {
+  if (static_cluster_threshold >= 0) {
     if (tx == 0) s_threshold = static_cluster_threshold;
   } else {
     for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-      const uint32_t sl = seq_lens[i];
+      const uint32_t seq_len = seq_lens[i];
       uint32_t count = 0;
 #pragma unroll
       for (uint32_t j = 0; j < kNumCandidates; ++j) {
-        count += (sl > kCandidates[j].threshold ? 1 : 0);
+        count += (seq_len > kCandidates[j].threshold ? 1 : 0);
       }
       if (count > 0) atomicAdd(&s_counts[count - 1], 1);
     }
@@ -429,15 +474,18 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
     }
   }
   __syncthreads();
+
+  constexpr uint32_t kClusterFloor = 32768;  // a very loose lower bound on threshold
   const auto cluster_threshold = max(s_threshold, kClusterFloor);
 
   // Compact items with seq_len > threshold into metadata[1..N]: their batch ids
   // are the work list the persistent cluster pool fetches.
   for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-    const uint32_t sl = seq_lens[i];
-    if (sl > cluster_threshold) {
+    const uint32_t seq_len = seq_lens[i];
+    assert(static_cast<int32_t>(seq_len) >= 0 && "negative seq_len detected");
+    if (seq_len > cluster_threshold) {
       const auto pos = atomicAdd(&s_count, 1);
-      metadata[1 + pos] = {i, sl};
+      metadata[1 + pos] = {i, seq_len};
     }
   }
   __syncthreads();
@@ -447,11 +495,14 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
   }
 }
 
+#endif  // SUPPORT_CLUSTER
+
+template <bool kUsePDL>
 struct TopKKernel {
   static void plan(  //
       const tvm::ffi::TensorView seq_lens,
       const tvm::ffi::TensorView metadata,
-      const uint32_t static_cluster_threshold) {
+      const int32_t static_cluster_threshold) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
     auto Bp1 = SymbolicSize{"batch_size_plus_1"};
@@ -462,25 +513,23 @@ struct TopKKernel {
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(seq_lens);
-    TensorMatcher({Bp1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
+    TensorMatcher({-1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(metadata);
 
-    RuntimeCheck(Bp1.unwrap() == B.unwrap() + 1, "invalid metadata shape");
-#ifdef USE_ROCM
-    // ROCm compiles out the cluster path, the only consumer of this plan.
-    (void)static_cluster_threshold;
-    return;
-#else
+    RuntimeCheck(metadata.size(0) == B.unwrap() + 1, "invalid metadata shape");
+#if SUPPORT_CLUSTER
     const auto batch_size = static_cast<uint32_t>(B.unwrap());
     const auto device = device_.unwrap();
     LaunchKernel(1, kBlockSize, device)(  //
-        topk_plan,
+        topk_plan_cluster,
         static_cast<const uint32_t*>(seq_lens.data_ptr()),
         static_cast<PlanItem*>(metadata.data_ptr()),
         batch_size,
         static_cluster_threshold);
+#else
+    static_cast<void>(static_cluster_threshold);
 #endif
   }
 
@@ -493,10 +542,8 @@ struct TopKKernel {
       const tvm::ffi::TensorView metadata) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
-    auto Bp1 = SymbolicSize{"batch_size_plus_1"};
     auto L = SymbolicSize{"max_seq_len"};
     auto S = SymbolicSize{"score_stride"};
-    auto P = SymbolicSize{"page_table_stride"};
     auto K = SymbolicSize{"topk"};
     auto device_ = SymbolicDevice{};
     device_.set_options<kDLGPU>();
@@ -516,25 +563,25 @@ struct TopKKernel {
     int64_t page_table_stride = 0;
     if (page_table.has_value()) {
       TensorMatcher({B, -1})  // page_table
-          .with_strides({P, 1})
+          .with_strides({-1, 1})
           .with_dtype<int32_t>()
           .with_device(device_)
           .verify(page_table.value());
       page_table_ptr = static_cast<const int32_t*>(page_table.value().data_ptr());
-      page_table_stride = P.unwrap();
+      page_table_stride = (page_table.value()).stride(0);
     }
     TensorMatcher({B, K})  // page_indices
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(page_indices);
-    TensorMatcher({Bp1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
+    TensorMatcher({-1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(metadata);
 
     RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
     RuntimeCheck(S.unwrap() % 4 == 0, "score_stride must be a multiple of 4 (16-byte vectorized load)");
-    RuntimeCheck(Bp1.unwrap() == B.unwrap() + 1, "invalid metadata shape");
+    RuntimeCheck(metadata.size(0) == B.unwrap() + 1, "invalid metadata shape");
     const auto topk = static_cast<uint32_t>(K.unwrap());
     RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 2048]");
 
@@ -543,13 +590,17 @@ struct TopKKernel {
     const auto max_seq_len = static_cast<uint32_t>(L.unwrap());
     const auto device = device_.unwrap();
 
-    // The fused kernel runs one 8-block cluster per batch element, and B200 fits one
-    // wave of exactly 15 such clusters (occ2). For batch <= 15 it stays latency-bound,
-    // so the 8-way split beats streaming from a much lower seq (measured crossover
-    // ~36-40K); batch 16 spills into a 2nd wave (+25%) and keeps the 64K floor.
-    // The floor is chosen on the host per launch.
-    constexpr uint32_t kClusterFloorSmall = 32768;
-    constexpr uint32_t kSmallBatchLowFloor = 15;
+    constexpr auto get_static_cluster_floor = [](uint32_t batch_size) -> uint32_t {
+      // NOTE: 15 is exactly 0.5 wave which saturate all cluster-8 SMs on Hopper/Blackwell
+      if constexpr (SGL_ARCH_BLACKWELL_OR_GREATER) {
+        return batch_size <= 15 ? 24576 : 30720;
+      } else if constexpr (SGL_ARCH_HOPPER_OR_GREATER) {
+        return batch_size <= 15 ? 32768 : 65536;
+      } else {
+        return UINT_MAX;
+      }
+    };
+
     const auto params = TopKPagedParams{
         .scores = static_cast<const float*>(scores.data_ptr()),
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
@@ -560,34 +611,54 @@ struct TopKKernel {
         .page_table_stride = page_table_stride,
         .topk = topk,
         .page_bits = page_bits,
-        .cluster_floor = (batch_size <= kSmallBatchLowFloor) ? kClusterFloorSmall : kClusterFloor,
+        // only used in small batch variant
+        .static_cluster_floor = get_static_cluster_floor(batch_size),
+        // used for persistent cluster kernel and main kernel
+        .batch_size = batch_size,
     };
 
-#ifndef USE_ROCM
-    const bool use_cluster = (max_seq_len > params.cluster_floor) && (batch_size <= kClusterMaxBatch);
-#endif
-    constexpr bool kUsePDL = true;
-    const auto mode = page_table.has_value() ? TopKMode::PAGE_TABLE : TopKMode::INDICES;
     const auto dispatch = [&]<typename F>(F&& f) {
+      const auto mode = page_table.has_value() ? TopKMode::PAGE_TABLE : TopKMode::INDICES;
       switch (mode) {
         case TopKMode::INDICES:
           return f.template operator()<TopKMode::INDICES>();
-        default:
+        case TopKMode::PAGE_TABLE:
           return f.template operator()<TopKMode::PAGE_TABLE>();
+        default:
+          Panic("Invalid mode, this path should be unreachable");
       }
     };
     dispatch([&]<TopKMode kMode>() {
-#ifndef USE_ROCM
+#if SUPPORT_CLUSTER
+      const bool use_cluster = (max_seq_len > params.static_cluster_floor) && (batch_size <= kClusterMaxBatch);
       if (use_cluster) {
-        if (batch_size <= kNumPersistentClusters) {
+        if (batch_size <= kMaxCluster16BatchSize) {
+          constexpr uint32_t kClusterSize = 16;
+          // Widths above 8 are non-portable; the launch is rejected without this.
+          static const bool once = [] {
+            RuntimeDeviceCheck(
+                ::cudaFuncSetAttribute(
+                    reinterpret_cast<const void*>(
+                        topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>),
+                    ::cudaFuncAttributeNonPortableClusterSizeAllowed,
+                    1));
+            return true;
+          }();
+          static_cast<void>(once);
           LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
               .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_small_batch_kernel<kUsePDL, kMode>, params);
+              .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>, params);
+        } else if (batch_size <= kNumPersistentClusters) {
+          constexpr uint32_t kClusterSize = 8;
+          LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
+              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+              .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 2>, params);
         } else {
+          constexpr uint32_t kClusterSize = 8;
           const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
           LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)
               .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_persistent_cluster_kernel<kUsePDL>, params);
+              .launch(topk_persistent_cluster_kernel<kUsePDL, kClusterSize>, params);
           LaunchKernel(batch_size, kBlockSize, device)
               .config({.use_pdl = kUsePDL})
               .launch(topk_main_kernel<kUsePDL, /*kLevel=*/3, kMode>, params);
@@ -668,7 +739,6 @@ struct TopKKernel {
     const auto topk = static_cast<uint32_t>(K.unwrap());
     RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 2048]");
 
-    constexpr bool kUsePDL = true;
     const auto params = TopKRaggedParams{
         .scores = static_cast<float*>(scores.data_ptr()),
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -23,7 +23,6 @@
 #include <climits>
 #include <cstdint>
 #include <iterator>
-#include <limits>
 
 namespace sglang {
 
@@ -216,16 +215,17 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
     device::PDLWaitPrimary<kPDL>();
     static_assert(kVecSize <= kBlockSize, "not enough threads ");
     if (const auto tx = threadIdx.x; tx < rem) {
-      score[row_start - rem + tx] = -std::numeric_limits<float>::max();
+      score[row_start - rem + tx] = impl::padding_value();
     }
   }
-
+  using device::topk::broadcast;
   const auto problem = TopKProblem{
       .in = score + (row_start - rem),
       .out = out,
       .topk = topk,
       .seq_len = seq_len + rem,
-      .bias = offset - static_cast<int32_t>(rem),
+      .bias = broadcast(offset - static_cast<int32_t>(rem)),
+      .input_start = broadcast(rem),
   };
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
   if (problem.seq_len <= Register2::kMaxSeqLen) {

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <iterator>
 #include <limits>
-#include <mutex>
 
 namespace sglang {
 

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -321,6 +321,7 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
 
 constexpr uint32_t kNumPersistentClusters = SGL_TOPK_V2_MAX_C8_OCC2;
 constexpr uint32_t kMaxCluster16BatchSize = SGL_TOPK_V2_MAX_C16_OCC1;
+static_assert(kNumPersistentClusters > 0 && kMaxCluster16BatchSize > 0);
 constexpr uint32_t kClusterMaxBatch = 512;
 #define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
 
@@ -638,8 +639,7 @@ struct TopKKernel {
           static const bool once = [] {
             RuntimeDeviceCheck(
                 ::cudaFuncSetAttribute(
-                    reinterpret_cast<const void*>(
-                        topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>),
+                    reinterpret_cast<const void*>(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>),
                     ::cudaFuncAttributeNonPortableClusterSizeAllowed,
                     1));
             return true;

--- a/python/sglang/kernels/jit/csrc/misc/probe.cuh
+++ b/python/sglang/kernels/jit/csrc/misc/probe.cuh
@@ -29,8 +29,8 @@ uint32_t get_max_active_clusters(uint32_t cluster_size, uint32_t num_waves) {
   // driver cannot round it back up and squeeze out a block.
   const auto reserved = static_cast<uint32_t>(smem_per_sm - smem_per_block);
   const auto budget = static_cast<uint32_t>(smem_per_sm) / num_waves;
-  const auto smem = (min(budget - min(budget, reserved), static_cast<uint32_t>(smem_per_block))) & ~uint32_t{1023};
-  const auto num_warps = max(1u, min(1024u, static_cast<uint32_t>(max_threads_per_sm) / num_waves) / 32);
+  const auto smem = (std::min(budget - std::min(budget, reserved), static_cast<uint32_t>(smem_per_block))) & ~1023u;
+  const auto num_warps = std::max(1u, std::min(1024u, static_cast<uint32_t>(max_threads_per_sm) / num_waves) / 32);
 
   // Widths above 8 are non-portable and the query rejects them without this.
   CHECK_CUDA(cudaFuncSetAttribute(

--- a/python/sglang/kernels/jit/csrc/misc/probe.cuh
+++ b/python/sglang/kernels/jit/csrc/misc/probe.cuh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+namespace sglang {
+
+__global__ void dummy_probe_kernel() {}
+
+uint32_t get_max_active_clusters(uint32_t cluster_size, uint32_t num_waves) {
+#if !SGL_ARCH_HOPPER_OR_GREATER
+  host::Panic("cluster is not supported on arch before CUDA sm90");
+#else
+  int device;
+  int max_threads_per_sm;
+  int smem_per_sm;
+  int smem_per_block;
+  int num_clusters;
+  CHECK_CUDA(cudaGetDevice(&device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  // Threads alone cannot pin the probe to `num_waves` blocks per SM: a block
+  // caps at 1024, so num_waves == 1 still leaves room for a second block. Spend
+  // the shared budget instead -- what one block gets at this occupancy, less the
+  // per-block driver reserve, floored to the 1 KiB allocation granularity so the
+  // driver cannot round it back up and squeeze out a block.
+  const auto reserved = static_cast<uint32_t>(smem_per_sm - smem_per_block);
+  const auto budget = static_cast<uint32_t>(smem_per_sm) / num_waves;
+  const auto smem = (min(budget - min(budget, reserved), static_cast<uint32_t>(smem_per_block))) & ~uint32_t{1023};
+  const auto num_warps = max(1u, min(1024u, static_cast<uint32_t>(max_threads_per_sm) / num_waves) / 32);
+
+  // Widths above 8 are non-portable and the query rejects them without this.
+  CHECK_CUDA(cudaFuncSetAttribute(
+      reinterpret_cast<const void*>(dummy_probe_kernel), cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+  CHECK_CUDA(cudaFuncSetAttribute(
+      reinterpret_cast<const void*>(dummy_probe_kernel),
+      cudaFuncAttributeMaxDynamicSharedMemorySize,
+      static_cast<int>(smem)));
+
+  cudaLaunchConfig_t config = {};  // stream/dynamicSmemBytes must not be garbage
+  config.gridDim = dim3{cluster_size, 1024u};
+  config.blockDim = dim3{32, num_warps};
+  config.dynamicSmemBytes = smem;
+  config.numAttrs = 1;
+  cudaLaunchAttribute attr = {};
+  attr.id = cudaLaunchAttributeClusterDimension;
+  attr.val.clusterDim = {cluster_size, 1, 1};
+  config.attrs = &attr;
+  CHECK_CUDA(cudaOccupancyMaxActiveClusters(&num_clusters, dummy_probe_kernel, &config));
+  return num_clusters;
+#endif
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -76,6 +76,14 @@ SGL_DEVICE uint32_t extract_exact_bin(float x) {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
+constexpr float padding_value() {
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+constexpr float infinity_value() {
+  return std::numeric_limits<float>::infinity();
+}
+
 // template <uint32_t kBits>
 // SGL_DEVICE uint32_t extract_coarse_bin(float x) {
 //   static_assert(0 < kBits && kBits < 15);
@@ -107,7 +115,6 @@ SGL_DEVICE uint16_t coarse_bin_to_bits_finite(uint32_t bin) {
 template <uint32_t kBits>
 SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
   constexpr uint32_t kShift = 16 - kBits;
-  constexpr float kInf = std::numeric_limits<float>::infinity();
   constexpr uint32_t kInfBin = 0xFC00u >> kShift;  // bin holding the +inf key
   const uint32_t key = bin << kShift;              // ordered16 key at the low edge
   // ordered16 -> fp16 value (inverse of the transform in extract_coarse_bin);
@@ -136,10 +143,10 @@ SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
   // [0x0400, 0xFC00) finite, 0xFC00 = +inf, (0xFC00, 0xFFFF] positive-NaN
   // space. The +/-inf keys stand in as +/-65536, one ideal step past fp16 max,
   // so the midpoint lands on the +/-65520 fp32 -> fp16 overflow threshold.
-  if (bin == 0) return -kInf;      // every value bins at >= 0
-  if (bin > kInfBin) return kInf;  // NaN key space: nothing bins that high
+  if (bin == 0) return -infinity_value();      // every value bins at >= 0
+  if (bin > kInfBin) return infinity_value();  // NaN key space: nothing bins that high
   const auto to_val = [&](uint32_t okey) -> float {
-    if (okey < 0x03FFu) return -kInf;
+    if (okey < 0x03FFu) return -infinity_value();
     if (okey == 0x03FFu) return -65536.0f;
     if (okey == 0xFC00u) return 65536.0f;
     return to_finite_val(okey);
@@ -180,7 +187,7 @@ struct alignas(8) TieValue {
   float value;
   uint32_t idx;
   inline static constexpr TieValue invalid() {
-    return TieValue{-FLT_MAX, 0xFFFFFFFFu};
+    return TieValue{padding_value(), 0xFFFFFFFFu};
   }
 };
 
@@ -193,7 +200,8 @@ struct TopKProblem {
   int32_t* __restrict__ out;  // page_indices [topk]
   uint32_t topk;
   uint32_t seq_len;
-  int32_t bias = 0;  // needed by ragged mode
+  int32_t bias = 0;
+  uint32_t input_start = 0;  // needed by ragged mode
 
   SGL_DEVICE void emit(uint32_t pos, uint32_t raw_idx) const {
     out[pos] = static_cast<int32_t>(raw_idx) + bias;
@@ -590,13 +598,18 @@ struct TopKRegister : TopKRadixBase<12> {
       if (vi == num_full - 1) {
 #pragma unroll
         for (uint32_t j = 0; j < kVecSize; ++j) {
-          if (j >= tail_start) local_vecs[i][j] = -FLT_MAX;
+          if (j >= tail_start) local_vecs[i][j] = padding_value();
         }
       }
 #pragma unroll
       for (uint32_t j = 0; j < kVecSize; ++j) {
         atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(local_vecs[i][j])], 1);
       }
+    }
+    const auto num_padding = kVecSize - tail_start + problem.input_start;
+    if (tx == 0 && num_padding > 0) {
+      atomicSub(&smem->histogram[kHistSize - 1], num_padding);
+      atomicAdd(&smem->histogram[0], num_padding);
     }
     __syncthreads();
 
@@ -672,6 +685,11 @@ struct TopKStreaming : TopKRadixBase<12> {
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
+    const auto num_padding = problem.input_start;
+    if (tx == 0 && num_padding != 0) {
+      atomicSub(&smem->histogram[kHistSize - 1], num_padding);
+      atomicAdd(&smem->histogram[0], num_padding);
+    }
     __syncthreads();
 
     // Phase 2: Find the threshold bin

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -93,6 +93,11 @@ SGL_DEVICE uint32_t extract_coarse_bin(float x) {
   return (b ^ (s | 0x80000000u)) >> (32 - kBits);
 }
 
+SGL_DEVICE uint16_t coarse_bin_to_bits_finite(uint32_t bin) {
+  const uint16_t ob = static_cast<uint16_t>(bin);
+  return (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
+}
+
 // Smallest fp32 `v` for which `extract_coarse_bin<kBits>(v) >= bin`, i.e. the
 // lower fp32 boundary of coarse bin `bin`. The collect pass classifies with two
 // comparisons against these instead of recomputing the fp16 bin per element, so
@@ -106,13 +111,8 @@ SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
   constexpr uint32_t kInfBin = 0xFC00u >> kShift;  // bin holding the +inf key
   const uint32_t key = bin << kShift;              // ordered16 key at the low edge
   // ordered16 -> fp16 value (inverse of the transform in extract_coarse_bin);
-  // finite keys only.
-  constexpr auto to_finite_bits = [](uint32_t okey) -> uint16_t {
-    const uint16_t ob = static_cast<uint16_t>(okey);
-    return (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
-  };
   constexpr auto to_finite_val = [](uint32_t okey) -> float {
-    const uint16_t hb = to_finite_bits(okey);
+    const uint16_t hb = coarse_bin_to_bits_finite(okey);
     return cast<float>(*reinterpret_cast<const fp16_t*>(&hb));
   };
   constexpr auto step_up = [](float v) -> float {
@@ -129,7 +129,7 @@ SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
     const float mid = 0.5f * (to_finite_val(key) + to_finite_val(key - 1));
     // fp32 -> fp16 rounds to nearest EVEN, so on the ~half of bins whose fp16
     // value has an odd significand the midpoint still bins as `bin - 1`.
-    return (to_finite_bits(key) & 1u) ? step_up(mid) : mid;
+    return (coarse_bin_to_bits_finite(key) & 1u) ? step_up(mid) : mid;
   }
   // Slow path: an edge of `bin` touches the +/-inf keys or NaN key space. The
   // ordered-key line is: [0, 0x03FF) negative-NaN space, 0x03FF = -inf,

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -27,7 +27,15 @@
 #include <cstdint>
 #include <limits>
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM)
+// currently only apply cluster for SM90 & SM100, SM120 has poor cluster performance
+#define SUPPORT_CLUSTER (SGL_CUDA_ARCH >= 900 && SGL_CUDA_ARCH < 1100)
+#else
+// AMD doesn't support cluster
+#define SUPPORT_CLUSTER false
+#endif
+
+#if SUPPORT_CLUSTER
 #include <cooperative_groups.h>
 #endif
 
@@ -35,40 +43,18 @@ namespace sglang {
 
 namespace device::topk {
 
-#ifndef USE_ROCM
-namespace cg = cooperative_groups;
-#endif
+template <typename T>
+SGL_DEVICE T broadcast(T value, uint32_t src = 0) {
+  return __shfl_sync(0xFFFFFFFF, value, src);
+}
 
 /// sgl_kernel names the warp size `kWarpThreads`; alias it locally as `kWarpSize`.
 inline constexpr uint32_t kWarpSize = kWarpThreads;
 
-// ---------------------------------------------------------------------------
-// Shared-memory storage sized/aligned for several impl `Smem` types
-// ---------------------------------------------------------------------------
-
-/// Compile-time max over a non-empty pack (avoids an <algorithm> dependency).
-template <typename T>
-constexpr T ct_max(T a) {
-  return a;
-}
-template <typename T, typename... Ts>
-constexpr T ct_max(T a, Ts... rest) {
-  const T m = ct_max(rest...);
-  return a > m ? a : m;
-}
-
-/// Static shared-memory buffer sized + aligned to hold any one of the given
-/// impl `Smem` types. A kernel that dispatches across several paths (e.g. the
-/// fused small-batch kernel runs either Streaming or Cluster; the main kernel
-/// runs any of Register2/Register4/Streaming) declares one
-/// `__shared__ MaxSmem<...> smem` and hands `&smem` to whichever forward() it
-/// calls -- instead of hand-picking "the largest" type and relying on it
-/// staying the largest. `&smem` converts to the `void*` the forwards expect;
-/// the buffer is aligned to the strictest member, so the cast is well-aligned.
 template <typename... Smems>
 struct MaxSmem {
-  static constexpr size_t kSize = ct_max(sizeof(Smems)...);
-  static constexpr size_t kAlign = ct_max(alignof(Smems)...);
+  static constexpr size_t kSize = std::max({sizeof(Smems)...});
+  static constexpr size_t kAlign = std::max({alignof(Smems)...});
   alignas(kAlign) uint8_t storage[kSize];
 };
 
@@ -81,64 +67,78 @@ SGL_DEVICE uint32_t extract_exact_bin(float x) {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
+// template <uint32_t kBits>
+// SGL_DEVICE uint32_t extract_coarse_bin(float x) {
+//   static_assert(0 < kBits && kBits < 15);
+//   const auto hx = cast<fp16_t>(x);
+//   const uint16_t bits = *reinterpret_cast<const uint16_t*>(&hx);
+//   const uint16_t key = (bits & 0x8000) ? ~bits : bits | 0x8000;
+//   return key >> (16 - kBits);
+// }
+
 template <uint32_t kBits>
 SGL_DEVICE uint32_t extract_coarse_bin(float x) {
   static_assert(0 < kBits && kBits < 15);
-  const auto hx = cast<fp16_t>(x);
-  const uint16_t bits = *reinterpret_cast<const uint16_t*>(&hx);
-  const uint16_t key = (bits & 0x8000) ? ~bits : bits | 0x8000;
-  return key >> (16 - kBits);
+  uint32_t b = (uint32_t)__half_as_ushort(__float2half_rn(x)) << 16;
+  uint32_t s = (uint32_t)((int32_t)b >> 31);
+  return (b ^ (s | 0x80000000u)) >> (32 - kBits);
 }
 
-// Smallest fp32 value `v` for which `extract_coarse_bin<kBits>(v) >= bin`, i.e. the
-// lower fp32 boundary of coarse bin `bin`. Because `extract_coarse_bin` is monotonic
-// non-decreasing in its argument, the collect pass can classify an element with two
-// fp32 comparisons against these boundaries instead of recomputing the fp16 bin --
-// removing the F2F conversion and bit-twiddle from the (compute-bound) second pass.
-// Returns -inf for bin 0 (everything qualifies) and +inf for bins past the top.
+// Smallest fp32 `v` for which `extract_coarse_bin<kBits>(v) >= bin`, i.e. the
+// lower fp32 boundary of coarse bin `bin`. The collect pass classifies with two
+// comparisons against these instead of recomputing the fp16 bin per element, so
+// this must agree with `extract_coarse_bin` on every value -- a score sitting
+// exactly on a boundary included. Two pairs no fp32 threshold can separate are
+// left: -0.0 at the zero bin, and +inf at a NaN-key bin.
 template <uint32_t kBits>
 SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
   constexpr uint32_t kShift = 16 - kBits;
-  const uint32_t key = bin << kShift;  // ordered16 key at the low edge of `bin`
+  constexpr float kInf = std::numeric_limits<float>::infinity();
+  constexpr uint32_t kInfBin = 0xFC00u >> kShift;  // bin holding the +inf key
+  const uint32_t key = bin << kShift;              // ordered16 key at the low edge
   // ordered16 -> fp16 value (inverse of the transform in extract_coarse_bin);
   // finite keys only.
-  const auto to_finite_val = [](uint32_t okey) -> float {
+  constexpr auto to_finite_bits = [](uint32_t okey) -> uint16_t {
     const uint16_t ob = static_cast<uint16_t>(okey);
-    const uint16_t hb = (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
+    return (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
+  };
+  constexpr auto to_finite_val = [](uint32_t okey) -> float {
+    const uint16_t hb = to_finite_bits(okey);
     return cast<float>(*reinterpret_cast<const fp16_t*>(&hb));
+  };
+  constexpr auto step_up = [](float v) -> float {
+    const int32_t b = __float_as_int(v);
+    return __int_as_float(b >= 0 ? b + 1 : b - 1);
   };
   // Fast path, hoisted above the per-key special cases so both keys are
   // range-checked at once: `key` and `key - 1` both land in the finite band
-  // [0x0401, 0xFBFF] -- every boundary a finite-score threshold produces.
-  // fp16 rounds to nearest, so the fp32 boundary is the midpoint between the
-  // fp16 values at `key` and `key - 1`. (Verified bit-exact against the slow
-  // path for every bin of kBits 10 and 12, and measured faster than either
-  // per-key dispatch or an ordered-bit decrement trick -- the two conversions
-  // are independent and issue in parallel.)
-  if (key - 0x0401u <= 0xFBFFu - 0x0401u && bin < (1u << kBits)) {
-    return 0.5f * (to_finite_val(key) + to_finite_val(key - 1));
+  // [0x0401, 0xFBFF] -- every boundary a finite-score threshold produces. fp16
+  // rounds to nearest, so the boundary is the midpoint between the fp16 values
+  // at `key` and `key - 1`. (Measured faster than a per-key dispatch: the two
+  // conversions are independent and issue in parallel.)
+  if (key - 0x0401u <= 0xFBFFu - 0x0401u) {
+    const float mid = 0.5f * (to_finite_val(key) + to_finite_val(key - 1));
+    // fp32 -> fp16 rounds to nearest EVEN, so on the ~half of bins whose fp16
+    // value has an odd significand the midpoint still bins as `bin - 1`.
+    return (to_finite_bits(key) & 1u) ? step_up(mid) : mid;
   }
-  // Slow path: an edge of `bin` touches the +/-inf keys or NaN key space.
-  // The ordered-key line is: [0, 0x03FF) negative-NaN space, 0x03FF = -inf,
+  // Slow path: an edge of `bin` touches the +/-inf keys or NaN key space. The
+  // ordered-key line is: [0, 0x03FF) negative-NaN space, 0x03FF = -inf,
   // [0x0400, 0xFC00) finite, 0xFC00 = +inf, (0xFC00, 0xFFFF] positive-NaN
-  // space. Treat the +/-inf keys as +/-65536 (one ideal step past fp16 max,
-  // so the midpoint lands exactly on +/-65520 -- the fp32->fp16
-  // round-to-nearest overflow threshold) and saturate NaN-space keys, keeping
-  // the returned boundaries finite-or-inf and monotone. Otherwise a threshold
-  // bin at/next to the inf bin gets NaN boundaries, the collect pass matches
-  // nothing, and rows whose scores contain >= topk (+/-)inf or >65504 values
-  // come back short -- the padded slots then illegal-address downstream.
-  if (bin == 0) return -FLT_MAX;
-  if (bin >= (1u << kBits)) return FLT_MAX;
+  // space. The +/-inf keys stand in as +/-65536, one ideal step past fp16 max,
+  // so the midpoint lands on the +/-65520 fp32 -> fp16 overflow threshold.
+  if (bin == 0) return -kInf;      // every value bins at >= 0
+  if (bin > kInfBin) return kInf;  // NaN key space: nothing bins that high
   const auto to_val = [&](uint32_t okey) -> float {
-    constexpr float k_Inf = std::numeric_limits<float>::infinity();
-    if (okey < 0x03FFu) return -k_Inf;
+    if (okey < 0x03FFu) return -kInf;
     if (okey == 0x03FFu) return -65536.0f;
     if (okey == 0xFC00u) return 65536.0f;
-    if (okey > 0xFC00u) return FLT_MAX;
     return to_finite_val(okey);
   };
-  return 0.5f * (to_val(key) + to_val(key - 1));
+  // The +/-65536 stand-ins are not real fp16 neighbours, so the parity rule
+  // does not apply here; test the property directly instead.
+  const float mid = 0.5f * (to_val(key) + to_val(key - 1));
+  return extract_coarse_bin<kBits>(mid) < bin ? step_up(mid) : mid;
 }
 
 SGL_DEVICE uint32_t warp_inclusive_sum(uint32_t lane_id, uint32_t val) {
@@ -179,28 +179,15 @@ struct alignas(8) TieValue {
 // Per-batch problem description + page-table transform sink
 // ---------------------------------------------------------------------------
 
-SGL_DEVICE int32_t page_to_indices(const int32_t* __restrict__ page_table, uint32_t i, uint32_t page_bits) {
-  const uint32_t mask = (1u << page_bits) - 1u;
-  return (page_table[i >> page_bits] << page_bits) | (i & mask);
-}
-
-/// One batch element's worth of work. `emit(pos, raw_idx)` writes the selected raw
-/// index to output slot `pos`; `transform_output` then applies the page-table
-/// transform in a separate pass.
 struct TopKProblem {
   const float* __restrict__ in;
   int32_t* __restrict__ out;  // page_indices [topk]
-  const int32_t* __restrict__ page_table;
   uint32_t topk;
   uint32_t seq_len;
-  uint32_t page_bits;
   int32_t bias = 0;  // needed by ragged mode
 
   SGL_DEVICE void emit(uint32_t pos, uint32_t raw_idx) const {
     out[pos] = static_cast<int32_t>(raw_idx) + bias;
-  }
-  SGL_DEVICE void transform_output(uint32_t t, int32_t raw) const {
-    out[t] = raw < 0 ? -1 : page_to_indices(page_table, raw, page_bits);
   }
 };
 
@@ -227,14 +214,13 @@ struct TopKConfig {
   static_assert(kMaxNumTie >= kMaxTopK && kMaxNumTie % kBlockSize == 0 && kBlockSize % kNumWarps == 0);
 
   struct TieHandleSmem {
-    struct alignas(16) MatchBin {
+    struct MatchBin {
       uint32_t bin;
       uint32_t above_count;
       uint32_t equal_count;
-      uint32_t _pad = 0;
     };
-    alignas(128) uint32_t counter;
-    alignas(128) uint32_t counter_final;
+    uint32_t counter;
+    uint32_t counter_final;
     MatchBin match;
     uint32_t warp_sum[kNumWarps];
     uint32_t histogram[2][kRadixSize];
@@ -255,7 +241,7 @@ struct TopKConfig {
     };
     const auto tx = threadIdx.x;
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
+    const auto warp_id = broadcast(tx / kWarpSize);
     static_assert(kNumWarps == kWarpSize);
 
     if (num_ties <= topk) {
@@ -322,11 +308,11 @@ struct TopKConfig {
       }
     } else if (num_ties <= kBlockSize) {
       // Common case: one candidate per thread.
-      radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem);
+      return radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem);
     } else {
-      // Rare overflow case (kBlockSize < num_ties <= kMaxNumTie), kept out of
-      // the common path so it alone pays the multi-item register cost.
-      radix_tie_select<kTieItems>(tie_buffer, problem, base, num_ties, topk, smem);
+      // Rare overflow case.
+      static_assert(kTieItems == 2);
+      return radix_tie_select<2>(tie_buffer, problem, base, num_ties, topk, smem);
     }
   }
 
@@ -343,7 +329,7 @@ struct TopKConfig {
       TieHandleSmem* smem) {
     const auto tx = threadIdx.x;
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
+    const auto warp_id = broadcast(tx / kWarpSize);
 
     bool active[kItems];
     uint32_t key[kItems];
@@ -398,7 +384,7 @@ struct TopKConfig {
       }
       __syncthreads();
 
-      const auto [threshold_bin, above_count, equal_count, __] = smem->match;
+      const auto [threshold_bin, above_count, equal_count] = smem->match;
       if (round < 3) total_active = equal_count;
       topk_remain -= above_count;
 
@@ -434,96 +420,119 @@ struct TopKConfig {
 
 template <uint32_t kHistBits_>
 struct TopKRadixBase : TopKConfig {
+ public:
   static constexpr uint32_t kVecSize = 4;
   static constexpr uint32_t kHistBits = kHistBits_;
   static constexpr uint32_t kHistSize = 1 << kHistBits;
   using vec_t = AlignedVector<float, kVecSize>;
 
   struct Smem {
-    using kHistVec = AlignedVector<uint32_t, kHistSize / kBlockSize>;
-    alignas(128) uint32_t count_eq;
-    alignas(128) uint32_t count_gt;
-    uint32_t threshold_bin;
+    uint32_t count_eq;
+    uint32_t count_gt;
+    float v_hi;
+    float v_lo;
     uint32_t warp_sum[kNumWarps];
     // The coarse histogram is dead once find_threshold() has published
     // threshold_bin, and the tie machinery only comes alive after that: the
-    // collect pass fills tie.values, then handle_tie works over them with
-    // tie.handle as scratch. Overlaying the two phases keeps the
+    // collect pass fills tie_values, then handle_tie works over them with
+    // tie_handle as scratch. Overlaying the two phases keeps the
     // kMaxNumTie-candidate buffer from growing the block's shared-memory
-    // footprint. tie.handle and tie.values are live TOGETHER, so they sit
+    // footprint. tie_handle and tie_values are live TOGETHER, so they sit
     // side by side inside the overlay, not in a union with each other.
     union {
-      uint32_t histogram[kHistSize];
-      kHistVec hist_vecs[kBlockSize];
+      alignas(16) uint32_t histogram[kHistSize];
       struct {
-        TieHandleSmem handle;
-        TieValue values[kMaxNumTie];
-      } tie;
+        TieValue tie_values[kMaxNumTie];
+        TieHandleSmem tie_handle;
+      };
     };
   };
 
  protected:
-  template <typename F>
+  template <uint32_t N = 1, typename F>
   SGL_DEVICE static void for_each_input(const float* __restrict__ in, uint32_t seq_len, F&& fn) {
+    constexpr auto kStride = N * kBlockSize;
     const auto tx = threadIdx.x;
-    const uint32_t num_full = seq_len / kVecSize;  // fully-in-bounds vectors
-
-    vec_t next_vec;
-    uint32_t vi = tx;
-    if (vi < num_full) next_vec.load(in, vi);
-    while (vi < num_full) {
-      const auto cur = next_vec;
-      const auto base = vi * kVecSize;
-      vi += kBlockSize;
-      if (vi < num_full) next_vec.load(in, vi);
+    const auto num_full = seq_len / kVecSize;  // fully-in-bounds vectors
+    const auto kChunk = 128u;
+    // lane | rank | warp
+    auto vi = N == 1 ? tx : (tx % kChunk) + blockIdx.y * kChunk + (tx / kChunk) * (N * kChunk);
+    if (vi < num_full) {
+      vec_t next_vec;
+      next_vec.load(in, vi);
+#pragma unroll 1
+      do {
+        const auto cur = next_vec;
+        vi += kStride;
+        if (vi < num_full) next_vec.load(in, vi);
+        const auto base = (vi - kStride) * kVecSize;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j) {
-        fn(cur[j], base + j);
-      }
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+          fn(cur[j], base + j);
+        }
+      } while (vi < num_full);
     }
 
-    // Tail: at most one partial vector, `rem` in [0, kVecSize).
-    static_assert(kVecSize <= kBlockSize);  // ensure tail correctness
-    const uint32_t tail_start = num_full * kVecSize;
-    if (tx < seq_len - tail_start) {
-      const auto idx = tail_start + tx;
-      fn(in[idx], idx);
+    if (vi == num_full) {
+      const auto base = vi * kVecSize;
+      if (base == seq_len) return;
+      vec_t cur;
+      cur.load(in, vi);
+#pragma unroll
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        if (base + j < seq_len) fn(cur[j], base + j);
+      }
     }
   }
 
-  SGL_DEVICE static void find_threshold(const uint32_t topk, const uint32_t seq_len, Smem* smem) {
+  SGL_DEVICE static void init_histogram(uint32_t (&histogram)[kHistSize], uint32_t tx) {
+    constexpr uint32_t kItems = kHistSize / kBlockSize;
+    AlignedVector<uint32_t, kItems> vec;
+    vec.fill(0);
+    vec.store(histogram, tx);
+  }
+
+  /// Same, but scanning a histogram that need not be `smem`'s own -- the cluster
+  /// path merges into one rank's copy and scans it there.
+  template <typename Smem, typename Fn>
+  SGL_DEVICE static void find_threshold(const uint32_t topk, const uint32_t seq_len, Smem* smem, Fn fn) {
     const auto tx = threadIdx.x;
     constexpr uint32_t kItems = kHistSize / kBlockSize;
-    uint32_t orig[kItems];
-    const auto hist_vec = smem->hist_vecs[tx];
-    uint32_t tmp_local_sum = 0;
+    uint32_t local_exc_sum[kItems + 1];
+    AlignedVector<uint32_t, kItems> hist_vec;
+    hist_vec.load(smem->histogram, tx);
 
+    local_exc_sum[0] = 0;
 #pragma unroll
     for (uint32_t i = 0; i < kItems; ++i) {
-      orig[i] = hist_vec[i];
-      tmp_local_sum += orig[i];
+      local_exc_sum[i + 1] = hist_vec[i] + local_exc_sum[i];
     }
 
+    const auto local_sum = local_exc_sum[kItems];
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
-    const auto warp_inc = warp_inclusive_sum(lane_id, tmp_local_sum);
-    const auto warp_exc = warp_inc - tmp_local_sum;
-    if (lane_id == kWarpSize - 1) smem->warp_sum[warp_id] = warp_inc;
+    const auto warp_id = broadcast(tx / kWarpSize);
+    const auto warp_inc_sum = warp_inclusive_sum(lane_id, local_sum);
+    const auto warp_exc_sum = warp_inc_sum - local_sum;
+    if (lane_id == kWarpSize - 1) smem->warp_sum[warp_id] = warp_inc_sum;
 
     __syncthreads();
 
     const auto tmp = smem->warp_sum[lane_id];
-    // Exactly one bin satisfies: above < K && above + count >= K
-    uint32_t prefix_sum = warp::reduce_sum(lane_id < warp_id ? tmp : 0);
-    prefix_sum += warp_exc;
+    const auto warp_prefix_sum = warp::reduce_sum(lane_id < warp_id ? tmp : 0);
+    const auto exc_sum = static_cast<int32_t>(warp_prefix_sum + warp_exc_sum);
+    const auto remained = static_cast<int32_t>(seq_len - topk - exc_sum);
+    // only 1 lane will execute this
+    if (remained >= 0 && remained < static_cast<int32_t>(local_sum)) [[unlikely]] {
+      uint32_t target = 0;
 #pragma unroll
-    for (uint32_t i = 0; i < kItems; ++i) {
-      prefix_sum += orig[i];
-      const auto above = seq_len - prefix_sum;
-      if (above < topk && above + orig[i] >= topk) {
-        smem->threshold_bin = tx * kItems + i;
+      for (uint32_t i = 0; i < kItems; ++i) {
+        const auto prev = static_cast<int32_t>(local_exc_sum[i + 0]);
+        const auto next = static_cast<int32_t>(local_exc_sum[i + 1]);
+        if (remained >= prev && remained < next) target = tx * kItems + i;
       }
+      fn(target);
     }
+
     __syncthreads();
   }
 };
@@ -542,15 +551,11 @@ struct TopKRegister : TopKRadixBase<12> {
   using Smem = typename TopKRadixBase<12>::Smem;
 
   template <bool kUsePDL>
-  SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
+  SGL_DEVICE static void forward(const TopKProblem& problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
 
-    {
-      Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
@@ -558,78 +563,77 @@ struct TopKRegister : TopKRadixBase<12> {
 
     __syncthreads();
     PDLWaitPrimary<kUsePDL>();
-
-    // A vector `vi` is fully in bounds iff vi < num_full; only full vectors are
-    // vector-loaded (16B aligned, never straddling seq_len). The <kVecSize tail is
-    // a scalar remainder on the LAST lanes (which own the fewest full vectors, so
-    // it overlaps the busy lanes' extra vector). The full path has no per-element
-    // bounds check, keeping register pressure low enough to hold all vectors.
-    const uint32_t num_full = problem.seq_len / kVecSize;
-    const uint32_t tail_start = num_full * kVecSize;
-    const uint32_t tail = problem.seq_len - tail_start;
+    const uint32_t num_full = div_ceil(problem.seq_len, kVecSize);
 
     // Phase 1: load full vectors + build histogram
     vec_t local_vecs[kLocalVecs];
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
-      if (vi >= num_full) break;
-      local_vecs[i].load(problem.in, vi);
+      if (vi < num_full) local_vecs[i].load(problem.in, vi);
     }
+
+    const auto tail_start = (problem.seq_len - 1) % kVecSize + 1;
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
       if (vi >= num_full) break;
+      if (vi == num_full - 1) {
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j)
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+          if (j >= tail_start) local_vecs[i][j] = -FLT_MAX;
+        }
+      }
+#pragma unroll
+      for (uint32_t j = 0; j < kVecSize; ++j) {
         atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(local_vecs[i][j])], 1);
-    }
-    if (tx >= kBlockSize - tail) {
-      const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
+      }
     }
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len, smem);
+    find_threshold(problem.topk, num_full * kVecSize, smem, [&](uint32_t threshold_bin) {
+      const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+      const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      smem->v_hi = v_hi;
+      smem->v_lo = v_lo;
+    });
 
-    // Phase 3: collect by two fp32 boundaries (raw indices; transform applied later)
+    // Phase 3: collect by two fp32 boundaries
     const auto topk = problem.topk;
-    const auto threshold_bin = smem->threshold_bin;
-    const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
-    const auto collect = [&](float val, uint32_t idx) {
-      if (val >= v_hi) {
-        const auto pos = atomicAdd(&smem->count_gt, 1);
-        if (pos < topk) [[likely]]
-          problem.emit(pos, idx);
-      } else if (val >= v_lo) {
-        const auto count_eq = atomicAdd(&smem->count_eq, 1);
-        if (count_eq < kMaxNumTie) [[likely]]
-          smem->tie.values[count_eq] = {val, idx};
-      }
-    };
+    const auto v_hi = smem->v_hi;
+    const auto v_lo = smem->v_lo;
+
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
       const auto base = vi * kVecSize;
       if (vi >= num_full) break;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j)
-        collect(local_vecs[i][j], base + j);
-    }
-    if (tx >= kBlockSize - tail) {
-      const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      collect(problem.in[idx], idx);
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        const auto idx = base + j;
+        const auto val = local_vecs[i][j];
+        if (val >= v_hi) {
+          const auto pos = atomicAdd(&smem->count_gt, 1);
+          if (pos < topk) [[likely]] {
+            problem.emit(pos, idx);
+          }
+        } else if (val >= v_lo) {
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
+          }
+        }
+      }
     }
 
     // Phase 4: Handle ties.
     __syncthreads();
-    const auto above_count = smem->count_gt;
-    const auto equal_count = smem->count_eq;
-    const auto remain_topk = above_count < topk ? topk - above_count : 0;
-    const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    const auto count_gt = smem->count_gt;
+    const auto count_eq = smem->count_eq;
+    const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+    const auto tie_count = min(count_eq, kMaxNumTie);
+    handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
   }
 };
 
@@ -637,20 +641,16 @@ struct TopKRegister : TopKRadixBase<12> {
 // Streaming path: seq_len > 8192 -- two vectorized passes over global memory
 // ---------------------------------------------------------------------------
 
-struct TopKStreaming : TopKRegister<2> {
+struct TopKStreaming : TopKRadixBase<12> {
  public:
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
 
   template <bool kUsePDL>
-  SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
+  SGL_DEVICE static void forward(TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
 
-    {
-      Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
@@ -666,16 +666,20 @@ struct TopKStreaming : TopKRegister<2> {
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len, smem);
+    find_threshold(problem.topk, problem.seq_len, smem, [&](uint32_t threshold_bin) {
+      const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+      const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      smem->v_hi = v_hi;
+      smem->v_lo = v_lo;
+    });
 
     // Phase 3: Collect candidates and sort. Classify by two fp32 boundaries derived
     // from the threshold bin instead of recomputing the fp16 bin per element: an
     // element is "above" iff val >= v_hi (bin > threshold) and a "tie" iff
     // v_lo <= val < v_hi (bin == threshold). This drops the F2F + bit-twiddle from
     // the second full pass over the input.
-    const auto threshold_bin = smem->threshold_bin;
-    const float v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
+    const auto v_hi = smem->v_hi;
+    const auto v_lo = smem->v_lo;
     const auto topk = problem.topk;
     for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
       if (val >= v_hi) {
@@ -684,9 +688,9 @@ struct TopKStreaming : TopKRegister<2> {
           problem.emit(pos, idx);
         }
       } else if (val >= v_lo) {
-        const auto count_eq = atomicAdd(&smem->count_eq, 1);
-        if (count_eq < kMaxNumTie) [[likely]] {
-          smem->tie.values[count_eq] = {val, idx};
+        const auto pos = atomicAdd(&smem->count_eq, 1);
+        if (pos < kMaxNumTie) [[likely]] {
+          smem->tie_values[pos] = {val, idx};
         }
       }
     });
@@ -697,11 +701,11 @@ struct TopKStreaming : TopKRegister<2> {
     // "above" and "tie" sets. above_count is < topk by the threshold-bin invariant,
     // so the count_gt guard above effectively never triggers.
     __syncthreads();
-    const auto above_count = smem->count_gt;
-    const auto equal_count = smem->count_eq;
-    const auto remain_topk = above_count < topk ? topk - above_count : 0;
-    const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    const auto count_gt = smem->count_gt;
+    const auto count_eq = smem->count_eq;
+    const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+    const auto tie_count = min(count_eq, kMaxNumTie);
+    handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
   }
 };
 
@@ -713,171 +717,167 @@ struct TopKStreaming : TopKRegister<2> {
 // equivalent.
 // ---------------------------------------------------------------------------
 
-#ifndef USE_ROCM
+#if SUPPORT_CLUSTER
 
-template <uint32_t kClusterSize_>
+template <uint32_t N>
 struct TopKCluster : TopKRadixBase<10> {
  public:
-  static constexpr uint32_t kClusterSize = kClusterSize_;
+  static constexpr uint32_t kClusterSize = N;
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
-  using Base = TopKRadixBase<10>;
-  struct Smem : Base::Smem {
-    using kHistVec = Base::Smem::kHistVec;
-    uint32_t start_eq_local, start_gt_local;
-    int32_t tmp_out[kMaxTopK];
+  struct Smem {
+    uint32_t count_eq;
+    uint32_t count_gt;
+    uint32_t local_start_eq;
+    uint32_t local_start_gt;
+    float v_lo;
+    float v_hi;
+    uint32_t warp_sum[kNumWarps];
+    union {
+      alignas(16) uint32_t histogram[kHistSize];
+      TieHandleSmem tie_handle;
+      int32_t stage_out_idxs[kMaxTopK];
+    };
+    TieValue tie_values[kMaxNumTie];
   };
 
-  // Process ONE batch element (one cluster). NO PDL and NO trailing barrier --
-  // the persistent kernel does PDLWaitPrimary once before its item loop and a
-  // cluster.sync() after each forward(). Writes raw indices to out; the kernel's
-  // transform pass applies the page-table transform.
+  SGL_DEVICE static void barrier_cluster_arrive_relaxed() {
+    asm volatile("barrier.cluster.arrive.relaxed.aligned;" ::: "memory");
+  }
+
+  SGL_DEVICE static void barrier_cluster_arrive_release() {
+    asm volatile("barrier.cluster.arrive.release.aligned;" ::: "memory");
+  }
+
+  SGL_DEVICE static void barrier_cluster_wait() {
+    asm volatile("barrier.cluster.wait.acquire.aligned;" ::: "memory");
+  }
+
   template <bool kUsePDL>
   SGL_DEVICE static void forward(TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const auto cluster = cg::this_cluster();
+    const auto cluster = cooperative_groups::this_cluster();
     const auto this_rank = blockIdx.y;
-    const bool is_primary = (this_rank == 0);
 
-    constexpr uint32_t kAlignElems = kWarpSize * kVecSize;
-    const uint32_t chunk_size = div_ceil(problem.seq_len, kClusterSize * kAlignElems) * kAlignElems;
-    const uint32_t chunk_start = min(this_rank * chunk_size, problem.seq_len);
-    const uint32_t chunk_finish = min(chunk_start + chunk_size, problem.seq_len);
-    const uint32_t local_seq_len = chunk_finish - chunk_start;
-    problem.in += chunk_start;
-
-    {
-      typename Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
     }
     __syncthreads();
+    barrier_cluster_arrive_relaxed();  // bar-0 arrive
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram over this rank's contiguous chunk.
-    for_each_input(problem.in, local_seq_len, [&](float val, uint32_t) {
+    for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t) {
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
+
+    barrier_cluster_wait();  // bar-0 wait
     __syncthreads();
+    if (this_rank != 0) {
+      const auto smem_0 = cluster.map_shared_rank(smem, 0);
+      // Phase 2. atomic flush all histogram into rank 0
+      static_assert(kHistSize == kBlockSize);  // one bin per thread
 
-    // Phase 1.5: reduce the histogram across the cluster
-    {
-      // 1-shot all-reduce: each rank owns kPartition consecutive bins;
-      // for each owned bin, gather the kClusterSize peer values (one per
-      // consecutive lane) via DSMEM, sum across the lanes, then scatter back.
-      cluster.sync();
-      static_assert(kHistSize == kBlockSize);  // we optimize on top of this
-      constexpr uint32_t kPartition = kHistSize / kClusterSize;
-      const auto start = this_rank * kPartition;
-      const auto which = start + tx / kClusterSize;
-      const auto peer_rank = tx % kClusterSize;
-      const auto addr = cluster.map_shared_rank(&smem->histogram[which], peer_rank);
-      const auto value = *addr;
-      *addr = warp::reduce_sum<kClusterSize>(value);
-      cluster.sync();
-    }
+      if (const auto count = smem->histogram[tx]; count != 0) {
+        atomicAdd(&smem_0->histogram[tx], count);
+      }
 
-    // Phase 2: Find the threshold bin (uses global seq_len)
-    find_threshold(problem.topk, problem.seq_len, smem);
+      barrier_cluster_arrive_release();  // bar-1 arrive
+      barrier_cluster_wait();            // bar-1 wait
 
-    // Phase 3: Collect candidates over this rank's chunk; convert local indices
-    // back to global by adding chunk_start. Classify by two fp32 boundaries derived
-    // from the (global) threshold bin instead of recomputing the fp16 bin per
-    // element -- see TopKStreaming for the rationale. threshold_bin is identical
-    // across ranks, so v_hi/v_lo are too.
-    const auto topk = problem.topk;
-    const auto threshold_bin = smem->threshold_bin;
-    const float v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
+      barrier_cluster_arrive_relaxed();  // bar-2 arrive
+      barrier_cluster_wait();            // bar-2 wait
 
-    // Phase 3: collect candidates. The primary scatters straight into
-    // `problem.out`, the others stage into block-local `smem->tmp_out`.
-    //
-    // DO NOT merge these two loops back into one by selecting the destination
-    // first (`cur_out = is_primary ? problem.out : smem->tmp_out`). `problem.out`
-    // can be a shared::cluster (DSMEM) alias of the elected rank's buffer while
-    // `tmp_out` is shared::cta; merging them into a single pointer variable makes
-    // cicc 13.1+ mis-lower the block-local arm on sm_90a and *silently drop every
-    // non-primary rank's staged output* -- `tmp_out` stays zero, and phase 3.5
-    // then faithfully copies zeros to correct DSMEM addresses. The result is a
-    // top-k output where only the primary's slots and the handle_tie tail are
-    // valid, which downstream sparse attention dereferences as garbage KV indices.
-    if (!is_primary) {
-      // stage to tmp_out first before writing to global/DSMEM
-      for_each_input(problem.in, local_seq_len, [&](float val, uint32_t local_idx) {
-        const auto idx = chunk_start + local_idx;
+      // Phase 4. non-0 rank stage to local smem, then write to rank-0 via DSMEM
+      const auto topk = problem.topk;
+      const auto v_hi = smem_0->v_hi;
+      const auto v_lo = smem_0->v_lo;
+      for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
         if (val >= v_hi) {
           const auto pos = atomicAdd(&smem->count_gt, 1);
           if (pos < topk) [[likely]] {
-            smem->tmp_out[pos] = idx;
+            smem->stage_out_idxs[pos] = idx;
           }
         } else if (val >= v_lo) {
-          const auto count_eq = atomicAdd(&smem->count_eq, 1);
-          if (count_eq < kMaxNumTie) [[likely]] {
-            smem->tie.values[count_eq] = {val, idx};
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
           }
         }
       });
       __syncthreads();
-      const auto local_above_count = smem->count_gt;
-      const auto local_equal_count = min(smem->count_eq, kMaxNumTie);
-      const auto smem_0 = cluster.map_shared_rank(smem, 0);
+      const auto local_count_gt = smem->count_gt;
+      const auto local_count_eq = min(smem->count_eq, kMaxNumTie);
       if (tx == 0) {
-        const auto gt = atomicAdd(&smem_0->count_gt, local_above_count);
-        const auto eq = atomicAdd(&smem_0->count_eq, local_equal_count);
-        smem->start_gt_local = gt;
-        smem->start_eq_local = eq;
+        const auto gt = atomicAdd(&smem_0->count_gt, local_count_gt);
+        const auto eq = atomicAdd(&smem_0->count_eq, local_count_eq);
+        smem->local_start_gt = gt;
+        smem->local_start_eq = eq;
       }
       __syncthreads();
-      const auto start_gt_local = smem->start_gt_local;
-      const auto start_eq_local = smem->start_eq_local;
+      const auto local_start_gt = smem->local_start_gt;
+      const auto local_start_eq = smem->local_start_eq;
 #pragma unroll
       for (uint32_t i = 0; i < kTieItems; ++i) {
         const auto t = tx + i * kBlockSize;
-        if (t < local_equal_count && start_eq_local + t < kMaxNumTie) {
-          smem_0->tie.values[start_eq_local + t] = smem->tie.values[t];
+        if (t < local_count_eq && local_start_eq + t < kMaxNumTie) {
+          smem_0->tie_values[local_start_eq + t] = smem->tie_values[t];
         }
       }
 
-      cluster.sync();
+      cluster.sync();  // bar 3
 
-      const auto start_write = start_gt_local;
-      const auto num_write = local_above_count;
+      const auto start_write = local_start_gt;
+      const auto num_write = local_count_gt;
 #pragma unroll
       for (uint32_t i = 0; i < kTopKItems; ++i) {
         if (const auto t = tx + i * kBlockSize; t < num_write && start_write + t < topk) {
-          problem.emit(start_write + t, smem->tmp_out[t]);
+          problem.emit(start_write + t, smem->stage_out_idxs[t]);
         }
       }
     } else {
-      for_each_input(problem.in, local_seq_len, [&](float val, uint32_t local_idx) {
-        const auto idx = chunk_start + local_idx;
+      barrier_cluster_arrive_relaxed();  // bar-1 arrive
+      barrier_cluster_wait();            // bar-1 wait
+
+      // Phase 3. rank-0 find threshold and write to local smem for other ranks to read
+      find_threshold(problem.topk, problem.seq_len, smem, [&](uint32_t threshold_bin) {
+        smem->v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+        smem->v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      });
+
+      // NOTE: zero write to DSMEM, so relaxed is strong enough here
+      barrier_cluster_arrive_relaxed();  // bar-2 arrive
+      barrier_cluster_wait();            // bar-2 wait
+
+      // Phase 4. rank-0 directly write to output
+      const auto topk = problem.topk;
+      const auto v_hi = smem->v_hi;
+      const auto v_lo = smem->v_lo;
+      for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
         if (val >= v_hi) {
           const auto pos = atomicAdd(&smem->count_gt, 1);
           if (pos < topk) [[likely]] {
             problem.emit(pos, idx);
           }
         } else if (val >= v_lo) {
-          const auto count_eq = atomicAdd(&smem->count_eq, 1);
-          if (count_eq < kMaxNumTie) [[likely]] {
-            smem->tie.values[count_eq] = {val, idx};
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
           }
         }
       });
 
-      cluster.sync();
+      cluster.sync();  // bar-3
 
       // Phase 4: Handle ties.
-      const auto above_count = smem->count_gt;
-      const auto equal_count = smem->count_eq;
-      const auto remain_topk = above_count < topk ? topk - above_count : 0;
-      const auto tie_count = min(equal_count, kMaxNumTie);
-      handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+      const auto count_gt = smem->count_gt;
+      const auto count_eq = smem->count_eq;
+      const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+      const auto tie_count = min(count_eq, kMaxNumTie);
+      handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
     }
   }
 };

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -171,7 +171,7 @@ struct alignas(8) TieValue {
   float value;
   uint32_t idx;
   inline static constexpr TieValue invalid() {
-    return TieValue{-std::numeric_limits<float>::infinity(), 0xFFFFFFFFu};
+    return TieValue{-FLT_MAX, 0xFFFFFFFFu};
   }
 };
 
@@ -194,8 +194,7 @@ struct TopKProblem {
   uint32_t topk;
   uint32_t seq_len;
   uint32_t page_bits;
-  int32_t bias = 0;          // needed by ragged mode
-  uint32_t input_start = 0;  // exclude the aligned prefix in ragged mode
+  int32_t bias = 0;  // needed by ragged mode
 
   SGL_DEVICE void emit(uint32_t pos, uint32_t raw_idx) const {
     out[pos] = static_cast<int32_t>(raw_idx) + bias;
@@ -542,11 +541,10 @@ struct TopKRegister : TopKRadixBase<12> {
   static constexpr uint32_t kMaxSeqLen = kBlockSize * kVecSize * kLocalVecs;
   using Smem = typename TopKRadixBase<12>::Smem;
 
-  template <bool kUsePDL, bool kHasInputStart = false>
+  template <bool kUsePDL>
   SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
     {
       Smem::kHistVec hist_vec;
@@ -583,21 +581,17 @@ struct TopKRegister : TopKRadixBase<12> {
       const auto vi = tx + kBlockSize * i;
       if (vi >= num_full) break;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j) {
-        if constexpr (kHasInputStart) {
-          if (vi * kVecSize + j < input_start) continue;
-        }
+      for (uint32_t j = 0; j < kVecSize; ++j)
         atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(local_vecs[i][j])], 1);
-      }
     }
     if (tx >= kBlockSize - tail) {
       const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      if (idx >= input_start) atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
+      atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
     }
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len - input_start, smem);
+    find_threshold(problem.topk, problem.seq_len, smem);
 
     // Phase 3: collect by two fp32 boundaries (raw indices; transform applied later)
     const auto topk = problem.topk;
@@ -605,9 +599,6 @@ struct TopKRegister : TopKRadixBase<12> {
     const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
     const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
     const auto collect = [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
       if (val >= v_hi) {
         const auto pos = atomicAdd(&smem->count_gt, 1);
         if (pos < topk) [[likely]]
@@ -650,11 +641,10 @@ struct TopKStreaming : TopKRegister<2> {
  public:
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
 
-  template <bool kUsePDL, bool kHasInputStart = false>
+  template <bool kUsePDL>
   SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
     {
       Smem::kHistVec hist_vec;
@@ -669,17 +659,14 @@ struct TopKStreaming : TopKRegister<2> {
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram
-    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
+    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t) {
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len - input_start, smem);
+    find_threshold(problem.topk, problem.seq_len, smem);
 
     // Phase 3: Collect candidates and sort. Classify by two fp32 boundaries derived
     // from the threshold bin instead of recomputing the fp16 bin per element: an
@@ -691,9 +678,6 @@ struct TopKStreaming : TopKRegister<2> {
     const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
     const auto topk = problem.topk;
     for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
       if (val >= v_hi) {
         const auto pos = atomicAdd(&smem->count_gt, 1);
         if (pos < topk) [[likely]] {

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -43,9 +43,18 @@ namespace sglang {
 
 namespace device::topk {
 
+/// Hints that `value` is warp-uniform so it can live in a uniform register. The
+/// caller must already guarantee that: on ROCm this is the identity, since the
+/// 32-bit mask below covers only half of a 64-lane wavefront and there is no
+/// uniform register file to hint at.
 template <typename T>
 SGL_DEVICE T broadcast(T value, uint32_t src = 0) {
+#if defined(USE_ROCM)
+  static_cast<void>(src);
+  return value;
+#else
   return __shfl_sync(0xFFFFFFFF, value, src);
+#endif
 }
 
 /// sgl_kernel names the warp size `kWarpThreads`; alias it locally as `kWarpSize`.

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -792,7 +792,16 @@ struct TopKCluster : TopKRadixBase<10> {
       smem->count_gt = 0;
     }
     __syncthreads();
-    barrier_cluster_arrive_relaxed();  // bar-0 arrive
+    // Rank 0's shared memory is read by its peers: the zeroed histogram they fold
+    // into after bar-0, v_hi / v_lo after bar-2. Those arrives release so the
+    // peers' acquire wait orders the reads after the writes at cluster scope;
+    // __syncthreads() alone is CTA-scoped. The peers publish nothing at these two
+    // barriers and keep the cheaper relaxed arrive.
+    if (this_rank == 0) {
+      barrier_cluster_arrive_release();  // bar-0 arrive
+    } else {
+      barrier_cluster_arrive_relaxed();  // bar-0 arrive
+    }
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram over this rank's contiguous chunk.
@@ -875,8 +884,7 @@ struct TopKCluster : TopKRadixBase<10> {
         smem->v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
       });
 
-      // NOTE: zero write to DSMEM, so relaxed is strong enough here
-      barrier_cluster_arrive_relaxed();  // bar-2 arrive
+      barrier_cluster_arrive_release();  // bar-2 arrive: publishes v_hi / v_lo
       barrier_cluster_wait();            // bar-2 wait
 
       // Phase 4. rank-0 directly write to output

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -32,22 +32,22 @@ def _jit_topk_v2_module():
     from sglang.kernels.ops.misc import get_max_active_clusters
 
     args = make_cpp_args(is_arch_support_pdl())
-    size = (0, 0)
+    # Leave these undefined if the probe fails: topk_v2.cuh carries per-arch
+    # defaults, and a 0 would size the persistent pool to an empty grid.
+    extra_cuda_cflags = []
     if is_arch_support_pdl():  # set the persistent cluster size after hopper
         try:
-            size0 = get_max_active_clusters(cluster_size=8, occupancy=2)
-            size1 = get_max_active_clusters(cluster_size=16, occupancy=1)
-            size = (size0, size1)
+            extra_cuda_cflags = [
+                f"-DSGL_TOPK_V2_MAX_C8_OCC2={get_max_active_clusters(8, occupancy=2)}",
+                f"-DSGL_TOPK_V2_MAX_C16_OCC1={get_max_active_clusters(16, occupancy=1)}",
+            ]
         except Exception:
             pass
     kernel = f"TopKKernel<{args}>"
     return load_jit(
         make_name("topk_v2"),
         *args,
-        extra_cuda_cflags=[
-            f"-DSGL_TOPK_V2_MAX_C8_OCC2={size[0]}",
-            f"-DSGL_TOPK_V2_MAX_C16_OCC1={size[1]}",
-        ],
+        extra_cuda_cflags=extra_cuda_cflags,
         cuda_files=["deepseek_v4/topk_v2.cuh"],
         cuda_wrappers=[
             ("topk_transform_paged", f"{kernel}::transform_paged"),

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -36,13 +36,17 @@ def _jit_topk_v2_module():
     # defaults, and a 0 would size the persistent pool to an empty grid.
     extra_cuda_cflags = []
     if is_arch_support_pdl():  # set the persistent cluster size after hopper
+        occ_8_2, occ_16_1 = 0, 0
         try:
-            extra_cuda_cflags = [
-                f"-DSGL_TOPK_V2_MAX_C8_OCC2={get_max_active_clusters(8, occupancy=2)}",
-                f"-DSGL_TOPK_V2_MAX_C16_OCC1={get_max_active_clusters(16, occupancy=1)}",
-            ]
+            occ_8_2 = get_max_active_clusters(8, occupancy=2)
+            # NOTE: cluster 16 might fail, but at least cluster 8 is ok
+            occ_16_1 = get_max_active_clusters(16, occupancy=1)
         except Exception:
             pass
+        extra_cuda_cflags = [
+            f"-DSGL_TOPK_V2_MAX_C8_OCC2={occ_8_2}",
+            f"-DSGL_TOPK_V2_MAX_C16_OCC1={occ_16_1}",
+        ]
     kernel = f"TopKKernel<{args}>"
     return load_jit(
         make_name("topk_v2"),

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -18,11 +18,6 @@ from .utils import make_name
 
 @cache_once
 def _jit_topk_v1_module():
-    # topk (<= 1024) is a runtime argument, not a compile-time constant, so a
-    # single module serves every k. Baking it in via -DSGL_TOPK used to build one
-    # module per k, and since the macro fed a `constexpr` rather than a template
-    # parameter every module exported identically mangled symbols -- see the
-    # comment in topk_v1.cuh for how that broke the second module's launch.
     args = make_cpp_args(is_arch_support_pdl())
     return load_jit(
         make_name("topk_v1"),
@@ -34,15 +29,30 @@ def _jit_topk_v1_module():
 
 @cache_once
 def _jit_topk_v2_module():
-    # v2 is universal: topk (<= 2048) is a runtime argument, not a compile-time
-    # constant, so a single module serves every k.
+    from sglang.kernels.ops.misc import get_max_active_clusters
+
+    args = make_cpp_args(is_arch_support_pdl())
+    size = (0, 0)
+    if is_arch_support_pdl():  # set the persistent cluster size after hopper
+        try:
+            size0 = get_max_active_clusters(cluster_size=8, occupancy=2)
+            size1 = get_max_active_clusters(cluster_size=16, occupancy=1)
+            size = (size0, size1)
+        except Exception:
+            pass
+    kernel = f"TopKKernel<{args}>"
     return load_jit(
         make_name("topk_v2"),
+        *args,
+        extra_cuda_cflags=[
+            f"-DSGL_TOPK_V2_MAX_C8_OCC2={size[0]}",
+            f"-DSGL_TOPK_V2_MAX_C16_OCC1={size[1]}",
+        ],
         cuda_files=["deepseek_v4/topk_v2.cuh"],
         cuda_wrappers=[
-            ("topk_transform_paged", "TopKKernel::transform_paged"),
-            ("topk_transform_ragged", "TopKKernel::transform_ragged"),
-            ("topk_plan", "TopKKernel::plan"),
+            ("topk_transform_paged", f"{kernel}::transform_paged"),
+            ("topk_transform_ragged", f"{kernel}::transform_ragged"),
+            ("topk_plan", f"{kernel}::plan"),
         ],
     )
 
@@ -75,15 +85,14 @@ def topk_transform_paged(
 _PLAN_METADATA_INTS_PER_BATCH = 2
 
 
-def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
-    """Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
+def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = -1) -> torch.Tensor:
+    """
+    Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
+    NOTE: every entry of ``seq_lens`` must be NON-NEGATIVE.
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE. The device
-    kernel reads the int32 buffer as ``uint32_t``, so a negative length (e.g.
-    -4 from a DP-padded / idle-companion row) reinterprets as ~4e9, poisons
-    the plan, and drives the transform kernel into an illegal memory access.
-    Producers of padded rows must clamp their lengths to 0 (0 selects the
-    trivial all-(-1) output path, which is safe).
+    :param static_threshold: If a batch item has `seq_len` > `static_threshold`,
+                             prefer the cluster implementation.
+                             Negative number means internal heuristic.
     """
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
@@ -111,7 +120,7 @@ def topk_transform_ragged_v2(
     Unlike :func:`topk_transform_paged_v2` this needs no page table and no plan
     (the cluster path only pays off for very few rows, and prefill has many).
 
-    IMPORTANT: ``scores`` is written in place -- the <= 3 columns ahead of each
+    NOTE: ``scores`` is written in place -- the <= 3 columns ahead of each
     row's window that the 16-byte-aligned read base pulls in are masked out.
     They are invalid for that row and the buffer must have no other consumer.
     ``seq_lens`` entries must be NON-NEGATIVE, as for the paged entry point.
@@ -148,14 +157,10 @@ def topk_transform_paged_v2(
     * ``page_tables`` given -- ``out_page_indices`` receives the page-table
       transform of them.
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE, and
-    ``metadata`` must come from :func:`plan_topk_v2` over the same ``seq_lens``
-    values. The kernel reads lengths as ``uint32_t``: a negative entry
-    reinterprets as a ~4e9-token sequence, sending the row down the cluster
-    path over garbage scores and crashing with an illegal memory access
-    (GLM 5.2 MTP DP-idle companion rows hit exactly this). A length of 0 is
-    the valid way to express "no tokens": the row takes the trivial path and
-    the output is all -1.
+    NOTE: every entry of `seq_lens` must be NON-NEGATIVE, and `metadata` must
+    come from :func:`plan_topk_v2` over the same `seq_lens` values.
+    A length of 0 is the valid way to express "no tokens": the row takes the
+    trivial path and the output is guaranteed to be all -1.
     """
     if is_xpu():
         torch.ops.sgl_kernel.topk_transform_paged(

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -111,6 +111,9 @@ def topk_transform_ragged_v2(
     Unlike :func:`topk_transform_paged_v2` this needs no page table and no plan
     (the cluster path only pays off for very few rows, and prefill has many).
 
+    IMPORTANT: ``scores`` is written in place -- the <= 3 columns ahead of each
+    row's window that the 16-byte-aligned read base pulls in are masked out.
+    They are invalid for that row and the buffer must have no other consumer.
     ``seq_lens`` entries must be NON-NEGATIVE, as for the paged entry point.
     """
     if is_xpu():

--- a/python/sglang/kernels/ops/misc.py
+++ b/python/sglang/kernels/ops/misc.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import torch
-
 from sglang.kernels.jit.utils import cache_once, load_jit
 
 if TYPE_CHECKING:
@@ -29,9 +27,7 @@ def _jit_probe_module() -> Module:
 
 
 @cache_once
-def _get_max_active_clusters(cluster_size: int, occupancy: int, device: int) -> int:
-    # In the cache key only: the answer is per device, the query reads the current one.
-    del device
+def _get_max_active_clusters(cluster_size: int, occupancy: int) -> int:
     return int(_jit_probe_module().get_max_active_clusters(cluster_size, occupancy))
 
 
@@ -56,9 +52,7 @@ def get_max_active_clusters(cluster_size: int, occupancy: int) -> int:
     :raises ValueError: If nothing is schedulable, which a real device should
                         never report for a cluster width it supports.
     """
-    result = _get_max_active_clusters(
-        cluster_size, occupancy, torch.cuda.current_device()
-    )
+    result = _get_max_active_clusters(cluster_size, occupancy)
     if result == 0:
         raise ValueError(
             f"no cluster of {cluster_size} fits at occupancy {occupancy}; "

--- a/python/sglang/kernels/ops/misc.py
+++ b/python/sglang/kernels/ops/misc.py
@@ -1,0 +1,67 @@
+"""Device probes that a launch configuration depends on.
+
+Not an operator group -- these answer "what will the hardware actually schedule",
+which a host-side dispatch needs before it can size a grid. Kept out of
+``ops/__init__``'s eager group import for that reason; import it directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+__all__ = ["get_max_active_clusters"]
+
+
+@cache_once
+def _jit_probe_module() -> Module:
+    return load_jit(
+        "misc_probe",
+        cuda_files=["misc/probe.cuh"],
+        cuda_wrappers=[("get_max_active_clusters", "get_max_active_clusters")],
+    )
+
+
+@cache_once
+def _get_max_active_clusters(cluster_size: int, occupancy: int, device: int) -> int:
+    # In the cache key only: the answer is per device, the query reads the current one.
+    del device
+    return int(_jit_probe_module().get_max_active_clusters(cluster_size, occupancy))
+
+
+def get_max_active_clusters(cluster_size: int, occupancy: int) -> int:
+    """Clusters of ``cluster_size`` blocks that can be resident at once.
+
+    Asks the driver (``cudaOccupancyMaxActiveClusters``) rather than dividing SM
+    count by cluster size: a cluster's blocks must be co-scheduled within one
+    GPC, so the answer falls short of ``num_sms * occupancy / cluster_size`` once
+    the cluster stops dividing a GPC evenly. On B200 (148 SMs) at occupancy 2 the
+    driver reports 33 clusters of 8 where the division says 37, and 14 of 16
+    where it says 18.
+
+    Probed with an empty kernel pinned to ``occupancy`` blocks per SM, so the
+    answer is the *scheduling* limit at that occupancy and nothing else. Pass the
+    occupancy the real kernel reaches (the second ``__launch_bounds__``
+    argument), not the one it asks for.
+
+    :param cluster_size: Blocks per cluster.
+    :param occupancy: Blocks per SM (``num_waves`` in ``csrc/misc/probe.cuh``).
+    :raises RuntimeError: On pre-sm90 devices, which have no clusters.
+    :raises ValueError: If nothing is schedulable, which a real device should
+                        never report for a cluster width it supports.
+    """
+    result = _get_max_active_clusters(
+        cluster_size, occupancy, torch.cuda.current_device()
+    )
+    if result == 0:
+        raise ValueError(
+            f"no cluster of {cluster_size} fits at occupancy {occupancy}; "
+            "the cluster width is likely beyond what this device supports"
+        )
+    return result

--- a/test/registered/kernels/benchmark/attention/bench_topk.py
+++ b/test/registered/kernels/benchmark/attention/bench_topk.py
@@ -104,14 +104,16 @@ if not DISABLE_TORCH:
     PRROVIDERS.append("torch")
 
 
+@marker.parametrize("page_size", [1, 64], [1, 64])
 @marker.parametrize("k", [512, 1024, 2048], [512])
 @marker.parametrize("seq_len", [2**x for x in range(10, 19)], [4096, 65536])
 @marker.parametrize("batch_size", [2**x for x in range(13)], [1, 128, 1024])
-@marker.parametrize("page_size", [1, 64], [1, 64])
 @marker.benchmark("provider", PRROVIDERS)
 def benchmark_paged(
     seq_len: int, batch_size: int, k: int, page_size: int, provider: str
 ):
+    seed = seq_len ^ (batch_size << 16) ^ (k << 32) ^ (page_size << 48)
+    torch.random.manual_seed(seed)
     if k > seq_len:
         marker.skip("k cannot be larger than seq_len")
     if k == 2048 and provider == "jit_v1":
@@ -127,6 +129,8 @@ def benchmark_paged(
 @marker.parametrize("batch_size", [2**x for x in range(7, 14)], [128, 1024])
 @marker.benchmark("provider", PRROVIDERS)
 def benchmark_ragged(seq_len: int, batch_size: int, k: int, provider: str):
+    seed = seq_len ^ (batch_size << 16) ^ (k << 32)
+    torch.random.manual_seed(seed)
     if k > seq_len:
         marker.skip("k cannot be larger than seq_len")
     if k != 2048 and provider == "jit_v1":

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -352,7 +352,56 @@ def test_topk_v2_ragged_window(name: str, rows, k: int, offset_shift: int) -> No
     ref_raw = _reference(windows, lengths.cpu(), k)
     _assert_topk_close(windows, ref_raw, our_raw, len(rows), lengths.cpu(), k)
 
-    assert torch.equal(scores, before)
+
+def _assert_topk_values(window, indices, k):
+    indices = indices.cpu().long()
+    window = window.cpu()
+    assert indices.numel() == k
+    assert ((indices >= 0) & (indices < window.numel())).all(), indices
+    assert indices.unique().numel() == k
+    expected = window.topk(k).values.sort().values
+    actual = window[indices].sort().values
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("num_ties", [48, 96])
+@torch.inference_mode()
+def test_topk_v2_negative_infinity_ties(num_ties: int) -> None:
+    """Inactive entries must not displace valid -inf scores or leave slots unwritten."""
+    k = 16
+    length = num_ties + 3
+    scores = torch.full((1, (length + 3) & ~3), -torch.inf, device="cuda")
+    scores[0, :3] = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+    lengths = torch.tensor([length], dtype=torch.int32, device="cuda")
+    out = torch.full((1, k), -2, dtype=torch.int32, device="cuda")
+
+    topk_transform_paged_v2(scores, lengths, None, out, PAGE_SIZE, _plan(lengths))
+
+    _assert_topk_values(scores[0, :length], out[0], k)
+
+
+@pytest.mark.parametrize("length", [257, 8193, 16385])
+@torch.inference_mode()
+def test_topk_v2_ragged_negative_infinity(length: int) -> None:
+    """Columns before an unaligned window must never beat its valid -inf scores."""
+    k = 16
+    scores = torch.full((3, (length + 6) & ~3), OUTSIDE_SCORE, device="cuda")
+    starts = torch.tensor([1, 2, 3], dtype=torch.int32, device="cuda")
+    lengths = torch.full((3,), length, dtype=torch.int32, device="cuda")
+    offsets = starts + 1024
+    out = torch.full((3, k), -2, dtype=torch.int32, device="cuda")
+    for row, start in enumerate((1, 2, 3)):
+        scores[row, start : start + length] = -torch.inf
+        scores[row, start : start + 3] = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+
+    topk_transform_ragged_v2(
+        scores, lengths, out_offsets=offsets, out_indices=out, row_starts=starts
+    )
+
+    for row, start in enumerate((1, 2, 3)):
+        _assert_topk_values(
+            scores[row, start : start + length], out[row] - offsets[row], k
+        )
 
 
 @pytest.mark.parametrize("k", [512, 2048])


### PR DESCRIPTION
## What

Brings the DSA top-k v2 rework of sgl-project/sglang#38640 onto `dsv4.1` (its six commits, unchanged) and fixes how the reworked kernels treat the lanes outside a row, which broke selection on rows with more `-inf` than finite scores.

## Why

The rework represents every lane outside a row with a sentinel score: the register path pads the last vector's tail with `-FLT_MAX` and counts it in the histogram, the ragged kernel masks the <= 3 aligned-prefix columns before a window in place with `-FLT_MAX`, and inactive tie entries are `-FLT_MAX` too. A valid score may itself be `-inf` (masked positions), and every one of these sentinels outranks it. On a 51-wide paged row with 3 finite scores and k = 16 the rework returned `[0, 1, 2, 51, -2 x 12]`: index 51 is the padding lane past the row, and 12 slots stay unwritten because `-FLT_MAX` inactive entries displaced the valid `-inf` ties. Ragged windows likewise selected prefix columns of the previous request.

## Fix (last commit)

A NaN score is not a valid input, so NaN is free to mean "drop":

- The lanes outside a row and the inactive tie entries become NaN. The collect pass rejects them for free (both `>=` tests fail), so they are never emitted nor tie candidates; the tie phase needs no index bookkeeping.
- The histogram's fp16 conversion canonicalises NaN to +NaN, the highest key, so after the histogram pass one thread moves the padding count from the top bin to bin 0 (two shared-memory atomics). Bin 0 is the negative-NaN key space that no real value reaches, so it can never become the threshold bin, and `coarse_bin_lower_bound(0)` is already `-inf`.
- The ragged kernel passes the prefix width (`input_start`, warp-uniform) for that count. The per-element loops of every path are unchanged.

`TopKProblem.input_start` and a NaN `TieValue::invalid()` are the only interface changes; the paged instantiations see `input_start = 0`.

## Tests

- `test_topk_v2.py`: **283 passed** on GB300, including five new regression cases (paged rows with more `-inf` than finite scores at 48 and 96 ties; ragged windows at every nonzero alignment residue). The ragged-window test no longer asserts an untouched score buffer: the prefix columns are written, as in the rework.
- A sweep of 852 cases: rows with 50 / 90 / 99 / 99.9 / 100 % `-inf` scores over the register2 / register4 / streaming / cluster paths, both kernels, k 512 / 2048, tie counts from 20 (warp branches) to thousands (radix path), three unaligned ragged starts. Every index in-window and unique, `-1` padding exact, selected-value multiset equal to torch's. 0 failures. The same sweep on the rework alone fails 75 cases; on the branch head's kernels the five regression cases pass but the rework's speed is missing.

## Performance (GB300, `bench_topk.py` inputs, `jit_v2`, us)

Against the branch head (`85f8105f5`), which carries the pre-rework kernels:

| paged, page 64, k 512 | bs 1 | bs 8 | bs 32 |
|---:|---|---|---|
| 4096 | 3.77 -> 3.54 | 3.89 -> 3.67 | 3.99 -> 3.77 |
| 16384 | 6.18 -> 5.63 | 6.39 -> 5.86 | 6.59 -> 6.08 |
| 65536 | 9.67 -> 7.37 | 9.88 -> 8.25 | 16.22 -> 12.14 |
| 131072 | 11.18 -> 8.25 | 11.35 -> 9.81 | 24.09 -> 14.31 |
| 262144 | 14.01 -> 9.75 | 14.20 -> 12.65 | 31.02 -> 18.16 |

| ragged, k 2048 | bs 8 | bs 128 |
|---:|---|---|
| 4096 | 4.16 -> 3.85 | 4.55 -> 4.26 |
| 16384 | 8.29 -> 7.25 | 8.70 -> 8.00 |
| 65536 | 20.88 -> 19.97 | 21.93 -> 21.04 |
| 131072 | 34.46 -> 33.01 | 36.62 -> 35.20 |

Against the six rework commits alone (same base, without the last commit), the last commit is neutral within +-0.5% on every row of both tables; the per-element loops are byte-for-byte the rework's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34462774522](https://github.com/sgl-project/sglang/actions/runs/34462774522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34462774254](https://github.com/sgl-project/sglang/actions/runs/34462774254)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34462774526](https://github.com/sgl-project/sglang/actions/runs/34462774526)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->