### PR TITLE
Fix FA4 vision attention window sinks

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -611,6 +611,9 @@ class VisionFlash4Attention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        window_size = kwargs.get("window_size", (-1, -1))
+        s_aux = kwargs.get("s_aux", None)
+
         if forward_metadata is not None:
             cu_seqlens_gpu = forward_metadata.cu_seqlens
             max_seqlen = forward_metadata.max_seqlen
@@ -621,17 +624,18 @@ class VisionFlash4Attention(nn.Module):
                 cu_seqlens_gpu, kwargs.get("max_seqlen")
             )
 
-        output = flash_attn_func(
-            q,
-            k,
-            v,
+        fa_kwargs = dict(
             cu_seqlens_q=cu_seqlens_gpu,
             cu_seqlens_k=cu_seqlens_gpu,
             max_seqlen_q=max_seqlen,
             max_seqlen_k=max_seqlen,
             softmax_scale=softmax_scale,
+            window_size=window_size,
             ver=4,
         )
+        if s_aux is not None:
+            fa_kwargs["sinks"] = s_aux
+        output = flash_attn_func(q, k, v, **fa_kwargs)
 
         return output
 

--- a/test/manual/attention/test_vision_fa4_attention.py
+++ b/test/manual/attention/test_vision_fa4_attention.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.attention.vision as vision_attention
+
+
+class TestVisionFlash4AttentionKwargs(unittest.TestCase):
+    def _run_with_captured_flash_attn(self, **forward_kwargs):
+        captured = {}
+
+        def fake_flash_attn_func(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return torch.empty_like(args[0])
+
+        q = torch.randn(4, 2, 8)
+        k = torch.randn(4, 2, 8)
+        v = torch.randn(4, 2, 8)
+        cu_seqlens = torch.tensor([0, 4], dtype=torch.int32)
+
+        with (
+            patch.object(vision_attention, "_is_cuda", True),
+            patch.object(
+                vision_attention,
+                "flash_attn_func",
+                side_effect=fake_flash_attn_func,
+                create=True,
+            ),
+        ):
+            attn = vision_attention.VisionFlash4Attention()
+            output = attn(
+                q=q,
+                k=k,
+                v=v,
+                cu_seqlens=cu_seqlens,
+                bsz=1,
+                seq_len=4,
+                softmax_scale=0.125,
+                **forward_kwargs,
+            )
+
+        self.assertEqual(output.shape, q.shape)
+        self.assertIs(captured["args"][0], q)
+        self.assertIs(captured["args"][1], k)
+        self.assertIs(captured["args"][2], v)
+        self.assertIs(captured["kwargs"]["cu_seqlens_q"], cu_seqlens)
+        self.assertIs(captured["kwargs"]["cu_seqlens_k"], cu_seqlens)
+        self.assertEqual(captured["kwargs"]["max_seqlen_q"], 4)
+        self.assertEqual(captured["kwargs"]["max_seqlen_k"], 4)
+        self.assertEqual(captured["kwargs"]["softmax_scale"], 0.125)
+        self.assertEqual(captured["kwargs"]["ver"], 4)
+        return captured["kwargs"]
+
+    def test_forwards_window_size_and_sinks_to_fa4_kernel(self):
+        s_aux = torch.randn(2)
+
+        kwargs = self._run_with_captured_flash_attn(
+            window_size=(32, 32),
+            s_aux=s_aux,
+        )
+
+        self.assertEqual(kwargs["window_size"], (32, 32))
+        self.assertIs(kwargs["sinks"], s_aux)
+
+    def test_defaults_to_full_attention_without_sinks(self):
+        kwargs = self._run_with_captured_flash_attn()
+
+        self.assertEqual(kwargs["window_size"], (-1, -1))
+        self.assertNotIn("sinks", kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the FA4 vision attention path so it preserves MiMo-style local-window attention and learned attention sinks.

`VisionFlash4Attention.forward()` now forwards:

- `window_size` from the vision attention kwargs
- `s_aux` as `sinks` when present
- `ver=4` to select the FA4 varlen kernel path

This keeps the FA4 multimodal attention backend consistent with the FA3 vision path and avoids silently changing vision attention semantics for models that rely on local windows and sinks.

## Related issue

Fixes #38871.

Related to #37983, which tracks the same missing-semantics problem in the Triton vision attention backend.

## Tests

- Added `test/manual/attention/test_vision_fa4_attention.py`
  - Covers forwarding `window_size` and `s_aux -> sinks` to `flash_attn_func(..., ver=4)`.
  - Covers the backwards-compatible default full-attention path when `s_aux` is absent.

Local verification:

- `python -m py_compile test/manual/attention/test_vision_fa4_attention.py`

The local environment does not have `torch` installed, so running the pytest file locally is blocked at import time. The test is written to avoid requiring the real FA4 kernel or CUDA by monkeypatching `flash_attn_func`.

Manual compatibility validation in a GPU environment:

- MiMo-V2.5 with `--mm-attention-backend fa4`: multimodal output becomes normal after the fix.
- Qwen3-4B: server starts with the patched FA4 path and text requests work.
- Qwen2.5-VL-3B-Instruct: server starts; text and image requests work with sufficient context length.
- Qwen3.5-4B: server starts; text and image requests work with sufficient context length.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #34473332551](https://github.com/sgl-project/sglang/actions/runs/34473332551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #34473332226](https://github.com/sgl-project/sglang/actions/runs/34473332226)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #34473332483](https://github.com/sgl-project/sglang/actions/runs/34473332483)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->