### PR TITLE
[plugins] Expose whether a hook was applied

### DIFF
--- a/python/sglang/srt/plugins/hook_registry.py
+++ b/python/sglang/srt/plugins/hook_registry.py
@@ -79,6 +79,7 @@ class HookRegistry:
         list
     )
     _patched: set[str] = set()
+    _applied_hooks: dict[str, tuple[tuple[HookType, Callable], ...]] = {}
 
     @classmethod
     def register(
@@ -143,6 +144,20 @@ class HookRegistry:
         )
 
     @classmethod
+    def is_hook_applied(
+        cls, target: str, callback: Callable, hook_type: HookType = HookType.AFTER
+    ) -> bool:
+        """Whether the registry successfully applied this callback and hook type.
+
+        This reports installation, not whether a call reaches the callback:
+        an outer hook or later patch can still bypass it.
+        """
+        return target in cls._patched and any(
+            applied_type == hook_type and applied_callback is callback
+            for applied_type, applied_callback in cls._applied_hooks.get(target, ())
+        )
+
+    @classmethod
     def apply_hooks(cls):
         """
         Apply all registered hooks to their target functions/classes.
@@ -162,6 +177,9 @@ class HookRegistry:
             try:
                 cls._apply_target(target, hooks)
                 cls._patched.add(target)
+                cls._applied_hooks[target] = tuple(
+                    (hook_type, callback) for hook_type, callback, _source in hooks
+                )
             except Exception:
                 logger.exception("Failed to apply hooks to %s", target)
 
@@ -315,6 +333,7 @@ class HookRegistry:
         """Reset all hooks and patches. Primarily for testing."""
         cls._hooks.clear()
         cls._patched.clear()
+        cls._applied_hooks.clear()
 
 
 def _propagate_patch(original: object, wrapped: object, source_module: object) -> int:

--- a/test/registered/unit/plugins/test_hook_registry_query.py
+++ b/test/registered/unit/plugins/test_hook_registry_query.py
@@ -1,0 +1,86 @@
+"""Public hook readiness queries reflect successful application."""
+
+import sys
+import types
+import unittest
+import uuid
+
+from sglang.srt.plugins.hook_registry import HookRegistry, HookType
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestHookRegistryQuery(CustomTestCase):
+    def setUp(self):
+        HookRegistry.reset()
+        self.module_name = f"_hook_query_test_{uuid.uuid4().hex}"
+        self.module = types.ModuleType(self.module_name)
+        self.module.operation = lambda value: value * 2
+        sys.modules[self.module_name] = self.module
+        self.target = f"{self.module_name}.operation"
+
+    def tearDown(self):
+        HookRegistry.reset()
+        sys.modules.pop(self.module_name, None)
+
+    def test_query_requires_successful_application_and_exact_callback_type(self):
+        def add_one(result, value):
+            return result + 1
+
+        self.assertFalse(HookRegistry.is_hook_applied(self.target, add_one))
+        HookRegistry.register(self.target, add_one, HookType.AFTER)
+        self.assertFalse(HookRegistry.is_hook_applied(self.target, add_one))
+
+        HookRegistry.apply_hooks()
+
+        self.assertEqual(self.module.operation(3), 7)
+        self.assertTrue(HookRegistry.is_hook_applied(self.target, add_one))
+        self.assertFalse(
+            HookRegistry.is_hook_applied(self.target, add_one, HookType.BEFORE)
+        )
+        self.assertFalse(
+            HookRegistry.is_hook_applied(self.target, lambda result, value: result + 1)
+        )
+        self.assertFalse(HookRegistry.is_hook_applied(self.target + "_other", add_one))
+
+    def test_late_registration_is_not_applied_when_target_was_already_patched(self):
+        def first(result, value):
+            return result + 1
+
+        def late(result, value):
+            return result + 100
+
+        HookRegistry.register(self.target, first)
+        HookRegistry.apply_hooks()
+        HookRegistry.register(self.target, late)
+        HookRegistry.apply_hooks()
+
+        self.assertEqual(self.module.operation(3), 7)
+        self.assertTrue(HookRegistry.is_hook_applied(self.target, first))
+        self.assertFalse(HookRegistry.is_hook_applied(self.target, late))
+
+        HookRegistry.reset()
+        self.assertFalse(HookRegistry.is_hook_applied(self.target, first))
+
+    def test_failed_target_reports_false_until_successful_retry(self):
+        target = f"{self.module_name}.missing"
+
+        def add_one(result, value):
+            return result + 1
+
+        HookRegistry.register(target, add_one)
+        with self.assertLogs("sglang.srt.plugins.hook_registry", level="ERROR"):
+            HookRegistry.apply_hooks()
+        self.assertFalse(HookRegistry.is_hook_applied(target, add_one))
+
+        self.module.missing = lambda value: value * 2
+        HookRegistry.apply_hooks()
+
+        self.assertEqual(self.module.missing(3), 7)
+        self.assertTrue(HookRegistry.is_hook_applied(target, add_one))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Withdrawn: the installation-status query is no longer needed by its consumer.

## Motivation

Plugins need to verify that a specific hook was installed before relying on it. Registration alone cannot establish that: applying a target can fail, and hooks registered after the target was patched are skipped.

## Modifications

Add `HookRegistry.is_hook_applied(target, callback, hook_type=HookType.AFTER)`, matching callback identity and hook type against a snapshot recorded after successful application. `reset()` clears the snapshot. The docstring explains that the query reports installation; an outer hook or later patch can still bypass the callback.

## Accuracy Tests

CPU unit tests cover callback identity/type, failed application followed by retry, late registration, and reset:

```text
PYTHONPATH=python python -m pytest -q test/registered/unit/plugins/
29 passed

PYTHONPATH=python python test/registered/unit/plugins/test_hook_registry_query.py
Ran 3 tests
OK
```

## Speed Tests and Profiling

Not applicable (registry API only).

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests, including a direct entry point for CPU CI.
- [x] Document the query semantics in its docstring.
- [x] State accuracy and speed test coverage above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34498107738](https://github.com/sgl-project/sglang/actions/runs/34498107738)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34498107486](https://github.com/sgl-project/sglang/actions/runs/34498107486)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34498107711](https://github.com/sgl-project/sglang/actions/runs/34498107711)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->