### PR TITLE
[Fix] Honor DSpark SPS profiler budget pins and handle ragged mRoPE positions

### DIFF
--- a/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
+++ b/python/sglang/kernels/ops/mamba/causal_conv1d_triton.py
@@ -507,9 +507,9 @@ def causal_conv1d_fn(
             assert padded_batch == cache_indices.size(0)
         if has_initial_state is not None:
             assert has_initial_state.size() == (padded_batch,)
-            assert conv_states is not None, (
-                "ERROR: `has_initial_state` is used, which needs also `conv_states`"
-            )
+            assert (
+                conv_states is not None
+            ), "ERROR: `has_initial_state` is used, which needs also `conv_states`"
         assert weight.stride(1) == 1
         assert (dim, width) == weight.shape
         assert is_channel_last, "Need to run in channel-last layout"
@@ -1058,9 +1058,9 @@ def causal_conv1d_update(
 
     if validate_data:
         assert dim == weight.size(0)
-        assert conv_state.stride(-2) == 1, (
-            f"ERROR: expect contiguous along feat-dim of conv_state (currently stride={conv_state.stride()})"
-        )
+        assert (
+            conv_state.stride(-2) == 1
+        ), f"ERROR: expect contiguous along feat-dim of conv_state (currently stride={conv_state.stride()})"
         assert state_len >= width - 1
         # when above happens, we don't shift-left to keep any records in conv_state
         assert dim == conv_state.size(1)
@@ -1207,4 +1207,250 @@ def causal_conv1d_update(
     )
     if unsqueeze:
         out = out.squeeze(-1)
+    return out
+
+
+@triton.jit()
+def _causal_conv1d_update_varlen_kernel(
+    x_ptr,
+    weight_ptr,
+    bias_ptr,
+    conv_state_ptr,
+    conv_state_indices_ptr,
+    intermediate_conv_window_ptr,
+    intermediate_state_indices_ptr,
+    query_start_loc_ptr,
+    out_ptr,
+    dim: tl.constexpr,
+    num_cache_lines: tl.constexpr,
+    stride_x_token: tl.constexpr,
+    stride_x_dim: tl.constexpr,
+    stride_weight_dim: tl.constexpr,
+    stride_weight_width: tl.constexpr,
+    stride_state_seq: tl.constexpr,
+    stride_state_dim: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    stride_state_indices: tl.constexpr,
+    stride_inter_seq: tl.constexpr,
+    stride_inter_step: tl.constexpr,
+    stride_inter_dim: tl.constexpr,
+    stride_inter_win: tl.constexpr,
+    stride_inter_indices: tl.constexpr,
+    stride_out_token: tl.constexpr,
+    stride_out_dim: tl.constexpr,
+    pad_slot_id: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    MAX_SEQLEN: tl.constexpr,
+    SILU_ACTIVATION: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    USE_GDC: tl.constexpr = False,
+):
+    if USE_GDC:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    row = tl.program_id(0)
+    feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    feat_mask = feats < dim
+
+    start = tl.load(query_start_loc_ptr + row).to(tl.int64)
+    end = tl.load(query_start_loc_ptr + row + 1).to(tl.int64)
+    seq_len = end - start
+    state_row = tl.load(conv_state_indices_ptr + row * stride_state_indices).to(
+        tl.int64
+    )
+    valid_state = (
+        (state_row != pad_slot_id) & (state_row >= 0) & (state_row < num_cache_lines)
+    )
+    safe_state_row = tl.where(valid_state, state_row, 0)
+    state_base = (
+        conv_state_ptr + safe_state_row * stride_state_seq + feats * stride_state_dim
+    )
+
+    if KERNEL_WIDTH >= 2:
+        col0 = tl.load(
+            state_base,
+            mask=feat_mask & valid_state,
+            other=0.0,
+        )
+        weight0 = tl.load(
+            weight_ptr + feats * stride_weight_dim,
+            mask=feat_mask,
+            other=0.0,
+        )
+    if KERNEL_WIDTH >= 3:
+        col1 = tl.load(
+            state_base + stride_state_token,
+            mask=feat_mask & valid_state,
+            other=0.0,
+        )
+        weight1 = tl.load(
+            weight_ptr + feats * stride_weight_dim + stride_weight_width,
+            mask=feat_mask,
+            other=0.0,
+        )
+    if KERNEL_WIDTH >= 4:
+        col2 = tl.load(
+            state_base + 2 * stride_state_token,
+            mask=feat_mask & valid_state,
+            other=0.0,
+        )
+        weight2 = tl.load(
+            weight_ptr + feats * stride_weight_dim + 2 * stride_weight_width,
+            mask=feat_mask,
+            other=0.0,
+        )
+    current_weight = tl.load(
+        weight_ptr
+        + feats * stride_weight_dim
+        + (KERNEL_WIDTH - 1) * stride_weight_width,
+        mask=feat_mask,
+        other=0.0,
+    )
+    if HAS_BIAS:
+        bias = tl.load(bias_ptr + feats, mask=feat_mask, other=0.0).to(tl.float32)
+    else:
+        bias = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    inter_row = tl.load(intermediate_state_indices_ptr + row * stride_inter_indices).to(
+        tl.int64
+    )
+    for step in tl.static_range(MAX_SEQLEN):
+        token_active = step < seq_len
+        active = token_active & valid_state
+        x = tl.load(
+            x_ptr + (start + step) * stride_x_token + feats * stride_x_dim,
+            mask=feat_mask & active,
+            other=0.0,
+        )
+        acc = bias
+        if KERNEL_WIDTH == 2:
+            acc += col0 * weight0 + x * current_weight
+            next_col0 = x
+        elif KERNEL_WIDTH == 3:
+            acc += col0 * weight0 + col1 * weight1 + x * current_weight
+            next_col0 = col1
+            next_col1 = x
+        elif KERNEL_WIDTH == 4:
+            acc += col0 * weight0 + col1 * weight1 + col2 * weight2 + x * current_weight
+            next_col0 = col1
+            next_col1 = col2
+            next_col2 = x
+        if SILU_ACTIVATION:
+            acc = acc / (1 + tl.exp(-acc))
+        tl.store(
+            out_ptr + (start + step) * stride_out_token + feats * stride_out_dim,
+            tl.where(valid_state, acc, 0.0),
+            mask=feat_mask & token_active,
+        )
+
+        inter_base = (
+            intermediate_conv_window_ptr
+            + inter_row * stride_inter_seq
+            + step * stride_inter_step
+            + feats * stride_inter_dim
+        )
+        if KERNEL_WIDTH >= 2:
+            tl.store(
+                inter_base,
+                next_col0,
+                mask=feat_mask & active,
+            )
+            col0 = tl.where(active, next_col0, col0)
+        if KERNEL_WIDTH >= 3:
+            tl.store(
+                inter_base + stride_inter_win,
+                next_col1,
+                mask=feat_mask & active,
+            )
+            col1 = tl.where(active, next_col1, col1)
+        if KERNEL_WIDTH >= 4:
+            tl.store(
+                inter_base + 2 * stride_inter_win,
+                next_col2,
+                mask=feat_mask & active,
+            )
+            col2 = tl.where(active, next_col2, col2)
+    if KERNEL_WIDTH >= 2:
+        tl.store(
+            state_base,
+            col0,
+            mask=feat_mask & valid_state,
+        )
+    if KERNEL_WIDTH >= 3:
+        tl.store(
+            state_base + stride_state_token,
+            col1,
+            mask=feat_mask & valid_state,
+        )
+    if KERNEL_WIDTH >= 4:
+        tl.store(
+            state_base + 2 * stride_state_token,
+            col2,
+            mask=feat_mask & valid_state,
+        )
+
+
+def causal_conv1d_update_varlen(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    activation: Union[bool, str, None],
+    *,
+    query_start_loc: torch.Tensor,
+    conv_state_indices: torch.Tensor,
+    intermediate_conv_window: torch.Tensor,
+    intermediate_state_indices: torch.Tensor,
+    max_seqlen: int,
+    pad_slot_id: int = PAD_SLOT_ID,
+) -> torch.Tensor:
+    """Causal-conv update over packed linear verify rows."""
+    assert x.dim() == 2
+    assert 2 <= weight.shape[1] <= 4
+    assert query_start_loc.shape[0] == conv_state_indices.shape[0] + 1
+    assert intermediate_state_indices.shape == conv_state_indices.shape
+    assert intermediate_conv_window.dim() == 4
+
+    out = torch.empty_like(x)
+    dim = x.shape[1]
+    width = weight.shape[1]
+    grid = (conv_state_indices.shape[0], triton.cdiv(dim, 256))
+    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+    _causal_conv1d_update_varlen_kernel[grid](
+        x,
+        weight,
+        bias,
+        conv_state,
+        conv_state_indices,
+        intermediate_conv_window,
+        intermediate_state_indices,
+        query_start_loc,
+        out,
+        dim,
+        conv_state.shape[0],
+        x.stride(0),
+        x.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        conv_state.stride(0),
+        conv_state.stride(1),
+        conv_state.stride(2),
+        conv_state_indices.stride(0),
+        intermediate_conv_window.stride(0),
+        intermediate_conv_window.stride(1),
+        intermediate_conv_window.stride(2),
+        intermediate_conv_window.stride(3),
+        intermediate_state_indices.stride(0),
+        out.stride(0),
+        out.stride(1),
+        pad_slot_id,
+        HAS_BIAS=bias is not None,
+        KERNEL_WIDTH=width,
+        MAX_SEQLEN=max_seqlen,
+        SILU_ACTIVATION=activation is True or activation in ["silu", "swish"],
+        BLOCK_N=256,
+        **pdl_kwargs,
+    )
     return out

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -327,6 +327,7 @@ class MambaAttnBackendBase(AttentionBackend):
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         metadata = self.forward_metadata
         metadata.ragged_verify_dense_indices = None
+        metadata.ragged_verify_dense_gather_indices = None
         spec_info = forward_batch.spec_info
         if (
             forward_batch.forward_mode.is_target_verify()
@@ -337,6 +338,14 @@ class MambaAttnBackendBase(AttentionBackend):
                 query_start_loc=metadata.query_start_loc,
                 seq_len=forward_batch.input_ids.shape[0],
                 draft_token_num=spec_info.draft_token_num,
+            )
+            num_dense_tokens = (
+                (metadata.query_start_loc.shape[0] - 1) * spec_info.draft_token_num
+            )
+            metadata.ragged_verify_dense_gather_indices = torch.where(
+                metadata.ragged_verify_dense_indices < num_dense_tokens,
+                metadata.ragged_verify_dense_indices,
+                0,
             )
 
     def update_verify_buffers_to_fill_after_draft(

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -35,6 +35,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_spec
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.speculative.ragged_verify import ragged_verify_dense_scatter_indices
 from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
@@ -321,6 +322,22 @@ class MambaAttnBackendBase(AttentionBackend):
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         self.forward_metadata = self._forward_metadata(forward_batch)
+        self.init_forward_metadata_in_graph(forward_batch)
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        metadata = self.forward_metadata
+        metadata.ragged_verify_dense_indices = None
+        spec_info = forward_batch.spec_info
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and spec_info is not None
+            and spec_info.ragged_verify_layout is not None
+        ):
+            metadata.ragged_verify_dense_indices = ragged_verify_dense_scatter_indices(
+                query_start_loc=metadata.query_start_loc,
+                seq_len=forward_batch.input_ids.shape[0],
+                draft_token_num=spec_info.draft_token_num,
+            )
 
     def update_verify_buffers_to_fill_after_draft(
         self, spec_info: SpecInput, cuda_graph_bs: Optional[int]

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -897,7 +897,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 num_dense_tokens = batch_size * draft_token_num
                 dense_token_indices = forward_metadata.ragged_verify_dense_indices
                 assert dense_token_indices is not None
-                dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
+                # Only real packed positions are gathered back and committed.
+                dense = mixed_qkv.new_empty(num_dense_tokens + 1, mixed_qkv.shape[-1])
                 dense.index_copy_(0, dense_token_indices, mixed_qkv)
                 mixed_qkv_dense = dense[:num_dense_tokens].view(
                     batch_size, draft_token_num, -1
@@ -923,12 +924,11 @@ class GDNAttnBackend(MambaAttnBackendBase):
             if dense_token_indices is None:
                 mixed_qkv = mixed_qkv_flat
             else:
-                # Graph-tier tail tokens gather from the discarded ghost row.
-                padded_flat = mixed_qkv_flat.new_zeros(
-                    batch_size * draft_token_num + 1, mixed_qkv_flat.shape[-1]
+                gather_indices = (
+                    forward_metadata.ragged_verify_dense_gather_indices
                 )
-                padded_flat[: batch_size * draft_token_num] = mixed_qkv_flat
-                mixed_qkv = padded_flat[dense_token_indices]
+                assert gather_indices is not None
+                mixed_qkv = mixed_qkv_flat[gather_indices]
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
             if forward_metadata.has_mamba_track_mask:

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -22,6 +22,9 @@ from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_schedule
+from sglang.srt.speculative.ragged_verify import (
+    ragged_verify_dense_scatter_indices,
+)
 from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu, is_xpu
 from sglang.srt.utils.common import rank0_log
 
@@ -503,6 +506,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
     """Attention backend for GDN (Gated Delta Network) linear attention."""
 
     needs_cpu_seq_lens: bool = False
+    # Conv uses dense scratch; recurrence consumes ragged query_start_loc.
+    supports_ragged_verify_graph: bool = True
     supports_mis: bool = True
 
     def __init__(self, model_runner: ModelRunner):
@@ -883,11 +888,28 @@ class GDNAttnBackend(MambaAttnBackendBase):
             state_cache_indices = cache_indices
 
         if is_target_verify:
-            batch_size = seq_len // forward_batch.spec_info.draft_token_num
             draft_token_num = forward_batch.spec_info.draft_token_num
-            mixed_qkv_reshaped = mixed_qkv.view(
-                batch_size, draft_token_num, -1
-            ).transpose(1, 2)
+            ragged_layout = forward_batch.spec_info.ragged_verify_layout
+            if ragged_layout is None:
+                batch_size = seq_len // draft_token_num
+                dense_token_indices = None
+                mixed_qkv_dense = mixed_qkv.view(batch_size, draft_token_num, -1)
+            else:
+                # Conv requires dense rows; compact verify stores packed rows.
+                batch_size = query_start_loc.shape[0] - 1
+                num_dense_tokens = batch_size * draft_token_num
+                dense_token_indices = ragged_verify_dense_scatter_indices(
+                    query_start_loc=query_start_loc,
+                    seq_len=seq_len,
+                    draft_token_num=draft_token_num,
+                )
+                dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
+                dense.index_copy_(0, dense_token_indices, mixed_qkv)
+                mixed_qkv_dense = dense[:num_dense_tokens].view(
+                    batch_size, draft_token_num, -1
+                )
+
+            mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
             mixed_qkv_processed = causal_conv1d_update(
                 mixed_qkv_reshaped,
                 conv_states,
@@ -901,7 +923,18 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 retrieve_next_sibling=retrieve_next_sibling,
                 retrieve_parent_token=retrieve_parent_token,
             )
-            mixed_qkv = mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
+            mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
+                batch_size * draft_token_num, -1
+            )
+            if dense_token_indices is None:
+                mixed_qkv = mixed_qkv_flat
+            else:
+                # Graph-tier tail tokens gather from the discarded ghost row.
+                padded_flat = mixed_qkv_flat.new_zeros(
+                    batch_size * draft_token_num + 1, mixed_qkv_flat.shape[-1]
+                )
+                padded_flat[: batch_size * draft_token_num] = mixed_qkv_flat
+                mixed_qkv = padded_flat[dense_token_indices]
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
             if forward_metadata.has_mamba_track_mask:
@@ -974,6 +1007,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
                     cache_indices=cache_indices,
                     query_start_loc=query_start_loc,
                     retrieve_parent_token=retrieve_parent_token,
+                    is_ragged=ragged_layout is not None,
                 )
             elif use_replayssm_spec:
                 core_attn_out = self._replayssm_target_verify(
@@ -1202,6 +1236,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         retrieve_parent_token: Optional[torch.Tensor],
+        is_ragged: bool,
     ) -> torch.Tensor:
         """Ring-writing verify; the commit fold replays the accepted prefix
         into ``temporal``. Uses the vendored CuTe DSL MTP kernel when the
@@ -1217,11 +1252,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
         )
         seq_len = query.shape[1]
         batch_size = query_start_loc.shape[0] - 1
-        draft_token_num = seq_len // batch_size
+        uniform_width = 0 if is_ragged else seq_len // batch_size
         if (
-            self.kernel_dispatcher.verify_kernel_is_flashinfer
+            not is_ragged
+            and self.kernel_dispatcher.verify_kernel_is_flashinfer
             and ssm_states.dtype == torch.bfloat16
-            and draft_token_num >= 3
+            and uniform_width >= 3
         ):
             from sglang.kernels.ops.attention.cutedsl_gdn_mtp_ring import (
                 gated_delta_rule_mtp,
@@ -1231,12 +1267,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
             head_v_dim = value.shape[3]
             out = gated_delta_rule_mtp(
                 A_log=layer.A_log.detach(),
-                a=a.view(batch_size, draft_token_num, num_v_heads),
+                a=a.view(batch_size, uniform_width, num_v_heads),
                 dt_bias=layer.dt_bias.detach(),
-                q=query.view(batch_size, draft_token_num, *query.shape[2:]),
-                k=key.view(batch_size, draft_token_num, *key.shape[2:]),
-                v=value.view(batch_size, draft_token_num, num_v_heads, head_v_dim),
-                b=b.view(batch_size, draft_token_num, num_v_heads),
+                q=query.view(batch_size, uniform_width, *query.shape[2:]),
+                k=key.view(batch_size, uniform_width, *key.shape[2:]),
+                v=value.view(batch_size, uniform_width, num_v_heads, head_v_dim),
+                b=b.view(batch_size, uniform_width, num_v_heads),
                 initial_state_source=ssm_states,
                 initial_state_indices=cache_indices,
                 use_qk_l2norm_in_kernel=True,

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -22,9 +22,6 @@ from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_schedule
-from sglang.srt.speculative.ragged_verify import (
-    ragged_verify_dense_scatter_indices,
-)
 from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu, is_xpu
 from sglang.srt.utils.common import rank0_log
 
@@ -898,11 +895,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 # Conv requires dense rows; compact verify stores packed rows.
                 batch_size = query_start_loc.shape[0] - 1
                 num_dense_tokens = batch_size * draft_token_num
-                dense_token_indices = ragged_verify_dense_scatter_indices(
-                    query_start_loc=query_start_loc,
-                    seq_len=seq_len,
-                    draft_token_num=draft_token_num,
-                )
+                dense_token_indices = forward_metadata.ragged_verify_dense_indices
+                assert dense_token_indices is not None
                 dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
                 dense.index_copy_(0, dense_token_indices, mixed_qkv)
                 mixed_qkv_dense = dense[:num_dense_tokens].view(

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -7,6 +7,7 @@ from sglang.kernels.ops.attention.fla.fused_gdn_gating import fused_gdn_gating
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_fn,
     causal_conv1d_update,
+    causal_conv1d_update_varlen,
 )
 from sglang.srt.configs.hybrid_arch import hybrid_gdn_config
 from sglang.srt.environ import envs
@@ -887,48 +888,68 @@ class GDNAttnBackend(MambaAttnBackendBase):
         if is_target_verify:
             draft_token_num = forward_batch.spec_info.draft_token_num
             ragged_layout = forward_batch.spec_info.ragged_verify_layout
-            if ragged_layout is None:
-                batch_size = seq_len // draft_token_num
-                dense_token_indices = None
-                mixed_qkv_dense = mixed_qkv.view(batch_size, draft_token_num, -1)
-            else:
-                # Conv requires dense rows; compact verify stores packed rows.
+            use_varlen_conv = (
+                ragged_layout is not None
+                and is_cuda()
+                and retrieve_next_token is None
+                and retrieve_next_sibling is None
+                and retrieve_parent_token is None
+            )
+            if use_varlen_conv:
                 batch_size = query_start_loc.shape[0] - 1
-                num_dense_tokens = batch_size * draft_token_num
-                dense_token_indices = forward_metadata.ragged_verify_dense_indices
-                assert dense_token_indices is not None
-                # Only real packed positions are gathered back and committed.
-                dense = mixed_qkv.new_empty(num_dense_tokens + 1, mixed_qkv.shape[-1])
-                dense.index_copy_(0, dense_token_indices, mixed_qkv)
-                mixed_qkv_dense = dense[:num_dense_tokens].view(
-                    batch_size, draft_token_num, -1
+                mixed_qkv = causal_conv1d_update_varlen(
+                    mixed_qkv,
+                    conv_states,
+                    layer.conv_weights,
+                    layer.bias,
+                    layer.activation,
+                    query_start_loc=query_start_loc,
+                    conv_state_indices=cache_indices[:batch_size],
+                    intermediate_conv_window=intermediate_conv_window_cache,
+                    intermediate_state_indices=intermediate_state_indices[:batch_size],
+                    max_seqlen=draft_token_num,
                 )
-
-            mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
-            mixed_qkv_processed = causal_conv1d_update(
-                mixed_qkv_reshaped,
-                conv_states,
-                layer.conv_weights,
-                layer.bias,
-                layer.activation,
-                conv_state_indices=cache_indices[:batch_size],
-                intermediate_conv_window=intermediate_conv_window_cache,
-                intermediate_state_indices=intermediate_state_indices[:batch_size],
-                retrieve_next_token=retrieve_next_token,
-                retrieve_next_sibling=retrieve_next_sibling,
-                retrieve_parent_token=retrieve_parent_token,
-            )
-            mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
-                batch_size * draft_token_num, -1
-            )
-            if dense_token_indices is None:
-                mixed_qkv = mixed_qkv_flat
             else:
-                gather_indices = (
-                    forward_metadata.ragged_verify_dense_gather_indices
+                if ragged_layout is None:
+                    batch_size = seq_len // draft_token_num
+                    dense_token_indices = None
+                    mixed_qkv_dense = mixed_qkv.view(batch_size, draft_token_num, -1)
+                else:
+                    batch_size = query_start_loc.shape[0] - 1
+                    num_dense_tokens = batch_size * draft_token_num
+                    dense_token_indices = forward_metadata.ragged_verify_dense_indices
+                    assert dense_token_indices is not None
+                    dense = mixed_qkv.new_empty(
+                        num_dense_tokens + 1, mixed_qkv.shape[-1]
+                    )
+                    dense.index_copy_(0, dense_token_indices, mixed_qkv)
+                    mixed_qkv_dense = dense[:num_dense_tokens].view(
+                        batch_size, draft_token_num, -1
+                    )
+
+                mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
+                mixed_qkv_processed = causal_conv1d_update(
+                    mixed_qkv_reshaped,
+                    conv_states,
+                    layer.conv_weights,
+                    layer.bias,
+                    layer.activation,
+                    conv_state_indices=cache_indices[:batch_size],
+                    intermediate_conv_window=intermediate_conv_window_cache,
+                    intermediate_state_indices=intermediate_state_indices[:batch_size],
+                    retrieve_next_token=retrieve_next_token,
+                    retrieve_next_sibling=retrieve_next_sibling,
+                    retrieve_parent_token=retrieve_parent_token,
                 )
-                assert gather_indices is not None
-                mixed_qkv = mixed_qkv_flat[gather_indices]
+                mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
+                    batch_size * draft_token_num, -1
+                )
+                if dense_token_indices is None:
+                    mixed_qkv = mixed_qkv_flat
+                else:
+                    gather_indices = forward_metadata.ragged_verify_dense_gather_indices
+                    assert gather_indices is not None
+                    mixed_qkv = mixed_qkv_flat[gather_indices]
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
             if forward_metadata.has_mamba_track_mask:

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -35,15 +35,7 @@ elif is_cpu():
 
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import (
-    get_disagg,
-    get_exec,
-    get_memory,
-    get_spec,
-)
-from sglang.srt.speculative.ragged_verify import (
-    ragged_verify_dense_scatter_indices,
-)
+from sglang.srt.runtime_context import get_disagg, get_exec, get_memory, get_spec
 
 
 class KDAKernelDispatcher:
@@ -1070,11 +1062,8 @@ class KDAAttnBackend(MambaAttnBackendBase):
             # value-irrelevant).
             batch_size = query_start_loc.shape[0] - 1
             num_dense_tokens = batch_size * draft_token_num
-            dense_token_indices = ragged_verify_dense_scatter_indices(
-                query_start_loc=query_start_loc,
-                seq_len=seq_len,
-                draft_token_num=draft_token_num,
-            )
+            dense_token_indices = forward_metadata.ragged_verify_dense_indices
+            assert dense_token_indices is not None
             dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
             dense.index_copy_(0, dense_token_indices, mixed_qkv)
             mixed_qkv_dense = dense[:num_dense_tokens].view(

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -41,6 +41,9 @@ from sglang.srt.runtime_context import (
     get_memory,
     get_spec,
 )
+from sglang.srt.speculative.ragged_verify import (
+    ragged_verify_dense_scatter_indices,
+)
 
 
 class KDAKernelDispatcher:
@@ -363,29 +366,6 @@ class KDAKernelDispatcher:
             query_start_loc=query_start_loc,
             **kwargs,
         )
-
-
-def ragged_verify_dense_scatter_indices(
-    *,
-    query_start_loc: torch.Tensor,
-    seq_len: int,
-    draft_token_num: int,
-) -> torch.Tensor:
-    """Dense [bs, draft_token_num] slot index per packed ragged-verify token.
-
-    Rows never exceed draft_token_num under either layout variant (cap for
-    graph replay, planner construction for eager -- see
-    RaggedVerifyLayout.padded_to_bucket), so in-row offsets stay in-row;
-    tokens past the layout's coverage collapse into one ghost row at index
-    bs * draft_token_num.
-    """
-    batch_size = query_start_loc.shape[0] - 1
-    token_pos = torch.arange(seq_len, device=query_start_loc.device, dtype=torch.int32)
-    token_slots = torch.searchsorted(query_start_loc[1:], token_pos, right=True)
-    return (
-        token_slots * draft_token_num
-        + (token_pos - query_start_loc[token_slots]).to(torch.int64)
-    ).clamp_(max=batch_size * draft_token_num)
 
 
 class KDAAttnBackend(MambaAttnBackendBase):

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -1064,7 +1064,8 @@ class KDAAttnBackend(MambaAttnBackendBase):
             num_dense_tokens = batch_size * draft_token_num
             dense_token_indices = forward_metadata.ragged_verify_dense_indices
             assert dense_token_indices is not None
-            dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
+            # Only real packed positions are gathered back and committed.
+            dense = mixed_qkv.new_empty(num_dense_tokens + 1, mixed_qkv.shape[-1])
             dense.index_copy_(0, dense_token_indices, mixed_qkv)
             mixed_qkv_dense = dense[:num_dense_tokens].view(
                 batch_size, draft_token_num, -1
@@ -1092,12 +1093,9 @@ class KDAAttnBackend(MambaAttnBackendBase):
         if dense_token_indices is None:
             mixed_qkv = mixed_qkv_flat
         else:
-            # Ghost row (zeros) so uncovered tail tokens gather finite values.
-            padded_flat = mixed_qkv_flat.new_zeros(
-                batch_size * draft_token_num + 1, mixed_qkv_flat.shape[-1]
-            )
-            padded_flat[: batch_size * draft_token_num] = mixed_qkv_flat
-            mixed_qkv = padded_flat[dense_token_indices]
+            gather_indices = forward_metadata.ragged_verify_dense_gather_indices
+            assert gather_indices is not None
+            mixed_qkv = mixed_qkv_flat[gather_indices]
 
         q, k, v = mixed_qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -7,6 +7,7 @@ from sglang.kernels.ops.attention import kda_fused_decode, kda_fused_decode_aite
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_fn,
     causal_conv1d_update,
+    causal_conv1d_update_varlen,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
@@ -996,6 +997,13 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 replayssm_g=mamba_cache_params.replayssm_g,
                 replayssm_beta=mamba_cache_params.replayssm_beta,
             )
+        use_varlen_conv = (
+            ragged_layout is not None
+            and is_cuda()
+            and retrieve_next_token is None
+            and retrieve_next_sibling is None
+            and retrieve_parent_token is None
+        )
         if ragged_layout is None:
             batch_size = seq_len // draft_token_num
             conv_state_indices = cache_indices[:batch_size]
@@ -1052,6 +1060,10 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 )
             dense_token_indices = None
             mixed_qkv_dense = mixed_qkv.view(batch_size, draft_token_num, -1)
+        elif use_varlen_conv:
+            batch_size = query_start_loc.shape[0] - 1
+            dense_token_indices = None
+            mixed_qkv_dense = None
         else:
             # Conv update and its per-step scratch want the dense
             # [bs, draft_token_num] layout: scatter ragged tokens to their
@@ -1062,7 +1074,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
             # value-irrelevant).
             batch_size = query_start_loc.shape[0] - 1
             num_dense_tokens = batch_size * draft_token_num
-            dense_token_indices = forward_metadata.ragged_verify_dense_indices
+            dense_token_indices = fm.ragged_verify_dense_indices
             assert dense_token_indices is not None
             # Only real packed positions are gathered back and committed.
             dense = mixed_qkv.new_empty(num_dense_tokens + 1, mixed_qkv.shape[-1])
@@ -1071,31 +1083,48 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 batch_size, draft_token_num, -1
             )
 
-        # causal_conv1d_update expects [.., dim, width]. KDA keeps dense conv-window
-        # scratch because the deduplicated overlapping layout cannot be transposed.
-        mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
-        mixed_qkv_processed = causal_conv1d_update(
-            mixed_qkv_reshaped,
-            conv_states.transpose(-1, -2),
-            layer.conv_weights,
-            layer.bias,
-            activation="silu",
-            conv_state_indices=cache_indices[:batch_size],
-            intermediate_conv_window=intermediate_conv_window_cache.transpose(-1, -2),
-            intermediate_state_indices=intermediate_state_indices[:batch_size],
-            retrieve_next_token=retrieve_next_token,
-            retrieve_next_sibling=retrieve_next_sibling,
-            retrieve_parent_token=retrieve_parent_token,
-        )
-        mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
-            batch_size * draft_token_num, -1
-        )
-        if dense_token_indices is None:
-            mixed_qkv = mixed_qkv_flat
+        if use_varlen_conv:
+            mixed_qkv = causal_conv1d_update_varlen(
+                mixed_qkv,
+                conv_states.transpose(-1, -2),
+                layer.conv_weights,
+                layer.bias,
+                activation="silu",
+                query_start_loc=query_start_loc,
+                conv_state_indices=cache_indices[:batch_size],
+                intermediate_conv_window=intermediate_conv_window_cache.transpose(
+                    -1, -2
+                ),
+                intermediate_state_indices=intermediate_state_indices[:batch_size],
+                max_seqlen=draft_token_num,
+            )
         else:
-            gather_indices = forward_metadata.ragged_verify_dense_gather_indices
-            assert gather_indices is not None
-            mixed_qkv = mixed_qkv_flat[gather_indices]
+            # causal_conv1d_update expects [.., dim, width].
+            mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
+            mixed_qkv_processed = causal_conv1d_update(
+                mixed_qkv_reshaped,
+                conv_states.transpose(-1, -2),
+                layer.conv_weights,
+                layer.bias,
+                activation="silu",
+                conv_state_indices=cache_indices[:batch_size],
+                intermediate_conv_window=intermediate_conv_window_cache.transpose(
+                    -1, -2
+                ),
+                intermediate_state_indices=intermediate_state_indices[:batch_size],
+                retrieve_next_token=retrieve_next_token,
+                retrieve_next_sibling=retrieve_next_sibling,
+                retrieve_parent_token=retrieve_parent_token,
+            )
+            mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
+                batch_size * draft_token_num, -1
+            )
+            if dense_token_indices is None:
+                mixed_qkv = mixed_qkv_flat
+            else:
+                gather_indices = fm.ragged_verify_dense_gather_indices
+                assert gather_indices is not None
+                mixed_qkv = mixed_qkv_flat[gather_indices]
 
         q, k, v = mixed_qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -71,6 +71,7 @@ class ForwardMetadata:
     draft_token_num: int = 1
     # Shared by all linear-attention layers in one compact verify forward.
     ragged_verify_dense_indices: Optional[torch.Tensor] = None
+    ragged_verify_dense_gather_indices: Optional[torch.Tensor] = None
 
     # KDA fused-accept: the [N, T] slot-indexed scratch rows and the per-request
     # accept length that seed the verify kernel. Every KDA layer of a forward

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -69,6 +69,8 @@ class ForwardMetadata:
 
     is_target_verify: bool = False
     draft_token_num: int = 1
+    # Shared by all linear-attention layers in one compact verify forward.
+    ragged_verify_dense_indices: Optional[torch.Tensor] = None
 
     # KDA fused-accept: the [N, T] slot-indexed scratch rows and the per-request
     # accept length that seed the verify kernel. Every KDA layer of a forward

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1167,7 +1167,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # passes its own positions (uniform num_draft_tokens per request).
         if seq_positions is None:
             seq_positions = batch.spec_info.positions
-        seq_positions = seq_positions.view(batch_size, -1)
         # Split text-only and mixed batches here because SpecV2 text-only batches can avoid an extra D2H.
         if all(mm_input is None for mm_input in mm_inputs):
             mrope_delta_tensor = torch.zeros(
@@ -1183,9 +1182,38 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 for i in range(batch_size)
             ]
             mrope_delta_tensor = torch.stack(mrope_deltas, dim=0).to(device=device)
-        next_input_positions = (
-            (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
-        )
+
+        ragged_layout = getattr(batch.spec_info, "ragged_verify_layout", None)
+        if ragged_layout is None:
+            seq_positions = seq_positions.view(batch_size, -1)
+            next_input_positions = (
+                (seq_positions + mrope_delta_tensor)
+                .flatten()
+                .unsqueeze(0)
+                .repeat(3, 1)
+            )
+        else:
+            # Ragged target verify packs real request rows first and pads the
+            # remaining graph-tier tokens at the tail. Map each packed token to
+            # its request through the QO indptr instead of assuming a uniform
+            # per-request width, and leave graph padding at position zero.
+            seq_positions = seq_positions.flatten()
+            qo_indptr = ragged_layout.qo_indptr_device
+            packed_offsets = torch.arange(
+                seq_positions.numel(), dtype=qo_indptr.dtype, device=device
+            )
+            request_indices = torch.searchsorted(
+                qo_indptr[1:], packed_offsets, right=True
+            )
+            valid = request_indices < batch_size
+            safe_request_indices = request_indices.clamp(max=batch_size - 1)
+            token_deltas = mrope_delta_tensor.flatten()[safe_request_indices]
+            adjusted_positions = torch.where(
+                valid,
+                seq_positions + token_deltas,
+                torch.zeros_like(seq_positions),
+            )
+            next_input_positions = adjusted_positions.unsqueeze(0).repeat(3, 1)
 
         self.mrope_positions = next_input_positions
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1187,10 +1187,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if ragged_layout is None:
             seq_positions = seq_positions.view(batch_size, -1)
             next_input_positions = (
-                (seq_positions + mrope_delta_tensor)
-                .flatten()
-                .unsqueeze(0)
-                .repeat(3, 1)
+                (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
             )
         else:
             # Ragged target verify packs real request rows first and pads the

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -135,7 +135,6 @@ class DSparkVerifyPlanner:
         self._dynamic_graph_tier = False
         self._dp_tier_gather_enabled = False
         self._is_verify_all = True
-        self._uniform_layout_cache: dict = {}
         if self._ragged_verify_mode is not RaggedVerifyMode.STATIC:
             if self._confidence_head is None:
                 raise ValueError(
@@ -428,33 +427,29 @@ class DSparkVerifyPlanner:
                 or self._budget_planner.forced_budget_frac is None
             )
         ):
-            # Verify-all: the uniform layout (or None, past the captured grid)
-            # is constant per (bs, tier); serve it from cache instead of paying
-            # the per-step schedule and its host<->device round-trips. A profiler
-            # budget pin must still reach the dynamic layout path even when the
-            # bootstrap SPS table is uninitialized.
-            key = (int(req_pool_indices.shape[0]), global_num_reqs)
-            if key not in self._uniform_layout_cache:
-                self._uniform_layout_cache[key] = uniform_ragged_layout(
-                    bs=key[0],
-                    device=device,
-                    verify_num_draft_tokens=self.verify_num_draft_tokens,
-                    ragged_verify_mode=self._ragged_verify_mode,
-                    model_runner=self.model_runner,
-                    tier_num_reqs=global_num_reqs,
-                )
-            return self._uniform_layout_cache[key]
+            # No SPS decision exists, so every request verifies the full window.
+            # Use the regular uniform verify path and avoid compact packing.
+            # A profiler budget pin must still reach the scheduler below.
+            return None
+        aligned_budget = self._budget_aligned_to_graph_tier(
+            req_pool_indices=req_pool_indices,
+            budget=budget,
+            global_num_reqs=global_num_reqs,
+            dp_tier_num_tokens=dp_tier_num_tokens,
+        )
+        local_bs = int(req_pool_indices.shape[0])
+        verify_floor = max(self._schedule_cfg.min_verify_len, 1)
+        full_budget = local_bs * (self.verify_num_draft_tokens - verify_floor)
+        if aligned_budget is not None and aligned_budget >= full_budget:
+            # A full compact layout is identical to regular uniform verify, but
+            # pays for ragged scheduling, packing, and linear-attention remapping.
+            return None
         verify_lens = self._schedule_verify_lens(
             req_pool_indices=req_pool_indices,
             prefix_lens=prefix_lens,
             device=device,
             confidence=confidence,
-            budget=self._budget_aligned_to_graph_tier(
-                req_pool_indices=req_pool_indices,
-                budget=budget,
-                global_num_reqs=global_num_reqs,
-                dp_tier_num_tokens=dp_tier_num_tokens,
-            ),
+            budget=aligned_budget,
         )
         if verify_lens is None:
             assert dp_tier_num_tokens is None, (

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -135,6 +135,7 @@ class DSparkVerifyPlanner:
         self._dynamic_graph_tier = False
         self._dp_tier_gather_enabled = False
         self._is_verify_all = True
+        self._uniform_layout_cache: dict = {}
         if self._ragged_verify_mode is not RaggedVerifyMode.STATIC:
             if self._confidence_head is None:
                 raise ValueError(
@@ -246,6 +247,25 @@ class DSparkVerifyPlanner:
         return (
             self._ragged_verify_mode is RaggedVerifyMode.COMPACT and layout is not None
         )
+
+    def _uniform_layout(
+        self,
+        *,
+        bs: int,
+        device: torch.device,
+        global_num_reqs: Optional[int],
+    ) -> Optional[RaggedVerifyLayout]:
+        key = (bs, global_num_reqs)
+        if key not in self._uniform_layout_cache:
+            self._uniform_layout_cache[key] = uniform_ragged_layout(
+                bs=bs,
+                device=device,
+                verify_num_draft_tokens=self.verify_num_draft_tokens,
+                ragged_verify_mode=self._ragged_verify_mode,
+                model_runner=self.model_runner,
+                tier_num_reqs=global_num_reqs,
+            )
+        return self._uniform_layout_cache[key]
 
     def compute_confidence_tensor(
         self,
@@ -427,10 +447,11 @@ class DSparkVerifyPlanner:
                 or self._budget_planner.forced_budget_frac is None
             )
         ):
-            # No SPS decision exists, so every request verifies the full window.
-            # Use the regular uniform verify path and avoid compact packing.
-            # A profiler budget pin must still reach the scheduler below.
-            return None
+            return self._uniform_layout(
+                bs=int(req_pool_indices.shape[0]),
+                device=device,
+                global_num_reqs=global_num_reqs,
+            )
         aligned_budget = self._budget_aligned_to_graph_tier(
             req_pool_indices=req_pool_indices,
             budget=budget,
@@ -441,9 +462,11 @@ class DSparkVerifyPlanner:
         verify_floor = max(self._schedule_cfg.min_verify_len, 1)
         full_budget = local_bs * (self.verify_num_draft_tokens - verify_floor)
         if aligned_budget is not None and aligned_budget >= full_budget:
-            # A full compact layout is identical to regular uniform verify, but
-            # pays for ragged scheduling, packing, and linear-attention remapping.
-            return None
+            return self._uniform_layout(
+                bs=local_bs,
+                device=device,
+                global_num_reqs=global_num_reqs,
+            )
         verify_lens = self._schedule_verify_lens(
             req_pool_indices=req_pool_indices,
             prefix_lens=prefix_lens,
@@ -457,13 +480,10 @@ class DSparkVerifyPlanner:
                 "the gathered hint and the local budget diverged"
             )
             if self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
-                return uniform_ragged_layout(
+                return self._uniform_layout(
                     bs=len(req_pool_indices),
                     device=device,
-                    verify_num_draft_tokens=self.verify_num_draft_tokens,
-                    ragged_verify_mode=self._ragged_verify_mode,
-                    model_runner=self.model_runner,
-                    tier_num_reqs=global_num_reqs,
+                    global_num_reqs=global_num_reqs,
                 )
             return None
         bs = int(verify_lens.shape[0])

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -420,10 +420,19 @@ class DSparkVerifyPlanner:
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
-        if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
+        if (
+            self._is_verify_all
+            and self._ragged_verify_mode is RaggedVerifyMode.COMPACT
+            and (
+                self._budget_planner is None
+                or self._budget_planner.forced_budget_frac is None
+            )
+        ):
             # Verify-all: the uniform layout (or None, past the captured grid)
             # is constant per (bs, tier); serve it from cache instead of paying
-            # the per-step schedule and its host<->device round-trips.
+            # the per-step schedule and its host<->device round-trips. A profiler
+            # budget pin must still reach the dynamic layout path even when the
+            # bootstrap SPS table is uninitialized.
             key = (int(req_pool_indices.shape[0]), global_num_reqs)
             if key not in self._uniform_layout_cache:
                 self._uniform_layout_cache[key] = uniform_ragged_layout(

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -225,6 +225,22 @@ def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
     return spec_info.ragged_verify_layout
 
 
+def ragged_verify_dense_scatter_indices(
+    *, query_start_loc: torch.Tensor, seq_len: int, draft_token_num: int
+) -> torch.Tensor:
+    """Map packed tokens to dense ``[request, step]`` slots.
+
+    Uncovered graph-tail tokens map to one value-irrelevant ghost slot.
+    """
+    batch_size = query_start_loc.shape[0] - 1
+    token_pos = torch.arange(seq_len, device=query_start_loc.device, dtype=torch.int32)
+    token_slots = torch.searchsorted(query_start_loc[1:], token_pos, right=True)
+    return (
+        token_slots * draft_token_num
+        + (token_pos - query_start_loc[token_slots]).to(torch.int64)
+    ).clamp_(max=batch_size * draft_token_num)
+
+
 class RaggedTargetVerifyGeometry(msgspec.Struct):
     cache_seqlens_int32: torch.Tensor
     cu_seqlens_q: torch.Tensor

--- a/test/registered/layers/mamba/test_causal_conv1d.py
+++ b/test/registered/layers/mamba/test_causal_conv1d.py
@@ -19,6 +19,7 @@ from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     PAD_SLOT_ID,
     causal_conv1d_fn,
     causal_conv1d_update,
+    causal_conv1d_update_varlen,
 )
 from sglang.srt.utils import get_device
 from sglang.test.test_utils import empty_gpu_cache
@@ -433,6 +434,71 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("width", [2, 4])
+def test_causal_conv1d_update_varlen_matches_per_row(width):
+    device = get_device()
+    dtype = torch.bfloat16
+    dim, max_seqlen, num_cache_lines = 128, 4, 8
+    lengths = [4, 1, 3, 0, 0]
+    query_start_loc = torch.tensor([0, 4, 5, 8, 8, 8], dtype=torch.int32, device=device)
+    cache_indices = torch.tensor(
+        [2, 6, 4, PAD_SLOT_ID, PAD_SLOT_ID],
+        dtype=torch.int32,
+        device=device,
+    )
+    x = torch.randn(sum(lengths), dim, dtype=dtype, device=device)
+    weight = torch.randn(dim, width, dtype=dtype, device=device)
+    bias = torch.randn(dim, dtype=dtype, device=device)
+    state = torch.randn(num_cache_lines, dim, width - 1, dtype=dtype, device=device)
+    expected_state = state.clone()
+    intermediate = torch.zeros(
+        num_cache_lines,
+        max_seqlen,
+        dim,
+        width - 1,
+        dtype=dtype,
+        device=device,
+    )
+    expected_intermediate = torch.zeros_like(intermediate)
+
+    expected_rows = []
+    for row, length in enumerate(lengths[:3]):
+        start = int(query_start_loc[row].item())
+        row_x = x[start : start + length].T.unsqueeze(0)
+        row_index = cache_indices[row : row + 1]
+        expected_rows.append(
+            causal_conv1d_update(
+                row_x,
+                expected_state,
+                weight,
+                bias,
+                activation="silu",
+                conv_state_indices=row_index,
+                intermediate_conv_window=expected_intermediate,
+                intermediate_state_indices=row_index,
+            )
+            .squeeze(0)
+            .T
+        )
+
+    actual = causal_conv1d_update_varlen(
+        x,
+        state,
+        weight,
+        bias,
+        activation="silu",
+        query_start_loc=query_start_loc,
+        conv_state_indices=cache_indices,
+        intermediate_conv_window=intermediate,
+        intermediate_state_indices=cache_indices,
+        max_seqlen=max_seqlen,
+    )
+
+    torch.testing.assert_close(actual, torch.cat(expected_rows), rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(state, expected_state, rtol=0, atol=0)
+    torch.testing.assert_close(intermediate, expected_intermediate, rtol=0, atol=0)
 
 
 def test_causal_conv1d_varlen_mixed_input_and_state_dtype():

--- a/test/registered/spec/dspark/test_ragged_verify.py
+++ b/test/registered/spec/dspark/test_ragged_verify.py
@@ -5,6 +5,7 @@ import torch
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyLayout,
     build_ragged_target_verify_geometry,
+    ragged_verify_dense_scatter_indices,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -20,6 +21,25 @@ _GRID = [8, 16, 24, 32, 64]
 
 
 class TestRaggedTargetVerifyGeometry(CustomTestCase):
+    def test_dense_scatter_indices_preserve_variable_row_boundaries(self):
+        query_start_loc = torch.tensor([0, 3, 4, 8], dtype=torch.int32)
+        indices = ragged_verify_dense_scatter_indices(
+            query_start_loc=query_start_loc,
+            seq_len=8,
+            draft_token_num=4,
+        )
+        self.assertEqual(indices.tolist(), [0, 1, 2, 4, 8, 9, 10, 11])
+
+    def test_dense_scatter_indices_map_uncovered_tail_to_ghost(self):
+        # The capped layout covers six tokens; two graph-tail tokens remain.
+        query_start_loc = torch.tensor([0, 2, 3, 6], dtype=torch.int32)
+        indices = ragged_verify_dense_scatter_indices(
+            query_start_loc=query_start_loc,
+            seq_len=8,
+            draft_token_num=4,
+        )
+        self.assertEqual(indices.tolist(), [0, 1, 4, 8, 9, 10, 12, 12])
+
     def test_mixed_verify_lens_geometry(self):
         layout = RaggedVerifyLayout.from_verify_lens(
             verify_lens_cpu=[8, 1, 3], device=_DEVICE, grid=_GRID

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -28,12 +28,14 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
         from sglang.srt.layers.attention.flashattention_backend import (
             FlashAttentionBackend,
         )
+        from sglang.srt.layers.attention.linear.gdn_backend import GDNAttnBackend
         from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 
         for backend in (
             TRTLLMHAAttnBackend,
             DeepseekV4AttnBackend,
             FlashAttentionBackend,
+            GDNAttnBackend,
         ):
             with self.subTest(backend=backend.__name__):
                 self.assertTrue(backend.supports_ragged_verify_graph)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes three issues exposed by DSpark compact adaptive verification:

1. **SPS profiler budget pins were ignored without an SPS table.** Compact mode
   used the uninitialized-table `verify-all` shortcut even after
   `dspark_sps_profiler` installed `dspark_force_budget_frac`. Consequently,
   every profiling fraction executed the full verify width and produced nearly
   identical timings instead of measuring the requested budgets.
2. **Speculative mRoPE positions assumed uniform verify widths.** Compact mode
   packs variable-length request rows and may pad to a CUDA Graph token tier, so
   the packed token count need not be divisible by the request count. Reshaping
   it to `[batch_size, -1]` either failed or silently associated tokens and
   request-specific mRoPE deltas incorrectly; graph padding could also receive
   an invalid negative position.
3. **GDN target verification reconstructed compact input as a uniform matrix.**
   `seq_len // draft_token_num` and a fixed-width `view()` do not describe a
   ragged layout. Non-divisible shapes failed immediately, while divisible
   shapes could silently cross request boundaries and later surface as an
   asynchronous illegal memory access. The ReplaySSM CuTe DSL subpath had the
   same fixed-width requirement. These assumptions also prevented GDN from
   safely opting into compact CUDA Graph replay.

Together, these issues blocked SPS-table profiling and compact adaptive serving
on Qwen3.5/Qwen3.8-style hybrid GDN models.

## Modifications

### `python/sglang/srt/speculative/dspark_components/dspark_planner.py`

- Honor forced profiler budgets even when the SPS table is uninitialized;
  retain verify-all for bootstrap/warmup when no fraction is forced.
- Detect full budgets before token scheduling and reuse cached uniform layouts
  by local request count and DP-global tier.
- Preserve compact CUDA Graphs keyed only by batched-token tier. Recording
  remains an observability switch, not a layout-selection flag.

### `python/sglang/srt/model_executor/forward_batch_info.py`

- Map packed verify tokens to request-specific mRoPE deltas using the ragged
  QO boundaries instead of a uniform-width reshape.
- Keep graph-tail padding at position zero and preserve the existing non-ragged
  path, without adding host synchronization.

### `python/sglang/srt/speculative/ragged_verify.py`

- Add a shared packed-to-dense slot mapping for compatibility paths; uncovered
  graph padding maps to a ghost slot rather than a real request.

### `python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py`
### `python/sglang/srt/layers/attention/mamba/mamba2_metadata.py`

- Store and prepare shared ragged scatter/gather indices once per forward,
  rather than rebuilding them in every linear-attention layer.

### `python/sglang/kernels/ops/mamba/causal_conv1d_triton.py`

- Add a packed varlen causal-convolution update kernel driven by
  `query_start_loc`, eliminating dense QKV scratch and scatter/gather on the
  supported CUDA chain-verify path.
- Preserve per-step convolution windows for acceptance-time state commit,
  skip padded cache slots, and retain PDL support.

### `python/sglang/srt/layers/attention/linear/gdn_backend.py`

- Remove uniform-width assumptions from ragged target verification and enable
  ragged CUDA Graph replay.
- Use packed varlen convolution for CUDA chain verification; retain the dense
  compatibility path for non-CUDA/tree verification and the existing uniform
  path.
- Keep ragged ReplaySSM verification on the varlen recurrent kernel instead of
  the fixed-width CuTe DSL path.

### `python/sglang/srt/layers/attention/linear/kda_backend.py`

- Integrate the same packed varlen convolution optimization while preserving
  uniform fused verification and non-CUDA/tree compatibility paths.
- Reuse shared dense mapping metadata and fix its metadata reference in the
  compatibility path.

### Tests

- `test/registered/spec/dspark/test_ragged_verify.py`: cover packed-to-dense
  mapping across request boundaries and graph padding.
- `test/registered/spec/dspark/test_ragged_verify_backend_capability.py`:
  update GDN's ragged graph capability expectation.
- `test/registered/layers/mamba/test_causal_conv1d.py`: add packed varlen
  convolution parity coverage for mixed lengths, padded slots, final states,
  and intermediate convolution windows.

## Validation

Hardware:

```text
2 x NVIDIA H200
```

### Profiling server

```bash
SGLANG_RAGGED_VERIFY_MODE=compact \
SGLANG_DSPARK_ENABLE_SPS_RECORD=1 \
SGLANG_SIMULATE_ACC_LEN=1 \
python -m sglang.launch_server \
  --model-path /models/Qwen/Qwen3.8-27B \
  --tp 2 \
  --speculative-algorithm DSPARK \
  --mem-fraction-static 0.85 \
  --speculative-draft-model-path /aicp_models/RadixArk/Qwen3.8-27B-DSpark/ \
  --speculative-dspark-block-size 15 \
  --max-running-requests 48 \
  --disable-radix-cache \
  --disable-prefill-cuda-graph \
  --host 0.0.0.0 \
  --port 30000
```

Profiler command:

```bash
python -m sglang.benchmark.dspark_sps_profiler all \
  --base-url http://127.0.0.1:30000 \
  --out /workspace/wyh/sps_tables/qwen3.8-27b-dspark-n16/sps_additive.json \
  --fracs 0.2 0.4666666666666667 0.7333333333333333 1.0 \
  --temperature 0 \
  --batch-size 48
```

### Results

| Fraction | Target verify tokens | Before steps/s | After steps/s | Before step time | After step time | SPS speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 0.2 | 192 | 4.747 | 11.050 | 0.2106 s | 0.0905 s | 2.33x |
| 0.4666666666666667 | 384 | 4.750 | 8.104 | 0.2105 s | 0.1234 s | 1.71x |
| 0.7333333333333333 | 575 | 4.750 | 5.552 | 0.2105 s | 0.1801 s | 1.17x |
| 1.0 | 768 | 4.753 | 4.848 | 0.2104 s | 0.2063 s | 1.02x |

Before the fix, all fractions had effectively identical latency because the
cached verify-all layout always verified 768 tokens. After the fix, latency
scales with the requested verify-token budget, while the full-budget result
remains close to the original verify-all baseline.

### Serving A/B

With 48 concurrent requests, compact verification improves throughput by 9.4%:

| Concurrency | Static throughput | Compact throughput | Difference |
|---:|---:|---:|---:|
| 48 | 1457.2 | 1593.9 | +9.4% |

### GSM8K accuracy

The accuracy run used 40 GSM8K questions in chat format without output
truncation:

| Mode | Accuracy |
|---|---:|
| Static | 37/40 = 0.925 |
| Compact | 38/40 = 0.950 |

### Online serving with the generated table

After profiling, the generated SPS table can be loaded for adaptive online
serving:

```bash
SGLANG_RAGGED_VERIFY_MODE=compact \
python -m sglang.launch_server \
  --model-path /models/Qwen/Qwen3.8-27B \
  --tp 2 \
  --speculative-algorithm DSPARK \
  --mem-fraction-static 0.85 \
  --speculative-draft-model-path /aicp_models/RadixArk/Qwen3.8-27B-DSpark/ \
  --speculative-dspark-block-size 15 \
  --speculative-dspark-sps-table-path /workspace/wyh/sps_tables/qwen3.8-27b-dspark-n16/sps_additive.json \
  --max-running-requests 48 \
  --disable-radix-cache \
  --disable-prefill-cuda-graph \
  --host 0.0.0.0 \
  --port 30000
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35554377964](https://github.com/sgl-project/sglang/actions/runs/35554377964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35554377808](https://github.com/sgl-project/sglang/actions/runs/35554377808)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35554377968](https://github.com/sgl-project/sglang/actions/runs/35554377968)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
