### PR TITLE
[Bugfix] Preserve NVFP4 AWQ prescaling in MLP fusion and Marlin paths

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1982,6 +1982,8 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if get_fp4_gemm_runner_backend().is_marlin():
+            if self.quant_config.is_awq:
+                x = x * layer.pre_quant_scale
             return apply_fp4_marlin_linear(
                 input=x,
                 weight=layer.weight,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -750,6 +750,9 @@ class DeepseekV2MoE(nn.Module):
                     self.shared_experts.down_proj.quant_method,
                     ModelOptFp4LinearMethod,
                 )
+                # Both input quantizations bypass the linear methods' AWQ prescales.
+                and not self.shared_experts.gate_up_proj.quant_method.quant_config.is_awq
+                and not self.shared_experts.down_proj.quant_method.quant_config.is_awq
                 and fc1_n % 128 == 0
                 and self.shared_experts.swiglu_limit is None
                 and not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -193,6 +193,9 @@ def _maybe_enable_silu_fp4_quant_fusion(mlp: nn.Module) -> None:
         and isinstance(mlp.down_proj.quant_method, ModelOptFp4LinearMethod)
     ):
         return
+    # The fused producer does not apply AWQ's per-input-channel scale.
+    if mlp.down_proj.quant_method.quant_config.is_awq:
+        return
     try:
         from flashinfer import silu_and_mul_scaled_nvfp4_experts_quantize  # noqa: F401
     except ImportError:

--- a/test/registered/kernel/quantization/test_nvfp4_mlp_fusion.py
+++ b/test/registered/kernel/quantization/test_nvfp4_mlp_fusion.py
@@ -1,0 +1,234 @@
+"""Compare NVFP4 MLP fusion selection with the same unfused computation."""
+
+import unittest
+from unittest import mock
+
+import torch
+from flashinfer import fp4_quantize
+
+from sglang.srt.layers.quantization import fp4_utils
+from sglang.srt.layers.quantization.fp4_utils import Fp4GemmRunnerBackend
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen2_moe import Qwen2MoeMLP
+from sglang.srt.models.qwen3_5 import _maybe_enable_silu_fp4_quant_fusion
+from sglang.srt.runtime_context import get_context, get_flags, get_platform
+from sglang.srt.utils import get_device_sm
+from sglang.srt.utils.common import calc_diff
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.layer_ut_utils import init_single_process_dist, load_linear_weights
+from sglang.test.quant_ref_utils import (
+    FLOAT4_E2M1_MAX,
+    FLOAT8_E4M3_MAX,
+    dequantize_nvfp4_to_dtype,
+    quantize_nvfp4_shard,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+class Nvfp4MlpFusionCases:
+    @classmethod
+    def setUpClass(cls):
+        init_single_process_dist()
+
+    @mock.patch.dict("os.environ", {"SGLANG_DISABLE_SILU_FP4_QUANT_FUSION": "0"})
+    @mock.patch.object(
+        fp4_utils, "FP4_GEMM_RUNNER_BACKEND", Fp4GemmRunnerBackend.FLASHINFER_CUTLASS
+    )
+    @torch.inference_mode()
+    def _check_output(self, is_awq, gate_channel_scale, down_channel_scale):
+        torch.manual_seed(8107)
+        hidden_size, intermediate_size = 128, 256
+        cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            is_awq=is_awq,
+            exclude_modules=["model.layers.0.mlp.experts"],
+            packed_modules_mapping={"gate_up_proj": ["gate_proj", "up_proj"]},
+        )
+        previous_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.bfloat16)
+            candidate = self._build_mlp(cfg, hidden_size, intermediate_size).cuda()
+            unfused = self._build_mlp(cfg, hidden_size, intermediate_size).cuda()
+        finally:
+            torch.set_default_dtype(previous_dtype)
+
+        # Disable only the reference copy's fusion, before weight preparation:
+        # DeepSeek's fused layout frees the ordinary gate/up weight storage.
+        unfused._enable_silu_fp4_quant_fusion = False
+        unfused._enable_nvfp4_gemm_swiglu_fusion = False
+        unfused.gate_up_proj._interleave_for_swiglu_fusion = False
+        unfused.down_proj._accepts_prequantized_fp4 = False
+
+        gate_scale = torch.ones(hidden_size, device="cuda", dtype=torch.bfloat16)
+        down_scale = torch.ones(intermediate_size, device="cuda", dtype=torch.bfloat16)
+        if gate_channel_scale:
+            gate_scale = torch.linspace(
+                0.25, 4, hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+        if down_channel_scale:
+            down_scale = torch.linspace(
+                0.25, 4, intermediate_size, device="cuda", dtype=torch.bfloat16
+            )
+
+        # Both copies load exactly the same quantized checkpoint weights.
+        # Compensate each weight's input channels for its activation prescale.
+        shards = (
+            torch.randn(
+                2, intermediate_size, hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+            / 10
+            / gate_scale
+        )
+        global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / shards.abs().max().float()
+        for shard_id, weight in enumerate(shards):
+            packed, scales, gs, _ = quantize_nvfp4_shard(weight, gs=global_scale)
+            for mlp in (candidate, unfused):
+                load_linear_weights(
+                    mlp.gate_up_proj,
+                    shard_id=shard_id,
+                    weight=packed,
+                    weight_scale=scales,
+                    weight_scale_2=1 / gs,
+                    input_scale=torch.tensor(1 / 256, device="cuda"),
+                )
+
+        weight = (
+            torch.randn(
+                hidden_size, intermediate_size, device="cuda", dtype=torch.bfloat16
+            )
+            / 10
+        )
+        packed, scales, gs, weight_ref = quantize_nvfp4_shard(weight / down_scale)
+        for mlp in (candidate, unfused):
+            load_linear_weights(
+                mlp.down_proj,
+                weight=packed,
+                weight_scale=scales,
+                weight_scale_2=1 / gs,
+                input_scale=torch.tensor(1 / 256, device="cuda"),
+            )
+            if is_awq:
+                # These are per-input-channel vectors, shared by gate/up shards.
+                default_weight_loader(mlp.gate_up_proj.pre_quant_scale, gate_scale)
+                default_weight_loader(mlp.down_proj.pre_quant_scale, down_scale)
+            for layer in (mlp.gate_up_proj, mlp.down_proj):
+                layer.quant_method.process_weights_after_loading(layer)
+
+        for num_tokens in (1, 33):
+            with self.subTest(num_tokens=num_tokens):
+                x = (
+                    torch.randn(
+                        num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+                    )
+                    / 10
+                )
+                actual = candidate(x).float()
+                expected = unfused(x).float()
+
+                # Retain a separate down-projection oracle so parity alone
+                # cannot hide both paths omitting the same prescale.
+                gate_up, _ = unfused.gate_up_proj(x)
+                gate, up = gate_up.float().chunk(2, dim=-1)
+                activation = (torch.nn.functional.silu(gate) * up).bfloat16()
+                q, sf = fp4_quantize(
+                    activation * down_scale, unfused.down_proj.input_scale_inv
+                )
+                reference = (
+                    dequantize_nvfp4_to_dtype(
+                        q, sf, unfused.down_proj.input_scale_inv, torch.float32
+                    )
+                    @ weight_ref.T
+                )
+                oracle_error = (expected - reference).norm() / reference.norm()
+                self.assertLess(oracle_error.item(), 0.03)
+                self._assert_fusion_close(actual, expected)
+
+    def _assert_fusion_close(self, actual, expected):
+        relative_error = (actual - expected).norm() / expected.norm()
+        self.assertLess(relative_error.item(), 0.03)
+
+    def test_awq_channel_prescale_output(self):
+        self._check_output(True, False, True)
+
+    def test_awq_gate_prescale_output(self):
+        self._check_output(True, True, False)
+
+    def test_awq_both_prescales_output(self):
+        self._check_output(True, True, True)
+
+    def test_awq_identity_prescale_output(self):
+        self._check_output(True, False, False)
+
+    def test_plain_nvfp4_output(self):
+        self._check_output(False, False, False)
+
+
+@unittest.skipIf(get_device_sm() < 100, "NVFP4 fusion requires Blackwell")
+class TestQwenMlpNvfp4Fusion(Nvfp4MlpFusionCases, CustomTestCase):
+    def _build_mlp(self, cfg, hidden_size, intermediate_size):
+        mlp = Qwen2MoeMLP(
+            hidden_size,
+            intermediate_size,
+            "silu",
+            quant_config=cfg,
+            prefix="model.layers.0.mlp",
+            tp_rank=0,
+            tp_size=1,
+        )
+        _maybe_enable_silu_fp4_quant_fusion(mlp)
+        return mlp
+
+
+@unittest.skipUnless(get_platform().is_sm100, "DeepSeek's fused kernel requires SM100")
+class TestDeepseekSharedExpertNvfp4Fusion(Nvfp4MlpFusionCases, CustomTestCase):
+    def _assert_fusion_close(self, actual, expected):
+        # The fused epilogue keeps FP32 accumulators through SwiGLU and FP4
+        # quantization; the unfused path materializes BF16 intermediates.
+        # Match the metric and bound used for this same kernel in
+        # test_flux2_fused_nvfp4_swiglu_quant_matches_unfused.
+        self.assertLess(calc_diff(actual, expected).item(), 0.02)
+
+    def _build_mlp(self, cfg, hidden_size, intermediate_size):
+        from transformers import DeepseekV3Config
+
+        from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+        from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
+
+        config = DeepseekV3Config(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            moe_intermediate_size=intermediate_size,
+            n_shared_experts=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            n_group=1,
+            topk_group=1,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            topk_method="noaux_tc",
+            scoring_func="sigmoid",
+            routed_scaling_factor=1.0,
+            norm_topk_prob=True,
+        )
+        # Keep routed experts unquantized and the shared expert separate.
+        # Construct the real owning module so its fusion selection is exercised.
+        with (
+            get_context().override_server_args(model_path="dummy"),
+            get_flags().moe.override(
+                runner_backend=MoeRunnerBackend.TRITON,
+                a2a_backend=MoeA2ABackend.NONE,
+                disable_shared_experts_fusion=True,
+            ),
+        ):
+            moe = DeepseekV2MoE(
+                config, 0, quant_config=cfg, prefix="model.layers.0.mlp"
+            )
+        return moe.shared_experts
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/quantization/test_nvfp4_marlin.py
+++ b/test/registered/kernels/ops/quantization/test_nvfp4_marlin.py
@@ -96,5 +96,64 @@ def test_nvfp4_marlin_dense_matches_dequant_reference(dtype):
     torch.testing.assert_close(output, output_ref, rtol=0.04, atol=0.04)
 
 
+@pytest.mark.skipif(
+    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
+    reason="NVFP4 Marlin requires CUDA SM8X/SM9X/SM120",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tokens", [1, 33])
+@pytest.mark.parametrize("prescale", ["awq", "identity", "plain"])
+def test_modelopt_nvfp4_marlin_prescale(dtype, num_tokens, prescale, monkeypatch):
+    from sglang.srt.layers.linear import RowParallelLinear
+    from sglang.srt.layers.quantization import fp4_utils
+    from sglang.srt.layers.quantization.fp4_utils import Fp4GemmRunnerBackend
+    from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+    from sglang.test.layer_ut_utils import init_single_process_dist, load_linear_weights
+
+    init_single_process_dist()
+    monkeypatch.setattr(
+        fp4_utils, "FP4_GEMM_RUNNER_BACKEND", Fp4GemmRunnerBackend.MARLIN
+    )
+    torch.manual_seed(7209)
+    config = ModelOptFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        group_size=16,
+        exclude_modules=[],
+        packed_modules_mapping={},
+        is_awq=prescale != "plain",
+    )
+    layer = RowParallelLinear(
+        256,
+        128,
+        bias=False,
+        params_dtype=dtype,
+        quant_config=config,
+        tp_rank=0,
+        tp_size=1,
+        prefix="model.layers.0.mlp.down_proj",
+    ).cuda()
+    packed, scales, global_scale, weight_ref = make_nvfp4_weight_and_ref(
+        128, 256, dtype
+    )
+    load_linear_weights(
+        layer,
+        weight=packed,
+        weight_scale=scales,
+        weight_scale_2=global_scale.float(),
+        input_scale=torch.ones((), device="cuda"),
+    )
+    channel_scale = torch.ones(256, dtype=dtype, device="cuda")
+    if prescale == "awq":
+        channel_scale = torch.linspace(0.25, 4, 256, dtype=dtype, device="cuda")
+    if config.is_awq:
+        layer.pre_quant_scale.weight_loader(layer.pre_quant_scale, channel_scale)
+    layer.quant_method.process_weights_after_loading(layer)
+    x = torch.randn(num_tokens, 256, dtype=dtype, device="cuda") / 10
+    actual = layer(x)[0].float()
+    expected = (x * channel_scale).float() @ weight_ref.float().T
+    relative_l2 = (actual - expected).norm() / expected.norm()
+    assert relative_l2.item() < 0.01
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

NVFP4_AWQ requires per-input-channel activation prescaling to compensate for the channel scaling applied to weights during quantization. Skipping this step changes the computation and can silently produce incorrect outputs. The scalar activation/global scale does not replace this channel-wise scale.

Three optimized paths bypass the required prescale:

- Qwen3.5's SiLU/FP4 fusion passes prequantized activations to the down projection, bypassing its normal prescaling step.
- DeepSeek's shared-expert GEMM/SwiGLU/FP4 fusion bypasses both the gate/up and down-projection prescales.
- The common ModelOpt Marlin linear method returns before applying the loaded prescale. This also affects ordinary attention output and MLP down projections, independently of fusion.

NVFP4_AWQ support was added in #31825; the Qwen fusion introduced in #34859 bypasses that existing scaling requirement. The fused interfaces used here cannot consume the channel scale, so the affected AWQ paths need to retain the existing unfused computation.

## Modifications

Keep the existing unfused computation when a fused operation would bypass an AWQ prescale. For Qwen3.5, this checks the down projection because gate/up still runs through its normal linear method. For the DeepSeek shared-expert fusion, both gate/up and down must be checked because the fused operation bypasses both linear methods.

Apply the loaded channel prescale before the common Marlin linear operation. This fixes the underlying linear method for all models using this path, including attention output projections as well as MLP down projections.

[FlashInfer #4537](https://github.com/flashinfer-ai/flashinfer/pull/4537) has a related fused-prescale implementation, but it is not exposed through the interface used here.

## Accuracy Tests

Compare MLP outputs with identical weights and inputs against unfused execution, and check Marlin outputs against an independently dequantized weight reference with explicit prescaling. Include identity-scale AWQ and plain NVFP4 controls.

| GPU | Tests | After fix |
|---|---|---|
| RTX PRO 6000 (SM120) | Qwen fusion and Marlin | 21 passed; 5 SM100-only DeepSeek tests skipped |
| B200 (SM100) | DeepSeek shared-expert fusion | 5 test methods / 10 numerical subcases passed; no skips |

The AWQ regression cases fail before the fix; identity-scale AWQ and plain NVFP4 controls pass before and after.

## Speed Tests and Profiling

Layer CUDA graph latency in μs, TP=1. Batch size counts input token rows. Each value is the median of 18 samples from two runs in opposite order, with nine samples per run and 100 calls per sample.

DeepSeek shared expert on B200: BF16, hidden size 7168, intermediate size 2048, synthetic AWQ weights.

| Batch size (tokens) | Before | After | Correct unfused reference |
|---|---:|---:|---:|
| 1 | 16.42 | 20.52 | 20.50 |
| 32 | 16.42 | 24.59 | 24.59 |
| 256 | 16.44 | 28.73 | 28.73 |
| 1024 | 30.74 | 59.76 | 59.51 |

Qwen3.5 MLP on RTX PRO 6000: BF16, hidden size 5120, intermediate size 17408, FlashInfer CUTLASS, real AWQ checkpoint weights.

| Batch size (tokens) | Before | After | Correct unfused reference |
|---|---:|---:|---:|
| 1 | 170.27 | 166.69 | 171.72 |
| 32 | 161.88 | 160.37 | 164.81 |
| 256 | 167.01 | 186.46 | 185.47 |
| 1024 | 487.03 | 537.57 | 533.38 |

Marlin on RTX PRO 6000, real checkpoint weights. Each cell is before → after; matrix dimensions are output × input.

| Projection | Batch 1 | Batch 32 | Batch 256 | Batch 1024 |
|---|---:|---:|---:|---:|
| Llama3.1 attention output, 4096 × 4096, FP16 | 10.26 → 12.30 | 26.59 → 28.59 | 34.86 → 37.78 | 102.41 → 108.68 |
| Qwen2.5 MLP down, 3584 × 18944, FP16 | 18.45 → 20.49 | 38.96 → 41.11 | 106.51 → 114.68 | 376.01 → 413.63 |
| Qwen3.5 MLP down, 5120 × 17408, BF16 | 20.48 → 20.51 | 38.92 → 40.98 | 135.11 → 141.41 | 503.54 → 546.93 |

## Checklist

- [x] Code formatted.
- [x] Unit tests added.
- [x] No documentation update is needed.
- [x] Accuracy and speed benchmark results provided.
- [x] Follow the SGLang code style.

Assisted-by: OpenAI Codex

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34466357072](https://github.com/sgl-project/sglang/actions/runs/34466357072)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34466356738](https://github.com/sgl-project/sglang/actions/runs/34466356738)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34466357022](https://github.com/sgl-project/sglang/actions/runs/34466357022)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->