### PR TITLE
[AMD] Resolve QSA packed-varlen decode to aiter on HIP

### DIFF
--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -65,7 +65,7 @@ def _resolve_trtllm_sparse_decode():
 
 @lru_cache(maxsize=1)
 def _resolve_flash_attn_varlen_func():
-    from sglang.srt.utils import is_sm121
+    from sglang.srt.utils import is_hip, is_sm121
 
     if is_sm121():
         from sglang.kernels.ops.attention import (
@@ -73,6 +73,22 @@ def _resolve_flash_attn_varlen_func():
         )
 
         return qwen38_qsa_sm121_varlen
+    if is_hip():
+        # ROCm ships neither flash_attn (FA2) nor flash-attn-4; aiter provides an
+        # FA2-compatible varlen kernel (CK) with the same call signature. Fall
+        # through to the flash_attn probes below if aiter is unavailable.
+        try:
+            from aiter import flash_attn_varlen_func as aiter_varlen_func
+        except ImportError:
+            aiter_varlen_func = None
+        if aiter_varlen_func is not None:
+
+            def flash_attn_varlen_func(*args, **kwargs):
+                output = aiter_varlen_func(*args, **kwargs)
+                # aiter returns a tuple when return_lse/return_attn_probs is set.
+                return output[0] if isinstance(output, tuple) else output
+
+            return flash_attn_varlen_func
     try:
         from flash_attn import flash_attn_varlen_func
 
@@ -90,8 +106,8 @@ def _resolve_flash_attn_varlen_func():
         return flash_attn_varlen_func
     except ImportError as exc:
         raise ImportError(
-            "QSA decode requires flash_attn (FA2) or flash-attn-4 "
-            "(FA4 cute) for its packed varlen fallback."
+            "QSA decode requires flash_attn (FA2), flash-attn-4 (FA4 cute), "
+            "or aiter (ROCm) for its packed varlen fallback."
         ) from exc
 
 

--- a/test/registered/kernel/qsa/test_qsa_rocm.py
+++ b/test/registered/kernel/qsa/test_qsa_rocm.py
@@ -1,0 +1,121 @@
+"""ROCm coverage for the QSA packed-varlen decode fallback.
+
+On HIP there is neither flash_attn (FA2) nor flash-attn-4, so
+``_resolve_flash_attn_varlen_func`` resolves to aiter's FA2-compatible varlen
+kernel. The first two tests are device-independent (fake modules); the last one
+runs the real aiter kernel against a torch reference and only executes on ROCm.
+"""
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention import qwen_sparse_attn_backend as qsa_backend_module
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-small")
+register_amd_ci(est_time=60, stage="jit-kernel-unit", runner_config="amd")
+
+
+def _fake_aiter(varlen_func):
+    module = ModuleType("aiter")
+    module.flash_attn_varlen_func = varlen_func
+    return module
+
+
+@pytest.mark.parametrize("returns_tuple", [False, True], ids=["tensor", "tuple"])
+def test_qsa_hip_resolves_aiter_varlen_kernel(monkeypatch, returns_tuple):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    sentinel = object()
+    calls = []
+
+    def aiter_varlen(*args, **kwargs):
+        calls.append(kwargs)
+        return (sentinel, None) if returns_tuple else sentinel
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm121", lambda: False)
+    monkeypatch.setattr("sglang.srt.utils.is_hip", lambda: True)
+    monkeypatch.setitem(sys.modules, "aiter", _fake_aiter(aiter_varlen))
+
+    try:
+        func = resolver()
+        assert func(q=1, causal=True) is sentinel
+        assert calls == [{"q": 1, "causal": True}]
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_hip_without_aiter_falls_through_to_flash_attn(monkeypatch):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    fa2_func = object()
+    flash_attn = ModuleType("flash_attn")
+    flash_attn.flash_attn_varlen_func = fa2_func
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm121", lambda: False)
+    monkeypatch.setattr("sglang.srt.utils.is_hip", lambda: True)
+    monkeypatch.setitem(sys.modules, "aiter", None)  # makes `import aiter` fail
+    monkeypatch.setitem(sys.modules, "flash_attn", flash_attn)
+
+    try:
+        assert resolver() is fa2_func
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_hip_aiter_varlen_matches_torch_reference():
+    if not (is_hip() and torch.cuda.is_available()):
+        pytest.skip("ROCm-only kernel")
+    pytest.importorskip("aiter")
+
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    torch.manual_seed(2028)
+    device = torch.device("cuda")
+    # Qwen3.8-Flash-Next full-attention shape: 24 query heads, 2 KV heads, d=256.
+    batch, topk = 3, 2048
+    num_q_heads, num_kv_heads, head_dim = 24, 2, 256
+    valid_counts = torch.tensor([5, topk, 700], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.zeros(batch + 1, dtype=torch.int32, device=device)
+    cu_seqlens_k[1:] = torch.cumsum(valid_counts, 0)
+    cu_seqlens_q = torch.arange(batch + 1, dtype=torch.int32, device=device)
+    q = torch.randn(batch, num_q_heads, head_dim, device=device, dtype=torch.bfloat16)
+    packed_k = torch.randn(
+        int(valid_counts.sum()),
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    packed_v = torch.randn_like(packed_k)
+    scale = head_dim**-0.5
+
+    try:
+        # Mirrors the decode call in QwenSparseAttnBackend._forward_paged_attention.
+        out = resolver()(
+            q=q,
+            k=packed_k,
+            v=packed_v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=1,
+            max_seqlen_k=topk,
+            softmax_scale=scale,
+            causal=True,
+        )
+    finally:
+        resolver.cache_clear()
+
+    assert out.shape == (batch, num_q_heads, head_dim)
+    repeats = num_q_heads // num_kv_heads
+    for row in range(batch):
+        start, end = int(cu_seqlens_k[row]), int(cu_seqlens_k[row + 1])
+        keys = packed_k[start:end].float().repeat_interleave(repeats, dim=1)
+        values = packed_v[start:end].float().repeat_interleave(repeats, dim=1)
+        scores = torch.einsum("hd,khd->hk", q[row].float(), keys) * scale
+        expected = torch.einsum("hk,khd->hd", scores.softmax(dim=-1), values)
+        torch.testing.assert_close(out[row].float(), expected, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
## Motivation

On ROCm, QSA models (e.g. `Qwen/Qwen3.8-Flash-Next-FP8`) load and prefill fine but crash at the first decode step:

```
ImportError: QSA decode requires flash_attn (FA2) or flash-attn-4 (FA4 cute) for its packed varlen fallback.
```

The decode path gathers the selected K/V into a packed buffer (two Triton kernels, which already work on ROCm) and then runs varlen attention over it. `_resolve_flash_attn_varlen_func` picks that attention kernel, and it only knows CUDA options: the SM121 kernel, `flash_attn` (FA2), and `flash_attn.cute` (FA4). None of these exist on ROCm, so the server crash-loops.

## Modifications

- `qwen_sparse_attn_backend.py::_resolve_flash_attn_varlen_func`: on `is_hip()`, use `aiter.flash_attn_varlen_func`, which has the same FA2 call signature (wrapped to unwrap the tuple aiter returns when `return_lse`/`return_attn_probs` is set, like the existing FA4 wrapper). If aiter is not installed, fall through to the existing `flash_attn` probes unchanged. The final error message now mentions aiter.
- New `test/registered/kernel/qsa/test_qsa_rocm.py` (separate file because `test_qsa.py` imports an SM121 CUDA kernel at module import time, which does not exist on ROCm):
  - `test_qsa_hip_resolves_aiter_varlen_kernel[tensor|tuple]` — with a fake `aiter`, the resolver returns it and unwraps tuples. Runs anywhere.
  - `test_qsa_hip_without_aiter_falls_through_to_flash_attn` — with `aiter` unimportable, the resolver still returns `flash_attn`'s function. Runs anywhere.
  - `test_qsa_hip_aiter_varlen_matches_torch_reference` — real aiter kernel vs. a torch softmax-attention reference, Qwen3.8-Flash-Next full-attention shape (24 query heads, 2 KV heads, head_dim 256; packed rows of 5 / 2048 / 700 keys), using the exact kwargs `_forward_paged_attention` passes (`max_seqlen_q=1`, `causal=True`). Skips off ROCm.

  Registered with `register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-small")` and `register_amd_ci(est_time=60, stage="jit-kernel-unit", runner_config="amd")` (same AMD bucket as the neighboring `kernel/aiter` tests). `pre-commit run` passes on both files, including `check-registered-tests`.

## Accuracy Tests

Hardware: 1x AMD Instinct MI355X (gfx950), image `rocm/sgl-dev:v0.5.19-rocm724-mi35x-20260909` (ROCm 7.2.4, torch 2.11+rocm7.2), model `Qwen/Qwen3.8-Flash-Next-FP8`, `--tp 1`.

- The new tests: 4 passed on the MI355X. Kernel vs. torch reference max abs error 0.0068 (5 keys) and 0.0007 (700 keys) in bf16.
- Server level, with this exact change: the server starts and decode HIP graphs capture (`bs=[1..43]`, 29 s). A 7,718-token-context retrieval prompt (four exact-answer questions, thinking off, greedy) gives the same answers as the pure-torch reference QSA path; with thinking on it converges to the correct answer. 16 concurrent requests, no faults.
- Long generations (up to 1,500 tokens, greedy) are coherent.

## Speed Tests and Profiling

`python -m sglang.benchmark.serving --backend sglang --dataset-name random --random-range-ratio 1.0`, same hardware and model, decode HIP graphs on:

| ISL / OSL | Concurrency | Output tok/s | Median TTFT | Median TPOT |
|---|---|---|---|---|
| 1024 / 512 | 1 | 76 | 108 ms | 12.7 ms |
| 1024 / 1024 | 16 | 664 | 1.05 s | 23.0 ms |
| 1024 / 1024 | 64 | 994 | 2.6 s | 38.2 ms |
| 8192 / 1024 | 16 | 538 | 4.36 s | 25.6 ms |

There is no "before" number: without this change the server does not decode on ROCm.

Note: on this image the QSA *indexer* (`qsa/mqa.py`) has a separate ROCm problem — tilelang's MFMA warp partition rejects the 4-head (padded to 8) indexer GEMM with `N must be divisible by 16`. That is independent of this PR; the tests above used the torch indexer fallback. A fix (pad to 16 on HIP) will follow once validated.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34661790453](https://github.com/sgl-project/sglang/actions/runs/34661790453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34661790158](https://github.com/sgl-project/sglang/actions/runs/34661790158)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34661790330](https://github.com/sgl-project/sglang/actions/runs/34661790330)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->