### PR TITLE
fix(parser): preserve Step tool calls across reasoning boundaries

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -92,6 +92,7 @@ class BaseReasoningFormatDetector:
 
         self._force_nonempty_content = force_nonempty_content
         self._accumulated_reasoning = ""
+        self._prefer_tool_start_boundary = False
 
         self.continue_final_message = continue_final_message
         if self.continue_final_message:
@@ -133,6 +134,17 @@ class BaseReasoningFormatDetector:
         processed_text = text
         while processed_text.startswith(think_start_text):
             processed_text = processed_text[len(think_start_text) :]
+
+        if self._prefer_tool_start_boundary and self.tool_start_token is not None:
+            think_end_idx = processed_text.find(self.think_end_token)
+            tool_start_idx = processed_text.find(self.tool_start_token)
+            if tool_start_idx != -1 and (
+                think_end_idx == -1 or tool_start_idx < think_end_idx
+            ):
+                return StreamingParseResult(
+                    normal_text=processed_text[tool_start_idx:],
+                    reasoning_text=processed_text[:tool_start_idx],
+                )
 
         if (
             self.think_end_token not in processed_text
@@ -209,6 +221,24 @@ class BaseReasoningFormatDetector:
             self._buffer = current_text
             self.stripped_think_start = True
             self._in_reasoning = True
+
+        # Step may start a tool call before a delayed reasoning end tag.
+        if (
+            self._in_reasoning
+            and self._prefer_tool_start_boundary
+            and self.tool_start_token is not None
+            and self.tool_start_token in current_text
+        ):
+            think_end_idx = current_text.find(self.think_end_token)
+            tool_start_idx = current_text.find(self.tool_start_token)
+            if think_end_idx == -1 or tool_start_idx < think_end_idx:
+                reasoning_text = current_text[:tool_start_idx]
+                normal_text = current_text[tool_start_idx:]
+                self._buffer = ""
+                self._in_reasoning = False
+                return StreamingParseResult(
+                    normal_text=normal_text, reasoning_text=reasoning_text
+                )
 
         # Handle end of reasoning block
         if self._in_reasoning and self.think_end_token in current_text:
@@ -350,6 +380,34 @@ class DeepSeekR1Detector(BaseReasoningFormatDetector):
             force_nonempty_content=force_nonempty_content,
         )
         # https://github.com/sgl-project/sglang/pull/3202#discussion_r1950153599
+
+
+class Step3p5Detector(DeepSeekR1Detector):
+    """Reasoning detector for Step-3.5 and Step-3.7 models.
+
+    Step models follow DeepSeek-R1's always-on reasoning behavior, but may
+    begin ``<tool_call>`` without first emitting ``</think>``. Treat the tool
+    marker as an implicit reasoning boundary so the downstream tool parser
+    receives the complete tool-call payload.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = True,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+        force_nonempty_content: bool = False,
+    ):
+        super().__init__(
+            stream_reasoning=stream_reasoning,
+            force_reasoning=force_reasoning,
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
+        )
+        self.tool_start_token = "<tool_call>"
+        self._prefer_tool_start_boundary = True
 
 
 class Qwen3Detector(BaseReasoningFormatDetector):
@@ -2120,7 +2178,7 @@ class ReasoningParser:
         "minimax-m3": MiniMaxM3Detector,
         "nanbeige": Qwen3Detector,
         "step3": DeepSeekR1Detector,
-        "step3p5": DeepSeekR1Detector,
+        "step3p5": Step3p5Detector,
         "mistral": MistralDetector,
         "nemotron_3": Nemotron3Detector,
         "interns1": Qwen3Detector,

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -18,6 +18,7 @@ from sglang.srt.parser.reasoning_parser import (
     Nemotron3Detector,
     Qwen3Detector,
     ReasoningParser,
+    Step3p5Detector,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -215,6 +216,142 @@ class TestDeepSeekR1Detector(CustomTestCase):
         end = detector.finish()
         self.assertEqual(end.reasoning_text, "reasoning with no end token")
         self.assertEqual(end.normal_text, "")
+
+
+class TestStep3p5Detector(CustomTestCase):
+    TOOL_CALL = (
+        "<tool_call><function=bash><parameter=command>pwd</parameter>"
+        "</function></tool_call>"
+    )
+
+    def test_preserves_deepseek_always_on_reasoning_semantics(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse("reasoning without an opening tag")
+        self.assertEqual(result.reasoning_text, "reasoning without an opening tag")
+        self.assertEqual(result.normal_text, "")
+
+    def test_non_streaming_tool_implicitly_ends_reasoning(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse("inspect the repo" + self.TOOL_CALL)
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, self.TOOL_CALL)
+
+    def test_explicit_reasoning_end_remains_supported(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse(
+            "inspect the repo</think>answer " + self.TOOL_CALL
+        )
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, "answer " + self.TOOL_CALL)
+
+    def test_first_boundary_wins(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse(
+            "inspect the repo" + self.TOOL_CALL + "</think>late close"
+        )
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, self.TOOL_CALL + "</think>late close")
+
+    def test_streaming_first_boundary_wins_at_every_split(self):
+        cases = (
+            (
+                "inspect the repo" + self.TOOL_CALL + "</think>late close",
+                "inspect the repo",
+                self.TOOL_CALL + "</think>late close",
+            ),
+            (
+                "inspect the repo</think>answer " + self.TOOL_CALL,
+                "inspect the repo",
+                "answer " + self.TOOL_CALL,
+            ),
+        )
+        for source, expected_reasoning, expected_normal in cases:
+            for split in range(1, len(source)):
+                detector = Step3p5Detector()
+                reasoning = ""
+                normal = ""
+                for chunk in (source[:split], source[split:]):
+                    result = detector.parse_streaming_increment(chunk)
+                    reasoning += result.reasoning_text
+                    normal += result.normal_text
+                end = detector.finish()
+                reasoning += end.reasoning_text
+                normal += end.normal_text
+                self.assertEqual(reasoning, expected_reasoning, msg=f"split={split}")
+                self.assertEqual(normal, expected_normal, msg=f"split={split}")
+
+    def test_streaming_tool_boundary_at_every_split(self):
+        source = "inspect the repo" + self.TOOL_CALL
+        for split in range(1, len(source)):
+            detector = Step3p5Detector()
+            reasoning = ""
+            normal = ""
+            for chunk in (source[:split], source[split:]):
+                result = detector.parse_streaming_increment(chunk)
+                reasoning += result.reasoning_text
+                normal += result.normal_text
+            end = detector.finish()
+            reasoning += end.reasoning_text
+            normal += end.normal_text
+            self.assertEqual(reasoning, "inspect the repo", msg=f"split={split}")
+            self.assertEqual(normal, self.TOOL_CALL, msg=f"split={split}")
+
+    def test_streaming_tool_boundary_one_character_at_a_time(self):
+        detector = Step3p5Detector()
+        reasoning = ""
+        normal = ""
+        for char in "inspect the repo" + self.TOOL_CALL:
+            result = detector.parse_streaming_increment(char)
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        end = detector.finish()
+        reasoning += end.reasoning_text
+        normal += end.normal_text
+        self.assertEqual(reasoning, "inspect the repo")
+        self.assertEqual(normal, self.TOOL_CALL)
+
+    def test_streaming_incomplete_marker_prefix_is_flushed(self):
+        detector = Step3p5Detector()
+        result = detector.parse_streaming_increment("reasoning<tool_")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "<tool_")
+        self.assertEqual(end.normal_text, "")
+
+    def test_buffered_reasoning_preserves_tool_boundary_at_every_split(self):
+        source = "reasoning" + self.TOOL_CALL + "</think>late close"
+        for split in range(len(source) + 1):
+            detector = Step3p5Detector(stream_reasoning=False)
+            results = [
+                detector.parse_streaming_increment(source[:split]),
+                detector.parse_streaming_increment(source[split:]),
+                detector.finish(),
+            ]
+            self.assertEqual("".join(r.reasoning_text for r in results), "reasoning")
+            self.assertEqual(
+                "".join(r.normal_text for r in results),
+                self.TOOL_CALL + "</think>late close",
+            )
+
+    def test_other_detectors_keep_explicit_end_precedence(self):
+        source = "reasoning" + self.TOOL_CALL + "</think>answer"
+        for detector in (DeepSeekR1Detector(), Qwen3Detector(force_reasoning=True)):
+            result = detector.detect_and_parse(source)
+            self.assertEqual(result.reasoning_text, "reasoning" + self.TOOL_CALL)
+            self.assertEqual(result.normal_text, "answer")
+
+    def test_streaming_multiple_tool_calls_are_preserved_for_tool_parser(self):
+        detector = Step3p5Detector()
+        source = "reasoning" + self.TOOL_CALL + self.TOOL_CALL
+        reasoning = ""
+        normal = ""
+        for char in source:
+            result = detector.parse_streaming_increment(char)
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, self.TOOL_CALL + self.TOOL_CALL)
 
 
 class TestQwen3Detector(CustomTestCase):
@@ -1373,7 +1510,7 @@ class TestReasoningParserAdvanced(CustomTestCase):
         alias_tests = {
             "deepseek-v3": Qwen3Detector,
             "step3": DeepSeekR1Detector,
-            "step3p5": DeepSeekR1Detector,
+            "step3p5": Step3p5Detector,
             "interns1": Qwen3Detector,
         }
         for model_type, expected_class in alias_tests.items():


### PR DESCRIPTION
## Motivation

The `step3p5` reasoning parser currently uses `DeepSeekR1Detector`. When a Step response emits `<tool_call>` before a missing or delayed `</think>`, the tool payload can remain in reasoning instead of reaching the tool-call parser.

For example, `reasoning<tool_call>...</tool_call></think>late` should split at the first tool marker, preserving the complete remaining text for downstream parsing.

## Modifications

- Add a Step-specific reasoning detector that retains always-on reasoning and treats `<tool_call>` as an implicit reasoning boundary.
- Give the earliest tool/explicit-end boundary precedence only for Step, in streaming and non-streaming parsing.
- Reuse main's existing partial-marker buffering and stream-end flush logic.
- Keep other detectors' existing boundary precedence.

## Accuracy Tests

**132 tests passed** in `test/registered/unit/parser/test_reasoning_parser.py`, including 11 added Step/boundary-isolation tests. Coverage includes every two-chunk split, character-at-a-time streaming, buffered reasoning, explicit/delayed end tags, partial markers at EOS, and multiple tool calls.

A public `ReasoningParser('step3p5')` reproducer fails on unmodified main `908226fea2` by swallowing the tool call into reasoning; it passes with this patch. Existing DeepSeek/Qwen behavior is covered.

All applicable pre-commit hooks on the changed files and `git diff --check` pass. Local environment: macOS arm64, Python 3.11.15, PyTorch 2.8.0, Transformers 5.12.1. No full serving/model-generation evaluation was run.

## Speed Tests and Profiling

No GPU/model-forward changes or measured performance claims. Parser latency benchmarking has not been run.

## Checklist

- [x] Format and lint changed files with pre-commit.
- [x] Add CPU regression tests.
- [x] Follow SGLang code style.
- [x] Documentation: existing parser selector is unchanged.
- [ ] Validate representative real-model responses through the serving endpoint before marking ready for review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34479339200](https://github.com/sgl-project/sglang/actions/runs/34479339200)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34479338989](https://github.com/sgl-project/sglang/actions/runs/34479338989)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34479339159](https://github.com/sgl-project/sglang/actions/runs/34479339159)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->