### PR TITLE
[Simulator] Fix the benchmark runner's ServerArgs field dump

### DIFF
--- a/benchmark/simulator/bench_runner.py
+++ b/benchmark/simulator/bench_runner.py
@@ -4,9 +4,9 @@ import asyncio
 import atexit
 import json
 import os
-from dataclasses import asdict
 from typing import Iterator
 
+import msgspec
 import numpy as np
 from sglang_simulator.compat import apply_simulator_server_args
 from sglang_simulator.dataset import BaseDataset, GenericRequest
@@ -38,7 +38,7 @@ class SGLangBenchmarkRunner(BaseBenchmarkRunner):
 
     def __init__(self, server_args: ServerArgs):
         # Disable features that are unnecessary for simulation.
-        server_args_kwargs = asdict(server_args)
+        server_args_kwargs = msgspec.structs.asdict(server_args)
         apply_simulator_server_args(server_args_kwargs)
         self.engine = SGLangSimulationEngine(**server_args_kwargs)
         self.server_args = self.engine.server_args


### PR DESCRIPTION
#38753 made `ServerArgs` a `msgspec.Struct`, so `dataclasses.asdict` on one raises.

```
FAILED tools/sglang-simulator/test/test_simulation_sglang_runner.py::test_benchmark_sglang_runs_paged_decode
  benchmark/simulator/bench_runner.py:41: in __init__
    server_args_kwargs = asdict(server_args)
E TypeError: asdict() should be called on dataclass instances
```

After: `1 passed`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34476518724](https://github.com/sgl-project/sglang/actions/runs/34476518724)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34476518128](https://github.com/sgl-project/sglang/actions/runs/34476518128)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->