### PR TITLE
[Fix] Preserve Pythonic tool calls and trailing text across streaming chunks

### DIFF
--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -129,7 +129,8 @@ class PythonicDetector(BaseFormatDetector):
     def _find_matching_bracket(self, buffer: str, start: int) -> int:
         """
         Find the matching closing bracket for the opening bracket at start position.
-        Properly handles nested brackets.
+        Ignore brackets inside Python string literals, including escaped quotes
+        and triple-quoted strings, while counting nested containers.
 
         Args:
             buffer: The text buffer to search in
@@ -138,14 +139,33 @@ class PythonicDetector(BaseFormatDetector):
         Returns:
             Position of the matching closing bracket ']', or -1 if not found
         """
+        # An apostrophe in ordinary bracketed prose (e.g. [O'Reilly]) is
+        # not a Python string opener. Only apply string rules to call lists.
+        is_call_list = re.match(r"\[[a-zA-Z]\w*\(", buffer[start:]) is not None
         bracket_count = 0
-        for i in range(start, len(buffer)):
-            if buffer[i] == "[":
+        quote = None
+        i = start
+        while i < len(buffer):
+            char = buffer[i]
+            if quote is not None:
+                if char == "\\":
+                    i += 2
+                    continue
+                if buffer.startswith(quote, i):
+                    i += len(quote)
+                    quote = None
+                    continue
+            elif is_call_list and char in ("'", '"'):
+                quote = char * 3 if buffer.startswith(char * 3, i) else char
+                i += len(quote)
+                continue
+            elif char == "[":
                 bracket_count += 1
-            elif buffer[i] == "]":
+            elif char == "]":
                 bracket_count -= 1
                 if bracket_count == 0:
                     return i
+            i += 1
         return -1  # No matching bracket found
 
     def _strip_and_split_buffer(self, buffer: str) -> tuple[str, str]:
@@ -185,40 +205,38 @@ class PythonicDetector(BaseFormatDetector):
         # Strip special tokens from entire buffer and handle partial tokens
         stripped_buffer, held_back = self._strip_and_split_buffer(self._buffer)
 
-        start = stripped_buffer.find("[")
+        normal_text = []
+        calls = []
+        position = 0
+        while position < len(stripped_buffer):
+            start = stripped_buffer.find("[", position)
+            if start == -1:
+                normal_text.append(stripped_buffer[position:])
+                position = len(stripped_buffer)
+                break
 
-        if start == -1:
-            # No tool call bracket found
-            self._buffer = held_back
-            return StreamingParseResult(normal_text=stripped_buffer)
+            normal_text.append(stripped_buffer[position:start])
+            end = self._find_matching_bracket(stripped_buffer, start)
+            if end == -1:
+                position = start
+                break
 
-        normal_text = stripped_buffer[:start] if start > 0 else ""
-
-        end = self._find_matching_bracket(stripped_buffer, start)
-        if end != -1:
-            # Found complete tool call
             call_text = stripped_buffer[start : end + 1]
             result = self.detect_and_parse(call_text, tools)
+            normal_text.append(result.normal_text)
+            for call in result.calls:
+                # detect_and_parse numbers calls within one list. Streaming
+                # indexes must remain unique across every list in the response.
+                self.current_tool_id += 1
+                call.tool_index = self.current_tool_id
+                calls.append(call)
+            position = end + 1
 
-            # Update buffer with remaining text after tool call plus any held back text
-            remaining_text = stripped_buffer[end + 1 :] + held_back
-            self._buffer = remaining_text
-
-            # If we had normal text before the tool call, add it to the result
-            if normal_text:
-                result.normal_text = normal_text + (result.normal_text or "")
-
-            return result
-
-        # We have an opening bracket but no closing bracket yet
-        # Put back everything from the bracket onwards plus held back text
-        self._buffer = stripped_buffer[start:] + held_back
-
-        if normal_text:
-            return StreamingParseResult(normal_text=normal_text)
-
-        # Otherwise, we're still accumulating a potential tool call
-        return StreamingParseResult(normal_text="")
+        # Only incomplete calls or special-token prefixes need another chunk.
+        # Drain complete calls and trailing text now: a final chunk may contain
+        # more than one call, and the serving layer need not invoke us again.
+        self._buffer = stripped_buffer[position:] + held_back
+        return StreamingParseResult(normal_text="".join(normal_text), calls=calls)
 
     def _get_parameter_value(self, val):
         if isinstance(val, ast.Constant):

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -582,16 +582,14 @@ class TestPythonicDetector(unittest.TestCase):
         text = "[get_weather(location='Tokyo')] Here's the forecast:"
         result = self.detector.parse_streaming_increment(text, self.tools)
 
-        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.normal_text, " Here's the forecast:")
         self.assertEqual(len(result.calls), 1)
         self.assertEqual(result.calls[0].name, "get_weather")
-        self.assertEqual(
-            self.detector._buffer, " Here's the forecast:"
-        )  # Text after tool call remains in buffer
+        self.assertEqual(self.detector._buffer, "")
 
-        # Process the remaining text in buffer
+        # An extra increment must not duplicate the already-emitted text.
         result2 = self.detector.parse_streaming_increment("", self.tools)
-        self.assertEqual(result2.normal_text, " Here's the forecast:")
+        self.assertEqual(result2.normal_text, "")
         self.assertEqual(result2.calls, [])
         self.assertEqual(self.detector._buffer, "")  # Buffer should be cleared
 
@@ -599,17 +597,19 @@ class TestPythonicDetector(unittest.TestCase):
         """Test parsing multiple tool calls in sequence."""
         text = "[get_weather(location='Berlin')] and [search(query='restaurants')]"
 
-        # First tool call
+        # Every complete call must be emitted even if this is the final chunk.
         result1 = self.detector.parse_streaming_increment(text, self.tools)
-        self.assertEqual(len(result1.calls), 1)
+        self.assertEqual(result1.normal_text, " and ")
+        self.assertEqual(len(result1.calls), 2)
         self.assertEqual(result1.calls[0].name, "get_weather")
-        self.assertEqual(self.detector._buffer, " and [search(query='restaurants')]")
+        self.assertEqual(result1.calls[1].name, "search")
+        self.assertEqual([call.tool_index for call in result1.calls], [0, 1])
+        self.assertEqual(self.detector._buffer, "")
 
-        # Second tool call
+        # No additional call should be emitted on an empty increment.
         result2 = self.detector.parse_streaming_increment("", self.tools)
-        self.assertEqual(result2.normal_text, " and ")
-        self.assertEqual(len(result2.calls), 1)
-        self.assertEqual(result2.calls[0].name, "search")
+        self.assertEqual(result2.normal_text, "")
+        self.assertEqual(result2.calls, [])
         self.assertEqual(self.detector._buffer, "")
 
     def test_parse_streaming_opening_bracket_only(self):

--- a/test/registered/unit/function_call/test_pythonic_streaming.py
+++ b/test/registered/unit/function_call/test_pythonic_streaming.py
@@ -1,0 +1,126 @@
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.pythonic_detector import PythonicDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestPythonicStreaming(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                ),
+            )
+        ]
+
+    def assert_stream(self, chunks, expected_text, expected_arguments):
+        detector = PythonicDetector()
+        text = []
+        calls = {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            text.append(result.normal_text)
+            for call in result.calls:
+                entry = calls.setdefault(call.tool_index, [None, ""])
+                if call.name is not None:
+                    self.assertIsNone(entry[0], "tool index was reused")
+                    entry[0] = call.name
+                entry[1] += call.parameters
+
+        self.assertEqual("".join(text), expected_text)
+        self.assertEqual(list(calls), list(range(len(expected_arguments))))
+        self.assertEqual(
+            [(name, json.loads(arguments)) for name, arguments in calls.values()],
+            [("search", arguments) for arguments in expected_arguments],
+        )
+        # The final input chunk must emit everything complete, without relying
+        # on a later empty increment to flush buffered calls or trailing prose.
+        self.assertEqual(detector._buffer, "")
+
+    def assert_all_chunkings(self, text, expected_text, expected_arguments):
+        chunkings = [[text], list(text)]
+        chunkings.extend([text[:split], text[split:]] for split in range(1, len(text)))
+        for chunks in chunkings:
+            with self.subTest(chunks=chunks):
+                self.assert_stream(chunks, expected_text, expected_arguments)
+
+    def test_quoted_brackets_match_non_streaming_for_every_split(self):
+        literals = [
+            '"hello]world"',
+            "'an unmatched [ in a query'",
+            r'"escaped quote: \" ] and backslash: \\"',
+            r"'escaped quote: \' ] and backslash: \\'",
+            "'''a single ' and ] inside a multiline\nquery'''",
+            '"""a double " and [ inside a multiline\nquery"""',
+        ]
+        for literal in literals:
+            text = f"[search(query={literal})]"
+            with self.subTest(literal=literal):
+                result = PythonicDetector().detect_and_parse(text, self.tools)
+                self.assertEqual(len(result.calls), 1)
+                self.assert_all_chunkings(
+                    text, "", [json.loads(result.calls[0].parameters)]
+                )
+
+    def test_nested_containers_preserve_string_brackets(self):
+        text = "[search(query={'terms': [']', {'value': '['}]})]"
+        self.assert_all_chunkings(
+            text, "", [{"query": {"terms": ["]", {"value": "["}]}}]
+        )
+
+    def test_trailing_text_is_emitted_with_the_final_tool_call(self):
+        text = "Searching. [search(query='hello')] Done."
+        self.assert_all_chunkings(text, "Searching.  Done.", [{"query": "hello"}])
+
+    def test_repeated_blocks_have_distinct_indexes_and_drain_final_chunk(self):
+        text = "[search(query='one')][search(query='two')] Done."
+        self.assert_all_chunkings(text, " Done.", [{"query": "one"}, {"query": "two"}])
+
+    def test_parallel_calls_and_later_block_keep_order(self):
+        text = "[search(query='one'), search(query='two')][search(query='three')]"
+        self.assert_all_chunkings(
+            text, "", [{"query": value} for value in ("one", "two", "three")]
+        )
+
+    def test_incomplete_call_stays_buffered_until_outer_bracket(self):
+        detector = PythonicDetector()
+        result = detector.parse_streaming_increment(
+            "[search(query='unfinished]')", self.tools
+        )
+        self.assertEqual(result.calls, [])
+        self.assertEqual(result.normal_text, "")
+        result = detector.parse_streaming_increment("] Done.", self.tools)
+        self.assertEqual(result.normal_text, " Done.")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters), {"query": "unfinished]"}
+        )
+
+    def test_special_markers_can_split_after_a_complete_call(self):
+        text = "<|python_start|>[search(query='hello')]<|python_end|> Done."
+        self.assert_all_chunkings(text, " Done.", [{"query": "hello"}])
+
+    def test_bracketed_prose_with_apostrophes_is_not_a_call(self):
+        for text in ("[O'Reilly] docs", "[don't panic] done", "[1] and []"):
+            self.assert_all_chunkings(text, text, [])
+        self.assert_all_chunkings(
+            '[O\'Reilly] docs [search(query="]")] Done.',
+            "[O'Reilly] docs  Done.",
+            [{"query": "]"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The Pythonic parser used by Llama 4 can lose valid streaming tool calls when an argument contains a square bracket inside a string. For example, `[search(query="hello]world")]` parses correctly in the non-streaming path, but streaming mistakes the quoted `]` for the end of the call list.

The parser also returns after the first complete list in an increment. When this is the final chunk, later calls and trailing text remain buffered indefinitely. Lists delivered in separate increments restart their tool indexes at zero, potentially combining unrelated calls at the client.

Related to #31915 (the Pythonic portion). Credit to @gorillassi for the earlier quoted-bracket diagnosis in #24899, which was closed without merging. Related work in #35625 covers other detectors; this PR is scoped to Pythonic.

## Modifications

- Respect single-, double-, and triple-quoted Python strings and escapes while matching the outer call-list bracket. Enable string handling only after a call-list prefix so ordinary prose such as `[O'Reilly]` remains intact.
- Consume every complete call list and trailing text in the current increment, retaining incomplete input and partial special markers.
- Keep tool indexes unique across successive lists in a response.
- Add registered CPU regression coverage for whole-input chunks, individual characters, and every two-way split. Update two existing tests to assert that the final real increment emits complete trailing content without an extra empty flush.

For example, `[search(query='one')][search(query='two')] Done.` now emits both calls with indexes 0 and 1 and the complete trailing text, even when delivered as one final chunk.

## Accuracy Tests

CPU validation on upstream base `a37ded1693f608c0aae50cff4a3c40146b0b643b`, using Python 3.12.1, PyTorch 2.14.0+cpu, Transformers 5.12.1, and OpenAI 2.6.1:

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/function_call/test_pythonic_streaming.py \
  test/registered/unit/function_call/test_function_call_parser.py -k Pythonic
# 32 tests and 673 subtests passed; 219 unrelated tests deselected

PYTHONPATH=python python test/registered/unit/function_call/test_pythonic_streaming.py
# 8 tests passed
```

The new tests reproduce failures against the original parser. They verify names, decoded arguments, exact ordinary text, call order, unique indexes, incomplete-call buffering, and complete emission without a synthetic trailing flush. Validation uses ordinary production-module imports.

All 17 applicable pre-commit hooks pass on the changed files. The whole-repository `pre-commit run --all-files --show-diff-on-failure` run passed all 27 executed non-Rust checks; one other hook had no matching files. Four Rust hooks were explicitly skipped because the required Rust 1.90, 1.92, and nightly toolchains are unavailable locally. The same whole-repository results hold on the unmodified base, and no formatter changes were produced.

## Speed Tests and Profiling

No model-generation or GPU benchmark was run. Fixed decoded output exercises the parser's data-loss cases deterministically on CPU. The existing buffering/rescanning strategy remains, and no inference-throughput improvement is claimed.

## Checklist

- [x] Format code according to the [pre-commit guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit), with the unrelated Rust-toolchain limitation documented above.
- [x] Add [unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests), including `CustomTestCase`, CPU CI registration, and a direct entry point.
- [x] Review [documentation requirements](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations): no new public API or option; this fixes existing Pythonic streaming behavior.
- [x] Provide applicable [accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) evidence: CPU parser correctness results above; model accuracy and inference-speed benchmarks are not applicable.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Ready for Merge Oncall and Codeowner review under the [PR merge process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process). Upstream CI requires the usual authorized `run-ci` labeling.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34469281016](https://github.com/sgl-project/sglang/actions/runs/34469281016)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34469280927](https://github.com/sgl-project/sglang/actions/runs/34469280927)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34469281031](https://github.com/sgl-project/sglang/actions/runs/34469281031)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->