### PR TITLE
[Perf] xgrammar: truncate accepted_tokens in place in rollback() (O(k) instead of O(N))

### DIFF
--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -105,7 +105,7 @@ class XGrammarGrammar(BaseGrammarObject):
 
     def rollback(self, k: int):
         self.matcher.rollback(k)
-        self.accepted_tokens = self.accepted_tokens[:-k]
+        del self.accepted_tokens[-k:]
 
     def is_terminated(self):
         return self.matcher.is_terminated()


### PR DESCRIPTION
## Motivation

`XGrammarGrammar.rollback()` rebinds a fresh list slice (`self.accepted_tokens = self.accepted_tokens[:-k]`), which copies the whole remaining list = O(len). Under speculative decoding with a grammar / structured-output request, `rollback(1)` is called once per draft-tree node on every verify step (`speculative/spec_utils.py` `traverse_tree` -> `dfs` calls `grammar.accept_token` then `grammar.rollback(1)` per node on the live `req.grammar`), and `accepted_tokens` grows to the output length N because committed tokens are accepted one-per-step via `_accept_grammar_tokens` (with no matching rollback). So grammar bitmask construction is O(num_draft_tokens x N^2) host-CPU work over an N-token generation, on the single scheduler thread, serially across all grammar requests in the batch.

`accepted_tokens` is a debug-only mirror: it is read only by the `ValueError` message in `accept_token` and by `__repr__`. The authoritative grammar state is the C++ `self.matcher` (bounded by `MAX_ROLLBACK_TOKENS = 200`). So the per-call cost can be made O(k) with no behavior change.

Fixes #38863.

## Modifications

`python/sglang/srt/constrained/xgrammar_backend.py`, `rollback()`:

```diff
     def rollback(self, k: int):
         self.matcher.rollback(k)
-        self.accepted_tokens = self.accepted_tokens[:-k]
+        del self.accepted_tokens[-k:]
```

`del lst[-k:]` is behavior-identical to `lst = lst[:-k]` for every `k` (including `k == 0`, where both clear the list, and `k >= len`, where both empty it), but truncates in place in O(k) instead of copying O(len) element references.

Note on the out-of-place-mutation convention: that convention targets `ScheduleBatch` direct fields (whose snapshots the overlap scheduler relies on). `accepted_tokens` is an internal field of the grammar object, not a `ScheduleBatch` field, and the grammar's authoritative state (the C++ `matcher`) is already mutated in place on the line above (`self.matcher.rollback(k)`), so truncating the debug mirror in place is consistent and safe.

## Accuracy Tests

No output change. `accepted_tokens` has no functional readers (only the debug message and `__repr__`); grammar state is the C++ matcher, which is untouched by this change. Existing constrained-decoding / speculative tests cover correctness.

## Speed Tests and Profiling

Complexity of `rollback`: O(len) -> O(k). Over an N-token generation on the speculative-decoding + xgrammar path: O(num_draft_tokens x N^2) -> O(num_draft_tokens x N). The gain grows with output length and concurrency; at short outputs the copy is small and dominated by the target-verify forward it overlaps, so this removes a latent quadratic rather than changing typical-case latency. (Happy to add an end-to-end benchmark of the large-N case if useful.)

## Checklist

- [ ] Format code with pre-commit
- [ ] Existing constrained-decoding / speculative tests pass

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34466470141](https://github.com/sgl-project/sglang/actions/runs/34466470141)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34466469989](https://github.com/sgl-project/sglang/actions/runs/34466469989)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34466470091](https://github.com/sgl-project/sglang/actions/runs/34466470091)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->