### PR TITLE
[AMD] Pad QSA MQA decode Q-heads to 16 for ROCm MFMA

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/mqa.py
+++ b/python/sglang/srt/layers/attention/qsa/mqa.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.utils.common import is_hip
+
 try:
     import flashinfer.comm  # noqa: F401
 except ImportError:
@@ -349,10 +351,14 @@ def tilelang_qsa_mqa_decode(
     )
     if not q.shape[0] or not max_model_len:
         return logits
-    # The validated MMA layout requires N (the Q-head dimension) to be a
-    # multiple of eight. Zero-padding preserves the weight-free head sum.
+    # CUDA MMA accepts an eight-wide N dimension, while ROCm MFMA requires
+    # sixteen. Zero-padding preserves the weight-free head sum on both paths.
     query_heads, head_dim = q.shape[1:]
-    kernel_heads = max(8, ((query_heads + 7) // 8) * 8)
+    head_alignment = 16 if is_hip() else 8
+    kernel_heads = max(
+        head_alignment,
+        ((query_heads + head_alignment - 1) // head_alignment) * head_alignment,
+    )
     q_kernel = q.to(torch.bfloat16)
     if kernel_heads != query_heads:
         q_kernel = torch.cat(


### PR DESCRIPTION
## Motivation

`Qwen3.8-Flash-Next` cannot serve on ROCm: the TileLang QSA MQA decode kernel fails to compile on gfx950.

`tilelang_qsa_mqa_decode` pads the Q-head dimension up to a multiple of 8, which is the CUDA MMA requirement. ROCm MFMA requires 16. With `indexer_n_heads=4` the kernel is asked for `N=8` and TVM aborts during layout inference:

```
tvm.error.InternalError: Check failed: (N % kNPerWarp == 0) is false: N must be divisible by 16, but got 8
```

In a real server run this does not surface as the check above. TileLang catches the build failure and retries the outer function through its eager-style path, which re-generates the source without the closure parameters, so the user-visible error is a confusing signature mismatch:

```
TypeError: make_closure.<locals>._tilelang_qsa_mqa_decode_kernel.<locals>._tilelang_qsa_mqa_decode_kernel()
missing 2 required positional arguments: 'heads' and 'head_dim'
```

The server dies with SIGQUIT at the first decode step.

## Modifications

`python/sglang/srt/layers/attention/qsa/mqa.py` — select the head-padding alignment per platform: 16 on HIP, 8 elsewhere. The padding is zero-fill and the indexer logit is a weight-free sum over heads, so the padded lanes contribute nothing and the result is unchanged on both platforms. The CUDA path keeps its existing alignment of 8 exactly as before.

This change is self-contained in one file and does not depend on any other PR.

## Accuracy Tests

Isolated correctness check of `tilelang_qsa_mqa_decode` against `torch_qsa_mqa_decode` on gfx950 (`heads=4`, `head_dim=128`, `page_size=8`), comparing only the finite (unmasked) logits:

| Platform | Alignment | Result |
| --- | --- | --- |
| MI355X (gfx950) | 16 (this PR) | max abs diff vs torch reference `4.77e-07` |
| MI355X (gfx950) | 8 (before) | fails to compile — `N must be divisible by 16` |

End-to-end on 8x MI355X with the released BF16 `Qwen3.8-Flash-Next` checkpoint (`--tp-size 8 --attention-backend aiter --page-size 32 --chunked-prefill-size 16384`). This PR is one of the changes required to reach a serving state; the numbers below are for the full ROCm enablement set:

| Config | GSM8K (200 examples) | Output throughput |
| --- | --- | --- |
| BF16 baseline | 0.980 | 936 tok/s |
| BF16 + EAGLE MTP (3 steps) | 0.975 | 1603 tok/s, accept length 3.16 |

No CUDA behavior change, so no CUDA accuracy re-run is required.

## Speed Tests and Profiling

Not a performance change — this is a compile-time correctness fix that makes the kernel buildable on ROCm. The zero-padded lanes add 8 extra columns of MFMA work per decode row, which is inside the same MFMA tile that the hardware would issue for `N=16` anyway.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). The correctness check above was run ad hoc against the existing `torch_qsa_mqa_decode` reference rather than added to `test/registered/kernels/test_qsa.py`; happy to add a registered ROCm case if reviewers want one.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34474932925](https://github.com/sgl-project/sglang/actions/runs/34474932925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34474951413](https://github.com/sgl-project/sglang/actions/runs/34474951413)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->