### PR TITLE
[NPU] Support GLM-5.2 DSpark loading

### DIFF
--- a/python/sglang/srt/configs/speculators.py
+++ b/python/sglang/srt/configs/speculators.py
@@ -1,0 +1,154 @@
+"""Translate the Speculators dense DSpark export into SGLang's config layout."""
+
+from copy import deepcopy
+from typing import Any, Optional
+
+
+def _require_int(config: dict, name: str, minimum: int = 1) -> int:
+    value = config.get(name)
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"Speculators DSpark {name} must be an integer >= {minimum}.")
+    return value
+
+
+def _check_alias(config: dict, name: str, expected: Any, source: str) -> None:
+    value = config.get(name)
+    if value is not None and value != expected:
+        raise ValueError(f"Speculators DSpark {name} conflicts with {source}.")
+
+
+def normalize_speculators_dspark_config(config: dict) -> Optional[dict]:
+    """Return a non-mutating translation, or None for an existing HF layout.
+
+    Speculators stores the decoder under ``transformer_layer_config`` and
+    numbers auxiliary hidden states one above SGLang's DFlash capture IDs.
+    The result uses the native HF layout, so reloading it never subtracts
+    twice. This only handles the Qwen3-style dense draft, not the verifier.
+    """
+    if "transformer_layer_config" not in config:
+        return None
+    if config.get("architectures") != ["DSparkDraftModel"]:
+        return None
+    if config.get("speculators_model_type", "dspark") != "dspark":
+        raise ValueError("Speculators DSpark speculators_model_type must be 'dspark'.")
+
+    speculators = config.get("speculators_config", {})
+    if not isinstance(speculators, dict):
+        raise ValueError("Speculators DSpark speculators_config must be an object.")
+    if speculators.get("algorithm", "dspark") != "dspark":
+        raise ValueError(
+            "Speculators DSpark speculators_config.algorithm must be 'dspark'."
+        )
+
+    decoder = config["transformer_layer_config"]
+    if not isinstance(decoder, dict) or decoder.get("model_type") != "qwen3":
+        raise ValueError(
+            "Speculators DSpark requires a qwen3 transformer_layer_config."
+        )
+    if config.get("model_type") not in (None, "dspark", "qwen3"):
+        raise ValueError("Speculators DSpark model_type conflicts with the decoder.")
+    if config.get("text_config") is not None:
+        raise ValueError(
+            "Speculators DSpark cannot use both text_config "
+            "and transformer_layer_config."
+        )
+
+    normalized = deepcopy(config)
+    for key, value in decoder.items():
+        # The outer architecture selects DSpark; the inner type selects its
+        # decoder configuration. Neither should select the target network.
+        if key in ("architectures", "model_type", "auto_map", "_name_or_path"):
+            continue
+        _check_alias(normalized, key, value, f"transformer_layer_config.{key}")
+        normalized[key] = deepcopy(value)
+    normalized["model_type"] = "qwen3"
+
+    for name in (
+        "hidden_size",
+        "intermediate_size",
+        "num_hidden_layers",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "vocab_size",
+        "block_size",
+        "markov_rank",
+    ):
+        _require_int(normalized, name)
+    if "head_dim" in normalized:
+        # head_dim need not equal hidden_size // num_attention_heads.
+        _require_int(normalized, "head_dim")
+    # The input-only mask can use a padded row of the shared target embedding;
+    # the runtime checks its upper bound against the actual target vocabulary.
+    _require_int(normalized, "mask_token_id", minimum=0)
+    _check_alias(normalized, "draft_vocab_size", normalized["vocab_size"], "vocab_size")
+    _check_alias(
+        normalized, "target_hidden_size", normalized["hidden_size"], "hidden_size"
+    )
+    if normalized.get("markov_head_type") not in ("vanilla", "gated", "rnn"):
+        raise ValueError("Speculators DSpark has an unsupported markov_head_type.")
+    for name in (
+        "enable_confidence_head",
+        "confidence_head_with_markov",
+        "sample_from_anchor",
+    ):
+        if name in normalized and type(normalized[name]) is not bool:
+            raise ValueError(f"Speculators DSpark {name} must be a boolean.")
+
+    aux_ids = normalized.get("aux_hidden_state_layer_ids")
+    if (
+        not isinstance(aux_ids, list)
+        or not aux_ids
+        or any(type(layer) is not int or layer < 1 for layer in aux_ids)
+    ):
+        raise ValueError(
+            "Speculators DSpark aux_hidden_state_layer_ids must be a non-empty "
+            "list of positive integers."
+        )
+    # Target hooks append features in model execution order. Sorting a trained
+    # list here would silently change the FC input, and duplicates cannot be
+    # captured by their membership-based hooks.
+    if any(left >= right for left, right in zip(aux_ids, aux_ids[1:])):
+        raise ValueError(
+            "Speculators DSpark aux_hidden_state_layer_ids must be strictly increasing."
+        )
+    # Capture count need not equal draft depth.
+    target_ids = [layer - 1 for layer in aux_ids]
+    _check_alias(
+        normalized, "target_layer_ids", target_ids, "aux_hidden_state_layer_ids"
+    )
+    normalized["target_layer_ids"] = target_ids
+
+    # Existing readers give these legacy aliases priority over the fields above.
+    # Accept matching aliases, but never silently override the export contract.
+    for alias, source in (
+        ("dspark_target_layer_ids", "target_layer_ids"),
+        ("dspark_block_size", "block_size"),
+        ("dspark_noise_token_id", "mask_token_id"),
+        ("dspark_markov_rank", "markov_rank"),
+        ("dspark_markov_head_type", "markov_head_type"),
+    ):
+        _check_alias(normalized, alias, normalized[source], source)
+    for section in ("dflash_config", "dspark_config"):
+        aliases = normalized.get(section, {})
+        if not isinstance(aliases, dict):
+            raise ValueError(f"Speculators DSpark {section} must be an object.")
+        for name in (
+            "target_layer_ids",
+            "block_size",
+            "mask_token_id",
+            "markov_rank",
+            "markov_head_type",
+        ):
+            # Native readers use dict.get(key, canonical), so an explicit null
+            # would hide the canonical value rather than use that fallback.
+            # In particular, null target IDs would silently enable auto-picking.
+            if name in aliases and aliases[name] is None:
+                del aliases[name]
+            _check_alias(aliases, name, normalized[name], f"top-level {name}")
+
+    # Keep the canonical IDs as provenance, but emit just one decoder layout.
+    # HF expands defaults (e.g. RoPE parameters) during construction, so keeping
+    # a second raw decoder would make a saved config conflict with itself.
+    normalized.pop("transformer_layer_config")
+    normalized.pop("auto_map", None)
+    return normalized

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -921,6 +921,11 @@ class Envs:
     # ===================================================================
     # Ascend NPU
     # ===================================================================
+    # "original" opts a GLM DSA QuaRot target + dense DSpark draft into
+    # checkpoint-local vocab and load-time FC rotation. The draft checkpoint
+    # must contain original (not already converted) weights. Empty keeps the
+    # existing loading behavior.
+    SGLANG_NPU_GLM_DSPARK_QUAROT = EnvStr("")
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
     SGLANG_NPU_USE_MLAPO = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/npu/dspark_quarot.py
+++ b/python/sglang/srt/hardware_backend/npu/dspark_quarot.py
@@ -1,0 +1,171 @@
+"""Explicit original-coordinate GLM DSpark loading on NPU.
+
+The configuration lives only around one draft construction. FC conversion is a
+load-time candidate, not an exact inverse for a non-orthogonal stored Q.
+"""
+
+import logging
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import torch
+from safetensors import safe_open
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GlmDSparkQuaRotConfig:
+    rotation_path: str
+    hidden_size: int
+    target_model_path: str
+
+
+_config: ContextVar[Optional[GlmDSparkQuaRotConfig]] = ContextVar(
+    "glm_dspark_quarot_config", default=None
+)
+
+
+def get_glm_dspark_quarot_config() -> Optional[GlmDSparkQuaRotConfig]:
+    return _config.get()
+
+
+@contextmanager
+def glm_dspark_quarot_scope(config: Optional[GlmDSparkQuaRotConfig]):
+    token = _config.set(config)
+    try:
+        yield
+    finally:
+        _config.reset(token)
+
+
+def build_glm_dspark_quarot_config(
+    *, device, mode, target_model_config, target_model
+) -> Optional[GlmDSparkQuaRotConfig]:
+    """Read metadata only after matching the explicit target-specific path.
+
+    ``original`` is the caller's declaration about the draft checkpoint. Target
+    QuaRot metadata alone cannot establish the draft's coordinate convention.
+    """
+    if not mode or str(device).split(":", 1)[0] != "npu":
+        return None
+    hf_config = getattr(target_model_config, "hf_text_config", None)
+    architectures = getattr(hf_config, "architectures", None)
+    if (
+        not isinstance(architectures, (list, tuple))
+        or "GlmMoeDsaForCausalLM" not in architectures
+    ):
+        return None
+    quant_config = getattr(target_model, "quant_config", None)
+    get_name = getattr(quant_config, "get_name", None)
+    if not callable(get_name) or get_name() != "modelslim":
+        return None
+    if mode != "original":
+        raise ValueError("SGLANG_NPU_GLM_DSPARK_QUAROT must be 'original' when enabled")
+
+    description = getattr(quant_config, "quant_description", None)
+    if not isinstance(description, dict) or description.get("is_rot_used") is not True:
+        raise ValueError("GLM DSpark original mode requires a ModelSlim QuaRot target")
+    try:
+        relative_path = description["optional"]["quarot"]["rotation_map"][
+            "global_rotation"
+        ]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            "GLM DSpark target has no QuaRot global_rotation path"
+        ) from exc
+    if (
+        not isinstance(relative_path, str)
+        or not relative_path
+        or Path(relative_path).is_absolute()
+    ):
+        raise ValueError("QuaRot global_rotation must be a relative target file path")
+    width = getattr(hf_config, "hidden_size", None)
+    if type(width) is not int or width <= 0:
+        raise ValueError("GLM DSpark target hidden_size must be a positive integer")
+    target_path = Path(target_model_config.model_path).resolve(strict=True)
+    rotation_path = (target_path / relative_path).resolve(strict=True)
+    # get_slice reads the header, not the full matrix during draft construction.
+    with safe_open(str(rotation_path), framework="pt", device="cpu") as reader:
+        if "global_rotation" not in reader.keys():
+            raise ValueError(f"Missing global_rotation tensor in {rotation_path}")
+        if reader.get_slice("global_rotation").get_shape() != [width, width]:
+            raise ValueError(
+                f"QuaRot global_rotation must have shape [{width}, {width}]: {rotation_path}"
+            )
+    return GlmDSparkQuaRotConfig(str(rotation_path), width, str(target_path))
+
+
+@torch.no_grad()
+def fold_glm_dspark_fc(
+    weight: torch.Tensor, config: GlmDSparkQuaRotConfig
+) -> torch.Tensor:
+    """Return fresh CPU FC blocks F_i @ Q in the original weight dtype.
+
+    This never transforms an existing model Parameter in place, rescales Q,
+    applies R, or changes CPU thread settings. Call it on newly read checkpoint
+    weights so reloading does not rotate already converted parameters again.
+    """
+    width = config.hidden_size
+    if (
+        type(width) is not int
+        or width <= 0
+        or weight.ndim != 2
+        or weight.shape[0] != width
+        or weight.shape[1] == 0
+        or weight.shape[1] % width
+        or not weight.is_floating_point()
+    ):
+        raise ValueError(
+            "GLM DSpark FC must be floating [hidden_size, K * hidden_size]"
+        )
+
+    started = time.monotonic()
+    logger.info(
+        "GLM DSpark original mode: folding FC %s with Q=%s from target=%s "
+        "on CPU in FP32, storing %s; no inverse or scale correction",
+        tuple(weight.shape),
+        config.rotation_path,
+        config.target_model_path,
+        weight.dtype,
+    )
+    with safe_open(config.rotation_path, framework="pt", device="cpu") as reader:
+        if "global_rotation" not in reader.keys():
+            raise ValueError(
+                f"Missing global_rotation tensor in {config.rotation_path}"
+            )
+        q = reader.get_tensor("global_rotation")
+    if q.shape != (width, width) or not q.is_floating_point():
+        raise ValueError(
+            "QuaRot global_rotation must be a floating hidden_size square matrix"
+        )
+    q = q.to(dtype=torch.float32, device="cpu")
+    if not torch.isfinite(q).all():
+        raise ValueError("QuaRot global_rotation contains non-finite FP32 values")
+
+    folded = torch.empty(weight.shape, dtype=weight.dtype, device="cpu")
+    # Keep only Q, the output, and small FP32 tiles; do not allocate a full FP32
+    # copy of the 6144 x 30720 checkpoint or a block-diagonal rotation matrix.
+    for start in range(0, weight.shape[1], width):
+        for row in range(0, width, 128):
+            source = (
+                weight[row : row + 128, start : start + width]
+                .detach()
+                .to(device="cpu", dtype=torch.float32)
+            )
+            if not torch.isfinite(source).all():
+                raise ValueError("GLM DSpark FC contains non-finite FP32 values")
+            converted = (source @ q).to(dtype=weight.dtype)
+            if not torch.isfinite(converted).all():
+                raise ValueError("GLM DSpark converted FC contains non-finite values")
+            folded[row : row + 128, start : start + width].copy_(converted)
+    del source, converted, q
+    logger.info(
+        "GLM DSpark FC load-time Q folding finished in %.3f seconds",
+        time.monotonic() - started,
+    )
+    return folded

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -25,6 +25,7 @@ from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
     read_ragged_verify_mode,
 )
+from sglang.srt.utils.common import is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -501,6 +502,45 @@ class DSparkDraftMixin:
             self.markov_head = build_markov_head(config)
         self.confidence_head = build_confidence_head(config)
         self.lm_head: Optional[nn.Module] = None
+        self._glm_dspark_quarot_config = None
+        if (
+            is_npu()
+            and not self.is_nemotron_35_draft
+            and envs.SGLANG_NPU_GLM_DSPARK_QUAROT.get()
+        ):
+            from sglang.srt.hardware_backend.npu.dspark_quarot import (
+                get_glm_dspark_quarot_config,
+            )
+
+            self._glm_dspark_quarot_config = get_glm_dspark_quarot_config()
+        if self._glm_dspark_quarot_config is not None:
+            if quant_config is not None:
+                raise ValueError(
+                    "GLM DSpark QuaRot original mode requires an unquantized draft."
+                )
+            if int(config.hidden_size) != self._glm_dspark_quarot_config.hidden_size:
+                raise ValueError("GLM DSpark QuaRot target/draft hidden sizes differ.")
+            from sglang.srt.layers.vocab_parallel_embedding import (
+                ParallelLMHead,
+                VocabParallelEmbedding,
+                get_embedding_tp_kwargs,
+            )
+
+            # Construct inside the draft's existing dtype/device/TP scope so
+            # normal loading, postprocessing and KV budgeting see both tables.
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens" if prefix else "embed_tokens",
+                **get_embedding_tp_kwargs(),
+            )
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.lm_head" if prefix else "lm_head",
+            )
+            self.uses_own_vocab_modules = True
+            self._glm_dspark_quarot_weights_loaded = False
         # Expose the draft's own layer count so the draft ModelRunner sizes the
         # draft KV pool correctly. Some DSpark draft checkpoints inherit the
         # target's ``num_nextn_predict_layers`` (>0) on the config; without this
@@ -552,8 +592,29 @@ class DSparkDraftMixin:
         confidence_weights = []
         backbone_weights = []
         params_dict = dict(self.named_parameters())
+        quarot_config = self._glm_dspark_quarot_config
+        quarot_loaded = set()
         for name, loaded_weight in weights:
             normalized_name = name.removeprefix("model.")
+            if quarot_config is not None:
+                if normalized_name in ("embed_tokens.weight", "lm_head.weight"):
+                    param = params_dict[normalized_name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    quarot_loaded.add(normalized_name)
+                    continue
+                if normalized_name in ("fc.weight", "encoder.fc.weight"):
+                    from sglang.srt.hardware_backend.npu.dspark_quarot import (
+                        fold_glm_dspark_fc,
+                    )
+
+                    # Always convert the newly received original weight, never
+                    # the already converted Parameter (including on reload).
+                    loaded_weight = fold_glm_dspark_fc(loaded_weight, quarot_config)
+                    name = "fc.weight"
+                    quarot_loaded.add(name)
             if any(
                 normalized_name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES
             ):
@@ -571,6 +632,18 @@ class DSparkDraftMixin:
             else:
                 backbone_weights.append((name, loaded_weight))
 
+        if quarot_config is not None and not self._glm_dspark_quarot_weights_loaded:
+            missing = {
+                "embed_tokens.weight",
+                "lm_head.weight",
+                "fc.weight",
+            } - quarot_loaded
+            if missing:
+                raise ValueError(
+                    "GLM DSpark QuaRot original mode is missing checkpoint weights: "
+                    + ", ".join(sorted(missing))
+                )
+
         super().load_weights(backbone_weights)
 
         for name, loaded_weight in markov_weights:
@@ -586,6 +659,8 @@ class DSparkDraftMixin:
         self._load_confidence_weights(
             confidence_weights=confidence_weights, params_dict=params_dict
         )
+        if quarot_config is not None:
+            self._glm_dspark_quarot_weights_loaded = True
 
     def _load_confidence_weights(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -252,7 +252,11 @@ class DraftBlockProposer:
     ) -> DraftProposal:
         embed_module = unwrap_lora_layer(
             self.draft_model.embed_tokens
-            if not self.sample_from_anchor
+            if (
+                not self.sample_from_anchor
+                or getattr(self.draft_model, "_glm_dspark_quarot_config", None)
+                is not None
+            )
             else target_model.get_input_embeddings()
         )
         draft_sampler = self._draft_sampler

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -165,7 +165,26 @@ class DSparkWorkerV2(BaseSpecWorker):
                 "MoE-under-DP all-reduce."
             )
 
-        with self._draft_context():
+        quarot_scope = nullcontext()
+        if (
+            _is_npu
+            and not self._draft_is_moe
+            and envs.SGLANG_NPU_GLM_DSPARK_QUAROT.get()
+        ):
+            from sglang.srt.hardware_backend.npu.dspark_quarot import (
+                build_glm_dspark_quarot_config,
+                glm_dspark_quarot_scope,
+            )
+
+            quarot_config = build_glm_dspark_quarot_config(
+                device=self.device,
+                mode=envs.SGLANG_NPU_GLM_DSPARK_QUAROT.get(),
+                target_model_config=target_worker.model_runner.model_config,
+                target_model=target_worker.model_runner.model,
+            )
+            quarot_scope = glm_dspark_quarot_scope(quarot_config)
+
+        with self._draft_context(), quarot_scope:
             bundle = build_draft_tp_worker(
                 server_args=server_args,
                 gpu_id=gpu_id,

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -16,7 +16,7 @@
 from pathlib import Path
 from typing import Optional
 
-from transformers import PretrainedConfig
+from transformers import PretrainedConfig, Qwen3Config
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
 from sglang.srt.configs.model_config_parser_registry import (
@@ -24,6 +24,7 @@ from sglang.srt.configs.model_config_parser_registry import (
     get_model_config_parser,
     register_model_config_parser,
 )
+from sglang.srt.configs.speculators import normalize_speculators_dspark_config
 from sglang.srt.connector import create_remote_connector
 from sglang.srt.utils import is_remote_url, lru_cache_frozenset
 
@@ -61,10 +62,18 @@ _LONGCAT_ARCHS = {
 }
 
 
-def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
-    config_dict, _ = PretrainedConfig.get_config_dict(
+def _try_load_custom_config(model, revision: Optional[str], **kwargs):
+    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(
         model, revision=revision, **kwargs
     )
+    normalized = normalize_speculators_dspark_config(config_dict)
+    if normalized is not None:
+        # The export's auto_map is not an HF AutoConfig entry. Construct the
+        # supported decoder locally while preserving the DSpark architecture.
+        config = Qwen3Config.from_dict(normalized, **unused_kwargs)
+        config._name_or_path = str(model)
+        return config
+
     architectures = config_dict.get("architectures") or []
     if not any(arch in _LONGCAT_ARCHS for arch in architectures):
         return None
@@ -83,7 +92,7 @@ class HfModelConfigParser(ModelConfigParserBase):
         revision: Optional[str] = None,
         **kwargs,
     ):
-        config = _try_load_longcat_config(model, revision, **kwargs)
+        config = _try_load_custom_config(model, revision, **kwargs)
         if config is None:
             config = AutoConfig.from_pretrained(
                 model,

--- a/test/registered/unit/configs/test_dspark_quantization_config.py
+++ b/test/registered/unit/configs/test_dspark_quantization_config.py
@@ -1,0 +1,278 @@
+"""Exercise DSpark draft quantization through real local configuration entry points.
+
+No weights or accelerator kernels are loaded. The complete ServerArgs resolution
+cases use a small Llama target to keep hardware-specific GLM DSA setup outside
+this CPU suite; the GLM case separately exercises the ModelConfig entry point.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from transformers import GlmMoeDsaConfig
+
+from sglang.srt.arg_groups.overrides import resolving_view
+from sglang.srt.arg_groups.serving_hook import handle_missing_default_values
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.environ import EnvField, envs
+from sglang.srt.server_args import prepare_server_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestDSparkQuantizationConfig(CustomTestCase):
+    def setUp(self):
+        # Resolution updates both os.environ and EnvField's explicit-None state.
+        environ = dict(os.environ)
+        fields = {
+            name: field
+            for klass in reversed(type(envs).__mro__)
+            for name, field in vars(klass).items()
+            if isinstance(field, EnvField)
+        }
+        none_flags = {name: field._set_to_none for name, field in fields.items()}
+
+        def restore_environment():
+            os.environ.clear()
+            os.environ.update(environ)
+            for name, value in none_flags.items():
+                fields[name]._set_to_none = value
+
+        self.addCleanup(restore_environment)
+        envs.SGLANG_RAGGED_VERIFY_MODE.set("static")
+
+        # prepare_server_args configures launcher logging; keep it test-local.
+        root_logger = logging.getLogger()
+        handlers, level = root_logger.handlers[:], root_logger.level
+
+        def restore_logging():
+            for handler in root_logger.handlers[:]:
+                root_logger.removeHandler(handler)
+                if handler not in handlers:
+                    handler.close()
+            for handler in handlers:
+                root_logger.addHandler(handler)
+            root_logger.setLevel(level)
+
+        self.addCleanup(restore_logging)
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.target = self.root / "target"
+        self.draft = self.root / "draft"
+        self.target.mkdir()
+        self.draft.mkdir()
+        self._write(
+            self.target / "config.json",
+            {
+                "architectures": ["LlamaForCausalLM"],
+                "model_type": "llama",
+                "dtype": "bfloat16",
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "vocab_size": 128,
+                "max_position_embeddings": 128,
+            },
+        )
+        self._write(
+            self.target / "quant_model_description.json",
+            {"model.layers.0.self_attn.q_proj.weight": "W8A8"},
+        )
+        self.raw_draft = {
+            "architectures": ["DSparkDraftModel"],
+            "speculators_model_type": "dspark",
+            "dtype": "bfloat16",
+            "block_size": 8,
+            "aux_hidden_state_layer_ids": [1, 3],
+            "draft_vocab_size": 128,
+            "mask_token_id": 127,
+            "markov_rank": 4,
+            "markov_head_type": "vanilla",
+            "enable_confidence_head": True,
+            "confidence_head_with_markov": True,
+            "transformer_layer_config": {
+                "model_type": "qwen3",
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "num_hidden_layers": 3,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 32,
+                "vocab_size": 128,
+                "max_position_embeddings": 128,
+                "rope_parameters": {"rope_type": "default", "rope_theta": 10000},
+                "layer_types": ["full_attention"] * 3,
+                "tie_word_embeddings": False,
+            },
+        }
+        self._write(self.draft / "config.json", self.raw_draft)
+
+    @staticmethod
+    def _write(path, value):
+        path.write_text(json.dumps(value))
+
+    def _args(self, draft_quantization="unquant", dtype="auto", target=None):
+        # cuda is only a configuration value. No CUDA platform or capability
+        # is mocked, and the generic target resolution does not run kernels.
+        argv = [
+            "--model-path",
+            str(target or self.target),
+            "--device",
+            "cuda",
+            "--quantization",
+            "modelslim",
+            "--dtype",
+            dtype,
+            "--speculative-algorithm",
+            "DSPARK",
+            "--speculative-draft-model-path",
+            str(self.draft),
+            "--cuda-graph-backend-decode",
+            "disabled",
+            "--cuda-graph-backend-prefill",
+            "disabled",
+            "--random-seed",
+            "42",
+        ]
+        if draft_quantization is not None:
+            argv += ["--speculative-draft-model-quantization", draft_quantization]
+        return prepare_server_args(argv)
+
+    def _resolved_args(self, **kwargs):
+        args = self._args(**kwargs)
+        args.resolve_once()
+        return args
+
+    def _draft_config(self, args, path=None):
+        # TpModelWorker supplies the draft path explicitly in production too.
+        return ModelConfig.from_server_args(
+            args, model_path=str(path or self.draft), is_draft_model=True
+        )
+
+    def test_unquant_isolates_bf16_draft_without_changing_target(self):
+        for dtype in ("auto", "bfloat16"):
+            with self.subTest(dtype=dtype):
+                args = self._resolved_args(dtype=dtype)
+                resolved = resolving_view(args)
+                self.assertEqual(resolved.quantization, "modelslim")
+                self.assertIsNone(resolved.speculative_draft_model_quantization)
+                self.assertTrue(resolved._speculative_draft_quantization_explicitly_set)
+                self.assertEqual(resolved.speculative_num_draft_tokens, 9)
+                target = ModelConfig.from_server_args(args)
+                before = target.hf_config.to_dict()
+                draft = self._draft_config(args)
+
+                self.assertEqual(target.quantization, "modelslim")
+                self.assertEqual(target.dtype, torch.bfloat16)
+                self.assertIsNone(draft.quantization)
+                self.assertEqual(draft.dtype, torch.bfloat16)
+                self.assertEqual(draft.hf_config.architectures, ["DSparkDraftModel"])
+                self.assertEqual(draft.hf_config.target_layer_ids, [0, 2])
+                self.assertTrue(draft.is_draft_quantization_explicit)
+                self.assertEqual(target.hf_config.to_dict(), before)
+                self.assertEqual(resolved.quantization, "modelslim")
+
+    def test_omitted_draft_quantization_inherits_modelslim(self):
+        args = self._resolved_args(draft_quantization=None)
+        resolved = resolving_view(args)
+        self.assertEqual(resolved.speculative_draft_model_quantization, "modelslim")
+        self.assertFalse(resolved._speculative_draft_quantization_explicitly_set)
+        draft = self._draft_config(args)
+        self.assertEqual(draft.quantization, "modelslim")
+        self.assertEqual(draft.dtype, torch.bfloat16)
+        self.assertFalse(draft.is_draft_quantization_explicit)
+
+    def test_unquant_does_not_force_bfloat16_over_explicit_dtype(self):
+        args = self._resolved_args(dtype="float16")
+        draft = self._draft_config(args)
+        self.assertIsNone(draft.quantization)
+        self.assertEqual(draft.dtype, torch.float16)
+        target = ModelConfig.from_server_args(args)
+        self.assertEqual(target.quantization, "modelslim")
+        self.assertEqual(target.dtype, torch.float16)
+
+    def test_unquant_does_not_suppress_draft_hf_quantization_metadata(self):
+        for key in ("quantization_config", "compression_config"):
+            with self.subTest(key=key):
+                config = {**self.raw_draft, key: {"quant_method": "fp8"}}
+                self._write(self.draft / "config.json", config)
+                args = self._resolved_args()
+                self.assertIsNone(
+                    resolving_view(args).speculative_draft_model_quantization
+                )
+                self.assertEqual(self._draft_config(args).quantization, "fp8")
+                self.assertEqual(
+                    ModelConfig.from_server_args(args).quantization, "modelslim"
+                )
+
+    def test_unquant_does_not_suppress_standalone_hf_quantization_metadata(self):
+        self._write(
+            self.draft / "hf_quant_config.json",
+            {"quantization": {"quant_algo": "FP8"}},
+        )
+        args = self._resolved_args()
+        self.assertIsNone(resolving_view(args).speculative_draft_model_quantization)
+        self.assertEqual(self._draft_config(args).quantization, "modelopt_fp8")
+
+    def test_draft_does_not_autodetect_modelslim_description(self):
+        self._write(
+            self.draft / "quant_model_description.json",
+            {"model.layers.0.self_attn.q_proj.weight": "W8A8"},
+        )
+        args = self._resolved_args()
+        self.assertIsNone(self._draft_config(args).quantization)
+        self.assertEqual(ModelConfig.from_server_args(args).quantization, "modelslim")
+
+    def test_saved_draft_keeps_bfloat16_and_capture_ids_on_reload(self):
+        args = self._resolved_args()
+        draft = self._draft_config(args)
+        saved = self.root / "saved"
+        draft.hf_config.save_pretrained(saved)
+        reloaded = self._draft_config(args, saved)
+        self.assertIsNone(reloaded.quantization)
+        self.assertEqual(reloaded.dtype, torch.bfloat16)
+        self.assertEqual(reloaded.hf_config.target_layer_ids, [0, 2])
+        self.assertEqual(reloaded.hf_config.aux_hidden_state_layer_ids, [1, 3])
+
+    def test_glm_model_config_entry_accepts_isolated_dspark_draft(self):
+        glm = self.root / "glm"
+        GlmMoeDsaConfig(
+            architectures=["GlmMoeDsaForCausalLM"],
+            dtype="bfloat16",
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=4,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            vocab_size=128,
+            max_position_embeddings=128,
+        ).save_pretrained(glm)
+        self._write(
+            glm / "quant_model_description.json",
+            {"model.layers.0.self_attn.q_a_proj.weight": "W8A8"},
+        )
+        args = self._args(target=glm)
+        # This is the actual default-resolution step. The remaining GLM DSA
+        # pipeline queries hardware, so this case only claims ModelConfig
+        # coverage; the other cases above cover the full generic pipeline.
+        handle_missing_default_values(args)
+        target = ModelConfig.from_server_args(args)
+        draft = self._draft_config(args)
+        self.assertEqual(target.hf_config.architectures, ["GlmMoeDsaForCausalLM"])
+        self.assertEqual(target.quantization, "modelslim")
+        self.assertEqual(target.dtype, torch.bfloat16)
+        self.assertIsNone(draft.quantization)
+        self.assertEqual(draft.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_dspark_npu_quarot_loading.py
+++ b/test/registered/unit/model_loader/test_dspark_npu_quarot_loading.py
@@ -1,0 +1,311 @@
+"""Exercise the opt-in QuaRot draft loader with a real, small BF16 checkpoint.
+
+Only the DSpark activation predicate is patched to NPU. Tensor allocation,
+checkpoint loading, FC and normalization run on CPU; this is not an NPU
+arithmetic, full-model correctness or acceptance-rate test.
+"""
+
+import json
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+from test_dspark_weight_loading import _checkpoint
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.distributed import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.npu.dspark_quarot import (
+    GlmDSparkQuaRotConfig,
+    glm_dspark_quarot_scope,
+)
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_loader.loader import DefaultModelLoader
+from sglang.srt.model_loader.utils import set_default_torch_dtype
+from sglang.srt.models.dspark import DSparkDraftModel
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+class TestDSparkNpuQuaRotLoading(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.group_dir = tempfile.TemporaryDirectory()
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method=f"file://{cls.group_dir.name}/gloo",
+            backend="gloo",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1, backend="gloo")
+
+    @classmethod
+    def tearDownClass(cls):
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        cls.group_dir.cleanup()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(envs.SGLANG_RAGGED_VERIFY_MODE.override("static"))
+        self.enterContext(
+            get_context().override_server_args(
+                speculative_algorithm="DSpark", device="cpu"
+            )
+        )
+        self.root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.model_dir = self.root / "draft"
+        self.model_dir.mkdir()
+        self.config, self.weights = _checkpoint()
+        self.config["transformer_layer_config"]["rms_norm_eps"] = 1e-5
+        # Three different feature blocks prevent a block-order error from
+        # disappearing behind repeated or constant input weights.
+        values = (torch.arange(16 * 48).reshape(16, 48) * 7) % 61 - 30
+        self.weights["fc.weight"] = (values.float() / 64).to(torch.bfloat16)
+        self.weights["hidden_norm.weight"] = (torch.arange(16).float() / 16 + 0.5).to(
+            torch.bfloat16
+        )
+        self.q = torch.zeros(16, 16, dtype=torch.float32)
+        # Binary-exact orthogonal coefficients permit exact weight assertions
+        # despite FP32 GEMM versus the independent FP64 scalar oracle. A column
+        # permutation makes Q non-symmetric, so transposing it changes results.
+        block = (
+            torch.tensor(
+                [[1, 1, 1, 1], [1, -1, 1, -1], [1, 1, -1, -1], [1, -1, -1, 1]],
+                dtype=torch.float32,
+            )[:, [1, 2, 3, 0]]
+            / 2
+        )
+        for index in range(0, 16, 4):
+            self.q[index : index + 4, index : index + 4] = block
+        self.q_path = self.root / "quarot.safetensors"
+        save_file({"global_rotation": self.q}, str(self.q_path))
+        self.quarot_config = GlmDSparkQuaRotConfig(
+            rotation_path=str(self.q_path),
+            hidden_size=16,
+            target_model_path=str(self.root / "target"),
+        )
+
+    def _load(self, *, mode="original", npu=True, scope=True, weights=None):
+        (self.model_dir / "config.json").write_text(json.dumps(self.config))
+        save_file(
+            self.weights if weights is None else weights,
+            str(self.model_dir / "model.safetensors"),
+        )
+        config = ModelConfig(
+            str(self.model_dir),
+            dtype="bfloat16",
+            is_draft_model=True,
+            speculative_algorithm="DSpark",
+        )
+        self.assertIsNone(config.quantization)
+        loader = DefaultModelLoader(LoadConfig(load_format="safetensors"))
+        with ExitStack() as stack:
+            stack.enter_context(envs.SGLANG_NPU_GLM_DSPARK_QUAROT.override(mode))
+            stack.enter_context(
+                patch("sglang.srt.models.dspark.is_npu", return_value=npu)
+            )
+            if scope:
+                stack.enter_context(glm_dspark_quarot_scope(self.quarot_config))
+            return loader.load_model(
+                model_config=config, device_config=DeviceConfig("cpu")
+            )
+
+    def _expected_fc(self, original):
+        # Independent scalar dot products use the actual serialized Q values.
+        # They avoid calling the production converter or sharing its reshape.
+        expected = torch.empty_like(original, dtype=torch.float64)
+        source = original.double()
+        q = self.q.double()
+        for row in range(16):
+            for feature in range(3):
+                for column in range(16):
+                    expected[row, feature * 16 + column] = sum(
+                        source[row, feature * 16 + index] * q[index, column]
+                        for index in range(16)
+                    )
+        return expected.to(torch.bfloat16)
+
+    def _assert_own_weights(self, model, original_fc):
+        self.assertIsInstance(model, DSparkDraftModel)
+        self.assertTrue(model.uses_own_vocab_modules)
+        self.assertEqual(model._glm_dspark_quarot_config, self.quarot_config)
+        for module, key in (
+            (model.embed_tokens, "embed_tokens.weight"),
+            (model.lm_head, "lm_head.weight"),
+        ):
+            self.assertEqual(module.weight.dtype, torch.bfloat16)
+            # VocabParallelEmbedding can pad its allocation beyond vocab_size.
+            torch.testing.assert_close(
+                module.weight[:32], self.weights[key], rtol=0, atol=0
+            )
+        torch.testing.assert_close(
+            model.fc.weight, self._expected_fc(original_fc), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            model.hidden_norm.weight,
+            self.weights["hidden_norm.weight"],
+            rtol=0,
+            atol=0,
+        )
+        self.assertEqual(model.fc.weight.dtype, torch.bfloat16)
+        self.assertIsNone(model.confidence_head)
+
+    def test_normal_loader_loads_own_vocab_and_rotates_each_original_fc_block(self):
+        before = {name: value.clone() for name, value in self.weights.items()}
+        model = self._load()
+        self._assert_own_weights(model, before["fc.weight"])
+        self.assertFalse(torch.equal(model.fc.weight, before["fc.weight"]))
+        for name, value in before.items():
+            torch.testing.assert_close(self.weights[name], value, rtol=0, atol=0)
+        token_ids = torch.tensor([0, 7, 31])
+        torch.testing.assert_close(
+            model.forward_embed(token_ids),
+            before["embed_tokens.weight"][token_ids],
+            rtol=0,
+            atol=0,
+        )
+        hidden = (torch.arange(32).reshape(2, 16).float() / 32).to(torch.bfloat16)
+        logits, _ = model.compute_base_logits(hidden)
+        torch.testing.assert_close(
+            logits, hidden @ before["lm_head.weight"].T, rtol=0, atol=0
+        )
+
+    def test_loaded_fc_and_original_norm_execute_the_cpu_reference(self):
+        model = self._load()
+        original = (torch.arange(3 * 3 * 16).reshape(3, 3, 16) * 5) % 37 - 18
+        original = original.double() / 32
+        original *= torch.tensor([1.0, 0.01, 0.0001]).reshape(3, 1, 1)
+        rotated = (original @ self.q.double()).reshape(3, 48).to(torch.bfloat16)
+        expected_fc = self._expected_fc(self.weights["fc.weight"])
+        pre_norm = (rotated.double() @ expected_fc.double().T).to(torch.bfloat16)
+        work = pre_norm.double()
+        expected = (
+            work
+            / (work.square().mean(dim=-1, keepdim=True) + 1e-5).sqrt()
+            * self.weights["hidden_norm.weight"].double()
+        ).to(torch.bfloat16)
+        with torch.no_grad():
+            actual = model.project_target_hidden(rotated)
+        # Use torch's dtype-specific tolerances for this synthetic CPU oracle;
+        # they are not a threshold for real NPU/model acceptance.
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(model.hidden_norm.variance_epsilon, 1e-5)
+
+    def test_active_loading_does_not_replace_or_modify_shared_target_modules(self):
+        shared_model = self._load(mode="", scope=False)
+        with set_default_torch_dtype(torch.bfloat16), torch.device("cpu"):
+            target_embedding = VocabParallelEmbedding(32, 16)
+            target_head = ParallelLMHead(32, 16)
+        with torch.no_grad():
+            target_embedding.weight.fill_(0.125)
+            target_head.weight.fill_(-0.25)
+        embedding_before = target_embedding.weight.detach().clone()
+        head_before = target_head.weight.detach().clone()
+        shared_model.attach_shared_modules(
+            embed_tokens=target_embedding, lm_head=target_head
+        )
+        active = self._load()
+        active.load_weights(self.weights.items())
+        self.assertIsNot(active.embed_tokens, target_embedding)
+        self.assertIsNot(active.lm_head, target_head)
+        self.assertIs(shared_model.embed_tokens, target_embedding)
+        self.assertIs(shared_model.lm_head, target_head)
+        torch.testing.assert_close(
+            target_embedding.weight, embedding_before, rtol=0, atol=0
+        )
+        torch.testing.assert_close(target_head.weight, head_before, rtol=0, atol=0)
+        # A subsequent draft has no lingering constructor scope or own vocab.
+        subsequent = self._load(scope=False)
+        self.assertIsNone(subsequent.embed_tokens)
+        self.assertIsNone(subsequent.lm_head)
+
+    def test_partial_original_fc_reload_converts_once_and_retains_parameter_identity(
+        self,
+    ):
+        model = self._load()
+        parameter = model.fc.weight
+        embedding = model.embed_tokens.weight.detach().clone()
+        head = model.lm_head.weight.detach().clone()
+        changed = (-self.weights["fc.weight"] + 0.125).to(torch.bfloat16)
+        for source in (self.weights["fc.weight"], self.weights["fc.weight"], changed):
+            with self.subTest(changed=source is changed):
+                before = source.clone()
+                model.load_weights([("fc.weight", source)])
+                self.assertIs(model.fc.weight, parameter)
+                torch.testing.assert_close(
+                    parameter, self._expected_fc(before), rtol=0, atol=0
+                )
+                torch.testing.assert_close(source, before, rtol=0, atol=0)
+        torch.testing.assert_close(model.embed_tokens.weight, embedding, rtol=0, atol=0)
+        torch.testing.assert_close(model.lm_head.weight, head, rtol=0, atol=0)
+
+    def test_initial_load_requires_own_embedding_head_and_fc(self):
+        for missing in ("embed_tokens.weight", "lm_head.weight", "fc.weight"):
+            with self.subTest(missing=missing):
+                incomplete = {
+                    name: value
+                    for name, value in self.weights.items()
+                    if name != missing
+                }
+                with self.assertRaisesRegex(
+                    ValueError, "(?i)(missing|required)"
+                ) as error:
+                    self._load(weights=incomplete)
+                self.assertIn(missing, str(error.exception))
+
+    def test_model_prefix_and_encoder_alias_load_the_same_original_parameters(self):
+        for fc_name in ("model.fc.weight", "encoder.fc.weight"):
+            with self.subTest(fc_name=fc_name):
+                aliases = dict(self.weights)
+                aliases[fc_name] = aliases.pop("fc.weight")
+                aliases["model.embed_tokens.weight"] = aliases.pop(
+                    "embed_tokens.weight"
+                )
+                aliases["model.lm_head.weight"] = aliases.pop("lm_head.weight")
+                aliases["encoder.output_norm_enc.weight"] = aliases.pop(
+                    "hidden_norm.weight"
+                )
+                model = self._load(weights=aliases)
+                self._assert_own_weights(model, self.weights["fc.weight"])
+
+    def test_inactive_paths_keep_the_shared_vocab_contract_without_reading_q(self):
+        self.q_path.unlink()
+        for options in (
+            {"mode": ""},
+            {"npu": False},
+            {"scope": False},
+        ):
+            with self.subTest(options=options):
+                model = self._load(**options)
+                self.assertIsNone(model._glm_dspark_quarot_config)
+                self.assertFalse(getattr(model, "uses_own_vocab_modules", False))
+                self.assertIsNone(model.embed_tokens)
+                self.assertIsNone(model.lm_head)
+                torch.testing.assert_close(
+                    model.fc.weight, self.weights["fc.weight"], rtol=0, atol=0
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_dspark_weight_loading.py
+++ b/test/registered/unit/model_loader/test_dspark_weight_loading.py
@@ -1,0 +1,265 @@
+"""Load a small dense DSpark checkpoint through the production CPU loader.
+
+The synthetic file has the same 64-tensor layout as a five-layer BF16 export.
+It verifies loading and shared-module contracts, not accelerator inference.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.distributed import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.environ import envs
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_loader.loader import DefaultModelLoader
+from sglang.srt.model_loader.utils import set_default_torch_dtype
+from sglang.srt.models.dspark import DSparkDraftModel
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=12, suite="base-a-test-cpu")
+
+
+def _checkpoint():
+    config = {
+        "architectures": ["DSparkDraftModel"],
+        "dtype": "bfloat16",
+        "block_size": 8,
+        "aux_hidden_state_layer_ids": [2, 4, 6],
+        "mask_token_id": 31,
+        "markov_rank": 4,
+        "markov_head_type": "vanilla",
+        "enable_confidence_head": True,
+        "confidence_head_with_markov": True,
+        "transformer_layer_config": {
+            "model_type": "qwen3",
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 5,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            # Keep head_dim independent of hidden_size / num_attention_heads,
+            # and three captured features independent of the five draft layers.
+            "head_dim": 16,
+            "vocab_size": 32,
+            "max_position_embeddings": 128,
+            "tie_word_embeddings": False,
+        },
+    }
+    weights = {}
+
+    def add(name, shape):
+        # Distinct values by source tensor and position reveal shard swaps and
+        # accidental transposes; all comparisons use the serialized BF16 data.
+        value = torch.arange(torch.Size(shape).numel()).reshape(shape) % 23
+        weights[name] = (value.float() / 32 + len(weights)).to(torch.bfloat16)
+
+    for index in range(5):
+        for name, shape in {
+            "self_attn.q_proj.weight": (32, 16),
+            "self_attn.k_proj.weight": (32, 16),
+            "self_attn.v_proj.weight": (32, 16),
+            "self_attn.o_proj.weight": (16, 32),
+            "self_attn.q_norm.weight": (16,),
+            "self_attn.k_norm.weight": (16,),
+            "mlp.gate_proj.weight": (32, 16),
+            "mlp.up_proj.weight": (32, 16),
+            "mlp.down_proj.weight": (16, 32),
+            "input_layernorm.weight": (16,),
+            "post_attention_layernorm.weight": (16,),
+        }.items():
+            add(f"layers.{index}.{name}", shape)
+    for name, shape in {
+        "fc.weight": (16, 48),
+        "hidden_norm.weight": (16,),
+        "norm.weight": (16,),
+        "markov_head.markov_w1.weight": (32, 4),
+        "markov_head.markov_w2.weight": (32, 4),
+        "confidence_head.proj.weight": (1, 20),
+        "confidence_head.proj.bias": (1,),
+        "embed_tokens.weight": (32, 16),
+        "lm_head.weight": (32, 16),
+    }.items():
+        add(name, shape)
+    return config, weights
+
+
+class TestDSparkWeightLoading(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.group_dir = tempfile.TemporaryDirectory()
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method=f"file://{cls.group_dir.name}/gloo",
+            backend="gloo",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1, backend="gloo")
+
+    @classmethod
+    def tearDownClass(cls):
+        destroy_model_parallel()
+        destroy_distributed_environment()
+        cls.group_dir.cleanup()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(envs.SGLANG_RAGGED_VERIFY_MODE.override("static"))
+        self.enterContext(
+            get_context().override_server_args(
+                speculative_algorithm="DSpark", device="cpu"
+            )
+        )
+        self.model_dir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.config, self.weights = _checkpoint()
+
+    def _load(self):
+        (self.model_dir / "config.json").write_text(json.dumps(self.config))
+        save_file(self.weights, str(self.model_dir / "model.safetensors"))
+        config = ModelConfig(
+            str(self.model_dir),
+            dtype="bfloat16",
+            is_draft_model=True,
+            speculative_algorithm="DSpark",
+        )
+        self.assertIsNone(config.quantization)
+        loader = DefaultModelLoader(LoadConfig(load_format="safetensors"))
+        return loader.load_model(model_config=config, device_config=DeviceConfig("cpu"))
+
+    def test_all_static_weights_and_shards_are_loaded_in_bfloat16(self):
+        model = self._load()
+        self.assertIsInstance(model, DSparkDraftModel)
+        self.assertEqual(len(self.weights), 64)
+        self.assertIsNone(model.confidence_head)
+        self.assertIsNone(model.embed_tokens)
+        self.assertIsNone(model.lm_head)
+        params = dict(model.named_parameters())
+        checked = set()
+        checked_source_count = 0
+        for name, source in self.weights.items():
+            if name.startswith(("confidence_head.", "embed_tokens.", "lm_head.")):
+                continue
+            loaded = None
+            for export_name, packed_name, shard in (
+                ("q_proj", "qkv_proj", 0),
+                ("k_proj", "qkv_proj", 1),
+                ("v_proj", "qkv_proj", 2),
+                ("gate_proj", "gate_up_proj", 0),
+                ("up_proj", "gate_up_proj", 1),
+            ):
+                if f".{export_name}." in name:
+                    destination = name.replace(export_name, packed_name)
+                    loaded = params[destination].narrow(0, shard * 32, 32)
+                    break
+            else:
+                destination = name
+                loaded = params[name]
+            self.assertEqual(loaded.dtype, torch.bfloat16)
+            torch.testing.assert_close(loaded, source, rtol=0, atol=0)
+            checked.add(destination)
+            checked_source_count += 1
+        self.assertEqual(checked_source_count, 60)
+        self.assertEqual(checked, set(params))
+        self.assertEqual(model.fc.in_features, 48)
+        self.assertEqual(len(model.layers), 5)
+        self.assertEqual(model.layers[0].self_attn.head_dim, 16)
+
+    def test_shared_target_modules_are_preserved_and_markov_is_used(self):
+        model = self._load()
+        with set_default_torch_dtype(torch.bfloat16), torch.device("cpu"):
+            embedding = VocabParallelEmbedding(32, 16)
+            head = ParallelLMHead(32, 16)
+        with torch.no_grad():
+            embedding.weight.fill_(0.25)
+            head.weight.copy_(
+                (torch.arange(head.weight.numel()).reshape_as(head.weight) % 7) / 16
+            )
+        embedding_before, head_before = (
+            embedding.weight.detach().clone(),
+            head.weight.detach().clone(),
+        )
+        model.attach_shared_modules(embed_tokens=embedding, lm_head=head)
+        # A reload must not replace target weights with the draft export's copy.
+        model.load_weights(self.weights.items())
+        self.assertIs(model.embed_tokens, embedding)
+        self.assertIs(model.lm_head, head)
+        torch.testing.assert_close(embedding.weight, embedding_before, rtol=0, atol=0)
+        torch.testing.assert_close(head.weight, head_before, rtol=0, atol=0)
+        hidden = torch.full((2, 16), 0.125, dtype=torch.bfloat16)
+        logits, _ = model.compute_base_logits(hidden)
+        expected = hidden @ head_before.T
+        torch.testing.assert_close(logits, expected[:, :32], rtol=0, atol=0)
+        previous = torch.tensor([1, 3])
+        corrected = model.markov_head.apply_step_logits(
+            logits, token_ids=previous, hidden_states=None
+        )
+        expected_bias = (
+            self.weights["markov_head.markov_w1.weight"][previous]
+            @ self.weights["markov_head.markov_w2.weight"].T
+        )
+        torch.testing.assert_close(corrected, logits + expected_bias, rtol=0, atol=0)
+        self.assertFalse(torch.equal(corrected, logits))
+
+    def test_fc_feature_count_mismatch_is_rejected(self):
+        self.weights["fc.weight"] = torch.ones(16, 80, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(ValueError, "fc.weight shape mismatch"):
+            self._load()
+
+    def test_native_config_packed_weights_and_backbone_aliases(self):
+        # Exercise the existing flat HF export, fused projections, backbone
+        # model prefix, and encoder aliases through the production loader.
+        from sglang.srt.configs.speculators import normalize_speculators_dspark_config
+
+        self.config = normalize_speculators_dspark_config(self.config)
+        packed_expected = {}
+        for index in range(5):
+            for packed, sources in (
+                ("self_attn.qkv_proj", ("q_proj", "k_proj", "v_proj")),
+                ("mlp.gate_up_proj", ("gate_proj", "up_proj")),
+            ):
+                family = packed.split(".")[0]
+                name = f"layers.{index}.{packed}.weight"
+                weight = torch.cat(
+                    [
+                        self.weights.pop(f"layers.{index}.{family}.{source}.weight")
+                        for source in sources
+                    ]
+                )
+                packed_expected[name] = weight
+                self.weights[name] = weight
+        self.weights["encoder.fc.weight"] = self.weights.pop("fc.weight")
+        self.weights["encoder.output_norm_enc.weight"] = self.weights.pop(
+            "hidden_norm.weight"
+        )
+        self.weights = {
+            f"model.{name}" if name.startswith("layers.") else name: value
+            for name, value in self.weights.items()
+        }
+        self.weights["model.layers.0.self_attn.rotary_emb.inv_freq"] = torch.ones(8)
+        model = self._load()
+        params = dict(model.named_parameters())
+        for name, weight in packed_expected.items():
+            torch.testing.assert_close(params[name], weight, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_dflash_npu_qk_norm_rope.py
+++ b/test/registered/unit/models/test_dflash_npu_qk_norm_rope.py
@@ -1,0 +1,312 @@
+"""Existing DFlash call contracts and CPU numerics.
+
+Real projection, norm, RoPE and worker code run with CPU tensors. NPU/table
+kernels and KV storage are mocked at their boundaries. These tests cover
+caller compatibility, not real accelerator execution or NPU 192 support.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.rotary_embedding.base import (
+    LinearScalingRotaryEmbedding,
+    RotaryEmbedding,
+)
+from sglang.srt.models import dflash
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _CountingLinear(nn.Linear):
+    def __init__(self, in_features, out_features, dtype):
+        super().__init__(in_features, out_features, bias=False, dtype=dtype)
+        self.calls = 0
+
+    def forward(self, hidden_states):
+        self.calls += 1
+        return super().forward(hidden_states), None
+
+
+class _CaptureAttention(nn.Module):
+    layer_id = 0
+
+    def forward(self, q, k, v, forward_batch):
+        self.qkv = tuple(x.detach().clone() for x in (q, k, v))
+        return q
+
+
+def _make_attention(head_dim, *, dtype=torch.float32, neox=True, scaling=1.0):
+    # Avoid distributed group initialization while exercising the production
+    # forward with real projection, norm and rotary modules.
+    attn = dflash.DFlashAttention.__new__(dflash.DFlashAttention)
+    nn.Module.__init__(attn)
+    attn.head_dim = head_dim
+    attn.num_heads = 4
+    attn.num_kv_heads = 2
+    attn.q_size = 4 * head_dim
+    attn.kv_size = 2 * head_dim
+    attn.qkv_proj = _CountingLinear(16, attn.q_size + 2 * attn.kv_size, dtype)
+    attn.o_proj = _CountingLinear(attn.q_size, 16, dtype)
+    attn.q_norm = RMSNorm(head_dim, eps=1e-6).to(dtype=dtype)
+    attn.k_norm = RMSNorm(head_dim, eps=1e-6).to(dtype=dtype)
+    with torch.no_grad():
+        attn.q_norm.weight.copy_(torch.linspace(0.5, 1.5, head_dim))
+        attn.k_norm.weight.copy_(torch.linspace(1.7, 0.7, head_dim))
+    rope_kwargs = dict(
+        head_size=head_dim,
+        rotary_dim=head_dim,
+        max_position_embeddings=64,
+        base=10000,
+        is_neox_style=neox,
+        dtype=dtype,
+    )
+    if scaling == 1.0:
+        attn.rotary_emb = RotaryEmbedding(**rope_kwargs)
+    else:
+        attn.rotary_emb = LinearScalingRotaryEmbedding(
+            **rope_kwargs, scaling_factors=[scaling]
+        )
+    attn.attn = _CaptureAttention()
+    attn.attention_sink_bias = None
+    attn.use_table_qk_norm_rope = False
+    return attn
+
+
+def _reference_qkv(attn, hidden_states, positions, *, neox, scaling):
+    q, k, v = F.linear(hidden_states, attn.qkv_proj.weight).split(
+        [attn.q_size, attn.kv_size, attn.kv_size], dim=-1
+    )
+
+    def norm_and_rotate(x, weight):
+        by_head = x.float().reshape(x.shape[0], -1, attn.head_dim)
+        normalized = by_head * torch.rsqrt(
+            by_head.square().mean(-1, keepdim=True) + 1e-6
+        )
+        normalized = (normalized.to(x.dtype) * weight).to(x.dtype)
+        inv_freq = 10000.0 ** (
+            -torch.arange(0, attn.head_dim, 2, dtype=torch.float32) / attn.head_dim
+        )
+        angles = positions.float()[:, None] / scaling * inv_freq[None, :]
+        cos = angles.cos().to(x.dtype)[:, None, :]
+        sin = angles.sin().to(x.dtype)[:, None, :]
+        if neox:
+            first, second = normalized.chunk(2, dim=-1)
+            rotated = torch.cat(
+                (first * cos - second * sin, second * cos + first * sin), dim=-1
+            )
+        else:
+            first, second = normalized[..., ::2], normalized[..., 1::2]
+            rotated = torch.stack(
+                (first * cos - second * sin, second * cos + first * sin), dim=-1
+            ).flatten(-2)
+        return rotated.reshape_as(x)
+
+    return (
+        norm_and_rotate(q, attn.q_norm.weight),
+        norm_and_rotate(k, attn.k_norm.weight),
+        v,
+    )
+
+
+class TestDFlashNpuQkNormRope(CustomTestCase):
+    def test_other_kv_rope_paths_keep_module_dispatch(self):
+        torch.manual_seed(2026)
+        for is_npu, head_dim in ((False, 192), (True, 128), (True, 256)):
+            with self.subTest(is_npu=is_npu, head_dim=head_dim):
+                attn = _make_attention(head_dim)
+                rope_forward = Mock(wraps=attn.rotary_emb.forward_native)
+                attn.rotary_emb._forward_method = rope_forward
+                hidden_states = torch.randn(3, 16)
+                positions = torch.tensor([0, 7, 31], dtype=torch.int64)
+                expected_qkv = _reference_qkv(
+                    attn, hidden_states, positions, neox=True, scaling=1.0
+                )
+                with patch.object(dflash, "_is_npu", is_npu):
+                    k, _ = attn.kv_proj_only(hidden_states)
+                    actual_k = attn.apply_k_rope(positions, attn.apply_k_norm(k))
+                rope_forward.assert_called_once()
+                torch.testing.assert_close(
+                    actual_k, expected_qkv[1], rtol=1e-5, atol=1e-5
+                )
+
+    def test_non_npu_forward_keeps_separate_ops(self):
+        torch.manual_seed(2026)
+        for head_dim in (128, 192, 256):
+            with self.subTest(head_dim=head_dim):
+                attn = _make_attention(head_dim)
+                hidden_states = torch.randn(3, 16)
+                positions = torch.tensor([0, 7, 31], dtype=torch.int64)
+                expected_qkv = _reference_qkv(
+                    attn, hidden_states, positions, neox=True, scaling=1.0
+                )
+                fused = Mock(
+                    side_effect=AssertionError("NPU kernel must not run on CPU")
+                )
+                with (
+                    patch.object(dflash, "_is_npu", False),
+                    patch.object(dflash, "split_qkv_rmsnorm_rope", fused, create=True),
+                ):
+                    actual = attn(positions, hidden_states, forward_batch=None)
+                fused.assert_not_called()
+                self.assertEqual(attn.qkv_proj.calls, 1)
+                for got, expected in zip(attn.attn.qkv, expected_qkv):
+                    torch.testing.assert_close(got, expected, rtol=1e-5, atol=1e-5)
+                torch.testing.assert_close(
+                    actual,
+                    F.linear(expected_qkv[0], attn.o_proj.weight),
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
+
+    def test_supported_head_dims_keep_fused_dispatch(self):
+        torch.manual_seed(2026)
+        for head_dim in (128, 256):
+            for neox in (True, False):
+                with self.subTest(head_dim=head_dim, neox=neox):
+                    attn = _make_attention(head_dim, neox=neox)
+                    hidden_states = torch.randn(3, 16)
+                    positions = torch.tensor([0, 7, 31], dtype=torch.int64)
+                    projected = F.linear(hidden_states, attn.qkv_proj.weight)
+                    fused_outputs = tuple(
+                        x.clone()
+                        for x in projected.split(
+                            [attn.q_size, attn.kv_size, attn.kv_size], dim=-1
+                        )
+                    )
+                    fused = Mock(return_value=fused_outputs)
+                    with (
+                        patch.object(dflash, "_is_npu", True),
+                        patch.object(
+                            dflash, "split_qkv_rmsnorm_rope", fused, create=True
+                        ),
+                        patch.object(
+                            dflash,
+                            "apply_qk_norm",
+                            side_effect=AssertionError(
+                                "separate norm must not run for supported fused sizes"
+                            ),
+                        ),
+                    ):
+                        actual = attn(positions, hidden_states, forward_batch=None)
+
+                    fused.assert_called_once()
+                    self.assertEqual(fused.call_args.args[5], head_dim)
+                    torch.testing.assert_close(fused.call_args.args[0], projected)
+                    for got, expected in zip(attn.attn.qkv, fused_outputs):
+                        torch.testing.assert_close(got, expected)
+                    torch.testing.assert_close(
+                        actual, F.linear(fused_outputs[0], attn.o_proj.weight)
+                    )
+
+    def test_npu_worker_projects_hidden_before_writing_layer_kv(self):
+        from sglang.srt.speculative import dflash_worker_v2
+
+        torch.manual_seed(2026)
+        for head_dim in (128, 256):
+            with self.subTest(head_dim=head_dim):
+                attentions = [_make_attention(head_dim) for _ in range(2)]
+                layers = [
+                    SimpleNamespace(self_attn=attn, offset=index + 1)
+                    for index, attn in enumerate(attentions)
+                ]
+                for attn in attentions:
+                    attn.attn.k_scale = None
+                    attn.attn.v_scale = None
+                pool = SimpleNamespace(set_kv_buffer=Mock())
+                worker = SimpleNamespace(
+                    draft_model=SimpleNamespace(
+                        layers=layers,
+                        prepare_context_hidden_for_kv=lambda layer, hidden: (
+                            hidden + layer.offset
+                        ),
+                    ),
+                    draft_model_runner=SimpleNamespace(token_to_kv_pool=pool),
+                )
+                hidden = torch.randn(3, 16)
+                positions = torch.tensor([0, 7, 31], dtype=torch.int64)
+                cache_loc = torch.tensor([2, 4, 6], dtype=torch.int64)
+
+                def fused_split(qkv, sin, cos, q_size, kv_size, dim, **kwargs):
+                    self.assertEqual(qkv.shape, (3, q_size + 2 * kv_size))
+                    self.assertEqual(dim, head_dim)
+                    return qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+                with (
+                    patch.object(dflash_worker_v2, "_is_npu", True),
+                    patch.object(
+                        dflash,
+                        "split_qkv_rmsnorm_rope",
+                        side_effect=fused_split,
+                        create=True,
+                    ) as fused,
+                ):
+                    dflash_worker_v2.DFlashWorkerV2._append_target_hidden_sequential(
+                        worker, hidden, positions, cache_loc
+                    )
+
+                self.assertEqual(fused.call_count, len(layers))
+                self.assertEqual(pool.set_kv_buffer.call_count, len(layers))
+                for layer, call in zip(layers, pool.set_kv_buffer.call_args_list):
+                    attn = layer.self_attn
+                    expected = F.linear(hidden + layer.offset, attn.qkv_proj.weight)
+                    _, expected_k, expected_v = expected.split(
+                        [attn.q_size, attn.kv_size, attn.kv_size], dim=-1
+                    )
+                    self.assertEqual(attn.qkv_proj.calls, 1)
+                    self.assertIs(call.args[0], attn.attn)
+                    torch.testing.assert_close(call.args[1], cache_loc)
+                    torch.testing.assert_close(
+                        call.args[2], expected_k.reshape(3, attn.num_kv_heads, head_dim)
+                    )
+                    torch.testing.assert_close(
+                        call.args[3], expected_v.reshape(3, attn.num_kv_heads, head_dim)
+                    )
+
+    def test_non_npu_bf16_keeps_table_dispatch(self):
+        from sglang.srt.speculative import dflash_utils
+
+        torch.manual_seed(2026)
+        attn = _make_attention(128, dtype=torch.bfloat16)
+        attn.use_table_qk_norm_rope = True
+        hidden = torch.randn(3, 16, dtype=torch.bfloat16)
+        positions = torch.tensor([0, 7, 31], dtype=torch.int64)
+        projected = F.linear(hidden, attn.qkv_proj.weight)
+        with (
+            patch.object(dflash, "_is_npu", False),
+            patch.object(dflash_utils, "table_qk_norm_rope_") as table,
+            patch.object(
+                dflash,
+                "apply_qk_norm",
+                side_effect=AssertionError("table path must not use separate norm"),
+            ),
+            patch.object(
+                dflash,
+                "split_qkv_rmsnorm_rope",
+                side_effect=AssertionError("non-NPU path must not use NPU split"),
+                create=True,
+            ),
+        ):
+            attn(positions, hidden, forward_batch=None)
+        table.assert_called_once()
+        torch.testing.assert_close(table.call_args.args[0], projected)
+        torch.testing.assert_close(table.call_args.args[1], positions)
+        self.assertIs(table.call_args.args[2], attn.q_norm.weight)
+        self.assertIs(table.call_args.args[3], attn.k_norm.weight)
+        self.assertEqual(attn.qkv_proj.calls, 1)
+        expected_qkv = projected.split(
+            [attn.q_size, attn.kv_size, attn.kv_size], dim=-1
+        )
+        for got, expected in zip(attn.attn.qkv, expected_qkv):
+            torch.testing.assert_close(got, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_dspark_npu_quarot.py
+++ b/test/registered/unit/models/test_dspark_npu_quarot.py
@@ -1,0 +1,266 @@
+"""CPU tests for the opt-in GLM DSpark loading contract, not NPU accuracy."""
+
+import asyncio
+import copy
+import tempfile
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.srt.hardware_backend.npu import dspark_quarot as qr
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestGlmDSparkQuaRot(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.q_path = self.root / "optional" / "quarot.safetensors"
+        self.q_path.parent.mkdir()
+        # An asymmetric permutation distinguishes Q from Q.T; its scale is
+        # deliberately not one so automatic norm compensation fails the test.
+        self.q = torch.tensor([[0, 0.5, 0], [0, 0, 0.5], [0.5, 0, 0]])
+        self.save_q(self.q)
+        self.hf = SimpleNamespace(architectures=["GlmMoeDsaForCausalLM"], hidden_size=3)
+        self.model_config = SimpleNamespace(
+            hf_text_config=self.hf, model_path=str(self.root)
+        )
+        self.description = {
+            "is_rot_used": True,
+            "metadata": {},
+            "optional": {
+                "quarot": {
+                    "rotation_map": {"global_rotation": "optional/quarot.safetensors"}
+                }
+            },
+        }
+        self.quant = SimpleNamespace(
+            get_name=lambda: "modelslim", quant_description=self.description
+        )
+        self.model = SimpleNamespace(quant_config=self.quant)
+        self.config = qr.GlmDSparkQuaRotConfig(str(self.q_path), 3, str(self.root))
+
+    def save_q(self, value, key="global_rotation"):
+        save_file({key: value.contiguous()}, str(self.q_path))
+
+    def build(self, **overrides):
+        arguments = {
+            "device": "npu:0",
+            "mode": "original",
+            "target_model_config": self.model_config,
+            "target_model": self.model,
+        }
+        arguments.update(overrides)
+        return qr.build_glm_dspark_quarot_config(**arguments)
+
+    def test_target_metadata_is_read_only_and_config_is_frozen(self):
+        before = copy.deepcopy(self.description)
+        self.assertEqual(self.build(), self.config)
+        self.assertEqual(self.description, before)
+        with self.assertRaises(FrozenInstanceError):
+            self.config.hidden_size = 4
+
+    def test_inactive_or_unrelated_targets_do_not_open_q(self):
+        cases = (
+            {"mode": None},
+            {"mode": ""},
+            {"device": "cuda:0"},
+            {"device": "cpu"},
+            {"target_model_config": SimpleNamespace()},
+            {
+                "target_model_config": SimpleNamespace(
+                    hf_text_config=SimpleNamespace(
+                        architectures=["DeepseekV4ForCausalLM"]
+                    )
+                )
+            },
+            {"target_model": SimpleNamespace()},
+            {
+                "target_model": SimpleNamespace(
+                    quant_config=SimpleNamespace(get_name=lambda: "fp8")
+                )
+            },
+        )
+        with patch.object(
+            qr, "safe_open", side_effect=AssertionError("unexpected Q read")
+        ):
+            for arguments in cases:
+                with self.subTest(arguments=arguments):
+                    self.assertIsNone(self.build(**arguments))
+
+    def test_enabled_target_rejects_unknown_mode_and_missing_quarot(self):
+        with self.assertRaisesRegex(ValueError, "must be 'original'"):
+            self.build(mode="auto")
+        self.description["is_rot_used"] = False
+        with self.assertRaisesRegex(ValueError, "QuaRot target"):
+            self.build()
+        self.description["is_rot_used"] = True
+        del self.description["optional"]
+        with self.assertRaisesRegex(ValueError, "global_rotation path"):
+            self.build()
+
+    def test_enabled_target_rejects_missing_file_bad_shape_and_bad_key(self):
+        self.q_path.unlink()
+        with self.assertRaises(FileNotFoundError):
+            self.build()
+        self.save_q(torch.eye(2))
+        with self.assertRaisesRegex(ValueError, "shape"):
+            self.build()
+        self.save_q(self.q, key="rot.weight")
+        with self.assertRaisesRegex(ValueError, "global_rotation tensor"):
+            self.build()
+
+    def test_relative_path_can_resolve_to_shared_q_symlink(self):
+        rotation_map = self.description["optional"]["quarot"]["rotation_map"]
+        rotation_map["global_rotation"] = str(self.q_path)
+        with self.assertRaisesRegex(ValueError, "relative"):
+            self.build()
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "other.safetensors"
+            save_file({"global_rotation": self.q}, str(target))
+            link = self.root / "outside.safetensors"
+            link.symlink_to(target)
+            rotation_map["global_rotation"] = link.name
+            config = self.build()
+            self.assertEqual(config.rotation_path, str(target.resolve()))
+            self.assertEqual(config.target_model_path, str(self.root))
+            weight = torch.arange(18, dtype=torch.float32).reshape(3, 6)
+            expected = torch.cat([block @ self.q for block in weight.split(3, 1)], 1)
+            torch.testing.assert_close(qr.fold_glm_dspark_fc(weight, config), expected)
+
+    def test_target_hidden_width_must_be_positive_integer(self):
+        for value in (None, 0, -1, True, 3.5):
+            with self.subTest(value=value):
+                self.hf.hidden_size = value
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    self.build()
+
+    def test_scope_nesting_none_and_exception_restore(self):
+        other = qr.GlmDSparkQuaRotConfig("other", 3, "target")
+        self.assertIsNone(qr.get_glm_dspark_quarot_config())
+        with qr.glm_dspark_quarot_scope(self.config):
+            self.assertIs(qr.get_glm_dspark_quarot_config(), self.config)
+            with qr.glm_dspark_quarot_scope(None):
+                self.assertIsNone(qr.get_glm_dspark_quarot_config())
+            with self.assertRaisesRegex(RuntimeError, "nested"):
+                with qr.glm_dspark_quarot_scope(other):
+                    self.assertIs(qr.get_glm_dspark_quarot_config(), other)
+                    raise RuntimeError("nested")
+            self.assertIs(qr.get_glm_dspark_quarot_config(), self.config)
+        self.assertIsNone(qr.get_glm_dspark_quarot_config())
+
+    def test_async_constructions_do_not_share_scope_updates(self):
+        async def visit(config):
+            with qr.glm_dspark_quarot_scope(config):
+                await asyncio.sleep(0)
+                self.assertIs(qr.get_glm_dspark_quarot_config(), config)
+            self.assertIsNone(qr.get_glm_dspark_quarot_config())
+
+        async def run():
+            await asyncio.gather(visit(self.config), visit(None))
+
+        asyncio.run(run())
+
+    def test_asymmetric_scaled_q_folds_each_block_without_correction(self):
+        original = torch.arange(18, dtype=torch.float32).reshape(3, 6) / 8 - 1
+        # Independent dense block-diagonal oracle also checks feature order.
+        rotation = torch.block_diag(self.q.double(), self.q.double())
+        expected = original.double() @ rotation
+        with patch.object(
+            torch, "set_num_threads", side_effect=AssertionError("threads")
+        ):
+            result = qr.fold_glm_dspark_fc(original, self.config)
+        torch.testing.assert_close(result.double(), expected, rtol=0, atol=0)
+        self.assertFalse(
+            torch.equal(result, (original.double() @ rotation * 4).float())
+        )
+
+    def test_dtype_source_and_reload_are_preserved(self):
+        file_before = self.q_path.read_bytes()
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                source = torch.arange(18, dtype=dtype).reshape(3, 6).requires_grad_()
+                before = source.detach().clone()
+                first = qr.fold_glm_dspark_fc(source, self.config)
+                again = qr.fold_glm_dspark_fc(source, self.config)
+                self.assertEqual(first.dtype, dtype)
+                self.assertEqual(first.device.type, "cpu")
+                self.assertFalse(first.requires_grad)
+                self.assertNotEqual(first.data_ptr(), source.data_ptr())
+                torch.testing.assert_close(first, again, rtol=0, atol=0)
+                torch.testing.assert_close(source, before, rtol=0, atol=0)
+        self.assertEqual(self.q_path.read_bytes(), file_before)
+
+    def test_fp32_product_rounds_once_to_bf16_storage(self):
+        q = torch.tensor(
+            [[0.12, 0.93, -0.27], [1.21, -0.48, 0.37], [-0.82, 0.45, 0.68]]
+        )
+        self.save_q(q)
+        source = (torch.arange(18).reshape(3, 6) / 7 - 1).bfloat16()
+        expected = (
+            source.double() @ torch.block_diag(q.double(), q.double())
+        ).bfloat16()
+        result = qr.fold_glm_dspark_fc(source, self.config)
+        torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+    def test_row_tiles_include_tail_and_second_feature_block(self):
+        width = 129
+        q = torch.roll(torch.eye(width), 7, 1) * 0.5
+        self.save_q(q)
+        config = qr.GlmDSparkQuaRotConfig(str(self.q_path), width, str(self.root))
+        source = torch.arange(width * width * 2, dtype=torch.float32).reshape(width, -1)
+        result = qr.fold_glm_dspark_fc(source, config)
+        expected = source.double() @ torch.block_diag(q.double(), q.double())
+        torch.testing.assert_close(result.double(), expected, rtol=0, atol=0)
+
+    def test_bad_fc_shapes_and_dtypes_are_rejected_before_q_read(self):
+        with patch.object(
+            qr, "safe_open", side_effect=AssertionError("unexpected Q read")
+        ):
+            for value in (
+                torch.ones(2, 6),
+                torch.ones(3, 5),
+                torch.ones(3, 0),
+                torch.ones(3),
+                torch.ones(3, 6, dtype=torch.int8),
+            ):
+                with self.subTest(shape=value.shape, dtype=value.dtype):
+                    with self.assertRaisesRegex(ValueError, "FC must be floating"):
+                        qr.fold_glm_dspark_fc(value, self.config)
+
+    def test_changed_or_nonfinite_q_and_fc_fail_without_source_changes(self):
+        source = torch.arange(18, dtype=torch.float32).reshape(3, 6)
+        before = source.clone()
+        for q in (
+            torch.eye(2),
+            torch.eye(3, dtype=torch.int32),
+            torch.full((3, 3), float("nan")),
+            torch.full((3, 3), float("inf")),
+        ):
+            with self.subTest(dtype=q.dtype, shape=q.shape):
+                self.save_q(q)
+                with self.assertRaises(ValueError):
+                    qr.fold_glm_dspark_fc(source, self.config)
+                torch.testing.assert_close(source, before, rtol=0, atol=0)
+        self.save_q(self.q)
+        source[1, 1] = float("inf")
+        with self.assertRaisesRegex(ValueError, "FC contains non-finite"):
+            qr.fold_glm_dspark_fc(source, self.config)
+
+    def test_overflow_on_bf16_storage_is_rejected(self):
+        self.save_q(torch.eye(3) * 1e4)
+        source = torch.full((3, 6), 1e35, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(ValueError, "converted FC contains non-finite"):
+            qr.fold_glm_dspark_fc(source, self.config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_dspark_quarot_vocab_parallel.py
+++ b/test/registered/unit/models/test_dspark_quarot_vocab_parallel.py
@@ -1,0 +1,193 @@
+"""CPU construction, vocab sharding and collectives for the GLM draft path.
+
+The production draft constructor creates both tables; their real weight loaders,
+embedding forward and base-logit gather are compared with full-table arithmetic.
+Two-rank Gloo covers TP2 and DP2 with effective draft TP1. It does not cover a
+multi-rank attention subgroup inside DP, HCCL, attention, or model acceptance.
+Only the constructor's NPU eligibility query is mocked; tensors stay on CPU.
+"""
+
+import tempfile
+import time
+import unittest
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import torch
+import torch.multiprocessing as mp
+from transformers import Qwen3Config
+
+from sglang.srt.distributed import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.npu.dspark_quarot import (
+    GlmDSparkQuaRotConfig,
+    glm_dspark_quarot_scope,
+)
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.models.dspark import DSparkDraftModel
+from sglang.srt.runtime_context import get_context, get_flags, get_parallel
+from sglang.srt.speculative.spec_utils import draft_tp_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+def _check_table_rows(module, source):
+    indices = module.shard_indices
+    expected = source[indices.org_vocab_start_index : indices.org_vocab_end_index]
+    torch.testing.assert_close(module.weight[: len(expected)], expected, rtol=0, atol=0)
+    assert torch.count_nonzero(module.weight[len(expected) :]) == 0
+
+
+def _check_vocab_case(rank, *, dp_enabled, replicate):
+    vocab, width = 97, 16
+    # With the default padding, TP2 splits at 64. Both ranks own real rows.
+    config = Qwen3Config(
+        hidden_size=width,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=16,
+        vocab_size=vocab,
+        max_position_embeddings=128,
+        aux_hidden_state_layer_ids=[0],
+        block_size=8,
+        mask_token_id=96,
+        markov_rank=4,
+        markov_head_type="vanilla",
+        sample_from_anchor=True,
+    )
+    # Construction only stores this plan. File reading / FC folding are tested
+    # by the separate loader tests, so no rotation file is needed here.
+    plan = GlmDSparkQuaRotConfig("unused", width, "unused")
+    parallel = get_parallel()
+    original_tp_group = parallel.tp_group
+    expected_tp = parallel.attn_tp_size if dp_enabled else parallel.tp_size
+    context = draft_tp_context(parallel.attn_tp_group) if dp_enabled else nullcontext()
+    with (
+        context,
+        envs.SGLANG_ENABLE_EMBED_REPLICATION.override(replicate),
+        envs.SGLANG_NPU_GLM_DSPARK_QUAROT.override("original"),
+        glm_dspark_quarot_scope(plan),
+        patch("sglang.srt.models.dspark.is_npu", return_value=True),
+        torch.device("cpu"),
+    ):
+        model = DSparkDraftModel(config)
+        assert isinstance(model.embed_tokens, VocabParallelEmbedding)
+        assert isinstance(model.lm_head, ParallelLMHead)
+        assert model._glm_dspark_quarot_config is plan
+        assert model.uses_own_vocab_modules
+        assert model.embed_tokens.tp_size == (1 if replicate else expected_tp)
+        assert model.embed_tokens.use_attn_tp_group == (dp_enabled and not replicate)
+        assert model.lm_head.tp_size == expected_tp
+        assert not model.lm_head.use_attn_tp_group
+        assert parallel.tp_size == expected_tp
+
+        embedding = (torch.arange(vocab * width).reshape(vocab, width) % 31) / 32
+        head = (torch.arange(vocab * width).reshape(vocab, width) % 23) / 16
+        model.embed_tokens.weight_loader(model.embed_tokens.weight, embedding)
+        model.lm_head.weight_loader(model.lm_head.weight, head)
+        _check_table_rows(model.embed_tokens, embedding)
+        _check_table_rows(model.lm_head, head)
+        if expected_tp == 2:
+            assert model.lm_head.weight.shape == (64, width)
+            assert model.lm_head.shard_indices.org_vocab_start_index == rank * 64
+
+        tokens = torch.tensor([0, 63, 64, 96])
+        hidden = (torch.arange(4 * width).reshape(4, width) % 7) / 8
+        if dp_enabled:
+            # Different requests in the singleton attention groups expose an
+            # accidental gather/reduce through the original two-rank TP group.
+            tokens = tokens.roll(rank)
+            hidden = hidden + rank / 4
+        actual_embedding = model.forward_embed(tokens)
+        actual_logits, _ = model.compute_base_logits(hidden)
+        torch.testing.assert_close(actual_embedding, embedding[tokens], rtol=0, atol=0)
+        torch.testing.assert_close(actual_logits, hidden @ head.T, rtol=0, atol=0)
+        assert actual_logits.shape == (4, vocab)
+
+    assert parallel.tp_group is original_tp_group
+
+
+def _run_vocab_worker(rank, world_size, init_path):
+    torch.set_num_threads(1)
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"file://{init_path}",
+        backend="gloo",
+        timeout=45,
+    )
+    try:
+        for dp_size in (1, 2) if world_size == 2 else (1,):
+            dp_enabled = dp_size > 1
+            with (
+                get_context().override_server_args(
+                    speculative_algorithm="DSpark",
+                    device="cpu",
+                    tp_size=world_size,
+                    dp_size=dp_size,
+                    enable_dp_attention=dp_enabled,
+                ),
+                get_flags().dp.override(enabled=dp_enabled),
+                envs.SGLANG_RAGGED_VERIFY_MODE.override("static"),
+                # These tests use tensor collectives, not the scheduler's
+                # shared-memory object-broadcast transport.
+                envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.override(False),
+            ):
+                initialize_model_parallel(
+                    tensor_model_parallel_size=world_size,
+                    attention_data_parallel_size=dp_size,
+                    backend="gloo",
+                )
+                try:
+                    for replicate in (False, True):
+                        _check_vocab_case(
+                            rank, dp_enabled=dp_enabled, replicate=replicate
+                        )
+                finally:
+                    destroy_model_parallel()
+    finally:
+        destroy_distributed_environment()
+
+
+class TestDSparkQuaRotVocabParallel(CustomTestCase):
+    def _run(self, world_size):
+        with tempfile.TemporaryDirectory() as directory:
+            processes = mp.spawn(
+                _run_vocab_worker,
+                args=(world_size, f"{directory}/gloo"),
+                nprocs=world_size,
+                join=False,
+            )
+            try:
+                deadline = time.monotonic() + 75
+                while not processes.join(timeout=1):
+                    if time.monotonic() > deadline:
+                        self.fail("CPU vocab process group exceeded 75 seconds")
+            finally:
+                for process in processes.processes:
+                    if process.is_alive():
+                        process.terminate()
+                    process.join(timeout=5)
+
+    def test_tp1_with_sharded_and_replicated_embedding(self):
+        self._run(1)
+
+    def test_tp2_and_dp2_with_sharded_and_replicated_embedding(self):
+        self._run(2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dspark_quarot_embedding_dispatch.py
+++ b/test/registered/unit/spec/test_dspark_quarot_embedding_dispatch.py
@@ -1,0 +1,188 @@
+"""Exercise the real proposer and both embedding-to-forward paths.
+
+This checks module selection and preserves the existing V4-style selection;
+it does not execute draft attention, graph replay, or acceptance.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+from torch import nn
+
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.models.dflash import DFlashDraftModel
+from sglang.srt.models.dspark import DSparkDraftModel
+from sglang.srt.runtime_context import get_context
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _ForwardBoundaryReached(Exception):
+    pass
+
+
+class _CaptureLayer(nn.Module):
+    def forward(self, positions, hidden_states, forward_batch, residual):
+        self.hidden_states = hidden_states.detach().clone()
+        raise _ForwardBoundaryReached
+
+
+class TestDSparkQuaRotEmbeddingDispatch(CustomTestCase):
+    def _check_selection(self, *, config_state, sample_from_anchor, own_vocab):
+        draft_embedding = nn.Embedding(4, 2)
+        target_embedding = nn.Embedding(4, 2)
+        draft_model = SimpleNamespace(
+            embed_tokens=draft_embedding,
+            uses_own_vocab_modules=own_vocab,
+        )
+        if config_state != "absent":
+            draft_model._glm_dspark_quarot_config = (
+                object() if config_state == "active" else None
+            )
+        target_model = SimpleNamespace(
+            get_input_embeddings=Mock(return_value=target_embedding)
+        )
+        proposer = DraftBlockProposer.__new__(DraftBlockProposer)
+        proposer.draft_model = draft_model
+        proposer.sample_from_anchor = sample_from_anchor
+        proposer._draft_sampler = None
+        proposer._run_forward = Mock(side_effect=_ForwardBoundaryReached)
+
+        with self.assertRaises(_ForwardBoundaryReached):
+            proposer.propose(
+                batch=None,
+                draft_input=None,
+                verify_window=None,
+                bs=1,
+                device="cpu",
+                target_model=target_model,
+                sampling_info=None,
+            )
+
+        proposer._run_forward.assert_called_once()
+        use_draft = config_state == "active" or not sample_from_anchor
+        self.assertIs(
+            proposer._run_forward.call_args.kwargs["embed_module"],
+            draft_embedding if use_draft else target_embedding,
+        )
+        if use_draft:
+            target_model.get_input_embeddings.assert_not_called()
+        else:
+            target_model.get_input_embeddings.assert_called_once_with()
+
+    def test_only_active_quarot_config_overrides_anchor_embedding(self):
+        for config_state in ("absent", "none", "active"):
+            for sample_from_anchor in (False, True):
+                with self.subTest(
+                    config_state=config_state, sample_from_anchor=sample_from_anchor
+                ):
+                    self._check_selection(
+                        config_state=config_state,
+                        sample_from_anchor=sample_from_anchor,
+                        own_vocab=False,
+                    )
+
+    def test_existing_own_vocab_flag_does_not_change_selection(self):
+        # V4 already exposes this flag. It is not the opt-in for the GLM path.
+        for config_state in ("absent", "none"):
+            for sample_from_anchor in (False, True):
+                with self.subTest(
+                    config_state=config_state, sample_from_anchor=sample_from_anchor
+                ):
+                    self._check_selection(
+                        config_state=config_state,
+                        sample_from_anchor=sample_from_anchor,
+                        own_vocab=True,
+                    )
+
+    def test_external_and_in_model_embedding_reach_the_same_layer_input(self):
+        for embed_in_graph in (False, True):
+            with (
+                self.subTest(embed_in_graph=embed_in_graph),
+                envs.SGLANG_DSPARK_EMBED_IN_GRAPH.override(embed_in_graph),
+                get_context().override_server_args(
+                    device="cpu", speculative_algorithm="DSpark"
+                ),
+            ):
+                # Use the production embedding and forward methods, stopping at
+                # the first layer instead of executing attention or graph replay.
+                model = DSparkDraftModel.__new__(DSparkDraftModel)
+                nn.Module.__init__(model)
+                model.embed_tokens = nn.Embedding(8, 4)
+                with torch.no_grad():
+                    model.embed_tokens.weight.copy_(torch.arange(32).reshape(8, 4))
+                model._glm_dspark_quarot_config = object()
+                capture = _CaptureLayer()
+                model.layers = nn.ModuleList([capture])
+                forwarded = []
+
+                def forward(batch):
+                    self.assertIsInstance(batch, ForwardBatch)
+                    forwarded.append(batch)
+                    return DFlashDraftModel.forward(
+                        model,
+                        batch.input_ids,
+                        batch.positions,
+                        batch,
+                        input_embeds=batch.input_embeds,
+                    )
+
+                proposer = DraftBlockProposer.__new__(DraftBlockProposer)
+                proposer.draft_model = model
+                proposer.draft_model_runner = SimpleNamespace(
+                    device=torch.device("cpu"),
+                    decode_cuda_graph_runner=None,
+                    forward=forward,
+                )
+                proposer.sample_from_anchor = True
+                proposer.gamma = proposer.query_token_num = 3
+                proposer._mask_token_id = 7
+                proposer._draft_block_ids_buf = None
+                proposer._draft_block_spec_info = None
+                proposer._draft_sampler = None
+                proposer._dp_moe_sync = False
+                proposer._num_token_non_padded = None
+                target = SimpleNamespace(
+                    get_input_embeddings=Mock(
+                        side_effect=AssertionError("target embedding must not be used")
+                    )
+                )
+                with self.assertRaises(_ForwardBoundaryReached):
+                    proposer.propose(
+                        batch=SimpleNamespace(
+                            seq_lens=torch.tensor([5, 9]),
+                            seq_lens_cpu=torch.tensor([5, 9]),
+                            req_pool_indices=torch.tensor([0, 1]),
+                            can_run_decode_cuda_graph=False,
+                        ),
+                        draft_input=SimpleNamespace(bonus_tokens=torch.tensor([1, 2])),
+                        verify_window=SimpleNamespace(
+                            positions_2d=torch.tensor([[5, 6, 7], [9, 10, 11]]),
+                            verify_cache_loc_2d=torch.arange(6).reshape(2, 3),
+                        ),
+                        bs=2,
+                        device="cpu",
+                        target_model=target,
+                        sampling_info=None,
+                    )
+
+                target.get_input_embeddings.assert_not_called()
+                self.assertEqual(len(forwarded), 1)
+                if embed_in_graph:
+                    self.assertIsNone(forwarded[0].input_embeds)
+                else:
+                    self.assertIsNotNone(forwarded[0].input_embeds)
+                expected = model.embed_tokens.weight[torch.tensor([1, 7, 7, 2, 7, 7])]
+                torch.testing.assert_close(
+                    capture.hidden_states, expected, rtol=0, atol=0
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -4,16 +4,26 @@ Tests cover the pure utility functions (compat patches, config helpers,
 context length, GGUF detection, etc.) that don't require actual model files.
 """
 
+import copy
 import inspect
+import json
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from transformers import PretrainedConfig
 from transformers.image_processing_utils import BaseImageProcessor
 
+import sglang.srt.utils.hf_transformers.config as config_utils
 import sglang.srt.utils.hf_transformers.processor as processor_utils
+from sglang.srt.configs.longcat_flash import LongcatFlashConfig
+from sglang.srt.configs.speculators import normalize_speculators_dspark_config
+from sglang.srt.speculative.dspark_components.dspark_config import (
+    parse_dspark_draft_config,
+    resolve_runtime_config,
+)
 from sglang.srt.utils import hf_transformers_patches
 from sglang.srt.utils.hf_transformers.common import (
     _is_deepseek_ocr2_model,
@@ -27,11 +37,320 @@ from sglang.srt.utils.hf_transformers.common import (
     get_rope_config,
     resolve_hf_gguf_reference,
 )
+from sglang.srt.utils.hf_transformers.config import get_config
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+
+class TestSpeculatorsDsparkConfig(CustomTestCase):
+    @staticmethod
+    def _raw_config():
+        # Small synthetic decoder, with the published GLM DSpark window/layer
+        # convention. Target feature count and draft depth are independent;
+        # Qwen3 also permits an explicit head_dim != hidden_size / head count.
+        return {
+            "architectures": ["DSparkDraftModel"],
+            "auto_map": {"": "config.DSparkSpeculatorConfig"},
+            "speculators_model_type": "dspark",
+            "dtype": "bfloat16",
+            "block_size": 8,
+            "aux_hidden_state_layer_ids": [8, 23, 39, 55, 70],
+            "draft_vocab_size": 128,
+            "mask_token_id": 127,
+            "markov_rank": 4,
+            "markov_head_type": "vanilla",
+            "enable_confidence_head": True,
+            "confidence_head_with_markov": True,
+            "target_hidden_size": None,
+            "transformer_layer_config": {
+                "model_type": "qwen3",
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "num_hidden_layers": 3,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 32,
+                "vocab_size": 128,
+                "max_position_embeddings": 128,
+                "rope_parameters": {
+                    "rope_theta": 8000000,
+                    "rope_type": "default",
+                },
+                "layer_types": ["full_attention"] * 3,
+                "tie_word_embeddings": False,
+            },
+        }
+
+    def _load_local_config(self, raw):
+        with tempfile.TemporaryDirectory() as model_dir:
+            config_path = Path(model_dir) / "config.json"
+            original = json.dumps(raw)
+            config_path.write_text(original)
+            config = get_config(
+                model_dir,
+                trust_remote_code=False,
+                model_config_parser="hf",
+                local_files_only=True,
+            )
+            self.assertEqual(config_path.read_text(), original)
+            return config
+
+    def test_raw_checkpoint_reaches_dspark_runtime_with_capture_convention(self):
+        """A nested decoder previously had no HF model_type and failed to load;
+        merely flattening it must not leave target capture shifted by one.
+        """
+        raw = self._raw_config()
+        config = self._load_local_config(raw)
+        draft = parse_dspark_draft_config(draft_hf_config=config)
+        runtime = resolve_runtime_config(
+            draft_hf_config=config,
+            speculative_num_draft_tokens=None,
+            target_vocab_size=128,
+        )
+
+        self.assertEqual(config.architectures, ["DSparkDraftModel"])
+        self.assertEqual(config.model_type, "qwen3")
+        self.assertEqual(config.hidden_size, 32)
+        self.assertEqual(config.head_dim, 32)
+        self.assertEqual(get_rope_config(config)[0], 8000000)
+        self.assertIn(str(config.dtype), ("bfloat16", "torch.bfloat16"))
+        self.assertEqual(draft.num_hidden_layers, 3)
+        self.assertEqual(draft.target_layer_ids, [7, 22, 38, 54, 69])
+        self.assertEqual((draft.markov_rank, draft.markov_head_type), (4, "vanilla"))
+        self.assertEqual((runtime.gamma, runtime.verify_num_draft_tokens), (8, 9))
+        self.assertEqual(runtime.mask_token_id, 127)
+        self.assertTrue(config.enable_confidence_head)
+        self.assertTrue(config.confidence_head_with_markov)
+        self.assertEqual(
+            config.layer_types, raw["transformer_layer_config"]["layer_types"]
+        )
+        # Saving the translated HF config retains both canonical and native
+        # IDs; reloading it must not apply the offset to the native IDs again.
+        reloaded = self._load_local_config(config.to_dict())
+        self.assertEqual(reloaded.target_layer_ids, [7, 22, 38, 54, 69])
+
+    def test_conflicts_and_invalid_capture_ids_fail_before_loading(self):
+        """Competing aliases must not silently override trained tensor or layer
+        semantics; bool/float IDs must not be truncated into valid layer IDs.
+        """
+        overrides = [
+            {"hidden_size": 64},
+            {"target_layer_ids": [8, 23, 39, 55, 70]},
+            {"dflash_config": {"block_size": 9}},
+            {"dspark_target_layer_ids": [0]},
+            {"aux_hidden_state_layer_ids": []},
+            {"aux_hidden_state_layer_ids": [0, 2]},
+            {"aux_hidden_state_layer_ids": [True, 2]},
+            {"aux_hidden_state_layer_ids": [1.5, 2]},
+            {"aux_hidden_state_layer_ids": [2, 2]},
+            {"aux_hidden_state_layer_ids": [5, 2]},
+            {"mask_token_id": -1},
+            {"draft_vocab_size": 64},
+            {"target_hidden_size": 64},
+        ]
+        for override in overrides:
+            with self.subTest(override=override):
+                raw = self._raw_config()
+                raw.update(override)
+                with self.assertRaises(ValueError):
+                    normalize_speculators_dspark_config(raw)
+
+    def test_normalization_preserves_source_and_does_not_shift_ids_twice(self):
+        """Retained canonical IDs must not trigger another -1 on reload, and
+        editing an in-memory normalized config must not rewrite its source.
+        """
+        raw = self._raw_config()
+        raw.pop("speculators_model_type")
+        raw["aux_hidden_state_layer_ids"] = [2, 5]
+        raw["target_hidden_size"] = 32
+        original = copy.deepcopy(raw)
+
+        normalized = normalize_speculators_dspark_config(raw)
+        self.assertEqual(normalized["target_layer_ids"], [1, 4])
+        self.assertIsNone(normalize_speculators_dspark_config(normalized))
+        self.assertEqual(raw, original)
+
+        normalized["layer_types"][0] = "changed"
+        normalized["aux_hidden_state_layer_ids"][0] = 99
+        self.assertEqual(raw, original)
+
+    def test_null_nested_aliases_preserve_canonical_runtime_values(self):
+        """Optional null aliases must not hide capture IDs or runtime settings
+        in readers that use dict.get(key, canonical_value).
+        """
+        for section, name in (
+            ("dflash_config", "target_layer_ids"),
+            ("dflash_config", "block_size"),
+            ("dspark_config", "mask_token_id"),
+            ("dspark_config", "markov_rank"),
+            ("dspark_config", "markov_head_type"),
+        ):
+            with self.subTest(section=section, name=name):
+                raw = self._raw_config()
+                raw[section] = {name: None}
+                original = copy.deepcopy(raw)
+
+                normalized = normalize_speculators_dspark_config(raw)
+                self.assertNotIn(name, normalized[section])
+                self.assertEqual(raw, original)
+
+                config = self._load_local_config(raw)
+                reloaded = self._load_local_config(config.to_dict())
+                for loaded in (config, reloaded):
+                    draft = parse_dspark_draft_config(draft_hf_config=loaded)
+                    runtime = resolve_runtime_config(
+                        draft_hf_config=loaded,
+                        speculative_num_draft_tokens=None,
+                        target_vocab_size=128,
+                    )
+                    self.assertEqual(draft.target_layer_ids, [7, 22, 38, 54, 69])
+                    self.assertEqual(draft.markov_rank, 4)
+                    self.assertEqual(draft.markov_head_type, "vanilla")
+                    self.assertEqual(runtime.gamma, 8)
+                    self.assertEqual(runtime.verify_num_draft_tokens, 9)
+                    self.assertEqual(runtime.mask_token_id, 127)
+
+    def test_native_hf_and_flat_dspark_keep_their_existing_contract(self):
+        """The new nested-schema reader must not hijack ordinary HF configs or
+        subtract one from already-native DSpark target_layer_ids.
+        """
+        native = self._raw_config()["transformer_layer_config"]
+        native["architectures"] = ["Qwen3ForCausalLM"]
+        flat = self._raw_config()
+        flat.update(flat.pop("transformer_layer_config"))
+        flat.pop("aux_hidden_state_layer_ids")
+        flat["target_layer_ids"] = [4, 1]
+
+        for raw in (native, flat):
+            with self.subTest(architecture=raw["architectures"]):
+                original = copy.deepcopy(raw)
+                self.assertIsNone(normalize_speculators_dspark_config(raw))
+                self.assertEqual(raw, original)
+                config = self._load_local_config(raw)
+                self.assertEqual(config.architectures, raw["architectures"])
+                self.assertEqual(config.num_hidden_layers, 3)
+                self.assertEqual(config.head_dim, 32)
+                if raw is flat:
+                    draft = parse_dspark_draft_config(draft_hf_config=config)
+                    self.assertEqual(draft.target_layer_ids, [4, 1])
+                    self.assertEqual(draft.gamma, 8)
+
+    def test_other_architectures_keep_native_config_loading_with_nested_metadata(self):
+        """The nested field name alone must not activate DSpark conversion.
+
+        Calls still use the real HF loader; the spy records forwarded options
+        without supplying a replacement configuration.
+        """
+        for model_type, architecture in (
+            ("llama", "LlamaForCausalLM"),
+            ("glm_moe_dsa", "GlmMoeDsaForCausalLM"),
+            ("qwen3", "Qwen3ForCausalLM"),
+        ):
+            for nested in (None, {"model_type": "other", "hidden_size": 999}):
+                with self.subTest(architecture=architecture, nested=nested):
+                    raw = self._raw_config()["transformer_layer_config"]
+                    raw.update(
+                        model_type=model_type,
+                        architectures=[architecture],
+                        transformer_layer_config=nested,
+                        speculators_model_type="other",
+                    )
+                    original = copy.deepcopy(raw)
+                    self.assertIsNone(normalize_speculators_dspark_config(raw))
+                    self.assertEqual(raw, original)
+
+                    with tempfile.TemporaryDirectory() as model_dir:
+                        config_path = Path(model_dir) / "config.json"
+                        contents = json.dumps(raw)
+                        config_path.write_text(contents)
+                        with patch.object(
+                            config_utils.AutoConfig,
+                            "from_pretrained",
+                            wraps=config_utils.AutoConfig.from_pretrained,
+                        ) as load:
+                            config = get_config(
+                                model_dir,
+                                trust_remote_code=False,
+                                revision="local-revision",
+                                model_config_parser="hf",
+                                local_files_only=True,
+                                max_position_embeddings=256,
+                            )
+                        load.assert_called_once_with(
+                            model_dir,
+                            trust_remote_code=False,
+                            revision="local-revision",
+                            local_files_only=True,
+                            max_position_embeddings=256,
+                        )
+                        self.assertEqual(config_path.read_text(), contents)
+                    self.assertEqual(config.model_type, model_type)
+                    self.assertEqual(config.architectures, [architecture])
+                    self.assertEqual(config.transformer_layer_config, nested)
+                    self.assertEqual(config.speculators_model_type, "other")
+                    self.assertEqual(config.hidden_size, 32)
+                    self.assertEqual(config.max_position_embeddings, 256)
+
+    def test_longcat_keeps_its_existing_config_dispatch_with_nested_metadata(self):
+        """Adding a DSpark reader must retain Longcat's custom HF dispatch."""
+        for architecture in (
+            "LongcatCausalLM",
+            "LongcatFlashForCausalLM",
+            "LongcatFlashNgramForCausalLM",
+        ):
+            with self.subTest(architecture=architecture):
+                raw = {
+                    "architectures": [architecture],
+                    "model_type": "longcat_flash",
+                    "hidden_size": 32,
+                    "num_hidden_layers": 3,
+                    "transformer_layer_config": {"format": "unrelated"},
+                }
+                with tempfile.TemporaryDirectory() as model_dir:
+                    config_path = Path(model_dir) / "config.json"
+                    contents = json.dumps(raw)
+                    config_path.write_text(contents)
+                    with (
+                        patch.object(
+                            LongcatFlashConfig,
+                            "from_pretrained",
+                            wraps=LongcatFlashConfig.from_pretrained,
+                        ) as load,
+                        patch.object(
+                            config_utils.AutoConfig,
+                            "from_pretrained",
+                            wraps=config_utils.AutoConfig.from_pretrained,
+                        ) as auto_load,
+                    ):
+                        config = get_config(
+                            model_dir,
+                            trust_remote_code=False,
+                            revision="local-revision",
+                            model_config_parser="hf",
+                            local_files_only=True,
+                        )
+                    # The parser also reloads registered configs later. Check
+                    # the first dispatch, without changing that existing flow.
+                    self.assertEqual(load.call_args_list[0].args, (model_dir,))
+                    self.assertEqual(
+                        load.call_args_list[0].kwargs,
+                        {"revision": "local-revision", "local_files_only": True},
+                    )
+                    auto_load.assert_not_called()
+                    self.assertEqual(config_path.read_text(), contents)
+                self.assertIsInstance(config, LongcatFlashConfig)
+                # The existing parser canonicalizes all three Longcat names.
+                self.assertEqual(config.architectures, ["LongcatFlashForCausalLM"])
+                self.assertEqual(config.model_type, "longcat_flash")
+                self.assertEqual(config.hidden_size, 32)
+                self.assertEqual(config.num_hidden_layers, 3)
+                self.assertEqual(
+                    config.transformer_layer_config, raw["transformer_layer_config"]
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Enable GLM-5.2 DSpark with a Speculators-format dense BF16 draft and a ModelSlim QuaRot target on Ascend NPU. The draft export needs configuration translation, and its original-coordinate vocabulary and target-feature projection must remain compatible with the rotated target.

This PR targets static DSpark. Single-node/two-node colocated validation and performance results are being completed. Full accuracy evaluation results will be added to this PR in a follow-up update. Compact mode support will be implemented in a separate follow-up PR.

Depends on [sgl-kernel-npu #791](https://github.com/sgl-project/sgl-kernel-npu/pull/791) for head_dim=192. Development testing uses the candidate `split_qkv_rmsnorm_rope.py` through a process-local Python package overlay; the binary library and other modules remain from the image-installed `sgl-kernel-npu` package. A released package version or reproducible image that includes #791 for normal installation is still **TODO**; the existing image is not claimed to contain this change.

## Modifications

- In `configs/speculators.py`, translate a copy of the loaded configuration dictionary: flatten `transformer_layer_config`, preserve `architectures=["DSparkDraftModel"]`, set `model_type="qwen3"`, derive `target_layer_ids` from the export's auxiliary IDs, and reject conflicting aliases. Remove the nested decoder and incompatible `auto_map` from the copy so reloading the normalized layout does not translate IDs again. The source JSON is not rewritten.
- Connect this translation through `_try_load_custom_config` in the existing HF parser. Build a `Qwen3Config` for the draft's decoder parameters while keeping `DSparkDraftModel` as the model implementation; retain LongCat handling and ordinary `AutoConfig` fallback.
- Add opt-in `SGLANG_NPU_GLM_DSPARK_QUAROT=original` for an NPU GLM DSA ModelSlim QuaRot target with an unquantized dense draft. `DSparkWorkerV2.__init__` scopes the validated target metadata to draft construction. The default remains disabled; `original` declares that the draft checkpoint has not already been converted.
- In `DSparkDraftMixin`, create and load the draft's own embedding/LM head through the existing loader. `DraftBlockProposer.propose` selects that embedding for the anchor-sampling path as well, keeping the external and in-model embedding entry points consistent.
- During `DSparkDraftMixin.load_weights`, `fold_glm_dspark_fc` converts each newly read FC block as `F_i @ Q` on CPU in FP32 and stores the original dtype. Validate the initial vocabulary/FC inputs; retain existing loader requirements on later reloads. Conversion changes the loaded tensor, not the checkpoint file.
- Add regression coverage for configuration, quantization selection, loading, QuaRot conversion, vocabulary parallelism and embedding dispatch in eight CPU-registered test files.

The DFlash backbone and NPU fused-QKV call, DSpark proposal/verification/commit flow, and source checkpoints are preserved. The stored Q is not assumed to have an exact floating-point inverse. Independent vocabulary modules add device memory, and FC conversion adds startup work; both costs need measurement.

Record fixed versions, weights, topology, requests, sampling, concurrency and warmup/cache preparation. Report actual cache hits and graph execution. No speedup claim is made before these results are available.

## Checklist

Targeted Ruff 0.15.1 formatting/lint, isort 7.0.0, codespell and syntax/diff checks passed on all 15 changed files without rewriting source. [GitHub Lint passed](https://github.com/sgl-project/sglang/actions/runs/34464589129) on this head. A separate local full-repository pre-commit run and the remaining CPU/NPU CI are still pending.

- [ ] Complete the final [pre-commit checks](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Confirm tests follow the [test contribution guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests), including test-base conventions.
- [ ] Add public usage and dependency documentation.
- [ ] Provide final-version accuracy and speed results.
- [ ] Complete code-style review, including the frozen dataclass container convention.

## Review and Merge Process

Validation and the kernel dependency remain pending. Follow the [maintainer process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process) for code-owner review, authorized CPU/NPU CI, and merge after the required checks and dependency release.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
