### PR TITLE
[GLM-5.3-Flash] Restore opt-in in-graph verify metadata

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -75,7 +75,11 @@ def topk_transform_paged(
 _PLAN_METADATA_INTS_PER_BATCH = 2
 
 
-def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
+def plan_topk_v2(
+    seq_lens: torch.Tensor,
+    static_threshold: int = 0,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
     """Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
 
     IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE. The device
@@ -84,12 +88,19 @@ def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Ten
     the plan, and drives the transform kernel into an illegal memory access.
     Producers of padded rows must clamp their lengths to 0 (0 selects the
     trivial all-(-1) output path, which is safe).
+
+    Pass a preallocated ``out`` plan to refresh CUDA-graph metadata in place.
     """
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
-    metadata = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
-    module.topk_plan(seq_lens, metadata, static_threshold)
-    return metadata
+    if out is None:
+        out = seq_lens.new_empty(bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
+    else:
+        assert out.shape == (bs + 1, _PLAN_METADATA_INTS_PER_BATCH)
+        assert out.dtype == seq_lens.dtype and out.device == seq_lens.device
+        assert out.is_contiguous()
+    module.topk_plan(seq_lens, out, static_threshold)
+    return out
 
 
 def topk_transform_ragged_v2(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1546,6 +1546,7 @@ class Envs:
     )
     # Enabled for supported CUDA KPool geometry; set to 0 to use ordinary metadata.
     SGLANG_EXPERIMENTAL_DSA_KPOOL_METADATA_FUSION = EnvBool(True)
+    SGLANG_EXPERIMENTAL_DSA_INGRAPH_VERIFY_METADATA = EnvBool(False)
     SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC = EnvBool(False)
     SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK = EnvStr(None)
     SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD = EnvIntWithAlias(

--- a/python/sglang/srt/layers/attention/dsa/dsa_metadata_ingraph.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_metadata_ingraph.py
@@ -1,0 +1,236 @@
+"""Capture DSA target-verify metadata refreshes into the model CUDA graph."""
+
+from __future__ import annotations
+
+import logging
+from functools import cache
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_parallel, get_platform
+from sglang.srt.utils import is_cuda, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.attention.dsa_backend import DSAMetadata
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+if is_cuda():
+    import deep_gemm
+
+_is_hip = is_hip()
+logger = logging.getLogger(__name__)
+
+
+@cache
+def get_plan_topk_v2():
+    # Resolving the JIT module at srt import time would initialize CUDA too early.
+    from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
+
+    return plan_topk_v2
+
+
+class _DSAInGraphVerifyMetadataState:
+    """Captured refreshes require fixed input-buffer identities at replay.
+    Mismatches must fail because captured nodes would overwrite fallback metadata."""
+
+    __slots__ = (
+        "prefill_impl_state",
+        "_seq_lens_ptr",
+        "_seq_lens_stride",
+        "_req_pool_indices_ptr",
+        "_req_pool_indices_stride",
+    )
+
+    def __init__(
+        self,
+        *,
+        prefill_impl_state: Tuple[bool, str],
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+    ):
+        self.prefill_impl_state = prefill_impl_state
+        self._seq_lens_ptr = seq_lens.data_ptr()
+        self._seq_lens_stride = seq_lens.stride(0)
+        self._req_pool_indices_ptr = req_pool_indices.data_ptr()
+        self._req_pool_indices_stride = req_pool_indices.stride(0)
+
+    def matches(self, seq_lens: torch.Tensor, req_pool_indices: torch.Tensor) -> bool:
+        # A [:bs] slice keeps the base data_ptr/stride, so the raw incoming
+        # graph-runner buffers compare equal to the sliced views recorded at
+        # capture time.
+        return (
+            seq_lens.data_ptr() == self._seq_lens_ptr
+            and req_pool_indices.data_ptr() == self._req_pool_indices_ptr
+            and seq_lens.stride(0) == self._seq_lens_stride
+            and req_pool_indices.stride(0) == self._req_pool_indices_stride
+        )
+
+
+class DSAInGraphVerifyMetadataMixin:
+    ingraph_verify_metadata_enabled = False
+
+    def _init_ingraph_verify_metadata(self):
+        self.ingraph_verify_metadata_enabled = (
+            envs.SGLANG_EXPERIMENTAL_DSA_INGRAPH_VERIFY_METADATA.get()
+        )
+
+    def _replay_ingraph_verify_metadata(
+        self, metadata, seq_lens, req_pool_indices, forward_mode
+    ):
+        if not forward_mode.is_target_verify():
+            return False
+        state = getattr(metadata, "_ingraph_verify_metadata", None)
+        if state is None:
+            return False
+        if not state.matches(seq_lens, req_pool_indices):
+            raise RuntimeError(
+                "DSA in-graph verify metadata replay requires the static buffers "
+                "for seq_lens and req_pool_indices used during capture"
+            )
+        self.use_mha, self.dsa_prefill_impl = state.prefill_impl_state
+        self.forward_metadata = metadata
+        return True
+
+    def _ingraph_verify_metadata_eligible(self) -> bool:
+        """Config-level eligibility for the in-graph TARGET_VERIFY refresh.
+
+        The recorded nodes reproduce the fused verify sequence. Configurations
+        that would take the unfused fallback
+        (kpool > 1 without the fusion gate), DCP, HIP, or flashmla_kv (whose
+        per-replay metadata recompute is host-side) stay out-of-graph.
+        """
+        return (
+            self.ingraph_verify_metadata_enabled
+            and is_cuda()
+            and not _is_hip
+            and not get_parallel().dcp_enabled
+            and (self.dsa_index_kpool <= 1 or self.experimental_kpool_metadata_fusion)
+            and self.dsa_decode_impl != "flashmla_kv"
+        )
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        """Record target-verify refreshes only for capture-safe configurations.
+        Replay reads the same static input buffers with updated contents."""
+        if not forward_batch.forward_mode.is_target_verify():
+            return
+        if not self._ingraph_verify_metadata_eligible():
+            return
+        bs = forward_batch.batch_size
+        metadata = self.decode_cuda_graph_metadata.get(bs)
+        if metadata is None:
+            return
+        self._record_ingraph_verify_metadata(
+            metadata,
+            bs,
+            forward_batch.seq_lens[:bs],
+            forward_batch.req_pool_indices[:bs],
+        )
+
+    def _record_ingraph_verify_metadata(
+        self,
+        metadata: DSAMetadata,
+        bs: int,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+    ) -> None:
+        """Publish replay state only after every structural check passes.
+        Otherwise the generic out-of-graph path remains responsible."""
+        if metadata.paged_mqa_schedule_metadata is None:
+            return
+        next_n = self.speculative_num_draft_tokens
+        if not next_n:
+            return
+        expanded_size = bs * next_n
+        max_seqlen_k = self._graph_page_table_width(metadata)
+
+        paged_mqa_ctx_lens_2d = None
+        if (
+            next_n >= 2
+            and get_platform().is_sm100
+            and metadata.paged_mqa_ctx_lens_2d is not None
+            and metadata.paged_mqa_ctx_lens_2d.dim() == 2
+            and metadata.paged_mqa_ctx_lens_2d.size(0) == bs
+            and metadata.paged_mqa_ctx_lens_2d.size(1) == next_n
+        ):
+            paged_mqa_ctx_lens_2d = metadata.paged_mqa_ctx_lens_2d
+        ctx_lens_written = paged_mqa_ctx_lens_2d is not None
+
+        if ctx_lens_written:
+            # DG-native layout: the fused kernel writes ctx lens straight
+            # into the captured (bs, next_n) buffer; the schedule reads it.
+            schedule_src_2d = metadata.paged_mqa_ctx_lens_2d
+            ctx_lens_copy_src = None
+        else:
+            if (
+                next_n >= 2 and get_platform().is_sm100
+            ):  # Degenerate capture (DG-native ctx-lens layout expected but
+                # missing); keep the whole refresh out-of-graph.
+                return
+            seqlens_view = metadata.dsa_seqlens_expanded[:expanded_size]
+            if not seqlens_view.is_contiguous():
+                return
+            schedule_src_2d = seqlens_view.view(-1, 1)
+            if metadata.paged_mqa_ctx_lens_2d is None:
+                # Verify capture always materializes the 2D ctx-lens buffer;
+                # if missing, leave the object.__setattr__ publication to
+                # the generic path.
+                return
+            ctx_lens_copy_src = schedule_src_2d
+
+        self._fused_verify_metadata(
+            seq_lens=seq_lens,
+            req_pool_indices=req_pool_indices,
+            req_to_token=self.req_to_token,
+            cache_seqlens=metadata.cache_seqlens_int32,
+            cu_seqlens_k=metadata.cu_seqlens_k,
+            page_table_1=metadata.page_table_1,
+            seqlens_expanded=metadata.dsa_seqlens_expanded,
+            dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
+            dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
+            real_page_table=metadata.real_page_table,
+            bs=bs,
+            max_seqlen_k=max_seqlen_k,
+            dsa_index_topk=self.dsa_index_topk,
+            real_page_size=self.real_page_size,
+            next_n=next_n,
+            paged_mqa_ctx_lens_2d=paged_mqa_ctx_lens_2d,
+        )
+
+        metadata.paged_mqa_schedule_metadata.copy_(
+            deep_gemm.get_paged_mqa_logits_metadata(
+                schedule_src_2d, 64, deep_gemm.get_num_sms()
+            )
+        )
+        if ctx_lens_copy_src is not None:
+            metadata.paged_mqa_ctx_lens_2d.copy_(ctx_lens_copy_src)
+
+        if metadata.topk_v2_plan is not None:
+            # A preallocated output avoids allocation during capture.
+            get_plan_topk_v2()(metadata.dsa_seqlens_expanded, out=metadata.topk_v2_plan)
+
+        self._update_kpool_metadata_replay(
+            metadata,
+            seq_lens,
+            req_pool_indices,
+            ForwardMode.TARGET_VERIFY,
+        )
+
+        self.set_dsa_prefill_impl(forward_batch=None)
+        state = _DSAInGraphVerifyMetadataState(
+            prefill_impl_state=(self.use_mha, self.dsa_prefill_impl),
+            seq_lens=seq_lens,
+            req_pool_indices=req_pool_indices,
+        )
+        # Undeclared attribute on the frozen dataclass: dropped by both
+        # recapture (fresh DSAMetadata) and dataclasses.replace().
+        object.__setattr__(metadata, "_ingraph_verify_metadata", state)
+        logger.info(
+            "DSA in-graph verify metadata recorded: bs=%d next_n=%d "
+            "ctx_lens_written=%s",
+            bs,
+            next_n,
+            ctx_lens_written,
+        )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -58,6 +58,9 @@ from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (
     compute_cu_seqlens,
 )
 from sglang.srt.layers.attention.dsa.dsa_indexer_metadata import DSAIndexerMetadata
+from sglang.srt.layers.attention.dsa.dsa_metadata_ingraph import (
+    DSAInGraphVerifyMetadataMixin,
+)
 from sglang.srt.layers.attention.dsa.dsa_metadata_manager import (
     DSAMetadataManagementMixin,
 )
@@ -297,6 +300,7 @@ _DSA_IMPL_T: TypeAlias = Literal[
 
 class DeepseekSparseAttnBackend(
     DSAMetadataManagementMixin,
+    DSAInGraphVerifyMetadataMixin,
     DeepseekSparseAttnBackendKPoolMixin,
     DeepseekSparseAttnBackendMTPPrecomputeMixin,
     AttentionBackend,
@@ -336,6 +340,7 @@ class DeepseekSparseAttnBackend(
         self.dsa_index_kpool = get_dsa_index_kpool(hf_config)
         self.needs_cpu_seq_lens = self.dsa_index_kpool > 1
         self._init_kpool_metadata_fusion()
+        self._init_ingraph_verify_metadata()
         self.max_context_len = model_runner.model_config.context_len
         self.num_q_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
@@ -814,6 +819,10 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
+        if in_capture:
+            metadata = self.decode_cuda_graph_metadata.get(forward_batch.batch_size)
+            if metadata is not None and hasattr(metadata, "_ingraph_verify_metadata"):
+                object.__delattr__(metadata, "_ingraph_verify_metadata")
         seq_lens_cpu = (
             forward_batch.seq_lens.cpu() if in_capture else forward_batch.seq_lens_cpu
         )
@@ -1507,6 +1516,10 @@ class DeepseekSparseAttnBackend(
 
         metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
 
+        if self._replay_ingraph_verify_metadata(
+            metadata, seq_lens, req_pool_indices, forward_mode
+        ):
+            return
         self.set_dsa_prefill_impl(forward_batch=None)
 
         seq_lens = seq_lens[:bs]

--- a/python/sglang/test/kits/dsa_metadata_kit.py
+++ b/python/sglang/test/kits/dsa_metadata_kit.py
@@ -26,14 +26,14 @@ def inputs(lengths, requests):
     )
 
 
-def make_backend(mode, seq, req, *, fusion=True):
+def make_backend(mode, seq, req, *, fusion=True, pool_size=POOL):
     backend = object.__new__(DeepseekSparseAttnBackend)
     backend.device = torch.device("cuda")
     backend.device_sm_major = torch.cuda.get_device_capability()[0]
     backend.num_q_heads = 64
     backend.real_page_size = 64
     backend.dsa_index_topk = TOPK
-    backend.dsa_index_kpool = POOL
+    backend.dsa_index_kpool = pool_size
     backend.speculative_num_draft_tokens = NEXT_N
     backend.dsa_drop_wide_page_table = False
     backend.dsa_decode_impl = "fa3"

--- a/test/registered/kernel/attention/test_dsa_ingraph_metadata.py
+++ b/test/registered/kernel/attention/test_dsa_ingraph_metadata.py
@@ -1,0 +1,125 @@
+"""Captured TARGET_VERIFY metadata follows the graph runner's static inputs."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.dsa_metadata_kit import (
+    BS,
+    POOL,
+    ROUNDS,
+    addresses,
+    apply_metadata,
+    assert_metadata_equal,
+    capture_verify_metadata,
+    inputs,
+    make_backend,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class TestDSAInGraphMetadata(CustomTestCase):
+    def test_captured_verify_refreshes_all_derived_buffers(self):
+        self._check_captured_verify_refresh(pool_size=POOL)
+
+    def test_captured_verify_without_kpool(self):
+        self._check_captured_verify_refresh(pool_size=1)
+
+    def _check_captured_verify_refresh(self, pool_size):
+        mode = ForwardMode.TARGET_VERIFY
+        seq, req = inputs(*ROUNDS[0])
+        backend = make_backend(
+            mode, seq, req, fusion=pool_size > 1, pool_size=pool_size
+        )
+        ordinary = make_backend(mode, seq, req, fusion=False, pool_size=pool_size)
+        if pool_size == 1:
+            self.assertFalse(backend.experimental_kpool_metadata_fusion)
+            self.assertIsNone(backend.forward_metadata.kpool_write_plan)
+        pointers = addresses(backend.forward_metadata)
+        graph = capture_verify_metadata(backend, seq, req)
+        self.assertIsNotNone(
+            getattr(backend.forward_metadata, "_ingraph_verify_metadata", None),
+            "the verify hook must install captured replay state",
+        )
+        for lengths, requests in ROUNDS[1:]:
+            seq.copy_(torch.tensor(lengths, device="cuda"))
+            req.copy_(torch.tensor(requests, device="cuda"))
+            # Eager replay must leave captured metadata refresh to the graph.
+            before = backend.forward_metadata.dsa_seqlens_expanded.clone()
+            apply_metadata(backend, mode, seq, req)
+            torch.testing.assert_close(
+                backend.forward_metadata.dsa_seqlens_expanded, before
+            )
+            graph.replay()
+            apply_metadata(ordinary, mode, seq, req)
+            assert_metadata_equal(
+                self, backend.forward_metadata, ordinary.forward_metadata
+            )
+            self.assertEqual(pointers, addresses(backend.forward_metadata))
+
+    def test_recapture_replaces_static_input_identities(self):
+        mode = ForwardMode.TARGET_VERIFY
+        old_seq, old_req = inputs(*ROUNDS[0])
+        backend = make_backend(mode, old_seq, old_req)
+        old_graph = capture_verify_metadata(backend, old_seq, old_req)
+        old_graph.replay()
+        old_state = getattr(backend.forward_metadata, "_ingraph_verify_metadata", None)
+        self.assertIsNotNone(old_state)
+
+        seq, req = inputs(*ROUNDS[1])
+        batch = SimpleNamespace(
+            batch_size=BS,
+            forward_mode=mode,
+            seq_lens=seq,
+            req_pool_indices=req,
+            spec_info=None,
+            out_cache_loc=None,
+        )
+        # The public capture preparation must retire the previous alias guard
+        # before refreshing metadata from a new graph runner's buffers.
+        backend.init_forward_metadata_out_graph(batch, in_capture=True)
+        self.assertIsNone(
+            getattr(backend.forward_metadata, "_ingraph_verify_metadata", None)
+        )
+        graph = capture_verify_metadata(backend, seq, req)
+        state = getattr(backend.forward_metadata, "_ingraph_verify_metadata", None)
+        self.assertIsNotNone(state)
+        self.assertIsNot(state, old_state)
+        pointers = addresses(backend.forward_metadata)
+        ordinary = make_backend(mode, seq, req, fusion=False)
+
+        lengths, requests = ROUNDS[2]
+        seq.copy_(torch.tensor(lengths, device="cuda"))
+        req.copy_(torch.tensor(requests, device="cuda"))
+        apply_metadata(backend, mode, seq, req)
+        graph.replay()
+        apply_metadata(ordinary, mode, seq, req)
+        assert_metadata_equal(self, backend.forward_metadata, ordinary.forward_metadata)
+        self.assertEqual(pointers, addresses(backend.forward_metadata))
+        with self.assertRaisesRegex(RuntimeError, "alias|static buffers"):
+            apply_metadata(backend, mode, old_seq, old_req)
+
+    def test_replay_rejects_replaced_input_buffers(self):
+        mode = ForwardMode.TARGET_VERIFY
+        seq, req = inputs(*ROUNDS[0])
+        backend = make_backend(mode, seq, req)
+        graph = capture_verify_metadata(backend, seq, req)
+        self.assertIsNotNone(
+            getattr(backend.forward_metadata, "_ingraph_verify_metadata", None)
+        )
+        for bad_seq, bad_req in ((seq.clone(), req), (seq, req.clone())):
+            with self.subTest(seq_replaced=bad_seq is not seq):
+                with self.assertRaisesRegex(RuntimeError, "alias|static buffers"):
+                    apply_metadata(backend, mode, bad_seq, bad_req)
+        # Views with the same pointer, shape and stride remain valid.
+        apply_metadata(backend, mode, seq[:], req[:])
+        graph.replay()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Restore `SGLANG_EXPERIMENTAL_DSA_INGRAPH_VERIFY_METADATA=1`, removed by #38071. With KPool fusion enabled, target verification can refresh its metadata inside the model CUDA graph instead of launching that sequence eagerly before each replay.

Builds on [PR #38845](https://github.com/sgl-project/sglang/pull/38845), now merged into `main`. KPool metadata fusion is enabled by default for supported CUDA geometry; this PR adds the separate, default-off in-graph verify flag.

The follow-up DeepGEMM option is [PR #38858](https://github.com/sgl-project/sglang/pull/38858). This PR is rebased onto `main` at `a66451c058dcce0799f5c6d1620b527371db4828` and targets `main`; its diff contains only the in-graph optimization.

## Modifications

- Keep eligibility, capture, replay and recorded state in the dedicated `dsa_metadata_ingraph.py` mixin; the backend contains only initialization and lifecycle hooks.
- Capture the fused verify metadata, DeepGEMM schedules, top-k plan and KPool write-plan refreshes. Preserve destination addresses and the captured static input identities.
- Reject replay with replaced input buffers; clear recorded state on recapture. Unsupported configurations retain the ordinary path.
- Restore an optional preallocated output for `plan_topk_v2`, with shape/dtype/device/layout validation.
- Add GPU coverage for updated sequence lengths and request mappings, non-KPool operation, input identity checks and recapture.

## Accuracy Tests

Rebased head: `3b8b48279969253e2d0fad43109328b94e766f6d`. The rebase preserves main's consolidated `DSAMetadataManagementMixin` and default-on KPool fusion, while retaining the default-off in-graph flag. Changed-file pre-commit checks and `git diff --check` pass. The B200 correctness and benchmark results below are the preserved pre-rebase measurements; GPU tests were not rerun for this rebase.

**Draft: the unchanged full-model accuracy gate did not pass.** On `baizhou-dev-b200` (4× B200), commit `65ec643b4707d13200edd7474445cf60fa2f1271` with both restoration flags enabled:

```bash
SGLANG_EXPERIMENTAL_DSA_KPOOL_METADATA_FUSION=1 \
SGLANG_EXPERIMENTAL_DSA_INGRAPH_VERIFY_METADATA=1 PYTHONPATH=python \
  python test/registered/e2e/models/test_glm53_flash_b200.py -v
# Ran 4 tests in 687.185 s: FAILED (errors=1)
```

The test file, 500 GSM8K examples, 20 shots and 0.930 floor are unchanged. The test wrapper reports the failing accuracy assertion as an error.

| Recipe | This PR GSM8K | Result |
| --- | ---: | --- |
| DFlash2 | 0.936 | Pass |
| HighThroughput | 0.944 | Pass |
| LowLatency | 0.926 | **Fail: below 0.930** |

The LowLatency speed/acceptance test passes: **353.51 tok/s**, **4.605 accept length** (gates: >250 tok/s and >4.0). The in-graph verify path is active in the real model logs.

Focused in-graph GPU regressions pass **4/4**:

```bash
PYTHONPATH=python python test/registered/kernel/attention/test_dsa_ingraph_metadata.py
```

Unmodified main also failed the LowLatency accuracy floor: **0.928** initially and **0.920** in one controlled repeat. The parent KPool PR passed its full run (LowLatency **0.936**). Baseline variability does not establish that this change is harmless. All original results and thresholds are retained. One controlled repeat of the unchanged LowLatency class passed **2/2** in **290.203 s**: GSM8K **0.936**, speed **350.79 tok/s**, accept length **4.422**. Run the same command above with `TestGLM53FlashB200LowLatency` appended to select that class. The initial **0.926** failure remains part of the evidence. This PR stays draft because the intermittent full-model accuracy failure remains unexplained; a passing repeat does not resolve its cause.

An additional real-GPU metadata diagnostic passed **16 configurations × 17 rounds = 272 graph replays**: bs=1/4/16/48, draft lengths 2/4/6/8, changing sequence lengths across pool/page/top-k boundaries through 100001 tokens, and remapped requests. It interleaves live graphs and compares ordinary versus optimized metadata and stable destination addresses. This isolates metadata construction; it is not a substitute for the full-model accuracy gate. The script, exact heads/flags and logs are in the evidence link below.

## Speed Tests and Profiling

Same four B200 GPUs on `baizhou-dev-b200`, TP4/EP4, CUDA 13.0, driver 580.173.02, PyTorch 2.13.0+cu130, Triton 3.7.1, DeepGEMM 0.1.7 and FlashInfer 0.6.18. The fixed main baseline is `9a2f17f41d185614a17f740c006c4aca84c016bf`.

Model revisions: `zai-org/GLM-5.3-Flash@eb9eb208eb0d988989d07a6a12d0fdeb5f52574a` and `incoai/GLM-5.3-Flash-DFlash2@bf582e4eacc1810f76656d1811693ff6c6737d2a`. Every weight shard was SHA256-verified.

Serving benchmarks use the test file's LowLatency EAGLE recipe, with radix caching disabled consistently for measurement. `bs` means `--max-concurrency`; each run sends `4 * bs` requests under that concurrency limit. Inputs are exactly 8192 token IDs, outputs exactly 1024 tokens, seed 42, temperature 0, one warmup request and a cache flush. EOS is ignored by the current CLI default. Each cell has three runs; throughput is the median of the three run-level rates, and latency is the median of the three run means; throughput ranges are retained. All measured requests completed with the expected token counts.

| bs | Main tok/s | Parent PR tok/s | This PR tok/s (min–max) | Speedup vs parent | Speedup vs main |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 511.93 | 537.30 | 523.69 (516.19–527.25) | 0.975× | 1.023× |
| 4 | 1319.90 | 1366.22 | 1354.75 (1351.42–1369.60) | 0.992× | 1.026× |
| 16 | 2100.45 | 2178.85 | 2159.02 (2152.35–2164.28) | 0.991× | 1.028× |

**This workload shows no incremental throughput gain over the parent PR:** the measured median throughput is lower by 2.5%, 0.8% and 0.9% at bs=1/4/16. The cumulative results remain above the fixed main baseline.

Latency medians for this PR:

| bs | Mean TTFT (ms) | Mean TPOT (ms) | Mean E2E (ms) |
| ---: | ---: | ---: | ---: |
| 1 | 262.041 | 1.633 | 1944.816 |
| 4 | 481.251 | 2.403 | 2958.062 |
| 16 | 2024.215 | 5.320 | 7466.935 |

Reproduce from this PR's checkout (other restored flags unset):

```bash
export PYTHONPATH=python
export SGLANG_EXPERIMENTAL_DSA_KPOOL_METADATA_FUSION=1
export SGLANG_EXPERIMENTAL_DSA_INGRAPH_VERIFY_METADATA=1

python -m sglang.launch_server --model-path zai-org/GLM-5.3-Flash --tp-size 4 --ep-size 4 --dsa-prefill-backend trtllm --dsa-decode-backend trtllm --kv-cache-dtype fp8_e4m3 --moe-runner-backend deep_gemm --reasoning-parser glm45 --tool-call-parser glm47 --speculative-algorithm EAGLE --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 6 --speculative-adaptive --disable-radix-cache --host 127.0.0.1 --port 31080
```

In another shell after the server is ready:

```bash
export PYTHONPATH=python
for rep in 1 2 3; do
  for bs in 1 4 16; do
    python -m sglang.bench_serving --backend sglang \
      --base-url http://127.0.0.1:31080 --model zai-org/GLM-5.3-Flash \
      --dataset-name random --num-prompts "$((4 * bs))" --max-concurrency "$bs" \
      --random-input-len 8192 --random-output-len 1024 --random-range-ratio 1 \
      --seed 42 --tokenize-prompt --warmup-requests 1 --flush-cache \
      --output-file "bs${bs}-rep${rep}.jsonl"
  done
done
```

[Raw run-level measurements, accuracy records and a standalone recomputation script](https://gist.github.com/Fridge003/5daf4717ddc08a9ce5cf194140e7594b) are available together.

## Checklist

- [x] Changed-file pre-commit checks pass.
- [x] GPU regression tests are registered in `base-b-kernel-unit`.
- [x] Feature behavior and activation are documented above.
- [x] Full-model correctness and serving benchmark results are recorded.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34724482723](https://github.com/sgl-project/sglang/actions/runs/34724482723)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34724482748](https://github.com/sgl-project/sglang/actions/runs/34724482748)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34724482716](https://github.com/sgl-project/sglang/actions/runs/34724482716)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->