### PR TITLE
[Benchmark] Isolate fast-prepare caches from measured token counts

### DIFF
--- a/docs/docs/developer_guide/bench_serving.mdx
+++ b/docs/docs/developer_guide/bench_serving.mdx
@@ -377,7 +377,7 @@ python3 -m sglang.bench_serving \
 
 `zipf` mode samples each request's prefix group from the rank-based distribution `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)` with rank starting at 1, so group index 0 is the hottest. The total request count stays `num_groups * prompts_per_group` — identical to `uniform` mode — and only the per-request group assignment changes. `alpha` must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups.
 
-The on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` includes `group_distribution` and `zipf_alpha` in its key, so uniform-mode and zipf-mode runs (or two zipf runs with different alpha) never share a cache file. Uniform-mode filenames are unchanged from the legacy format, so existing caches remain valid.
+The on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` includes `group_distribution`, `zipf_alpha`, and the `--gsp-fast-prepare` setting in its key. Fast preparation stores placeholder prompt lengths, so its cache is separate from runs that compute token counts. Uniform and Zipf runs, or Zipf runs with different alpha values, also use separate files. Existing dataset caches without a preparation-mode marker are regenerated because their token counts may be placeholders.
 
 This flag controls prefix-popularity shape only. It does not by itself reproduce any production trace or guarantee an observed cache-hit rate for a given engine.
 

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -130,18 +130,22 @@ def get_gen_prefix_cache_path(
     tokenizer,
     group_distribution: str = "uniform",
     zipf_alpha: Optional[float] = None,
+    fast_prepare: Optional[bool] = None,
 ):
     """Create cache directory under ~/.cache/sglang/benchmark.
 
-    The uniform-mode filename is preserved exactly as before so existing
-    on-disk caches remain valid. Non-default sampling modes get an extra
-    suffix encoding the parameters that affect the cached payload.
+    Leaving fast_prepare unset preserves the legacy path used by the HiCache
+    benchmark. Dataset generation specifies the preparation mode to keep
+    placeholder token counts separate from measured counts and avoid legacy
+    caches whose preparation mode is unknown.
     """
     cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
 
     suffix = ""
     if group_distribution != "uniform":
         suffix = f"_{group_distribution}_{zipf_alpha}"
+    if fast_prepare is not None:
+        suffix += "_fast" if fast_prepare else "_tokenized"
 
     cache_key = (
         f"gen_shared_prefix_{seed}_{num_groups}_{prompts_per_group}_"
@@ -190,6 +194,7 @@ def sample_generated_shared_prefix_requests(
         tokenizer,
         group_distribution=group_distribution,
         zipf_alpha=zipf_alpha,
+        fast_prepare=fast_prepare,
     )
     # range_ratio != 1 / num_turns > 1 perturb the payload but are not in the
     # cache key; send_routing_key embeds a per-run uuid + timestamp that is

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -1116,6 +1116,43 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         self.assertTrue(path.name.endswith(".pkl"))
         self.assertEqual(path.parent, Path.home() / ".cache" / "sglang" / "benchmark")
 
+    def test_gsp_cache_respects_fast_prepare(self):
+        for mode, alpha in [("uniform", None), ("zipf", 1.5)]:
+            for first_fast in (True, False):
+                with self.subTest(mode=mode, first_fast=first_fast):
+                    kwargs = dict(mode=mode, alpha=alpha, seed=42 + int(first_fast))
+                    first = self._run_gsp(fast_prepare=first_fast, **kwargs)
+                    second = self._run_gsp(fast_prepare=not first_fast, **kwargs)
+                    self.assertEqual(
+                        [row.prompt for row in first], [row.prompt for row in second]
+                    )
+                    for rows, fast in [(first, first_fast), (second, not first_fast)]:
+                        for row in rows:
+                            expected_len = (
+                                1 if fast else len(self.tokenizer.encode(row.prompt))
+                            )
+                            self.assertEqual(row.prompt_len, expected_len)
+                            self.assertEqual(row.text_prompt_len, expected_len)
+
+    def test_gsp_precise_mode_ignores_legacy_fast_cache(self):
+        legacy_path = get_gen_prefix_cache_path(
+            seed=42,
+            num_groups=4,
+            prompts_per_group=5,
+            system_prompt_len=4,
+            question_len=3,
+            output_len=2,
+            tokenizer=self.tokenizer,
+        )
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(legacy_path, "wb") as f:
+            pickle.dump([DatasetRow(prompt="LEGACY", prompt_len=1, output_len=2)], f)
+
+        rows = self._run_gsp(fast_prepare=False)
+        self.assertEqual(len(rows), 20)
+        for row in rows:
+            self.assertEqual(row.prompt_len, len(self.tokenizer.encode(row.prompt)))
+
     def test_zipf_group_probs_helper(self):
         # Rank-based probability vector: weight(rank) = 1 / rank ** alpha,
         # normalized to sum to 1, with rank starting at 1.
@@ -1275,6 +1312,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 question_len=common["question_len"],
                 output_len=common["output_len"],
                 tokenizer=self.tokenizer,
+                fast_prepare=common["fast_prepare"],
             )
             zipf_path_a = get_gen_prefix_cache_path(
                 seed=common["seed"],
@@ -1286,6 +1324,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 tokenizer=self.tokenizer,
                 group_distribution="zipf",
                 zipf_alpha=1.5,
+                fast_prepare=common["fast_prepare"],
             )
             zipf_path_b = get_gen_prefix_cache_path(
                 seed=common["seed"],
@@ -1297,6 +1336,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
                 tokenizer=self.tokenizer,
                 group_distribution="zipf",
                 zipf_alpha=2.0,
+                fast_prepare=common["fast_prepare"],
             )
             self.assertNotEqual(uniform_path, zipf_path_a)
             self.assertNotEqual(zipf_path_a, zipf_path_b)


### PR DESCRIPTION
## Motivation

Running the generated-shared-prefix benchmark with `--gsp-fast-prepare` caches placeholder `prompt_len=1` values. A later run without that flag reuses the same cache and reports those placeholders as measured input-token counts. The reverse transition also reuses the wrong preparation mode.

## Modifications

Include preparation mode in the generated dataset's cache filename. Both modes avoid legacy cache entries whose token-count provenance is unknown. Callers that omit the new optional helper argument, including the HiCache benchmark, retain their existing cache path. Update the cache documentation and add regression coverage for both transition directions under uniform/Zipf sampling and for old cache files.

I checked the open PR inventory and the diff of #38705. That PR isolates request ordering; it does not address `fast_prepare` or placeholder token counts. This fixes a separate cache dimension, although both PRs touch the cache helper and documentation and may need conflict resolution when combined.

## Accuracy Tests

- Before the production change, the new tests fail in all four mode-switch subcases (`1 != 7` / `7 != 1` with a local tokenizer), plus the legacy-cache case.
- After the fix, all 15 selected GSP/Zipf/from-args component tests pass. This includes the existing same-mode cache reload and sampling tests.
- Local validation uses Python 3.11, actual dataset modules, real pickle cache files in temporary directories, and a real local Transformers tokenizer. A lightweight runner executes the repository's unchanged selected test bodies with `unittest.TestCase` instead of the CI retry wrapper, bypassing unrelated SGLang server/package initializers. Full server imports and GPU inference were not tested locally.
- In a configured SGLang environment, run `python test/registered/bench_fn/test_benchmark_datasets_api.py`.
- `git diff --check` passes.

## Speed Tests and Profiling

This corrects benchmark input-token accounting and cache selection; it does not change model inference. No GPU performance claim is made. Each preparation mode generates its cache once, then can reuse it on subsequent runs.

## Checklist

- [x] Applicable pre-commit hooks pass for the three changed files.
- [x] Regression tests added to the existing CPU-registered dataset test file.
- [x] Cache migration behavior documented.

Prepared with Codex assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34498756237](https://github.com/sgl-project/sglang/actions/runs/34498756237)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34498756114](https://github.com/sgl-project/sglang/actions/runs/34498756114)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34498756269](https://github.com/sgl-project/sglang/actions/runs/34498756269)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->