### PR TITLE
[RadixCache] Fuse unfinished insert and match

### DIFF
--- a/python/sglang/srt/mem_cache/cpp_radix_tree/radix_tree.py
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/radix_tree.py
@@ -101,6 +101,17 @@ if TYPE_CHECKING:
             """
             return self.tree.writing_through(key, indices)
 
+        def writing_through_and_match_prefix(
+            self, key: List[int], indices: torch.Tensor
+        ) -> Tuple[
+            List[Tuple[IOHandle, torch.Tensor, torch.Tensor]],
+            int,
+            List[torch.Tensor],
+            TreeNodeCpp,
+        ]:
+            """Insert a key and return its complete device match in one tree walk."""
+            return self.tree.writing_through_and_match_prefix(key, indices)
+
         def loading_onboard(
             self,
             host_node: TreeNodeCpp,

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
@@ -75,9 +75,7 @@ std::vector<at::Tensor> RadixTree::evict(std::size_t num_tokens) {
   return evicted_values;
 }
 
-std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t>
-RadixTree::writing_through(const token_vec_t& _key, at::Tensor value) {
-  if (m_impl->disabled) return {};
+RadixTree::WriteThroughState RadixTree::writing_through_impl(const token_vec_t& _key, at::Tensor value) {
   _assert(_key.size() == std::size_t(value.size(0)), "Key and value must have the same size");
 
   // just align the key to the page size, clip the unaligned tail
@@ -87,8 +85,9 @@ RadixTree::writing_through(const token_vec_t& _key, at::Tensor value) {
   const auto [host_node, host_prefix_length] = m_impl->tree_walk(key);
 
   // insert and create a new node if the remaining part of the key is not empty
+  auto last_node = host_node;
   if (host_prefix_length != key.size()) {
-    m_impl->create_device_node(
+    last_node = m_impl->create_device_node(
         host_node,
         {key.begin() + host_prefix_length, key.end()},
         value.slice(/*dim=*/0, host_prefix_length, key.size()));
@@ -97,11 +96,29 @@ RadixTree::writing_through(const token_vec_t& _key, at::Tensor value) {
   // add the hit count for the device node
   walk_to_root(host_node, [&](TreeNode* n) { n->hit_count++; });
 
-  std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>> result;
+  WriteThroughActions actions;
 
   // don't write through if hicache is disabled (no host memory), fast path
-  if (!m_impl->use_hicache) return {std::move(result), host_prefix_length};
+  if (!m_impl->use_hicache) return {std::move(actions), host_prefix_length, last_node};
   throw std::runtime_error("Not implemented yet");
+}
+
+std::tuple<WriteThroughActions, std::size_t> RadixTree::writing_through(const token_vec_t& key, at::Tensor value) {
+  if (m_impl->disabled) return {};
+  auto result = writing_through_impl(key, std::move(value));
+  return {std::move(result.actions), result.matched_length};
+}
+
+std::tuple<WriteThroughActions, std::size_t, std::vector<at::Tensor>, NodeHandle>
+RadixTree::writing_through_and_match_prefix(const token_vec_t& key, at::Tensor value) {
+  if (m_impl->disabled) return {};
+
+  auto result = writing_through_impl(key, std::move(value));
+  std::vector<at::Tensor> indices;
+  walk_to_root(result.last_node, [&](TreeNode* node) { indices.push_back(node->device_indices()); });
+  std::reverse(indices.begin(), indices.end());
+
+  return {std::move(result.actions), result.matched_length, std::move(indices), node2id(result.last_node)};
 }
 
 std::tuple<IOTicket, std::vector<at::Tensor>> RadixTree::loading_onboard(NodeHandle, at::Tensor) {

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
@@ -12,6 +12,10 @@
 
 namespace radix_tree_v2 {
 
+struct TreeNode;
+
+using WriteThroughActions = std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>;
+
 struct RadixTree {
  public:
   RadixTree(bool disabled, std::optional<std::size_t> host_size, std::size_t page_size, std::size_t threshold);
@@ -30,8 +34,11 @@ struct RadixTree {
   /// @brief (Un-)Lock a node.
   void lock_ref(NodeHandle node_id, bool increment /* increment or decrement */);
   /// @brief Update new key-value pair and try to perform write-through.
-  std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t>
-  writing_through(const token_vec_t& key, at::Tensor value);
+  std::tuple<WriteThroughActions, std::size_t> writing_through(const token_vec_t& key, at::Tensor value);
+  /// @brief Insert a key-value pair and return its complete device match without a second tree walk.
+  /// @return (pending writes, pre-existing prefix length, device indices, final device node).
+  std::tuple<WriteThroughActions, std::size_t, std::vector<at::Tensor>, NodeHandle>
+  writing_through_and_match_prefix(const token_vec_t& key, at::Tensor value);
   /// @brief Load to device from host within a range of nodes.
   std::tuple<IOTicket, std::vector<at::Tensor>> loading_onboard(NodeHandle host_id, at::Tensor indices);
   /// @brief Commit a transaction of write-through.
@@ -53,6 +60,13 @@ struct RadixTree {
 
  private:
   struct Impl;
+  struct WriteThroughState {
+    WriteThroughActions actions;
+    std::size_t matched_length;
+    TreeNode* last_node;
+  };
+
+  WriteThroughState writing_through_impl(const token_vec_t& key, at::Tensor value);
   std::unique_ptr<Impl> m_impl;
 };
 

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
@@ -24,6 +24,7 @@ PYBIND11_MODULE(radix_tree_cpp, m) {
       .def("protected_size", &RadixTree::protected_size)
       .def("total_size", &RadixTree::total_size)
       .def("writing_through", &RadixTree::writing_through)
+      .def("writing_through_and_match_prefix", &RadixTree::writing_through_and_match_prefix)
       .def("loading_onboard", &RadixTree::loading_onboard)
       .def("commit_writing_through", &RadixTree::commit_writing_through)
       .def("commit_loading_onboard", &RadixTree::commit_loading_onboard)

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -233,16 +233,17 @@ class RadixCacheCpp(BasePrefixCache):
         # NOTE: our C++ implementation don't need `token_ids` and `kv_indices` to be page-aligned
         # it will automatically align them, but length of them should be equal
         old_prefix_len = len(req.prefix_indices) // self.page_size * self.page_size
-        new_prefix_len = self._insert(RadixKey(token_ids, req.extra_key), kv_indices)
+        ongoing_write, new_prefix_len, new_indices_vec, new_last_node = (
+            self.tree.writing_through_and_match_prefix(token_ids, kv_indices)
+        )
+        assert self.cache_controller is None and len(ongoing_write) == 0, (
+            "Implementation error"
+        )
 
         # NOTE: kv_indices[:old_prefix_len] == req.prefix_indices
         assert old_prefix_len <= new_prefix_len, "Wrong prefix indices"
 
-        # TODO(dark): optimize the `insert` and `match` (e.g. merge into 1 function)
         # The prefix indices need to updated to reuse the kv indices in the pool
-        new_indices_vec, _, new_last_node, _ = self.tree.match_prefix(
-            RadixKey(token_ids, req.extra_key).token_ids
-        )
         new_indices = self._merge_tensor(new_indices_vec)
         assert new_prefix_len <= len(new_indices)
 

--- a/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
@@ -4,16 +4,21 @@ import importlib
 import sys
 import types
 import unittest
-from unittest.mock import patch
+from array import array
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
+import torch
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=11, suite="base-a-test-cpu")
+register_cpu_ci(est_time=60, suite="base-a-test-cpu")
 
 
-class TestRadixCacheCppCacheSalt(CustomTestCase):
-    def test_cache_salt_is_rejected_without_loading_cpp_extension(self):
+class TestRadixCacheCpp(CustomTestCase):
+    @contextmanager
+    def _import_with_fake_extension(self):
         extension_name = "sglang.srt.mem_cache.cpp_radix_tree.radix_tree"
         module_name = "sglang.srt.mem_cache.radix_cache_cpp"
         fake_extension = types.ModuleType(extension_name)
@@ -24,14 +29,153 @@ class TestRadixCacheCppCacheSalt(CustomTestCase):
         original_module = sys.modules.pop(module_name, None)
         try:
             with patch.dict(sys.modules, {extension_name: fake_extension}):
-                module = importlib.import_module(module_name)
-                module.RadixCacheCpp._reject_cache_salt(None)
-                with self.assertRaisesRegex(ValueError, "experimental C\\+\\+"):
-                    module.RadixCacheCpp._reject_cache_salt("tenant-a")
+                yield importlib.import_module(module_name)
         finally:
             sys.modules.pop(module_name, None)
             if original_module is not None:
                 sys.modules[module_name] = original_module
+
+    def test_cache_unfinished_req_uses_combined_insert_and_match(self):
+        with self._import_with_fake_extension() as module:
+            cache = module.RadixCacheCpp.__new__(module.RadixCacheCpp)
+            cache.cache_controller = None
+            cache.device = torch.device("cpu")
+            cache.page_size = 1
+            cache.tree = MagicMock()
+            old_node, new_node = 7, 9
+            cache.tree.writing_through_and_match_prefix.return_value = (
+                [],
+                2,
+                [torch.tensor([10, 11]), torch.tensor([12, 13])],
+                new_node,
+            )
+            cache.token_to_kv_pool_allocator = SimpleNamespace(free=MagicMock())
+            cache.req_to_token_pool = SimpleNamespace(
+                req_to_token=torch.tensor([[10, 101, 102, 103]])
+            )
+            req = SimpleNamespace(
+                cache_salt=None,
+                extra_key=None,
+                kv=SimpleNamespace(holds_kv=True, req_pool_idx=0),
+                get_fill_ids=MagicMock(return_value=array("q", [1, 2, 3, 4])),
+                prefix_indices=torch.tensor([10]),
+                last_node=old_node,
+            )
+
+            cache.cache_unfinished_req(req)
+
+            cache.tree.writing_through_and_match_prefix.assert_called_once()
+            key_arg, indices_arg = (
+                cache.tree.writing_through_and_match_prefix.call_args.args
+            )
+            self.assertEqual(key_arg, array("q", [1, 2, 3, 4]))
+            self.assertTrue(torch.equal(indices_arg, torch.tensor([10, 101, 102, 103])))
+            cache.tree.writing_through.assert_not_called()
+            cache.tree.match_prefix.assert_not_called()
+            self.assertEqual(
+                cache.tree.lock_ref.call_args_list,
+                [call(old_node, False), call(new_node, True)],
+            )
+            freed = cache.token_to_kv_pool_allocator.free.call_args.args[0]
+            self.assertTrue(torch.equal(freed, torch.tensor([101])))
+            self.assertTrue(
+                torch.equal(
+                    cache.req_to_token_pool.req_to_token[0],
+                    torch.tensor([10, 11, 102, 103]),
+                )
+            )
+            self.assertTrue(
+                torch.equal(req.prefix_indices, torch.tensor([10, 11, 12, 13]))
+            )
+            self.assertEqual(req.last_node, new_node)
+
+    def test_cache_salt_is_rejected_without_loading_cpp_extension(self):
+        with self._import_with_fake_extension() as module:
+            module.RadixCacheCpp._reject_cache_salt(None)
+            with self.assertRaisesRegex(ValueError, "experimental C\\+\\+"):
+                module.RadixCacheCpp._reject_cache_salt("tenant-a")
+
+
+class TestRadixTreeCppFusedInsertMatch(CustomTestCase):
+    @staticmethod
+    def _flatten(indices):
+        return torch.cat(indices) if indices else torch.empty(0, dtype=torch.int64)
+
+    def test_fused_insert_match_semantics(self):
+        extension = importlib.import_module(
+            "sglang.srt.mem_cache.cpp_radix_tree.radix_tree"
+        )
+        legacy_tree = extension.RadixTreeCpp(False, None, 1, 2)
+        legacy_actions, legacy_match = legacy_tree.writing_through(
+            [8, 9], torch.tensor([80, 90])
+        )
+        self.assertEqual((legacy_actions, legacy_match), ([], 0))
+        self.assertTrue(
+            torch.equal(
+                self._flatten(legacy_tree.match_prefix([8, 9])[0]),
+                torch.tensor([80, 90]),
+            )
+        )
+
+        tree = extension.RadixTreeCpp(False, None, 1, 2)
+
+        actions, matched, indices, first_node = tree.writing_through_and_match_prefix(
+            [1, 2, 3, 4], torch.tensor([10, 11, 12, 13])
+        )
+        self.assertEqual(actions, [])
+        self.assertEqual(matched, 0)
+        self.assertTrue(
+            torch.equal(self._flatten(indices), torch.tensor([10, 11, 12, 13]))
+        )
+        standalone_indices, host_length, device_node, host_node = tree.match_prefix(
+            [1, 2, 3, 4]
+        )
+        self.assertEqual(
+            (host_length, device_node, host_node), (0, first_node, first_node)
+        )
+        self.assertTrue(
+            torch.equal(self._flatten(standalone_indices), self._flatten(indices))
+        )
+
+        _, matched, duplicate_indices, duplicate_node = (
+            tree.writing_through_and_match_prefix(
+                [1, 2, 3, 4], torch.tensor([20, 21, 22, 23])
+            )
+        )
+        self.assertEqual((matched, duplicate_node), (4, first_node))
+        self.assertTrue(
+            torch.equal(
+                self._flatten(duplicate_indices), torch.tensor([10, 11, 12, 13])
+            )
+        )
+
+        _, matched, branch_indices, branch_node = tree.writing_through_and_match_prefix(
+            [1, 2, 5, 6], torch.tensor([30, 31, 32, 33])
+        )
+        self.assertEqual(matched, 2)
+        self.assertNotEqual(branch_node, first_node)
+        self.assertTrue(
+            torch.equal(self._flatten(branch_indices), torch.tensor([10, 11, 32, 33]))
+        )
+        self.assertEqual(tree.total_size(), 6)
+
+        paged_tree = extension.RadixTreeCpp(False, None, 2, 2)
+        _, matched, paged_indices, _ = paged_tree.writing_through_and_match_prefix(
+            [1, 2, 3, 4, 5], torch.tensor([40, 41, 42, 43, 44])
+        )
+        self.assertEqual(matched, 0)
+        self.assertTrue(
+            torch.equal(self._flatten(paged_indices), torch.tensor([40, 41, 42, 43]))
+        )
+        self.assertEqual(paged_tree.total_size(), 4)
+
+        disabled_tree = extension.RadixTreeCpp(True, None, 1, 2)
+        actions, matched, indices, node = (
+            disabled_tree.writing_through_and_match_prefix(
+                [1], torch.tensor([1], dtype=torch.int64)
+            )
+        )
+        self.assertEqual((actions, matched, indices, node), ([], 0, [], 0))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import torch
+
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 


### PR DESCRIPTION
## Motivation

`RadixCacheCpp.cache_unfinished_req` currently inserts the request prefix through the C++ radix tree and then immediately calls `match_prefix` with the same key. The second call repeats the root-to-key lookup and crosses the Python/C++ boundary again even though insertion already found or created the final device node.

This change reuses that final node to return the complete device-index chain in the insertion call. The scope is the experimental C++ radix cache without HiCache; it does not change GPU kernels or claim a server-level speedup yet.

## Modifications

- Factor the existing C++ write-through work into a private result carrying the matched length and final node.
- Add `writing_through_and_match_prefix`, which collects the device-index chain from that node without another radix lookup.
- Use the combined call from `RadixCacheCpp.cache_unfinished_req` while preserving duplicate-KV freeing, request-row updates, prefix indices, and lock transfer.
- Keep the legacy `writing_through` API unchanged.
- Add controller and real C++ extension tests covering first insert, duplicate, branching, page alignment, disabled mode, and request-side side effects.

Known pending overlap: #38738 changes the same Python controller and unit-test file to add an explicit skip-insert path. This branch is correct against current `main`; if #38738 lands first, I will replay this single commit while preserving its `is_insert=False` early return and add that path as a negative control.

## Accuracy Tests

Supporting focused results on commit `68002bea5cfa78ae05f9d3bf980a2ea457ebb6d4`:

- Real CPU C++ extension fused semantics: 1/1 passed on the current production C++ blobs.
- Python controller side effects with a fake extension boundary: 2/2 passed.
- Ruff 0.15.1, Ruff format, clang-format 20.1.7, and `git diff --check`: passed.

The dependency-complete official `base-a-test-cpu` run is still pending. This Draft must not be marked Ready until all three registered tests execute and pass there.

## Speed Tests and Profiling

A CPU direct-extension attribution sweep over nine prefix shapes measured a ratio-of-medians range of 1.284x–1.979x for the fused operation, with the minimum paired-bootstrap 95% lower bound at 1.238x. This is supporting micro-attribution only.

No server, GPU, TTFT, or throughput result is claimed. Before marking the PR Ready, the unchanged control must demonstrate that this branch is reached in the frozen chunked-prefill workload and that its critical-path share has an Amdahl ceiling above the predeclared 0.5% weighted-TTFT materiality floor. Candidate A/B runs follow only if that early-stop gate passes.

## Checklist

- [x] Format the modified Python and C++ files with the repository-pinned tools.
- [x] Add focused unit tests for controller and C++ tree semantics.
- [x] Keep the claim limited to the experimental C++ radix-cache path.
- [ ] Run dependency-complete official CPU CI (3/3 registered tests).
- [ ] Run the frozen production reachability/component-share gate.
- [ ] Report target-hardware server performance if the materiality gate remains recoverable.
- [x] No documentation change is required for this internal implementation detail.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

This is intentionally a Draft. It is not ready for merge or a broad performance label until the unchecked correctness and production-performance items above are complete.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34494694234](https://github.com/sgl-project/sglang/actions/runs/34494694234)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34494693719](https://github.com/sgl-project/sglang/actions/runs/34494693719)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34494694531](https://github.com/sgl-project/sglang/actions/runs/34494694531)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->