### PR TITLE
Add a versioned KV-hint envelope to the request transport

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package sglang.runtime.v1;
 
+import "google/protobuf/struct.proto";
+
 service SglangService {
   // SGLang-native RPCs (typed proto)
   rpc TextGenerate(TextGenerateRequest) returns (stream TextGenerateResponse);
@@ -103,6 +105,7 @@ message TextGenerateRequest {
   optional int32 priority = 15;
   optional bool require_reasoning = 16;
   optional uint32 max_thinking_tokens = 17;
+  optional KVHintsEnvelope kv_hints = 18;
 }
 
 message TextGenerateResponse {
@@ -130,6 +133,25 @@ message GenerateRequest {
   optional int32 priority = 14;
   optional bool require_reasoning = 15;
   optional uint32 max_thinking_tokens = 16;
+  optional KVHintsEnvelope kv_hints = 17;
+}
+
+// Versioned KV-hint envelope attached by a trusted orchestrator after worker
+// selection. Forwarded untouched to the HiCache storage backends; each reads
+// only the action types it implements. Wire-compatible with vLLM's
+// KVHintsEnvelope (vllm-project/vllm#53423).
+message KVHintsEnvelope {
+  string protocol_version = 1;
+  string message_id = 2;
+  repeated KVHintAction actions = 3;
+}
+
+message KVHintAction {
+  string action_id = 1;
+  string action_type = 2;
+  string action_version = 3;
+  // Action-specific; validated by the component implementing action_type.
+  google.protobuf.Struct payload = 4;
 }
 
 message GenerateResponse {

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -422,6 +422,9 @@ class Engine(EngineScoreMixin, EngineBase):
         bootstrap_room: Optional[Union[List[int], int]] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        # Versioned KV-hint envelope forwarded untouched to the HiCache storage
+        # backends. See GenerateReqInput.kv_hints.
+        kv_hints: Optional[Dict] = None,
         # Deprecated: use routed_dp_rank instead
         data_parallel_rank: Optional[int] = None,
         external_trace_header: Optional[Dict] = None,
@@ -466,6 +469,7 @@ class Engine(EngineScoreMixin, EngineBase):
             bootstrap_room=bootstrap_room,
             routed_dp_rank=routed_dp_rank,
             disagg_prefill_dp_rank=disagg_prefill_dp_rank,
+            kv_hints=kv_hints,
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,
@@ -535,6 +539,9 @@ class Engine(EngineScoreMixin, EngineBase):
         bootstrap_room: Optional[Union[List[int], int]] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        # Versioned KV-hint envelope forwarded untouched to the HiCache storage
+        # backends. See GenerateReqInput.kv_hints.
+        kv_hints: Optional[Dict] = None,
         # Deprecated: use routed_dp_rank instead
         data_parallel_rank: Optional[int] = None,
         external_trace_header: Optional[Dict] = None,
@@ -579,6 +586,7 @@ class Engine(EngineScoreMixin, EngineBase):
             bootstrap_room=bootstrap_room,
             routed_dp_rank=routed_dp_rank,
             disagg_prefill_dp_rank=disagg_prefill_dp_rank,
+            kv_hints=kv_hints,
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -54,6 +54,7 @@ from sglang.srt.beam_search.types import BeamSearchSequence
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.kv_hints import KvHintsEnvelope, decode_kv_hints_envelope
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalProcessorOutput,
@@ -351,6 +352,16 @@ class GenerateReqInput:
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[Union[List[str], str]] = None
 
+    # Versioned KV-hint envelope, set by a trusted orchestrator after worker
+    # selection and never by an application client. Passed through untouched to
+    # the HiCache storage backends, each of which reads only the action types it
+    # implements. Accepts a plain dict from HTTP/gRPC; normalization converts it
+    # to KvHintsEnvelope. A hint describes one request's prefix, so a batch
+    # carries one envelope per request.
+    kv_hints: Optional[
+        Union[List[Optional[Union[Dict, KvHintsEnvelope]]], Dict, KvHintsEnvelope]
+    ] = None
+
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
         if isinstance(self.rid, list):
@@ -536,6 +547,11 @@ class GenerateReqInput:
                 )
             if value == "":
                 setattr(self, field_name, None)
+        if isinstance(self.kv_hints, list):
+            raise ValueError("kv_hints should be a single envelope for one request.")
+        self.kv_hints = (
+            decode_kv_hints_envelope(self.kv_hints) if self.kv_hints else None
+        )
 
     def _normalize_batch_inputs(self):
         """Normalize inputs for a batch of examples, including parallel sampling expansion."""
@@ -560,6 +576,7 @@ class GenerateReqInput:
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
         self._normalize_cache_salt(num)
+        self._normalize_kv_hints(num)
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -821,6 +838,28 @@ class GenerateReqInput:
         else:
             raise ValueError("cache_salt should be a list or a string.")
 
+    def _normalize_kv_hints(self, num):
+        """Normalize kv_hints for batch processing."""
+        if self.kv_hints is None:
+            return
+        if isinstance(self.kv_hints, (dict, KvHintsEnvelope)):
+            # One envelope broadcast to the batch: every request shares the
+            # orchestrator's routing decision, which is what a router sending a
+            # single decision for a fanned-out prompt means.
+            self.kv_hints = [decode_kv_hints_envelope(self.kv_hints)] * num
+        elif isinstance(self.kv_hints, list):
+            if len(self.kv_hints) != self.batch_size:
+                raise ValueError(
+                    "The length of kv_hints should be equal to the batch size."
+                )
+            self.kv_hints = [
+                decode_kv_hints_envelope(value) if value else None
+                for value in self.kv_hints
+            ]
+            self.kv_hints = self.kv_hints * self.parallel_sample_num
+        else:
+            raise ValueError("kv_hints should be a list or a dict.")
+
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
         # Normalize bootstrap_host
@@ -952,6 +991,7 @@ class GenerateReqInput:
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
             cache_salt=(self.cache_salt[i] if self.cache_salt is not None else None),
+            kv_hints=(self.kv_hints[i] if self.kv_hints is not None else None),
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,
@@ -1067,6 +1107,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
+
+    # See GenerateReqInput.kv_hints.
+    kv_hints: Optional[KvHintsEnvelope] = None
 
     def wrap_pickle_fields(self):
         self.time_stats = wrap_as_pickle(self.time_stats)

--- a/python/sglang/srt/managers/kv_hints.py
+++ b/python/sglang/srt/managers/kv_hints.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Versioned KV-hint envelope carried on a request.
+
+A KV hint is advisory routing metadata attached by a trusted orchestrator (a
+router or a scheduler) *after* it has picked a worker -- never by an application
+client. SGLang transports it unchanged from the entrypoint down to the HiCache
+storage backends; nothing in the core reads a payload.
+
+The envelope is a list of independent actions. Each action names its own type
+and version, so one consumer implementing ``foo.bar@1.0`` must ignore -- not
+reject -- an action it does not implement sitting next to it in the same
+envelope. ``payload`` is therefore deliberately untyped here: the component
+that implements an action owns its schema and validates it.
+
+Wire-compatible with vLLM's ``vllm.v1.kv_hints`` (vllm-project/vllm#53423) so
+one orchestrator can address either engine with the same envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import msgspec
+
+from sglang.srt.utils.msgspec_utils import msgspec_struct_pydantic_core_schema
+
+
+class KvHintAction(msgspec.Struct, frozen=True, kw_only=True):
+    """One versioned action inside a KV-hint envelope."""
+
+    action_id: str
+    action_type: str
+    action_version: str
+    # JSON-compatible values only; validated by whichever component implements
+    # `action_type`, not here.
+    payload: Dict[str, Any] = {}
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+class KvHintsEnvelope(msgspec.Struct, frozen=True, kw_only=True):
+    """Orchestrator-provided KV hints attached to one request."""
+
+    protocol_version: str
+    message_id: str
+    actions: List[KvHintAction] = []
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+# Envelope version this transport was specified against. Not enforced: an
+# action carries its own version, and a consumer that finds no action it
+# implements already falls back to normal behavior.
+KV_HINTS_PROTOCOL_VERSION = "0.1"
+
+
+def decode_kv_hints_envelope(value: Any) -> KvHintsEnvelope:
+    """Convert a JSON/dict envelope into :class:`KvHintsEnvelope`.
+
+    Raises ``ValueError`` on a malformed envelope so an entrypoint rejects the
+    request outright. This is the one place the shape is enforced; every layer
+    below holds the typed struct.
+    """
+    if isinstance(value, KvHintsEnvelope):
+        return value
+    try:
+        return msgspec.convert(value, KvHintsEnvelope)
+    except (msgspec.ValidationError, TypeError) as e:
+        raise ValueError(f"Malformed kv_hints envelope: {e}") from e

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -96,6 +96,7 @@ from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationM
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.kv_hints import KvHintsEnvelope
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
 )
@@ -958,6 +959,7 @@ class Req(ReqDllmMixin):
         disagg_mode: Optional[DisaggregationMode] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        kv_hints: Optional[KvHintsEnvelope] = None,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
@@ -1277,6 +1279,8 @@ class Req(ReqDllmMixin):
 
         self.routed_dp_rank: Optional[int] = routed_dp_rank
         self.disagg_prefill_dp_rank: Optional[int] = disagg_prefill_dp_rank
+        # Orchestrator KV hints, forwarded to the HiCache storage backends.
+        self.kv_hints: Optional[KvHintsEnvelope] = kv_hints
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2761,6 +2761,7 @@ class Scheduler(
                 disagg_mode=self.disaggregation_mode,
                 routed_dp_rank=recv_req.routed_dp_rank,
                 disagg_prefill_dp_rank=recv_req.disagg_prefill_dp_rank,
+                kv_hints=recv_req.kv_hints,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,
                 metrics_collector=(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1427,6 +1427,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 routed_dp_rank=obj.routed_dp_rank,
                 disagg_prefill_dp_rank=obj.disagg_prefill_dp_rank,
                 priority=obj.priority,
+                kv_hints=obj.kv_hints,
                 extra_key=obj.extra_key,
                 cache_salt=obj.cache_salt,
                 routing_key=obj.routing_key,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3667,6 +3667,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "prost",
+ "prost-types",
  "protoc-bin-vendored",
  "pyo3",
  "serde_json",

--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -34,6 +34,8 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 prost = "0.13"
+# google.protobuf.Struct, carried by KVHintAction.payload.
+prost-types = "0.13"
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 tonic = { version = "0.12", features = ["gzip", "transport"] }
 

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -178,6 +178,76 @@ fn insert_disaggregated_params(
     }
 }
 
+/// Convert a `google.protobuf.Value` to JSON.
+///
+/// An integral `number_value` becomes a JSON integer: the Python side decodes
+/// action payloads into typed fields (block hashes and the like), where a float
+/// would not convert. Struct only carries f64, so a value above 2^53 has already
+/// lost precision on the wire -- an action that needs exact 64-bit integers must
+/// encode them as strings.
+fn prost_value_to_json(value: &prost_types::Value) -> serde_json::Value {
+    use prost_types::value::Kind;
+    match &value.kind {
+        None | Some(Kind::NullValue(_)) => serde_json::Value::Null,
+        Some(Kind::NumberValue(n)) => {
+            if n.fract() == 0.0 && *n >= i64::MIN as f64 && *n <= i64::MAX as f64 {
+                serde_json::json!(*n as i64)
+            } else {
+                serde_json::json!(n)
+            }
+        }
+        Some(Kind::StringValue(s)) => serde_json::json!(s),
+        Some(Kind::BoolValue(b)) => serde_json::json!(b),
+        Some(Kind::StructValue(s)) => prost_struct_to_json(s),
+        Some(Kind::ListValue(l)) => {
+            serde_json::Value::Array(l.values.iter().map(prost_value_to_json).collect())
+        }
+    }
+}
+
+fn prost_struct_to_json(s: &prost_types::Struct) -> serde_json::Value {
+    serde_json::Value::Object(
+        s.fields
+            .iter()
+            .map(|(k, v)| (k.clone(), prost_value_to_json(v)))
+            .collect(),
+    )
+}
+
+/// Forward the KV-hint envelope untouched. Action payloads are opaque here; the
+/// component implementing an `action_type` owns its schema.
+fn insert_kv_hints(
+    request: &mut HashMap<String, serde_json::Value>,
+    kv_hints: &Option<proto::KvHintsEnvelope>,
+) {
+    let Some(envelope) = kv_hints else {
+        return;
+    };
+    let actions: Vec<serde_json::Value> = envelope
+        .actions
+        .iter()
+        .map(|action| {
+            serde_json::json!({
+                "action_id": action.action_id,
+                "action_type": action.action_type,
+                "action_version": action.action_version,
+                "payload": action
+                    .payload
+                    .as_ref()
+                    .map_or_else(|| serde_json::json!({}), prost_struct_to_json),
+            })
+        })
+        .collect();
+    request.insert(
+        "kv_hints".into(),
+        serde_json::json!({
+            "protocol_version": envelope.protocol_version,
+            "message_id": envelope.message_id,
+            "actions": actions,
+        }),
+    );
+}
+
 fn now_timestamp() -> f64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -250,6 +320,7 @@ pub(crate) fn build_text_generate_dict(
         req.max_thinking_tokens,
     );
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
+    insert_kv_hints(&mut d, &req.kv_hints);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
@@ -304,6 +375,7 @@ pub(crate) fn build_generate_dict(
         req.max_thinking_tokens,
     );
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
+    insert_kv_hints(&mut d, &req.kv_hints);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
@@ -448,6 +520,90 @@ mod tests {
             assert!(!request.contains_key("bootstrap_host"));
             assert!(!request.contains_key("bootstrap_port"));
             assert!(!request.contains_key("bootstrap_room"));
+        }
+    }
+
+    #[test]
+    fn generate_dicts_forward_kv_hints_envelope() {
+        let payload = prost_types::Struct {
+            fields: [
+                (
+                    "endpoint".to_string(),
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue(
+                            "tcp://10.0.0.2:7000".to_string(),
+                        )),
+                    },
+                ),
+                (
+                    "block_hashes".to_string(),
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::ListValue(
+                            prost_types::ListValue {
+                                values: vec![prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::NumberValue(7.0)),
+                                }],
+                            },
+                        )),
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        let kv_hints = Some(proto::KvHintsEnvelope {
+            protocol_version: "0.1".to_string(),
+            message_id: "msg-1".to_string(),
+            actions: vec![proto::KvHintAction {
+                action_id: "a-1".to_string(),
+                action_type: "kv.example".to_string(),
+                action_version: "1.0".to_string(),
+                payload: Some(payload),
+            }],
+        });
+        let text_req = proto::TextGenerateRequest {
+            kv_hints: kv_hints.clone(),
+            ..Default::default()
+        };
+        let token_req = proto::GenerateRequest {
+            kv_hints,
+            ..Default::default()
+        };
+
+        for request in [
+            build_text_generate_dict("request-1", &text_req),
+            build_generate_dict("request-2", &token_req),
+        ] {
+            assert_eq!(
+                request.unwrap().get("kv_hints"),
+                Some(&serde_json::json!({
+                    "protocol_version": "0.1",
+                    "message_id": "msg-1",
+                    "actions": [{
+                        "action_id": "a-1",
+                        "action_type": "kv.example",
+                        "action_version": "1.0",
+                        // An integral number stays an integer: the Python side
+                        // decodes payloads into typed fields.
+                        "payload": {
+                            "endpoint": "tcp://10.0.0.2:7000",
+                            "block_hashes": [7],
+                        },
+                    }],
+                }))
+            );
+        }
+    }
+
+    #[test]
+    fn generate_dicts_omit_kv_hints_when_absent() {
+        let text_request =
+            build_text_generate_dict("request-1", &proto::TextGenerateRequest::default()).unwrap();
+        let token_request =
+            build_generate_dict("request-2", &proto::GenerateRequest::default()).unwrap();
+
+        for request in [text_request, token_request] {
+            assert!(!request.contains_key("kv_hints"));
         }
     }
 

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -17,6 +17,11 @@ from sglang.srt.managers.io_struct import (
     msgpack_decode,
     msgpack_encode,
 )
+from sglang.srt.managers.kv_hints import (
+    KvHintAction,
+    KvHintsEnvelope,
+    decode_kv_hints_envelope,
+)
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -1139,6 +1144,142 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req[0].routed_dp_rank, 3)
         self.assertEqual(req[1].routed_dp_rank, 3)
+
+
+class TestKvHintsTransport(CustomTestCase):
+    """The kv_hints envelope must survive every hop from HTTP to the scheduler."""
+
+    ENVELOPE = {
+        "protocol_version": "0.1",
+        "message_id": "msg-1",
+        "actions": [
+            {
+                "action_id": "a-1",
+                "action_type": "kv.example",
+                "action_version": "1.0",
+                # An action payload is opaque to the transport; a consumer that
+                # implements the type validates it.
+                "payload": {"endpoint": "tcp://10.0.0.2:7000", "hashes": [7]},
+            }
+        ],
+    }
+
+    def test_single_request_decodes_dict_into_typed_envelope(self):
+        req = GenerateReqInput(text="Hello", kv_hints=copy.deepcopy(self.ENVELOPE))
+        req.normalize_batch_and_arguments()
+
+        self.assertIsInstance(req.kv_hints, KvHintsEnvelope)
+        self.assertEqual(req.kv_hints.protocol_version, "0.1")
+        (action,) = req.kv_hints.actions
+        self.assertIsInstance(action, KvHintAction)
+        self.assertEqual(action.action_type, "kv.example")
+        self.assertEqual(
+            action.payload, {"endpoint": "tcp://10.0.0.2:7000", "hashes": [7]}
+        )
+
+    def test_unknown_action_type_is_carried_not_rejected(self):
+        """A consumer must be able to ignore a neighboring action it does not
+        implement, so the transport cannot reject one."""
+        envelope = copy.deepcopy(self.ENVELOPE)
+        envelope["actions"].append(
+            {
+                "action_id": "a-2",
+                "action_type": "some.future.action",
+                "action_version": "9.9",
+                "payload": {"anything": True},
+            }
+        )
+        req = GenerateReqInput(text="Hello", kv_hints=envelope)
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            [action.action_type for action in req.kv_hints.actions],
+            ["kv.example", "some.future.action"],
+        )
+
+    def test_malformed_envelope_is_rejected(self):
+        for bad in (
+            {"message_id": "msg-1"},  # missing protocol_version
+            {"protocol_version": "0.1", "message_id": "msg-1", "actions": [{}]},
+            {"protocol_version": 1, "message_id": "msg-1"},
+            [{"protocol_version": "0.1", "message_id": "msg-1"}],
+        ):
+            with self.subTest(bad=bad):
+                req = GenerateReqInput(text="Hello", kv_hints=bad)
+                with self.assertRaises(ValueError):
+                    req.normalize_batch_and_arguments()
+
+    def test_single_envelope_broadcasts_to_every_batch_item(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"], kv_hints=copy.deepcopy(self.ENVELOPE)
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            [req[i].kv_hints.message_id for i in range(2)], ["msg-1", "msg-1"]
+        )
+
+    def test_per_item_envelopes_stay_with_their_item(self):
+        second = copy.deepcopy(self.ENVELOPE)
+        second["message_id"] = "msg-2"
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            kv_hints=[copy.deepcopy(self.ENVELOPE), second],
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            [req[i].kv_hints.message_id for i in range(2)], ["msg-1", "msg-2"]
+        )
+
+    def test_per_item_envelopes_may_be_none(self):
+        """A router hints only the requests it has a decision for."""
+        req = GenerateReqInput(
+            text=["Hello", "World"], kv_hints=[None, copy.deepcopy(self.ENVELOPE)]
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertIsNone(req[0].kv_hints)
+        self.assertEqual(req[1].kv_hints.message_id, "msg-1")
+
+    def test_partial_kv_hints_list_is_rejected(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"], kv_hints=[copy.deepcopy(self.ENVELOPE)]
+        )
+        with self.assertRaisesRegex(ValueError, "equal to the batch size"):
+            req.normalize_batch_and_arguments()
+
+    def test_parallel_samples_each_carry_the_envelope(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            kv_hints=copy.deepcopy(self.ENVELOPE),
+            sampling_params={"n": 2},
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual([req[i].kv_hints.message_id for i in range(4)], ["msg-1"] * 4)
+
+    def test_envelope_survives_the_msgpack_ipc_hop(self):
+        """The tokenizer-to-scheduler hop is msgpack, not pickle."""
+        tokenized = TokenizedGenerateReqInput(
+            input_text="",
+            input_ids=array("q", [1, 2]),
+            input_embeds=None,
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            kv_hints=decode_kv_hints_envelope(copy.deepcopy(self.ENVELOPE)),
+        )
+        tokenized.wrap_pickle_fields()
+        decoded = msgpack_decode(msgpack_encode(tokenized))
+        decoded.unwrap_pickle_fields()
+
+        self.assertEqual(decoded.kv_hints, tokenized.kv_hints)
 
 
 class TestEmbeddingReqInputGetItem(CustomTestCase):


### PR DESCRIPTION
## Motivation                                                                                                                                                                         
                                                                                                                                                                                        
 A KV hint is advisory routing metadata attached by a trusted orchestrator (a router or a scheduler) after it has picked a worker -- never by an application client. A KV-aware router already knows which worker holds a prefix; today there is no way for it to tell the worker it just picked. This adds the transport for that, and nothing else.                                                                                                        
                                                                                                                                                                                        
This is the transport-only half of #36224, split out on review feedback so the KVCR backend that consumes a hint lands as a purely additive follow-up.                        
                                                                                            
## Modifications                                                                                                                                                                      
                                                                                                                                                                                        
The envelope travels unchanged from the entrypoint down to the scheduler's `Req`, and nothing in the core reads a payload:                                                      
                                                                                                                                                                              
  GenerateReqInput (HTTP/Engine) and the gRPC KVHintsEnvelope message                                                                                                                   
                                                                                                                                                                                        
    -> normalization (single, per-batch-item, and parallel-sample expansion)                                                                                                            
    -> TokenizedGenerateReqInput over msgpack IPC                                                                                                                                                                        
    -> Req                                                                                  
                                                                                                                                                                                     
 The envelope is a list of independent actions, each naming its own type and version, so a consumer implementing one action type ignores -- rather than rejects -- an action it                                                                                                
                                                                                                                                                                                        
    -> normalization (single, per-batch-item, and parallel-sample expansion)                                                                                                            
    -> TokenizedGenerateReqInput over msgpack IPC                           
    -> Req                                    

The envelope is a list of independent actions, each naming its own type and version, so a consumer implementing one action type ignores -- rather than rejects -- an action it does not implement sitting next to it. The payload is therefore untyped here; the component that implements an action owns its schema and validates it. **No action types are defined by this change.**

 New module `python/sglang/srt/managers/kv_hints.py` holds the `KvHintAction` / `KvHintsEnvelope` msgspec structs and `decode_kv_hints_envelope()`.

 Wire-compatible with vLLM's `KVHintsEnvelope` (vllm-project/vllm#53423) so one orchestrator can address either engine with the same envelope.

 ## Accuracy Test

  No model behavior changes -- an absent or malformed envelope leaves the request on the existing path.

 ## Benchmarking and Profiling

 No hot-path change; the field is `None` for every request that does not carry a hint.

  ## Checklist

  - [x] Format your code according to the Code Formatting with Pre-Commit.
  - [x] Add unit tests (`test/registered/unit/managers/test_io_struct.py`, covering normalization, batch expansion, parallel-sample expansion, and rejection of a malformed envelope).
  - [x] Update documentation as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35683764595](https://github.com/sgl-project/sglang/actions/runs/35683764595)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35683764509](https://github.com/sgl-project/sglang/actions/runs/35683764509)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35683764593](https://github.com/sgl-project/sglang/actions/runs/35683764593)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->