### PR TITLE
Fix Qwen3.5 MTP partial MXFP4 quantization

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -68,17 +68,36 @@ def _mtp_quant_config(quant_config):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:
         return None
-    # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in bf16;
-    # every `mtp.*` layer appears under the quantization exclude list. Detect
-    # that and skip quantization here so linear/MoE weight loaders allocate
-    # bf16 shapes (see sgl-project/sglang#23113).
+    # Quark checkpoints may keep all MTP weights in bf16, or only exclude
+    # non-expert MTP layers while routed experts are MXFP4. Disable MTP
+    # quantization only when the routed experts themselves are excluded.
     if quant_config and quant_config.get_name() == "quark":
         exclude_layers = getattr(quant_config, "exclude_layers", [])
         if any(
-            isinstance(layer, str) and layer.startswith("mtp.")
+            isinstance(layer, str)
+            and (
+                layer == "mtp.*"
+                or layer.startswith("mtp.layers.0.mlp.experts")
+            )
             for layer in exclude_layers
         ):
             return None
+
+        expanded_exclude_layers = list(exclude_layers)
+        for layer in exclude_layers:
+            if not isinstance(layer, str):
+                continue
+            if layer.startswith("mtp.layers.") and ".self_attn." in layer:
+                if layer.endswith((".q_proj", ".k_proj", ".v_proj")):
+                    expanded_exclude_layers.append(
+                        layer.rsplit(".", 1)[0] + ".qkv_proj"
+                    )
+            if layer.startswith("mtp.layers.") and ".mlp.shared_expert." in layer:
+                if layer.endswith((".gate_proj", ".up_proj")):
+                    expanded_exclude_layers.append(
+                        layer.rsplit(".", 1)[0] + ".gate_up_proj"
+                    )
+        quant_config.exclude_layers = list(dict.fromkeys(expanded_exclude_layers))
     return quant_config
 
 


### PR DESCRIPTION
## Summary

Fix Qwen3.5 MTP loading for Quark checkpoints where only the MTP routed experts are MXFP4 while the rest of the MTP module remains unquantized.

## Motivation

Some Quark MXFP4 Qwen3.5 checkpoints use mixed precision inside the embedded MTP draft:

- `mtp.layers.0.mlp.experts.*.{gate_proj,up_proj,down_proj}` are MXFP4 packed weights.
- `mtp.fc`, `mtp.layers.0.self_attn.*`, `mtp.layers.0.mlp.gate`, and `mtp.layers.0.mlp.shared_expert.*` remain BF16 and are listed in `quantization_config.exclude`.

The existing Qwen3.5 MTP logic treats any `mtp.*` exclude entry as meaning that the entire MTP module is unquantized. That builds the routed experts as BF16 and fails when loading MXFP4 packed weights with a hidden-dimension mismatch.

After preserving the Quark quant config for this partial-MTP case, the attention path also needs the fused module names to be excluded. The checkpoint exclude list names `q_proj`, `k_proj`, and `v_proj`, while SGLang constructs `qkv_proj`; similarly, shared-expert `gate_proj` and `up_proj` may be constructed as `gate_up_proj`.

## Changes

- Only disable MTP quantization for Quark when the exclude list explicitly covers the whole MTP module (`mtp.*`) or the MTP routed experts (`mtp.layers.0.mlp.experts...`).
- Expand MTP exclude entries for fused runtime module names:
  - `self_attn.{q,k,v}_proj` -> `self_attn.qkv_proj`
  - `mlp.shared_expert.{gate,up}_proj` -> `mlp.shared_expert.gate_up_proj`

## Validation

Validated on an MI35X setup with a Quark MXFP4 Qwen3.5-397B checkpoint whose MTP routed experts are MXFP4 and non-expert MTP layers are BF16.

Before the patch, MTP startup failed with shape mismatches such as:

```text
RuntimeError: The size of tensor a (4096) must match the size of tensor b (2048)
```

and then:

```text
AssertionError: param_data.shape=torch.Size([8192, 2048]), loaded_weight.shape=torch.Size([8192, 4096])
```

After the patch, the server starts with MTP enabled.

Server command:

```bash
MODEL="/data2/amd/Qwen3.5-397B-A17B-Quark-MXFP4"
AITER_FLYDSL_FORCE=1 HIP_VISIBLE_DEVICES=2,3 \
SGLANG_USE_AITER_UNIFIED_ATTN=1 SGLANG_USE_AITER=1 \
nohup python3 -m sglang.launch_server \
  --model-path "${MODEL}" --tp 2 \
  --attention-backend aiter --trust-remote-code \
  --chunked-prefill-size 32768 \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --watchdog-timeout 1200 --mem-fraction-static 0.9 \
  --host 0.0.0.0 --port 8002 --disable-radix-cache \
  --enable-aiter-allreduce-fusion --max-running-requests 128 \
  --page-size 16 \
  --speculative-algorithm NEXTN \
  --speculative-draft-model-path "${MODEL}" \
  --speculative-num-steps 1 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 2 > "tmp_qwen35_mar_mi35x_accuracy_$(date +%Y%m%d_%H%M%S).log" 2>&1 &
```

GSM8K eval command:

```bash
python3 -m sglang.test.run_eval \
  --port 8002 \
  --model /data2/amd/Qwen3.5-397B-A17B-Quark-MXFP4 \
  --eval-name gsm8k \
  --num-examples 1319 \
  --num-threads 512 \
  --max-tokens 2048 \
  --chat-template-kwargs '{"enable_thinking": false}' \
  2>&1 | tee /tmp/gsm8k_run_eval.log
```

Result:

```text
100% completed: 1314/1314 [02:27<00:00, 8.92it/s]
Total latency: 147.383 s
Score: 0.973
Output throughput: 1522.994 token/s
[METRIC] gsm8k_score=0.9733637747336378 labels={"model": "/data2/amd/Qwen3.5-397B-A17B-Quark-MXFP4", "eval": "gsm8k"}
[METRIC] gsm8k_latency=147.38271566526964 labels={"model": "/data2/amd/Qwen3.5-397B-A17B-Quark-MXFP4", "eval": "gsm8k"}
Speculative accept length (per-request, from meta_info): n=1314 mean=1.9117 min=1.7143 max=2.0385
```

The accept length is close to the `--speculative-num-draft-tokens 2` budget, confirming that the MTP draft path is active.

Also ran:

```text
python3 -m py_compile python/sglang/srt/models/qwen3_5_mtp.py
git diff --check
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34471310413](https://github.com/sgl-project/sglang/actions/runs/34471310413)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34471310074](https://github.com/sgl-project/sglang/actions/runs/34471310074)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34471310228](https://github.com/sgl-project/sglang/actions/runs/34471310228)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->