### PR TITLE
[AMD] Load fused shared experts for Qwen4-Exp and Qwen3.5 MTP

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -291,8 +291,9 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             "_input_scale",
         )
 
-        # fused experts: experts.w13_weight / experts.w2_weight
-        is_fused_expert = False
+        # Fused checkpoint tensors: experts.gate_up_proj / experts.down_proj.
+        # The checkpoint interleaves these with separate shared-expert tensors,
+        # so picking one mapping must not affect the next weight.
         fused_expert_params_mapping = [
             ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
             ("experts.w2_weight", "experts.down_proj", 0, "w2"),
@@ -368,13 +369,17 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                     f"mlp.experts.{num_experts}.",
                 )
 
+            is_fused_expert = (
+                "experts.gate_up_proj" in name or "experts.down_proj" in name
+            )
+            current_expert_params_mapping = (
+                fused_expert_params_mapping
+                if is_fused_expert
+                else expert_params_mapping
+            )
+
             # 1) Process stacked parameters (q_proj/k_proj/v_proj & gate_proj/up_proj)
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                # Check if this is a fused expert weight
-                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
-                    is_fused_expert = True
-                    expert_params_mapping = fused_expert_params_mapping
-
                 # Skip non-matching weights
                 if weight_name not in name:
                     continue
@@ -404,7 +409,7 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                 # 2) Process MoE expert weights (including fused experts)
                 is_expert_weight = False
 
-                for mapping in expert_params_mapping:
+                for mapping in current_expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -61,7 +61,9 @@ from sglang.srt.models.qwen3_5 import (
 )
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import logger
+from sglang.srt.utils import get_bool_env_var, is_hip, logger
+
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 
 # Decode/verify-sized batches only: at prefill sizes both chains are compute
 # bound and serializing them on one stream is faster than contending.
@@ -1786,12 +1788,21 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         ]
 
         num_experts = getattr(self.config, "num_experts", None)
+        # A fused shared expert lives in routed slot `num_experts`, so the
+        # mapping has to cover one more expert than the config declares.
+        num_fused_shared_experts = 0
+        if _use_aiter:
+            for module in self.modules():
+                fused = getattr(module, "num_fused_shared_experts", 0)
+                if fused:
+                    num_fused_shared_experts = fused
+                    break
         expert_params_mapping = (
             FusedMoE.make_expert_params_mapping(
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
-                num_experts=num_experts,
+                num_experts=num_experts + num_fused_shared_experts,
             )
             if num_experts is not None
             else []
@@ -1986,6 +1997,17 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 layer_id < self.start_layer or layer_id >= self.end_layer
             ):
                 continue
+
+            if (
+                _use_aiter
+                and num_fused_shared_experts > 0
+                and "mlp.shared_expert." in name
+            ):
+                # Map mlp.shared_expert.xx_proj to mlp.experts.{num_experts}.xx_proj
+                name = name.replace(
+                    "mlp.shared_expert.",
+                    f"mlp.experts.{num_experts}.",
+                )
 
             is_fused_expert = (
                 "experts.gate_up_proj" in name or "experts.down_proj" in name


### PR DESCRIPTION
## Motivation

`Qwen3.8-Flash-Next` loads with its shared experts uninitialized whenever shared-expert fusion is active. There are two independent instances of this, one in the main model and one in the MTP draft.

**Main model.** When fusion is enabled the model has no separate `mlp.shared_expert.*` parameters — the shared expert lives in routed slot `num_experts` of the fused MoE. The checkpoint still ships the tensors separately, and `Qwen4ExpForConditionalGeneration.load_weights` has no mapping for them, so every one is dropped with only a warning:

```
Parameter model.layers.18.mlp.shared_expert.down_proj.weight not found while loading Qwen4-Exp VL weights
```

144 warnings per TP rank (3 projections x 48 layers), 1152 across TP8. There is no error and no failed assertion: the server starts, reports ready, and generates fluent text with 48 layers of garbage shared-expert contribution.

**MTP draft.** `qwen3_5_mtp.py` rebinds `expert_params_mapping` to `fused_expert_params_mapping` permanently on the first fused tensor it sees, inside the stacked-params loop. This checkpoint interleaves the two forms — 49 fused `experts.gate_up_proj` tensors and 196 separate `mlp.shared_expert.*` tensors, with no per-expert `experts.N.gate_proj` — so every shared-expert tensor that follows a fused one looks up the wrong mapping and falls through:

```
Parameter model.layers.0.mlp.experts.512.gate_proj.weight not found in params_dict
```

ROCm images set `SGLANG_USE_AITER=1` by default, so fusion is on out of the box and every ROCm run of this model hits both.

## Modifications

Both changes are the minimum needed to load the weights. Each was verified necessary by reverting it in isolation on an 8x MI355X host and re-measuring — see Accuracy Tests.

`python/sglang/srt/models/qwen4_exp.py` (+26/-2)

- Discover `num_fused_shared_experts` from the built modules, and build `expert_params_mapping` with `num_experts + num_fused_shared_experts` so the mapping covers routed slot `num_experts`.
- Rewrite `mlp.shared_expert.` to `mlp.experts.{num_experts}.` before the stacked/expert loops, so the existing per-expert loader handles the tensor.

This reuses the idiom `qwen3_5.py` already applies to the identical problem rather than adding a second mechanism. `FusedMoE.make_expert_params_mapping(num_experts=513)` already emits exactly the entries needed:

```
('experts.w13_', 'experts.512.gate_proj.', 512, 'w1')
('experts.w2_',  'experts.512.down_proj.', 512, 'w2')
('experts.w13_', 'experts.512.up_proj.',   512, 'w3')
```

`qwen4_exp.py` already computed `is_fused_expert` per weight, so a rewritten `experts.512.gate_proj` name correctly selects the per-expert mapping rather than the fused one.

`python/sglang/srt/models/qwen3_5_mtp.py` (+13/-8)

- Compute `is_fused_expert` per weight and select `current_expert_params_mapping` from it, instead of rebinding the shared `expert_params_mapping` local inside the stacked-params loop. Selecting a mapping for one weight no longer affects the next.

### Scope: both loaders gate on `_use_aiter`

Both shared-expert paths are gated on `_use_aiter` (`SGLANG_USE_AITER and is_hip()`), matching the gate `qwen3_5_mtp.py` already used. That keeps this PR provably free of CUDA impact: nothing today enables shared-expert fusion for Qwen3.5 / Qwen4-Exp on CUDA, since `enable_cuda_shared_expert_fusion` defaults to `False` in `qwen2_moe.py` and only `qwen3_next.py` passes `True`. On ROCm the gate is always true because the images ship `SGLANG_USE_AITER=1`.

To be explicit about the tradeoff: `_use_aiter` is a proxy, and the precise predicate is `num_fused_shared_experts > 0` (derived from the built module), which is what `qwen2_moe.py` actually branches on. If someone later wires `enable_cuda_shared_expert_fusion=True` for these models the way `qwen3_next.py` does, both gates here will need to drop. That change belongs with whoever can validate the CUDA fusion path; this PR has no way to test it, so it keeps the blast radius at zero rather than making an unverifiable claim.

Measured both ways on the hardware below — gated and ungated are equivalent on ROCm (accept length 3.164 vs 3.157, inside run-to-run noise), so the gate costs nothing here.

## Accuracy Tests

8x MI355X (gfx950), released BF16 `Qwen3.8-Flash-Next` checkpoint, `--tp-size 8 --attention-backend aiter --page-size 32 --chunked-prefill-size 16384`, EAGLE MTP (3 steps, topk 1, 4 draft tokens), `SGLANG_USE_AITER=1` (the ROCm image default, so fusion is on). GSM8K, 200 examples.

Each row reverts one part of this PR and leaves the rest applied:

| Variant | Missing-weight warnings | GSM8K | Accept length |
| --- | --- | --- | --- |
| This PR | 0 | 0.980 | 3.164 |
| Revert the `qwen3_5_mtp.py` change | 24 (`experts.512.*` in the draft) | 0.975 | 3.067 |
| Revert both (main today) | 1152 (`mlp.shared_expert.*`) + 24 | not meaningful | not meaningful |

The MTP row is why that change is included: with the draft's shared experts dropped, accept length falls 3.1% (3.164 to 3.067) while GSM8K is unchanged. That is the expected signature — EAGLE verification against the target model keeps the output distribution correct no matter how bad the draft is, so a broken draft costs throughput, not accuracy. Nothing in an accuracy gate would catch it.

The last row cannot be scored meaningfully: dropped shared experts in the main model do not raise, they quietly degrade it, so 0 remaining warnings is the direct signal that the tensors now reach a parameter.

An 18k-token prompt retrieval check passes and the server stays healthy through the full eval.

## Speed Tests and Profiling

Weight loading only, run once at startup, so there is no steady-state cost. The measurable effect is the MTP accept-length recovery in the table above (3.164 vs 3.067, +3.1%), which is a throughput gain in proportion. This PR measures 1608 tok/s output throughput on the GSM8K run; the reverted variant's throughput was not captured, so only the accept-length delta is quoted as evidence.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Validated end to end against a served model, including the per-part ablations above. A CPU unit test over the name rewrite and mapping selection would be straightforward — happy to add one if reviewers want it.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34496100214](https://github.com/sgl-project/sglang/actions/runs/34496100214)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34496099425](https://github.com/sgl-project/sglang/actions/runs/34496099425)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34496099813](https://github.com/sgl-project/sglang/actions/runs/34496099813)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->