### PR TITLE
[AMD] Clamp padded QSA indexer gathers on ROCm

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/kernel.py
+++ b/python/sglang/srt/layers/attention/qsa/kernel.py
@@ -268,6 +268,50 @@ def expand_qsa_block_indices(
     )
 
 
+@triton.jit
+def _zero_padded_group_locs_kernel(
+    group_locs,
+    compressed_locs,
+    group_stride: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if tl.load(compressed_locs + row) != 0:
+        return
+    cols = tl.arange(0, BLOCK)
+    tl.store(
+        group_locs + row * group_stride + cols,
+        tl.zeros([BLOCK], dtype=tl.int64),
+        mask=cols < COMPRESS_RATIO,
+    )
+
+
+def zero_padded_group_locs(
+    group_locs: torch.Tensor,
+    compressed_locs: torch.Tensor,
+) -> torch.Tensor:
+    """Point the write plan's no-op rows at token row 0, in place.
+
+    A row is a no-op when it targets reserved compressed slot 0; real writes
+    never target it. Only those rows are stored to, so planned rows keep the
+    member spans the caller computed.
+    """
+
+    rows = group_locs.shape[0]
+    if rows == 0:
+        return group_locs
+    compress_ratio = group_locs.shape[1]
+    _zero_padded_group_locs_kernel[(rows,)](
+        group_locs,
+        compressed_locs,
+        group_locs.stride(0),
+        COMPRESS_RATIO=compress_ratio,
+        BLOCK=triton.next_power_of_2(compress_ratio),
+    )
+    return group_locs
+
+
 def qsa_sparse_attention(
     q: torch.Tensor,
     k_cache: torch.Tensor,

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.model_executor.runner import get_is_capture_mode
+from sglang.srt.utils import is_hip
 
 # Cap on the fp32 [query_rows, compressed_keys] prefill logits workspace;
 # top-k is per row, so tiling rows does not change the selection.
@@ -320,6 +321,16 @@ class QSAIndexer(MultiPlatformOp):
             group_locs = member_rows[:, None] + torch.arange(
                 self.compress_ratio, device=member_rows.device, dtype=torch.long
             )
+            if is_hip():
+                # The device-side write plan pads capacity with no-op entries
+                # targeting reserved compressed slot 0; real writes never target
+                # it. Clamp those padded gathers to row 0 so a short extend
+                # (one MTP token) cannot index out of bounds.
+                group_locs = torch.where(
+                    (compressed_locs != 0)[:, None],
+                    group_locs,
+                    torch.zeros_like(group_locs),
+                )
             source_keys = token_k
             source_rope = metadata.extend_rope_matrix
             if source_rope is None:

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.qsa.kernel import (
     average_pool_qsa_keys,
     expand_qsa_block_indices,
     qsa_fast_topk,
+    zero_padded_group_locs,
 )
 from sglang.srt.layers.attention.qsa.metadata import (
     build_group_ring_slots,
@@ -326,11 +327,7 @@ class QSAIndexer(MultiPlatformOp):
                 # targeting reserved compressed slot 0; real writes never target
                 # it. Clamp those padded gathers to row 0 so a short extend
                 # (one MTP token) cannot index out of bounds.
-                group_locs = torch.where(
-                    (compressed_locs != 0)[:, None],
-                    group_locs,
-                    torch.zeros_like(group_locs),
-                )
+                group_locs = zero_padded_group_locs(group_locs, compressed_locs)
             source_keys = token_k
             source_rope = metadata.extend_rope_matrix
             if source_rope is None:


### PR DESCRIPTION
## Motivation

The QSA indexer's device-side write plan pads its capacity with no-op entries that target the reserved compressed slot 0. When an extend step has fewer source rows than `compress_ratio` — a single MTP token is the common case — the padded entries still take part in the advanced-indexing gather, so `group_locs` addresses rows past the end of the source tensor.

## Modifications

`python/sglang/srt/layers/attention/qsa/qsa_indexer.py` — on HIP, point the padded gather rows at token row 0 before the gather. Real writes never target compressed slot 0, so this only rewrites the no-op entries and leaves every genuine gather untouched.

`python/sglang/srt/layers/attention/qsa/kernel.py` — the rewrite itself, as `zero_padded_group_locs`.

The first version of the rewrite was a naive `torch.where` over the `[rows, compress_ratio]` index matrix, keyed on `(compressed_locs != 0)[:, None]`. That costs three elementwise launches — the compare, a `zeros_like` fill, and the select — plus a full-size temporary, and it rewrites every row including the majority that need nothing done. The index matrix is a few tens of KB at most, so there is no arithmetic to amortize those launches against, and `update_key_state_and_compress` runs once per layer per extend.

It is now a single Triton kernel: one program per plan row, an early return when the row targets a real compressed slot, and a store only on the no-op rows. Three launches become one, the temporary is gone, and planned rows are not written at all. The surrounding structure is unchanged — the member-row span stays a torch broadcast and the `is_hip()` gate stays, so only the mask is a kernel.

The kernel is bit-exact with the `torch.where` it replaces, checked on MI355 across `compress_ratio` in {16, 24, 32}, `member_rows` and `compressed_locs` dtypes in {int32, int64}, and row counts in {0, 1, 4, 8, 64, 257}, with both padded and planned rows present in every case.

The clamp is scoped to `is_hip()`. CUDA is untouched.

This change is self-contained in the QSA indexer and its kernel module, and does not depend on any other PR.

## Accuracy Tests

8x MI355X (gfx950), released BF16 `Qwen3.8-Flash-Next` checkpoint, `--tp-size 8 --attention-backend aiter --page-size 32 --chunked-prefill-size 16384`.

This PR is one of several changes required to reach a serving state on ROCm, so these numbers cover the full ROCm enablement set rather than this file alone:

| Config | GSM8K (200 examples) | Output throughput |
| --- | --- | --- |
| BF16 baseline | 0.980 | 936 tok/s |
| BF16 + EAGLE MTP (3 steps, topk 1, 4 draft tokens) | 0.975 | 1603 tok/s, accept length 3.16 |

### Reproduction without this patch

Ablation on the same 8x MI355X host, same MTP config, with every other ROCm fix applied and only this clamp removed. The scheduler aborts:

```
:0:rocdevice.cpp :3586: Callback: Queue aborting with error :
HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception. code: 0x1016
Fatal Python error: Aborted

  File "sglang/srt/model_executor/runner/eager_runner.py", line 372, in _execute_extend
  File "sglang/srt/models/qwen4_exp.py", line 1495, in _compute_qsa_topk_indices
  File "sglang/srt/layers/attention/qsa/qsa_indexer.py", line 592, in forward_cuda
  File "sglang/srt/layers/attention/qsa/qsa_indexer.py", line 355, in update_key_state_and_compress
  File "sglang/srt/layers/attention/qsa/qsa_indexer.py", line 211, in normalize_compressed_keys
  File "sglang/srt/layers/attention/qsa/qsa_indexer.py", line 403, in apply_rope
```

`Subprocess scheduler_0 crashed with exit code -6`.

The HSA exception is asynchronous, so it is reported a few kernels after the faulting one; the call chain is the `is_extend` branch of `update_key_state_and_compress`, whose gather at `key_groups = source_keys[group_locs]` is what this patch clamps.

The failure is latent rather than immediate — the run served 200 GSM8K problems at 0.975 with accept length 3.16 before aborting, which is why this is worth guarding rather than leaving to chance. With the clamp applied, the identical workload plus an 18k-token prompt, an image prompt, and a concurrency-16 throughput sweep all complete with the server healthy throughout.

No CUDA behavior change, so no CUDA accuracy re-run is required.

## Speed Tests and Profiling

Not a performance change. The added work is one Triton kernel over the `[rows, compress_ratio]` index matrix per layer per extend, which is negligible next to the gather it guards, and it runs only on HIP. Folding the original three-op `torch.where` into that one kernel removes two launches and a temporary per call; at this size the work is launch-bound rather than bandwidth-bound, so the saving is real but far below e2e benchmark noise, and no throughput change is claimed for it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Validated end to end against a served model with MTP enabled rather than through a registered kernel test; happy to add a short-extend regression case if reviewers want one.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34483589598](https://github.com/sgl-project/sglang/actions/runs/34483589598)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34483589098](https://github.com/sgl-project/sglang/actions/runs/34483589098)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34483589803](https://github.com/sgl-project/sglang/actions/runs/34483589803)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
