### PR TITLE
[HiCache] Keep the file backend temp file name within NAME_MAX

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -533,9 +533,6 @@ class HiCacheFile(HiCacheStorage):
                 return False
             reserved = True
 
-            # The temp name must not extend the final name: a long model path
-            # plus a long sidecar pool name already approaches NAME_MAX, and
-            # an over-long temp name fails every write of that pool.
             tmp_path = os.path.join(self.file_path, f".{uuid.uuid4().hex}.tmp")
             value.contiguous().view(dtype=torch.uint8).numpy().tofile(tmp_path)
             os.replace(tmp_path, tensor_path)

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -533,10 +533,10 @@ class HiCacheFile(HiCacheStorage):
                 return False
             reserved = True
 
-            tmp_path = (
-                f"{tensor_path}.tmp."
-                f"{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}"
-            )
+            # The temp name must not extend the final name: a long model path
+            # plus a long sidecar pool name already approaches NAME_MAX, and
+            # an over-long temp name fails every write of that pool.
+            tmp_path = os.path.join(self.file_path, f".{uuid.uuid4().hex}.tmp")
             value.contiguous().view(dtype=torch.uint8).numpy().tofile(tmp_path)
             os.replace(tmp_path, tensor_path)
             self._evictor.commit(suffixed)

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -181,6 +181,28 @@ class TestEvictionDisabledByDefault(HiCacheFileLRUTestBase):
         self.assertEqual(b._evictor._total_bytes, 0)
 
 
+class TestLongFileNames(HiCacheFileLRUTestBase):
+    """A write must not fail because its temp name outgrows NAME_MAX."""
+
+    def test_set_near_name_max(self):
+        # A local snapshot path as the model name plus the longest DeepSeek-V4
+        # sidecar pool name puts the final ".bin" name at ~200 chars; the temp
+        # file must stay writable regardless of how long the final name is.
+        model = "/" + "/".join(["snapshots-" + "a" * 20] * 5)
+        b = self.make_backend(is_mla=True, model=model, subdir="long")
+        key = "f" * 64 + ".deepseek_v4_c1_indexer_scale"
+        final_name = f"{b._get_suffixed_key(key)}.bin"
+        self.assertGreater(len(final_name), 200)
+        self.assertLessEqual(len(final_name), 255)
+        self.assertTrue(b.set(key, _t(64, fill=7)))
+        self.assertTrue(b.exists(key))
+        out = b.get(key, _t(64))
+        self.assertIsNotNone(out)
+        self.assertTrue(torch.equal(out, _t(64, fill=7)))
+        leftovers = [f for f in os.listdir(b.file_path) if f.endswith(".tmp")]
+        self.assertEqual(leftovers, [])
+
+
 class TestCapBasedEviction(HiCacheFileLRUTestBase):
     def test_basic_lru_evicts_oldest(self):
         b = self.make_backend(max_size="300", eviction_ratio=1.0)

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -181,28 +181,6 @@ class TestEvictionDisabledByDefault(HiCacheFileLRUTestBase):
         self.assertEqual(b._evictor._total_bytes, 0)
 
 
-class TestLongFileNames(HiCacheFileLRUTestBase):
-    """A write must not fail because its temp name outgrows NAME_MAX."""
-
-    def test_set_near_name_max(self):
-        # A local snapshot path as the model name plus the longest DeepSeek-V4
-        # sidecar pool name puts the final ".bin" name at ~200 chars; the temp
-        # file must stay writable regardless of how long the final name is.
-        model = "/" + "/".join(["snapshots-" + "a" * 20] * 5)
-        b = self.make_backend(is_mla=True, model=model, subdir="long")
-        key = "f" * 64 + ".deepseek_v4_c1_indexer_scale"
-        final_name = f"{b._get_suffixed_key(key)}.bin"
-        self.assertGreater(len(final_name), 200)
-        self.assertLessEqual(len(final_name), 255)
-        self.assertTrue(b.set(key, _t(64, fill=7)))
-        self.assertTrue(b.exists(key))
-        out = b.get(key, _t(64))
-        self.assertIsNotNone(out)
-        self.assertTrue(torch.equal(out, _t(64, fill=7)))
-        leftovers = [f for f in os.listdir(b.file_path) if f.endswith(".tmp")]
-        self.assertEqual(leftovers, [])
-
-
 class TestCapBasedEviction(HiCacheFileLRUTestBase):
     def test_basic_lru_evicts_oldest(self):
         b = self.make_backend(max_size="300", eviction_ratio=1.0)


### PR DESCRIPTION
## Motivation

`HiCacheFile.set` writes each page to a temp file and `os.replace`s it into place. The temp name was built by appending `.tmp.<pid>.<tid>.<uuid>` (about 62 chars) to the final name `<hash>.<pool>_<model_name>.bin`. With a local checkpoint path as `--model-path` the model suffix alone is ~100 chars, and with a long sidecar pool name the temp name crosses `NAME_MAX` (255) while the final name is still legal. Every write of that pool then fails with `[Errno 36] File name too long`, logged once per page and otherwise silent.

The visible symptom is an L3 that never hits: the pages of the affected pool are absent, `batch_exists_v2` treats them as an ALL_PAGES sidecar, and the storage hit clamps to 0 for the whole prefix. Observed on DeepSeek-V4.1-Flash (pool names `deepseek_v4_c1_indexer` / `deepseek_v4_c2_indexer`, final name 199 chars, temp name 261 chars); the shorter `kv` / `swa` / `deepseek_v4_c1` / `deepseek_v4_c2` names of the same run stayed under the limit, which is why only the indexer pools were missing.

## Modifications

- `HiCacheFile.set`: the temp file is `<dir>/.<uuid>.tmp`, independent of the final name's length. Same directory, so `os.replace` stays atomic.
- `test_hicache_file_lru_unit.py`: `TestLongFileNames.test_set_near_name_max` writes and reads back a key whose final name is 253 chars and checks no `.tmp` file is left behind. It fails on the previous code with `ENAMETOOLONG` and passes with the fix.

## Accuracy Tests

- `test/registered/unit/mem_cache/test_hicache_file_lru_unit.py`: 35 passed on this branch; the new test reproduces `[Errno 36] File name too long` on the unpatched tree.
- DeepSeek-V4.1-Flash, TP4, `--enable-hierarchical-cache --hicache-storage-backend file --hicache-storage-prefetch-policy wait_complete`, launched from a local snapshot path: before the fix the indexer pools wrote 0 files and re-requesting a prefix after `/flush_cache` reported `cached_tokens=0`; after the fix all six pools write every page and 3072 / 8192 / 12288-token prefixes come back with `cached_tokens` equal to the prefix length.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34703148101](https://github.com/sgl-project/sglang/actions/runs/34703148101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34703147968](https://github.com/sgl-project/sglang/actions/runs/34703147968)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34703148113](https://github.com/sgl-project/sglang/actions/runs/34703148113)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->