### PR TITLE
fix(multimodal): manage auxiliary patch feature transport and lifetime

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -57,10 +57,25 @@ from sglang.utils import logger
 # propagation that can cause some log messages (like 'server is fired up') to not appear
 # in the console when multimodal support is enabled.
 
+# Only large auxiliary features belong here; unrelated model metadata keeps
+# its original device and transport semantics.
+AUXILIARY_TRANSPORT_FEATURE_NAMES = frozenset(("patch_pixel_values",))
+_AUXILIARY_SHM_MIN_BYTES = 1024 * 1024
+
 _GPU_FEATURE_BUFFER: Optional[torch.Tensor] = None
 _BUFFER_OFFSET = 0
 
 _is_default_tensor_transport = None
+
+
+def _offload_auxiliary_features(item):
+    updates = {}
+    for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+        value = item.model_specific_data.get(key)
+        if isinstance(value, torch.Tensor) and value.is_cuda:
+            updates[key] = value.to("cpu", non_blocking=True)
+    if updates:
+        item.model_specific_data = {**item.model_specific_data, **updates}
 
 
 def init_feature_buffer(device):
@@ -721,6 +736,7 @@ def general_mm_embed_routine(
                             feature = getattr(mm_item, "feature", None)
                             if isinstance(feature, torch.Tensor) and feature.is_cuda:
                                 mm_item.feature = feature.to("cpu", non_blocking=True)
+                            _offload_auxiliary_features(mm_item)
                             if get_disagg().language_only:
                                 precomputed_embeddings = getattr(
                                     mm_item, "precomputed_embeddings", None
@@ -1416,6 +1432,9 @@ def _wrap_shm_or_inline(tensor: torch.Tensor, precomputed_hash: Optional[int] = 
     """Wrap a tensor in ShmPointerMMData, falling back to inline (pickled)
     transport when shared memory cannot be allocated, e.g. /dev/shm is full
     under a burst of multimodal requests."""
+    if tensor.numel() == 0:
+        # multiprocessing.shared_memory rejects size=0.
+        return tensor
     try:
         return ShmPointerMMData(tensor, precomputed_hash=precomputed_hash)
     except OSError as e:
@@ -1445,6 +1464,38 @@ def _wrap_tensor_or_list(value, precomputed_hash: Optional[int] = None):
     return value
 
 
+def _wrap_auxiliary_transport_value(value):
+    """Move a registered auxiliary feature to CPU and use SHM when large.
+
+    CUDA IPC proxies are already transport-ready and are intentionally left
+    untouched. Containers are rebuilt instead of modified in place because
+    parallel-sampling requests can share nested model-specific objects.
+    """
+    if isinstance(value, CudaIpcTensorTransportProxy):
+        return value
+    if isinstance(value, torch.Tensor):
+        cpu_value = value if value.is_cpu else value.cpu()
+        nbytes = cpu_value.numel() * cpu_value.element_size()
+        if nbytes >= _AUXILIARY_SHM_MIN_BYTES:
+            return _wrap_shm_or_inline(cpu_value)
+        return cpu_value
+    if isinstance(value, (dict, list, tuple)):
+        wrapped = []
+        try:
+            for child in value.values() if isinstance(value, dict) else value:
+                wrapped.append(_wrap_auxiliary_transport_value(child))
+        except BaseException:
+            # Some children may already own segments even though the enclosing
+            # value has not been attached to its request yet.
+            for child in wrapped:
+                _discard_tensor_or_list(child)
+            raise
+        if isinstance(value, dict):
+            return dict(zip(value, wrapped))
+        return tuple(wrapped) if isinstance(value, tuple) else wrapped
+    return value
+
+
 def wrap_shm_features(obj):
     """
     Scan the object for multimodal tensors and wrap them in SHM pointers.
@@ -1463,15 +1514,31 @@ def wrap_shm_features(obj):
                 item.precomputed_embeddings = _wrap_tensor_or_list(
                     item.precomputed_embeddings, precomputed_hash=item_hash
                 )
+            model_specific_data = item.model_specific_data
+            updated_model_specific_data = None
+            for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+                if key not in model_specific_data:
+                    continue
+                original_value = model_specific_data[key]
+                wrapped_value = _wrap_auxiliary_transport_value(original_value)
+                if wrapped_value is original_value:
+                    continue
+                if updated_model_specific_data is None:
+                    updated_model_specific_data = dict(model_specific_data)
+                updated_model_specific_data[key] = wrapped_value
+            if updated_model_specific_data is not None:
+                item.model_specific_data = updated_model_specific_data
     return obj
 
 
-def _feature_has_shm(feat) -> bool:
-    """Check whether a single feature (tensor, ShmPointer, or list) contains ShmPointerMMData."""
-    if isinstance(feat, ShmPointerMMData):
+def _feature_has_shm(value) -> bool:
+    """Recursively detect SHM pointers in a multimodal transport value."""
+    if isinstance(value, ShmPointerMMData):
         return True
-    if isinstance(feat, (list, tuple)):
-        return any(isinstance(t, ShmPointerMMData) for t in feat)
+    if isinstance(value, dict):
+        return any(_feature_has_shm(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_feature_has_shm(item) for item in value)
     return False
 
 
@@ -1489,16 +1556,21 @@ def has_shm_features(recv_reqs):
                     return True
                 if _feature_has_shm(item.precomputed_embeddings):
                     return True
+                for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+                    if _feature_has_shm(item.model_specific_data.get(key)):
+                        return True
     return False
 
 
 def _discard_tensor_or_list(value) -> None:
     if isinstance(value, ShmPointerMMData):
         value.close_and_unlink()
+    elif isinstance(value, dict):
+        for tensor in value.values():
+            _discard_tensor_or_list(tensor)
     elif isinstance(value, (list, tuple)):
         for tensor in value:
-            if isinstance(tensor, ShmPointerMMData):
-                tensor.close_and_unlink()
+            _discard_tensor_or_list(tensor)
 
 
 def discard_shm_features(obj) -> None:
@@ -1514,31 +1586,39 @@ def discard_shm_features(obj) -> None:
     for item in obj.mm_inputs.mm_items:
         _discard_tensor_or_list(item.feature)
         _discard_tensor_or_list(item.precomputed_embeddings)
+        for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+            _discard_tensor_or_list(item.model_specific_data.get(key))
 
 
-def _unwrap_tensor_or_list(value):
-    """Restore ShmPointerMMData wrappers back into standard torch.Tensors."""
+def _unwrap_transport_value(value, memo):
+    """Restore nested SHM pointers while preserving repeated references."""
     if isinstance(value, ShmPointerMMData):
-        return value.materialize()
-    elif isinstance(value, (list, tuple)):
-        unwrapped = [
-            t.materialize() if isinstance(t, ShmPointerMMData) else t for t in value
-        ]
-        return type(value)(unwrapped) if isinstance(value, tuple) else unwrapped
+        proxy_id = id(value)
+        if proxy_id not in memo:
+            memo[proxy_id] = value.materialize()
+        return memo[proxy_id]
+    if isinstance(value, dict):
+        return {key: _unwrap_transport_value(item, memo) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_unwrap_transport_value(item, memo) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_unwrap_transport_value(item, memo) for item in value)
     return value
 
 
-def unwrap_shm_features(obj):
+def unwrap_shm_features(obj, _memo=None):
     """
     Restore ShmPointerMMData wrappers back into standard torch.Tensors.
     Handles both single requests and batch requests.
     """
     if _get_is_default_transport() or get_serving().skip_tokenizer_init:
         return obj
+    if _memo is None:
+        _memo = {}
     # Handle batch requests
     if isinstance(obj, BaseBatchReq):
         for sub_obj in obj.batch:
-            unwrap_shm_features(sub_obj)
+            unwrap_shm_features(sub_obj, _memo)
         return obj
     # Handle single requests
     if isinstance(
@@ -1546,9 +1626,20 @@ def unwrap_shm_features(obj):
     ) and isinstance(obj.mm_inputs, (MultimodalProcessorOutput, MultimodalInputs)):
         for item in obj.mm_inputs.mm_items:
             if item.feature is not None:
-                item.feature = _unwrap_tensor_or_list(item.feature)
+                item.feature = _unwrap_transport_value(item.feature, _memo)
             if item.precomputed_embeddings is not None:
-                item.precomputed_embeddings = _unwrap_tensor_or_list(
-                    item.precomputed_embeddings
+                item.precomputed_embeddings = _unwrap_transport_value(
+                    item.precomputed_embeddings, _memo
                 )
+            model_specific_data = item.model_specific_data
+            updated_model_specific_data = None
+            for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+                value = model_specific_data.get(key)
+                if not _feature_has_shm(value):
+                    continue
+                if updated_model_specific_data is None:
+                    updated_model_specific_data = dict(model_specific_data)
+                updated_model_specific_data[key] = _unwrap_transport_value(value, _memo)
+            if updated_model_specific_data is not None:
+                item.model_specific_data = updated_model_specific_data
     return obj

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -493,6 +493,12 @@ class MultimodalDataItem(msgspec.Struct, kw_only=True, dict=True, array_like=Tru
             self.precomputed_embeddings = (
                 self.precomputed_embeddings.reconstruct_on_target_device(target_device)
             )
+        # Parallel sampling can shallow-copy the item and share this dictionary.
+        if any(
+            isinstance(value, CudaIpcTensorTransportProxy)
+            for value in self.model_specific_data.values()
+        ):
+            self.model_specific_data = dict(self.model_specific_data)
         for extra_key in self.model_specific_data:
             if isinstance(
                 self.model_specific_data[extra_key], CudaIpcTensorTransportProxy

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -94,7 +94,7 @@ from sglang.srt.managers.io_struct import (
     unwrap_from_pickle,
 )
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
-from sglang.srt.managers.mm_utils import wrap_shm_features
+from sglang.srt.managers.mm_utils import discard_shm_features, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
@@ -1591,8 +1591,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             time_stats = tokenized_obj.time_stats
             tokenized_obj.wrap_pickle_fields()
             self._dispatch_to_scheduler(tokenized_obj)
-            self._mark_state_dispatched(tokenized_obj.rid)
             dispatched = True
+            self._mark_state_dispatched(tokenized_obj.rid)
             dispatch_ready = self.encoder_dispatch_ready.pop(tokenized_obj.rid, None)
             if dispatch_ready is not None:
                 dispatch_ready.set()
@@ -1600,6 +1600,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             tokenized_obj.time_stats.set_api_server_dispatch_finish_time()
         finally:
             if not dispatched:
+                discard_shm_features(tokenized_obj)
                 self.cuda_vmm_feature_transport.cancel_for_dispatch(prepared_mm_items)
 
     def _mark_state_dispatched(self, rid: str):
@@ -1630,7 +1631,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             set_time_batch(tokenized_objs, "set_api_server_dispatch_time")
             time_stats = [tokenized_obj.time_stats for tokenized_obj in tokenized_objs]
-            for tokenized_obj in tokenized_objs:
+            for index, tokenized_obj in enumerate(tokenized_objs):
+                tokenized_obj = wrap_shm_features(tokenized_obj)
+                tokenized_objs[index] = tokenized_obj
                 tokenized_obj.wrap_pickle_fields()
 
             if isinstance(tokenized_objs[0], TokenizedGenerateReqInput):
@@ -1639,14 +1642,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs)
 
             self._dispatch_to_scheduler(batch_req)
+            dispatched = True
             for tokenized_obj in tokenized_objs:
                 self._mark_state_dispatched(tokenized_obj.rid)
-            dispatched = True
             for tokenized_obj, time_stat in zip(tokenized_objs, time_stats):
                 tokenized_obj.time_stats = time_stat
             set_time_batch(tokenized_objs, "set_api_server_dispatch_finish_time")
         finally:
             if not dispatched:
+                for tokenized_obj in tokenized_objs:
+                    discard_shm_features(tokenized_obj)
                 self.cuda_vmm_feature_transport.cancel_for_dispatch(prepared_mm_items)
 
     def _coalesce_streaming_chunks(

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1973,7 +1973,10 @@ class BaseMultimodalProcessor(ABC):
 
         # Pool misses fall back to plain CPU tensors. The scheduler copies out
         # and releases each successful pool slice.
+        from sglang.srt.managers.mm_utils import AUXILIARY_TRANSPORT_FEATURE_NAMES
+
         updates = []
+        metadata_updates = []
         try:
             for item in mm_items:
                 fields = (
@@ -1986,6 +1989,21 @@ class BaseMultimodalProcessor(ABC):
                     wrapped = self._wrap_tensor_for_cuda_ipc(tensor)
                     setattr(item, field, wrapped)
                     updates.append((item, field, tensor, wrapped))
+                original_data = item.model_specific_data
+                for key in AUXILIARY_TRANSPORT_FEATURE_NAMES:
+                    tensor = original_data.get(key)
+                    if not isinstance(tensor, torch.Tensor):
+                        continue
+                    if item.model_specific_data is original_data:
+                        item.model_specific_data = dict(original_data)
+                        metadata_updates.append((item, original_data))
+                    wrapped = (
+                        tensor.cpu()
+                        if tensor.numel() == 0
+                        else self._wrap_tensor_for_cuda_ipc(tensor)
+                    )
+                    item.model_specific_data[key] = wrapped
+                    updates.append((item.model_specific_data, key, tensor, wrapped))
         except BaseException as error:
             rollback_errors = []
             for item, field, tensor, wrapped in reversed(updates):
@@ -1995,7 +2013,12 @@ class BaseMultimodalProcessor(ABC):
                 except BaseException as rollback_error:
                     rollback_errors.append(rollback_error)
                 finally:
-                    setattr(item, field, tensor)
+                    if isinstance(item, dict):
+                        item[field] = tensor
+                    else:
+                        setattr(item, field, tensor)
+            for item, original_data in reversed(metadata_updates):
+                item.model_specific_data = original_data
             if rollback_errors:
                 error.add_note(
                     f"{len(rollback_errors)} CUDA IPC rollback operation(s) also failed"

--- a/test/registered/unit/managers/test_mm_auxiliary_transport.py
+++ b/test/registered/unit/managers/test_mm_auxiliary_transport.py
@@ -1,0 +1,487 @@
+"""CPU-only coverage for auxiliary multimodal feature transport."""
+
+import asyncio
+import copy
+import pickle
+import unittest
+from multiprocessing import shared_memory
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers import mm_utils  # noqa: E402
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    BatchTokenizedGenerateReqInput,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.schedule_batch import (  # noqa: E402
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+from sglang.srt.multimodal.processors.base_processor import (  # noqa: E402
+    BaseMultimodalProcessor,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _tokenized_request(item, rid="request"):
+    return TokenizedGenerateReqInput(
+        rid=rid,
+        input_text="",
+        input_ids=[1],
+        input_embeds=None,
+        mm_inputs=MultimodalInputs(mm_items=[item]),
+        token_type_ids=None,
+        sampling_params=SamplingParams(),
+        return_logprob=False,
+        logprob_start_len=0,
+        top_logprobs_num=0,
+        token_ids_logprob=None,
+        stream=False,
+        time_stats=MagicMock(),
+    )
+
+
+class _TestMultimodalProcessor(BaseMultimodalProcessor):
+    async def process_mm_data_async(
+        self,
+        image_data,
+        audio_data,
+        input_text,
+        request_obj,
+        **kwargs,
+    ):
+        raise NotImplementedError
+
+
+class TestAuxiliaryFeatureSharedMemory(CustomTestCase):
+    def setUp(self):
+        self.transport_patches = (
+            patch.object(mm_utils, "_get_is_default_transport", return_value=False),
+            patch.object(
+                mm_utils,
+                "get_serving",
+                return_value=SimpleNamespace(skip_tokenizer_init=False),
+            ),
+        )
+        for transport_patch in self.transport_patches:
+            transport_patch.start()
+            self.addCleanup(transport_patch.stop)
+
+    def test_round_trip_preserves_nested_repeated_auxiliary_feature(self):
+        tensor = torch.arange(256 * 1024, dtype=torch.float32)
+        metadata = object()
+        original_model_specific_data = {
+            "patch_pixel_values": tensor,
+            "metadata": metadata,
+        }
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=123,
+            model_specific_data=original_model_specific_data,
+        )
+        request = _tokenized_request(item)
+        shm_name = None
+
+        try:
+            mm_utils.wrap_shm_features(request)
+
+            producer_proxy = item.model_specific_data["patch_pixel_values"]
+            self.assertIsInstance(producer_proxy, mm_utils.ShmPointerMMData)
+            self.assertIsNot(item.model_specific_data, original_model_specific_data)
+            self.assertIs(original_model_specific_data["patch_pixel_values"], tensor)
+            self.assertIs(item.model_specific_data["metadata"], metadata)
+            shm_name = producer_proxy.shm_name
+
+            # Pickle/unpickle models the tokenizer-to-scheduler process boundary.
+            consumer_proxy = pickle.loads(pickle.dumps(producer_proxy))
+            item.model_specific_data["patch_pixel_values"] = {
+                "first": consumer_proxy,
+                "again": [consumer_proxy],
+            }
+            self.assertTrue(mm_utils.has_shm_features([request]))
+
+            with patch.object(
+                consumer_proxy,
+                "materialize",
+                wraps=consumer_proxy.materialize,
+            ) as materialize:
+                mm_utils.unwrap_shm_features(request)
+
+            restored = item.model_specific_data["patch_pixel_values"]
+            materialize.assert_called_once_with()
+            self.assertIs(restored["first"], restored["again"][0])
+            self.assertTrue(torch.equal(restored["first"], tensor))
+            self.assertFalse(mm_utils.has_shm_features([request]))
+
+            # A second scheduler-side scan is harmless after materialization.
+            self.assertIs(mm_utils.unwrap_shm_features(request), request)
+        finally:
+            if shm_name is not None:
+                try:
+                    shm = shared_memory.SharedMemory(name=shm_name)
+                except FileNotFoundError:
+                    pass
+                else:
+                    shm.close()
+                    shm.unlink()
+
+    def test_zero_sized_and_allocation_failure_fall_back_inline(self):
+        empty = torch.empty(0)
+        with patch.object(mm_utils, "ShmPointerMMData") as shm_pointer:
+            self.assertIs(mm_utils._wrap_shm_or_inline(empty), empty)
+        shm_pointer.assert_not_called()
+
+        tensor = torch.ones(8)
+        with (
+            patch.object(
+                mm_utils,
+                "ShmPointerMMData",
+                side_effect=OSError("shared memory full"),
+            ),
+            patch.object(mm_utils, "print_warning_once") as warning,
+        ):
+            self.assertIs(mm_utils._wrap_shm_or_inline(tensor), tensor)
+        warning.assert_called_once()
+
+
+class TestAuxiliaryFeatureProducerTransport(CustomTestCase):
+    def test_processor_wraps_only_registered_auxiliary_tensor_copy_on_write(self):
+        feature = torch.tensor([[1.0]])
+        patch_pixels = torch.tensor([[2.0]])
+        unrelated_tensor = torch.tensor([3.0])
+        feature_proxy = object()
+        patch_proxy = object()
+        original_model_specific_data = {
+            "patch_pixel_values": patch_pixels,
+            "unrelated_tensor": unrelated_tensor,
+        }
+        source_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=11,
+            pad_value=12,
+            offsets=[(0, 0)],
+            feature=feature,
+            model_specific_data=original_model_specific_data,
+        )
+        processor = _TestMultimodalProcessor.__new__(_TestMultimodalProcessor)
+        processor.use_cuda_ipc = True
+        processor._wrap_tensor_for_cuda_ipc = Mock(
+            side_effect=[feature_proxy, patch_proxy]
+        )
+        items = processor._prepare_mm_items_for_transport([source_item])
+
+        self.assertEqual(len(items), 1)
+        item = items[0]
+        self.assertIs(item.feature, feature_proxy)
+        self.assertIsNot(item.model_specific_data, original_model_specific_data)
+        self.assertIs(item.model_specific_data["patch_pixel_values"], patch_proxy)
+        self.assertIs(item.model_specific_data["unrelated_tensor"], unrelated_tensor)
+        processor._wrap_tensor_for_cuda_ipc.assert_has_calls(
+            [call(feature), call(patch_pixels)]
+        )
+
+        # The shallow-copied source dictionary remains unchanged.
+        self.assertIs(original_model_specific_data["patch_pixel_values"], patch_pixels)
+
+
+class TestBatchedTokenizerAuxiliaryTransport(CustomTestCase):
+    def test_each_subrequest_is_wrapped_before_pickle_and_dispatch(self):
+        original_requests = [
+            _tokenized_request(
+                MultimodalDataItem(modality=Modality.IMAGE), rid=f"request-{index}"
+            )
+            for index in range(2)
+        ]
+        wrapped_requests = [
+            _tokenized_request(
+                MultimodalDataItem(modality=Modality.IMAGE),
+                rid=f"wrapped-request-{index}",
+            )
+            for index in range(2)
+        ]
+        requests = list(original_requests)
+        replacement_by_rid = {
+            original.rid: wrapped
+            for original, wrapped in zip(original_requests, wrapped_requests)
+        }
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager._dispatch_to_scheduler = Mock()
+        manager._mark_state_dispatched = Mock()
+        manager.cuda_vmm_feature_transport = SimpleNamespace(
+            prepare_for_dispatch_async=AsyncMock(return_value=[]),
+            cancel_for_dispatch=Mock(),
+        )
+        events = []
+
+        def record_wrap(request):
+            events.append(("wrap", request.rid))
+            return replacement_by_rid[request.rid]
+
+        def record_pickle(request):
+            events.append(("pickle", request.rid))
+
+        with (
+            patch(
+                "sglang.srt.managers.tokenizer_manager.wrap_shm_features",
+                side_effect=record_wrap,
+            ) as wrap,
+            patch.object(
+                TokenizedGenerateReqInput,
+                "wrap_pickle_fields",
+                autospec=True,
+                side_effect=record_pickle,
+            ),
+        ):
+            asyncio.run(manager._send_batch_request(requests))
+
+        self.assertEqual(
+            events,
+            [
+                ("wrap", "request-0"),
+                ("pickle", "wrapped-request-0"),
+                ("wrap", "request-1"),
+                ("pickle", "wrapped-request-1"),
+            ],
+        )
+        self.assertEqual(
+            wrap.call_args_list,
+            [call(original_requests[0]), call(original_requests[1])],
+        )
+        batch = manager._dispatch_to_scheduler.call_args.args[0]
+        self.assertEqual(list(batch), wrapped_requests)
+        self.assertEqual(requests, wrapped_requests)
+
+
+class TestAuxiliaryLifecycle(CustomTestCase):
+    def setUp(self):
+        for context in (
+            patch.object(mm_utils, "_get_is_default_transport", return_value=False),
+            patch.object(
+                mm_utils,
+                "get_serving",
+                return_value=SimpleNamespace(skip_tokenizer_init=False),
+            ),
+        ):
+            context.start()
+            self.addCleanup(context.stop)
+
+    def make_request(self):
+        request = _tokenized_request(
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                model_specific_data={"patch_pixel_values": torch.ones(256 * 1024)},
+            )
+        )
+        self.addCleanup(mm_utils.discard_shm_features, request)
+        return request
+
+    def assert_segment_removed(self, name):
+        with self.assertRaises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name)
+
+    def test_discard_releases_nested_auxiliary_segments(self):
+        request = self.make_request()
+        mm_utils.wrap_shm_features(request)
+        item = request.mm_inputs.mm_items[0]
+        proxy = item.model_specific_data["patch_pixel_values"]
+        item.model_specific_data["patch_pixel_values"] = {
+            "first": proxy,
+            "again": (proxy,),
+        }
+        batch = BatchTokenizedGenerateReqInput(batch=[request])
+        mm_utils.discard_shm_features(batch)
+        mm_utils.discard_shm_features(batch)
+        self.assert_segment_removed(proxy.shm_name)
+
+    def test_repeated_proxy_across_requests_materializes_once(self):
+        request = self.make_request()
+        mm_utils.wrap_shm_features(request)
+        producer = request.mm_inputs.mm_items[0].model_specific_data[
+            "patch_pixel_values"
+        ]
+        consumer = pickle.loads(pickle.dumps(producer))
+        first = request.mm_inputs.mm_items[0]
+        first.model_specific_data = {"patch_pixel_values": consumer}
+        second = copy.copy(first)
+        second.model_specific_data = dict(first.model_specific_data)
+        other = _tokenized_request(second)
+        with patch.object(
+            consumer, "materialize", wraps=consumer.materialize
+        ) as materialize:
+            mm_utils.unwrap_shm_features(
+                BatchTokenizedGenerateReqInput(batch=[request, other])
+            )
+        materialize.assert_called_once()
+        self.assertIs(
+            first.model_specific_data["patch_pixel_values"],
+            second.model_specific_data["patch_pixel_values"],
+        )
+        self.assert_segment_removed(producer.shm_name)
+
+    def test_nested_wrap_failure_releases_already_created_segment(self):
+        proxy = mm_utils.ShmPointerMMData(torch.ones(256 * 1024))
+        self.addCleanup(proxy.close_and_unlink)
+        with patch.object(
+            mm_utils,
+            "_wrap_shm_or_inline",
+            side_effect=[proxy, RuntimeError("copy failed")],
+        ):
+            with self.assertRaisesRegex(RuntimeError, "copy failed"):
+                mm_utils._wrap_auxiliary_transport_value(
+                    [torch.ones(256 * 1024), torch.ones(256 * 1024)]
+                )
+        self.assert_segment_removed(proxy.shm_name)
+
+    def test_dispatch_failure_releases_single_and_batch_shm(self):
+        for batched in (False, True):
+            with self.subTest(batched=batched):
+                requests = [self.make_request() for _ in range(2 if batched else 1)]
+                names = []
+
+                def dispatch(_request):
+                    names.extend(
+                        r.mm_inputs.mm_items[0]
+                        .model_specific_data["patch_pixel_values"]
+                        .shm_name
+                        for r in requests
+                    )
+                    raise RuntimeError("send failed")
+
+                manager = TokenizerManager.__new__(TokenizerManager)
+                manager.cuda_vmm_feature_transport = SimpleNamespace(
+                    prepare_for_dispatch_async=AsyncMock(return_value=[]),
+                    cancel_for_dispatch=Mock(),
+                )
+                manager._dispatch_to_scheduler = dispatch
+                with self.assertRaisesRegex(RuntimeError, "send failed"):
+                    asyncio.run(
+                        manager._send_batch_request(requests)
+                        if batched
+                        else manager._send_one_request(requests[0])
+                    )
+                self.assertEqual(len(names), len(requests))
+                for name in names:
+                    self.assert_segment_removed(name)
+                manager.cuda_vmm_feature_transport.cancel_for_dispatch.assert_called_once_with(
+                    []
+                )
+
+    def test_post_dispatch_failure_keeps_scheduler_owned_shm(self):
+        for batched in (False, True):
+            with self.subTest(batched=batched):
+                request = self.make_request()
+                manager = TokenizerManager.__new__(TokenizerManager)
+                manager.cuda_vmm_feature_transport = SimpleNamespace(
+                    prepare_for_dispatch_async=AsyncMock(return_value=[]),
+                    cancel_for_dispatch=Mock(),
+                )
+                manager._dispatch_to_scheduler = Mock()
+                manager._mark_state_dispatched = Mock(
+                    side_effect=RuntimeError("state failed")
+                )
+                with self.assertRaisesRegex(RuntimeError, "state failed"):
+                    asyncio.run(
+                        manager._send_batch_request([request])
+                        if batched
+                        else manager._send_one_request(request)
+                    )
+                manager._dispatch_to_scheduler.assert_called_once()
+                manager.cuda_vmm_feature_transport.cancel_for_dispatch.assert_not_called()
+                proxy = request.mm_inputs.mm_items[0].model_specific_data[
+                    "patch_pixel_values"
+                ]
+                segment = shared_memory.SharedMemory(name=proxy.shm_name)
+                segment.close()
+
+    def test_offload_preserves_parallel_sampling_metadata(self):
+        gpu = Mock(spec=torch.Tensor)
+        gpu.is_cuda = True
+        cpu = torch.ones(4)
+        gpu.to.return_value = cpu
+        metadata = {"patch_pixel_values": gpu, "unrelated": gpu}
+        item = MultimodalDataItem(modality=Modality.IMAGE, model_specific_data=metadata)
+        sibling = copy.copy(item)
+        mm_utils._offload_auxiliary_features(item)
+        self.assertIs(item.model_specific_data["patch_pixel_values"], cpu)
+        self.assertIs(item.model_specific_data["unrelated"], gpu)
+        self.assertIs(sibling.model_specific_data, metadata)
+        self.assertIs(metadata["patch_pixel_values"], gpu)
+        gpu.to.assert_called_once_with("cpu", non_blocking=True)
+
+    def test_auxiliary_reconstruction_is_copy_on_write(self):
+        proxy = Mock(spec=mm_utils.CudaIpcTensorTransportProxy)
+        tensor = torch.ones(4)
+        proxy.reconstruct_on_target_device.return_value = tensor
+        metadata = {"patch_pixel_values": proxy}
+        item = MultimodalDataItem(modality=Modality.IMAGE, model_specific_data=metadata)
+        sibling = copy.copy(item)
+        item.reconstruct(0)
+        self.assertIs(item.model_specific_data["patch_pixel_values"], tensor)
+        self.assertIs(sibling.model_specific_data["patch_pixel_values"], proxy)
+        proxy.reconstruct_on_target_device.assert_called_once_with(0)
+
+    def test_cuda_wrap_failure_rolls_back_auxiliary_and_primary_features(self):
+        for fail_cancel in (False, True):
+            with self.subTest(fail_cancel=fail_cancel):
+                feature, auxiliary, later = torch.ones(4), torch.ones(4), torch.ones(4)
+                metadata = {"patch_pixel_values": auxiliary}
+                items = [
+                    MultimodalDataItem(
+                        modality=Modality.IMAGE,
+                        feature=feature,
+                        model_specific_data=metadata,
+                    ),
+                    MultimodalDataItem(modality=Modality.IMAGE, feature=later),
+                ]
+                proxies = [
+                    Mock(spec=mm_utils.CudaIpcTensorTransportProxy) for _ in range(2)
+                ]
+                processor = _TestMultimodalProcessor.__new__(_TestMultimodalProcessor)
+                processor.use_cuda_ipc = True
+                processor._wrap_tensor_for_cuda_ipc = Mock(
+                    side_effect=[*proxies, RuntimeError("wrap failed")]
+                )
+                processor.cudaipc_mmfeature_pool = SimpleNamespace(
+                    cancel_proxy=Mock(
+                        side_effect=[RuntimeError("cancel failed"), None]
+                        if fail_cancel
+                        else None
+                    )
+                )
+                with self.assertRaisesRegex(RuntimeError, "wrap failed"):
+                    processor._prepare_mm_items_for_transport(items)
+                self.assertEqual(
+                    processor.cudaipc_mmfeature_pool.cancel_proxy.call_args_list,
+                    [call(proxies[1]), call(proxies[0])],
+                )
+                self.assertIs(items[0].feature, feature)
+                self.assertIs(items[0].model_specific_data, metadata)
+                self.assertIs(metadata["patch_pixel_values"], auxiliary)
+                self.assertIs(items[1].feature, later)
+
+    def test_empty_auxiliary_tensor_does_not_allocate_ipc_pool_slice(self):
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            model_specific_data={"patch_pixel_values": torch.empty(0)},
+        )
+        processor = _TestMultimodalProcessor.__new__(_TestMultimodalProcessor)
+        processor.use_cuda_ipc = True
+        processor._wrap_tensor_for_cuda_ipc = Mock()
+        processor._prepare_mm_items_for_transport([item])
+        processor._wrap_tensor_for_cuda_ipc.assert_not_called()
+        self.assertEqual(item.model_specific_data["patch_pixel_values"].numel(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/multimodal/test_cuda_ipc_transport.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_transport.py
@@ -5,6 +5,7 @@ the bounded pool and the scheduler process opens the shared CUDA allocation.
 CPU-only policy tests intentionally cannot exercise this cross-process handle.
 """
 
+import copy
 import gc
 import multiprocessing as mp
 import queue
@@ -28,7 +29,7 @@ from sglang.srt.multimodal.transport.cuda_ipc import (
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=37, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=75, stage="base-b", runner_config="1-gpu-large")
 
 
 def _produce_pooled_tensor(proxy_queue, consumer_done, result_queue):
@@ -73,6 +74,61 @@ def _produce_pooled_tensor(proxy_queue, consumer_done, result_queue):
         gc.collect()
         torch.cuda.ipc_collect()
     result_queue.put(("ok", None))
+
+
+def _produce_auxiliary_items(proxy_queue, consumer_done, result_queue):
+    """Reuse one bounded producer pool across multiple auxiliary transfers."""
+    from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+    pool = None
+    try:
+        torch.cuda.set_device(0)
+        pool = MmItemMemoryPool(
+            memory_size=1 << 20,
+            recycle_interval=0.01,
+            base_gpu_id=0,
+            consumer_count=1,
+        )
+        with patch.object(BaseMultimodalProcessor, "__abstractmethods__", set()):
+            processor = BaseMultimodalProcessor.__new__(BaseMultimodalProcessor)
+        processor.use_cuda_ipc = True
+        processor.use_ipc_pool_handle_cache = True
+        processor.cudaipc_mmfeature_pool = pool
+        for iteration in range(8):
+            consumer_done.clear()
+            item = MultimodalDataItem(
+                modality=Modality.IMAGE,
+                feature=torch.full(
+                    (16,), iteration, dtype=torch.float32, device="cuda"
+                ),
+                model_specific_data={
+                    "patch_pixel_values": torch.full(
+                        (256, 256), iteration + 1, dtype=torch.float32, device="cuda"
+                    )
+                },
+            )
+            processor._prepare_mm_items_for_transport([item])
+            if not isinstance(
+                item.model_specific_data["patch_pixel_values"],
+                CudaIpcTensorTransportProxy,
+            ):
+                raise AssertionError("auxiliary tensor bypassed the CUDA IPC pool")
+            proxy_queue.put(item)
+            if not consumer_done.wait(timeout=60):
+                raise TimeoutError("auxiliary consumer did not finish")
+            deadline = time.monotonic() + 5
+            while pool.active_lease_count and time.monotonic() < deadline:
+                time.sleep(0.01)
+            if pool.active_lease_count:
+                raise AssertionError(f"iteration {iteration}: unreleased pool leases")
+            del item
+    except Exception as exc:
+        result_queue.put(("error", repr(exc)))
+    else:
+        result_queue.put(("ok", None))
+    finally:
+        if pool is not None:
+            pool.shutdown()
 
 
 class TestCudaIpcTransport(CustomTestCase):
@@ -127,6 +183,70 @@ class TestCudaIpcTransport(CustomTestCase):
                     producer.terminate()
                     producer.join(timeout=10)
             self.assertEqual(producer.exitcode, 0)
+
+    def test_auxiliary_round_trips_release_pool_leases(self):
+        from sglang.srt.managers.mm_utils import _offload_auxiliary_features
+
+        ctx = mp.get_context("spawn")
+        proxy_queue, results = ctx.Queue(), ctx.Queue()
+        consumer_done = ctx.Event()
+        producer = ctx.Process(
+            target=_produce_auxiliary_items,
+            args=(proxy_queue, consumer_done, results),
+        )
+        producer.start()
+        item = original_metadata = None
+        try:
+            for iteration in range(8):
+                item = proxy_queue.get(timeout=60)
+                self.assertIsInstance(
+                    item.model_specific_data["patch_pixel_values"],
+                    CudaIpcTensorTransportProxy,
+                )
+                if iteration % 2:
+                    # Rejected requests must release both primary and auxiliary
+                    # leases without ever reconstructing their GPU tensors.
+                    item.release_transport_proxies()
+                    torch.cuda.synchronize()
+                else:
+                    item.reconstruct(0)
+                    torch.cuda.synchronize()
+                    self.assertTrue(
+                        torch.equal(
+                            item.feature.cpu(), torch.full((16,), float(iteration))
+                        )
+                    )
+                    original_metadata = item.model_specific_data
+                    _offload_auxiliary_features(item)
+                    torch.cuda.synchronize()
+                    self.assertTrue(original_metadata["patch_pixel_values"].is_cuda)
+                    auxiliary = item.model_specific_data["patch_pixel_values"]
+                    self.assertEqual(auxiliary.device.type, "cpu")
+                    self.assertTrue(
+                        torch.equal(
+                            auxiliary, torch.full((256, 256), float(iteration + 1))
+                        )
+                    )
+                item = original_metadata = None
+                _pool_handle_cache_clear()
+                gc.collect()
+                torch.cuda.ipc_collect()
+                consumer_done.set()
+            status, error = results.get(timeout=15)
+            self.assertEqual(status, "ok", error)
+        finally:
+            item = original_metadata = None
+            _pool_handle_cache_clear()
+            gc.collect()
+            torch.cuda.ipc_collect()
+            consumer_done.set()
+            producer.join(timeout=15)
+            if producer.is_alive():
+                producer.terminate()
+                producer.join(timeout=10)
+            proxy_queue.close()
+            results.close()
+        self.assertEqual(producer.exitcode, 0)
 
     def test_failed_reconstruction_releases_pooled_tensor(self):
         ctx = mp.get_context("spawn")
@@ -237,6 +357,10 @@ class TestCudaIpcTransport(CustomTestCase):
             for feature in features
         ]
 
+        auxiliary = torch.ones(32, device="cuda")
+        original_metadata = {"patch_pixel_values": auxiliary}
+        items[0].model_specific_data = original_metadata
+        sibling = copy.copy(items[0])
         try:
             with self.assertRaisesRegex(ValueError, "empty tensor"):
                 processor._prepare_mm_items_for_transport(items)
@@ -247,6 +371,8 @@ class TestCudaIpcTransport(CustomTestCase):
             self.assertEqual(pool.active_lease_count, 0)
             self.assertIs(items[0].feature, features[0])
             self.assertIs(items[1].feature, features[1])
+            self.assertIs(items[0].model_specific_data, original_metadata)
+            self.assertIs(sibling.model_specific_data["patch_pixel_values"], auxiliary)
         finally:
             pool.shutdown()
 


### PR DESCRIPTION
## Motivation

Step multimodal inputs store `patch_pixel_values` in `MultimodalDataItem.model_specific_data`. The primary feature transport and post-encoding offload paths do not manage this auxiliary tensor, leaving it outside the bounded CUDA IPC/SHM lifecycle and potentially retaining request-dependent GPU allocations after vision encoding.

This change explicitly includes patch features in that lifecycle. It is independent of the Step3.7 vision batching change in #38874.

## Modifications

- Wrap auxiliary patch tensors through the existing CUDA IPC pool, with CPU fallback and SHM for auxiliary tensors of at least 1 MiB. Empty auxiliary tensors do not allocate pool slices or SHM segments.
- Include auxiliary proxies in producer rollback, restoring metadata even when cancellation of another lease fails.
- Extend SHM detection, reconstruction, and discard to auxiliary fields and nested containers. Memoize reconstruction within a batch so repeated references materialize once, preserving the existing SHM error/cleanup semantics.
- Wrap batched tokenizer requests before dispatch and clean up SHM on failed sends. Once dispatch succeeds, later bookkeeping errors must not release scheduler-owned resources.
- Offload GPU patch features after encoding; use copy-on-write metadata during wrapping, reconstruction, and offload to protect shallow-copied parallel-sampling items.

## Accuracy Tests

- **64 CPU tests passed:** 13 auxiliary transport tests plus 51 existing tests in `test_gpu_feature_transport.py`, `test_mm_shm_error_consensus.py`, and `test_mm_utils_split.py`.
- Coverage includes real CPU SHM round trips and cleanup, repeated references across requests, failed sends, post-dispatch ownership, rollback failures, and Gloo two-process error propagation. CUDA wrapping/cancellation and GPU offload boundaries are mocked.
- The auxiliary SHM round-trip and producer wrapping regressions both fail on unmodified base `908226fea2` and pass with this change.
- All applicable pre-commit hooks pass for the five changed files, including CI test registration; `git diff --check` passes.

Local environment: macOS arm64, Python 3.11.15, PyTorch 2.8.0, Transformers 5.12.1. To run existing scheduler tests without the optional MLX dependency, a local runner mocks `sglang.srt.utils.is_mps` to `False` after SGLang platform initialization, including in spawned Gloo workers. That runner is not part of this PR. These results do not validate the full pinned serving environment or real CUDA IPC.

## Speed Tests and Profiling

Real-model CUDA IPC/TP validation, sustained concurrent Step image requests, GPU allocated/reserved/peak-memory measurements, and latency/throughput measurements are pending. No measured memory reduction or speedup is claimed. This PR remains a draft while those results are collected.

## Checklist

- [x] Format and lint changed files with pre-commit.
- [x] Add registered CPU regression tests.
- [x] Follow SGLang code style guidance.
- [x] Documentation: no new user-facing flags or public API.
- [ ] Validate real CUDA IPC, TP consumer release, and model output correctness.
- [ ] Provide sustained-request GPU memory and performance results before marking ready for review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34561697875](https://github.com/sgl-project/sglang/actions/runs/34561697875)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34561697610](https://github.com/sgl-project/sglang/actions/runs/34561697610)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34561697754](https://github.com/sgl-project/sglang/actions/runs/34561697754)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

Replaces #38885 with the same commits under a branch name without the `codex/` prefix.