### PR TITLE
Revert "[CI] Temporarily disable GB300 tests"

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -139,20 +139,20 @@ jobs:
       scheduled: true
     secrets: inherit
 
-  # nightly-4-gpu-gb300:
-  #   needs: check-changes
-  #   if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '4-gpu-gb300')
-  #   uses: ./.github/workflows/_pr-test-stage.yml
-  #   with:
-  #     self_name: nightly-test-4-gpu-gb300
-  #     runner_config: 4-gpu-gb300
-  #     check_changes: ${{ toJson(needs.check-changes.outputs) }}
-  #     caller_inputs: ${{ toJson(inputs) }}
-  #     partitions: ${{ needs.check-changes.outputs.partitions }}
-  #     run_timeout_minutes: '360'
-  #     job_timeout_minutes: '420'
-  #     scheduled: true
-  #   secrets: inherit
+  nightly-4-gpu-gb300:
+    needs: check-changes
+    if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '4-gpu-gb300')
+    uses: ./.github/workflows/_pr-test-stage.yml
+    with:
+      self_name: nightly-test-4-gpu-gb300
+      runner_config: 4-gpu-gb300
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
+      partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '360'
+      job_timeout_minutes: '420'
+      scheduled: true
+    secrets: inherit
 
   nightly-8-gpu-h200:
     needs: check-changes
@@ -265,7 +265,7 @@ jobs:
       - nightly-2-gpu-large
       - nightly-4-gpu-h100
       - nightly-4-gpu-b200
-      # - nightly-4-gpu-gb300
+      - nightly-4-gpu-gb300
       - nightly-8-gpu-h200
       - nightly-8-gpu-b200
     runs-on: ubuntu-latest
@@ -312,7 +312,7 @@ jobs:
       - nightly-2-gpu-large
       - nightly-4-gpu-h100
       - nightly-4-gpu-b200
-      # - nightly-4-gpu-gb300
+      - nightly-4-gpu-gb300
       - nightly-8-gpu-h200
       - nightly-8-gpu-b200
       - nightly-test-diffusion

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -474,21 +474,21 @@ jobs:
       rust_ext_artifact: ${{ needs.rust-ext-build.outputs.artifact_name }}
     secrets: inherit
 
-  # base-c-test-4-gpu-gb300:
-  #   needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels, rust-ext-build-aarch64]
-  #   if: ${{ !failure() && !cancelled() }}
-  #   uses: ./.github/workflows/_pr-test-stage.yml
-  #   with:
-  #     self_name: base-c-test-4-gpu-gb300
-  #     runner_config: 4-gpu-gb300
-  #     check_changes: ${{ toJson(needs.check-changes.outputs) }}
-  #     caller_inputs: ${{ toJson(inputs) }}
-  #     partitions: ${{ needs.check-changes.outputs.partitions }}
-  #     run_timeout_minutes: '30'
-  #     timeout_per_file: '1800'
-  #     # The one aarch64 stage, so it takes the aarch64 build, not rust-ext-build's.
-  #     rust_ext_artifact: ${{ needs.rust-ext-build-aarch64.outputs.artifact_name }}
-  #   secrets: inherit
+  base-c-test-4-gpu-gb300:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels, rust-ext-build-aarch64]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_pr-test-stage.yml
+    with:
+      self_name: base-c-test-4-gpu-gb300
+      runner_config: 4-gpu-gb300
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
+      partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
+      timeout_per_file: '1800'
+      # The one aarch64 stage, so it takes the aarch64 build, not rust-ext-build's.
+      rust_ext_artifact: ${{ needs.rust-ext-build-aarch64.outputs.artifact_name }}
+    secrets: inherit
 
   base-c-test-8-gpu-b300:
     needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels, rust-ext-build]
@@ -537,7 +537,7 @@ jobs:
         base-c-test-8-gpu-h20,
         base-c-test-8-gpu-h200,
         base-c-test-4-gpu-b200,
-        # base-c-test-4-gpu-gb300,
+        base-c-test-4-gpu-gb300,
         base-c-test-8-gpu-b300,
       ]
     if: always()

--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -194,9 +194,9 @@ jobs:
           # - arch_label: sm120
           #   runner: 1-gpu-5090
           #   wheel_arch: x86_64
-          # - arch_label: sm100-aarch64
-          #   runner: 4-gpu-gb300
-          #   wheel_arch: aarch64
+          - arch_label: sm100-aarch64
+            runner: 4-gpu-gb300
+            wheel_arch: aarch64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Reverts sgl-project/sglang#38770

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34457817109](https://github.com/sgl-project/sglang/actions/runs/34457817109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34457816906](https://github.com/sgl-project/sglang/actions/runs/34457816906)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->