### PR TITLE
[CUDA graph] Support a persistent pool for shared graph state

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -299,6 +299,7 @@ class CudaGraphBufferRegistry:
         max_bs: int,
         max_num_tokens: int,
         share_pool: bool = False,
+        memory_pool: Optional[torch.cuda.MemPool] = None,
     ) -> None:
         self.device = device
         self.max_bs = max_bs
@@ -306,6 +307,7 @@ class CudaGraphBufferRegistry:
         # Coalesce allocated slot buffers through the global pool; only applies
         # when allocating (bind/source bypasses the pool).
         self.share_pool = share_pool
+        self.memory_pool = memory_pool
         self._slots: Dict[str, GraphSlot] = {}
 
     # ---- registration ------------------------------------------------------
@@ -356,7 +358,7 @@ class CudaGraphBufferRegistry:
             # Coalesce with any same-named buffer (e.g. the legacy
             # DecodeInputBuffers field) so capture and replay see one
             # physical allocation with a stable data_ptr.
-            buffer = share_input_buffer(slot.name, buffer)
+            buffer = share_input_buffer(slot.name, buffer, self.memory_pool)
         if (
             slot.padding_policy
             in (PaddingPolicy.FILL_SENTINEL, PaddingPolicy.FILL_ONCE)
@@ -526,6 +528,7 @@ def build_decode_registry(
     dp_size: int = 1,
     register_global_num_tokens: bool = True,
     share_pool: bool = True,
+    memory_pool: Optional[torch.cuda.MemPool] = None,
     source: Optional[Any] = None,
 ) -> CudaGraphBufferRegistry:
     """Registry mirroring the always-on (+ mamba / mrope) FB-shared decode
@@ -554,6 +557,7 @@ def build_decode_registry(
         max_bs=max_bs,
         max_num_tokens=max_num_token,
         share_pool=share_pool,
+        memory_pool=memory_pool,
     )
 
     def _tokens(_bs: int, mt: int) -> Tuple[int, ...]:
@@ -1009,6 +1013,7 @@ def build_eager_registry(
     encoder_len_fill_value: int = 0,
     encoder_lens_dtype: torch.dtype = torch.int32,
     dp_size: int = 1,
+    memory_pool: Optional[torch.cuda.MemPool] = None,
 ) -> CudaGraphBufferRegistry:
     """One fixed-max input registry for the ``EagerRunner``, serving BOTH eager
     decode and eager prefill.
@@ -1041,5 +1046,6 @@ def build_eager_registry(
         require_mlp_tp_gather=False,
         dp_size=dp_size,
         share_pool=True,
+        memory_pool=memory_pool,
         source=None,
     )

--- a/python/sglang/srt/model_executor/graph_shared_output.py
+++ b/python/sglang/srt/model_executor/graph_shared_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Dict, Optional
 
 import torch
@@ -23,9 +24,11 @@ class GraphSharedOutput:
         *,
         device: torch.device,
         max_rows: int,
+        memory_pool: Optional[torch.cuda.MemPool] = None,
     ) -> None:
         self.device = torch.device(device)
         self.max_rows = max_rows
+        self.memory_pool = memory_pool
         self._logits_buffers: Dict[int, torch.Tensor] = {}
 
     @classmethod
@@ -45,14 +48,20 @@ class GraphSharedOutput:
             return None
 
         device = torch.device(model_runner.device)
+        memory_pool = model_runner.cuda_graph_persistent_pool
         shared = cls._process_shared
         if (
             shared is not None
             and shared.device == device
             and shared.max_rows >= max_rows
+            and shared.memory_pool is memory_pool
         ):
             return shared
-        cls._process_shared = cls(device=device, max_rows=max_rows)
+        cls._process_shared = cls(
+            device=device,
+            max_rows=max_rows,
+            memory_pool=memory_pool,
+        )
         return cls._process_shared
 
     def get_logits_buffer(self, vocab_size: int, *, rows: int) -> torch.Tensor:
@@ -62,8 +71,16 @@ class GraphSharedOutput:
         )
         buffer = self._logits_buffers.get(vocab_size)
         if buffer is None:
-            buffer = torch.zeros(
-                (self.max_rows, vocab_size), dtype=torch.float, device=self.device
+            allocation_context = (
+                torch.cuda.use_mem_pool(self.memory_pool)
+                if self.memory_pool is not None
+                else contextlib.nullcontext()
             )
+            with allocation_context:
+                buffer = torch.zeros(
+                    (self.max_rows, vocab_size),
+                    dtype=torch.float,
+                    device=self.device,
+                )
             self._logits_buffers[vocab_size] = buffer
         return buffer[:rows]

--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, fields
-from typing import Collection, Dict, Tuple
+from typing import AbstractSet, Collection, Dict, Optional, Tuple
 
 import torch
 
@@ -13,17 +13,21 @@ _PoolKey = Tuple[str, int, torch.dtype, torch.device]
 _forward_input_buffer_pool: Dict[_PoolKey, torch.Tensor] = {}
 
 
-def share_input_buffer(name: str, new_buffer: torch.Tensor) -> torch.Tensor:
+def share_input_buffer(
+    name: str,
+    new_buffer: torch.Tensor,
+    memory_pool: Optional[torch.cuda.MemPool] = None,
+) -> torch.Tensor:
     """Coalesce a buffer by ``(name, size, dtype, device)`` into the
     process-wide input-buffer pool.
 
     Distinct callers that request the same field ``name`` with the same
     size/dtype/device share one physical allocation (and therefore one
-    ``data_ptr``): the first registrant's buffer becomes canonical and every
-    later identical request is returned as a view aliased onto it. Requests
-    that differ in size get their own allocation — they never reuse or displace
-    an existing entry — so the sharing *structure* is independent of
-    registration order and no already-captured buffer is ever repointed.
+    ``data_ptr``). When ``memory_pool`` is provided for the first registration,
+    clone the candidate into that pool before making it canonical. Later
+    identical requests are returned as views aliased onto the canonical tensor.
+    Requests that differ in size get their own allocation — they never reuse or
+    displace an existing entry — so no already-captured buffer is repointed.
 
     This pool is process-wide and governs *every* ``share_buffers()`` caller —
     including graph runners not yet on the registry (the speculative draft /
@@ -36,8 +40,12 @@ def share_input_buffer(name: str, new_buffer: torch.Tensor) -> torch.Tensor:
     key: _PoolKey = (name, new_buffer.numel(), new_buffer.dtype, new_buffer.device)
     canonical = _forward_input_buffer_pool.get(key, None)
     if canonical is None:
-        _forward_input_buffer_pool[key] = new_buffer
-        canonical = new_buffer
+        if memory_pool is not None and new_buffer.device.type == "cuda":
+            with torch.cuda.use_mem_pool(memory_pool):
+                canonical = new_buffer.clone()
+        else:
+            canonical = new_buffer
+        _forward_input_buffer_pool[key] = canonical
     return canonical.as_strided(new_buffer.size(), new_buffer.stride())
 
 
@@ -67,10 +75,19 @@ class ForwardInputBuffers:
             if buffer is not None:
                 buffer.zero_()
 
-    def share_buffers(self, *, exclude: Collection[str] = ()):
+    def share_buffers(
+        self,
+        memory_pool: Optional[torch.cuda.MemPool] = None,
+        memory_pool_exclusions: AbstractSet[str] = frozenset(),
+        *,
+        exclude: Collection[str] = (),
+    ):
         # disable share input buffer on npu due to accuracy issue
         if is_npu():
             return
+
+        def pool_for(name: str) -> Optional[torch.cuda.MemPool]:
+            return None if name in memory_pool_exclusions else memory_pool
 
         for f in fields(self):
             name = f.name
@@ -89,11 +106,12 @@ class ForwardInputBuffers:
                     assert isinstance(sub_buffer, torch.Tensor), (
                         f"Field {name}.{sub_name} is expected to be a torch.Tensor, but got {type(sub_buffer)}."
                     )
+                    qualified_name = f"{name}.{sub_name}"
                     buffer[sub_name] = share_input_buffer(
-                        f"{name}.{sub_name}", sub_buffer
+                        qualified_name, sub_buffer, pool_for(qualified_name)
                     )
             else:
                 assert isinstance(buffer, torch.Tensor), (
                     f"Field {name} is expected to be a torch.Tensor, a dict of torch.Tensor, or a dataclass of torch.Tensor, but got {type(buffer)}."
                 )
-                setattr(self, name, share_input_buffer(name, buffer))
+                setattr(self, name, share_input_buffer(name, buffer, pool_for(name)))

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -315,6 +315,11 @@ class ModelRunner:
         """Whether this runner's sampling path publishes observer output."""
         return get_exec().dllm.dllm_algorithm is None and self.spec_algorithm.is_none()
 
+    def cuda_graph_persistent_pool_context(self):
+        if self.cuda_graph_persistent_pool is None:
+            return contextlib.nullcontext()
+        return torch.cuda.use_mem_pool(self.cuda_graph_persistent_pool)
+
     def __init__(
         self,
         model_config: ModelConfig,
@@ -341,6 +346,7 @@ class ModelRunner:
         self.model_config = model_config
         self.dist_port = nccl_port
         self.server_args = server_args
+        self.cuda_graph_persistent_pool: Optional[torch.cuda.MemPool] = None
         self.is_draft_worker = is_draft_worker
         # The process entry published; a draft runner is not one (it must not
         # clobber the target's config), so only the target checks.

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -229,7 +229,8 @@ class BaseRunner(ABC):
         self.enable_return_hidden_states = self.return_hidden_states_mode.need_capture()
         self.attn_tp_size = get_parallel().attn_tp_size
         self.attn_tp_rank = get_parallel().attn_tp_rank
-        self.tbo_plugin = TboCudaGraphRunnerPlugin()
+        with model_runner.cuda_graph_persistent_pool_context():
+            self.tbo_plugin = TboCudaGraphRunnerPlugin()
 
     def warmup(self) -> None:
         """Run kernel warmup + autotune once, gated by mr._kernel_warmed_up."""

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -132,6 +132,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+_PERSISTENT_POOL_EXCLUSIONS = frozenset(
+    {
+        "next_token_logits_buffer",
+        "ngram_embedding_info.token_table",
+    }
+)
+
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -367,7 +374,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             if self.capture_num_tokens is not None
             else self.max_bs * self.captured_req_width
         )
-        self.attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
+        self._init_attention_cuda_graph_state(self.attn_backend)
 
         # Init PDMux if needed
         self.maybe_init_pdmux()
@@ -391,10 +398,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             # Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
             # Phase 1 (MoE buffers) was handled earlier in ModelRunner via
             # lora_manager.init_cuda_graph_moe_buffers().
-            self.model_runner.lora_manager.init_cuda_graph_batch_info(
-                max_bs_in_cuda_graph=self.max_bs,
-                num_tokens_per_req=self.captured_req_width,
-            )
+            with self.model_runner.cuda_graph_persistent_pool_context():
+                self.model_runner.lora_manager.init_cuda_graph_batch_info(
+                    max_bs_in_cuda_graph=self.max_bs,
+                    num_tokens_per_req=self.captured_req_width,
+                )
 
         enable_mamba_track = (
             get_exec().mamba.enable_mamba_extra_buffer
@@ -436,7 +444,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 self.model_runner.get_pp_proxy_residual_num_blocks()
             ),
         )
-        self.buffers.share_buffers()
+        self._share_input_buffers()
         # FB-shared slot registry adopting DecodeInputBuffers storage (same
         # physical tensors, stable data_ptr for capture vs replay). Provides
         # the unified fill_from / slot access surface for capture/replay.
@@ -556,7 +564,17 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if self.enable_pdmux:
             self.stream_groups = get_stream_groups()
             for attn_backend in self.model_runner.decode_attn_backend_group:
-                attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
+                self._init_attention_cuda_graph_state(attn_backend)
+
+    def _init_attention_cuda_graph_state(self, attn_backend: AttentionBackend) -> None:
+        with self.model_runner.cuda_graph_persistent_pool_context():
+            attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
+
+    def _share_input_buffers(self) -> None:
+        self.buffers.share_buffers(
+            memory_pool=self.model_runner.cuda_graph_persistent_pool,
+            memory_pool_exclusions=_PERSISTENT_POOL_EXCLUSIONS,
+        )
 
     def _cache_loc_dtype(self):
         return torch.int64
@@ -1179,7 +1197,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             if forward_batch.lora_ids is not None:
                 self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
-            attn_backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
+            with self.model_runner.cuda_graph_persistent_pool_context():
+                attn_backend.init_forward_metadata_out_graph(
+                    forward_batch, in_capture=True
+                )
 
             def run_once():
                 # Graph-recordable metadata-prep hook. The unified memory pool

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -151,6 +151,7 @@ class EagerRunner(BaseRunner):
                 torch.int64 if torch.device(mr.device).type == "cpu" else torch.int32
             ),
             dp_size=get_parallel().dp_size,
+            memory_pool=mr.cuda_graph_persistent_pool,
         )
         # Eager has no capture step, so warm up here (run-once via mr._kernel_warmed_up).
         self.warmup()

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -42,7 +42,7 @@ import dataclasses
 import inspect
 import logging
 from collections.abc import Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
@@ -362,7 +362,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 self.model_runner.get_pp_proxy_residual_num_blocks()
             ),
         )
-        self.buffers.share_buffers()
+        self._share_input_buffers()
         # Token-axis FB-shared slot registry adopting PrefillInputBuffers
         # storage; same physical tensors, stable data_ptr for capture vs replay.
         self.buffer_registry: CudaGraphBufferRegistry = build_prefill_registry(
@@ -403,6 +403,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         # TcPiecewise resolves by running a compile pass that calls back into
         # capture_prepare / _run_forward, so these fields must exist first.
         self._prefill_static_buffers: Optional[Dict[str, torch.Tensor]] = None
+        self._persistent_capture_global_num_tokens: Dict[
+            tuple[int, ...], torch.Tensor
+        ] = {}
         self.static_draft_hidden_states: Optional[torch.Tensor] = None
         self.layer_model = None
         self._capture_req_slots = 1
@@ -440,9 +443,10 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self.backend, (BreakableCudaGraphBackend, FullCudaGraphBackend)
         )
         if self._capture_lora:
-            model_runner.lora_manager.init_prefill_cuda_graph_batch_info(
-                max_num_tokens=self.max_num_tokens
-            )
+            with model_runner.cuda_graph_persistent_pool_context():
+                model_runner.lora_manager.init_prefill_cuda_graph_batch_info(
+                    max_num_tokens=self.max_num_tokens
+                )
             # Clamp Full's request slots to the LoRA segment-slot count
             # rather than fail capture.
             lora_max_bs = model_runner.lora_manager.prefill_cuda_graph_max_bs
@@ -489,7 +493,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self._prefix_capture_variants = tuple(
                 n for n in _CHUNKED_PREFIX_VARIANTS if n // 2 < max_real_chunks
             )
-            self._prefix_capture_buffers = self._create_chunked_prefix_buffers()
+            self._prefix_capture_buffers = self._create_chunked_prefix_buffers(
+                memory_pool=model_runner.cuda_graph_persistent_pool
+            )
             logger.info(
                 "Full prefill CUDA graph cached-prefix chunks: "
                 "%d aggregate tokens/chunk (%d/request x %d slots), "
@@ -505,11 +511,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 ),
             )
         if isinstance(self.backend, (BreakableCudaGraphBackend, FullCudaGraphBackend)):
-            with torch.device(self.device):
-                self._prefill_static_buffers = {
-                    name: torch.zeros((self.max_bs,), dtype=torch.int64)
-                    for name in _PREFILL_STATIC_FIELDS
-                }
+            self._prefill_static_buffers = self._create_prefill_static_buffers()
 
         server_args = model_runner.server_args
         self.enable_cp_bcg_capture = isinstance(
@@ -587,6 +589,48 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
     def _cache_loc_dtype(self):
         return torch.int64 if not is_npu() else torch.int32
+
+    def _share_input_buffers(self) -> None:
+        self.buffers.share_buffers(
+            memory_pool=self.model_runner.cuda_graph_persistent_pool
+        )
+
+    def _create_prefill_static_buffers(self) -> Dict[str, torch.Tensor]:
+        with (
+            torch.device(self.device),
+            self.model_runner.cuda_graph_persistent_pool_context(),
+        ):
+            return {
+                name: torch.zeros((self.max_bs,), dtype=torch.int64)
+                for name in _PREFILL_STATIC_FIELDS
+            }
+
+    def _create_capture_global_num_tokens(
+        self, global_num_tokens_cpu: list[int]
+    ) -> torch.Tensor:
+        pool = self.model_runner.cuda_graph_persistent_pool
+        if pool is None:
+            return torch.tensor(
+                global_num_tokens_cpu, dtype=torch.int32, device=self.device
+            )
+
+        # FullCudaGraphBackend does not retain capture_inputs, so keep each
+        # bucket's graph-read count tensor alive on the runner.
+        key = tuple(global_num_tokens_cpu)
+        if key in self._persistent_capture_global_num_tokens:
+            return self._persistent_capture_global_num_tokens[key]
+        with self.model_runner.cuda_graph_persistent_pool_context():
+            buffer = torch.tensor(
+                global_num_tokens_cpu, dtype=torch.int32, device=self.device
+            )
+        self._persistent_capture_global_num_tokens[key] = buffer
+        return buffer
+
+    def _init_full_cuda_graph_attention_metadata(
+        self, attn_backend: AttentionBackend, forward_batch: ForwardBatch
+    ) -> None:
+        with self.model_runner.cuda_graph_persistent_pool_context():
+            attn_backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
 
     def _input_embeds_hidden_size(self) -> int:
         """Width of the `input_embeds` the model writes inside the graph.
@@ -926,7 +970,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 variant = _chunked_prefix_variant(captured_n)
         return ShapeKey(size=num_tokens, variant_label=variant)
 
-    def _create_chunked_prefix_buffers(self) -> _ChunkedPrefixCaptureBuffers:
+    def _create_chunked_prefix_buffers(
+        self, *, memory_pool: Optional[torch.cuda.MemPool] = None
+    ) -> _ChunkedPrefixCaptureBuffers:
         """Allocate the stable chunk-metadata tensors shared by all variants."""
         max_chunks = max(self._prefix_capture_variants)
         bs = self._capture_req_slots
@@ -935,22 +981,29 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             .unsqueeze(1)
             .repeat(1, bs)
         )
-        return _ChunkedPrefixCaptureBuffers(
-            starts=starts_cpu.to(self.device, copy=True),
-            seq_lens=torch.zeros(
-                (max_chunks, bs), dtype=torch.int32, device=self.device
-            ),
-            cu_seq_lens=torch.zeros(
-                (max_chunks, bs + 1), dtype=torch.int32, device=self.device
-            ),
-            starts_cpu=starts_cpu,
-            seq_lens_cpu=torch.zeros((max_chunks, bs), dtype=torch.int32),
-            kv_indices=torch.zeros(
-                (max_chunks, self._prefix_chunk_capacity),
-                dtype=torch.int32,
-                device=self.device,
-            ),
+        seq_lens_cpu = torch.zeros((max_chunks, bs), dtype=torch.int32)
+        allocation_context = (
+            torch.cuda.use_mem_pool(memory_pool)
+            if memory_pool is not None
+            else nullcontext()
         )
+        with allocation_context:
+            return _ChunkedPrefixCaptureBuffers(
+                starts=starts_cpu.to(self.device, copy=True),
+                seq_lens=torch.zeros(
+                    (max_chunks, bs), dtype=torch.int32, device=self.device
+                ),
+                cu_seq_lens=torch.zeros(
+                    (max_chunks, bs + 1), dtype=torch.int32, device=self.device
+                ),
+                starts_cpu=starts_cpu,
+                seq_lens_cpu=seq_lens_cpu,
+                kv_indices=torch.zeros(
+                    (max_chunks, self._prefix_chunk_capacity),
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+            )
 
     def _prepare_chunked_prefix_capture(
         self,
@@ -1328,8 +1381,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         if global_num_tokens_cpu is not None:
             global_dp_buffer_len = sum(global_num_tokens_cpu)
-            num_tokens_tensor = torch.tensor(
-                global_num_tokens_cpu, dtype=torch.int32, device=self.device
+            num_tokens_tensor = self._create_capture_global_num_tokens(
+                global_num_tokens_cpu
             )
             global_num_tokens_gpu = num_tokens_tensor
             global_num_tokens_for_logprob_gpu = num_tokens_tensor
@@ -1494,8 +1547,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             )
         if self._is_full_backend:
             if not prefix_num_chunks:
-                attn_backend.init_forward_metadata_out_graph(
-                    forward_batch, in_capture=True
+                self._init_full_cuda_graph_attention_metadata(
+                    attn_backend, forward_batch
                 )
             # The prefix variant intentionally reuses the capture-stable
             # metadata object initialized by the suffix-only variant above.

--- a/test/registered/unit/model_executor/runner/test_cuda_graph_persistent_pool.py
+++ b/test/registered/unit/model_executor/runner/test_cuda_graph_persistent_pool.py
@@ -1,0 +1,140 @@
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.model_executor.runner.base_runner import BaseRunner
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestPersistentCudaGraphPool(CustomTestCase):
+    def test_model_runner_uses_nullcontext_without_pool(self):
+        model_runner = ModelRunner.__new__(ModelRunner)
+        model_runner.cuda_graph_persistent_pool = None
+
+        context = model_runner.cuda_graph_persistent_pool_context()
+
+        self.assertIsInstance(context, contextlib.nullcontext)
+
+    def test_attention_state_initializes_in_selected_pool(self):
+        events = []
+
+        class RecordingContext:
+            def __enter__(self):
+                events.append("enter")
+
+            def __exit__(self, *_args):
+                events.append("exit")
+
+        pool = object()
+        model_runner = ModelRunner.__new__(ModelRunner)
+        model_runner.cuda_graph_persistent_pool = pool
+        backend = mock.Mock()
+        backend.init_cuda_graph_state.side_effect = lambda *_args: events.append(
+            "initialize"
+        )
+        runner = SimpleNamespace(
+            model_runner=model_runner,
+            max_bs=8,
+            max_num_token=128,
+        )
+
+        with mock.patch.object(
+            torch.cuda, "use_mem_pool", return_value=RecordingContext()
+        ) as use_mem_pool:
+            DecodeCudaGraphRunner._init_attention_cuda_graph_state(runner, backend)
+
+        use_mem_pool.assert_called_once_with(pool)
+        backend.init_cuda_graph_state.assert_called_once_with(8, 128)
+        self.assertEqual(events, ["enter", "initialize", "exit"])
+
+    def test_shared_inputs_use_pool_except_externally_owned_storage(self):
+        pool = object()
+        buffers = mock.Mock()
+        runner = SimpleNamespace(
+            model_runner=SimpleNamespace(cuda_graph_persistent_pool=pool),
+            buffers=buffers,
+        )
+
+        DecodeCudaGraphRunner._share_input_buffers(runner)
+
+        buffers.share_buffers.assert_called_once_with(
+            memory_pool=pool,
+            memory_pool_exclusions=frozenset(
+                {
+                    "next_token_logits_buffer",
+                    "ngram_embedding_info.token_table",
+                }
+            ),
+        )
+
+    def test_base_runner_constructs_tbo_plugin_in_selected_pool(self):
+        events = []
+        in_context = False
+
+        class RecordingContext:
+            def __enter__(self):
+                nonlocal in_context
+                in_context = True
+                events.append("enter")
+
+            def __exit__(self, *_args):
+                nonlocal in_context
+                in_context = False
+                events.append("exit")
+
+        def construct_plugin():
+            self.assertTrue(in_context)
+            events.append("construct")
+            return object()
+
+        model_runner = SimpleNamespace(
+            device="cpu",
+            server_args=SimpleNamespace(tp_size=1, pp_size=1, enable_pdmux=False),
+            is_draft_worker=False,
+            cuda_graph_persistent_pool_context=RecordingContext,
+        )
+        parallel = SimpleNamespace(
+            tp_size=1,
+            dp_size=1,
+            pp_size=1,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+        )
+        return_hidden_states_mode = SimpleNamespace(need_capture=lambda: False)
+        runner = SimpleNamespace()
+
+        with (
+            mock.patch(
+                "sglang.srt.model_executor.runner.base_runner.get_parallel",
+                return_value=parallel,
+            ),
+            mock.patch(
+                "sglang.srt.model_executor.runner.base_runner.get_disagg",
+                return_value=SimpleNamespace(enable_pdmux=False),
+            ),
+            mock.patch(
+                "sglang.srt.model_executor.runner.base_runner.get_server_return_hidden_states_mode",
+                return_value=return_hidden_states_mode,
+            ),
+            mock.patch(
+                "sglang.srt.model_executor.runner.base_runner.TboCudaGraphRunnerPlugin",
+                side_effect=construct_plugin,
+            ),
+        ):
+            BaseRunner.__init__(runner, model_runner)
+
+        self.assertEqual(events, ["enter", "construct", "exit"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_graph_shared_output.py
+++ b/test/registered/unit/model_executor/test_graph_shared_output.py
@@ -1,0 +1,116 @@
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.model_executor import graph_shared_output
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGraphSharedOutput(CustomTestCase):
+    def setUp(self) -> None:
+        GraphSharedOutput._process_shared = None
+
+    def tearDown(self) -> None:
+        GraphSharedOutput._process_shared = None
+
+    @staticmethod
+    def _model_runner(*, memory_pool, max_rows: int = 8):
+        return SimpleNamespace(
+            device="cuda",
+            cuda_graph_persistent_pool=memory_pool,
+            server_args=SimpleNamespace(
+                cuda_graph_config=SimpleNamespace(
+                    decode=SimpleNamespace(backend=Backend.FULL, bs=[1])
+                )
+            ),
+            max_decode_logits_rows=mock.Mock(return_value=max_rows),
+        )
+
+    def test_logits_buffer_allocates_in_selected_pool(self) -> None:
+        pool = object()
+        allocation_context = mock.MagicMock()
+        backing = torch.empty((8, 16))
+
+        def allocate(*_args, **_kwargs):
+            allocation_context.__enter__.assert_called_once_with()
+            allocation_context.__exit__.assert_not_called()
+            return backing
+
+        output = GraphSharedOutput(
+            device=torch.device("cuda"),
+            max_rows=8,
+            memory_pool=pool,
+        )
+        with (
+            mock.patch.object(
+                torch.cuda, "use_mem_pool", return_value=allocation_context
+            ) as use_mem_pool,
+            mock.patch.object(torch, "zeros", side_effect=allocate) as zeros,
+        ):
+            result = output.get_logits_buffer(16, rows=3)
+
+        use_mem_pool.assert_called_once_with(pool)
+        zeros.assert_called_once_with(
+            (8, 16), dtype=torch.float, device=torch.device("cuda")
+        )
+        allocation_context.__exit__.assert_called_once()
+        self.assertEqual(result.shape, (3, 16))
+        self.assertEqual(result.data_ptr(), backing.data_ptr())
+
+    def test_logits_buffer_uses_nullcontext_without_pool(self) -> None:
+        allocation_context = contextlib.nullcontext()
+        backing = torch.empty((4, 12))
+        output = GraphSharedOutput(device=torch.device("cpu"), max_rows=4)
+
+        with (
+            mock.patch.object(
+                graph_shared_output.contextlib,
+                "nullcontext",
+                return_value=allocation_context,
+            ) as nullcontext,
+            mock.patch.object(torch.cuda, "use_mem_pool") as use_mem_pool,
+            mock.patch.object(torch, "zeros", return_value=backing),
+        ):
+            result = output.get_logits_buffer(12, rows=2)
+
+        nullcontext.assert_called_once_with()
+        use_mem_pool.assert_not_called()
+        self.assertEqual(result.shape, (2, 12))
+        self.assertEqual(result.data_ptr(), backing.data_ptr())
+
+    def test_process_shared_reuse_requires_same_pool(self) -> None:
+        config = SimpleNamespace(decode=SimpleNamespace(backend=Backend.FULL, bs=[1]))
+        with mock.patch.object(
+            graph_shared_output,
+            "get_exec",
+            return_value=SimpleNamespace(
+                graph=SimpleNamespace(cuda_graph_config=config)
+            ),
+        ):
+            first_pool = object()
+            first = GraphSharedOutput.create_for_model_runner(
+                self._model_runner(memory_pool=first_pool)
+            )
+            reused = GraphSharedOutput.create_for_model_runner(
+                self._model_runner(memory_pool=first_pool, max_rows=4)
+            )
+            replacement_pool = object()
+            replaced = GraphSharedOutput.create_for_model_runner(
+                self._model_runner(memory_pool=replacement_pool, max_rows=4)
+            )
+
+        self.assertIs(reused, first)
+        self.assertIsNot(replaced, first)
+        self.assertIs(replaced.memory_pool, replacement_pool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_input_buffers.py
+++ b/test/registered/unit/model_executor/test_input_buffers.py
@@ -1,0 +1,169 @@
+import math
+from dataclasses import dataclass
+from unittest import mock
+
+import torch
+
+from sglang.srt.model_executor import cuda_graph_buffer_registry, input_buffers
+from sglang.srt.model_executor.cuda_graph_buffer_registry import GraphSlot
+from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+@dataclass
+class _NestedBuffers:
+    token_table: torch.Tensor
+    offsets: torch.Tensor
+
+
+@dataclass
+class _TestBuffers(ForwardInputBuffers):
+    pooled: torch.Tensor
+    next_token_logits_buffer: torch.Tensor
+    ngram_embedding_info: _NestedBuffers
+
+
+class TestForwardInputBufferPool(CustomTestCase):
+    def setUp(self) -> None:
+        input_buffers._forward_input_buffer_pool.clear()
+
+    def tearDown(self) -> None:
+        input_buffers._forward_input_buffer_pool.clear()
+
+    @staticmethod
+    def _cuda_tensor_mock(*, clone=None, shape=(2, 2)):
+        tensor = mock.Mock()
+        tensor.numel.return_value = math.prod(shape)
+        tensor.dtype = torch.int64
+        tensor.device = torch.device("cuda")
+        tensor.size.return_value = torch.Size(shape)
+        tensor.stride.return_value = torch.empty(shape).stride()
+        if clone is not None:
+            tensor.clone.return_value = clone
+        return tensor
+
+    def test_first_cuda_registration_uses_selected_pool_and_is_reused(self) -> None:
+        pool = object()
+        canonical = mock.Mock()
+        canonical.as_strided.return_value = object()
+        first = self._cuda_tensor_mock(clone=canonical)
+        second = self._cuda_tensor_mock()
+
+        with mock.patch.object(
+            torch.cuda, "use_mem_pool", return_value=mock.MagicMock()
+        ) as use_mem_pool:
+            input_buffers.share_input_buffer("seq_lens", first, pool)
+            input_buffers.share_input_buffer("seq_lens", second, pool)
+
+        use_mem_pool.assert_called_once_with(pool)
+        first.clone.assert_called_once_with()
+        second.clone.assert_not_called()
+        self.assertIs(
+            input_buffers._forward_input_buffer_pool[
+                ("seq_lens", 4, torch.int64, torch.device("cuda"))
+            ],
+            canonical,
+        )
+
+    def test_eager_first_registry_canonical_uses_selected_pool(self) -> None:
+        pool = object()
+        canonical = mock.Mock()
+        canonical.as_strided.return_value = mock.Mock()
+        eager_buffer = self._cuda_tensor_mock(clone=canonical, shape=(4,))
+        later_decode_buffer = self._cuda_tensor_mock(shape=(4,))
+        registry = cuda_graph_buffer_registry.CudaGraphBufferRegistry(
+            device=torch.device("cuda"),
+            max_bs=4,
+            max_num_tokens=4,
+            share_pool=True,
+            memory_pool=pool,
+        )
+        slot = GraphSlot(
+            name="req_pool_indices",
+            shape_fn=lambda bs, _num_tokens: (bs,),
+            dtype=torch.int64,
+            axis="bs",
+        )
+
+        with (
+            mock.patch.object(
+                cuda_graph_buffer_registry.torch, "zeros", return_value=eager_buffer
+            ),
+            mock.patch.object(
+                torch.cuda, "use_mem_pool", return_value=mock.MagicMock()
+            ) as use_mem_pool,
+        ):
+            registry.register_slot(slot)
+            input_buffers.share_input_buffer(
+                "req_pool_indices", later_decode_buffer, pool
+            )
+
+        use_mem_pool.assert_called_once_with(pool)
+        eager_buffer.clone.assert_called_once_with()
+        later_decode_buffer.clone.assert_not_called()
+        self.assertIs(
+            input_buffers._forward_input_buffer_pool[
+                ("req_pool_indices", 4, torch.int64, torch.device("cuda"))
+            ],
+            canonical,
+        )
+
+    def test_build_eager_registry_forwards_selected_pool(self) -> None:
+        pool = object()
+        sentinel = object()
+        with mock.patch.object(
+            cuda_graph_buffer_registry,
+            "build_decode_registry",
+            return_value=sentinel,
+        ) as build_decode:
+            result = cuda_graph_buffer_registry.build_eager_registry(
+                device=torch.device("cuda"),
+                max_bs=4,
+                max_num_token=16,
+                cache_loc_dtype=torch.int64,
+                memory_pool=pool,
+            )
+
+        self.assertIs(result, sentinel)
+        self.assertIs(build_decode.call_args.kwargs["memory_pool"], pool)
+
+    def test_share_buffers_routes_only_owned_storage_to_pool(self) -> None:
+        pool = object()
+        buffers = _TestBuffers(
+            pooled=torch.zeros(2),
+            next_token_logits_buffer=torch.zeros(2),
+            ngram_embedding_info=_NestedBuffers(
+                token_table=torch.zeros(2),
+                offsets=torch.zeros(2),
+            ),
+        )
+
+        with mock.patch.object(
+            input_buffers,
+            "share_input_buffer",
+            side_effect=lambda _name, tensor, _pool: tensor,
+        ) as share:
+            buffers.share_buffers(
+                memory_pool=pool,
+                memory_pool_exclusions=frozenset(
+                    {
+                        "next_token_logits_buffer",
+                        "ngram_embedding_info.token_table",
+                    }
+                ),
+            )
+
+        routed_pools = {call.args[0]: call.args[2] for call in share.call_args_list}
+        self.assertIs(routed_pools["pooled"], pool)
+        self.assertIsNone(routed_pools["next_token_logits_buffer"])
+        self.assertIsNone(routed_pools["ngram_embedding_info.token_table"])
+        self.assertIs(routed_pools["ngram_embedding_info.offsets"], pool)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -1,8 +1,9 @@
-"""CPU coverage for chunked-prefix Full prefill CUDA-graph state."""
+"""CPU coverage for persistent Full prefill CUDA-graph state."""
 
 import unittest
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -139,6 +140,119 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
 
                 self.assertIs(runner.prepare_dummy_forward_batch(batch), batch)
                 self.assertEqual(batch.attn_tp_sequence_sharded, expected)
+
+    def test_persistent_pool_covers_prefill_graph_state(self):
+        pool = object()
+        pool_active = False
+
+        @contextmanager
+        def pool_context():
+            nonlocal pool_active
+            self.assertFalse(pool_active)
+            pool_active = True
+            try:
+                yield
+            finally:
+                pool_active = False
+
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.device = torch.device("cpu")
+        runner.max_bs = 4
+        runner.buffers = Mock()
+        runner._persistent_capture_global_num_tokens = {}
+        runner.model_runner = SimpleNamespace(
+            cuda_graph_persistent_pool=pool,
+            cuda_graph_persistent_pool_context=pool_context,
+        )
+
+        runner._share_input_buffers()
+        runner.buffers.share_buffers.assert_called_once_with(memory_pool=pool)
+
+        real_zeros = torch.zeros
+
+        def zeros_in_pool(*args, **kwargs):
+            self.assertTrue(pool_active)
+            return real_zeros(*args, **kwargs)
+
+        with patch.object(runner_module.torch, "zeros", side_effect=zeros_in_pool):
+            static_buffers = runner._create_prefill_static_buffers()
+        self.assertEqual(set(static_buffers), set(runner_module._PREFILL_STATIC_FIELDS))
+
+        real_tensor = torch.tensor
+
+        def tensor_in_pool(*args, **kwargs):
+            self.assertTrue(pool_active)
+            return real_tensor(*args, **kwargs)
+
+        with patch.object(runner_module.torch, "tensor", side_effect=tensor_in_pool):
+            global_num_tokens = runner._create_capture_global_num_tokens([8, 8, 8, 8])
+            reused_global_num_tokens = runner._create_capture_global_num_tokens(
+                [8, 8, 8, 8]
+            )
+        self.assertEqual(global_num_tokens.tolist(), [8, 8, 8, 8])
+        self.assertIs(reused_global_num_tokens, global_num_tokens)
+
+        forward_batch = object()
+        attn_backend = Mock()
+        attn_backend.init_forward_metadata_out_graph.side_effect = (
+            lambda *_args, **_kwargs: self.assertTrue(pool_active)
+        )
+        runner._init_full_cuda_graph_attention_metadata(attn_backend, forward_batch)
+        attn_backend.init_forward_metadata_out_graph.assert_called_once_with(
+            forward_batch, in_capture=True
+        )
+
+    def test_chunked_prefix_buffers_preserve_no_pool_behavior(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner._capture_req_slots = 2
+        runner._prefix_chunk_len = 4
+        runner._prefix_chunk_capacity = 8
+        runner._prefix_capture_variants = (1, 2)
+        runner.device = torch.device("cpu")
+        runner._persistent_capture_global_num_tokens = {}
+        runner.model_runner = SimpleNamespace(
+            cuda_graph_persistent_pool=None,
+            cuda_graph_persistent_pool_context=nullcontext,
+        )
+
+        with patch.object(runner_module.torch.cuda, "use_mem_pool") as use_mem_pool:
+            buffers = runner._create_chunked_prefix_buffers()
+        first_counts = runner._create_capture_global_num_tokens([8, 8])
+        second_counts = runner._create_capture_global_num_tokens([8, 8])
+
+        use_mem_pool.assert_not_called()
+        self.assertEqual(buffers.starts_cpu.device.type, "cpu")
+        self.assertEqual(buffers.seq_lens_cpu.device.type, "cpu")
+        self.assertIsNot(first_counts, second_counts)
+
+    def test_chunked_prefix_cuda_buffers_use_persistent_pool(self):
+        pool = object()
+        entered = False
+
+        @contextmanager
+        def pool_context():
+            nonlocal entered
+            entered = True
+            yield
+
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner._capture_req_slots = 2
+        runner._prefix_chunk_len = 4
+        runner._prefix_chunk_capacity = 8
+        runner._prefix_capture_variants = (1, 2)
+        runner.device = torch.device("cpu")
+
+        with patch.object(
+            runner_module.torch.cuda,
+            "use_mem_pool",
+            return_value=pool_context(),
+        ) as use_mem_pool:
+            buffers = runner._create_chunked_prefix_buffers(memory_pool=pool)
+
+        use_mem_pool.assert_called_once_with(pool)
+        self.assertTrue(entered)
+        self.assertEqual(buffers.starts_cpu.device.type, "cpu")
+        self.assertEqual(buffers.seq_lens_cpu.device.type, "cpu")
 
     def test_low_free_memory_still_captures_prefill_graph(self):
         eager_runner = object()


### PR DESCRIPTION
## Motivation

Graph inputs, logits and attention metadata are allocated through separate initialization paths. Callers that manage persistent graph storage need those allocations to use the same CUDA memory pool.

## Modifications

Add an optional persistent pool on `ModelRunner` and pass it through eager, decode and prefill graph setup. Allocate shared logits and first-registration input buffers in that pool, and retain full-prefill count tensors for the lifetime of their captured graphs. The default `None` preserves the existing allocator behavior.

Input sharing keeps its first-registration semantics: select the pool before initializing shared inputs. Later calls reuse the canonical buffer and do not migrate it to a different pool. Logits reuse also checks pool identity. Externally owned input storage keeps its existing addresses.

## Accuracy Tests

CPU tests cover selected-pool allocation, canonical-buffer reuse, externally owned storage, prefill state lifetime and the default path:

```bash
PYTHONPATH=python uv run --no-project python -m pytest -q \
  test/registered/unit/model_executor/runner/test_cuda_graph_persistent_pool.py \
  test/registered/unit/model_executor/test_graph_shared_output.py \
  test/registered/unit/model_executor/test_input_buffers.py \
  test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
```

24 passed, 7 subtests passed. The four files also pass through their direct `python <file> -f` CI entrypoints.

A small CUDA allocation/replay check confirmed 14 buffers belong to the selected pool. All 10 replays matched the expected output, with unchanged buffer addresses. This used synthetic tensors without loading a model.

## Speed Tests and Profiling

Full-model accuracy and performance benchmarks were not run. Validation covers allocation ownership, aliasing and graph replay with the optional pool.

## Checklist

- [x] Format code with pre-commit.
- [x] Add CPU unit tests and validate CUDA allocation/replay.
- [x] Document pool selection and reuse in the shared-input docstring.
- [x] State accuracy and speed test coverage above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34498625509](https://github.com/sgl-project/sglang/actions/runs/34498625509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34498625238](https://github.com/sgl-project/sglang/actions/runs/34498625238)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34498625417](https://github.com/sgl-project/sglang/actions/runs/34498625417)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->