### PR TITLE
[XPU][MoE] Enable FP8 MoE dispatch across FP8 quantization methods

### DIFF
--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -165,6 +165,9 @@ class _MoeRunnerBackendPredicates:
     def is_aiter(self):
         return self.value == MoeRunnerBackend.AITER.value
 
+    def is_intel_xpu(self):
+        return self.value == MoeRunnerBackend.INTEL_XPU.value
+
 
 class MoeRunnerBackend(_MoeRunnerBackendPredicates, Enum):
     AUTO = "auto"
@@ -226,9 +229,6 @@ def resolve_moe_runner_backend(
         raise ValueError(
             f"MoE runner backend {backend!r} is neither built in nor registered"
         ) from None
-
-    def is_intel_xpu(self):
-        return self == MoeRunnerBackend.INTEL_XPU
 
 
 class DeepEPv2Fp8ScaleFormat(NamedTuple):

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8_moe.py
@@ -27,7 +27,7 @@ from sglang.srt.layers.quantization.utils import (
     swap_w13_to_w31,
 )
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.utils import get_bool_env_var, is_hip, set_weight_attrs
+from sglang.srt.utils import get_bool_env_var, is_hip, is_xpu, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
@@ -375,6 +375,33 @@ class CompressedTensorsW8A8Fp8MoE(CompressedTensorsMoEScheme):
         topk_output = dispatch_output.topk_output
 
         moe_runner_config = self.moe_runner_config
+
+        if is_xpu() and not get_moe_runner_backend().is_triton():
+            from sgl_kernel import fused_experts
+
+            from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+            topk_weights, topk_ids, _ = topk_output
+            is_block = self.weight_quant.strategy == QuantizationStrategy.BLOCK
+            output = fused_experts(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                b1=getattr(layer, "w13_weight_bias", None),
+                b2=getattr(layer, "w2_weight_bias", None),
+                use_fp8_w8a8=True,
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                block_shape=self.weight_block_size if is_block else None,
+                activation=moe_runner_config.activation,
+                routed_scaling_factor=moe_runner_config.routed_scaling_factor,
+                gemm1_alpha=moe_runner_config.gemm1_alpha,
+                gemm1_limit=moe_runner_config.gemm1_clamp_limit,
+                swiglu_limit=moe_runner_config.swiglu_limit,
+            )
+            return StandardCombineInput(hidden_states=output)
 
         if self.runner.runner_backend.is_aiter():
             from sglang.srt.layers.moe.moe_runner.aiter import (

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2551,6 +2551,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     if self.block_quant
                     else layer.w2_weight_scale
                 ),
+                block_shape=(
+                    getattr(self.quant_config, "weight_block_size", None)
+                    if self.block_quant
+                    else None
+                ),
                 activation=moe_runner_config.activation,
                 routed_scaling_factor=moe_runner_config.routed_scaling_factor,
                 gemm1_alpha=moe_runner_config.gemm1_alpha,

--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
@@ -12,6 +12,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 )
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
@@ -25,7 +26,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
 )
-from sglang.srt.utils import set_weight_attrs
+from sglang.srt.utils import is_xpu, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -302,6 +303,32 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         layer: torch.nn.Module,
         dispatch_output: StandardDispatchOutput,
     ) -> CombineInput:
+        if is_xpu() and not get_moe_runner_backend().is_triton():
+            from sgl_kernel import fused_experts
+
+            from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+            x = dispatch_output.hidden_states
+            topk_weights, topk_ids, _ = dispatch_output.topk_output
+            moe_runner_config = self.moe_runner_config
+            output = fused_experts(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                b1=getattr(layer, "w13_weight_bias", None),
+                b2=getattr(layer, "w2_weight_bias", None),
+                use_fp8_w8a8=True,
+                w1_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                activation=moe_runner_config.activation,
+                routed_scaling_factor=moe_runner_config.routed_scaling_factor,
+                gemm1_alpha=moe_runner_config.gemm1_alpha,
+                gemm1_limit=moe_runner_config.gemm1_clamp_limit,
+                swiglu_limit=moe_runner_config.swiglu_limit,
+            )
+            return StandardCombineInput(hidden_states=output)
 
         quant_info = self.get_triton_quant_info(layer)
         return self.runner.run(dispatch_output, quant_info)

--- a/test/registered/e2e/xpu/test_moe_wna16.py
+++ b/test/registered/e2e/xpu/test_moe_wna16.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for XPU MoE WnA16 quantization methods and execution paths.
+"""
+
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher import (
+    StandardCombineInput,
+    StandardDispatchOutput,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.utils import resolve_moe_runner_backend
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8_moe import (
+    CompressedTensorsW8A8Fp8MoE,
+    QuantizationStrategy,
+)
+from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
+from sglang.srt.layers.quantization.w8a8_fp8 import W8A8FP8MoEMethod
+from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_xpu_ci(est_time=15, suite="stage-b-test-1-gpu-xpu")
+
+
+class TestXpuMoeWna16(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.xpu.is_available():
+            raise unittest.SkipTest("XPU device not available")
+        cls.device = "xpu"
+        cls.num_tokens = 4
+        cls.num_experts = 4
+        cls.topk = 2
+        cls.hidden = 256
+        cls.intermediate = 256
+
+    def _create_dispatch_output(self):
+        x = torch.randn(
+            self.num_tokens, self.hidden, dtype=torch.bfloat16, device=self.device
+        )
+        topk_weights = torch.full(
+            (self.num_tokens, self.topk), 0.5, dtype=torch.float32, device=self.device
+        )
+        topk_ids = torch.tensor(
+            [[0, 1], [1, 2], [2, 3], [3, 0]], dtype=torch.int32, device=self.device
+        )
+        return StandardDispatchOutput(
+            x, None, StandardTopKOutput(topk_weights, topk_ids, None)
+        )
+
+    def test_moe_runner_backend_is_intel_xpu(self):
+        backend = resolve_moe_runner_backend("intel_xpu")
+        self.assertTrue(
+            backend.is_intel_xpu(),
+            "MoeRunnerBackend.INTEL_XPU.is_intel_xpu() must return True",
+        )
+
+    def test_fp8_moe_method_scalar_scale(self):
+        dispatch_output = self._create_dispatch_output()
+        quant_config = MagicMock(
+            is_checkpoint_fp8_serialized=False,
+            is_fp4_experts=False,
+            use_mxfp8=False,
+            weight_block_size=None,
+        )
+        method = Fp8MoEMethod(quant_config)
+        layer = nn.Module()
+        method.create_moe_runner(layer, MoeRunnerConfig())
+
+        layer.w13_weight = torch.randn(
+            self.num_experts,
+            2 * self.intermediate,
+            self.hidden,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w2_weight = torch.randn(
+            self.num_experts,
+            self.hidden,
+            self.intermediate,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w13_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+        layer.w2_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+
+        output = method.apply(layer, dispatch_output)
+        self.assertIsInstance(output, StandardCombineInput)
+        self.assertEqual(output.hidden_states.shape, (self.num_tokens, self.hidden))
+        self.assertEqual(output.hidden_states.dtype, torch.bfloat16)
+
+    def test_fp8_moe_method_block_scale(self):
+        dispatch_output = self._create_dispatch_output()
+        block_quant_config = MagicMock(
+            is_checkpoint_fp8_serialized=False,
+            is_fp4_experts=False,
+            use_mxfp8=False,
+            weight_block_size=[128, 128],
+        )
+        method = Fp8MoEMethod(block_quant_config)
+        layer = nn.Module()
+        method.create_moe_runner(layer, MoeRunnerConfig())
+
+        layer.w13_weight = torch.randn(
+            self.num_experts,
+            2 * self.intermediate,
+            self.hidden,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w2_weight = torch.randn(
+            self.num_experts,
+            self.hidden,
+            self.intermediate,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w13_weight_scale_inv = torch.ones(
+            self.num_experts,
+            (2 * self.intermediate + 127) // 128,
+            (self.hidden + 127) // 128,
+            dtype=torch.float32,
+            device=self.device,
+        )
+        layer.w2_weight_scale_inv = torch.ones(
+            self.num_experts,
+            (self.hidden + 127) // 128,
+            (self.intermediate + 127) // 128,
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        output = method.apply(layer, dispatch_output)
+        self.assertIsInstance(output, StandardCombineInput)
+        self.assertEqual(output.hidden_states.shape, (self.num_tokens, self.hidden))
+        self.assertEqual(output.hidden_states.dtype, torch.bfloat16)
+
+    def test_w8a8_fp8_moe_method(self):
+        dispatch_output = self._create_dispatch_output()
+        quant_config = MagicMock(
+            is_checkpoint_fp8_serialized=False,
+            is_fp4_experts=False,
+            use_mxfp8=False,
+            weight_block_size=None,
+        )
+        method = W8A8FP8MoEMethod(quant_config)
+        layer = nn.Module()
+        method.create_moe_runner(layer, MoeRunnerConfig())
+
+        layer.w13_weight = torch.randn(
+            self.num_experts,
+            2 * self.intermediate,
+            self.hidden,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w2_weight = torch.randn(
+            self.num_experts,
+            self.hidden,
+            self.intermediate,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w13_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+        layer.w2_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+
+        output = method.apply(layer, dispatch_output)
+        self.assertIsInstance(output, StandardCombineInput)
+        self.assertEqual(output.hidden_states.shape, (self.num_tokens, self.hidden))
+        self.assertEqual(output.hidden_states.dtype, torch.bfloat16)
+
+    def test_compressed_tensors_w8a8_fp8_moe(self):
+        dispatch_output = self._create_dispatch_output()
+        weight_quant = MagicMock(strategy=QuantizationStrategy.TENSOR)
+        input_quant = MagicMock(strategy=QuantizationStrategy.TENSOR, dynamic=True)
+        scheme = CompressedTensorsW8A8Fp8MoE(weight_quant, input_quant)
+        scheme.moe_runner_config = MoeRunnerConfig()
+        layer = nn.Module()
+
+        layer.w13_weight = torch.randn(
+            self.num_experts,
+            2 * self.intermediate,
+            self.hidden,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w2_weight = torch.randn(
+            self.num_experts,
+            self.hidden,
+            self.intermediate,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+        layer.w13_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+        layer.w2_weight_scale = torch.ones(
+            self.num_experts, 1, dtype=torch.float32, device=self.device
+        )
+
+        output = scheme.apply_weights(layer, dispatch_output)
+        self.assertIsInstance(output, StandardCombineInput)
+        self.assertEqual(output.hidden_states.shape, (self.num_tokens, self.hidden))
+        self.assertEqual(output.hidden_states.dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Enable FP8 MoE dispatch across all FP8 quantization methods as FP8 W8A16 grouped GEMM is supported in sgl-kernel on XPU.

## Modifications

- Pass block_shape parameter in Fp8MoEMethod.apply for block-quantized FP8 MoE weights.
- Route XPU path to sgl_kernel.fused_experts in W8A8FP8MoEMethod and CompressedTensorsW8A8Fp8MoE.
- Fix _MoeRunnerBackendPredicates.is_intel_xpu method placement.
- Add TestXpuMoeWna16 in test/registered/e2e/xpu/test_moe_wna16.py registered to stage-b-test-1-gpu-xpu.

## Accuracy Tests

- Test Fp8MoEMethod with scalar per-expert and 128x128 block scales on XPU.
- Test W8A8FP8MoEMethod and CompressedTensorsW8A8Fp8MoE XPU execution paths.
- Test MoeRunnerBackend.is_intel_xpu predicate.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34485120134](https://github.com/sgl-project/sglang/actions/runs/34485120134)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34485119878](https://github.com/sgl-project/sglang/actions/runs/34485119878)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34485120137](https://github.com/sgl-project/sglang/actions/runs/34485120137)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->