### PR TITLE
fix(kimi-k3): use int64 attn-residual row indices

### DIFF
--- a/python/sglang/srt/layers/attn_residual.py
+++ b/python/sglang/srt/layers/attn_residual.py
@@ -133,7 +133,8 @@ def _score_kernel(
     BLOCK_H: tl.constexpr,
 ):
     """One CTA per (token, row): scan H, output one scalar score."""
-    pid_t = tl.program_id(0)
+    # bank.stride(0) can be large enough for the row offset to overflow int32.
+    pid_t = tl.program_id(0).to(tl.int64)
     j = tl.program_id(1)
     if j > NVB:
         return
@@ -174,7 +175,8 @@ def _combine_kernel(
     Softmax is redundantly computed by each H-chunk CTA (≤16 elements, trivial).
     This gives full H-parallelism: 7 CTAs for H=7168/1024.
     """
-    pid_t = tl.program_id(0)
+    # Keep the bank row offset in int64, as in the score kernel above.
+    pid_t = tl.program_id(0).to(tl.int64)
     pid_h = tl.program_id(1)
     h0 = pid_h * BLOCK_H
 


### PR DESCRIPTION
## Motivation

Kimi-K3 large prefill batches can hit an illegal memory access in the attention-residual Triton fallback. The bank row stride is `8 * 7168 = 57344` elements for the tested model, while `tl.program_id(0)` is int32. `pid_t * stride_bm` therefore overflows after roughly 37,449 token rows.

With asynchronous CUDA error reporting, the failure can surface at a later NCCL collective. Running with `CUDA_LAUNCH_BLOCKING=1` located the first failure in `_score_kernel`. The original kernel is stable at 32K and fails at tested 40K, 48K, 60K, and 64K real batch shapes, matching the calculated threshold.

## Modifications

Cast the token program id to `tl.int64` in both `_score_kernel` and `_combine_kernel`, so accesses to the shared `[T, NB, H]` bank use 64-bit row-offset arithmetic.

This does not change tensor layouts, numerical types, reduction order, launch grids, or the aggregation algorithm.

## Accuracy Tests

Tested end to end on 8x NVIDIA B300 with Kimi-K3, TP8/EP8, MegaMoE + DeepGEMM, prefill CUDA graph disabled, and output length 1.

- `chunked-prefill-size=max-prefill-tokens=65536`
- Server logs confirmed a real `new-seq=2, new-token=65536` batch
- 0% and approximately 90% prefix-cache hit rates
- Concurrency 10, 20, 25, and 30
- Three rounds per configuration: 24/24 runs succeeded

The same 64K shape crashed before this change. No illegal memory accesses were observed after the fix.

## Speed Tests and Profiling

32K A/B tests used identical graph-off, TP8/EP8, MegaMoE + DeepGEMM, fused-front-off settings. Each point is the median of three rounds.

Across 0%/90% cache hit and concurrency 10/20/25/30:

- P50 TTFT change: -0.17% to +0.28%
- P90 TTFT change: -0.15% to +0.45%
- Prompt throughput change: -0.27% to +0.41%

The maximum absolute difference was 0.45%, so the int64 indexing has no measurable end-to-end performance cost at 32K.

The fix also makes a real 64K prefill budget usable. For 32K requests with a 0% cache-hit rate, increasing both `chunked-prefill-size` and `max-prefill-tokens` from 32K to 64K allowed two requests to enter one `new-token=65536` batch. The table compares the stable 32K baseline with the fixed 64K deployment configuration; each value is the median of three rounds. The 64K run used `mem-fraction-static=0.83` and `max-running-requests=32`, while the 32K baseline used the original resource settings, so this is an end-to-end deployment comparison rather than a single-variable kernel benchmark.

| Concurrency | P50 TTFT: 32K / 64K / change | P90 TTFT: 32K / 64K / change | TPM: 32K / 64K / change |
|---:|---:|---:|---:|
| 10 | 6,807 / 6,097 / -10.4% | 10,467 / 9,275 / -11.4% | 1,869,937 / 1,905,438 / +1.9% |
| 20 | 12,044 / 11,215 / -6.9% | 19,860 / 18,556 / -6.6% | 1,869,344 / 1,902,005 / +1.7% |
| 25 | 13,625 / 13,321 / -2.2% | 24,681 / 23,683 / -4.0% | 1,869,355 / 1,905,345 / +1.9% |
| 30 | 17,292 / 15,879 / -8.2% | 29,402 / 27,685 / -5.8% | 1,867,515 / 1,906,094 / +2.1% |

This is a scheduling/batching benefit enabled by the correctness fix, rather than a claim that 64K is universally faster. At an approximately 90% cache-hit rate, each request had only about 3,328 uncached tokens and the 64K budget regressed TTFT and throughput compared with 32K. A cache-aware dynamic budget would be preferable for production workloads with mixed hit rates.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior or API change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34494096803](https://github.com/sgl-project/sglang/actions/runs/34494096803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34494096452](https://github.com/sgl-project/sglang/actions/runs/34494096452)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34494096497](https://github.com/sgl-project/sglang/actions/runs/34494096497)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->