### PR TITLE
[AMD] Add a Triton packed sparse decode path for QSA on ROCm

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -309,6 +309,58 @@ def sparse_gqa_fwd_interface_triton_ck(q, k, v, indices, cu_q, cu_k, kv_lens, sc
     return out
 
 
+def sparse_gqa_packed_decode_triton(q, k, v, indices, cu_q, cu_k, kv_lens, scale):
+    """Run one packed sparse-attention row per request without a host sync.
+
+    Reuses the chunk-prefill kernel at a fixed query length of one, so graph
+    capture never hits the ``.item()`` that the general interface needs to
+    derive ``max_q``.
+    """
+
+    k, v = k.contiguous(), v.contiguous()
+    total_q, num_q_heads, head_dim = q.shape
+    num_kv_heads = k.shape[1]
+    group_size = num_q_heads // num_kv_heads
+    block_m = max(16, triton.next_power_of_2(group_size))
+    block_n, warps, stages = _get_best_config(total_q)
+    out = torch.empty_like(q)
+    _sparse_gqa_chunk_prefill[(1, (cu_q.shape[0] - 1) * num_kv_heads)](
+        q,
+        k,
+        v,
+        out,
+        indices,
+        cu_q,
+        cu_k,
+        kv_lens,
+        scale,
+        indices.shape[-1],
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        v.stride(0),
+        v.stride(1),
+        v.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        indices.stride(0),
+        indices.stride(1) if indices.ndim == 3 else 0,
+        indices.stride(2) if indices.ndim == 3 else indices.stride(1),
+        NUM_KV_HEADS=num_kv_heads,
+        GROUP_SIZE=group_size,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        HEAD_DIM=head_dim,
+        num_warps=warps,
+        num_stages=stages,
+    )
+    return out
+
+
 @triton.jit
 def _fa2_valid_counts(
     seq_lens,
@@ -450,4 +502,5 @@ __all__ = [
     "qwen_sparse_kv_extraction_compact_triton",
     "sparse_gqa_fwd_interface_triton",
     "sparse_gqa_fwd_interface_triton_ck",
+    "sparse_gqa_packed_decode_triton",
 ]

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -36,8 +36,10 @@ from sglang.srt.layers.attention.qsa.sparse_attn import (
     qwen_sparse_valid_counts_triton,
     sparse_gqa_fwd_interface_triton,
     sparse_gqa_fwd_interface_triton_ck,
+    sparse_gqa_packed_decode_triton,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils import is_hip
 
 logger = logging.getLogger(__name__)
 
@@ -1557,7 +1559,6 @@ class QwenSparseAttnBackend(AttentionBackend):
                 trtllm_decode,
             )
 
-        flash_attn_varlen_func = _resolve_flash_attn_varlen_func()
         batch, topk = topk_indices.shape
         sequence_lens = metadata.sequence_lengths
         if metadata.is_cuda_graph:
@@ -1607,6 +1608,26 @@ class QwenSparseAttnBackend(AttentionBackend):
             batch,
             topk,
         )
+        if is_hip():
+            relative_indices = torch.arange(
+                topk, dtype=torch.int32, device=q.device
+            ).expand(batch, -1)
+            relative_indices = relative_indices.masked_fill(
+                relative_indices >= valid_counts[:, None], -1
+            ).contiguous()
+            output = sparse_gqa_packed_decode_triton(
+                q.contiguous(),
+                packed_k,
+                packed_v,
+                relative_indices,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                valid_counts,
+                layer.scaling,
+            )
+            return output.reshape(q.shape[0], -1)
+
+        flash_attn_varlen_func = _resolve_flash_attn_varlen_func()
         output = flash_attn_varlen_func(
             q=q,
             k=packed_k,


### PR DESCRIPTION
## Motivation

The QSA sparse-attention decode path calls `flash_attn_varlen_func`, resolved through `_resolve_flash_attn_varlen_func()`. That entry point has no ROCm equivalent, so once a `Qwen3.8-Flash-Next` request reaches the sparse decode step on gfx950 there is nothing to dispatch to.

The general chunk-prefill interface is not a drop-in replacement during CUDA/HIP graph capture: it derives `max_q` with a `.item()`, which is a host sync and therefore illegal inside a captured graph.

## Modifications

`python/sglang/srt/layers/attention/qsa/sparse_attn.py` — add `sparse_gqa_packed_decode_triton`, a thin wrapper over the existing `_sparse_gqa_chunk_prefill` Triton kernel at a fixed query length of one. Decode and speculative-verify have already compacted the selected K/V rows into contiguous per-request segments, so the query length is known to be one and `max_q` never has to be read back from the device. Exported through `__all__`.

`python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py` — on HIP, build the relative index matrix (masking entries at or beyond `valid_counts` to `-1`) and route decode through the new wrapper. The `flash_attn_varlen_func` resolution moves below this branch so it is only performed on the path that actually uses it.

CUDA is untouched: the `is_hip()` branch returns early and the existing `flash_attn_varlen_func` call is reached unchanged on every non-HIP platform.

This change is self-contained in these two files and does not depend on any other PR.

## Accuracy Tests

8x MI355X (gfx950), released BF16 `Qwen3.8-Flash-Next` checkpoint, `--tp-size 8 --attention-backend aiter --page-size 32 --chunked-prefill-size 16384 --mem-fraction-static 0.9`.

This PR is one of several changes required to reach a serving state on ROCm, so these numbers cover the full ROCm enablement set rather than this file alone:

| Config | GSM8K (200 examples) | Output throughput |
| --- | --- | --- |
| BF16 baseline | 0.980 | 936 tok/s |
| BF16 + EAGLE MTP (3 steps, topk 1, 4 draft tokens) | 0.975 | 1603 tok/s, accept length 3.16 |

Targeted checks that exercise this specific path:

| Check | Result |
| --- | --- |
| 18k-token prompt, fact retrieval past `indexer_budget=2048` | correct — engages sparse decode rather than the dense path |
| Decode under HIP graph replay at 18k context | `cuda graph: True` in the decode log, no host-sync abort |
| Image + text prompt (vision tower + sparse text decode) | correct |

The 18k-token case is the one that matters here: prompts shorter than `indexer_budget` never reach the sparse decode branch, so a short-prompt eval alone would not cover this change.

No CUDA behavior change, so no CUDA accuracy re-run is required.

## Speed Tests and Profiling

8x MI355X, `random` dataset, input 1024 / output 512, 64 prompts at concurrency 16:

| Metric | Value |
| --- | --- |
| Total token throughput | 2790 tok/s |
| Output token throughput (peak) | 1040 tok/s |
| Median TTFT | 861 ms |
| Median TPOT | 15.55 ms |
| Median ITL | 15.55 ms |

There is no ROCm before/after to compare against — before this change the sparse decode path has no callable kernel on ROCm, so the baseline is "does not run".

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Validated end to end against a served model rather than through a registered kernel test; happy to add a ROCm case to `test/registered/kernels/test_qsa.py` if reviewers want one.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34474934795](https://github.com/sgl-project/sglang/actions/runs/34474934795)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34474954432](https://github.com/sgl-project/sglang/actions/runs/34474954432)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34474934807](https://github.com/sgl-project/sglang/actions/runs/34474934807)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->