### PR TITLE
fix(qsa): restore ROCm MFMA head-alignment padding in QSA MQA decode

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/mqa.py
+++ b/python/sglang/srt/layers/attention/qsa/mqa.py
@@ -349,10 +349,15 @@ def tilelang_qsa_mqa_decode(
     )
     if not q.shape[0] or not max_model_len:
         return logits
-    # The validated MMA layout requires N (the Q-head dimension) to be a
-    # multiple of eight. Zero-padding preserves the weight-free head sum.
+    # The MMA layout requires N (the Q-head dimension) to be aligned.
+    # ROCm MFMA needs a multiple of 16; CUDA accepts 8.
+    # Zero-padding preserves the weight-free head sum.
     query_heads, head_dim = q.shape[1:]
-    kernel_heads = max(8, ((query_heads + 7) // 8) * 8)
+    head_multiple = 16 if torch.version.hip else 8
+    kernel_heads = max(
+        head_multiple,
+        ((query_heads + head_multiple - 1) // head_multiple) * head_multiple,
+    )
     q_kernel = q.to(torch.bfloat16)
     if kernel_heads != query_heads:
         q_kernel = torch.cat(


### PR DESCRIPTION
## Motivation

[PR #37500](https://github.com/sgl-project/sglang/pull/37500) (merged 2026-09-08, "support qwen 3.8 flash next") inadvertently removed the ROCm-specific head-alignment padding in the tilelang QSA MQA decode kernel (`python/sglang/srt/layers/attention/qsa/mqa.py`).

The previous code (present in the `qwen38flashnext` image) correctly padded the query-head dimension to a multiple of **16** on ROCm (MFMA instructions require `kNPerWarp = 16`) and **8** on CUDA:

```python
# Before PR #37500
head_multiple = 16 if torch.version.hip else 8
kernel_heads = max(
    head_multiple,
    ((query_heads + head_multiple - 1) // head_multiple) * head_multiple,
)
```

PR #37500 replaced this with a hardcoded multiple of 8:

```python
# After PR #37500 (current main)
kernel_heads = max(8, ((query_heads + 7) // 8) * 8)
```

## Problem

For **Qwen3.8-Flash-Next** (FP8), the model config has `heads_per_ngram = 8`. The QSA indexer passes `query_heads = 8` to the tilelang MQA decode kernel during CUDA graph capture.

On ROCm/MI355X with MFMA instructions, tilelang's `GemmWarpPolicyNode::computeWarpPartition` requires `N % kNPerWarp == 0` where `kNPerWarp = 16`. With the hardcoded padding to 8, the GEMM receives `N = 8 < 16`, causing:

```
tvm.error.InternalError: Check failed: (N % kNPerWarp == 0) is false:
N must be divisible by 16, but got 8
```

**Full error call chain:**
```
decode_cuda_graph_runner.__init__
  → capture_decode_graph → model.forward → qwen4_exp layer.forward
    → _compute_qsa_topk_indices → qsa_indexer.select_decode_tokens
      → qsa_mqa_decode → tilelang_qsa_mqa_decode
        → tilelang.lower → LayoutInference → GemmPyNode.InferLayout
          → gemm_mfma.py:infer_layout → computeWarpPartition(M, N=8, ...)
            ❌ N=8 < kNPerWarp=16
```

## Fix

Restore the original ROCm-aware guard:

```python
head_multiple = 16 if torch.version.hip else 8
kernel_heads = max(
    head_multiple,
    ((query_heads + head_multiple - 1) // head_multiple) * head_multiple,
)
```

This pads `query_heads = 8` to `kernel_heads = 16` on ROCm (the zero-padded heads preserve the weight-free head sum), while keeping `kernel_heads = 8` on CUDA where MFMA alignment is not required.

## Test environment

- **GPU**: MI355X (8× 288 GB VRAM, gfx950)
- **ROCm**: 7.0
- **Image**: `lmsysorg/sglang-rocm:v0.5.19-rocm700-mi35x-20260909`
- **Model**: `Qwen/Qwen3.8-Flash-Next-FP8` (176B total, 6B active, hybrid GDN+QSA, FP8)
- **Config**: TP=4, aiter attention, page-size 32, NEXTN MTP (3 steps, eagle-topk 1, 4 draft tokens)

## Test results

| Test | Without fix | With fix (old image had this guard) |
|------|------------|------|
| FP8 model load | ✅ | ✅ |
| Decode CUDA graph capture | ❌ `N must be divisible by 16, but got 8` | ✅ |
| NEXTN MTP speculative decoding | ❌ blocked by above | ✅ |
| Inference correctness ("2+2=?") | ❌ blocked | ✅ correct output |

## Related

- [PR #37500](https://github.com/sgl-project/sglang/pull/37500) — introduced the regression
- [PR #36497](https://github.com/sgl-project/sglang/pull/36497) — initial Qwen3.8-Flash-Next PR (closed, superseded by #37500)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34492690062](https://github.com/sgl-project/sglang/actions/runs/34492690062)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34492689839](https://github.com/sgl-project/sglang/actions/runs/34492689839)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34492689935](https://github.com/sgl-project/sglang/actions/runs/34492689935)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->