### PR TITLE
[Bugfix] Escape literal paths when discovering profile traces

### DIFF
--- a/python/sglang/srt/utils/profile_merger.py
+++ b/python/sglang/srt/utils/profile_merger.py
@@ -83,11 +83,11 @@ class ProfileMerger:
 
     def _discover_trace_files(self) -> List[str]:
         """Discover trace files matching profile_id (supports TP/DP/PP/EP formats)."""
-        patterns = [f"{self.profile_id}*.trace.json.gz"]
+        patterns = [f"{glob.escape(self.profile_id)}*.trace.json.gz"]
 
         trace_files = []
         for pattern in patterns:
-            search_pattern = os.path.join(self.output_dir, pattern)
+            search_pattern = os.path.join(glob.escape(self.output_dir), pattern)
             trace_files.extend(glob.glob(search_pattern))
 
         trace_files = [

--- a/test/registered/unit/utils/test_profile_merger.py
+++ b/test/registered/unit/utils/test_profile_merger.py
@@ -119,6 +119,42 @@ class TestProfileMerger(CustomTestCase):
         discovered = empty_merger._discover_trace_files()
         self.assertEqual(len(discovered), 0)
 
+    def test_merge_with_glob_characters_in_paths(self):
+        for directory, profile_id in [
+            ("trace[1]", "profile"),
+            ("traces", "profile[1]"),
+            ("trace[1]", "profile[1]"),
+        ]:
+            with self.subTest(directory=directory, profile_id=profile_id):
+                with tempfile.TemporaryDirectory(dir=self.temp_dir) as root:
+                    output_dir = os.path.join(root, directory)
+                    decoy_dir = output_dir.replace("[1]", "1")
+                    decoy_id = profile_id.replace("[1]", "1")
+                    for folder, identifier, name in [
+                        (output_dir, profile_id, "expected"),
+                        (decoy_dir, decoy_id, "decoy"),
+                    ]:
+                        os.makedirs(folder, exist_ok=True)
+                        path = os.path.join(folder, f"{identifier}-TP-0.trace.json.gz")
+                        with gzip.open(path, "wt") as f:
+                            json.dump(
+                                {"traceEvents": [{"ph": "X", "name": name, "pid": 1}]},
+                                f,
+                            )
+
+                    merger = ProfileMerger(output_dir, profile_id)
+                    expected_path = os.path.join(
+                        output_dir, f"{profile_id}-TP-0.trace.json.gz"
+                    )
+                    self.assertEqual(merger._discover_trace_files(), [expected_path])
+                    merged_path = merger.merge_chrome_traces()
+                    with gzip.open(merged_path, "rt") as f:
+                        merged = json.load(f)
+                    self.assertEqual(
+                        [event["name"] for event in merged["traceEvents"]], ["expected"]
+                    )
+                    self.assertEqual(merger.get_merge_summary()["total_files"], 1)
+
     def test_merge_chrome_traces(self):
         # Create multiple trace files in random order
         trace_files = [


### PR DESCRIPTION
## Motivation

`ProfileMerger` inserts the output directory and profile ID directly into a glob. A literal directory such as `trace[1]` therefore does not match itself: merging fails with `No trace files found`, or silently reads `trace1` if that directory also exists. The same problem affects bracketed profile IDs.

## Modifications

Escape the two literal components with `glob.escape`, leaving the existing rank/stage suffix wildcard intact. Add regression coverage for brackets in the directory, profile ID, and both, with decoy files to verify that only the requested trace is merged and counted.

## Accuracy Tests

- The new regression fails in all three subcases on the unmodified production module and passes after the fix.
- All 9 component tests in `TestProfileMerger` and `TestProfileMergerEdgeCases` pass against the actual production module. Local validation used Python 3.11 on Windows with a standard-library harness: it loads the production module via `importlib`, runs the unchanged component test bodies with `unittest.TestCase` instead of the CI retry wrapper, and excludes the unrelated `ProfileReq` integration class. The normal SGLang/GPU import path was not tested locally.
- Run in a configured SGLang environment: `python test/registered/unit/utils/test_profile_merger.py`.
- `git diff --check` passes.

## Speed Tests and Profiling

No inference execution or model-output change; this fixes discovery of already exported profiling files. No GPU benchmark was run.

## Checklist

- [x] Run pre-commit on the changed files (all applicable hooks pass).
- [x] Add focused regression coverage in the existing CPU-registered test module.
- [x] Follow the existing code style.

Prepared with Codex assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34496057234](https://github.com/sgl-project/sglang/actions/runs/34496057234)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34496056682](https://github.com/sgl-project/sglang/actions/runs/34496056682)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34496057148](https://github.com/sgl-project/sglang/actions/runs/34496057148)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->