### PR TITLE
[Kernel] Add H20 block-FP8 MoE configs for GLM-5.3-Flash EP4/EP8

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -106,6 +106,7 @@ def get_model_config(
         "Glm4MoeForCausalLM",
         "Glm4MoeLiteForCausalLM",
         "GlmMoeDsaForCausalLM",
+        "Glm5NextForConditionalGeneration",
         "KimiVLForConditionalGeneration",
         "MistralLarge3ForCausalLM",
     ]:

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,106 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "768": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=36,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,6 +1,22 @@
 {
     "1": {
-        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 32,
@@ -8,26 +24,42 @@
         "num_stages": 3
     },
     "8": {
-        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
-    "16": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 64,
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 3
     },
     "32": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 3
     },
@@ -35,37 +67,37 @@
         "BLOCK_SIZE_M": 32,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
         "num_warps": 4,
         "num_stages": 3
     },
     "128": {
         "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
     "256": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
     "512": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
-        "num_warps": 4,
-        "num_stages": 3
-    },
-    "768": {
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 32,
         "num_warps": 4,
@@ -75,7 +107,15 @@
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
@@ -87,7 +127,7 @@
         "num_warps": 4,
         "num_stages": 3
     },
-    "4096": {
+    "3072": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
@@ -95,11 +135,11 @@
         "num_warps": 4,
         "num_stages": 3
     },
-    "8192": {
+    "4096": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     }

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=72,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=72,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,21 +1,101 @@
 {
     "1": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 32,
         "num_warps": 4,
         "num_stages": 3
     },
-    "807": {
-        "BLOCK_SIZE_M": 64,
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 32,
         "num_warps": 4,
         "num_stages": 3
     },
-    "808": {
+    "512": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
@@ -23,11 +103,43 @@
         "num_warps": 4,
         "num_stages": 3
     },
-    "8192": {
+    "1024": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 64,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
         "num_stages": 3
     }

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=72,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=72,N=2048,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,34 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "807": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "808": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/test/registered/unit/layers/moe/test_fused_moe_common_utils.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_common_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -50,6 +51,43 @@ def test_get_model_config_supports_kimi_vl():
         "dtype": torch.bfloat16,
         "block_shape": None,
         "architecture": "KimiVLForConditionalGeneration",
+    }
+
+
+@pytest.mark.parametrize(
+    "tp_size,ep_size,experts,intermediate",
+    [(4, 4, 72, 4096), (8, 8, 36, 4096), (8, 4, 72, 2048)],
+)
+def test_get_model_config_supports_glm5_next(tp_size, ep_size, experts, intermediate):
+    common_utils = _load_common_utils()
+    text_config = SimpleNamespace(
+        hidden_size=4096,
+        n_routed_experts=288,
+        num_experts_per_tok=8,
+        moe_intermediate_size=2048,
+        torch_dtype=torch.bfloat16,
+    )
+    model_config = SimpleNamespace(
+        architectures=["Glm5NextForConditionalGeneration"],
+        quantization_config={"weight_block_size": [128, 128]},
+        text_config=text_config,
+        get_text_config=lambda: text_config,
+    )
+    with patch.object(common_utils, "get_config", return_value=model_config):
+        tuned_config = common_utils.get_model_config(
+            "zai-org/GLM-5.3-Flash",
+            tp_size=tp_size,
+            ep_size=ep_size,
+            disable_shared_experts_fusion=True,
+        )
+    assert tuned_config == {
+        "num_experts": experts,
+        "topk": 8,
+        "hidden_size": 4096,
+        "shard_intermediate_size": intermediate,
+        "dtype": torch.bfloat16,
+        "block_shape": [128, 128],
+        "architecture": "Glm5NextForConditionalGeneration",
     }
 
 


### PR DESCRIPTION
## Summary

Add H20 block-FP8 Triton MoE configs for GLM-5.3-Flash TP4/EP4 and TP8/EP8, generated with the official tuner. Recognize `Glm5NextForConditionalGeneration` in the tuner so it reads the nested text config.

## Performance

NVIDIA H20 96 GB, PyTorch 2.13.0+cu130, Triton 3.7.1. Each baseline/tuned pair uses the same model, runtime and settings; only the two PR MoE configurations are removed for baseline and enabled for tuned.

### Official MoE kernel benchmark

Official benchmark script, all 18 default M points, 100 CUDA-graph iterations. EP4/EP8 denote local expert shapes measured on one GPU; these timings exclude EP communication. Speedup = default / tuned time.

| M | EP4 default (us) | EP4 tuned (us) | Speedup | EP8 default (us) | EP8 tuned (us) | Speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 131.15 | 69.57 | 1.885x | 133.20 | 72.90 | 1.827x |
| 2 | 230.83 | 121.14 | 1.905x | 214.04 | 119.90 | 1.785x |
| 4 | 367.57 | 215.06 | 1.709x | 320.43 | 184.90 | 1.733x |
| 8 | 584.91 | 342.55 | 1.708x | 426.26 | 251.17 | 1.697x |
| 16 | 795.21 | 460.77 | 1.726x | 482.55 | 277.04 | 1.742x |
| 24 | 879.80 | 512.15 | 1.718x | 494.09 | 305.59 | 1.617x |
| 32 | 910.72 | 537.20 | 1.695x | 495.51 | 299.01 | 1.657x |
| 48 | 913.14 | 545.04 | 1.675x | 498.42 | 292.91 | 1.702x |
| 64 | 915.06 | 553.26 | 1.654x | 501.76 | 329.60 | 1.522x |
| 96 | 919.42 | 564.03 | 1.630x | 507.74 | 343.34 | 1.479x |
| 128 | 924.45 | 621.21 | 1.488x | 503.44 | 390.46 | 1.289x |
| 256 | 944.34 | 742.79 | 1.271x | 565.95 | 525.66 | 1.077x |
| 512 | 1093.89 | 1103.39 | 0.991x | 996.07 | 948.46 | 1.050x |
| 1024 | 1948.75 | 1850.98 | 1.053x | 1896.94 | 1795.87 | 1.056x |
| 1536 | 2830.54 | 2690.81 | 1.052x | 2761.97 | 2612.80 | 1.057x |
| 2048 | 3724.76 | 3541.74 | 1.052x | 3552.71 | 3371.69 | 1.054x |
| 3072 | 5439.42 | 5171.33 | 1.052x | 5143.99 | 4902.98 | 1.049x |
| 4096 | 7014.84 | 6694.01 | 1.048x | 6777.16 | 6475.46 | 1.047x |

EP4 M=512 was 0.991x initially; paired repeats gave 1.004x (1100.86 / 1096.05 us) and 1.002x (1100.92 / 1098.20 us), approximately neutral. Other points were measured once.

### TP4/EP4 serving

Single-node, full-model serving with 1,024 input / 1,024 output tokens. EvalScope, temperature 0, identical requests per pair. C1: 1 warmup + 4 measured requests; C16: 16 warmups + 64 measured requests. Startup and warmups excluded. Triton MoE, shared-expert fusion disabled, BF16 KV cache, TileLang DSA, decode CUDA Graph enabled; no CPU offload or speculative decoding.

| Concurrency | Measured requests per variant | Default output tok/s | Tuned output tok/s | Throughput change | TTFT ms, default → tuned | TPOT ms, default → tuned |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4 | 96.88 | 109.59 | +13.1% | 204.84 → 208.30 | 10.13 → 8.93 |
| 16 | 64 | 744.02 | 986.22 | +32.6% | 1269.40 → 1238.61 | 20.25 → 14.99 |

### TP8/EP8 serving

One node with 8 H20 GPUs, using the same serving settings, workload and sample counts described above.

| Concurrency | Measured requests per variant | Default output tok/s | Tuned output tok/s | Throughput change | TTFT ms, default → tuned | TPOT ms, default → tuned |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4 | 104.08 | 118.96 | +14.3% | 187.39 → 185.95 | 9.43 → 8.23 |
| 16 | 64 | 1002.76 | 1241.41 | +23.8% | 948.78 → 923.09 | 15.01 → 11.96 |

All 68 measured requests succeeded per variant for both GPU layouts. One paired run per concurrency; gains are specific to this workload. TP4 C1 TTFT increased slightly. TP4 and TP8 ran on different nodes, so these are not a controlled 4-to-8-GPU scaling comparison.

## Validation

GSM8K test, first 64 samples, EvalScope 4-shot, temperature 0, TP8/EP8:

| Configuration | Correct / Total | Accuracy | Failed requests | Truncated outputs |
| --- | ---: | ---: | ---: | ---: |
| Baseline | 63 / 64 | 98.44% | 0 | 0 |
| Tuned | 63 / 64 | 98.44% | 0 | 0 |

Both variants missed the same sample.

- File-scoped pre-commit and `git diff --check` passed.
- PR remains draft; upstream GPU CI has not run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34802614754](https://github.com/sgl-project/sglang/actions/runs/34802614754)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34802614679](https://github.com/sgl-project/sglang/actions/runs/34802614679)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34802614705](https://github.com/sgl-project/sglang/actions/runs/34802614705)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
