### PR TITLE
Make the remaining DeepSeek-V4.1 NVIDIA cells start

### DIFF
--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx
@@ -1,8 +1,16 @@
 // Single `export const config` literal — no spreads/calls/IIFE (Mintlify re-evals at hydration).
 //
 // Cells marked `verified` are transcribed from recorded runs on that hardware with
-// real weights. DP-Attention, DeepEP and MegaMoE are absent by design: they have
-// never been enabled on this model. EP is set equal to TP on every shape here.
+// real weights.
+//
+// Every DSpark cell caps --cuda-graph-max-bs-decode: the derived batch list does
+// not fit while capturing the DSpark decode graphs, on any NVIDIA platform. The
+// MI350X cell already carried the equivalent --cuda-graph-max-bs. H200 is the
+// tightest board at 140 GiB and needs the cap on both cells plus a lower memory
+// fraction; the three other High-Throughput cells start without either.
+//
+// DP-Attention, DeepEP and MegaMoE are absent by design: they have never been
+// enabled on this model. EP is set equal to TP on every shape here.
 
 export const config = {
   modelName: "DeepSeek-V4.1",
@@ -169,6 +177,8 @@ export const config = {
         "--mem-fraction-static 0.8",
         "--speculative-algorithm DSPARK",
         "--speculative-dspark-block-size 5",
+        // Decode CUDA graphs: the derived batch list does not fit here.
+        "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--host {{HOST_IP}}",
@@ -196,20 +206,24 @@ export const config = {
       ],
     },
 
-    // ---------- H200: 8x H200, TP8 + EP8. No MXFP8 dense path on Hopper;
-    // verification round open. ----------
+    // ---------- H200: 8x H200, TP8 + EP8. No MXFP8 dense path on Hopper. The
+    // tightest board here at 140 GiB, so both cells also need the memory
+    // fraction pulled back; the cap alone still leaves the graphs short. ------
     {
       match: { hw: "h200", strategy: "low-latency" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 8",
         "--ep-size 8",
+        "--mem-fraction-static 0.8",
         "--attention-backend dsv4",
         "--moe-runner-backend flashinfer_mxfp4",
         "--enable-decoder-swa-bounded-replay",
+        // Decode CUDA graphs: the derived batch list does not fit here.
+        "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--host {{HOST_IP}}",
@@ -219,15 +233,18 @@ export const config = {
     {
       match: { hw: "h200", strategy: "high-throughput" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp 8",
         "--ep-size 8",
+        "--mem-fraction-static 0.8",
         "--attention-backend dsv4",
         "--moe-runner-backend flashinfer_mxfp4",
         "--max-running-requests 256",
+        // Decode CUDA graphs: the derived batch list does not fit here.
+        "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--host {{HOST_IP}}",
@@ -235,12 +252,12 @@ export const config = {
       ],
     },
 
-    // ---------- B200: verification round open. Mirrors the GB300 recipe because
-    // the kernels dispatch by architecture family. ----------
+    // ---------- B200: 4x B200, TP4 + EP4. Mirrors the GB300 recipe — the
+    // kernels dispatch by architecture family. ----------
     {
       match: { hw: "b200", strategy: "low-latency" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
@@ -249,6 +266,8 @@ export const config = {
         "--mem-fraction-static 0.8",
         "--speculative-algorithm DSPARK",
         "--speculative-dspark-block-size 5",
+        // Decode CUDA graphs: the derived batch list does not fit here.
+        "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--host {{HOST_IP}}",
@@ -258,7 +277,7 @@ export const config = {
     {
       match: { hw: "b200", strategy: "high-throughput" },
       nnodes: 1,
-      verificationStatus: "in-progress",
+      verified: true,
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
@@ -273,8 +292,7 @@ export const config = {
     },
 
     // ---------- B300: 4x B300, TP4 + EP4. Same recipe as GB300 — the kernels
-    // dispatch by architecture family — with one extra memory knob on
-    // Low-Latency that GB300 does not need. ----------
+    // dispatch by architecture family. ----------
     {
       match: { hw: "b300", strategy: "low-latency" },
       nnodes: 1,
@@ -287,8 +305,7 @@ export const config = {
         "--mem-fraction-static 0.8",
         "--speculative-algorithm DSPARK",
         "--speculative-dspark-block-size 5",
-        // GB300 does not need this, B300 does: the derived value (256) runs
-        // out of memory capturing the DSpark decode graphs at this fraction.
+        // Decode CUDA graphs: the derived batch list does not fit here.
         "--cuda-graph-max-bs-decode 64",
         "--reasoning-parser auto",
         "--tool-call-parser auto",


### PR DESCRIPTION
## Motivation

Follow-up to #38839.

That PR capped the decode CUDA graphs on the B300 Low-Latency cell after it failed to start,
and flagged one caveat: B300 was measured on a stock sglang image with the #38798 tree on
`PYTHONPATH`, not on the page's own `lmsysorg/sglang:dev-dsv41`, so it was left open whether
the failure was B300-specific or an artifact of that setup.

It is neither. Running the other three platforms on the page's own image settles it: **every
DSpark cell fails to start**, and on H200 both cells do.

```
Exception: Capture cuda graph failed: CUDA out of memory.
```

The derived `--cuda-graph-max-bs-decode` does not fit while capturing the decode graphs in
`decode_cuda_graph_runner`. The server never becomes ready — this is a startup failure, not
something you would only meet under load.

Two things make it worth fixing rather than documenting:

- The **GB300 Low-Latency cell is already marked `verified`** and is the page's reference
  platform, so the badge is not reproducible today.
- The **MI350X Low-Latency cell already carries the equivalent `--cuda-graph-max-bs 64`** —
  the ROCm author hit this and capped it. Only the NVIDIA cells were missing it.

## Modifications

`docs/src/snippets/configs/deepseek-ai/deepseek-v4_1.jsx`

- `--cuda-graph-max-bs-decode 64` on the GB300 and B200 Low-Latency cells and on both H200
  cells (B300 got it in #38839).
- `--mem-fraction-static 0.8` on both H200 cells — the cap alone is not enough there.
- The four cells still `in-progress` (H200 ×2, B200 ×2) move to `verified`.
- Header comment states the rule once instead of per-cell.
- MI350X untouched — not tested here, and it already carries the equivalent cap.

Config only; the page prose is unchanged.

## Accuracy Tests

Each cell run on its own hardware with real `deepseek-ai/DeepSeek-V4.1-Flash` weights.
GB300 / B200 / H200 on `lmsysorg/sglang:dev-dsv41`, the image the page prescribes. The B300
rows are from #38839 and are included for completeness.

| platform | cell | as published | with this PR's flags |
|---|---|---|---|
| 4x GB300 (aarch64) | Low-Latency | **OOM** — 5.82 GiB wanted, 2.15 GiB free of 276.62 | starts, serves |
| 4x GB300 | High-Throughput | starts, serves | unchanged |
| 8x H200 | Low-Latency | **OOM** — 2.00 GiB wanted, 0.96 GiB free of 139.80 | starts, serves |
| 8x H200 | High-Throughput | **OOM** — 2.00 GiB wanted, 0.48 GiB free of 139.80 | starts, serves |
| 4x B200 | Low-Latency | **OOM** — 6.00 GiB wanted, 1.48 GiB free of 178.35 | starts, serves |
| 4x B200 | High-Throughput | starts, serves | unchanged |
| 4x B300 (#38839) | Low-Latency | **OOM** — 5.82 GiB wanted, 1.25 GiB free of 267.69 | starts, serves |
| 4x B300 (#38839) | High-Throughput | starts, serves | unchanged |

Notes on the two that needed more than the cap: on H200 the cap alone reaches 1.89 GiB free
against a 2.00 GiB allocation and still dies, which is why those cells also drop the memory
fraction to 0.8; with both, capture runs with 19.3 GiB free.

Every "starts, serves" row was confirmed with a real completion through
`/v1/chat/completions`, not just `/health`. The §3.1 reasoning behaviour fixed in #38839 also
reproduces identically on the `dev-dsv41` image on GB300/aarch64 — empty `reasoning_content`
without `reasoning_effort`, populated with it, HTTP 400 on an integer effort.

## Speed Tests and Profiling

Not applicable — no runtime code is touched. 64 is a startup-feasibility value rather than a
tuned one; it is ample for the interactive batch sizes these recipes target, and the three
High-Throughput cells that start without a cap are deliberately left uncapped.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] `node docs/scripts/check_cookbook_configs.mjs` → `cookbook config check: OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34510083944](https://github.com/sgl-project/sglang/actions/runs/34510083944)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34510083682](https://github.com/sgl-project/sglang/actions/runs/34510083682)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->