### PR TITLE
fix(qsa): dequantize FP8 cached prefixes in the sparse prefill kernels

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -243,6 +243,13 @@ def _sparse_gqa_chunk_prefill(
             mask=valid[:, None],
             other=0.0,
         )
+        # The chunk-prefill K/V tensors are gathered from the KV pool and can
+        # therefore carry the FP8 storage dtype, which Triton's dot rejects
+        # (`Unsupported rhs dtype fp8e4nv`). Convert to Q's dtype; the QSA
+        # backend writes the pool without per-tensor k/v scales, so this is a
+        # plain cast (no-op for BF16 pools).
+        keys = keys.to(q_values.dtype)
+        values = values.to(q_values.dtype)
         scores = tl.where(valid[None, :], tl.dot(q_values, keys), -float("inf"))
         next_max = tl.maximum(max_value, tl.max(scores, 1))
         alpha = tl.math.exp2(max_value - next_max)

--- a/test/registered/kernel/qsa/test_qsa.py
+++ b/test/registered/kernel/qsa/test_qsa.py
@@ -28,6 +28,7 @@ from sglang.srt.layers.attention.qsa.qsa_indexer import QSAIndexer
 from sglang.srt.layers.attention.qsa.sparse_attn import (
     qwen_sparse_fa2_cu_seqlens_triton,
     qwen_sparse_kv_extraction_compact_triton,
+    sparse_gqa_fwd_interface_triton_ck,
 )
 from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
     QwenSparseAttnBackend,
@@ -42,6 +43,60 @@ COMPRESS_RATIO = 4
 TOKEN_TOPK = 2048
 BLOCK_TOPK = TOKEN_TOPK // COMPRESS_RATIO
 FINAL_TOPK = TOKEN_TOPK + COMPRESS_RATIO - 1
+
+
+def test_qsa_chunk_prefill_accepts_fp8_cached_prefix():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
+        pytest.skip("FP8-capable CUDA GPU required")
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    num_requests, num_q_heads, num_kv_heads, head_dim, topk = 2, 4, 1, 128, 16
+    q = torch.randn(
+        num_requests, num_q_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    k = torch.randn(
+        num_requests * topk,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+    v = torch.randn(
+        num_requests * topk,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+    indices = torch.arange(topk, dtype=torch.int32, device=device).repeat(
+        num_requests, 1
+    )
+    cu_q = torch.arange(num_requests + 1, dtype=torch.int32, device=device)
+    cu_k = torch.arange(
+        0,
+        (num_requests + 1) * topk,
+        topk,
+        dtype=torch.int32,
+        device=device,
+    )
+    kv_lens = torch.full((num_requests,), topk, dtype=torch.int32, device=device)
+    scale = head_dim**-0.5
+
+    actual = sparse_gqa_fwd_interface_triton_ck(
+        q, k, v, indices, cu_q, cu_k, kv_lens, scale
+    )
+    expected = sparse_gqa_fwd_interface_triton_ck(
+        q,
+        k.to(torch.bfloat16),
+        v.to(torch.bfloat16),
+        indices,
+        cu_q,
+        cu_k,
+        kv_lens,
+        scale,
+    )
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

With `--kv-cache-dtype fp8_e4m3`, the first cached-prefix continuation of a Qwen3.8-Flash-Next request (radix-cache hit or chunked prefill) reaches the QSA Triton chunk-prefill kernel with FP8 K/V rows gathered from the cache while Q is BF16, and Triton rejects the matmul:

```
AssertionError: Unsupported rhs dtype fp8e4nv
```

Reproduced on GB300 with clean `main`; it blocks FP8 KV cache for this model entirely.

## Modifications

Cast the loaded K/V tiles to the query compute dtype inside `_sparse_gqa_chunk_prefill` before the two `tl.dot`s (BF16 storage is a no-op cast). `_sparse_gqa_prefill` is untouched: it only ever receives the current chunk's bf16 K/V. The QSA backend writes the pool without per-tensor k/v scales, so this is a plain cast, consistent with the gather-side conversion in #38851. Adds a registered kernel test that runs the chunk-prefill interface with an FP8 cached prefix.

Together with #38851 (zero-fill of the sparse-decode scratch) this makes FP8 E4M3 KV cache run end to end on GB300: AIME25/GPQA BF16-vs-FP8 comparisons are being collected there.

## Accuracy Tests

`test/registered/kernel/qsa/test_qsa.py` → 38 passed, 1 skipped on GB300 (including the new `test_qsa_chunk_prefill_accepts_fp8_cached_prefix`).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our Slack channel if you have any questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34515434332](https://github.com/sgl-project/sglang/actions/runs/34515434332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34515788302](https://github.com/sgl-project/sglang/actions/runs/34515788302)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34515434433](https://github.com/sgl-project/sglang/actions/runs/34515434433)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
