### PR TITLE
feat: Support DeepSeek V4.1 PD with DSpark

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -280,13 +280,6 @@ def validate_deepseek_v41_features(server_args: ServerArgs) -> None:
             cfg.speculative_algorithm is not None
             and str(cfg.speculative_algorithm).upper() != "DSPARK",
         ),
-        # The ratio-2 pair ring ships as one item per request and its ring size
-        # follows the speculative window, so prefill and decode layouts only
-        # agree when neither side speculates.
-        (
-            "PD disaggregation with speculative decoding",
-            cfg.disaggregation_mode != "null" and cfg.speculative_algorithm is not None,
-        ),
         ("HiSparse", cfg.enable_hisparse),
         ("the unified KV layout", is_unified_kv_triton()),
         ("two-batch overlap", cfg.enable_two_batch_overlap),

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -99,13 +99,7 @@ def get_dsv4_c128_state_indices(
 
 
 def get_dsv4_request_state_indices(pool, req_pool_idx: int, seq_len: int) -> np.ndarray:
-    """PD transfer indices of the request-scoped state component (C128_STATE).
-
-    The component carries the c128 ring, whose item is one c128 page (or the
-    single online row), or the ratio-2 pair ring, whose item is one request's
-    whole ring; there only an odd prefix leaves a pending half-pair that decode
-    reads, so an even prefix ships nothing.
-    """
+    """C128 pages or the single pending C2 row at the processed prefix boundary."""
     if 128 in pool.kv_pools:
         online = is_dsv4_c128_online_enabled()
         ring_size = 1 if online else pool.get_ring_size(128)
@@ -117,7 +111,9 @@ def get_dsv4_request_state_indices(pool, req_pool_idx: int, seq_len: int) -> np.
     )
     if seq_len % 2 == 0:
         return np.empty((0,), dtype=np.int32)
-    return np.array([int(req_pool_idx)], dtype=np.int32)
+    ring_size = pool.get_ring_size(2)
+    row = int(req_pool_idx) * ring_size + (seq_len - 1) % ring_size
+    return np.array([row], dtype=np.int32)
 
 
 class DisaggregationMode(Enum):

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -21,7 +21,7 @@ from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
-from sglang.srt.runtime_context import get_exec, get_spec
+from sglang.srt.runtime_context import get_disagg, get_exec, get_spec
 from sglang.srt.utils import ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
@@ -790,6 +790,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
 
     def get_ring_size(self, compress_ratio: int) -> int:
+        if compress_ratio == 2 and get_disagg().disaggregation_mode == "prefill":
+            # Prefill only carries one unfinished pair across chunk boundaries.
+            return get_compress_state_ring_size(2)
         spec = get_spec()
         return get_compress_state_ring_size(
             compress_ratio,
@@ -960,9 +963,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_c128_state_buf_infos(
         self,
     ) -> Tuple[List[int], List[int], List[int]]:
-        """The request-scoped state component, named after its first member: the
-        c128 raw-token ring (or its single online row) and the ratio-2
-        pending-pair ring. One item is one c128 page / one request's pair ring."""
+        """Transfer C128 pages and C2 pending rows independently of ring capacity."""
         data_ptrs: List[int] = []
         data_lens: List[int] = []
         item_lens: List[int] = []
@@ -974,7 +975,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             data_ptrs.append(t.data_ptr())
             data_lens.append(t.nbytes)
             if pool.ratio == 2:
-                item_lens.append(t[0].nbytes * pool.ring_size)
+                item_lens.append(t[0].nbytes)
             else:
                 item_lens.append(t[0].nbytes if ONLINE_C128 else t[0].nbytes * 128)
         return data_ptrs, data_lens, item_lens

--- a/test/registered/unit/disaggregation/test_dsv41_pair_transfer.py
+++ b/test/registered/unit/disaggregation/test_dsv41_pair_transfer.py
@@ -1,0 +1,238 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.arg_groups.deepseek_v4_hook import (  # noqa: E402
+    validate_deepseek_v41_features,
+)
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager  # noqa: E402
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager  # noqa: E402
+from sglang.srt.disaggregation.utils import (  # noqa: E402
+    get_dsv4_request_state_indices,
+)
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (  # noqa: E402
+    DeepSeekV4TokenToKVPool,
+)
+from sglang.srt.model_executor.cuda_graph_config import Backend  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _PairPool:
+    kv_pools = {1: None, 2: None}
+
+    def __init__(self, ring_size):
+        self.ring_size = ring_size
+
+    def get_ring_size(self, ratio):
+        assert ratio == 2
+        return self.ring_size
+
+
+class TestDSV41PairTransfer(CustomTestCase):
+    def test_pending_row_uses_local_ring_and_request_slot(self):
+        for ring in (2, 8, 16):
+            for req_slot in (0, 3, 7):
+                for length in (1, 3, 7, 9, 101, 257, 4097):
+                    with self.subTest(ring=ring, slot=req_slot, length=length):
+                        indices = get_dsv4_request_state_indices(
+                            _PairPool(ring), req_slot, length
+                        )
+                        np.testing.assert_array_equal(
+                            indices, [req_slot * ring + (length - 1) % ring]
+                        )
+                        self.assertEqual(indices.dtype, np.int32)
+
+    def test_even_boundary_has_no_payload(self):
+        for length in (0, 2, 8, 256, 4096):
+            self.assertEqual(
+                get_dsv4_request_state_indices(_PairPool(8), 3, length).size, 0
+            )
+
+    def test_c128_page_indices_are_unchanged(self):
+        pool = SimpleNamespace(kv_pools={128: None}, get_ring_size=lambda _: 256)
+        with patch(
+            "sglang.srt.disaggregation.utils.is_dsv4_c128_online_enabled",
+            return_value=False,
+        ):
+            np.testing.assert_array_equal(
+                get_dsv4_request_state_indices(pool, 3, 129), [7]
+            )
+            self.assertEqual(get_dsv4_request_state_indices(pool, 3, 256).size, 0)
+
+    def test_pair_state_registers_one_row_per_transfer_item(self):
+        states = [torch.empty((64, 1024), dtype=torch.float32) for _ in range(3)]
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool.compress_state_pools = [
+            SimpleNamespace(
+                ratio=2,
+                ring_size=8,
+                kv_score_buffer=SimpleNamespace(kv_score=state),
+            )
+            for state in states
+        ]
+
+        ptrs, lens, item_lens = pool.get_c128_state_buf_infos()
+
+        self.assertEqual(ptrs, [state.data_ptr() for state in states])
+        self.assertEqual(lens, [state.nbytes for state in states])
+        self.assertEqual(item_lens, [state[0].nbytes for state in states])
+        self.assertEqual(sum(item_lens), 12 * 1024)
+
+    def test_prefill_uses_minimal_pair_ring_while_decode_uses_spec_ring(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        spec = SimpleNamespace(
+            speculative_algorithm="DSPARK", speculative_num_draft_tokens=5
+        )
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.get_disagg",
+                return_value=SimpleNamespace(disaggregation_mode="prefill"),
+            ),
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.get_spec",
+                return_value=spec,
+            ),
+        ):
+            self.assertEqual(pool.get_ring_size(2), 2)
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.get_disagg",
+                return_value=SimpleNamespace(disaggregation_mode="decode"),
+            ),
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.get_spec",
+                return_value=spec,
+            ),
+        ):
+            self.assertEqual(pool.get_ring_size(2), 8)
+
+
+class TestDSV41PDDSparkValidation(CustomTestCase):
+    def _config(self, algorithm):
+        return SimpleNamespace(
+            enable_encoder_swa_bounded_replay=False,
+            speculative_algorithm=algorithm,
+            disaggregation_mode="decode",
+            enable_hisparse=False,
+            enable_two_batch_overlap=False,
+            pp_size=1,
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(backend=Backend.DISABLED, max_seq_len=None)
+            ),
+            enable_decoder_swa_bounded_replay=False,
+        )
+
+    def _validate(self, algorithm):
+        with (
+            patch(
+                "sglang.srt.arg_groups.deepseek_v4_hook.resolving_view",
+                return_value=self._config(algorithm),
+            ),
+            patch(
+                "sglang.srt.arg_groups.deepseek_v4_hook.model_config_of",
+                return_value=SimpleNamespace(
+                    hf_config=SimpleNamespace(model_type="deepseek_v41")
+                ),
+            ),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate.is_unified_kv_triton",
+                return_value=False,
+            ),
+        ):
+            validate_deepseek_v41_features(SimpleNamespace())
+
+    def test_pd_dspark_is_allowed(self):
+        self._validate("DSPARK")
+
+    def test_pd_other_speculative_algorithm_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, "speculative decoding other than DSpark"
+        ):
+            self._validate("EAGLE")
+
+
+class _RecordingMooncakeManager:
+    def __init__(self):
+        self.is_mla_backend = True
+        self.is_hybrid_mla_backend = False
+        self.enable_custom_mem_pool = False
+        self.blocks = []
+
+    def get_mla_kv_ptrs_with_pp(self, src, dst, state_type):
+        return src, dst, len(src)
+
+    def _transfer_data(self, session_id, blocks):
+        self.blocks.extend(blocks)
+        return 0
+
+
+class _RecordingNixlAgent:
+    def __init__(self):
+        self.requests = []
+
+    def get_xfer_descs(self, requests, mem_kind):
+        self.requests.append(requests)
+        return requests
+
+    def initialize_xfer(self, *args):
+        return "handle"
+
+    def transfer(self, handle):
+        return "DONE"
+
+
+class TestDSV41PairTransferAddressing(CustomTestCase):
+    def test_mooncake_maps_source_and_destination_ring_rows(self):
+        manager = _RecordingMooncakeManager()
+
+        MooncakeKVManager._send_kvcache_generic(
+            manager,
+            mooncake_session_id="session",
+            src_data_ptrs=[1000],
+            dst_data_ptrs=[2000],
+            item_lens=[4096],
+            prefill_data_indices=np.array([6], dtype=np.int32),
+            dst_data_indices=np.array([28], dtype=np.int32),
+            executor=None,
+        )
+
+        self.assertEqual(manager.blocks, [(1000 + 6 * 4096, 2000 + 28 * 4096, 4096)])
+
+    def test_nixl_maps_source_and_destination_ring_rows(self):
+        manager = object.__new__(NixlKVManager)
+        manager.is_mla_backend = True
+        manager.prep_handles = {}
+        manager.kv_args = SimpleNamespace(gpu_id=0, kv_data_ptrs=[])
+        manager.agent = _RecordingNixlAgent()
+
+        handle = NixlKVManager._send_kvcache_generic(
+            manager,
+            peer_name="decode",
+            src_data_ptrs=[1000],
+            dst_data_ptrs=[2000],
+            item_lens=[4096],
+            prefill_data_indices=np.array([6], dtype=np.int32),
+            dst_data_indices=np.array([28], dtype=np.int32),
+            dst_gpu_id=1,
+            notif="state",
+        )
+
+        self.assertEqual(handle, "handle")
+        src, dst = manager.agent.requests
+        np.testing.assert_array_equal(src[:, :2], [[1000 + 6 * 4096, 4096]])
+        np.testing.assert_array_equal(dst[:, :2], [[2000 + 28 * 4096, 4096]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek-V4.1 currently rejects PD disaggregation when DSpark speculative decoding is enabled because the prefill and decode workers may use different C2 pending-pair ring layouts.

C2 keeps the final unpaired token's FP32 `(kv, score)` state at:

```text
request_slot * ring_size + position % ring_size
```
Prefill only requires a two-row ring, while DSpark decode requires a larger ring determined by the speculative window. Transferring the entire request ring therefore produces incompatible source and destination strides and offsets.

This PR enables end-to-end DeepSeek-V4.1 PD + DSpark while decoupling the transfer format from each worker's local ring geometry.

## Modifications

- Transfer only the unfinished C2 boundary row instead of the entire request ring.
  - Even processed prefix length: no C2 state is transferred.
  - Odd processed prefix length: transfer the row for position `prefix_len - 1`.
- Compute source and destination row indices independently using each worker's local request slot and ring size.
- Register one C2 `(kv, score)` row as one transfer item.
- Keep the prefill C2 ring at the minimal size of 2.
- Preserve the larger speculative ring required by DSpark on decode workers.
- Reuse the existing Mooncake and NIXL support for distinct source and destination indices.
- Preserve existing C128 transfer semantics.
- Remove the DeepSeek-V4.1 validation restriction for PD + DSpark while continuing to reject unsupported speculative algorithms.
- Add unit coverage for:
  - Different prefill/decode ring sizes and request slots.
  - Odd and even handoff boundaries.
  - Ring wraparound and long prefixes.
  - Mooncake and NIXL address construction.
  - C128 compatibility.
  - PD + DSpark argument validation.
  - C2 transfer size.

For the released DeepSeek-V4.1 configuration, an odd boundary transfers one 4 KiB row for each of the three C2 source layers, for a total logical payload of 12 KiB per request. Even boundaries transfer no C2 pending state.

## Accuracy Tests
```
#prefill
GLOO_SOCKET_IFNAME=eth0 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 sglang serve --trust-remote-code --model-path /data02/models/DeepSeek-V4.1-Flash --tp 8 --ep-size 8 --attention-backend dsv4 --moe-runner-backend flashinfer_mxfp4 --speculative-algorithm DSPARK --enable-decoder-swa-bounded-replay --cuda-graph-backend-prefill disabled --disaggregation-mode prefill --disaggregation-transfer-backend mooncake --disaggregation-bootstrap-port 8998 --disaggregation-ib-device "mlx5_1,mlx5_2,mlx5_3,mlx5_4" --reasoning-parser auto --tool-call-parser auto --host 0.0.0.0 --port 30000 --flashinfer-mxfp4-moe-precision fp8 --mem-fraction-static 0.85

#decode
GLOO_SOCKET_IFNAME=eth0 NCCL_MIN_NCHANNELS=24 NCCL_IB_QPS_PER_CONNECTION=8 sglang serve --trust-remote-code --model-path /data02/models/DeepSeek-V4.1-Flash --tp 8 --ep-size 8 --attention-backend dsv4 --moe-runner-backend flashinfer_mxfp4 --speculative-algorithm DSPARK --speculative-dspark-block-size 5 --disaggregation-mode decode --disaggregation-transfer-backend mooncake --disaggregation-bootstrap-port 8998 --disaggregation-ib-device "mlx5_1,mlx5_2,mlx5_3,mlx5_4" --reasoning-parser auto --tool-call-parser auto --host 0.0.0.0 --port 30000 --flashinfer-mxfp4-moe-precision fp8 --mem-fraction-static 0.8 --disable-flashinfer-autotune --cuda-graph-max-bs-decode 32 --max-running-requests 32
```
GSM8K
```
python3 bench_sglang.py --host http://localhost  --port 8090 --data-path /data00 --num-questions 5000 --parallel 32
100%|██████| 1319/1319 [12:27<00:00,  1.77it/s]
Accuracy: 0.911
Invalid: 0.001
Latency: 747.070 s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34499952607](https://github.com/sgl-project/sglang/actions/runs/34499952607)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34499951921](https://github.com/sgl-project/sglang/actions/runs/34499951921)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34499952207](https://github.com/sgl-project/sglang/actions/runs/34499952207)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->