### PR TITLE
Fix granite_thinking_parser auto-detection and fallback boundaries

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1076,23 +1076,32 @@ class GraniteThinkingDetector(BaseReasoningFormatDetector):
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         ret = self._detect_and_parse_impl(text)
         think_end_present = self.think_end_token in text
+        # HF plugin swaps when the parsed content is absent: that covers text
+        # ending exactly at </think>, but not newline-only content, which the
+        # plugin strips itself and keeps as empty content.
+        content_absent = think_end_present and not ret.normal_text
         if think_end_present and ret.normal_text:
             ret.normal_text = ret.normal_text.lstrip("\n")
-        # Match HF plugin: only swap reasoning→content when </think> was NOT
-        # found (content truly absent). When </think> IS present but content
-        # is empty after lstrip, do not swap.
         if (
             self._force_nonempty_content
             and not ret.normal_text
-            and not think_end_present
+            and (content_absent or not think_end_present)
         ):
             ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
         return ret
 
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
-        if self._in_reasoning:
-            self._reasoning_seen = True
+        was_in_reasoning = self._in_reasoning
         ret = super().parse_streaming_increment(new_text)
+        # Sampling only the pre-call state misses a whole think block arriving
+        # in one chunk; post-call evidence keeps stripping chunk-independent.
+        if (
+            was_in_reasoning
+            or self._in_reasoning
+            or self.stripped_think_start
+            or ret.reasoning_text
+        ):
+            self._reasoning_seen = True
         if self._reasoning_seen and not self._content_started and ret.normal_text:
             ret.normal_text = ret.normal_text.lstrip("\n")
             if ret.normal_text:

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1043,6 +1043,63 @@ class Nemotron3Detector(BaseReasoningFormatDetector):
         )
 
 
+class GraniteThinkingDetector(BaseReasoningFormatDetector):
+    """Detector for Granite 4.2 thinking models (ibm-granite/granite-4.2-*).
+
+    Strips leading newlines from content after </think> — the Granite chat
+    template writes ``\\n</think>\\n``, so content starts with ``\\n``.
+    Matches the behavior of the HF plugin ``granite_thinking_parser.py``.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+        force_nonempty_content: bool = False,
+    ):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            tool_start_token="<tool_call>",
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+            reasoning_default="enable_thinking",
+            force_nonempty_content=force_nonempty_content,
+        )
+        self._content_started = False
+        self._reasoning_seen = False
+
+    def detect_and_parse(self, text: str) -> StreamingParseResult:
+        ret = self._detect_and_parse_impl(text)
+        think_end_present = self.think_end_token in text
+        if think_end_present and ret.normal_text:
+            ret.normal_text = ret.normal_text.lstrip("\n")
+        # Match HF plugin: only swap reasoning→content when </think> was NOT
+        # found (content truly absent). When </think> IS present but content
+        # is empty after lstrip, do not swap.
+        if (
+            self._force_nonempty_content
+            and not ret.normal_text
+            and not think_end_present
+        ):
+            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
+        return ret
+
+    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+        if self._in_reasoning:
+            self._reasoning_seen = True
+        ret = super().parse_streaming_increment(new_text)
+        if self._reasoning_seen and not self._content_started and ret.normal_text:
+            ret.normal_text = ret.normal_text.lstrip("\n")
+            if ret.normal_text:
+                self._content_started = True
+        return ret
+
+
 class MiniMaxM3Detector(BaseReasoningFormatDetector):
     """MiniMax-M3 detector. Format: (<mm:think>)*(.*)</mm:think>.
 
@@ -2123,6 +2180,7 @@ class ReasoningParser:
         "step3p5": DeepSeekR1Detector,
         "mistral": MistralDetector,
         "nemotron_3": Nemotron3Detector,
+        "granite_thinking_parser": GraniteThinkingDetector,
         "interns1": Qwen3Detector,
         "gemma4": Gemma4Detector,
         "inkling": InklingDetector,
@@ -2176,6 +2234,10 @@ class ReasoningParser:
 
         if chat_template_kwargs.get("force_nonempty_content") is True:
             kwargs["force_nonempty_content"] = True
+
+        if model_type.lower() == "granite_thinking_parser":
+            if chat_template_kwargs.get("enable_thinking") is False:
+                kwargs["force_nonempty_content"] = True
 
         if model_type.lower() == "k2_horizon":
             # Template kwargs are the final values passed to Jinja and therefore

--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -314,6 +314,16 @@ def _is_k2_v3(ctx):
     )
 
 
+def _is_granite_thinking_parser(ctx):
+    return (
+        ctx.has_text("truncate_history_thinking")
+        and ctx.has_text("<parameter=")
+        and ctx.reasoning_config is not None
+        and ctx.reasoning_config.toggle_param == "enable_thinking"
+        and ctx.reasoning_config.default_enabled is True
+    )
+
+
 def _is_nemotron_3(ctx):
     return ctx.has_text("truncate_history_thinking") and (
         ctx.reasoning_config is not None
@@ -485,6 +495,11 @@ REASONING_PARSER_RULES = (
     DetectionRule(name="mistral", value="mistral", predicate=_is_mistral),
     DetectionRule(name="gpt_oss", value="gpt-oss", predicate=_is_gpt_oss),
     DetectionRule(name="kimi_k2", value="kimi_k2", predicate=_is_kimi_k2),
+    DetectionRule(
+        name="granite_thinking_parser",
+        value="granite_thinking_parser",
+        predicate=_is_granite_thinking_parser,
+    ),
     DetectionRule(name="nemotron_3", value="nemotron_3", predicate=_is_nemotron_3),
     DetectionRule(name="glm45", value="glm45", predicate=_is_glm45),
     DetectionRule(name="hunyuan", value="hunyuan", predicate=_is_hunyuan),

--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -315,9 +315,11 @@ def _is_k2_v3(ctx):
 
 
 def _is_granite_thinking_parser(ctx):
+    # Nemotron-3 templates share the same <parameter= tool-call block, so it
+    # cannot discriminate; defer_loading is Granite's deferred tool loading.
     return (
         ctx.has_text("truncate_history_thinking")
-        and ctx.has_text("<parameter=")
+        and ctx.has_text("defer_loading")
         and ctx.reasoning_config is not None
         and ctx.reasoning_config.toggle_param == "enable_thinking"
         and ctx.reasoning_config.default_enabled is True

--- a/test/registered/unit/parser/test_granite_thinking_parity.py
+++ b/test/registered/unit/parser/test_granite_thinking_parity.py
@@ -20,8 +20,22 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 #  expected_reasoning, expected_content)
 # All cases produce identical results in both streaming and non-streaming.
 PARITY_CASES = [
-    ("leading_nl", "<think>reasoning</think>\nHello", True, False, "reasoning", "Hello"),
-    ("multi_nl", "<think>reasoning</think>\n\n\nHello", True, False, "reasoning", "Hello"),
+    (
+        "leading_nl",
+        "<think>reasoning</think>\nHello",
+        True,
+        False,
+        "reasoning",
+        "Hello",
+    ),
+    (
+        "multi_nl",
+        "<think>reasoning</think>\n\n\nHello",
+        True,
+        False,
+        "reasoning",
+        "Hello",
+    ),
     ("simple_no_nl", "<think>r</think>c", True, False, "r", "c"),
     ("reasoning_only", "<think>reasoning</think>", True, False, "reasoning", ""),
     ("ws_only_content", "<think>reasoning</think>\n\n", True, False, "reasoning", ""),

--- a/test/registered/unit/parser/test_granite_thinking_parity.py
+++ b/test/registered/unit/parser/test_granite_thinking_parity.py
@@ -1,0 +1,196 @@
+"""Parity tests for Granite thinking parser.
+
+Verifies that the SGLang built-in GraniteThinkingDetector produces the exact
+same (reasoning, content) outputs as the HF plugin granite_thinking_parser.py
+shipped with ibm-granite/granite-4.2-30b, for both streaming and non-streaming.
+
+Expected values were verified against the live HF plugin with the real Granite
+4.2 tokenizer. No GPU or external dependencies needed to run these tests.
+"""
+
+import unittest
+
+from sglang.srt.parser.reasoning_parser import GraniteThinkingDetector, ReasoningParser
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# (id, text, enable_thinking, force_nonempty_content,
+#  expected_reasoning, expected_content)
+# All cases produce identical results in both streaming and non-streaming.
+PARITY_CASES = [
+    ("leading_nl", "<think>reasoning</think>\nHello", True, False, "reasoning", "Hello"),
+    ("multi_nl", "<think>reasoning</think>\n\n\nHello", True, False, "reasoning", "Hello"),
+    ("simple_no_nl", "<think>r</think>c", True, False, "r", "c"),
+    ("reasoning_only", "<think>reasoning</think>", True, False, "reasoning", ""),
+    ("ws_only_content", "<think>reasoning</think>\n\n", True, False, "reasoning", ""),
+    (
+        "force_swap_empty",
+        "<think>reasoning</think>\n\n",
+        True,
+        True,
+        "reasoning",
+        "",
+    ),
+    (
+        "force_keep_real",
+        "<think>reasoning</think>\nreal answer",
+        True,
+        True,
+        "reasoning",
+        "real answer",
+    ),
+    ("truncated", "<think>truncated reasoning", True, False, "truncated reasoning", ""),
+    (
+        "multiline",
+        "<think>line1\nline2</think>\nresult1\nresult2",
+        True,
+        False,
+        "line1\nline2",
+        "result1\nresult2",
+    ),
+    ("empty_block", "<think></think>content", True, False, "", "content"),
+    ("empty_block_nl", "<think></think>\ncontent", True, False, "", "content"),
+    ("plain_force", "This is plain content", False, False, "", "This is plain content"),
+    ("empty_reasoning_nl", "<think></think>\n\nHello", True, False, "", "Hello"),
+    (
+        "nested_nl_in_reasoning",
+        "<think>think\n\n</think>\nresult",
+        True,
+        False,
+        "think\n\n",
+        "result",
+    ),
+    ("only_nl_content", "<think>r</think>\n", True, False, "r", ""),
+    (
+        "force_w_content",
+        "<think>r</think>\n\nanswer",
+        True,
+        True,
+        "r",
+        "answer",
+    ),
+    ("enable_false_tags", "<think></think>content", False, False, "", "content"),
+    (
+        "tool_after_think",
+        "<think>reasoning</think>\n<tool_call>fn</tool_call>",
+        True,
+        False,
+        "reasoning",
+        "<tool_call>fn</tool_call>",
+    ),
+]
+
+
+def _run_sglang_non_streaming(text, enable_thinking, force_nonempty_content):
+    det = GraniteThinkingDetector(
+        force_nonempty_content=(force_nonempty_content or (not enable_thinking))
+    )
+    result = det.detect_and_parse(text)
+    return result.reasoning_text, result.normal_text
+
+
+def _run_sglang_streaming(text, enable_thinking, force_nonempty_content):
+    det = GraniteThinkingDetector(
+        force_nonempty_content=(force_nonempty_content or (not enable_thinking))
+    )
+    all_r, all_c = "", ""
+    for ch in text:
+        res = det.parse_streaming_increment(ch)
+        all_r += res.reasoning_text
+        all_c += res.normal_text
+    end = det.finish()
+    all_r += end.reasoning_text
+    all_c += end.normal_text
+    return all_r, all_c
+
+
+class TestGraniteThinkingParityNonStreaming(CustomTestCase):
+    """Non-streaming parity against hardcoded expected values."""
+
+    def test_all_cases(self):
+        for case_id, text, et, fnc, exp_r, exp_c in PARITY_CASES:
+            with self.subTest(case_id=case_id):
+                r, c = _run_sglang_non_streaming(text, et, fnc)
+                self.assertEqual(r, exp_r, f"[{case_id}] reasoning")
+                self.assertEqual(c, exp_c, f"[{case_id}] content")
+
+    def test_truncated_force_nonempty(self):
+        """Truncated reasoning (no </think>) with force_nonempty_content swaps."""
+        r, c = _run_sglang_non_streaming("<think>truncated reasoning", True, True)
+        self.assertEqual(r, "")
+        self.assertEqual(c, "truncated reasoning")
+
+
+class TestGraniteThinkingParityStreaming(CustomTestCase):
+    """Streaming parity against hardcoded expected values."""
+
+    def test_all_cases(self):
+        for case_id, text, et, fnc, exp_r, exp_c in PARITY_CASES:
+            with self.subTest(case_id=case_id):
+                r, c = _run_sglang_streaming(text, et, fnc)
+                self.assertEqual(r, exp_r, f"[{case_id}] streaming reasoning")
+                self.assertEqual(c, exp_c, f"[{case_id}] streaming content")
+
+    def test_truncated_force_nonempty(self):
+        """Truncated reasoning with force_nonempty_content in streaming:
+        reasoning is emitted incrementally, then finish() reclassifies the
+        accumulated reasoning as content. Both fields contain the text."""
+        r, c = _run_sglang_streaming("<think>truncated reasoning", True, True)
+        self.assertEqual(r, "truncated reasoning")
+        self.assertEqual(c, "truncated reasoning")
+
+
+class TestGraniteThinkingStreamingMatchesNonStreaming(CustomTestCase):
+    """Streaming and non-streaming produce the same outputs."""
+
+    def test_all_cases(self):
+        for case_id, text, et, fnc, _, _ in PARITY_CASES:
+            with self.subTest(case_id=case_id):
+                ns_r, ns_c = _run_sglang_non_streaming(text, et, fnc)
+                s_r, s_c = _run_sglang_streaming(text, et, fnc)
+                self.assertEqual(ns_r, s_r, f"[{case_id}] reasoning mismatch")
+                self.assertEqual(ns_c, s_c, f"[{case_id}] content mismatch")
+
+
+class TestGraniteThinkingReasoningParserIntegration(CustomTestCase):
+    """ReasoningParser('granite_thinking_parser') routes correctly."""
+
+    def test_non_stream(self):
+        parser = ReasoningParser("granite_thinking_parser")
+        r, c = parser.parse_non_stream("<think>thinking</think>\nThe answer is 42.")
+        self.assertEqual(r, "thinking")
+        self.assertEqual(c, "The answer is 42.")
+
+    def test_stream(self):
+        parser = ReasoningParser("granite_thinking_parser")
+        all_r, all_c = "", ""
+        for chunk in ["<think>", "thinking", "</think>", "\n", "The answer"]:
+            r, c = parser.parse_stream_chunk(chunk)
+            if r:
+                all_r += r
+            if c:
+                all_c += c
+        r, c = parser.parse_stream_end()
+        if r:
+            all_r += r
+        if c:
+            all_c += c
+        self.assertEqual(all_r, "thinking")
+        self.assertEqual(all_c, "The answer")
+
+    def test_enable_thinking_false_maps_to_force_nonempty(self):
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+
+        request = ChatCompletionRequest(
+            model="granite-4.2-30b",
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        parser = ReasoningParser("granite_thinking_parser", request=request)
+        self.assertTrue(parser.detector._force_nonempty_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -10,6 +10,7 @@ from sglang.srt.parser.reasoning_parser import (
     DeepSeekV4Detector,
     Gemma4Detector,
     Glm45Detector,
+    GraniteThinkingDetector,
     HunyuanDetector,
     InklingDetector,
     KimiDetector,
@@ -1593,6 +1594,154 @@ class TestCohereCommand4DetectorFinish(CustomTestCase):
         end = detector.finish()
         self.assertEqual(end.normal_text, "the answer")
         self.assertEqual(end.reasoning_text, "")
+
+
+class TestGraniteThinkingDetector(CustomTestCase):
+    def setUp(self):
+        self.detector = GraniteThinkingDetector()
+
+    def test_init(self):
+        self.assertEqual(self.detector.think_start_token, "<think>")
+        self.assertEqual(self.detector.think_end_token, "</think>")
+        self.assertEqual(self.detector.tool_start_token, "<tool_call>")
+        self.assertEqual(self.detector.reasoning_default, "enable_thinking")
+        self.assertFalse(self.detector._in_reasoning)
+
+    def test_leading_newline_stripped(self):
+        text = "<think>reasoning</think>\nHello"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "Hello")
+
+    def test_multiple_leading_newlines_stripped(self):
+        text = "<think>reasoning</think>\n\n\nHello"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "Hello")
+
+    def test_no_newline(self):
+        text = "<think>r</think>c"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "r")
+        self.assertEqual(result.normal_text, "c")
+
+    def test_reasoning_only(self):
+        text = "<think>reasoning</think>"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+
+    def test_whitespace_only_content_stripped(self):
+        text = "<think>reasoning</think>\n\n"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+
+    def test_force_nonempty_no_swap_when_think_end_present(self):
+        """When </think> is present, force_nonempty_content does NOT swap
+        even if content is empty after lstrip. Matches HF plugin behavior."""
+        detector = GraniteThinkingDetector(force_nonempty_content=True)
+        text = "<think>reasoning</think>\n\n"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+
+    def test_force_nonempty_swaps_truncated_reasoning(self):
+        """When </think> is NOT present (truncated), force_nonempty_content
+        swaps reasoning to content. Matches HF plugin behavior."""
+        detector = GraniteThinkingDetector(force_nonempty_content=True)
+        text = "<think>only reasoning no end token"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, "only reasoning no end token")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_force_nonempty_content_no_swap_when_content_exists(self):
+        detector = GraniteThinkingDetector(force_nonempty_content=True)
+        text = "<think>reasoning</think>\nreal answer"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "real answer")
+
+    def test_force_nonempty_content_truncated_reasoning(self):
+        detector = GraniteThinkingDetector(force_nonempty_content=True)
+        text = "<think>truncated reasoning"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, "truncated reasoning")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_plain_text_no_think_tags(self):
+        text = "Hello"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, "Hello")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_tool_interrupt(self):
+        text = "<think>reasoning<tool_call>get_weather</tool_call>"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "<tool_call>get_weather</tool_call>")
+
+    def test_multiline_reasoning_and_content(self):
+        text = "<think>line1\nline2</think>\nresult1\nresult2"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "line1\nline2")
+        self.assertEqual(result.normal_text, "result1\nresult2")
+
+    def test_empty_think_block(self):
+        text = "<think></think>content"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "content")
+
+    def test_streaming_leading_newline_stripped(self):
+        self.detector.parse_streaming_increment("<think>")
+        result = self.detector.parse_streaming_increment("reason")
+        self.assertEqual(result.reasoning_text, "reason")
+        result = self.detector.parse_streaming_increment("</think>")
+        result = self.detector.parse_streaming_increment("\n")
+        self.assertEqual(result.normal_text, "")
+        result = self.detector.parse_streaming_increment("Hello")
+        self.assertEqual(result.normal_text, "Hello")
+
+    def test_streaming_multiple_newline_chunks_stripped(self):
+        self.detector.parse_streaming_increment("<think>")
+        self.detector.parse_streaming_increment("r")
+        self.detector.parse_streaming_increment("</think>")
+        r1 = self.detector.parse_streaming_increment("\n")
+        self.assertEqual(r1.normal_text, "")
+        r2 = self.detector.parse_streaming_increment("\n")
+        self.assertEqual(r2.normal_text, "")
+        r3 = self.detector.parse_streaming_increment("Hello")
+        self.assertEqual(r3.normal_text, "Hello")
+
+    def test_streaming_newlines_preserved_after_content_starts(self):
+        self.detector.parse_streaming_increment("<think>")
+        self.detector.parse_streaming_increment("r")
+        self.detector.parse_streaming_increment("</think>")
+        self.detector.parse_streaming_increment("\n")
+        self.detector.parse_streaming_increment("Hello")
+        result = self.detector.parse_streaming_increment("\nworld")
+        self.assertEqual(result.normal_text, "\nworld")
+
+    def test_streaming_think_end_with_newline_in_same_chunk(self):
+        self.detector.parse_streaming_increment("<think>")
+        r1 = self.detector.parse_streaming_increment("r")
+        self.assertEqual(r1.reasoning_text, "r")
+        result = self.detector.parse_streaming_increment("</think>\nHello")
+        self.assertEqual(result.normal_text, "Hello")
+
+    def test_streaming_no_strip_without_reasoning(self):
+        result = self.detector.parse_streaming_increment("\nHello")
+        self.assertEqual(result.normal_text, "\nHello")
+
+    def test_reasoning_parser_integration(self):
+        parser = ReasoningParser("granite_thinking_parser")
+        self.assertIsInstance(parser.detector, GraniteThinkingDetector)
+        reasoning, normal = parser.parse_non_stream(
+            "<think>thinking</think>\nThe answer"
+        )
+        self.assertEqual(reasoning, "thinking")
+        self.assertEqual(normal, "The answer")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1655,6 +1655,14 @@ class TestGraniteThinkingDetector(CustomTestCase):
         self.assertEqual(result.normal_text, "only reasoning no end token")
         self.assertEqual(result.reasoning_text, "")
 
+    def test_force_nonempty_swaps_when_text_ends_at_think_end(self):
+        """Content absent right after </think> (e.g. max_tokens cut there) swaps
+        like the truncated case; newline-only content still does not."""
+        detector = GraniteThinkingDetector(force_nonempty_content=True)
+        result = detector.detect_and_parse("<think>reasoning</think>")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "reasoning")
+
     def test_force_nonempty_content_no_swap_when_content_exists(self):
         detector = GraniteThinkingDetector(force_nonempty_content=True)
         text = "<think>reasoning</think>\nreal answer"
@@ -1733,6 +1741,44 @@ class TestGraniteThinkingDetector(CustomTestCase):
     def test_streaming_no_strip_without_reasoning(self):
         result = self.detector.parse_streaming_increment("\nHello")
         self.assertEqual(result.normal_text, "\nHello")
+
+    def test_streaming_result_is_chunking_independent(self):
+        """A whole think block in one chunk must strip the leading newline the
+        same as tag-by-tag chunking."""
+        # The empty think block only trips stripped_think_start evidence:
+        # reasoning text and pre/post _in_reasoning are all empty/False there.
+        for text, exp_r, exp_c in (
+            ("<think>r</think>\nHello", "r", "Hello"),
+            ("<think></think>\nHello", "", "Hello"),
+        ):
+            for stream_reasoning in (True, False):
+                for chunks in (
+                    [text],
+                    [text[: text.index("</think>") + len("</think>")], "\nHello"],
+                    [
+                        "<think>",
+                        text[len("<think>") : text.index("</think>")],
+                        "</think>",
+                        "\nHello",
+                    ],
+                    list(text),
+                ):
+                    with self.subTest(
+                        text=text, stream_reasoning=stream_reasoning, chunks=chunks
+                    ):
+                        detector = GraniteThinkingDetector(
+                            stream_reasoning=stream_reasoning
+                        )
+                        all_r = all_c = ""
+                        for chunk in chunks:
+                            ret = detector.parse_streaming_increment(chunk)
+                            all_r += ret.reasoning_text
+                            all_c += ret.normal_text
+                        end = detector.finish()
+                        all_r += end.reasoning_text
+                        all_c += end.normal_text
+                        self.assertEqual(all_r, exp_r)
+                        self.assertEqual(all_c, exp_c)
 
     def test_reasoning_parser_integration(self):
         parser = ReasoningParser("granite_thinking_parser")

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -241,6 +241,38 @@ class TestTemplateManagerReasoningDetection(unittest.TestCase):
         )
         self.assertEqual(parser, "nemotron_3")
 
+    def test_nemotron_with_shared_parameter_block_not_misclassified_as_granite(self):
+        # Granite 4.2 and Nemotron-3 templates share the same
+        # <function=name>/<parameter=key> tool-call instruction block; without
+        # a Granite-only signature (defer_loading) this must stay nemotron_3.
+        template = """
+        {% set enable_thinking = enable_thinking if enable_thinking is defined else True %}
+        {% set truncate_history_thinking = truncate_history_thinking if truncate_history_thinking is defined else True %}
+        {{- '<tool_call>\\n<function=example_function_name>\\n<parameter=example_parameter_1>\\nvalue_1\\n</parameter>\\n</function>\\n</tool_call>' }}
+        """
+        _, config, parser = self._detect(template, ["<|endoftext|>"])
+
+        self.assertEqual(
+            config,
+            ReasoningToggleConfig(toggle_param="enable_thinking", default_enabled=True),
+        )
+        self.assertEqual(parser, "nemotron_3")
+
+    def test_granite_detected_via_defer_loading_signature(self):
+        template = """
+        {% set enable_thinking = enable_thinking if enable_thinking is defined else True %}
+        {% set truncate_history_thinking = truncate_history_thinking if truncate_history_thinking is defined else True %}
+        {%- if tool.defer_loading is not defined or not tool.defer_loading %}{%- endif %}
+        {{- '<tool_call>\\n<function=example_function_name>\\n<parameter=example_parameter_1>\\nvalue_1\\n</parameter>\\n</function>\\n</tool_call>' }}
+        """
+        _, config, parser = self._detect(template, [])
+
+        self.assertEqual(
+            config,
+            ReasoningToggleConfig(toggle_param="enable_thinking", default_enabled=True),
+        )
+        self.assertEqual(parser, "granite_thinking_parser")
+
     def test_minimax_uses_template_signature_without_toggle_config(self):
         template = """
         {%- set toolcall_begin_token = '<minimax:tool_call>' -%}


### PR DESCRIPTION
Stacked on #38693 (includes its commit, rebased onto latest main). Fixes three issues found in review of the `granite_thinking_parser`:

1. **Auto-detection misroutes Nemotron-3** — `_is_granite_thinking_parser` used the `<parameter=` tool-call block as a Granite signature, but the Granite 4.2 and Nemotron-3 chat templates share that block verbatim, so `--reasoning-parser auto` switched existing Nemotron deployments to the Granite detector. Discriminate via `defer_loading` (Granite's deferred tool loading) instead. Verified against the real official templates: Granite 4.2 3B/8B/30B/MLX → `granite_thinking_parser`; Nemotron-3 Nano/Super/Ultra → `nemotron_3`.
2. **Empty-content fallback misses the end-tag boundary** — with `force_nonempty_content`, text ending exactly at `</think>` (e.g. max_tokens cut) returned empty content; the HF plugin swaps reasoning→content whenever parsed content is absent. Now matches the plugin: swap when content is truly absent, keep newline-only content as empty without swap.
3. **Streaming newline strip was chunking-dependent** — `_reasoning_seen` sampled only the pre-call `_in_reasoning`, so a whole think block arriving in one chunk leaked the leading newline into content. Now derived from post-call evidence too (`_in_reasoning`, `stripped_think_start`, returned reasoning), making accumulated output identical across chunkings for both `stream_reasoning` values.

Regression tests added for all three (template detection Nemotron/Granite split, end-tag fallback boundary, chunking independence incl. `stream_reasoning=False` and empty think blocks).

## Verification

- Standalone harness (detector classes extracted from the worktree): 79/79 checks — 18 parity cases × non-stream/char-stream/one-chunk-stream, fallback boundaries, chunking patterns, real-template detection; the same harness fails exactly the corresponding checks against the pre-fix code
- `pre-commit` on changed files: black/isort/ruff/ruff-format/codespell pass (`check-registered-tests` fails identically on clean upstream/main — pre-existing whole-tree scan issue, no violations in these files)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34456345980](https://github.com/sgl-project/sglang/actions/runs/34456345980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34456345822](https://github.com/sgl-project/sglang/actions/runs/34456345822)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34456345817](https://github.com/sgl-project/sglang/actions/runs/34456345817)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->