### PR TITLE
fix(parser): preserve and recover Step tool calls across reasoning and XML parsing

### DIFF
--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -47,6 +47,7 @@ from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.spark25_detector import Spark25Detector
 from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.srt.function_call.step3p5_detector import Step3p5Detector
 from sglang.srt.function_call.trinity_detector import TrinityDetector
 from sglang.srt.function_call.utils import (
     _get_tool_schema_defs,
@@ -94,7 +95,7 @@ class FunctionCallParser:
         "qwen3_coder": Qwen3CoderDetector,
         "spark25": Spark25Detector,
         "step3": Step3Detector,
-        "step3p5": Qwen3CoderDetector,
+        "step3p5": Step3p5Detector,
         "minimax-m2": MinimaxM2Detector,
         "minimax-m3": MinimaxM3Detector,
         "nanbeige": Qwen3CoderDetector,

--- a/python/sglang/srt/function_call/step3p5_detector.py
+++ b/python/sglang/srt/function_call/step3p5_detector.py
@@ -1,0 +1,539 @@
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.core_types import StreamingParseResult, ToolCallItem
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+
+
+@dataclass
+class _NormalizedSegment:
+    text: str
+    literal: bool = False
+
+
+class _Step3p5XMLNormalizer:
+    """Normalize high-confidence Step3p5 XML mistakes incrementally.
+
+    Step models use the same canonical XML protocol as Qwen3-Coder, but they
+    occasionally omit a delimiter or a closing tag. Repairs are deliberately
+    schema-gated and only happen when a later tag provides an unambiguous
+    boundary. A stream truncated at EOS is left untouched.
+    """
+
+    _FIXED_TAGS = (
+        "<tool_call>",
+        "</tool_call>",
+        "</function>",
+        "</parameter>",
+    )
+    _PARTIAL_PREFIXES = _FIXED_TAGS + ("<function", "<parameter")
+
+    def __init__(self, tools: List[Tool]):
+        self._buffer = ""
+        self._input_length = 0
+        self._function_parameters = self._collect_tool_schema(tools)
+
+        self._inside_tool_call = False
+        self._synthetic_tool_call = False
+        self._function_open = False
+        self._parameter_open = False
+        self._current_function: Optional[str] = None
+        self._suppress_current_tool = False
+        self._current_tool_raw_start: Optional[int] = None
+        self._redundant_synthetic_close_pending = False
+        self._pending_synthetic_whitespace = ""
+
+    @staticmethod
+    def _collect_tool_schema(tools: List[Tool]) -> dict[str, set[str]]:
+        schemas: dict[str, set[str]] = {}
+        for tool in tools:
+            try:
+                if tool.type != "function" or not tool.function.name:
+                    continue
+                parameters = tool.function.parameters
+                if isinstance(parameters, dict):
+                    properties = parameters.get("properties", {})
+                    parameter_names = (
+                        set(properties) if isinstance(properties, dict) else set()
+                    )
+                else:
+                    parameter_names = set()
+                schemas[tool.function.name] = parameter_names
+            except AttributeError:
+                continue
+        return schemas
+
+    def _is_partial_tag(self, text: str) -> bool:
+        return any(prefix.startswith(text) for prefix in self._PARTIAL_PREFIXES)
+
+    def _looks_like_function_candidate(self, text: str) -> bool:
+        suffix = text[len("<function") :]
+        if not suffix:
+            return True
+
+        if self._inside_tool_call and not self._function_open:
+            return suffix[0] in "= \t\r\n" or suffix[0].isalpha()
+
+        if suffix[0] == "=":
+            candidate_name = re.split(r"[\s<>]", suffix[1:], maxsplit=1)[0]
+            return not candidate_name or any(
+                name.startswith(candidate_name) for name in self._function_parameters
+            )
+
+        if suffix[0] in " \t\r\n":
+            candidate_name = re.split(r"[\s<>]", suffix.lstrip(), maxsplit=1)[0]
+            if not candidate_name:
+                return True
+            if ">" in text:
+                return candidate_name in self._function_parameters
+            return any(
+                name.startswith(candidate_name) for name in self._function_parameters
+            )
+
+        candidate_name = re.split(r"[\s<>]", suffix, maxsplit=1)[0]
+        return any(
+            name.startswith(candidate_name) for name in self._function_parameters
+        )
+
+    @staticmethod
+    def _looks_like_parameter_candidate(text: str) -> bool:
+        suffix = text[len("<parameter") :]
+        return not suffix or suffix.startswith("=")
+
+    @staticmethod
+    def _append(
+        output: list[_NormalizedSegment], text: str, *, literal: bool = False
+    ) -> None:
+        if not text:
+            return
+        if output and output[-1].literal == literal:
+            output[-1].text += text
+        else:
+            output.append(_NormalizedSegment(text=text, literal=literal))
+
+    @staticmethod
+    def _split_missing_angle_body(body: str) -> tuple[str, str]:
+        """Split a missing-``>`` tag into its name and preserved suffix."""
+        match = re.match(r"([^\s<]+)(.*)", body, re.DOTALL)
+        if match is None:
+            return "", body
+        return match.group(1), match.group(2)
+
+    def _normalize_function_tag(
+        self, raw_tag: str, complete: bool
+    ) -> tuple[Optional[str], Optional[str]]:
+        if complete:
+            canonical = re.fullmatch(r"<function=([^<>]+)>", raw_tag)
+            if canonical:
+                return raw_tag, canonical.group(1)
+
+            missing_equals = re.fullmatch(
+                r"<function(?:\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*>", raw_tag
+            )
+            if missing_equals:
+                name = missing_equals.group(1)
+                if name in self._function_parameters:
+                    return f"<function={name}>", name
+            return None, None
+
+        if not raw_tag.startswith("<function="):
+            return None, None
+        name, suffix = self._split_missing_angle_body(raw_tag[len("<function=") :])
+        if name in self._function_parameters:
+            return f"<function={name}>{suffix}", name
+        return None, None
+
+    def _normalize_parameter_tag(
+        self, raw_tag: str, complete: bool
+    ) -> tuple[Optional[str], Optional[str]]:
+        if complete:
+            canonical = re.fullmatch(r"<parameter=([^<>]+)>", raw_tag)
+            if canonical:
+                return raw_tag, canonical.group(1)
+            return None, None
+
+        if not raw_tag.startswith("<parameter=") or not self._current_function:
+            return None, None
+
+        name, suffix = self._split_missing_angle_body(raw_tag[len("<parameter=") :])
+        if name.startswith("parameter="):
+            name = name[len("parameter=") :]
+        name = name.rstrip(":,;")
+        declared = self._function_parameters.get(self._current_function, set())
+        if name in declared:
+            return f"<parameter={name}>{suffix}", name
+        return None, None
+
+    def _take_named_tag(self, kind: str) -> Optional[tuple[str, bool, int]]:
+        """Return ``(raw_tag, complete, consumed)`` or wait for more input."""
+        gt_pos = self._buffer.find(">", 1)
+        next_lt = self._buffer.find("<", 1)
+        if gt_pos != -1 and (next_lt == -1 or gt_pos < next_lt):
+            return self._buffer[: gt_pos + 1], True, gt_pos + 1
+        if next_lt != -1:
+            return self._buffer[:next_lt], False, next_lt
+
+        # A missing right angle is only repairable once a later tag supplies
+        # the boundary. Until then this may simply be a split canonical tag.
+        expected = f"<{kind}"
+        if self._buffer.startswith(expected):
+            return None
+        return self._buffer[0], True, 1
+
+    def _close_parameter(self, output: list[_NormalizedSegment]) -> None:
+        if self._parameter_open:
+            self._append(output, "</parameter>")
+            self._parameter_open = False
+
+    def _close_function(self, output: list[_NormalizedSegment]) -> None:
+        self._close_parameter(output)
+        if self._function_open:
+            self._append(output, "</function>")
+            self._function_open = False
+            self._current_function = None
+
+    def _close_tool_call(self, output: list[_NormalizedSegment]) -> None:
+        self._close_function(output)
+        if self._inside_tool_call:
+            self._append(output, "</tool_call>")
+        self._inside_tool_call = False
+        self._synthetic_tool_call = False
+        self._suppress_current_tool = False
+        self._current_tool_raw_start = None
+        self._redundant_synthetic_close_pending = False
+        self._pending_synthetic_whitespace = ""
+
+    def _handle_tool_start(
+        self, output: list[_NormalizedSegment], raw_start: int
+    ) -> None:
+        if self._inside_tool_call:
+            self._close_tool_call(output)
+        self._append(output, "<tool_call>")
+        self._inside_tool_call = True
+        self._current_tool_raw_start = raw_start
+
+    def _handle_function_start(
+        self,
+        output: list[_NormalizedSegment],
+        raw_tag: str,
+        complete: bool,
+        raw_start: int,
+    ) -> None:
+        if self._suppress_current_tool:
+            return
+
+        if self._parameter_open or self._function_open:
+            # A function-looking fragment inside an existing function may be
+            # literal parameter content. Step's protocol permits one function
+            # per tool-call wrapper, so treating it as a second function would
+            # be an unsafe repair.
+            self._append(output, raw_tag)
+            return
+
+        normalized, name = self._normalize_function_tag(raw_tag, complete)
+        if normalized is None or name is None:
+            if self._inside_tool_call:
+                # The wrapper has already been consumed by the downstream
+                # parser. Suppress malformed internals until its close rather
+                # than emitting argument fragments with tool_index=-1.
+                self._suppress_current_tool = True
+            else:
+                self._append(output, raw_tag, literal=True)
+            return
+
+        if not self._inside_tool_call:
+            # A missing outer wrapper is repaired only for a declared tool.
+            # Canonical unknown functions inside a real wrapper retain the
+            # existing Qwen parser behavior, but a bare unknown call is not
+            # promoted from text into a structured action.
+            if name not in self._function_parameters:
+                self._append(output, raw_tag, literal=True)
+                return
+            self._append(output, "<tool_call>")
+            self._inside_tool_call = True
+            self._synthetic_tool_call = True
+            self._current_tool_raw_start = raw_start
+
+        if self._function_open:
+            self._close_function(output)
+        self._suppress_current_tool = False
+        self._append(output, normalized)
+        self._function_open = True
+        self._current_function = name
+
+    def _handle_parameter_start(
+        self, output: list[_NormalizedSegment], raw_tag: str, complete: bool
+    ) -> None:
+        if self._suppress_current_tool:
+            return
+        if not self._function_open:
+            self._append(output, raw_tag, literal=True)
+            return
+        normalized, name = self._normalize_parameter_tag(raw_tag, complete)
+        if normalized is None or name is None:
+            # Preserve unsupported XML-like text as parameter content instead
+            # of silently deleting it or manufacturing a parameter name.
+            self._append(output, raw_tag)
+            return
+        self._close_parameter(output)
+        self._append(output, normalized)
+        self._parameter_open = True
+
+    def feed(self, text: str) -> list[_NormalizedSegment]:
+        self._buffer += text
+        self._input_length += len(text)
+        output: list[_NormalizedSegment] = []
+
+        while self._buffer:
+            if self._redundant_synthetic_close_pending:
+                if self._buffer.startswith("</tool_call>"):
+                    pass
+                elif "</tool_call>".startswith(self._buffer):
+                    break
+                elif self._buffer[0].isspace():
+                    whitespace_len = len(self._buffer) - len(self._buffer.lstrip())
+                    self._pending_synthetic_whitespace += self._buffer[:whitespace_len]
+                    self._buffer = self._buffer[whitespace_len:]
+                    continue
+                else:
+                    self._append(
+                        output,
+                        self._pending_synthetic_whitespace,
+                        literal=True,
+                    )
+                    self._pending_synthetic_whitespace = ""
+                    self._redundant_synthetic_close_pending = False
+
+            lt_pos = self._buffer.find("<")
+            if lt_pos == -1:
+                self._append(
+                    output,
+                    self._buffer,
+                    literal=not self._inside_tool_call,
+                )
+                self._redundant_synthetic_close_pending = False
+                self._buffer = ""
+                break
+            if lt_pos > 0:
+                self._append(
+                    output,
+                    self._buffer[:lt_pos],
+                    literal=not self._inside_tool_call,
+                )
+                self._redundant_synthetic_close_pending = False
+                self._buffer = self._buffer[lt_pos:]
+                continue
+
+            if self._buffer.startswith("<tool_call>"):
+                if self._parameter_open or self._function_open:
+                    # Tool XML can be literal shell/code-edit payload. The
+                    # downstream Qwen parser already buffers the enclosing
+                    # parameter until its close, so preserve it verbatim.
+                    self._append(output, "<tool_call>")
+                    self._buffer = self._buffer[len("<tool_call>") :]
+                    continue
+                raw_start = self._input_length - len(self._buffer)
+                self._handle_tool_start(output, raw_start)
+                self._buffer = self._buffer[len("<tool_call>") :]
+                continue
+
+            if self._buffer.startswith("</tool_call>"):
+                if self._suppress_current_tool:
+                    # Let Qwen3CoderDetector leave its already-open wrapper,
+                    # but do not manufacture a function or argument object.
+                    self._append(output, "</tool_call>")
+                    self._inside_tool_call = False
+                    self._synthetic_tool_call = False
+                    self._suppress_current_tool = False
+                    self._function_open = False
+                    self._parameter_open = False
+                    self._current_function = None
+                    self._current_tool_raw_start = None
+                elif self._inside_tool_call:
+                    self._close_tool_call(output)
+                elif self._redundant_synthetic_close_pending:
+                    self._redundant_synthetic_close_pending = False
+                    self._pending_synthetic_whitespace = ""
+                else:
+                    self._append(output, "</tool_call>", literal=True)
+                self._buffer = self._buffer[len("</tool_call>") :]
+                continue
+
+            if self._buffer.startswith("</function>"):
+                if not self._suppress_current_tool and self._function_open:
+                    self._close_parameter(output)
+                    self._append(output, "</function>")
+                    self._function_open = False
+                    self._current_function = None
+                    if self._synthetic_tool_call:
+                        self._append(output, "</tool_call>")
+                        self._inside_tool_call = False
+                        self._synthetic_tool_call = False
+                        self._current_tool_raw_start = None
+                        self._redundant_synthetic_close_pending = True
+                        self._pending_synthetic_whitespace = ""
+                elif not self._suppress_current_tool:
+                    self._append(output, "</function>", literal=True)
+                self._buffer = self._buffer[len("</function>") :]
+                continue
+
+            if self._buffer.startswith("</parameter>"):
+                if not self._suppress_current_tool and self._parameter_open:
+                    self._append(output, "</parameter>")
+                    self._parameter_open = False
+                elif not self._suppress_current_tool:
+                    self._append(output, "</parameter>", literal=True)
+                self._buffer = self._buffer[len("</parameter>") :]
+                continue
+
+            if self._buffer.startswith("<function"):
+                if not self._looks_like_function_candidate(self._buffer):
+                    self._append(
+                        output,
+                        "<",
+                        literal=not self._inside_tool_call,
+                    )
+                    self._buffer = self._buffer[1:]
+                    continue
+                taken = self._take_named_tag("function")
+                if taken is None:
+                    break
+                raw_tag, complete, consumed = taken
+                raw_start = self._input_length - len(self._buffer)
+                self._handle_function_start(output, raw_tag, complete, raw_start)
+                self._buffer = self._buffer[consumed:]
+                continue
+
+            if self._buffer.startswith("<parameter"):
+                if not self._looks_like_parameter_candidate(self._buffer):
+                    self._append(
+                        output,
+                        "<",
+                        literal=not self._inside_tool_call,
+                    )
+                    self._buffer = self._buffer[1:]
+                    continue
+                taken = self._take_named_tag("parameter")
+                if taken is None:
+                    break
+                raw_tag, complete, consumed = taken
+                self._handle_parameter_start(output, raw_tag, complete)
+                self._buffer = self._buffer[consumed:]
+                continue
+
+            if self._is_partial_tag(self._buffer):
+                break
+
+            # Not Step tool XML. Preserve the byte and let the canonical Qwen
+            # parser apply its established text/value behavior.
+            self._append(output, "<", literal=not self._inside_tool_call)
+            self._buffer = self._buffer[1:]
+
+        return output
+
+    @property
+    def incomplete_tool_raw_start(self) -> Optional[int]:
+        if self._inside_tool_call and self._buffer:
+            return self._current_tool_raw_start
+        return None
+
+    def flush_unrepairable(self) -> list[_NormalizedSegment]:
+        """Return an EOS-truncated suffix verbatim without claiming repair."""
+        suffix = self._pending_synthetic_whitespace + self._buffer
+        self._pending_synthetic_whitespace = ""
+        self._redundant_synthetic_close_pending = False
+        self._buffer = ""
+        return [_NormalizedSegment(suffix, literal=True)] if suffix else []
+
+
+class Step3p5Detector(Qwen3CoderDetector):
+    """Step3.5/3.7 tool parser with schema-gated malformed XML recovery."""
+
+    _FUNCTION_CANDIDATE = re.compile(r"<function(?:=|\s+|[A-Za-z_])", re.DOTALL)
+
+    def __init__(self):
+        super().__init__()
+        self._step_normalizer: Optional[_Step3p5XMLNormalizer] = None
+
+    def has_tool_call(self, text: str) -> bool:
+        # Serving checks this before non-stream parsing. Recognize a bare
+        # function candidate so the Step-only missing-wrapper repair is reachable.
+        return super().has_tool_call(text) or bool(
+            self._FUNCTION_CANDIDATE.search(text)
+        )
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        normalizer = _Step3p5XMLNormalizer(tools)
+        segments = normalizer.feed(text)
+
+        # A partial opening tag has no reliable boundary. Do not turn it into
+        # an empty/invalid tool call merely because the non-streaming request
+        # reached EOS.
+        incomplete_start = normalizer.incomplete_tool_raw_start
+        if incomplete_start is not None:
+            # Keep completed calls before the truncated suffix. Re-running the
+            # prefix makes the rollback local to the unfinished wrapper rather
+            # than turning the entire response back into ordinary text.
+            prefix_result = (
+                self.detect_and_parse(text[:incomplete_start], tools)
+                if incomplete_start > 0
+                else StreamingParseResult()
+            )
+            prefix_result.normal_text += text[incomplete_start:]
+            return prefix_result
+
+        # Non-streaming owns the complete output and can safely close a
+        # schema-confirmed Step call at EOS. Streaming deliberately waits for
+        # a later chunk because it has no explicit finish callback.
+        trailing: list[_NormalizedSegment] = []
+        if normalizer._inside_tool_call and normalizer._function_open:
+            normalizer._close_tool_call(trailing)
+        else:
+            trailing = normalizer.flush_unrepairable()
+        segments += trailing
+
+        try:
+            result = self._parse_segments(Qwen3CoderDetector(), segments, tools)
+        except Exception:
+            return StreamingParseResult(normal_text=text)
+
+        calls_by_index: dict[int, ToolCallItem] = {}
+        for call in result.calls:
+            state = calls_by_index.setdefault(
+                call.tool_index,
+                ToolCallItem(tool_index=call.tool_index, parameters=""),
+            )
+            if call.name:
+                state.name = call.name
+            state.parameters += call.parameters
+        result.calls = [calls_by_index[index] for index in sorted(calls_by_index)]
+        return result
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        if self._step_normalizer is None:
+            self._step_normalizer = _Step3p5XMLNormalizer(tools)
+        segments = self._step_normalizer.feed(new_text)
+        return self._parse_segments(self, segments, tools)
+
+    @staticmethod
+    def _parse_segments(
+        parser: Qwen3CoderDetector,
+        segments: list[_NormalizedSegment],
+        tools: List[Tool],
+    ) -> StreamingParseResult:
+        normal_text: list[str] = []
+        calls: list[ToolCallItem] = []
+        for segment in segments:
+            if segment.literal:
+                normal_text.append(segment.text)
+                continue
+            result = Qwen3CoderDetector.parse_streaming_increment(
+                parser, segment.text, tools
+            )
+            normal_text.append(result.normal_text)
+            calls.extend(result.calls)
+        return StreamingParseResult(normal_text="".join(normal_text), calls=calls)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -92,6 +92,7 @@ class BaseReasoningFormatDetector:
 
         self._force_nonempty_content = force_nonempty_content
         self._accumulated_reasoning = ""
+        self._prefer_tool_start_boundary = False
 
         self.continue_final_message = continue_final_message
         if self.continue_final_message:
@@ -133,6 +134,17 @@ class BaseReasoningFormatDetector:
         processed_text = text
         while processed_text.startswith(think_start_text):
             processed_text = processed_text[len(think_start_text) :]
+
+        if self._prefer_tool_start_boundary and self.tool_start_token is not None:
+            think_end_idx = processed_text.find(self.think_end_token)
+            tool_start_idx = processed_text.find(self.tool_start_token)
+            if tool_start_idx != -1 and (
+                think_end_idx == -1 or tool_start_idx < think_end_idx
+            ):
+                return StreamingParseResult(
+                    normal_text=processed_text[tool_start_idx:],
+                    reasoning_text=processed_text[:tool_start_idx],
+                )
 
         if (
             self.think_end_token not in processed_text
@@ -209,6 +221,24 @@ class BaseReasoningFormatDetector:
             self._buffer = current_text
             self.stripped_think_start = True
             self._in_reasoning = True
+
+        # Step may start a tool call before a delayed reasoning end tag.
+        if (
+            self._in_reasoning
+            and self._prefer_tool_start_boundary
+            and self.tool_start_token is not None
+            and self.tool_start_token in current_text
+        ):
+            think_end_idx = current_text.find(self.think_end_token)
+            tool_start_idx = current_text.find(self.tool_start_token)
+            if think_end_idx == -1 or tool_start_idx < think_end_idx:
+                reasoning_text = current_text[:tool_start_idx]
+                normal_text = current_text[tool_start_idx:]
+                self._buffer = ""
+                self._in_reasoning = False
+                return StreamingParseResult(
+                    normal_text=normal_text, reasoning_text=reasoning_text
+                )
 
         # Handle end of reasoning block
         if self._in_reasoning and self.think_end_token in current_text:
@@ -350,6 +380,34 @@ class DeepSeekR1Detector(BaseReasoningFormatDetector):
             force_nonempty_content=force_nonempty_content,
         )
         # https://github.com/sgl-project/sglang/pull/3202#discussion_r1950153599
+
+
+class Step3p5Detector(DeepSeekR1Detector):
+    """Reasoning detector for Step-3.5 and Step-3.7 models.
+
+    Step models follow DeepSeek-R1's always-on reasoning behavior, but may
+    begin ``<tool_call>`` without first emitting ``</think>``. Treat the tool
+    marker as an implicit reasoning boundary so the downstream tool parser
+    receives the complete tool-call payload.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = True,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+        force_nonempty_content: bool = False,
+    ):
+        super().__init__(
+            stream_reasoning=stream_reasoning,
+            force_reasoning=force_reasoning,
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
+        )
+        self.tool_start_token = "<tool_call>"
+        self._prefer_tool_start_boundary = True
 
 
 class Qwen3Detector(BaseReasoningFormatDetector):
@@ -2120,7 +2178,7 @@ class ReasoningParser:
         "minimax-m3": MiniMaxM3Detector,
         "nanbeige": Qwen3Detector,
         "step3": DeepSeekR1Detector,
-        "step3p5": DeepSeekR1Detector,
+        "step3p5": Step3p5Detector,
         "mistral": MistralDetector,
         "nemotron_3": Nemotron3Detector,
         "interns1": Qwen3Detector,

--- a/test/registered/unit/function_call/test_step3p5_detector.py
+++ b/test/registered/unit/function_call/test_step3p5_detector.py
@@ -5,6 +5,7 @@ from sglang.srt.entrypoints.openai.protocol import Function, Tool
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.step3p5_detector import Step3p5Detector
+from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -81,6 +82,54 @@ class TestStep3p5Detector(CustomTestCase):
                 expected,
                 msg=f"split={split}",
             )
+
+    def test_reasoning_then_malformed_tool_non_stream(self):
+        tool = "<tool_call><function bash><parameter=command>pwd</parameter></function></tool_call>"
+        for suffix in ("", "</think>late close"):
+            reasoning, content = ReasoningParser("step3p5").parse_non_stream(
+                "inspect the repo" + tool + suffix
+            )
+            normal, calls = FunctionCallParser(self.tools, "step3p5").parse_non_stream(
+                content
+            )
+            self.assertEqual(reasoning, "inspect the repo")
+            self.assertEqual(normal, suffix)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0].name, "bash")
+            self.assertEqual(json.loads(calls[0].parameters), {"command": "pwd"})
+
+    def test_reasoning_then_malformed_tool_stream_at_every_split(self):
+        tool = "<tool_call><function bash><parameter=command>pwd</parameter></function></tool_call>"
+        for suffix in ("", "</think>late close"):
+            source = "inspect the repo" + tool + suffix
+            chunkings = [list(source)] + [
+                [source[:i], source[i:]] for i in range(len(source) + 1)
+            ]
+            for chunks in chunkings:
+                reasoning_parser = ReasoningParser("step3p5")
+                tool_parser = FunctionCallParser(self.tools, "step3p5")
+                reasoning, normal, calls = "", "", []
+                for chunk in chunks:
+                    thinking, content = reasoning_parser.parse_stream_chunk(chunk)
+                    reasoning += thinking
+                    text, updates = tool_parser.parse_stream_chunk(content)
+                    normal += text
+                    calls.extend(updates)
+                thinking, content = reasoning_parser.parse_stream_end()
+                reasoning += thinking
+                text, updates = tool_parser.parse_stream_chunk(content)
+                normal += text
+                calls.extend(updates)
+                text, updates = tool_parser.parse_stream_end()
+                normal += text
+                calls.extend(updates)
+                self.assertEqual(reasoning, "inspect the repo")
+                self.assertEqual(normal, suffix)
+                self.assertEqual([c.name for c in calls if c.name], ["bash"])
+                self.assertTrue(all(c.tool_index == 0 for c in calls))
+                self.assertEqual(
+                    json.loads("".join(c.parameters for c in calls)), {"command": "pwd"}
+                )
 
     def test_registry_isolated_from_qwen3_coder(self):
         self.assertIs(FunctionCallParser.ToolCallParserEnum["step3p5"], Step3p5Detector)

--- a/test/registered/unit/function_call/test_step3p5_detector.py
+++ b/test/registered/unit/function_call/test_step3p5_detector.py
@@ -1,0 +1,469 @@
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.srt.function_call.step3p5_detector import Step3p5Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestStep3p5Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="bash",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string"},
+                            "items": {"type": "array"},
+                            "options": {"type": "object"},
+                            "timeout": {"type": "integer"},
+                        },
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "state": {"type": "string"},
+                        },
+                    },
+                ),
+            ),
+        ]
+
+    def _parse_stream(self, chunks):
+        detector = Step3p5Detector()
+        normal_text = ""
+        calls = {}
+        name_counts = {}
+
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            for call in result.calls:
+                self.assertGreaterEqual(call.tool_index, 0)
+                state = calls.setdefault(
+                    call.tool_index, {"name": None, "arguments": ""}
+                )
+                if call.name:
+                    state["name"] = call.name
+                    name_counts[call.tool_index] = (
+                        name_counts.get(call.tool_index, 0) + 1
+                    )
+                state["arguments"] += call.parameters
+
+        for index, state in calls.items():
+            self.assertEqual(name_counts[index], 1)
+            state["arguments"] = json.loads(state["arguments"])
+        self.assertEqual(list(calls), list(range(len(calls))))
+        return normal_text, calls
+
+    def _assert_stream_invariant(self, source, expected_normal, expected_calls):
+        expected = (expected_normal, expected_calls)
+        self.assertEqual(self._parse_stream([source]), expected)
+        self.assertEqual(self._parse_stream(list(source)), expected)
+        for split in range(len(source) + 1):
+            self.assertEqual(
+                self._parse_stream([source[:split], source[split:]]),
+                expected,
+                msg=f"split={split}",
+            )
+
+    def test_registry_isolated_from_qwen3_coder(self):
+        self.assertIs(FunctionCallParser.ToolCallParserEnum["step3p5"], Step3p5Detector)
+        self.assertIs(
+            FunctionCallParser.ToolCallParserEnum["qwen3_coder"],
+            Qwen3CoderDetector,
+        )
+        self.assertIsNot(Step3p5Detector, Qwen3CoderDetector)
+
+    def test_canonical_xml_matches_qwen_parser(self):
+        source = (
+            "prefix<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "<parameter=timeout>5</parameter>"
+            "</function></tool_call>"
+        )
+        step_result = Step3p5Detector().detect_and_parse(source, self.tools)
+        qwen_result = Qwen3CoderDetector().detect_and_parse(source, self.tools)
+        self.assertEqual(step_result, qwen_result)
+        self._assert_stream_invariant(
+            source,
+            "prefix",
+            {0: {"name": "bash", "arguments": {"command": "pwd", "timeout": 5}}},
+        )
+
+    def test_missing_equals_in_known_function_tag(self):
+        for function_tag in ("<function bash>", "<functionbash>"):
+            source = (
+                f"<tool_call>{function_tag}"
+                "<parameter=command>pwd</parameter>"
+                "</function></tool_call>"
+            )
+            self._assert_stream_invariant(
+                source,
+                "",
+                {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+            )
+            result = Step3p5Detector().detect_and_parse(source, self.tools)
+            self.assertEqual(result.calls[0].name, "bash")
+            self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+
+    def test_missing_right_angle_in_function_and_parameter_tags(self):
+        source = (
+            "<tool_call><function=bash\n"
+            "<parameter=command\npwd</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+
+    def test_duplicate_parameter_prefix_is_repaired_when_boundary_is_known(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=parameter=command\npwd</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+
+    def test_missing_outer_tool_call_wrapper(self):
+        source = "<function=bash><parameter=command>pwd</parameter></function>"
+        parser = FunctionCallParser(self.tools, "step3p5")
+        self.assertTrue(parser.has_tool_call(source))
+        normal_text, calls = parser.parse_non_stream(source)
+        self.assertEqual(normal_text, "")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "bash")
+        self.assertEqual(json.loads(calls[0].parameters), {"command": "pwd"})
+        self._assert_stream_invariant(
+            source,
+            "",
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+
+    def test_missing_parameter_close_before_next_parameter(self):
+        source = (
+            "<tool_call><function=weather>"
+            "<parameter=city>Dallas"
+            "<parameter=state>TX</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {
+                0: {
+                    "name": "weather",
+                    "arguments": {"city": "Dallas", "state": "TX"},
+                }
+            },
+        )
+
+    def test_tool_close_repairs_open_parameter_and_function(self):
+        source = "<tool_call><function=bash><parameter=command>pwd</tool_call>"
+        self._assert_stream_invariant(
+            source,
+            "",
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+
+    def test_adjacent_calls_in_one_mtp_chunk(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call><tool_call><function=weather>"
+            "<parameter=city>Paris</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {
+                0: {"name": "bash", "arguments": {"command": "pwd"}},
+                1: {"name": "weather", "arguments": {"city": "Paris"}},
+            },
+        )
+
+    def test_interleaved_text_is_preserved_in_both_modes(self):
+        first = (
+            "<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        second = (
+            "<tool_call><function=weather>"
+            "<parameter=city>Paris</parameter>"
+            "</function></tool_call>"
+        )
+        source = f"hello{first}between{second}bye"
+        expected_calls = {
+            0: {"name": "bash", "arguments": {"command": "pwd"}},
+            1: {"name": "weather", "arguments": {"city": "Paris"}},
+        }
+        self._assert_stream_invariant(source, "hellobetweenbye", expected_calls)
+
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, "hellobetweenbye")
+        self.assertEqual(
+            {
+                call.tool_index: {
+                    "name": call.name,
+                    "arguments": json.loads(call.parameters),
+                }
+                for call in result.calls
+            },
+            expected_calls,
+        )
+
+    def test_python_literal_container_parameters_remain_supported(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=options>{'check': True}</parameter>"
+            "<parameter=items>[1, 2]</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {
+                0: {
+                    "name": "bash",
+                    "arguments": {"options": {"check": True}, "items": [1, 2]},
+                }
+            },
+        )
+
+    def test_unknown_malformed_function_is_not_repaired(self):
+        source = (
+            "<tool_call><function unknown>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.calls, [])
+        normal_text, calls = self._parse_stream(list(source))
+        self.assertEqual(normal_text, "")
+        self.assertEqual(calls, {})
+
+    def test_bare_unknown_function_is_preserved_as_text(self):
+        source = (
+            "prefix<function=unknown>"
+            "<parameter=command>pwd</parameter>"
+            "</function>suffix"
+        )
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, source)
+        self.assertEqual(result.calls, [])
+        self.assertEqual(self._parse_stream(list(source)), (source, {}))
+
+    def test_xml_like_prose_does_not_block_a_later_real_call(self):
+        real_call = (
+            "<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        prefix = "intro<functions>x</functions><function_name>y</function_name>"
+        source = prefix + real_call
+        self._assert_stream_invariant(
+            source,
+            prefix,
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+
+    def test_partial_function_words_are_plain_stream_content(self):
+        for source in (
+            "This uses <functionality in prose",
+            "This uses <functionbashful in prose",
+            "This uses <function unknown in prose",
+            "This discusses <parameterization forever",
+        ):
+            result = Step3p5Detector().detect_and_parse(source, self.tools)
+            self.assertEqual(result.normal_text, source)
+            self.assertEqual(result.calls, [])
+            self.assertEqual(self._parse_stream(list(source)), (source, {}))
+
+    def test_unmatched_closing_tags_are_preserved_as_text(self):
+        source = "a</function>b</parameter>c</tool_call>d"
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, source)
+        self.assertEqual(result.calls, [])
+        self.assertEqual(self._parse_stream(list(source)), (source, {}))
+
+    def test_private_use_text_has_no_special_meaning(self):
+        source = "prefix\ue000step3p5-literal-lt\ue001suffix"
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, source)
+        self.assertEqual(result.calls, [])
+        self.assertEqual(self._parse_stream(list(source)), (source, {}))
+
+    def test_literal_and_parser_segments_do_not_reorder_text(self):
+        call = (
+            "<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        source = f"a<</function>b{call}"
+        self._assert_stream_invariant(
+            source,
+            "a<</function>b",
+            {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+        )
+
+    def test_non_stream_closes_confirmed_call_at_eos(self):
+        source = "<tool_call><function=bash><parameter=command>pwd"
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "bash")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+
+    def test_non_stream_does_not_invent_call_from_partial_opening_tag(self):
+        for source in (
+            "<tool_call><function=bash",
+            "<tool_call><function=bash><parameter=command",
+        ):
+            result = Step3p5Detector().detect_and_parse(source, self.tools)
+            self.assertEqual(result.normal_text, source)
+            self.assertEqual(result.calls, [])
+
+    def test_non_stream_partial_second_call_keeps_completed_first_call(self):
+        first = (
+            "<tool_call><function=bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        partial = "<tool_call><function=weather"
+        result = Step3p5Detector().detect_and_parse(first + partial, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "bash")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+        self.assertEqual(result.normal_text, partial)
+
+    def test_redundant_close_after_synthetic_wrapper_is_consumed(self):
+        for separator in ("", "\n", "\n  "):
+            source = (
+                "<function=bash><parameter=command>pwd</parameter>"
+                f"</function>{separator}</tool_call>"
+            )
+            result = Step3p5Detector().detect_and_parse(source, self.tools)
+
+            self.assertEqual(result.normal_text, "")
+            self.assertEqual(len(result.calls), 1)
+            self.assertEqual(result.calls[0].name, "bash")
+            self.assertEqual(json.loads(result.calls[0].parameters), {"command": "pwd"})
+            self._assert_stream_invariant(
+                source,
+                "",
+                {0: {"name": "bash", "arguments": {"command": "pwd"}}},
+            )
+
+    def test_whitespace_after_synthetic_wrapper_is_preserved_without_close(self):
+        source = "<function=bash></function>\n"
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, "\n")
+        self.assertEqual(result.calls[0].name, "bash")
+
+    def test_non_stream_conversion_error_falls_back_to_text(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=options>{1, 2}</parameter>"
+            "</function></tool_call>"
+        )
+        result = Step3p5Detector().detect_and_parse(source, self.tools)
+        self.assertEqual(result.normal_text, source)
+        self.assertEqual(result.calls, [])
+
+    def test_function_like_text_inside_parameter_is_not_repaired(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=command>printf '&lt;function bash&gt;'</parameter>"
+            "</function></tool_call>"
+        )
+        expected_arguments = {"command": "printf '&lt;function bash&gt;'"}
+        self._assert_stream_invariant(
+            source,
+            "",
+            {0: {"name": "bash", "arguments": expected_arguments}},
+        )
+
+        # The raw form is legal parameter text too. Keeping it verbatim is
+        # important because shell/code-edit tools frequently carry XML-like
+        # snippets as data.
+        raw_source = source.replace("&lt;function bash&gt;", "<function bash>")
+        self._assert_stream_invariant(
+            raw_source,
+            "",
+            {
+                0: {
+                    "name": "bash",
+                    "arguments": {"command": "printf '<function bash>'"},
+                }
+            },
+        )
+        result = Step3p5Detector().detect_and_parse(raw_source, self.tools)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters),
+            {"command": "printf '<function bash>'"},
+        )
+
+    def test_tool_call_start_text_inside_parameter_is_not_repaired(self):
+        source = (
+            "<tool_call><function=bash>"
+            "<parameter=command>printf '<tool_call>'</parameter>"
+            "</function></tool_call>"
+        )
+        self._assert_stream_invariant(
+            source,
+            "",
+            {
+                0: {
+                    "name": "bash",
+                    "arguments": {"command": "printf '<tool_call>'"},
+                }
+            },
+        )
+
+    def test_qwen_parser_does_not_gain_step_repair(self):
+        source = (
+            "<tool_call><function bash>"
+            "<parameter=command>pwd</parameter>"
+            "</function></tool_call>"
+        )
+        step_result = Step3p5Detector().detect_and_parse(source, self.tools)
+        qwen_result = Qwen3CoderDetector().detect_and_parse(source, self.tools)
+        self.assertEqual(step_result.calls[0].name, "bash")
+        self.assertEqual(qwen_result.calls, [])
+
+    def test_structural_tag_contract_is_inherited(self):
+        detector = Step3p5Detector()
+        self.assertTrue(detector.supports_structural_tag())
+        self.assertEqual(detector.get_structural_tag_name(), "qwen_3_coder")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -18,6 +18,7 @@ from sglang.srt.parser.reasoning_parser import (
     Nemotron3Detector,
     Qwen3Detector,
     ReasoningParser,
+    Step3p5Detector,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -215,6 +216,142 @@ class TestDeepSeekR1Detector(CustomTestCase):
         end = detector.finish()
         self.assertEqual(end.reasoning_text, "reasoning with no end token")
         self.assertEqual(end.normal_text, "")
+
+
+class TestStep3p5Detector(CustomTestCase):
+    TOOL_CALL = (
+        "<tool_call><function=bash><parameter=command>pwd</parameter>"
+        "</function></tool_call>"
+    )
+
+    def test_preserves_deepseek_always_on_reasoning_semantics(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse("reasoning without an opening tag")
+        self.assertEqual(result.reasoning_text, "reasoning without an opening tag")
+        self.assertEqual(result.normal_text, "")
+
+    def test_non_streaming_tool_implicitly_ends_reasoning(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse("inspect the repo" + self.TOOL_CALL)
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, self.TOOL_CALL)
+
+    def test_explicit_reasoning_end_remains_supported(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse(
+            "inspect the repo</think>answer " + self.TOOL_CALL
+        )
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, "answer " + self.TOOL_CALL)
+
+    def test_first_boundary_wins(self):
+        detector = Step3p5Detector()
+        result = detector.detect_and_parse(
+            "inspect the repo" + self.TOOL_CALL + "</think>late close"
+        )
+        self.assertEqual(result.reasoning_text, "inspect the repo")
+        self.assertEqual(result.normal_text, self.TOOL_CALL + "</think>late close")
+
+    def test_streaming_first_boundary_wins_at_every_split(self):
+        cases = (
+            (
+                "inspect the repo" + self.TOOL_CALL + "</think>late close",
+                "inspect the repo",
+                self.TOOL_CALL + "</think>late close",
+            ),
+            (
+                "inspect the repo</think>answer " + self.TOOL_CALL,
+                "inspect the repo",
+                "answer " + self.TOOL_CALL,
+            ),
+        )
+        for source, expected_reasoning, expected_normal in cases:
+            for split in range(1, len(source)):
+                detector = Step3p5Detector()
+                reasoning = ""
+                normal = ""
+                for chunk in (source[:split], source[split:]):
+                    result = detector.parse_streaming_increment(chunk)
+                    reasoning += result.reasoning_text
+                    normal += result.normal_text
+                end = detector.finish()
+                reasoning += end.reasoning_text
+                normal += end.normal_text
+                self.assertEqual(reasoning, expected_reasoning, msg=f"split={split}")
+                self.assertEqual(normal, expected_normal, msg=f"split={split}")
+
+    def test_streaming_tool_boundary_at_every_split(self):
+        source = "inspect the repo" + self.TOOL_CALL
+        for split in range(1, len(source)):
+            detector = Step3p5Detector()
+            reasoning = ""
+            normal = ""
+            for chunk in (source[:split], source[split:]):
+                result = detector.parse_streaming_increment(chunk)
+                reasoning += result.reasoning_text
+                normal += result.normal_text
+            end = detector.finish()
+            reasoning += end.reasoning_text
+            normal += end.normal_text
+            self.assertEqual(reasoning, "inspect the repo", msg=f"split={split}")
+            self.assertEqual(normal, self.TOOL_CALL, msg=f"split={split}")
+
+    def test_streaming_tool_boundary_one_character_at_a_time(self):
+        detector = Step3p5Detector()
+        reasoning = ""
+        normal = ""
+        for char in "inspect the repo" + self.TOOL_CALL:
+            result = detector.parse_streaming_increment(char)
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        end = detector.finish()
+        reasoning += end.reasoning_text
+        normal += end.normal_text
+        self.assertEqual(reasoning, "inspect the repo")
+        self.assertEqual(normal, self.TOOL_CALL)
+
+    def test_streaming_incomplete_marker_prefix_is_flushed(self):
+        detector = Step3p5Detector()
+        result = detector.parse_streaming_increment("reasoning<tool_")
+        self.assertEqual(result.reasoning_text, "reasoning")
+        self.assertEqual(result.normal_text, "")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "<tool_")
+        self.assertEqual(end.normal_text, "")
+
+    def test_buffered_reasoning_preserves_tool_boundary_at_every_split(self):
+        source = "reasoning" + self.TOOL_CALL + "</think>late close"
+        for split in range(len(source) + 1):
+            detector = Step3p5Detector(stream_reasoning=False)
+            results = [
+                detector.parse_streaming_increment(source[:split]),
+                detector.parse_streaming_increment(source[split:]),
+                detector.finish(),
+            ]
+            self.assertEqual("".join(r.reasoning_text for r in results), "reasoning")
+            self.assertEqual(
+                "".join(r.normal_text for r in results),
+                self.TOOL_CALL + "</think>late close",
+            )
+
+    def test_other_detectors_keep_explicit_end_precedence(self):
+        source = "reasoning" + self.TOOL_CALL + "</think>answer"
+        for detector in (DeepSeekR1Detector(), Qwen3Detector(force_reasoning=True)):
+            result = detector.detect_and_parse(source)
+            self.assertEqual(result.reasoning_text, "reasoning" + self.TOOL_CALL)
+            self.assertEqual(result.normal_text, "answer")
+
+    def test_streaming_multiple_tool_calls_are_preserved_for_tool_parser(self):
+        detector = Step3p5Detector()
+        source = "reasoning" + self.TOOL_CALL + self.TOOL_CALL
+        reasoning = ""
+        normal = ""
+        for char in source:
+            result = detector.parse_streaming_increment(char)
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(normal, self.TOOL_CALL + self.TOOL_CALL)
 
 
 class TestQwen3Detector(CustomTestCase):
@@ -1373,7 +1510,7 @@ class TestReasoningParserAdvanced(CustomTestCase):
         alias_tests = {
             "deepseek-v3": Qwen3Detector,
             "step3": DeepSeekR1Detector,
-            "step3p5": DeepSeekR1Detector,
+            "step3p5": Step3p5Detector,
             "interns1": Qwen3Detector,
         }
         for model_type, expected_class in alias_tests.items():


### PR DESCRIPTION
## Motivation

Step tool calls can be lost at two consecutive parsing stages: a missing or delayed `</think>` keeps the call in reasoning, and malformed function XML can then prevent tool-call extraction. This PR fixes both stages together, superseding #38892 and #38893.

For example, `inspect the repo<tool_call><function bash><parameter=command>pwd</parameter></function></tool_call>` should yield reasoning `inspect the repo` and one `bash` call with `{"command":"pwd"}`.

## Modifications

- Add a Step-specific reasoning detector that preserves always-on reasoning and treats the earliest `<tool_call>` as an implicit reasoning boundary. Reuse main's partial-marker buffering and end-of-stream handling.
- Add a Step XML normalizer before the canonical Qwen3-Coder parser. Gate supported delimiter/missing-wrapper recovery with declared names, and preserve unknown bare functions, XML-like prose, and literal function-like parameter text.
- Preserve other reasoning detectors' precedence, the Qwen tool-parser registry entry, and its structural-tag contract.
- Retain separate commits for the two fixes, followed by a focused test commit connecting the public reasoning and tool-call parser APIs.

## Accuracy Tests

**408 tests passed** across `test_reasoning_parser.py`, `test_step3p5_detector.py`, `test_function_call_parser.py`, `test_parallel_tool_calls.py`, and `test_unknown_tool_name.py`.

Two added pipeline tests cover reasoning followed by malformed tool XML, with a missing or delayed reasoning-end marker, in non-streaming mode, character-at-a-time streaming, and every two-chunk split. They check reasoning/text preservation, argument contents, and a single stable tool index/name. These exercise parser APIs, not an HTTP server or actual tool execution.

The individual public-API reproducers fail on unmodified main `908226fea2` and pass with the respective fixes. Applicable pre-commit hooks for all changed files and `git diff --check` pass.

Local environment: macOS arm64, Python 3.11.15, PyTorch 2.8.0, Transformers 5.12.1. Full serving/model-generation evaluation has not been run.

## Speed Tests and Profiling

No GPU/model-forward changes or measured performance claims. Parser latency benchmarking has not been run.

## Checklist

- [x] Format and lint changed files with pre-commit.
- [x] Add CPU regression and chained-parser tests.
- [x] Follow SGLang code style.
- [x] Documentation: existing parser selectors are unchanged.
- [ ] Validate representative real-model responses through the serving endpoint before marking ready for review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34479905043](https://github.com/sgl-project/sglang/actions/runs/34479905043)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34479904704](https://github.com/sgl-project/sglang/actions/runs/34479904704)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34479904839](https://github.com/sgl-project/sglang/actions/runs/34479904839)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->