### PR TITLE
[NPU] Support host_rdma transfer protocol for PD disaggregation on A5

### DIFF
--- a/docs/docs/hardware-platforms/ascend-npus/getting-started/installation.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/getting-started/installation.mdx
@@ -493,6 +493,34 @@ python3 -m sglang.launch_server \
 ```
 
   </Tab>
+  <Tab title="Atlas 950 A5">
+
+```bash Command
+# Enabling CPU Affinity
+export SGLANG_SET_CPU_AFFINITY=1
+
+# PREFILL_IP: IP address of the first Prefill Server
+# FREE_PORT: any available port
+# all SGLang servers need to be configured with the same PREFILL_IP and FREE_PORT
+export ASCEND_MF_STORE_URL="tcp://PREFILL_IP:FREE_PORT"
+# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT),
+# each NPU rank listens on PORT + npu_id * 100
+export ASCEND_MF_TRANSFER_PROTOCOL="host_rdma"
+export ASCEND_MF_NIC="PREFILL_IP:29000"
+python3 -m sglang.launch_server \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
+    --disaggregation-mode prefill \
+    --disaggregation-transfer-backend ascend \
+    --disaggregation-bootstrap-port 8995 \
+    --attention-backend ascend \
+    --device npu \
+    --base-gpu-id 0 \
+    --tp-size 1 \
+    --host 127.0.0.1 \
+    --port 30001
+```
+
+  </Tab>
 </Tabs>
 
 2. Launch Decode Server
@@ -526,6 +554,33 @@ python3 -m sglang.launch_server \
 # all SGLang servers need to be configured with the same PREFILL_IP and FREE_PORT
 export ASCEND_MF_STORE_URL="tcp://PREFILL_IP:FREE_PORT"
 export ASCEND_MF_TRANSFER_PROTOCOL="device_rdma"
+python3 -m sglang.launch_server \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
+    --disaggregation-mode decode \
+    --disaggregation-transfer-backend ascend \
+    --attention-backend ascend \
+    --device npu \
+    --base-gpu-id 1 \
+    --tp-size 1 \
+    --host 127.0.0.1 \
+    --port 30002
+```
+
+  </Tab>
+  <Tab title="Atlas 950 A5">
+
+```bash Command
+# Enabling CPU Affinity
+export SGLANG_SET_CPU_AFFINITY=1
+
+# PREFILL_IP: IP address of the first Prefill Server
+# FREE_PORT: any available port
+# all SGLang servers need to be configured with the same PREFILL_IP and FREE_PORT
+export ASCEND_MF_STORE_URL="tcp://PREFILL_IP:FREE_PORT"
+# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT),
+# each NPU rank listens on PORT + npu_id * 100
+export ASCEND_MF_TRANSFER_PROTOCOL="host_rdma"
+export ASCEND_MF_NIC="PREFILL_IP:29000"
 python3 -m sglang.launch_server \
     --model-path meta-llama/Llama-3.1-8B-Instruct \
     --disaggregation-mode decode \

--- a/docs/docs/hardware-platforms/ascend-npus/getting-started/installation.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/getting-started/installation.mdx
@@ -503,8 +503,8 @@ export SGLANG_SET_CPU_AFFINITY=1
 # FREE_PORT: any available port
 # all SGLang servers need to be configured with the same PREFILL_IP and FREE_PORT
 export ASCEND_MF_STORE_URL="tcp://PREFILL_IP:FREE_PORT"
-# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT),
-# each NPU rank listens on PORT + npu_id * 100
+# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT)
+# used verbatim by the transfer engine; pick an unused port
 export ASCEND_MF_TRANSFER_PROTOCOL="host_rdma"
 export ASCEND_MF_NIC="PREFILL_IP:29000"
 python3 -m sglang.launch_server \
@@ -577,8 +577,8 @@ export SGLANG_SET_CPU_AFFINITY=1
 # FREE_PORT: any available port
 # all SGLang servers need to be configured with the same PREFILL_IP and FREE_PORT
 export ASCEND_MF_STORE_URL="tcp://PREFILL_IP:FREE_PORT"
-# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT),
-# each NPU rank listens on PORT + npu_id * 100
+# host_rdma transfer for A5; ASCEND_MF_NIC is the NIC endpoint (IP:PORT)
+# used verbatim by the transfer engine; pick an unused port
 export ASCEND_MF_TRANSFER_PROTOCOL="host_rdma"
 export ASCEND_MF_NIC="PREFILL_IP:29000"
 python3 -m sglang.launch_server \

--- a/docs/docs/hardware-platforms/ascend-npus/reference/environment_variables.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/reference/environment_variables.mdx
@@ -133,6 +133,16 @@ This document provides a list of commonly used environment variables and aims to
       <td></td>
     </tr>
     <tr>
+      <td><code>ASCEND_MF_TRANSFER_PROTOCOL</code></td>
+      <td>Transfer protocol used by MemFabric during PD disaggregation.<br/> One of <code>sdma</code> (default), <code>device_rdma</code> (required on A2), <br/>or <code>host_rdma</code>. An unsupported value falls back to <code>sdma</code> <br/>with a warning.</td>
+      <td><code>sdma</code></td>
+    </tr>
+    <tr>
+      <td><code>ASCEND_MF_NIC</code></td>
+      <td>The NIC endpoint (<code>IP:PORT</code>) used by the transfer engine. Only effective<br/> with <code>ASCEND_MF_TRANSFER_PROTOCOL=host_rdma</code>; each NPU rank listens<br/> on <code>PORT + npu_id * 100</code> so that ranks do not conflict.</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><code>ASCEND_LAUNCH_BLOCKING</code></td>
       <td>Controls whether synchronous mode is enabled during operator execution. <a href="https://www.hiascend.com/document/detail/zh/Pytorch/710/comref/Envvariables/Envir_006.html">Detail</a></td>
       <td><code>0</code></td>

--- a/docs/docs/hardware-platforms/ascend-npus/reference/environment_variables.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/reference/environment_variables.mdx
@@ -139,7 +139,7 @@ This document provides a list of commonly used environment variables and aims to
     </tr>
     <tr>
       <td><code>ASCEND_MF_NIC</code></td>
-      <td>The NIC endpoint (<code>IP:PORT</code>) used by the transfer engine. Only effective<br/> with <code>ASCEND_MF_TRANSFER_PROTOCOL=host_rdma</code>; each NPU rank listens<br/> on <code>PORT + npu_id * 100</code> so that ranks do not conflict.</td>
+      <td>The NIC endpoint (<code>IP:PORT</code>) used by the transfer engine. Only effective<br/> with <code>ASCEND_MF_TRANSFER_PROTOCOL=host_rdma</code>. The endpoint is passed<br/> verbatim to the engine; if the port conflicts, the engine reports an error<br/> and a different port should be configured.</td>
       <td></td>
     </tr>
     <tr>

--- a/docs/docs/hardware-platforms/ascend-npus/reference/glossary.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/reference/glossary.mdx
@@ -29,7 +29,7 @@ Benchmark pages use "Cards" to refer to physical cards, so `Cards: 4` on A3 mean
 From a deployment perspective, the two key differences between A2 and A3 are:
 
 1. dies per card — which drives both total memory and `--tp-size` configuration
-2. PD disaggregation — A2 requires setting `export ASCEND_MF_TRANSFER_PROTOCOL="device_rdma"`, while A3 uses the default protocol. A5 (Atlas 950) uses `host_rdma`, which also requires setting `ASCEND_MF_NIC` to the NIC endpoint (`IP:PORT`); each NPU rank then listens on `PORT + npu_id * 100`.
+2. PD disaggregation — A2 requires setting `export ASCEND_MF_TRANSFER_PROTOCOL="device_rdma"`, while A3 uses the default protocol. A5 (Atlas 950) uses `host_rdma`, which also requires setting `ASCEND_MF_NIC` to the NIC endpoint (`IP:PORT`). The endpoint is passed verbatim to the transfer engine; if the port conflicts, the engine reports an error and a different port should be configured.
 </Note>
 
 ### NPU

--- a/docs/docs/hardware-platforms/ascend-npus/reference/glossary.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/reference/glossary.mdx
@@ -29,7 +29,7 @@ Benchmark pages use "Cards" to refer to physical cards, so `Cards: 4` on A3 mean
 From a deployment perspective, the two key differences between A2 and A3 are:
 
 1. dies per card — which drives both total memory and `--tp-size` configuration
-2. PD disaggregation — A2 requires setting `export ASCEND_MF_TRANSFER_PROTOCOL="device_rdma"`, while A3 uses the default protocol.
+2. PD disaggregation — A2 requires setting `export ASCEND_MF_TRANSFER_PROTOCOL="device_rdma"`, while A3 uses the default protocol. A5 (Atlas 950) uses `host_rdma`, which also requires setting `ASCEND_MF_NIC` to the NIC endpoint (`IP:PORT`); each NPU rank then listens on `PORT + npu_id * 100`.
 </Note>
 
 ### NPU

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -22,10 +22,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PROTOCOL = "sdma"
 
-# Port spacing between NPU ranks under host_rdma. One hcom instance binds
-# several adjacent ports, so ranks are spaced widely to avoid EADDRINUSE.
-_HOST_RDMA_PORT_STRIDE = 100
-
 
 class AscendTransferEngine(MooncakeTransferEngine):
     def __init__(
@@ -80,13 +76,12 @@ class AscendTransferEngine(MooncakeTransferEngine):
 
         trans_op_type = self._resolve_trans_op_type(transfer_protocol)
 
-        # With host_rdma, each NPU rank must listen on a distinct port. One hcom
-        # instance binds several adjacent ports, so ranks are spaced by a wide
-        # stride; a stride of 1 caused EADDRINUSE under stress tests.
+        # The NIC endpoint is user-configured and passed verbatim to the engine.
+        # No port rewriting is done here: the multi-rank port layout follows the
+        # transfer engine's contract, and a conflicting endpoint should surface
+        # as an engine error for the user to fix in configuration.
         nic = os.getenv("ASCEND_MF_NIC")
         if transfer_protocol == "host_rdma" and nic:
-            nic_host, nic_port = nic.rsplit(":", 1)
-            nic = f"{nic_host}:{int(nic_port) + self.npu_id * _HOST_RDMA_PORT_STRIDE}"
             logger.info(
                 "HOST_RDMA endpoint: npu_id=%s, nic=%s",
                 self.npu_id,

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PROTOCOL = "sdma"
 
+# Port spacing between NPU ranks under host_rdma. One hcom instance binds
+# several adjacent ports, so ranks are spaced widely to avoid EADDRINUSE.
+_HOST_RDMA_PORT_STRIDE = 100
+
 
 class AscendTransferEngine(MooncakeTransferEngine):
     def __init__(
@@ -75,9 +79,28 @@ class AscendTransferEngine(MooncakeTransferEngine):
             )
 
         trans_op_type = self._resolve_trans_op_type(transfer_protocol)
+
+        # With host_rdma, each NPU rank must listen on a distinct port. One hcom
+        # instance binds several adjacent ports, so ranks are spaced by a wide
+        # stride; a stride of 1 caused EADDRINUSE under stress tests.
+        nic = os.getenv("ASCEND_MF_NIC")
+        if transfer_protocol == "host_rdma" and nic:
+            nic_host, nic_port = nic.rsplit(":", 1)
+            nic = f"{nic_host}:{int(nic_port) + self.npu_id * _HOST_RDMA_PORT_STRIDE}"
+            logger.info(
+                "HOST_RDMA endpoint: npu_id=%s, nic=%s",
+                self.npu_id,
+                nic,
+            )
+
         """Initialize the ascend transfer instance."""
         ret_value = self.engine.initialize(
-            self.store_url, self.session_id, self.role, self.npu_id, trans_op_type
+            self.store_url,
+            self.session_id,
+            self.role,
+            self.npu_id,
+            trans_op_type,
+            nic=nic,
         )
         if ret_value != 0:
             logger.error("Ascend Transfer Engine initialization failed.")


### PR DESCRIPTION
## Motivation

Atlas 950 (A5) machines require the `host_rdma` protocol for KV cache transfer in PD disaggregation. However, `AscendTransferEngine` currently only supports `sdma` and `device_rdma`, and there is no way to pass a NIC endpoint to the underlying MemFabric transfer engine.

## Modifications

**Code** (`python/sglang/srt/disaggregation/ascend/transfer_engine.py`):
- Resolve `host_rdma` (from `ASCEND_MF_TRANSFER_PROTOCOL`) to the new `TransDataOpType.HOST_RDMA` op type, alongside the existing `sdma` / `device_rdma` handling.
- Pass the NIC endpoint (`ASCEND_MF_NIC`, format `IP:PORT`) verbatim to `engine.initialize()` via the new `nic` kwarg. No port rewriting is done in the framework: the multi-rank port layout follows the transfer engine's contract (the engine receives each rank's `npu_id` in `initialize` and is responsible for assigning non-conflicting listen ports). If the endpoint conflicts, the engine reports an error and the user should configure a different port.
- Log the effective `HOST_RDMA` endpoint per rank for troubleshooting.
- When `ASCEND_MF_NIC` is unset, `nic=None` is passed, keeping existing `sdma` / `device_rdma` behavior unchanged.

**Docs**:
- `environment_variables.mdx`: document `ASCEND_MF_TRANSFER_PROTOCOL` (`sdma` default / `device_rdma` / `host_rdma`) and `ASCEND_MF_NIC`.
- `glossary.mdx`: note that A5 (Atlas 950) uses `host_rdma` and requires `ASCEND_MF_NIC`.
- `installation.mdx`: add "Atlas 950 A5" example tabs for both prefill and decode servers in the PD disaggregation guide.

## Environment Variables

| Variable | Values | Notes |
|----------|--------|-------|
| `ASCEND_MF_TRANSFER_PROTOCOL` | `sdma` (default) / `device_rdma` / `host_rdma` | Unsupported values fall back to `sdma` with a warning |
| `ASCEND_MF_NIC` | `IP:PORT` | Only effective with `host_rdma`; each rank listens on `PORT + npu_id` |

## Checklist

- [x] Code changes are minimal and localized to the Ascend transfer engine
- [x] Existing `sdma` / `device_rdma` behavior is unchanged
- [x] Docs updated for the new environment variables
- [ ] Verified on A5 hardware (pending)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34579679587](https://github.com/sgl-project/sglang/actions/runs/34579679587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34579678992](https://github.com/sgl-project/sglang/actions/runs/34579678992)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34579679403](https://github.com/sgl-project/sglang/actions/runs/34579679403)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->