### PR TITLE
[Kernel][FP8] Fuse SiluAndMul with static FP8 quantization

### DIFF
--- a/benchmark/kernels/bench_silu_fp8_fusion_mlp.py
+++ b/benchmark/kernels/bench_silu_fp8_fusion_mlp.py
@@ -1,0 +1,310 @@
+"""Full synthetic shared MLP benchmark through the fused producer and consumer.
+
+From the repository root, select an idle SM89 GPU and run:
+    SGLANG_ENABLE_SILU_STATIC_FP8_FUSION=1 python \
+        benchmark/kernels/bench_silu_fp8_fusion_mlp.py \
+        --model-path /path/to/Qwen3-8B-FP8 --output /path/to/new-results
+
+The checkpoint bootstraps the normal Engine runtime; loading and the bootstrap
+request are outside module timing. Measures both projections and the fused or
+unfused activation/quantization with synthetic weights, 9 alternating pairs and
+20 Graph replays per measurement. Untimed traces record the actual GEMMs.
+This is not a full MoE checkpoint accuracy test or an HTTP latency benchmark.
+"""
+
+import gc
+import json
+import statistics
+import traceback
+from pathlib import Path
+
+import torch
+
+
+def capture(fn, x):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(4):
+            fn(x)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        y = fn(x)
+    return graph, y
+
+
+def measure(graphs, iterations=20):
+    start, end = [torch.cuda.Event(enable_timing=True) for _ in range(2)]
+    start.record()
+    for i in range(iterations):
+        graphs[i % len(graphs)].replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000 / iterations
+
+
+def make_hook(config):
+    done = False
+    OUT = Path(config["output"])
+
+    def hook(module, args, output):
+        nonlocal done
+        if done:
+            return
+        done = True
+        from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+            silu_and_mul_static_fp8,
+        )
+        from sglang.srt.layers.quantization.fp8_utils import static_quant_fp8
+        from sglang.srt.models.qwen2_moe import Qwen2MoeMLP
+
+        OUT.mkdir(parents=True, exist_ok=False)
+        result = dict(
+            status="running",
+            synthetic_weights=True,
+            tp=1,
+            torch=torch.__version__,
+            gpu=torch.cuda.get_device_name(),
+            scope="gate_up + activation/quant + down; actual delivered Qwen2MoeMLP.forward and ModelOpt.apply",
+            baseline="real Qwen2MoeMLP.forward; reduce_results=False",
+            cases=[],
+        )
+
+        def save():
+            (OUT / "results.json").write_text(json.dumps(result, indent=2))
+
+        original_dtype = torch.get_default_dtype()
+        try:
+            with (
+                torch.inference_mode(),
+                torch.random.fork_rng(devices=[0]),
+                torch.device("cuda"),
+            ):
+                torch.manual_seed(9271)
+                for dtype in (torch.bfloat16, torch.float16):
+                    torch.set_default_dtype(dtype)
+                    for width in (256, 512, 1024):
+                        mlp = Qwen2MoeMLP(
+                            4096,
+                            width,
+                            "silu",
+                            module.down_proj.quant_method.quant_config,
+                            reduce_results=False,
+                            prefix="validation.shared_expert",
+                            tp_rank=0,
+                            tp_size=1,
+                            allow_silu_fp8_quant=True,
+                        )
+                        for linear in (mlp.gate_up_proj, mlp.down_proj):
+                            assert (
+                                type(linear.quant_method).__name__
+                                == "ModelOptFp8LinearMethod"
+                            )
+                            linear.weight.copy_(
+                                torch.randn(linear.weight.shape, dtype=dtype).to(
+                                    torch.float8_e4m3fn
+                                )
+                            )
+                            linear.weight_scale.fill_(0.01)
+                            linear.input_scale.fill_(0.02)
+                            linear.quant_method.process_weights_after_loading(linear)
+                        down = mlp.down_proj
+                        method = down.quant_method
+                        assert not method.use_marlin and not method.use_sm120_fp8
+                        assert not down.use_flashinfer_bmm and down.bias is None
+                        assert not mlp._enable_silu_fp4_quant_fusion
+
+                        fusion = mlp._silu_fp8_fusion
+                        assert fusion is not None
+
+                        def baseline(x, mlp=mlp, fusion=fusion):
+                            mlp._silu_fp8_fusion = None
+                            try:
+                                return mlp(x)
+                            finally:
+                                mlp._silu_fp8_fusion = fusion
+
+                        candidate = mlp
+
+                        for m in (1, 16, 128, 512, 2048, 8192):
+                            xs = [torch.randn(m, 4096, dtype=dtype) for _ in range(4)]
+                            gate, _ = mlp.gate_up_proj(xs[0])
+                            q, rows = silu_and_mul_static_fp8(gate, down.input_scale)
+                            qr, rr = static_quant_fp8(
+                                mlp.act_fn(gate), down.input_scale, repeat_scale=True
+                            )
+                            assert torch.equal(
+                                q.view(torch.uint8), qr.view(torch.uint8)
+                            )
+                            assert torch.equal(rows, rr)
+                            ref = baseline(xs[0])
+                            assert torch.equal(ref, candidate(xs[0])) and bool(
+                                ref.isfinite().all()
+                            )
+                            base_pairs = [capture(baseline, x) for x in xs]
+                            fused_pairs = [capture(candidate, x) for x in xs]
+                            for factor in (0.75, -0.5):
+                                xs[0].mul_(factor)
+                                down.input_scale.mul_(1.25)
+                                base_pairs[0][0].replay()
+                                fused_pairs[0][0].replay()
+                                torch.cuda.synchronize()
+                                assert torch.equal(base_pairs[0][1], fused_pairs[0][1])
+                                assert torch.equal(mlp(xs[0]), fused_pairs[0][1])
+                            down.input_scale.fill_(0.02)
+                            timing = {}
+                            for mode, count in (
+                                ("hot", 1),
+                                ("rotating_inputs_outputs", 4),
+                            ):
+                                ga = [p[0] for p in base_pairs[:count]]
+                                gb = [p[0] for p in fused_pairs[:count]]
+                                pairs = []
+                                for i in range(9):
+                                    order = [("base", ga), ("fused", gb)]
+                                    if i % 2:
+                                        order.reverse()
+                                    values = {
+                                        name: measure(graphs) for name, graphs in order
+                                    }
+                                    pairs.append(
+                                        dict(
+                                            baseline_us=values["base"],
+                                            fused_us=values["fused"],
+                                            reduction_pct=100
+                                            * (1 - values["fused"] / values["base"]),
+                                        )
+                                    )
+                                timing[mode] = pairs
+                            row = dict(
+                                dtype=str(dtype),
+                                M=m,
+                                K=width,
+                                H=4096,
+                                numeric="byte_and_output_exact",
+                                changed_input_scale_replays=2,
+                                timing=timing,
+                            )
+                            result["cases"].append(row)
+                            save()
+                            print(
+                                "CASE",
+                                str(dtype),
+                                width,
+                                m,
+                                {
+                                    mode: round(
+                                        statistics.median(
+                                            p["reduction_pct"] for p in pairs
+                                        ),
+                                        3,
+                                    )
+                                    for mode, pairs in timing.items()
+                                },
+                                flush=True,
+                            )
+                            if dtype == torch.bfloat16 and m == 2048:
+                                for name, fn in (
+                                    ("baseline", baseline),
+                                    ("fused", candidate),
+                                ):
+                                    torch.cuda.synchronize()
+                                    with torch.profiler.profile(
+                                        activities=[
+                                            torch.profiler.ProfilerActivity.CPU,
+                                            torch.profiler.ProfilerActivity.CUDA,
+                                        ]
+                                    ) as prof:
+                                        fn(xs[0])
+                                        torch.cuda.synchronize()
+                                    prof.export_chrome_trace(
+                                        str(OUT / f"K{width}-{name}-trace.json")
+                                    )
+                            del (
+                                base_pairs,
+                                fused_pairs,
+                                ga,
+                                gb,
+                                xs,
+                                gate,
+                                q,
+                                rows,
+                                qr,
+                                rr,
+                                ref,
+                            )
+                            gc.collect()
+                        del mlp, down, method
+                        gc.collect()
+                result["status"] = "passed"
+        except BaseException:
+            result["status"] = "failed"
+            result["error"] = traceback.format_exc()
+            raise
+        finally:
+            torch.set_default_dtype(original_dtype)
+            save()
+
+    return hook
+
+
+def main():
+    import argparse
+
+    import sglang
+    from sglang.srt.environ import envs
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Local Qwen3-8B ModelOpt FP8 checkpoint for runtime initialization",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="New result directory; existing directories are rejected",
+    )
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("--output must not exist")
+    if not envs.SGLANG_ENABLE_SILU_STATIC_FP8_FUSION.get():
+        parser.error("Set SGLANG_ENABLE_SILU_STATIC_FP8_FUSION=1")
+
+    engine = None
+    try:
+        engine = sglang.Engine(
+            model_path=args.model_path,
+            tp_size=1,
+            dtype="bfloat16",
+            kv_cache_dtype="bfloat16",
+            random_seed=9271,
+            context_length=4096,
+            max_running_requests=4,
+            max_total_tokens=8192,
+            mem_fraction_static=0.5,
+            disable_cuda_graph=True,
+            disable_radix_cache=True,
+            log_level="info",
+            forward_hooks=[
+                dict(
+                    name="shared-full-module",
+                    target_modules=["model.layers.0.mlp"],
+                    hook_factory="bench_silu_fp8_fusion_mlp:make_hook",
+                    config=dict(output=str(args.output.resolve())),
+                )
+            ],
+        )
+        engine.generate(
+            "The capital of France is", dict(temperature=0, max_new_tokens=8)
+        )
+    finally:
+        if engine is not None:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/kernels/jit/csrc/elementwise/silu_and_mul_static_fp8.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/silu_and_mul_static_fp8.cuh
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "activation.cuh"
+#include <cuda_fp8.h>
+
+namespace sglang {
+template <typename T>
+__global__ void silu_and_mul_static_fp8_kernel(
+    const T* input, uint8_t* output, const float* scale, float* rows, uint32_t m, uint32_t n) {
+  using namespace device;
+  constexpr uint32_t V = 8;
+  using in_vec = AlignedVector<T, V>;
+  using out_vec = AlignedVector<uint8_t, V>;
+  const uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint32_t vectors = n / V;
+  const uint32_t row = tid / vectors;
+  if (row >= m) return;
+  const uint32_t col = tid % vectors;
+  const auto gate = load_as<in_vec>(input, row * vectors * 2 + col);
+  const auto up = load_as<in_vec>(input, row * vectors * 2 + vectors + col);
+  const float s = *scale;
+  const float inv = 1.0f / s;
+  out_vec q;
+#pragma unroll
+  for (int i = 0; i < V; ++i) {
+    const float activated = apply_activation_f32<ActivationKind::kSiLU>(cast<fp32_t>(gate[i]));
+    // Match the intermediate dtype of the unfused activation output.
+    const T rounded = cast<T>(activated * cast<fp32_t>(up[i]));
+    float value = cast<fp32_t>(rounded) * inv;
+    // Match Triton's max/min NaN handling as well as finite saturation.
+    value = fminf(448.0f, fmaxf(-448.0f, value));
+    // Match the reference SM89 static-quant lowering: FP32 -> FP16
+    // toward zero, then FP16 -> E4M3 round-to-nearest. Direct FP32 -> FP8
+    // differs at values just above an FP8 rounding midpoint.
+    q[i] = __nv_cvt_halfraw_to_fp8(static_cast<__half_raw>(__float2half_rz(value)), __NV_SATFINITE, __NV_E4M3);
+  }
+  store_as<out_vec>(output, q, tid);
+  if (col == 0) rows[row] = s;
+}
+
+template <typename T>
+struct SiluAndMulStaticFP8 {
+  static void
+  run(tvm::ffi::TensorView input, tvm::ffi::TensorView output, tvm::ffi::TensorView scale, tvm::ffi::TensorView rows) {
+    using namespace host;
+    auto M = SymbolicSize{"M"};
+    auto K = SymbolicSize{"K"};
+    auto K2 = SymbolicSize{"K2"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    TensorMatcher({M, K2}).with_dtype<T>().with_device(device).verify(input);
+    TensorMatcher({M, K}).with_dtype<uint8_t>().with_device(device).verify(output);
+    TensorMatcher({1}).with_dtype<float>().with_device(device).verify(scale);
+    TensorMatcher({M, 1}).with_dtype<float>().with_device(device).verify(rows);
+    const auto m = M.unwrap(), n = K.unwrap();
+    RuntimeCheck(n > 0 && n % 8 == 0 && K2.unwrap() == n * 2, "unsupported dimensions");
+    RuntimeCheck(m * n <= std::numeric_limits<uint32_t>::max() / 2, "index overflow");
+    if (m == 0) return;
+    // A contiguous view may still start at an unaligned storage offset.
+    RuntimeCheck(reinterpret_cast<uintptr_t>(input.data_ptr()) % 16 == 0, "input must be 16-byte aligned");
+    RuntimeCheck(reinterpret_cast<uintptr_t>(output.data_ptr()) % 8 == 0, "output must be 8-byte aligned");
+    LaunchKernel(div_ceil(static_cast<uint32_t>(m * n / 8), 256u), 256u, device.unwrap())(
+        silu_and_mul_static_fp8_kernel<T>,
+        static_cast<const T*>(input.data_ptr()),
+        static_cast<uint8_t*>(output.data_ptr()),
+        static_cast<const float*>(scale.data_ptr()),
+        static_cast<float*>(rows.data_ptr()),
+        static_cast<uint32_t>(m),
+        static_cast<uint32_t>(n));
+  }
+};
+}  // namespace sglang
+using sglang::SiluAndMulStaticFP8;

--- a/python/sglang/kernels/ops/quantization/silu_and_mul_static_fp8.py
+++ b/python/sglang/kernels/ops/quantization/silu_and_mul_static_fp8.py
@@ -1,0 +1,55 @@
+"""Fused SiLU-and-mul with static per-tensor FP8 quantization on SM89."""
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.kernels.ops.activation.activation import _fast_math_flags
+from sglang.srt.utils.custom_op import register_custom_op
+
+
+@cache_once
+def silu_and_mul_static_fp8_module(dtype):
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "silu_and_mul_static_fp8",
+        *args,
+        cuda_files=["elementwise/silu_and_mul_static_fp8.cuh"],
+        extra_cuda_cflags=_fast_math_flags(),
+        cuda_wrappers=[("run", f"SiluAndMulStaticFP8<{args}>::run")],
+    )
+
+
+@register_custom_op(mutates_args=["q", "rows"])
+def silu_and_mul_static_fp8_out(
+    x: torch.Tensor, scale: torch.Tensor, q: torch.Tensor, rows: torch.Tensor
+) -> None:
+    if torch.cuda.get_device_capability(x.device) != (8, 9):
+        raise ValueError("SiLU static-FP8 fusion is qualified only on SM89")
+    silu_and_mul_static_fp8_module(x.dtype).run(x, q, scale.reshape(1), rows)
+
+
+def silu_and_mul_static_fp8(x, scale):
+    """Quantize SiLU(gate) * up for x=[M, 2K] using a scalar FP32 scale.
+
+    Return FP8 [M, K] activations and FP32 [M, 1] copies of the input scale.
+    """
+    if (
+        not x.is_cuda
+        or x.dtype not in (torch.bfloat16, torch.float16)
+        or x.ndim != 2
+        or not x.is_contiguous()
+        or x.storage_offset() % 8
+        or x.shape[1] == 0
+        or x.shape[1] % 16
+        or x.numel() > 2**32 - 1
+        or scale.numel() != 1
+        or scale.dtype != torch.float32
+        or scale.device != x.device
+        or not scale.is_contiguous()
+    ):
+        raise ValueError("unsupported SiLU static-FP8 fusion input")
+    m, k2 = x.shape
+    q = torch.empty((m, k2 // 2), device=x.device, dtype=torch.uint8)
+    rows = torch.empty((m, 1), device=x.device, dtype=torch.float32)
+    silu_and_mul_static_fp8_out(x, scale, q, rows)
+    return q.view(torch.float8_e4m3fn), rows

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -955,6 +955,8 @@ class Envs:
     SGLANG_CPU_QUANTIZATION = EnvBool(False)
     SGLANG_USE_DYNAMIC_MXFP4_LINEAR = EnvBool(False)
     SGLANG_FORCE_FP8_MARLIN = EnvBool(False)
+    # Opt-in for supported ModelOpt static-FP8 MLPs on SM89.
+    SGLANG_ENABLE_SILU_STATIC_FP8_FUSION = EnvBool(False)
     SGLANG_MOE_NVFP4_DISPATCH = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_GEMM_IN_ATTN = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE = EnvBool(False)

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1867,6 +1867,7 @@ def apply_fp8_linear(
     pad_output: Optional[bool] = None,
     compressed_tensor_quant: bool = False,
     pre_quant_output_dtype: Optional[torch.dtype] = None,
+    pre_quant_row_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     # Note: we pad the input because torch._scaled_mm is more performant
     # for matrices with batch dimension > 16.
@@ -1918,7 +1919,16 @@ def apply_fp8_linear(
         qinput = input_2d
         if channelwise_cutlass and not native_scalar_a_scale:
             # Unsupported CUTLASS epilogues require one A scale per row.
-            x_scale = input_scale.repeat(input_2d.shape[0]).view(-1, 1)
+            if pre_quant_row_scale is not None:
+                assert pre_quant_row_scale.shape == (input_2d.shape[0], 1)
+                assert pre_quant_row_scale.dtype == torch.float32
+                assert pre_quant_row_scale.device == input_2d.device
+                assert pre_quant_row_scale.is_contiguous()
+                # The fused producer supplies repeats of the original scalar.
+                # Do not materialize a new row-scale tensor or change GEMM dispatch.
+                x_scale = pre_quant_row_scale
+            else:
+                x_scale = input_scale.repeat(input_2d.shape[0]).view(-1, 1)
         else:
             x_scale = input_scale
     elif compressed_tensor_quant:

--- a/python/sglang/srt/layers/quantization/modelopt_fp8_input.py
+++ b/python/sglang/srt/layers/quantization/modelopt_fp8_input.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit static-FP8 input; row scales never replace the layer's scalar."""
+
+from typing import Optional, Tuple, Union
+
+import msgspec
+import torch
+
+
+class ModelOptFp8Input(msgspec.Struct, frozen=True):
+    """Prequantized activations using the layer's static input scale.
+
+    scale must be layer.input_scale; optional row_scales repeats that scalar
+    as FP32 [M, 1], where M is the flattened row count. orig_dtype is the
+    linear output dtype. The producer is responsible for scale consistency.
+    """
+
+    qx: torch.Tensor
+    scale: torch.Tensor
+    orig_dtype: torch.dtype
+    row_scales: Optional[torch.Tensor] = None
+
+
+ModelOptFp8LinearInput = Union[
+    torch.Tensor,
+    ModelOptFp8Input,
+    Tuple[torch.Tensor, torch.Tensor],
+    Tuple[torch.Tensor, torch.Tensor, torch.dtype],
+]
+
+
+def normalize_and_validate_modelopt_fp8_input(value: object, layer) -> ModelOptFp8Input:
+    # Tuple inputs omit row scales; infer a missing output dtype from the layer.
+    if isinstance(value, tuple):
+        if len(value) not in (2, 3):
+            raise ValueError("Expected (qx, scalar[, original dtype])")
+        value = ModelOptFp8Input(
+            value[0], value[1], value[2] if len(value) == 3 else layer.orig_dtype
+        )
+    if not isinstance(value, ModelOptFp8Input):
+        raise TypeError("Expected a ModelOptFp8Input or a two-/three-field tuple")
+    qx, scale, dtype, rows = value.qx, value.scale, value.orig_dtype, value.row_scales
+    if not isinstance(qx, torch.Tensor) or qx.dtype != torch.float8_e4m3fn:
+        raise TypeError("Static FP8 input must contain an E4M3FN tensor")
+    if not qx.is_cuda or qx.ndim < 2 or not qx.is_contiguous():
+        raise ValueError("Static FP8 input must be a contiguous CUDA matrix or batch")
+    if qx.shape[-1] == 0:
+        raise ValueError("Static FP8 input must have a nonzero feature dimension")
+    if scale is not layer.input_scale:
+        raise ValueError("Static FP8 input must retain the layer.input_scale object")
+    if scale.numel() != 1 or scale.dtype != torch.float32 or scale.device != qx.device:
+        raise ValueError("Expected the original FP32 scalar on the input device")
+    if dtype not in (torch.float16, torch.bfloat16) or dtype != layer.orig_dtype:
+        raise ValueError("Static FP8 input must retain the layer's original dtype")
+    if qx.shape[-1] != layer.weight.shape[0] or qx.device != layer.weight.device:
+        raise ValueError("Static FP8 input is incompatible with the linear weight")
+    if rows is not None:
+        if not isinstance(rows, torch.Tensor) or (
+            rows.shape != (qx.numel() // qx.shape[-1], 1)
+            or rows.dtype != torch.float32
+            or rows.device != qx.device
+            or not rows.is_contiguous()
+        ):
+            raise ValueError("Expected contiguous FP32 [M, 1] row scales")
+    # Row-scale values must match the scalar; avoid a hot-path GPU readback.
+    return value

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -54,6 +54,11 @@ from sglang.srt.layers.quantization.marlin_utils_fp4 import (
 from sglang.srt.layers.quantization.marlin_utils_fp8 import (
     prepare_fp8_layer_for_marlin,
 )
+from sglang.srt.layers.quantization.modelopt_fp8_input import (
+    ModelOptFp8Input,
+    ModelOptFp8LinearInput,
+    normalize_and_validate_modelopt_fp8_input,
+)
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.quantization.utils import (
     convert_to_channelwise,
@@ -547,6 +552,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         # The SM12x facade selects the best qualified small-M FP8 kernel.
         cuda_capability = torch.cuda.get_device_capability() if is_cuda() else None
         self.use_sm120_fp8 = cuda_capability is not None and cuda_capability[0] == 12
+        self._static_fp8_sm89 = cuda_capability == (8, 9)
 
     def create_weights(
         self,
@@ -632,13 +638,50 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
             # Marlin uses FP8 weights with unquantized activations.
             del layer.input_scale
 
+    def supports_static_fp8_input(self, layer: torch.nn.Module) -> bool:
+        """Metadata/row-scale capability, not a promise of a specific GEMM.
+
+        AUTO may select a tuned Triton GEMM for a particular token count.
+        Both it and CUTLASS retain apply_fp8_linear's channelwise scale contract.
+        """
+        return (
+            self._static_fp8_sm89
+            and self.cutlass_fp8_supported
+            and not self.use_marlin
+            and not self.use_sm120_fp8
+            and not getattr(layer, "use_flashinfer_bmm", False)
+        )
+
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: ModelOptFp8LinearInput,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Applies FP8 linear transformation."""
+        """Apply FP8 linear to floating-point or prequantized activations."""
+        if isinstance(x, (ModelOptFp8Input, tuple)):
+            if not self.supports_static_fp8_input(layer):
+                raise TypeError(
+                    "Pre-quantized ModelOpt input requires the SM89 channelwise FP8 path"
+                )
+            value = normalize_and_validate_modelopt_fp8_input(x, layer)
+            return apply_fp8_linear(
+                input=value.qx,
+                weight=layer.weight,
+                weight_scale=layer.weight_scale,
+                input_scale=value.scale,
+                bias=bias,
+                cutlass_fp8_supported=self.cutlass_fp8_supported,
+                pre_quant_output_dtype=value.orig_dtype,
+                pre_quant_row_scale=value.row_scales,
+            )
+        if isinstance(x, torch.Tensor) and x.dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+        ):
+            raise TypeError(
+                "A pre-quantized activation requires scalar and dtype metadata"
+            )
         if self.use_marlin:
             return torch.ops.sglang.apply_fp8_marlin_linear(
                 input=x,

--- a/python/sglang/srt/layers/quantization/silu_fp8_fusion.py
+++ b/python/sglang/srt/layers/quantization/silu_fp8_fusion.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared producer policy for explicitly opted-in dense/shared-expert callers."""
+
+from functools import lru_cache
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.quantization.modelopt_fp8_input import ModelOptFp8Input
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_forward,
+    get_lora,
+    get_parallel,
+    get_spec,
+)
+
+
+@lru_cache(maxsize=1)
+def silu_static_fp8_supported() -> bool:
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        return False
+    if torch.cuda.get_device_capability() != (8, 9):
+        return False
+    from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
+
+    # Reuse the consumer's CUDA/architecture requirement (SM89: CUDA >= 12.4).
+    return cutlass_fp8_supported()
+
+
+def supports_silu_fp8_graph(graph) -> bool:
+    # Admission depends on the graph backend; tc_compiler alone does not imply
+    # torch.compile execution for the full/breakable runners.
+    return graph is None or all(
+        getattr(graph, phase).backend in ("disabled", "full", "breakable")
+        for phase in ("prefill", "decode")
+    )
+
+
+def make_silu_fp8_fusion(down, *, allowed: bool):
+    if not allowed or not envs.SGLANG_ENABLE_SILU_STATIC_FP8_FUSION.get():
+        return None
+    # Linear construction imports the quantization registry. Keep its concrete
+    # method imports here to avoid coupling module import to registry loading.
+    from sglang.srt.layers.linear import RowParallelLinear
+    from sglang.srt.layers.moe import get_moe_a2a_backend
+    from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp8LinearMethod
+
+    method = down.quant_method
+    parallel, execution = get_parallel(), get_exec()
+    if (
+        # Consumer/input contract: retain the validated linear wrapper and
+        # channelwise scale path. Aligned shapes also retain its AUTO choices.
+        type(down) is not RowParallelLinear
+        or type(method) is not ModelOptFp8LinearMethod
+        or not method.supports_static_fp8_input(down)
+        or method.enable_flashinfer_bmm
+        or not method.quant_config.is_checkpoint_fp8_serialized
+        or not down.input_is_parallel
+        or down.use_dp_attention_reduce
+        or down.use_decode_attn_tp
+        or down.input_size_per_partition % 16
+        or down.output_size_per_partition % 16
+        # Require the expected TP group. Mixed topologies are not yet supported
+        # by this integration.
+        or down.tp_size != parallel.tp_size
+        or parallel.dp_size != 1
+        or parallel.pp_size != 1
+        or parallel.moe_ep_size != 1
+        or parallel.attn_cp_size != 1
+        or parallel.dcp_size != 1
+        or parallel.enable_dp_attention
+        # SP g-bar requires Tensor input for contiguous() and token padding,
+        # even when it eventually calls apply; its fused path can bypass apply.
+        or parallel.enable_layernorm_sp
+        # Special execution modes are not yet supported by this integration.
+        # RL/compile can select a different activation reference implementation.
+        or get_lora().enable_lora
+        or get_spec().speculative_algorithm is not None
+        or execution.deterministic.enable_deterministic_inference
+        or execution.deterministic.rl_on_policy_target is not None
+        or execution.graph.enable_torch_compile
+        or not get_moe_a2a_backend().is_none()
+        or down.orig_dtype not in (torch.float16, torch.bfloat16)
+    ):
+        return None
+    graph = execution.graph.cuda_graph_config
+    if not supports_silu_fp8_graph(graph):
+        return None
+    if not silu_static_fp8_supported():
+        return None
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8_module,
+    )
+
+    silu_and_mul_static_fp8_module(
+        down.orig_dtype
+    )  # Compile before model forward / Graph capture.
+    return SiluFp8Fusion(down)
+
+
+class SiluFp8Fusion:
+    # Not an nn.Module: do not register the linear twice or change state_dict.
+    def __init__(self, down):
+        # Cache the producer callable to avoid imports in forward.
+        from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+            silu_and_mul_static_fp8,
+        )
+
+        self.down = down
+        self._producer = silu_and_mul_static_fp8
+
+    def __call__(self, gate_up):
+        """Return prequantized input, or None to use the unfused activation."""
+        down = self.down
+        scale = getattr(down, "input_scale", None)
+        if (
+            not isinstance(gate_up, torch.Tensor)
+            or get_forward().sp_active
+            or gate_up.ndim != 2
+            or not gate_up.is_contiguous()
+            or gate_up.storage_offset() % 8
+            or gate_up.dtype != down.orig_dtype
+            or not gate_up.is_cuda
+            or gate_up.shape[1] != 2 * down.input_size_per_partition
+            or gate_up.shape[1] == 0
+            or gate_up.shape[1] % 32
+            or gate_up.numel() > 2**32 - 1
+            or not isinstance(scale, torch.Tensor)
+            or scale.numel() != 1
+            or scale.dtype != torch.float32
+            or scale.device != gate_up.device
+            or not scale.is_contiguous()
+            or down.weight.device != gate_up.device
+            or down.weight.dtype != torch.float8_e4m3fn
+            or down.weight.shape
+            != (down.input_size_per_partition, down.output_size_per_partition)
+            or down.weight_scale.numel() != down.output_size_per_partition
+            or down.output_size_per_partition % 16
+            or down.use_flashinfer_bmm
+        ):
+            return None
+        qx, rows = self._producer(gate_up, scale)
+        return ModelOptFp8Input(qx, scale, gate_up.dtype, rows)

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -17,7 +17,7 @@
 """Inference-only Qwen2 model compatible with HuggingFace weights."""
 
 import logging
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -37,6 +37,7 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.silu_fp8_fusion import make_silu_fp8_fusion
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
@@ -68,6 +69,7 @@ class Qwen2MLP(nn.Module):
         hidden_act: str,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -89,6 +91,9 @@ class Qwen2MLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."
             )
         self.act_fn = SiluAndMul()
+        self._silu_fp8_fusion = make_silu_fp8_fusion(
+            self.down_proj, allowed=allow_silu_fp8_quant
+        )
 
     def forward(
         self,
@@ -99,7 +104,13 @@ class Qwen2MLP(nn.Module):
             x = x.bfloat16()
 
         gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
+        x = (
+            self._silu_fp8_fusion(gate_up)
+            if self._silu_fp8_fusion is not None
+            else None
+        )
+        if x is None:
+            x = self.act_fn(gate_up)
         x, _ = self.down_proj(x, forward_batch=forward_batch)
         return x
 
@@ -317,7 +328,7 @@ class Qwen2Model(nn.Module):
         config: Qwen2Config,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        decoder_layer_type: type[nn.Module] = Qwen2DecoderLayer,
+        decoder_layer_type: Callable[..., nn.Module] = Qwen2DecoderLayer,
         alt_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -73,6 +73,7 @@ from sglang.srt.layers.moe.utils import (
     uses_per_rank_fused_shared_slots,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.silu_fp8_fusion import make_silu_fp8_fusion
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
@@ -185,6 +186,7 @@ class Qwen2MoeMLP(nn.Module):
         prefix: str = "",
         tp_rank: Optional[int] = None,
         tp_size: Optional[int] = None,
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -211,6 +213,9 @@ class Qwen2MoeMLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."
             )
         self.act_fn = SiluAndMul()
+        self._silu_fp8_fusion = make_silu_fp8_fusion(
+            self.down_proj, allowed=allow_silu_fp8_quant
+        )
         # Set externally (see qwen3_5.py) when both projections are NVFP4 and
         # the FlashInfer fused SiLU+mul+FP4-quant kernel is available. The
         # fused path replaces act_fn + the down_proj input quantization with a
@@ -255,7 +260,13 @@ class Qwen2MoeMLP(nn.Module):
         if self._enable_silu_fp4_quant_fusion and not isinstance(gate_up, tuple):
             x, _ = self.down_proj(self._silu_fp4_quant_fused(gate_up))
             return x
-        x = self.act_fn(gate_up)
+        x = (
+            self._silu_fp8_fusion(gate_up)
+            if self._silu_fp8_fusion is not None
+            else None
+        )
+        if x is None:
+            x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
 
@@ -271,6 +282,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         is_nextn: bool = False,
         support_shared_expert_fusion: bool = False,
         enable_cuda_shared_expert_fusion: bool = False,
+        allow_silu_fp8_quant: bool = False,
     ):
         super().__init__()
         self.tp_size = get_parallel().tp_size
@@ -369,6 +381,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 quant_config=quant_config,
                 reduce_results=False,
                 prefix=add_prefix("shared_expert", prefix),
+                allow_silu_fp8_quant=allow_silu_fp8_quant and not is_nextn,
                 **(
                     dict(tp_rank=0, tp_size=1)
                     if (

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -1,5 +1,6 @@
 # Adapted from qwen2.py
 import logging
+from functools import partial
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
@@ -316,6 +317,7 @@ class Qwen3DecoderLayer(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -353,6 +355,7 @@ class Qwen3DecoderLayer(nn.Module):
             hidden_act=config.hidden_act,
             quant_config=quant_config,
             prefix=add_prefix("mlp", prefix),
+            allow_silu_fp8_quant=allow_silu_fp8_quant,
         )
 
         norm_kwargs = (
@@ -438,13 +441,16 @@ class Qwen3Model(Qwen2Model):
         config: Qwen3Config,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         alt_stream = get_stream("alt") if _is_cuda else None
         super().__init__(
             config=config,
             quant_config=quant_config,
             prefix=prefix,
-            decoder_layer_type=Qwen3DecoderLayer,
+            decoder_layer_type=partial(
+                Qwen3DecoderLayer, allow_silu_fp8_quant=allow_silu_fp8_quant
+            ),
             alt_stream=alt_stream,
         )
 
@@ -480,7 +486,10 @@ class Qwen3ForCausalLM(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.model = Qwen3Model(
-            config, quant_config=quant_config, prefix=add_prefix("model", prefix)
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("model", prefix),
+            allow_silu_fp8_quant=type(self) is Qwen3ForCausalLM,
         )
 
         # handle the lm head on different pp ranks

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -937,6 +937,7 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
         is_nextn: bool = False,
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
@@ -961,6 +962,7 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
                 prefix=add_prefix("mlp", prefix.replace(".linear_attn", "")),
                 is_nextn=is_nextn,
                 support_shared_expert_fusion=not _disable_shared_experts_fusion(),
+                allow_silu_fp8_quant=allow_silu_fp8_quant and not is_nextn,
             )
             is_layer_sparse = True
             is_previous_layer_sparse = True
@@ -1102,6 +1104,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
         is_nextn: bool = False,
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
@@ -1213,6 +1216,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 prefix=add_prefix("mlp", prefix.replace(".self_attn", "")),
                 is_nextn=is_nextn,
                 support_shared_expert_fusion=not _disable_shared_experts_fusion(),
+                allow_silu_fp8_quant=allow_silu_fp8_quant and not is_nextn,
             )
             is_layer_sparse = True
             is_previous_layer_sparse = True
@@ -1624,6 +1628,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         is_nextn: bool = False,
+        allow_silu_fp8_quant: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
@@ -1650,6 +1655,7 @@ class Qwen3_5ForCausalLM(nn.Module):
                 prefix=prefix,
                 alt_stream=alt_stream,
                 is_nextn=is_nextn,
+                allow_silu_fp8_quant=allow_silu_fp8_quant and not is_nextn,
             )
 
         self.layers, self._start_layer, self._end_layer = make_layers(
@@ -1966,7 +1972,12 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
-        super().__init__(config=config, quant_config=quant_config, prefix=prefix)
+        super().__init__(
+            config=config,
+            quant_config=quant_config,
+            prefix=prefix,
+            allow_silu_fp8_quant=type(self) is Qwen3_5MoeForCausalLM,
+        )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)

--- a/test/manual/quant/test_silu_and_mul_static_fp8.py
+++ b/test/manual/quant/test_silu_and_mul_static_fp8.py
@@ -1,0 +1,427 @@
+"""SM89 SiLU-and-mul + static per-tensor FP8 operator/consumer regressions.
+
+No checkpoint is required. From the repository root, with CUDA test dependencies:
+    SGLANG_TEST_REQUIRE_STATIC_FP8=1 python -m pytest -q \
+        test/manual/quant/test_silu_and_mul_static_fp8.py
+
+Unsupported hardware skips by default; require mode fails instead. Covers exact
+bytes, 441 rounding cases including direct-conversion counterexamples, streams,
+CUDA Graph replay, real GEMM consumption and row-scale storage reuse.
+"""
+
+import json
+import os
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _inspect(scales, before, intermediate, quantized, count: tl.constexpr):
+    offsets = tl.program_id(0) * 256 + tl.arange(0, 256)
+    scale = tl.load(scales + offsets, offsets < count, other=1)
+    value = 20.0 * (1.0 / scale)
+    value = tl.clamp(value, -448.0, 448.0)
+    half = value.to(tl.float16, fp_downcast_rounding="rtz").to(tl.float32)
+    q = value.to(tl.float8e4nv).to(tl.uint8, bitcast=True)
+    tl.store(before + offsets, value, offsets < count)
+    tl.store(intermediate + offsets, half, offsets < count)
+    tl.store(quantized + offsets, q, offsets < count)
+
+
+def rounding_cases():
+    levels = torch.arange(127, dtype=torch.uint8).view(torch.float8_e4m3fn).float()
+    midpoints = (levels[:-1] + levels[1:]) / 2
+    halves = midpoints.half()
+    targets = torch.stack(
+        [
+            torch.nextafter(halves, torch.full_like(halves, -float("inf"))),
+            halves,
+            torch.nextafter(halves, torch.full_like(halves, float("inf"))),
+        ],
+        dim=1,
+    ).float()
+    centers = (20.0 / targets).contiguous().view(torch.int32)
+    bits = centers[:, :, None] + torch.arange(-64, 65, dtype=torch.int32)
+    scales = bits.contiguous().view(torch.float32).cuda().flatten()
+    before = torch.empty_like(scales)
+    half = torch.empty_like(scales)
+    quantized = torch.empty_like(scales, dtype=torch.uint8)
+    compiled = _inspect[(triton.cdiv(scales.numel(), 256),)](
+        scales, before, half, quantized, scales.numel()
+    )
+    # Detect the tempting but incompatible direct FP32->FP8 replacement.
+    native = before.to(torch.float8_e4m3fn).view(torch.uint8)
+    assert torch.any(native != quantized), (
+        "Dataset must distinguish direct FP8 conversion"
+    )
+    b, h, s, q, direct = [
+        x.cpu().reshape(126, -1) for x in (before, half, scales, quantized, native)
+    ]
+    cases = []
+    for index, midpoint in enumerate(midpoints):
+        for side, mask in (
+            ("below", h[index] < midpoint),
+            ("tie", h[index] == midpoint),
+            ("above", h[index] > midpoint),
+        ):
+            candidates = torch.where(mask)[0]
+            assert candidates.numel(), (index, side)
+            distance = (b[index, candidates] - midpoint).abs()
+            chosen = candidates[distance.argmin()]
+            # The FP32 side and the post-RTZ side are deliberately separate.
+            cases.append(
+                dict(
+                    midpoint=float(midpoint),
+                    side=side,
+                    before=float(b[index, chosen]),
+                    half=float(h[index, chosen]),
+                    scale=float(s[index, chosen]),
+                    byte=int(q[index, chosen]),
+                )
+            )
+        # Nearest-to-midpoint selection can discard every double-rounding
+        # counterexample. Keep one explicitly wherever this midpoint has one.
+        different = torch.where(direct[index] != q[index])[0]
+        if different.numel():
+            chosen = different[0]
+            cases.append(
+                dict(
+                    midpoint=float(midpoint),
+                    side="direct_conversion_differs",
+                    before=float(b[index, chosen]),
+                    half=float(h[index, chosen]),
+                    scale=float(s[index, chosen]),
+                    byte=int(q[index, chosen]),
+                )
+            )
+    # Check the returned dataset, not just the search pool. CPU conversion is
+    # deliberately independent of Triton's SM89 FP16 intermediate lowering.
+    selected = torch.tensor([case["before"] for case in cases], dtype=torch.float32)
+    direct_bytes = selected.to(torch.float8_e4m3fn).view(torch.uint8)
+    reference_bytes = torch.tensor([case["byte"] for case in cases], dtype=torch.uint8)
+    assert torch.any(direct_bytes != reference_bytes), (
+        "Returned cases must distinguish direct FP32-to-FP8 conversion"
+    )
+    return cases, compiled.asm["ptx"]
+
+
+def assert_current_stream(launch, dtype, stream, trace_path):
+    # Warm up the producer before profiling. Updates, the producer, and dependent
+    # copies must execute on the same side stream.
+    x = torch.zeros(17, 512, device="cuda", dtype=dtype)
+    scale = torch.ones((), device="cuda")
+    q, rows = launch(x, scale)
+    observed_q, observed_rows = torch.empty_like(q), torch.empty_like(rows)
+    torch.cuda.synchronize()
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ]
+    ) as profiler:
+        with torch.cuda.stream(stream):
+            x.fill_(2)
+            scale.fill_(0.02)
+            q, rows = launch(x, scale)
+            observed_q.copy_(q)
+            observed_rows.copy_(rows)
+        torch.cuda.synchronize()
+    profiler.export_chrome_trace(str(trace_path))
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    kernels = [e for e in events if e.get("cat") == "kernel"]
+    fused = [e for e in kernels if "silu_and_mul_static_fp8_kernel" in e["name"]]
+    assert len(fused) == 1, "Trace must contain the real fused producer"
+    assert len(kernels) >= 3, "Trace must include updates and producer"
+    streams = {e["args"]["stream"] for e in kernels}
+    assert len(streams) == 1, f"Current-stream violation: GPU kernels used {streams}"
+    expected_q, expected_rows = launch(x, scale)
+    assert torch.equal(observed_q.view(torch.uint8), expected_q.view(torch.uint8))
+    assert torch.equal(observed_rows, expected_rows)
+
+
+@contextmanager
+def observe_gemm():
+    from sglang.srt.layers.quantization import fp8_utils
+
+    calls = []
+
+    def wrap(name, original):
+        def call(*args, **kwargs):
+            calls.append(
+                dict(
+                    backend=name,
+                    input_shape=list(args[0].shape),
+                    a_scale_ptr=args[2].data_ptr(),
+                    options={k: str(v) for k, v in kwargs.items()},
+                )
+            )
+            return original(*args, **kwargs)
+
+        return call
+
+    with ExitStack() as stack:
+        for name in ("fp8_scaled_mm", "triton_scaled_mm"):
+            stack.enter_context(
+                patch.object(fp8_utils, name, wrap(name, getattr(fp8_utils, name)))
+            )
+        yield calls
+
+
+def assert_row_reuse(call, rows):
+    assert call["a_scale_ptr"] == rows.data_ptr(), "row scales were not reused by GEMM"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qualified_environment():
+    from sglang.srt.layers.quantization.silu_fp8_fusion import (
+        silu_static_fp8_supported,
+    )
+
+    supported = torch.cuda.is_available()
+    if supported:
+        supported = torch.cuda.get_device_capability() == (8, 9)
+    supported = supported and silu_static_fp8_supported()
+    if not supported:
+        if os.environ.get("SGLANG_TEST_REQUIRE_STATIC_FP8") == "1":
+            pytest.fail("This run requires the qualified SM89 environment")
+        pytest.skip("Requires the qualified SM89 static-FP8 environment")
+
+
+def check(x, scale):
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8,
+    )
+    from sglang.srt.layers.activation import silu_and_mul
+    from sglang.srt.layers.quantization.fp8_utils import static_quant_fp8
+
+    before = x.clone()
+    q, rows = silu_and_mul_static_fp8(x, scale)
+    assert q.shape == (x.shape[0], x.shape[1] // 2)
+    assert q.dtype == torch.float8_e4m3fn
+    assert rows.shape == (x.shape[0], 1)
+    if x.shape[0]:
+        expected, scales = static_quant_fp8(silu_and_mul(x), scale, repeat_scale=True)
+        assert torch.equal(q.view(torch.uint8), expected.view(torch.uint8))
+        assert torch.equal(rows, scales)
+    assert torch.equal(x.view(torch.uint8), before.view(torch.uint8))
+    return q, rows
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", [(0, 16), (1, 24), (3, 256), (129, 512), (17, 12288)])
+@pytest.mark.parametrize("scalar", [0.0001, 0.02, 0.0287388414144516, 1.0])
+def test_byte_exact(dtype, shape, scalar):
+    m, k = shape
+    generator = torch.Generator(device="cuda").manual_seed(9271)
+    x = torch.randn(m, 2 * k, dtype=dtype, device="cuda", generator=generator) * 5
+    check(x, torch.tensor(scalar, device="cuda", dtype=torch.float32))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_rounding_midpoints_and_special_values(dtype, tmp_path):
+
+    cases, ptx = rounding_cases()
+    (tmp_path / "rounding-cases.json").write_text(json.dumps(cases, indent=2))
+    (tmp_path / "rounding-diagnostic.ptx").write_text(ptx)
+    for sign in (-1, 1):
+        x = torch.cat(
+            (
+                torch.full((1, 16), 20.0, device="cuda", dtype=dtype),
+                torch.full((1, 16), float(sign), device="cuda", dtype=dtype),
+            ),
+            dim=1,
+        )
+        for case in cases:
+            q, _ = check(
+                x, torch.tensor(case["scale"], device="cuda", dtype=torch.float32)
+            )
+            # The diagnostic must also predict the actual unfused/fused bytes.
+            expected = case["byte"] if sign > 0 else case["byte"] ^ 128
+            assert torch.all(q.view(torch.uint8) == expected), case
+    edge = torch.tensor(
+        [0.0, -0.0, float("inf"), -float("inf"), float("nan"), 1e-7, -1e-7, 1000.0],
+        device="cuda",
+        dtype=dtype,
+    )
+    check(edge.repeat(64).view(1, 512), torch.tensor(0.02, device="cuda"))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_graph_replay_updates_input_and_scale(dtype):
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8,
+    )
+
+    x = torch.randn(17, 512, dtype=dtype, device="cuda")
+    scale = torch.tensor(0.02, device="cuda")
+    check(x, scale)
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        silu_and_mul_static_fp8(x, scale)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        q, rows = silu_and_mul_static_fp8(x, scale)
+    for scalar in (0.01, 0.04):
+        x.mul_(0.75)
+        scale.fill_(scalar)
+        graph.replay()
+        torch.cuda.synchronize()
+        expected, erows = check(x, scale)
+        assert torch.equal(q.view(torch.uint8), expected.view(torch.uint8))
+        assert torch.equal(rows, erows)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_independent_streams_and_opcheck(dtype, tmp_path):
+
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8,
+    )
+
+    for index in range(2):
+        assert_current_stream(
+            silu_and_mul_static_fp8,
+            dtype,
+            torch.cuda.Stream(),
+            tmp_path / f"stream-{index}.json",
+        )
+
+    def wrong_stream(x, scale):
+        with torch.cuda.stream(torch.cuda.default_stream()):
+            return silu_and_mul_static_fp8(x, scale)
+
+    # The assertion must catch an actual wrong-stream launch even if its
+    # values happen to be correct. No random race or sleep is required.
+    with pytest.raises(AssertionError, match="Current-stream violation"):
+        assert_current_stream(
+            wrong_stream, dtype, torch.cuda.Stream(), tmp_path / "wrong-stream.json"
+        )
+    x = torch.randn(7, 512, device="cuda", dtype=dtype)
+    scale = torch.tensor(0.02, device="cuda")
+    q = torch.empty(7, 256, device="cuda", dtype=torch.uint8)
+    rows = torch.empty(7, 1, device="cuda")
+    result = torch.library.opcheck(
+        torch.ops.sglang.silu_and_mul_static_fp8_out.default, (x, scale, q, rows)
+    )
+    assert all(value == "SUCCESS" for value in result.values())
+
+
+def test_invalid_and_unaligned_inputs():
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8,
+        silu_and_mul_static_fp8_module,
+    )
+
+    scale = torch.tensor(0.02, device="cuda")
+    x = torch.randn(2, 32, device="cuda", dtype=torch.bfloat16)
+    unaligned = torch.empty(65, device="cuda", dtype=x.dtype)[1:].view(2, 32)
+    assert unaligned.is_contiguous()
+    for invalid in (unaligned, x[:, ::2], x.float(), x.cpu(), x.view(64), x[:, :0]):
+        with pytest.raises(ValueError):
+            silu_and_mul_static_fp8(invalid, scale)
+    with pytest.raises(ValueError):
+        silu_and_mul_static_fp8(x, scale.double())
+    # The raw entry point must reject misalignment before launching a kernel.
+    q = torch.empty(2, 16, device="cuda", dtype=torch.uint8)
+    rows = torch.empty(2, 1, device="cuda")
+    with pytest.raises(Exception, match="16-byte aligned"):
+        silu_and_mul_static_fp8_module(x.dtype).run(
+            unaligned, q, scale.reshape(1), rows
+        )
+    bad_q = torch.empty(33, device="cuda", dtype=torch.uint8)[1:].view(2, 16)
+    with pytest.raises(Exception, match="8-byte aligned"):
+        silu_and_mul_static_fp8_module(x.dtype).run(x, bad_q, scale.reshape(1), rows)
+    check(x, scale)  # CUDA context remains healthy after rejected inputs.
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("m", [1, 7, 129])
+@pytest.mark.parametrize("backend", ["auto", "cutlass", "triton"])
+def test_real_modelopt_consumer_and_legacy_contract(
+    dtype, m, backend, tmp_path, monkeypatch
+):
+
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.activation import silu_and_mul
+    from sglang.srt.layers.quantization import fp8_utils
+    from sglang.srt.layers.quantization.modelopt_fp8_input import ModelOptFp8Input
+    from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp8LinearMethod
+
+    # Construct only the state consumed by apply; no fake GEMM or checkpoint.
+    method = object.__new__(ModelOptFp8LinearMethod)
+    method._static_fp8_sm89 = True
+    method.use_marlin = False
+    method.use_sm120_fp8 = False
+    method.cutlass_fp8_supported = True
+    if backend != "auto":
+        monkeypatch.setattr(
+            fp8_utils, "use_triton_w8a8_fp8_kernel", backend == "triton"
+        )
+        monkeypatch.setenv("SGLANG_ENABLE_FP8_GEMM_CONFIG_TUNE", "0")
+        assert not envs.SGLANG_ENABLE_FP8_GEMM_CONFIG_TUNE.get()
+    weight = (
+        torch.randn(64, 256, device="cuda", dtype=dtype).to(torch.float8_e4m3fn).t()
+    )
+    scale = torch.tensor(0.02, device="cuda")
+    layer = SimpleNamespace(
+        weight=weight,
+        input_scale=scale,
+        orig_dtype=dtype,
+        weight_scale=torch.full((64, 1), 0.01, device="cuda"),
+        use_flashinfer_bmm=False,
+    )
+    x = torch.randn(m, 512, device="cuda", dtype=dtype)
+    activated = silu_and_mul(x)
+    with observe_gemm() as baseline_calls:
+        expected = method.apply(layer, activated)
+    assert len(baseline_calls) == 1
+    if backend != "auto":
+        assert baseline_calls[0]["backend"] == (
+            "fp8_scaled_mm" if backend == "cutlass" else "triton_scaled_mm"
+        )
+    q, rows = check(x, scale)
+    value = ModelOptFp8Input(q, scale, dtype, rows)
+    with (
+        observe_gemm() as calls,
+        patch(
+            "sglang.srt.layers.quantization.fp8_utils.static_quant_fp8",
+            side_effect=AssertionError("pre-quantized input was quantized again"),
+        ),
+    ):
+        for payload in (value, (q, scale), (q, scale, dtype)):
+            assert torch.equal(method.apply(layer, payload), expected)
+            assert calls[-1]["backend"] == baseline_calls[0]["backend"]
+            assert calls[-1]["options"] == baseline_calls[0]["options"]
+            if payload is value:
+                assert_row_reuse(calls[-1], rows)
+        # Dropping row scales preserves numerical results but must fail the
+        # storage-reuse assertion for the fused producer.
+        assert torch.equal(
+            method.apply(layer, ModelOptFp8Input(q, scale, dtype)), expected
+        )
+        with pytest.raises(AssertionError, match="row scales were not reused"):
+            assert_row_reuse(calls[-1], rows)
+    (tmp_path / "gemm-calls.json").write_text(
+        json.dumps(dict(baseline=baseline_calls, candidate=calls), indent=2)
+    )
+    for bad in (
+        q,
+        (q,),
+        (q, scale.clone()),
+        (q, scale, torch.float32),
+        ModelOptFp8Input(q[:, :0], scale, dtype, rows),
+        ModelOptFp8Input(q, scale, dtype, rows.flatten()),
+    ):
+        with pytest.raises((ValueError, TypeError)):
+            method.apply(layer, bad)
+    with patch.object(method, "_static_fp8_sm89", False):
+        with pytest.raises(TypeError, match="SM89"):
+            method.apply(layer, value)

--- a/test/manual/quant/test_silu_fp8_fusion_integration.py
+++ b/test/manual/quant/test_silu_fp8_fusion_integration.py
@@ -1,0 +1,712 @@
+"""Checkpoint-backed tests of the ModelOpt static-FP8 model entry points.
+
+Set SGLANG_TEST_STATIC_FP8_MODEL to a local Qwen3-8B-FP8 checkpoint and select
+free devices through CUDA_VISIBLE_DEVICES. From the repository root:
+    SGLANG_TEST_STATIC_FP8_TP=1 SGLANG_TEST_REQUIRE_STATIC_FP8=1 python -m pytest -q -s \
+        test/manual/quant/test_silu_fp8_fusion_integration.py
+
+Repeat TP2/4 with sufficient GPUs; select "not breakable_inductor_field" there.
+Missing checkpoint/hardware skips unless require mode is set. TP count is not a
+runtime allowlist. Tests compare off/on tokens and selected/top-5 logprobs, and
+associate fused kernels with Graph launches per rank. Worker factories below are
+importable top-level functions, not separate pytest tests. Synthetic shared MLP
+checks need the initialized worker and are not MoE checkpoint quality evidence.
+"""
+
+import json
+import os
+import traceback
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+
+
+def run_module_checks(real_mlp, target: Path):
+    from sglang.kernels.ops.quantization.silu_and_mul_static_fp8 import (
+        silu_and_mul_static_fp8,
+    )
+    from sglang.srt.distributed.parallel_state import graph_capture
+    from sglang.srt.layers.quantization.fp8_utils import static_quant_fp8
+    from sglang.srt.layers.quantization.modelopt_fp8_input import ModelOptFp8Input
+    from sglang.srt.layers.quantization.silu_fp8_fusion import make_silu_fp8_fusion
+    from sglang.srt.models.qwen2 import Qwen2MLP
+    from sglang.srt.models.qwen2_moe import Qwen2MoeMLP
+    from sglang.srt.runtime_context import get_parallel
+
+    rank = torch.distributed.get_rank()
+    tp = get_parallel().tp_size
+    result = dict(
+        status="running",
+        tp=tp,
+        synthetic_weights=True,
+        cases=[],
+        producer_byte_checks=0,
+        legacy_contract_checks=0,
+        negative_checks=0,
+        graph_checks=0,
+    )
+
+    def save():
+        if rank == 0:
+            (target / "module-tests.json").write_text(json.dumps(result, indent=2))
+
+    def expect_error(fn):
+        try:
+            fn()
+        except (ValueError, TypeError):
+            result["negative_checks"] += 1
+        else:
+            raise AssertionError("invalid payload was accepted")
+
+    original_dtype = torch.get_default_dtype()
+    try:
+        with (
+            torch.inference_mode(),
+            torch.random.fork_rng(devices=[torch.cuda.current_device()]),
+            torch.device("cuda"),
+        ):
+            torch.manual_seed(9271)
+            for dtype in (torch.bfloat16, torch.float16):
+                torch.set_default_dtype(dtype)
+                for cls, width in [
+                    (Qwen2MoeMLP, 256),
+                    (Qwen2MoeMLP, 512),
+                    (Qwen2MoeMLP, 1024),
+                    (Qwen2MLP, 12288),
+                ]:
+                    kwargs = dict(
+                        hidden_size=4096,
+                        intermediate_size=width * tp,
+                        hidden_act="silu",
+                        quant_config=real_mlp.down_proj.quant_method.quant_config,
+                        prefix="validation.mlp",
+                        allow_silu_fp8_quant=True,
+                    )
+                    if cls is Qwen2MoeMLP:
+                        kwargs["reduce_results"] = False
+                    mlp = cls(**kwargs)
+                    for linear in (mlp.gate_up_proj, mlp.down_proj):
+                        linear.weight.copy_(
+                            torch.randn(linear.weight.shape, dtype=dtype).to(
+                                torch.float8_e4m3fn
+                            )
+                        )
+                        linear.weight_scale.fill_(0.01)
+                        linear.input_scale.fill_(0.02)
+                        linear.quant_method.process_weights_after_loading(linear)
+                    down, fusion = mlp.down_proj, mlp._silu_fp8_fusion
+                    assert fusion is not None
+                    assert make_silu_fp8_fusion(down, allowed=False) is None
+                    result["negative_checks"] += 1
+                    for m in (1, 7, 16, 129, 512, 2048):
+                        x = torch.randn(m, 4096, dtype=dtype)
+                        gate, _ = mlp.gate_up_proj(x)
+                        activated = mlp.act_fn(gate)
+                        qref, _ = static_quant_fp8(
+                            activated, down.input_scale, repeat_scale=True
+                        )
+                        value = fusion(gate)
+                        assert isinstance(value, ModelOptFp8Input)
+                        assert (
+                            value.scale is down.input_scale
+                            and value.orig_dtype == dtype
+                        )
+                        assert torch.equal(
+                            value.qx.view(torch.uint8), qref.view(torch.uint8)
+                        )
+                        assert torch.equal(
+                            value.row_scales, down.input_scale.expand(m, 1)
+                        )
+                        result["producer_byte_checks"] += 1
+                        expected_down = down.quant_method.apply(down, activated)
+                        # Patches are assertions against accidental second quantization,
+                        # not alternate implementations of the consumer.
+                        with patch(
+                            "sglang.srt.layers.quantization.fp8_utils.static_quant_fp8",
+                            side_effect=AssertionError("double quantization"),
+                        ):
+                            for payload in (
+                                value,
+                                (value.qx, value.scale),
+                                (value.qx, value.scale, dtype),
+                            ):
+                                actual_down = down.quant_method.apply(down, payload)
+                                assert torch.equal(actual_down, expected_down)
+                                result["legacy_contract_checks"] += 1
+                        mlp._silu_fp8_fusion = None
+                        expected = mlp(x)
+                        mlp._silu_fp8_fusion = fusion
+                        actual = mlp(x)
+                        assert torch.equal(actual, expected), (
+                            cls.__name__,
+                            dtype,
+                            m,
+                            width,
+                        )
+                        assert torch.isfinite(actual).all()
+                        if m in (1, 129, 2048):
+                            stream = torch.cuda.Stream()
+                            stream.wait_stream(torch.cuda.current_stream())
+                            with torch.cuda.stream(stream):
+                                mlp(x)
+                            torch.cuda.current_stream().wait_stream(stream)
+                            graph = torch.cuda.CUDAGraph()
+                            # SGLang must register graph collective buffers and
+                            # enter its graph communicator modes for TP>1.
+                            with graph_capture(stream=stream):
+                                with torch.cuda.graph(graph, stream=stream):
+                                    captured = mlp(x)
+                            for _ in range(2):
+                                x.copy_(torch.randn_like(x))
+                                down.input_scale.mul_(1.0625)
+                                mlp._silu_fp8_fusion = None
+                                expected = mlp(x)
+                                mlp._silu_fp8_fusion = fusion
+                                graph.replay()
+                                torch.cuda.synchronize()
+                                assert torch.equal(captured, expected)
+                                result["graph_checks"] += 1
+                            del graph, captured
+                        result["cases"].append(
+                            dict(cls=cls.__name__, dtype=str(dtype), m=m, local_k=width)
+                        )
+                        save()
+                    expect_error(lambda: down.quant_method.apply(down, value.qx))
+                    expect_error(
+                        lambda: down.quant_method.apply(
+                            down, (value.qx, value.scale.clone())
+                        )
+                    )
+                    expect_error(
+                        lambda: down.quant_method.apply(
+                            down, (value.qx, value.scale, torch.float32)
+                        )
+                    )
+                    expect_error(lambda: down.quant_method.apply(down, (value.qx,)))
+                    expect_error(
+                        lambda: down.quant_method.apply(
+                            down,
+                            ModelOptFp8Input(
+                                value.qx,
+                                value.scale,
+                                dtype,
+                                torch.empty(1, device="cuda"),
+                            ),
+                        )
+                    )
+                    assert fusion(gate[:, ::2]) is None
+                    result["negative_checks"] += 1
+                    unaligned = torch.empty(gate.numel() + 1, dtype=dtype)[1:].view_as(
+                        gate
+                    )
+                    assert unaligned.is_contiguous()
+                    assert fusion(unaligned) is None
+                    result["negative_checks"] += 1
+                    # Actual same-class caller without explicit permission stays off.
+                    kwargs["allow_silu_fp8_quant"] = False
+                    unauthorized = cls(**kwargs)
+                    assert unauthorized._silu_fp8_fusion is None
+                    result["negative_checks"] += 1
+                    del unauthorized, mlp, fusion
+                q, rows = silu_and_mul_static_fp8(
+                    torch.empty(0, 32, dtype=dtype), torch.ones(1, dtype=torch.float32)
+                )
+                assert q.shape == (0, 16) and rows.shape == (0, 1)
+        result["status"] = "passed"
+        print(
+            "PRODUCTION_MODULE_TESTS_PASSED", tp, rank, len(result["cases"]), flush=True
+        )
+    except BaseException:
+        result["status"] = "failed"
+        result["error"] = traceback.format_exc()
+        raise
+    finally:
+        torch.set_default_dtype(original_dtype)
+        save()
+
+
+def run_boundary_checks(target):
+    from sglang.srt.configs.qwen3_5 import Qwen3_5MoeTextConfig, Qwen3_5TextConfig
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp8Config
+    from sglang.srt.layers.quantization.silu_fp8_fusion import (
+        make_silu_fp8_fusion,
+        silu_static_fp8_supported,
+    )
+    from sglang.srt.models.qwen2_moe import Qwen2MoeSparseMoeBlock
+    from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5MoeForCausalLM
+    from sglang.srt.runtime_context import get_exec, get_lora, get_parallel, get_spec
+
+    result = dict(status="running", synthetic=True, checks=[])
+    dtype = torch.get_default_dtype()
+    try:
+        with torch.inference_mode(), torch.device("cuda"):
+            torch.set_default_dtype(torch.bfloat16)
+            kw = dict(
+                vocab_size=128,
+                hidden_size=512,
+                intermediate_size=1024,
+                num_hidden_layers=2,
+                num_attention_heads=8,
+                num_key_value_heads=4,
+                head_dim=64,
+                linear_key_head_dim=32,
+                linear_value_head_dim=32,
+                linear_num_key_heads=4,
+                linear_num_value_heads=8,
+                full_attention_interval=2,
+                moe_intermediate_size=512,
+                shared_expert_intermediate_size=256,
+                num_experts=8,
+                num_experts_per_tok=2,
+                rope_parameters=dict(rope_type="default", rope_theta=10000000.0),
+            )
+            quant = ModelOptFp8Config(
+                is_checkpoint_fp8_serialized=True, packed_modules_mapping={}
+            )
+            config = Qwen3_5MoeTextConfig(**kw)
+            model = Qwen3_5MoeForCausalLM(config, quant, prefix="boundary")
+            assert len(model.layers) == 2
+            for layer in model.layers:
+                shared = layer.mlp.shared_expert
+                assert shared is not None and shared._silu_fp8_fusion is not None
+                assert not layer.mlp.enable_shared_expert_fusion
+                for linear in (shared.gate_up_proj, shared.down_proj):
+                    linear.weight.copy_(
+                        torch.randn_like(linear.weight, dtype=torch.bfloat16).to(
+                            torch.float8_e4m3fn
+                        )
+                    )
+                    linear.weight_scale.fill_(0.01)
+                    linear.input_scale.fill_(0.02)
+                    linear.quant_method.process_weights_after_loading(linear)
+                x = torch.randn(129, 512, dtype=torch.bfloat16)
+                fusion = shared._silu_fp8_fusion
+                shared._silu_fp8_fusion = None
+                expected = shared(x)
+                shared._silu_fp8_fusion = fusion
+                actual = shared(x)
+                assert torch.equal(expected, actual)
+                result["checks"].append(
+                    type(layer).__name__ + ": actual standalone shared forward exact"
+                )
+            down = model.layers[0].mlp.shared_expert.down_proj
+            # Policy-only test: no TP8 process group or collective is executed.
+            # A larger TP value alone must not reject otherwise valid local data.
+            with get_parallel().override(tp_size=8), patch.object(down, "tp_size", 8):
+                assert make_silu_fp8_fusion(down, allowed=True) is not None
+                with patch.object(down, "input_size_per_partition", 17):
+                    assert make_silu_fp8_fusion(down, allowed=True) is None
+            result["checks"].append(
+                "TP count is not a policy allowlist; local alignment remains required"
+            )
+            for bag, change in (
+                # ParallelContext.override accepts topology fields only;
+                # these two flags are leaves of its published config bag.
+                (get_parallel()._config, dict(enable_layernorm_sp=True)),
+                (get_parallel()._config, dict(enable_dp_attention=True)),
+                (get_lora(), dict(enable_lora=True)),
+                (get_spec(), dict(speculative_algorithm="EAGLE")),
+                (get_exec().deterministic, dict(enable_deterministic_inference=True)),
+                (get_exec().graph, dict(enable_torch_compile=True)),
+            ):
+                with bag.override(**change):
+                    assert make_silu_fp8_fusion(down, allowed=True) is None
+                result["checks"].append("config fallback: " + next(iter(change)))
+            for obj, field, value in (
+                (down.quant_method, "use_marlin", True),
+                (down.quant_method, "_static_fp8_sm89", False),
+                (down.quant_method, "enable_flashinfer_bmm", True),
+                (down, "input_is_parallel", False),
+                (down, "use_decode_attn_tp", True),
+            ):
+                with patch.object(obj, field, value):
+                    assert make_silu_fp8_fusion(down, allowed=True) is None
+                result["checks"].append("metadata fallback: " + field)
+            with envs.SGLANG_ENABLE_SILU_STATIC_FP8_FUSION.override(False):
+                assert make_silu_fp8_fusion(down, allowed=True) is None
+            result["checks"].append("global off")
+            # Capability is checked at initialization, once; no compiler-version
+            # whitelist or compiler mutation is involved in this fallback test.
+            silu_static_fp8_supported.cache_clear()
+            with patch(
+                "sglang.srt.layers.quantization.fp8_utils.cutlass_fp8_supported",
+                return_value=False,
+            ):
+                assert not silu_static_fp8_supported()
+                assert make_silu_fp8_fusion(down, allowed=True) is None
+            silu_static_fp8_supported.cache_clear()
+            assert silu_static_fp8_supported()
+            result["checks"].append("unsupported consumer capability fallback")
+            del model
+
+            class UnapprovedSubclass(Qwen3_5MoeForCausalLM):
+                pass
+
+            for name, cls, cfg, extras in (
+                ("generic base with MoE config", Qwen3_5ForCausalLM, config, {}),
+                ("unapproved subclass", UnapprovedSubclass, config, {}),
+                (
+                    "nextn",
+                    Qwen3_5ForCausalLM,
+                    config,
+                    dict(is_nextn=True, allow_silu_fp8_quant=True),
+                ),
+                ("Qwen3.5 dense", Qwen3_5ForCausalLM, Qwen3_5TextConfig(**kw), {}),
+            ):
+                model = cls(cfg, quant, prefix="boundary.negative", **extras)
+                for layer in model.layers:
+                    mlp = getattr(layer.mlp, "shared_expert", layer.mlp)
+                    assert mlp._silu_fp8_fusion is None
+                result["checks"].append(name + ": no implicit authorization")
+                del model
+            already_fused = Qwen2MoeSparseMoeBlock(
+                0,
+                Qwen3_5MoeTextConfig(**dict(kw, shared_expert_intermediate_size=512)),
+                quant,
+                prefix="boundary.fused",
+                support_shared_expert_fusion=True,
+                enable_cuda_shared_expert_fusion=True,
+                allow_silu_fp8_quant=True,
+            )
+            assert (
+                already_fused.enable_shared_expert_fusion
+                and already_fused.shared_expert is None
+            )
+            result["checks"].append("already routed-fused shared expert remains absent")
+        result["status"] = "passed"
+        print("PRODUCTION_BOUNDARIES_PASSED", len(result["checks"]), flush=True)
+    except BaseException:
+        result["status"] = "failed"
+        result["error"] = traceback.format_exc()
+        raise
+    finally:
+        torch.set_default_dtype(dtype)
+        (target / "boundary-tests.json").write_text(json.dumps(result, indent=2))
+
+
+def make_boundary_hook(config):
+    # Factories execute during initialized worker setup, outside forward.
+    # Constructor-only decisions must never be tested inside a forward hook.
+    run_boundary_checks(Path(config["target"]))
+    return None
+
+
+def make_mlp_hook(config):
+    done = False
+    target = Path(config["target"])
+
+    def hook(module, args, output):
+        nonlocal done
+        if done or torch.cuda.is_current_stream_capturing():
+            return
+        done = True
+        if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
+            # Module TP tests run on all ranks; only rank zero writes evidence.
+            if config["module_tests"]:
+                run_module_checks(module, target)
+            return
+        record = dict(
+            fusion_present=module._silu_fp8_fusion is not None,
+            module_type=type(module).__name__,
+            consumer_type=type(module.down_proj.quant_method).__name__,
+        )
+        (target / "entrypoint.json").write_text(json.dumps(record, indent=2))
+        assert record["fusion_present"] == (config["flag"] == "1"), record
+        if config["module_tests"]:
+            run_module_checks(module, target)
+
+    return hook
+
+
+def make_consumer_hook(config):
+    done = False
+
+    def hook(module, args, output):
+        nonlocal done
+        if done or torch.cuda.is_current_stream_capturing():
+            return
+        done = True
+        from sglang.srt.layers.quantization.modelopt_fp8_input import ModelOptFp8Input
+
+        value = args[0]
+        prequantized = isinstance(value, ModelOptFp8Input)
+        assert prequantized == (config["flag"] == "1")
+        if prequantized:
+            assert value.scale is module.input_scale
+            assert value.orig_dtype == output[0].dtype == module.orig_dtype
+        record = dict(
+            prequantized=prequantized,
+            input_type=type(value).__name__,
+            output_dtype=str(output[0].dtype),
+        )
+        if torch.distributed.get_rank() == 0:
+            (Path(config["target"]) / "consumer.json").write_text(
+                json.dumps(record, indent=2)
+            )
+
+    return hook
+
+
+def assert_fusion_graph_replay(events, enabled):
+    fused = [
+        e
+        for e in events
+        if e.get("cat") == "kernel"
+        and "silu_and_mul_static_fp8_kernel" in e.get("name", "")
+    ]
+    launches = [
+        e
+        for e in events
+        if e.get("cat") == "cuda_runtime" and "cudaGraphLaunch" in e.get("name", "")
+    ]
+    correlations = {
+        e["args"]["correlation"]
+        for e in launches
+        if e.get("args", {}).get("correlation") is not None
+    }
+    assert bool(fused) == enabled
+    assert launches, "No actual CUDA Graph replay observed"
+    for event in fused:
+        args = event.get("args", {})
+        assert args.get("graph id", 0) > 0, "Fused kernel is not in a CUDA Graph"
+        assert args.get("correlation") in correlations, (
+            "Fused kernel is not associated with a CUDA Graph launch"
+        )
+    return dict(fused=len(fused), graph_launches=len(launches), graph_fused=len(fused))
+
+
+@pytest.mark.parametrize("graph_id,correlation", [(0, 7), (5, 8), (5, None)])
+def test_reject_unassociated_fusion(graph_id, correlation):
+    events = [
+        dict(cat="cuda_runtime", name="cudaGraphLaunch", args=dict(correlation=7)),
+        dict(
+            cat="kernel",
+            name="silu_and_mul_static_fp8_kernel",
+            args={"graph id": graph_id, "correlation": correlation},
+        ),
+    ]
+    with pytest.raises(AssertionError, match="Fused kernel"):
+        assert_fusion_graph_replay(events, True)
+
+
+def test_accept_associated_fusion():
+    events = [
+        dict(cat="cuda_runtime", name="cudaGraphLaunch", args=dict(correlation=7)),
+        dict(
+            cat="kernel",
+            name="silu_and_mul_static_fp8_kernel",
+            args={"graph id": 5, "correlation": 7},
+        ),
+    ]
+    assert assert_fusion_graph_replay(events, True)["graph_fused"] == 1
+    assert assert_fusion_graph_replay(events[:1], False)["graph_fused"] == 0
+
+
+@pytest.fixture(scope="module")
+def model_path():
+    from sglang.srt.layers.quantization.silu_fp8_fusion import (
+        silu_static_fp8_supported,
+    )
+
+    model = os.environ.get("SGLANG_TEST_STATIC_FP8_MODEL")
+    if not model or not Path(model).is_dir():
+        if os.environ.get("SGLANG_TEST_REQUIRE_STATIC_FP8") == "1":
+            pytest.fail("A local SGLANG_TEST_STATIC_FP8_MODEL checkpoint is required")
+        pytest.skip(
+            "Set SGLANG_TEST_STATIC_FP8_MODEL to a local Qwen3-8B-FP8 checkpoint"
+        )
+    if (
+        not torch.cuda.is_available()
+        or torch.cuda.get_device_capability() != (8, 9)
+        or not silu_static_fp8_supported()
+    ):
+        if os.environ.get("SGLANG_TEST_REQUIRE_STATIC_FP8") == "1":
+            pytest.fail("This run requires the qualified SM89 environment")
+        pytest.skip("Requires the qualified SM89 environment")
+    return model
+
+
+def require_visible_gpus(tp):
+    if torch.cuda.device_count() < tp:
+        if os.environ.get("SGLANG_TEST_REQUIRE_STATIC_FP8") == "1":
+            pytest.fail(f"Requires {tp} visible GPUs")
+        pytest.skip(f"Requires {tp} visible GPUs")
+
+
+@pytest.mark.parametrize("required", ["0", "1"])
+def test_insufficient_gpu_contract(monkeypatch, required):
+    monkeypatch.setenv("SGLANG_TEST_REQUIRE_STATIC_FP8", required)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+    outcome = pytest.fail.Exception if required == "1" else pytest.skip.Exception
+    with pytest.raises(outcome, match="Requires 2 visible GPUs"):
+        require_visible_gpus(2)
+
+
+@pytest.mark.parametrize("mode", ["eager", "default_graph", "breakable_inductor_field"])
+def test_delivered_entrypoint(model_path, tmp_path, monkeypatch, mode):
+    import gzip
+
+    from transformers import AutoTokenizer
+
+    import sglang
+
+    tp = int(os.environ.get("SGLANG_TEST_STATIC_FP8_TP", "1"))
+    assert tp > 0, "SGLANG_TEST_STATIC_FP8_TP must be positive"
+    require_visible_gpus(tp)
+    helpers = str(Path(__file__).parent.resolve())
+    monkeypatch.setenv(
+        "PYTHONPATH", helpers + os.pathsep + os.environ.get("PYTHONPATH", "")
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_path, local_files_only=True)
+    inputs = []
+    for length in (128, 2048):
+        for index in range(4):
+            seed = tokenizer.encode(
+                f"Example {index}: Explain why addition and multiplication are useful. ",
+                add_special_tokens=False,
+            )
+            inputs.append((seed * (length // len(seed) + 1))[:length])
+    (tmp_path / "inputs.json").write_text(json.dumps(inputs))
+    results = {}
+    for flag in ("0", "1"):
+        monkeypatch.setenv("SGLANG_ENABLE_SILU_STATIC_FP8_FUSION", flag)
+        target = tmp_path / ("off" if flag == "0" else "on")
+        target.mkdir()
+        hooks = []
+        if mode == "eager":
+            hooks = [
+                dict(
+                    name="modules",
+                    target_modules=["model.layers.0.mlp"],
+                    hook_factory="test_silu_fp8_fusion_integration:make_mlp_hook",
+                    config=dict(
+                        target=str(target), flag=flag, module_tests=flag == "1"
+                    ),
+                ),
+                dict(
+                    name="consumer",
+                    target_modules=["model.layers.0.mlp.down_proj"],
+                    hook_factory="test_silu_fp8_fusion_integration:make_consumer_hook",
+                    config=dict(target=str(target), flag=flag),
+                ),
+            ]
+            if flag == "1" and tp == 1:
+                hooks.insert(
+                    0,
+                    dict(
+                        name="boundaries",
+                        target_modules=["model.layers.0.mlp"],
+                        hook_factory="test_silu_fp8_fusion_integration:make_boundary_hook",
+                        config=dict(target=str(target)),
+                    ),
+                )
+        engine = None
+        outputs = []
+        try:
+            engine = sglang.Engine(
+                model_path=model_path,
+                tp_size=tp,
+                dtype="bfloat16",
+                kv_cache_dtype="bfloat16",
+                random_seed=9271,
+                context_length=4096,
+                max_running_requests=8,
+                max_total_tokens=8192,
+                mem_fraction_static=0.6,
+                chunked_prefill_size=2048,
+                disable_radix_cache=True,
+                disable_cuda_graph=mode == "eager",
+                cuda_graph_max_bs_decode=4,
+                log_level="warning",
+                forward_hooks=hooks,
+                **(
+                    {"cuda_graph_tc_compiler": "inductor"}
+                    if mode == "breakable_inductor_field"
+                    else {}
+                ),
+            )
+            for ids in inputs:
+                repeats = []
+                for _ in range(2):
+                    response = engine.generate(
+                        input_ids=ids,
+                        sampling_params=dict(
+                            temperature=0, max_new_tokens=32, ignore_eos=True
+                        ),
+                        return_logprob=True,
+                        top_logprobs_num=5,
+                    )
+                    meta = response["meta_info"]
+                    tokens = [entry[1] for entry in meta["output_token_logprobs"]]
+                    assert len(tokens) == meta["completion_tokens"] == 32
+                    assert meta["prompt_tokens"] == len(ids)
+                    repeats.append(
+                        dict(
+                            tokens=tokens,
+                            logprobs=meta["output_token_logprobs"],
+                            top_logprobs=meta["output_top_logprobs"],
+                        )
+                    )
+                outputs.append(repeats)
+                (target / "outputs.json").write_text(json.dumps(outputs, indent=2))
+                assert repeats[0] == repeats[1], (
+                    "Same-flag controlled generation changed"
+                )
+            if mode == "eager":
+                assert json.loads((target / "entrypoint.json").read_text())[
+                    "fusion_present"
+                ] == (flag == "1")
+                assert json.loads((target / "consumer.json").read_text())[
+                    "prequantized"
+                ] == (flag == "1")
+                if flag == "1":
+                    assert (
+                        json.loads((target / "module-tests.json").read_text())["status"]
+                        == "passed"
+                    )
+                    if tp == 1:
+                        assert (
+                            json.loads((target / "boundary-tests.json").read_text())[
+                                "status"
+                            ]
+                            == "passed"
+                        )
+            else:
+                # No numerical hooks in this model: independently observe actual
+                # replay and the fused producer rather than just a Graph flag.
+                engine.start_profile(
+                    output_dir=str(target / "profile"),
+                    activities=["CPU", "GPU"],
+                    record_shapes=True,
+                    profile_prefix="silu-static-fp8",
+                )
+                engine.generate(
+                    input_ids=inputs[-1],
+                    sampling_params=dict(
+                        temperature=0, max_new_tokens=8, ignore_eos=True
+                    ),
+                )
+                engine.stop_profile()
+                traces = list((target / "profile").rglob("*.trace.json.gz"))
+                assert len(traces) == tp
+                observations = []
+                for path in traces:
+                    with gzip.open(path, "rt") as handle:
+                        events = json.load(handle)["traceEvents"]
+                    observations.append(
+                        dict(
+                            file=path.name,
+                            **assert_fusion_graph_replay(events, flag == "1"),
+                        )
+                    )
+                (target / "graph-observations.json").write_text(
+                    json.dumps(observations, indent=2)
+                )
+        finally:
+            if engine is not None:
+                engine.shutdown()
+        results[flag] = outputs
+    assert results["0"] == results["1"], "Flag-off/on tokens or logprobs differ"

--- a/test/registered/unit/layers/quantization/test_modelopt_fp8_input.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_fp8_input.py
@@ -1,0 +1,50 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.quantization.modelopt_fp8_input import (
+    ModelOptFp8Input,
+    normalize_and_validate_modelopt_fp8_input,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestModelOptFp8InputRejection(CustomTestCase):
+    """CPU contract rejection; CUDA execution lives in the qualified SM89 suite."""
+
+    def test_frozen_fields_preserve_tensor_identity(self):
+        qx, scale = torch.zeros(1, 16), torch.ones(1)
+        value = ModelOptFp8Input(qx, scale, torch.bfloat16)
+        self.assertIs(value.qx, qx)
+        self.assertIs(value.scale, scale)
+        self.assertIsNone(value.row_scales)
+        with self.assertRaises(AttributeError):
+            value.scale = torch.zeros(1)
+
+    def test_invalid_container_and_tuple(self):
+        layer = SimpleNamespace(orig_dtype=torch.bfloat16)
+        for value in (None, [], object()):
+            with self.subTest(value=type(value)):
+                with self.assertRaises(TypeError):
+                    normalize_and_validate_modelopt_fp8_input(value, layer)
+        for value in ((), (None,), (None, None, None, None)):
+            with self.subTest(length=len(value)):
+                with self.assertRaises(ValueError):
+                    normalize_and_validate_modelopt_fp8_input(value, layer)
+
+    def test_non_fp8_and_cpu_payloads_rejected(self):
+        layer = SimpleNamespace(orig_dtype=torch.bfloat16)
+        with self.assertRaises(TypeError):
+            normalize_and_validate_modelopt_fp8_input((torch.zeros(1, 16), None), layer)
+        with self.assertRaisesRegex(ValueError, "CUDA"):
+            normalize_and_validate_modelopt_fp8_input(
+                (torch.zeros(1, 16, dtype=torch.float8_e4m3fn), None), layer
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_silu_fp8_fusion.py
+++ b/test/registered/unit/layers/quantization/test_silu_fp8_fusion.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization import silu_fp8_fusion as fusion
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSiluFp8Support(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        fusion.silu_static_fp8_supported.cache_clear()
+
+    def tearDown(self):
+        fusion.silu_static_fp8_supported.cache_clear()
+        super().tearDown()
+
+    def test_consumer_capability(self):
+        with (
+            patch.object(fusion.torch.cuda, "is_available", return_value=True),
+            patch.object(fusion.torch.version, "hip", None),
+            patch.object(
+                fusion.torch.cuda, "get_device_capability", return_value=(8, 9)
+            ),
+        ):
+            for supported in (False, True):
+                fusion.silu_static_fp8_supported.cache_clear()
+                with patch(
+                    "sglang.srt.layers.quantization.fp8_utils.cutlass_fp8_supported",
+                    return_value=supported,
+                ):
+                    self.assertEqual(fusion.silu_static_fp8_supported(), supported)
+
+    def test_no_cuda(self):
+        with patch.object(fusion.torch.cuda, "is_available", return_value=False):
+            self.assertFalse(fusion.silu_static_fp8_supported())
+
+    def test_graph_backend_not_unused_compiler_field(self):
+        from sglang.srt.layers.quantization.silu_fp8_fusion import (
+            supports_silu_fp8_graph,
+        )
+
+        for backend in ("disabled", "full", "breakable"):
+            for compiler in ("eager", "inductor"):
+                phase = SimpleNamespace(backend=backend, tc_compiler=compiler)
+                self.assertTrue(
+                    supports_silu_fp8_graph(
+                        SimpleNamespace(prefill=phase, decode=phase)
+                    )
+                )
+        phase = SimpleNamespace(backend="tc_piecewise", tc_compiler="eager")
+        self.assertFalse(
+            supports_silu_fp8_graph(SimpleNamespace(prefill=phase, decode=phase))
+        )
+
+    def test_other_architecture(self):
+        with (
+            patch.object(fusion.torch.cuda, "is_available", return_value=True),
+            patch.object(fusion.torch.version, "hip", None),
+            patch.object(
+                fusion.torch.cuda, "get_device_capability", return_value=(9, 0)
+            ),
+        ):
+            self.assertFalse(fusion.silu_static_fp8_supported())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [Perf] Fuse SiLU-and-mul with ModelOpt static FP8 quantization on SM89

## Summary

This implements the Optional A producer category discussed in [the static FP8 producer-fusion proposal](https://github.com/sgl-project/sglang/issues/31504): `SiLU(gate) * up` followed by static per-tensor FP8 quantization.

The split path writes the activation output and then launches a separate quantization kernel before the down projection. This change fuses that producer boundary and passes the prequantized input directly to the ModelOpt consumer. On SM89, the producer also writes repeated row scales, avoiding a separate scale-materialization launch in the supported consumer path.

The scope is limited to eligible ModelOpt static-FP8 MLPs: the standalone shared-expert path in Qwen3.5 and the `Qwen2MLP` path used by Qwen3 dense. Qwen3-8B-FP8 therefore exercises the actual model integration, not a test-only replacement forward. Other users of these shared classes are not automatically enabled.

## Modifications

- Add a CUDA JIT `silu_and_mul_static_fp8` producer and its Python wrapper.
- Add an explicit ModelOpt prequantized-input payload carrying FP8 activations,
  the layer-owned scalar scale, original output dtype, and optional repeated
  row scales. Preserve floating-point input handling and the existing GEMM
  selection after payload validation.
- Share eligibility and invocation logic in `silu_fp8_fusion.py`; model entry
  points opt in explicitly and retain the unfused path when ineligible.
- Add focused CPU/operator/integration tests and a reproducible full-MLP
  benchmark.

The feature is **disabled by default**. Enable it with `SGLANG_ENABLE_SILU_STATIC_FP8_FUSION=1` on an eligible configuration.

This does not change norm/allreduce producers, routers, routed-expert kernels, FP4 quantization, weight calibration, or GEMM algorithms. The prequantized consumer interface overlaps with the work in [#36501](https://github.com/sgl-project/sglang/pull/36501); that shared interface should be aligned during review without importing its collective-specific scope into this change.

## Correctness and regression tests

The numerical reference is the existing CUDA activation followed by the existing static FP8 quantizer. The producer preserves the intermediate activation dtype and the SM89 reference conversion sequence `FP32 -> FP16 RTZ -> E4M3 RN`, including the reference clamp behavior.

Tests cover:

- BF16/FP16 inputs, FP8 output bytes and scales, rounding boundaries, special
  values, empty batches, alignment, and invalid inputs. The final rounding
  sample set retains counterexamples to a direct FP32-to-FP8 conversion.
- Actual ModelOpt GEMM consumption and complete MLP output comparisons;
  scalar ownership, output dtype, tuple/named payload validation, and row-scale
  storage reuse.
- CUDA Graph replay with changed inputs/scales, side-stream execution, and
  profiler correlation between fused kernels and Graph launches.
- Real model off/on execution, unsupported-configuration fallback, and exact
  output-token and selected/top-5 logprob comparisons for controlled prompts.
  These integration checks are not full-vocabulary logits comparisons.

### Recorded checks

| Check | Result |
| --- | --- |
| Combined non-model operator, protocol, support, and trace-check suite | 78 passed |
| Qwen3-8B-FP8 TP1, eager and default CUDA Graph | 2 passed |
| Qwen3-8B-FP8 TP2 / TP4, eager and default CUDA Graph | 2 passed per TP size |
| Full synthetic shared-expert MLP benchmark | 36 cases passed; byte/output checks passed |
| Project pre-commit on the 16 candidate files | All applicable checks passed |

These are recorded local results, not upstream CI results. Benchmark cases are counted separately from pytest tests. Additional Graph and cross-stack coverage is summarized below.

## Performance

### Test environment

- Hardware: NVIDIA L20, SM89, approximately 46 GiB usable memory per GPU;
  one GPU for TP1, two/four for TP2/TP4. Multi-GPU tests used physical GPUs 4–7;
  other GPUs on the host were not reserved, so whole-host isolation is not claimed.
- Main environment: Python 3.12.14, Torch 2.13.0+cu129, Triton 3.7.1,
  NVCC 12.8.61, NVIDIA driver 570.86.10.
- Model: `nvidia/Qwen3-8B-FP8`; BF16 model and KV-cache dtype for serving.
- Fixed upstream baseline: `a88e852fabd74c7666447e874fe1f113fbed72dd`.

### Measurement overview

**A:** original baseline; **B:** patched code with fusion disabled; **C:** the same patched code with fusion enabled. Serving tests use fresh servers and fixed-concurrency requests, with warm-up and profiling excluded from timing. Tables report median paired changes; positive values indicate improvement. Exact counts, execution order, and commands are in **Test parameters and reproduction commands** below.

TTFT measures time to first output; TPOT is the request-average time per subsequent output token. Output throughput is total output tokens divided by workload wall time, including prefill and decode, at the stated concurrency.

### Prefill-relevant full shared-expert MLP

The benchmark runs the actual `Qwen2MoeMLP.forward` and ModelOpt consumer with synthetic weights, including both projections and activation/quantization but excluding collectives (`reduce_results=False`). Each Graph capture has four warm-up calls; CUDA-event timing uses 20 replays per measurement and nine alternating baseline/fused pairs.

The table shows `M=2048`, `H=4096`, TP1, with rotating input/output buffers.

| Input dtype | Local K | Unfused median (µs) | Fused median (µs) | Paired latency reduction |
| --- | ---: | ---: | ---: | ---: |
| BF16 | 256 | 131.840 | 129.690 | 1.669% |
| BF16 | 512 | 206.544 | 204.742 | 0.879% |
| BF16 | 1024 | 302.870 | 300.818 | 0.689% |
| FP16 | 256 | 130.733 | 128.546 | 1.691% |
| FP16 | 512 | 205.394 | 203.566 | 0.893% |
| FP16 | 1024 | 301.658 | 299.866 | 0.608% |

Percentages are medians of paired reductions, not ratios of the displayed absolute medians. All 36 dtype/shape cases are retained in the benchmark output.

Shared-expert performance is validated at the full-MLP level using synthetic weights. End-to-end performance is validated with Qwen3-8B-FP8.

### Qwen3-8B-FP8 end-to-end performance: TP1 / TP2 / TP4

Qwen3-8B-FP8 is tested with TP1/2/4 using fixed-length requests, temperature 0, and radix caching disabled. Each workload is warmed before formal timing. TTFT/TPOT columns use per-run request medians; percentages compare variants within each TP configuration.

| TP | ISL / OSL / concurrency | TTFT reduction C/A | TTFT reduction C/B | TPOT reduction C/A | Output throughput gain C/A |
| --- | --- | ---: | ---: | ---: | ---: |
| 1 | 2048 / 32 / 1 | 1.521% | 1.611% | 0.483% | 0.820% |
| 1 | 8192 / 32 / 1 | 2.444% | 2.485% | 0.471% | 1.797% |
| 1 | 128 / 512 / 8 | 0.756% | 0.887% | 0.576% | 0.584% |
| 1 | 1024 / 1024 / 8 | 2.637% | 2.744% | 0.529% | 0.618% |
| 2 | 2048 / 32 / 1 | 0.531% | 0.614% | 0.629% | 0.478% |
| 2 | 8192 / 32 / 1 | 1.489% | 1.454% | 0.643% | 1.285% |
| 2 | 128 / 512 / 8 | 0.698% | 0.503% | 0.741% | 0.741% |
| 2 | 1024 / 1024 / 8 | 1.752% | 1.707% | 0.693% | 0.753% |
| 4 | 2048 / 32 / 1 | 0.049% | 0.067% | 0.655% | 0.063% |
| 4 | 8192 / 32 / 1 | 0.129% | 0.169% | 0.659% | 0.255% |
| 4 | 128 / 512 / 8 | 0.373% | 0.607% | 0.465% | 0.405% |
| 4 | 1024 / 1024 / 8 | 0.197% | 0.229% | 0.431% | 0.381% |

### P95/P99 latency: TP1 / TP2 / TP4

All values are median paired latency reductions for C/B (fusion enabled versus disabled). Positive values indicate improvement; negative values indicate regression.

P95/P99 are calculated within each run, then summarized as median paired reductions. Full sample counts and warm-up settings are in the reproduction details. These measurements do not establish uniform tail improvement.

| TP | ISL / OSL / concurrency | TTFT P95 reduction C/B | TTFT P99 reduction C/B | TPOT P95 reduction C/B | TPOT P99 reduction C/B |
| --- | --- | ---: | ---: | ---: | ---: |
| 1 | 2048 / 32 / 1 | 2.866% | 1.496% | 0.362% | 1.003% |
| 1 | 8192 / 32 / 1 | 2.450% | 2.192% | 0.891% | 1.418% |
| 1 | 128 / 512 / 8 | 8.217% | 8.178% | 0.593% | 0.592% |
| 1 | 1024 / 1024 / 8 | 2.910% | 2.866% | 0.524% | 0.524% |
| 2 | 2048 / 32 / 1 | 0.489% | 1.247% | 0.171% | 0.790% |
| 2 | 8192 / 32 / 1 | 1.155% | 1.203% | 0.035% | -0.457% |
| 2 | 128 / 512 / 8 | 2.825% | 1.615% | 0.676% | 0.681% |
| 2 | 1024 / 1024 / 8 | 2.421% | 2.270% | 0.653% | 0.478% |
| 4 | 2048 / 32 / 1 | 0.698% | 1.453% | 0.659% | 1.928% |
| 4 | 8192 / 32 / 1 | −0.051% | 0.300% | 0.997% | 0.817% |
| 4 | 128 / 512 / 8 | 0.797% | 4.167% | 1.009% | 1.233% |
| 4 | 1024 / 1024 / 8 | −0.446% | −0.312% | 1.651% | 0.913% |

### Profiler attribution

Separate full-MLP traces showed:

| Observation | Unfused | Fused |
| --- | --- | --- |
| Total kernel launches per MLP invocation | 5 | 4 |
| Activation/down-input quantization boundary | Separate activation and quantization | One fused producer |
| Two projection GEMMs | Same two CUTLASS kernels | Same two CUTLASS kernels |
| Replacement standalone row-scale materialization | — | None observed |

This identifies the removed launch without conflating it with a GEMM backend change. The benchmark emits separate untimed traces so the same accounting can be checked for each measured candidate. A 5-to-4 launch reduction is not a claim of 20% MLP speedup, and no measured HBM/L2/occupancy claim is made.

TP4 diagnostic traces separately confirm the delivered fusion path: each of four ranks has 0 fused calls with B and 1,152 with C, all 1,152 associated with CUDA Graph launches. These traces establish execution and Graph association, not a tail-latency diagnosis. Aggregate Graph launch counts are not used as a speedup metric because the traced scheduling differs.

## Compatibility and limitations

| Area | Scope |
| --- | --- |
| Hardware | Opt-in SM89 implementation, tested on L20; other architectures fall back at model integration |
| Quantization | ModelOpt static per-tensor E4M3FN with the layer-owned FP32 scalar; BF16/FP16 activation/output contract |
| Layout | Local shape, alignment, weight/scale, and consumer requirements are checked |
| Tensor parallelism | No TP-size enumeration in runtime or test input parsing; matching TP group, local contracts, and sufficient visible GPUs are required. TP1/2/4 eager/default Graph tested; TP8 not tested |
| CUDA Graph | Full/breakable runner coverage; this does not imply torch.compile support |
| Unadapted wrapper/execution paths | Tensor-only input splitting, SP contiguous/padding, and compile-related paths remain excluded |
| First-release integration policy | Mixed PP/DP/EP/CP/DCP topologies and other excluded execution modes require follow-up integration validation, not a claim of mathematical incompatibility |
| Model evidence | End-to-end performance validated with Qwen3-8B-FP8; shared-expert performance validated with synthetic full-MLP tests |

Ineligible model inputs retain the original activation path. Invalid explicit prequantized payloads are rejected by the consumer; silently treating an invalid payload as ordinary floating-point input would violate its contract.

There is no file-hash, machine, driver-patch, or Triton-minor-version allowlist. The implementation reuses the existing consumer CUDA capability requirement and the project's dependency constraints. Passing a version range is not a substitute for numerical regression testing.

## Reproduction

<details>
<summary>Test parameters and reproduction commands</summary>

Run from the repository root with compatible project/test dependencies and local `nvidia/Qwen3-8B-FP8` weights. Replace example GPU IDs with idle devices and use fresh output directories. Require mode fails on missing prerequisites instead of silently skipping the manual tests.

#### Full-MLP timing parameters

Before each capture, run four untimed forward calls on a side stream and synchronize. Capture four input/output buffer sets per variant, for 16 explicit pre-capture warm-up calls per variant per dtype/shape. The hot-buffer mode uses one set; the displayed rotating-buffer mode cycles through all four. CUDA events enclose 20 replays, with elapsed time divided by 20. Baseline/fused order alternates over nine pairs; there is no additional warm-up per pair. Compilation, capture, and correctness checks are not timed. Replay repetitions are not independent process runs. The model initializes the runtime; the benchmarked MLP weights are synthetic.

#### Main serving-table parameters

TP1 used three paired blocks (`ABC, BCA, CAB`); TP2 and TP4 each used six (`ABC, CBA, BCA, ACB, CAB, BAC`). Each variant ran in a fresh server process.

**Main serving-table warm-up:** on each fresh A/B/C server, execute one warm-up phase immediately before each workload's timed phase. Use that workload's input/output lengths and target concurrency, and wait for all warm-up requests to finish before starting the timer. Repeat this procedure for every server in every paired block. Counts below are inference requests, not kernel iterations or numbers of independent test rounds.

| ISL / OSL / concurrency | Warm-up requests | Timed requests, TP1 | Timed requests, TP2/TP4 |
| --- | ---: | ---: | ---: |
| 2048 / 32 / 1 | 4 | 32 | 32 |
| 8192 / 32 / 1 | 4 | 32 | 32 |
| 128 / 512 / 8 | 8 | 64 | 128 |
| 1024 / 1024 / 8 | 8 | 64 | 64 |

Serving inputs are deterministic synthetic token-ID sequences, with matching prompts between variants, temperature 0, EOS ignored, and radix caching disabled. Request counts and token lengths were checked. The closed-loop client replaces completed requests up to the target concurrency.

#### Tail-table parameters

**Tail-table warm-up:** each B/C server executes one warm-up phase per workload at the target concurrency and input/output lengths. All warm-up requests finish before formal timing begins. Per-server counts are:

| ISL / OSL / concurrency | TP1 warm-up / timed | TP2 warm-up / timed | TP4 warm-up / timed |
| --- | ---: | ---: | ---: |
| 2048 / 32 / 1 | 4 / 32 | 4 / 32 | 16 / 512 |
| 8192 / 32 / 1 | 4 / 32 | 4 / 32 | 4 / 32 |
| 128 / 512 / 8 | 8 / 64 | 8 / 128 | 32 / 1,024 |
| 1024 / 1024 / 8 | 8 / 64 | 8 / 64 | 8 / 64 |

Paired-block counts are three for TP1, six for TP2, and six for TP4 8192/32/C1 and 1024/1024/C8. TP4 2048/32/C1 and 128/512/C8 use two pairs in B→C/C→B order.

#### Metric calculations

TTFT is measured at the first nonempty text event, which can contain multiple tokens. TPOT is each request's average post-first-output time per token, not a distribution of individual token gaps. Percentiles use linear interpolation within a run. Pairwise latency reductions are `100 * (1 - candidate/reference)`; throughput gains are `100 * (candidate/reference - 1)`. The reported percentage is the median over paired runs. Warm-up requests are excluded and runs are not pooled. Request/run counts differ; these are not production P99/SLO certification or cross-TP absolute-performance comparisons.

#### Correctness and full-MLP commands

CPU tests:

```bash
python -m pytest -q \
  test/registered/unit/layers/quantization/test_modelopt_fp8_input.py \
  test/registered/unit/layers/quantization/test_silu_fp8_fusion.py
```

Checkpoint-free GPU operator/consumer suite:

```bash
CUDA_VISIBLE_DEVICES=0 SGLANG_TEST_REQUIRE_STATIC_FP8=1 \
  python -m pytest -q test/manual/quant/test_silu_and_mul_static_fp8.py
```

TP1 eager/default Graph integration matching the latest two model cases:

```bash
CUDA_VISIBLE_DEVICES=0 \
SGLANG_TEST_STATIC_FP8_MODEL=/path/to/Qwen3-8B-FP8 \
SGLANG_TEST_STATIC_FP8_TP=1 SGLANG_TEST_REQUIRE_STATIC_FP8=1 \
  python -m pytest -q -s \
  test/manual/quant/test_silu_fp8_fusion_integration.py \
  -k 'delivered_entrypoint and not breakable_inductor_field'
```

Remove the `-k` filter to include the breakable configuration and non-model checks. For TP2/TP4, select the corresponding number of idle GPUs, set `SGLANG_TEST_STATIC_FP8_TP`, and retain the filter above.

Full-MLP benchmark:

```bash
CUDA_VISIBLE_DEVICES=0 SGLANG_ENABLE_SILU_STATIC_FP8_FUSION=1 \
  python benchmark/kernels/bench_silu_fp8_fusion_mlp.py \
  --model-path /path/to/Qwen3-8B-FP8 --output /path/to/new-results
```

The benchmark saves all 36 cases, paired timings, and untimed profiling artifacts. Repeat in a fresh process/output directory for independent process-level evidence. Performance thresholds are not ordinary unit-test assertions.

#### Portable serving benchmark commands

This standard-client recipe is not a byte-identical replay of the archived custom HTTP drivers. Results generated with it must be recorded as a separate dataset, not pooled with the table above.

Example C server; use the original checkout and flag 0 for A, and the patched checkout with flag 0 for B:

```bash
SGLANG_ENABLE_SILU_STATIC_FP8_FUSION=1 CUDA_VISIBLE_DEVICES=0 \
  python -m sglang.launch_server --model-path /path/to/Qwen3-8B-FP8 \
  --tp-size 1 --dtype bfloat16 --kv-cache-dtype bfloat16 \
  --disable-radix-cache --random-seed 9271 --context-length 16384 \
  --max-running-requests 32 --max-total-tokens 65536 \
  --mem-fraction-static 0.6 --chunked-prefill-size 8192 \
  --cuda-graph-max-bs 32 --stream-interval 1 --port 30000
```

For the main-table 2048/32/C1 example, run the command below once with `--num-prompts 4` for warm-up, wait for completion and exclude that result, then run it with `--num-prompts 32` for formal timing. For other workloads, use their exact warm-up/timed counts from the corresponding tables above.

```bash
python -m sglang.benchmark.serving --backend sglang --port 30000 \
  --model /path/to/Qwen3-8B-FP8 --dataset-name random \
  --random-input-len 2048 --random-output-len 32 --random-range-ratio 1 \
  --num-prompts 32 --max-concurrency 1
```

For TP2/TP4, select the required number of idle GPUs and set `--tp-size`. Use the warm-up/request counts and orders above. TP4's two-pair sequence runs 128/512/C8 followed by 2048/32/C1 on each server. Keep inputs, generation settings, software, and server arguments identical between variants. Exact replay of the reported numbers requires the archived custom token-ID/streaming driver; this standard-client recipe is an alternative benchmark. Collect profiles separately and retain all paired results, including regressions.

</details>

## Additional validation

<details>
<summary>Cross-stack tests and asynchronous quality observations</summary>

The following paired environments ran 50 focused tests each:

| Torch | Triton | Torch CUDA build | Coverage |
| --- | --- | --- | --- |
| 2.11.0 | 3.6.0 | 13.0 | Focused producer/reference-quantization/Triton-GEMM suite |
| 2.13.0+cu129 | 3.7.1 | 12.9 | Same focused suite, plus the main full-stack environment |
| 2.14.0+cu130 | 3.8.0 | 13.0 | Focused producer/reference-quantization/Triton-GEMM suite |

The CUDA 13 tests used isolated per-process compatibility libraries, without changing the system driver. The main environment's `sgl_kernel` AOT wheel is Torch-ABI-specific and could not be reused in the other two environments. These results therefore do not certify complete ModelOpt/CUTLASS/Engine compatibility across all three stacks, nor all future Triton releases.

Historical asynchronous GSM8K TP1 totals were A/B/C = 1214/1217/1214 out of 1319. Equal A/C totals did not mean identical per-question outcomes. Follow-up diagnostics on eight differing questions found identical text and returned token logprobs across A/B/C in controlled single-request runs, while changing baseline request load could itself change answers.

This supports baseline batch sensitivity as an explanation, but does not establish the exact scheduling cause of every historical difference or quality equivalence under arbitrary asynchronous scheduling. Controlled numerical/generation checks and asynchronous quality observations are kept separate; deterministic mode was not used to bypass the fusion path.

</details>

## Validation on other GPU architectures

Testing was performed on NVIDIA L20 (SM89), and this initial implementation is enabled only for eligible SM89 configurations. If support for SM90 or other architectures would be useful, please let me know. I can help with the adaptation, but I would need maintainers or contributors with access to those GPUs to run correctness and performance validation before enabling them.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34499263001](https://github.com/sgl-project/sglang/actions/runs/34499263001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34499262669](https://github.com/sgl-project/sglang/actions/runs/34499262669)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34499262924](https://github.com/sgl-project/sglang/actions/runs/34499262924)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->