### PR TITLE
fix(qsa): make the paged sparse-decode gather memory-safe (zero-fill scratch, int64 offsets, dequant FP8 on gather)

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -381,8 +381,10 @@ def _compact_kv(
     dim: tl.constexpr,
     req_stride: tl.constexpr,
     idx_stride: tl.constexpr,
+    pad_cols,
     BLOCK_TOPK: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    ZERO_FILL: tl.constexpr,
 ):
     batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
@@ -400,9 +402,17 @@ def _compact_kv(
     )
     src = slots[:, None] * heads * dim + head * dim + dims[None, :]
     dst = (pack_start + cols)[:, None] * heads * dim + head * dim + dims[None, :]
-    mask = valid[:, None] & (dims[None, :] < dim)
-    tl.store(out_k + dst, tl.load(k + src, mask=mask, other=0.0), mask=mask)
-    tl.store(out_v + dst, tl.load(v + src, mask=mask, other=0.0), mask=mask)
+    load_mask = valid[:, None] & (dims[None, :] < dim)
+    if ZERO_FILL:
+        # Strided (page-aligned) packing: the paged decode kernel reads whole pages,
+        # so every slot in [valid_count, pad_cols) must hold zeros, never stale bytes.
+        # `valid_count` here is the row's page-aligned stride, not its valid count, so
+        # the store covers the full region while the load stays limited to valid rows.
+        store_mask = (cols < pad_cols)[:, None] & (dims[None, :] < dim)
+    else:
+        store_mask = load_mask
+    tl.store(out_k + dst, tl.load(k + src, mask=load_mask, other=0.0), mask=store_mask)
+    tl.store(out_v + dst, tl.load(v + src, mask=load_mask, other=0.0), mask=store_mask)
 
 
 def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
@@ -419,11 +429,33 @@ def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
 
 
 def qwen_sparse_kv_extraction_compact_triton(
-    k, v, req_to_token, req_indices, indices, seq_lens, cu_k, out_k, out_v, batch, topk
+    k,
+    v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    topk,
+    zero_fill_cols: int = 0,
 ):
+    """Gather the selected K/V rows into ``out_k``/``out_v``.
+
+    ``zero_fill_cols`` > 0 selects the strided (page-aligned) layout used by the paged
+    decode kernel: row ``b`` owns ``[cu_k[b], cu_k[b] + zero_fill_cols)`` and every slot
+    past its valid rows is zero-filled. Paged kernels read whole pages and multiply the
+    masked probabilities into V, so stale or uninitialized bytes there (NaN/Inf bit
+    patterns) would otherwise leak into the output. ``0`` keeps the compact layout for
+    the varlen fallback, whose rows are packed back-to-back.
+    """
     _, heads, dim = k.shape
     block_topk = 16
-    _compact_kv[(batch, heads, triton.cdiv(topk, block_topk))](
+    zero_fill = zero_fill_cols > 0
+    num_cols = zero_fill_cols if zero_fill else topk
+    _compact_kv[(batch, heads, triton.cdiv(num_cols, block_topk))](
         k,
         v,
         req_to_token,
@@ -438,8 +470,10 @@ def qwen_sparse_kv_extraction_compact_triton(
         dim,
         req_to_token.stride(0),
         indices.stride(0),
+        num_cols,
         BLOCK_TOPK=block_topk,
         BLOCK_D=triton.next_power_of_2(dim),
+        ZERO_FILL=zero_fill,
         num_warps=8,
     )
 

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -402,8 +402,15 @@ def _compact_kv(
         mask=valid,
         other=0,
     )
-    src = slots[:, None] * heads * dim + head * dim + dims[None, :]
-    dst = (pack_start + cols)[:, None] * heads * dim + head * dim + dims[None, :]
+    # 64-bit element offsets: slot * heads * dim exceeds int32 once the pool holds
+    # more than 2^31 / (heads * dim) tokens (~4.2M for 2 x 256), which an FP8 pool
+    # on one GPU does reach.
+    src = slots.to(tl.int64)[:, None] * heads * dim + head * dim + dims[None, :]
+    dst = (
+        (pack_start + cols).to(tl.int64)[:, None] * heads * dim
+        + head * dim
+        + dims[None, :]
+    )
     load_mask = valid[:, None] & (dims[None, :] < dim)
     if ZERO_FILL:
         # Strided (page-aligned) packing: the paged decode kernel reads whole pages,

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -382,6 +382,8 @@ def _compact_kv(
     req_stride: tl.constexpr,
     idx_stride: tl.constexpr,
     pad_cols,
+    k_scale,
+    v_scale,
     BLOCK_TOPK: tl.constexpr,
     BLOCK_D: tl.constexpr,
     ZERO_FILL: tl.constexpr,
@@ -411,8 +413,13 @@ def _compact_kv(
         store_mask = (cols < pad_cols)[:, None] & (dims[None, :] < dim)
     else:
         store_mask = load_mask
-    tl.store(out_k + dst, tl.load(k + src, mask=load_mask, other=0.0), mask=store_mask)
-    tl.store(out_v + dst, tl.load(v + src, mask=load_mask, other=0.0), mask=store_mask)
+    # Dequantize while gathering: the scratch is allocated in the query dtype, so
+    # FP8 pools are read as fp8 and stored as bf16 (times the per-tensor scale).
+    out_dtype = out_k.dtype.element_ty
+    k_vals = tl.load(k + src, mask=load_mask, other=0.0).to(tl.float32) * k_scale
+    v_vals = tl.load(v + src, mask=load_mask, other=0.0).to(tl.float32) * v_scale
+    tl.store(out_k + dst, k_vals.to(out_dtype), mask=store_mask)
+    tl.store(out_v + dst, v_vals.to(out_dtype), mask=store_mask)
 
 
 def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
@@ -441,6 +448,8 @@ def qwen_sparse_kv_extraction_compact_triton(
     batch,
     topk,
     zero_fill_cols: int = 0,
+    k_scale: float = 1.0,
+    v_scale: float = 1.0,
 ):
     """Gather the selected K/V rows into ``out_k``/``out_v``.
 
@@ -450,6 +459,9 @@ def qwen_sparse_kv_extraction_compact_triton(
     masked probabilities into V, so stale or uninitialized bytes there (NaN/Inf bit
     patterns) would otherwise leak into the output. ``0`` keeps the compact layout for
     the varlen fallback, whose rows are packed back-to-back.
+
+    ``out_k``/``out_v`` may use a wider dtype than the pool (bf16 scratch for an FP8
+    pool); rows are dequantized with ``k_scale``/``v_scale`` while gathering.
     """
     _, heads, dim = k.shape
     block_topk = 16
@@ -471,6 +483,8 @@ def qwen_sparse_kv_extraction_compact_triton(
         req_to_token.stride(0),
         indices.stride(0),
         num_cols,
+        float(k_scale),
+        float(v_scale),
         BLOCK_TOPK=block_topk,
         BLOCK_D=triton.next_power_of_2(dim),
         ZERO_FILL=zero_fill,

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -382,8 +382,6 @@ def _compact_kv(
     req_stride: tl.constexpr,
     idx_stride: tl.constexpr,
     pad_cols,
-    k_scale,
-    v_scale,
     BLOCK_TOPK: tl.constexpr,
     BLOCK_D: tl.constexpr,
     ZERO_FILL: tl.constexpr,
@@ -420,13 +418,21 @@ def _compact_kv(
         store_mask = (cols < pad_cols)[:, None] & (dims[None, :] < dim)
     else:
         store_mask = load_mask
-    # Dequantize while gathering: the scratch is allocated in the query dtype, so
-    # FP8 pools are read as fp8 and stored as bf16 (times the per-tensor scale).
+    # Dequantize while gathering: the scratch is allocated in the query dtype, so an
+    # FP8 pool is read as fp8 and stored as bf16. The QSA backend writes the pool
+    # without per-tensor k/v scales (see set_kv_buffer calls in
+    # qwen_sparse_attn_backend.py), so no scale is applied here either.
     out_dtype = out_k.dtype.element_ty
-    k_vals = tl.load(k + src, mask=load_mask, other=0.0).to(tl.float32) * k_scale
-    v_vals = tl.load(v + src, mask=load_mask, other=0.0).to(tl.float32) * v_scale
-    tl.store(out_k + dst, k_vals.to(out_dtype), mask=store_mask)
-    tl.store(out_v + dst, v_vals.to(out_dtype), mask=store_mask)
+    tl.store(
+        out_k + dst,
+        tl.load(k + src, mask=load_mask, other=0.0).to(out_dtype),
+        mask=store_mask,
+    )
+    tl.store(
+        out_v + dst,
+        tl.load(v + src, mask=load_mask, other=0.0).to(out_dtype),
+        mask=store_mask,
+    )
 
 
 def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
@@ -455,8 +461,6 @@ def qwen_sparse_kv_extraction_compact_triton(
     batch,
     topk,
     zero_fill_cols: int = 0,
-    k_scale: float = 1.0,
-    v_scale: float = 1.0,
 ):
     """Gather the selected K/V rows into ``out_k``/``out_v``.
 
@@ -468,7 +472,11 @@ def qwen_sparse_kv_extraction_compact_triton(
     the varlen fallback, whose rows are packed back-to-back.
 
     ``out_k``/``out_v`` may use a wider dtype than the pool (bf16 scratch for an FP8
-    pool); rows are dequantized with ``k_scale``/``v_scale`` while gathering.
+    pool); rows are converted while gathering.
+
+    Both layouts assume the valid entries of each ``indices`` row are contiguous at
+    the front (``expand_qsa_block_indices`` sorts them that way): ``valid_count`` is a
+    count, not a mask, so a ``-1`` in the middle of a row would shift the packing.
     """
     _, heads, dim = k.shape
     block_topk = 16
@@ -490,8 +498,6 @@ def qwen_sparse_kv_extraction_compact_triton(
         req_to_token.stride(0),
         indices.stride(0),
         num_cols,
-        float(k_scale),
-        float(v_scale),
         BLOCK_TOPK=block_topk,
         BLOCK_D=triton.next_power_of_2(dim),
         ZERO_FILL=zero_fill,

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -1477,6 +1477,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
+            zero_fill_cols=stride,
         )
         num_kv_heads = k_buffer.shape[1]
         head_dim = k_buffer.shape[2]

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -1407,22 +1407,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
 
-    @staticmethod
-    def _kv_dequant_scales(layer) -> Tuple[float, float]:
-        """Per-tensor K/V scales for an FP8 pool (1.0 when the checkpoint ships none)."""
-
-        def scalar(name_float, name):
-            value = getattr(layer, name_float, None)
-            if value is None:
-                value = getattr(layer, name, None)
-            if value is None:
-                return 1.0
-            if isinstance(value, torch.Tensor):
-                return float(value.item()) if value.numel() == 1 else 1.0
-            return float(value)
-
-        return scalar("k_scale_float", "k_scale"), scalar("v_scale_float", "v_scale")
-
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)
         cached = self._trtllm_sparse_tables.get(key)
@@ -1472,7 +1456,6 @@ class QwenSparseAttnBackend(AttentionBackend):
         capacity_rows = self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
         # Gather into the query dtype: an FP8 pool is dequantized on the way in, so the
         # paged kernel always runs the bf16 q + bf16 KV path.
-        k_scale, v_scale = self._kv_dequant_scales(layer)
         packed_k, packed_v = self._get_fa2_scratch(
             max(capacity_rows, batch) * stride,
             k_buffer.shape[1],
@@ -1497,8 +1480,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             batch,
             topk,
             zero_fill_cols=stride,
-            k_scale=k_scale,
-            v_scale=v_scale,
         )
         num_kv_heads = k_buffer.shape[1]
         head_dim = k_buffer.shape[2]
@@ -1605,7 +1586,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             if metadata.is_cuda_graph
             else batch * topk
         )
-        k_scale, v_scale = self._kv_dequant_scales(layer)
         packed_k, packed_v = self._get_fa2_scratch(
             scratch_capacity,
             k_buffer.shape[1],
@@ -1629,8 +1609,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
-            k_scale=k_scale,
-            v_scale=v_scale,
         )
         output = flash_attn_varlen_func(
             q=q,

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -1407,6 +1407,22 @@ class QwenSparseAttnBackend(AttentionBackend):
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
 
+    @staticmethod
+    def _kv_dequant_scales(layer) -> Tuple[float, float]:
+        """Per-tensor K/V scales for an FP8 pool (1.0 when the checkpoint ships none)."""
+
+        def scalar(name_float, name):
+            value = getattr(layer, name_float, None)
+            if value is None:
+                value = getattr(layer, name, None)
+            if value is None:
+                return 1.0
+            if isinstance(value, torch.Tensor):
+                return float(value.item()) if value.numel() == 1 else 1.0
+            return float(value)
+
+        return scalar("k_scale_float", "k_scale"), scalar("v_scale_float", "v_scale")
+
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)
         cached = self._trtllm_sparse_tables.get(key)
@@ -1454,11 +1470,14 @@ class QwenSparseAttnBackend(AttentionBackend):
             batch, pages_per_row, page, device
         )
         capacity_rows = self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
+        # Gather into the query dtype: an FP8 pool is dequantized on the way in, so the
+        # paged kernel always runs the bf16 q + bf16 KV path.
+        k_scale, v_scale = self._kv_dequant_scales(layer)
         packed_k, packed_v = self._get_fa2_scratch(
             max(capacity_rows, batch) * stride,
             k_buffer.shape[1],
             k_buffer.shape[2],
-            k_buffer.dtype,
+            q.dtype,
             k_buffer.device,
         )
         qwen_sparse_kv_extraction_compact_triton(
@@ -1478,6 +1497,8 @@ class QwenSparseAttnBackend(AttentionBackend):
             batch,
             topk,
             zero_fill_cols=stride,
+            k_scale=k_scale,
+            v_scale=v_scale,
         )
         num_kv_heads = k_buffer.shape[1]
         head_dim = k_buffer.shape[2]
@@ -1584,11 +1605,12 @@ class QwenSparseAttnBackend(AttentionBackend):
             if metadata.is_cuda_graph
             else batch * topk
         )
+        k_scale, v_scale = self._kv_dequant_scales(layer)
         packed_k, packed_v = self._get_fa2_scratch(
             scratch_capacity,
             k_buffer.shape[1],
             k_buffer.shape[2],
-            k_buffer.dtype,
+            q.dtype,
             k_buffer.device,
         )
         qwen_sparse_kv_extraction_compact_triton(
@@ -1607,6 +1629,8 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
+            k_scale=k_scale,
+            v_scale=v_scale,
         )
         output = flash_attn_varlen_func(
             q=q,

--- a/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
+++ b/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
@@ -7,6 +7,8 @@ multiply masked probabilities into stale NaN/Inf bytes. Also checks the compact
 (FA2 fallback) layout is unchanged. Intended for test/registered/kernel/qsa/.
 """
 
+import sys
+
 import pytest
 import torch
 
@@ -184,3 +186,7 @@ def test_strided_gather_addresses_pool_beyond_int32_elements():
     torch.testing.assert_close(packed_k[:300], k_pool[hi].to(torch.bfloat16))
     torch.testing.assert_close(packed_v[:300], v_pool[hi].to(torch.bfloat16))
     assert (packed_k[300:] == 0).all() and (packed_v[300:] == 0).all()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
+++ b/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
@@ -10,10 +10,13 @@ multiply masked probabilities into stale NaN/Inf bytes. Also checks the compact
 import pytest
 import torch
 
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
 from sglang.srt.layers.attention.qsa.sparse_attn import (
     qwen_sparse_fa2_cu_seqlens_triton,
     qwen_sparse_kv_extraction_compact_triton,
-    qwen_sparse_valid_counts_triton,
 )
 
 
@@ -47,7 +50,6 @@ def test_strided_gather_zero_fills_tail(dtype):
         indices[b, :n] = torch.arange(n, device=device, dtype=torch.int32)
     cu_strided = torch.arange(batch + 1, device=device, dtype=torch.int32) * stride
     # the scratch is always in the compute dtype (bf16); an FP8 pool is dequantized on the way in
-    k_scale, v_scale = (1.0, 1.0) if dtype == torch.bfloat16 else (0.5, 2.0)
     packed_k = torch.full(
         (batch * stride, heads, dim), float("nan"), device=device, dtype=torch.bfloat16
     )
@@ -66,8 +68,6 @@ def test_strided_gather_zero_fills_tail(dtype):
         batch,
         topk,
         zero_fill_cols=stride,
-        k_scale=k_scale,
-        v_scale=v_scale,
     )
     pk, pv = (
         packed_k.float().view(batch, stride, heads, dim),
@@ -77,12 +77,8 @@ def test_strided_gather_zero_fills_tail(dtype):
     for b in range(batch):
         n = min(int(seq_lens[b]), topk)
         slots = req_to_token[b, :n].long()
-        torch.testing.assert_close(
-            pk[b, :n], (k_pool[slots].float() * k_scale).to(torch.bfloat16).float()
-        )
-        torch.testing.assert_close(
-            pv[b, :n], (v_pool[slots].float() * v_scale).to(torch.bfloat16).float()
-        )
+        torch.testing.assert_close(pk[b, :n], k_pool[slots].to(torch.bfloat16).float())
+        torch.testing.assert_close(pv[b, :n], v_pool[slots].to(torch.bfloat16).float())
         assert (pk[b, n:] == 0).all() and (pv[b, n:] == 0).all()
 
 
@@ -139,8 +135,8 @@ def test_strided_gather_addresses_pool_beyond_int32_elements():
     """
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
-    if torch.cuda.get_device_properties(0).total_memory < 8 * 1024**3:
-        pytest.skip("needs ~4.5 GB of device memory")
+    if torch.cuda.get_device_properties(0).total_memory < 6 * 1024**3:
+        pytest.skip("needs ~2.5 GB of device memory")
     torch.manual_seed(0)
     device = torch.device("cuda")
     heads, dim = 2, 256

--- a/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
+++ b/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
@@ -46,9 +46,11 @@ def test_strided_gather_zero_fills_tail(dtype):
         n = min(int(seq_lens[b]), topk)
         indices[b, :n] = torch.arange(n, device=device, dtype=torch.int32)
     cu_strided = torch.arange(batch + 1, device=device, dtype=torch.int32) * stride
+    # the scratch is always in the compute dtype (bf16); an FP8 pool is dequantized on the way in
+    k_scale, v_scale = (1.0, 1.0) if dtype == torch.bfloat16 else (0.5, 2.0)
     packed_k = torch.full(
         (batch * stride, heads, dim), float("nan"), device=device, dtype=torch.bfloat16
-    ).to(dtype)
+    )
     packed_v = packed_k.clone()
 
     qwen_sparse_kv_extraction_compact_triton(
@@ -64,6 +66,8 @@ def test_strided_gather_zero_fills_tail(dtype):
         batch,
         topk,
         zero_fill_cols=stride,
+        k_scale=k_scale,
+        v_scale=v_scale,
     )
     pk, pv = (
         packed_k.float().view(batch, stride, heads, dim),
@@ -73,8 +77,12 @@ def test_strided_gather_zero_fills_tail(dtype):
     for b in range(batch):
         n = min(int(seq_lens[b]), topk)
         slots = req_to_token[b, :n].long()
-        torch.testing.assert_close(pk[b, :n], k_pool[slots].float())
-        torch.testing.assert_close(pv[b, :n], v_pool[slots].float())
+        torch.testing.assert_close(
+            pk[b, :n], (k_pool[slots].float() * k_scale).to(torch.bfloat16).float()
+        )
+        torch.testing.assert_close(
+            pv[b, :n], (v_pool[slots].float() * v_scale).to(torch.bfloat16).float()
+        )
         assert (pk[b, n:] == 0).all() and (pv[b, n:] == 0).all()
 
 

--- a/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
+++ b/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
@@ -129,3 +129,62 @@ def test_compact_gather_unchanged():
     torch.testing.assert_close(packed_k[300:350], k_pool[req_to_token[1, :50].long()])
     # compact layout leaves the region past the packed rows untouched (still NaN)
     assert torch.isnan(packed_k[350:]).all()
+
+
+def test_strided_gather_addresses_pool_beyond_int32_elements():
+    """Slots past 2^31 / (heads * dim) must be addressed with 64-bit offsets.
+
+    An FP8 KV pool on one GB300 holds ~7.6M tokens for Qwen3.8-Flash-Next (2 kv heads x 256),
+    so slot indices above 4,194,304 occur in production; int32 element offsets wrap there.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if torch.cuda.get_device_properties(0).total_memory < 8 * 1024**3:
+        pytest.skip("needs ~4.5 GB of device memory")
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    heads, dim = 2, 256
+    threshold = (1 << 31) // (heads * dim)  # 4,194,304
+    pool_rows = threshold + 4096
+    k_pool = torch.zeros(
+        pool_rows, heads, dim, device=device, dtype=torch.float8_e4m3fn
+    )
+    v_pool = torch.zeros(
+        pool_rows, heads, dim, device=device, dtype=torch.float8_e4m3fn
+    )
+    hi = torch.arange(threshold + 64, threshold + 64 + 300, device=device)
+    k_pool[hi] = torch.randn(300, heads, dim, device=device, dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    v_pool[hi] = torch.randn(300, heads, dim, device=device, dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    batch, topk, page = 1, 2051, 64
+    stride = ((topk + page - 1) // page) * page
+    seq_lens = torch.tensor([300], device=device, dtype=torch.int32)
+    req_to_token = torch.zeros(batch, 512, device=device, dtype=torch.int32)
+    req_to_token[0, :300] = hi.to(torch.int32)
+    indices = torch.full((batch, topk), -1, device=device, dtype=torch.int32)
+    indices[0, :300] = torch.arange(300, device=device, dtype=torch.int32)
+    cu_strided = torch.arange(batch + 1, device=device, dtype=torch.int32) * stride
+    packed_k = torch.full(
+        (batch * stride, heads, dim), float("nan"), device=device, dtype=torch.bfloat16
+    )
+    packed_v = packed_k.clone()
+    qwen_sparse_kv_extraction_compact_triton(
+        k_pool,
+        v_pool,
+        req_to_token,
+        torch.zeros(1, device=device, dtype=torch.int32),
+        indices,
+        seq_lens,
+        cu_strided,
+        packed_k,
+        packed_v,
+        batch,
+        topk,
+        zero_fill_cols=stride,
+    )
+    torch.testing.assert_close(packed_k[:300], k_pool[hi].to(torch.bfloat16))
+    torch.testing.assert_close(packed_v[:300], v_pool[hi].to(torch.bfloat16))
+    assert (packed_k[300:] == 0).all() and (packed_v[300:] == 0).all()

--- a/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
+++ b/test/registered/kernel/qsa/test_qsa_strided_zero_fill.py
@@ -1,0 +1,123 @@
+"""Regression test for the QSA strided sparse-decode scratch zero-fill.
+
+Poison the packed scratch with NaN, gather with the strided layout used by
+`_forward_trtllm_sparse`, and require that (a) valid rows are copied exactly and
+(b) every slot in [valid_count, stride) is zero, so the paged decode kernel can never
+multiply masked probabilities into stale NaN/Inf bytes. Also checks the compact
+(FA2 fallback) layout is unchanged. Intended for test/registered/kernel/qsa/.
+"""
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    qwen_sparse_fa2_cu_seqlens_triton,
+    qwen_sparse_kv_extraction_compact_triton,
+    qwen_sparse_valid_counts_triton,
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_strided_gather_zero_fills_tail(dtype):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, topk, page, heads, dim = 3, 2051, 64, 2, 256
+    pages_per_row = (topk + page - 1) // page
+    stride = pages_per_row * page
+    pool_rows = 8192
+    k_pool = torch.randn(pool_rows, heads, dim, device=device, dtype=torch.bfloat16).to(
+        dtype
+    )
+    v_pool = torch.randn(pool_rows, heads, dim, device=device, dtype=torch.bfloat16).to(
+        dtype
+    )
+    seq_lens = torch.tensor([733, 109, 2500], device=device, dtype=torch.int32)
+    req_to_token = (
+        torch.randperm(pool_rows, device=device)[: batch * 2600]
+        .reshape(batch, 2600)
+        .to(torch.int32)
+    )
+    req_indices = torch.arange(batch, device=device, dtype=torch.int32)
+    # top-k rows: the first min(seq_len, topk) logical positions, then -1 padding
+    indices = torch.full((batch, topk), -1, device=device, dtype=torch.int32)
+    for b in range(batch):
+        n = min(int(seq_lens[b]), topk)
+        indices[b, :n] = torch.arange(n, device=device, dtype=torch.int32)
+    cu_strided = torch.arange(batch + 1, device=device, dtype=torch.int32) * stride
+    packed_k = torch.full(
+        (batch * stride, heads, dim), float("nan"), device=device, dtype=torch.bfloat16
+    ).to(dtype)
+    packed_v = packed_k.clone()
+
+    qwen_sparse_kv_extraction_compact_triton(
+        k_pool,
+        v_pool,
+        req_to_token,
+        req_indices,
+        indices,
+        seq_lens,
+        cu_strided,
+        packed_k,
+        packed_v,
+        batch,
+        topk,
+        zero_fill_cols=stride,
+    )
+    pk, pv = (
+        packed_k.float().view(batch, stride, heads, dim),
+        packed_v.float().view(batch, stride, heads, dim),
+    )
+    assert torch.isfinite(pk).all() and torch.isfinite(pv).all()
+    for b in range(batch):
+        n = min(int(seq_lens[b]), topk)
+        slots = req_to_token[b, :n].long()
+        torch.testing.assert_close(pk[b, :n], k_pool[slots].float())
+        torch.testing.assert_close(pv[b, :n], v_pool[slots].float())
+        assert (pk[b, n:] == 0).all() and (pv[b, n:] == 0).all()
+
+
+def test_compact_gather_unchanged():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, topk, heads, dim = 2, 2051, 2, 256
+    k_pool = torch.randn(4096, heads, dim, device=device, dtype=torch.bfloat16)
+    v_pool = torch.randn(4096, heads, dim, device=device, dtype=torch.bfloat16)
+    seq_lens = torch.tensor([300, 50], device=device, dtype=torch.int32)
+    req_to_token = torch.arange(batch * 512, device=device, dtype=torch.int32).reshape(
+        batch, 512
+    )
+    req_indices = torch.arange(batch, device=device, dtype=torch.int32)
+    indices = torch.full((batch, topk), -1, device=device, dtype=torch.int32)
+    for b in range(batch):
+        indices[b, : int(seq_lens[b])] = torch.arange(
+            int(seq_lens[b]), device=device, dtype=torch.int32
+        )
+    counts = torch.empty(batch, device=device, dtype=torch.int32)
+    cu_k = torch.empty(batch + 1, device=device, dtype=torch.int32)
+    qwen_sparse_fa2_cu_seqlens_triton(seq_lens, indices, counts, cu_k, batch, topk)
+    assert cu_k.tolist() == [0, 300, 350]
+    packed_k = torch.full(
+        (batch * topk, heads, dim), float("nan"), device=device, dtype=torch.bfloat16
+    )
+    packed_v = packed_k.clone()
+    qwen_sparse_kv_extraction_compact_triton(
+        k_pool,
+        v_pool,
+        req_to_token,
+        req_indices,
+        indices,
+        seq_lens,
+        cu_k,
+        packed_k,
+        packed_v,
+        batch,
+        topk,
+    )
+    torch.testing.assert_close(packed_k[:300], k_pool[req_to_token[0, :300].long()])
+    torch.testing.assert_close(packed_k[300:350], k_pool[req_to_token[1, :50].long()])
+    # compact layout leaves the region past the packed rows untouched (still NaN)
+    assert torch.isnan(packed_k[350:]).all()


### PR DESCRIPTION
## Motivation

On GB300 (SM103), Qwen3.8-Flash-Next plain decode degenerates into an endless stream of token 0 (`!!!!…`) for a large fraction of long requests (40–60% of AIME25 samples at 32K `max_tokens`), and with `--kv-cache-dtype fp8_e4m3` the same happens on the MTP/NEXTN verify path (accept length collapses to 1.0, 86–88% of AIME/GPQA samples truncated). `--sampling-backend pytorch` instead dies with `CUDA error: device-side assert triggered`, i.e. the logits are non-finite.

Per-layer instrumentation puts the first non-finite value in the **attention output of the first QSA sparse layer** with finite q/k/v and correct top-k indices, and the NaNs follow a V-dimension pattern (specific head-dims for each kv-head group) – i.e. `P(=0) × V(garbage)`.

Direct evidence (instrumented eager run, no fix): at the first NaN event the poisoned request's K/V rows in the KV pool are all finite, while its packed-scratch slot has 73 NaN **V** rows in the unwritten tail `[729, 2112)` and no NaN in K or in the valid range – matching the V-dimension NaN pattern of the attention output.

Root cause: `QwenSparseAttnBackend._forward_trtllm_sparse` gathers the selected K/V rows into a `torch.empty` scratch laid out at page-aligned strides (2112 rows per request) and writes only the valid rows. The FlashInfer trtllm-gen paged decode kernel consumes whole pages and multiplies the masked probabilities into V, so any stale bytes in `[valid_count, stride)` that decode to NaN/Inf leak into the output. Once a request is poisoned it writes NaN K/V back into the same scratch slot, and later requests sharing that batch slot inherit the poison – which is why a long-running server ends up emitting `!` from the first decode token of every new request.

### Second root cause (FP8-only): int32 offset overflow in the same gather kernel

With the zero-fill in place, BF16 runs were clean but FP8 runs still collapsed server-wide ~18 minutes in, and in every case the collapse coincided with the first request approaching 64K generated tokens. `_compact_kv` forms the pool element offset as `slots * heads * dim` with int32 `slots` from `req_to_token`, so it wraps once the pool holds more than 2^31 / (heads·dim) tokens – 4,194,304 (= 65,536 pages) for Qwen3.8-Flash-Next's 2×256 KV heads. A BF16 pool on one GB300 has ~3.9M tokens and never reaches it; the FP8 pool has ~7.6M and does as soon as the page allocator's high-water mark passes 2^16 pages, after which the gather reads wrong addresses (garbage/NaN, or an illegal address beyond the pool – the `illegal memory access` previously reported for FP8 KV on GB300). The new regression test allocates a >2^22-row FP8 pool and fails with `CUDA error: an illegal memory access was encountered` on main.

## Modifications

- `_compact_kv` gains a `ZERO_FILL` mode: in the strided layout every slot in `[valid_count, stride)` is stored as zero in the same gather kernel (store mask covers the full row region, load mask stays limited to valid rows). The compact varlen-fallback layout is unchanged.
- `_forward_trtllm_sparse` passes `zero_fill_cols=stride`.
- `_compact_kv` computes `src`/`dst` element offsets in int64.
- The scratch is allocated in the query dtype and the gather dequantizes FP8 pool rows (× per-tensor k/v scale) on the way in, so the paged attention kernel always runs the bf16 q + bf16 KV path regardless of `--kv-cache-dtype` (top-k ≤ 2051 rows per query row, so the wider scratch is not measurable).
- New `test/registered/kernel/qsa/test_qsa_strided_zero_fill.py`: poisons the scratch with NaN and checks the strided layout is fully finite with exact (dequantized) valid rows for bf16 and fp8 pools, that the compact layout is untouched, and that slots beyond 2^22 are gathered correctly.

## Validation (1× GB300, TP1, `RadixArk/Qwen3.8-Flash-Next-NVFP4`, sgl-eval)

| Config | Before | After |
|---|---|---|
| BF16 KV, STP, AIME25 n=4 @32K | 40–48% samples runaway to token 0 | 0 NaN events, 0 runaway (remaining `length` finishes are coherent 32K reasoning) |
| FP8 KV, STP | 62–80% runaway | 0 |
| FP8 KV, NEXTN 3/1/4 | accept len 1.00–1.06, 86% runaway | accept len **2.32** (BF16: 2.40), 0 runaway |
| BF16 KV, AIME25 n=16 @65K | STP pass@1 0.354 (64% runaway) | MTP **0.946** / STP **0.933**, majority@16 1.0 |
| GSM8K 200 @64 | – | BF16 MTP 0.96, FP8 STP 0.97 |

Final four-arm comparison with all three commits (AIME25, 30 problems × 16 samples, `max_tokens` 65536, temperature 1.0 / top_p 0.95):

| Arm | pass@1 (±sem) | majority@16 | truncated | accept len |
|---|---:|---:|---:|---:|
| BF16 KV, no spec | 0.9396 ±0.0070 | 1.0 | 5.8% | – |
| FP8 KV, no spec | 0.9333 ±0.0061 | 0.9667 | 6.0% | – |
| BF16 KV, NEXTN 3/1/4 | 0.9437 ±0.0059 | 1.0 | 5.0% | 2.40 |
| FP8 KV, NEXTN 3/1/4 | 0.9417 ±0.0048 | 1.0 | 5.4% | 2.34 |

GPQA Diamond (198 questions × 8 samples, same settings):

| Arm | pass@1 (±sem) | majority@8 | truncated | accept len |
|---|---:|---:|---:|---:|
| BF16 KV, no spec | 0.8731 ±0.0034 | 0.9192 | 8.0% | – |
| FP8 KV, no spec | 0.8769 ±0.0046 | 0.9242 | 7.3% | – |
| BF16 KV, NEXTN 3/1/4 | 0.8807 ±0.0050 | 0.9217 | 6.8% | 2.31 |
| FP8 KV, NEXTN 3/1/4 | 0.8788 ±0.0051 | 0.9167 | 7.0% | 2.26 |

Before the fixes the FP8 NEXTN arms scored 0.142 (AIME25) / 0.111 (GPQA) with 86–88% of samples running away to token 0; FP8 KV now matches BF16 within one standard error on both benchmarks while doubling device KV capacity.

Note: FP8 KV on this model additionally needs #38855 (dequantize FP8 cached prefixes in the QSA Triton prefill kernels), otherwise the first cached-prefix continuation fails with `Unsupported rhs dtype fp8e4nv`.

## Review notes (round 1)

- **KV scales**: the QSA backend writes the pool without per-tensor k/v scales (both `set_kv_buffer` calls), so the gather now converts FP8 → bf16 without multiplying by a scale either; both sides are scale-free and this is documented in the kernel. Honoring checkpoint kv scales on this path needs the write side too (and `set_kv_buffer`'s in-place `div_` on `k` would then need care because the same `k` feeds the prefill attention afterwards), so that is left for a separate change. `_kv_dequant_scales` (and its `.item()` sync) is gone.
- **Cost of the gather changes** (Triton microbench on GB300, one layer, top-k 2051, page 64, 2×256 KV heads; `harness` = strided layout as used by `_forward_trtllm_sparse`):

  | batch | valid rows | pool | before | after (zero-fill + int64 + bf16 scratch) |
  |---:|---:|---|---:|---:|
  | 64 | 2051 | bf16 | 85.1 µs | 85.2 µs |
  | 64 | 2051 | fp8 | 50.6 µs | 74.8 µs |
  | 64 | 300 | bf16 | 23.8 µs | 49.9 µs |
  | 64 | 300 | fp8 | 22.2 µs | 47.9 µs |
  | 256 | 2051 | bf16 | 319.8 µs | 323.7 µs |
  | 256 | 2051 | fp8 | 181.0 µs | 279.3 µs |

  Worst case is ~+25 µs per layer (12 sparse layers → ~0.3 ms per decode step). At the service level, FP8-STP and BF16-STP in the same job decode at 4308 vs 4298 tok/s; the BF16-MTP arm moved 4077 → 4043 tok/s (−0.8%) between the unfixed and fixed runs. The zero-fill writes the full stride rather than a page-rounded tail because the exact tile extent the paged kernel touches past `seq_lens` is not part of its contract.
- **Why also gather into bf16**: with the two memory-safety fixes alone the FP8 path still runs the bf16-query/FP8-KV transform cubins, which had no prior validation on this model; converting on gather makes FP8 KV use exactly the kernel path every BF16 user exercises, at the cost above. An A/B with only the two memory-safety fixes is running; if it is clean the commit can be dropped from this PR on request.
- The docstring now states the valid-entries-first contract that `valid_count` relies on (`expand_qsa_block_indices` produces it).
- The >2^22-slot test shares one pool for K and V (~2.2 GB), is registered with `register_cuda_ci` on `1-gpu-large`.

## Accuracy Tests

`python3 -m pytest test/registered/kernel/qsa/test_qsa_strided_zero_fill.py test/registered/kernel/qsa/test_qsa.py` → 4 + 37 passed, 1 skipped on GB300 (the >2^22-slot case fails with an illegal memory access without the int64 fix).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our Slack channel if you have any questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34523163786](https://github.com/sgl-project/sglang/actions/runs/34523163786)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34523163466](https://github.com/sgl-project/sglang/actions/runs/34523163466)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34523163703](https://github.com/sgl-project/sglang/actions/runs/34523163703)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->




