### PR TITLE
[NPU] Keep Qwen3-ASR fused kernels compile-safe under torch.compile

### DIFF
--- a/python/sglang/srt/compilation/torch_compile_decoration.py
+++ b/python/sglang/srt/compilation/torch_compile_decoration.py
@@ -40,6 +40,27 @@ def _to_torch(model: torch.nn.Module, reverse: bool, num_tokens: int) -> None:
 
 
 @contextmanager
+def prepare_model_for_torch_compile(
+    model: torch.nn.Module,
+    num_tokens: int,
+    tp_group: GroupCoordinator,
+):
+    """Put fused ops into their compile-safe form for one compile scope.
+
+    Platform-specific ``patch_model`` implementations must use this helper as
+    well as the default CUDA path. Otherwise Dynamo can trace through Python
+    launchers for device kernels instead of seeing their custom-op boundary.
+    """
+    _to_torch(model, reverse=False, num_tokens=num_tokens)
+    backup_ca_comm = tp_group.ca_comm
+    try:
+        yield
+    finally:
+        _to_torch(model, reverse=True, num_tokens=num_tokens)
+        tp_group.ca_comm = backup_ca_comm
+
+
+@contextmanager
 def patch_model(
     model: torch.nn.Module,
     enable_compile: bool,
@@ -47,12 +68,8 @@ def patch_model(
     tp_group: GroupCoordinator,
 ):
     """Patch the model to make it compatible with torch.compile."""
-    backup_ca_comm = None
-
-    try:
-        if enable_compile:
-            _to_torch(model, reverse=False, num_tokens=num_tokens)
-            backup_ca_comm = tp_group.ca_comm
+    if enable_compile:
+        with prepare_model_for_torch_compile(model, num_tokens, tp_group):
             yield torch.compile(
                 torch.no_grad()(model.forward),
                 mode=os.environ.get(
@@ -60,12 +77,8 @@ def patch_model(
                 ),
                 dynamic=_is_hip and get_bool_env_var("SGLANG_TORCH_DYNAMIC_SHAPE"),
             )
-        else:
-            yield model.forward
-    finally:
-        if enable_compile:
-            _to_torch(model, reverse=True, num_tokens=num_tokens)
-            tp_group.ca_comm = backup_ca_comm
+    else:
+        yield model.forward
 
 
 def set_torch_compile_config() -> None:

--- a/python/sglang/srt/hardware_backend/npu/fused_ops.py
+++ b/python/sglang/srt/hardware_backend/npu/fused_ops.py
@@ -1,0 +1,74 @@
+"""Compile-safe boundaries for out-of-tree NPU fused operators."""
+
+from __future__ import annotations
+
+import torch
+from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
+    split_qkv_rmsnorm_rope as _split_qkv_rmsnorm_rope_kernel,
+)
+
+from sglang.srt.utils.custom_op import register_custom_op
+
+
+def _split_qkv_rmsnorm_rope_fake(
+    input: torch.Tensor,
+    sin: torch.Tensor,
+    cos: torch.Tensor,
+    q_hidden_size: int,
+    kv_hidden_size: int,
+    head_dim: int,
+    eps: float | None = None,
+    q_weight: torch.Tensor | None = None,
+    k_weight: torch.Tensor | None = None,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+    is_neox_style: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del sin, cos, head_dim, eps, q_weight, k_weight, q_bias, k_bias, is_neox_style
+    batch_size = input.shape[0]
+    return (
+        input.new_empty((batch_size, q_hidden_size)),
+        input.new_empty((batch_size, kv_hidden_size)),
+        input.new_empty((batch_size, kv_hidden_size)),
+    )
+
+
+@register_custom_op(
+    op_name="npu_split_qkv_rmsnorm_rope",
+    fake_impl=_split_qkv_rmsnorm_rope_fake,
+)
+def split_qkv_rmsnorm_rope(
+    input: torch.Tensor,
+    sin: torch.Tensor,
+    cos: torch.Tensor,
+    q_hidden_size: int,
+    kv_hidden_size: int,
+    head_dim: int,
+    eps: float | None = None,
+    q_weight: torch.Tensor | None = None,
+    k_weight: torch.Tensor | None = None,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+    is_neox_style: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the external Triton kernel behind an opaque Dynamo boundary.
+
+    ``sgl_kernel_npu`` selects its launch grid by querying Triton's active
+    driver. That eager-only query must not be traced by ``torch.compile``.
+    The custom op keeps the external implementation unchanged at runtime and
+    supplies only tensor metadata while Dynamo constructs the graph.
+    """
+    return _split_qkv_rmsnorm_rope_kernel(
+        input,
+        sin,
+        cos,
+        q_hidden_size,
+        kv_hidden_size,
+        head_dim,
+        eps=eps,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        q_bias=q_bias,
+        k_bias=k_bias,
+        is_neox_style=is_neox_style,
+    )

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -35,6 +35,9 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 import numpy as np
 import torch
 
+from sglang.srt.compilation.torch_compile_decoration import (
+    prepare_model_for_torch_compile,
+)
 from sglang.srt.configs.model_config import (
     AttentionArch,
     is_deepseek_dsa,
@@ -73,13 +76,13 @@ def patch_model_npu(
     tp_group: GroupCoordinator,
 ):
     if enable_compile:
-        backend = get_compiler_backend("npugraph_ex")
-        yield torch.compile(
-            torch.no_grad()(model.forward),
-            fullgraph=True,
-            dynamic=False,
-            backend=backend,
-        )
+        with prepare_model_for_torch_compile(model, num_tokens, tp_group):
+            yield torch.compile(
+                torch.no_grad()(model.forward),
+                fullgraph=True,
+                dynamic=False,
+                backend=get_compiler_backend("npugraph_ex"),
+            )
     else:
         yield model.forward
 

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -138,6 +138,14 @@ class SiluAndMul(BaseFusedOp):
         elif _use_aiter and envs.SGLANG_OPT_USE_AITER_SILU_MUL.get():
             self._forward_method = self.forward_aiter
 
+    def _torch_compile_forward(self, num_tokens: int):
+        # npu_swiglu is a torch_npu operator boundary. Keep it in the outer
+        # Dynamo trace instead of replacing the NPU implementation with the
+        # generic native expression, which changes the active fused-op path.
+        if _is_npu:
+            return None
+        return super()._torch_compile_forward(num_tokens)
+
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         d = x.shape[-1] // 2
         return F.silu(x[..., :d]) * x[..., d:]

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -487,6 +487,16 @@ class RMSNorm(BaseFusedOp):
         if force_native:
             self._forward_method = self.forward_native
 
+    def _torch_compile_forward(self, num_tokens: int):
+        # torch_npu exposes RMSNorm as an operator boundary that Dynamo can
+        # retain.  The generic compile-safe fallback is a float32 reference
+        # implementation; switching to it changes the NPU execution contract
+        # and has corrupted Qwen3-ASR decode output before any compiler backend
+        # is involved.
+        if _is_npu:
+            return None
+        return super()._torch_compile_forward(num_tokens)
+
     def forward_cuda(
         self,
         x: torch.Tensor,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -604,6 +604,15 @@ class TopK(BaseFusedOp):
         return self.forward_cuda(*args, **kwargs)
 
     def _torch_compile_forward(self, num_tokens: int) -> Optional[Callable]:
+        # The NPU implementation is expressed through torch.ops.npu custom-op
+        # boundaries, so it is safe for the outer Dynamo trace and preserves
+        # the routing semantics used by eager NPU execution.  Replacing it
+        # with forward_native changes the TopKConfig.torch_native contract and
+        # has been observed to corrupt Qwen3-ASR decode output even when the
+        # outer torch.compile backend is eager.
+        if _is_npu:
+            return None
+
         # torch.compile of the native TopK only pays off at bs=1; for larger
         # batches keep the current optimized dispatch (see MultiPlatformOp
         # history: the compiled path regressed bs > 1).

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -55,9 +55,8 @@ if _use_aiter:
         pass
 
 if _is_npu:
-    from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
-
     from sglang.srt.hardware_backend.npu.cmo import get_cmo_stream, wait_cmo_stream
+    from sglang.srt.hardware_backend.npu.fused_ops import split_qkv_rmsnorm_rope
 
 
 class Qwen3Attention(nn.Module):

--- a/test/registered/unit/layers/moe/test_topk_torch_compile_dispatch.py
+++ b/test/registered/unit/layers/moe/test_topk_torch_compile_dispatch.py
@@ -1,0 +1,27 @@
+import torch
+
+from sglang.srt.layers.moe import topk as topk_module
+from sglang.srt.layers.moe.topk import TopK
+
+
+def _bare_topk() -> TopK:
+    """Build only the dispatch surface; TopK.__init__ needs runtime context."""
+    topk = object.__new__(TopK)
+    torch.nn.Module.__init__(topk)
+    return topk
+
+
+def test_torch_compile_keeps_npu_topk_dispatch(monkeypatch):
+    topk = _bare_topk()
+    monkeypatch.setattr(topk_module, "_is_npu", True)
+
+    assert topk._torch_compile_forward(num_tokens=1) is None
+    assert topk._torch_compile_forward(num_tokens=2) is None
+
+
+def test_torch_compile_keeps_existing_non_npu_policy(monkeypatch):
+    topk = _bare_topk()
+    monkeypatch.setattr(topk_module, "_is_npu", False)
+
+    assert topk._torch_compile_forward(num_tokens=1) == topk.forward_native
+    assert topk._torch_compile_forward(num_tokens=2) is None

--- a/test/registered/unit/layers/test_npu_torch_compile_dispatch.py
+++ b/test/registered/unit/layers/test_npu_torch_compile_dispatch.py
@@ -1,0 +1,37 @@
+import torch
+
+from sglang.srt.layers import activation as activation_module
+from sglang.srt.layers import layernorm as layernorm_module
+from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.layernorm import RMSNorm
+
+
+def _bare_fused_op(cls):
+    """Create only the dispatch surface; constructors need runtime context."""
+    op = object.__new__(cls)
+    torch.nn.Module.__init__(op)
+    return op
+
+
+def test_torch_compile_keeps_npu_rmsnorm_dispatch(monkeypatch):
+    op = _bare_fused_op(RMSNorm)
+    monkeypatch.setattr(layernorm_module, "_is_npu", True)
+
+    assert op._torch_compile_forward(num_tokens=1) is None
+
+
+def test_torch_compile_keeps_npu_swiglu_dispatch(monkeypatch):
+    op = _bare_fused_op(SiluAndMul)
+    monkeypatch.setattr(activation_module, "_is_npu", True)
+
+    assert op._torch_compile_forward(num_tokens=1) is None
+
+
+def test_torch_compile_keeps_non_npu_reference_policy(monkeypatch):
+    rmsnorm = _bare_fused_op(RMSNorm)
+    swiglu = _bare_fused_op(SiluAndMul)
+    monkeypatch.setattr(layernorm_module, "_is_npu", False)
+    monkeypatch.setattr(activation_module, "_is_npu", False)
+
+    assert rmsnorm._torch_compile_forward(num_tokens=1) == rmsnorm.forward_native
+    assert swiglu._torch_compile_forward(num_tokens=1) == swiglu.forward_native

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -25,6 +25,7 @@ server is constructed.
 import os
 import tempfile
 import unittest
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest import mock
 
@@ -40,6 +41,67 @@ register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 _CAPTURE_TRACE = "SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE"
 _BATCH_CAPTURE = "SGLANG_GRAPH_BATCH_CAPTURE"
+
+
+def test_compile_safe_model_context_restores_fused_ops_and_ca_comm():
+    from sglang.srt.compilation import torch_compile_decoration
+
+    model = object()
+    original_ca_comm = object()
+    tp_group = SimpleNamespace(ca_comm=original_ca_comm)
+    with mock.patch.object(torch_compile_decoration, "_to_torch") as toggle:
+        with torch_compile_decoration.prepare_model_for_torch_compile(
+            model, num_tokens=4, tp_group=tp_group
+        ):
+            tp_group.ca_comm = object()
+            toggle.assert_called_once_with(model, reverse=False, num_tokens=4)
+
+    assert toggle.call_args_list == [
+        mock.call(model, reverse=False, num_tokens=4),
+        mock.call(model, reverse=True, num_tokens=4),
+    ]
+    assert tp_group.ca_comm is original_ca_comm
+
+
+def test_npu_patch_model_uses_compile_safe_model_context():
+    from sglang.srt.hardware_backend.npu.graph_runner import npu_graph_runner
+
+    events = []
+
+    @contextmanager
+    def fake_prepare(model, num_tokens, tp_group):
+        events.append(("enter", model, num_tokens, tp_group))
+        try:
+            yield
+        finally:
+            events.append(("exit", model, num_tokens, tp_group))
+
+    model = SimpleNamespace(forward=lambda *args, **kwargs: None)
+    tp_group = SimpleNamespace(ca_comm=object())
+    compiled = object()
+    with (
+        mock.patch.object(
+            npu_graph_runner, "prepare_model_for_torch_compile", fake_prepare
+        ),
+        mock.patch.object(
+            npu_graph_runner, "get_compiler_backend", return_value="npugraph_ex"
+        ),
+        mock.patch.object(
+            npu_graph_runner.torch, "compile", return_value=compiled
+        ) as compile_mock,
+    ):
+        with npu_graph_runner.patch_model_npu(
+            model, True, num_tokens=8, tp_group=tp_group
+        ) as forward:
+            assert forward is compiled
+            assert [event[0] for event in events] == ["enter"]
+
+    assert [event[0] for event in events] == ["enter", "exit"]
+    assert compile_mock.call_args.kwargs == {
+        "fullgraph": True,
+        "dynamic": False,
+        "backend": "npugraph_ex",
+    }
 
 
 def _make_fake_self(capture_bs):

--- a/test/registered/unit/model_executor/runner/test_npu_fused_ops.py
+++ b/test/registered/unit/model_executor/runner/test_npu_fused_ops.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("sgl_kernel_npu")
+
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+
+from sglang.srt.hardware_backend.npu.fused_ops import (
+    _split_qkv_rmsnorm_rope_fake,
+    _split_qkv_rmsnorm_rope_kernel,
+    split_qkv_rmsnorm_rope,
+)
+from sglang.srt.utils import get_compiler_backend
+
+
+def test_split_qkv_rmsnorm_rope_fake_preserves_output_metadata():
+    with FakeTensorMode():
+        qkv = torch.empty((1, 4096), dtype=torch.bfloat16)
+        sin = torch.empty((1, 128), dtype=torch.bfloat16)
+        cos = torch.empty((1, 128), dtype=torch.bfloat16)
+        weight = torch.empty((128,), dtype=torch.bfloat16)
+
+        q, k, v = _split_qkv_rmsnorm_rope_fake(
+            qkv,
+            sin,
+            cos,
+            q_hidden_size=3072,
+            kv_hidden_size=512,
+            head_dim=128,
+            eps=1e-6,
+            q_weight=weight,
+            k_weight=weight,
+        )
+
+    assert q.shape == (1, 3072)
+    assert k.shape == (1, 512)
+    assert v.shape == (1, 512)
+    assert q.dtype == k.dtype == v.dtype == torch.bfloat16
+
+
+def test_split_qkv_rmsnorm_rope_is_registered_as_custom_op():
+    assert hasattr(torch.ops.sglang, "npu_split_qkv_rmsnorm_rope")
+
+
+def test_split_qkv_rmsnorm_rope_is_opaque_to_symbolic_trace():
+    def call_op(qkv, sin, cos, weight):
+        return split_qkv_rmsnorm_rope(
+            qkv,
+            sin,
+            cos,
+            q_hidden_size=3072,
+            kv_hidden_size=512,
+            head_dim=128,
+            eps=1e-6,
+            q_weight=weight,
+            k_weight=weight,
+        )
+
+    graph = make_fx(call_op, tracing_mode="fake")(
+        torch.empty((1, 4096), dtype=torch.bfloat16),
+        torch.empty((1, 128), dtype=torch.bfloat16),
+        torch.empty((1, 128), dtype=torch.bfloat16),
+        torch.empty((128,), dtype=torch.bfloat16),
+    )
+
+    call_targets = [
+        node.target for node in graph.graph.nodes if node.op == "call_function"
+    ]
+    assert torch.ops.sglang.npu_split_qkv_rmsnorm_rope.default in call_targets
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_compiled_split_qkv_rmsnorm_rope_matches_external_kernel(batch_size):
+    """The opaque boundary must preserve values, not only fake metadata.
+
+    This is an NPU qualification test.  It intentionally compares the exact
+    installed ``sgl_kernel_npu`` implementation with the registered custom op
+    after Dynamo/TorchAir compilation for the two Qwen3-ASR compile buckets.
+    """
+    torch_npu = pytest.importorskip("torch_npu")
+    if not torch_npu.npu.is_available():
+        pytest.skip("Ascend NPU is required")
+
+    device = torch.device("npu", torch_npu.npu.current_device())
+    q_hidden_size = 3072
+    kv_hidden_size = 512
+    head_dim = 128
+    total_hidden_size = q_hidden_size + 2 * kv_hidden_size
+
+    torch.manual_seed(0)
+    qkv = torch.randn(
+        (batch_size, total_hidden_size), dtype=torch.bfloat16, device=device
+    )
+    sin = torch.randn((batch_size, head_dim), dtype=torch.bfloat16, device=device)
+    cos = torch.randn((batch_size, head_dim), dtype=torch.bfloat16, device=device)
+    weight = torch.randn((head_dim,), dtype=torch.bfloat16, device=device)
+
+    def call_op(qkv, sin, cos, weight):
+        return split_qkv_rmsnorm_rope(
+            qkv,
+            sin,
+            cos,
+            q_hidden_size=q_hidden_size,
+            kv_hidden_size=kv_hidden_size,
+            head_dim=head_dim,
+            eps=1e-6,
+            q_weight=weight,
+            k_weight=weight,
+        )
+
+    expected = _split_qkv_rmsnorm_rope_kernel(
+        qkv,
+        sin,
+        cos,
+        q_hidden_size,
+        kv_hidden_size,
+        head_dim,
+        eps=1e-6,
+        q_weight=weight,
+        k_weight=weight,
+    )
+    eager_wrapped = call_op(qkv, sin, cos, weight)
+    compiled = torch.compile(
+        call_op,
+        fullgraph=True,
+        dynamic=False,
+        backend=get_compiler_backend("npugraph_ex"),
+    )
+    actual = compiled(qkv, sin, cos, weight)
+    torch_npu.npu.synchronize()
+
+    for wrapped_tensor, expected_tensor in zip(eager_wrapped, expected):
+        torch.testing.assert_close(wrapped_tensor, expected_tensor, rtol=0, atol=0)
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)


### PR DESCRIPTION
## Motivation

On Ascend, `torch.compile` of Qwen3-ASR could either fail while Dynamo traced the Python launcher of an external NPU kernel or replace NPU fused operators with their generic torch reference implementations. Both cases change or block the device execution path before the compiler backend runs.

This PR keeps the existing NPU kernels behind explicit compile-safe boundaries so graph capture sees stable tensor metadata without changing the runtime implementation.

## Changes

- `hardware_backend/npu/fused_ops.py` and `models/qwen3.py`: register `split_qkv_rmsnorm_rope` as a custom op with a fake implementation. During NPU qualification, Dynamo followed `split_qkv_rmsnorm_rope -> get_device_properties` and failed at batch 1; with this boundary the complete 13-bucket capture completed.
- `activation.SiluAndMul`, `layernorm.RMSNorm`, and `moe.TopK`: on NPU, `_torch_compile_forward` returns `None`, keeping the existing `torch_npu` / `sgl_kernel_npu` dispatch inside the outer trace. The generic compile-safe reference path is unchanged for non-NPU platforms.
- `compilation/torch_compile_decoration.py` and the NPU graph runner: factor `prepare_model_for_torch_compile` so `patch_model_npu` uses the same enter/leave handling and `ca_comm` restoration. `fullgraph` remains `True`.
- Tests cover dispatch preservation, custom-op registration and fake metadata, symbolic tracing, compile-context restoration, and optional NPU exact-value parity for the wrapped kernel.

## NPU qualification

The `910C-071` run passed on this SGLang head (`891a70626`) with the Qwen3-ASR Omni candidate at `d58afeda`:

- 3/3 cold concurrency-8 gates passed with zero failures and timeouts.
- The 140-request correctness gate passed at WER `0.0181` with zero garbled outputs.
- 3/3 fresh-process C70 repeats measured p95 `1.460-1.623` s at `58.47-59.16` requests/s.

This qualifies the tested code path on one Ascend 910B/910C-class card. It does not claim a general performance improvement over eager execution.

## Scope

This PR does not include decode-attention graph routing, decode graph context hooks, or explicit compile bucket selection. Those changes and their WER/latency measurements were removed from the branch; the remaining changes are limited to compile-safe fused-kernel dispatch and the shared compile scope.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests)
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations)
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the performance](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-performance)
- [ ] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34615087519](https://github.com/sgl-project/sglang/actions/runs/34615087519)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34615087885](https://github.com/sgl-project/sglang/actions/runs/34615087885)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34615088249](https://github.com/sgl-project/sglang/actions/runs/34615088249)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->