### PR TITLE
[Diffusion][SenseNova] Reduce host-device syncs in denoising

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_neo_chat.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_neo_chat.py
@@ -511,6 +511,15 @@ class NEOChatModel(PreTrainedModel):
         z_next = z + (t_next - t) * v_pred
         return z_next
 
+    @staticmethod
+    def _build_cfg_schedule(timesteps, cfg_interval, needs_cfg):
+        # Compare on the original device to preserve rounding at boundaries.
+        if not needs_cfg:
+            return [False] * (timesteps.numel() - 1)
+        return (
+            (timesteps[:-1] >= cfg_interval[0]) & (timesteps[:-1] <= cfg_interval[1])
+        ).tolist()
+
     def _calculate_dynamic_mu(self, image_seq_len: int) -> float:
         denom = self.max_image_seq_len - self.base_image_seq_len
         if denom == 0:
@@ -706,11 +715,7 @@ class NEOChatModel(PreTrainedModel):
 
         outputs = self.language_model.model(
             inputs_embeds=input_embeds,
-            image_gen_indicators=torch.ones(
-                (input_embeds.shape[0], input_embeds.shape[1]),
-                dtype=torch.bool,
-                device=input_embeds.device,
-            ),
+            image_only=True,
             indexes=indexes_image,
             attention_mask=attn_mask,
             past_key_values=past_key_values,
@@ -2473,6 +2478,10 @@ class NEOChatModel(PreTrainedModel):
                 timesteps, token_h * token_w, timestep_shift
             )
 
+        # Preserve GPU timestep rounding and inclusive CFG boundaries, but
+        # transfer the decisions only once instead of synchronizing every step.
+        cfg_active = self._build_cfg_schedule(timesteps, cfg_interval, needs_cfg)
+
         for step_i in range(num_steps):
             t = timesteps[step_i]
             t_next = timesteps[step_i + 1]
@@ -2512,7 +2521,7 @@ class NEOChatModel(PreTrainedModel):
                 image_size=image_size,
             )
 
-            if t >= cfg_interval[0] and t <= cfg_interval[1] and cfg_scale > 1:
+            if cfg_active[step_i]:
                 v_pred_uncondition = self._t2i_predict_v(
                     image_embeds,
                     indexes_image_uncondition,

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
@@ -1310,6 +1310,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        image_only: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
 
@@ -1317,7 +1318,11 @@ class Qwen3Model(Qwen3PreTrainedModel):
         # assert cache_position is not None
         # assert past_key_values is not None
 
-        if image_gen_indicators is None:
+        # Denoising callers know the token type without reading GPU scalars.
+        if image_only:
+            exist_non_image_gen_tokens = False
+            exist_image_gen_tokens = True
+        elif image_gen_indicators is None:
             exist_non_image_gen_tokens = True
             exist_image_gen_tokens = False
         else:

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3_moe.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3_moe.py
@@ -443,9 +443,14 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        image_only: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
-        if image_gen_indicators is None:
+        # Denoising callers know the token type without reading GPU scalars.
+        if image_only:
+            exist_non_image_gen_tokens = False
+            exist_image_gen_tokens = True
+        elif image_gen_indicators is None:
             exist_non_image_gen_tokens = True
             exist_image_gen_tokens = False
         else:

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -849,3 +849,122 @@ def test_sensenova_u1_multi_output_entrypoint_mixed_failure_fails_parent(
     assert trace_ctx.started_slices == [("gpu_forward", 2)]
     assert trace_ctx.finished_slices == [("gpu_forward", 2)]
     assert trace_ctx.finish_count == 1
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("image_only", [False, True])
+def test_sensenova_image_only_forward_preserves_outputs_and_prefix(device, image_only):
+    from transformers import Qwen3Config
+
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_neo_chat import (
+        prepare_flash_kv_cache,
+    )
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        Qwen3Model,
+        get_attn_backend,
+        set_attn_backend,
+    )
+
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    config = Qwen3Config(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=16,
+        max_position_embeddings=128,
+    )
+    config.rope_theta_hw = 10000.0
+    config.max_position_embeddings_hw = 128
+    config._attn_implementation = "eager"
+    previous_backend = get_attn_backend()
+    set_attn_backend("sdpa")
+    try:
+        model = Qwen3Model(config).to(device).eval()
+        prefix_indexes = torch.tensor([[0, 1], [0, 0], [0, 0]], device=device)
+        indexes = torch.tensor([[2, 2], [0, 0], [0, 1]], device=device)
+        inputs = torch.randn(1, 2, 32, device=device)
+        with torch.no_grad():
+            cache = model(
+                input_ids=torch.tensor([[1, 2]], device=device),
+                indexes=prefix_indexes,
+                attention_mask={"full_attention": None},
+                use_cache=True,
+            ).past_key_values
+            prefix = [
+                (layer.keys.clone(), layer.values.clone()) for layer in cache.layers
+            ]
+            prepare_flash_kv_cache(cache, current_len=2, batch_size=1)
+            for _ in range(2):
+                common = dict(
+                    inputs_embeds=inputs,
+                    indexes=indexes,
+                    attention_mask={"full_attention": None},
+                    past_key_values=cache,
+                    use_cache=True,
+                    update_cache=False,
+                )
+                expected = model(
+                    image_gen_indicators=torch.ones(
+                        1, 2, dtype=torch.bool, device=device
+                    ),
+                    **common,
+                ).last_hidden_state
+                actual = model(
+                    image_only=image_only,
+                    image_gen_indicators=(
+                        None
+                        if image_only
+                        else torch.ones(1, 2, dtype=torch.bool, device=device)
+                    ),
+                    **common,
+                ).last_hidden_state
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                assert cache.get_seq_length() == 2
+                for layer, (keys, values) in zip(cache.layers, prefix):
+                    torch.testing.assert_close(layer.keys, keys, rtol=0, atol=0)
+                    torch.testing.assert_close(layer.values, values, rtol=0, atol=0)
+                inputs = actual
+    finally:
+        set_attn_backend(previous_backend)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("needs_cfg", [False, True])
+@pytest.mark.parametrize("shift", [1.0, 3.0])
+@pytest.mark.parametrize("interval", [(0.0, 1.0), (0.25, 0.75), (0.5, 0.5)])
+def test_sensenova_cfg_schedule_preserves_scalar_decisions(
+    device, needs_cfg, shift, interval
+):
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_neo_chat import (
+        NEOChatModel,
+    )
+
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    timesteps = torch.linspace(0, 1, 9, device=device)
+    timesteps = NEOChatModel._apply_time_schedule(
+        SimpleNamespace(), timesteps, 4, shift
+    )
+    boundary = torch.tensor(0.5, device=device)
+    timesteps = torch.cat(
+        [
+            timesteps[:-1],
+            torch.stack(
+                [
+                    torch.nextafter(boundary, boundary.new_tensor(0.0)),
+                    boundary,
+                    torch.nextafter(boundary, boundary.new_tensor(1.0)),
+                ]
+            ),
+            timesteps[-1:],
+        ]
+    )
+    expected = [
+        bool(t >= interval[0] and t <= interval[1] and needs_cfg)
+        for t in timesteps[:-1]
+    ]
+    assert NEOChatModel._build_cfg_schedule(timesteps, interval, needs_cfg) == expected

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -854,8 +854,9 @@ def test_sensenova_u1_multi_output_entrypoint_mixed_failure_fails_parent(
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("image_only", [False, True])
 def test_sensenova_image_only_forward_preserves_outputs_and_prefix(device, image_only):
-    from transformers import Qwen3Config
-
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.configuration_neo_chat import (
+        NEOLLMConfig,
+    )
     from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_neo_chat import (
         prepare_flash_kv_cache,
     )
@@ -867,7 +868,7 @@ def test_sensenova_image_only_forward_preserves_outputs_and_prefix(device, image
 
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA is not available")
-    config = Qwen3Config(
+    config = NEOLLMConfig(
         vocab_size=32,
         hidden_size=32,
         intermediate_size=64,


### PR DESCRIPTION
## Motivation

SenseNova-U1's denoising loop reads CUDA scalar results in Python to determine token types and whether CFG is active. These checks introduce repeated host-device synchronization.

The token type is already known during denoising, and the CFG decisions can be computed before the loop.

## Modifications

- Add an `image_only` flag to Qwen3 and Qwen3-MoE so denoising can skip the `image_gen_indicators` reductions.
- Compute the CFG schedule on the original device before the loop, then copy the decisions to a Python list once. This preserves the existing timestep rounding and inclusive interval boundaries.
- Add CPU/CUDA regression tests for Qwen3 output equality, prefix KV cache preservation, and CFG schedule equivalence.

## Accuracy Tests

- The Qwen3 tests compare the new path with the existing indicator path using zero tolerance and check that the prefix KV cache remains unchanged.
- The CFG tests compare the precomputed schedule with the original scalar conditions, including the representable values immediately below and above 0.5.
- `test_sensenova_u1.py`: 81/81 passed on Linux with torch 2.13.0+cu130 and transformers 5.12.1.
- End-to-end runs with the same checkpoint and seed produced byte-identical images at 512×512 with 4 and 20 steps, and 2048×2048 with 50 steps. Reported peak GPU memory was unchanged at 33,984 MB.

## Speed Tests and Profiling

Using `torch.cuda.set_sync_debug_mode("warn")`, the estimated number of detected synchronizations fell from 17 to 11 per denoising step. This estimate comes from the difference between 1-step and 4-step runs. The check was injected through `sitecustomize.py` to cover both the CLI and its worker subprocess.

No wall-clock speedup was observed on the test machine. At 512×512 with 20 steps, four alternating runs per version averaged 5.28 s before the change and 5.33 s after.

Additional runs at 2048×2048 with 50 steps took 61.67 s before and 61.79 s after; runs at 256×256 with 50 steps took 11.0–11.1 s for both versions.

These results show fewer detected synchronizations, but do not demonstrate a latency improvement.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34816769382](https://github.com/sgl-project/sglang/actions/runs/34816769382)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34816768873](https://github.com/sgl-project/sglang/actions/runs/34816768873)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34816769465](https://github.com/sgl-project/sglang/actions/runs/34816769465)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
