### PR TITLE
Fix the DeepSeek-V4.1 reasoning example and make every NVIDIA cell start

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4_1.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4_1.mdx
@@ -114,6 +114,8 @@ Overriding them is the most common cause of a disappointing measurement: it leav
 
 Enable the reasoning parser — `--reasoning-parser auto` resolves to `deepseek-v41` (toggle **Reasoning Parser** in the **Parsers** card of the [Playground above](#playground)) to separate thinking from the final answer. The parser puts the thinking block in `reasoning_content` and the answer in `content`; without it both arrive concatenated in `content`.
 
+The parser can only split a thinking block the model actually produced, and **thinking is off by default** (`SGLANG_DEFAULT_THINKING=false`). Sending `reasoning_effort` turns it on: any value other than `none` also switches `chat_template_kwargs.thinking` on for you. A request that carries neither comes back with an empty `reasoning_content` however the parser is configured.
+
 <Accordion title="Reasoning Example (Python)">
 
 ```python Example
@@ -123,6 +125,7 @@ client = OpenAI(base_url="http://localhost:30000/v1", api_key="EMPTY")
 resp = client.chat.completions.create(
     model="deepseek-ai/DeepSeek-V4.1-Flash",
     messages=[{"role": "user", "content": "What is 15% of 240?"}],
+    reasoning_effort="high",
 )
 msg = resp.choices[0].message
 print("Reasoning:", getattr(msg, "reasoning_content", None))
@@ -131,7 +134,7 @@ print("Answer:", msg.content)
 
 </Accordion>
 
-Reasoning effort is part of the request contract for this model: send `reasoning_effort` on the request, either as a tier or as an integer budget. Tiers with no V4.1 counterpart (`none`, `minimal`, `medium`) log a warning and fall back to the server-side default rather than erroring; that default is `high`, and `SGLANG_DSV41_REASONING_EFFORT` overrides it.
+On the request, `reasoning_effort` accepts the tiers `low`, `high`, `xhigh` and `max`, or a float in `[0.0, 0.99]` that maps onto the model's 1–100 budget. An integer budget is reachable only through `chat_template_kwargs.reasoning_effort`, and that route does not switch thinking on by itself — pair it with `chat_template_kwargs.thinking`. `none` turns thinking off. The remaining OpenAI tiers, which have no V4.1 counterpart (`minimal`, `medium`), log a warning and fall back to the server-side default rather than erroring; that default is `high`, and `SGLANG_DSV41_REASONING_EFFORT` overrides it.
 
 ### 3.2 Tool Calling
 
@@ -160,6 +163,7 @@ resp = client.chat.completions.create(
     model="deepseek-ai/DeepSeek-V4.1-Flash",
     messages=[{"role": "user", "content": "What's the weather in Beijing?"}],
     tools=tools,
+    reasoning_effort="high",
 )
 choice = resp.choices[0]
 print("finish_reason:", choice.finish_reason)

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx
@@ -235,8 +235,8 @@ export const config = {
       ],
     },
 
-    // ---------- B200 / B300: verification round open. Mirrors the GB300 recipe
-    // because the kernels dispatch by architecture family. ----------
+    // ---------- B200: verification round open. Mirrors the GB300 recipe because
+    // the kernels dispatch by architecture family. ----------
     {
       match: { hw: "b200", strategy: "low-latency" },
       nnodes: 1,
@@ -271,10 +271,14 @@ export const config = {
         "--port {{PORT}}",
       ],
     },
+
+    // ---------- B300: 4x B300, TP4 + EP4. Same recipe as GB300 — the kernels
+    // dispatch by architecture family — with one extra memory knob on
+    // Low-Latency that GB300 does not need. ----------
     {
       match: { hw: "b300", strategy: "low-latency" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
@@ -283,6 +287,9 @@ export const config = {
         "--mem-fraction-static 0.8",
         "--speculative-algorithm DSPARK",
         "--speculative-dspark-block-size 5",
+        // GB300 does not need this, B300 does: the derived value (256) runs
+        // out of memory capturing the DSpark decode graphs at this fraction.
+        "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--host {{HOST_IP}}",
@@ -292,7 +299,7 @@ export const config = {
     {
       match: { hw: "b300", strategy: "high-throughput" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",


### PR DESCRIPTION
## Motivation

Two independent problems in the DeepSeek-V4.1 cookbook (#38802), both found by running the
page as written on real hardware.

### 1. §3.1 never showed any reasoning

The "Reasoning" example comes back with an empty `reasoning_content`.

Thinking is **off** by default (`SGLANG_DEFAULT_THINKING = EnvBool(False)`). `serving_chat.py`
reads the switch from `chat_template_kwargs.thinking`, and with it off `encoding_dsv41` closes
the assistant turn with `</think>` instead of prefilling `<think>` — the model emits no
thinking block and the reasoning parser has nothing to split. The example sent neither
`reasoning_effort` nor `chat_template_kwargs.thinking`, i.e. it demonstrated exactly the case
where the section's subject does not appear.

Sending `reasoning_effort` is both the fix and the idiomatic route for this model:
`ChatCompletionRequest.normalize_reasoning_inputs` derives `thinking = effort != "none"` and
`setdefault`s it onto `chat_template_kwargs`.

Two claims in the same paragraph were also inaccurate:

- *"either as a tier or as an integer budget"* — the request field is
  `Optional[Union[ReasoningEffortTier, float in [0.0, 0.99]]]`, so an integer is rejected with
  a 400. Integer budgets 1–100 are reachable only through
  `chat_template_kwargs.reasoning_effort`, which is popped and re-assigned *after* validation
  and therefore does not switch thinking on by itself.
- `none` was grouped with `minimal` / `medium` as a plain warn-and-fall-back. True of the
  effort *value*, but `none` also turns thinking off — the part a reader most needs.

### 2. Five of the eight NVIDIA cells did not start

Every DSpark cell, plus both H200 cells, dies during startup:

```
Exception: Capture cuda graph failed: CUDA out of memory.
```

The derived `--cuda-graph-max-bs-decode` does not fit while capturing the decode graphs. This
is a startup failure, not a runtime one — the server never becomes ready. It includes the
GB300 Low-Latency cell, which the page already marked `verified`.

The MI350X Low-Latency cell already carried the equivalent `--cuda-graph-max-bs 64`, so this
was only ever missing on the NVIDIA side.

## Modifications

`docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4_1.mdx`

- §3.1: add `reasoning_effort="high"` to the example; state that thinking is off by default
  and that `reasoning_effort` turns it on; rewrite the effort paragraph to give the accepted
  request values, the `chat_template_kwargs` integer route, and what `none` does.
- §3.2: the tool-calling example prints `reasoning_content` too, so it takes the same argument.
- §2: new "Cap the decode CUDA graphs" tip, for readers assembling a command by hand.

`docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx`

- `--cuda-graph-max-bs-decode 64` on every DSpark cell (GB300 / B200 / B300 Low-Latency) and
  on both H200 cells; `--mem-fraction-static 0.8` on both H200 cells.
- All eight NVIDIA cells move to `verified`. MI350X is untouched (not tested here).

## Accuracy Tests

Every NVIDIA cell was run on its own hardware with real `deepseek-ai/DeepSeek-V4.1-Flash`
weights. GB300 / B200 / H200 used the page's own image `lmsysorg/sglang:dev-dsv41`; B300 used
the #38798 tree (`1aa0e96`) on `PYTHONPATH` over a stock image, no B300 running that tag being
available.

| platform | cell | as published | with this PR's flags |
|---|---|---|---|
| 4x GB300 (aarch64) | Low-Latency | **OOM** — 5.82 GiB wanted, 2.15 GiB free of 276.62 | starts, serves |
| 4x GB300 | High-Throughput | starts, serves | unchanged |
| 8x H200 | Low-Latency | **OOM** — 2.00 GiB wanted, 0.96 GiB free of 139.80 | starts, serves |
| 8x H200 | High-Throughput | **OOM** — 2.00 GiB wanted, 0.48 GiB free of 139.80 | starts, serves |
| 4x B200 | Low-Latency | **OOM** — 6.00 GiB wanted, 1.48 GiB free of 178.35 | starts, serves |
| 4x B200 | High-Throughput | starts, serves | unchanged |
| 4x B300 | Low-Latency | **OOM** — 5.82 GiB wanted, 1.25 GiB free of 267.69 | starts, serves |
| 4x B300 | High-Throughput | starts, serves | unchanged |

The B300 Low-Latency OOM was reproduced twice on an idle box, failing on a different GPU each
time. On H200 the cap alone is not enough — it gets to 1.89 GiB free against a 2.00 GiB
allocation — which is why those two cells also pull the memory fraction back to 0.8.

Every "starts, serves" row was confirmed with a real completion, not just `/health`.

§3.1 / the effort contract, measured against both the `dev-dsv41` image (GB300) and the
#38798 tree (B300), with identical results:

| case | `reasoning_content` | note |
|---|---|---|
| example **as published** (no `reasoning_effort`) | **empty** | the bug |
| `reasoning_effort="high"` (this PR) | populated | `content: "15% of 240 is **36**."` |
| `reasoning_effort="none"` | empty | thinking off, as the PR now states |
| `reasoning_effort=50` (int) | — | **HTTP 400** `literal_error` |
| `reasoning_effort=0.5` (float) | populated | resolves to budget 50 |

§3.2 tool calling — `finish_reason: "tool_calls"` and a single correct `get_weather` call
both ways; only the reasoning channel differs (empty as published, populated with the
argument this PR adds).

Offline against the same tree: `REASONING_EFFORT_MAPPINGS = {low: 25, high: 50, xhigh: 75,
max: 100}`, `DEFAULT_REASONING_EFFORT = "high"`, `SGLANG_DEFAULT_THINKING = False`;
`encode_messages(thinking_mode="chat")` ends the prompt with `</think>` and emits no effort
prefix, `thinking_mode="thinking"` ends with `<think>` and does.

## Speed Tests and Profiling

Not applicable — no runtime code is touched. 64 is a startup-feasibility value, not a tuned
one; it is ample for the interactive batch sizes these recipes target, and the three
High-Throughput cells that start without a cap are left uncapped.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] `node docs/scripts/check_cookbook_configs.mjs` → `cookbook config check: OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
