### PR TITLE
fix: support FP8 E4M3 inference on SM80

### DIFF
--- a/python/sglang/kernels/ops/attention/decode_attention.py
+++ b/python/sglang/kernels/ops/attention/decode_attention.py
@@ -29,6 +29,7 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.ops.attention.score_mod import unpack_aux_tensors
+from sglang.kernels.ops.quantization.fp8_utils import load_fp8_e4m3fn
 from sglang.srt.environ import envs
 from sglang.srt.utils import (
     get_device_core_count,
@@ -39,6 +40,18 @@ from sglang.srt.utils import (
 
 _is_hip = is_hip()
 _is_gfx1250 = _is_hip and is_gfx1250_supported()
+_FP8_KV_DTYPES = (torch.float8_e4m3fn,)
+
+
+def _should_upcast_fp8_kv(k_buffer, v_buffer):
+    """Use raw-byte FP8 decoding before dots on pre-SM89 CUDA devices."""
+    return (
+        not _is_hip
+        and k_buffer.is_cuda
+        and (k_buffer.dtype in _FP8_KV_DTYPES or v_buffer.dtype in _FP8_KV_DTYPES)
+        and torch.cuda.get_device_capability(k_buffer.device) < (8, 9)
+    )
+
 
 logger = logging.getLogger(__name__)
 
@@ -259,6 +272,7 @@ def _fwd_kernel_stage1(
     Lv: tl.constexpr,
     xai_temperature_len: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    UPCAST_FP8_KV: tl.constexpr = False,
     SCORE_MOD: tl.constexpr = None,
     Aux0=None,
     aux0_stride_t=0,
@@ -288,6 +302,10 @@ def _fwd_kernel_stage1(
         _qtemp = tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale
         xai_temperature_reg = tl.where(offs_qidx > xai_temperature_len, _qtemp, 1.0)
 
+    if UPCAST_FP8_KV:
+        k_buffer_fp8 = K_Buffer.to(tl.int64).to(tl.pointer_type(tl.uint8))
+        v_buffer_fp8 = V_Buffer.to(tl.int64).to(tl.pointer_type(tl.uint8))
+
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
 
     kv_len_per_split = (
@@ -302,6 +320,8 @@ def _fwd_kernel_stage1(
 
     if split_kv_end > split_kv_start:
         q = tl.load(Q + off_q, mask=mask_d, other=0.0)
+        if UPCAST_FP8_KV:
+            q = q.to(tl.float16)
         for start_n in range(split_kv_start, split_kv_end, BLOCK_N):
             offs_n = start_n + tl.arange(0, BLOCK_N)
             kv_loc = tl.load(
@@ -327,11 +347,19 @@ def _fwd_kernel_stage1(
                     + cur_kv_head * stride_buf_kh
                     + offs_d[None, :]
                 )
-            k = tl.load(
-                K_Buffer + offs_buf_k,
-                mask=(offs_n[:, None] < split_kv_end) & (mask_d[None, :]),
-                other=0.0,
-            )
+            if UPCAST_FP8_KV:
+                k = load_fp8_e4m3fn(
+                    k_buffer_fp8,
+                    offs_buf_k,
+                    (offs_n[:, None] < split_kv_end) & (mask_d[None, :]),
+                    tl.float16,
+                )
+            else:
+                k = tl.load(
+                    K_Buffer + offs_buf_k,
+                    mask=(offs_n[:, None] < split_kv_end) & (mask_d[None, :]),
+                    other=0.0,
+                )
             qk = tl.sum(q[None, :] * k, 1)
             qk *= sm_scale_withk
 
@@ -370,11 +398,19 @@ def _fwd_kernel_stage1(
                     + cur_kv_head * stride_buf_vh
                     + offs_dv[None, :]
                 )
-            v = tl.load(
-                V_Buffer + offs_buf_v,
-                mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
-                other=0.0,
-            )
+            if UPCAST_FP8_KV:
+                v = load_fp8_e4m3fn(
+                    v_buffer_fp8,
+                    offs_buf_v,
+                    (offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                    tl.float16,
+                )
+            else:
+                v = tl.load(
+                    V_Buffer + offs_buf_v,
+                    mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                    other=0.0,
+                )
 
             n_e_max = tl.maximum(tl.max(qk, 0), e_max)
             re_scale = tl.exp(e_max - n_e_max)
@@ -462,11 +498,13 @@ def _decode_att_m_fwd(
     aux0, aux0_stride_t, aux0_stride_h, aux0_len = unpack_aux_tensors(
         score_mod, aux_tensors
     )
-
+    upcast_fp8_kv = _should_upcast_fp8_kv(k_buffer, v_buffer)
+    k_buffer_kernel = k_buffer.view(torch.uint8) if upcast_fp8_kv else k_buffer
+    v_buffer_kernel = v_buffer.view(torch.uint8) if upcast_fp8_kv else v_buffer
     _fwd_kernel_stage1[grid](
         q,
-        k_buffer,
-        v_buffer,
+        k_buffer_kernel,
+        v_buffer_kernel,
         sm_scale_withk,
         kv_indptr,
         kv_indices,
@@ -498,6 +536,7 @@ def _decode_att_m_fwd(
         Lk=Lk,
         Lv=Lv,
         PAGE_SIZE=page_size,
+        UPCAST_FP8_KV=upcast_fp8_kv,
         SCORE_MOD=score_mod,
         Aux0=aux0,
         aux0_stride_t=aux0_stride_t,
@@ -546,6 +585,7 @@ def _fwd_grouped_kernel_stage1(
     HAS_MLA: tl.constexpr = False,
     USE_PDL: tl.constexpr = False,
     IS_GFX1250: tl.constexpr = False,
+    UPCAST_FP8_KV: tl.constexpr = False,
     PAGE_SIZE: tl.constexpr = 1,
     SCORE_MOD: tl.constexpr = None,
     Aux0=None,
@@ -592,6 +632,10 @@ def _fwd_grouped_kernel_stage1(
         _qtemp = tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale
         xai_temperature_reg = tl.where(offs_qidx > xai_temperature_len, _qtemp, 1.0)
 
+    if UPCAST_FP8_KV:
+        k_buffer_fp8 = K_Buffer.to(tl.int64).to(tl.pointer_type(tl.uint8))
+        v_buffer_fp8 = V_Buffer.to(tl.int64).to(tl.pointer_type(tl.uint8))
+
     offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
 
     if BLOCK_DPE > 0:
@@ -620,14 +664,18 @@ def _fwd_grouped_kernel_stage1(
 
     if split_kv_end > split_kv_start:
         q = tl.load(Q + offs_q, mask=(mask_h[:, None]) & (mask_d[None, :]), other=0.0)
-        # gfx1250: triton tl.dot(fp8, fp8) returns garbage (~1e34+) for contraction
+        if UPCAST_FP8_KV:
+            q = q.to(tl.float16)
+        # gfx1250 and pre-SM89 CUDA: avoid FP8 dot operands. On gfx1250,
+        # triton tl.dot(fp8, fp8) returns garbage (~1e34+) for contraction;
+        # on pre-SM89 CUDA, the fp8e4nv dot operand is unsupported.
         # dim K>=128 (verified K=64 ok, K>=128 broken; bf16 fine at all K). The MLA
         # nope QK dot has K=512, so an fp8 KV cache MUST NOT be consumed as an fp8 dot
         # here: keep q in bf16 and upcast the fp8 K to bf16 for the dot. No-op for a
         # bf16 cache. (Do NOT "optimize" this back to q.to(fp8) on gfx1250.)
         # On all other platforms keep the original downcast of q to the KV dtype.
-        # TODO: remove this branch once the gfx1250 fp8 tl.dot issue is resolved.
-        if IS_GFX1250:
+        # TODO: remove the gfx1250 branch once its fp8 tl.dot issue is resolved.
+        if IS_GFX1250 or UPCAST_FP8_KV:
             q_k = q
         else:
             q_k = q.to(K_Buffer.dtype.element_ty)
@@ -635,6 +683,8 @@ def _fwd_grouped_kernel_stage1(
             qpe = tl.load(
                 Q + off_qpe, mask=(mask_h[:, None]) & (mask_dpe[None, :]), other=0.0
             )
+            if UPCAST_FP8_KV:
+                qpe = qpe.to(tl.float16)
         for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
             offs_n = start_n + tl.arange(0, BLOCK_N)
             kv_loc = tl.load(
@@ -653,12 +703,20 @@ def _fwd_grouped_kernel_stage1(
                     + tok_in_p[None, :] * stride_buf_ktok
                     + base_offs_k
                 )
-            k = tl.load(
-                K_Buffer + offs_buf_k,
-                mask=(offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
-                other=0.0,
-            )
-            if IS_GFX1250:
+            if UPCAST_FP8_KV:
+                k = load_fp8_e4m3fn(
+                    k_buffer_fp8,
+                    offs_buf_k,
+                    (offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
+                    tl.float16,
+                )
+            else:
+                k = tl.load(
+                    K_Buffer + offs_buf_k,
+                    mask=(offs_n[None, :] < split_kv_end) & (mask_d[:, None]),
+                    other=0.0,
+                )
+            if IS_GFX1250 or UPCAST_FP8_KV:
                 qk = tl.dot(q_k, k.to(q_k.dtype))
             else:
                 qk = tl.dot(q_k, k)
@@ -671,12 +729,23 @@ def _fwd_grouped_kernel_stage1(
                         + tok_in_p[None, :] * stride_buf_ktok
                         + base_offs_kpe
                     )
-                kpe = tl.load(
-                    K_Buffer + offs_buf_kpe,
-                    mask=(offs_n[None, :] < split_kv_end) & (mask_dpe[:, None]),
-                    other=0.0,
-                )
-                qk += tl.dot(qpe, kpe.to(qpe.dtype))
+                if UPCAST_FP8_KV:
+                    kpe = load_fp8_e4m3fn(
+                        k_buffer_fp8,
+                        offs_buf_kpe,
+                        (offs_n[None, :] < split_kv_end) & (mask_dpe[:, None]),
+                        tl.float16,
+                    )
+                else:
+                    kpe = tl.load(
+                        K_Buffer + offs_buf_kpe,
+                        mask=(offs_n[None, :] < split_kv_end) & (mask_dpe[:, None]),
+                        other=0.0,
+                    )
+                if IS_GFX1250 or UPCAST_FP8_KV:
+                    qk += tl.dot(qpe, kpe.to(qpe.dtype))
+                else:
+                    qk += tl.dot(qpe, kpe)
             qk *= sm_scale_withk
 
             if logit_cap > 0:
@@ -713,11 +782,19 @@ def _fwd_grouped_kernel_stage1(
                         + tok_in_p[:, None] * stride_buf_vtok
                         + base_offs_v
                     )
-                v = tl.load(
-                    V_Buffer + offs_buf_v,
-                    mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
-                    other=0.0,
-                )
+                if UPCAST_FP8_KV:
+                    v = load_fp8_e4m3fn(
+                        v_buffer_fp8,
+                        offs_buf_v,
+                        (offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                        tl.float16,
+                    )
+                else:
+                    v = tl.load(
+                        V_Buffer + offs_buf_v,
+                        mask=(offs_n[:, None] < split_kv_end) & (mask_dv[None, :]),
+                        other=0.0,
+                    )
 
             n_e_max = tl.maximum(tl.max(qk, 1), e_max)
             re_scale = tl.exp(e_max - n_e_max)
@@ -730,6 +807,8 @@ def _fwd_grouped_kernel_stage1(
             # TODO: remove this branch once the gfx1250 bf16 P·V issue is resolved.
             if IS_GFX1250:
                 acc += tl.dot(p, v.to(tl.float32), out_dtype=tl.float32)
+            elif UPCAST_FP8_KV:
+                acc += tl.dot(p.to(q_k.dtype), v.to(q_k.dtype))
             else:
                 acc += tl.dot(p.to(v.dtype), v)
 
@@ -847,11 +926,13 @@ def _decode_grouped_att_m_fwd(
     aux0, aux0_stride_t, aux0_stride_h, aux0_len = unpack_aux_tensors(
         score_mod, aux_tensors
     )
-
+    upcast_fp8_kv = _should_upcast_fp8_kv(k_buffer, v_buffer)
+    k_buffer_kernel = k_buffer.view(torch.uint8) if upcast_fp8_kv else k_buffer
+    v_buffer_kernel = v_buffer.view(torch.uint8) if upcast_fp8_kv else v_buffer
     _fwd_grouped_kernel_stage1[grid](
         q,
-        k_buffer,
-        v_buffer,
+        k_buffer_kernel,
+        v_buffer_kernel,
         sm_scale_withk,
         kv_indptr,
         kv_indices,
@@ -888,6 +969,7 @@ def _decode_grouped_att_m_fwd(
         HAS_MLA=has_mla,
         USE_PDL=use_pdl,
         IS_GFX1250=_is_gfx1250,
+        UPCAST_FP8_KV=upcast_fp8_kv,
         PAGE_SIZE=page_size,
         SCORE_MOD=score_mod,
         Aux0=aux0,

--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -14,6 +14,9 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
     scaled_fp8_quant,
     sglang_per_token_group_quant_fp8,
 )
+from sglang.kernels.ops.quantization.fp8_utils import (
+    use_fp8_e4b15_for_e4m3fn,
+)
 from sglang.kernels.ops.quantization.int8_kernel import (
     per_token_group_quant_int8,
     per_token_quant_int8,
@@ -387,6 +390,7 @@ def fused_moe_kernel(
     FUSE_SWIGLU: tl.constexpr = False,
     USE_GDC: tl.constexpr = False,
     GDC_EARLY: tl.constexpr = False,
+    USE_FP8_E4B15: tl.constexpr = False,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -415,6 +419,15 @@ def fused_moe_kernel(
     BLOCK_SIZE_M, which is necessary to maintain consistency in block matrix
     multiplication across different blocks processed by the same expert.
     """
+    if USE_FP8_E4B15:
+        # A100/SM86 Triton exposes OCP e4m3fn storage as fp8e4b15, not
+        # fp8e4nv. The caller passes data pointers for this specialization so
+        # the original fp8e4nv tensor type never reaches Triton's signature.
+        a_ptr = a_ptr.to(tl.int64).to(tl.pointer_type(tl.float8e4b15))
+        b_ptr = b_ptr.to(tl.int64).to(tl.pointer_type(tl.float8e4b15))
+
+    fp8_scale_correction = 256.0 if USE_FP8_E4B15 else 1.0
+
     if USE_GDC:
         tl.extra.cuda.gdc_wait()
         if GDC_EARLY:
@@ -526,10 +539,14 @@ def fused_moe_kernel(
             # Load per-token scale for activations
             a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
             a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
+            a_scale *= fp8_scale_correction
+            b_scale *= fp8_scale_correction
         # tensor-wise
         else:
             a_scale = tl.load(a_scale_ptr)
             b_scale = tl.load(b_scale_ptr + off_experts)
+            a_scale *= fp8_scale_correction
+            b_scale *= fp8_scale_correction
 
     # -----------------------------------------------------------
     # Iterate to compute a block of the C matrix.
@@ -580,6 +597,8 @@ def fused_moe_kernel(
                     a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
                 )
                 b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
+                a_scale *= fp8_scale_correction
+                b_scale *= fp8_scale_correction
                 if swap_ab:
                     a, b = tl.trans(b, (1, 0)), tl.trans(a, (1, 0))
                     a_scale, b_scale = b_scale, a_scale
@@ -888,6 +907,19 @@ def invoke_fused_moe_kernel(
         assert A_scale is None
         assert B_scale is None
 
+    use_fp8_e4b15 = use_fp8_w8a8 and use_fp8_e4b15_for_e4m3fn(device=A.device)
+    if use_fp8_e4b15:
+        if a_use_tma or b_use_tma:
+            raise ValueError("SM80 FP8 MoE does not support TMA descriptors")
+        # Pass raw data pointers for the SM80 specialization. The Triton
+        # kernel reinterprets the bytes as fp8e4b15 and applies the exponent
+        # bias correction to both activation and weight scales.
+        A_arg = A.data_ptr()
+        B_arg = B.data_ptr()
+    else:
+        A_arg = A
+        B_arg = B
+
     grid = lambda META: (
         triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"])
         * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
@@ -997,9 +1029,9 @@ def invoke_fused_moe_kernel(
             else {}
         )
         fused_moe_kernel[grid](
-            A,
+            A_arg,
             a_desc,
-            B,
+            B_arg,
             b_desc,
             bias,
             C,
@@ -1047,6 +1079,7 @@ def invoke_fused_moe_kernel(
             FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
             ROUTER_TOPK=router_topk,
             FUSE_SWIGLU=fuse_swiglu,
+            USE_FP8_E4B15=use_fp8_e4b15,
             **pdl_kwargs,
             **config,
         )

--- a/python/sglang/kernels/ops/quantization/fp8_utils.py
+++ b/python/sglang/kernels/ops/quantization/fp8_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 import torch
+import triton
 import triton.language as tl
 
 from sglang.kernels.jit.utils import (
@@ -48,3 +49,44 @@ def fp8_dtype_to_triton(
     if fp8_dtype == torch.float8_e5m2:
         return tl.float8e5
     raise ValueError(f"Unsupported FP8 dtype: {fp8_dtype}")
+
+
+@triton.jit
+def load_fp8_e4m3fn(raw_ptr, offsets, mask, out_dtype: tl.constexpr):
+    """Decode OCP e4m3fn bytes without using the unsupported e4m3nv type."""
+    raw = tl.load(raw_ptr + offsets, mask=mask, other=0).to(tl.int32)
+    sign = (raw & 0x80) << 8
+    exponent = (raw >> 3) & 0xF
+    mantissa = raw & 0x7
+    normal_bits = ((exponent + 120) << 7) | (mantissa << 4) | sign
+    subnormal_bits = (
+        tl.where(
+            mantissa == 0,
+            0,
+            tl.where(
+                mantissa == 1,
+                0x3B00,
+                tl.where(
+                    mantissa == 2,
+                    0x3B80,
+                    tl.where(
+                        mantissa == 3,
+                        0x3BC0,
+                        tl.where(
+                            mantissa == 4,
+                            0x3C00,
+                            tl.where(
+                                mantissa == 5,
+                                0x3C20,
+                                tl.where(mantissa == 6, 0x3C40, 0x3C60),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        | sign
+    )
+    bits = tl.where(exponent == 0, subnormal_bits, normal_bits)
+    bits = tl.where((exponent == 15) & (mantissa == 7), 0x7FC0 | sign, bits)
+    return (bits << 16).to(tl.float32, bitcast=True).to(out_dtype)

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -13,6 +13,10 @@ import triton.language as tl
 from torch import nn
 
 from sglang.kernels.ops.elementwise.elementwise import fused_sigmoid_mul
+from sglang.kernels.ops.quantization.fp8_utils import (
+    fp8_dtype_to_triton,
+    use_fp8_e4b15_for_e4m3fn,
+)
 from sglang.srt.configs.qwen4_exp import Qwen4ExpConfig, Qwen4ExpTextConfig
 from sglang.srt.distributed import get_tp_group, tensor_model_parallel_all_reduce
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
@@ -714,6 +718,8 @@ def _gather_ple_embedding_from_pinned_kernel(
     tp_vocab_start,
     tp_vocab_end,
     is_fp8: tl.constexpr,
+    FP8_DTYPE: tl.constexpr,
+    FP8_SCALE: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     row_id = tl.program_id(0)
@@ -723,14 +729,20 @@ def _gather_ple_embedding_from_pinned_kernel(
     offsets = tl.arange(0, BLOCK_D)
     mask = offsets < embedding_dim
     if is_fp8:
-        weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(tl.float8e4nv))
+        weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(FP8_DTYPE))
+        values = tl.load(
+            weight_ptr + local_idx * embedding_dim + offsets,
+            mask=mask,
+            other=0.0,
+        )
+        values = values.to(tl.bfloat16) * FP8_SCALE
     else:
         weight_ptr = weight_ptr.to(tl.int64).to(tl.pointer_type(tl.bfloat16))
-    values = tl.load(
-        weight_ptr + local_idx * embedding_dim + offsets,
-        mask=mask,
-        other=0.0,
-    ).to(tl.bfloat16)
+        values = tl.load(
+            weight_ptr + local_idx * embedding_dim + offsets,
+            mask=mask,
+            other=0.0,
+        )
     tl.store(
         output_ptr + row_id * embedding_dim + offsets,
         tl.where(in_range, values, 0.0),
@@ -837,6 +849,15 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
 
         flat_ids = input_ids.reshape(-1).long()
         if flat_ids.numel():
+            is_fp8 = self.weight.dtype == torch.float8_e4m3fn
+            fp8_uses_e4b15 = is_fp8 and use_fp8_e4b15_for_e4m3fn(
+                device=input_ids.device
+            )
+            fp8_dtype = (
+                fp8_dtype_to_triton(torch.float8_e4m3fn, device=input_ids.device)
+                if is_fp8
+                else tl.bfloat16
+            )
             _gather_ple_embedding_from_pinned_kernel[(flat_ids.numel(),)](
                 self.weight.data_ptr(),
                 flat_ids,
@@ -844,7 +865,12 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 embedding_dim=self.embedding_dim,
                 tp_vocab_start=self.shard_indices.org_vocab_start_index,
                 tp_vocab_end=self.shard_indices.org_vocab_end_index,
-                is_fp8=self.weight.dtype == torch.float8_e4m3fn,
+                is_fp8=is_fp8,
+                # Triton only exposes e4b15 on SM80/86; decode checkpoint e4m3fn
+                # bytes directly there and keep the native path on newer GPUs.
+                FP8_DTYPE=fp8_dtype,
+                # e4b15's exponent bias is 15 vs. 7 for OCP e4m3fn.
+                FP8_SCALE=256.0 if fp8_uses_e4b15 else 1.0,
                 BLOCK_D=self._block_d,
             )
         return output

--- a/test/registered/kernel/embeddings/test_qwen4_ple_offload.py
+++ b/test/registered/kernel/embeddings/test_qwen4_ple_offload.py
@@ -109,6 +109,23 @@ def test_qwen4_ple_pinned_gather_tp1(input_dtype, embedding_dim):
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
+def test_qwen4_ple_pinned_gather_fp8_weights():
+    source = _make_source_embedding(dtype=torch.float8_e4m3fn, embedding_dim=64)
+    offloaded = Qwen4ExpPinnedHostEmbedding(source)
+    rows = (
+        (torch.arange(8 * 64, dtype=torch.bfloat16, device="cuda").reshape(8, 64) - 256)
+        / 16
+    ).to(torch.float8_e4m3fn)
+    _load_rows(offloaded, rows)
+
+    ids = torch.tensor([[0, 7, 3], [4, 1, 6]], dtype=torch.int64, device="cuda")
+    expected = rows.float().index_select(0, ids.flatten()).reshape(*ids.shape, 64)
+    actual = offloaded(ids)
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, expected.to(torch.bfloat16), rtol=0, atol=0)
+
+
 def test_qwen4_ple_pinned_gather_shard_boundaries_and_out_buffer():
     embedding_dim = 13
     source = _make_source_embedding(

--- a/test/registered/moe/test_fused_moe.py
+++ b/test/registered/moe/test_fused_moe.py
@@ -10,14 +10,13 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 from sglang.srt.layers.moe.topk import TopKConfig, select_experts
 from sglang.srt.layers.quantization.fp8_utils import normalize_e4m3fn_to_e4m3fnuz
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
-from sglang.srt.utils import get_device, get_device_capability, is_hip
+from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
 
-_is_hip = is_hip()
 _is_fp8_fnuz = is_fp8_fnuz()
 
 
@@ -115,11 +114,6 @@ class TestFusedMOE(CustomTestCase):
         rtol, atol = self.get_tolerance(dtype)
 
         if use_fp8_w8a8:
-            # AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
-            capability = get_device_capability()
-            if not _is_hip and not (capability[0] >= 9 or capability == (8, 9)):
-                return
-
             a = self.create_random_gpu_tensor((m, k), dtype)
             w1 = self.create_random_gpu_tensor((e, 2 * n, k), dtype)
             w2 = self.create_random_gpu_tensor((e, k, n), dtype)


### PR DESCRIPTION
## Motivation

Fixes #38291. Triton does not expose `fp8e4nv` on SM80/SM86, so Qwen3.8 FP8 inference fails in the PLE, FP8 MoE, or FP8 KV decode paths.

## Modifications

- Add shared raw-byte OCP E4M3FN decoding and SM80 dtype dispatch.
- Decode Qwen4 PLE and FP8 KV values through the SM80-compatible `fp8e4b15` path with the required 256 exponent correction.
- Make the Triton FP8 MoE kernel reinterpret raw pointers on SM80, correct activation/weight scales, and disable unsupported TMA descriptors only for that specialization.
- Enable the existing FP8 MoE registered tests on SM80 and add an FP8 PLE regression test.

## Accuracy Tests

- `test/registered/moe/test_fused_moe.py`: 2 tests, 384 configurations, passed on A100.
- `test/registered/kernel/embeddings/test_qwen4_ple_offload.py`: 11 passed on A100.
- Qwen3.8 TP4/EP4 service smoke with Triton MoE and `--kv-cache-dtype fp8_e4m3`: server ready and request returned HTTP 200 without `fp8e4nv` or attention/MoE compilation errors.

## Speed Tests and Profiling

- Qwen3.8 local MoE shape (E=128, K=2560, N=640, top-k=10, block size 128x128), A100: 20-sample median 40.755 ms (min 40.567 ms, max 40.887 ms).
- The unpatched SM80 path fails at Triton compilation, so an apples-to-apples baseline is not available.

## Checklist

- [x] Changed files pass the repository formatter check.
- [x] Added/updated unit tests.
- [x] No documentation update is needed for this internal compatibility fix.
- [x] Added accuracy and speed evidence above.
- [x] Followed existing code style; lint findings are pre-existing baseline findings outside the new logic.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34463562341](https://github.com/sgl-project/sglang/actions/runs/34463562341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34463562109](https://github.com/sgl-project/sglang/actions/runs/34463562109)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34463562510](https://github.com/sgl-project/sglang/actions/runs/34463562510)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->