### PR TITLE
[Bugfix] Reject non-leading system messages in the DeepSeek-V4 chat encoder path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1019,7 +1019,15 @@ class OpenAIServingChat(OpenAIServingBase):
             if schema is None:
                 return "schema_ is required for json_schema response format request."
 
-        if self.chat_encoding_spec == "dsv4":
+        # Only requests that actually reach the dsv4 encoder can be mis-rendered:
+        # client-supplied input_ids skip tokenization, and a named conversation
+        # template is rendered by its own code, which is allowed to handle inline
+        # system messages.
+        if (
+            self.chat_encoding_spec == "dsv4"
+            and request.input_ids is None
+            and self.template_manager.chat_template_name is None
+        ):
             # The dsv4 encoder renders a `system` turn as plain content, so a
             # non-leading system message can produce a malformed prompt without
             # an assistant generation boundary

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1019,6 +1019,20 @@ class OpenAIServingChat(OpenAIServingBase):
             if schema is None:
                 return "schema_ is required for json_schema response format request."
 
+        if self.chat_encoding_spec == "dsv4":
+            # The dsv4 encoder renders a `system` turn as plain content, so a
+            # non-leading system message can produce a malformed prompt without
+            # an assistant generation boundary
+            # (https://github.com/sgl-project/sglang/issues/35433).
+            for index, message in enumerate(request.messages):
+                if index > 0 and getattr(message, "role", None) == "system":
+                    return (
+                        "DeepSeek-V4 only supports a system message at the "
+                        f"beginning of the conversation, but messages[{index}] "
+                        "has role='system'. Move system instructions to the "
+                        "first message."
+                    )
+
         return None
 
     def _validate_media_content(self, request: ChatCompletionRequest) -> Optional[str]:

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -21,6 +21,7 @@ from typing import Optional
 from unittest.mock import Mock, patch
 
 from fastapi import Request
+from fastapi.responses import StreamingResponse
 
 from sglang.srt.entrypoints.openai import chat_encoding
 from sglang.srt.entrypoints.openai.chat_encoding import (
@@ -28,6 +29,7 @@ from sglang.srt.entrypoints.openai.chat_encoding import (
 )
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    ChatCompletionResponse,
     MessageProcessingResult,
     ToolChoice,
     ToolChoiceFuncName,
@@ -2549,6 +2551,153 @@ class ServingChatTestCase(unittest.TestCase):
         }
         with self.assertRaisesRegex(ValueError, "dsv4_reasoning_effort_profile"):
             OpenAIServingChat(tm, TemplateManager())
+
+    # ------------- dsv4 system message position -------------
+    @staticmethod
+    def _dsv4_trailing_system_messages():
+        """#35433: the client appends a `system` reminder as the final turn."""
+        return [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Summarize the tool result."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": '{"id":"demo"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "status=ok"},
+            {
+                "role": "system",
+                "content": "<runtime_reminder>123 tokens left</runtime_reminder>",
+            },
+        ]
+
+    @staticmethod
+    def _dsv4_mid_conversation_system_messages():
+        """A `system` turn in the middle also produces no generation boundary."""
+        return [
+            {"role": "system", "content": "Be brief."},
+            {"role": "user", "content": "Hi?"},
+            {"role": "system", "content": "<reminder>answer briefly</reminder>"},
+            {"role": "assistant", "content": "Hello!"},
+            {"role": "user", "content": "Next?"},
+        ]
+
+    def _dsv4_non_leading_system_cases(self):
+        return {
+            "trailing_system": (self._dsv4_trailing_system_messages(), 4),
+            "trailing_system_simple": (
+                [
+                    {"role": "system", "content": "Be brief."},
+                    {"role": "user", "content": "Hi?"},
+                    {"role": "system", "content": "<reminder>brief</reminder>"},
+                ],
+                2,
+            ),
+            "mid_conversation_system": (
+                self._dsv4_mid_conversation_system_messages(),
+                2,
+            ),
+        }
+
+    def _serving_chat_for_spec(self, spec, architecture):
+        """Serving chat whose encoding spec resolves like a real server's.
+
+        Both halves matter: the resolved spec puts requests on the custom
+        encoder, and ``chat_template_name = None`` keeps them off the legacy
+        conversation-template path.
+        """
+        tm = _MockTokenizerManager()
+        tm.model_config.hf_config.architectures = [architecture]
+        tm.model_config.hf_config.to_dict.return_value = (
+            {"dsv4_reasoning_effort_profile": "preview"} if spec == "dsv4" else {}
+        )
+        tm.tokenizer.chat_template = None
+        tm.chat_template_name = None
+        template_manager = _MockTemplateManager()
+        template_manager.chat_template_name = None
+        chat = OpenAIServingChat(tm, template_manager)
+        self.assertEqual(chat.chat_encoding_spec, spec)
+        return chat, tm
+
+    def test_dsv4_rejects_non_leading_system_before_generation(self):
+        for name, (messages, index) in self._dsv4_non_leading_system_cases().items():
+            with self.subTest(shape=name):
+                chat, tm = self._serving_chat_for_spec("dsv4", "DeepseekV4ForCausalLM")
+                request = ChatCompletionRequest(model="x", messages=messages)
+                response = get_or_create_event_loop().run_until_complete(
+                    chat.handle_request(request, self.fastapi_request)
+                )
+                error = json.loads(response.body)
+                self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+                self.assertEqual(error["type"], "BadRequestError")
+                self.assertIn("system message at the beginning", error["message"])
+                self.assertIn(f"messages[{index}]", error["message"])
+                self.assertIn("first message", error["message"])
+                tm.generate_request.assert_not_called()
+
+    def test_dsv4_rejects_trailing_system_when_streaming(self):
+        chat, tm = self._serving_chat_for_spec("dsv4", "DeepseekV4ForCausalLM")
+        request = ChatCompletionRequest(
+            model="x",
+            messages=self._dsv4_trailing_system_messages(),
+            stream=True,
+        )
+        response = get_or_create_event_loop().run_until_complete(
+            chat.handle_request(request, self.fastapi_request)
+        )
+        # A plain JSON error, not an SSE stream that already claimed HTTP 200.
+        self.assertNotIsInstance(response, StreamingResponse)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(json.loads(response.body)["type"], "BadRequestError")
+        tm.generate_request.assert_not_called()
+
+    def test_dsv4_supported_system_shapes_reach_generation(self):
+        """Leading-system / no-system requests still reach generation."""
+        shapes = {
+            "leading_system": [
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "Hi?"},
+            ],
+            "without_system": [{"role": "user", "content": "Hi?"}],
+            "leading_system_multi_turn": [
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "a"},
+                {"role": "assistant", "content": "b"},
+                {"role": "user", "content": "c"},
+            ],
+        }
+        for name, messages in shapes.items():
+            with self.subTest(shape=name):
+                chat, tm = self._serving_chat_for_spec("dsv4", "DeepseekV4ForCausalLM")
+                request = ChatCompletionRequest(model="x", messages=messages)
+                self.assertIsNone(chat._validate_request(request))
+                response = get_or_create_event_loop().run_until_complete(
+                    chat.handle_request(request, self.fastapi_request)
+                )
+                self.assertIsInstance(response, ChatCompletionResponse)
+                self.assertTrue(response.choices)
+                tm.generate_request.assert_called_once()
+
+    def test_dsv4_system_position_guard_leaves_dsv32_alone(self):
+        """dsv32 has its own encoder; the new guard must not touch it."""
+        chat, tm = self._serving_chat_for_spec("dsv32", "DeepseekV32ForCausalLM")
+        request = ChatCompletionRequest(
+            model="x", messages=self._dsv4_trailing_system_messages()
+        )
+        self.assertIsNone(chat._validate_request(request))
+        get_or_create_event_loop().run_until_complete(
+            chat.handle_request(request, self.fastapi_request)
+        )
+        tm.generate_request.assert_called_once()
 
     def test_streaming_abort_yields_error(self):
         """Test that an abort finish reason during streaming correctly yields an error and stops."""

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2699,6 +2699,46 @@ class ServingChatTestCase(unittest.TestCase):
         )
         tm.generate_request.assert_called_once()
 
+    def test_dsv4_bypass_input_ids_skips_guard(self):
+        """Pre-computed input_ids skip tokenization, so the guard must not fire."""
+        chat, tm = self._serving_chat_for_spec("dsv4", "DeepseekV4ForCausalLM")
+        request = ChatCompletionRequest(
+            model="x",
+            messages=self._dsv4_trailing_system_messages(),
+            input_ids=[11, 12, 13],
+        )
+        self.assertIsNone(chat._validate_request(request))
+        response = get_or_create_event_loop().run_until_complete(
+            chat.handle_request(request, self.fastapi_request)
+        )
+        self.assertIsInstance(response, ChatCompletionResponse)
+        tm.generate_request.assert_called_once()
+        # The client's ids reach generation verbatim; the encoder never ran.
+        self.assertEqual(
+            list(tm.generate_request.call_args.args[0].input_ids), [11, 12, 13]
+        )
+
+    def test_dsv4_bypass_named_conversation_template_skips_guard(self):
+        """A named template renders its own messages and may allow inline system."""
+        chat, tm = self._serving_chat_for_spec("dsv4", "DeepseekV4ForCausalLM")
+        # Route the request through the legacy conversation-template path.
+        chat.template_manager.chat_template_name = "llama-2"
+        tm.chat_template_name = "llama-2"
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {"role": "system", "content": "Be brief."},
+                {"role": "user", "content": "Hi?"},
+                {"role": "system", "content": "<reminder>brief</reminder>"},
+            ],
+        )
+        self.assertIsNone(chat._validate_request(request))
+        response = get_or_create_event_loop().run_until_complete(
+            chat.handle_request(request, self.fastapi_request)
+        )
+        self.assertIsInstance(response, ChatCompletionResponse)
+        tm.generate_request.assert_called_once()
+
     def test_streaming_abort_yields_error(self):
         """Test that an abort finish reason during streaming correctly yields an error and stops."""
         err_msg = "Aborted by scheduler"


### PR DESCRIPTION
## Motivation

Fixes #35433.

DeepSeek-V4's OpenAI chat path currently accepts a system message after the first message. The reference encoder renders system content as plain text, which can produce a malformed prompt without the expected assistant boundary. A trailing system reminder after a tool result therefore reaches generation instead of receiving a client error.

## Modifications

Validate system-message positions for requests that actually use the `dsv4` encoder. Return HTTP 400 with the offending message index and instructions to move system instructions to the first message. Validation runs before both streaming and non-streaming generation. Requests with precomputed `input_ids` or a named conversation template bypass this encoder and remain unaffected, with regression coverage for both paths.

Keep the reference encoder unchanged. This takes the explicit-rejection option proposed in the issue, rather than moving instructions within the conversation. The change does not cover system-only requests or change `dsv32` handling.

Add handler-level unit coverage for trailing and intermediate system messages, including a reminder after a tool result and streaming requests. Invalid requests must not call the generation backend. Positive controls exercise the resolved DeepSeek-V4 encoding path with a leading system message or no system message; a DeepSeek-V3.2 control verifies the guard is scoped to V4.

## Accuracy Tests

No model weights or GPU inference were used. These tests exercise the real serving handler and encoder with a mocked tokenizer/generation backend; they do not establish model-output quality or reproduce the issue author's EOS statistics.

The new rejection cases fail against the unmodified production code and pass with this change. The unmodified handler reaches the mock generation backend, including an HTTP 200 streaming response.

```bash
PYTHONPATH=python python -m pytest \
  test/registered/unit/entrypoints/openai/test_serving_chat.py \
  test/registered/unit/entrypoints/anthropic/test_serving.py -q
```

Result: **202 passed, 79 subtests passed**. Independently rerun after the final implementation commit.

A broader run of the OpenAI and Anthropic entrypoint unit directories produced 407 passed and 8 failures in the audio-chunking/transcription tests. The same eight failures were reproduced on the unchanged base commit; they are not counted as passing validation here.

`pre-commit run --all-files`: **exit 0, 32 passed, 1 skipped** (no `docs_new/` files), including all four Rust hooks. Run with the project Python environment and the repository-specified Rust toolchains on `PATH`; the working tree remained clean.

## Speed Tests and Profiling

Not run. The change adds a linear scan of message roles during request validation; it does not modify inference kernels or scheduling.

## Checklist

- [x] Format your code according to the contribution guide (`pre-commit run --all-files` passed).
- [x] Add unit tests in the existing serving-chat test suite.
- [ ] Update documentation: no documentation files changed; the client error provides corrective guidance.
- [ ] Provide accuracy and speed benchmarks: not run; validation-only change, with limits described above.
- [x] Follow the existing serving validation and error-response conventions.

Implementation and tests were produced with AI assistance (DeepSeek), with separate Codex/Astra review and test execution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34462107073](https://github.com/sgl-project/sglang/actions/runs/34462107073)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34462106758](https://github.com/sgl-project/sglang/actions/runs/34462106758)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34462106974](https://github.com/sgl-project/sglang/actions/runs/34462106974)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->