### PR TITLE
Fixed mla pp prefill + non-pp decode disagg

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -986,11 +986,17 @@ class CommonKVManager(BaseKVManager):
             )
 
         # Regular MLA PP slicing
-        start_layer = self.kv_args.prefill_start_layer
-        end_layer = start_layer + len(src_kv_ptrs)
         # Decode pp size should be equal to prefill pp size or 1
+        start_layer, end_layer = self._mla_kv_entry_span_with_pp(len(src_kv_ptrs))
         sliced_dst_kv_ptrs = dst_kv_ptrs[start_layer:end_layer]
         return src_kv_ptrs, sliced_dst_kv_ptrs, len(src_kv_ptrs)
+
+    def _mla_kv_entry_span_with_pp(self, n_src: int) -> Tuple[int, int]:
+        # A plain MLA pool registers one region per layer ascending, addressed as
+        # layer_id - start_layer, so this stage occupies [start, start + n_src) of a
+        # peer that registered the whole model. Pointer view: get_mla_kv_ptrs_with_pp.
+        start_layer = self.kv_args.prefill_start_layer
+        return start_layer, start_layer + n_src
 
     def _mla_slice_ptrs_for_pp(
         self,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -962,6 +962,43 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             )
         peer_info.kv_xfer_segments = prepared_segments
 
+    def _pp_layer_offset_dst_indices(
+        self, *, peer_info: KVArgsRegisterInfo, n_src: int, n_dst: int
+    ) -> Optional[List[int]]:
+        # Index view of _mla_kv_entry_span_with_pp: the prepped path pre-registers
+        # descriptor lists, so it needs entry indices where the non-prepped path takes
+        # sliced pointers. None keeps the caller on its layer-id pairing.
+        if self.pp_size <= 1 or n_src == n_dst:
+            return None
+        if self.kv_args.kv_layer_ids or peer_info.dst_kv_layer_ids:
+            return None
+        # Only a plain MLA pool is one region per layer: MHA registers a K block then a
+        # V block, the hybrid pool is dense over full-attention layers, and compressed
+        # MLA groups regions by compression bucket.
+        if not self.is_mla_backend or self.is_hybrid_mla_backend:
+            return None
+        if self.kv_args.mla_compression_ratios:
+            return None
+
+        start, end = self._mla_kv_entry_span_with_pp(n_src)
+        # Bootstrap admits a peer running our pp or 1, so a peer that does not cover the
+        # span is a matched-pp stage above 0, whose entries start at its own index 0.
+        if end > n_dst:
+            return None
+
+        indices = list(range(start, end))
+        src_item_lens = list(self.kv_args.kv_item_lens)
+        dst_item_lens = [peer_info.dst_kv_item_lens[j] for j in indices]
+        if src_item_lens != dst_item_lens:
+            # Disagreeing cell sizes mean the peers did not build the same KV geometry;
+            # writing anyway would silently corrupt the peer's pool.
+            raise RuntimeError(
+                "PP-heterogeneous MLA transfer: decode KV cell geometry differs from "
+                f"prefill over layers [{start}, {end}): prefill item_lens="
+                f"{src_item_lens}, decode item_lens={dst_item_lens}"
+            )
+        return indices
+
     def _prepare_payload_xfer(self, peer_info: KVArgsRegisterInfo):
         # If prefill does not run speculative decoding (the usual case),
         # decode with speculative decoding will have more kv items.
@@ -1045,14 +1082,18 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 else self._num_slots_src
             )
 
-            pairs = build_transfer_entry_pairs(
-                self.kv_args.kv_layer_ids,
-                peer_info.dst_kv_layer_ids,
-                n_src,
-                n_dst,
-                allow_positional_fallback=self.pp_size == 1,
+            dst_indices = self._pp_layer_offset_dst_indices(
+                peer_info=peer_info, n_src=n_src, n_dst=n_dst
             )
-            dst_indices = [j for _, j in pairs]
+            if dst_indices is None:
+                pairs = build_transfer_entry_pairs(
+                    self.kv_args.kv_layer_ids,
+                    peer_info.dst_kv_layer_ids,
+                    n_src,
+                    n_dst,
+                    allow_positional_fallback=self.pp_size == 1,
+                )
+                dst_indices = [j for _, j in pairs]
             dst_kv_ptrs = [peer_info.dst_kv_ptrs[j] for j in dst_indices]
             dst_kv_item_lens = [peer_info.dst_kv_item_lens[j] for j in dst_indices]
             dst_kv_data_lens = [

--- a/test/registered/unit/disaggregation/test_pp_mla_kv_transfer.py
+++ b/test/registered/unit/disaggregation/test_pp_mla_kv_transfer.py
@@ -1,0 +1,258 @@
+"""Unit tests for NIXL KV transfer from a prefill with pp_size > 1 to a decode
+peer that is not pipelined, on plain-MLA models (MLATokenToKVPool)."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+NUM_LAYERS = 78
+ITEM_LEN = 576
+
+
+def _pp_layer_split(total: int, pp: int) -> list:
+    """(start_layer, num_layers) per PP rank, remainder to the last ranks."""
+    base, rem = divmod(total, pp)
+    out, start = [], 0
+    for rank in range(pp):
+        num = base + (1 if rank >= pp - rem else 0)
+        out.append((start, num))
+        start += num
+    return out
+
+
+class _StubKVManager:
+    """Carries the real span primitive, so the cases exercise the shared mapping
+    rather than a reimplementation of it."""
+
+    _mla_kv_entry_span_with_pp = CommonKVManager._mla_kv_entry_span_with_pp
+    get_mla_kv_ptrs_with_pp = CommonKVManager.get_mla_kv_ptrs_with_pp
+
+    def __init__(
+        self,
+        *,
+        pp_size: int,
+        prefill_start_layer: int,
+        n_src: int,
+        is_mla_backend: bool = True,
+        is_hybrid_mla_backend: bool = False,
+        kv_layer_ids: list = (),
+        mla_compression_ratios=None,
+        item_len: int = ITEM_LEN,
+    ):
+        self.pp_size = pp_size
+        self.is_mla_backend = is_mla_backend
+        self.is_hybrid_mla_backend = is_hybrid_mla_backend
+        self.kv_args = SimpleNamespace(
+            prefill_start_layer=prefill_start_layer,
+            kv_layer_ids=list(kv_layer_ids),
+            kv_item_lens=[item_len] * n_src,
+            mla_compression_ratios=mla_compression_ratios,
+        )
+
+
+def _peer(*, n_dst: int, dst_kv_layer_ids: list = (), item_len: int = ITEM_LEN):
+    return SimpleNamespace(
+        dst_kv_layer_ids=list(dst_kv_layer_ids),
+        dst_kv_item_lens=[item_len] * n_dst,
+    )
+
+
+def _resolve(manager, peer, n_src, n_dst):
+    return NixlKVManager._pp_layer_offset_dst_indices(
+        manager, peer_info=peer, n_src=n_src, n_dst=n_dst
+    )
+
+
+class TestPpPrefillToUnpipelinedDecode(CustomTestCase):
+    """Bug regression: a pp>1 prefill paired with a pp=1 decode never transferred
+    KV on NIXL, and failed after /health was green so the request hung rather
+    than the launch failing. Each stage must write into its own layer range of
+    the peer's pool."""
+
+    def test_stages_tile_the_decode_pool_exactly_once(self):
+        covered = []
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                indices = _resolve(
+                    _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                    _peer(n_dst=NUM_LAYERS),
+                    num,
+                    NUM_LAYERS,
+                )
+                self.assertEqual(indices, list(range(start, start + num)))
+                covered += indices
+        self.assertEqual(sorted(covered), list(range(NUM_LAYERS)))
+        self.assertEqual(len(covered), len(set(covered)))
+
+    def test_decode_side_draft_regions_are_never_targeted(self):
+        """Decode-only speculative decoding appends draft buffers after the
+        target's, so the span must stay inside the target layer range."""
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[3]
+        indices = _resolve(
+            _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+            _peer(n_dst=NUM_LAYERS + 1),
+            num,
+            NUM_LAYERS + 1,
+        )
+        self.assertEqual(indices, list(range(start, start + num)))
+        self.assertNotIn(NUM_LAYERS, indices)
+
+    def test_cell_geometry_disagreement_raises(self):
+        """A per-layer item_len mismatch means the peers did not build the same
+        KV geometry, which must fail loudly instead of corrupting the pool."""
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[3]
+        with self.assertRaisesRegex(RuntimeError, "geometry differs"):
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=NUM_LAYERS, item_len=ITEM_LEN + 80),
+                num,
+                NUM_LAYERS,
+            )
+
+
+class TestExistingPairingIsUnchanged(CustomTestCase):
+    """Derived property: the span is reachable only from the geometry the layer-id
+    pairing cannot express. Every other deployment must fall through to
+    build_transfer_entry_pairs, which the resolver signals with None."""
+
+    def test_unpipelined_prefill_defers(self):
+        for n_dst in (NUM_LAYERS, NUM_LAYERS + 1):
+            with self.subTest(n_dst=n_dst):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(
+                            pp_size=1, prefill_start_layer=0, n_src=NUM_LAYERS
+                        ),
+                        _peer(n_dst=n_dst),
+                        NUM_LAYERS,
+                        n_dst,
+                    )
+                )
+
+    def test_matched_pp_defers(self):
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                        _peer(n_dst=num),
+                        num,
+                        num,
+                    )
+                )
+
+    def test_published_layer_ids_defer(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[2]
+        self.assertIsNone(
+            _resolve(
+                _StubKVManager(
+                    pp_size=4,
+                    prefill_start_layer=start,
+                    n_src=num,
+                    kv_layer_ids=range(start, start + num),
+                ),
+                _peer(n_dst=NUM_LAYERS),
+                num,
+                NUM_LAYERS,
+            )
+        )
+        self.assertIsNone(
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=NUM_LAYERS, dst_kv_layer_ids=range(NUM_LAYERS)),
+                num,
+                NUM_LAYERS,
+            )
+        )
+
+    def test_pools_that_are_not_one_region_per_layer_defer(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[2]
+        for label, kwargs, n_dst in (
+            ("mha", {"is_mla_backend": False}, 2 * NUM_LAYERS),
+            ("hybrid_mla", {"is_hybrid_mla_backend": True}, NUM_LAYERS),
+            (
+                "compressed_mla",
+                {"mla_compression_ratios": [4] * NUM_LAYERS},
+                2 * NUM_LAYERS,
+            ),
+        ):
+            with self.subTest(pool=label):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(
+                            pp_size=4,
+                            prefill_start_layer=start,
+                            n_src=num,
+                            **kwargs,
+                        ),
+                        _peer(n_dst=n_dst),
+                        num,
+                        n_dst,
+                    )
+                )
+
+
+class TestMatchedPpWithDraftRegions(CustomTestCase):
+    """Derived property: bootstrap admits a peer at our pp or at 1, so under
+    matched pp a decode-side draft buffer makes n_src != n_dst and reaches the
+    span. Stage 0 degenerates to the identity and stays correct; every stage
+    above it must be rejected by the bound rather than writing at an offset the
+    peer does not have."""
+
+    def test_rank0_identity_span_stays_correct(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[0]
+        self.assertEqual(start, 0)
+        self.assertEqual(
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=num + 1),
+                num,
+                num + 1,
+            ),
+            list(range(num)),
+        )
+
+    def test_later_ranks_are_rejected(self):
+        for start, num in _pp_layer_split(NUM_LAYERS, 4)[1:]:
+            with self.subTest(start_layer=start):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                        _peer(n_dst=num + 1),
+                        num,
+                        num + 1,
+                    )
+                )
+
+
+class TestPointerAndIndexViewsAgree(CustomTestCase):
+    """Derived property: get_mla_kv_ptrs_with_pp (pointer view) and
+    _pp_layer_offset_dst_indices (index view) read the same span, so a change to
+    one must not silently diverge from the other."""
+
+    def test_views_select_the_same_destination_entries(self):
+        dst_ptrs = [9000 + i for i in range(NUM_LAYERS)]
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                manager = _StubKVManager(
+                    pp_size=4, prefill_start_layer=start, n_src=num
+                )
+                src_ptrs = [1000 + i for i in range(num)]
+
+                _, sliced_dst, count = manager.get_mla_kv_ptrs_with_pp(
+                    src_ptrs, dst_ptrs
+                )
+                indices = _resolve(manager, _peer(n_dst=NUM_LAYERS), num, NUM_LAYERS)
+
+                self.assertEqual(count, num)
+                self.assertEqual(sliced_dst, [dst_ptrs[j] for j in indices])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Running any kind of MLA with pp>1 prefill + pp=1 decode will result in error
```
    File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/nixl/conn.py", line 2842, in bootstrap_thread
      self._add_remote_peer(
    File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/nixl/conn.py", line 1488, in _add_remote_peer
      self._prepare_payload_xfer(decode_kv_args)
    File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/nixl/conn.py", line 1048, in _prepare_payload_xfer
      pairs = build_transfer_entry_pairs(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/utils.py", line 940, in build_transfer_entry_pairs
      raise RuntimeError(
  RuntimeError: PP-heterogeneous transfer requires layer ids on both peers; got src=20 dst=78 entries
```
Because currently kv-transfer for MLA isn't aware of PP at all.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Add the correct indices mapping for MLA+PP, no-op on other cases.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34461664447](https://github.com/sgl-project/sglang/actions/runs/34461664447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34461664154](https://github.com/sgl-project/sglang/actions/runs/34461664154)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34461664390](https://github.com/sgl-project/sglang/actions/runs/34461664390)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->