### PR TITLE
[DeepSeek-V4.1] Optimize DSpark verify and MoE kernels on Blackwell

### DIFF
--- a/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
@@ -1,0 +1,466 @@
+// Fused deferred-MoE finalize -> 1shot lamport push all-reduce [-> RMSNorm]
+// over the CustomAllReduceV2 push plane, for decode-sized batches (bf16).
+//
+// A generalisation of the K3 `finalize_push_norm` kernel
+// (csrc/kimi_k3/comm/ar_fusion.cuh): the hidden width, top_k and cluster
+// geometry are template parameters chosen from Python, the shared-expert add
+// and the RMSNorm epilogue are optional, and the result goes to a separate
+// output tensor. Per token row t:
+//
+//   local[t] = sum_k expert_weights[t, k] * gemm2_out[idx[t * top_k + k]]
+//              (+ shared_output[t])                     -- stage 1, registers only
+//   out[t]   = sum over ranks of local[t]               -- stage 2
+//   out[t]   = out[t] * rsqrt(mean(out[t]^2) + eps) * w -- kNorm only
+//
+// `idx == -1` marks a dropped slot (EP: the token was routed to an expert
+// that is not local) and contributes nothing. Accumulation is fp32; the bf16
+// rounding points are exactly the unfused path's: the routed combine (what
+// TRT-LLM's finalize returns), the `+ shared` (torch's bf16 add) and the
+// all-reduce output, so the plain (kNorm=false) result equals TRT-LLM finalize
+// -> `shared.add_(routed)` -> fp32-accumulating bf16 all-reduce in rank order,
+// and the staged vector is bit-identical to what the unfused path reduces.
+//
+// The rank-local finalize never materializes in global memory: each thread
+// computes one 16B vector of it and pushes it straight into every peer's push
+// slot with unicast `st.relaxed.sys` stores, exactly like the generic
+// `all_reduce_1shot_push_kernel`, so no multicast mapping is required.
+//
+// Push-plane protocol (see include/sgl_kernel/distributed/communicator.cuh):
+//   * every rank owns 2 phases x kWorldSize slots of `slot_bytes`; a round
+//     uses phase `counter & 1`, producer r writes slot r of every peer, the
+//     consumer polls its own kWorldSize slots until no +0.0 marker remains,
+//     reduces, and restores the +0.0 markers before it exits;
+//   * +0.0 payload words are remapped to -0.0 (numerically identical) so a
+//     written word is never 0 and `word == 0` means "not arrived yet";
+//   * the phase counters are per block of the GENERIC push kernel, which
+//     launches `num_blocks` blocks and flips one counter each. This kernel
+//     uses one counter per row cluster (flipped by the cluster's leader block
+//     after a cluster barrier, since every block of the cluster reads it) and
+//     a trailing "bumper" cluster flips every remaining one, so the whole
+//     array keeps one parity and the two kernel families can share the plane
+//     freely (single-stream calls are serialized);
+//   * every rank must call with the same num_tokens / hidden / top_k / epilogue:
+//     slots are addressed by 16B vector index of the [T, hidden] row view.
+#include <sgl_kernel/ffi.h>
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/distributed/communicator.cuh>
+#include <sgl_kernel/distributed/ptx.cuh>
+
+#include <tvm/ffi/extra/stl.h>
+
+#include <cooperative_groups.h>
+#include <cstdint>
+#include <optional>
+
+namespace sglang {
+
+using device::distributed::PushWorkSpace;
+using host::distributed::CommunicatorRef;
+
+/// One 16B staging vector (8 bf16) viewed as the 4 u32 words the lamport marker
+/// protocol tests, matching the generic push kernel's `LamportTrait<T, 8, 4>`.
+using Lamport = device::distributed::LamportTrait<bf16_t, 8, /*kAtom=*/4>;
+using StageVec = device::AlignedVector<bf16x2_t, 4>;
+
+SGL_DEVICE void barrier_cluster_arrive_relaxed() {
+  asm volatile("barrier.cluster.arrive.relaxed.aligned;" ::: "memory");
+}
+
+SGL_DEVICE void barrier_cluster_wait() {
+  asm volatile("barrier.cluster.wait.aligned;" ::: "memory");
+}
+
+template <uint32_t kWorldSize>
+struct FinalizeAllReduceParams {
+  bf16_t* out;                // [num_tokens, kHiddenDim], output-only
+  const bf16_t* gemm2;        // [P, kHiddenDim], permuted / padded rows
+  const int32_t* idx;         // [num_tokens * kTopK], -1 = dropped slot
+  const bf16_t* weights;      // [num_tokens, kTopK], scaling already folded in
+  const bf16_t* shared;       // [num_tokens, kHiddenDim] (kHasShared only)
+  const bf16_t* norm_weight;  // [kHiddenDim] (kNorm only)
+  float norm_eps;             // kNorm only
+  // Caller's promise that everything this kernel reads before its PDL wait is
+  // complete when the preceding kernel merely *triggers*: no all-reduce on this
+  // plane right before it, and the routing metadata's producers finished (not
+  // just the immediate predecessor -- PDL completion is not transitive through
+  // early-triggering kernels). False (the safe default) waits first.
+  bool prefetch_metadata;
+  uint32_t rank;
+  uint32_t num_tokens;
+  uint32_t num_push_counters;  // full counter array size (bumper range end)
+  PushWorkSpace<kWorldSize> ws;
+};
+
+/// Row geometry: one 16B vector per thread, one cluster per row, so the block
+/// size follows from the hidden width and the cluster size. The cluster size
+/// is the tuning knob (dims per block = kHiddenDim / kClusterSize).
+template <uint32_t kHiddenDim, uint32_t kClusterSize>
+struct AllReduceNormTrait {
+  static constexpr uint32_t kRowVecs = kHiddenDim / 8;             // 16B vectors per row
+  static constexpr uint32_t kBlockSize = kRowVecs / kClusterSize;  // threads per block
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static_assert(kHiddenDim % 8 == 0, "hidden must be a whole number of 16B vectors");
+  static_assert(1 <= kClusterSize && kClusterSize <= 8, "portable cluster sizes only");
+  static_assert(kRowVecs % kClusterSize == 0, "cluster size must divide the row's vector count");
+  static_assert(kBlockSize % device::kWarpThreads == 0, "block must be whole warps");
+  static_assert(kBlockSize <= 1024, "block too large: raise the cluster size");
+};
+
+// --- stage 1: the deferred finalize of one 16B vector ------------------------
+// The shared-expert vector is loaded first so that load is in flight while the
+// routing rows and the kTopK gathers are fetched; the routed combine is then
+// accumulated in ascending k from zero, rounded to bf16, and the shared vector
+// is added with one more bf16 rounding (see the header: the unfused path's
+// numerics, reproduced so the fusion does not move the greedy output).
+// Threads of the same token read the same kTopK indices / weights (a broadcast
+// load per warp). All arithmetic is on bf16 pairs: one cast converts two
+// elements.
+template <uint32_t kHiddenDim, uint32_t kTopK, bool kHasShared, bool kUsePDL, uint32_t kWorldSize>
+SGL_DEVICE StageVec finalize_vec(const FinalizeAllReduceParams<kWorldSize>& params, uint32_t token, uint32_t hvec) {
+  using namespace device;
+  const auto* idx = params.idx + static_cast<int64_t>(token) * kTopK;
+  const auto* weights = params.weights + static_cast<int64_t>(token) * kTopK;
+  int32_t rows[kTopK];
+  bf16_t w[kTopK];
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    rows[k] = idx[k];
+    w[k] = weights[k];
+  }
+
+  // delay PDL wait until here
+  PDLWaitPrimary<kUsePDL>();
+
+  StageVec shared_in;
+  if constexpr (kHasShared) {
+    shared_in.load(params.shared + static_cast<int64_t>(token) * kHiddenDim, hvec);
+  }
+
+  StageVec in[kTopK];
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    if (rows[k] >= 0) in[k].load(params.gemm2 + static_cast<int64_t>(rows[k]) * kHiddenDim, hvec);
+  }
+
+  fp32x2_t acc[4];
+#pragma unroll
+  for (uint32_t j = 0; j < 4; ++j) {
+    acc[j] = fp32x2_t{0.0f, 0.0f};
+  }
+
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    if (rows[k] < 0) continue;
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      acc[j].x = math::fma_f32_bf16(in[k][j].x, w[k], acc[j].x);
+      acc[j].y = math::fma_f32_bf16(in[k][j].y, w[k], acc[j].y);
+    }
+#else
+    const auto w_fp32 = cast<fp32_t>(w[k]);
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      const auto [x, y] = cast<fp32x2_t>(in[k][j]);
+      acc[j].x = fmaf(x, w_fp32, acc[j].x);
+      acc[j].y = fmaf(y, w_fp32, acc[j].y);
+    }
+#endif
+  }
+  // Same rounding as the unfused path: TRT-LLM's finalize returns the routed
+  // combine rounded to bf16, and `shared.add_(routed)` then rounds the bf16 +
+  // bf16 sum once more (torch adds in fp32). Reproducing both roundings keeps
+  // the staged vector bit-identical to what `dev` all-reduces, so the greedy
+  // output does not move with the fusion.
+  StageVec out;
+#pragma unroll
+  for (uint32_t j = 0; j < 4; ++j) {
+    if constexpr (kHasShared) {
+      const auto routed = cast<fp32x2_t>(cast<bf16x2_t>(acc[j]));
+      const auto sh = cast<fp32x2_t>(shared_in[j]);
+      out[j] = cast<bf16x2_t>(fp32x2_t{routed.x + sh.x, routed.y + sh.y});
+    } else {
+      out[j] = cast<bf16x2_t>(acc[j]);
+    }
+  }
+  return out;
+}
+
+// --- the kernel --------------------------------------------------------------
+// Grid: dim3(num_tokens [+ 1], kClusterSize) with the cluster laid along y, so
+// blockIdx.x is the token row (and its phase counter: PushEpoch's default) and
+// blockIdx.y the rank inside the cluster. When rows do not own every counter
+// of the plane, one extra cluster (blockIdx.x == num_tokens) is the bumper: it
+// only flips the counters [num_tokens, num_push_counters) and exits; with
+// num_tokens == num_push_counters no bumper is launched. The plane holds
+// num_sm counters, so decode batches always fit.
+template <
+    uint32_t kWorldSize,
+    uint32_t kHiddenDim,
+    uint32_t kTopK,
+    uint32_t kClusterSize,
+    bool kUsePDL,
+    bool kHasShared,
+    bool kNorm>
+__global__ __launch_bounds__(AllReduceNormTrait<kHiddenDim, kClusterSize>::kBlockSize)
+    __cluster_dims__(1, kClusterSize, 1) void moe_finalize_all_reduce_kernel(
+        const __grid_constant__ FinalizeAllReduceParams<kWorldSize> params) {
+  namespace cg = cooperative_groups;
+  using namespace device;
+  using T = AllReduceNormTrait<kHiddenDim, kClusterSize>;
+  constexpr uint32_t kRowVecs = T::kRowVecs;
+  constexpr uint32_t kBlockSize = T::kBlockSize;
+  constexpr uint32_t kNumWarps = T::kNumWarps;
+
+  const auto tx = threadIdx.x;
+  const auto row_idx = blockIdx.x;
+  const auto cluster_rank = blockIdx.y;
+  // this thread's vector within a row: cluster rank picks the block's chunk
+  const auto hvec = cluster_rank * kBlockSize + tx;
+
+  // Under PDL this grid may start while the preceding kernel is still running.
+  // If that kernel is an all-reduce on this plane, it is still flipping the
+  // phase counters and resetting slot markers: reading the epoch now would see
+  // a half-done state and the poll below would never complete. Only a caller
+  // who knows the predecessor is a compute kernel (the MoE GEMM in the model)
+  // may defer the wait to finalize_vec, past the routing-metadata prefetch;
+  // the second wait there is then a no-op.
+  if (!params.prefetch_metadata) PDLWaitPrimary<kUsePDL>();
+
+  if (row_idx == params.num_tokens) {
+    PDLWaitPrimary<kUsePDL>();
+    if (cluster_rank == 0) {
+      const auto epoch = distributed::PushEpoch<kWorldSize>{params.ws};
+      __syncthreads();
+      epoch.unsafe_flip_range(row_idx, params.num_push_counters);
+    }
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+
+  // this cluster's epoch: the counter at blockIdx.x, one per row cluster
+  // (every block of the cluster reads the same one)
+  const auto epoch = distributed::PushEpoch<kWorldSize>{params.ws};
+  const auto r = params.rank;
+  // my slot (`src = r`) inside every peer's workspace, and every peer's slot
+  // inside mine (`dst = r`), for this epoch
+  void* push_ptrs[kWorldSize];
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    push_ptrs[i] = epoch.slot_ptr(/*dst=*/i, /*src=*/r);
+  }
+
+  // stage 1: finalize this row's vector in registers and push it to every peer
+  const auto vid = row_idx * kRowVecs + hvec;
+  {
+    auto vec = finalize_vec<kHiddenDim, kTopK, kHasShared, kUsePDL>(params, row_idx, hvec);
+    Lamport::clear_pos_zero(vec.data());
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      ptx::st_relaxed_16B(vec, push_ptrs[i], vid);
+    }
+  }
+
+  // ensure epoch is consumed, so flipping it won't lead to error
+  if constexpr (!kNorm) barrier_cluster_arrive_relaxed();
+
+  // stage 2: poll own slots, reduce across ranks, [norm], write, reset markers
+  void* poll_ptrs[kWorldSize];
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    poll_ptrs[i] = epoch.slot_ptr(/*dst=*/r, /*src=*/i);
+  }
+  StageVec vec[kWorldSize];
+  do {
+    bool has_zero = false;
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      ptx::ld_relaxed_16B(vec[i], poll_ptrs[i], vid);
+    }
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      // the producer remapped +0.0 words, so a written word is never 0:
+      // word == 0 <=> the slot still holds the empty marker
+      has_zero |= Lamport::has_pos_zero(vec[i].data());
+    }
+    if (!has_zero) break;
+  } while (true);
+
+  if constexpr (!kNorm) {
+    const auto red = reduce_vec(vec);
+    ptx::st_global_16B(red, params.out, vid);
+    // ensure epoch is consumed, so flipping it won't lead to error
+    barrier_cluster_wait();
+  } else {
+    // push to peer
+    __shared__ float smem_sq[kClusterSize][kNumWarps];
+    const auto red = reduce_vec(vec);
+    StageVec w;
+    w.load(params.norm_weight, hvec);
+    const auto cluster = cg::this_cluster();
+    fp32x2_t acc[4];
+    float sq = 0.0f;
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      acc[j] = cast<fp32x2_t>(red[j]);
+      sq = fmaf(acc[j].x, acc[j].x, sq);
+      sq = fmaf(acc[j].y, acc[j].y, sq);
+    }
+    sq = warp::reduce_sum(sq);
+    const auto lane = tx % kWarpThreads;
+    const auto warp = tx / kWarpThreads;
+    if (lane < kClusterSize) {
+      *cluster.map_shared_rank(&smem_sq[cluster_rank][warp], lane) = sq;
+    }
+    cluster.sync();
+    float total = 0.0f;
+#pragma unroll
+    for (uint32_t c = 0; c < kClusterSize; ++c) {
+#pragma unroll
+      for (uint32_t wp = 0; wp < kNumWarps; ++wp) {
+        total += smem_sq[c][wp];
+      }
+    }
+    const auto factor = math::rsqrt(total / static_cast<float>(kHiddenDim) + params.norm_eps);
+    StageVec out;
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      const auto [wa, wb] = cast<fp32x2_t>(w[j]);
+      out[j] = cast<bf16x2_t>(fp32x2_t{acc[j].x * factor * wa, acc[j].y * factor * wb});
+    }
+    ptx::st_global_16B(out, params.out, vid);
+  }
+  PDLTriggerSecondary<kUsePDL>();
+
+  // re-establish the empty markers for the next same-phase round
+  StageVec zero_vec;
+  Lamport::fill_pos_zero(zero_vec.data());
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    ptx::st_global_16B(zero_vec, poll_ptrs[i], vid);
+  }
+
+  if (cluster_rank == 0) epoch.flip();
+}
+
+// --- host --------------------------------------------------------------------
+
+template <uint32_t kWorldSize, uint32_t kHiddenDim, uint32_t kTopK, uint32_t kClusterSize, bool kUsePDL>
+struct MoeFinalizeAllReduceKernel {
+ private:
+  using TensorView = tvm::ffi::TensorView;
+  using Params = FinalizeAllReduceParams<kWorldSize>;
+  using Trait = AllReduceNormTrait<kHiddenDim, kClusterSize>;
+
+  template <bool kHasShared, bool kNorm>
+  static constexpr auto kernel =
+      moe_finalize_all_reduce_kernel<kWorldSize, kHiddenDim, kTopK, kClusterSize, kUsePDL, kHasShared, kNorm>;
+
+ public:
+  /// out = [allreduce over ranks of] finalize(gemm2_out, idx, weights) [+ shared] [-> RMSNorm(norm_weight, eps)].
+  /// `out` ([T, kHiddenDim] bf16) is output-only. `shared_output` and `norm_weight`
+  /// select the epilogue at runtime (four kernel instantiations per module).
+  static void
+  run(CommunicatorRef ref,
+      TensorView out,
+      TensorView gemm2_out,
+      TensorView permuted_idx,
+      TensorView expert_weights,
+      std::optional<TensorView> shared_output,
+      std::optional<TensorView> norm_weight,
+      double eps,
+      bool prefetch_metadata) {
+    using namespace host;
+    const auto& comm = *ref.get();
+    const auto& push = comm.get_push_obj();
+    CHECK_HOST(push.world_size == kWorldSize)
+        << "communicator holds " << push.world_size << " ranks, kernel built for " << kWorldSize;
+
+    auto T = SymbolicSize{"num_tokens"};
+    auto P = SymbolicSize{"num_permuted_rows"};
+    auto TK = SymbolicSize{"num_expanded"};
+    SymbolicDevice device;
+    device.set_options<kDLCUDA>();
+    TensorMatcher({T, kHiddenDim})
+        .with_strides({kHiddenDim, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(out);
+    TensorMatcher({P, kHiddenDim})
+        .with_strides({kHiddenDim, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(gemm2_out);
+    TensorMatcher({T, kTopK})
+        .with_strides({kTopK, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(expert_weights);
+    TK.set_value(T.unwrap() * kTopK);
+    TensorMatcher({TK}).with_strides({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device).verify(permuted_idx);
+    if (shared_output.has_value()) {
+      TensorMatcher({T, kHiddenDim})
+          .with_strides({kHiddenDim, 1})
+          .with_dtype<bf16_t>()
+          .with_device<kDLCUDA>(device)
+          .verify(shared_output.value());
+    }
+    if (norm_weight.has_value()) {
+      TensorMatcher({kHiddenDim})
+          .with_strides({1})
+          .with_dtype<bf16_t>()
+          .with_device<kDLCUDA>(device)
+          .verify(norm_weight.value());
+    }
+    const auto num_tokens = static_cast<uint32_t>(T.unwrap());
+    CHECK_HOST(num_tokens > 0) << "num_tokens must be positive";
+    CHECK_HOST(reinterpret_cast<uintptr_t>(gemm2_out.data_ptr()) % 16 == 0) << "gemm2_out must be 16B aligned";
+    CHECK_HOST(reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0) << "out must be 16B aligned";
+
+    // the whole [T, hidden] row view is staged by vector index, so it must fit
+    // one push slot; the generic push kernel's callers pick the slot size
+    const int64_t nbytes = num_tokens * int64_t(kHiddenDim) * sizeof(bf16_t);
+    CHECK_HOST(nbytes <= push.slot_bytes) << "num_tokens * hidden * 2 = " << nbytes << " bytes exceeds the "
+                                          << push.slot_bytes << "-byte push slot (reduce the batch or enlarge "
+                                          << "max_push_size)";
+    // one cluster (and phase counter) per row; the bumper cluster is launched
+    // only when counters are left over for it to flip (num_tokens < num_blocks),
+    // so a batch that owns every counter runs without it
+    CHECK_HOST(num_tokens <= push.num_blocks)
+        << "num_tokens = " << num_tokens << " exceeds the " << push.num_blocks << " push phase counters of the plane";
+    const uint32_t num_clusters = num_tokens + (num_tokens < push.num_blocks ? 1 : 0);
+
+    const auto params = Params{
+        .out = static_cast<bf16_t*>(out.data_ptr()),
+        .gemm2 = static_cast<const bf16_t*>(gemm2_out.data_ptr()),
+        .idx = static_cast<const int32_t*>(permuted_idx.data_ptr()),
+        .weights = static_cast<const bf16_t*>(expert_weights.data_ptr()),
+        .shared = shared_output.has_value() ? static_cast<const bf16_t*>(shared_output.value().data_ptr()) : nullptr,
+        .norm_weight = norm_weight.has_value() ? static_cast<const bf16_t*>(norm_weight.value().data_ptr()) : nullptr,
+        .norm_eps = static_cast<float>(eps),
+        .prefetch_metadata = prefetch_metadata,
+        .rank = push.rank,
+        .num_tokens = num_tokens,
+        .num_push_counters = push.num_blocks,
+        .ws = push.get_workspace<kWorldSize>(nbytes),
+    };
+
+    const auto has_shared = shared_output.has_value();
+    const auto has_norm = norm_weight.has_value();
+    const auto kern = has_shared ? (has_norm ? kernel<true, true> : kernel<true, false>)
+                                 : (has_norm ? kernel<false, true> : kernel<false, false>);
+    // __cluster_dims__(1, kClusterSize, 1) is compiled in, so a plain launch
+    // already forms the clusters along y
+    LaunchKernel(dim3(num_clusters, kClusterSize), Trait::kBlockSize, out.device()).enable_pdl(kUsePDL)(kern, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
@@ -120,7 +120,7 @@ struct AllReduceNormTrait {
 // routing rows and the kTopK gathers are fetched; the routed combine is then
 // accumulated in ascending k from zero, rounded to bf16, and the shared vector
 // is added with one more bf16 rounding (see the header: the unfused path's
-// numerics, reproduced so the fusion does not move the greedy output).
+// numerics, preserving the rank-local rounding points).
 // Threads of the same token read the same kTopK indices / weights (a broadcast
 // load per warp). All arithmetic is on bf16 pairs: one cast converts two
 // elements.
@@ -179,8 +179,7 @@ SGL_DEVICE StageVec finalize_vec(const FinalizeAllReduceParams<kWorldSize>& para
   // Same rounding as the unfused path: TRT-LLM's finalize returns the routed
   // combine rounded to bf16, and `shared.add_(routed)` then rounds the bf16 +
   // bf16 sum once more (torch adds in fp32). Reproducing both roundings keeps
-  // the staged vector bit-identical to what `dev` all-reduces, so the greedy
-  // output does not move with the fusion.
+  // the staged vector bit-identical to the unfused rank-local result.
   StageVec out;
 #pragma unroll
   for (uint32_t j = 0; j < 4; ++j) {

--- a/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
+++ b/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
@@ -1,0 +1,115 @@
+"""Candidate-block scores and visibility masking for paged indexer logits."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _maximum_with_nan(a, b):
+    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit
+def _candidate_scores_kernel(
+    X,
+    LENS,
+    OUT,
+    SCORES,
+    WIDTH: tl.constexpr,
+    STRIDE: tl.constexpr,
+    BLOCKS: tl.constexpr,
+    GROUP: tl.constexpr,
+    GROUP_PAD: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    blocks = tl.program_id(1) * TILE + tl.arange(0, TILE)
+    offsets = tl.arange(0, GROUP_PAD)
+    cols = blocks[:, None] * GROUP + offsets[None, :]
+    length = tl.load(LENS + row)
+    in_bounds = (cols < WIDTH) & (offsets[None, :] < GROUP)
+    values = tl.load(
+        X + row * STRIDE + cols, in_bounds & (cols < length), other=-float("inf")
+    ).to(tl.float32)
+    tl.store(OUT + row * WIDTH + cols, values, in_bounds)
+    scores = tl.reduce(values, axis=1, combine_fn=_maximum_with_nan)
+    scores = tl.where(
+        (length > 0) & (blocks == (length - 1) // GROUP), float("inf"), scores
+    )
+    tl.store(SCORES + row * BLOCKS + blocks, scores, blocks < BLOCKS)
+
+
+@triton.jit
+def _candidate_mask_kernel(
+    X,
+    LENS,
+    KEEP,
+    OUT,
+    WIDTH: tl.constexpr,
+    STRIDE: tl.constexpr,
+    KEEP_STRIDE: tl.constexpr,
+    KEEP_COL_STRIDE: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    cols = tl.program_id(1) * TILE + tl.arange(0, TILE)
+    visible = (cols < WIDTH) & (cols < tl.load(LENS + row))
+    keep = tl.load(KEEP + row * KEEP_STRIDE + cols * KEEP_COL_STRIDE, visible, other=0)
+    values = tl.load(X + row * STRIDE + cols, visible & keep, other=-float("inf")).to(
+        tl.float32
+    )
+    tl.store(OUT + row * WIDTH + cols, values, cols < WIDTH)
+
+
+def candidate_block_logits(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    topk_blocks: int,
+    block_size: int,
+    published: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Keep torch.topk's block selection, including its tie behavior.
+
+    A source masks the unread tail while reducing each block. A consumer masks
+    visibility and the published candidates in one pass, without copying the
+    capacity-sized logits before each masked_fill.
+    """
+    rows, width = logits.shape
+    output = torch.empty((rows, width), dtype=torch.float32, device=logits.device)
+    if published is not None:
+        _candidate_mask_kernel[(rows, triton.cdiv(width, 4096))](
+            logits,
+            seq_lens,
+            published,
+            output,
+            width,
+            logits.stride(0),
+            published.stride(0),
+            published.stride(1),
+            4096,
+        )
+        return output, None
+
+    blocks = triton.cdiv(width, block_size)
+    scores = torch.empty((rows, blocks), dtype=torch.float32, device=logits.device)
+    group_pad = triton.next_power_of_2(block_size)
+    tile = max(1, 1024 // group_pad)
+    _candidate_scores_kernel[(rows, triton.cdiv(blocks, tile))](
+        logits,
+        seq_lens,
+        output,
+        scores,
+        width,
+        logits.stride(0),
+        blocks,
+        block_size,
+        group_pad,
+        tile,
+    )
+    top = scores.topk(min(topk_blocks, blocks), dim=-1)
+    keep = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, top.indices, top.values > -torch.inf
+    )
+    return output, keep.repeat_interleave(block_size, dim=-1)[..., :width]

--- a/python/sglang/kernels/ops/communication/all_reduce_fusion.py
+++ b/python/sglang/kernels/ops/communication/all_reduce_fusion.py
@@ -1,0 +1,243 @@
+"""Fused deferred-MoE finalize + 1shot push all-reduce [+ RMSNorm] (bf16).
+
+One entry point, :func:`moe_finalize_all_reduce`, over
+``csrc/distributed/all_reduce_fusion.cuh``::
+
+    out[t] = allreduce( sum_k expert_weights[t, k] * gemm2_out[idx[t*top_k + k]]
+                        (+ shared_output[t]) )            # then, optionally,
+    out[t] = out[t] * rsqrt(mean(out[t]^2) + eps) * norm_weight
+
+The rank-local finalize (the trtllm-gen ``do_finalize=False`` triple, see
+``moe_runner/flashinfer_trtllm.py``) is computed in registers and pushed
+straight into every peer's CustomAllReduceV2 push slot, so it never
+materializes; ``idx == -1`` slots (EP: non-local expert) contribute nothing.
+Small-batch only: the whole ``[T, hidden]`` bf16 row view must fit one push
+slot (checked C++-side; :func:`fits_push_slot` lets callers pre-check).
+
+The un-normed result is what DeepSeek-V4.1 consumes (its consumer is the mHC
+post-split, not an RMSNorm), so ``norm_weight=None`` is the primary
+configuration; ``norm_weight`` + ``norm_eps`` give the K3-style fused norm.
+
+Geometry: one thread-block cluster per token row plus a bumper cluster that
+keeps the plane's phase counters uniform; ``cluster_size`` blocks share a
+row (``hidden / cluster_size`` dims each). :func:`default_cluster_size` holds
+the tuned default per hidden size and can be overridden per call.
+
+Needs :func:`register_comm` once per process (the CustomAllReduceV2
+``Communicator``); the ops key on ``world_size`` alone, like the K3 ones.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+    from sglang.kernels.ops.communication.all_reduce import Communicator
+
+
+# Storage plane: the CustomAllReduceV2 Communicator (push plane only)
+
+_COMM_MAP: dict[int, Communicator] = {}
+
+
+def register_comm(comm: Communicator) -> None:
+    """Register the CustomAllReduceV2 communicator whose push plane the fused
+    kernel stages through.
+
+    ``world_size`` is the whole key (the custom op takes nothing else), so at
+    most one communicator per size may be registered in a process; a second
+    group of the same size would silently inherit the first one's peer
+    pointers and the symptom would be a hang, hence the assert.
+    """
+    prev = _COMM_MAP.get(comm.world_size)
+    assert prev is None or prev is comm, (
+        f"a different communicator is already registered for world_size="
+        f"{comm.world_size}; these ops key only on world_size, so two groups of "
+        f"the same size cannot coexist in one process"
+    )
+    _COMM_MAP[comm.world_size] = comm
+
+
+def get_registered_comm(world_size: int) -> Optional[Communicator]:
+    return _COMM_MAP.get(world_size)
+
+
+# Geometry
+
+_VEC_ELEMS = 8  # bf16 per 16B vector = per thread
+_MAX_CLUSTER_SIZE = 8  # portable cluster size limit
+
+
+def valid_cluster_sizes(hidden_dim: int) -> list[int]:
+    """Cluster sizes the kernel can be built for at this hidden width: whole
+    16B vectors per row, whole warps per block, <= 1024 threads, <= 8 blocks."""
+    if hidden_dim % _VEC_ELEMS != 0:
+        return []
+    row_vecs = hidden_dim // _VEC_ELEMS
+    return [
+        c
+        for c in range(1, _MAX_CLUSTER_SIZE + 1)
+        if row_vecs % c == 0 and (row_vecs // c) % 32 == 0 and row_vecs // c <= 1024
+    ]
+
+
+@cache_once
+def default_cluster_size(hidden_dim: int) -> int:
+    if hidden_dim % 1024 == 0 and hidden_dim <= 8192:
+        return hidden_dim // 1024
+    if hidden_dim % 512 == 0 and hidden_dim <= 3584:
+        return hidden_dim // 512
+    candidates = valid_cluster_sizes(hidden_dim)
+    if not candidates:
+        raise ValueError(
+            f"hidden_dim={hidden_dim} has no valid cluster geometry (needs a "
+            f"multiple of {_VEC_ELEMS * 32} bf16)"
+        )
+    # closest to 128 threads per block, larger block on ties
+    return min(candidates, key=lambda c: (abs(hidden_dim // _VEC_ELEMS // c - 128), c))
+
+
+def fits_push_slot(max_push_size: int, num_tokens: int, hidden_dim: int) -> bool:
+    """Whether a ``[num_tokens, hidden_dim]`` bf16 row view fits one push slot
+    (``CustomAllReduceV2.max_push_size``)."""
+    return 0 < num_tokens * hidden_dim * 2 <= max_push_size
+
+
+# JIT module: one per (world_size, hidden_dim, top_k, cluster_size); the
+# shared-add and norm variants are compiled into it and picked at call time.
+
+
+@cache_once
+def _jit_module(
+    world_size: int, hidden_dim: int, top_k: int, cluster_size: int
+) -> Module:
+    assert cluster_size in valid_cluster_sizes(hidden_dim), (
+        f"cluster_size={cluster_size} is not valid for hidden_dim={hidden_dim}; "
+        f"choose from {valid_cluster_sizes(hidden_dim)}"
+    )
+    args = make_cpp_args(
+        world_size, hidden_dim, top_k, cluster_size, is_arch_support_pdl()
+    )
+    return load_jit(
+        "moe_finalize_all_reduce",
+        *args,
+        cuda_files=["distributed/all_reduce_fusion.cuh"],
+        cuda_wrappers=[("run", f"MoeFinalizeAllReduceKernel<{args}>::run")],
+    )
+
+
+def compile_moe_finalize_all_reduce(
+    world_size: int, hidden_dim: int, top_k: int, cluster_size: Optional[int] = None
+) -> None:
+    """Warm the JIT module (tests / benches precompile in parallel)."""
+    _jit_module(
+        world_size, hidden_dim, top_k, cluster_size or default_cluster_size(hidden_dim)
+    )
+
+
+@register_custom_op(mutates_args=["out"])
+def _moe_finalize_all_reduce_op(
+    world_size: int,
+    hidden_dim: int,
+    top_k: int,
+    cluster_size: int,
+    out: torch.Tensor,
+    gemm2_out: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_weights: torch.Tensor,
+    shared_output: Optional[torch.Tensor],
+    norm_weight: Optional[torch.Tensor],
+    norm_eps: float,
+    prefetch_metadata: bool,
+) -> None:
+    comm = _COMM_MAP.get(world_size)
+    assert comm is not None, (
+        f"no communicator registered for world_size={world_size}; call "
+        "all_reduce_fusion.register_comm(comm.obj) first"
+    )
+    _jit_module(world_size, hidden_dim, top_k, cluster_size).run(
+        comm,
+        out,
+        gemm2_out,
+        expanded_idx_to_permuted_idx,
+        expert_weights,
+        shared_output,
+        norm_weight,
+        norm_eps,
+        prefetch_metadata,
+    )
+
+
+def moe_finalize_all_reduce(
+    gemm2_out: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_weights: torch.Tensor,
+    top_k: int,
+    shared_output: Optional[torch.Tensor] = None,
+    norm_weight: Optional[torch.Tensor] = None,
+    norm_eps: Optional[float] = None,
+    *,
+    world_size: int,
+    hidden_dim: int,
+    cluster_size: Optional[int] = None,
+    prefetch_metadata: bool = False,
+) -> torch.Tensor:
+    """Deferred MoE finalize [+ shared add] -> 1shot push all-reduce [-> RMSNorm].
+
+    :param gemm2_out: ``[P, hidden_dim]`` bf16, trtllm-gen permuted / padded rows.
+    :param expanded_idx_to_permuted_idx: ``[T * top_k]`` int32, ``-1`` = dropped slot.
+    :param expert_weights: ``[T, top_k]`` bf16; any routed scaling factor is
+                           already folded in (nothing is rescaled here).
+    :param shared_output: optional ``[T, hidden_dim]`` bf16 added before the reduce.
+    :param norm_weight: optional ``[hidden_dim]`` bf16 RMSNorm weight; with
+                        ``norm_eps`` it turns on the fused norm epilogue.
+    :param prefetch_metadata: let the kernel read the plane's phase counter and
+                              the routing metadata before its PDL wait. Under
+                              PDL the kernel may start as soon as the preceding
+                              kernel *triggers*, and nothing earlier in the
+                              stream is guaranteed complete until the wait: so
+                              this is only valid when the preceding kernel is
+                              not an all-reduce on the same plane AND the
+                              producers of ``expanded_idx_to_permuted_idx`` /
+                              ``expert_weights`` are known complete (a chain of
+                              early-triggering kernels such as the TRT-LLM MoE
+                              GEMMs is not). Defaults to False (wait first).
+    :returns: a new ``[T, hidden_dim]`` bf16 tensor (not in place).
+    """
+    num_tokens = expert_weights.shape[0]
+    assert expert_weights.shape[1] == top_k, (expert_weights.shape, top_k)
+    assert (norm_weight is None) == (norm_eps is None), (
+        "norm_weight and norm_eps must be given together"
+    )
+    out = torch.empty(
+        num_tokens, hidden_dim, dtype=torch.bfloat16, device=gemm2_out.device
+    )
+    if num_tokens == 0:  # nothing staged: no phase flip on any rank, stays in step
+        return out
+    _moe_finalize_all_reduce_op(
+        world_size,
+        hidden_dim,
+        top_k,
+        cluster_size or default_cluster_size(hidden_dim),
+        out,
+        gemm2_out,
+        expanded_idx_to_permuted_idx,
+        expert_weights,
+        shared_output,
+        norm_weight,
+        float(norm_eps) if norm_eps is not None else 0.0,
+        prefetch_metadata,
+    )
+    return out

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -18,6 +18,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.runtime_context import get_platform
 from sglang.srt.utils.common import is_gfx1250_supported
 
 logger = logging.getLogger(__name__)
@@ -2143,6 +2144,14 @@ def _block_m_for(m: int) -> int:
     return _HC_MIX_BLOCK_M
 
 
+def _num_stages_for(m: int, k: int) -> int:
+    # GB300 verify batches benefit from a smaller shared-memory footprint.
+    # This changes memory scheduling only; K tiles and reduction order stay fixed.
+    if get_platform().is_blackwell and k == 20480 and 64 <= m <= 384:
+        return 1
+    return _HC_MIX_NUM_STAGES
+
+
 def _num_slices_for(k: int) -> int:
     """Slice count depends only on K, never on batch size M."""
     blocks = k // _HC_MIX_BLOCK_K
@@ -2193,7 +2202,7 @@ def hc_mix_stats(x_flat: torch.Tensor, hc_fn: torch.Tensor, eps: float) -> torch
         BLOCK_K=_HC_MIX_BLOCK_K,
         DOT_PRECISION=_HC_MIX_DOT_PRECISION,
         num_warps=_HC_MIX_NUM_WARPS,
-        num_stages=_HC_MIX_NUM_STAGES,
+        num_stages=_num_stages_for(m, k),
     )
     _hc_mix_stats_reduce_kernel[(grid_m,)](
         part_mix,
@@ -2319,7 +2328,7 @@ def hc_mix_stats_sinkhorn(
         BLOCK_K=_HC_MIX_BLOCK_K,
         DOT_PRECISION=_HC_MIX_DOT_PRECISION,
         num_warps=_HC_MIX_NUM_WARPS,
-        num_stages=_HC_MIX_NUM_STAGES,
+        num_stages=_num_stages_for(m, k),
     )
     _hc_mix_reduce_sinkhorn_kernel[(m,)](
         part_mix,

--- a/python/sglang/kernels/ops/moe/moe_fused_gate.py
+++ b/python/sglang/kernels/ops/moe/moe_fused_gate.py
@@ -96,6 +96,7 @@ def _router_triton_kernel(
     num_token_non_padded_ptr,
     out_weights_ptr,  # [M, K] fp32
     out_indices_ptr,  # [M, K] int32
+    out_packed_ptr,  # [M, K] int32, (id << 16) | bf16 bits of weight (HAS_PACKED)
     M,
     routed_scaling_factor,
     moe_softcapping,
@@ -117,6 +118,7 @@ def _router_triton_kernel(
     HAS_TOKEN_BIAS: tl.constexpr,
     BIAS_ALT_TOKEN_ID: tl.constexpr,
     HAS_PADDING: tl.constexpr,
+    HAS_PACKED: tl.constexpr,
     RENORMALIZE_EPSILON: tl.constexpr,
     USE_PDL: tl.constexpr,
     stride_bias,
@@ -128,6 +130,8 @@ def _router_triton_kernel(
     stride_wk,
     stride_im,
     stride_ik,
+    stride_pm,
+    stride_pk,
 ) -> None:
     # Row-tiled: each program handles BLOCK_M rows; all reductions run along the
     # expert (N) axis. Tiling rows keeps CTAs large enough to stay occupancy-bound
@@ -291,6 +295,17 @@ def _router_triton_kernel(
     store_mask = mask_m[:, None] & mask_k_total[None, :]
     tl.store(out_w_ptr, selected_vals, mask=store_mask)
     tl.store(out_i_ptr, selected_idx, mask=store_mask)
+    if HAS_PACKED:
+        # FlashInfer routed-MoE packed entry, the exact expression of
+        # _pack_topk_ids_triton_kernel applied in-register to the values stored
+        # above (same fp32 -> bf16 rounding, same -1 sentinel on padded rows),
+        # so it is bitwise identical to the separate pack launch it replaces.
+        w_bits = selected_vals.to(tl.bfloat16).to(tl.int16, bitcast=True).to(tl.int32)
+        packed = (selected_idx << 16) | (w_bits & 0xFFFF)
+        out_p_ptr = (
+            out_packed_ptr + offs_m[:, None] * stride_pm + offs_k[None, :] * stride_pk
+        )
+        tl.store(out_p_ptr, packed, mask=store_mask)
 
 
 @debug_kernel_api
@@ -312,6 +327,7 @@ def moe_fused_gate(
     bias_alt_token_id: Optional[int] = None,
     num_token_non_padded: Optional[torch.Tensor] = None,
     renormalize_epsilon: float = 0.0,
+    packed_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Triton fused router: scoring + bias + topk + (optional) renorm/scale.
 
@@ -323,6 +339,10 @@ def moe_fused_gate(
     Rows with ``input_ids == bias_alt_token_id`` use ``bias_alt`` instead of ``bias``.
     Rows past the device scalar ``num_token_non_padded`` return zero weights and -1 ids.
     Positive ``renormalize_epsilon`` uses ``sum + epsilon`` instead of the zero-sum guard.
+    ``packed_out`` ([M, topk] int32, optional) additionally receives the FlashInfer
+    routed-MoE form ``(id << 16) | bf16_bits(weight)`` of the returned pair, computed
+    in-register (bitwise the separate ``PackTopkIds`` kernel; the radix fast path is
+    skipped when it is requested).
     """
     scoring_func_int = _SCORING_FUNC_MAP.get(scoring_func.lower())
     assert scoring_func_int is not None, (
@@ -356,6 +376,11 @@ def moe_fused_gate(
         assert bias_alt is not None and bias_alt_token_id is not None
         assert bias is not None and bias_alt.shape == bias.shape
         assert input_ids.shape == (scores.size(0),)
+    if packed_out is not None:
+        assert packed_out.dtype == torch.int32, "packed_out must be int32"
+        assert packed_out.shape == (scores.size(0), topk), (
+            "packed_out must be [M, topk]"
+        )
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
 
@@ -374,6 +399,7 @@ def moe_fused_gate(
         and input_ids is None
         and num_token_non_padded is None
         and renormalize_epsilon == 0.0
+        and packed_out is None
         and bias.stride(0) == 1
     ):
         radix_args = (
@@ -423,6 +449,7 @@ def moe_fused_gate(
         num_token_non_padded,
         weights,
         indices,
+        packed_out if packed_out is not None else indices,
         M,
         float(routed_scaling_factor),
         float(moe_softcapping),
@@ -444,6 +471,7 @@ def moe_fused_gate(
         HAS_TOKEN_BIAS=input_ids is not None,
         BIAS_ALT_TOKEN_ID=bias_alt_token_id,
         HAS_PADDING=num_token_non_padded is not None,
+        HAS_PACKED=packed_out is not None,
         RENORMALIZE_EPSILON=renormalize_epsilon,
         USE_PDL=use_pdl,
         stride_bias=bias.stride(0) if bias is not None else 0,
@@ -455,6 +483,8 @@ def moe_fused_gate(
         stride_wk=weights.stride(1),
         stride_im=indices.stride(0),
         stride_ik=indices.stride(1),
+        stride_pm=packed_out.stride(0) if packed_out is not None else 0,
+        stride_pk=packed_out.stride(1) if packed_out is not None else 0,
         num_warps=num_warps,
         **extra,
     )

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -942,11 +942,12 @@ def _sparse_head_overlap_disable(view: Any) -> dict:
 
 # Architectures with explicit FlashInfer AllReduce Fusion support. Keep in
 # sync with the model-side fusion implementations.
+# V4 uses the custom push plane for its small decode all-reduces and fused
+# MoE finalize. Its mHC post-split does not use the FlashInfer norm epilogue.
 _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
-        "DeepseekV4ForCausalLM",
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -942,12 +942,11 @@ def _sparse_head_overlap_disable(view: Any) -> dict:
 
 # Architectures with explicit FlashInfer AllReduce Fusion support. Keep in
 # sync with the model-side fusion implementations.
-# V4 uses the custom push plane for its small decode all-reduces and fused
-# MoE finalize. Its mHC post-split does not use the FlashInfer norm epilogue.
 _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
+        "DeepseekV4ForCausalLM",
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",
@@ -974,7 +973,18 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     single-node systems. Reads the mid-resolution enable_dp_attention /
     moe_a2a_backend (after the DeepSeek CP and a2a declarations), exactly
     like the legacy tail block."""
-    model_arch = model_config_of(view).hf_config.architectures[0]
+    hf_config = model_config_of(view).hf_config
+    model_arch = hf_config.architectures[0]
+    # V4.1 TP4 uses the custom push plane for decode and fused MoE finalize.
+    # Keep the existing default for other models and parallel configurations.
+    prefer_custom_dsv41 = (
+        getattr(hf_config, "model_type", None) == "deepseek_v41"
+        and getattr(hf_config, "hidden_size", None) == 5120
+        and get_platform().is_blackwell
+        and view.tp_size == 4
+        and view.nnodes == 1
+        and not view.disable_custom_all_reduce
+    )
     if envs.SGLANG_FLASHINFER_MNNVL_CUTEDSL_AR_FUSION.get() and model_arch in {
         "Qwen3_5MoeForCausalLM",
         "Qwen3_5MoeForConditionalGeneration",
@@ -992,6 +1002,7 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     if (
         view.flashinfer_allreduce_fusion_backend is None
         and model_arch in _FLASHINFER_ALLREDUCE_FUSION_ARCHS
+        and not prefer_custom_dsv41
         and (get_platform().is_sm90 or get_platform().is_sm100)
         and view.tp_size > 1
         and not view.enable_dp_attention

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -280,6 +280,36 @@ def two_level_decode_logits(
         # All requests fit the candidate budget; paged top-k masks their tails.
         return logits, None
 
+    if (
+        logits.is_cuda
+        and torch.version.cuda is not None
+        and logits.ndim == 2
+        and logits.stride(1) == 1
+        and seq_lens.device == logits.device
+        and seq_lens.dtype in (torch.int32, torch.int64)
+        and seq_lens.is_contiguous()
+        and seq_lens.shape in ((logits.shape[0],), (logits.shape[0], 1))
+        and logits.numel() > 0
+        and 0 < block_size <= 1024
+    ):
+        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+            candidate_block_logits,
+        )
+
+        if not is_candidate_source:
+            assert (
+                torch.is_tensor(published)
+                and published.shape[0] == logits.shape[0]
+                and published.shape[1] >= logits.shape[1]
+            ), "candidate mask missing for decode"
+        return candidate_block_logits(
+            logits,
+            seq_lens,
+            topk_blocks=topk_blocks,
+            block_size=block_size,
+            published=None if is_candidate_source else published,
+        )
+
     lens_col = seq_lens if seq_lens.dim() > 1 else seq_lens.unsqueeze(-1)
     reachable = torch.arange(logits.shape[-1], device=logits.device) < lens_col
     logits = logits.float().masked_fill(~reachable, -torch.inf)
@@ -2778,7 +2808,16 @@ class DeepseekV4AttnBackend(
         if forward_batch.forward_mode.is_decode():
             self._low_ratio_compress_decode(layer, x, req, pos)
         else:
-            self._low_ratio_compress_torch(layer, x, req, pos)
+            self._low_ratio_compress_torch(
+                layer,
+                x,
+                req,
+                pos,
+                fuse_index_store=(
+                    forward_batch.forward_mode.is_target_verify()
+                    and layer.compressor.use_fused_compress
+                ),
+            )
 
     def _low_ratio_in_prefill_graph(self) -> bool:
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
@@ -2908,14 +2947,22 @@ class DeepseekV4AttnBackend(
                 ratio=layer.compress_ratio,
             )
 
-    def _low_ratio_compress_torch(self, layer, x, req, pos, projected=None) -> None:
+    def _low_ratio_compress_torch(
+        self, layer, x, req, pos, projected=None, *, fuse_index_store=False
+    ) -> None:
         core = self.forward_metadata.core_metadata
         num_tokens = pos.shape[0]
         kv, score = projected if projected is not None else layer.compressor.project(x)
         if not num_tokens:
             return
         if layer.compress_ratio == 1:
-            self._low_ratio_write_group(layer, kv, core.c1_out_loc[:num_tokens], pos)
+            self._low_ratio_write_group(
+                layer,
+                kv,
+                core.c1_out_loc[:num_tokens],
+                pos,
+                fuse_index_store=fuse_index_store,
+            )
             return
 
         partner_kv, partner_score = self._low_ratio_pair_partners(
@@ -2933,7 +2980,9 @@ class DeepseekV4AttnBackend(
         group_pos = torch.where(pos % 2 == 1, pos - 1, pos)
         out_loc = core.c2_out_loc[:num_tokens]
         slots = torch.where(out_loc >= 0, out_loc, torch.zeros_like(out_loc))
-        self._low_ratio_write_group(layer, pooled, slots, group_pos)
+        self._low_ratio_write_group(
+            layer, pooled, slots, group_pos, fuse_index_store=fuse_index_store
+        )
 
     def _low_ratio_pair_partners(
         self, *, layer_id, kv, score, req, pos, pad
@@ -2975,7 +3024,13 @@ class DeepseekV4AttnBackend(
         return partner_kv, partner_score
 
     def _low_ratio_write_group(
-        self, layer, pooled, slots, group_pos, *, fuse_index_store=False
+        self,
+        layer,
+        pooled,
+        slots,
+        group_pos,
+        *,
+        fuse_index_store=False,
     ) -> None:
         pool = self.token_to_kv_pool
         latent = layer.compressor.finish(pooled)

--- a/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
+++ b/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
@@ -50,7 +50,6 @@ class RMSNorm(nn.Module):
             and x.dtype in (torch.bfloat16, torch.float32)
             and self.weight.dtype in (torch.bfloat16, torch.float32)
             and x.shape[-1] in (128, 512)
-            and x.numel() <= 64 * x.shape[-1]
             and x.is_contiguous()
             and self.weight.is_contiguous()
         ):

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1487,7 +1487,7 @@ class FusedMoE(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
-        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         if self._use_ascend_fuseep:
             from sglang.srt.hardware_backend.npu.moe.fuseep import forward_fuseep
@@ -1528,7 +1528,7 @@ class FusedMoE(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
-        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         origin_hidden_states_dim = hidden_states.shape[-1]
         assert self.quant_method is not None
@@ -1537,21 +1537,9 @@ class FusedMoE(torch.nn.Module):
             dwdp_mgr = get_global_dwdp_manager()
             dwdp_mgr.wait_prefetch(self.layer_id)
 
-        dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
+        dispatch_output = self._dispatch_with_pre_quant(
+            hidden_states, topk_output, pre_quant_input
         )
-        if (
-            pre_quant_input is not None
-            and dispatch_output.format.is_standard()
-            and dispatch_output.hidden_states_scale is None
-        ):
-            # SGLANG_OPT_MOE_QUANT_ONCE: the standard dispatch was a pure
-            # passthrough, so the caller's pre-quantized (q, scale) pair still
-            # matches dispatch_output.hidden_states; attach it for the triton
-            # fused runner to skip its own activation quant.
-            dispatch_output = dispatch_output._replace(
-                hidden_states_pre_quant=pre_quant_input
-            )
 
         combine_input = self.run_moe_core(
             dispatch_output=dispatch_output,
@@ -1575,16 +1563,46 @@ class FusedMoE(torch.nn.Module):
 
         return final_hidden_states
 
+    def _dispatch_with_pre_quant(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        pre_quant_input: Optional[Tuple],
+    ) -> DispatchOutput:
+        dispatch_output = self.dispatcher.dispatch(
+            hidden_states=hidden_states, topk_output=topk_output
+        )
+        if (
+            pre_quant_input is not None
+            and dispatch_output.format.is_standard()
+            and dispatch_output.hidden_states_scale is None
+        ):
+            # The standard dispatch was a pure passthrough, so the caller's
+            # pre-quantized activation still matches dispatch_output.hidden_states;
+            # attach it so the runner skips its own activation quant. Either the
+            # SGLANG_OPT_MOE_QUANT_ONCE (q, scale) pair for the triton fused
+            # runner, or Mxfp8RoutedInputPreQuant for the flashinfer_mxfp4
+            # TRT-LLM method (quantized on a side stream, joined on its event --
+            # dropping it here would leave that stream unjoined under CUDA-graph
+            # capture).
+            dispatch_output = dispatch_output._replace(
+                hidden_states_pre_quant=pre_quant_input
+            )
+        return dispatch_output
+
     def forward_deferred_finalize(
-        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         assert self.quant_method is not None
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
             flashinfer_trtllm_deferred_finalize_context,
         )
 
-        dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
+        dispatch_output = self._dispatch_with_pre_quant(
+            hidden_states, topk_output, pre_quant_input
         )
 
         with flashinfer_trtllm_deferred_finalize_context():

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -76,6 +76,11 @@ def flashinfer_trtllm_deferred_finalize_context(
         _deferred_finalize_enabled.reset(token)
 
 
+def is_deferred_finalize_enabled() -> bool:
+    """Whether the caller asked for the ``do_finalize=False`` output ABI."""
+    return _deferred_finalize_enabled.get()
+
+
 def finalize_flashinfer_trtllm_deferred_output(
     deferred_output: FlashInferTrtllmDeferredFinalizeOutput,
     shared_output: torch.Tensor,

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -68,11 +68,14 @@ class StandardDispatchOutput(NamedTuple):
     hidden_states: torch.Tensor
     hidden_states_scale: Optional[torch.Tensor]
     topk_output: TopKOutput
-    # SGLANG_OPT_MOE_QUANT_ONCE: optional pre-quantized (q, scale) pair for
-    # ``hidden_states`` (per-token-group-128 fp8, q rows possibly padded to a
-    # multiple of 4). Consumed by the standard->triton fused runner so it can
-    # skip its own activation quant; ``hidden_states`` itself stays bf16.
-    hidden_states_pre_quant: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    # Optional pre-quantized activation for ``hidden_states`` (which itself
+    # stays bf16), so the runner skips its own activation quant. Either the
+    # SGLANG_OPT_MOE_QUANT_ONCE (q, scale) pair (per-token-group-128 fp8, q
+    # rows possibly padded to a multiple of 4) consumed by the standard->triton
+    # fused runner, or ``Mxfp8RoutedInputPreQuant`` (x_q, x_sf, ready event;
+    # MXFP8 linear scale layout, quantized on a side stream) consumed by
+    # ``Mxfp4FlashinferTrtllmMoEMethod.apply``.
+    hidden_states_pre_quant: Optional[Tuple] = None
 
     @property
     def format(self) -> DispatchOutputFormat:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -272,14 +272,10 @@ class TopKConfig:
 class TopKOutputChecker:
     @staticmethod
     def format_is_standard(topk_output: TopKOutput) -> TypeGuard[StandardTopKOutput]:
-        # ===== TO BE REFACTORED ====
-        # The experimental fused topk+pack carrier only exists under the master switch.
-        if _SGLANG_EXPERIMENTAL_LORA_OPTI:
-            return isinstance(
-                topk_output, (StandardTopKOutput, StandardTopKOutputPacked)
-            )
-        # ===== END TO BE REFACTORED ====
-        return isinstance(topk_output, StandardTopKOutput)
+        # StandardTopKOutputPacked is the standard (weights, ids, logits) triple
+        # plus the FlashInfer routed-MoE packed ids the router emitted alongside
+        # them; every standard-format consumer reads it by field name.
+        return isinstance(topk_output, (StandardTopKOutput, StandardTopKOutputPacked))
 
     @staticmethod
     def format_is_triton_kernels(
@@ -325,11 +321,13 @@ class StandardTopKOutput(NamedTuple):
         return TopKOutputFormat.STANDARD
 
 
-# ===== TO BE REFACTORED ====
-# Experimental fused topk+pack (SGLANG_OPT_LORA_FUSED_TOPK_PACK) carrier: the FlashInfer
-# routed-MoE packed topk produced fused in the gating kernel. Kept a SEPARATE type rather
-# than a 4th StandardTopKOutput field so the OSS `a, b, _ = topk_output` 3-tuple unpack
-# stays valid; only the gated experimental MoE dispatch reads .packed_topk_ids (getattr).
+# Standard top-k output carrying, in addition, the FlashInfer routed-MoE packed
+# topk ``(id << 16) | bf16_bits(weight)`` that the gating kernel produced in the
+# same launch (the sqrtsoftplus Triton router under the flashinfer_mxfp4 runner
+# backend, and the experimental Qwen3 fused topk+pack). Kept a SEPARATE type
+# rather than a 4th StandardTopKOutput field so the `a, b, _ = topk_output`
+# 3-tuple unpack in runners that never see it stays valid; consumers read
+# .packed_topk_ids via _get_packed_topk_ids_for_flashinfer_routed (getattr).
 class StandardTopKOutputPacked(NamedTuple):
     topk_weights: torch.Tensor
     topk_ids: torch.Tensor
@@ -339,9 +337,6 @@ class StandardTopKOutputPacked(NamedTuple):
     @property
     def format(self) -> TopKOutputFormat:
         return TopKOutputFormat.STANDARD
-
-
-# ===== END TO BE REFACTORED ====
 
 
 class TritonKernelTopKOutput(NamedTuple):
@@ -1365,10 +1360,12 @@ def biased_topk_jit_kernel_impl(
     num_token_non_padded: Optional[torch.Tensor] = None,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     apply_routed_scaling_factor_on_output: Optional[bool] = False,
+    packed_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
 
     if _use_aiter and scoring_func == "sqrtsoftplus" and num_fused_shared_experts == 0:
+        assert packed_out is None, "aiter topk_gating cannot emit packed ids"
         from aiter import topk_gating
 
         num_tokens = gating_output.shape[0]
@@ -1407,6 +1404,17 @@ def biased_topk_jit_kernel_impl(
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+            # The router masks rows >= num_token_non_padded itself (id -1,
+            # weight 0), saving the post-process mask launch; see
+            # _fused_gate_masks_padded_rows for why this is sqrtsoftplus-only.
+            num_token_non_padded=(
+                num_token_non_padded
+                if _fused_gate_masks_padded_rows(scoring_func)
+                else None
+            ),
+            # Optional FlashInfer routed-MoE packed ids, written in the same
+            # launch (see _fused_gate_emits_packed_ids).
+            packed_out=packed_out,
         )
         topk_weights, topk_ids = (
             topk_weights.to(torch.float32),
@@ -1559,6 +1567,48 @@ def _eplb_remap_enabled() -> bool:
         get_exec().moe.enable_eplb
         or get_exec().moe.init_expert_location != "trivial"
         or get_exec().moe.ep_num_redundant_experts > 0
+    )
+
+
+def _fused_gate_masks_padded_rows(scoring_func: str) -> bool:
+    """Whether the CUDA sqrtsoftplus router masks its own padded rows.
+
+    ``moe_fused_gate``'s Triton kernel already implements ``num_token_non_padded``
+    (rows >= it get id -1 and weight 0, ``HAS_PADDING``), so on this path the
+    count is handed to the router and :func:`_post_process_topk_ids` skips the
+    separate ``mask_topk_ids_padded_region`` launch. Live rows are bitwise
+    unchanged (the kernel only adds a final ``tl.where``); padded rows get the
+    same -1 ids and a 0 weight instead of a stale one, which every consumer of
+    a -1 id ignores. Restricted to sqrtsoftplus (DeepSeek-V4): on the sigmoid
+    path a padding count would bypass the Kimi-K3 radix fast path, which does
+    not take one, and on HIP the post-process fills padded ids with 0, not -1.
+    """
+    return _is_cuda and not _use_aiter and scoring_func == "sqrtsoftplus"
+
+
+def _fused_gate_emits_packed_ids(
+    scoring_func: str,
+    num_fused_shared_experts: int,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo],
+    routing_overridden: bool,
+) -> bool:
+    """Whether the sqrtsoftplus router also writes the FlashInfer routed-MoE
+    packed ids ``(id << 16) | bf16_bits(weight)``, replacing the separate
+    ``PackTopkIds`` launch in ``Mxfp4FlashinferTrtllmMoEMethod.apply``.
+
+    Same admission as the Qwen3 fused topk+pack precedent: the pack is taken
+    from the router's final (renormalized, scaled, padding-masked) values, so
+    nothing may rewrite ids or weights afterwards -- no EPLB logical->physical
+    remap, no fused shared-expert slots (which also implies waterfill is off),
+    no benchmark routing override. Only the flashinfer_mxfp4 runner backend
+    consumes the packed form.
+    """
+    return (
+        _fused_gate_masks_padded_rows(scoring_func)
+        and get_moe_runner_backend().is_flashinfer_mxfp4()
+        and expert_location_dispatch_info is None
+        and num_fused_shared_experts == 0
+        and not routing_overridden
     )
 
 
@@ -2113,7 +2163,13 @@ def _post_process_topk_ids(
     layer_id: int,
     num_token_non_padded: Optional[torch.Tensor] = None,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    padded_rows_masked: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """``padded_rows_masked``: the router already wrote id -1 / weight 0 into
+    rows >= ``num_token_non_padded`` (see :func:`_fused_gate_masks_padded_rows`),
+    so the CUDA identity-remap branch skips its mask launch. Every branch that
+    remaps ids keeps the mask: a remap table indexed by -1 aliases its last
+    entry, so the mask must run after it."""
     num_fused_shared_experts = topk_config.num_fused_shared_experts
     use_per_rank_shared_slots = has_per_rank_fused_shared_slots(
         num_fused_shared_experts
@@ -2160,7 +2216,13 @@ def _post_process_topk_ids(
             recorder_topk_ids = routed_cols
         else:
             topk_ids = _biased_grouped_topk_postprocess(
-                topk_ids, expert_location_dispatch_info, num_token_non_padded
+                topk_ids,
+                expert_location_dispatch_info,
+                (
+                    None
+                    if padded_rows_masked and expert_location_dispatch_info is None
+                    else num_token_non_padded
+                ),
             )
     elif _is_hip:
         # On AMD HIP the aiter MoE kernels do not handle topk_ids=-1 safely
@@ -2320,8 +2382,20 @@ def select_experts(
 
     scoring_func = topk_config.scoring_func
 
-    # Set by the fused-gating+pack branch below; None everywhere else.
+    # Set by the fused-gating+pack branches below; None everywhere else.
     packed_topk = None
+    # True when the router itself masked rows >= num_token_non_padded, so the
+    # post-process can skip its mask launch (see _fused_gate_masks_padded_rows).
+    padded_rows_masked = False
+
+    simulate_uniform_experts = envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
+    simulate_round_robin_experts = envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
+    if simulate_uniform_experts and simulate_round_robin_experts:
+        raise ValueError(
+            "SGLANG_SIMULATE_UNIFORM_EXPERTS and "
+            "SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS are mutually exclusive"
+        )
+    routing_overridden = simulate_uniform_experts or simulate_round_robin_experts
 
     (
         router_logits,
@@ -2404,6 +2478,19 @@ def select_experts(
             scoring_func == "sqrtsoftplus" or scoring_func == "sigmoid"
         ):
             _biased_topk = biased_topk_xpu if _is_xpu else biased_topk_jit_kernel_impl
+            _packed_kwargs = {}
+            if _fused_gate_emits_packed_ids(
+                scoring_func,
+                num_fused_shared_experts,
+                expert_location_dispatch_info,
+                routing_overridden,
+            ):
+                packed_topk = torch.empty(
+                    (hidden_states.shape[0], top_k),
+                    dtype=torch.int32,
+                    device=hidden_states.device,
+                )
+                _packed_kwargs = dict(packed_out=packed_topk)
             topk_weights, topk_ids = _biased_topk(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
@@ -2416,7 +2503,9 @@ def select_experts(
                 num_token_non_padded=num_token_non_padded,
                 expert_location_dispatch_info=expert_location_dispatch_info,
                 apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                **_packed_kwargs,
             )
+            padded_rows_masked = _fused_gate_masks_padded_rows(scoring_func)
         elif (
             get_moe_runner_backend().is_flashinfer_trtllm_routed()
             and scoring_func == "softmax"
@@ -2445,8 +2534,7 @@ def select_experts(
                 and correction_bias is None
                 and expert_location_dispatch_info is None
                 and num_fused_shared_experts == 0
-                and not envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
-                and not envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
+                and not routing_overridden
             ):
                 num_experts = router_logits.shape[-1]
                 if num_experts & (num_experts - 1) == 0 and num_experts <= 512:
@@ -2492,15 +2580,7 @@ def select_experts(
             renormalize=renormalize,
         )
 
-    simulate_uniform_experts = envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
-    simulate_round_robin_experts = envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
-    if simulate_uniform_experts and simulate_round_robin_experts:
-        raise ValueError(
-            "SGLANG_SIMULATE_UNIFORM_EXPERTS and "
-            "SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS are mutually exclusive"
-        )
-
-    if simulate_uniform_experts or simulate_round_robin_experts:
+    if routing_overridden:
         # Benchmark-only: override gating with a balanced expert assignment (so
         # dummy/random benchmark tokens don't skew MoE load) via a single fused
         # Triton kernel — one launch instead of the ~5-7 small elementwise ops it
@@ -2523,6 +2603,8 @@ def select_experts(
             token_shard_rank=token_shard_rank,
             num_token_shards=num_token_shards,
         )
+        # The override rewrote every row, including the router-masked ones.
+        padded_rows_masked = False
 
     topk_ids, topk_weights, recorder_topk_ids = _post_process_topk_ids(
         topk_ids=topk_ids,
@@ -2532,18 +2614,17 @@ def select_experts(
         num_token_non_padded=num_token_non_padded,
         layer_id=layer_id,
         expert_location_dispatch_info=expert_location_dispatch_info,
+        padded_rows_masked=padded_rows_masked,
     )
 
     get_global_expert_distribution_recorder().on_select_experts(
         topk_ids=recorder_topk_ids
     )
 
-    # ===== TO BE REFACTORED ====
     if packed_topk is not None:
         return StandardTopKOutputPacked(
             topk_weights, topk_ids, router_logits, packed_topk
         )
-    # ===== END TO BE REFACTORED ====
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple
 
 import torch
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
-from sglang.kernels.ops.moe.pack_topk_ids import PackTopkIds
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
@@ -96,6 +95,27 @@ def _pad_intermediate_size(layer: Module) -> None:
         "compute and memory. Use this TP MoE configuration with caution and "
         "benchmark it against a TP/EP configuration that avoids padding."
     )
+
+
+def routed_hidden_size(layer: Module) -> int:
+    """Hidden size the routed GEMM1 expects (uint8 weights hold two fp4/row)."""
+    w13 = layer.w13_weight
+    return w13.shape[2] * 2 if w13.dtype == torch.uint8 else w13.shape[2]
+
+
+class Mxfp8RoutedInputPreQuant(NamedTuple):
+    """MXFP8 linear-layout quant of the routed MoE input, produced ahead of
+    :meth:`Mxfp4FlashinferTrtllmMoEMethod.apply` by
+    :meth:`Mxfp4FlashinferTrtllmMoEMethod.quantize_routed_input` -- e.g. on a
+    side stream while the gate GEMM and the router run on the main stream.
+    ``ready`` is the event recorded on the producing stream after the quant;
+    ``apply`` makes its stream wait on it right before the routed MoE op, whose
+    first kernel (routing) precedes the GEMM that reads ``x_q``/``x_sf``.
+    Carried in ``StandardDispatchOutput.hidden_states_pre_quant``."""
+
+    x_q: torch.Tensor
+    x_sf: torch.Tensor
+    ready: Optional[torch.cuda.Event]
 
 
 class Mxfp4FlashinferTrtllmMoEMethod:
@@ -312,6 +332,28 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 persistent=False,
             )
 
+    def quantize_routed_input(
+        self, hidden_states: torch.Tensor, hidden_size: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """MXFP8 quant of the routed input in the linear scale layout the
+        routed MoE op requires (``hidden_states_scale`` [tokens, hidden // 32]),
+        on the current stream. This is the only front-end kernel that depends
+        on ``hidden_states`` alone, so callers may run it on a side stream and
+        hand the result to :meth:`apply` as :class:`Mxfp8RoutedInputPreQuant`;
+        ``apply`` runs the identical call inline otherwise."""
+        from sglang.srt.layers.quantization.fp8_utils import flashinfer_mxfp8_quantize
+
+        x_quant, x_scale = flashinfer_mxfp8_quantize(
+            hidden_states,
+            False,
+            alignment=hidden_size,
+            backend=_MXFP8_QUANTIZE_BACKEND,
+        )
+        x_scale = x_scale.view(torch.float8_e4m3fn).reshape(
+            *hidden_states.shape[:-1], -1
+        )
+        return x_quant, x_scale
+
     def apply(
         self,
         layer: Module,
@@ -322,6 +364,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
 
         hidden_states = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
+        pre_quant = getattr(dispatch_output, "hidden_states_pre_quant", None)
 
         w13 = layer.w13_weight
         w2 = layer.w2_weight
@@ -329,7 +372,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         w2_scale = layer.w2_weight_scale_inv
 
         intermediate_size = w2.shape[2] * 2 if w2.dtype == torch.uint8 else w2.shape[2]
-        hidden_size = w13.shape[2] * 2 if w13.dtype == torch.uint8 else w13.shape[2]
+        hidden_size = routed_hidden_size(layer)
 
         num_local_experts = layer.num_local_experts
         if w13_scale.dim() == 2:
@@ -337,19 +380,24 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         if w2_scale.dim() == 2:
             w2_scale = w2_scale.reshape(num_local_experts, hidden_size, -1)
 
-        if TopKOutputChecker.format_is_standard(topk_output):
-            topk_ids = topk_output.topk_ids
-            topk_weights = topk_output.topk_weights
-        elif TopKOutputChecker.format_is_bypassed(topk_output):
+        if TopKOutputChecker.format_is_bypassed(topk_output):
             raise NotImplementedError(
                 "the old code in this branch is WRONG. e.g. it does not consider HashTopK, and may miss args"
             )
-        else:
+        if not TopKOutputChecker.format_is_standard(topk_output):
             raise ValueError(f"Unsupported topk output format: {topk_output.format}")
 
-        packed_topk = PackTopkIds.execute(topk_ids, topk_weights)
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            _get_packed_topk_ids_for_flashinfer_routed,
+            trtllm_moe_enable_pdl,
+        )
+
+        # The sqrtsoftplus router emits the packed ids in its own launch
+        # (StandardTopKOutputPacked); pack here only when it did not.
+        packed_topk = _get_packed_topk_ids_for_flashinfer_routed(topk_output)
 
         precision = self.flashinfer_mxfp4_moe_precision
+        input_ready: Optional[torch.cuda.Event] = None
         if precision == "bf16":
             assert hidden_states.dtype == torch.bfloat16
             x_quant = hidden_states
@@ -363,40 +411,54 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                     value=0.0,
                 )
         elif precision == "default":
-            from sglang.srt.layers.quantization.fp8_utils import (
-                flashinfer_mxfp8_quantize,
-            )
-
-            x_quant, x_scale = flashinfer_mxfp8_quantize(
-                hidden_states,
-                False,
-                alignment=hidden_size,
-                backend=_MXFP8_QUANTIZE_BACKEND,
-            )
-            x_scale = x_scale.view(torch.float8_e4m3fn).reshape(
-                *hidden_states.shape[:-1], -1
-            )
+            if isinstance(pre_quant, Mxfp8RoutedInputPreQuant):
+                # Quantized ahead of time (on a side stream) by the caller via
+                # quantize_routed_input on the same hidden_states.
+                assert pre_quant.x_q.shape[0] == hidden_states.shape[0]
+                x_quant, x_scale, input_ready = pre_quant
+            else:
+                x_quant, x_scale = self.quantize_routed_input(
+                    hidden_states, hidden_size
+                )
         else:
             raise NotImplementedError(f"Unsupported mxfp4 moe precision: {precision}")
 
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            _make_deferred_finalize_output,
+            is_deferred_finalize_enabled,
             trtllm_moe_enable_pdl,
         )
 
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            num_tokens = x_quant.shape[0]
-            out_hidden_size = (
-                x_quant.shape[-1] * 2
-                if x_quant.dtype == torch.uint8
-                else x_quant.shape[-1]
-            )
-            symm_output = torch.empty(
-                num_tokens, out_hidden_size, dtype=torch.bfloat16, device=x_quant.device
-            )
+        num_tokens = x_quant.shape[0]
+        # Deferred finalize (flashinfer_trtllm_deferred_finalize_context): hand
+        # back FlashInfer's permuted GEMM2 output + routing triple instead of
+        # the finalized [T, hidden] tensor, for a caller that fuses the
+        # finalize into its shared add / all-reduce
+        # (kernels.ops.communication.all_reduce_fusion).
+        defer_finalize = is_deferred_finalize_enabled()
+        symm_output = None
+        if not defer_finalize:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                out_hidden_size = (
+                    x_quant.shape[-1] * 2
+                    if x_quant.dtype == torch.uint8
+                    else x_quant.shape[-1]
+                )
+                symm_output = torch.empty(
+                    num_tokens,
+                    out_hidden_size,
+                    dtype=torch.bfloat16,
+                    device=x_quant.device,
+                )
 
-        output = trtllm_fp4_block_scale_routed_moe(
+        if input_ready is not None:
+            # The routing kernel is launched inside the op below, so the
+            # cross-stream join for x_quant/x_scale must precede the op call.
+            torch.cuda.current_stream().wait_event(input_ready)
+
+        result = trtllm_fp4_block_scale_routed_moe(
             topk_ids=packed_topk,
             routing_bias=None,
             hidden_states=x_quant,
@@ -422,11 +484,15 @@ class Mxfp4FlashinferTrtllmMoEMethod:
             local_num_experts=num_local_experts,
             routed_scaling_factor=1.0,
             routing_method_type=int(RoutingMethodType.TopK),
-            do_finalize=True,
-            tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
+            do_finalize=not defer_finalize,
+            tune_max_num_tokens=next_power_of_2(num_tokens),
             output=symm_output,
             enable_pdl=trtllm_moe_enable_pdl(num_tokens),
-        )[0]
+        )
+        if defer_finalize:
+            output = _make_deferred_finalize_output(result, top_k=packed_topk.shape[1])
+        else:
+            output = result[0]
 
         return StandardCombineInput(hidden_states=output)
 
@@ -470,3 +536,68 @@ def maybe_fuse_routed_scale_and_shared_add(
     if shared is not None:
         routed += shared
     return routed
+
+
+# Fused finalize + shared add + TP all-reduce
+_fused_finalize_all_reduce_world_size: Optional[int] = None
+_fused_finalize_all_reduce_probed = False
+
+
+def _fused_finalize_all_reduce_comm_world_size() -> Optional[int]:
+    """Register the TP group's CustomAllReduceV2 push plane with the fused
+    kernel once; None when the TP group has no usable v2 communicator."""
+    global _fused_finalize_all_reduce_world_size, _fused_finalize_all_reduce_probed
+    if not _fused_finalize_all_reduce_probed:
+        _fused_finalize_all_reduce_probed = True
+        from sglang.kernels.ops.communication import all_reduce_fusion
+        from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
+            CustomAllReduceV2,
+        )
+
+        ca_comm = get_tp_group().ca_comm
+        if isinstance(ca_comm, CustomAllReduceV2) and not ca_comm.disabled:
+            all_reduce_fusion.register_comm(ca_comm.obj)
+            _fused_finalize_all_reduce_world_size = ca_comm.world_size
+        else:
+            log_info_on_rank0(
+                logger,
+                "Fused MoE finalize: TP group has no "
+                "CustomAllReduceV2 push plane; keeping the unfused finalize path",
+            )
+    return _fused_finalize_all_reduce_world_size
+
+
+def should_use_fuse_finalize_all_reduce(
+    experts, num_tokens: int, hidden_dim: int
+) -> bool:
+    """Whether ``moe_finalize_all_reduce`` can replace finalize + shared add +
+    TP all-reduce for this layer and batch.
+
+    Capability only, no routing policy (the batch-size cap lives at the call
+    site): this MXFP4 TRT-LLM method (its deferred-finalize
+    ABI, expert weights already carrying the routed scaling factor -- the
+    kernel never rescales), a hidden width the kernel has a geometry for, a
+    CustomAllReduceV2 push plane on the TP group, and a batch that fits one of
+    its push slots.
+    """
+    if not isinstance(experts.quant_method, Mxfp4FlashinferTrtllmMoEMethod):
+        return False
+    if experts.quant_method.flashinfer_mxfp4_moe_precision != "default":
+        return False
+    if not experts.should_fuse_routed_scaling_factor_in_topk:
+        return False
+    if num_tokens <= 0:
+        return False
+    from sglang.kernels.ops.communication import all_reduce_fusion
+
+    if not all_reduce_fusion.valid_cluster_sizes(hidden_dim):
+        return False
+    tp_group = get_tp_group()
+    if _fused_finalize_all_reduce_comm_world_size() != tp_group.world_size:
+        return False
+    # one push phase counter per row (the plane has num_sm of them)
+    if num_tokens > tp_group.ca_comm.config.num_push_blocks:
+        return False
+    return all_reduce_fusion.fits_push_slot(
+        tp_group.ca_comm.max_push_size, num_tokens, hidden_dim
+    )

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -389,7 +389,6 @@ class Mxfp4FlashinferTrtllmMoEMethod:
 
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
             _get_packed_topk_ids_for_flashinfer_routed,
-            trtllm_moe_enable_pdl,
         )
 
         # The sqrtsoftplus router emits the packed ids in its own launch

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager, nullcontext
+from functools import cached_property
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -128,7 +129,11 @@ from sglang.srt.layers.quantization.fp8_utils import (
     view_aiter_fused_rms_transposed_fp8_scale,
 )
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
+    Mxfp4FlashinferTrtllmMoEMethod,
+    Mxfp8RoutedInputPreQuant,
     maybe_fuse_routed_scale_and_shared_add,
+    routed_hidden_size,
+    should_use_fuse_finalize_all_reduce,
 )
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -568,6 +573,14 @@ class MoEGate(nn.Module):
         return logits
 
 
+# Fused finalize + shared add + TP all-reduce:
+# batch cap for routing onto the fused kernel. It stages the whole [T, hidden]
+# row view through one CustomAllReduceV2 push slot; 96 rows of 5120 bf16 fill
+# the 1 MiB slot the plane allocates, and larger batches keep the unfused
+# finalize + all-reduce chain (the slot fit itself is re-checked in the gate).
+_FUSED_FINALIZE_ALL_REDUCE_MAX_TOKENS = 96
+
+
 class DeepseekV2MoE(nn.Module):
     def __init__(
         self,
@@ -576,6 +589,7 @@ class DeepseekV2MoE(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
+        routed_quant_stream: Optional[torch.cuda.Stream] = None,
         is_nextn: bool = False,
         is_deepseek_v4: bool = False,
         dsa_enable_prefill_cp: bool = False,
@@ -617,7 +631,11 @@ class DeepseekV2MoE(nn.Module):
         self.config = config
         self.layer_id = layer_id
         self.alt_stream = alt_stream
+        self.routed_quant_stream = routed_quant_stream
         self.is_nextn = is_nextn
+        self._fuse_finalize_all_reduce = (
+            is_deepseek_v4 and get_platform().is_blackwell and self.tp_size == 4
+        )
 
         n_hash_layers = getattr(config, "num_hash_layers", 0)
         self.is_hash = layer_id < n_hash_layers and not (is_deepseek_v4 and is_nextn)
@@ -973,7 +991,8 @@ class DeepseekV2MoE(nn.Module):
         # - no stream explosion: main (routed) issued before alt block -> capture reuses 1 alt stream;
         # - PDL overlap: routed is the last main-stream kernel (fuses w/ residual add);
         # - dispose_tensor: disabled during capture (CaptureFlags.disable_dispose_tensor) so the routed
-        #   deep_gemm does not free hidden_states, which the shared expert reads on the alt stream.
+        #   deep_gemm does not free hidden_states, which the shared expert reads on the alt stream
+        #   (and the routed-input pre-quant reads on its own stream).
         use_flashinfer_trtllm_bypass = get_forward().flashinfer_trtllm_bypass
         current_stream = torch.cuda.current_stream()
         # Quantize-once (SGLANG_OPT_MOE_QUANT_ONCE) must happen on the main
@@ -984,6 +1003,13 @@ class DeepseekV2MoE(nn.Module):
             else self._maybe_quant_moe_input_once(hidden_states)
         )
         self.alt_stream.wait_stream(current_stream)
+        should_quant_routed_input_mxfp8 = (
+            not use_flashinfer_trtllm_bypass
+            and pre_quant_input is None
+            and self._should_quant_routed_input_mxfp8(hidden_states)
+        )
+        if should_quant_routed_input_mxfp8:
+            self.routed_quant_stream.wait_stream(current_stream)
         has_shared_output = (
             hidden_states.shape[0] > 0 and self.num_fused_shared_experts == 0
         )
@@ -992,8 +1018,22 @@ class DeepseekV2MoE(nn.Module):
             if get_exec().moe.enable_eplb and not self.is_nextn
             else None
         )
+
         # router_logits: (num_tokens, n_experts)
         router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+        # What the routed experts receive as their pre-quantized input: the
+        # quant-once fp8 pair when that is on (also fed to the shared expert),
+        # otherwise the MXFP8 pre-quant issued on routed_quant_stream, whose
+        # layout the shared expert cannot take, or None.
+        routed_pre_quant_input = pre_quant_input
+        if should_quant_routed_input_mxfp8:
+            with torch.cuda.stream(self.routed_quant_stream):
+                x_q, x_sf = self.experts.quant_method.quantize_routed_input(
+                    hidden_states, routed_hidden_size(self.experts)
+                )
+                ready = self.routed_quant_stream.record_event()
+            routed_pre_quant_input = Mxfp8RoutedInputPreQuant(x_q, x_sf, ready)
+
         if use_flashinfer_trtllm_bypass:
             topk_output = BypassedTopKOutput(
                 hidden_states=hidden_states,
@@ -1021,24 +1061,37 @@ class DeepseekV2MoE(nn.Module):
                     expert_location_dispatch_info=dispatch_info,
                     **topk_kwargs,
                 )
-        deferred_finalize = (
+        # The mHC post-split consumes the reduced row without an RMSNorm.
+        use_fused_finalize_all_reduce = (
+            self._fuse_finalize_all_reduce
+            and has_shared_output
+            and hidden_states.shape[-1] == 5120
+            and not self._shared_expert_tp1
+            and self.tp_size > 1
+            and hidden_states.shape[0] <= _FUSED_FINALIZE_ALL_REDUCE_MAX_TOKENS
+            and not should_skip_post_experts_all_reduce(is_tp_path=True)
+            and should_use_fuse_finalize_all_reduce(
+                self.experts, hidden_states.shape[0], hidden_states.shape[-1]
+            )
+        )
+        deferred_finalize = use_fused_finalize_all_reduce or (
             has_shared_output
             and not self._shared_expert_tp1
             and topk_output.format == TopKOutputFormat.BYPASSED
             and self.experts.supports_deferred_finalize
         )
         if deferred_finalize:
+            # carries the routed pre-quant: the apply joins routed_quant_stream on
+            # its event, which the CUDA-graph capture requires
             final_hidden_states = self.experts.forward_deferred_finalize(
-                hidden_states, topk_output
+                hidden_states, topk_output, pre_quant_input=routed_pre_quant_input
             )
         elif use_flashinfer_trtllm_bypass:
             final_hidden_states = self.experts.forward_impl(hidden_states, topk_output)
-        elif pre_quant_input is not None:
-            final_hidden_states = self.experts(
-                hidden_states, topk_output, pre_quant_input=pre_quant_input
-            )
         else:
-            final_hidden_states = self.experts(hidden_states, topk_output)
+            final_hidden_states = self.experts(
+                hidden_states, topk_output, pre_quant_input=routed_pre_quant_input
+            )
         if (
             not _is_cuda
             and not _is_musa
@@ -1048,6 +1101,7 @@ class DeepseekV2MoE(nn.Module):
             final_hidden_states *= self.routed_scaling_factor
 
         # Shared expert on alt stream, issued AFTER the main (routed) branch. See note above.
+        # Only the quant-once fp8 pair is shared with it; the routed MXFP8 pre-quant is not.
         with torch.cuda.stream(self.alt_stream):
             shared_output = self._forward_shared_experts(
                 hidden_states,
@@ -1055,17 +1109,42 @@ class DeepseekV2MoE(nn.Module):
                 pre_quant_input=pre_quant_input,
             )
 
+        # Joins the shared expert; the routed-input pre-quant on its own stream
+        # was already joined by the event wait inside the routed MoE apply.
         current_stream.wait_stream(self.alt_stream)
 
+        all_reduce_done = False
         if deferred_finalize:
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
                 finalize_flashinfer_trtllm_deferred_output,
             )
 
-            final_hidden_states = finalize_flashinfer_trtllm_deferred_output(
-                final_hidden_states,
-                shared_output,
-            )
+            deferred = final_hidden_states
+            if (
+                use_fused_finalize_all_reduce
+                and deferred.gemm2_out.shape[1] == hidden_states.shape[-1]
+            ):
+                from sglang.kernels.ops.communication.all_reduce_fusion import (
+                    moe_finalize_all_reduce,
+                )
+
+                final_hidden_states = moe_finalize_all_reduce(
+                    deferred.gemm2_out,
+                    deferred.expanded_idx_to_permuted_idx,
+                    deferred.expert_weights,
+                    deferred.top_k,
+                    shared_output,
+                    world_size=self.tp_size,
+                    hidden_dim=hidden_states.shape[-1],
+                    # Routing metadata must be ready before it is consumed.
+                    prefetch_metadata=False,
+                )
+                all_reduce_done = True
+            else:
+                final_hidden_states = finalize_flashinfer_trtllm_deferred_output(
+                    deferred,
+                    shared_output,
+                )
         else:
             final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
                 self.experts,
@@ -1074,8 +1153,10 @@ class DeepseekV2MoE(nn.Module):
                 self.routed_scaling_factor,
             )
 
-        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
-            is_tp_path=True,
+        if (
+            self.tp_size > 1
+            and not all_reduce_done
+            and not should_skip_post_experts_all_reduce(is_tp_path=True)
         ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         # TP1 shared experts are replicated, so add them after all-reduce to
@@ -1652,6 +1733,59 @@ class DeepseekV2MoE(nn.Module):
 
         q, s = sglang_per_token_group_quant_fp8_row_padded(hidden_states, 128)
         return q, s
+
+    @cached_property
+    def _routed_mxfp8_prequant_static_enabled(self) -> bool:
+        """Whether forward_normal_dual_stream may quantize the routed MoE input
+        (MXFP8, linear scale layout) on ``routed_quant_stream`` ahead of
+        Mxfp4FlashinferTrtllmMoEMethod.apply instead of inline on the main
+        stream. Cached per layer; see _compute_routed_mxfp8_prequant_enabled."""
+        return self._compute_routed_mxfp8_prequant_enabled()[0]
+
+    def _compute_routed_mxfp8_prequant_enabled(self) -> Tuple[bool, str]:
+        """Returns (eligible, reason); reason names the first failing check."""
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+
+        if not _is_cuda:
+            return False, "not CUDA"
+        if self.routed_quant_stream is None:
+            return False, "no routed_quant_stream"
+        if self._enable_a2a_moe or self._fuse_shared_experts_inside_sbo:
+            return False, "a2a MoE or SBO shared-expert fusion"
+        if not get_moe_runner_backend().is_flashinfer_mxfp4():
+            return False, "MoE runner backend not flashinfer_mxfp4"
+        experts = self.experts
+        if not isinstance(experts, FusedMoE):
+            return False, "experts not FusedMoE"
+        quant_method = experts.quant_method
+        if not isinstance(quant_method, Mxfp4FlashinferTrtllmMoEMethod):
+            return False, "experts quant method not Mxfp4FlashinferTrtllmMoEMethod"
+        if quant_method.flashinfer_mxfp4_moe_precision != "default":
+            return False, "flashinfer_mxfp4_moe_precision not default (no MXFP8 quant)"
+        # The pre-quant must describe exactly the tensor apply() receives: the
+        # standard dispatcher passes hidden_states through unchanged (the mxfp4
+        # backend keeps global expert ids), the fp4 all-gather does not.
+        if not isinstance(experts.dispatcher, StandardDispatcher):
+            return False, "dispatcher not StandardDispatcher"
+        if should_use_flashinfer_cutlass_moe_fp4_allgather():
+            return False, "flashinfer cutlass fp4 all-gather dispatch"
+        return True, "ok"
+
+    def _should_quant_routed_input_mxfp8(self, hidden_states: torch.Tensor) -> bool:
+        """Per-call gate for the routed-input pre-quant on ``routed_quant_stream``:
+        only while the current stream is being captured (this path is
+        capture-only; the graph then replays the side-stream quant and its event
+        join, and the tensors come from the graph pool, so no ``record_stream``
+        is needed), never inside a piecewise TC graph (its MoE op drops
+        ``pre_quant_input``), and only for a non-empty bf16 batch on a layer the
+        static check admits."""
+        return (
+            torch.cuda.is_current_stream_capturing()
+            and not is_in_tc_piecewise_cuda_graph()
+            and hidden_states.shape[0] > 0
+            and hidden_states.dtype == torch.bfloat16
+            and self._routed_mxfp8_prequant_static_enabled
+        )
 
     def op_gate(self, state):
         if state.hidden_states_mlp_input.shape[0] > 0:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -575,7 +575,7 @@ class MoEGate(nn.Module):
 
 # Fused finalize + shared add + TP all-reduce:
 # batch cap for routing onto the fused kernel. It stages the whole [T, hidden]
-# row view through one CustomAllReduceV2 push slot; 96 rows of 5120 bf16 fill
+# row view through one CustomAllReduceV2 push slot; 96 rows of 5120 bf16 fit
 # the 1 MiB slot the plane allocates, and larger batches keep the unfused
 # finalize + all-reduce chain (the slot fit itself is re-checked in the gate).
 _FUSED_FINALIZE_ALL_REDUCE_MAX_TOKENS = 96

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -454,26 +454,51 @@ if _is_hip:
 
 
 def _apply_wo_a_bf16_matmul(
-    o: torch.Tensor, wo_a: torch.Tensor, is_decode: bool
+    o: torch.Tensor, wo_a: torch.Tensor, is_decode: bool, is_target_verify: bool = False
 ) -> torch.Tensor:
     """Compute bf16 wo_a: o [T, G, D] @ wo_a [G, R, D] -> [T, G, R].
 
-    Single-token Blackwell decode uses a GEMV for the validated TP4 shape.
-    ROCm decode can use aiter batched GEMM; its first runtime failure disables
-    that path for the process. Other cases use torch.einsum.
+    Single-token decode uses a GEMV for the validated TP4 shape. Blackwell
+    verify batches up to 384 rows write token-major output directly to avoid
+    the layout copy before wo_b. ROCm decode can use aiter batched GEMM;
+    other cases use torch.einsum.
     """
     global _wo_a_aiter_batched_gemm_disabled
     if (
-        is_decode
-        and _is_cuda
-        and (get_platform().is_blackwell or get_platform().is_sm90)
-        and o.shape == (1, 2, 4096)
+        _is_cuda
+        and (
+            (
+                is_decode
+                and o.shape[0] == 1
+                and (get_platform().is_blackwell or get_platform().is_sm90)
+            )
+            or (
+                is_target_verify
+                and 0 < o.shape[0] <= 384
+                and get_platform().is_blackwell
+            )
+        )
+        and o.shape[1:] == (2, 4096)
         and wo_a.shape == (2, 1024, 4096)
         and o.dtype == wo_a.dtype == torch.bfloat16
-        and o.is_contiguous()
+        and o.stride(2) == 1
+        and o.stride(1) == 4096
+        and o.stride(0) >= 8192
         and wo_a.is_contiguous()
     ):
-        return wo_a_bf16_gemv(o, wo_a)
+        if is_decode and o.shape[0] == 1:
+            return wo_a_bf16_gemv(o, wo_a)
+        result = torch.empty(
+            (o.shape[0], wo_a.shape[0], wo_a.shape[1]), dtype=o.dtype, device=o.device
+        )
+        # cuBLAS accepts the strided destination, preserving the einsum
+        # reduction while producing the contiguous layout consumed by wo_b.
+        # Draft warmup/capture can enter with grad tracking enabled.
+        with torch.no_grad():
+            torch.bmm(
+                o.transpose(0, 1), wo_a.transpose(1, 2), out=result.transpose(0, 1)
+            )
+        return result
     if (
         is_decode
         and _wo_a_aiter_batched_gemm_enabled
@@ -1498,7 +1523,15 @@ class MQALayer(MqaAttentionBase):
             and self.compress_ratio in (1, 2)
             and self.alt_streams is not None
             and (self.compressor is not None or self.indexer is not None)
-            and forward_batch.forward_mode.is_decode()
+            and (
+                forward_batch.forward_mode.is_decode()
+                or (
+                    forward_batch.forward_mode.is_target_verify()
+                    # Other MXFP8 backends may share mutable GEMM workspace.
+                    and getattr(self.wq_b.quant_method, "mxfp8_dense_backend", None)
+                    == Mxfp8DenseGemmBackend.FLASHINFER_CUTEDSL
+                )
+            )
         )
         src_stream = None
         if early_sources:
@@ -2065,7 +2098,10 @@ class MQALayer(MqaAttentionBase):
                 if wo_a_weight is not None:
                     wo_a = wo_a_weight.view(self.n_local_groups, self.o_lora_rank, -1)
                     o = _apply_wo_a_bf16_matmul(
-                        o, wo_a, is_decode=forward_batch.forward_mode.is_decode()
+                        o,
+                        wo_a,
+                        is_decode=forward_batch.forward_mode.is_decode(),
+                        is_target_verify=forward_batch.forward_mode.is_target_verify(),
                     )
                 else:
                     o = _apply_gguf_grouped_wo_a(
@@ -2125,6 +2161,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         compress_ratio_override: Optional[int] = None,
         engram_layout: Optional[EngramLayout] = None,
         hc_stats_stream: Optional[torch.cuda.Stream] = None,
+        moe_routed_quant_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
         self.hc_stats_stream = hc_stats_stream
@@ -2157,6 +2194,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=add_prefix("mlp", prefix),
             layer_id=self.layer_id,
             alt_stream=moe_alt_stream,
+            routed_quant_stream=moe_routed_quant_stream,
             is_nextn=is_nextn,
             is_deepseek_v4=True,
         )
@@ -2412,7 +2450,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             and self.hc_pre_from_prev_sublayer
             and self.hc_mult == 4
             and x.shape[1] == 5120
-            and x.shape[0] <= 64
+            and x.shape[0] <= 384
             and x.dtype == residual.dtype == torch.bfloat16
             and post.dtype == comb.dtype == torch.float32
             and all(t.is_contiguous() for t in (x, residual, post, comb))
@@ -2731,6 +2769,22 @@ class DeepseekV4DecoderLayer(nn.Module):
             y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
         return y, pre.squeeze(1), post.squeeze(1), comb.squeeze(1)
 
+    def _get_hc_stats_stream(self, hidden_states, forward_batch):
+        # Verify batches can also compute coefficients beside the
+        # sublayer; each branch joins before hc_post reads those coefficients.
+        return (
+            self.hc_stats_stream
+            if (
+                forward_batch.forward_mode.is_decode()
+                or (
+                    forward_batch.forward_mode.is_target_verify()
+                    and hidden_states.shape[0] > 0
+                )
+            )
+            and (not get_platform().is_sm90 or hidden_states.shape[0] == 1)
+            else None
+        )
+
     def forward_hc_pre_from_prev(
         self,
         positions: torch.Tensor,
@@ -2742,12 +2796,7 @@ class DeepseekV4DecoderLayer(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Layer forward where attention consumes the previous FFN's pre-mix and
         the FFN consumes this attention's. Returns (hidden_states, ffn_pre)."""
-        stats_stream = (
-            self.hc_stats_stream
-            if forward_batch.forward_mode.is_decode()
-            and (not get_platform().is_sm90 or hidden_states.shape[0] == 1)
-            else None
-        )
+        stats_stream = self._get_hc_stats_stream(hidden_states, forward_batch)
         residual = hidden_states
         x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
             hidden_states,
@@ -3334,6 +3383,14 @@ class DeepseekV4Model(nn.Module):
             if use_stream_pool
             else None
         )
+        # One stream for every layer's routed-MoE input pre-quant, separate from
+        # the attention/indexer streams and the shared expert's; each layer joins
+        # it (event wait) before its routed MoE op.
+        self.moe_routed_quant_stream = (
+            device_module.Stream()
+            if _is_cuda and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
+            else None
+        )
         # One shared stream for all layers, separate from attention/indexer and
         # shared-expert streams. Every sublayer joins before reusing its residual.
         self.hc_stats_stream = (
@@ -3355,6 +3412,7 @@ class DeepseekV4Model(nn.Module):
                 alt_streams=self.alt_streams,
                 engram_layout=self.engram_layout,
                 hc_stats_stream=self.hc_stats_stream,
+                moe_routed_quant_stream=self.moe_routed_quant_stream,
             ),
             pp_rank=self.pp_group.rank_in_group,
             pp_size=self.pp_group.world_size,

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -40,6 +40,7 @@ from sglang.srt.models.deepseek_v4 import (
     DeepseekV4DecoderLayer,
     DeepseekV4ForCausalLM,
     MqaAttentionBase,
+    _apply_wo_a_bf16_matmul,
     _dequant_fp8_wo_a_streaming,
     hc_head_torch,
     make_hc_head_params,
@@ -253,7 +254,6 @@ class DSparkAttention(MqaAttentionBase):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-
         if _is_npu and forward_batch.forward_mode.is_idle():
             return torch.zeros_like(hidden_states)
 
@@ -353,7 +353,12 @@ class DSparkAttention(MqaAttentionBase):
         )
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         if self._use_fast_kernel:
-            o = torch.einsum("bgd,grd->bgr", o, wo_a)
+            o = _apply_wo_a_bf16_matmul(
+                o,
+                wo_a,
+                is_decode=forward_batch.forward_mode.is_decode(),
+                is_target_verify=forward_batch.forward_mode.is_target_verify(),
+            )
         else:
             o = torch.einsum("bgd,grd->bgr", o.float(), wo_a.float()).to(q.dtype)
         out, _ = self.wo_b(o.reshape(o.shape[0], o.shape[1] * o.shape[2]))
@@ -572,6 +577,8 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         alt_streams: Optional[List[torch.cuda.Stream]] = None,
+        hc_stats_stream: Optional[torch.cuda.Stream] = None,
+        moe_routed_quant_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__(
             config=_dspark_stage_config(config),
@@ -580,6 +587,8 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             prefix=prefix,
             is_nextn=True,
             alt_streams=alt_streams,
+            hc_stats_stream=hc_stats_stream,
+            moe_routed_quant_stream=moe_routed_quant_stream,
         )
         self.stage_id = stage_id
         self.dim = config.hidden_size
@@ -685,6 +694,7 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         forward_batch: ForwardBatch,
         prev_pre: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        stats_stream = self._get_hc_stats_stream(hidden_states, forward_batch)
         residual = hidden_states
         x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
             hidden_states,
@@ -692,10 +702,13 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_attn_scale,
             self.hc_attn_base,
             apply_pre=prev_pre,
+            stats_stream=stats_stream,
         )
         x = self.input_layernorm(x)
         with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
             x = self.self_attn(positions, x, forward_batch)
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
         hidden_states = self.hc_post(x, residual, attn_post, attn_comb)
 
         residual = hidden_states
@@ -705,9 +718,12 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_ffn_scale,
             self.hc_ffn_base,
             apply_pre=attn_pre,
+            stats_stream=stats_stream,
         )
         x = self.post_attention_layernorm(x)
         x = self._run_ffn(x, forward_batch)
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
         hidden_states = self.hc_post(x, residual, ffn_post, ffn_comb)
         return hidden_states, ffn_pre
 
@@ -797,6 +813,19 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.alt_streams: Optional[List[torch.cuda.Stream]] = (
             [torch.cuda.Stream()] if use_multi_stream else None
         )
+        self.moe_routed_quant_stream = (
+            torch.cuda.Stream()
+            if use_multi_stream and torch.version.cuda is not None
+            else None
+        )
+        self.hc_stats_stream = (
+            torch.cuda.Stream()
+            if use_multi_stream
+            and torch.version.cuda is not None
+            and get_platform().is_blackwell
+            and getattr(config, "hc_pre_from_prev_sublayer", False)
+            else None
+        )
         self.stages = nn.ModuleList(
             [
                 DSparkV4Stage(
@@ -808,6 +837,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
                     quant_config=quant_config,
                     prefix=add_prefix(f"stages.{stage_id}", prefix),
                     alt_streams=self.alt_streams,
+                    hc_stats_stream=self.hc_stats_stream,
+                    moe_routed_quant_stream=self.moe_routed_quant_stream,
                 )
                 for stage_id in range(self.num_stages)
             ]


### PR DESCRIPTION
## Motivation

DSpark target verification and draft steps miss several decode fast paths. MoE routing, input quantization, and finalize also leave work on the critical path. This carries the compatible kernel changes onto `dsv4.1`.

## Modifications

- Use mHC statistics overlap in target verify and all three draft stages, and widen the validated verify shapes.
- Write WO-A output directly in token-major layout and fuse index candidate masking.
- Produce padded, packed router outputs and run routed-input MXFP8 quantization on a separate stream.
- Fuse deferred MoE finalize, shared-expert addition, and custom push all-reduce for supported small TP4 batches. Preserve the BF16 rounding points and synchronize phase-counter reuse.
- Prefer custom all-reduce for the supported single-node Blackwell V4.1 configuration. Other configurations retain their defaults and fallbacks. No new environment flags.

The updated public top-k implementation is retained. This PR contains production changes only; standalone validation harnesses are kept outside the source diff.

Co-authored with @DarkSharpness (Ziyi Xu), who contributed the MoE router and input prequantization, finalize/shared-add/all-reduce fusion, and custom all-reduce backend selection.

## Speed Tests

Base: public `dsv4.1` at `7bdebdab7db4befb71c64ae0d6f0eb37fe7d8402`. Candidate: `1b742acd2a49ebd7acd017032875552099d12391`.

4x B300 SXM6 AC, TP4/EP4, PyTorch 2.13.0+cu130, FlashInfer 0.6.18, Triton 3.7.1, `sglang-kernel==0.4.6.post1`, `sgl-deep-gemm==0.1.7`, CUTLASS DSL 4.6.2, nvcc 13.0.88, driver 580.126.20. DSpark block size 5 with real acceptance. Both arms use the same checkpoint, package environment, fixed KV pool sizes, and hashed input IDs.

Two independent server launches per arm, with one warmup and three measured repetitions each. Order: baseline A, candidate A, candidate B, baseline B. Medians below use all six measured repetitions.

| Workload | Baseline | Candidate | Change |
|---|---:|---:|---:|
| BS1, input 4096/output 1024, post-first-event output tok/s | 569.88 | 764.29 | +34.1% |
| BS64, input 4096/output 2048, stable decode output tok/s | 6,555.95 | 13,472.51 | +105.5% |
| BS64, same workload, full batch output tok/s including prefill | 4,114.78 | 6,434.55 | +56.4% |

Median BS1 acceptance length: 5.658 → 5.818; BS64: 5.407 → 5.479. No simulated acceptance. BS1 acceptance/TPS cycle proxy: 9.897 → 7.603 ms. This proxy is separate from the GPU trace timings below.

BS64 decode samples require consecutive log intervals with exactly 64 running requests and CUDA graphs active, excluding intervals across prefill. The full-batch metric includes prefill and the draining tail. BS1 excludes the first SSE event and counts only the remaining output tokens. These metrics should not be compared interchangeably.

<details>
<summary>Per-server measurements</summary>

| Run | BS1 measured tok/s | BS64 decode tok/s | BS64 full-batch tok/s |
|---|---|---|---|
| base-a | 577.07, 570.83, 556.71 | 6491.16, 6577.62, 6534.28 | 4229.08, 3910.66, 3969.39 |
| candidate-a | 766.36, 763.00, 764.22 | 13771.38, 13120.99, 13846.63 | 6634.80, 6262.78, 6643.85 |
| candidate-b | 754.66, 764.37, 766.16 | 12872.41, 13572.70, 13372.32 | 5847.66, 6405.10, 6464.00 |
| base-b | 558.82, 585.27, 568.93 | 6501.85, 6849.70, 6691.80 | 4000.47, 4540.29, 4276.04 |

</details>

## Accuracy Tests

| Test | Baseline | Candidate | Budget truncations (base/candidate) |
|---|---:|---:|---:|
| GSM8K, serial 100 | 97/100 (97.00%) | 98/100 (98.00%) | 0/0 |
| GSM8K, five-shot held-out 1314, concurrency 64 | 1268/1314 (96.50%) | 1266/1314 (96.35%) | 0/0 |
| AIME 2026, serial 30, temperature 0 | 25/30 (83.33%) | 25/30 (83.33%) | 4/5 |
| AIME 2026, 30 questions × 16 samples, concurrency 64, temperature 1 | 446/480 (92.92%) | 451/480 (93.96%) | 13/18 |

All requested samples completed with zero request errors. GSM8K has no empty or truncated responses. AIME budget truncations are counted in the score, not dropped. The repeated AIME score is correct samples / 480, not pass@16.

GSM8K has 14 correct-to-incorrect and 12 incorrect-to-correct changes under the unchanged prompt and scorer. Generated text is not bitwise identical. These results and the kernel checks do not establish exact model equivalence for every input.

GSM8K uses the first five test rows as demonstrations and excludes them from evaluation. AIME uses `sgl-eval==0.1.0`, the bundled MathArena prompt and NeMo-Skills revision `645cf567ff08c0ae9cc3fc8e1edbb975b3067816`, thinking mode, top-p 0.95, and max tokens 65,536. Serial AIME uses seed 0; repeated AIME leaves the request seed unset.

## Kernel validation and profiling

- 60 kernel/integration tests and 224 subtests passed.
- Four-GPU all-reduce/finalize suites: 99 + 61 cases passed, including graph replay, mixed token counts, independent unfused/FP32 references, and delayed-reader phase-counter probes.
- Coverage includes router packing/padding, routed-input quantization events, WO-A layout, mHC target/draft overlap, source-stream dependency guards, candidate masking, and verify compressor state/cache writes.
- Repository pre-commit hooks and public lint passed.

GPU-only TP0 traces, BS1 with 4096 input tokens, 20 target graph replays and 20 draft graph replays per arm. Each draft graph contains the three draft stages. Trace timings are reported separately from unprofiled serving throughput.

| GPU timeline metric | Baseline | Candidate |
|---|---:|---:|
| Target verify graph median | 9.049 ms | 6.927 ms |
| Draft graph median | 0.833 ms | 0.719 ms |
| Median target-start to next target-start | 10.050 ms | 7.810 ms |
| Target kernels per graph | 2209 | 1965 |
| Draft kernels per graph | 196 | 181 |

The following launch counts cover the complete 20-cycle trace:

| Kernel path | Baseline launches | Candidate launches |
|---|---:|---:|
| Separate router padding mask | 860 | 0 |
| Separate router ID packing | 860 | 0 |
| Standalone MoE finalize | 860 | 0 |
| Fused MoE finalize + shared add + all-reduce | 0 | 860 |
| FlashInfer oneshot all-reduce | 1760 | 0 |
| Custom push all-reduce | 40 | 940 |

mHC statistics overlap with other kernel families on different CUDA streams increases from 0.18% to 93.50% of its kernel duration. This measures time overlap in the trace; it is not an occupancy metric or a guarantee that the overlapped work has zero cost. Graph spans above measure the net effect.


### Server command (both arms)

```bash
# Run from the corresponding SGLang checkout.
MODEL_PATH=/path/to/DeepSeek-V4.1
CUDA_VISIBLE_DEVICES=4,5,6,7 PYTHONPATH="$PWD/python" MAX_JOBS=16 \
python -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --tp 4 --ep-size 4 --trust-remote-code \
  --mem-fraction-static 0.80 --max-total-tokens 33554432 \
  --chunked-prefill-size 4096 \
  --cuda-graph-bs-decode 1 2 4 8 16 32 64 \
  --max-running-requests 128 \
  --speculative-algorithm DSPARK --speculative-dspark-block-size 5 \
  --skip-server-warmup --reasoning-parser deepseek-v41 \
  --random-seed 42 --decode-log-interval 10 \
  --host 127.0.0.1 --port 30021
```

After the server is ready, call `POST /freeze_gc`. Flush the request cache before each measured repetition. Both arms use the identical launch command; the runtime selects the compatible kernel paths.


<details>
<summary>Checkouts used for the comparison</summary>

From a clone of `sgl-project/sglang`:

```bash
git fetch origin dsv4.1
git fetch origin pull/38879/head:pr-38879-validation
git worktree add ../sglang-baseline-38879 7bdebdab7db4befb71c64ae0d6f0eb37fe7d8402
git worktree add ../sglang-candidate-38879 1b742acd2a49ebd7acd017032875552099d12391
```

Run each arm from its own worktree with the same installed dependency versions. Start with inherited `SGLANG_*` overrides removed; the measured controllers clear those variables. The same checkpoint directory is used for both arms.

</details>

<details>
<summary>Benchmark and GSM8K client commands and harnesses</summary>

Save the three Python blocks below beside `gsm8k-test.jsonl`. Set `MODEL_PATH` to the same checkpoint used by the server and `SERVER_LOG` to its log file. Keep the serving checkout first on `PYTHONPATH`; the preinstalled editable SGLang package is not the source under test. The benchmark scripts differ from the measured copies only in making the tokenizer path configurable.

```bash
export PYTHONPATH="$PWD/python"
python -c "import sglang; print(sglang.__file__)"
export MODEL_PATH=/path/to/DeepSeek-V4.1
SERVER_LOG=/path/to/server.log
mkdir -p results/bs1 results/bs64 results/gsm-serial100 results/gsm-full
curl -f -X POST http://127.0.0.1:30021/freeze_gc
python bench_bs1.py --out results/bs1 --server-log "$SERVER_LOG"
python bench_bs64.py --out results/bs64 --server-log "$SERVER_LOG"
curl -f -X POST 'http://127.0.0.1:30021/flush_cache?timeout=30'
python gsm_eval.py --out results/gsm-serial100 --count 100 --threads 1
curl -f -X POST 'http://127.0.0.1:30021/flush_cache?timeout=30'
python gsm_eval.py --out results/gsm-full --count 1314 --threads 64
```

GSM8K uses the public `openai/grade-school-math` `grade_school_math/data/test.jsonl` file, SHA256 `3730d312f6e3440559ace48831e51066acaca737f6eabec99bccb9e4b3c39d14`. The first five rows are demonstrations and are excluded from the 1,314 evaluated questions.

`bench_bs1.py`

```python
"""Fixed-input, real-acceptance BS1 measurements on the owned server only."""
import argparse
import os
import hashlib
import json
import re
import time
from pathlib import Path

import requests
from tokenizers import Tokenizer


def save(path, value):
    path.write_text(json.dumps(value, indent=2, ensure_ascii=False))


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--out', type=Path, required=True)
    parser.add_argument('--server-log', type=Path, required=True)
    parser.add_argument('--url', default='http://127.0.0.1:30021')
    parser.add_argument('--repeat', type=int, default=3)
    parser.add_argument('--profile', action='store_true')
    args = parser.parse_args()
    tok = Tokenizer.from_file(os.path.join(os.environ['MODEL_PATH'], 'tokenizer.json'))
    prefix = tok.encode('Read these notes and summarize them.\n', add_special_tokens=False).ids
    unit = tok.encode('The observatory records the temperature, wind, and rainfall each day. Researchers compare the measurements across seasons.\n', add_special_tokens=False).ids
    suffix = tok.encode('\nWrite a detailed summary of the notes above.\n', add_special_tokens=False).ids

    def post(route, body=None, timeout=1800):
        r = requests.post(args.url+route, json=body or {}, timeout=timeout)
        r.raise_for_status()
        return r

    def warm(ids, rate):
        # The final SSE response can precede scheduler request cleanup.
        # Use the server's bounded idle wait, outside the measured interval.
        post('/flush_cache?timeout=30', timeout=60)
        if rate:
            r = post('/generate', {'input_ids':ids[:int(len(ids)*rate)], 'sampling_params':{'temperature':0, 'max_new_tokens':1, 'ignore_eos':True}})
            assert r.json()['meta_info']['completion_tokens']==1

    results=[]
    for length, out_len, rate in ((4096,1024,0.),):
        n = length-len(prefix)-len(suffix)
        ids = prefix + (unit*((n+len(unit)-1)//len(unit)))[:n] + suffix
        assert len(ids)==length
        save(args.out/f'input-{length}.json',ids)
        input_hash=hashlib.sha256(json.dumps(ids).encode()).hexdigest()
        for rep in range(args.repeat+1):
            warm(ids,rate)
            log_offset=args.server_log.stat().st_size
            body={'input_ids':ids,'sampling_params':{'temperature':0,'max_new_tokens':out_len,'ignore_eos':True,'stream_interval':1},'stream':True}
            start=time.perf_counter();first=None;first_count=None;last=None
            with requests.post(args.url+'/generate',json=body,stream=True,timeout=(30,1800)) as r:
                r.raise_for_status()
                for line in r.iter_lines():
                    if not line.startswith(b'data: '):continue
                    raw=line[6:]
                    if raw==b'[DONE]':break
                    last=json.loads(raw)
                    if 'error' in last:raise RuntimeError(last)
                    count=last.get('meta_info',{}).get('completion_tokens',0)
                    if first is None and count>0:first=time.perf_counter();first_count=count
            end=time.perf_counter()
            assert last is not None and first is not None,last
            meta=last['meta_info']
            assert meta['completion_tokens']==out_len and meta['prompt_tokens']==length,meta
            # Required evidence of actual speculative execution and acceptance.
            assert meta.get('spec_verify_ct',0)>0 and meta.get('spec_accept_length',0)>0,meta
            with args.server_log.open() as f:f.seek(log_offset);log=f.read()
            samples=[float(v) for v in re.findall(r'gen throughput \(token/s\):\s*([0-9.]+)',log)]
            result=dict(input_tokens=length,output_tokens=out_len,requested_cache_hit_rate=rate,repeat=rep,warmup=(rep==0),input_sha256=input_hash,elapsed_s=end-start,ttft_s=first-start,first_stream_completion_tokens=first_count,post_first_event_tps=(out_len-first_count)/(end-first),full_request_tps=out_len/(end-start),decode_log_samples=samples,response=last)
            results.append(result);save(args.out/'performance.json',results)
            print('PERF',length,rep,result['post_first_event_tps'],'accept',meta['spec_accept_length'],'cached',meta.get('cached_tokens'),flush=True)

        if args.profile:
            for activities in (['GPU'],):
                if length==131072 and activities==['CPU','GPU']:continue
                warm(ids,rate)
                tag=f'{length}-'+('-'.join(activities)).lower()
                folder=args.out/('profile-'+tag);folder.mkdir()
                request=dict(output_dir=str(folder),num_steps=20,activities=activities,profile_by_stage=True,profile_stages=['decode'],with_stack=(activities==['CPU','GPU']),record_shapes=(activities==['CPU','GPU']),profile_id=args.out.name+'-'+tag)
                save(folder/'request.json',request)
                post('/start_profile',request,timeout=60)
                response=post('/generate',{'input_ids':ids,'sampling_params':{'temperature':0,'max_new_tokens':200,'ignore_eos':True}}).json()
                save(folder/'response.json',response)
                # At most six tokens per verify step: 200 output tokens
                # always cover the 20 requested decode steps. Export is automatic.
                traces=list(folder.rglob('*.trace.json*'))
                assert len(traces)>=4,(tag,'Missing TP traces',traces)
                save(folder/'trace-files.json',[str(p) for p in traces])
                print('PROFILE',tag,len(traces),flush=True)


if __name__=='__main__':
    main()
```

`bench_bs64.py`

```python
"""BS64 serving regression measurement; raw requests and log intervals retained."""
import argparse
import os
from concurrent.futures import ThreadPoolExecutor
import hashlib
import json
from pathlib import Path
import re
import statistics
import threading
import time
import urllib.request

from tokenizers import Tokenizer


def save(path, value):
    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + '\n')


def post(url, route, body=None):
    request = urllib.request.Request(url + route, data=json.dumps(body or {}).encode(),
                                     headers={'Content-Type': 'application/json'})
    with urllib.request.urlopen(request, timeout=1800) as response:
        if route.startswith(('/flush_cache', '/start_profile', '/stop_profile')):
            return response.read().decode()
        return json.load(response)


def decode_samples(log):
    rows = []
    previous_bs = None
    for line in log.replace('\r', '\n').splitlines():
        if 'Prefill batch' in line:
            previous_bs = None
        if 'Decode batch' not in line:
            continue
        bs = re.search(r'#running-req: (\d+)', line)
        tps = re.search(r'gen throughput \(token/s\): ([0-9.]+)', line)
        al = re.search(r'accept len: ([0-9.]+)', line)
        graph = re.search(r'(?:CUDA graph|cuda graph|cuda_graph|full graph): (True|False)', line)
        if not bs or not tps:
            continue
        batch = int(bs.group(1))
        rows.append(dict(batch_size=batch, tps=float(tps.group(1)),
                         accept_length=float(al.group(1)) if al else None,
                         graph=graph.group(1) == 'True' if graph else None,
                         eligible=(batch == 64 and previous_bs == 64), line=line))
        previous_bs = batch
    return rows


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--out', type=Path, required=True)
    parser.add_argument('--server-log', type=Path, required=True)
    parser.add_argument('--url', default='http://127.0.0.1:30021')
    parser.add_argument('--no-spec', action='store_true')
    args = parser.parse_args()
    tok = Tokenizer.from_file(os.path.join(os.environ['MODEL_PATH'], 'tokenizer.json'))
    unit = tok.encode('The observatory records the temperature, wind, and rainfall each day. Researchers compare the measurements across seasons.\n', add_special_tokens=False).ids
    suffix = tok.encode('\nWrite a detailed summary of the notes above.\n', add_special_tokens=False).ids
    inputs = []
    for i in range(64):
        prefix = tok.encode(f'Notebook {i:03d}. Read these notes and summarize them.\n', add_special_tokens=False).ids
        n = 4096 - len(prefix) - len(suffix)
        inputs.append(prefix + (unit * ((n + len(unit) - 1) // len(unit)))[:n] + suffix)
    assert len({tuple(ids) for ids in inputs}) == 64
    assert all(len(ids) == 4096 for ids in inputs)
    save(args.out/'inputs.json', inputs)
    input_hash = hashlib.sha256(json.dumps(inputs).encode()).hexdigest()
    waves = []
    for rep in range(4):
        warmup = rep == 0
        output_length = 256 if warmup else 2048
        post(args.url, '/flush_cache?timeout=30')
        offset = args.server_log.stat().st_size
        barrier = threading.Barrier(65)

        def request_one(i):
            body = {'input_ids': inputs[i], 'sampling_params': {
                'temperature': 0, 'max_new_tokens': output_length, 'ignore_eos': True}}
            barrier.wait()
            begin = time.perf_counter()
            response = post(args.url, '/generate', body)
            elapsed = time.perf_counter() - begin
            meta = response['meta_info']
            assert meta['completion_tokens'] == output_length, meta
            assert meta['prompt_tokens'] == 4096, meta
            if not args.no_spec:
                assert meta.get('spec_verify_ct', 0) > 0, meta
                assert meta.get('spec_accept_length', 0) > 0, meta
            return dict(index=i, elapsed_s=elapsed, response=response)

        with ThreadPoolExecutor(max_workers=64) as executor:
            futures = [executor.submit(request_one, i) for i in range(64)]
            start = time.perf_counter()
            barrier.wait()
            responses = [future.result() for future in futures]
            elapsed = time.perf_counter() - start
        save(args.out/f'wave-{rep}-responses.json', responses)
        # Drain scheduler request cleanup before the next cache flush.
        time.sleep(1)
        with args.server_log.open('rb') as log:
            log.seek(offset)
            text = log.read().decode(errors='replace')
        (args.out/f'wave-{rep}-server.log').write_text(text)
        rows = decode_samples(text)
        eligible = [row for row in rows if row['eligible']]
        if not warmup:
            assert len(eligible) >= 3, ('Insufficient actual BS64 intervals', rows)
            assert all(row['graph'] is True for row in eligible), eligible[:3]
        completed = sum(r['response']['meta_info']['completion_tokens'] for r in responses)
        verifies = sum(r['response']['meta_info'].get('spec_verify_ct', 0) for r in responses)
        wave = dict(repeat=rep, warmup=warmup, requests=64, input_tokens=4096,
                    output_tokens_per_request=output_length, input_sha256=input_hash,
                    elapsed_s=elapsed, aggregate_full_request_tps=completed/elapsed,
                    weighted_accept_length=completed/verifies if verifies else None,
                    bs64_decode_median_tps=statistics.median(row['tps'] for row in eligible) if eligible else None,
                    bs64_decode_intervals=len(eligible), decode_intervals=rows)
        waves.append(wave)
        save(args.out/'performance.json', waves)
        print('WAVE', rep, 'warmup', warmup, 'actual BS64 decode', wave['bs64_decode_median_tps'],
              'intervals', len(eligible), 'full-request', wave['aggregate_full_request_tps'],
              'AL', wave['weighted_accept_length'], flush=True)


if __name__ == '__main__':
    main()
```

`gsm_eval.py`

```python
"""Pinned legacy five-shot GSM8K prompts/scorer, with complete response/error records."""
import argparse,hashlib,json,time
from pathlib import Path
from concurrent.futures import ThreadPoolExecutor,as_completed
import requests
from sglang.test.simple_eval_mixed_prefix_gsm8k import get_few_shot_examples,get_one_example,get_answer_value

def main():
 p=argparse.ArgumentParser();p.add_argument('--out',type=Path,required=True);p.add_argument('--threads',type=int,required=True);p.add_argument('--count',type=int,default=1314);p.add_argument('--url',default='http://127.0.0.1:30021');a=p.parse_args()
 a.out.mkdir(exist_ok=True);data=Path(__file__).with_name('gsm8k-test.jsonl');rows=[json.loads(l) for l in data.read_text().splitlines()];assert len(rows)==1319
 prefix=get_few_shot_examples(rows,5);ids=list(range(5,min(1319,5+a.count)))
 models=requests.get(a.url+'/v1/models',timeout=30);models.raise_for_status();model=models.json()['data'][0]['id']
 def run(i):
  prompt=prefix+get_one_example(rows,i,False);start=time.perf_counter()
  rec=dict(index=i,prompt=prompt,prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),expected=get_answer_value(rows[i]['answer']))
  try:
   r=requests.post(a.url+'/v1/chat/completions',json=dict(model=model,messages=[dict(role='user',content=prompt)],temperature=0,top_p=1,max_tokens=4096,seed=0,return_meta_info=True),timeout=(30,1800));r.raise_for_status();j=r.json();rec['response']=j
   ch=j['choices'][0];content=ch['message'].get('content') or '';rec.update(answer=get_answer_value(content),correct=get_answer_value(content)==rec['expected'],truncated=ch['finish_reason']=='length',empty=not bool(content.strip()))
  except Exception as e:rec.update(error=repr(e),correct=False,truncated=False,empty=True)
  rec['elapsed_s']=time.perf_counter()-start;return rec
 results=[];begin=time.perf_counter()
 with (a.out/'samples.jsonl').open('w') as f,ThreadPoolExecutor(max_workers=a.threads) as pool:
  futures=[pool.submit(run,i) for i in ids]
  for future in as_completed(futures):
   r=future.result();results.append(r);f.write(json.dumps(r,ensure_ascii=False)+'\n');f.flush()
   if len(results)%25==0 or len(results)==len(ids):print('GSM',len(results),'/',len(ids),'correct',sum(x['correct'] for x in results),'errors',sum('error' in x for x in results),flush=True)
 summary=dict(count=len(results),correct=sum(r['correct'] for r in results),score=sum(r['correct'] for r in results)/len(results),errors=sum('error' in r for r in results),truncated=sum(r['truncated'] for r in results),empty=sum(r['empty'] for r in results),threads=a.threads,elapsed_s=time.perf_counter()-begin,dataset_sha256=hashlib.sha256(data.read_bytes()).hexdigest(),num_shots=5,held_out_indices=ids,temperature=0,top_p=1,seed=0,max_tokens=4096)
 (a.out/'summary.json').write_text(json.dumps(summary,indent=2));print(json.dumps(summary),flush=True)
 assert summary['errors']==0,summary
 assert summary['score']>=.9,summary
if __name__=='__main__':main()
```

</details>

<details>
<summary>AIME 2026 commands</summary>

The run uses `sgl-eval==0.1.0` with its bundled NeMo-Skills data/prompt (`645cf567ff08c0ae9cc3fc8e1edbb975b3067816`). The evaluator is installed outside the serving environment. Both arms use the same files and sampling settings.

```bash
# Run with the serving checkout on PYTHONPATH.
python -m pip install --target /tmp/sgl-eval-pinned --no-deps \
  sgl-eval==0.1.0 math-verify==0.9.0 latex2sympy2_extended==1.11.0 \
  antlr4-python3-runtime==4.9.3 editdistance==0.8.1
export PYTHONPATH="/tmp/sgl-eval-pinned:$PWD/python"
EVAL_DATA=/tmp/sgl-eval-pinned/sgl_eval/_vendored/nemo_skills/dataset/aime26/test.txt
EVAL_PROMPT=/tmp/sgl-eval-pinned/sgl_eval/_vendored/nemo_skills/prompts/matharena-aime.yaml
python -m sgl_eval.cli run aime26 \
  --base-url http://127.0.0.1:30021/v1 --model "$MODEL_PATH" \
  --from-dataset "$EVAL_DATA" --prompt "$EVAL_PROMPT" \
  --num-threads 1 --n-repeats 1 --thinking --reasoning-effort max \
  --temperature 0 --top-p 0.95 --max-tokens 65536 --seed 0 \
  --out-dir results/aime-serial30
python -m sgl_eval.cli run aime26 \
  --base-url http://127.0.0.1:30021/v1 --model "$MODEL_PATH" \
  --from-dataset "$EVAL_DATA" --prompt "$EVAL_PROMPT" \
  --num-threads 64 --n-repeats 16 --thinking --reasoning-effort max \
  --temperature 1 --top-p 0.95 --max-tokens 65536 \
  --out-dir results/aime-repeat16
```

The repeated lane leaves the request seed unset. Accuracy is the fraction of correct samples, not pass@16. Errors and token-budget truncations are counted separately.

</details>

## CI

GPU CI is blocked before tests by the global requirement to include `main` commit `3700c4ee26a1`, which also rejects this `dsv4.1`-based PR ([job log](https://github.com/sgl-project/sglang/actions/runs/34478244464/job/102874238483)). The B300 results above were collected directly against the stated base and candidate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34478244464](https://github.com/sgl-project/sglang/actions/runs/34478244464)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34478243976](https://github.com/sgl-project/sglang/actions/runs/34478243976)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34478244607](https://github.com/sgl-project/sglang/actions/runs/34478244607)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->



