### PR TITLE
[HiCache] Make cudaHostRegister idempotent and tolerate already-registered ranges

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -15,6 +15,13 @@ logger = logging.getLogger(__name__)
 
 _CUDA_HOST_REGISTERED_RANGES_ATTR = "_sglang_cuda_host_registered_ranges"
 
+# cudaErrorHostMemoryAlreadyRegistered. Registering an already-pinned range
+# returns this error instead of succeeding; it also lingers in the thread's
+# CUDA error slot (torch's cudart binding exposes no cudaGetLastError to
+# clear it) and later surfaces at an unrelated CUDA call as a confusing
+# failure (e.g. torch.empty failing with "operation not supported").
+_CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712
+
 
 class HostTensorAllocator:
     def __init__(self):
@@ -125,6 +132,12 @@ def _cuda_host_register(
     buffer: torch.Tensor, registration_granularity_bytes: int | None = None
 ) -> None:
     # Avoid oversized cudaHostRegister calls on large host pools.
+    if getattr(buffer, _CUDA_HOST_REGISTERED_RANGES_ATTR, None):
+        # This buffer was already registered by a previous call. Re-issuing
+        # cudaHostRegister on the same ranges fails with
+        # cudaErrorHostMemoryAlreadyRegistered, so treat registration as
+        # idempotent and keep the ranges recorded by the first call.
+        return
     cudart = torch.cuda.cudart()
     base = buffer.data_ptr()
     total = buffer.numel() * buffer.element_size()
@@ -151,12 +164,21 @@ def _cuda_host_register(
             chunk_limit_bytes // registration_granularity_bytes
         ) * registration_granularity_bytes
     registered_ranges: list[tuple[int, int]] = []
+    already_registered_ranges: list[tuple[int, int]] = []
     try:
         offset = 0
         while offset < total:
             size = min(chunk_bytes, total - offset)
             ptr = base + offset
             rc = int(cudart.cudaHostRegister(ptr, size, 0))
+            if rc == _CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED:
+                # The range is already pinned by another owner of the same
+                # mapped memory (e.g. a background pre-registration path).
+                # It is not ours to unregister, so do not record it in the
+                # buffer's managed ranges.
+                already_registered_ranges.append((ptr, size))
+                offset += size
+                continue
             if rc != 0:
                 raise RuntimeError(
                     f"cudaHostRegister failed (rc={rc}, "
@@ -166,6 +188,15 @@ def _cuda_host_register(
                 )
             registered_ranges.append((ptr, size))
             offset += size
+
+        if already_registered_ranges:
+            logger.warning(
+                "cudaHostRegister: %d of %d chunk(s) of this buffer were already "
+                "registered by another owner and were skipped; they will not be "
+                "unregistered together with this buffer",
+                len(already_registered_ranges),
+                len(already_registered_ranges) + len(registered_ranges),
+            )
 
         # Keep the exact registration bases alive with the tensor. CUDA requires
         # cudaHostUnregister to receive each base pointer, not just the tensor's

--- a/test/registered/unit/mem_cache/test_hicache_host_register.py
+++ b/test/registered/unit/mem_cache/test_hicache_host_register.py
@@ -46,15 +46,27 @@ class _FakeBuffer:
 
 
 class _FakeCudart:
-    def __init__(self, fail_on_registration: int | None = None):
+    def __init__(
+        self,
+        fail_on_registration: int | None = None,
+        already_registered_from_call: int | None = None,
+    ):
         self.registrations = []
         self.unregistrations = []
         self.fail_on_registration = fail_on_registration
+        # When set, cudaHostRegister calls from this 1-based index onward
+        # return cudaErrorHostMemoryAlreadyRegistered (712).
+        self.already_registered_from_call = already_registered_from_call
 
     def cudaHostRegister(self, ptr: int, size: int, flags: int) -> int:
         self.registrations.append((ptr, size, flags))
         if len(self.registrations) == self.fail_on_registration:
             return 1
+        if (
+            self.already_registered_from_call is not None
+            and len(self.registrations) >= self.already_registered_from_call
+        ):
+            return 712
         return 0
 
     def cudaHostUnregister(self, ptr: int) -> int:
@@ -352,6 +364,92 @@ class TestHiCacheHostRegister(unittest.TestCase):
             cudart.registrations,
             [(base, gib, 0), (base + gib, gib, 0)],
         )
+        self.assertEqual(cudart.unregistrations, [base])
+
+    def test_reregistering_same_buffer_is_idempotent(self):
+        gib = 1024**3
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 2 * gib + 17)
+        cudart = _FakeCudart()
+
+        with (
+            mock.patch.object(
+                envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB,
+                "get",
+                return_value=1,
+            ),
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+            calls_after_first = list(cudart.registrations)
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+
+        self.assertEqual(cudart.registrations, calls_after_first)
+
+    def test_reregister_after_unregister_registers_again(self):
+        gib = 1024**3
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 2 * gib)
+        cudart = _FakeCudart()
+
+        with (
+            mock.patch.object(
+                envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB,
+                "get",
+                return_value=1,
+            ),
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+            _cuda_host_unregister(buffer)
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+
+        self.assertEqual(
+            cudart.registrations,
+            [(base, gib, 0), (base + gib, gib, 0)] * 2,
+        )
+
+    def test_already_registered_chunks_are_tolerated_and_not_unregistered(self):
+        gib = 1024**3
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 2 * gib)
+        cudart = _FakeCudart(already_registered_from_call=1)
+
+        with (
+            mock.patch.object(
+                envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB,
+                "get",
+                return_value=1,
+            ),
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+            _cuda_host_unregister(buffer)
+
+        self.assertEqual(
+            cudart.registrations,
+            [(base, gib, 0), (base + gib, gib, 0)],
+        )
+        self.assertEqual(cudart.unregistrations, [])
+
+    def test_partially_preexisting_ranges_unregister_only_new_chunks(self):
+        gib = 1024**3
+        base = 0x10000000
+        buffer = _FakeBuffer(base, 3 * gib)
+        # Chunks from the second onward are already registered by another owner.
+        cudart = _FakeCudart(already_registered_from_call=2)
+
+        with (
+            mock.patch.object(
+                envs.SGLANG_HICACHE_HOST_REGISTER_CHUNK_GB,
+                "get",
+                return_value=1,
+            ),
+            mock.patch.object(torch.cuda, "cudart", return_value=cudart),
+        ):
+            _cuda_host_register(buffer, registration_granularity_bytes=gib)
+            _cuda_host_unregister(buffer)
+
         self.assertEqual(cudart.unregistrations, [base])
 
     def test_missing_copy_granularity_preserves_single_registration(self):


### PR DESCRIPTION
## Motivation

Registering an already-pinned host range with `cudaHostRegister` fails with `cudaErrorHostMemoryAlreadyRegistered` (712) instead of succeeding silently, and the sticky error later surfaces at an **unrelated** CUDA call — e.g. `torch.empty` raising `operation not supported` — because torch's cudart binding exposes no `cudaGetLastError` to clear it. We root-caused exactly this failure mode while bringing up a multi-TP hierarchical-cache deployment where host pools get registered a second time on the same mapped memory (engine re-initialization / a background pre-registration path that pins the pool ahead of the pool constructor).

Before this patch, a duplicate registration took down the process with a misleading message ("host buffer is not pinned and device transfers may silently return stale data" — factually wrong for 712: the memory **is** pinned), and the poisoned error slot made the subsequent crash appear somewhere else entirely.

## Changes

`_cuda_host_register` in `python/sglang/srt/mem_cache/pool_host/common.py`:

1. **Idempotence**: return early when the buffer already carries registered ranges from a previous call, so a duplicate registration never re-issues `cudaHostRegister` on the same ranges. An empty ranges list (i.e. the buffer was fully unregistered, or nothing was ours to manage) does **not** trigger the early return, so legitimate re-registration after unregister keeps working.
2. **712 tolerance per chunk**: ranges already pinned by another owner are skipped and deliberately kept out of the buffer's managed ranges, so `_cuda_host_unregister` never releases a registration this buffer did not create. Other error codes still raise and roll back prior chunks (unchanged); the post-loop warning reports how many chunks were skipped.

## Tests

Extends the existing fake-cudart unit tests in `test/registered/unit/mem_cache/test_hicache_host_register.py`:

- re-registering the same buffer issues no duplicate `cudaHostRegister` calls
- re-registering after unregister registers again (empty-ranges semantics)
- fully preexisting (712 on every chunk) registration succeeds and unregisters nothing
- partially preexisting ranges unregister only the chunks this buffer created

All 15 tests + 12 subtests pass: `pytest test/registered/unit/mem_cache/test_hicache_host_register.py`.

## Notes for reviewers

- Concurrency: two threads registering the *same* buffer concurrently is a pre-existing race this PR does not attempt to fix (the alloc path is single-threaded per pool); the patch only makes the sequential double-registration path correct.
- The early return intentionally skips re-validating `registration_granularity_bytes`: the physical registration from the first call is what exists; chunking is an internal detail and the unregister path handles arbitrary range lists.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34454984657](https://github.com/sgl-project/sglang/actions/runs/34454984657)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34454984476](https://github.com/sgl-project/sglang/actions/runs/34454984476)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34454984736](https://github.com/sgl-project/sglang/actions/runs/34454984736)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->