### PR TITLE
[Benchmark] Fail requests on server-side streaming errors

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -149,6 +149,13 @@ def _combine_openai_chat_content(message: Dict[str, Any]) -> str:
     return reasoning + (message.get("content") or "")
 
 
+def _raise_for_stream_error(data: Dict[str, Any]) -> None:
+    # Streaming responses may report an error after committing HTTP 200.
+    # Let the request's exception handler exclude it from successful metrics.
+    if "error" in data:
+        raise RuntimeError(f"Server returned an error: {data['error']}")
+
+
 def wait_for_endpoint(url: str, timeout_sec: int = 60) -> bool:
     """Wait for the server to become ready by polling the given URL."""
     print(f"Waiting up to {timeout_sec}s for {url} to become ready...")
@@ -327,6 +334,7 @@ async def async_request_openai_completions(
                             pass
                         else:
                             data = json.loads(chunk)
+                            _raise_for_stream_error(data)
 
                             if getattr(args, "cache_report", False):
                                 _extract_cache_from_sglext(data, output)
@@ -512,6 +520,7 @@ async def async_request_openai_chat_completions(
                                 pass
                             else:
                                 data = json.loads(chunk)
+                                _raise_for_stream_error(data)
                                 # Check for usage info in final chunks. OpenAI-compatible
                                 # servers may emit usage-only chunks with choices=[].
                                 output_len = (data.get("usage") or {}).get(
@@ -724,6 +733,7 @@ async def async_request_sglang_generate(
                             pass
                         else:
                             data = orjson.loads(sse_data)
+                            _raise_for_stream_error(data)
 
                             _meta_info = data.get("meta_info") or {}
                             if _meta_info.get("spec_accept_length") is not None:

--- a/test/registered/unit/benchmark/test_bench_serving_stream_errors.py
+++ b/test/registered/unit/benchmark/test_bench_serving_stream_errors.py
@@ -1,0 +1,183 @@
+"""An HTTP 200 SSE response can still end in a server-side error."""
+
+import json
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from aiohttp import web
+
+import sglang.benchmark.serving as serving
+from sglang.benchmark.datasets.common import DatasetRow
+from sglang.benchmark.serving import (
+    RequestFuncInput,
+    async_request_openai_chat_completions,
+    async_request_openai_completions,
+    async_request_sglang_generate,
+    calculate_metrics,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _Tokenizer:
+    def encode(self, text, add_special_tokens=False):
+        return text.split()
+
+
+class TestBenchServingStreamErrors(CustomTestCase, unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        super().setUp()
+        args_patch = patch.object(
+            serving,
+            "args",
+            Namespace(
+                disable_stream=False,
+                disable_ignore_eos=True,
+                return_logprob=False,
+                return_routed_experts=False,
+                logprob_start_len=-1,
+                top_logprobs_num=0,
+                token_ids_logprob=None,
+                temperature=0.0,
+                top_p=1.0,
+                header=None,
+                tokenizer="",
+                print_requests=False,
+            ),
+            create=True,
+        )
+        args_patch.start()
+        self.addCleanup(args_patch.stop)
+
+    async def _run(self, request_func, chunks):
+        async def handle(request):
+            await request.json()
+            body = b"".join(
+                b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks
+            )
+            return web.Response(
+                body=body + b"data: [DONE]\n\n", content_type="text/event-stream"
+            )
+
+        path = {
+            async_request_openai_chat_completions: "/v1/chat/completions",
+            async_request_openai_completions: "/v1/completions",
+            async_request_sglang_generate: "/generate",
+        }[request_func]
+        app = web.Application()
+        app.router.add_post(path, handle)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            site = web.TCPSite(runner, "127.0.0.1", 0)
+            await site.start()
+            port = runner.addresses[0][1]
+            request = RequestFuncInput(
+                prompt="hello",
+                api_url=f"http://127.0.0.1:{port}{path}",
+                prompt_len=1,
+                output_len=64,
+                model="dummy-model",
+                lora_name="",
+                image_data=None,
+                extra_request_body={},
+            )
+            return await request_func(request)
+        finally:
+            await runner.cleanup()
+
+    @staticmethod
+    def _backends():
+        return (
+            (
+                async_request_openai_chat_completions,
+                {
+                    "choices": [{"delta": {"content": "partial answer"}}],
+                    "usage": {"completion_tokens": 2},
+                },
+            ),
+            (
+                async_request_openai_completions,
+                {
+                    "choices": [{"text": "partial answer"}],
+                    "usage": {"completion_tokens": 2},
+                },
+            ),
+            (
+                async_request_sglang_generate,
+                {
+                    "text": "partial answer",
+                    "meta_info": {"completion_tokens": 2},
+                },
+            ),
+        )
+
+    async def test_stream_error_before_or_after_content_fails_request(self):
+        error = {"message": "Generation timed out", "code": 503}
+        for request_func, content in self._backends():
+            for prefix in ([], [content]):
+                with self.subTest(backend=request_func.__name__, prefix=bool(prefix)):
+                    output = await self._run(request_func, prefix + [{"error": error}])
+                    self.assertFalse(output.success)
+                    self.assertIn("Generation timed out", output.error)
+                    self.assertIn("503", output.error)
+                    self.assertEqual(output.output_len, 0)
+
+    async def test_string_error_preserves_server_message(self):
+        for request_func, _ in self._backends():
+            with self.subTest(backend=request_func.__name__):
+                output = await self._run(
+                    request_func, [{"error": "Engine unavailable"}]
+                )
+                self.assertFalse(output.success)
+                self.assertIn("Engine unavailable", output.error)
+
+    async def test_stream_errors_do_not_count_toward_success_metrics(self):
+        for request_func, content in self._backends():
+            with self.subTest(backend=request_func.__name__):
+                success = await self._run(request_func, [content])
+                failed = await self._run(
+                    request_func,
+                    [content, {"error": {"message": "Generation timed out"}}],
+                )
+                self.assertTrue(success.success, success.error)
+                self.assertEqual(success.generated_text, "partial answer")
+                self.assertEqual(success.output_len, 2)
+                metrics, output_lens = calculate_metrics(
+                    input_requests=[
+                        DatasetRow(prompt="hello", prompt_len=1, output_len=64),
+                        DatasetRow(prompt="hello", prompt_len=1, output_len=64),
+                    ],
+                    outputs=[success, failed],
+                    dur_s=1.0,
+                    tokenizer=_Tokenizer(),
+                    backend="sglang",
+                )
+                self.assertEqual(metrics.completed, 1)
+                self.assertEqual(metrics.total_input, 1)
+                self.assertEqual(metrics.total_output, 2)
+                self.assertEqual(metrics.output_throughput, 2.0)
+                self.assertAlmostEqual(metrics.mean_ttft_ms, success.ttft * 1000)
+                self.assertAlmostEqual(
+                    metrics.mean_e2e_latency_ms, success.latency * 1000
+                )
+                self.assertEqual(output_lens, [2, 0])
+
+    async def test_chat_usage_only_chunk_remains_successful(self):
+        output = await self._run(
+            async_request_openai_chat_completions,
+            [
+                {"choices": [{"delta": {"content": "answer"}}]},
+                {"choices": [], "usage": {"completion_tokens": 1}},
+            ],
+        )
+        self.assertTrue(output.success, output.error)
+        self.assertEqual(output.generated_text, "answer")
+        self.assertEqual(output.output_len, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

An HTTP 200 SSE response can report a generation error after its headers have been sent. The serving benchmark currently counts these responses as successful for native `/generate` and OpenAI chat. An error before the first token even credits the requested maximum output length as generated tokens. OpenAI completions instead fails with a missing `choices` key, losing the server's error message.

Check explicit error envelopes in all three streaming readers so the existing exception handlers mark the request unsuccessful and preserve the server error. Failed requests are then excluded from successful-request throughput and latency metrics.

Credit to @jpy794 for identifying and proposing a fix for the native generation case in #7747, which was closed without merging. This change covers the current native and OpenAI readers and adds regression tests.

## Modifications

- Add a shared error-envelope check immediately after decoding each streaming payload in the native, OpenAI completions, and OpenAI chat request functions.
- Add registered CPU tests using real HTTP 200 SSE responses from an ephemeral aiohttp loopback endpoint. Cover errors before/after partial output, dictionary/string error payloads, exclusion from success metrics, and successful usage-only chat chunks.

The metric regression includes a successful peer alongside the failed request. The separately tracked all-failed aggregate case in #35005 remains outside this change.

## Accuracy Tests

CPU validation on upstream base `a37ded1693f608c0aae50cff4a3c40146b0b643b`, using Python 3.12.1, PyTorch 2.14.0+cpu, Transformers 5.12.1, and aiohttp 3.14.3:

```bash
PYTHONPATH=python python test/registered/unit/benchmark/test_bench_serving_stream_errors.py
# 4 test methods / 13 cases passed
PYTHONPATH=python python test/registered/bench_fn/test_bench_serving_reasoning_stream.py
# 10 existing tests passed
```

The new regression tests fail against the original readers (11 failing assertions across subcases). The patched tests import and exercise the production module directly; no model weights or GPU are required.

All 17 applicable pre-commit hooks pass on the changed files. The whole-repository `pre-commit run --all-files --show-diff-on-failure` run passed all 27 executed non-Rust checks; one other hook had no matching files. Four Rust hooks were explicitly skipped because the required Rust 1.90, 1.92, and nightly toolchains are unavailable locally. The same whole-repository results hold on the unmodified base, and no formatter changes were produced.

## Speed Tests and Profiling

No GPU/model inference benchmark was run. This change corrects benchmark client error accounting after decoding a response; the protocol and metric assertions above validate its behavior.

## Checklist

- [x] Format code according to the [pre-commit guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit), with the unrelated Rust-toolchain limitation documented above.
- [x] Add [unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests), including `CustomTestCase`, CPU CI registration, and a direct entry point.
- [x] Review [documentation requirements](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations): no new public API or option; this restores existing error-accounting behavior.
- [x] Provide applicable [accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) evidence: CPU correctness results above; model accuracy and inference-speed benchmarks are not applicable.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Ready for Merge Oncall and Codeowner review under the [PR merge process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process). Upstream CI requires the usual authorized `run-ci` labeling.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34469278914](https://github.com/sgl-project/sglang/actions/runs/34469278914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34469278746](https://github.com/sgl-project/sglang/actions/runs/34469278746)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34469278910](https://github.com/sgl-project/sglang/actions/runs/34469278910)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->