### PR TITLE
[DeepSeek-V4.1] Add HiCache L2/L3 unified radix cache tests for V4.1 Flash

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -2421,6 +2421,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--cuda-graph-max-seq-len-prefill`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Longest sequence a prefill CUDA graph replay admits; longer batches run eager prefill. Folds into `cuda_graph_config[prefill].max_seq_len`.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--cuda-graph-bs-decode`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Explicit list of batch sizes to capture for the decode CUDA graph.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c1.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c1.cuh
@@ -1,0 +1,296 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp4_utils.cuh>
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+
+namespace sglang {
+
+/// \brief Ratio-1 decode compressor: RMSNorm and the whole main-KV write.
+///
+/// The ratio-1 compressor pools nothing -- `project` is a single bf16 `wkv`
+/// GEMM and the latent it produces stands for the token itself -- so the
+/// kernel's input is the GEMM output and its RoPE position is `positions`, not
+/// `positions - 1`. `kv_output` is the pre-RoPE latent, for the index-K
+/// branch's `wk` projection.
+struct C1Params {
+  const bf16_t* __restrict__ kv_input;     // [num_tokens, kHeadDim] bf16
+  bf16_t* __restrict__ kv_output;          // [num_tokens, kHeadDim] bf16, pre-RoPE
+  const bf16_t* __restrict__ norm_weight;  // [kHeadDim] bf16
+  const float* __restrict__ freqs_cis;     // [max_pos, kRopeDim] fp32, real/imag interleaved
+  const void* __restrict__ positions;      // [num_tokens] PosT
+  const void* __restrict__ out_loc;        // [num_tokens] LocT compressed slot; 0 marks a padded row
+  uint8_t* __restrict__ kvcache;           // [npages, kPageBytes] uint8
+  float eps;
+};
+
+/// Elements per thread; 256 threads per token was measured fastest on B200 decode batches.
+/// At head_dim 512, (512 - 64) / 2 = 224 threads keeps the nope/rope split warp-aligned;
+/// the fp8 amax reduction requires every lane in its full-warp mask to participate.
+constexpr uint32_t kC1VecSize = 2;
+
+/// \brief RMSNorm + RoPE tail + fp4 fake-quant + the 584-byte FlashMLA store.
+///
+/// One CTA per token, `kHeadDim / kC1VecSize` threads over the row.
+///
+/// The three reductions have three different widths and are not
+/// interchangeable: the RMSNorm statistic spans the row, an fp8 store scale
+/// spans 64 elements, an fp4 block spans 16. All asserted below.
+template <bool kUsePDL, int64_t kHeadDim, int64_t kRopeDim, int32_t kPageBits, typename PosT, typename LocT>
+__global__
+__launch_bounds__(kHeadDim / kC1VecSize) void flash_c1_decode_kernel(const __grid_constant__ C1Params params) {
+  using namespace device;
+  using deepseek_v4::fp8::cast_to_ue8m0;
+  using deepseek_v4::fp8::inv_scale_ue8m0;
+  using deepseek_v4::fp8::pack_fp8;
+
+  /// Threads over one token, and the leading ones of those that carry the fp8
+  /// nope part; the rest carry the bf16 RoPE tail.
+  constexpr uint32_t kVecSize = kC1VecSize;
+  constexpr uint32_t kRowLanes = kHeadDim / kVecSize;
+  constexpr uint32_t kNopeLanes = (kHeadDim - kRopeDim) / kVecSize;
+  constexpr uint32_t kRowWarps = kRowLanes / kWarpThreads;
+  constexpr uint32_t kFp8Lanes = 64 / kVecSize;
+  constexpr uint32_t kFp4Lanes = deepseek_v4::fp4::kCompressedKVBlockSize / kVecSize;
+  constexpr int64_t kPageBytes = host::div_ceil(584ll << kPageBits, 576) * 576;
+  static_assert(kHeadDim == 512 && kRopeDim == 64, "the 584-byte layout requires (512, 64)");
+  static_assert(kHeadDim % kVecSize == 0 && kVecSize % 2 == 0);
+  static_assert(kRowLanes % kWarpThreads == 0, "a token owns a whole number of warps");
+  static_assert(kNopeLanes % kFp8Lanes == 0, "the nope part must end on an fp8 scale block");
+  static_assert(
+      (kHeadDim - kRopeDim) % deepseek_v4::fp4::kCompressedKVBlockSize == 0,
+      "no fp4 block may straddle the nope/rope seam");
+  static_assert(kFp8Lanes <= kWarpThreads && kFp4Lanes <= kWarpThreads);
+
+  using bf16_vec_t = AlignedVector<bf16x2_t, kVecSize / 2>;
+  using fp8_vec_t = AlignedVector<fp8x2_e4m3_t, kVecSize / 2>;
+  using freq_vec_t = AlignedVector<float, kVecSize>;
+
+  const uint32_t tx = threadIdx.x;
+  const uint32_t row = blockIdx.x;
+
+  // `out_loc` and `positions` are step metadata, independent of the PDL producer.
+  // Slots fit in int32; padded rows are suppressed at the cache store.
+  const auto out_loc = static_cast<int32_t>(static_cast<const LocT*>(params.out_loc)[row]);
+  const auto position = static_cast<int64_t>(static_cast<const PosT*>(params.positions)[row]);
+  PDLWaitPrimary<kUsePDL>();
+
+  float data[kVecSize];
+  bf16_vec_t latent;
+  {
+    bf16_vec_t input, weight;
+    input.load(params.kv_input + row * kHeadDim, tx);
+    weight.load(params.norm_weight, tx);
+
+    // `project` already returns bf16 at ratio 1, so `finish`'s `.to(bfloat16)`
+    // is a no-op and the statistic is taken over the loaded values as they are.
+    float local_sqrsum = 0.0f;
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize / 2; ++j) {
+      const auto [x, y] = cast<fp32x2_t>(input[j]);
+      local_sqrsum += x * x;
+      local_sqrsum += y * y;
+      data[j * 2 + 0] = x;
+      data[j * 2 + 1] = y;
+    }
+
+    __shared__ float s_warp_sum[kRowWarps];
+    s_warp_sum[tx / kWarpThreads] = warp::reduce_sum(local_sqrsum);
+    __syncthreads();
+    float sqrsum = 0.0f;
+#pragma unroll
+    for (uint32_t i = 0; i < kRowWarps; ++i) {
+      sqrsum += s_warp_sum[i];
+    }
+    constexpr float kInvHeadDim = 1.0f / static_cast<float>(kHeadDim);
+    const auto norm_factor = math::rsqrt(sqrsum * kInvHeadDim + params.eps);
+
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize / 2; ++j) {
+      const auto [wx, wy] = cast<fp32x2_t>(weight[j]);
+      const auto x = data[j * 2 + 0] * norm_factor * wx;
+      const auto y = data[j * 2 + 1] * norm_factor * wy;
+      latent[j] = cast<bf16x2_t>(fp32x2_t{x, y});
+    }
+  }
+
+  // Publish the pre-RoPE latent before the PDL trigger for the index-K `wk` GEMM.
+  // Padded rows publish a latent too; the caller discards it.
+  latent.store(params.kv_output + row * kHeadDim, tx);
+  PDLTriggerSecondary<kUsePDL>();
+
+  // Match finish()'s bf16 rounding before the main-KV RoPE.
+#pragma unroll
+  for (uint32_t j = 0; j < kVecSize / 2; ++j) {
+    const auto [x, y] = cast<fp32x2_t>(latent[j]);
+    data[j * 2 + 0] = x;
+    data[j * 2 + 1] = y;
+  }
+
+  if (tx >= kNopeLanes) {
+    // `rope_tail` ends in `.to(x.dtype)`, so the rotated value is rounded back
+    // to bf16 before the fake-quant widens it again.
+    freq_vec_t freq;
+    freq.load(params.freqs_cis + position * kRopeDim, tx - kNopeLanes);
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize / 2; ++j) {
+      const auto k = j * 2;
+      const auto x_real = data[k + 0];
+      const auto x_imag = data[k + 1];
+      const auto f_real = freq[k + 0];
+      const auto f_imag = freq[k + 1];
+      const auto rotated =
+          cast<bf16x2_t>(fp32x2_t{x_real * f_real - x_imag * f_imag, x_real * f_imag + x_imag * f_real});
+      const auto [r0, r1] = cast<fp32x2_t>(rotated);
+      data[k + 0] = r0;
+      data[k + 1] = r1;
+    }
+  }
+
+  // FP4/E4M3 fake-quant over 16 elements, i.e. kFp4Lanes threads.
+  {
+    float amax = fabsf(data[0]);
+#pragma unroll
+    for (uint32_t i = 1; i < kVecSize; ++i) {
+      amax = fmaxf(amax, fabsf(data[i]));
+    }
+    amax = warp::reduce_max<kFp4Lanes>(amax);
+    const auto scale = deepseek_v4::fp4::compressed_kv_scale(amax);
+#pragma unroll
+    for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+      const auto [x, y] = deepseek_v4::fp4::fake_quant_compressed_kv_x2({data[i * 2 + 0], data[i * 2 + 1]}, scale);
+      data[i * 2 + 0] = x;
+      data[i * 2 + 1] = y;
+    }
+  }
+
+  // A padded CUDA-graph row carries `out_loc == 0`, the reserved dummy slot,
+  // and must publish nothing: at ratio 1 the compressed slot *is* the FULL
+  // slot, so there is nothing to divide and no other marker to read.
+  if (out_loc <= 0) return;
+  const int32_t page = out_loc >> kPageBits;
+  const int32_t slot = out_loc & ((1 << kPageBits) - 1);
+  const auto page_ptr = params.kvcache + page * kPageBytes;
+  const auto value_ptr = page_ptr + slot * 576;
+
+  if (tx >= kNopeLanes) {
+    bf16_vec_t rope_out;
+#pragma unroll
+    for (uint32_t j = 0; j < kVecSize / 2; ++j) {
+      rope_out[j] = cast<bf16x2_t>(fp32x2_t{data[j * 2 + 0], data[j * 2 + 1]});
+    }
+    rope_out.store(value_ptr + (kHeadDim - kRopeDim), tx - kNopeLanes);
+  } else {
+    // fp8 e4m3 with one ue8m0 scale per 64 elements.
+    float abs_max = fabsf(data[0]);
+#pragma unroll
+    for (uint32_t i = 1; i < kVecSize; ++i) {
+      abs_max = fmaxf(abs_max, fabsf(data[i]));
+    }
+    abs_max = warp::reduce_max<kFp8Lanes>(abs_max);
+    const auto scale_ue8m0 = cast_to_ue8m0(fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX);
+    const auto inv_scale = inv_scale_ue8m0(scale_ue8m0);
+    fp8_vec_t nope_out;
+#pragma unroll
+    for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+      nope_out[i] = pack_fp8(data[i * 2 + 0] * inv_scale, data[i * 2 + 1] * inv_scale);
+    }
+    nope_out.store(value_ptr, tx);
+    if (tx % kFp8Lanes == 0) {
+      (page_ptr + (576 << kPageBits) + slot * 8)[tx / kFp8Lanes] = scale_ue8m0;
+    }
+  }
+}
+
+/// \brief Host side of `flash_c1_decode_kernel`.
+template <int64_t kHeadDim, int64_t kRopeDim, uint32_t kPageSize, bool kUsePDL>
+struct FlashC1DecodeKernel {
+  static constexpr int32_t kPageBits = std::bit_width(kPageSize) - 1;
+  static constexpr int64_t kPageBytes = host::div_ceil(584ll * kPageSize, 576) * 576;
+  static constexpr uint32_t kBlockSize = kHeadDim / kC1VecSize;
+
+  static_assert(std::has_single_bit(kPageSize), "the page/slot split needs a power-of-two page");
+  static_assert(kBlockSize % device::kWarpThreads == 0 && kBlockSize <= 1024);
+
+  template <typename PosT, typename LocT>
+  static constexpr auto kernel = flash_c1_decode_kernel<kUsePDL, kHeadDim, kRopeDim, kPageBits, PosT, LocT>;
+
+  /// \brief The (`positions`, `out_loc`) dtype pair, resolved at run time.
+  static auto select(const bool pos_i32, const bool loc_i32) {
+    if (pos_i32) return loc_i32 ? kernel<int32_t, int32_t> : kernel<int32_t, int64_t>;
+    return loc_i32 ? kernel<int64_t, int32_t> : kernel<int64_t, int64_t>;
+  }
+
+  /// \brief RMSNorm + RoPE + fp4 fake-quant + the 584-byte store, one launch.
+  ///
+  /// \param kv_input `[num_tokens, kHeadDim]` bf16, the `wkv` projection.
+  /// \param kv_output `[num_tokens, kHeadDim]` bf16, the pre-RoPE latent.
+  /// \param norm_weight `[kHeadDim]` bf16.
+  /// \param freqs_cis `[max_pos, kRopeDim]` fp32, real/imag interleaved.
+  /// \param positions `[num_tokens]` int32 or int64, indexed as-is.
+  /// \param out_loc `[num_tokens]` int32 or int64, the compressed slot; `0` is a padded row.
+  /// \param kvcache `[npages, kPageBytes]` uint8, or the pool's fp8 view of it.
+  static void run_decode_fusion(
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView kv_output,
+      const tvm::ffi::TensorView norm_weight,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView out_loc,
+      const tvm::ffi::TensorView kvcache,
+      const float eps) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N, kHeadDim})  //
+        .with_dtype<bf16_t>()
+        .with_device(device_)
+        .verify(kv_input)
+        .verify(kv_output);
+    TensorMatcher({kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(norm_weight);
+    // Real/imag interleaved, so the trailing dim is kRopeDim, not kRopeDim / 2.
+    TensorMatcher({-1, kRopeDim}).with_dtype<fp32_t>().with_device(device_).verify(freqs_cis);
+    // The scheduler's `out_cache_loc` (which `c1_out_loc` aliases at ratio 1)
+    // is int64; the unit tests hand int32. Both are indexed as-is.
+    auto pos_dtype = SymbolicDType{};
+    auto loc_dtype = SymbolicDType{};
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(pos_dtype).with_device(device_).verify(positions);
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(loc_dtype).with_device(device_).verify(out_loc);
+    // The pool allocates the buffer as uint8 and hands it out viewed as its fp8
+    // dtype (`get_extra_key_buffer`); both are one byte per element.
+    TensorMatcher({-1, kPageBytes}).with_dtype<uint8_t, fp8_e4m3_t>().with_device(device_).verify(kvcache);
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    if (num_tokens == 0) return;
+
+    const auto params = C1Params{
+        .kv_input = static_cast<const bf16_t*>(kv_input.data_ptr()),
+        .kv_output = static_cast<bf16_t*>(kv_output.data_ptr()),
+        .norm_weight = static_cast<const bf16_t*>(norm_weight.data_ptr()),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .positions = positions.data_ptr(),
+        .out_loc = out_loc.data_ptr(),
+        .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
+        .eps = eps,
+    };
+    const auto k = select(pos_dtype.is_type<int32_t>(), loc_dtype.is_type<int32_t>());
+    LaunchKernel(num_tokens, kBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(k, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c2.cuh
@@ -1,0 +1,390 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp4_utils.cuh>
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+#include <optional>
+
+namespace sglang {
+
+/// \brief Ratio-2 decode compressor: pair-pool, RMSNorm and the main-KV write.
+///
+/// `kv_input` and `kv_state` rows are `2 * kHeadDim` floats, kv then score.
+/// `kv_output` is the pre-RoPE latent, for the index-K branch's `wk`.
+struct C2Params {
+  const float* __restrict__ kv_input;  // [num_tokens, 2 * kHeadDim] fp32
+  /// `CompressStatePool`'s flat `KVAndScore` buffer, `[size, 2 * kHeadDim]`
+  /// fp32 with kv in the low half and score in the high half. A request's
+  /// pending pair lives at `req * ring_size + pos % ring_size`.
+  float* __restrict__ kv_state;
+  bf16_t* __restrict__ kv_output;          // [num_tokens, kHeadDim] bf16, pre-RoPE
+  const bf16_t* __restrict__ norm_weight;  // [kHeadDim] bf16
+  const float* __restrict__ freqs_cis;     // [max_pos, kRopeDim] fp32, real/imag interleaved
+  const void* __restrict__ positions;      // [num_tokens] PosT
+  const int64_t* __restrict__ req;         // [num_tokens], req_pool_idx per token
+  const void* __restrict__ raw_out_loc;    // [num_tokens] LocT, the FULL slot; 0 marks a padded row
+  uint8_t* __restrict__ kvcache;           // [npages, kPageBytes] uint8
+  /// Positions per request slot in the pair-state ring.
+  uint32_t ring_size;
+  float eps;
+};
+
+/// Elements per thread; 256 threads per token was measured fastest on B200 decode batches.
+/// The launcher and launch bounds share this value. At head_dim 512, the nope/rope split
+/// is (512 - 64) / 2 = 224 threads, keeping the fp8 amax reduction's full-warp mask valid.
+constexpr uint32_t kC2VecSize = 2;
+
+/// \brief grid = num_tokens, block = kHeadDim / kC2VecSize.
+///
+/// An odd position completes a group with its even predecessor; an even one
+/// parks itself in the state.
+///
+/// The three reductions below have three different widths and are not
+/// interchangeable: the RMSNorm statistic spans the row, an fp8 store scale
+/// spans 64 elements, an fp4 block spans 16. All asserted.
+template <
+    bool kUsePDL,
+    bool kStore,
+    int64_t kHeadDim,
+    int64_t kRopeDim,
+    int32_t kPageBits,
+    typename PosT,
+    typename LocT>
+__global__ __launch_bounds__(kHeadDim / kC2VecSize) void flash_c2_decode_kernel(const C2Params params) {
+  using namespace device;
+  using deepseek_v4::fp8::cast_to_ue8m0;
+  using deepseek_v4::fp8::inv_scale_ue8m0;
+  using deepseek_v4::fp8::pack_fp8;
+
+  constexpr uint32_t kVecSize = kC2VecSize;
+  constexpr uint32_t kCTASize = kHeadDim / kVecSize;
+  constexpr int64_t kStride = kHeadDim * 2;
+  /// Threads covering the fp8 nope part; the rest carry the bf16 RoPE tail.
+  constexpr uint32_t kNopeThreads = (kHeadDim - kRopeDim) / kVecSize;
+  constexpr uint32_t kFp8Lanes = 64 / kVecSize;
+  constexpr uint32_t kFp4Lanes = deepseek_v4::fp4::kCompressedKVBlockSize / kVecSize;
+  constexpr int64_t kPageBytes = host::div_ceil(584ll << kPageBits, 576) * 576;
+
+  static_assert(kHeadDim == (kVecSize * kCTASize));
+  static_assert(kCTASize % kWarpThreads == 0);
+  static_assert(kNopeThreads % kFp8Lanes == 0, "the nope part must end on an fp8 scale block");
+  static_assert(kWarpThreads % kFp8Lanes == 0 && kWarpThreads % kFp4Lanes == 0);
+  static_assert(kHeadDim == 512 && kRopeDim == 64, "the 584-byte layout requires (512, 64)");
+  using fp32_vec_t = AlignedVector<float, kVecSize>;
+  using bf16_vec_t = AlignedVector<bf16x2_t, kVecSize / 2>;
+
+  const auto tx = threadIdx.x;
+  const auto row = blockIdx.x;
+  // Slots fit in int32 whatever width the scheduler hands them in.
+  const auto raw_out_loc = static_cast<int32_t>(static_cast<const LocT*>(params.raw_out_loc)[row]);
+  const auto pos = static_cast<const PosT*>(params.positions)[row];
+  // A completing row reads the slot left by `pos - 1`;
+  // a pending row writes its own slot, so reads and writes stay disjoint.
+  const auto ring = static_cast<int64_t>(params.req[row]) * params.ring_size;
+  const auto read_row = ring + (pos - 1 + params.ring_size) % params.ring_size;
+  const auto write_row = ring + pos % params.ring_size;
+  PDLWaitPrimary<kUsePDL>();
+
+  fp32_vec_t kv_new, score_new;
+  kv_new.load(params.kv_input + row * kStride, tx);
+  score_new.load(params.kv_input + row * kStride, tx + kCTASize);
+
+  fp32_vec_t kv_old, score_old;
+  kv_old.load(params.kv_state + read_row * kStride, tx);
+  score_old.load(params.kv_state + read_row * kStride, tx + kCTASize);
+
+  if ((pos & 1) == 0) {
+    // padded case
+    if (raw_out_loc == 0) return PDLTriggerSecondary<kUsePDL>();
+    kv_new.store(params.kv_state + write_row * kStride, tx);
+    score_new.store(params.kv_state + write_row * kStride, tx + kCTASize);
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+
+  constexpr uint32_t kNumWarps = kCTASize / kWarpThreads;
+  __shared__ float s_warp_sum[kNumWarps];
+  fp32_vec_t staged, freq;
+  bf16_vec_t weight, out;
+  weight.load(params.norm_weight, tx);
+  if constexpr (kStore) {
+    if (tx >= kNopeThreads) freq.load(params.freqs_cis + (pos - 1) * kRopeDim, tx - kNopeThreads);
+  }
+
+  // With two scores `exp(-|s0 - s1|)` is the whole softmax: one exp, argument
+  // always <= 0, so no max-subtraction pass and no overflow.
+#pragma unroll
+  for (uint32_t i = 0; i < kVecSize; ++i) {
+    const auto delta = score_old[i] - score_new[i];
+    const auto scale = expf(-fabsf(delta));
+    const auto scale_0 = delta > 0 ? 1.0f : scale;
+    const auto scale_1 = delta > 0 ? scale : 1.0f;
+    staged[i] = (kv_old[i] * scale_0 + kv_new[i] * scale_1) / (1.0f + scale);
+  }
+
+  // `finish` casts to bf16 before the norm, so the sum of squares has to see
+  // the rounded values.
+  float local_sqrsum = 0.0f;
+#pragma unroll
+  for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+    const auto packed = fp32x2_t{staged[i * 2 + 0], staged[i * 2 + 1]};
+    const auto [x, y] = cast<fp32x2_t>(cast<bf16x2_t>(packed));
+    local_sqrsum += x * x;
+    local_sqrsum += y * y;
+    staged[i * 2 + 0] = x;
+    staged[i * 2 + 1] = y;
+  }
+  const auto warp_sum = warp::reduce_sum(local_sqrsum);
+  s_warp_sum[tx / kWarpThreads] = warp_sum;
+  __syncthreads();
+
+  float sqrsum = 0.0f;
+#pragma unroll
+  for (uint32_t i = 0; i < kNumWarps; ++i) {
+    sqrsum += s_warp_sum[i];
+  }
+  constexpr float kInvScale = 1.0f / static_cast<float>(kHeadDim);
+  const auto norm_factor = math::rsqrt(sqrsum * kInvScale + params.eps);
+
+#pragma unroll
+  for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+    const auto [wx, wy] = cast<fp32x2_t>(weight[i]);
+    const auto x = staged[i * 2 + 0] * norm_factor * wx;
+    const auto y = staged[i * 2 + 1] * norm_factor * wy;
+    out[i] = cast<bf16x2_t>(fp32x2_t{x, y});
+  }
+  // The pre-RoPE latent, for the index-K branch's `wk` projection. Published
+  // before the trigger because that GEMM is the successor that reads it.
+  out.store(params.kv_output, static_cast<int64_t>(row) * kCTASize + tx);
+  PDLTriggerSecondary<kUsePDL>();
+
+  if constexpr (kStore) {
+    // ---- main-KV branch: RoPE tail, fp4 fake-quant, 584-byte store ----
+    // Match finish()'s bf16 rounding before RoPE.
+#pragma unroll
+    for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+      const auto [x, y] = cast<fp32x2_t>(out[i]);
+      staged[i * 2 + 0] = x;
+      staged[i * 2 + 1] = y;
+    }
+
+    if (tx >= kNopeThreads) {
+      // Match rope_tail()'s bf16 rounding before fake quantization.
+      // Only odd positions reach here; the latent represents `pos - 1`.
+      freq.load(params.freqs_cis + (pos - 1) * kRopeDim, tx - kNopeThreads);
+#pragma unroll
+      for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+        const auto x_real = staged[i * 2 + 0];
+        const auto x_imag = staged[i * 2 + 1];
+        const auto f_real = x_real * freq[i * 2 + 0] - x_imag * freq[i * 2 + 1];
+        const auto f_imag = x_real * freq[i * 2 + 1] + x_imag * freq[i * 2 + 0];
+        const auto rotated = cast<bf16x2_t>(fp32x2_t{f_real, f_imag});
+        const auto [r0, r1] = cast<fp32x2_t>(rotated);
+        staged[i * 2 + 0] = r0;
+        staged[i * 2 + 1] = r1;
+      }
+    }
+
+    // FP4/E4M3 fake-quant over 16 elements, i.e. kFp4Lanes threads.
+    {
+      float amax = fabsf(staged[0]);
+#pragma unroll
+      for (uint32_t i = 1; i < kVecSize; ++i) {
+        amax = fmaxf(amax, fabsf(staged[i]));
+      }
+      amax = warp::reduce_max<kFp4Lanes>(amax);
+      const auto scale = deepseek_v4::fp4::compressed_kv_scale(amax);
+#pragma unroll
+      for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+        const auto [x, y] =
+            deepseek_v4::fp4::fake_quant_compressed_kv_x2({staged[i * 2 + 0], staged[i * 2 + 1]}, scale);
+        staged[i * 2 + 0] = x;
+        staged[i * 2 + 1] = y;
+      }
+    }
+
+    // padded case
+    if (raw_out_loc == 0) return;
+    // `raw_out_loc / ratio`; ratio 2 makes it a shift.
+    const int32_t out_loc = raw_out_loc >> 1;
+    const int32_t page = out_loc >> kPageBits;
+    const int32_t slot = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    const auto value_ptr = page_ptr + slot * 576;
+
+    if (tx >= kNopeThreads) {
+      bf16_vec_t rope_out;
+#pragma unroll
+      for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+        rope_out[i] = cast<bf16x2_t>(fp32x2_t{staged[i * 2 + 0], staged[i * 2 + 1]});
+      }
+      rope_out.store(value_ptr + (kHeadDim - kRopeDim), tx - kNopeThreads);
+    } else {
+      // fp8 e4m3 with one ue8m0 scale per 64 elements.
+      auto abs_max = fabsf(staged[0]);
+#pragma unroll
+      for (uint32_t i = 1; i < kVecSize; ++i) {
+        abs_max = fmaxf(abs_max, fabsf(staged[i]));
+      }
+      abs_max = warp::reduce_max<kFp8Lanes>(abs_max);
+      const auto scale_ue8m0 = cast_to_ue8m0(fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX);
+      const auto inv_scale = inv_scale_ue8m0(scale_ue8m0);
+#pragma unroll
+      for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+        reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[tx * (kVecSize / 2) + i] =
+            pack_fp8(staged[i * 2 + 0] * inv_scale, staged[i * 2 + 1] * inv_scale);
+      }
+      if (tx % kFp8Lanes == 0) {
+        (page_ptr + (576 << kPageBits) + slot * 8)[tx / kFp8Lanes] = scale_ue8m0;
+      }
+    }
+  }
+}
+
+template <int64_t kHeadDim, int64_t kRopeDim, uint32_t kPageSize, bool kUsePDL>
+struct FlashC2DecodeKernel {
+  static constexpr uint32_t kBlockSize = kHeadDim / kC2VecSize;
+  static constexpr int32_t kPageBits = std::bit_width(kPageSize) - 1;
+  static constexpr int64_t kPageBytes = host::div_ceil(584ll * kPageSize, 576) * 576;
+  template <bool kStore, typename PosT, typename LocT>
+  static constexpr auto kernel = flash_c2_decode_kernel<kUsePDL, kStore, kHeadDim, kRopeDim, kPageBits, PosT, LocT>;
+
+  /// \brief The (`positions`, `raw_out_loc`) dtype pair, resolved at run time.
+  template <bool kStore>
+  static auto select(const bool pos_i32, const bool loc_i32) {
+    if (pos_i32) return loc_i32 ? kernel<kStore, int32_t, int32_t> : kernel<kStore, int32_t, int64_t>;
+    return loc_i32 ? kernel<kStore, int64_t, int32_t> : kernel<kStore, int64_t, int64_t>;
+  }
+
+  // The sum of squares is reduced through a fixed-size shared array, so the CTA
+  // has to be a whole number of warps.
+  static_assert(kHeadDim % (4 * device::kWarpThreads) == 0, "head_dim must be a multiple of 128");
+  static_assert(std::has_single_bit(kPageSize), "the page/slot split needs a power-of-two page");
+
+  /// \brief Pool + norm only. The main-KV write stays with the caller.
+  static void run_decode(
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView kv_state,
+      const tvm::ffi::TensorView kv_output,
+      const tvm::ffi::TensorView norm_weight,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView req,
+      const tvm::ffi::TensorView raw_out_loc,
+      const float eps,
+      const int64_t ring_size) {
+    launch(
+        kv_input,
+        kv_state,
+        kv_output,
+        norm_weight,
+        positions,
+        req,
+        raw_out_loc,
+        eps,
+        ring_size,
+        std::nullopt,
+        std::nullopt);
+  }
+
+  /// \brief Pool + norm + the RoPE tail, fp4 fake-quant and 584-byte store.
+  static void run_decode_fusion(
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView kv_state,
+      const tvm::ffi::TensorView kv_output,
+      const tvm::ffi::TensorView norm_weight,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView req,
+      const tvm::ffi::TensorView raw_out_loc,
+      const float eps,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView kvcache,
+      const int64_t ring_size) {
+    launch(kv_input, kv_state, kv_output, norm_weight, positions, req, raw_out_loc, eps, ring_size, freqs_cis, kvcache);
+  }
+
+ private:
+  using MaybeTensor = std::optional<tvm::ffi::TensorView>;
+
+  static void launch(
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView kv_state,
+      const tvm::ffi::TensorView kv_output,
+      const tvm::ffi::TensorView norm_weight,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView req,
+      const tvm::ffi::TensorView raw_out_loc,
+      const float eps,
+      const int64_t ring_size,
+      const MaybeTensor freqs_cis,
+      const MaybeTensor kvcache) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({N, kHeadDim * 2}).with_dtype<fp32_t>().with_device(device_).verify(kv_input);
+    TensorMatcher({-1, kHeadDim * 2}).with_dtype<fp32_t>().with_device(device_).verify(kv_state);
+    // Only rows that complete a group are written.
+    TensorMatcher({N, kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(kv_output);
+    TensorMatcher({kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(norm_weight);
+    // Metadata retains its original dtypes: the scheduler uses int64 locations,
+    // while callers may also supply int32 locations and positions.
+    auto pos_dtype = SymbolicDType{};
+    auto loc_dtype = SymbolicDType{};
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(pos_dtype).with_device(device_).verify(positions);
+    TensorMatcher({N}).with_dtype<int64_t>().with_device(device_).verify(req);
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(loc_dtype).with_device(device_).verify(raw_out_loc);
+
+    const auto store = freqs_cis.has_value();
+    if (store) {
+      // Real/imag interleaved, so the trailing dim is kRopeDim, not kRopeDim / 2.
+      TensorMatcher({-1, kRopeDim}).with_dtype<fp32_t>().with_device(device_).verify(*freqs_cis);
+      // The pool allocates the buffer as uint8 and hands it out viewed as its
+      // fp8 dtype (`get_extra_key_buffer`); both are one byte per element.
+      TensorMatcher({-1, kPageBytes}).with_dtype<uint8_t, fp8_e4m3_t>().with_device(device_).verify(*kvcache);
+    }
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    if (num_tokens == 0) return;
+    RuntimeCheck(ring_size > 0, "the pair-state ring must have at least one position");
+
+    const auto params = C2Params{
+        .kv_input = static_cast<const float*>(kv_input.data_ptr()),
+        .kv_state = static_cast<float*>(kv_state.data_ptr()),
+        .kv_output = static_cast<bf16_t*>(kv_output.data_ptr()),
+        .norm_weight = static_cast<const bf16_t*>(norm_weight.data_ptr()),
+        .freqs_cis = store ? static_cast<const float*>(freqs_cis->data_ptr()) : nullptr,
+        .positions = positions.data_ptr(),
+        .req = static_cast<const int64_t*>(req.data_ptr()),
+        .raw_out_loc = raw_out_loc.data_ptr(),
+        .kvcache = store ? static_cast<uint8_t*>(kvcache->data_ptr()) : nullptr,
+        .ring_size = static_cast<uint32_t>(ring_size),
+        .eps = eps,
+    };
+    // `LaunchKernel` is move-only, so each arm builds its own.
+    const auto pos_i32 = pos_dtype.is_type<int32_t>();
+    const auto loc_i32 = loc_dtype.is_type<int32_t>();
+    if (store) {
+      const auto k = select<true>(pos_i32, loc_i32);
+      LaunchKernel(num_tokens, kBlockSize, device_.unwrap())  //
+          .enable_pdl(kUsePDL)(k, params);
+    } else {
+      const auto k = select<false>(pos_i32, loc_i32);
+      LaunchKernel(num_tokens, kBlockSize, device_.unwrap())  //
+          .enable_pdl(kUsePDL)(k, params);
+    }
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/fp4_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/fp4_rope.cuh
@@ -1,0 +1,458 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp4_utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+#include <optional>
+
+namespace sglang {
+
+/// \brief RMSNorm, RoPE, two FP4 stages and a 68-byte index-K cache store.
+///
+/// `input` is `wk(latent)`, before `k_norm`. A ratio-r group's latent uses
+/// its first position, `positions & ~(r - 1)`, for power-of-two ratios.
+struct IndexKParams {
+  const bf16_t* __restrict__ input;        // [num_tokens, kHeadDim] bf16, pre-norm
+  const bf16_t* __restrict__ norm_weight;  // [kHeadDim] bf16
+  const float* __restrict__ freqs_cis;     // [max_pos, kRopeDim] fp32, real/imag interleaved
+  const void* __restrict__ positions;      // [num_tokens] PosT
+  const int64_t* __restrict__ loc;         // [num_tokens] index-K slot; 0 publishes nothing
+  uint8_t* __restrict__ cache;             // [npages, kPageSize * 68] uint8
+  uint32_t num_tokens;
+  float eps;
+};
+
+/// \brief RoPE and two-stage FP4 packing for index-Q, after `wq_b`.
+///
+/// Each (token, head) row uses its token's own position, without RMSNorm
+/// or a ratio mask. Payload and scales are contiguous outputs, not a paged cache.
+struct IndexQParams {
+  const bf16_t* __restrict__ input;     // [num_tokens, heads, kHeadDim] bf16
+  const float* __restrict__ freqs_cis;  // [max_pos, kRopeDim] fp32, real/imag interleaved
+  const void* __restrict__ positions;   // [num_tokens] PosT
+  int8_t* __restrict__ payload;         // [num_tokens * heads, kHeadDim / 2] int8
+  int32_t* __restrict__ scale;          // [num_tokens * heads] int32, four ue8m0 bytes
+  // Optional head-weight epilogue (kWeights): the raw `weights_proj` output for
+  // the same (token, head) rows, and where `float(bf16(w * weight_scale))` goes.
+  const bf16_t* __restrict__ head_weights;  // [num_tokens * heads] bf16, or nullptr
+  float* __restrict__ weights_out;          // [num_tokens * heads] fp32, or nullptr
+  float weight_scale;
+  uint32_t num_rows;
+  uint32_t heads;
+};
+
+/// Warps per CTA; one warp owns one row. Chosen from B200 decode measurements,
+/// where occupancy has little effect; multiple warps avoid starving larger batches.
+constexpr uint32_t kFp4RopeWarpsPerCTA = 4;
+
+/// \brief Indexer packer scale: `_ceil_ue8m0_exp(max(amax / 6, 1e-4))`.
+///
+/// Unlike fake quantization, the floor follows the divide, division is not
+/// replaced by multiplication by 1/6, and the exponent is clamped.
+/// The two stages therefore require separate scales.
+SGL_DEVICE uint32_t index_pack_exponent(float amax) {
+  const auto bits = __float_as_uint(fmaxf(amax / 6.0f, 1.0e-4f));
+  const auto exponent = static_cast<int32_t>((bits >> 23) & 0xFF) + ((bits & 0x7FFFFF) != 0);
+  // Neither bound is reachable for finite fp32 inputs: the 1e-4 floor keeps
+  // the exponent above 1, and reaching 254 requires absmax > 6 * 2^126.
+  return static_cast<uint32_t>(min(max(exponent, 1), 254));
+}
+
+/// \brief Clear the sign of every packed nibble whose magnitude rounded to zero.
+///
+/// `cvt.rn.satfinite.e2m1x2.f32` keeps the sign of a small negative, giving the
+/// `-0` code `0x8`; the reference packer drops it (`sign = (x < 0) & (idx != 0)`).
+/// Both dequantize to zero, but the stored byte differs, so match the reference.
+/// Branchless and independent of how many nibbles the word holds: bit 4k+3 of
+/// each nibble survives only if one of bits 4k..4k+2 is set.
+SGL_DEVICE uint32_t clear_negative_zero(uint32_t packed) {
+  const auto any_magnitude = (packed | (packed >> 1) | (packed >> 2)) & 0x11111111u;
+  return packed & ((any_magnitude << 3) | 0x77777777u);
+}
+
+/// One lane's share of a packed 128-element row: two payload bytes and the two
+/// block exponents its half of the warp owns.
+struct IndexPacked {
+  uint32_t payload[2];   // the head pair's byte, then the tail pair's
+  uint32_t exponent[2];  // blocks {0, 1} then {2, 3}, by half of the warp
+};
+
+/// \brief The whole shared body of both directions: RoPE tail, both fp4 stages,
+///        and the indexer's pack.
+///
+/// `head` and `tail` are the lane's two bf16 pairs, widened and already rounded
+/// to bf16 by whatever produced them (the caller's RMSNorm, or the load itself).
+/// `tail` is pre-rotation and `freq` is its matching `(real, imag)`.
+///
+/// A 32-element fp4 block is 16 lanes of *one* half -- blocks 0/1 are the head
+/// on lanes 0-15 / 16-31 and blocks 2/3 the tail -- so each quantization stage
+/// costs two `reduce_max<16>`, not four, and nothing here spans the row.
+SGL_DEVICE IndexPacked index_rope_quant_pack(fp32x2_t head, fp32x2_t tail, fp32x2_t freq) {
+  using namespace device;
+  namespace fp4 = deepseek_v4::fp4;
+
+  constexpr uint32_t kHalfLanes = kWarpThreads / 2;
+  static_assert(fp4::kBlockSize == kHalfLanes * 2, "an fp4 block must be half a warp of one half");
+
+  float data[4];
+  data[0] = head.x;
+  data[1] = head.y;
+  // `rope_tail` ends in `.to(x.dtype)`, so the rotated pair is rounded again.
+  const auto rotated =
+      cast<fp32x2_t>(cast<bf16x2_t>(fp32x2_t{tail.x * freq.x - tail.y * freq.y, tail.x * freq.y + tail.y * freq.x}));
+  data[2] = rotated.x;
+  data[3] = rotated.y;
+
+  // The fake-quant result is already exact in bf16: e2m1 needs at most three
+  // significant bits, and the power-of-two scales admitted by the amax floor fit bf16.
+#pragma unroll
+  for (uint32_t half = 0; half < 2; ++half) {
+    const auto amax = warp::reduce_max<kHalfLanes>(fmaxf(fabsf(data[half * 2]), fabsf(data[half * 2 + 1])));
+    const auto [scale, inv_scale] = fp4::block_scale(amax);
+    const auto q = fp4::fake_quant_x2({data[half * 2], data[half * 2 + 1]}, scale, inv_scale);
+    data[half * 2 + 0] = q.x;
+    data[half * 2 + 1] = q.y;
+  }
+
+  // The packer's scale floor differs from fake quantization; keep both stages.
+  // Each packed byte puts `.x` in the low nibble.
+  IndexPacked out;
+#pragma unroll
+  for (uint32_t half = 0; half < 2; ++half) {
+    const auto amax = warp::reduce_max<kHalfLanes>(fmaxf(fabsf(data[half * 2]), fabsf(data[half * 2 + 1])));
+    out.exponent[half] = index_pack_exponent(amax);
+    // `inv_scale_ue8m0` instead of the reference's division: the scale is a
+    // power of two so both are exact, except at exponent 254, which needs a
+    // block absmax above `6 * 2^126` and so cannot come from a finite float.
+    const auto inv_scale = deepseek_v4::fp8::inv_scale_ue8m0(static_cast<int32_t>(out.exponent[half]));
+    const auto code = __nv_cvt_float2_to_fp4x2(
+        fp32x2_t{data[half * 2] * inv_scale, data[half * 2 + 1] * inv_scale}, __NV_E2M1, cudaRoundNearest);
+    out.payload[half] = clear_negative_zero(static_cast<uint32_t>(code));
+  }
+  return out;
+}
+
+/// \brief The row's four block exponents, packed little-endian into one word.
+///
+/// They live on two lanes -- 0 holds blocks 0 and 2, 16 holds 1 and 3 -- so this
+/// costs two shuffles, and the result is the word only for the lower half of
+/// the warp. Every lane must reach it: the shuffles are warp-wide.
+SGL_DEVICE uint32_t index_scale_word(const uint32_t (&exponent)[2]) {
+  using namespace device;
+  const auto exp_1 = __shfl_sync(warp::kFullMask, exponent[0], kWarpThreads / 2);
+  const auto exp_3 = __shfl_sync(warp::kFullMask, exponent[1], kWarpThreads / 2);
+  return exponent[0] | (exp_1 << 8) | (exponent[1] << 16) | (exp_3 << 24);
+}
+
+/// \brief One warp per token; grid = ceil(num_tokens / kFp4RopeWarpsPerCTA).
+///
+/// Lane L owns head elements {2L, 2L+1} and tail elements {64+2L, 64+2L+1},
+/// so each lane carries one complex RoPE pair. Only RMSNorm spans the full
+/// row; the remaining reductions use the FP4 block layout.
+template <bool kUsePDL, int64_t kHeadDim, int64_t kRopeDim, uint32_t kPageSize, uint32_t kRatio, typename PosT>
+__global__
+__launch_bounds__(kFp4RopeWarpsPerCTA* device::kWarpThreads) void flash_index_k_kernel(const IndexKParams params) {
+  using namespace device;
+  namespace fp4 = deepseek_v4::fp4;
+
+  constexpr uint32_t kPayloadBytes = kHeadDim / 2;
+  constexpr uint32_t kScaleBytes = kHeadDim / fp4::kBlockSize;
+  constexpr uint32_t kSlotBytes = kPayloadBytes + kScaleBytes;
+
+  static_assert(
+      kHeadDim == 128 && kRopeDim == 64,
+      "the one-warp tiling is specific to a 128-wide row whose second half is the RoPE tail");
+  static_assert(kHeadDim == 2 * kWarpThreads * 2, "a lane owns one bf16x2 of each half");
+  static_assert(kScaleBytes == 4, "the four block exponents are packed into one uint32 store");
+  static_assert(std::has_single_bit(kRatio), "group_pos is derived by masking, so the ratio must be a power of two");
+
+  using bf16_vec_t = AlignedVector<bf16x2_t, 1>;
+  using fp32_vec_t = AlignedVector<float, 2>;
+
+  const auto lane = threadIdx.x % kWarpThreads;
+  const auto row = blockIdx.x * kFp4RopeWarpsPerCTA + threadIdx.x / kWarpThreads;
+  // Warp-uniform, so the reductions below still see a full warp.
+  if (row >= params.num_tokens) return;
+
+  // Both come from the step's metadata rather than the predecessor, so
+  // prefetching them ahead of the PDL gate overlaps with the `wk` GEMM's tail.
+  // A row that publishes nothing is dropped at the store, not here.
+  const auto slot_id = params.loc[row];
+  const auto position = static_cast<int64_t>(static_cast<const PosT*>(params.positions)[row]);
+  PDLWaitPrimary<kUsePDL>();
+
+  bf16_vec_t head_in, tail_in, head_w, tail_w;
+  head_in.load(params.input + row * kHeadDim, lane);
+  tail_in.load(params.input + row * kHeadDim, lane + kWarpThreads);
+  head_w.load(params.norm_weight, lane);
+  tail_w.load(params.norm_weight, lane + kWarpThreads);
+  fp32_vec_t freq;
+  freq.load(params.freqs_cis + (position & ~static_cast<int64_t>(kRatio - 1)) * kRopeDim, lane);
+
+  fp32x2_t head, tail;
+  {
+    const auto [h0, h1] = cast<fp32x2_t>(head_in[0]);
+    const auto [t0, t1] = cast<fp32x2_t>(tail_in[0]);
+    const auto sqrsum = warp::reduce_sum(h0 * h0 + h1 * h1 + t0 * t0 + t1 * t1);
+    const auto inv_rms = math::rsqrt(sqrsum * (1.0f / static_cast<float>(kHeadDim)) + params.eps);
+    const auto [wh0, wh1] = cast<fp32x2_t>(head_w[0]);
+    const auto [wt0, wt1] = cast<fp32x2_t>(tail_w[0]);
+    // `k_norm` materializes a bf16 tensor, so the norm result is rounded before
+    // anything downstream sees it -- the RoPE below included.
+    head = cast<fp32x2_t>(cast<bf16x2_t>(fp32x2_t{wh0 * (h0 * inv_rms), wh1 * (h1 * inv_rms)}));
+    tail = cast<fp32x2_t>(cast<bf16x2_t>(fp32x2_t{wt0 * (t0 * inv_rms), wt1 * (t1 * inv_rms)}));
+  }
+
+  const auto packed = index_rope_quant_pack(head, tail, fp32x2_t{freq[0], freq[1]});
+  const auto scale_word = index_scale_word(packed.exponent);
+
+  // A padded graph row, and at ratio > 1 a row completing no group, carry the
+  // reserved slot 0 and must publish nothing.
+  if (slot_id <= 0) return;
+  const auto page = slot_id / kPageSize;
+  const auto slot = slot_id % kPageSize;
+  const auto page_ptr = params.cache + page * (kPageSize * kSlotBytes);
+
+  // Byte i of the payload covers elements (2i, 2i+1), so a lane's head pair is
+  // byte `lane` and its tail pair byte `lane + 32`: two coalesced 32-byte runs.
+  const auto payload_ptr = page_ptr + slot * kPayloadBytes;
+  payload_ptr[lane] = static_cast<uint8_t>(packed.payload[0]);
+  payload_ptr[lane + kWarpThreads] = static_cast<uint8_t>(packed.payload[1]);
+
+  if (lane == 0) {
+    *reinterpret_cast<uint32_t*>(page_ptr + kPageSize * kPayloadBytes + slot * kScaleBytes) = scale_word;
+  }
+}
+
+/// \brief One warp per (token, head); grid = ceil(num_rows / kFp4RopeWarpsPerCTA).
+///
+/// Input is contiguous [num_tokens, heads, kHeadDim]; row r uses token r / heads
+/// and head r % heads. Queries use their own position, without a ratio mask.
+template <bool kUsePDL, int64_t kHeadDim, int64_t kRopeDim, typename PosT, bool kWeights>
+__global__
+__launch_bounds__(kFp4RopeWarpsPerCTA* device::kWarpThreads) void flash_index_q_kernel(const IndexQParams params) {
+  using namespace device;
+
+  constexpr uint32_t kPayloadBytes = kHeadDim / 2;
+
+  static_assert(
+      kHeadDim == 128 && kRopeDim == 64,
+      "the one-warp tiling is specific to a 128-wide row whose second half is the RoPE tail");
+  static_assert(kHeadDim == 2 * kWarpThreads * 2, "a lane owns one bf16x2 of each half");
+
+  using bf16_vec_t = AlignedVector<bf16x2_t, 1>;
+  using fp32_vec_t = AlignedVector<float, 2>;
+
+  const auto lane = threadIdx.x % kWarpThreads;
+  const auto row = blockIdx.x * kFp4RopeWarpsPerCTA + threadIdx.x / kWarpThreads;
+  // Warp-uniform, so the reductions below still see a full warp.
+  if (row >= params.num_rows) return;
+
+  // The position lookup is independent of the PDL producer.
+  const auto position = static_cast<int64_t>(static_cast<const PosT*>(params.positions)[row / params.heads]);
+  PDLWaitPrimary<kUsePDL>();
+
+  bf16_vec_t head_in, tail_in;
+  head_in.load(params.input + row * kHeadDim, lane);
+  tail_in.load(params.input + row * kHeadDim, lane + kWarpThreads);
+  fp32_vec_t freq;
+  freq.load(params.freqs_cis + position * kRopeDim, lane);
+
+  const auto packed =
+      index_rope_quant_pack(cast<fp32x2_t>(head_in[0]), cast<fp32x2_t>(tail_in[0]), fp32x2_t{freq[0], freq[1]});
+  const auto scale_word = index_scale_word(packed.exponent);
+
+  const auto payload_ptr = params.payload + row * kPayloadBytes;
+  payload_ptr[lane] = static_cast<int8_t>(packed.payload[0]);
+  payload_ptr[lane + kWarpThreads] = static_cast<int8_t>(packed.payload[1]);
+
+  if (lane == 0) params.scale[row] = static_cast<int32_t>(scale_word);
+
+  if constexpr (kWeights) {
+    // Match head_weights(x).float(): multiply by the fp32-rounded scale,
+    // round to nearest-even bf16, then widen to fp32.
+    if (lane == 0) {
+      const auto w = cast<float>(params.head_weights[row]) * params.weight_scale;
+      params.weights_out[row] = cast<float>(cast<bf16_t>(w));
+    }
+  }
+}
+
+/// \brief Host side of `flash_index_k_kernel`.
+template <int64_t kHeadDim, int64_t kRopeDim, uint32_t kPageSize, uint32_t kRatio, bool kUsePDL>
+struct FlashIndexKKernel {
+  static constexpr uint32_t kBlockSize = kFp4RopeWarpsPerCTA * device::kWarpThreads;
+  static constexpr int64_t kSlotBytes = kHeadDim / 2 + kHeadDim / deepseek_v4::fp4::kBlockSize;
+
+  template <typename PosT>
+  static constexpr auto kernel = flash_index_k_kernel<kUsePDL, kHeadDim, kRopeDim, kPageSize, kRatio, PosT>;
+
+  /// \param input `[num_tokens, kHeadDim]` bf16, `wk(latent)` before `k_norm`.
+  /// \param norm_weight `[kHeadDim]` bf16, `k_norm.weight`.
+  /// \param freqs_cis `[max_pos, kRopeDim]` fp32, real/imag interleaved.
+  /// \param positions `[num_tokens]` int32 or int64, the *token* position; the
+  ///        group position is derived from it and the ratio.
+  /// \param loc `[num_tokens]` int64, the index-K slot; `0` publishes nothing.
+  /// \param cache `[npages, kPageSize * 68]` uint8.
+  static void run_index_k(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView norm_weight,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView loc,
+      const tvm::ffi::TensorView cache,
+      const float eps) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N, kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(input);
+    TensorMatcher({kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(norm_weight);
+    // Real/imag interleaved, so the trailing dim is kRopeDim, not kRopeDim / 2.
+    TensorMatcher({-1, kRopeDim}).with_dtype<fp32_t>().with_device(device_).verify(freqs_cis);
+    auto pos_dtype = SymbolicDType{};
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(pos_dtype).with_device(device_).verify(positions);
+    TensorMatcher({N}).with_dtype<int64_t>().with_device(device_).verify(loc);
+    TensorMatcher({-1, kPageSize * kSlotBytes}).with_dtype<uint8_t>().with_device(device_).verify(cache);
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    if (num_tokens == 0) return;
+
+    const auto params = IndexKParams{
+        .input = static_cast<const bf16_t*>(input.data_ptr()),
+        .norm_weight = static_cast<const bf16_t*>(norm_weight.data_ptr()),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .positions = positions.data_ptr(),
+        .loc = static_cast<const int64_t*>(loc.data_ptr()),
+        .cache = static_cast<uint8_t*>(cache.data_ptr()),
+        .num_tokens = num_tokens,
+        .eps = eps,
+    };
+    const auto k_int32 = kernel<int32_t>;
+    const auto k_int64 = kernel<int64_t>;
+    const auto k = pos_dtype.is_type<int32_t>() ? k_int32 : k_int64;
+    LaunchKernel(div_ceil(num_tokens, kFp4RopeWarpsPerCTA), kBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(k, params);
+  }
+};
+
+/// \brief Host side of `flash_index_q_kernel`.
+template <int64_t kHeadDim, int64_t kRopeDim, bool kUsePDL>
+struct FlashIndexQKernel {
+  static constexpr uint32_t kBlockSize = kFp4RopeWarpsPerCTA * device::kWarpThreads;
+
+  template <typename PosT, bool kWeights>
+  static constexpr auto kernel = flash_index_q_kernel<kUsePDL, kHeadDim, kRopeDim, PosT, kWeights>;
+
+  /// \param input `[num_tokens, heads, kHeadDim]` bf16, `wq_b(q_lora)`.
+  /// \param freqs_cis `[max_pos, kRopeDim]` fp32, real/imag interleaved.
+  /// \param positions `[num_tokens]` int32 or int64, the query's own position.
+  /// \param payload `[num_tokens * heads, kHeadDim / 2]` int8.
+  /// \param scale `[num_tokens * heads]` int32, the four ue8m0 block exponents
+  ///        packed little-endian.
+  static void run_index_q(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView payload,
+      const tvm::ffi::TensorView scale) {
+    launch(input, freqs_cis, positions, payload, scale, std::nullopt, std::nullopt, 0.0f);
+  }
+
+  /// \brief `run_index_q` plus the indexer's head-weight epilogue.
+  ///
+  /// \param head_weights `[num_tokens, heads]` bf16, the raw `weights_proj(x)`.
+  /// \param weights_out `[num_tokens, heads]` fp32, receives
+  ///        `float(bf16(head_weights * weight_scale))`, i.e. `head_weights(x).float()`.
+  /// \param weight_scale `softmax_scale * heads^-0.5`, applied in fp32.
+  static void run_index_q_weights(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView payload,
+      const tvm::ffi::TensorView scale,
+      const tvm::ffi::TensorView head_weights,
+      const tvm::ffi::TensorView weights_out,
+      const double weight_scale) {
+    launch(input, freqs_cis, positions, payload, scale, head_weights, weights_out, static_cast<float>(weight_scale));
+  }
+
+ private:
+  using MaybeTensor = std::optional<tvm::ffi::TensorView>;
+
+  static void launch(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView positions,
+      const tvm::ffi::TensorView payload,
+      const tvm::ffi::TensorView scale,
+      const MaybeTensor head_weights,
+      const MaybeTensor weights_out,
+      const float weight_scale) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto H = SymbolicSize{"heads"};
+    auto R = SymbolicSize{"num_rows"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N, H, kHeadDim}).with_dtype<bf16_t>().with_device(device_).verify(input);
+    // Real/imag interleaved, so the trailing dim is kRopeDim, not kRopeDim / 2.
+    TensorMatcher({-1, kRopeDim}).with_dtype<fp32_t>().with_device(device_).verify(freqs_cis);
+    auto pos_dtype = SymbolicDType{};
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(pos_dtype).with_device(device_).verify(positions);
+    TensorMatcher({R, kHeadDim / 2}).with_dtype<int8_t>().with_device(device_).verify(payload);
+    TensorMatcher({R}).with_dtype<int32_t>().with_device(device_).verify(scale);
+    const auto weights = head_weights.has_value();
+    RuntimeCheck(weights == weights_out.has_value(), "head_weights and weights_out come together");
+    if (weights) {
+      TensorMatcher({N, H}).with_dtype<bf16_t>().with_device(device_).verify(*head_weights);
+      TensorMatcher({N, H}).with_dtype<fp32_t>().with_device(device_).verify(*weights_out);
+    }
+    RuntimeCheck(
+        R.unwrap() == N.unwrap() * H.unwrap(),
+        "payload holds ",
+        R.unwrap(),
+        " rows, but the input is ",
+        N.unwrap(),
+        " tokens x ",
+        H.unwrap(),
+        " heads");
+
+    const auto num_rows = static_cast<uint32_t>(R.unwrap());
+    if (num_rows == 0) return;
+
+    const auto params = IndexQParams{
+        .input = static_cast<const bf16_t*>(input.data_ptr()),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .positions = positions.data_ptr(),
+        .payload = static_cast<int8_t*>(payload.data_ptr()),
+        .scale = static_cast<int32_t*>(scale.data_ptr()),
+        .head_weights = weights ? static_cast<const bf16_t*>(head_weights->data_ptr()) : nullptr,
+        .weights_out = weights ? static_cast<float*>(weights_out->data_ptr()) : nullptr,
+        .weight_scale = weight_scale,
+        .num_rows = num_rows,
+        .heads = static_cast<uint32_t>(H.unwrap()),
+    };
+    const auto i32 = pos_dtype.is_type<int32_t>();
+    const auto k = weights ? (i32 ? kernel<int32_t, true> : kernel<int64_t, true>)
+                           : (i32 ? kernel<int32_t, false> : kernel<int64_t, false>);
+    LaunchKernel(div_ceil(num_rows, kFp4RopeWarpsPerCTA), kBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(k, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -20,9 +20,9 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <bit>
+#include <climits>
 #include <cstdint>
 #include <iterator>
-#include <limits>
 
 namespace sglang {
 
@@ -37,27 +37,14 @@ enum class TopKMode {
 using Register2 = impl::TopKRegister<2>;  // <= 8192, register-resident, 1 read
 using Register4 = impl::TopKRegister<4>;  // <= 16384, register-resident, 1 read
 using Streaming = impl::TopKStreaming;
-#ifndef USE_ROCM
-using Cluster = impl::TopKCluster<8>;
-#endif
 
 constexpr uint32_t kBlockSize = impl::TopKConfig::kBlockSize;
 constexpr uint32_t kOccupancy = impl::TopKConfig::kOccupancy;
 constexpr uint32_t kMaxTopK = impl::TopKConfig::kMaxTopK;
-#ifndef USE_ROCM
-constexpr uint32_t kClusterSize = Cluster::kClusterSize;
-#endif
 constexpr uint32_t kReg2MaxSeqLen = Register2::kMaxSeqLen;  // 8192
 constexpr uint32_t kReg4MaxSeqLen = Register4::kMaxSeqLen;  // 16384
 
 #define TOPK_KERNEL __global__ __launch_bounds__(kBlockSize, kOccupancy)
-#ifndef USE_ROCM
-#define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
-#endif
-
-constexpr uint32_t kClusterFloor = 65536;
-constexpr uint32_t kClusterMaxBatch = 512;
-constexpr uint32_t kNumPersistentClusters = 15 * kOccupancy;
 
 /// Metadata tensor rows (each 8 B / 2 int32). Row 0 is the global plan result;
 /// rows 1..N are the (batch_id, seq_len) of items routed to the cluster pool.
@@ -71,6 +58,16 @@ struct alignas(8) PlanItem {
 };
 static_assert(sizeof(GlobalMetadata) == 2 * sizeof(int32_t) && sizeof(PlanItem) == sizeof(GlobalMetadata));
 
+struct PageTransform {
+  const int32_t* __restrict__ page_table;
+  uint32_t page_bits;
+
+  SGL_DEVICE int32_t page_to_indices(uint32_t i) const {
+    const uint32_t mask = (1u << page_bits) - 1u;
+    return (page_table[i >> page_bits] << page_bits) | (i & mask);
+  }
+};
+
 struct TopKPagedParams {
   const float* __restrict__ scores;
   const int32_t* __restrict__ seq_lens;
@@ -81,7 +78,8 @@ struct TopKPagedParams {
   int64_t page_table_stride;
   uint32_t topk;
   uint32_t page_bits;
-  uint32_t cluster_floor;  // seq_len > this routes to the cluster path (batch-aware, host-set)
+  uint32_t static_cluster_floor;  // only used in small batch variant
+  uint32_t batch_size;
 
   SGL_DEVICE const GlobalMetadata& global() const {
     return *reinterpret_cast<const GlobalMetadata*>(metadata);
@@ -95,15 +93,16 @@ struct TopKPagedParams {
   SGL_DEVICE int32_t* get_output_ptr(uint32_t batch_id) const {
     return page_indices + batch_id * static_cast<int64_t>(topk);
   }
+  SGL_DEVICE PageTransform get_transform(uint32_t batch_id) const {
+    return {page_table + batch_id * page_table_stride, page_bits};
+  }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id, uint32_t seq_len) const {
     const auto k = static_cast<int64_t>(topk);
     return TopKProblem{
         .in = scores + batch_id * score_stride,
         .out = page_indices + batch_id * k,
-        .page_table = page_table + batch_id * page_table_stride,
         .topk = topk,
         .seq_len = seq_len,
-        .page_bits = page_bits,
     };
   }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id) const {
@@ -121,30 +120,9 @@ struct TopKRaggedParams {
   uint32_t topk;
 };
 
-#ifndef USE_ROCM
-/**
- * \brief Persistent cluster kernel for the long items. It will handle long inputs.
- * The short items are handled by the separate topk_kernel.
- */
-template <bool kPDL>
-CLUSTER_TOPK_KERNEL void topk_persistent_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
-  device::enable_smem_spilling();
-  __shared__ impl::MaxSmem<Cluster::Smem> smem;
-  const uint32_t num_cluster_items = params.global().num_cluster_items;
-  device::PDLWaitPrimary<kPDL>();
-  device::PDLTriggerSecondary<kPDL>();
-#pragma unroll 1
-  for (uint32_t w = blockIdx.x; w < num_cluster_items; w += kNumPersistentClusters) {
-    const auto it = params.item(w);
-    const auto problem = params.problem(it.batch_id, it.seq_len);
-    Cluster::forward<false>(problem, &smem);
-    __syncthreads();
-  }
-}
-#endif  // !USE_ROCM
-
 template <typename F>
 SGL_DEVICE void for_each_item(uint32_t topk, const F& f) {
+  static_assert(kMaxTopK % kBlockSize == 0);
   constexpr uint32_t kNumElems = kMaxTopK / kBlockSize;
 #pragma unroll
   for (uint32_t i = 0; i < kNumElems; ++i) {
@@ -156,26 +134,30 @@ SGL_DEVICE void for_each_item(uint32_t topk, const F& f) {
 }
 
 template <bool kPDL, TopKMode kMode>
-SGL_DEVICE void trivial_transform(const TopKProblem& problem) {
+SGL_DEVICE void trivial_transform(const TopKProblem& problem, const PageTransform& transform) {
   device::PDLWaitPrimary<kPDL>();
   device::PDLTriggerSecondary<kPDL>();
   for_each_item(problem.topk, [&](uint32_t tx, uint32_t) {
-    const auto idx = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
     if constexpr (kMode == TopKMode::INDICES) {
-      problem.emit(tx, idx);
+      problem.out[tx] = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
     } else {
-      problem.transform_output(tx, idx);
+      problem.out[tx] = tx < problem.seq_len ? transform.page_to_indices(tx) : -1;
     }
   });
 }
 
-SGL_DEVICE void problem_transform(TopKProblem& problem, int32_t* output_ptr) {
+SGL_DEVICE void paged_transform(const TopKProblem& problem, int32_t* out, const PageTransform& transform) {
   static_assert(kMaxTopK % kBlockSize == 0);
   constexpr uint32_t kNumElems = kMaxTopK / kBlockSize;
-  int32_t source_index[kNumElems];
-  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) { source_index[i] = problem.out[tx]; });
-  problem.out = output_ptr;
-  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) { problem.transform_output(tx, source_index[i]); });
+  int32_t indices[kNumElems];
+  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) {
+    // load into register at once
+    indices[i] = problem.out[tx];
+  });
+  for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) {
+    // safe write to output
+    out[tx] = indices[i] >= 0 ? transform.page_to_indices(indices[i]) : -1;
+  });
 }
 
 /**
@@ -190,9 +172,20 @@ SGL_DEVICE void problem_transform(TopKProblem& problem, int32_t* output_ptr) {
  * the cluster path (which exists to split ONE row across blocks) is never worth
  * it here.
  *
- * Round the input down for aligned vector loads, then exclude the preceding
- * columns from both histogram and candidate collection. A score sentinel cannot
- * mask them: valid scores may also be negative infinity.
+ * The window start is an arbitrary token offset, so the 16-byte vectorized load
+ * needs the row pointer rounded down to a 4-float boundary. The <= 3 elements
+ * that pulls in are columns of a preceding request -- real finite scores that
+ * would otherwise win the selection -- so they are masked in place first. That
+ * write races with nothing and needs no barrier of its own:
+ *   - one block owns the row, and a column of row `b` is read by no other row;
+ *   - the score buffer is dead once the top-k has run;
+ *   - every forward() below opens with its smem init and a `__syncthreads()`
+ *     before it reads any score. That barrier both publishes the mask to
+ *     whichever thread loads the head vector and keeps the compiler from
+ *     hoisting those loads above the store -- store and loads reach the same row
+ *     through two `__restrict__` pointers, which otherwise licenses exactly that
+ *     reordering.
+ * It must however land after the PDL wait, or the indexer overwrites it.
  */
 template <bool kPDL>
 TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams params) {
@@ -216,24 +209,31 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
 
   const auto rem = row_start % kVecSize;
   const auto score = params.scores + bx * params.score_stride;
-
+  if (rem != 0) {
+    // The mask has to land after the indexer has retired
+    // Otherwise it may be accidentally overwritten by DG upstream
+    device::PDLWaitPrimary<kPDL>();
+    static_assert(kVecSize <= kBlockSize, "not enough threads ");
+    if (const auto tx = threadIdx.x; tx < rem) {
+      score[row_start - rem + tx] = impl::padding_value();
+    }
+  }
+  using device::topk::broadcast;
   const auto problem = TopKProblem{
       .in = score + (row_start - rem),
       .out = out,
-      .page_table = nullptr,  // unused
       .topk = topk,
       .seq_len = seq_len + rem,
-      .page_bits = 1,  // unused
-      .bias = offset - static_cast<int32_t>(rem),
-      .input_start = rem,
+      .bias = broadcast(offset - static_cast<int32_t>(rem)),
+      .input_start = broadcast(rem),
   };
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
   if (problem.seq_len <= Register2::kMaxSeqLen) {
-    Register2::forward<kPDL, true>(problem, &smem);
+    Register2::forward<kPDL>(problem, &smem);
   } else if (problem.seq_len <= Register4::kMaxSeqLen) {
-    Register4::forward<kPDL, true>(problem, &smem);
+    Register4::forward<kPDL>(problem, &smem);
   } else {
-    Streaming::forward<kPDL, true>(problem, &smem);
+    Streaming::forward<kPDL>(problem, &smem);
   }
   // PDL trigger secondary at the end the block typically has no use, so ignore it
 }
@@ -250,8 +250,7 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
 template <bool kPDL, int kLevel, TopKMode kMode>
 TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params) {
   device::enable_smem_spilling();
-  auto problem = params.problem(blockIdx.x);
-  constexpr uint32_t kU32Max = std::numeric_limits<uint32_t>::max();
+  constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
   constexpr bool kHandleCluster = (kLevel == 3);
   // Only the cluster path consumes the cluster kernel's output, so only it waits
   // on that kernel (kPDLFinal). Every other path waits at most on the indexer
@@ -260,14 +259,18 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
   constexpr bool kPDLEarly = kPDL && !kHandleCluster;
   constexpr bool kPDLFinal = kPDL && kHandleCluster;
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDLEarly, kMode>(problem);
+  __shared__ int32_t s_topk_indices[kMaxTopK];
 
-  constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
-  __shared__ int32_t s_topk_indices[kNeedStaging ? kMaxTopK : 1];
-  if constexpr (kNeedStaging) problem.out = s_topk_indices;
+  const auto bx = blockIdx.x;
+  auto problem = params.problem(bx);
+  if (problem.seq_len <= problem.topk) {
+    return trivial_transform<kPDLEarly, kMode>(problem, params.get_transform(bx));
+  }
+  if constexpr (kNeedStaging) {
+    problem.out = s_topk_indices;  // write into stage buffer in smem first
+  }
 
   // non-trivial path: dispatch based on level and seq_len
-  const auto cluster_threshold = kHandleCluster ? params.cluster_threshold() : kU32Max;
   if constexpr (kLevel == 0) {
     __builtin_assume(problem.seq_len <= kReg2MaxSeqLen);
     Register2::forward<kPDL>(problem, &smem);
@@ -275,82 +278,135 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
     __builtin_assume(problem.seq_len <= kReg4MaxSeqLen);
     Register4::forward<kPDL>(problem, &smem);  // max_seq_len <= 16384 guarantees seq <= 16384
   } else {
+    const auto cluster_threshold = kHandleCluster ? params.cluster_threshold() : UINT_MAX;
     static_assert(kLevel == 2 || kLevel == 3, "we only support level = 0,1,2,3 now");
     if (problem.seq_len <= kReg4MaxSeqLen) {
       Register4::forward<kPDLEarly>(problem, &smem);
     } else if (problem.seq_len <= cluster_threshold) {
       Streaming::forward<kPDLEarly>(problem, &smem);
-    } else {
+    } else [[unlikely]] {
       // Cluster path: the pool already selected into our output row; the only
       // work left is the epilogue, so this is the one path that waits for it.
-      problem.out = params.get_output_ptr(blockIdx.x);
-      device::PDLWaitPrimary<kPDLFinal>();
+      if constexpr (kNeedStaging) {
+        device::PDLWaitPrimary<kPDLFinal>();
+        problem.out = params.get_output_ptr(bx);  // in-place transform
+        device::PDLTriggerSecondary<kPDL>();
+        return paged_transform(problem, problem.out, params.get_transform(bx));
+      } else {
+        return device::PDLTriggerSecondary<kPDL>();
+      }
     }
   }
 
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
     __syncthreads();
-    problem_transform(problem, params.get_output_ptr(blockIdx.x));
+    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
 
-#ifndef USE_ROCM
-template <bool kPDL, TopKMode kMode>
-CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKPagedParams params) {
-  device::enable_smem_spilling();
-  auto problem = params.problem(blockIdx.x);
-  __shared__ impl::MaxSmem<Streaming::Smem, Cluster::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDL, kMode>(problem);
+#if SUPPORT_CLUSTER
 
+#ifndef SGL_TOPK_V2_MAX_C8_OCC2
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+#define SGL_TOPK_V2_MAX_C8_OCC2 33  // NOTE: B200
+#else
+#define SGL_TOPK_V2_MAX_C8_OCC2 30  // NOTE: H200
+#endif
+#endif
+
+#ifndef SGL_TOPK_V2_MAX_C16_OCC1
+#define SGL_TOPK_V2_MAX_C16_OCC1 7
+#endif
+
+constexpr uint32_t kNumPersistentClusters = SGL_TOPK_V2_MAX_C8_OCC2;
+constexpr uint32_t kMaxCluster16BatchSize = SGL_TOPK_V2_MAX_C16_OCC1;
+constexpr uint32_t kClusterMaxBatch = 512;
+#define CLUSTER_TOPK_KERNEL TOPK_KERNEL __cluster_dims__(1, kClusterSize, 1)
+
+/**
+ * \brief Persistent cluster kernel for the long items. It will handle long inputs.
+ * The short items are handled by the separate topk_kernel.
+ */
+template <bool kPDL, uint32_t kClusterSize>
+CLUSTER_TOPK_KERNEL void topk_persistent_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
+  device::enable_smem_spilling();
+  using ClusterN = impl::TopKCluster<kClusterSize>;
+  __shared__ impl::MaxSmem<typename ClusterN::Smem> smem;
+  const auto bx = blockIdx.x;
+  const auto num_cluster_items = params.global().num_cluster_items;
+  device::PDLWaitPrimary<kPDL>();
+  if (bx >= params.batch_size) return;
+  device::PDLTriggerSecondary<kPDL>();
+  auto idx = static_cast<int32_t>(num_cluster_items - 1 - bx);
+#pragma unroll 1
+  while (idx >= 0) {
+    const auto it = params.item(idx);
+    const auto problem = params.problem(it.batch_id, it.seq_len);
+    ClusterN::template forward<false>(problem, &smem);
+    idx -= kNumPersistentClusters;
+    if (idx >= 0) __syncthreads();
+  }
+}
+
+template <bool kPDL, TopKMode kMode, uint32_t kClusterSize, uint32_t kOccupancy>
+CLUSTER_TOPK_KERNEL void topk_small_batch_cluster_kernel(const __grid_constant__ TopKPagedParams params) {
+  device::enable_smem_spilling();
   constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
-  __shared__ int32_t s_topk_indices[kNeedStaging ? kMaxTopK : 1];
-  if constexpr (kNeedStaging) problem.out = s_topk_indices;
+  const auto bx = blockIdx.x;
+  const auto by = blockIdx.y;
+  auto problem = params.problem(bx);
+  __shared__ int32_t s_topk_indices[kMaxTopK];
+  using ClusterN = impl::TopKCluster<kClusterSize>;
+  __shared__ impl::MaxSmem<Register4::Smem, Streaming::Smem, typename ClusterN::Smem> smem;
 
   // randomly elect one worker rank to avoid workload imbalance
-  const auto worker_rank = blockIdx.x % kClusterSize;
+  const auto worker_rank = bx % kClusterSize;
+  if (problem.seq_len <= problem.topk) {
+    if (by != worker_rank) return;
+    return trivial_transform<kPDL, kMode>(problem, params.get_transform(bx));
+  }
 
+  if constexpr (kNeedStaging) {
+    problem.out = s_topk_indices;  // write into stage buffer in smem first
+  }
   // for small batch, we will fuse in the cluster case
   if (problem.seq_len <= kReg4MaxSeqLen) {
-    if (blockIdx.y != worker_rank) return;
+    if (by != worker_rank) return;
     Register4::forward<kPDL>(problem, &smem);
-    __syncthreads();
-  } else if (problem.seq_len <= params.cluster_floor) {
-    if (blockIdx.y != worker_rank) return;
+  } else if (problem.seq_len <= params.static_cluster_floor) {
+    if (by != worker_rank) return;
     Streaming::forward<kPDL>(problem, &smem);
-    __syncthreads();
   } else {
     auto cluster = cooperative_groups::this_cluster();
     if constexpr (kNeedStaging) {
-      problem.out = cluster.map_shared_rank(s_topk_indices, worker_rank);
+      problem.out = cluster.map_shared_rank(s_topk_indices, 0);
     }
-    Cluster::forward<kPDL>(problem, &smem);
+    ClusterN::forward<kPDL>(problem, &smem);
     if constexpr (kNeedStaging) {
+      device::PDLTriggerSecondary<kPDL>();
       cluster.sync();
-      if (blockIdx.y != worker_rank) return;
+      if (by != 0) return;
+      problem.out = s_topk_indices;
+      return paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
+    } else {
+      return device::PDLTriggerSecondary<kPDL>();
     }
   }
 
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
-    // Only the elected worker reaches here, and it mapped `topk_indices` to
-    // itself, so `problem.out` is this block's own buffer. Stating that keeps the
-    // shared::cluster address out of the load problem_transform issues -- which is
-    // load-bearing, not an optimization: without it cicc segfaults on CUDA 13.1+
-    // for sm_90a (issue #32830, previously worked around by copying `problem` in
-    // #32910). Verified: dropping this line reproduces the crash on 13.1/13.2/13.3.
-    __builtin_assume(problem.out == s_topk_indices);
-    problem_transform(problem, params.get_output_ptr(blockIdx.x));
+    __syncthreads();
+    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
-#endif  // !USE_ROCM
 
 // --- Plan: choose cluster_threshold from the seq_len distribution -----------
-__global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
+__global__ __launch_bounds__(kBlockSize, 1) void topk_plan_cluster(
     const uint32_t* __restrict__ seq_lens,
     PlanItem* __restrict__ metadata,  // [0]=GlobalMetadata, [1+i]=PlanItem
     const uint32_t batch_size,
-    const uint32_t static_cluster_threshold) {
+    const int32_t static_cluster_threshold) {
   // Candidate (threshold T_j, cap_j) pairs, T strictly increasing. The plan lowers
   // cluster_threshold to T_j while #(items with seq_len > T_j) <= cap_j, so cap_j
   // bounds how many long items go to the persistent pool. The pool runs N items in
@@ -363,16 +419,24 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
     uint32_t max_batch_size;
   };
   constexpr Pair kCandidates[] = {
-      {65536, 30},    // (65536,98304]:    ~1 pool wave, streams beyond 30
-      {98304, 48},    // (98304,131072]
-      {131072, 60},   // (131072,196608]
-      {196608, 80},   // (196608,262144]
-      {262144, 112},  // (262144,393216]
-      {393216, 128},  // (393216,inf):     longest -- worth many pool waves; a top
-                      // threshold here lets overloaded ~280-393K batches still stream
+#if SGL_ARCH_BLACKWELL_OR_GREATER  // tuned on B200
+      {32768, 48},
+      {131072, 66},
+      {163840, 99},
+      {196608, 132},
+      {262144, 198},
+      {393216, 231},
+      {524288, 264},
+#else  // tuned on H200
+      {65536, 30},
+      {98304, 45},
+      {131072, 60},
+      {196608, 80},
+      {262144, 112},
+      {393216, 128},
+#endif
   };
   constexpr uint32_t kNumCandidates = std::size(kCandidates);
-  static_assert(kCandidates[0].threshold == kClusterFloor);
 
   __shared__ uint32_t s_counts[kNumCandidates];
   __shared__ uint32_t s_threshold;
@@ -383,15 +447,15 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
   if (tx == 0) s_count = 0;
   __syncthreads();
 
-  if (static_cluster_threshold > 0) {
+  if (static_cluster_threshold >= 0) {
     if (tx == 0) s_threshold = static_cluster_threshold;
   } else {
     for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-      const uint32_t sl = seq_lens[i];
+      const uint32_t seq_len = seq_lens[i];
       uint32_t count = 0;
 #pragma unroll
       for (uint32_t j = 0; j < kNumCandidates; ++j) {
-        count += (sl > kCandidates[j].threshold ? 1 : 0);
+        count += (seq_len > kCandidates[j].threshold ? 1 : 0);
       }
       if (count > 0) atomicAdd(&s_counts[count - 1], 1);
     }
@@ -410,15 +474,18 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
     }
   }
   __syncthreads();
+
+  constexpr uint32_t kClusterFloor = 32768;  // a very loose lower bound on threshold
   const auto cluster_threshold = max(s_threshold, kClusterFloor);
 
   // Compact items with seq_len > threshold into metadata[1..N]: their batch ids
   // are the work list the persistent cluster pool fetches.
   for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-    const uint32_t sl = seq_lens[i];
-    if (sl > cluster_threshold) {
+    const uint32_t seq_len = seq_lens[i];
+    assert(static_cast<int32_t>(seq_len) >= 0 && "negative seq_len detected");
+    if (seq_len > cluster_threshold) {
       const auto pos = atomicAdd(&s_count, 1);
-      metadata[1 + pos] = {i, sl};
+      metadata[1 + pos] = {i, seq_len};
     }
   }
   __syncthreads();
@@ -428,11 +495,14 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
   }
 }
 
+#endif  // SUPPORT_CLUSTER
+
+template <bool kUsePDL>
 struct TopKKernel {
   static void plan(  //
       const tvm::ffi::TensorView seq_lens,
       const tvm::ffi::TensorView metadata,
-      const uint32_t static_cluster_threshold) {
+      const int32_t static_cluster_threshold) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
     auto Bp1 = SymbolicSize{"batch_size_plus_1"};
@@ -443,25 +513,23 @@ struct TopKKernel {
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(seq_lens);
-    TensorMatcher({Bp1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
+    TensorMatcher({-1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(metadata);
 
-    RuntimeCheck(Bp1.unwrap() == B.unwrap() + 1, "invalid metadata shape");
-#ifdef USE_ROCM
-    // ROCm compiles out the cluster path, the only consumer of this plan.
-    (void)static_cluster_threshold;
-    return;
-#else
+    RuntimeCheck(metadata.size(0) == B.unwrap() + 1, "invalid metadata shape");
+#if SUPPORT_CLUSTER
     const auto batch_size = static_cast<uint32_t>(B.unwrap());
     const auto device = device_.unwrap();
     LaunchKernel(1, kBlockSize, device)(  //
-        topk_plan,
+        topk_plan_cluster,
         static_cast<const uint32_t*>(seq_lens.data_ptr()),
         static_cast<PlanItem*>(metadata.data_ptr()),
         batch_size,
         static_cluster_threshold);
+#else
+    static_cast<void>(static_cluster_threshold);
 #endif
   }
 
@@ -474,10 +542,8 @@ struct TopKKernel {
       const tvm::ffi::TensorView metadata) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
-    auto Bp1 = SymbolicSize{"batch_size_plus_1"};
     auto L = SymbolicSize{"max_seq_len"};
     auto S = SymbolicSize{"score_stride"};
-    auto P = SymbolicSize{"page_table_stride"};
     auto K = SymbolicSize{"topk"};
     auto device_ = SymbolicDevice{};
     device_.set_options<kDLGPU>();
@@ -497,25 +563,25 @@ struct TopKKernel {
     int64_t page_table_stride = 0;
     if (page_table.has_value()) {
       TensorMatcher({B, -1})  // page_table
-          .with_strides({P, 1})
+          .with_strides({-1, 1})
           .with_dtype<int32_t>()
           .with_device(device_)
           .verify(page_table.value());
       page_table_ptr = static_cast<const int32_t*>(page_table.value().data_ptr());
-      page_table_stride = P.unwrap();
+      page_table_stride = (page_table.value()).stride(0);
     }
     TensorMatcher({B, K})  // page_indices
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(page_indices);
-    TensorMatcher({Bp1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
+    TensorMatcher({-1, 2})  // metadata: [0]=GlobalMetadata, [1..N]=PlanItem(batch_id, seq_len)
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(metadata);
 
     RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
     RuntimeCheck(S.unwrap() % 4 == 0, "score_stride must be a multiple of 4 (16-byte vectorized load)");
-    RuntimeCheck(Bp1.unwrap() == B.unwrap() + 1, "invalid metadata shape");
+    RuntimeCheck(metadata.size(0) == B.unwrap() + 1, "invalid metadata shape");
     const auto topk = static_cast<uint32_t>(K.unwrap());
     RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 2048]");
 
@@ -524,13 +590,17 @@ struct TopKKernel {
     const auto max_seq_len = static_cast<uint32_t>(L.unwrap());
     const auto device = device_.unwrap();
 
-    // The fused kernel runs one 8-block cluster per batch element, and B200 fits one
-    // wave of exactly 15 such clusters (occ2). For batch <= 15 it stays latency-bound,
-    // so the 8-way split beats streaming from a much lower seq (measured crossover
-    // ~36-40K); batch 16 spills into a 2nd wave (+25%) and keeps the 64K floor.
-    // The floor is chosen on the host per launch.
-    constexpr uint32_t kClusterFloorSmall = 32768;
-    constexpr uint32_t kSmallBatchLowFloor = 15;
+    constexpr auto get_static_cluster_floor = [](uint32_t batch_size) -> uint32_t {
+      // NOTE: 15 is exactly 0.5 wave which saturate all cluster-8 SMs on Hopper/Blackwell
+      if constexpr (SGL_ARCH_BLACKWELL_OR_GREATER) {
+        return batch_size <= 15 ? 24576 : 30720;
+      } else if constexpr (SGL_ARCH_HOPPER_OR_GREATER) {
+        return batch_size <= 15 ? 32768 : 65536;
+      } else {
+        return UINT_MAX;
+      }
+    };
+
     const auto params = TopKPagedParams{
         .scores = static_cast<const float*>(scores.data_ptr()),
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
@@ -541,39 +611,62 @@ struct TopKKernel {
         .page_table_stride = page_table_stride,
         .topk = topk,
         .page_bits = page_bits,
-        .cluster_floor = (batch_size <= kSmallBatchLowFloor) ? kClusterFloorSmall : kClusterFloor,
+        // only used in small batch variant
+        .static_cluster_floor = get_static_cluster_floor(batch_size),
+        // used for persistent cluster kernel and main kernel
+        .batch_size = batch_size,
     };
 
-#ifndef USE_ROCM
-    const bool use_cluster = (max_seq_len > params.cluster_floor) && (batch_size <= kClusterMaxBatch);
-#endif
-    constexpr bool kUsePDL = true;
-    const auto mode = page_table.has_value() ? TopKMode::PAGE_TABLE : TopKMode::INDICES;
     const auto dispatch = [&]<typename F>(F&& f) {
+      const auto mode = page_table.has_value() ? TopKMode::PAGE_TABLE : TopKMode::INDICES;
       switch (mode) {
         case TopKMode::INDICES:
           return f.template operator()<TopKMode::INDICES>();
-        default:
+        case TopKMode::PAGE_TABLE:
           return f.template operator()<TopKMode::PAGE_TABLE>();
+        default:
+          Panic("Invalid mode, this path should be unreachable");
       }
     };
     dispatch([&]<TopKMode kMode>() {
-#ifndef USE_ROCM
+#if SUPPORT_CLUSTER
+      const bool use_cluster = (max_seq_len > params.static_cluster_floor) && (batch_size <= kClusterMaxBatch);
       if (use_cluster) {
-        if (batch_size <= kNumPersistentClusters) {
-          LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
-              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_small_batch_kernel<kUsePDL, kMode>, params);
-        } else {
-          const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
-          LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)
-              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_persistent_cluster_kernel<kUsePDL>, params);
-          LaunchKernel(batch_size, kBlockSize, device)
-              .config({.use_pdl = kUsePDL})
-              .launch(topk_main_kernel<kUsePDL, /*kLevel=*/3, kMode>, params);
+        if constexpr (kMaxCluster16BatchSize > 0) {
+          if (batch_size <= kMaxCluster16BatchSize) {
+            constexpr uint32_t kClusterSize = 16;
+            // Widths above 8 are non-portable; the launch is rejected without this.
+            const auto kernel = topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 1>;
+            [[maybe_unused]]
+            static const bool _ = [&kernel] {
+              const auto kernel_ptr = reinterpret_cast<const void*>(kernel);
+              CHECK_CUDA(::cudaFuncSetAttribute(kernel_ptr, ::cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+              return true;
+            }();
+            return LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(kernel, params);
+          }
         }
-        return;
+
+        if constexpr (kNumPersistentClusters > 0) {
+          if (batch_size <= kNumPersistentClusters) {
+            constexpr uint32_t kClusterSize = 8;
+            return LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(topk_small_batch_cluster_kernel<kUsePDL, kMode, kClusterSize, 2>, params);
+          } else {
+            constexpr uint32_t kClusterSize = 8;
+            const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
+            LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)
+                .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
+                .launch(topk_persistent_cluster_kernel<kUsePDL, kClusterSize>, params);
+            LaunchKernel(batch_size, kBlockSize, device)
+                .config({.use_pdl = kUsePDL})
+                .launch(topk_main_kernel<kUsePDL, /*kLevel=*/3, kMode>, params);
+            return void();
+          }
+        }
       }
 #endif
       if (max_seq_len <= kReg2MaxSeqLen) {
@@ -595,6 +688,11 @@ struct TopKKernel {
   /**
    * \brief Ragged (prefill) variant of `transform`: per-row window, additive
    * output transform, no page table and no plan.
+   *
+   * `scores` is written in place: the <= 3 columns the 16-byte-aligned read base
+   * pulls in ahead of each row's window are masked out (see
+   * `topk_ragged_kernel`). They are invalid for that row, and the buffer has no
+   * consumer after this call.
    *
    * `row_starts` absent means every window starts at column 0, which is the
    * single-request case; `out_offsets` is added to every selected position and
@@ -644,7 +742,6 @@ struct TopKKernel {
     const auto topk = static_cast<uint32_t>(K.unwrap());
     RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 2048]");
 
-    constexpr bool kUsePDL = true;
     const auto params = TopKRaggedParams{
         .scores = static_cast<float*>(scores.data_ptr()),
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -190,20 +190,9 @@ SGL_DEVICE void problem_transform(TopKProblem& problem, int32_t* output_ptr) {
  * the cluster path (which exists to split ONE row across blocks) is never worth
  * it here.
  *
- * The window start is an arbitrary token offset, so the 16-byte vectorized load
- * needs the row pointer rounded down to a 4-float boundary. The <= 3 elements
- * that pulls in are columns of a preceding request -- real finite scores that
- * would otherwise win the selection -- so they are masked in place first. That
- * write races with nothing and needs no barrier of its own:
- *   - one block owns the row, and a column of row `b` is read by no other row;
- *   - the score buffer is dead once the top-k has run;
- *   - every forward() below opens with its smem init and a `__syncthreads()`
- *     before it reads any score. That barrier both publishes the mask to
- *     whichever thread loads the head vector and keeps the compiler from
- *     hoisting those loads above the store -- store and loads reach the same row
- *     through two `__restrict__` pointers, which otherwise licenses exactly that
- *     reordering.
- * It must however land after the PDL wait, or the indexer overwrites it.
+ * Round the input down for aligned vector loads, then exclude the preceding
+ * columns from both histogram and candidate collection. A score sentinel cannot
+ * mask them: valid scores may also be negative infinity.
  */
 template <bool kPDL>
 TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams params) {
@@ -227,15 +216,6 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
 
   const auto rem = row_start % kVecSize;
   const auto score = params.scores + bx * params.score_stride;
-  if (rem != 0) {
-    // The mask has to land after the indexer has retired
-    // Otherwise it may be accidentally overwritten by DG upstream
-    device::PDLWaitPrimary<kPDL>();
-    static_assert(kVecSize <= kBlockSize, "not enough threads ");
-    if (const auto tx = threadIdx.x; tx < rem) {
-      score[row_start - rem + tx] = -std::numeric_limits<float>::max();
-    }
-  }
 
   const auto problem = TopKProblem{
       .in = score + (row_start - rem),
@@ -245,14 +225,15 @@ TOPK_KERNEL void topk_ragged_kernel(const __grid_constant__ TopKRaggedParams par
       .seq_len = seq_len + rem,
       .page_bits = 1,  // unused
       .bias = offset - static_cast<int32_t>(rem),
+      .input_start = rem,
   };
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
   if (problem.seq_len <= Register2::kMaxSeqLen) {
-    Register2::forward<kPDL>(problem, &smem);
+    Register2::forward<kPDL, true>(problem, &smem);
   } else if (problem.seq_len <= Register4::kMaxSeqLen) {
-    Register4::forward<kPDL>(problem, &smem);
+    Register4::forward<kPDL, true>(problem, &smem);
   } else {
-    Streaming::forward<kPDL>(problem, &smem);
+    Streaming::forward<kPDL, true>(problem, &smem);
   }
   // PDL trigger secondary at the end the block typically has no use, so ignore it
 }
@@ -614,11 +595,6 @@ struct TopKKernel {
   /**
    * \brief Ragged (prefill) variant of `transform`: per-row window, additive
    * output transform, no page table and no plan.
-   *
-   * `scores` is written in place: the <= 3 columns the 16-byte-aligned read base
-   * pulls in ahead of each row's window are masked out (see
-   * `topk_ragged_kernel`). They are invalid for that row, and the buffer has no
-   * consumer after this call.
    *
    * `row_starts` absent means every window starts at column 0, which is the
    * single-request case; `out_offsets` is added to every selected position and

--- a/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/all_reduce_fusion.cuh
@@ -1,0 +1,465 @@
+// Fused deferred-MoE finalize -> 1shot lamport push all-reduce [-> RMSNorm]
+// over the CustomAllReduceV2 push plane, for decode-sized batches (bf16).
+//
+// A generalisation of the K3 `finalize_push_norm` kernel
+// (csrc/kimi_k3/comm/ar_fusion.cuh): the hidden width, top_k and cluster
+// geometry are template parameters chosen from Python, the shared-expert add
+// and the RMSNorm epilogue are optional, and the result goes to a separate
+// output tensor. Per token row t:
+//
+//   local[t] = sum_k expert_weights[t, k] * gemm2_out[idx[t * top_k + k]]
+//              (+ shared_output[t])                     -- stage 1, registers only
+//   out[t]   = sum over ranks of local[t]               -- stage 2
+//   out[t]   = out[t] * rsqrt(mean(out[t]^2) + eps) * w -- kNorm only
+//
+// `idx == -1` marks a dropped slot (EP: the token was routed to an expert
+// that is not local) and contributes nothing. Accumulation is fp32; the bf16
+// rounding points are exactly the unfused path's: the routed combine (what
+// TRT-LLM's finalize returns), the `+ shared` (torch's bf16 add) and the
+// all-reduce output, so the plain (kNorm=false) result equals TRT-LLM finalize
+// -> `shared.add_(routed)` -> fp32-accumulating bf16 all-reduce in rank order,
+// and the staged vector is bit-identical to what the unfused path reduces.
+//
+// The rank-local finalize never materializes in global memory: each thread
+// computes one 16B vector of it and pushes it straight into every peer's push
+// slot with unicast `st.relaxed.sys` stores, exactly like the generic
+// `all_reduce_1shot_push_kernel`, so no multicast mapping is required.
+//
+// Push-plane protocol (see include/sgl_kernel/distributed/communicator.cuh):
+//   * every rank owns 2 phases x kWorldSize slots of `slot_bytes`; a round
+//     uses phase `counter & 1`, producer r writes slot r of every peer, the
+//     consumer polls its own kWorldSize slots until no +0.0 marker remains,
+//     reduces, and restores the +0.0 markers before it exits;
+//   * +0.0 payload words are remapped to -0.0 (numerically identical) so a
+//     written word is never 0 and `word == 0` means "not arrived yet";
+//   * the phase counters are per block of the GENERIC push kernel, which
+//     launches `num_blocks` blocks and flips one counter each. This kernel
+//     uses one counter per row cluster (flipped by the cluster's leader block
+//     after a cluster barrier, since every block of the cluster reads it) and
+//     a trailing "bumper" cluster flips every remaining one, so the whole
+//     array keeps one parity and the two kernel families can share the plane
+//     freely (single-stream calls are serialized);
+//   * every rank must call with the same num_tokens / hidden / top_k / epilogue:
+//     slots are addressed by 16B vector index of the [T, hidden] row view.
+#include <sgl_kernel/ffi.h>
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/distributed/communicator.cuh>
+#include <sgl_kernel/distributed/ptx.cuh>
+
+#include <tvm/ffi/extra/stl.h>
+
+#include <cooperative_groups.h>
+#include <cstdint>
+#include <optional>
+
+namespace sglang {
+
+using device::distributed::PushWorkSpace;
+using host::distributed::CommunicatorRef;
+
+/// One 16B staging vector (8 bf16) viewed as the 4 u32 words the lamport marker
+/// protocol tests, matching the generic push kernel's `LamportTrait<T, 8, 4>`.
+using Lamport = device::distributed::LamportTrait<bf16_t, 8, /*kAtom=*/4>;
+using StageVec = device::AlignedVector<bf16x2_t, 4>;
+
+SGL_DEVICE void barrier_cluster_arrive_relaxed() {
+  asm volatile("barrier.cluster.arrive.relaxed.aligned;" ::: "memory");
+}
+
+SGL_DEVICE void barrier_cluster_wait() {
+  asm volatile("barrier.cluster.wait.aligned;" ::: "memory");
+}
+
+template <uint32_t kWorldSize>
+struct FinalizeAllReduceParams {
+  bf16_t* out;                // [num_tokens, kHiddenDim], output-only
+  const bf16_t* gemm2;        // [P, kHiddenDim], permuted / padded rows
+  const int32_t* idx;         // [num_tokens * kTopK], -1 = dropped slot
+  const bf16_t* weights;      // [num_tokens, kTopK], scaling already folded in
+  const bf16_t* shared;       // [num_tokens, kHiddenDim] (kHasShared only)
+  const bf16_t* norm_weight;  // [kHiddenDim] (kNorm only)
+  float norm_eps;             // kNorm only
+  // Caller's promise that everything this kernel reads before its PDL wait is
+  // complete when the preceding kernel merely *triggers*: no all-reduce on this
+  // plane right before it, and the routing metadata's producers finished (not
+  // just the immediate predecessor -- PDL completion is not transitive through
+  // early-triggering kernels). False (the safe default) waits first.
+  bool prefetch_metadata;
+  uint32_t rank;
+  uint32_t num_tokens;
+  uint32_t num_push_counters;  // full counter array size (bumper range end)
+  PushWorkSpace<kWorldSize> ws;
+};
+
+/// Row geometry: one 16B vector per thread, one cluster per row, so the block
+/// size follows from the hidden width and the cluster size. The cluster size
+/// is the tuning knob (dims per block = kHiddenDim / kClusterSize).
+template <uint32_t kHiddenDim, uint32_t kClusterSize>
+struct AllReduceNormTrait {
+  static constexpr uint32_t kRowVecs = kHiddenDim / 8;             // 16B vectors per row
+  static constexpr uint32_t kBlockSize = kRowVecs / kClusterSize;  // threads per block
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static_assert(kHiddenDim % 8 == 0, "hidden must be a whole number of 16B vectors");
+  static_assert(1 <= kClusterSize && kClusterSize <= 8, "portable cluster sizes only");
+  static_assert(kRowVecs % kClusterSize == 0, "cluster size must divide the row's vector count");
+  static_assert(kBlockSize % device::kWarpThreads == 0, "block must be whole warps");
+  static_assert(kBlockSize <= 1024, "block too large: raise the cluster size");
+};
+
+// --- stage 1: the deferred finalize of one 16B vector ------------------------
+// The shared-expert vector is loaded first so that load is in flight while the
+// routing rows and the kTopK gathers are fetched; the routed combine is then
+// accumulated in ascending k from zero, rounded to bf16, and the shared vector
+// is added with one more bf16 rounding (see the header: the unfused path's
+// numerics, preserving the rank-local rounding points).
+// Threads of the same token read the same kTopK indices / weights (a broadcast
+// load per warp). All arithmetic is on bf16 pairs: one cast converts two
+// elements.
+template <uint32_t kHiddenDim, uint32_t kTopK, bool kHasShared, bool kUsePDL, uint32_t kWorldSize>
+SGL_DEVICE StageVec finalize_vec(const FinalizeAllReduceParams<kWorldSize>& params, uint32_t token, uint32_t hvec) {
+  using namespace device;
+  const auto* idx = params.idx + static_cast<int64_t>(token) * kTopK;
+  const auto* weights = params.weights + static_cast<int64_t>(token) * kTopK;
+  int32_t rows[kTopK];
+  bf16_t w[kTopK];
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    rows[k] = idx[k];
+    w[k] = weights[k];
+  }
+
+  // delay PDL wait until here
+  PDLWaitPrimary<kUsePDL>();
+
+  StageVec shared_in;
+  if constexpr (kHasShared) {
+    shared_in.load(params.shared + static_cast<int64_t>(token) * kHiddenDim, hvec);
+  }
+
+  StageVec in[kTopK];
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    if (rows[k] >= 0) in[k].load(params.gemm2 + static_cast<int64_t>(rows[k]) * kHiddenDim, hvec);
+  }
+
+  fp32x2_t acc[4];
+#pragma unroll
+  for (uint32_t j = 0; j < 4; ++j) {
+    acc[j] = fp32x2_t{0.0f, 0.0f};
+  }
+
+#pragma unroll
+  for (uint32_t k = 0; k < kTopK; ++k) {
+    if (rows[k] < 0) continue;
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      acc[j].x = math::fma_f32_bf16(in[k][j].x, w[k], acc[j].x);
+      acc[j].y = math::fma_f32_bf16(in[k][j].y, w[k], acc[j].y);
+    }
+#else
+    const auto w_fp32 = cast<fp32_t>(w[k]);
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      const auto [x, y] = cast<fp32x2_t>(in[k][j]);
+      acc[j].x = fmaf(x, w_fp32, acc[j].x);
+      acc[j].y = fmaf(y, w_fp32, acc[j].y);
+    }
+#endif
+  }
+  // Same rounding as the unfused path: TRT-LLM's finalize returns the routed
+  // combine rounded to bf16, and `shared.add_(routed)` then rounds the bf16 +
+  // bf16 sum once more (torch adds in fp32). Reproducing both roundings keeps
+  // the staged vector bit-identical to the unfused rank-local result.
+  StageVec out;
+#pragma unroll
+  for (uint32_t j = 0; j < 4; ++j) {
+    if constexpr (kHasShared) {
+      const auto routed = cast<fp32x2_t>(cast<bf16x2_t>(acc[j]));
+      const auto sh = cast<fp32x2_t>(shared_in[j]);
+      out[j] = cast<bf16x2_t>(fp32x2_t{routed.x + sh.x, routed.y + sh.y});
+    } else {
+      out[j] = cast<bf16x2_t>(acc[j]);
+    }
+  }
+  return out;
+}
+
+// --- the kernel --------------------------------------------------------------
+// Grid: dim3(num_tokens [+ 1], kClusterSize) with the cluster laid along y, so
+// blockIdx.x is the token row (and its phase counter: PushEpoch's default) and
+// blockIdx.y the rank inside the cluster. When rows do not own every counter
+// of the plane, one extra cluster (blockIdx.x == num_tokens) is the bumper: it
+// only flips the counters [num_tokens, num_push_counters) and exits; with
+// num_tokens == num_push_counters no bumper is launched. The plane holds
+// num_sm counters, so decode batches always fit.
+template <
+    uint32_t kWorldSize,
+    uint32_t kHiddenDim,
+    uint32_t kTopK,
+    uint32_t kClusterSize,
+    bool kUsePDL,
+    bool kHasShared,
+    bool kNorm>
+__global__ __launch_bounds__(AllReduceNormTrait<kHiddenDim, kClusterSize>::kBlockSize)
+    __cluster_dims__(1, kClusterSize, 1) void moe_finalize_all_reduce_kernel(
+        const __grid_constant__ FinalizeAllReduceParams<kWorldSize> params) {
+  namespace cg = cooperative_groups;
+  using namespace device;
+  using T = AllReduceNormTrait<kHiddenDim, kClusterSize>;
+  constexpr uint32_t kRowVecs = T::kRowVecs;
+  constexpr uint32_t kBlockSize = T::kBlockSize;
+  constexpr uint32_t kNumWarps = T::kNumWarps;
+
+  const auto tx = threadIdx.x;
+  const auto row_idx = blockIdx.x;
+  const auto cluster_rank = blockIdx.y;
+  // this thread's vector within a row: cluster rank picks the block's chunk
+  const auto hvec = cluster_rank * kBlockSize + tx;
+
+  // Under PDL this grid may start while the preceding kernel is still running.
+  // If that kernel is an all-reduce on this plane, it is still flipping the
+  // phase counters and resetting slot markers: reading the epoch now would see
+  // a half-done state and the poll below would never complete. Only a caller
+  // who knows the predecessor is a compute kernel (the MoE GEMM in the model)
+  // may defer the wait to finalize_vec, past the routing-metadata prefetch;
+  // the second wait there is then a no-op.
+  if (!params.prefetch_metadata) PDLWaitPrimary<kUsePDL>();
+
+  if (row_idx == params.num_tokens) {
+    PDLWaitPrimary<kUsePDL>();
+    if (cluster_rank == 0) {
+      const auto epoch = distributed::PushEpoch<kWorldSize>{params.ws};
+      __syncthreads();
+      epoch.unsafe_flip_range(row_idx, params.num_push_counters);
+    }
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+
+  // this cluster's epoch: the counter at blockIdx.x, one per row cluster
+  // (every block of the cluster reads the same one)
+  const auto epoch = distributed::PushEpoch<kWorldSize>{params.ws};
+  const auto r = params.rank;
+  // my slot (`src = r`) inside every peer's workspace, and every peer's slot
+  // inside mine (`dst = r`), for this epoch
+  void* push_ptrs[kWorldSize];
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    push_ptrs[i] = epoch.slot_ptr(/*dst=*/i, /*src=*/r);
+  }
+
+  // stage 1: finalize this row's vector in registers and push it to every peer
+  const auto vid = row_idx * kRowVecs + hvec;
+  {
+    auto vec = finalize_vec<kHiddenDim, kTopK, kHasShared, kUsePDL>(params, row_idx, hvec);
+    Lamport::clear_pos_zero(vec.data());
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      ptx::st_relaxed_16B(vec, push_ptrs[i], vid);
+    }
+  }
+
+  // ensure epoch is consumed, so flipping it won't lead to error
+  if constexpr (!kNorm) barrier_cluster_arrive_relaxed();
+
+  // stage 2: poll own slots, reduce across ranks, [norm], write, reset markers
+  void* poll_ptrs[kWorldSize];
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    poll_ptrs[i] = epoch.slot_ptr(/*dst=*/r, /*src=*/i);
+  }
+  StageVec vec[kWorldSize];
+  do {
+    bool has_zero = false;
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      ptx::ld_relaxed_16B(vec[i], poll_ptrs[i], vid);
+    }
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      // the producer remapped +0.0 words, so a written word is never 0:
+      // word == 0 <=> the slot still holds the empty marker
+      has_zero |= Lamport::has_pos_zero(vec[i].data());
+    }
+    if (!has_zero) break;
+  } while (true);
+
+  if constexpr (!kNorm) {
+    const auto red = reduce_vec(vec);
+    ptx::st_global_16B(red, params.out, vid);
+    // ensure epoch is consumed, so flipping it won't lead to error
+    barrier_cluster_wait();
+  } else {
+    // push to peer
+    __shared__ float smem_sq[kClusterSize][kNumWarps];
+    const auto red = reduce_vec(vec);
+    StageVec w;
+    w.load(params.norm_weight, hvec);
+    const auto cluster = cg::this_cluster();
+    fp32x2_t acc[4];
+    float sq = 0.0f;
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      acc[j] = cast<fp32x2_t>(red[j]);
+      sq = fmaf(acc[j].x, acc[j].x, sq);
+      sq = fmaf(acc[j].y, acc[j].y, sq);
+    }
+    sq = warp::reduce_sum(sq);
+    const auto lane = tx % kWarpThreads;
+    const auto warp = tx / kWarpThreads;
+    if (lane < kClusterSize) {
+      *cluster.map_shared_rank(&smem_sq[cluster_rank][warp], lane) = sq;
+    }
+    cluster.sync();
+    float total = 0.0f;
+#pragma unroll
+    for (uint32_t c = 0; c < kClusterSize; ++c) {
+#pragma unroll
+      for (uint32_t wp = 0; wp < kNumWarps; ++wp) {
+        total += smem_sq[c][wp];
+      }
+    }
+    const auto factor = math::rsqrt(total / static_cast<float>(kHiddenDim) + params.norm_eps);
+    StageVec out;
+#pragma unroll
+    for (uint32_t j = 0; j < 4; ++j) {
+      const auto [wa, wb] = cast<fp32x2_t>(w[j]);
+      out[j] = cast<bf16x2_t>(fp32x2_t{acc[j].x * factor * wa, acc[j].y * factor * wb});
+    }
+    ptx::st_global_16B(out, params.out, vid);
+  }
+  PDLTriggerSecondary<kUsePDL>();
+
+  // re-establish the empty markers for the next same-phase round
+  StageVec zero_vec;
+  Lamport::fill_pos_zero(zero_vec.data());
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    ptx::st_global_16B(zero_vec, poll_ptrs[i], vid);
+  }
+
+  if (cluster_rank == 0) epoch.flip();
+}
+
+// --- host --------------------------------------------------------------------
+
+template <uint32_t kWorldSize, uint32_t kHiddenDim, uint32_t kTopK, uint32_t kClusterSize, bool kUsePDL>
+struct MoeFinalizeAllReduceKernel {
+ private:
+  using TensorView = tvm::ffi::TensorView;
+  using Params = FinalizeAllReduceParams<kWorldSize>;
+  using Trait = AllReduceNormTrait<kHiddenDim, kClusterSize>;
+
+  template <bool kHasShared, bool kNorm>
+  static constexpr auto kernel =
+      moe_finalize_all_reduce_kernel<kWorldSize, kHiddenDim, kTopK, kClusterSize, kUsePDL, kHasShared, kNorm>;
+
+ public:
+  /// out = [allreduce over ranks of] finalize(gemm2_out, idx, weights) [+ shared] [-> RMSNorm(norm_weight, eps)].
+  /// `out` ([T, kHiddenDim] bf16) is output-only. `shared_output` and `norm_weight`
+  /// select the epilogue at runtime (four kernel instantiations per module).
+  static void
+  run(CommunicatorRef ref,
+      TensorView out,
+      TensorView gemm2_out,
+      TensorView permuted_idx,
+      TensorView expert_weights,
+      std::optional<TensorView> shared_output,
+      std::optional<TensorView> norm_weight,
+      double eps,
+      bool prefetch_metadata) {
+    using namespace host;
+    const auto& comm = *ref.get();
+    const auto& push = comm.get_push_obj();
+    CHECK_HOST(push.world_size == kWorldSize)
+        << "communicator holds " << push.world_size << " ranks, kernel built for " << kWorldSize;
+
+    auto T = SymbolicSize{"num_tokens"};
+    auto P = SymbolicSize{"num_permuted_rows"};
+    auto TK = SymbolicSize{"num_expanded"};
+    SymbolicDevice device;
+    device.set_options<kDLCUDA>();
+    TensorMatcher({T, kHiddenDim})
+        .with_strides({kHiddenDim, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(out);
+    TensorMatcher({P, kHiddenDim})
+        .with_strides({kHiddenDim, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(gemm2_out);
+    TensorMatcher({T, kTopK})
+        .with_strides({kTopK, 1})
+        .with_dtype<bf16_t>()
+        .with_device<kDLCUDA>(device)
+        .verify(expert_weights);
+    TK.set_value(T.unwrap() * kTopK);
+    TensorMatcher({TK}).with_strides({1}).with_dtype<int32_t>().with_device<kDLCUDA>(device).verify(permuted_idx);
+    if (shared_output.has_value()) {
+      TensorMatcher({T, kHiddenDim})
+          .with_strides({kHiddenDim, 1})
+          .with_dtype<bf16_t>()
+          .with_device<kDLCUDA>(device)
+          .verify(shared_output.value());
+    }
+    if (norm_weight.has_value()) {
+      TensorMatcher({kHiddenDim})
+          .with_strides({1})
+          .with_dtype<bf16_t>()
+          .with_device<kDLCUDA>(device)
+          .verify(norm_weight.value());
+    }
+    const auto num_tokens = static_cast<uint32_t>(T.unwrap());
+    CHECK_HOST(num_tokens > 0) << "num_tokens must be positive";
+    CHECK_HOST(reinterpret_cast<uintptr_t>(gemm2_out.data_ptr()) % 16 == 0) << "gemm2_out must be 16B aligned";
+    CHECK_HOST(reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0) << "out must be 16B aligned";
+
+    // the whole [T, hidden] row view is staged by vector index, so it must fit
+    // one push slot; the generic push kernel's callers pick the slot size
+    const int64_t nbytes = num_tokens * int64_t(kHiddenDim) * sizeof(bf16_t);
+    CHECK_HOST(nbytes <= push.slot_bytes) << "num_tokens * hidden * 2 = " << nbytes << " bytes exceeds the "
+                                          << push.slot_bytes << "-byte push slot (reduce the batch or enlarge "
+                                          << "max_push_size)";
+    // one cluster (and phase counter) per row; the bumper cluster is launched
+    // only when counters are left over for it to flip (num_tokens < num_blocks),
+    // so a batch that owns every counter runs without it
+    CHECK_HOST(num_tokens <= push.num_blocks)
+        << "num_tokens = " << num_tokens << " exceeds the " << push.num_blocks << " push phase counters of the plane";
+    const uint32_t num_clusters = num_tokens + (num_tokens < push.num_blocks ? 1 : 0);
+
+    const auto params = Params{
+        .out = static_cast<bf16_t*>(out.data_ptr()),
+        .gemm2 = static_cast<const bf16_t*>(gemm2_out.data_ptr()),
+        .idx = static_cast<const int32_t*>(permuted_idx.data_ptr()),
+        .weights = static_cast<const bf16_t*>(expert_weights.data_ptr()),
+        .shared = shared_output.has_value() ? static_cast<const bf16_t*>(shared_output.value().data_ptr()) : nullptr,
+        .norm_weight = norm_weight.has_value() ? static_cast<const bf16_t*>(norm_weight.value().data_ptr()) : nullptr,
+        .norm_eps = static_cast<float>(eps),
+        .prefetch_metadata = prefetch_metadata,
+        .rank = push.rank,
+        .num_tokens = num_tokens,
+        .num_push_counters = push.num_blocks,
+        .ws = push.get_workspace<kWorldSize>(nbytes),
+    };
+
+    const auto has_shared = shared_output.has_value();
+    const auto has_norm = norm_weight.has_value();
+    const auto kern = has_shared ? (has_norm ? kernel<true, true> : kernel<true, false>)
+                                 : (has_norm ? kernel<false, true> : kernel<false, false>);
+    // __cluster_dims__(1, kClusterSize, 1) is compiled in, so a plain launch
+    // already forms the clusters along y
+    LaunchKernel(dim3(num_clusters, kClusterSize), Trait::kBlockSize, out.device()).enable_pdl(kUsePDL)(kern, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/gemm/small/n128k512.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/small/n128k512.cuh
@@ -1,0 +1,151 @@
+/// \file n128k512.cuh
+/// \brief Small bf16 GEMM specialised for N = 128, K = 512: `out[m, n] = sum_k a[m, k] * b[n, k]`.
+///
+/// One warp owns one output column n and keeps that whole 1 KB weight row in
+/// registers (32 lanes x 32 bytes); it is prefetched before the PDL wait so the
+/// load overlaps the tail of the previous kernel. Rows of `a` are handled in
+/// groups of `M_SPLIT` (at most 8) per warp along `blockIdx.y`; the batch size is
+/// read from the params at run time, so eight compiled kernels serve every M.
+/// The reduction is a per-lane in-order fma over 16 elements followed by a warp
+/// butterfly, the same as `tiny_n_gemm_kernel`: results are row-invariant across
+/// M and bitwise equal to tiny_gemm where both apply.
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/tile.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/gemm/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace sglang {
+
+template <uint32_t M_SPLIT_>
+struct N128K512Trait {
+  static constexpr uint32_t N = 128;
+  static constexpr uint32_t K = 512;
+  static constexpr uint32_t kMaxMSplit = 8;
+  static constexpr uint32_t M_SPLIT = M_SPLIT_;  // rows of `a` one warp handles
+  static_assert(M_SPLIT >= 1 && M_SPLIT <= kMaxMSplit, "M_SPLIT must be in [1, 8]");
+  static constexpr uint32_t kVecSize = device::kMaxVecBytes / sizeof(bf16_t);
+  static constexpr uint32_t kNumVecs = K / (kVecSize * device::kWarpThreads);
+  static_assert(K % (kVecSize * device::kWarpThreads) == 0, "K must be a whole number of warp-wide vectors");
+  using vec_t = device::AlignedVector<bf16x2_t, kVecSize / 2>;
+  static constexpr uint32_t kBlockSize = 128;
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static_assert(N % kNumWarps == 0, "every warp of a block owns one output column");
+  static constexpr uint32_t kGridX = N / kNumWarps;
+};
+
+struct N128K512Params {
+  bf16_t* __restrict__ out;
+  const bf16_t* __restrict__ a;
+  const bf16_t* __restrict__ b;
+  int64_t stride_a;  // row stride of `a`, in elements
+  uint32_t m;        // batch size
+};
+
+template <typename T, bool kUsePDL>
+__global__ __launch_bounds__(T::kBlockSize, 1) void n128k512_kernel(const N128K512Params params) {
+  using namespace device;
+  constexpr uint32_t kNumVecs = T::kNumVecs;
+  constexpr uint32_t M_SPLIT = T::M_SPLIT;
+  constexpr uint32_t K = T::K;
+  constexpr uint32_t N = T::N;
+  using vec_t = typename T::vec_t;
+
+  const uint32_t M = params.m;
+  const uint32_t warp_id = threadIdx.x / kWarpThreads;
+  const uint32_t n = blockIdx.x * T::kNumWarps + warp_id;
+  const uint32_t m_start = blockIdx.y * M_SPLIT;
+  const auto gmem = tile::Memory<vec_t>::warp();
+
+  // The weight row does not depend on the previous kernel: load it before the PDL wait.
+  vec_t b[kNumVecs];
+#pragma unroll
+  for (uint32_t j = 0; j < kNumVecs; ++j) {
+    b[j] = gmem.load(params.b + n * K, j);
+  }
+
+  PDLWaitPrimary<kUsePDL>();
+
+  // Clamp padded loads to the last valid row to keep vector loads branch-free;
+  // only stores are guarded.
+  vec_t a[M_SPLIT][kNumVecs];
+#pragma unroll
+  for (uint32_t i = 0; i < M_SPLIT; ++i) {
+    const uint32_t m = min(m_start + i, M - 1);
+#pragma unroll
+    for (uint32_t j = 0; j < kNumVecs; ++j) {
+      a[i][j] = gmem.load(params.a + m * params.stride_a, j);
+    }
+  }
+
+#pragma unroll
+  for (uint32_t i = 0; i < M_SPLIT; ++i) {
+    float acc = 0.0f;
+#pragma unroll
+    for (uint32_t j = 0; j < kNumVecs; ++j) {
+      dot_product_vec(a[i][j], b[j], acc);
+    }
+    acc = warp::reduce_sum(acc);
+    const uint32_t m = m_start + i;
+    if (m < M) {
+      params.out[m * N + n] = cast<bf16_t>(acc);
+    }
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+template <bool kUsePDL>
+struct N128K512Kernel {
+  using Trait1 = N128K512Trait<1>;
+  static constexpr uint32_t kMaxMSplit = Trait1::kMaxMSplit;
+  using KernelFn = void (*)(N128K512Params);
+
+  template <std::size_t... I>
+  static constexpr auto make_table(std::index_sequence<I...>) {
+    return std::array<KernelFn, kMaxMSplit + 1>{nullptr, n128k512_kernel<N128K512Trait<I + 1>, kUsePDL>...};
+  }
+  static constexpr auto kTable = make_table(std::make_index_sequence<kMaxMSplit>{});
+
+  static void run(const tvm::ffi::TensorView a, const tvm::ffi::TensorView b, const tvm::ffi::TensorView out) {
+    using namespace host;
+    auto M = SymbolicSize{"num_tokens"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    TensorMatcher({M, Trait1::K}).with_strides({-1, 1}).with_dtype<bf16_t>().with_device(device).verify(a);
+    TensorMatcher({Trait1::N, Trait1::K}).with_dtype<bf16_t>().with_device(device).verify(b);
+    TensorMatcher({M, Trait1::N}).with_dtype<bf16_t>().with_device(device).verify(out);
+    const auto m = static_cast<uint32_t>(M.unwrap());
+    if (m == 0) return;
+    // Rows are loaded as whole vectors, so a row-sliced view must keep its row starts vector-aligned.
+    CHECK_HOST(a.stride(0) % Trait1::kVecSize == 0)
+        << "a rows must stay aligned to the vector width, got stride " << a.stride(0);
+    // Spread the rows evenly over as few y-blocks as eight rows per warp allow.
+    const uint32_t grid_y = div_ceil(m, kMaxMSplit);
+    const uint32_t m_split = div_ceil(m, grid_y);
+    const auto params = N128K512Params{
+        .out = static_cast<bf16_t*>(out.data_ptr()),
+        .a = static_cast<const bf16_t*>(a.data_ptr()),
+        .b = static_cast<const bf16_t*>(b.data_ptr()),
+        .stride_a = static_cast<int64_t>(a.stride(0)),
+        .m = m,
+    };
+    LaunchKernel(dim3(Trait1::kGridX, grid_y), dim3(Trait1::kBlockSize), device.unwrap())
+        .enable_pdl(kUsePDL)(kTable[m_split], params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/gemm/small/n32k5120.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/small/n32k5120.cuh
@@ -1,0 +1,169 @@
+/// \file n32k5120.cuh
+/// \brief Small bf16 GEMM for N = 32, K = 5120: `out[m, n] = sum_k a[m, k] * b[n, k]`.
+///
+/// One CTA owns an output column; threads share its 10 KB weight row and
+/// prefetch it before the PDL wait. Groups of at most 8 input rows map to
+/// blockIdx.y, with batch size read at run time.
+///
+/// The thread-to-K mapping and dot_product_vec reduction order match tiny_gemm's
+/// N-variant, giving bitwise parity where both apply (m <= 16) and row invariance
+/// across M. Accumulation is fp32 with one final bf16 rounding; cuBLAS uses
+/// a different reduction order.
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/tile.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/gemm/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace sglang {
+
+template <uint32_t M_SPLIT_>
+struct N32K5120Trait {
+  static constexpr uint32_t N = 32;
+  static constexpr uint32_t K = 5120;
+  static constexpr uint32_t kMaxMSplit = 8;
+  static constexpr uint32_t M_SPLIT = M_SPLIT_;  // rows of `a` one CTA handles
+  static_assert(M_SPLIT >= 1 && M_SPLIT <= kMaxMSplit, "M_SPLIT must be in [1, 8]");
+  static constexpr uint32_t kVecSize = device::kMaxVecBytes / sizeof(bf16_t);
+  // Ten warps preserve tiny_gemm's mapping: thread t owns [16t, 16t + 16).
+  // B200 measurements found no latency benefit from a 160-thread alternative.
+  static constexpr uint32_t kBlockSize = 320;
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static constexpr uint32_t kNumVecs = K / (kVecSize * kBlockSize);  // vectors per thread
+  static_assert(K % (kVecSize * kBlockSize) == 0, "K must be a whole number of CTA-wide vectors");
+  static_assert(kBlockSize % device::kWarpThreads == 0, "the reduction needs whole warps");
+  static_assert(M_SPLIT <= kBlockSize, "one thread finishes one row");
+  using vec_t = device::AlignedVector<bf16x2_t, kVecSize / 2>;
+  static constexpr uint32_t kGridX = N;  // one CTA per output column
+};
+
+struct N32K5120Params {
+  bf16_t* __restrict__ out;
+  const bf16_t* __restrict__ a;
+  const bf16_t* __restrict__ b;
+  int64_t stride_a;  // row stride of `a`, in elements
+  uint32_t m;        // batch size
+};
+
+template <typename T, bool kUsePDL>
+__global__ __launch_bounds__(T::kBlockSize, 1) void n32k5120_kernel(const N32K5120Params params) {
+  using namespace device;
+  constexpr uint32_t kNumVecs = T::kNumVecs;
+  constexpr uint32_t kNumWarps = T::kNumWarps;
+  constexpr uint32_t M_SPLIT = T::M_SPLIT;
+  constexpr uint32_t K = T::K;
+  constexpr uint32_t N = T::N;
+  using vec_t = typename T::vec_t;
+
+  const uint32_t M = params.m;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t warp_id = tx / kWarpThreads;
+  const uint32_t n = blockIdx.x;
+  const uint32_t m_start = blockIdx.y * M_SPLIT;
+  const auto gmem = tile::Memory<vec_t>::cta(T::kBlockSize);
+
+  // The weight column does not depend on the previous kernel: load it before the PDL wait.
+  vec_t b[kNumVecs];
+#pragma unroll
+  for (uint32_t j = 0; j < kNumVecs; ++j) {
+    b[j] = gmem.load(params.b + n * K, j);
+  }
+
+  PDLWaitPrimary<kUsePDL>();
+
+  // Clamp padded loads to the last valid row to keep vector loads branch-free;
+  // only stores are guarded.
+  vec_t a[M_SPLIT][kNumVecs];
+#pragma unroll
+  for (uint32_t i = 0; i < M_SPLIT; ++i) {
+    const uint32_t m = min(m_start + i, M - 1);
+#pragma unroll
+    for (uint32_t j = 0; j < kNumVecs; ++j) {
+      a[i][j] = gmem.load(params.a + m * params.stride_a, j);
+    }
+  }
+
+  __shared__ float s_acc[kNumWarps][M_SPLIT];
+#pragma unroll
+  for (uint32_t i = 0; i < M_SPLIT; ++i) {
+    float acc = 0.0f;
+#pragma unroll
+    for (uint32_t j = 0; j < kNumVecs; ++j) {
+      dot_product_vec(a[i][j], b[j], acc);
+    }
+    acc = warp::reduce_sum(acc);
+    if (tx % kWarpThreads == 0) s_acc[warp_id][i] = acc;
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+  __syncthreads();
+
+  // One thread per row sums the warps in a fixed order, so a row's result does
+  // not depend on which rows share its CTA.
+  if (tx < M_SPLIT) {
+    float acc = s_acc[0][tx];
+#pragma unroll
+    for (uint32_t w = 1; w < kNumWarps; ++w) {
+      acc += s_acc[w][tx];
+    }
+    const uint32_t m = m_start + tx;
+    if (m < M) {
+      params.out[m * N + n] = cast<bf16_t>(acc);
+    }
+  }
+}
+
+template <bool kUsePDL>
+struct N32K5120Kernel {
+  using Trait1 = N32K5120Trait<1>;
+  static constexpr uint32_t kMaxMSplit = Trait1::kMaxMSplit;
+  using KernelFn = void (*)(N32K5120Params);
+
+  template <std::size_t... I>
+  static constexpr auto make_table(std::index_sequence<I...>) {
+    return std::array<KernelFn, kMaxMSplit + 1>{nullptr, n32k5120_kernel<N32K5120Trait<I + 1>, kUsePDL>...};
+  }
+  static constexpr auto kTable = make_table(std::make_index_sequence<kMaxMSplit>{});
+
+  static void run(const tvm::ffi::TensorView a, const tvm::ffi::TensorView b, const tvm::ffi::TensorView out) {
+    using namespace host;
+    auto M = SymbolicSize{"num_tokens"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    TensorMatcher({M, Trait1::K}).with_strides({-1, 1}).with_dtype<bf16_t>().with_device(device).verify(a);
+    TensorMatcher({Trait1::N, Trait1::K}).with_dtype<bf16_t>().with_device(device).verify(b);
+    TensorMatcher({M, Trait1::N}).with_dtype<bf16_t>().with_device(device).verify(out);
+    const auto m = static_cast<uint32_t>(M.unwrap());
+    if (m == 0) return;
+    // Rows are loaded as whole vectors, so a row-sliced view must keep its row starts vector-aligned.
+    CHECK_HOST(a.stride(0) % Trait1::kVecSize == 0)
+        << "a rows must stay aligned to the vector width, got stride " << a.stride(0);
+    // Spread the rows evenly over as few y-blocks as eight rows per CTA allow.
+    const uint32_t grid_y = div_ceil(m, kMaxMSplit);
+    const uint32_t m_split = div_ceil(m, grid_y);
+    const auto params = N32K5120Params{
+        .out = static_cast<bf16_t*>(out.data_ptr()),
+        .a = static_cast<const bf16_t*>(a.data_ptr()),
+        .b = static_cast<const bf16_t*>(b.data_ptr()),
+        .stride_a = static_cast<int64_t>(a.stride(0)),
+        .m = m,
+    };
+    LaunchKernel(dim3(Trait1::kGridX, grid_y), dim3(Trait1::kBlockSize), device.unwrap())
+        .enable_pdl(kUsePDL)(kTable[m_split], params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/gemm/tiny_gemm.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/tiny_gemm.cuh
@@ -6,6 +6,8 @@
 #include <sgl_kernel/vec.cuh>
 #include <sgl_kernel/warp.cuh>
 
+#include <sgl_kernel/gemm/utils.cuh>
+
 #include <tvm/ffi/container/tensor.h>
 
 #include <array>
@@ -66,23 +68,6 @@ struct TinyGEMMParams {
   int64_t stride_x;
 };
 
-template <std::size_t N>
-SGL_DEVICE void dot_product(device::AlignedVector<bf16x2_t, N> a, device::AlignedVector<bf16x2_t, N> b, float& acc) {
-  using namespace device;
-#pragma unroll
-  for (uint32_t i = 0; i < N; ++i) {
-#if SGL_ARCH_BLACKWELL_OR_GREATER
-    acc = device::math::fma_f32_bf16(a[i].x, b[i].x, acc);
-    acc = device::math::fma_f32_bf16(a[i].y, b[i].y, acc);
-#else
-    const auto [a0, a1] = cast<fp32x2_t>(a[i]);
-    const auto [b0, b1] = cast<fp32x2_t>(b[i]);
-    acc += a0 * b0;
-    acc += a1 * b1;
-#endif
-  }
-}
-
 template <typename Trait, uint32_t M, typename Out, bool kUsePDL>
 TINY_GEMM_KERNEL void tiny_n_gemm_kernel(const TinyGEMMParams params) {
   using namespace device;
@@ -130,7 +115,7 @@ TINY_GEMM_KERNEL void tiny_n_gemm_kernel(const TinyGEMMParams params) {
       float acc = 0.0f;
 #pragma unroll
       for (uint32_t u = 0; u < kUnroll; ++u) {
-        dot_product(xv[m][u], wv[n][u], acc);
+        dot_product_vec(xv[m][u], wv[n][u], acc);
       }
       s_acc[warp_id][m * N_SPLIT + n] = warp::reduce_sum(acc);
     }
@@ -185,7 +170,7 @@ TINY_GEMM_KERNEL void tiny_k_gemm_kernel(const TinyGEMMParams params) {
 #pragma unroll
   for (uint32_t m = 0; m < M; ++m) {
     float acc = 0.0f;
-    dot_product(xv[m], wv, acc);
+    dot_product_vec(xv[m], wv, acc);
     // Broadcast store: every lane of the group holds the reduced sum.
     const auto sum = warp::reduce_sum<kNumKLanes>(acc);
     static_cast<Out*>(params.out)[m * N + n_idx] = cast<Out>(sum);

--- a/python/sglang/kernels/jit/csrc/misc/probe.cuh
+++ b/python/sglang/kernels/jit/csrc/misc/probe.cuh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+namespace sglang {
+
+__global__ void dummy_probe_kernel() {}
+
+uint32_t get_max_active_clusters(uint32_t cluster_size, uint32_t num_waves) {
+#if !SGL_ARCH_HOPPER_OR_GREATER
+  host::Panic("cluster is not supported on arch before CUDA sm90");
+#else
+  int device;
+  int max_threads_per_sm;
+  int smem_per_sm;
+  int smem_per_block;
+  int num_clusters;
+  CHECK_CUDA(cudaGetDevice(&device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device));
+  CHECK_CUDA(cudaDeviceGetAttribute(&smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  // Threads alone cannot pin the probe to `num_waves` blocks per SM: a block
+  // caps at 1024, so num_waves == 1 still leaves room for a second block. Spend
+  // the shared budget instead -- what one block gets at this occupancy, less the
+  // per-block driver reserve, floored to the 1 KiB allocation granularity so the
+  // driver cannot round it back up and squeeze out a block.
+  const auto reserved = static_cast<uint32_t>(smem_per_sm - smem_per_block);
+  const auto budget = static_cast<uint32_t>(smem_per_sm) / num_waves;
+  const auto smem = (std::min(budget - std::min(budget, reserved), static_cast<uint32_t>(smem_per_block))) & ~1023u;
+  const auto num_warps = std::max(1u, std::min(1024u, static_cast<uint32_t>(max_threads_per_sm) / num_waves) / 32);
+
+  // Widths above 8 are non-portable and the query rejects them without this.
+  CHECK_CUDA(cudaFuncSetAttribute(
+      reinterpret_cast<const void*>(dummy_probe_kernel), cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+  CHECK_CUDA(cudaFuncSetAttribute(
+      reinterpret_cast<const void*>(dummy_probe_kernel),
+      cudaFuncAttributeMaxDynamicSharedMemorySize,
+      static_cast<int>(smem)));
+
+  cudaLaunchConfig_t config = {};  // stream/dynamicSmemBytes must not be garbage
+  config.gridDim = dim3{cluster_size, 1024u};
+  config.blockDim = dim3{32, num_warps};
+  config.dynamicSmemBytes = smem;
+  config.numAttrs = 1;
+  cudaLaunchAttribute attr = {};
+  attr.id = cudaLaunchAttributeClusterDimension;
+  attr.val.clusterDim = {cluster_size, 1, 1};
+  config.attrs = &attr;
+  CHECK_CUDA(cudaOccupancyMaxActiveClusters(&num_clusters, dummy_probe_kernel, &config));
+  return num_clusters;
+#endif
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/fp4_utils.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/fp4_utils.cuh
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#ifndef USE_ROCM
+#include <cuda_fp4.h>
+#endif
+
+// FP4 (e2m1) helpers: per-32 UE8M0 for the indexer, per-16 E4M3 for compressed KV.
+
+namespace sglang {
+
+namespace deepseek_v4::fp4 {
+
+/// Largest finite e2m1 value.
+constexpr float kMax = 6.0f;
+/// `6 * 2^-126`, the amax floor `torch_quant.fake_quant_fp4` clamps to.
+constexpr float kAmaxFloor = 6.0f * 1.1754943508222875e-38f;
+/// Elements sharing one ue8m0 scale.
+constexpr uint32_t kBlockSize = 32;
+/// Compressed-KV elements sharing one E4M3 scale.
+constexpr uint32_t kCompressedKVBlockSize = 16;
+
+/// \brief Round amax / 6 to a positive finite E4M3 scale, ties to even.
+SGL_DEVICE float compressed_kv_scale(float amax) {
+  const auto raw = fminf(fmaxf(amax * (1.0f / kMax), 0x1p-9f), 448.0f);
+  return static_cast<float>(__nv_fp8_e4m3(raw));
+}
+
+/// \brief Quantize compressed KV with its E4M3 scale and return dequantized values.
+SGL_DEVICE fp32x2_t fake_quant_compressed_kv_x2(fp32x2_t x, float scale) {
+  const fp32x2_t scaled{__fdiv_rn(x.x, scale) + 0.0f, __fdiv_rn(x.y, scale) + 0.0f};
+  const auto code = __nv_cvt_float2_to_fp4x2(scaled, __NV_E2M1, cudaRoundNearest);
+  const auto grid = device::cast<fp32x2_t>(fp16x2_t{__nv_cvt_fp4x2_to_halfraw2(code, __NV_E2M1)});
+  return {grid.x * scale, grid.y * scale};
+}
+
+/// \brief Per-block ue8m0 scale and its reciprocal, from the block's absmax.
+///
+/// Both come out of one biased exponent, so the reciprocal costs a subtract
+/// rather than a division.
+SGL_DEVICE fp32x2_t block_scale(float amax) {
+  const auto exponent = fp8::cast_to_ue8m0(fmaxf(amax, kAmaxFloor) * (1.0f / kMax));
+  return {__uint_as_float(static_cast<uint32_t>(exponent) << 23), fp8::inv_scale_ue8m0(exponent)};
+}
+
+/// \brief Round a pair onto the e2m1 grid and back, through `scale`.
+///
+/// `cvt.rn.satfinite.e2m1x2.f32` rounds to nearest even and saturates to +-6;
+/// every e2m1 value is exact in fp16. Adding `0.0f` during scaling clears negative
+/// zero to match `torch.sign(0) == 0` in `torch_quant.round_fp4`.
+SGL_DEVICE fp32x2_t fake_quant_x2(fp32x2_t x, float scale, float inv_scale) {
+  const fp32x2_t scaled{__fmaf_rn(x.x, inv_scale, 0.0f), __fmaf_rn(x.y, inv_scale, 0.0f)};
+  const auto code = __nv_cvt_float2_to_fp4x2(scaled, __NV_E2M1, cudaRoundNearest);
+  const auto grid = device::cast<fp32x2_t>(fp16x2_t{__nv_cvt_fp4x2_to_halfraw2(code, __NV_E2M1)});
+  return {grid.x * scale, grid.y * scale};
+}
+
+}  // namespace deepseek_v4::fp4
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -171,7 +171,7 @@ struct alignas(8) TieValue {
   float value;
   uint32_t idx;
   inline static constexpr TieValue invalid() {
-    return TieValue{-FLT_MAX, 0xFFFFFFFFu};
+    return TieValue{-std::numeric_limits<float>::infinity(), 0xFFFFFFFFu};
   }
 };
 
@@ -194,7 +194,8 @@ struct TopKProblem {
   uint32_t topk;
   uint32_t seq_len;
   uint32_t page_bits;
-  int32_t bias = 0;  // needed by ragged mode
+  int32_t bias = 0;          // needed by ragged mode
+  uint32_t input_start = 0;  // exclude the aligned prefix in ragged mode
 
   SGL_DEVICE void emit(uint32_t pos, uint32_t raw_idx) const {
     out[pos] = static_cast<int32_t>(raw_idx) + bias;
@@ -541,10 +542,11 @@ struct TopKRegister : TopKRadixBase<12> {
   static constexpr uint32_t kMaxSeqLen = kBlockSize * kVecSize * kLocalVecs;
   using Smem = typename TopKRadixBase<12>::Smem;
 
-  template <bool kUsePDL>
+  template <bool kUsePDL, bool kHasInputStart = false>
   SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
+    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
     {
       Smem::kHistVec hist_vec;
@@ -581,17 +583,21 @@ struct TopKRegister : TopKRadixBase<12> {
       const auto vi = tx + kBlockSize * i;
       if (vi >= num_full) break;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j)
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        if constexpr (kHasInputStart) {
+          if (vi * kVecSize + j < input_start) continue;
+        }
         atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(local_vecs[i][j])], 1);
+      }
     }
     if (tx >= kBlockSize - tail) {
       const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
+      if (idx >= input_start) atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
     }
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len, smem);
+    find_threshold(problem.topk, problem.seq_len - input_start, smem);
 
     // Phase 3: collect by two fp32 boundaries (raw indices; transform applied later)
     const auto topk = problem.topk;
@@ -599,6 +605,9 @@ struct TopKRegister : TopKRadixBase<12> {
     const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
     const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
     const auto collect = [&](float val, uint32_t idx) {
+      if constexpr (kHasInputStart) {
+        if (idx < input_start) return;
+      }
       if (val >= v_hi) {
         const auto pos = atomicAdd(&smem->count_gt, 1);
         if (pos < topk) [[likely]]
@@ -641,10 +650,11 @@ struct TopKStreaming : TopKRegister<2> {
  public:
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
 
-  template <bool kUsePDL>
+  template <bool kUsePDL, bool kHasInputStart = false>
   SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
+    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
     {
       Smem::kHistVec hist_vec;
@@ -659,14 +669,17 @@ struct TopKStreaming : TopKRegister<2> {
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram
-    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t) {
+    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
+      if constexpr (kHasInputStart) {
+        if (idx < input_start) return;
+      }
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len, smem);
+    find_threshold(problem.topk, problem.seq_len - input_start, smem);
 
     // Phase 3: Collect candidates and sort. Classify by two fp32 boundaries derived
     // from the threshold bin instead of recomputing the fp16 bin per element: an
@@ -678,6 +691,9 @@ struct TopKStreaming : TopKRegister<2> {
     const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
     const auto topk = problem.topk;
     for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
+      if constexpr (kHasInputStart) {
+        if (idx < input_start) return;
+      }
       if (val >= v_hi) {
         const auto pos = atomicAdd(&smem->count_gt, 1);
         if (pos < topk) [[likely]] {

--- a/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh
@@ -27,7 +27,15 @@
 #include <cstdint>
 #include <limits>
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM)
+// currently only apply cluster for SM90 & SM100, SM120 has poor cluster performance
+#define SUPPORT_CLUSTER (SGL_CUDA_ARCH >= 900 && SGL_CUDA_ARCH < 1100)
+#else
+// AMD doesn't support cluster
+#define SUPPORT_CLUSTER false
+#endif
+
+#if SUPPORT_CLUSTER
 #include <cooperative_groups.h>
 #endif
 
@@ -35,40 +43,27 @@ namespace sglang {
 
 namespace device::topk {
 
-#ifndef USE_ROCM
-namespace cg = cooperative_groups;
+/// Hints that `value` is warp-uniform so it can live in a uniform register. The
+/// caller must already guarantee that: on ROCm this is the identity, since the
+/// 32-bit mask below covers only half of a 64-lane wavefront and there is no
+/// uniform register file to hint at.
+template <typename T>
+SGL_DEVICE T broadcast(T value, uint32_t src = 0) {
+#if defined(USE_ROCM)
+  static_cast<void>(src);
+  return value;
+#else
+  return __shfl_sync(0xFFFFFFFF, value, src);
 #endif
+}
 
 /// sgl_kernel names the warp size `kWarpThreads`; alias it locally as `kWarpSize`.
 inline constexpr uint32_t kWarpSize = kWarpThreads;
 
-// ---------------------------------------------------------------------------
-// Shared-memory storage sized/aligned for several impl `Smem` types
-// ---------------------------------------------------------------------------
-
-/// Compile-time max over a non-empty pack (avoids an <algorithm> dependency).
-template <typename T>
-constexpr T ct_max(T a) {
-  return a;
-}
-template <typename T, typename... Ts>
-constexpr T ct_max(T a, Ts... rest) {
-  const T m = ct_max(rest...);
-  return a > m ? a : m;
-}
-
-/// Static shared-memory buffer sized + aligned to hold any one of the given
-/// impl `Smem` types. A kernel that dispatches across several paths (e.g. the
-/// fused small-batch kernel runs either Streaming or Cluster; the main kernel
-/// runs any of Register2/Register4/Streaming) declares one
-/// `__shared__ MaxSmem<...> smem` and hands `&smem` to whichever forward() it
-/// calls -- instead of hand-picking "the largest" type and relying on it
-/// staying the largest. `&smem` converts to the `void*` the forwards expect;
-/// the buffer is aligned to the strictest member, so the cast is well-aligned.
 template <typename... Smems>
 struct MaxSmem {
-  static constexpr size_t kSize = ct_max(sizeof(Smems)...);
-  static constexpr size_t kAlign = ct_max(alignof(Smems)...);
+  static constexpr size_t kSize = std::max({sizeof(Smems)...});
+  static constexpr size_t kAlign = std::max({alignof(Smems)...});
   alignas(kAlign) uint8_t storage[kSize];
 };
 
@@ -81,64 +76,85 @@ SGL_DEVICE uint32_t extract_exact_bin(float x) {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
+constexpr float padding_value() {
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+constexpr float infinity_value() {
+  return std::numeric_limits<float>::infinity();
+}
+
+// template <uint32_t kBits>
+// SGL_DEVICE uint32_t extract_coarse_bin(float x) {
+//   static_assert(0 < kBits && kBits < 15);
+//   const auto hx = cast<fp16_t>(x);
+//   const uint16_t bits = *reinterpret_cast<const uint16_t*>(&hx);
+//   const uint16_t key = (bits & 0x8000) ? ~bits : bits | 0x8000;
+//   return key >> (16 - kBits);
+// }
+
 template <uint32_t kBits>
 SGL_DEVICE uint32_t extract_coarse_bin(float x) {
   static_assert(0 < kBits && kBits < 15);
-  const auto hx = cast<fp16_t>(x);
-  const uint16_t bits = *reinterpret_cast<const uint16_t*>(&hx);
-  const uint16_t key = (bits & 0x8000) ? ~bits : bits | 0x8000;
-  return key >> (16 - kBits);
+  uint32_t b = (uint32_t)__half_as_ushort(__float2half_rn(x)) << 16;
+  uint32_t s = (uint32_t)((int32_t)b >> 31);
+  return (b ^ (s | 0x80000000u)) >> (32 - kBits);
 }
 
-// Smallest fp32 value `v` for which `extract_coarse_bin<kBits>(v) >= bin`, i.e. the
-// lower fp32 boundary of coarse bin `bin`. Because `extract_coarse_bin` is monotonic
-// non-decreasing in its argument, the collect pass can classify an element with two
-// fp32 comparisons against these boundaries instead of recomputing the fp16 bin --
-// removing the F2F conversion and bit-twiddle from the (compute-bound) second pass.
-// Returns -inf for bin 0 (everything qualifies) and +inf for bins past the top.
+SGL_DEVICE uint16_t coarse_bin_to_bits_finite(uint32_t bin) {
+  const uint16_t ob = static_cast<uint16_t>(bin);
+  return (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
+}
+
+// Smallest fp32 `v` for which `extract_coarse_bin<kBits>(v) >= bin`, i.e. the
+// lower fp32 boundary of coarse bin `bin`. The collect pass classifies with two
+// comparisons against these instead of recomputing the fp16 bin per element, so
+// this must agree with `extract_coarse_bin` on every value -- a score sitting
+// exactly on a boundary included. Two pairs no fp32 threshold can separate are
+// left: -0.0 at the zero bin, and +inf at a NaN-key bin.
 template <uint32_t kBits>
 SGL_DEVICE float coarse_bin_lower_bound(uint32_t bin) {
   constexpr uint32_t kShift = 16 - kBits;
-  const uint32_t key = bin << kShift;  // ordered16 key at the low edge of `bin`
+  constexpr uint32_t kInfBin = 0xFC00u >> kShift;  // bin holding the +inf key
+  const uint32_t key = bin << kShift;              // ordered16 key at the low edge
   // ordered16 -> fp16 value (inverse of the transform in extract_coarse_bin);
-  // finite keys only.
-  const auto to_finite_val = [](uint32_t okey) -> float {
-    const uint16_t ob = static_cast<uint16_t>(okey);
-    const uint16_t hb = (ob & 0x8000) ? static_cast<uint16_t>(ob ^ 0x8000) : static_cast<uint16_t>(~ob);
+  constexpr auto to_finite_val = [](uint32_t okey) -> float {
+    const uint16_t hb = coarse_bin_to_bits_finite(okey);
     return cast<float>(*reinterpret_cast<const fp16_t*>(&hb));
+  };
+  constexpr auto step_up = [](float v) -> float {
+    const int32_t b = __float_as_int(v);
+    return __int_as_float(b >= 0 ? b + 1 : b - 1);
   };
   // Fast path, hoisted above the per-key special cases so both keys are
   // range-checked at once: `key` and `key - 1` both land in the finite band
-  // [0x0401, 0xFBFF] -- every boundary a finite-score threshold produces.
-  // fp16 rounds to nearest, so the fp32 boundary is the midpoint between the
-  // fp16 values at `key` and `key - 1`. (Verified bit-exact against the slow
-  // path for every bin of kBits 10 and 12, and measured faster than either
-  // per-key dispatch or an ordered-bit decrement trick -- the two conversions
-  // are independent and issue in parallel.)
-  if (key - 0x0401u <= 0xFBFFu - 0x0401u && bin < (1u << kBits)) {
-    return 0.5f * (to_finite_val(key) + to_finite_val(key - 1));
+  // [0x0401, 0xFBFF] -- every boundary a finite-score threshold produces. fp16
+  // rounds to nearest, so the boundary is the midpoint between the fp16 values
+  // at `key` and `key - 1`. (Measured faster than a per-key dispatch: the two
+  // conversions are independent and issue in parallel.)
+  if (key - 0x0401u <= 0xFBFFu - 0x0401u) {
+    const float mid = 0.5f * (to_finite_val(key) + to_finite_val(key - 1));
+    // fp32 -> fp16 rounds to nearest EVEN, so on the ~half of bins whose fp16
+    // value has an odd significand the midpoint still bins as `bin - 1`.
+    return (coarse_bin_to_bits_finite(key) & 1u) ? step_up(mid) : mid;
   }
-  // Slow path: an edge of `bin` touches the +/-inf keys or NaN key space.
-  // The ordered-key line is: [0, 0x03FF) negative-NaN space, 0x03FF = -inf,
+  // Slow path: an edge of `bin` touches the +/-inf keys or NaN key space. The
+  // ordered-key line is: [0, 0x03FF) negative-NaN space, 0x03FF = -inf,
   // [0x0400, 0xFC00) finite, 0xFC00 = +inf, (0xFC00, 0xFFFF] positive-NaN
-  // space. Treat the +/-inf keys as +/-65536 (one ideal step past fp16 max,
-  // so the midpoint lands exactly on +/-65520 -- the fp32->fp16
-  // round-to-nearest overflow threshold) and saturate NaN-space keys, keeping
-  // the returned boundaries finite-or-inf and monotone. Otherwise a threshold
-  // bin at/next to the inf bin gets NaN boundaries, the collect pass matches
-  // nothing, and rows whose scores contain >= topk (+/-)inf or >65504 values
-  // come back short -- the padded slots then illegal-address downstream.
-  if (bin == 0) return -FLT_MAX;
-  if (bin >= (1u << kBits)) return FLT_MAX;
+  // space. The +/-inf keys stand in as +/-65536, one ideal step past fp16 max,
+  // so the midpoint lands on the +/-65520 fp32 -> fp16 overflow threshold.
+  if (bin == 0) return -infinity_value();      // every value bins at >= 0
+  if (bin > kInfBin) return infinity_value();  // NaN key space: nothing bins that high
   const auto to_val = [&](uint32_t okey) -> float {
-    constexpr float k_Inf = std::numeric_limits<float>::infinity();
-    if (okey < 0x03FFu) return -k_Inf;
+    if (okey < 0x03FFu) return -infinity_value();
     if (okey == 0x03FFu) return -65536.0f;
     if (okey == 0xFC00u) return 65536.0f;
-    if (okey > 0xFC00u) return FLT_MAX;
     return to_finite_val(okey);
   };
-  return 0.5f * (to_val(key) + to_val(key - 1));
+  // The +/-65536 stand-ins are not real fp16 neighbours, so the parity rule
+  // does not apply here; test the property directly instead.
+  const float mid = 0.5f * (to_val(key) + to_val(key - 1));
+  return extract_coarse_bin<kBits>(mid) < bin ? step_up(mid) : mid;
 }
 
 SGL_DEVICE uint32_t warp_inclusive_sum(uint32_t lane_id, uint32_t val) {
@@ -171,7 +187,7 @@ struct alignas(8) TieValue {
   float value;
   uint32_t idx;
   inline static constexpr TieValue invalid() {
-    return TieValue{-std::numeric_limits<float>::infinity(), 0xFFFFFFFFu};
+    return TieValue{padding_value(), 0xFFFFFFFFu};
   }
 };
 
@@ -179,29 +195,16 @@ struct alignas(8) TieValue {
 // Per-batch problem description + page-table transform sink
 // ---------------------------------------------------------------------------
 
-SGL_DEVICE int32_t page_to_indices(const int32_t* __restrict__ page_table, uint32_t i, uint32_t page_bits) {
-  const uint32_t mask = (1u << page_bits) - 1u;
-  return (page_table[i >> page_bits] << page_bits) | (i & mask);
-}
-
-/// One batch element's worth of work. `emit(pos, raw_idx)` writes the selected raw
-/// index to output slot `pos`; `transform_output` then applies the page-table
-/// transform in a separate pass.
 struct TopKProblem {
   const float* __restrict__ in;
   int32_t* __restrict__ out;  // page_indices [topk]
-  const int32_t* __restrict__ page_table;
   uint32_t topk;
   uint32_t seq_len;
-  uint32_t page_bits;
-  int32_t bias = 0;          // needed by ragged mode
-  uint32_t input_start = 0;  // exclude the aligned prefix in ragged mode
+  int32_t bias = 0;
+  uint32_t input_start = 0;  // needed by ragged mode
 
   SGL_DEVICE void emit(uint32_t pos, uint32_t raw_idx) const {
     out[pos] = static_cast<int32_t>(raw_idx) + bias;
-  }
-  SGL_DEVICE void transform_output(uint32_t t, int32_t raw) const {
-    out[t] = raw < 0 ? -1 : page_to_indices(page_table, raw, page_bits);
   }
 };
 
@@ -228,14 +231,13 @@ struct TopKConfig {
   static_assert(kMaxNumTie >= kMaxTopK && kMaxNumTie % kBlockSize == 0 && kBlockSize % kNumWarps == 0);
 
   struct TieHandleSmem {
-    struct alignas(16) MatchBin {
+    struct MatchBin {
       uint32_t bin;
       uint32_t above_count;
       uint32_t equal_count;
-      uint32_t _pad = 0;
     };
-    alignas(128) uint32_t counter;
-    alignas(128) uint32_t counter_final;
+    uint32_t counter;
+    uint32_t counter_final;
     MatchBin match;
     uint32_t warp_sum[kNumWarps];
     uint32_t histogram[2][kRadixSize];
@@ -256,7 +258,7 @@ struct TopKConfig {
     };
     const auto tx = threadIdx.x;
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
+    const auto warp_id = broadcast(tx / kWarpSize);
     static_assert(kNumWarps == kWarpSize);
 
     if (num_ties <= topk) {
@@ -323,11 +325,11 @@ struct TopKConfig {
       }
     } else if (num_ties <= kBlockSize) {
       // Common case: one candidate per thread.
-      radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem);
+      return radix_tie_select<1>(tie_buffer, problem, base, num_ties, topk, smem);
     } else {
-      // Rare overflow case (kBlockSize < num_ties <= kMaxNumTie), kept out of
-      // the common path so it alone pays the multi-item register cost.
-      radix_tie_select<kTieItems>(tie_buffer, problem, base, num_ties, topk, smem);
+      // Rare overflow case.
+      static_assert(kTieItems == 2);
+      return radix_tie_select<2>(tie_buffer, problem, base, num_ties, topk, smem);
     }
   }
 
@@ -344,7 +346,7 @@ struct TopKConfig {
       TieHandleSmem* smem) {
     const auto tx = threadIdx.x;
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
+    const auto warp_id = broadcast(tx / kWarpSize);
 
     bool active[kItems];
     uint32_t key[kItems];
@@ -399,7 +401,7 @@ struct TopKConfig {
       }
       __syncthreads();
 
-      const auto [threshold_bin, above_count, equal_count, __] = smem->match;
+      const auto [threshold_bin, above_count, equal_count] = smem->match;
       if (round < 3) total_active = equal_count;
       topk_remain -= above_count;
 
@@ -435,96 +437,119 @@ struct TopKConfig {
 
 template <uint32_t kHistBits_>
 struct TopKRadixBase : TopKConfig {
+ public:
   static constexpr uint32_t kVecSize = 4;
   static constexpr uint32_t kHistBits = kHistBits_;
   static constexpr uint32_t kHistSize = 1 << kHistBits;
   using vec_t = AlignedVector<float, kVecSize>;
 
   struct Smem {
-    using kHistVec = AlignedVector<uint32_t, kHistSize / kBlockSize>;
-    alignas(128) uint32_t count_eq;
-    alignas(128) uint32_t count_gt;
-    uint32_t threshold_bin;
+    uint32_t count_eq;
+    uint32_t count_gt;
+    float v_hi;
+    float v_lo;
     uint32_t warp_sum[kNumWarps];
     // The coarse histogram is dead once find_threshold() has published
     // threshold_bin, and the tie machinery only comes alive after that: the
-    // collect pass fills tie.values, then handle_tie works over them with
-    // tie.handle as scratch. Overlaying the two phases keeps the
+    // collect pass fills tie_values, then handle_tie works over them with
+    // tie_handle as scratch. Overlaying the two phases keeps the
     // kMaxNumTie-candidate buffer from growing the block's shared-memory
-    // footprint. tie.handle and tie.values are live TOGETHER, so they sit
+    // footprint. tie_handle and tie_values are live TOGETHER, so they sit
     // side by side inside the overlay, not in a union with each other.
     union {
-      uint32_t histogram[kHistSize];
-      kHistVec hist_vecs[kBlockSize];
+      alignas(16) uint32_t histogram[kHistSize];
       struct {
-        TieHandleSmem handle;
-        TieValue values[kMaxNumTie];
-      } tie;
+        TieValue tie_values[kMaxNumTie];
+        TieHandleSmem tie_handle;
+      };
     };
   };
 
  protected:
-  template <typename F>
+  template <uint32_t N = 1, typename F>
   SGL_DEVICE static void for_each_input(const float* __restrict__ in, uint32_t seq_len, F&& fn) {
+    constexpr auto kStride = N * kBlockSize;
     const auto tx = threadIdx.x;
-    const uint32_t num_full = seq_len / kVecSize;  // fully-in-bounds vectors
-
-    vec_t next_vec;
-    uint32_t vi = tx;
-    if (vi < num_full) next_vec.load(in, vi);
-    while (vi < num_full) {
-      const auto cur = next_vec;
-      const auto base = vi * kVecSize;
-      vi += kBlockSize;
-      if (vi < num_full) next_vec.load(in, vi);
+    const auto num_full = seq_len / kVecSize;  // fully-in-bounds vectors
+    const auto kChunk = 128u;
+    // lane | rank | warp
+    auto vi = N == 1 ? tx : (tx % kChunk) + blockIdx.y * kChunk + (tx / kChunk) * (N * kChunk);
+    if (vi < num_full) {
+      vec_t next_vec;
+      next_vec.load(in, vi);
+#pragma unroll 1
+      do {
+        const auto cur = next_vec;
+        vi += kStride;
+        if (vi < num_full) next_vec.load(in, vi);
+        const auto base = (vi - kStride) * kVecSize;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j) {
-        fn(cur[j], base + j);
-      }
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+          fn(cur[j], base + j);
+        }
+      } while (vi < num_full);
     }
 
-    // Tail: at most one partial vector, `rem` in [0, kVecSize).
-    static_assert(kVecSize <= kBlockSize);  // ensure tail correctness
-    const uint32_t tail_start = num_full * kVecSize;
-    if (tx < seq_len - tail_start) {
-      const auto idx = tail_start + tx;
-      fn(in[idx], idx);
+    if (vi == num_full) {
+      const auto base = vi * kVecSize;
+      if (base == seq_len) return;
+      vec_t cur;
+      cur.load(in, vi);
+#pragma unroll
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        if (base + j < seq_len) fn(cur[j], base + j);
+      }
     }
   }
 
-  SGL_DEVICE static void find_threshold(const uint32_t topk, const uint32_t seq_len, Smem* smem) {
+  SGL_DEVICE static void init_histogram(uint32_t (&histogram)[kHistSize], uint32_t tx) {
+    constexpr uint32_t kItems = kHistSize / kBlockSize;
+    AlignedVector<uint32_t, kItems> vec;
+    vec.fill(0);
+    vec.store(histogram, tx);
+  }
+
+  /// Same, but scanning a histogram that need not be `smem`'s own -- the cluster
+  /// path merges into one rank's copy and scans it there.
+  template <typename Smem, typename Fn>
+  SGL_DEVICE static void find_threshold(const uint32_t topk, const uint32_t seq_len, Smem* smem, Fn fn) {
     const auto tx = threadIdx.x;
     constexpr uint32_t kItems = kHistSize / kBlockSize;
-    uint32_t orig[kItems];
-    const auto hist_vec = smem->hist_vecs[tx];
-    uint32_t tmp_local_sum = 0;
+    uint32_t local_exc_sum[kItems + 1];
+    AlignedVector<uint32_t, kItems> hist_vec;
+    hist_vec.load(smem->histogram, tx);
 
+    local_exc_sum[0] = 0;
 #pragma unroll
     for (uint32_t i = 0; i < kItems; ++i) {
-      orig[i] = hist_vec[i];
-      tmp_local_sum += orig[i];
+      local_exc_sum[i + 1] = hist_vec[i] + local_exc_sum[i];
     }
 
+    const auto local_sum = local_exc_sum[kItems];
     const auto lane_id = tx % kWarpSize;
-    const auto warp_id = tx / kWarpSize;
-    const auto warp_inc = warp_inclusive_sum(lane_id, tmp_local_sum);
-    const auto warp_exc = warp_inc - tmp_local_sum;
-    if (lane_id == kWarpSize - 1) smem->warp_sum[warp_id] = warp_inc;
+    const auto warp_id = broadcast(tx / kWarpSize);
+    const auto warp_inc_sum = warp_inclusive_sum(lane_id, local_sum);
+    const auto warp_exc_sum = warp_inc_sum - local_sum;
+    if (lane_id == kWarpSize - 1) smem->warp_sum[warp_id] = warp_inc_sum;
 
     __syncthreads();
 
     const auto tmp = smem->warp_sum[lane_id];
-    // Exactly one bin satisfies: above < K && above + count >= K
-    uint32_t prefix_sum = warp::reduce_sum(lane_id < warp_id ? tmp : 0);
-    prefix_sum += warp_exc;
+    const auto warp_prefix_sum = warp::reduce_sum(lane_id < warp_id ? tmp : 0);
+    const auto exc_sum = static_cast<int32_t>(warp_prefix_sum + warp_exc_sum);
+    const auto remained = static_cast<int32_t>(seq_len - topk - exc_sum);
+    // only 1 lane will execute this
+    if (remained >= 0 && remained < static_cast<int32_t>(local_sum)) [[unlikely]] {
+      uint32_t target = 0;
 #pragma unroll
-    for (uint32_t i = 0; i < kItems; ++i) {
-      prefix_sum += orig[i];
-      const auto above = seq_len - prefix_sum;
-      if (above < topk && above + orig[i] >= topk) {
-        smem->threshold_bin = tx * kItems + i;
+      for (uint32_t i = 0; i < kItems; ++i) {
+        const auto prev = static_cast<int32_t>(local_exc_sum[i + 0]);
+        const auto next = static_cast<int32_t>(local_exc_sum[i + 1]);
+        if (remained >= prev && remained < next) target = tx * kItems + i;
       }
+      fn(target);
     }
+
     __syncthreads();
   }
 };
@@ -542,17 +567,12 @@ struct TopKRegister : TopKRadixBase<12> {
   static constexpr uint32_t kMaxSeqLen = kBlockSize * kVecSize * kLocalVecs;
   using Smem = typename TopKRadixBase<12>::Smem;
 
-  template <bool kUsePDL, bool kHasInputStart = false>
-  SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
+  template <bool kUsePDL>
+  SGL_DEVICE static void forward(const TopKProblem& problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
-    {
-      Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
@@ -560,85 +580,82 @@ struct TopKRegister : TopKRadixBase<12> {
 
     __syncthreads();
     PDLWaitPrimary<kUsePDL>();
-
-    // A vector `vi` is fully in bounds iff vi < num_full; only full vectors are
-    // vector-loaded (16B aligned, never straddling seq_len). The <kVecSize tail is
-    // a scalar remainder on the LAST lanes (which own the fewest full vectors, so
-    // it overlaps the busy lanes' extra vector). The full path has no per-element
-    // bounds check, keeping register pressure low enough to hold all vectors.
-    const uint32_t num_full = problem.seq_len / kVecSize;
-    const uint32_t tail_start = num_full * kVecSize;
-    const uint32_t tail = problem.seq_len - tail_start;
+    const uint32_t num_full = div_ceil(problem.seq_len, kVecSize);
 
     // Phase 1: load full vectors + build histogram
     vec_t local_vecs[kLocalVecs];
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
-      if (vi >= num_full) break;
-      local_vecs[i].load(problem.in, vi);
+      if (vi < num_full) local_vecs[i].load(problem.in, vi);
     }
+
+    const auto tail_start = (problem.seq_len - 1) % kVecSize + 1;
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
       if (vi >= num_full) break;
+      if (vi == num_full - 1) {
+#pragma unroll
+        for (uint32_t j = 0; j < kVecSize; ++j) {
+          if (j >= tail_start) local_vecs[i][j] = padding_value();
+        }
+      }
 #pragma unroll
       for (uint32_t j = 0; j < kVecSize; ++j) {
-        if constexpr (kHasInputStart) {
-          if (vi * kVecSize + j < input_start) continue;
-        }
         atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(local_vecs[i][j])], 1);
       }
     }
-    if (tx >= kBlockSize - tail) {
-      const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      if (idx >= input_start) atomicAdd(&smem->histogram[extract_coarse_bin<kHistBits>(problem.in[idx])], 1);
+    const auto num_padding = kVecSize - tail_start + problem.input_start;
+    if (tx == 0 && num_padding > 0) {
+      atomicSub(&smem->histogram[kHistSize - 1], num_padding);
+      atomicAdd(&smem->histogram[0], num_padding);
     }
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len - input_start, smem);
+    find_threshold(problem.topk, num_full * kVecSize, smem, [&](uint32_t threshold_bin) {
+      const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+      const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      smem->v_hi = v_hi;
+      smem->v_lo = v_lo;
+    });
 
-    // Phase 3: collect by two fp32 boundaries (raw indices; transform applied later)
+    // Phase 3: collect by two fp32 boundaries
     const auto topk = problem.topk;
-    const auto threshold_bin = smem->threshold_bin;
-    const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
-    const auto collect = [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
-      if (val >= v_hi) {
-        const auto pos = atomicAdd(&smem->count_gt, 1);
-        if (pos < topk) [[likely]]
-          problem.emit(pos, idx);
-      } else if (val >= v_lo) {
-        const auto count_eq = atomicAdd(&smem->count_eq, 1);
-        if (count_eq < kMaxNumTie) [[likely]]
-          smem->tie.values[count_eq] = {val, idx};
-      }
-    };
+    const auto v_hi = smem->v_hi;
+    const auto v_lo = smem->v_lo;
+
 #pragma unroll
     for (uint32_t i = 0; i < kLocalVecs; ++i) {
       const auto vi = tx + kBlockSize * i;
       const auto base = vi * kVecSize;
       if (vi >= num_full) break;
 #pragma unroll
-      for (uint32_t j = 0; j < kVecSize; ++j)
-        collect(local_vecs[i][j], base + j);
-    }
-    if (tx >= kBlockSize - tail) {
-      const uint32_t idx = tail_start + tx - (kBlockSize - tail);
-      collect(problem.in[idx], idx);
+      for (uint32_t j = 0; j < kVecSize; ++j) {
+        const auto idx = base + j;
+        const auto val = local_vecs[i][j];
+        if (val >= v_hi) {
+          const auto pos = atomicAdd(&smem->count_gt, 1);
+          if (pos < topk) [[likely]] {
+            problem.emit(pos, idx);
+          }
+        } else if (val >= v_lo) {
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
+          }
+        }
+      }
     }
 
     // Phase 4: Handle ties.
     __syncthreads();
-    const auto above_count = smem->count_gt;
-    const auto equal_count = smem->count_eq;
-    const auto remain_topk = above_count < topk ? topk - above_count : 0;
-    const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    const auto count_gt = smem->count_gt;
+    const auto count_eq = smem->count_eq;
+    const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+    const auto tie_count = min(count_eq, kMaxNumTie);
+    handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
   }
 };
 
@@ -646,21 +663,16 @@ struct TopKRegister : TopKRadixBase<12> {
 // Streaming path: seq_len > 8192 -- two vectorized passes over global memory
 // ---------------------------------------------------------------------------
 
-struct TopKStreaming : TopKRegister<2> {
+struct TopKStreaming : TopKRadixBase<12> {
  public:
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
 
-  template <bool kUsePDL, bool kHasInputStart = false>
-  SGL_DEVICE static void forward(const TopKProblem problem, void* _smem) {
+  template <bool kUsePDL>
+  SGL_DEVICE static void forward(TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const uint32_t input_start = kHasInputStart ? problem.input_start : 0;
 
-    {
-      Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
@@ -669,40 +681,43 @@ struct TopKStreaming : TopKRegister<2> {
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram
-    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
+    for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t) {
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
+    const auto num_padding = problem.input_start;
+    if (tx == 0 && num_padding != 0) {
+      atomicSub(&smem->histogram[kHistSize - 1], num_padding);
+      atomicAdd(&smem->histogram[0], num_padding);
+    }
     __syncthreads();
 
     // Phase 2: Find the threshold bin
-    find_threshold(problem.topk, problem.seq_len - input_start, smem);
+    find_threshold(problem.topk, problem.seq_len, smem, [&](uint32_t threshold_bin) {
+      const auto v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+      const auto v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      smem->v_hi = v_hi;
+      smem->v_lo = v_lo;
+    });
 
     // Phase 3: Collect candidates and sort. Classify by two fp32 boundaries derived
     // from the threshold bin instead of recomputing the fp16 bin per element: an
     // element is "above" iff val >= v_hi (bin > threshold) and a "tie" iff
     // v_lo <= val < v_hi (bin == threshold). This drops the F2F + bit-twiddle from
     // the second full pass over the input.
-    const auto threshold_bin = smem->threshold_bin;
-    const float v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
+    const auto v_hi = smem->v_hi;
+    const auto v_lo = smem->v_lo;
     const auto topk = problem.topk;
     for_each_input(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
-      if constexpr (kHasInputStart) {
-        if (idx < input_start) return;
-      }
       if (val >= v_hi) {
         const auto pos = atomicAdd(&smem->count_gt, 1);
         if (pos < topk) [[likely]] {
           problem.emit(pos, idx);
         }
       } else if (val >= v_lo) {
-        const auto count_eq = atomicAdd(&smem->count_eq, 1);
-        if (count_eq < kMaxNumTie) [[likely]] {
-          smem->tie.values[count_eq] = {val, idx};
+        const auto pos = atomicAdd(&smem->count_eq, 1);
+        if (pos < kMaxNumTie) [[likely]] {
+          smem->tie_values[pos] = {val, idx};
         }
       }
     });
@@ -713,11 +728,11 @@ struct TopKStreaming : TopKRegister<2> {
     // "above" and "tie" sets. above_count is < topk by the threshold-bin invariant,
     // so the count_gt guard above effectively never triggers.
     __syncthreads();
-    const auto above_count = smem->count_gt;
-    const auto equal_count = smem->count_eq;
-    const auto remain_topk = above_count < topk ? topk - above_count : 0;
-    const auto tie_count = min(equal_count, kMaxNumTie);
-    handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+    const auto count_gt = smem->count_gt;
+    const auto count_eq = smem->count_eq;
+    const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+    const auto tie_count = min(count_eq, kMaxNumTie);
+    handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
   }
 };
 
@@ -729,171 +744,175 @@ struct TopKStreaming : TopKRegister<2> {
 // equivalent.
 // ---------------------------------------------------------------------------
 
-#ifndef USE_ROCM
+#if SUPPORT_CLUSTER
 
-template <uint32_t kClusterSize_>
+template <uint32_t N>
 struct TopKCluster : TopKRadixBase<10> {
  public:
-  static constexpr uint32_t kClusterSize = kClusterSize_;
+  static constexpr uint32_t kClusterSize = N;
   static constexpr uint32_t kMaxSeqLen = std::numeric_limits<uint32_t>::max();
-  using Base = TopKRadixBase<10>;
-  struct Smem : Base::Smem {
-    using kHistVec = Base::Smem::kHistVec;
-    uint32_t start_eq_local, start_gt_local;
-    int32_t tmp_out[kMaxTopK];
+  struct Smem {
+    uint32_t count_eq;
+    uint32_t count_gt;
+    uint32_t local_start_eq;
+    uint32_t local_start_gt;
+    float v_lo;
+    float v_hi;
+    uint32_t warp_sum[kNumWarps];
+    union {
+      alignas(16) uint32_t histogram[kHistSize];
+      TieHandleSmem tie_handle;
+      int32_t stage_out_idxs[kMaxTopK];
+    };
+    TieValue tie_values[kMaxNumTie];
   };
 
-  // Process ONE batch element (one cluster). NO PDL and NO trailing barrier --
-  // the persistent kernel does PDLWaitPrimary once before its item loop and a
-  // cluster.sync() after each forward(). Writes raw indices to out; the kernel's
-  // transform pass applies the page-table transform.
+  SGL_DEVICE static void barrier_cluster_arrive_relaxed() {
+    asm volatile("barrier.cluster.arrive.relaxed.aligned;" ::: "memory");
+  }
+
+  SGL_DEVICE static void barrier_cluster_arrive_release() {
+    asm volatile("barrier.cluster.arrive.release.aligned;" ::: "memory");
+  }
+
+  SGL_DEVICE static void barrier_cluster_wait() {
+    asm volatile("barrier.cluster.wait.acquire.aligned;" ::: "memory");
+  }
+
   template <bool kUsePDL>
   SGL_DEVICE static void forward(TopKProblem problem, void* _smem) {
     const auto tx = threadIdx.x;
     const auto smem = static_cast<Smem*>(_smem);
-    const auto cluster = cg::this_cluster();
+    const auto cluster = cooperative_groups::this_cluster();
     const auto this_rank = blockIdx.y;
-    const bool is_primary = (this_rank == 0);
 
-    constexpr uint32_t kAlignElems = kWarpSize * kVecSize;
-    const uint32_t chunk_size = div_ceil(problem.seq_len, kClusterSize * kAlignElems) * kAlignElems;
-    const uint32_t chunk_start = min(this_rank * chunk_size, problem.seq_len);
-    const uint32_t chunk_finish = min(chunk_start + chunk_size, problem.seq_len);
-    const uint32_t local_seq_len = chunk_finish - chunk_start;
-    problem.in += chunk_start;
-
-    {
-      typename Smem::kHistVec hist_vec;
-      hist_vec.fill(0);
-      smem->hist_vecs[tx] = hist_vec;
-    }
+    init_histogram(smem->histogram, tx);
     if (tx == 0) {
       smem->count_eq = 0;
       smem->count_gt = 0;
     }
     __syncthreads();
+    // Rank 0's shared memory is read by its peers: the zeroed histogram they fold
+    // into after bar-0, v_hi / v_lo after bar-2. Those arrives release so the
+    // peers' acquire wait orders the reads after the writes at cluster scope;
+    // __syncthreads() alone is CTA-scoped. The peers publish nothing at these two
+    // barriers and keep the cheaper relaxed arrive.
+    if (this_rank == 0) {
+      barrier_cluster_arrive_release();  // bar-0 arrive
+    } else {
+      barrier_cluster_arrive_relaxed();  // bar-0 arrive
+    }
     PDLWaitPrimary<kUsePDL>();
 
     // Phase 1: Load and build histogram over this rank's contiguous chunk.
-    for_each_input(problem.in, local_seq_len, [&](float val, uint32_t) {
+    for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t) {
       const auto bin = extract_coarse_bin<kHistBits>(val);
       atomicAdd(&smem->histogram[bin], 1);
     });
+
+    barrier_cluster_wait();  // bar-0 wait
     __syncthreads();
+    if (this_rank != 0) {
+      const auto smem_0 = cluster.map_shared_rank(smem, 0);
+      // Phase 2. atomic flush all histogram into rank 0
+      static_assert(kHistSize == kBlockSize);  // one bin per thread
 
-    // Phase 1.5: reduce the histogram across the cluster
-    {
-      // 1-shot all-reduce: each rank owns kPartition consecutive bins;
-      // for each owned bin, gather the kClusterSize peer values (one per
-      // consecutive lane) via DSMEM, sum across the lanes, then scatter back.
-      cluster.sync();
-      static_assert(kHistSize == kBlockSize);  // we optimize on top of this
-      constexpr uint32_t kPartition = kHistSize / kClusterSize;
-      const auto start = this_rank * kPartition;
-      const auto which = start + tx / kClusterSize;
-      const auto peer_rank = tx % kClusterSize;
-      const auto addr = cluster.map_shared_rank(&smem->histogram[which], peer_rank);
-      const auto value = *addr;
-      *addr = warp::reduce_sum<kClusterSize>(value);
-      cluster.sync();
-    }
+      if (const auto count = smem->histogram[tx]; count != 0) {
+        atomicAdd(&smem_0->histogram[tx], count);
+      }
 
-    // Phase 2: Find the threshold bin (uses global seq_len)
-    find_threshold(problem.topk, problem.seq_len, smem);
+      barrier_cluster_arrive_release();  // bar-1 arrive
+      barrier_cluster_wait();            // bar-1 wait
 
-    // Phase 3: Collect candidates over this rank's chunk; convert local indices
-    // back to global by adding chunk_start. Classify by two fp32 boundaries derived
-    // from the (global) threshold bin instead of recomputing the fp16 bin per
-    // element -- see TopKStreaming for the rationale. threshold_bin is identical
-    // across ranks, so v_hi/v_lo are too.
-    const auto topk = problem.topk;
-    const auto threshold_bin = smem->threshold_bin;
-    const float v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
-    const float v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin);
+      barrier_cluster_arrive_relaxed();  // bar-2 arrive
+      barrier_cluster_wait();            // bar-2 wait
 
-    // Phase 3: collect candidates. The primary scatters straight into
-    // `problem.out`, the others stage into block-local `smem->tmp_out`.
-    //
-    // DO NOT merge these two loops back into one by selecting the destination
-    // first (`cur_out = is_primary ? problem.out : smem->tmp_out`). `problem.out`
-    // can be a shared::cluster (DSMEM) alias of the elected rank's buffer while
-    // `tmp_out` is shared::cta; merging them into a single pointer variable makes
-    // cicc 13.1+ mis-lower the block-local arm on sm_90a and *silently drop every
-    // non-primary rank's staged output* -- `tmp_out` stays zero, and phase 3.5
-    // then faithfully copies zeros to correct DSMEM addresses. The result is a
-    // top-k output where only the primary's slots and the handle_tie tail are
-    // valid, which downstream sparse attention dereferences as garbage KV indices.
-    if (!is_primary) {
-      // stage to tmp_out first before writing to global/DSMEM
-      for_each_input(problem.in, local_seq_len, [&](float val, uint32_t local_idx) {
-        const auto idx = chunk_start + local_idx;
+      // Phase 4. non-0 rank stage to local smem, then write to rank-0 via DSMEM
+      const auto topk = problem.topk;
+      const auto v_hi = smem_0->v_hi;
+      const auto v_lo = smem_0->v_lo;
+      for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
         if (val >= v_hi) {
           const auto pos = atomicAdd(&smem->count_gt, 1);
           if (pos < topk) [[likely]] {
-            smem->tmp_out[pos] = idx;
+            smem->stage_out_idxs[pos] = idx;
           }
         } else if (val >= v_lo) {
-          const auto count_eq = atomicAdd(&smem->count_eq, 1);
-          if (count_eq < kMaxNumTie) [[likely]] {
-            smem->tie.values[count_eq] = {val, idx};
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
           }
         }
       });
       __syncthreads();
-      const auto local_above_count = smem->count_gt;
-      const auto local_equal_count = min(smem->count_eq, kMaxNumTie);
-      const auto smem_0 = cluster.map_shared_rank(smem, 0);
+      const auto local_count_gt = smem->count_gt;
+      const auto local_count_eq = min(smem->count_eq, kMaxNumTie);
       if (tx == 0) {
-        const auto gt = atomicAdd(&smem_0->count_gt, local_above_count);
-        const auto eq = atomicAdd(&smem_0->count_eq, local_equal_count);
-        smem->start_gt_local = gt;
-        smem->start_eq_local = eq;
+        const auto gt = atomicAdd(&smem_0->count_gt, local_count_gt);
+        const auto eq = atomicAdd(&smem_0->count_eq, local_count_eq);
+        smem->local_start_gt = gt;
+        smem->local_start_eq = eq;
       }
       __syncthreads();
-      const auto start_gt_local = smem->start_gt_local;
-      const auto start_eq_local = smem->start_eq_local;
+      const auto local_start_gt = smem->local_start_gt;
+      const auto local_start_eq = smem->local_start_eq;
 #pragma unroll
       for (uint32_t i = 0; i < kTieItems; ++i) {
         const auto t = tx + i * kBlockSize;
-        if (t < local_equal_count && start_eq_local + t < kMaxNumTie) {
-          smem_0->tie.values[start_eq_local + t] = smem->tie.values[t];
+        if (t < local_count_eq && local_start_eq + t < kMaxNumTie) {
+          smem_0->tie_values[local_start_eq + t] = smem->tie_values[t];
         }
       }
 
-      cluster.sync();
+      cluster.sync();  // bar 3
 
-      const auto start_write = start_gt_local;
-      const auto num_write = local_above_count;
+      const auto start_write = local_start_gt;
+      const auto num_write = local_count_gt;
 #pragma unroll
       for (uint32_t i = 0; i < kTopKItems; ++i) {
         if (const auto t = tx + i * kBlockSize; t < num_write && start_write + t < topk) {
-          problem.emit(start_write + t, smem->tmp_out[t]);
+          problem.emit(start_write + t, smem->stage_out_idxs[t]);
         }
       }
     } else {
-      for_each_input(problem.in, local_seq_len, [&](float val, uint32_t local_idx) {
-        const auto idx = chunk_start + local_idx;
+      barrier_cluster_arrive_relaxed();  // bar-1 arrive
+      barrier_cluster_wait();            // bar-1 wait
+
+      // Phase 3. rank-0 find threshold and write to local smem for other ranks to read
+      find_threshold(problem.topk, problem.seq_len, smem, [&](uint32_t threshold_bin) {
+        smem->v_hi = coarse_bin_lower_bound<kHistBits>(threshold_bin + 1);
+        smem->v_lo = coarse_bin_lower_bound<kHistBits>(threshold_bin + 0);
+      });
+
+      barrier_cluster_arrive_release();  // bar-2 arrive: publishes v_hi / v_lo
+      barrier_cluster_wait();            // bar-2 wait
+
+      // Phase 4. rank-0 directly write to output
+      const auto topk = problem.topk;
+      const auto v_hi = smem->v_hi;
+      const auto v_lo = smem->v_lo;
+      for_each_input<N>(problem.in, problem.seq_len, [&](float val, uint32_t idx) {
         if (val >= v_hi) {
           const auto pos = atomicAdd(&smem->count_gt, 1);
           if (pos < topk) [[likely]] {
             problem.emit(pos, idx);
           }
         } else if (val >= v_lo) {
-          const auto count_eq = atomicAdd(&smem->count_eq, 1);
-          if (count_eq < kMaxNumTie) [[likely]] {
-            smem->tie.values[count_eq] = {val, idx};
+          const auto pos = atomicAdd(&smem->count_eq, 1);
+          if (pos < kMaxNumTie) [[likely]] {
+            smem->tie_values[pos] = {val, idx};
           }
         }
       });
 
-      cluster.sync();
+      cluster.sync();  // bar-3
 
       // Phase 4: Handle ties.
-      const auto above_count = smem->count_gt;
-      const auto equal_count = smem->count_eq;
-      const auto remain_topk = above_count < topk ? topk - above_count : 0;
-      const auto tie_count = min(equal_count, kMaxNumTie);
-      handle_tie(smem->tie.values, problem, above_count, tie_count, remain_topk, &smem->tie.handle);
+      const auto count_gt = smem->count_gt;
+      const auto count_eq = smem->count_eq;
+      const auto remain_topk = count_gt < topk ? topk - count_gt : 0;
+      const auto tie_count = min(count_eq, kMaxNumTie);
+      handle_tie(smem->tie_values, problem, count_gt, tie_count, remain_topk, &smem->tie_handle);
     }
   }
 };

--- a/python/sglang/kernels/jit/include/sgl_kernel/gemm/utils.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/gemm/utils.cuh
@@ -1,0 +1,40 @@
+/// \file utils.cuh
+/// \brief bf16 x bf16 -> fp32 dot product of two packed vectors, shared by the
+/// small-GEMM kernels (`gemm/tiny_gemm.cuh`, `gemm/small/n128k512.cuh`) so that
+/// they accumulate in the same order and agree bitwise where both apply.
+#pragma once
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace sglang {
+
+namespace device {
+
+/// Accumulate `sum_i a[i] * b[i]` into `acc`, in element order, one fp32 fma per
+/// product. On Blackwell the mixed-precision fma consumes bf16 directly; the
+/// fallback converts first, which is exact, so both round once per product.
+template <std::size_t N>
+SGL_DEVICE void dot_product_vec(AlignedVector<bf16x2_t, N> a, AlignedVector<bf16x2_t, N> b, float& acc) {
+#pragma unroll
+  for (uint32_t i = 0; i < N; ++i) {
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+    acc = math::fma_f32_bf16(a[i].x, b[i].x, acc);
+    acc = math::fma_f32_bf16(a[i].y, b[i].y, acc);
+#else
+    const auto [a0, a1] = cast<fp32x2_t>(a[i]);
+    const auto [b0, b1] = cast<fp32x2_t>(b[i]);
+    acc += a0 * b0;
+    acc += a1 * b1;
+#endif
+  }
+}
+
+}  // namespace device
+
+}  // namespace sglang

--- a/python/sglang/kernels/ops/attention/dsv4/__init__.py
+++ b/python/sglang/kernels/ops/attention/dsv4/__init__.py
@@ -32,7 +32,12 @@ from .moe import (
     silu_and_mul_contig_post_quant,
     silu_and_mul_masked_post_quant,
 )
-from .topk import plan_topk_v2, topk_transform_paged, topk_transform_paged_v2
+from .topk import (
+    plan_topk_v2,
+    topk_transform_paged,
+    topk_transform_paged_v2,
+    topk_transform_ragged_v2,
+)
 from .utils import make_name
 
 __all__ = [
@@ -56,6 +61,7 @@ __all__ = [
     "triton_create_paged_compress_data",
     "topk_transform_paged",
     "topk_transform_paged_v2",
+    "topk_transform_ragged_v2",
     "plan_topk_v2",
     "hash_topk",
     "mega_moe_pre_dispatch",

--- a/python/sglang/kernels/ops/attention/dsv4/c1.py
+++ b/python/sglang/kernels/ops/attention/dsv4/c1.py
@@ -1,0 +1,95 @@
+"""Fused ratio-1 decode RMSNorm, RoPE, fp4 fake-quant and FlashMLA cache write.
+
+The input is bf16 with no pooling. RoPE uses the token's own position, and the
+compressed slot equals the FULL slot; out_loc == 0 marks graph padding.
+The pre-RoPE latent is also returned for the index-key projection.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+
+from .utils import make_name
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_c1_module(head_dim: int, rope_dim: int, page_size: int) -> Module:
+    args = make_cpp_args(head_dim, rope_dim, page_size, is_arch_support_pdl())
+    return load_jit(
+        make_name("c1"),
+        *args,
+        cuda_files=["deepseek_v4/c1.cuh"],
+        cuda_wrappers=[
+            ("decode_fusion", f"FlashC1DecodeKernel<{args}>::run_decode_fusion"),
+        ],
+    )
+
+
+def c1_decode_norm_rope_store(
+    kv_input: torch.Tensor,
+    norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    out_loc: torch.Tensor,
+    eps: float,
+    freqs_cis: torch.Tensor,
+    k_cache: torch.Tensor,
+    *,
+    page_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """RMSNorm ``kv_input`` and write the main KV slot, in a single launch.
+
+    ``out`` contains the pre-RoPE latent for the index-K branch's ``wk`` projection;
+    the main KV cache receives the rotated and quantized value.
+
+    :param kv_input: ``[num_tokens, head_dim]`` bf16 -- ``compressor.project(x)``
+                     at ratio 1, i.e. the raw ``wkv`` output.
+    :param norm_weight: ``[head_dim]`` bf16. ``DeepseekV41Compressor.norm`` holds
+                        its weight in the model dtype and the multiply is done in
+                        fp32 by promoting it, exactly as the module does.
+    :param positions: ``[num_tokens]`` int32 or int64, the token's position.
+                      Indexed into ``freqs_cis`` as-is: at ratio 1 the latent
+                      stands for the token itself, so there is no ``- 1`` and no
+                      gather launch.
+    :param out_loc: ``[num_tokens]`` int32 or int64 ``c1_out_loc``, which at ratio 1
+                    equals ``raw_out_loc`` (the scheduler's int64 ``out_cache_loc``).
+                    ``0`` marks a padded graph row: it computes
+                    and publishes its latent, which the caller discards, but
+                    writes nothing to the cache.
+    :param eps: RMSNorm epsilon.
+    :param freqs_cis: ``[max_pos, rope_dim]`` fp32, real/imag interleaved --
+                      ``torch.view_as_real(freqs).flatten(-2)``.
+    :param k_cache: the compressed KV pool buffer for this layer.
+    :param page_size: slots per page of that pool (``page_size // ratio``, i.e.
+                      the FULL page size at ratio 1).
+    :param out: ``[num_tokens, head_dim]`` bf16 destination for the pre-RoPE
+                latent. Pass a persistent buffer under CUDA graphs.
+    :return: ``out``, the pre-RoPE post-norm latent.
+    """
+    num_tokens, head_dim = kv_input.shape
+    if out is None:
+        out = kv_input.new_empty((num_tokens, head_dim))
+
+    _jit_c1_module(head_dim, freqs_cis.shape[-1], page_size).decode_fusion(
+        kv_input,
+        out,
+        norm_weight,
+        freqs_cis,
+        positions,
+        out_loc,
+        k_cache,
+        float(eps),
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/c2.py
+++ b/python/sglang/kernels/ops/attention/dsv4/c2.py
@@ -1,0 +1,152 @@
+"""Fused ratio-2 decode pair-pooling, RMSNorm and optional main-KV write.
+
+Closed-form softmax and FMA contraction can differ from torch by fp32 ulps;
+bf16 rounding boundaries can preserve those differences. The pooling tests
+use a tolerance, while state updates and stores from a given latent are bitwise.
+Positions and state-ring indices describe the per-request decode schedule.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+
+from .utils import make_name
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_c2_module(head_dim: int, rope_dim: int = 64, page_size: int = 128) -> Module:
+    # rope_dim / page_size only shape the store half; the norm-only wrapper is
+    # unaffected by them and just takes the defaults.
+    args = make_cpp_args(head_dim, rope_dim, page_size, is_arch_support_pdl())
+    return load_jit(
+        make_name("c2"),
+        *args,
+        cuda_files=["deepseek_v4/c2.cuh"],
+        cuda_wrappers=[
+            ("decode", f"FlashC2DecodeKernel<{args}>::run_decode"),
+            ("decode_fusion", f"FlashC2DecodeKernel<{args}>::run_decode_fusion"),
+        ],
+    )
+
+
+def c2_decode_norm(
+    kv_input: torch.Tensor,
+    kv_state: torch.Tensor,
+    norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    req: torch.Tensor,
+    raw_out_loc: torch.Tensor,
+    eps: float,
+    *,
+    ring_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Pair-pool ``kv_input`` against ``kv_state`` and RMSNorm the result.
+
+    :param kv_input: ``[num_tokens, 2 * head_dim]`` fp32, ``| kv | score |``.
+    :param kv_state: ``CompressStatePool``'s flat ``KVAndScore`` buffer,
+                     ``[size, 2 * head_dim]`` fp32, same ``| kv | score |``
+                     layout. A request's pending pair lives at
+                     ``req * ring_size + pos % ring_size``, so a completing row
+                     reads what ``pos - 1`` left and a pending one writes its
+                     own slot -- read and write never touch the same row.
+    :param ring_size: ``CompressStatePool.ring_size``, positions per request.
+    :param norm_weight: ``[head_dim]`` bf16 -- ``DeepseekV41Compressor.norm``
+                        holds its weight in the model dtype, and the multiply is
+                        done in fp32 by promoting it, exactly as the module does.
+    :param positions: ``[num_tokens]`` int32 or int64. An odd position completes a group
+                      with its even predecessor.
+    :param req: ``[num_tokens]`` int64 ``req_pool_idx``, the ``kv_state`` row
+                this token pairs through.
+    :param raw_out_loc: ``[num_tokens]`` int32 or int64, the token's FULL-pool slot
+                        (the scheduler's ``out_cache_loc`` is int64).
+                        ``0`` marks a padded graph row, which the kernel skips
+                        entirely -- reading nothing and writing nothing, so no
+                        spare pair-state row is needed.
+    :param eps: RMSNorm epsilon.
+    :param out: ``[num_tokens, head_dim]`` bf16 destination. Pass a persistent
+                buffer under CUDA graphs.
+    :return: ``out``, the pre-RoPE post-norm latent.
+
+    .. note:: **Rows at an even position, and padded rows, are not written.**
+       They complete no group, so the kernel skips their output row rather than
+       paying for a store the caller discards. Anything already in ``out`` on
+       those rows survives the call.
+    """
+    num_tokens, fused_dim = kv_input.shape
+    head_dim = fused_dim // 2
+    if out is None:
+        out = kv_input.new_empty((num_tokens, head_dim), dtype=torch.bfloat16)
+
+    _jit_c2_module(head_dim).decode(
+        kv_input,
+        kv_state,
+        out,
+        norm_weight,
+        positions,
+        req,
+        raw_out_loc,
+        float(eps),
+        int(ring_size),
+    )
+    return out
+
+
+def c2_decode_norm_rope_store(
+    kv_input: torch.Tensor,
+    kv_state: torch.Tensor,
+    norm_weight: torch.Tensor,
+    positions: torch.Tensor,
+    req: torch.Tensor,
+    raw_out_loc: torch.Tensor,
+    eps: float,
+    freqs_cis: torch.Tensor,
+    k_cache: torch.Tensor,
+    *,
+    page_size: int,
+    ring_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """``c2_decode_norm`` plus the whole main-KV write, in the same launch.
+
+    ``out`` contains the pre-RoPE latent for the index-K branch's ``wk`` projection.
+    The cache store uses ``raw_out_loc // 2`` as its slot.
+
+    :param freqs_cis: ``[max_pos, rope_dim]`` fp32, real/imag interleaved --
+                      ``torch.view_as_real(freqs).flatten(-2)``. Indexed
+                      in-kernel at ``positions - 1``, the position the latent
+                      stands for, so there is no gather launch.
+    :param k_cache: the compressed KV pool buffer for this layer.
+    :param page_size: slots per page of that pool (``page_size // ratio``).
+    """
+    num_tokens, fused_dim = kv_input.shape
+    head_dim = fused_dim // 2
+    if out is None:
+        out = kv_input.new_empty((num_tokens, head_dim), dtype=torch.bfloat16)
+
+    _jit_c2_module(head_dim, freqs_cis.shape[-1], page_size).decode_fusion(
+        kv_input,
+        kv_state,
+        out,
+        norm_weight,
+        positions,
+        req,
+        raw_out_loc,
+        float(eps),
+        freqs_cis,
+        k_cache,
+        int(ring_size),
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
+++ b/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
@@ -1,0 +1,115 @@
+"""Candidate-block scores and visibility masking for paged indexer logits."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _maximum_with_nan(a, b):
+    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit
+def _candidate_scores_kernel(
+    X,
+    LENS,
+    OUT,
+    SCORES,
+    WIDTH: tl.constexpr,
+    STRIDE: tl.constexpr,
+    BLOCKS: tl.constexpr,
+    GROUP: tl.constexpr,
+    GROUP_PAD: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    blocks = tl.program_id(1) * TILE + tl.arange(0, TILE)
+    offsets = tl.arange(0, GROUP_PAD)
+    cols = blocks[:, None] * GROUP + offsets[None, :]
+    length = tl.load(LENS + row)
+    in_bounds = (cols < WIDTH) & (offsets[None, :] < GROUP)
+    values = tl.load(
+        X + row * STRIDE + cols, in_bounds & (cols < length), other=-float("inf")
+    ).to(tl.float32)
+    tl.store(OUT + row * WIDTH + cols, values, in_bounds)
+    scores = tl.reduce(values, axis=1, combine_fn=_maximum_with_nan)
+    scores = tl.where(
+        (length > 0) & (blocks == (length - 1) // GROUP), float("inf"), scores
+    )
+    tl.store(SCORES + row * BLOCKS + blocks, scores, blocks < BLOCKS)
+
+
+@triton.jit
+def _candidate_mask_kernel(
+    X,
+    LENS,
+    KEEP,
+    OUT,
+    WIDTH: tl.constexpr,
+    STRIDE: tl.constexpr,
+    KEEP_STRIDE: tl.constexpr,
+    KEEP_COL_STRIDE: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    cols = tl.program_id(1) * TILE + tl.arange(0, TILE)
+    visible = (cols < WIDTH) & (cols < tl.load(LENS + row))
+    keep = tl.load(KEEP + row * KEEP_STRIDE + cols * KEEP_COL_STRIDE, visible, other=0)
+    values = tl.load(X + row * STRIDE + cols, visible & keep, other=-float("inf")).to(
+        tl.float32
+    )
+    tl.store(OUT + row * WIDTH + cols, values, cols < WIDTH)
+
+
+def candidate_block_logits(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    topk_blocks: int,
+    block_size: int,
+    published: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Keep torch.topk's block selection, including its tie behavior.
+
+    A source masks the unread tail while reducing each block. A consumer masks
+    visibility and the published candidates in one pass, without copying the
+    capacity-sized logits before each masked_fill.
+    """
+    rows, width = logits.shape
+    output = torch.empty((rows, width), dtype=torch.float32, device=logits.device)
+    if published is not None:
+        _candidate_mask_kernel[(rows, triton.cdiv(width, 4096))](
+            logits,
+            seq_lens,
+            published,
+            output,
+            width,
+            logits.stride(0),
+            published.stride(0),
+            published.stride(1),
+            4096,
+        )
+        return output, None
+
+    blocks = triton.cdiv(width, block_size)
+    scores = torch.empty((rows, blocks), dtype=torch.float32, device=logits.device)
+    group_pad = triton.next_power_of_2(block_size)
+    tile = max(1, 1024 // group_pad)
+    _candidate_scores_kernel[(rows, triton.cdiv(blocks, tile))](
+        logits,
+        seq_lens,
+        output,
+        scores,
+        width,
+        logits.stride(0),
+        blocks,
+        block_size,
+        group_pad,
+        tile,
+    )
+    top = scores.topk(min(topk_blocks, blocks), dim=-1)
+    keep = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, top.indices, top.values > -torch.inf
+    )
+    return output, keep.repeat_interleave(block_size, dim=-1)[..., :width]

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_indexer.py
@@ -38,12 +38,40 @@ def _fp4_e2m1_code(x):
 
 
 @triton.jit
+def _fp4_e2m1_code_rne(x):
+    """Round-to-nearest-even e2m1 code, matching the reference rounding: at an
+    exact half-way value the even grid index wins."""
+    ax = tl.minimum(tl.abs(x), 6.0)
+    idx = (ax >= 0.25).to(tl.uint8)
+    idx += (ax >= 0.75).to(tl.uint8)
+    idx += (ax >= 1.25).to(tl.uint8)
+    idx += (ax >= 1.75).to(tl.uint8)
+    idx += (ax >= 2.5).to(tl.uint8)
+    idx += (ax >= 3.5).to(tl.uint8)
+    idx += (ax >= 5.0).to(tl.uint8)
+    # Round-half-to-even: an odd index at an exact boundary drops to the even one.
+    is_boundary = (
+        (ax == 0.25)
+        | (ax == 0.75)
+        | (ax == 1.25)
+        | (ax == 1.75)
+        | (ax == 2.5)
+        | (ax == 3.5)
+        | (ax == 5.0)
+    )
+    idx = tl.where(is_boundary & ((idx & 1) == 1), idx - 1, idx)
+    sign = ((x < 0) & (idx != 0)).to(tl.uint8)
+    return idx | (sign << 3)
+
+
+@triton.jit
 def _quantize_fp4_indexer_kernel(
     x,
     x_fp4,
     x_sf,
     BLOCK_N: tl.constexpr,
     GROUP_N: tl.constexpr,
+    RNE: tl.constexpr,
 ):
     token_id = tl.program_id(0)
     offs = tl.arange(0, BLOCK_N)
@@ -86,8 +114,12 @@ def _quantize_fp4_indexer_kernel(
 
     v0 = tl.load(x + token_id * BLOCK_N + offs0).to(tl.float32) / scale0
     v1 = tl.load(x + token_id * BLOCK_N + offs1).to(tl.float32) / scale1
-    code0 = _fp4_e2m1_code(v0)
-    code1 = _fp4_e2m1_code(v1)
+    if RNE:
+        code0 = _fp4_e2m1_code_rne(v0)
+        code1 = _fp4_e2m1_code_rne(v1)
+    else:
+        code0 = _fp4_e2m1_code(v0)
+        code1 = _fp4_e2m1_code(v1)
     packed = (code0 & 0x0F) | ((code1 & 0x0F) << 4)
     tl.store(x_fp4 + token_id * (BLOCK_N // 2) + pair_offsets, packed)
 
@@ -120,7 +152,11 @@ def _store_fp4_index_k_cache_kernel(
     )
 
 
-def quantize_fp4_indexer_tensor(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+def quantize_fp4_indexer_tensor(
+    x: torch.Tensor, rne: bool = False
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-32 ue8m0 fp4 quantize. rne=True uses round-to-nearest-even (the dsv41
+    reference rounding); the default keeps the c4 threshold behavior."""
     assert x.shape[-1] == 128
     x = x.contiguous().view(-1, x.shape[-1])
     x_fp4 = torch.empty((x.shape[0], 64), device=x.device, dtype=torch.int8)
@@ -132,6 +168,7 @@ def quantize_fp4_indexer_tensor(x: torch.Tensor) -> tuple[torch.Tensor, torch.Te
             x_sf,
             BLOCK_N=128,
             GROUP_N=32,
+            RNE=rne,
         )
     return x_fp4, x_sf
 
@@ -142,9 +179,10 @@ def store_fp4_index_k_cache(
     loc: torch.Tensor,
     *,
     page_size: int,
+    rne: bool = False,
 ) -> None:
     assert input.shape[-1] == 128
-    k_fp4, k_sf = quantize_fp4_indexer_tensor(input.contiguous())
+    k_fp4, k_sf = quantize_fp4_indexer_tensor(input.contiguous(), rne=rne)
     n_tokens = input.numel() // input.shape[-1]
     assert k_fp4.shape == (n_tokens, 64)
     assert k_sf.shape == (n_tokens,)

--- a/python/sglang/kernels/ops/attention/dsv4/fp4_rope.py
+++ b/python/sglang/kernels/ops/attention/dsv4/fp4_rope.py
@@ -1,0 +1,166 @@
+"""Fused RoPE and two-stage fp4 packing for low-ratio index keys and queries.
+
+Keys include RMSNorm and a 68-byte cache store, using the group's first position.
+Queries use each token's own position, without RMSNorm or a cache store.
+The decode backend uses index_q_rope_pack_weights to also produce FP32 head weights.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+
+from .utils import make_name
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+# Payload bytes plus one ue8m0 exponent per 32 elements, per compressed token.
+SLOT_BYTES = 68
+INDEX_PAGE_SIZE = 64
+
+
+@cache_once
+def _jit_index_k_module(
+    head_dim: int, rope_dim: int, page_size: int, ratio: int
+) -> Module:
+    args = make_cpp_args(head_dim, rope_dim, page_size, ratio, is_arch_support_pdl())
+    return load_jit(
+        make_name("fp4_rope"),
+        *args,
+        cuda_files=["deepseek_v4/fp4_rope.cuh"],
+        cuda_wrappers=[("index_k", f"FlashIndexKKernel<{args}>::run_index_k")],
+    )
+
+
+@cache_once
+def _jit_index_q_module(head_dim: int, rope_dim: int) -> Module:
+    args = make_cpp_args(head_dim, rope_dim, is_arch_support_pdl())
+    return load_jit(
+        make_name("fp4_rope"),
+        *args,
+        cuda_files=["deepseek_v4/fp4_rope.cuh"],
+        cuda_wrappers=[
+            ("index_q", f"FlashIndexQKernel<{args}>::run_index_q"),
+            ("index_q_weights", f"FlashIndexQKernel<{args}>::run_index_q_weights"),
+        ],
+    )
+
+
+def index_k_norm_rope_pack_store(
+    input: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor,
+    loc: torch.Tensor,
+    cache: torch.Tensor,
+    *,
+    ratio: int,
+) -> None:
+    """Normalize, rotate, quantize twice and store one index-K slot per token.
+
+    :param input: ``[num_tokens, index_head_dim]`` bf16 -- ``wk(latent)``,
+                  *before* ``k_norm``.
+    :param norm_weight: ``[index_head_dim]`` bf16, ``k_norm.weight``.
+    :param eps: ``k_norm.eps``.
+    :param freqs_cis: ``[max_pos, rope_head_dim]`` fp32, real/imag interleaved --
+                      ``torch.view_as_real(freqs).flatten(-2)``. Indexed
+                      in-kernel, so pass the whole table rather than a gather.
+    :param positions: ``[num_tokens]`` int32 or int64, the token position. The
+                      group position is masked out of it in-kernel.
+    :param loc: ``[num_tokens]`` int64, the index-K slot. ``0`` is the reserved
+                dummy: those rows publish nothing, which covers both padded
+                graph rows and, at ratio > 1, rows completing no group.
+    :param cache: the layer's index-K buffer, ``[npages, page_size * 68]`` uint8.
+    :param ratio: the layer's compress ratio. A power of two.
+
+    .. note:: Two quantization stages, not one. The fake-quant's amax floor is
+       ``6 * 2**-126`` and the packer's is ``1e-4``, applied on opposite sides
+       of the divide by 6, so the packer can recover an exponent the fake-quant
+       gave away and collapsing them is not equivalent.
+    """
+    head_dim = input.shape[-1]
+    _jit_index_k_module(
+        head_dim, freqs_cis.shape[-1], cache.shape[1] // SLOT_BYTES, ratio
+    ).index_k(input, norm_weight, freqs_cis, positions, loc, cache, float(eps))
+
+
+def index_q_rope_pack(
+    input: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Rotate, quantize twice and pack one indexer query per (token, head).
+
+    :param input: ``[num_tokens, heads, index_head_dim]`` bf16 contiguous --
+                  ``wq_b(q_lora)`` viewed per head.
+    :param freqs_cis: ``[max_pos, rope_head_dim]`` fp32, real/imag interleaved --
+                      ``torch.view_as_real(freqs).flatten(-2)``. Indexed
+                      in-kernel, so pass the whole table rather than a gather.
+    :param positions: ``[num_tokens]`` int32 or int64. A query rotates by its
+                      own position, so this is used unmasked.
+    :return: ``(payload, scale)`` -- ``[num_tokens * heads, index_head_dim // 2]``
+             int8 and ``[num_tokens * heads]`` int32, the four ue8m0 block
+             exponents packed little-endian. Exactly what the paged MQA logits
+             kernel takes and what the Triton path returns without a cache.
+
+    .. note:: Two quantization stages, not one -- see
+       :func:`index_k_norm_rope_pack_store`. Neither can be dropped.
+    """
+    num_tokens, heads, head_dim = input.shape
+    rows = num_tokens * heads
+    payload = input.new_empty((rows, head_dim // 2), dtype=torch.int8)
+    scale = input.new_empty((rows,), dtype=torch.int32)
+
+    _jit_index_q_module(head_dim, freqs_cis.shape[-1]).index_q(
+        input, freqs_cis, positions, payload, scale
+    )
+    return payload, scale
+
+
+def index_q_rope_pack_weights(
+    input: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor,
+    head_weights: torch.Tensor,
+    weight_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """:func:`index_q_rope_pack` plus the indexer's head weights, one launch.
+
+    Head weights match ``head_weights(x).float()``: multiply in fp32,
+    round to nearest-even bf16, then widen to fp32.
+
+    :param head_weights: ``[num_tokens, heads]`` bf16, the raw ``weights_proj``
+                         output (before the scale).
+    :param weight_scale: ``softmax_scale * heads**-0.5``; rounded to fp32 in the
+                         kernel exactly as torch rounds a Python scalar for a
+                         bf16 tensor multiply.
+    :return: ``(payload, scale, weights)`` -- the first two as
+             :func:`index_q_rope_pack`, ``weights`` ``[num_tokens, heads]`` fp32.
+    """
+    num_tokens, heads, head_dim = input.shape
+    rows = num_tokens * heads
+    payload = input.new_empty((rows, head_dim // 2), dtype=torch.int8)
+    scale = input.new_empty((rows,), dtype=torch.int32)
+    weights = input.new_empty((num_tokens, heads), dtype=torch.float32)
+
+    _jit_index_q_module(head_dim, freqs_cis.shape[-1]).index_q_weights(
+        input,
+        freqs_cis,
+        positions,
+        payload,
+        scale,
+        head_weights,
+        weights,
+        float(weight_scale),
+    )
+    return payload, scale, weights

--- a/python/sglang/kernels/ops/attention/dsv4/metadata_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsv4/metadata_kernel.py
@@ -5,6 +5,66 @@ import triton
 import triton.language as tl
 
 
+@triton.jit
+def _fill_all_compressed_indices_kernel(
+    page_table,
+    seq_lens,
+    page_indices,
+    raw_indices,
+    PAGE_STRIDE: tl.constexpr,
+    TOPK: tl.constexpr,
+    RATIO: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    positions = tl.arange(0, BLOCK)
+    length = tl.load(seq_lens + row)
+    valid = (positions < length) & (positions < TOPK)
+    slots_per_page = PAGE_SIZE // RATIO
+    pages = tl.load(
+        page_table + row * PAGE_STRIDE + positions // slots_per_page,
+        mask=valid,
+        other=0,
+    )
+    slots = pages * slots_per_page + positions % slots_per_page
+    tl.store(
+        page_indices + row * TOPK + positions,
+        tl.where(valid, slots, -1),
+        positions < TOPK,
+    )
+    if raw_indices is not None:
+        tl.store(
+            raw_indices + row * TOPK + positions,
+            tl.where(valid, positions, -1),
+            positions < TOPK,
+        )
+
+
+def fill_all_compressed_indices(
+    page_table: torch.Tensor,
+    compressed_seq_lens: torch.Tensor,
+    page_indices: torch.Tensor,
+    *,
+    compress_ratio: int,
+    page_size: int,
+    raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    """Fill all reachable slots; the caller guarantees compressed length <= top-k."""
+    topk = page_indices.shape[1]
+    _fill_all_compressed_indices_kernel[(compressed_seq_lens.numel(),)](
+        page_table,
+        compressed_seq_lens,
+        page_indices,
+        raw_indices,
+        page_table.stride(0),
+        topk,
+        compress_ratio,
+        page_size,
+        triton.next_power_of_2(topk),
+    )
+
+
 @triton.jit(do_not_specialize=["bs", "num_write_tokens", "c128_cur_max_seq_len"])
 def _init_compressed_attn_metadata_kernel(
     seq_lens_ptr,

--- a/python/sglang/kernels/ops/attention/dsv4/pair_pool_decode.py
+++ b/python/sglang/kernels/ops/attention/dsv4/pair_pool_decode.py
@@ -1,0 +1,158 @@
+"""Fused ratio-2 decode pair-pooling with bitwise parity to torch pool_pairs.
+
+Softmax follows torch's operation order with correctly rounded exp and division.
+The weighted products must round separately before summation; FMA contraction
+would change the latent and can change the indexer's top-k selection.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def _pair_pool_decode_kernel(
+    kv_ptr,  # [n, D] fp32
+    score_ptr,  # [n, D] fp32
+    pos_ptr,  # [n] int64
+    raw_out_loc_ptr,  # [n] int32/int64
+    out_loc_ptr,  # [n] int32/int64
+    req_ptr,  # [n] int64
+    state_kv_ptr,  # [R, D] fp32, in/out
+    state_score_ptr,  # [R, D] fp32, in/out
+    pooled_ptr,  # [n, D] fp32, out
+    group_pos_ptr,  # [n] int64, out
+    slots_ptr,  # [n] int64, out
+    pad_row,
+    RING_SIZE: tl.constexpr,
+    STATE_KV_STRIDE: tl.constexpr,
+    STATE_SCORE_STRIDE: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+
+    pos = tl.load(pos_ptr + row)
+    raw_loc = tl.load(raw_out_loc_ptr + row)
+    out_loc = tl.load(out_loc_ptr + row)
+    req = tl.load(req_ptr + row)
+
+    # `pos % 2 == 1`, and the padded-graph-row reroute: a row whose raw location
+    # is the reserved slot 0 carries req_pool_idx 0 -- possibly a live request --
+    # so its pair state goes to the spare row instead.
+    odd = (pos % 2) == 1
+    if RING_SIZE:
+        r = tl.where(
+            (raw_loc == 0) | (pos == 0),
+            pad_row,
+            req * RING_SIZE + (pos - 1) % RING_SIZE,
+        )
+    else:
+        r = tl.where(raw_loc == 0, pad_row, req)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < D
+
+    kv = tl.load(kv_ptr + row * D + offs, mask=mask, other=0.0)
+    score = tl.load(score_ptr + row * D + offs, mask=mask, other=0.0)
+    p_kv = tl.load(state_kv_ptr + r * STATE_KV_STRIDE + offs, mask=mask, other=0.0)
+    p_score = tl.load(
+        state_score_ptr + r * STATE_SCORE_STRIDE + offs, mask=mask, other=0.0
+    )
+
+    if RING_SIZE:
+        # Each live request has one decode row. Pad rows never modify the ring.
+        write_row = req * RING_SIZE + pos % RING_SIZE
+        tl.store(
+            state_kv_ptr + write_row * STATE_KV_STRIDE + offs,
+            kv,
+            mask=mask & (raw_loc != 0),
+        )
+        tl.store(
+            state_score_ptr + write_row * STATE_SCORE_STRIDE + offs,
+            score,
+            mask=mask & (raw_loc != 0),
+        )
+    else:
+        tl.store(
+            state_kv_ptr + r * STATE_KV_STRIDE + offs,
+            tl.where(odd, p_kv, kv),
+            mask=mask,
+        )
+        tl.store(
+            state_score_ptr + r * STATE_SCORE_STRIDE + offs,
+            tl.where(odd, p_score, score),
+            mask=mask,
+        )
+
+    # Match torch's pair-axis softmax operation order. libdevice.exp is required;
+    # tl.exp uses an approximate exponential and can change the pooled latent.
+    m = tl.maximum(p_score, score)
+    e0 = libdevice.exp(p_score - m)
+    e1 = libdevice.exp(score - m)
+    denom = e0 + e1
+    # The + 0.0 prevents FMA contraction: torch rounds both products before summing.
+    # Use libdevice.div_rn to match torch division; Triton's / uses an approximate reciprocal.
+    t0 = p_kv * libdevice.div_rn(e0, denom)
+    t1 = kv * libdevice.div_rn(e1, denom)
+    t0 = t0 + 0.0
+    t1 = t1 + 0.0
+    pooled = t0 + t1
+    tl.store(pooled_ptr + row * D + offs, pooled, mask=mask)
+
+    # One program per row, so these are written exactly once each; no guard.
+    tl.store(group_pos_ptr + row, tl.where(odd, pos - 1, pos))
+    tl.store(slots_ptr + row, tl.where(out_loc >= 0, out_loc, 0))
+
+
+def pair_pool_decode(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    pos: torch.Tensor,
+    raw_out_loc: torch.Tensor,
+    out_loc: torch.Tensor,
+    req: torch.Tensor,
+    state_kv: torch.Tensor,
+    state_score: torch.Tensor,
+    pad_row: int,
+    *,
+    ring_size: int = 0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One launch for the ratio-2 decode epilogue.
+
+    Returns `(pooled, group_pos, slots)` and updates `state_kv` / `state_score`
+    in place. With ring_size > 0, the state halves may be views of an interleaved
+    CompressStatePool ring; pad_row is its sentinel row and stays untouched.
+    The default retains the legacy single-row-per-request state contract.
+    """
+    assert kv.is_contiguous() and score.is_contiguous()
+    assert state_kv.stride(1) == state_score.stride(1) == 1
+    assert kv.dtype == torch.float32 and score.dtype == torch.float32
+    n, D = kv.shape
+    pooled = torch.empty_like(kv)
+    group_pos = torch.empty_like(pos)
+    slots = torch.empty(n, dtype=out_loc.dtype, device=out_loc.device)
+    _pair_pool_decode_kernel[(n,)](
+        kv,
+        score,
+        pos,
+        raw_out_loc,
+        out_loc,
+        req,
+        state_kv,
+        state_score,
+        pooled,
+        group_pos,
+        slots,
+        pad_row,
+        RING_SIZE=ring_size,
+        STATE_KV_STRIDE=state_kv.stride(0),
+        STATE_SCORE_STRIDE=state_score.stride(0),
+        D=D,
+        BLOCK_D=triton.next_power_of_2(D),
+        num_warps=4,
+    )
+    return pooled, group_pos, slots

--- a/python/sglang/kernels/ops/attention/dsv4/rmsnorm_fp32.py
+++ b/python/sglang/kernels/ops/attention/dsv4/rmsnorm_fp32.py
@@ -1,0 +1,39 @@
+"""Out-of-place RMSNorm with FP32 statistics and weight multiplication."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _rmsnorm_fp32_kernel(X, W, Y, D: tl.constexpr, EPS: tl.constexpr, B: tl.constexpr):
+    row = tl.program_id(0)
+    col = tl.arange(0, B)
+    x = tl.load(X + row * D + col, col < D, 0).to(tl.float32)
+    weight = tl.load(W + col, col < D, 0).to(tl.float32)
+    inv_rms = tl.rsqrt(tl.sum(x * x, axis=0) / D + EPS)
+    normalized = x * inv_rms
+    tl.store(Y + row * D + col, normalized * weight, col < D)
+
+
+def rmsnorm_fp32(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Match ``weight * (x.float() * rsqrt(mean(x.float()**2) + eps))``."""
+    assert x.is_cuda and x.is_contiguous() and weight.is_contiguous()
+    assert x.dtype in (torch.bfloat16, torch.float32)
+    assert weight.dtype in (torch.bfloat16, torch.float32)
+    assert x.device == weight.device and weight.shape == (x.shape[-1],)
+    output = torch.empty_like(x)
+    dim = x.shape[-1]
+    rows = x.numel() // dim
+    if rows:
+        _rmsnorm_fp32_kernel[(rows,)](
+            x,
+            weight,
+            output,
+            dim,
+            eps,
+            triton.next_power_of_2(dim),
+            num_warps=4,
+            enable_fp_fusion=False,
+        )
+    return output

--- a/python/sglang/kernels/ops/attention/dsv4/rope_fake_quant_fp4.py
+++ b/python/sglang/kernels/ops/attention/dsv4/rope_fake_quant_fp4.py
@@ -1,0 +1,130 @@
+"""Fused RoPE tail and fp4 fake-quant for the DeepSeek-V4.1 low-ratio path.
+
+Preserves the bf16 round-trip after RoPE and before quantization, and the
+round-half-to-even behavior of torch.round.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+FP4_MAX = 6.0
+FP4_AMAX_FLOOR = 6 * (2.0**-126)
+
+
+@triton.jit
+def _rope_tail_fake_quant_fp4_kernel(
+    x_ptr,
+    f_ptr,
+    out_ptr,
+    x_stride_r,
+    out_stride_r,
+    f_stride_t,
+    rows_per_token,
+    D: tl.constexpr,
+    RD: tl.constexpr,
+    BLK: tl.constexpr,
+    AMAX_FLOOR: tl.constexpr,
+    INVERSE: tl.constexpr,
+    COMPRESSED_KV: tl.constexpr,
+):
+    r = tl.program_id(0)
+    t = r // rows_per_token
+    offs = tl.arange(0, D)
+    v = tl.load(x_ptr + r * x_stride_r + offs).to(tl.float32)
+
+    # ---- rope_tail: adjacent pairs of the last RD features as one complex number
+    head_len = D - RD
+    in_tail = offs >= head_len
+    pos = offs - head_len
+    j = pos // 2
+    is_im = (pos % 2) == 1
+    re = tl.load(x_ptr + x_stride_r * r + head_len + 2 * j, mask=in_tail, other=0.0).to(
+        tl.float32
+    )
+    im = tl.load(
+        x_ptr + x_stride_r * r + head_len + 2 * j + 1, mask=in_tail, other=0.0
+    ).to(tl.float32)
+    # freqs is a real/imag-interleaved view with stride 2 between complex pairs;
+    # index 2*j / 2*j+1 to preserve that layout.
+    fr = tl.load(f_ptr + t * f_stride_t + 2 * j, mask=in_tail, other=1.0)
+    fi = tl.load(f_ptr + t * f_stride_t + 2 * j + 1, mask=in_tail, other=0.0)
+    if INVERSE:
+        fi = -fi
+    rot = tl.where(is_im, re * fi + im * fr, re * fr - im * fi)
+    # rope_tail casts the rotated tail back to x.dtype before the cat; the head
+    # never leaves it. Reproduce that rounding or the quant sees different input.
+    rot = rot.to(tl.bfloat16).to(tl.float32)
+    v = tl.where(in_tail, rot, v)
+
+    # ---- FP4 round-trip, with a separate scale format for compressed KV.
+    vb = tl.reshape(v, (D // BLK, BLK))
+    amax = tl.max(tl.abs(vb), axis=1)
+    if COMPRESSED_KV:
+        scale = tl.minimum(tl.maximum(amax * (1.0 / 6.0), 2.0**-9), 448.0)
+        scale = scale.to(tl.float8e4nv).to(tl.float32)
+        s = tl.div_rn(vb, scale[:, None])
+    else:
+        amax = tl.maximum(amax, AMAX_FLOOR) * (1.0 / 6.0)
+        # ceil_pow2 on the IEEE bits, exact at powers of two
+        bits = amax.to(tl.int32, bitcast=True)
+        expo = ((bits >> 23) & 0xFF) - 127
+        expo = expo + ((bits & 0x7FFFFF) != 0).to(tl.int32)
+        scale = ((expo + 127) << 23).to(tl.float32, bitcast=True)
+        s = vb / scale[:, None]
+    s = tl.minimum(tl.maximum(s, -6.0), 6.0)
+    mag = tl.abs(s)
+    step = tl.where(mag < 2.0, 0.5, tl.where(mag < 4.0, 1.0, 2.0))
+    # torch.round is round-half-to-even; torch.sign(0) is 0
+    sgn = tl.where(s > 0, 1.0, tl.where(s < 0, -1.0, 0.0))
+    q = libdevice.rint(mag / step) * step * sgn
+    out = tl.reshape(q * scale[:, None], (D,))
+    tl.store(out_ptr + r * out_stride_r + offs, out.to(out_ptr.dtype.element_ty))
+
+
+def rope_tail_fake_quant_fp4(
+    x: torch.Tensor,
+    freqs: torch.Tensor,
+    rope_dim: int,
+    inverse: bool = False,
+    block_size: int = 32,
+    *,
+    compressed_kv: bool = False,
+) -> torch.Tensor:
+    """RoPE and FP4 round-trip: per-16 E4M3 for compressed KV, per-32 UE8M0 otherwise.
+
+    x: [T, ..., D] contiguous in the last dim; freqs: complex [T, rope_dim // 2].
+    """
+    x = x.contiguous()
+    if compressed_kv:
+        block_size = 16
+    assert x.shape[-1] % block_size == 0
+    assert rope_dim % 2 == 0 and rope_dim <= x.shape[-1]
+    d = x.shape[-1]
+    x2 = x.reshape(-1, d)
+    rows = x2.shape[0]
+    out = torch.empty_like(x)
+    if rows == 0:
+        return out
+    rows_per_token = rows // x.shape[0]
+    f_real = torch.view_as_real(freqs.contiguous()).contiguous()
+    _rope_tail_fake_quant_fp4_kernel[(rows,)](
+        x2,
+        f_real,
+        out.reshape(-1, d),
+        x2.stride(0),
+        d,
+        f_real.stride(0),
+        rows_per_token,
+        D=d,
+        RD=rope_dim,
+        BLK=block_size,
+        AMAX_FLOOR=FP4_AMAX_FLOOR,
+        INVERSE=inverse,
+        COMPRESSED_KV=compressed_kv,
+        num_warps=4,
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/rope_pack_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsv4/rope_pack_indexer.py
@@ -1,0 +1,138 @@
+"""Fuse low-ratio RoPE, fake FP4 quantization and indexer packing/cache store.
+
+Keep both quantization stages: the indexer packer has a different scale floor
+from fake_quant_fp4, so directly packing the first stage is not equivalent.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
+    _ceil_ue8m0_exp,
+    _fp4_e2m1_code_rne,
+)
+from sglang.kernels.ops.attention.dsv4.rope_fake_quant_fp4 import FP4_AMAX_FLOOR
+
+
+@triton.jit
+def _rope_fake_quant_pack_indexer_kernel(
+    X,
+    F,
+    Pos,
+    Payload,
+    Scale,
+    Cache,
+    Loc,
+    F_STRIDE: tl.constexpr,
+    HEADS: tl.constexpr,
+    RD: tl.constexpr,
+    INDEXED: tl.constexpr,
+    STORE_CACHE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    CACHE_STRIDE: tl.constexpr,
+    AMAX_FLOOR: tl.constexpr,
+):
+    row = tl.program_id(0)
+    token = row // HEADS
+    frow = tl.load(Pos + token) if INDEXED else token
+    offsets = tl.arange(0, 128)
+    value = tl.load(X + row * 128 + offsets).to(tl.float32)
+    tail = offsets >= 128 - RD
+    pair = (offsets - (128 - RD)) // 2
+    imaginary = (offsets % 2) == 1
+    real = tl.load(X + row * 128 + 128 - RD + 2 * pair, tail, 0).to(tl.float32)
+    imag = tl.load(X + row * 128 + 128 - RD + 2 * pair + 1, tail, 0).to(tl.float32)
+    fr = tl.load(F + frow * F_STRIDE + 2 * pair, tail, 1.0)
+    fi = tl.load(F + frow * F_STRIDE + 2 * pair + 1, tail, 0.0)
+    rotated = tl.where(imaginary, real * fi + imag * fr, real * fr - imag * fi)
+    value = tl.where(tail, rotated.to(tl.bfloat16).to(tl.float32), value)
+
+    blocks = tl.reshape(value, (4, 32))
+    amax = tl.maximum(tl.max(tl.abs(blocks), 1), AMAX_FLOOR) * (1.0 / 6.0)
+    bits = amax.to(tl.int32, bitcast=True)
+    exponent = ((bits >> 23) & 0xFF) + ((bits & 0x7FFFFF) != 0).to(tl.int32)
+    fake_scale = (exponent << 23).to(tl.float32, bitcast=True)
+    scaled = tl.minimum(tl.maximum(blocks / fake_scale[:, None], -6.0), 6.0)
+    magnitude = tl.abs(scaled)
+    step = tl.where(magnitude < 2.0, 0.5, tl.where(magnitude < 4.0, 1.0, 2.0))
+    sign = tl.where(scaled > 0, 1.0, tl.where(scaled < 0, -1.0, 0.0))
+    rounded = libdevice.rint(magnitude / step) * step * sign
+    # Preserve the BF16 intermediate before recomputing the indexer scale,
+    # including its 1e-4 lower bound.
+    dequantized = (rounded * fake_scale[:, None]).to(tl.bfloat16).to(tl.float32)
+    pack_amax = tl.max(tl.abs(dequantized), 1)
+    pack_exponent = _ceil_ue8m0_exp(tl.maximum(pack_amax / 6.0, 1.0e-4))
+    pack_scale = (pack_exponent << 23).to(tl.float32, bitcast=True)
+    codes = _fp4_e2m1_code_rne(dequantized / pack_scale[:, None])
+    low, high = tl.split(tl.reshape(codes, (64, 2)))
+    payload = low | (high << 4)
+    sf = tl.sum(pack_exponent.to(tl.uint32) << (tl.arange(0, 4) * 8), 0)
+    byte_offsets = tl.arange(0, 64)
+    if STORE_CACHE:
+        location = tl.load(Loc + token)
+        page = location // PAGE_SIZE
+        slot = location % PAGE_SIZE
+        tl.store(Cache + page * CACHE_STRIDE + slot * 64 + byte_offsets, payload)
+        scale_bytes = (sf >> (tl.arange(0, 4) * 8)) & 0xFF
+        tl.store(
+            Cache + page * CACHE_STRIDE + PAGE_SIZE * 64 + slot * 4 + tl.arange(0, 4),
+            scale_bytes,
+        )
+    else:
+        tl.store(Payload + row * 64 + byte_offsets, payload)
+        tl.store(Scale + row, sf)
+
+
+def rope_fake_quant_pack_indexer(
+    x: torch.Tensor,
+    freqs: torch.Tensor,
+    rope_dim: int,
+    *,
+    positions: torch.Tensor | None = None,
+    cache: torch.Tensor | None = None,
+    loc: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Return packed [T*heads,64] / [T*heads], or write paged key cache.
+
+    Without positions, freqs is already gathered per token; otherwise the
+    kernel reads freqs[positions] directly, removing the gather launch.
+    """
+    assert x.dtype == torch.bfloat16 and x.shape[-1] == 128
+    assert 0 <= rope_dim <= 128 and rope_dim % 2 == 0
+    x = x.contiguous()
+    rows = x.numel() // 128
+    heads = x[0].numel() // 128 if x.shape[0] else 1
+    f = torch.view_as_real(freqs.contiguous())
+    if cache is None:
+        payload = torch.empty((rows, 64), dtype=torch.int8, device=x.device)
+        scale = torch.empty((rows,), dtype=torch.int32, device=x.device)
+        page_size = cache_stride = 0
+    else:
+        assert heads == 1 and loc is not None and loc.numel() == rows
+        assert cache.ndim == 2 and cache.shape[1] % 68 == 0
+        payload = scale = None
+        page_size, cache_stride = cache.shape[1] // 68, cache.stride(0)
+    if rows:
+        _rope_fake_quant_pack_indexer_kernel[(rows,)](
+            x,
+            f,
+            positions,
+            payload,
+            scale,
+            cache,
+            loc,
+            F_STRIDE=f.stride(0),
+            HEADS=heads,
+            RD=rope_dim,
+            INDEXED=positions is not None,
+            STORE_CACHE=cache is not None,
+            PAGE_SIZE=page_size,
+            CACHE_STRIDE=cache_stride,
+            AMAX_FLOOR=FP4_AMAX_FLOOR,
+            num_warps=4,
+        )
+    return (payload, scale) if cache is None else None

--- a/python/sglang/kernels/ops/attention/dsv4/sm90_fp4_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsv4/sm90_fp4_indexer.py
@@ -1,0 +1,151 @@
+"""Decode-time low-ratio indexer logits for Hopper.
+
+DeepGEMM's fp8_fp4 mqa-logits kernels need SM100/SM120. This Triton kernel covers
+the same decode step on SM90: one query token per request, scored against the
+request's visible compressed positions read straight out of the fp4 indexer
+pool (e2m1 payload + e8m0 per-32 block scales, page layout of
+store_fp4_index_k_cache), summed over heads with relu and the per-head weights.
+
+Numerics follow the torch reference path (bf16 dot, bf16 relu/weight product,
+bf16 head reduction); the caller runs the same masking / candidate / top-k
+logic on the returned fp32 logits as the per-request torch loop.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+INDEX_HEAD_DIM = 128
+PAYLOAD_BYTES = tl.constexpr(64)
+SCALE_BYTES = tl.constexpr(4)
+
+
+@triton.jit
+def _e2m1_decode(code):
+    # code: uint 0..15 -> e2m1 value. exp = bits 2..1, mantissa = bit 0, sign = bit 3.
+    e = (code >> 1) & 3
+    m = (code & 1).to(tl.float32)
+    sub = m * 0.5
+    nor = (1.0 + m * 0.5) * tl.exp2((e - 1).to(tl.float32))
+    v = tl.where(e == 0, sub, nor)
+    return tl.where((code >> 3) == 1, -v, v)
+
+
+@triton.jit
+def _fp4_index_logits_kernel(
+    q_ptr,  # [B, H, D] bf16, fq4 queries (already rope'd)
+    w_ptr,  # [B, H] bf16 head weights (softmax scale folded in)
+    slots_ptr,  # [B, L] int64 pool slots per (request, compressed position)
+    lens_ptr,  # [B] int64 visible compressed positions per request
+    table_ptr,  # [num_pages, page_size * 64 + page_size * 4] uint8
+    out_ptr,  # [B, L] fp32 logits, -inf beyond lens
+    L,
+    page_size,
+    row_stride,
+    stride_qb,
+    stride_qh,
+    stride_wb,
+    H: tl.constexpr,
+    HALF_D: tl.constexpr,  # D // 2 == 64 nibble-pairs per row
+    BLOCK_L: tl.constexpr,
+):
+    b = tl.program_id(0)
+    lb = tl.program_id(1)
+    offs_l = lb * BLOCK_L + tl.arange(0, BLOCK_L)
+    offs_h = tl.arange(0, H)
+    offs_i = tl.arange(
+        0, HALF_D
+    )  # byte index i holds elements 2i (low nibble), 2i+1 (high nibble)
+
+    n_vis = tl.load(lens_ptr + b)
+    valid = offs_l < tl.minimum(n_vis, L)
+    slot = tl.load(slots_ptr + b * L + offs_l, mask=offs_l < L, other=0).to(tl.int64)
+    page = slot // page_size
+    off = slot % page_size
+    row_base = page * row_stride
+
+    # K payload: [BLOCK_L, HALF_D] uint8
+    pay = tl.load(
+        table_ptr + row_base[:, None] + off[:, None] * PAYLOAD_BYTES + offs_i[None, :],
+        mask=valid[:, None],
+        other=0,
+    )
+    low = _e2m1_decode(pay & 0x0F)
+    high = _e2m1_decode((pay >> 4) & 0x0F)
+    # e8m0 block scales: element j uses block j // 32 -> byte i uses block i // 16.
+    sc_idx = offs_i // 16
+    exps = tl.load(
+        table_ptr
+        + row_base[:, None]
+        + page_size * PAYLOAD_BYTES
+        + off[:, None] * SCALE_BYTES
+        + sc_idx[None, :],
+        mask=valid[:, None],
+        other=127,
+    )
+    scale = tl.exp2(exps.to(tl.float32) - 127.0)
+    k_low = (low * scale).to(tl.bfloat16)  # [BLOCK_L, HALF_D] elements 2i
+    k_high = (high * scale).to(tl.bfloat16)  # elements 2i+1
+
+    # queries: even / odd elements, [H, HALF_D] bf16
+    q_even = tl.load(
+        q_ptr + b * stride_qb + offs_h[:, None] * stride_qh + 2 * offs_i[None, :]
+    )
+    q_odd = tl.load(
+        q_ptr + b * stride_qb + offs_h[:, None] * stride_qh + 2 * offs_i[None, :] + 1
+    )
+
+    acc = tl.dot(q_even, tl.trans(k_low))  # [H, BLOCK_L] fp32
+    acc += tl.dot(q_odd, tl.trans(k_high))
+    # reference rounding points: bf16 dot -> relu -> * bf16 weight -> bf16 -> sum -> bf16
+    s = acc.to(tl.bfloat16).to(tl.float32)
+    s = tl.maximum(s, 0.0)
+    w = tl.load(w_ptr + b * stride_wb + offs_h).to(tl.float32)
+    s = (s * w[:, None]).to(tl.bfloat16).to(tl.float32)
+    logit = tl.sum(s, axis=0).to(tl.bfloat16).to(tl.float32)
+    logit = tl.where(valid, logit, float("-inf"))
+    tl.store(out_ptr + b * L + offs_l, logit, mask=offs_l < L)
+
+
+def fp4_index_logits_decode(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    slots: torch.Tensor,
+    lens: torch.Tensor,
+    table: torch.Tensor,
+    page_size: int,
+) -> torch.Tensor:
+    """q [B, H, 128] bf16, weights [B, H], slots [B, L] int64, lens [B] int64,
+    table = the layer's fp4 index-K page buffer (uint8, 2D). Returns [B, L] fp32
+    logits with -inf at positions >= lens."""
+    assert q.dtype == torch.bfloat16 and q.shape[-1] == INDEX_HEAD_DIM
+    B, H, _ = q.shape
+    L = slots.shape[1]
+    assert table.dtype == torch.uint8 and table.dim() == 2
+    q = q.contiguous()
+    weights = weights.to(torch.bfloat16).contiguous()
+    slots = slots.contiguous()
+    out = torch.empty((B, L), dtype=torch.float32, device=q.device)
+    if L == 0:
+        return out
+    BLOCK_L = 64
+    grid = (B, triton.cdiv(L, BLOCK_L))
+    _fp4_index_logits_kernel[grid](
+        q,
+        weights,
+        slots,
+        lens.to(torch.int64).contiguous(),
+        table,
+        out,
+        L,
+        page_size,
+        table.stride(0),
+        q.stride(0),
+        q.stride(1),
+        weights.stride(0),
+        H=H,
+        HALF_D=INDEX_HEAD_DIM // 2,
+        BLOCK_L=BLOCK_L,
+        num_warps=4,
+    )
+    return out

--- a/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4/sparse_prefill_kernels.py
@@ -44,6 +44,7 @@ def _combine_topk_swa_indices_kernel(
     topk_indices_ptr,
     topk_indices_stride,
     query_start_loc_ptr,
+    query_pos_ptr,
     seq_lens_ptr,
     gather_lens_ptr,
     compressed_base_ptr,
@@ -62,23 +63,19 @@ def _combine_topk_swa_indices_kernel(
     base = tl.load(query_start_loc_ptr)
     query_start = tl.load(query_start_loc_ptr + batch_idx) - base
     query_end = tl.load(query_start_loc_ptr + batch_idx + 1) - base
-    query_len = query_end - query_start
     seq_len = tl.load(seq_lens_ptr + batch_idx)
     gather_len = tl.load(gather_lens_ptr + batch_idx)
     compressed_base = tl.load(compressed_base_ptr + batch_idx)
     swa_base = tl.load(swa_base_ptr + batch_idx)
-    start_pos = seq_len - query_len
     # SWA portion of the gathered buffer starts from position
     # (seq_len - gather_len), not 0. The +pos-gather_start formula maps a
     # query's window back into the workspace's SWA region.
     gather_start = seq_len - gather_len
 
     for token_idx in range(query_start + worker_id, query_end, num_workers):
-        token_idx_in_query = token_idx - query_start
-        pos = start_pos + token_idx_in_query
-        # Both the C4 indexer and the C128 metadata builder emit
-        # min((pos+1)//compress_ratio, topk_tokens) valid entries. Caller
-        # passes top_k=0 for SWA-only layers to zero this out.
+        pos = tl.load(query_pos_ptr + token_idx)
+        # Candidate filtering can leave -1 holes within the top-k span.
+        # top_k=0 disables the compressed portion for SWA-only layers.
         topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, top_k)
         swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
 
@@ -93,7 +90,7 @@ def _combine_topk_swa_indices_kernel(
         )
         tl.store(
             combined_indices_ptr + combined_row + offset,
-            topk_vals + compressed_base,
+            tl.where(topk_vals >= 0, topk_vals + compressed_base, -1),
             mask=mask,
         )
 

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -18,11 +18,6 @@ from .utils import make_name
 
 @cache_once
 def _jit_topk_v1_module():
-    # topk (<= 1024) is a runtime argument, not a compile-time constant, so a
-    # single module serves every k. Baking it in via -DSGL_TOPK used to build one
-    # module per k, and since the macro fed a `constexpr` rather than a template
-    # parameter every module exported identically mangled symbols -- see the
-    # comment in topk_v1.cuh for how that broke the second module's launch.
     args = make_cpp_args(is_arch_support_pdl())
     return load_jit(
         make_name("topk_v1"),
@@ -34,15 +29,34 @@ def _jit_topk_v1_module():
 
 @cache_once
 def _jit_topk_v2_module():
-    # v2 is universal: topk (<= 2048) is a runtime argument, not a compile-time
-    # constant, so a single module serves every k.
+    from sglang.kernels.ops.misc import get_max_active_clusters
+
+    args = make_cpp_args(is_arch_support_pdl())
+    # Leave these undefined if the probe fails: topk_v2.cuh carries per-arch
+    # defaults, and a 0 would size the persistent pool to an empty grid.
+    extra_cuda_cflags = []
+    if is_arch_support_pdl():  # set the persistent cluster size after hopper
+        occ_8_2, occ_16_1 = 0, 0
+        try:
+            occ_8_2 = get_max_active_clusters(8, occupancy=2)
+            # NOTE: cluster 16 might fail, but at least cluster 8 is ok
+            occ_16_1 = get_max_active_clusters(16, occupancy=1)
+        except Exception:
+            pass
+        extra_cuda_cflags = [
+            f"-DSGL_TOPK_V2_MAX_C8_OCC2={occ_8_2}",
+            f"-DSGL_TOPK_V2_MAX_C16_OCC1={occ_16_1}",
+        ]
+    kernel = f"TopKKernel<{args}>"
     return load_jit(
         make_name("topk_v2"),
+        *args,
+        extra_cuda_cflags=extra_cuda_cflags,
         cuda_files=["deepseek_v4/topk_v2.cuh"],
         cuda_wrappers=[
-            ("topk_transform_paged", "TopKKernel::transform_paged"),
-            ("topk_transform_ragged", "TopKKernel::transform_ragged"),
-            ("topk_plan", "TopKKernel::plan"),
+            ("topk_transform_paged", f"{kernel}::transform_paged"),
+            ("topk_transform_ragged", f"{kernel}::transform_ragged"),
+            ("topk_plan", f"{kernel}::plan"),
         ],
     )
 
@@ -75,15 +89,14 @@ def topk_transform_paged(
 _PLAN_METADATA_INTS_PER_BATCH = 2
 
 
-def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
-    """Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
+def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = -1) -> torch.Tensor:
+    """
+    Preprocess the per-batch routing plan for :func:`topk_transform_paged_v2`.
+    NOTE: every entry of ``seq_lens`` must be NON-NEGATIVE.
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE. The device
-    kernel reads the int32 buffer as ``uint32_t``, so a negative length (e.g.
-    -4 from a DP-padded / idle-companion row) reinterprets as ~4e9, poisons
-    the plan, and drives the transform kernel into an illegal memory access.
-    Producers of padded rows must clamp their lengths to 0 (0 selects the
-    trivial all-(-1) output path, which is safe).
+    :param static_threshold: If a batch item has `seq_len` > `static_threshold`,
+                             prefer the cluster implementation.
+                             Negative number means internal heuristic.
     """
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
@@ -111,6 +124,9 @@ def topk_transform_ragged_v2(
     Unlike :func:`topk_transform_paged_v2` this needs no page table and no plan
     (the cluster path only pays off for very few rows, and prefill has many).
 
+    NOTE: ``scores`` is written in place -- the <= 3 columns ahead of each
+    row's window that the 16-byte-aligned read base pulls in are masked out.
+    They are invalid for that row and the buffer must have no other consumer.
     ``seq_lens`` entries must be NON-NEGATIVE, as for the paged entry point.
     """
     if is_xpu():
@@ -145,14 +161,10 @@ def topk_transform_paged_v2(
     * ``page_tables`` given -- ``out_page_indices`` receives the page-table
       transform of them.
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE, and
-    ``metadata`` must come from :func:`plan_topk_v2` over the same ``seq_lens``
-    values. The kernel reads lengths as ``uint32_t``: a negative entry
-    reinterprets as a ~4e9-token sequence, sending the row down the cluster
-    path over garbage scores and crashing with an illegal memory access
-    (GLM 5.2 MTP DP-idle companion rows hit exactly this). A length of 0 is
-    the valid way to express "no tokens": the row takes the trivial path and
-    the output is all -1.
+    NOTE: every entry of `seq_lens` must be NON-NEGATIVE, and `metadata` must
+    come from :func:`plan_topk_v2` over the same `seq_lens` values.
+    A length of 0 is the valid way to express "no tokens": the row takes the
+    trivial path and the output is guaranteed to be all -1.
     """
     if is_xpu():
         torch.ops.sgl_kernel.topk_transform_paged(

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -111,9 +111,6 @@ def topk_transform_ragged_v2(
     Unlike :func:`topk_transform_paged_v2` this needs no page table and no plan
     (the cluster path only pays off for very few rows, and prefill has many).
 
-    IMPORTANT: ``scores`` is written in place -- the <= 3 columns ahead of each
-    row's window that the 16-byte-aligned read base pulls in are masked out.
-    They are invalid for that row and the buffer must have no other consumer.
     ``seq_lens`` entries must be NON-NEGATIVE, as for the paged entry point.
     """
     if is_xpu():

--- a/python/sglang/kernels/ops/attention/dsv4/wo_a_bf16_gemv.py
+++ b/python/sglang/kernels/ops/attention/dsv4/wo_a_bf16_gemv.py
@@ -1,0 +1,44 @@
+"""Grouped BF16 matrix-vector projection for single-token decode."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _wo_a_bf16_gemv_kernel(X, W, Y, R: tl.constexpr, D: tl.constexpr, BN: tl.constexpr):
+    group = tl.program_id(1)
+    rows = tl.program_id(0) * BN + tl.arange(0, BN)
+    columns = tl.arange(0, D)
+    x = tl.load(X + group * D + columns).to(tl.float32)
+    w = tl.load(
+        W + (group * R + rows[:, None]) * D + columns[None, :],
+        rows[:, None] < R,
+        0,
+    ).to(tl.float32)
+    result = tl.sum(w * x[None, :], axis=1)
+    tl.store(Y + group * R + rows, result, rows < R)
+
+
+def wo_a_bf16_gemv(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute ``einsum('tgd,grd->tgr', x, weight)`` for one token."""
+    assert x.shape[0] == 1 and x.ndim == weight.ndim == 3
+    assert x.dtype == weight.dtype == torch.bfloat16
+    assert x.is_cuda and x.device == weight.device
+    assert x.is_contiguous() and weight.is_contiguous()
+    groups, rows, dim = weight.shape
+    assert x.shape[1:] == (groups, dim) and dim == triton.next_power_of_2(dim)
+    result = torch.empty((1, groups, rows), dtype=x.dtype, device=x.device)
+    # One output row per CTA keeps register use low and exposes enough
+    # independent weight loads for single-token decode.
+    _wo_a_bf16_gemv_kernel[(rows, groups)](
+        x,
+        weight,
+        result,
+        rows,
+        dim,
+        1,
+        num_warps=4,
+        enable_fp_fusion=False,
+    )
+    return result

--- a/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
+++ b/python/sglang/kernels/ops/attention/dsv4_attn_metadata_kernels.py
@@ -399,6 +399,7 @@ class BuildCausalSwaPageIndices:
         seq_lens_casual: torch.Tensor,
         swa_window: int,
         page_index_aligned_size: int,
+        swa_replay_start: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return build_causal_swa_page_indices(
             req_to_token=req_to_token,
@@ -407,6 +408,7 @@ class BuildCausalSwaPageIndices:
             seq_lens_casual=seq_lens_casual,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            swa_replay_start=swa_replay_start,
         )
 
     @classmethod
@@ -419,6 +421,7 @@ class BuildCausalSwaPageIndices:
         seq_lens_casual: torch.Tensor,
         swa_window: int,
         page_index_aligned_size: int,
+        swa_replay_start: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return build_causal_swa_page_indices_triton(
             req_to_token=req_to_token,
@@ -427,7 +430,40 @@ class BuildCausalSwaPageIndices:
             seq_lens_casual=seq_lens_casual,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            swa_replay_start=swa_replay_start,
         )
+
+
+def late_layer_tail_layout(
+    *,
+    extend_lens_cpu: list[int],
+    seq_lens_cpu: list[int],
+    tail_len: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, list[int], torch.Tensor]:
+    """Rows of a prefill extend that the late layers run over under decoder SWA
+    bounded replay: the last min(tail_len, extend_len) tokens of each request.
+    Returns (token indices into the extend, per-request tail lengths, and one
+    absolute window floor per tail row: the tail's first position)."""
+    tail_lens_cpu = [min(tail_len, n) for n in extend_lens_cpu]
+    if len(extend_lens_cpu) == 1:
+        n, t, s = extend_lens_cpu[0], tail_lens_cpu[0], seq_lens_cpu[0]
+        floor = torch.full((t,), s - t, dtype=torch.int32, device=device)
+        return torch.arange(n - t, n, device=device), tail_lens_cpu, floor
+    # One H2D copy for the three length vectors; launch count does not grow with bs.
+    lens = torch.tensor([extend_lens_cpu, tail_lens_cpu, seq_lens_cpu], device=device)
+    extend_lens, tail_lens, seq_lens = lens[0], lens[1], lens[2]
+    total = sum(tail_lens_cpu)
+    req = torch.repeat_interleave(
+        torch.arange(len(tail_lens_cpu), device=device), tail_lens, output_size=total
+    )
+    offs = (
+        torch.arange(total, device=device)
+        - (torch.cumsum(tail_lens, 0) - tail_lens)[req]
+    )
+    token_indices = (torch.cumsum(extend_lens, 0) - tail_lens)[req] + offs
+    floor = (seq_lens - tail_lens)[req].to(torch.int32)
+    return token_indices, tail_lens_cpu, floor
 
 
 def build_causal_swa_page_indices(
@@ -438,14 +474,20 @@ def build_causal_swa_page_indices(
     seq_lens_casual: torch.Tensor,
     swa_window: int,
     page_index_aligned_size: int,
+    swa_replay_start: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    """Window slots each query attends to, -1 where empty. swa_replay_start floors
+    each row's window at that absolute position; None is the plain causal window."""
     device = seq_lens_casual.device
     pos_causal = seq_lens_casual - 1
     num_qo_tokens = seq_lens_casual.size(0)
     offsets = pos_causal.unsqueeze(1) - torch.arange(
         swa_window, dtype=torch.int32, device=device
     ).unsqueeze(0)
-    invalid_offset_mask = offsets < 0
+    if swa_replay_start is None:
+        invalid_offset_mask = offsets < 0
+    else:
+        invalid_offset_mask = offsets < swa_replay_start.to(offsets.dtype).unsqueeze(1)
     offsets.masked_fill_(invalid_offset_mask, 0)
     raw_indices = req_to_token[req_pool_indices_repeated[:, None], offsets]
     assert raw_indices.shape == (num_qo_tokens, swa_window)
@@ -469,10 +511,12 @@ def _causal_swa_page_indices_kernel(
     full_to_swa_ptr,
     req_pool_ptr,
     seq_lens_ptr,
+    swa_replay_start_ptr,
     out_ptr,
     rt_stride,
     swa_window,
     padded_width,
+    HAS_SWA_REPLAY_START: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
     row = tl.program_id(0)
@@ -480,12 +524,16 @@ def _causal_swa_page_indices_kernel(
     rp = tl.load(req_pool_ptr + row).to(tl.int64)
     base = req_to_token_ptr + rp * rt_stride
     out_base = out_ptr + row.to(tl.int64) * padded_width
+    if HAS_SWA_REPLAY_START:
+        floor = tl.load(swa_replay_start_ptr + row).to(tl.int64)
+    else:
+        floor = tl.zeros((), dtype=tl.int64)
 
     for k0 in range(0, padded_width, BLOCK_K):
         k = k0 + tl.arange(0, BLOCK_K)
         kmask = k < padded_width
         off = pos - k.to(tl.int64)
-        valid = (k < swa_window) & (off >= 0) & kmask
+        valid = (k < swa_window) & (off >= floor) & kmask
         full_loc = tl.load(base + tl.where(valid, off, 0), mask=valid, other=-1).to(
             tl.int64
         )
@@ -501,6 +549,7 @@ def build_causal_swa_page_indices_triton(
     seq_lens_casual: torch.Tensor,
     swa_window: int,
     page_index_aligned_size: int,
+    swa_replay_start: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     num_qo_tokens = seq_lens_casual.size(0)
     padded_width = (
@@ -512,15 +561,19 @@ def build_causal_swa_page_indices_triton(
         device=seq_lens_casual.device,
     )
     BLOCK_K = 256
+    has_swa_replay_start = swa_replay_start is not None
     _causal_swa_page_indices_kernel[(num_qo_tokens,)](
         req_to_token,
         full_to_swa_mapping,
         req_pool_indices_repeated,
         seq_lens_casual,
+        # Unused when HAS_SWA_REPLAY_START is False; any valid pointer will do.
+        swa_replay_start if has_swa_replay_start else seq_lens_casual,
         out,
         req_to_token.stride(0),
         swa_window,
         padded_width,
+        HAS_SWA_REPLAY_START=has_swa_replay_start,
         BLOCK_K=BLOCK_K,
     )
     return out

--- a/python/sglang/kernels/ops/communication/all_reduce_fusion.py
+++ b/python/sglang/kernels/ops/communication/all_reduce_fusion.py
@@ -1,0 +1,243 @@
+"""Fused deferred-MoE finalize + 1shot push all-reduce [+ RMSNorm] (bf16).
+
+One entry point, :func:`moe_finalize_all_reduce`, over
+``csrc/distributed/all_reduce_fusion.cuh``::
+
+    out[t] = allreduce( sum_k expert_weights[t, k] * gemm2_out[idx[t*top_k + k]]
+                        (+ shared_output[t]) )            # then, optionally,
+    out[t] = out[t] * rsqrt(mean(out[t]^2) + eps) * norm_weight
+
+The rank-local finalize (the trtllm-gen ``do_finalize=False`` triple, see
+``moe_runner/flashinfer_trtllm.py``) is computed in registers and pushed
+straight into every peer's CustomAllReduceV2 push slot, so it never
+materializes; ``idx == -1`` slots (EP: non-local expert) contribute nothing.
+Small-batch only: the whole ``[T, hidden]`` bf16 row view must fit one push
+slot (checked C++-side; :func:`fits_push_slot` lets callers pre-check).
+
+The un-normed result is what DeepSeek-V4.1 consumes (its consumer is the mHC
+post-split, not an RMSNorm), so ``norm_weight=None`` is the primary
+configuration; ``norm_weight`` + ``norm_eps`` give the K3-style fused norm.
+
+Geometry: one thread-block cluster per token row plus a bumper cluster that
+keeps the plane's phase counters uniform; ``cluster_size`` blocks share a
+row (``hidden / cluster_size`` dims each). :func:`default_cluster_size` holds
+the tuned default per hidden size and can be overridden per call.
+
+Needs :func:`register_comm` once per process (the CustomAllReduceV2
+``Communicator``); the ops key on ``world_size`` alone, like the K3 ones.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+    from sglang.kernels.ops.communication.all_reduce import Communicator
+
+
+# Storage plane: the CustomAllReduceV2 Communicator (push plane only)
+
+_COMM_MAP: dict[int, Communicator] = {}
+
+
+def register_comm(comm: Communicator) -> None:
+    """Register the CustomAllReduceV2 communicator whose push plane the fused
+    kernel stages through.
+
+    ``world_size`` is the whole key (the custom op takes nothing else), so at
+    most one communicator per size may be registered in a process; a second
+    group of the same size would silently inherit the first one's peer
+    pointers and the symptom would be a hang, hence the assert.
+    """
+    prev = _COMM_MAP.get(comm.world_size)
+    assert prev is None or prev is comm, (
+        f"a different communicator is already registered for world_size="
+        f"{comm.world_size}; these ops key only on world_size, so two groups of "
+        f"the same size cannot coexist in one process"
+    )
+    _COMM_MAP[comm.world_size] = comm
+
+
+def get_registered_comm(world_size: int) -> Optional[Communicator]:
+    return _COMM_MAP.get(world_size)
+
+
+# Geometry
+
+_VEC_ELEMS = 8  # bf16 per 16B vector = per thread
+_MAX_CLUSTER_SIZE = 8  # portable cluster size limit
+
+
+def valid_cluster_sizes(hidden_dim: int) -> list[int]:
+    """Cluster sizes the kernel can be built for at this hidden width: whole
+    16B vectors per row, whole warps per block, <= 1024 threads, <= 8 blocks."""
+    if hidden_dim % _VEC_ELEMS != 0:
+        return []
+    row_vecs = hidden_dim // _VEC_ELEMS
+    return [
+        c
+        for c in range(1, _MAX_CLUSTER_SIZE + 1)
+        if row_vecs % c == 0 and (row_vecs // c) % 32 == 0 and row_vecs // c <= 1024
+    ]
+
+
+@cache_once
+def default_cluster_size(hidden_dim: int) -> int:
+    if hidden_dim % 1024 == 0 and hidden_dim <= 8192:
+        return hidden_dim // 1024
+    if hidden_dim % 512 == 0 and hidden_dim <= 3584:
+        return hidden_dim // 512
+    candidates = valid_cluster_sizes(hidden_dim)
+    if not candidates:
+        raise ValueError(
+            f"hidden_dim={hidden_dim} has no valid cluster geometry (needs a "
+            f"multiple of {_VEC_ELEMS * 32} bf16)"
+        )
+    # closest to 128 threads per block, larger block on ties
+    return min(candidates, key=lambda c: (abs(hidden_dim // _VEC_ELEMS // c - 128), c))
+
+
+def fits_push_slot(max_push_size: int, num_tokens: int, hidden_dim: int) -> bool:
+    """Whether a ``[num_tokens, hidden_dim]`` bf16 row view fits one push slot
+    (``CustomAllReduceV2.max_push_size``)."""
+    return 0 < num_tokens * hidden_dim * 2 <= max_push_size
+
+
+# JIT module: one per (world_size, hidden_dim, top_k, cluster_size); the
+# shared-add and norm variants are compiled into it and picked at call time.
+
+
+@cache_once
+def _jit_module(
+    world_size: int, hidden_dim: int, top_k: int, cluster_size: int
+) -> Module:
+    assert cluster_size in valid_cluster_sizes(hidden_dim), (
+        f"cluster_size={cluster_size} is not valid for hidden_dim={hidden_dim}; "
+        f"choose from {valid_cluster_sizes(hidden_dim)}"
+    )
+    args = make_cpp_args(
+        world_size, hidden_dim, top_k, cluster_size, is_arch_support_pdl()
+    )
+    return load_jit(
+        "moe_finalize_all_reduce",
+        *args,
+        cuda_files=["distributed/all_reduce_fusion.cuh"],
+        cuda_wrappers=[("run", f"MoeFinalizeAllReduceKernel<{args}>::run")],
+    )
+
+
+def compile_moe_finalize_all_reduce(
+    world_size: int, hidden_dim: int, top_k: int, cluster_size: Optional[int] = None
+) -> None:
+    """Warm the JIT module (tests / benches precompile in parallel)."""
+    _jit_module(
+        world_size, hidden_dim, top_k, cluster_size or default_cluster_size(hidden_dim)
+    )
+
+
+@register_custom_op(mutates_args=["out"])
+def _moe_finalize_all_reduce_op(
+    world_size: int,
+    hidden_dim: int,
+    top_k: int,
+    cluster_size: int,
+    out: torch.Tensor,
+    gemm2_out: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_weights: torch.Tensor,
+    shared_output: Optional[torch.Tensor],
+    norm_weight: Optional[torch.Tensor],
+    norm_eps: float,
+    prefetch_metadata: bool,
+) -> None:
+    comm = _COMM_MAP.get(world_size)
+    assert comm is not None, (
+        f"no communicator registered for world_size={world_size}; call "
+        "all_reduce_fusion.register_comm(comm.obj) first"
+    )
+    _jit_module(world_size, hidden_dim, top_k, cluster_size).run(
+        comm,
+        out,
+        gemm2_out,
+        expanded_idx_to_permuted_idx,
+        expert_weights,
+        shared_output,
+        norm_weight,
+        norm_eps,
+        prefetch_metadata,
+    )
+
+
+def moe_finalize_all_reduce(
+    gemm2_out: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    expert_weights: torch.Tensor,
+    top_k: int,
+    shared_output: Optional[torch.Tensor] = None,
+    norm_weight: Optional[torch.Tensor] = None,
+    norm_eps: Optional[float] = None,
+    *,
+    world_size: int,
+    hidden_dim: int,
+    cluster_size: Optional[int] = None,
+    prefetch_metadata: bool = False,
+) -> torch.Tensor:
+    """Deferred MoE finalize [+ shared add] -> 1shot push all-reduce [-> RMSNorm].
+
+    :param gemm2_out: ``[P, hidden_dim]`` bf16, trtllm-gen permuted / padded rows.
+    :param expanded_idx_to_permuted_idx: ``[T * top_k]`` int32, ``-1`` = dropped slot.
+    :param expert_weights: ``[T, top_k]`` bf16; any routed scaling factor is
+                           already folded in (nothing is rescaled here).
+    :param shared_output: optional ``[T, hidden_dim]`` bf16 added before the reduce.
+    :param norm_weight: optional ``[hidden_dim]`` bf16 RMSNorm weight; with
+                        ``norm_eps`` it turns on the fused norm epilogue.
+    :param prefetch_metadata: let the kernel read the plane's phase counter and
+                              the routing metadata before its PDL wait. Under
+                              PDL the kernel may start as soon as the preceding
+                              kernel *triggers*, and nothing earlier in the
+                              stream is guaranteed complete until the wait: so
+                              this is only valid when the preceding kernel is
+                              not an all-reduce on the same plane AND the
+                              producers of ``expanded_idx_to_permuted_idx`` /
+                              ``expert_weights`` are known complete (a chain of
+                              early-triggering kernels such as the TRT-LLM MoE
+                              GEMMs is not). Defaults to False (wait first).
+    :returns: a new ``[T, hidden_dim]`` bf16 tensor (not in place).
+    """
+    num_tokens = expert_weights.shape[0]
+    assert expert_weights.shape[1] == top_k, (expert_weights.shape, top_k)
+    assert (norm_weight is None) == (norm_eps is None), (
+        "norm_weight and norm_eps must be given together"
+    )
+    out = torch.empty(
+        num_tokens, hidden_dim, dtype=torch.bfloat16, device=gemm2_out.device
+    )
+    if num_tokens == 0:  # nothing staged: no phase flip on any rank, stays in step
+        return out
+    _moe_finalize_all_reduce_op(
+        world_size,
+        hidden_dim,
+        top_k,
+        cluster_size or default_cluster_size(hidden_dim),
+        out,
+        gemm2_out,
+        expanded_idx_to_permuted_idx,
+        expert_weights,
+        shared_output,
+        norm_weight,
+        float(norm_eps) if norm_eps is not None else 0.0,
+        prefetch_metadata,
+    )
+    return out

--- a/python/sglang/kernels/ops/embeddings/__init__.py
+++ b/python/sglang/kernels/ops/embeddings/__init__.py
@@ -14,4 +14,20 @@ register_kernel(
     )
 )
 
+register_kernel(
+    KernelSpec(
+        op="embeddings.engram_gather",
+        backend=KernelBackend.TRITON,
+        target="sglang.kernels.ops.embeddings.engram_gather:engram_gather",
+    )
+)
+
+register_kernel(
+    KernelSpec(
+        op="embeddings.engram_hash_ids",
+        backend=KernelBackend.TRITON,
+        target="sglang.kernels.ops.embeddings.engram_hash:engram_hash_ids",
+    )
+)
+
 __all__ = []

--- a/python/sglang/kernels/ops/embeddings/engram_gate.py
+++ b/python/sglang/kernels/ops/embeddings/engram_gate.py
@@ -1,0 +1,76 @@
+"""Fused FP32 Engram gate with a single final cast to the activation dtype."""
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def _engram_gate_kernel(
+    X,
+    KV,
+    QW,
+    KW,
+    O,
+    D: tl.constexpr,
+    HC: tl.constexpr,
+    EPS: tl.constexpr,
+    CLAMP: tl.constexpr,
+    B: tl.constexpr,
+):
+    row = tl.program_id(0)
+    token = row // HC
+    hc = row % HC
+    col = tl.arange(0, B)
+    mask = col < D
+    x = tl.load(X + row * D + col, mask, 0).to(tl.float32)
+    key = tl.load(KV + token * (HC + 1) * D + hc * D + col, mask, 0).to(tl.float32)
+    q_weight = tl.load(QW + hc * D + col, mask, 0).to(tl.float32)
+    k_weight = tl.load(KW + hc * D + col, mask, 0).to(tl.float32)
+    weight = q_weight * k_weight
+    rstd = tl.rsqrt(tl.sum(x * x, 0) / D + EPS) * tl.rsqrt(
+        tl.sum(key * key, 0) / D + EPS
+    )
+    dot = tl.sum((x * weight) * key, 0) * rstd * (D**-0.5)
+    gate = tl.sigmoid(libdevice.copysign(tl.sqrt(tl.maximum(tl.abs(dot), CLAMP)), dot))
+    value = tl.load(KV + token * (HC + 1) * D + HC * D + col, mask, 0).to(tl.float32)
+    tl.store(O + row * D + col, x + gate * value, mask)
+
+
+def fused_engram_gate(
+    x: torch.Tensor,
+    kv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    clamp_value: float,
+) -> torch.Tensor:
+    assert x.ndim == 3 and kv.ndim == 2
+    t, hc, d = x.shape
+    assert kv.shape == (t, (hc + 1) * d)
+    assert q_weight.shape == k_weight.shape == (hc, d)
+    assert all(
+        a.is_cuda and a.is_contiguous() and a.device == x.device
+        for a in (x, kv, q_weight, k_weight)
+    )
+    assert all(
+        a.dtype in (torch.bfloat16, torch.float32) for a in (x, kv, q_weight, k_weight)
+    )
+    out = torch.empty_like(x)
+    if t:
+        _engram_gate_kernel[(t * hc,)](
+            x,
+            kv,
+            q_weight,
+            k_weight,
+            out,
+            d,
+            hc,
+            eps,
+            clamp_value,
+            triton.next_power_of_2(d),
+            num_warps=4,
+            enable_fp_fusion=False,
+        )
+    return out

--- a/python/sglang/kernels/ops/embeddings/engram_gather.py
+++ b/python/sglang/kernels/ops/embeddings/engram_gather.py
@@ -1,0 +1,80 @@
+"""Triton gather of DeepSeek-V4.1 engram rows: fp8 e4m3 payload, e8m0 block scales.
+
+The table pointers arrive as raw addresses so one kernel serves a device table, a
+pinned host table, or (on Grace-Blackwell, through ATS) a plain host mapping. The
+output is bf16 computed as fp32(row) * 2**(exp - 127) then rounded once, which is
+the arithmetic of the torch lookup it replaces.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+# e8m0 has no zero: the exponent byte 0 encodes 2**-127.
+_E8M0_ZERO = 2.0**-127
+
+
+@triton.jit
+def _engram_gather_kernel(
+    w_ptr,
+    s_ptr,
+    ids_ptr,
+    out_ptr,
+    row_lo,
+    row_hi,
+    DIM: tl.constexpr,
+    BLK: tl.constexpr,
+    E8M0_ZERO: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    idx = tl.load(ids_ptr + row).to(tl.int64)
+    # The table holds rows [row_lo, row_hi); an id outside it is not read and
+    # comes out as zeros, which is what the sharded all-reduce sums.
+    owned = (idx >= row_lo) & (idx < row_hi)
+    local = tl.where(owned, idx - row_lo, 0)
+    w = w_ptr.to(tl.int64).to(tl.pointer_type(tl.float8e4nv))
+    s = s_ptr.to(tl.int64).to(tl.pointer_type(tl.uint8))
+    offs = tl.arange(0, DIM)
+    vals = tl.load(w + local * DIM + offs, mask=owned, other=0.0).to(tl.float32)
+    exps = tl.load(s + local * (DIM // BLK) + offs // BLK, mask=owned, other=0).to(
+        tl.int32
+    )
+    # 2**(e - 127) from the exponent bits: exact, no exp2 rounding or denormal flush.
+    scale = (exps << 23).to(tl.float32, bitcast=True)
+    scale = tl.where(exps == 0, E8M0_ZERO, scale)
+    out = tl.where(owned, vals * scale, 0.0)
+    tl.store(out_ptr + row * DIM + offs, out.to(tl.bfloat16))
+
+
+def engram_gather(
+    weight_ptr: int,
+    scale_ptr: int,
+    ids: torch.Tensor,
+    out: torch.Tensor,
+    dim: int,
+    block_size: int,
+    row_lo: int = 0,
+    row_hi: int = 2**62,
+) -> torch.Tensor:
+    """Gather rows ``ids`` ([N] int) into ``out`` ([N, dim] bf16, contiguous).
+
+    ``weight_ptr`` addresses [rows, dim] fp8 e4m3 bytes and ``scale_ptr``
+    [rows, dim // block_size] e8m0 bytes for global rows [row_lo, row_hi); both
+    may live in device or host memory. Ids outside the range produce zero rows.
+    """
+    assert dim & (dim - 1) == 0 and dim % block_size == 0, (dim, block_size)
+    assert out.dtype == torch.bfloat16 and out.is_contiguous()
+    n = ids.numel()
+    if n:
+        _engram_gather_kernel[(n,)](
+            weight_ptr,
+            scale_ptr,
+            ids,
+            out,
+            row_lo,
+            row_hi,
+            DIM=dim,
+            BLK=block_size,
+            E8M0_ZERO=_E8M0_ZERO,
+        )
+    return out

--- a/python/sglang/kernels/ops/embeddings/engram_hash.py
+++ b/python/sglang/kernels/ops/embeddings/engram_hash.py
@@ -1,0 +1,247 @@
+"""Triton n-gram hash ids for the DeepSeek-V4.1 engram, one launch per forward.
+
+Each token t needs its n predecessors: shift 0 is the token itself, shift s an
+earlier token of the same request. Shifts that reach past the request's first token
+of this forward come from a per-request history row (oldest first). A shift that runs
+off the sequence start, or (with vision) reaches an image token, is PAD, and so is
+every older shift. The compressed ids are multiplied per (layer, shift), XOR-folded
+one shift at a time and bucketed by that n-gram size's per-head primes.
+
+The arithmetic must remain bit-identical to EngramHasher's torch path
+in sglang.srt.layers.engram.
+"""
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+MODE_DECODE = 0
+MODE_VERIFY = 1
+MODE_EXTEND = 2
+
+
+@triton.jit
+def _engram_commit_history_kernel(
+    history_ptr,
+    tokens_ptr,
+    slots_ptr,
+    commit_ptr,
+    HISTORY_STRIDE: tl.constexpr,
+    HISTORY_WIDTH: tl.constexpr,
+    TOKEN_STRIDE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    slot = tl.load(slots_ptr + row).to(tl.int64)
+    commit = tl.load(commit_ptr + row)
+    col = tl.arange(0, BLOCK)
+    source_col = commit + col
+    valid = col < HISTORY_WIDTH
+    old = tl.load(
+        history_ptr + slot * HISTORY_STRIDE + source_col,
+        mask=valid & (source_col < HISTORY_WIDTH),
+        other=0,
+    )
+    new = tl.load(
+        tokens_ptr + row * TOKEN_STRIDE + source_col - HISTORY_WIDTH,
+        mask=valid & (source_col >= HISTORY_WIDTH),
+        other=0,
+    )
+    values = tl.where(source_col < HISTORY_WIDTH, old, new)
+    # Every lane must finish reading the old row before any lane overwrites it.
+    tl.debug_barrier()
+    tl.store(history_ptr + slot * HISTORY_STRIDE + col, values, mask=valid)
+
+
+def engram_commit_history(
+    history: torch.Tensor,
+    verify_ids: torch.Tensor,
+    req_slots: torch.Tensor,
+    commit_lens: torch.Tensor,
+) -> None:
+    """Update distinct live request slots with anchor + correct drafts, not bonus."""
+    bs = req_slots.numel()
+    width = history.shape[1]
+    if bs == 0 or width == 0:
+        return
+    assert history.stride(1) == 1 and verify_ids.stride(1) == 1
+    assert req_slots.stride(0) == 1 and commit_lens.stride(0) == 1
+    _engram_commit_history_kernel[(bs,)](
+        history,
+        verify_ids,
+        req_slots,
+        commit_lens,
+        HISTORY_STRIDE=history.stride(0),
+        HISTORY_WIDTH=width,
+        TOKEN_STRIDE=verify_ids.stride(0),
+        BLOCK=triton.next_power_of_2(width),
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _engram_hash_kernel(
+    ids_ptr,
+    pos_ptr,
+    row_ptr,
+    starts_ptr,
+    slots_ptr,
+    hist_ptr,
+    token_map_ptr,
+    mult_ptr,
+    primes_ptr,
+    offsets_ptr,
+    tokens_out_ptr,
+    out_ptr,
+    num_tokens,
+    num_real,
+    pad_id,
+    image_token_id,
+    mm_pad_shift,
+    MODE: tl.constexpr,
+    BLOCK: tl.constexpr,
+    HIST_VIA_SLOTS: tl.constexpr,
+    HAS_IMAGE: tl.constexpr,
+    N: tl.constexpr,
+    L: tl.constexpr,
+    H: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    COLS: tl.constexpr = (N - 1) * H
+    t = tl.program_id(0) * BLOCK_T + tl.arange(0, BLOCK_T)
+    tmask = t < num_tokens
+    real = t < num_real
+    # Request row r and the token's offset inside its run for this forward.
+    if MODE == 0:
+        r = t.to(tl.int64)
+        off = t * 0
+    elif MODE == 1:
+        r = (t // BLOCK).to(tl.int64)
+        off = t - (t // BLOCK) * BLOCK
+    else:
+        r = tl.load(row_ptr + t, mask=real, other=0).to(tl.int64)
+        off = t - tl.load(starts_ptr + r, mask=real, other=0).to(tl.int32)
+    if HIST_VIA_SLOTS:
+        hrow = tl.load(slots_ptr + r, mask=real, other=0).to(tl.int64)
+    else:
+        hrow = r
+    pos = tl.load(pos_ptr + t, mask=tmask, other=0).to(tl.int32)
+
+    t2 = t[:, None]
+    s = tl.arange(0, N)[None, :]
+    tmask2 = tmask[:, None] & (s >= 0)
+    real2 = real[:, None] & (s >= 0)
+    off2 = off[:, None]
+    # Predecessor at shift s: an earlier token of the same run when s <= off, else
+    # history[row, n - 2 - (s - off - 1)]; the history is oldest first.
+    from_batch = tl.load(ids_ptr + tl.maximum(t2 - s, 0), mask=tmask2, other=0).to(
+        tl.int64
+    )
+    hcol = tl.minimum(tl.maximum(N - 2 - (s - off2 - 1), 0), N - 2)
+    from_hist = tl.load(
+        hist_ptr + hrow[:, None] * (N - 1) + hcol, mask=tmask2, other=0
+    ).to(tl.int64)
+    tok = tl.where(s <= off2, from_batch, from_hist)
+    tok = tl.where(real2, tok, 0)
+    blk = (pos[:, None] < s) | (real2 == 0)
+    if HAS_IMAGE:
+        # Scheduler-provided history still carries the multimodal pad ids.
+        tok = tl.where(tok >= mm_pad_shift, image_token_id, tok)
+        blk = blk | (tok == image_token_id)
+    # Once a shift is blocked every older shift is too (cummax along s).
+    blocked = tl.cumsum(blk.to(tl.int32), axis=1) > 0
+    tl.store(tokens_out_ptr + t2 * N + s, tok.to(tl.int32), mask=tmask2)
+    mapped = tl.load(token_map_ptr + tok, mask=tmask2, other=0).to(tl.int64)
+    comp = tl.where(blocked, pad_id, mapped)
+
+    h = tl.arange(0, H)[None, :]
+    omask = tmask[:, None] & (h >= 0)
+    for l in tl.static_range(L):
+        mult = tl.load(mult_ptr + l * N + s)
+        prod = comp * mult
+        for i in tl.static_range(1, N):
+            # (i + 1)-gram hash: XOR of the first i + 1 shifts' products.
+            rolling = tl.xor_sum(tl.where(s <= i, prod, 0), axis=1)
+            primes = tl.load(primes_ptr + l * COLS + (i - 1) * H + h)
+            offsets = tl.load(offsets_ptr + l * COLS + (i - 1) * H + h)
+            val = rolling[:, None] % primes + offsets
+            tl.store(
+                out_ptr + t2 * (L * COLS) + l * COLS + (i - 1) * H + h, val, mask=omask
+            )
+
+
+def engram_hash_ids(
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    mode: int,
+    history: torch.Tensor,
+    token_map: torch.Tensor,
+    multipliers: torch.Tensor,
+    primes: torch.Tensor,
+    offsets: torch.Tensor,
+    pad_id: int,
+    num_real: Optional[int] = None,
+    req_slots: Optional[torch.Tensor] = None,
+    block: int = 1,
+    row: Optional[torch.Tensor] = None,
+    starts: Optional[torch.Tensor] = None,
+    image_token_id: Optional[int] = None,
+    mm_pad_shift: int = 0,
+    block_t: int = 32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Hash ids [T, L, (n - 1) * heads] int64 and the predecessor table [T, n] int32.
+
+    ``mode``: MODE_DECODE (row = t, offset 0), MODE_VERIFY (row = t // block),
+    MODE_EXTEND (``row`` [num_real] and ``starts`` [bs] give each token's request and
+    the run's first token). ``history`` is [rows, n - 1] oldest first; with
+    ``req_slots`` given it is indexed by ``req_slots[row]``, else by ``row``.
+    Tokens at or past ``num_real`` are padding: PAD ids, zero predecessors.
+    """
+    num_tokens = input_ids.shape[0]
+    L, N = multipliers.shape
+    H = primes.shape[-1]
+    assert N & (N - 1) == 0 and H & (H - 1) == 0, (N, H)
+    assert primes.shape == (L, N - 1, H) and offsets.shape == (L, (N - 1) * H)
+    assert history.dim() == 2 and history.shape[1] == N - 1, history.shape
+    if mode == MODE_EXTEND:
+        assert row is not None and starts is not None
+    if num_real is None:
+        num_real = num_tokens
+    device = input_ids.device
+    out = torch.empty(num_tokens, L, (N - 1) * H, dtype=torch.int64, device=device)
+    tokens = torch.empty(num_tokens, N, dtype=torch.int32, device=device)
+    if num_tokens == 0:
+        return out, tokens
+    dummy = out  # unused pointer slots; never dereferenced under their constexprs
+    _engram_hash_kernel[(triton.cdiv(num_tokens, block_t),)](
+        input_ids,
+        positions,
+        row if row is not None else dummy,
+        starts if starts is not None else dummy,
+        req_slots if req_slots is not None else dummy,
+        history,
+        token_map,
+        multipliers,
+        primes,
+        offsets,
+        tokens,
+        out,
+        num_tokens,
+        num_real,
+        pad_id,
+        image_token_id if image_token_id is not None else -1,
+        mm_pad_shift,
+        MODE=mode,
+        BLOCK=block,
+        HIST_VIA_SLOTS=req_slots is not None,
+        HAS_IMAGE=image_token_id is not None,
+        N=N,
+        L=L,
+        H=H,
+        BLOCK_T=block_t,
+        num_warps=4,
+    )
+    return out, tokens

--- a/python/sglang/kernels/ops/gemm/__init__.py
+++ b/python/sglang/kernels/ops/gemm/__init__.py
@@ -216,6 +216,32 @@ register_kernel(
 )
 register_kernel(
     KernelSpec(
+        op="gemm.n128k512",
+        backend=KernelBackend.JIT,
+        target="sglang.kernels.ops.gemm.n128k512:n128k512_gemm_bf16",
+        capabilities=_CUDA,
+        format_signature=FormatSignature(
+            supported_dtypes=("bfloat16",),
+            description="[m, 512] @ [128, 512].T for decode batches m <= 32; the DeepSeek-V4.1 low-ratio index-key projection",
+        ),
+        description="bf16 GEMM specialised for N = 128, K = 512 (sglang.kernels.jit, JIT-only).",
+    )
+)
+register_kernel(
+    KernelSpec(
+        op="gemm.n32k5120",
+        backend=KernelBackend.JIT,
+        target="sglang.kernels.ops.gemm.n32k5120:n32k5120_gemm_bf16",
+        capabilities=_CUDA,
+        format_signature=FormatSignature(
+            supported_dtypes=("bfloat16",),
+            description="[m, 5120] @ [32, 5120].T for decode batches m <= 32; the DeepSeek-V4.1 indexer head-weight projection",
+        ),
+        description="bf16 GEMM specialised for N = 128, K = 512 (sglang.kernels.jit, JIT-only).",
+    )
+)
+register_kernel(
+    KernelSpec(
         op="gemm.qwen3x_nvfp4",
         backend=KernelBackend.KDA,
         target=f"{_KDA_PACKAGE}.qwen3x_nvfp4_gemm:try_qwen3x_nvfp4_gemm",
@@ -282,6 +308,26 @@ def tiny_gemm_bf16(
     return impl(x, w, out, out_dtype=out_dtype, max_m=max_m)
 
 
+def n128k512_gemm_bf16(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """bf16 GEMM ``x[m, 512] @ w[128, 512].T`` for decode batches (m <= 32)."""
+    impl = get_kernel("gemm.n128k512", KernelBackend.JIT)
+    return impl(x, w, out)
+
+
+def n32k5120_gemm_bf16(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """bf16 GEMM ``x[m, 5120] @ w[32, 5120].T`` for decode batches (m <= 32)."""
+    impl = get_kernel("gemm.n32k5120", KernelBackend.JIT)
+    return impl(x, w, out)
+
+
 def try_qwen3x_nvfp4_gemm(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -302,6 +348,8 @@ __all__ = [
     "bmm_fp8",
     "dsv3_fused_a_gemm",
     "fp8_scaled_mm",
+    "n128k512_gemm_bf16",
+    "n32k5120_gemm_bf16",
     "tiny_gemm_bf16",
     "try_qwen3x_nvfp4_gemm",
 ]

--- a/python/sglang/kernels/ops/gemm/n128k512.py
+++ b/python/sglang/kernels/ops/gemm/n128k512.py
@@ -1,0 +1,86 @@
+"""Decode-batch bf16 GEMM for x[m, 512] @ w[128, 512].T.
+
+Shares dot_product's reduction order with tiny_gemm_bf16 for bitwise parity;
+a row's result does not depend on the batch composition.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    get_jit_cuda_arch,
+    is_arch_support_pdl,
+    is_hip_runtime,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.kernels.kernel_api_logging import debug_kernel_api
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+N: int = 128
+K: int = 512
+# Decode batches only: above this the caller keeps the general GEMM. The kernel
+# itself accepts any m (rows are split over blockIdx.y), this is a policy cap.
+MAX_M: int = 32
+
+
+@cache_once
+def _jit_n128k512_module() -> Module:
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        "n128k512_gemm",
+        *args,
+        cuda_files=["gemm/small/n128k512.cuh"],
+        cuda_wrappers=[("run", f"N128K512Kernel<{args}>::run")],
+        extra_cuda_cflags=["-O3"],
+    )
+
+
+@register_custom_op(op_name="n128k512_gemm_bf16", mutates_args=["out"])
+def _n128k512_gemm_custom_op(
+    x: torch.Tensor, w: torch.Tensor, out: torch.Tensor
+) -> None:
+    _jit_n128k512_module().run(x, w, out)
+
+
+@cache_once
+def _arch_supported() -> bool:
+    return not is_hip_runtime() and get_jit_cuda_arch().major >= 9
+
+
+def can_use_n128k512_gemm(n: int, k: int, m: int, max_m: int = MAX_M) -> bool:
+    """Whether :func:`n128k512_gemm_bf16` serves ``[m, k] @ [n, k].T``.
+    Callers fall back to a general GEMM when this is False."""
+    return n == N and k == K and 1 <= m <= max_m and _arch_supported()
+
+
+@debug_kernel_api
+def n128k512_gemm_bf16(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Equal to ``torch.nn.functional.linear(x, w)`` for ``w`` of shape [128, 512].
+
+    Call :func:`can_use_n128k512_gemm` first: other shapes raise rather than fall
+    back. ``x`` may be a row-sliced view (``x.stride(1) == 1``), but each row must
+    start on a 32-byte boundary because rows are loaded as whole vectors.
+
+    :param x: Shape [m, 512], bf16.
+    :param w: Shape [128, 512], bf16, contiguous.
+    :param out: Optional [m, 128] bf16 buffer to write into.
+    """
+    m = x.shape[0]
+    if out is None:
+        out = torch.empty((m, N), dtype=torch.bfloat16, device=x.device)
+    if m == 0:
+        return out
+    _n128k512_gemm_custom_op(x, w, out)
+    return out

--- a/python/sglang/kernels/ops/gemm/n32k5120.py
+++ b/python/sglang/kernels/ops/gemm/n32k5120.py
@@ -1,0 +1,89 @@
+"""Decode-batch bf16 GEMM for ``x[m, 5120] @ w[32, 5120].T``.
+
+Each CTA prefetches one weight row before the PDL wait. Row groups map to
+blockIdx.y, keeping per-CTA work independent of batch size.
+The thread-to-K mapping and shared dot_product reduction match tiny_gemm_bf16,
+so results agree bitwise where both apply and are invariant to batch composition.
+cuBLAS uses a different reduction order. See ``gemm/small/n32k5120.cuh``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    get_jit_cuda_arch,
+    is_arch_support_pdl,
+    is_hip_runtime,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.kernels.kernel_api_logging import debug_kernel_api
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+N: int = 32
+K: int = 5120
+# Decode batches only: above this the caller keeps the general GEMM. The kernel
+# itself accepts any m (rows are split over blockIdx.y), this is a policy cap.
+MAX_M: int = 32
+
+
+@cache_once
+def _jit_n32k5120_module() -> Module:
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        "n32k5120_gemm",
+        *args,
+        cuda_files=["gemm/small/n32k5120.cuh"],
+        cuda_wrappers=[("run", f"N32K5120Kernel<{args}>::run")],
+        extra_cuda_cflags=["-O3"],
+    )
+
+
+@register_custom_op(op_name="n32k5120_gemm_bf16", mutates_args=["out"])
+def _n32k5120_gemm_custom_op(
+    x: torch.Tensor, w: torch.Tensor, out: torch.Tensor
+) -> None:
+    _jit_n32k5120_module().run(x, w, out)
+
+
+@cache_once
+def _arch_supported() -> bool:
+    return not is_hip_runtime() and get_jit_cuda_arch().major >= 9
+
+
+def can_use_n32k5120_gemm(n: int, k: int, m: int, max_m: int = MAX_M) -> bool:
+    """Whether :func:`n32k5120_gemm_bf16` serves ``[m, k] @ [n, k].T``.
+    Callers fall back to a general GEMM when this is False."""
+    return n == N and k == K and 1 <= m <= max_m and _arch_supported()
+
+
+@debug_kernel_api
+def n32k5120_gemm_bf16(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Equal to ``torch.nn.functional.linear(x, w)`` for ``w`` of shape [32, 5120].
+
+    Call :func:`can_use_n32k5120_gemm` first: other shapes raise rather than fall
+    back. ``x`` may be a row-sliced view (``x.stride(1) == 1``), but each row must
+    start on a 32-byte boundary because rows are loaded as whole vectors.
+
+    :param x: Shape [m, 5120], bf16.
+    :param w: Shape [32, 5120], bf16, contiguous.
+    :param out: Optional [m, 32] bf16 buffer to write into.
+    """
+    m = x.shape[0]
+    if out is None:
+        out = torch.empty((m, N), dtype=torch.bfloat16, device=x.device)
+    if m == 0:
+        return out
+    _n32k5120_gemm_custom_op(x, w, out)
+    return out

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -18,6 +18,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.runtime_context import get_platform
 from sglang.srt.utils.common import is_gfx1250_supported
 
 logger = logging.getLogger(__name__)
@@ -2143,6 +2144,14 @@ def _block_m_for(m: int) -> int:
     return _HC_MIX_BLOCK_M
 
 
+def _num_stages_for(m: int, k: int) -> int:
+    # GB300 verify batches benefit from a smaller shared-memory footprint.
+    # This changes memory scheduling only; K tiles and reduction order stay fixed.
+    if get_platform().is_blackwell and k == 20480 and 64 <= m <= 384:
+        return 1
+    return _HC_MIX_NUM_STAGES
+
+
 def _num_slices_for(k: int) -> int:
     """Slice count depends only on K, never on batch size M."""
     blocks = k // _HC_MIX_BLOCK_K
@@ -2193,7 +2202,7 @@ def hc_mix_stats(x_flat: torch.Tensor, hc_fn: torch.Tensor, eps: float) -> torch
         BLOCK_K=_HC_MIX_BLOCK_K,
         DOT_PRECISION=_HC_MIX_DOT_PRECISION,
         num_warps=_HC_MIX_NUM_WARPS,
-        num_stages=_HC_MIX_NUM_STAGES,
+        num_stages=_num_stages_for(m, k),
     )
     _hc_mix_stats_reduce_kernel[(grid_m,)](
         part_mix,
@@ -2319,7 +2328,7 @@ def hc_mix_stats_sinkhorn(
         BLOCK_K=_HC_MIX_BLOCK_K,
         DOT_PRECISION=_HC_MIX_DOT_PRECISION,
         num_warps=_HC_MIX_NUM_WARPS,
-        num_stages=_HC_MIX_NUM_STAGES,
+        num_stages=_num_stages_for(m, k),
     )
     _hc_mix_reduce_sinkhorn_kernel[(m,)](
         part_mix,

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -2027,6 +2027,321 @@ def _hc_combine_kernel(
     tl.store(y_ptr + pid_m * y_stride_m + offs_h, acc, mask=mask)
 
 
+@triton.jit
+def _hc_mix_stats_partial_kernel(
+    x_ptr,
+    w_ptr,
+    part_mix_ptr,
+    part_sq_ptr,
+    M,
+    K,
+    x_stride_m,
+    w_stride_n,
+    MIX: tl.constexpr,
+    MIX_PAD: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    """Mixing dot products and row sum of squares over one K slice; the slicing
+    and tiles are compile-time constants, so a row's fp32 operation sequence
+    does not depend on the batch size."""
+    pid_m = tl.program_id(0)
+    pid_s = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, MIX_PAD)
+    mask_m = offs_m < M
+    mask_n = offs_n < MIX
+    k_per_slice = K // NUM_SLICES
+    k_start = pid_s * k_per_slice
+    acc = tl.zeros([BLOCK_M, MIX_PAD], dtype=tl.float32)
+    sq = tl.zeros([BLOCK_M], dtype=tl.float32)
+    for kb in range(0, k_per_slice, BLOCK_K):
+        offs_k = k_start + kb + tl.arange(0, BLOCK_K)
+        mask_k = offs_k < k_start + k_per_slice
+        x_tile = tl.load(
+            x_ptr + offs_m[:, None] * x_stride_m + offs_k[None, :],
+            mask=mask_m[:, None] & mask_k[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        w_tile = tl.load(
+            w_ptr + offs_n[None, :] * w_stride_n + offs_k[:, None],
+            mask=mask_n[None, :] & mask_k[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.dot(x_tile, w_tile, input_precision=DOT_PRECISION)
+        sq += tl.sum(x_tile * x_tile, axis=1)
+    tl.store(
+        part_mix_ptr + (pid_s * M + offs_m[:, None]) * MIX + offs_n[None, :],
+        acc,
+        mask=mask_m[:, None] & mask_n[None, :],
+    )
+    tl.store(part_sq_ptr + pid_s * M + offs_m, sq, mask=mask_m)
+
+
+@triton.jit
+def _hc_mix_stats_reduce_kernel(
+    part_mix_ptr,
+    part_sq_ptr,
+    mixes_ptr,
+    M,
+    inv_k,
+    eps,
+    MIX: tl.constexpr,
+    MIX_PAD: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """Sum the NUM_SLICES partials in slice order and apply the rms scaling."""
+    pid_m = tl.program_id(0)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, MIX_PAD)
+    mask_m = offs_m < M
+    mask_n = offs_n < MIX
+    acc = tl.zeros([BLOCK_M, MIX_PAD], dtype=tl.float32)
+    sq = tl.zeros([BLOCK_M], dtype=tl.float32)
+    for s in tl.static_range(NUM_SLICES):
+        acc += tl.load(
+            part_mix_ptr + (s * M + offs_m[:, None]) * MIX + offs_n[None, :],
+            mask=mask_m[:, None] & mask_n[None, :],
+            other=0.0,
+        )
+        sq += tl.load(part_sq_ptr + s * M + offs_m, mask=mask_m, other=0.0)
+    rsqrt = 1.0 / tl.sqrt(sq * inv_k + eps)
+    tl.store(
+        mixes_ptr + offs_m[:, None] * MIX + offs_n[None, :],
+        acc * rsqrt[:, None],
+        mask=mask_m[:, None] & mask_n[None, :],
+    )
+
+
+# K slicing, BLOCK_K and dot precision must stay independent of M;
+# a row must produce the same bits alone and in any batch.
+_HC_MIX_SLICE_CHOICES = (80, 64, 40, 32, 16, 8, 4, 2, 1)
+_HC_MIX_BLOCK_M = 32
+_HC_MIX_BLOCK_K = 64
+_HC_MIX_NUM_WARPS = 4
+_HC_MIX_DOT_PRECISION = "tf32x3"
+# num_stages only reorders memory issue, not arithmetic; 2 is enough to cover the
+# short k_per_slice loop (K=20480 gives 80 slices, i.e. 4 BLOCK_K tiles per CTA).
+_HC_MIX_NUM_STAGES = 2
+
+# BLOCK_M 8/16/32 preserve each row's K reduction order; thresholds were measured on GB300.
+# Keep BLOCK_M below 64, where Triton lowers tf32x3 to plain TF32 and changes rounding.
+_HC_MIX_BLOCK_M_SMALL = 8
+_HC_MIX_BLOCK_M_MID = 16
+_HC_MIX_MID_MAX_M = 2048
+
+
+def _block_m_for(m: int) -> int:
+    """Row-tile choices preserve each row's arithmetic and may depend on M."""
+    if m <= _HC_MIX_BLOCK_M_SMALL:
+        return _HC_MIX_BLOCK_M_SMALL
+    if m <= _HC_MIX_MID_MAX_M:
+        return _HC_MIX_BLOCK_M_MID
+    return _HC_MIX_BLOCK_M
+
+
+def _num_slices_for(k: int) -> int:
+    """Slice count depends only on K, never on batch size M."""
+    blocks = k // _HC_MIX_BLOCK_K
+    assert k % _HC_MIX_BLOCK_K == 0, k
+    for n in _HC_MIX_SLICE_CHOICES:
+        if blocks % n == 0:
+            return n
+    return 1
+
+
+def hc_mix_stats(x_flat: torch.Tensor, hc_fn: torch.Tensor, eps: float) -> torch.Tensor:
+    """Batch-invariant F.linear(x_flat.float(), hc_fn) * rsqrt(mean(x_flat^2) + eps).
+
+    x_flat is [M, K] in any float dtype; hc_fn is [MIX, K] fp32; returns [M, MIX] fp32.
+    K slicing and reduction order are independent of M, so each row is bitwise
+    identical whether computed alone or in a batch.
+    """
+    assert x_flat.dim() == 2 and hc_fn.dim() == 2
+    assert x_flat.stride(1) == 1 and hc_fn.stride(1) == 1
+    assert hc_fn.dtype == torch.float32
+    m, k = x_flat.shape
+    mix = hc_fn.shape[0]
+    assert hc_fn.shape[1] == k
+    num_slices = _num_slices_for(k)
+    mix_pad = max(16, triton.next_power_of_2(mix))
+    part_mix = torch.empty(
+        (num_slices, m, mix), dtype=torch.float32, device=x_flat.device
+    )
+    part_sq = torch.empty((num_slices, m), dtype=torch.float32, device=x_flat.device)
+    mixes = torch.empty((m, mix), dtype=torch.float32, device=x_flat.device)
+    if m == 0:
+        return mixes
+    block_m = _block_m_for(m)
+    grid_m = triton.cdiv(m, block_m)
+    _hc_mix_stats_partial_kernel[(grid_m, num_slices)](
+        x_flat,
+        hc_fn,
+        part_mix,
+        part_sq,
+        m,
+        k,
+        x_flat.stride(0),
+        hc_fn.stride(0),
+        MIX=mix,
+        MIX_PAD=mix_pad,
+        NUM_SLICES=num_slices,
+        BLOCK_M=block_m,
+        BLOCK_K=_HC_MIX_BLOCK_K,
+        DOT_PRECISION=_HC_MIX_DOT_PRECISION,
+        num_warps=_HC_MIX_NUM_WARPS,
+        num_stages=_HC_MIX_NUM_STAGES,
+    )
+    _hc_mix_stats_reduce_kernel[(grid_m,)](
+        part_mix,
+        part_sq,
+        mixes,
+        m,
+        1.0 / k,
+        eps,
+        MIX=mix,
+        MIX_PAD=mix_pad,
+        NUM_SLICES=num_slices,
+        BLOCK_M=block_m,
+        num_warps=4,
+    )
+    return mixes
+
+
+@triton.jit
+def _hc_mix_reduce_sinkhorn_kernel(
+    part_mix_ptr,
+    part_sq_ptr,
+    scale_ptr,
+    base_ptr,
+    pre_ptr,
+    post_ptr,
+    comb_ptr,
+    m,
+    inv_k,
+    rms_eps,
+    MIX: tl.constexpr,
+    HC: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    ITERS: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    """One CTA per row keeps the sinkhorn reductions two-dimensional.
+    Per-row arithmetic follows the slice reduction, then the Triton sinkhorn.
+    """
+    row = tl.program_id(0)
+    if row >= m:
+        return
+    j = tl.arange(0, HC)
+    jj = j[:, None]
+    kk = j[None, :]
+
+    a_pre = tl.zeros([HC], dtype=tl.float32)
+    a_post = tl.zeros([HC], dtype=tl.float32)
+    a_comb = tl.zeros([HC, HC], dtype=tl.float32)
+    sq = tl.zeros([], dtype=tl.float32)
+    for s in tl.static_range(NUM_SLICES):
+        off = (s * m + row) * MIX
+        a_pre += tl.load(part_mix_ptr + off + j)
+        a_post += tl.load(part_mix_ptr + off + HC + j)
+        a_comb += tl.load(part_mix_ptr + off + 2 * HC + jj * HC + kk)
+        sq += tl.load(part_sq_ptr + s * m + row)
+    rsqrt = 1.0 / tl.sqrt(sq * inv_k + rms_eps)
+
+    s0 = tl.load(scale_ptr + 0)
+    s1 = tl.load(scale_ptr + 1)
+    s2 = tl.load(scale_ptr + 2)
+
+    pre = tl.sigmoid(a_pre * rsqrt * s0 + tl.load(base_ptr + j)) + EPS
+    tl.store(pre_ptr + row * HC + j, pre)
+    post = 2.0 * tl.sigmoid(a_post * rsqrt * s1 + tl.load(base_ptr + HC + j))
+    tl.store(post_ptr + row * HC + j, post)
+
+    comb = a_comb * rsqrt * s2 + tl.load(base_ptr + 2 * HC + jj * HC + kk)
+    comb = tl.exp(comb - tl.max(comb, axis=1)[:, None])
+    comb = comb / tl.sum(comb, axis=1)[:, None] + EPS
+    comb = comb / (tl.sum(comb, axis=0)[None, :] + EPS)
+    for _ in tl.static_range(ITERS - 1):
+        comb = comb / (tl.sum(comb, axis=1)[:, None] + EPS)
+        comb = comb / (tl.sum(comb, axis=0)[None, :] + EPS)
+    tl.store(comb_ptr + row * HC * HC + jj * HC + kk, comb)
+
+
+def hc_mix_stats_sinkhorn(
+    x_flat: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    rms_eps: float,
+    hc_eps: float,
+):
+    """Fuse the reduce and sinkhorn stages of hc_mix_stats followed by hc_split_sinkhorn.
+
+    The split-K kernel fixes the reduction order and preserves batch invariance.
+    Sinkhorn uses the Triton port's transcendental lowering, which differs from TileLang.
+    """
+    assert x_flat.dim() == 2 and hc_fn.dim() == 2
+    assert x_flat.stride(1) == 1 and hc_fn.stride(1) == 1
+    assert hc_fn.dtype == torch.float32
+    m, k = x_flat.shape
+    mix = hc_fn.shape[0]
+    assert mix == (2 + hc_mult) * hc_mult and hc_fn.shape[1] == k
+    dev = x_flat.device
+    pre = torch.empty(m, hc_mult, dtype=torch.float32, device=dev)
+    post = torch.empty(m, hc_mult, dtype=torch.float32, device=dev)
+    comb = torch.empty(m, hc_mult, hc_mult, dtype=torch.float32, device=dev)
+    if m == 0:
+        return pre, post, comb
+
+    num_slices = _num_slices_for(k)
+    mix_pad = max(16, triton.next_power_of_2(mix))
+    part_mix = torch.empty((num_slices, m, mix), dtype=torch.float32, device=dev)
+    part_sq = torch.empty((num_slices, m), dtype=torch.float32, device=dev)
+    block_m = _block_m_for(m)
+    _hc_mix_stats_partial_kernel[(triton.cdiv(m, block_m), num_slices)](
+        x_flat,
+        hc_fn,
+        part_mix,
+        part_sq,
+        m,
+        k,
+        x_flat.stride(0),
+        hc_fn.stride(0),
+        MIX=mix,
+        MIX_PAD=mix_pad,
+        NUM_SLICES=num_slices,
+        BLOCK_M=block_m,
+        BLOCK_K=_HC_MIX_BLOCK_K,
+        DOT_PRECISION=_HC_MIX_DOT_PRECISION,
+        num_warps=_HC_MIX_NUM_WARPS,
+        num_stages=_HC_MIX_NUM_STAGES,
+    )
+    _hc_mix_reduce_sinkhorn_kernel[(m,)](
+        part_mix,
+        part_sq,
+        hc_scale.float().contiguous(),
+        hc_base.float().contiguous(),
+        pre,
+        post,
+        comb,
+        m,
+        1.0 / k,
+        rms_eps,
+        MIX=mix,
+        HC=hc_mult,
+        NUM_SLICES=num_slices,
+        ITERS=sinkhorn_iters,
+        EPS=hc_eps,
+        num_warps=1,
+    )
+    return pre, post, comb
+
+
 def hc_combine(
     x_flat: torch.Tensor, pre: torch.Tensor, hc: int, out_dtype: torch.dtype
 ) -> torch.Tensor:

--- a/python/sglang/kernels/ops/layernorm/mhc_post_split_h.py
+++ b/python/sglang/kernels/ops/layernorm/mhc_post_split_h.py
@@ -1,0 +1,47 @@
+"""Small-batch HC=4 post-mix with independent hidden-dimension CTAs."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mhc_post_split_h_kernel(X, R, P, C, Y, H: tl.constexpr, B: tl.constexpr):
+    token = tl.program_id(0)
+    h = tl.program_id(1) * B + tl.arange(0, B)
+    channel = tl.arange(0, 4)
+    x = tl.load(X + token * H + h, h < H, 0).to(tl.float32)
+    post = tl.load(P + token * 4 + channel)
+    residual0 = tl.load(R + token * 4 * H + h, h < H, 0).to(tl.float32)
+    comb0 = tl.load(C + token * 16 + channel)
+    # Match NVCC's contraction in mhc_post_tilelang: round comb[0]*residual[0]
+    # first, then FMA post*x into it. Reversing these two terms changes BF16
+    # rounding on rare ties even though the symbolic expression is the same.
+    acc = tl.fma(post[:, None], x[None, :], comb0[:, None] * residual0[None, :])
+    for i in tl.static_range(1, 4):
+        residual = tl.load(R + (token * 4 + i) * H + h, h < H, 0).to(tl.float32)
+        comb = tl.load(C + token * 16 + i * 4 + channel)
+        acc = tl.fma(comb[:, None], residual[None, :], acc)
+    tl.store(Y + (token * 4 + channel[:, None]) * H + h[None, :], acc, h[None, :] < H)
+
+
+def mhc_post_split_h(x, residual, post, comb):
+    """Same result as the TileLang post kernel for contiguous BF16 HC=4 inputs."""
+    assert x.dtype == residual.dtype == torch.bfloat16
+    assert post.dtype == comb.dtype == torch.float32
+    assert residual.shape == (x.shape[0], 4, x.shape[1])
+    assert all(t.is_contiguous() for t in (x, residual, post, comb))
+    output = torch.empty_like(residual)
+    block = 128 if x.shape[0] <= 8 else 1024
+    _mhc_post_split_h_kernel[(x.shape[0], triton.cdiv(x.shape[1], block))](
+        x,
+        residual,
+        post,
+        comb,
+        output,
+        H=x.shape[1],
+        B=block,
+        num_warps=4,
+        enable_fp_fusion=False,
+    )
+    return output

--- a/python/sglang/kernels/ops/misc.py
+++ b/python/sglang/kernels/ops/misc.py
@@ -1,0 +1,61 @@
+"""Device probes that a launch configuration depends on.
+
+Not an operator group -- these answer "what will the hardware actually schedule",
+which a host-side dispatch needs before it can size a grid. Kept out of
+``ops/__init__``'s eager group import for that reason; import it directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+__all__ = ["get_max_active_clusters"]
+
+
+@cache_once
+def _jit_probe_module() -> Module:
+    return load_jit(
+        "misc_probe",
+        cuda_files=["misc/probe.cuh"],
+        cuda_wrappers=[("get_max_active_clusters", "get_max_active_clusters")],
+    )
+
+
+@cache_once
+def _get_max_active_clusters(cluster_size: int, occupancy: int) -> int:
+    return int(_jit_probe_module().get_max_active_clusters(cluster_size, occupancy))
+
+
+def get_max_active_clusters(cluster_size: int, occupancy: int) -> int:
+    """Clusters of ``cluster_size`` blocks that can be resident at once.
+
+    Asks the driver (``cudaOccupancyMaxActiveClusters``) rather than dividing SM
+    count by cluster size: a cluster's blocks must be co-scheduled within one
+    GPC, so the answer falls short of ``num_sms * occupancy / cluster_size`` once
+    the cluster stops dividing a GPC evenly. On B200 (148 SMs) at occupancy 2 the
+    driver reports 33 clusters of 8 where the division says 37, and 14 of 16
+    where it says 18.
+
+    Probed with an empty kernel pinned to ``occupancy`` blocks per SM, so the
+    answer is the *scheduling* limit at that occupancy and nothing else. Pass the
+    occupancy the real kernel reaches (the second ``__launch_bounds__``
+    argument), not the one it asks for.
+
+    :param cluster_size: Blocks per cluster.
+    :param occupancy: Blocks per SM (``num_waves`` in ``csrc/misc/probe.cuh``).
+    :raises RuntimeError: On pre-sm90 devices, which have no clusters.
+    :raises ValueError: If nothing is schedulable, which a real device should
+                        never report for a cluster width it supports.
+    """
+    result = _get_max_active_clusters(cluster_size, occupancy)
+    if result == 0:
+        raise ValueError(
+            f"no cluster of {cluster_size} fits at occupancy {occupancy}; "
+            "the cluster width is likely beyond what this device supports"
+        )
+    return result

--- a/python/sglang/kernels/ops/moe/moe_fused_gate.py
+++ b/python/sglang/kernels/ops/moe/moe_fused_gate.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
 
 from sglang.kernels.jit.utils import cache_once, is_arch_support_pdl, load_jit
 from sglang.kernels.kernel_api_logging import debug_kernel_api
@@ -90,6 +91,9 @@ def moe_fused_gate_jit(
 def _router_triton_kernel(
     scores_ptr,  # [M, N] fp32, GEMM output (raw logits)
     bias_ptr,  # [N]    fp32/fp16/bf16 (upcast to fp32 on load)
+    bias_alt_ptr,
+    input_ids_ptr,
+    num_token_non_padded_ptr,
     out_weights_ptr,  # [M, K] fp32
     out_indices_ptr,  # [M, K] int32
     M,
@@ -110,7 +114,14 @@ def _router_triton_kernel(
     RENORMALIZE: tl.constexpr,
     APPLY_SCALE: tl.constexpr,  # apply_routed_scaling_factor_on_output
     HAS_BIAS: tl.constexpr,
+    HAS_TOKEN_BIAS: tl.constexpr,
+    BIAS_ALT_TOKEN_ID: tl.constexpr,
+    HAS_PADDING: tl.constexpr,
+    RENORMALIZE_EPSILON: tl.constexpr,
     USE_PDL: tl.constexpr,
+    stride_bias,
+    stride_bias_alt,
+    stride_input_ids,
     stride_sm,
     stride_sn,
     stride_wm,
@@ -131,15 +142,33 @@ def _router_triton_kernel(
     # bias, so keep the zero value in registers rather than materializing and
     # clearing a device tensor for every routing call.
     if HAS_BIAS:
-        bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0).to(tl.float32)
+        bias = tl.load(bias_ptr + offs_n * stride_bias, mask=mask_n, other=0.0).to(
+            tl.float32
+        )
     else:
         bias = tl.zeros([BLOCK_N], dtype=tl.float32)
+    if HAS_TOKEN_BIAS:
+        bias_alt = tl.load(
+            bias_alt_ptr + offs_n * stride_bias_alt, mask=mask_n, other=0.0
+        ).to(tl.float32)
 
     if USE_PDL:
         tl.extra.cuda.gdc_wait()
 
+    live_m = mask_m
+    if HAS_PADDING:
+        live_m = live_m & (offs_m < tl.load(num_token_non_padded_ptr))
+    row_bias = bias[None, :]
+    if HAS_TOKEN_BIAS:
+        input_ids = tl.load(
+            input_ids_ptr + offs_m * stride_input_ids, mask=live_m, other=0
+        )
+        row_bias = tl.where(
+            (input_ids == BIAS_ALT_TOKEN_ID)[:, None], bias_alt[None, :], row_bias
+        )
+
     row_ptr = scores_ptr + offs_m[:, None] * stride_sm + offs_n[None, :] * stride_sn
-    mask2d = mask_m[:, None] & mask_n[None, :]
+    mask2d = live_m[:, None] & mask_n[None, :]
     scores = tl.load(row_ptr, mask=mask2d, other=0.0).to(
         tl.float32
     )  # [BLOCK_M, BLOCK_N]
@@ -147,12 +176,12 @@ def _router_triton_kernel(
     if SCORING_FUNC == 0:
         # sigmoid(x) = 1 / (1 + exp(-x)); bias is for ranking only, weight is bias-free.
         activated = tl.sigmoid(scores)
-        biased = activated + bias[None, :]
+        biased = activated + row_bias
     elif SCORING_FUNC == 1:
-        # sqrt(softplus(x)) = sqrt(log1p(exp(x))); guard against overflow when x is large.
-        sp = tl.where(scores > 20.0, scores, tl.log(1.0 + tl.exp(scores)))
-        activated = tl.sqrt(sp)
-        biased = activated + bias[None, :]
+        # log1p preserves small positive scores for negative logits.
+        sp = tl.where(scores > 20.0, scores, libdevice.log1p(libdevice.exp(scores)))
+        activated = libdevice.sqrt(sp)
+        biased = activated + row_bias
     else:
         # softmax over the row: weight is the softmax probability (bias kept), with
         # optional tanh softcapping. Ranking by the (softcapped, biased) logit is
@@ -162,7 +191,7 @@ def _router_triton_kernel(
             # tanh(z) = 2*sigmoid(2z) - 1 (avoids relying on tl.math.tanh availability).
             z = logit / moe_softcapping
             logit = moe_softcapping * (2.0 * tl.sigmoid(2.0 * z) - 1.0)
-        biased = logit + bias[None, :]
+        biased = logit + row_bias
         biased = tl.where(mask_n[None, :], biased, -float("inf"))
         row_max = tl.max(biased, axis=1)[:, None]  # [BLOCK_M, 1]
         exp_row = tl.where(mask_n[None, :], tl.exp(biased - row_max), 0.0)
@@ -171,8 +200,11 @@ def _router_triton_kernel(
 
     biased = tl.where(mask_n[None, :], biased, -float("inf"))  # [BLOCK_M, BLOCK_N]
 
-    # Map NaN -> a finite floor
-    biased = tl.where(biased == biased, biased, -1e30)  # [BLOCK_M, BLOCK_N]
+    if SCORING_FUNC == 1:
+        # Rank NaNs above finite scores, matching torch.topk.
+        biased = tl.where(biased == biased, biased, float("inf"))
+    else:
+        biased = tl.where(biased == biased, biased, -1e30)
 
     # Grouped routing (DeepSeek-V3 noaux_tc): per-group score = sum of the top-2
     # biased values; keep TOPK_GROUP groups (lowest group id wins ties); mask the
@@ -207,9 +239,10 @@ def _router_triton_kernel(
     selected_idx = tl.zeros([BLOCK_M, BLOCK_K], dtype=tl.int32)
 
     cur = biased  # [BLOCK_M, BLOCK_N]
+    remaining = tl.broadcast_to(mask_n[None, :], (BLOCK_M, BLOCK_N))
     for k in tl.static_range(K_ROUTED):
         max_val = tl.max(cur, axis=1)[:, None]  # [BLOCK_M, 1]
-        is_max = cur == max_val
+        is_max = remaining & (cur == max_val)
         lane_id = tl.where(is_max, offs_n[None, :], N + 1)  # lowest expert id wins ties
         win_lane = tl.min(lane_id, axis=1)[:, None].to(tl.int32)  # [BLOCK_M, 1]
         win_activated = tl.sum(
@@ -218,7 +251,8 @@ def _router_triton_kernel(
         slot = offs_k[None, :] == k  # [1, BLOCK_K]
         selected_vals = tl.where(slot, win_activated, selected_vals)
         selected_idx = tl.where(slot, win_lane, selected_idx)
-        cur = tl.where(offs_n[None, :] == win_lane, -float("inf"), cur)
+        remaining = remaining & (offs_n[None, :] != win_lane)
+        cur = tl.where(remaining, cur, -float("inf"))
 
     routed_sum = tl.sum(tl.where(mask_k_routed[None, :], selected_vals, 0.0), axis=1)[
         :, None
@@ -237,10 +271,16 @@ def _router_triton_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
     if RENORMALIZE:
-        norm = tl.where(routed_sum > 0.0, routed_sum, 1.0)  # [BLOCK_M, 1]
+        if RENORMALIZE_EPSILON > 0.0:
+            norm = routed_sum + RENORMALIZE_EPSILON
+        else:
+            norm = tl.where(routed_sum > 0.0, routed_sum, 1.0)  # [BLOCK_M, 1]
         selected_vals = selected_vals / norm
     if APPLY_SCALE:
         selected_vals = selected_vals * routed_scaling_factor
+    if HAS_PADDING:
+        selected_vals = tl.where(live_m[:, None], selected_vals, 0.0)
+        selected_idx = tl.where(live_m[:, None], selected_idx, -1)
 
     out_w_ptr = (
         out_weights_ptr + offs_m[:, None] * stride_wm + offs_k[None, :] * stride_wk
@@ -266,14 +306,23 @@ def moe_fused_gate(
     moe_softcapping: float = 0.0,
     num_expert_group: int = 1,
     topk_group: int = 1,
+    *,
+    bias_alt: Optional[torch.Tensor] = None,
+    input_ids: Optional[torch.Tensor] = None,
+    bias_alt_token_id: Optional[int] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    renormalize_epsilon: float = 0.0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Triton fused router: scoring + bias + topk + (optional) renorm/scale.
 
     Mirrors the semantics of :func:`moe_fused_gate_jit` (the CUDA JIT kernel).
     With ``num_expert_group > 1`` it performs DeepSeek-V3 grouped routing
     (per-group top-2-sum group scores, keep ``topk_group`` groups, then top-k
-    within). The first argument is named ``scores`` (raw GEMM logits) to match
-    the existing call sites.
+    within). ``scores`` contains raw GEMM logits.
+
+    Rows with ``input_ids == bias_alt_token_id`` use ``bias_alt`` instead of ``bias``.
+    Rows past the device scalar ``num_token_non_padded`` return zero weights and -1 ids.
+    Positive ``renormalize_epsilon`` uses ``sum + epsilon`` instead of the zero-sum guard.
     """
     scoring_func_int = _SCORING_FUNC_MAP.get(scoring_func.lower())
     assert scoring_func_int is not None, (
@@ -303,6 +352,10 @@ def moe_fused_gate(
             "scores and bias must have same num_experts"
         )
     assert topk > num_fused_shared_experts, "topk must be > num_fused_shared_experts"
+    if input_ids is not None:
+        assert bias_alt is not None and bias_alt_token_id is not None
+        assert bias is not None and bias_alt.shape == bias.shape
+        assert input_ids.shape == (scores.size(0),)
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
 
@@ -318,6 +371,10 @@ def moe_fused_gate(
         and num_fused_shared_experts == 0
         and num_expert_group <= 1
         and moe_softcapping == 0.0
+        and input_ids is None
+        and num_token_non_padded is None
+        and renormalize_epsilon == 0.0
+        and bias.stride(0) == 1
     ):
         radix_args = (
             scores,
@@ -341,6 +398,8 @@ def moe_fused_gate(
 
     weights = torch.empty((M, K), dtype=torch.float32, device=scores.device)
     indices = torch.empty((M, K), dtype=torch.int32, device=scores.device)
+    if M == 0:
+        return weights, indices
 
     BLOCK_N = triton.next_power_of_2(N)  # 256 -> 256, 384 -> 512
     BLOCK_K = triton.next_power_of_2(K)  # 6 -> 8, 8 -> 8
@@ -359,6 +418,9 @@ def moe_fused_gate(
     _router_triton_kernel[grid](
         scores,
         bias if bias is not None else scores,
+        bias_alt,
+        input_ids,
+        num_token_non_padded,
         weights,
         indices,
         M,
@@ -379,7 +441,14 @@ def moe_fused_gate(
         RENORMALIZE=bool(renormalize),
         APPLY_SCALE=bool(apply_routed_scaling_factor_on_output),
         HAS_BIAS=bias is not None,
+        HAS_TOKEN_BIAS=input_ids is not None,
+        BIAS_ALT_TOKEN_ID=bias_alt_token_id,
+        HAS_PADDING=num_token_non_padded is not None,
+        RENORMALIZE_EPSILON=renormalize_epsilon,
         USE_PDL=use_pdl,
+        stride_bias=bias.stride(0) if bias is not None else 0,
+        stride_bias_alt=bias_alt.stride(0) if bias_alt is not None else 0,
+        stride_input_ids=input_ids.stride(0) if input_ids is not None else 0,
         stride_sm=scores.stride(0),
         stride_sn=scores.stride(1),
         stride_wm=weights.stride(0),

--- a/python/sglang/kernels/ops/moe/moe_fused_gate.py
+++ b/python/sglang/kernels/ops/moe/moe_fused_gate.py
@@ -96,6 +96,7 @@ def _router_triton_kernel(
     num_token_non_padded_ptr,
     out_weights_ptr,  # [M, K] fp32
     out_indices_ptr,  # [M, K] int32
+    out_packed_ptr,  # [M, K] int32, (id << 16) | bf16 bits of weight (HAS_PACKED)
     M,
     routed_scaling_factor,
     moe_softcapping,
@@ -117,6 +118,7 @@ def _router_triton_kernel(
     HAS_TOKEN_BIAS: tl.constexpr,
     BIAS_ALT_TOKEN_ID: tl.constexpr,
     HAS_PADDING: tl.constexpr,
+    HAS_PACKED: tl.constexpr,
     RENORMALIZE_EPSILON: tl.constexpr,
     USE_PDL: tl.constexpr,
     stride_bias,
@@ -128,6 +130,8 @@ def _router_triton_kernel(
     stride_wk,
     stride_im,
     stride_ik,
+    stride_pm,
+    stride_pk,
 ) -> None:
     # Row-tiled: each program handles BLOCK_M rows; all reductions run along the
     # expert (N) axis. Tiling rows keeps CTAs large enough to stay occupancy-bound
@@ -291,6 +295,17 @@ def _router_triton_kernel(
     store_mask = mask_m[:, None] & mask_k_total[None, :]
     tl.store(out_w_ptr, selected_vals, mask=store_mask)
     tl.store(out_i_ptr, selected_idx, mask=store_mask)
+    if HAS_PACKED:
+        # FlashInfer routed-MoE packed entry, the exact expression of
+        # _pack_topk_ids_triton_kernel applied in-register to the values stored
+        # above (same fp32 -> bf16 rounding, same -1 sentinel on padded rows),
+        # so it is bitwise identical to the separate pack launch it replaces.
+        w_bits = selected_vals.to(tl.bfloat16).to(tl.int16, bitcast=True).to(tl.int32)
+        packed = (selected_idx << 16) | (w_bits & 0xFFFF)
+        out_p_ptr = (
+            out_packed_ptr + offs_m[:, None] * stride_pm + offs_k[None, :] * stride_pk
+        )
+        tl.store(out_p_ptr, packed, mask=store_mask)
 
 
 @debug_kernel_api
@@ -312,6 +327,7 @@ def moe_fused_gate(
     bias_alt_token_id: Optional[int] = None,
     num_token_non_padded: Optional[torch.Tensor] = None,
     renormalize_epsilon: float = 0.0,
+    packed_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Triton fused router: scoring + bias + topk + (optional) renorm/scale.
 
@@ -323,6 +339,10 @@ def moe_fused_gate(
     Rows with ``input_ids == bias_alt_token_id`` use ``bias_alt`` instead of ``bias``.
     Rows past the device scalar ``num_token_non_padded`` return zero weights and -1 ids.
     Positive ``renormalize_epsilon`` uses ``sum + epsilon`` instead of the zero-sum guard.
+    ``packed_out`` ([M, topk] int32, optional) additionally receives the FlashInfer
+    routed-MoE form ``(id << 16) | bf16_bits(weight)`` of the returned pair, computed
+    in-register (bitwise the separate ``PackTopkIds`` kernel; the radix fast path is
+    skipped when it is requested).
     """
     scoring_func_int = _SCORING_FUNC_MAP.get(scoring_func.lower())
     assert scoring_func_int is not None, (
@@ -356,6 +376,11 @@ def moe_fused_gate(
         assert bias_alt is not None and bias_alt_token_id is not None
         assert bias is not None and bias_alt.shape == bias.shape
         assert input_ids.shape == (scores.size(0),)
+    if packed_out is not None:
+        assert packed_out.dtype == torch.int32, "packed_out must be int32"
+        assert packed_out.shape == (scores.size(0), topk), (
+            "packed_out must be [M, topk]"
+        )
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
 
@@ -374,6 +399,7 @@ def moe_fused_gate(
         and input_ids is None
         and num_token_non_padded is None
         and renormalize_epsilon == 0.0
+        and packed_out is None
         and bias.stride(0) == 1
     ):
         radix_args = (
@@ -423,6 +449,7 @@ def moe_fused_gate(
         num_token_non_padded,
         weights,
         indices,
+        packed_out if packed_out is not None else indices,
         M,
         float(routed_scaling_factor),
         float(moe_softcapping),
@@ -444,6 +471,7 @@ def moe_fused_gate(
         HAS_TOKEN_BIAS=input_ids is not None,
         BIAS_ALT_TOKEN_ID=bias_alt_token_id,
         HAS_PADDING=num_token_non_padded is not None,
+        HAS_PACKED=packed_out is not None,
         RENORMALIZE_EPSILON=renormalize_epsilon,
         USE_PDL=use_pdl,
         stride_bias=bias.stride(0) if bias is not None else 0,
@@ -455,6 +483,8 @@ def moe_fused_gate(
         stride_wk=weights.stride(1),
         stride_im=indices.stride(0),
         stride_ik=indices.stride(1),
+        stride_pm=packed_out.stride(0) if packed_out is not None else 0,
+        stride_pk=packed_out.stride(1) if packed_out is not None else 0,
         num_warps=num_warps,
         **extra,
     )

--- a/python/sglang/kernels/ops/quantization/configs/N=1152,K=5120,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=1152,K=5120,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 16
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=1792,K=5120,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=1792,K=5120,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 8
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=25600,K=6144,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=25600,K=6144,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,19 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=4096,K=1280,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=4096,K=1280,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=5120,K=2048,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=5120,K=2048,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 8
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=5120,K=576,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=5120,K=576,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/configs/N=8192,K=1280,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
+++ b/python/sglang/kernels/ops/quantization/configs/N=8192,K=1280,device_name=NVIDIA_H200,dtype=fp8_w8a8,block_shape=[32, 32].json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4,
+        "SWAP_AB": true,
+        "SPLIT_K": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -26,6 +26,7 @@ import triton.language as tl
 from sglang.kernels.jit.utils import is_arch_support_pdl
 from sglang.kernels.ops.quantization.fp8_utils import fp8_dtype_to_triton
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.runtime_context import get_platform
 from sglang.srt.utils import (
     ceil_align,
     get_bool_env_var,
@@ -1030,6 +1031,133 @@ def _w8a8_block_fp8_matmul(
 
 
 @triton.jit
+def _w8a8_block_fp8_matmul_hopper(
+    # Pointers to inputs and output
+    A,
+    B,
+    C,
+    As,
+    Bs,
+    # Shape for matmul
+    M,
+    N,
+    K,
+    # Block size for block-wise quantization
+    group_n,
+    group_k,
+    # Stride for inputs and output
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_As_m,
+    stride_As_k,
+    stride_Bs_k,
+    stride_Bs_n,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    needs_masking: tl.constexpr,
+    SWAP_AB: tl.constexpr = False,
+    SPLIT_K: tl.constexpr = 1,
+):
+
+    pid = tl.program_id(axis=0)
+    split = tl.program_id(axis=1)
+    tiles_per_split = tl.cdiv(tl.cdiv(K, BLOCK_SIZE_K), SPLIT_K)
+    first_tile = split * tiles_per_split
+    C += split * M * N
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    As_ptrs = As + offs_am * stride_As_m
+    offs_bsn = offs_bn // group_n
+    Bs_ptrs = Bs + offs_bsn * stride_Bs_n
+    n_tiles_k_per_group_k = group_k // BLOCK_SIZE_K
+
+    a_ptrs += first_tile * BLOCK_SIZE_K * stride_ak
+    b_ptrs += first_tile * BLOCK_SIZE_K * stride_bk
+    As_ptrs += (first_tile // n_tiles_k_per_group_k) * stride_As_k
+    Bs_ptrs += (first_tile // n_tiles_k_per_group_k) * stride_Bs_k
+
+    # Small-M Hopper configs transpose the MMA so the weight tile occupies M.
+    if SWAP_AB:
+        accumulator = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+    else:
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(
+        first_tile, tl.minimum(first_tile + tiles_per_split, tl.cdiv(K, BLOCK_SIZE_K))
+    ):
+        if needs_masking:
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        else:
+            a = tl.load(a_ptrs)
+            b = tl.load(b_ptrs)
+
+        a_s = tl.load(As_ptrs)
+        b_s = tl.load(Bs_ptrs)
+
+        scale_step_k = tl.where((k + 1) % n_tiles_k_per_group_k == 0, 1, 0)
+        if SWAP_AB:
+            accumulator += (
+                tl.dot(tl.trans(b), tl.trans(a)) * b_s[:, None] * a_s[None, :]
+            )
+        else:
+            accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+        As_ptrs += scale_step_k * stride_As_k
+        Bs_ptrs += scale_step_k * stride_Bs_k
+
+    if SWAP_AB:
+        accumulator = tl.trans(accumulator)
+
+    if C.dtype.element_ty == tl.bfloat16:
+        c = accumulator.to(tl.bfloat16)
+    elif C.dtype.element_ty == tl.float16:
+        c = accumulator.to(tl.float16)
+    else:
+        c = accumulator.to(tl.float32)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+@triton.jit
+def _reduce_block_fp8_split_k(
+    Parts, Out, ELEMENTS: tl.constexpr, SPLITS: tl.constexpr, BLOCK: tl.constexpr
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    splits = tl.arange(0, SPLITS)
+    values = tl.load(
+        Parts + splits[:, None] * ELEMENTS + offsets[None, :],
+        offsets[None, :] < ELEMENTS,
+        0.0,
+    )
+    tl.store(Out + offsets, tl.sum(values, axis=0), offsets < ELEMENTS)
+
+
+@triton.jit
 def _w8a8_block_fp8_matmul_gfx1250(
     # Pointers to inputs and output
     A,
@@ -1585,17 +1713,30 @@ def w8a8_block_fp8_matmul_triton(
     else:
         kernel = select_w8a8_block_fp8_matmul_kernel(M, N, config)
 
+    hopper_tuned = get_platform().is_sm90 and (
+        config.get("SWAP_AB", False) or config.get("SPLIT_K", 1) > 1
+    )
+    if hopper_tuned:
+        kernel = _w8a8_block_fp8_matmul_hopper
+    split_k = config.get("SPLIT_K", 1) if hopper_tuned else 1
+    if split_k > 1:
+        assert split_k & (split_k - 1) == 0
+        partials = torch.empty((split_k, M, N), device=A.device, dtype=torch.float32)
+    else:
+        partials = C
+
     needs_masking = bool(K % config["BLOCK_SIZE_K"] != 0)
 
     def grid(META):
-        return (
-            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        blocks = triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(
+            N, META["BLOCK_SIZE_N"]
         )
+        return (blocks, split_k) if hopper_tuned else (blocks,)
 
     kernel[grid](
         A,
         B,
-        C,
+        partials,
         As,
         Bs,
         M,
@@ -1616,6 +1757,11 @@ def w8a8_block_fp8_matmul_triton(
         **config,
         needs_masking=needs_masking,
     )
+
+    if split_k > 1:
+        _reduce_block_fp8_split_k[(triton.cdiv(M * N, 256),)](
+            partials, C, M * N, split_k, 256
+        )
 
     return C
 

--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -78,6 +78,8 @@ def parse_cuda_graph_config(server_args: Any):
         _set(Phase.DECODE, "max_bs", cfg.cuda_graph_max_bs_decode)
     if cfg.cuda_graph_max_bs_prefill is not None:
         _set(Phase.PREFILL, "max_bs", cfg.cuda_graph_max_bs_prefill)
+    if cfg.cuda_graph_max_seq_len_prefill is not None:
+        _set(Phase.PREFILL, "max_seq_len", cfg.cuda_graph_max_seq_len_prefill)
     if cfg.cuda_graph_bs_decode is not None:
         _set(Phase.DECODE, "bs", cfg.cuda_graph_bs_decode)
     if cfg.cuda_graph_bs_prefill is not None:

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from sglang.srt.arg_groups.overrides import (
     _deepseek_v4_kv_cache_dtype,
     declare_resolution,
+    model_config_of,
     resolving_view,
     run_post_process_pass,
 )
@@ -214,12 +215,125 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
             f"got {cfg.moe_a2a_backend!r}."
         )
     logger.warning(
-        "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL because DeepSeekV4 "
-        "context parallelism is enabled."
-    )
-    envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
-    logger.warning(
         f"Enable Context Parallel for DeepSeekV4, "
         f"dp_size={cfg.dp_size}, moe_dense_tp_size={cfg.moe_dense_tp_size}, "
         f"attn_cp_size={cfg.attn_cp_size}, ep_size={cfg.ep_size}, tp_size={cfg.tp_size}"
     )
+
+
+def validate_deepseek_v41_features(server_args: ServerArgs) -> None:
+    """Reject the server features DeepSeek-V4.1 cannot serve yet."""
+    from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+        is_unified_kv_triton,
+    )
+
+    cfg = resolving_view(server_args)
+    if model_config_of(server_args).hf_config.model_type != "deepseek_v41":
+        if cfg.enable_encoder_swa_bounded_replay:
+            raise ValueError(
+                "--enable-encoder-swa-bounded-replay requires DeepSeek-V4.1"
+            )
+        return
+    if cfg.enable_encoder_swa_bounded_replay:
+        from sglang.srt.model_executor.cuda_graph_config import Backend
+
+        incompatible = (
+            ("non-CUDA hardware", not get_platform().is_cuda),
+            (
+                "prefill CUDA graphs",
+                cfg.cuda_graph_config.prefill.backend != Backend.DISABLED,
+            ),
+            ("DP attention", cfg.enable_dp_attention),
+            # Note(kpham-sgl): DSpark keeps its paged SWA pool; encoder replay
+            # does not yet support speculative decoding.
+            ("speculative decoding", cfg.speculative_algorithm is not None),
+            (
+                "context parallelism",
+                cfg.enable_prefill_context_parallel or cfg.attn_cp_size > 1,
+            ),
+            ("HiCache", cfg.enable_hierarchical_cache),
+            ("external cache linker", cfg.enable_unified_cache_external_linker),
+            ("unified memory", cfg.enable_unified_memory),
+            ("PD disaggregation", cfg.disaggregation_mode != "null"),
+            ("mixed prefill/decode", cfg.enable_mixed_chunk),
+            ("LoRA", cfg.enable_lora),
+            ("radix sessions", cfg.enable_session_radix_cache),
+        )
+        for feature, enabled in incompatible:
+            if enabled:
+                raise ValueError(
+                    f"--enable-encoder-swa-bounded-replay does not support {feature} yet"
+                )
+        if (
+            cfg.max_running_requests is None
+            or cfg.max_running_requests <= 0
+            or not cfg.chunked_prefill_size
+            or cfg.chunked_prefill_size < 128
+        ):
+            raise ValueError(
+                "encoder SWA replay requires explicit --max-running-requests and --chunked-prefill-size >= 128"
+            )
+
+    unsupported = (
+        (
+            "speculative decoding other than DSpark",
+            cfg.speculative_algorithm is not None
+            and str(cfg.speculative_algorithm).upper() != "DSPARK",
+        ),
+        # The ratio-2 pair ring ships as one item per request and its ring size
+        # follows the speculative window, so prefill and decode layouts only
+        # agree when neither side speculates.
+        (
+            "PD disaggregation with speculative decoding",
+            cfg.disaggregation_mode != "null" and cfg.speculative_algorithm is not None,
+        ),
+        ("HiSparse", cfg.enable_hisparse),
+        ("the unified KV layout", is_unified_kv_triton()),
+        ("two-batch overlap", cfg.enable_two_batch_overlap),
+        ("pipeline parallelism", cfg.pp_size > 1),
+    )
+    for feature, enabled in unsupported:
+        if enabled:
+            raise ValueError(
+                f"DeepSeek-V4.1 does not support {feature} yet; disable it to "
+                "serve this model."
+            )
+
+    from sglang.srt.model_executor.cuda_graph_config import Backend, Phase, with_phase
+
+    prefill_graph = cfg.cuda_graph_config.prefill
+    if prefill_graph.backend != Backend.DISABLED and prefill_graph.max_seq_len is None:
+        # The captured low-ratio indexer scores a static context width; 16k
+        # keeps it inside the candidate window at under 1 ms per layer.
+        declare_resolution(
+            server_args,
+            "validate_deepseek_v41_features",
+            cuda_graph_config=with_phase(
+                cfg.cuda_graph_config, Phase.PREFILL, max_seq_len=16 * 1024
+            ),
+        )
+        logger.warning(
+            "Setting cuda_graph_config[prefill].max_seq_len to 16384 for "
+            "DeepSeek-V4.1; longer contexts run eager prefill."
+        )
+
+    if cfg.enable_decoder_swa_bounded_replay:
+        from sglang.srt.model_executor.cuda_graph_config import Backend
+
+        # The late layers see a per-request tail slice, so their token count is
+        # no longer the captured prefill shape.
+        incompatible = (
+            (
+                "the prefill CUDA graph",
+                cfg.cuda_graph_config.prefill.backend != Backend.DISABLED,
+            ),
+            # input_ids_global is a DP-wide gather, not a per-local-token tensor,
+            # so the tail slice does not apply to it.
+            ("DP attention", cfg.enable_dp_attention),
+        )
+        for feature, enabled in incompatible:
+            if enabled:
+                raise ValueError(
+                    "--enable-decoder-swa-bounded-replay cannot be combined with "
+                    f"{feature} yet; disable one of them."
+                )

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -191,6 +191,9 @@ def handle_cache_compatibility(server_args: Any) -> None:
     # the user input before it ever takes effect.
     if not (0 < resolved_view(server_args).swa_full_tokens_ratio <= 1.0):
         raise ValueError("--swa-full-tokens-ratio should be in range (0, 1.0].")
+    prefix_tails = resolved_view(server_args).swa_prefix_tails
+    if prefix_tails is not None and prefix_tails < 0:
+        raise ValueError("--swa-prefix-tails should be a non-negative integer.")
 
 
 def handle_unified_memory_pool(server_args: Any) -> None:

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -347,8 +347,12 @@ def handle_model_specific_adjustments(server_args: Any):
         from sglang.srt.arg_groups.deepseek_v4_hook import (
             validate_deepseek_v4_cp,
             validate_deepseek_v4_mega_moe_token_budget,
+            validate_deepseek_v41_features,
         )
 
+        # Ahead of the CP validation: DeepSeek-V4.1 rejects CP outright, and
+        # that message is the actionable one.
+        validate_deepseek_v41_features(server_args)
         validate_deepseek_v4_cp(server_args)
         validate_deepseek_v4_mega_moe_token_budget(server_args)
 

--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v4.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v4.py
@@ -13,21 +13,37 @@ from sglang.srt.arg_groups.model_override_base import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
+from sglang.srt.utils import is_flashinfer_available
 
 logger = logging.getLogger(__name__)
 
 
 @_register_for("DeepseekV4ForCausalLM")
 def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
-    """DeepSeek V4 attention/page/window/MoE-runner defaults (from
-    arg_groups/deepseek_v4_hook.py). The kv-cache dtype and NPU split-backend
-    writes, the max_running_requests fill and the validations stay in the
-    hook at its legacy slot."""
+    """Attention, page and MoE defaults; KV-cache dtype, NPU split-backend setup,
+    request limits and validation remain in deepseek_v4_hook.
+    """
     cfg = resolving_view(server_args)
-    from sglang.srt.server_args import ServerArgs
 
     model_arch = hf_config.architectures[0]
     overrides: Dict[str, Any] = {"attention_backend": "dsv4"}
+
+    # MXFP8 serves this checkpoint's 32-wide ue8m0 blocks on SM100/SM103;
+    # explicit backend choices, including Triton, take precedence.
+    quant = getattr(hf_config, "quantization_config", None) or {}
+    if (
+        getattr(hf_config, "model_type", None) == "deepseek_v41"
+        and cfg.device == "cuda"
+        and not get_platform().is_hip
+        and get_platform().is_sm100
+        and cfg.fp8_gemm_runner_backend == "auto"
+        and quant.get("quant_method") == "fp8"
+        and quant.get("weight_block_size") == [32, 32]
+        and quant.get("scale_fmt") == "ue8m0"
+        and is_flashinfer_available()
+    ):
+        overrides["fp8_gemm_runner_backend"] = "flashinfer_cutedsl"
+        logger.info("Use flashinfer_cutedsl for DeepSeek-V4.1 MXFP8 dense GEMMs.")
 
     page_size = 256
     if cfg.device == "npu":
@@ -43,10 +59,6 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
     logger.info(
         f"Use dsv4 attention backend for {model_arch}, setting page_size to {page_size}."
     )
-
-    if cfg.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
-        overrides["swa_full_tokens_ratio"] = 0.1
-        logger.info(f"Setting swa_full_tokens_ratio to 0.1 for {model_arch}.")
 
     if cfg.moe_runner_backend == "auto":
         model_config = model_config_of(server_args)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -973,7 +973,18 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     single-node systems. Reads the mid-resolution enable_dp_attention /
     moe_a2a_backend (after the DeepSeek CP and a2a declarations), exactly
     like the legacy tail block."""
-    model_arch = model_config_of(view).hf_config.architectures[0]
+    hf_config = model_config_of(view).hf_config
+    model_arch = hf_config.architectures[0]
+    # V4.1 TP4 uses the custom push plane for decode and fused MoE finalize.
+    # Keep the existing default for other models and parallel configurations.
+    prefer_custom_dsv41 = (
+        getattr(hf_config, "model_type", None) == "deepseek_v41"
+        and getattr(hf_config, "hidden_size", None) == 5120
+        and get_platform().is_blackwell
+        and view.tp_size == 4
+        and view.nnodes == 1
+        and not view.disable_custom_all_reduce
+    )
     if envs.SGLANG_FLASHINFER_MNNVL_CUTEDSL_AR_FUSION.get() and model_arch in {
         "Qwen3_5MoeForCausalLM",
         "Qwen3_5MoeForConditionalGeneration",
@@ -991,6 +1002,7 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     if (
         view.flashinfer_allreduce_fusion_backend is None
         and model_arch in _FLASHINFER_ALLREDUCE_FUSION_ARCHS
+        and not prefer_custom_dsv41
         and (get_platform().is_sm90 or get_platform().is_sm100)
         and view.tp_size > 1
         and not view.enable_dp_attention

--- a/python/sglang/srt/configs/deepseek_v4.py
+++ b/python/sglang/srt/configs/deepseek_v4.py
@@ -103,8 +103,36 @@ class DeepSeekV4Config(PretrainedConfig):
 
     compress_rope_theta: int = 40000
     compress_ratios: List[int] = field(default_factory=list)
+    kv_source_layer_ids: List[int] = field(default_factory=list)
+    index_source_layer_ids: List[int] = field(default_factory=list)
+    candidate_source_layer_id: int = -1
+    candidate_topk_blocks: int = 0
+    candidate_block_size: int = 0
+
+    engram_layer_ids: List[int] = field(default_factory=list)
+    engram_num_embeddings: List[int] = field(default_factory=list)
+    engram_max_ngram_size: int = 1
+    engram_vocab_size: int = 0
+    engram_n_heads: int = 0
+    engram_head_dim: int = 0
+    engram_pad_token_id: int = 2
+    engram_compressed_vocab_size: int = 0
+
+    vision_n_layers: int = 0
+    vision_dim: int = 1024
+    vision_n_heads: int = 16
+    vision_inter_dim: int = 2816
+    vision_patch_size: int = 14
+    vision_rope_theta: float = 10000.0
+    vision_downsample_ratio: int = 3
+    vision_max_n_token: int = 1024
+    vision_min_pixels: int = 295936
+    vision_max_wh_ratio: Optional[int] = None
+    image_token_id: int = 129264
 
     n_hash_layers: int = 3
     hc_mult: int = 4
+    hc_pre_from_prev_sublayer: bool = False
+    q_head_norm: bool = True
     hc_sinkhorn_iters: int = 20
     hc_eps: float = 1e-6

--- a/python/sglang/srt/configs/deepseek_v41.py
+++ b/python/sglang/srt/configs/deepseek_v41.py
@@ -1,0 +1,140 @@
+"""Translate DeepSeek V4.1 HF configs to the runtime's flat config schema."""
+
+from transformers import DeepseekV3Config, PretrainedConfig
+
+_FIELD_ALIASES = {
+    "dspark_n_activated_experts": "dspark_num_experts_per_tok",
+    "kv_source_layers": "kv_source_layer_ids",
+    "index_source_layers": "index_source_layer_ids",
+    "candidate_source_layer": "candidate_source_layer_id",
+    "engram_pad_id": "engram_pad_token_id",
+}
+
+_VISION_FIELDS = {
+    "num_hidden_layers": "vision_n_layers",
+    "hidden_size": "vision_dim",
+    "num_attention_heads": "vision_n_heads",
+    "intermediate_size": "vision_inter_dim",
+    "patch_size": "vision_patch_size",
+    "rope_theta": "vision_rope_theta",
+    "downsample_ratio": "vision_downsample_ratio",
+    "max_image_tokens": "vision_max_n_token",
+    "min_pixels": "vision_min_pixels",
+    "max_wh_ratio": "vision_max_wh_ratio",
+}
+
+
+def normalize_deepseek_v4_fields(values):
+    values = dict(values)
+    for old, new in _FIELD_ALIASES.items():
+        if old in values:
+            legacy_value = values.pop(old)
+            values.setdefault(new, legacy_value)
+    return values
+
+
+def _config_dict(config):
+    return config.to_dict() if isinstance(config, PretrainedConfig) else dict(config)
+
+
+def normalize_deepseek_v41_config(values):
+    values = normalize_deepseek_v4_fields(values)
+    text = values.pop("text_config", None)
+    vision = values.pop("vision_config", None)
+    if text is not None:
+        text = normalize_deepseek_v4_fields(_config_dict(text))
+        text.pop("model_type", None)
+        values = {**text, **values}
+    if vision is not None:
+        vision = _config_dict(vision)
+        if "max_num_tokens" in vision:
+            vision.setdefault("max_image_tokens", vision["max_num_tokens"])
+        for source, target in _VISION_FIELDS.items():
+            if source in vision:
+                values.setdefault(target, vision[source])
+    if "model_type" in values:
+        values["model_type"] = "deepseek_v41"
+    if values.get("architectures") in (
+        ["DeepseekV41ForCausalLM"],
+        ["DeepseekV41ForConditionalGeneration"],
+    ):
+        values["architectures"] = ["DeepseekV4ForCausalLM"]
+    return values
+
+
+class DeepseekV41Config(DeepseekV3Config):
+    # V3 accepts the V4.1 compression ratios; the native V4 config rejects 1/2.
+    model_type = "deepseek_v41"
+    vision_n_layers = 0
+    hc_pre_from_prev_sublayer = True
+    q_head_norm = False
+    kv_source_layer_ids = ()
+    index_source_layer_ids = ()
+    candidate_source_layer_id = -1
+    candidate_topk_blocks = 0
+    candidate_block_size = 0
+    engram_layer_ids = ()
+    engram_num_embeddings = ()
+    engram_max_ngram_size = 1
+    engram_vocab_size = 0
+    engram_n_heads = 0
+    engram_head_dim = 0
+    engram_pad_token_id = 2
+    engram_compressed_vocab_size = 0
+
+    def __init__(self, **kwargs):
+        kwargs = normalize_deepseek_v41_config(kwargs)
+        kwargs["model_type"] = "deepseek_v41"
+        super().__init__(**kwargs)
+
+    def to_dict(self):
+        values = super().to_dict()
+        values["model_type"] = "deepseek_v41"
+        return values
+
+
+class DeepseekV41TextConfig(DeepseekV41Config):
+    model_type = "deepseek_v41_text"
+    # Transformers regenerates a dataclass initializer unless it is explicit.
+    __init__ = DeepseekV41Config.__init__
+
+
+class DeepseekV41VisionConfig(PretrainedConfig):
+    model_type = "deepseek_v41_vision"
+
+    def __init__(self, **kwargs):
+        if "max_num_tokens" in kwargs:
+            legacy_value = kwargs.pop("max_num_tokens")
+            kwargs.setdefault("max_image_tokens", legacy_value)
+        kwargs["model_type"] = "deepseek_v41_vision"
+        super().__init__(**kwargs)
+
+    def to_dict(self):
+        values = super().to_dict()
+        values["model_type"] = "deepseek_v41_vision"
+        return values
+
+
+class LegacyDeepseekV41Config(DeepseekV41Config):
+    model_type = "deepseek_v4.1"
+    __init__ = DeepseekV41Config.__init__
+
+
+class LegacyDeepseekV41TextConfig(DeepseekV41TextConfig):
+    model_type = "deepseek_v4.1_text"
+    __init__ = DeepseekV41Config.__init__
+
+
+class LegacyDeepseekV41VisionConfig(DeepseekV41VisionConfig):
+    model_type = "deepseek_v4.1_vision"
+    __init__ = DeepseekV41VisionConfig.__init__
+
+
+DEEPSEEK_V41_CONFIG_CLASSES = (
+    DeepseekV41Config,
+    DeepseekV41TextConfig,
+    DeepseekV41VisionConfig,
+    LegacyDeepseekV41Config,
+    LegacyDeepseekV41TextConfig,
+    LegacyDeepseekV41VisionConfig,
+)

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -483,12 +483,17 @@ class ModelConfig:
                 or hasattr(self.hf_config, "audio_config")
             )
         )
+        has_dsv41_vision = (
+            self.hf_config.model_type == "deepseek_v41"
+            and self.hf_config.vision_n_layers > 0
+        )
         self.is_multimodal = (
             enable_multimodal
             and not self.is_lm_only
             and (
                 is_multimodal_model(self.hf_config.architectures)
                 or has_multimodal_subconfig
+                or has_dsv41_vision
             )
         )
         self.is_audio_model = enable_multimodal and is_audio_model(
@@ -507,6 +512,8 @@ class ModelConfig:
             self.is_multimodal
             and getattr(self.hf_config, "vision_config", None) is not None
         )
+        if self.is_multimodal and has_dsv41_vision:
+            self.is_image_understandable_model = True
 
         # Models expose audio_config at different nesting levels:
         #   - top-level audio_config: e.g. Qwen2Audio
@@ -535,7 +542,11 @@ class ModelConfig:
         self.is_local_attention_model = is_local_attention_model(
             self.hf_config.architectures
         )
-        self.use_ngram_embedding = getattr(self.hf_config, "use_ngram_embedding", False)
+        # Tokens (the token itself plus its predecessors) each position reads from the
+        # per-request n-gram token table (LongCat); 0 disables the table.
+        self.ngram_context_size = ngram_context_size(self.hf_config)
+        self.use_ngram_embedding = self.ngram_context_size > 0
+        self.engram_ngram_size = engram_ngram_size(self.hf_config)
         # A multimodal arch is piecewise-incompatible until its LM prefill is validated.
         self.is_piecewise_cuda_graph_disabled_model = (
             is_piecewise_cuda_graph_disabled_model(self.hf_config.architectures)
@@ -2274,3 +2285,15 @@ def get_hybrid_layer_ids(
         swa_attention_layer_ids = None
         full_attention_layer_ids = None
     return swa_attention_layer_ids, full_attention_layer_ids
+
+
+def ngram_context_size(hf_config) -> int:
+    if getattr(hf_config, "use_ngram_embedding", False):
+        return hf_config.ngram_embedding_n
+    return 0
+
+
+def engram_ngram_size(hf_config) -> int:
+    if getattr(hf_config, "engram_layer_ids", ()):
+        return hf_config.engram_max_ngram_size
+    return 0

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -54,9 +54,8 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     build_kv_layer_ids,
     build_staging_slot_metadata,
-    get_dsv4_c128_state_indices,
+    get_dsv4_request_state_indices,
     get_kv_class,
-    is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
     poll_and_all_reduce_pp,
@@ -1419,13 +1418,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 return ring_rows.astype(np.int32)
 
             def _c128_state_payload():
-                online = is_dsv4_c128_online_enabled()
-                ring_size = 1 if online else self.token_to_kv_pool.get_ring_size(128)
-                return get_dsv4_c128_state_indices(
+                return get_dsv4_request_state_indices(
+                    self.token_to_kv_pool,
                     int(decode_req.req.kv.req_pool_idx),
                     seq_len,
-                    online=online,
-                    ring_size=ring_size,
                 )
 
             state_types = self.kv_manager.kv_args.state_types
@@ -2683,6 +2679,11 @@ class SchedulerDisaggregationDecodeMixin:
             # A finished request can still have one redundant forward in flight.
             # Drain it before a prebuilt request seeds a potentially reused row.
             self.schedule_stream.wait_stream(self.forward_stream)
+        # The prebuilt batch never reaches the forward loop's prepare call, and
+        # its requests skip EXTEND here, so seed their engram history now.
+        self.ngram_embedding_manager.prepare_for_forward(
+            new_batch, chunked_req=self.chunked_req
+        )
         new_batch.process_prebuilt(self.future_map)
 
         return new_batch

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -45,10 +45,9 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     build_kv_layer_ids,
     build_staging_slot_metadata,
-    get_dsv4_c128_state_indices,
+    get_dsv4_request_state_indices,
     get_kv_class,
     is_aborted,
-    is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce_attn_cp_tp_group,
     poll_and_all_reduce_pp,
@@ -1256,19 +1255,10 @@ class SchedulerDisaggregationPrefillMixin:
                 return ring_rows.astype(np.int32)
 
             def _c128_state_payload():
-                online = is_dsv4_c128_online_enabled()
-                ring_size = (
-                    1
-                    if online
-                    else self.token_to_kv_pool_allocator.get_kvcache().get_ring_size(
-                        128
-                    )
-                )
-                return get_dsv4_c128_state_indices(
+                return get_dsv4_request_state_indices(
+                    self.token_to_kv_pool_allocator.get_kvcache(),
                     int(req.kv.req_pool_idx),
                     c128_seq_len,
-                    online=online,
-                    ring_size=ring_size,
                 )
 
             state_types = (

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -98,6 +98,28 @@ def get_dsv4_c128_state_indices(
     return np.array([page], dtype=np.int32)
 
 
+def get_dsv4_request_state_indices(pool, req_pool_idx: int, seq_len: int) -> np.ndarray:
+    """PD transfer indices of the request-scoped state component (C128_STATE).
+
+    The component carries the c128 ring, whose item is one c128 page (or the
+    single online row), or the ratio-2 pair ring, whose item is one request's
+    whole ring; there only an odd prefix leaves a pending half-pair that decode
+    reads, so an even prefix ships nothing.
+    """
+    if 128 in pool.kv_pools:
+        online = is_dsv4_c128_online_enabled()
+        ring_size = 1 if online else pool.get_ring_size(128)
+        return get_dsv4_c128_state_indices(
+            req_pool_idx, seq_len, online=online, ring_size=ring_size
+        )
+    assert 2 in pool.kv_pools, (
+        "the request-scoped state component holds the c128 or the ratio-2 ring"
+    )
+    if seq_len % 2 == 0:
+        return np.empty((0,), dtype=np.int32)
+    return np.array([int(req_pool_idx)], dtype=np.int32)
+
+
 class DisaggregationMode(Enum):
     NULL = "null"
     PREFILL = "prefill"

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2234,6 +2234,7 @@ def _execute_server_warmup(server_args: ServerArgs):
         bool(model_info.get("has_image_understanding", False))
         and not server_args.language_only
         and not server_args.language_model_only
+        and not server_args.enable_encoder_swa_bounded_replay
         and not is_mps()
     )
     if model_info["is_generation"]:

--- a/python/sglang/srt/entrypoints/openai/chat_encoding.py
+++ b/python/sglang/srt/entrypoints/openai/chat_encoding.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import ast
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from sglang.srt.entrypoints.openai import encoding_dsv4
+from sglang.srt.entrypoints.openai import encoding_dsv4, encoding_dsv41
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,13 @@ def resolve_dsv4_reasoning_effort_profile(
     )
 
 
+def is_deepseek_v41_config(*, arch: str, model_type: str) -> bool:
+    """Check model_type before matching the DeepseekV4 architecture substring;
+    V4.1 configs can also use the V4 architecture name.
+    """
+    return model_type == "deepseek_v41" or "DeepseekV41" in arch
+
+
 def resolve_chat_encoding_spec(
     *,
     hf_config: Any,
@@ -116,6 +123,8 @@ def resolve_chat_encoding_spec(
     None means the default path (HF chat template); any non-None spec also owns
     reasoning-history rendering (:func:`spec_owns_reasoning_history`).
     """
+    if tool_call_parser == "deepseekv41":
+        return "dsv41"
     if tool_call_parser == "deepseekv4":
         return "dsv4"
     if tool_call_parser == "deepseekv32":
@@ -126,6 +135,8 @@ def resolve_chat_encoding_spec(
     architectures = hf_config.architectures
     arch = architectures[0] if architectures else ""
 
+    if is_deepseek_v41_config(arch=arch, model_type=hf_config.model_type):
+        return "dsv41"
     if "DeepseekV4" in arch:
         return "dsv4"
     if "KimiK3" in arch:
@@ -141,6 +152,55 @@ def resolve_chat_encoding_spec(
     if "DeepseekV3" in arch and not has_chat_template:
         return "dsv32"
     return None
+
+
+def resolve_dsv41_reasoning_effort(value: Any) -> Union[str, int, None]:
+    """Map an API ``reasoning_effort`` onto what the V4.1 encoder accepts.
+
+    Tiers pass through; an OpenAI float in [0, 0.99] becomes a 1-100 budget;
+    an int budget (only reachable via ``chat_template_kwargs``) passes through
+    when in range. None means unsupported and the caller applies its default.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 1 <= value <= 100 else None
+    if isinstance(value, float):
+        return min(100, max(1, round(value * 100)))
+    if value in encoding_dsv41.REASONING_EFFORT_MAPPINGS:
+        return value
+    return None
+
+
+_OPENAI_FUNCTION_FIELD_ORDER = ("name", "description", "parameters")
+
+
+def dsv41_tool_payload(tool: Any) -> Dict[str, Any]:
+    """The tool dict the V4.1 encoder renders verbatim into the prompt.
+
+    Only fields the client sent, in the OpenAI field order; pydantic would
+    otherwise add defaults (strict=false) and reorder keys by declaration.
+    """
+    payload = tool.model_dump(exclude_unset=True, exclude_none=True)
+    function = dict(payload.get("function") or {})
+    ordered = {
+        k: function.pop(k) for k in _OPENAI_FUNCTION_FIELD_ORDER if k in function
+    }
+    ordered.update(function)
+    payload["function"] = ordered
+    return payload
+
+
+def default_dsv41_reasoning_effort_from_env(raw: str) -> Union[str, int]:
+    """Parse ``SGLANG_DSV41_REASONING_EFFORT``; raises so a bad value fails at boot."""
+    value: Any = int(raw) if raw.strip().isdigit() else raw.strip()
+    effort = resolve_dsv41_reasoning_effort(value)
+    if effort is None:
+        raise ValueError(
+            f"Invalid SGLANG_DSV41_REASONING_EFFORT={raw!r}; expected one of "
+            f"{list(encoding_dsv41.REASONING_EFFORT_MAPPINGS)} or an integer in [1, 100]"
+        )
+    return effort
 
 
 def spec_owns_reasoning_history(spec: Optional[str]) -> bool:
@@ -168,11 +228,9 @@ def encode_simple_chat(
 
     Minimal encode for offline tools: no tools, no multimodal content, no
     continue_final_message; the serving path keeps its full request-level
-    pipeline in ``serving_chat``. Like
-    ``serving_chat``, an empty system message is prepended when the
-    conversation does not start with one (for the dsv4/dsv32 encoders this
-    currently renders to zero tokens, but keeping the insertion explicit ties
-    this helper to the serving semantics rather than to that coincidence).
+    pipeline in ``serving_chat``. System-message handling matches
+    ``serving_chat``: dsv4/dsv32 get an empty one prepended, dsv41 does not
+    (it renders a system token even for empty content).
     """
     if spec == "inkling":
         from sglang.srt.parser.inkling_renderer import render_inkling_messages
@@ -184,13 +242,17 @@ def encode_simple_chat(
             add_generation_prompt=False,
         )
 
-    if spec in ("dsv4", "dsv32"):
-        if messages and messages[0]["role"] != "system":
+    if spec in ("dsv4", "dsv32", "dsv41"):
+        if spec != "dsv41" and messages and messages[0]["role"] != "system":
             messages = [{"role": "system", "content": ""}] + list(messages)
         if spec == "dsv4":
             from sglang.srt.entrypoints.openai import encoding_dsv4
 
             real_input = encoding_dsv4.encode_messages(
+                messages, thinking_mode=thinking_mode
+            )
+        elif spec == "dsv41":
+            real_input = encoding_dsv41.encode_messages(
                 messages, thinking_mode=thinking_mode
             )
         else:

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv41.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv41.py
@@ -1,0 +1,734 @@
+# Adapted from the DeepSeek-V4.1 release reference implementation.
+"""Encode DeepSeek-V4.1 chat messages.
+
+Supports tool calls, reasoning effort, quick instruction tasks and image content.
+Mid-conversation system messages trigger the assistant generation header;
+image records are returned alongside the encoded prompt.
+"""
+
+import copy
+import json
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+SYSTEM_SP_TOKEN = "<｜System｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+
+tool_calls_block_name: str = " calls"
+tool_call_tag_name: str = " invoke"
+tool_parameter_tag_name: str = " parameter"
+
+tool_call_template: str = '<{dsml_token}{tool_call_tag_name} name="{name}">\n{arguments}\n</{dsml_token}{tool_call_tag_name}>'
+tool_calls_template = (
+    "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+)
+
+tool_output_template: str = "<tool_result>{content}</tool_result>"
+
+REASONING_EFFORT_TEMPLATE = (
+    "Reasoning Effort: {budget} "
+    "(range 1-100, the higher the value, the more thorough the reasoning)\n\n"
+)
+
+REASONING_EFFORT_MAPPINGS: Dict[str, int] = {
+    "low": 25,
+    "high": 50,
+    "xhigh": 75,
+    "max": 100,
+}
+DEFAULT_REASONING_EFFORT = "high"
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}{tc_block_name}>" block like the following:
+
+<{dsml_token}{tc_block_name}>
+<{dsml_token}{tool_call_tag_name} name="$TOOL_NAME">
+<{dsml_token}{tool_parameter_tag_name} name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}{tool_parameter_tag_name}>
+...
+</{dsml_token}{tool_call_tag_name}>
+<{dsml_token}{tool_call_tag_name} name="$TOOL_NAME2">
+...
+</{dsml_token}{tool_call_tag_name}>
+</{dsml_token}{tc_block_name}>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+
+def to_json(value: Any) -> str:
+    """Serialize a value to JSON string."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    """Extract function definitions from OpenAI-format tool list."""
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """Convert OpenAI-format tool calls to internal format."""
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
+    """Encode tool call arguments into V4.1 DSML parameter format."""
+    p_dsml_template = (
+        '<{dsml_token}{tool_parameter_tag_name} name="{key}" string="{is_str}">'
+        "{value}</{dsml_token}{tool_parameter_tag_name}>"
+    )
+    P_dsml_strs = []
+
+    raw_arguments = tool_call["arguments"]
+    arguments = (
+        json.loads(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
+    )
+    if not isinstance(arguments, dict):
+        raise ValueError(
+            "Assistant tool call function.arguments must be a JSON object."
+        )
+
+    for k, v in arguments.items():
+        P_dsml_strs.append(
+            p_dsml_template.format(
+                dsml_token=dsml_token,
+                tool_parameter_tag_name=tool_parameter_tag_name,
+                key=k,
+                is_str="true" if isinstance(v, str) else "false",
+                value=v if isinstance(v, str) else to_json(v),
+            )
+        )
+
+    return "\n".join(P_dsml_strs)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    """Render tool schemas into the V4.1 system prompt format."""
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        tc_block_name=tool_calls_block_name,
+        tool_call_tag_name=tool_call_tag_name,
+        tool_parameter_tag_name=tool_parameter_tag_name,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def render_reasoning_effort(
+    index: int,
+    thinking_mode: str,
+    effort: Union[str, int, None],
+) -> str:
+    """Render the numeric reasoning effort prefix (thinking mode, index 0 only)."""
+    if effort is None:
+        effort = DEFAULT_REASONING_EFFORT
+    if not (
+        (type(effort) is int and 1 <= effort <= 100)
+        or effort in REASONING_EFFORT_MAPPINGS
+    ):
+        raise ValueError(
+            f"Invalid reasoning effort for deepseek_v41: {effort!r}, should be "
+            f"int within [1,100] or {list(REASONING_EFFORT_MAPPINGS)}"
+        )
+    if type(effort) is str:
+        effort = REASONING_EFFORT_MAPPINGS[effort]
+    if index == 0 and thinking_mode == "thinking":
+        return REASONING_EFFORT_TEMPLATE.format(budget=effort)
+    return ""
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    """Mid-conversation system messages also count as user messages here;
+    they trigger the assistant generation header.
+    """
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        role = messages[idx].get("role")
+        if role in ["user", "developer"] or (role == "system" and idx > 0):
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+def attach_task_to_last_user_message(messages: List[Dict[str, Any]], task: str) -> None:
+    """Set `task` on the most recent user/developer message; raise if none exists."""
+    idx = find_last_user_index(messages)
+    if idx == -1:
+        raise ValueError(
+            "`task` requires at least one message with role='user' or 'developer'."
+        )
+    messages[idx]["task"] = task
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+
+def render_message(
+    index: int,
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+) -> str:
+    """Render the message at `index` into its DeepSeek-V4.1 encoded string form."""
+    assert 0 <= index < len(messages)
+    assert thinking_mode in [
+        "chat",
+        "thinking",
+    ], f"Invalid thinking_mode `{thinking_mode}`"
+
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+    wo_eos = msg.get("wo_eos", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    reasoning_effort_prompt = render_reasoning_effort(
+        index, thinking_mode, reasoning_effort
+    )
+    # The leading system token is emitted whenever there is something to host
+    # at index 0: a system message or the effort prompt (even before a user).
+    prompt = (
+        SYSTEM_SP_TOKEN
+        if index == 0 and (reasoning_effort_prompt or role == "system")
+        else ""
+    )
+    prompt += reasoning_effort_prompt
+
+    if role == "system":
+        if index > 0:
+            prompt += SYSTEM_SP_TOKEN
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+
+        content_developer = USER_SP_TOKEN
+        content_developer += content
+
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+        prompt += user_msg_template.format(content=content_developer)
+
+    elif role == "user":
+        prompt += USER_SP_TOKEN
+
+        # Handle content blocks (tool results mixed with text)
+        content_blocks = msg.get("content_blocks")
+        if content_blocks:
+            parts = []
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    parts.append(block.get("text", ""))
+                elif block_type == "tool_result":
+                    tool_content = block.get("content", "")
+                    if isinstance(tool_content, list):
+                        text_parts = []
+                        for b in tool_content:
+                            if b.get("type") == "text":
+                                text_parts.append(b.get("text", ""))
+                            else:
+                                text_parts.append(f"[Unsupported {b.get('type')}]")
+                        tool_content = "\n\n".join(text_parts)
+                    parts.append(tool_output_template.format(content=tool_content))
+                else:
+                    parts.append(f"[Unsupported {block_type}]")
+            prompt += "\n\n".join(parts)
+        else:
+            prompt += content or ""
+
+    elif role == "latest_reminder":
+        prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(
+            content=content
+        )
+
+    elif role == "tool":
+        raise NotImplementedError(
+            "deepseek_v41 merges tool messages into user; please preprocess with merge_tool_messages()"
+        )
+
+    elif role == "assistant":
+        thinking_part = ""
+        tc_content = ""
+
+        if tool_calls:
+            tc_list = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    tool_call_tag_name=tool_call_tag_name,
+                    name=tc.get("name"),
+                    arguments=encode_arguments_to_dsml(tc),
+                )
+                for tc in tool_calls
+            ]
+            tc_content += "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token,
+                tool_calls="\n".join(tc_list),
+                tc_block_name=tool_calls_block_name,
+            )
+
+        summary_content = content or ""
+        rc = reasoning_content or ""
+
+        # Check if previous message has a task - if so, this is a task output (no thinking)
+        prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+        if thinking_mode == "thinking" and not prev_has_task:
+            if not drop_thinking or index > last_user_idx:
+                thinking_part = (
+                    thinking_template.format(reasoning_content=rc) + thinking_end_token
+                )
+            else:
+                thinking_part = ""
+
+        if wo_eos:
+            prompt += assistant_msg_wo_eos_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    # Append transition tokens based on what follows
+    if index + 1 < len(messages) and messages[index + 1].get("role") not in [
+        "assistant",
+        "latest_reminder",
+    ]:
+        return prompt
+
+    task = messages[index].get("task")
+    if task is not None:
+        # Task special token for internal classification tasks
+        assert task in VALID_TASKS, (
+            f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        )
+        task_sp_token = DS_TASK_SP_TOKENS[task]
+
+        if task != "action":
+            # Non-action tasks: append task sp token directly after the message
+            prompt += task_sp_token
+        else:
+            # Action task: append Assistant + thinking token + action sp token
+            prompt += ASSISTANT_SP_TOKEN
+            prompt += (
+                thinking_end_token
+                if thinking_mode != "thinking"
+                else thinking_start_token
+            )
+            prompt += task_sp_token
+
+    elif messages[index].get("role") in ["user", "developer"] or (
+        messages[index].get("role") == "system" and index > 0
+    ):
+        # Normal generation: append Assistant + thinking token
+        prompt += ASSISTANT_SP_TOKEN
+        if not drop_thinking and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    return prompt
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Tool results are encoded within user messages;
+    DeepSeek-V4.1 has no standalone tool role.
+    """
+    merged: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        role = msg.get("role")
+
+        if role == "tool":
+            # Convert tool message to a user message with tool_result block
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            # Merge into previous message if it's already a user (merged tool)
+            if (
+                merged
+                and merged[-1].get("role") == "user"
+                and "content_blocks" in merged[-1]
+            ):
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append(
+                    {
+                        "role": "user",
+                        "content_blocks": [tool_block],
+                    }
+                )
+        elif role == "user":
+            content_blocks = msg.get("content_blocks")
+            if content_blocks is None:
+                content_blocks = [{"type": "text", "text": msg.get("content", "")}]
+            if (
+                merged
+                and merged[-1].get("role") == "user"
+                and "content_blocks" in merged[-1]
+                and merged[-1].get("task") is None
+            ):
+                merged[-1]["content_blocks"].extend(content_blocks)
+            else:
+                # Keeps structured content and every message-level field.
+                new_msg = msg
+                new_msg["content_blocks"] = content_blocks
+                merged.append(new_msg)
+        else:
+            merged.append(msg)
+
+    return merged
+
+
+def sort_tool_results_by_call_order(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Sort tool_result blocks within user messages by the order of tool_calls
+    in the preceding assistant message.
+    """
+    last_tool_call_order: Dict[str, int] = {}
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_tool_call_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                if tc_id:
+                    last_tool_call_order[tc_id] = idx
+
+        elif role == "user" and msg.get("content_blocks"):
+            tool_blocks = [
+                b for b in msg["content_blocks"] if b.get("type") == "tool_result"
+            ]
+            if len(tool_blocks) > 1 and last_tool_call_order:
+                sorted_blocks = sorted(
+                    tool_blocks,
+                    key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0),
+                )
+                sorted_idx = 0
+                new_blocks = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[sorted_idx])
+                        sorted_idx += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+
+    return messages
+
+
+# ============================================================
+# Vision Message Preprocessing
+# ============================================================
+
+
+def _is_image_block(block: Dict[str, Any]) -> bool:
+    return isinstance(block, dict) and block.get("type") in ("image", "image_url")
+
+
+def _extract_image(block: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a supported image block into an internal image record."""
+    record: Dict[str, Any] = {"type": "image"}
+    if block.get("type") == "image_url":
+        image_url = block.get("image_url")
+        if isinstance(image_url, str):
+            record["url"] = image_url
+        else:
+            record["url"] = (image_url or {}).get("url", "")
+    else:
+        for key in ("source", "url", "data"):
+            if key in block:
+                record[key] = block[key]
+    if not any(record.get(key) for key in ("source", "url", "data")):
+        raise ValueError("Image block does not contain a valid source")
+    return record
+
+
+def _process_image_blocks(
+    blocks: List[Any], image_placeholder: str = IMAGE_PLACEHOLDER
+) -> Tuple[List[Any], List[Dict[str, Any]]]:
+    """Replace image blocks with placeholders and collect their records in order."""
+    new_blocks: List[Any] = []
+    images: List[Dict[str, Any]] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            new_blocks.append(block)
+            continue
+        if _is_image_block(block):
+            new_blocks.append({"type": "text", "text": image_placeholder})
+            images.append(_extract_image(block))
+        elif block.get("type") == "tool_result" and isinstance(
+            block.get("content"), list
+        ):
+            block = copy.copy(block)
+            block["content"], nested_images = _process_image_blocks(
+                block["content"], image_placeholder
+            )
+            new_blocks.append(block)
+            images.extend(nested_images)
+        elif block.get("type") == "text":
+            text = block.get("text") or ""
+            if IMAGE_PLACEHOLDER in text:
+                raise ValueError(
+                    f"Text block contains image placeholder '{IMAGE_PLACEHOLDER}': "
+                    f"'{text[:100]}'. Images should be separate content blocks."
+                )
+            new_blocks.append(block)
+        else:
+            new_blocks.append(block)
+    return new_blocks, images
+
+
+def _validate_no_image_sp_tokens(msg: Dict[str, Any]) -> None:
+    """Reject user-supplied image placeholder tokens in textual fields."""
+    content = msg.get("content")
+    if isinstance(content, str) and IMAGE_PLACEHOLDER in content:
+        raise ValueError(
+            f"Message content contains image special token '{IMAGE_PLACEHOLDER}'. "
+            "Images should be provided as image content blocks."
+        )
+    reasoning_content = msg.get("reasoning_content")
+    if isinstance(reasoning_content, str) and IMAGE_PLACEHOLDER in reasoning_content:
+        raise ValueError(
+            f"reasoning_content contains image special token '{IMAGE_PLACEHOLDER}'"
+        )
+
+
+def process_image_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Normalize image blocks and return their records in prompt order."""
+    processed: List[Dict[str, Any]] = []
+    images: List[Dict[str, Any]] = []
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        _validate_no_image_sp_tokens(msg)
+
+        if isinstance(msg.get("content"), list) and "content_blocks" not in msg:
+            msg["content_blocks"] = msg.pop("content")
+
+        if msg.get("content_blocks"):
+            msg["content_blocks"], message_images = _process_image_blocks(
+                msg["content_blocks"]
+            )
+            images.extend(message_images)
+            if not isinstance(msg.get("content"), str):
+                texts = [
+                    block.get("text", "")
+                    for block in msg["content_blocks"]
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                msg["content"] = "\n\n".join(texts)
+
+        processed.append(msg)
+    return processed, images
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    last_user_idx = find_last_user_index(messages)
+    result = []
+    keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in keep_roles or idx >= last_user_idx:
+            result.append(msg)
+        elif role == "assistant":
+            msg = copy.copy(msg)
+            msg.pop("reasoning_content", None)
+            result.append(msg)
+        # developer and other roles before last_user_idx are dropped
+
+    return result
+
+
+def _encode_messages_text(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+) -> str:
+    """Encode preprocessed (text-only) messages into the V4.1 prompt format."""
+    context = context if context else []
+
+    # Preprocess: merge tool messages and sort tool results
+    messages = merge_tool_messages(messages)
+    messages = sort_tool_results_by_call_order(context + messages)[len(context) :]
+    if context:
+        context = merge_tool_messages(context)
+        context = sort_tool_results_by_call_order(context)
+
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+    effective_drop_thinking = drop_thinking
+    if any(m.get("tools") for m in full_messages):
+        effective_drop_thinking = False
+
+    if thinking_mode == "thinking" and effective_drop_thinking:
+        full_messages = _drop_thinking_messages(full_messages)
+        num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+        context_len = len(full_messages) - num_to_render
+    else:
+        num_to_render = len(messages)
+        context_len = len(context)
+
+    for idx in range(num_to_render):
+        prompt += render_message(
+            idx + context_len,
+            full_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=effective_drop_thinking,
+            reasoning_effort=reasoning_effort,
+        )
+
+    return prompt
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Union[str, int, None] = None,
+    return_multi_modal_data: bool = False,
+) -> Any:
+    """
+    Encode a list of messages into the DeepSeek-V4.1 prompt format.
+
+    Handles BOS insertion, thinking mode with optional reasoning dropping, tool
+    message merging, multi-turn context, and image content blocks. Returns the
+    prompt string, or ``(prompt, {"images": [...]})`` when
+    ``return_multi_modal_data`` is set; the image records are in prompt order.
+    """
+    context = context or []
+    processed_context, _ = process_image_messages(context) if context else ([], [])
+    processed_messages, images = process_image_messages(messages)
+    prompt = _encode_messages_text(
+        processed_messages,
+        thinking_mode=thinking_mode,
+        context=processed_context if processed_context else None,
+        drop_thinking=drop_thinking,
+        add_default_bos_token=add_default_bos_token,
+        reasoning_effort=reasoning_effort,
+    )
+    if return_multi_modal_data:
+        return prompt, {"images": images}
+    return prompt

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -890,7 +890,7 @@ class ChatCompletionRequest(BaseModel):
         description="DeepSeek-V4 quick instruction task. When set, the last "
         "user/developer message is treated as a single-shot classification prompt "
         "and the corresponding task special token (e.g. `<｜domain｜>`) is appended "
-        "before generation. Only honored by the dsv4 chat encoder; ignored otherwise.",
+        "before generation. Only honored by the dsv4/dsv41 chat encoders; ignored otherwise.",
     )
 
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -36,7 +36,12 @@ _CHAT_TEMPLATE_CLIENT_ERRORS: tuple[type[BaseException], ...] = (
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
-from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv4, encoding_dsv32
+from sglang.srt.entrypoints.openai import (
+    chat_encoding,
+    encoding_dsv4,
+    encoding_dsv32,
+    encoding_dsv41,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageContentTextPart,
     ChatCompletionMessageContentVideoPart,
@@ -330,6 +335,14 @@ class OpenAIServingChat(OpenAIServingBase):
             if self.chat_encoding_spec == "inkling"
             else None
         )
+        self._dsv41_default_reasoning_effort: Optional[Union[str, int]] = (
+            chat_encoding.default_dsv41_reasoning_effort_from_env(
+                envs.SGLANG_DSV41_REASONING_EFFORT.get()
+            )
+            if self.chat_encoding_spec == "dsv41"
+            else None
+        )
+        self._dsv41_unsupported_efforts_warned: set = set()
 
         # Per-request response parser for custom decoding (set by _encode_messages)
         self._response_parser: Optional[ResponseParserProtocol] = None
@@ -673,6 +686,25 @@ class OpenAIServingChat(OpenAIServingBase):
         if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
             raise ValueError("Inkling reasoning_effort must be in [0.0, 0.99]")
         return parsed
+
+    def _resolve_dsv41_reasoning_effort(self, value: Any) -> Union[str, int]:
+        """Request effort for the V4.1 encoder; unsupported tiers warn once and fall back."""
+        effort = chat_encoding.resolve_dsv41_reasoning_effort(value)
+        if effort is not None:
+            return effort
+        if (
+            value is not None
+            and repr(value) not in self._dsv41_unsupported_efforts_warned
+        ):
+            self._dsv41_unsupported_efforts_warned.add(repr(value))
+            logger.warning(
+                "DeepSeek-V4.1 does not support reasoning_effort=%r; using the "
+                "default %r (low/high/xhigh/max, a float in [0, 0.99], or an "
+                "integer budget in [1, 100] via chat_template_kwargs are accepted).",
+                value,
+                self._dsv41_default_reasoning_effort,
+            )
+        return self._dsv41_default_reasoning_effort
 
     @staticmethod
     def _get_inkling_default_reasoning_effort() -> float:
@@ -1083,7 +1115,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # Handle single vs multiple requests
         if request.input_ids is not None:
             prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
-        elif is_multimodal and self.chat_encoding_spec == "kimi_k3":
+        elif is_multimodal and self.chat_encoding_spec in ("kimi_k3", "dsv41"):
             prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
         elif is_multimodal:
             # Standard VLMs render a text prompt (with placeholder strings) for the MM
@@ -1349,43 +1381,60 @@ class OpenAIServingChat(OpenAIServingBase):
                         modalities,
                     )
         elif self.chat_encoding_spec is not None:
-            # dsv4/dsv32 encoding path
+            # dsv4/dsv41/dsv32 encoding path
             messages = copy.deepcopy(messages)
+            is_dsv41 = self.chat_encoding_spec == "dsv41"
 
-            # dsv4/dsv32 are text-only and consume string content; flatten
-            # OpenAI parts-list content here so the encoder sees a plain string.
-            for i, msg in enumerate(messages):
-                if isinstance(msg.get("content"), list):
-                    messages[i] = process_content_for_template_format(
-                        msg, "string", [], [], [], []
+            if is_dsv41:
+                # The V4.1 encoder consumes OpenAI parts lists itself (image
+                # parts become placeholders), so no flattening here.
+                for msg in messages:
+                    if msg.get("content") is None:
+                        msg["content"] = ""
+            else:
+                # dsv4/dsv32 are text-only and consume string content; flatten
+                # OpenAI parts-list content here so the encoder sees a plain string.
+                for i, msg in enumerate(messages):
+                    if isinstance(msg.get("content"), list):
+                        messages[i] = process_content_for_template_format(
+                            msg, "string", [], [], [], []
+                        )
+
+                for msg in messages:
+                    if msg.get("content") is None:
+                        msg["content"] = ""
+                    processed_msg = process_content_for_template_format(
+                        msg,
+                        template_content_format,
+                        image_data,
+                        video_data,
+                        audio_data,
+                        modalities,
+                        use_dpsk_v32_encoding=self.chat_encoding_spec == "dsv32",
                     )
-
-            for msg in messages:
-                if msg.get("content") is None:
-                    msg["content"] = ""
-                processed_msg = process_content_for_template_format(
-                    msg,
-                    template_content_format,
-                    image_data,
-                    video_data,
-                    audio_data,
-                    modalities,
-                    use_dpsk_v32_encoding=self.chat_encoding_spec == "dsv32",
-                )
-                msg.update(processed_msg)
+                    msg.update(processed_msg)
 
             # Handle continue_final_message: separate final assistant message
             messages, assistant_prefix = self._handle_last_assistant_message(
                 messages, request
             )
 
-            if messages[0]["role"] != "system":
-                # insert an empty system prompt to help render tool system prompt
+            # An empty system message hosts the request tools. dsv4/dsv32 render
+            # it to nothing, so they always insert one; dsv41 renders a system
+            # token for it, so it only gets one when tools need the host.
+            if messages[0]["role"] != "system" and (request.tools or not is_dsv41):
                 messages.insert(0, {"role": "system", "content": ""})
             if request.tools:
-                messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
+                messages[0]["tools"] = [
+                    (
+                        chat_encoding.dsv41_tool_payload(tool)
+                        if is_dsv41
+                        else tool.model_dump()
+                    )
+                    for tool in request.tools
+                ]
 
-            # Default encoding (dsv4/dsv32)
+            # Default encoding (dsv4/dsv41/dsv32)
             if self.chat_encoding_spec == "dsv4":
                 effort_source = request.reasoning_effort
                 if effort_source is None:
@@ -1410,6 +1459,31 @@ class OpenAIServingChat(OpenAIServingBase):
                     reasoning_effort=v4_reasoning_effort,
                     reasoning_effort_profile=reasoning_effort_profile,
                 )
+                prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
+            elif is_dsv41:
+                if request.task is not None:
+                    encoding_dsv41.attach_task_to_last_user_message(
+                        messages, request.task
+                    )
+                real_input, media = encoding_dsv41.encode_messages(
+                    messages,
+                    thinking_mode=thinking_mode,
+                    reasoning_effort=self._resolve_dsv41_reasoning_effort(
+                        request.reasoning_effort
+                    ),
+                    return_multi_modal_data=True,
+                )
+                if media["images"]:
+                    if not is_multimodal:
+                        raise ValueError("image input is not supported for this model")
+                    image_data.extend(image["url"] for image in media["images"])
+                    tokenizer = self.tokenizer_manager.tokenizer
+                    real_input = real_input.replace(
+                        encoding_dsv41.IMAGE_PLACEHOLDER,
+                        tokenizer.convert_ids_to_tokens(
+                            self.tokenizer_manager.model_config.hf_config.image_token_id
+                        ),
+                    )
                 prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
             else:
                 real_input = encoding_dsv32.encode_messages(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1378,6 +1378,9 @@ class Envs:
     SGLANG_DSV4_FP4_DEQUANT = EnvBool(False)
     # Flash-0731 also accepts "low"; the active profile is checkpoint-resolved.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")
+    # DeepSeek-V4.1 default when a request carries no reasoning_effort: one of
+    # low/high/xhigh/max or an integer budget in [1, 100].
+    SGLANG_DSV41_REASONING_EFFORT = EnvStr("high")
     # Quantize the SWA fp8 KV cache from bf16-rounded values (matches
     # trainer-side QAT and the DSA-CP path) instead of fp32 registers.
     SGLANG_DSV4_USE_BF16_KV_QUANT_SOURCE = EnvBool(False)
@@ -1397,6 +1400,28 @@ class Envs:
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)
     SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
+    # Run the DeepSeek-V4.1 ratio-1/2 prefill indexer on the torch path instead
+    # of the DeepGEMM dense fp4 logits kernel (test oracle / fallback).
+    SGLANG_DSV41_TORCH_PREFILL_INDEXER = EnvBool(False)
+    # Keep the DeepSeek-V4.1 engram tables in host memory (layout below) and gather
+    # rows from the GPU instead of sharding them over HBM.
+    SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE = EnvBool(False)
+    # Overlap layer 14's shared-host lookup and WKV with earlier layers at BS=1.
+    SGLANG_ENABLE_DSV41_ENGRAM_KV_PREFETCH = EnvBool(False)
+    # Pin and map the host table with cudaHostRegister. False leaves the plain
+    # mapping to the platform (Grace-Blackwell ATS reaches it directly).
+    SGLANG_DSV41_ENGRAM_HOST_TABLE_PIN = EnvBool(True)
+    # How the host table is laid out: "shared" is one memfd copy for the TP group
+    # with no all-reduce; "private" is one anonymous mapping per rank holding its
+    # row range, gathered with the all-reduce. "auto" picks shared when shmem THP
+    # (transparent_hugepage/shmem_enabled) is on, else private when anonymous THP
+    # is on, else shared without huge pages.
+    SGLANG_DSV41_ENGRAM_HOST_TABLE_LAYOUT = EnvStr("auto")
+    # With the host table on, drop the checkpoint's page cache (posix_fadvise
+    # DONTNEED on the safetensors) before pre-faulting the table and again after
+    # loading: cached checkpoint pages fragment host memory and starve the 512 MiB
+    # huge-page faults. Costs the next restart its warm page cache.
+    SGLANG_ENABLE_DSV41_ENGRAM_DROP_PAGE_CACHE = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
 

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -70,33 +70,54 @@ class DeepSeekV32Detector(BaseFormatDetector):
     Reference: DeepSeek V3.2 format specification
     """
 
+    # Tag names after the DSML marker; subclasses override for newer formats.
+    dsml_token = "｜DSML｜"
+    tool_calls_block_name = "function_calls"
+    invoke_tag_name = "invoke"
+    parameter_tag_name = "parameter"
+
     def __init__(self):
         super().__init__()
-        self.bot_token = "<｜DSML｜function_calls>"
-        self.eot_token = "</｜DSML｜function_calls>"
-        self.invoke_end_token = "</｜DSML｜invoke>"
-        self.parameter_regex = r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*?)</｜DSML｜parameter>'
+        block = f"{self.dsml_token}{self.tool_calls_block_name}"
+        invoke = f"{self.dsml_token}{self.invoke_tag_name}"
+        parameter = f"{self.dsml_token}{self.parameter_tag_name}"
+        self.bot_token = f"<{block}>"
+        self.eot_token = f"</{block}>"
+        self.invoke_start_token = f"<{invoke}"
+        self.invoke_end_token = f"</{invoke}>"
+        self.parameter_regex = (
+            rf'<{parameter}\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*?)</{parameter}>'
+        )
         self.partial_parameter_regex = (
-            r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*)$'
+            rf'<{parameter}\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*)$'
         )
-        self.function_calls_regex = (
-            r"<｜DSML｜function_calls>(.*?)</｜DSML｜function_calls>"
-        )
+        self.function_calls_regex = rf"<{block}>(.*?)</{block}>"
         # Long-form `<｜DSML｜invoke name="x">...</｜DSML｜invoke>` and the
         # self-closing `<｜DSML｜invoke name="x"/>` shape V4 emits for zero-arg
         # tools. The `end` group is empty when the closer hasn't streamed in.
         self.invoke_regex = (
-            r'<｜DSML｜invoke\s+name="(?P<name>[^"]+)"\s*'
+            rf'<{invoke}\s+name="(?P<name>[^"]+)"\s*'
             r"(?:(?P<self_close>/>)"
-            r"|>(?P<body>.*?)(?P<end>(?:</｜DSML｜invoke>|$)))"
+            rf"|>(?P<body>.*?)(?P<end>(?:</{invoke}>|$)))"
         )
-        self.prefix_parameter_end_call = ["</", "｜DSML｜", "parameter"]
-        self.prefix_invoke_end_call = ["</", "｜DSML｜", "inv", "oke"]
+        # Consumed right-to-left by rstrip (a character set, not a suffix), so the
+        # invoke name is split to limit how much of a partial value gets eaten.
+        self.prefix_parameter_end_call = [
+            "</",
+            self.dsml_token,
+            self.parameter_tag_name,
+        ]
+        self.prefix_invoke_end_call = [
+            "</",
+            self.dsml_token,
+            self.invoke_tag_name[:-3],
+            self.invoke_tag_name[-3:],
+        ]
         self.current_tool_id = -1
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a deepseek v32 format tool call."""
-        return self.bot_token in text or "<｜DSML｜invoke" in text
+        return self.bot_token in text or self.invoke_start_token in text
 
     @staticmethod
     def _unpack_invoke_match(m: "re.Match[str]") -> tuple[str, str, bool]:
@@ -379,9 +400,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(
-            begin=f'<｜DSML｜invoke name="{name}">',
-            end="</｜DSML｜invoke>",
-            trigger="<｜DSML｜invoke",
+            begin=f'{self.invoke_start_token} name="{name}">',
+            end=self.invoke_end_token,
+            trigger=self.invoke_start_token,
         )
 
     def get_structural_tag_name(self) -> str:

--- a/python/sglang/srt/function_call/deepseekv41_detector.py
+++ b/python/sglang/srt/function_call/deepseekv41_detector.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+
+
+class DeepSeekV41Detector(DeepSeekV32Detector):
+    """DeepSeek V4.1 DSML detector.
+
+    Tag names have a leading space: " calls", " invoke", and " parameter".
+    """
+
+    tool_calls_block_name = " calls"
+    invoke_tag_name = " invoke"
+    parameter_tag_name = " parameter"
+
+    def get_structural_tag_name(self) -> Optional[str]:
+        # xgrammar's builtin "deepseek_v4" tag is the unspaced grammar; fall
+        # back to structure_info so constrained decoding uses the spaced tags.
+        return None

--- a/python/sglang/srt/function_call/deepseekv4_detector.py
+++ b/python/sglang/srt/function_call/deepseekv4_detector.py
@@ -57,11 +57,7 @@ class DeepSeekV4Detector(DeepSeekV32Detector):
     Reference: DeepSeek V4 format specification
     """
 
-    def __init__(self):
-        super().__init__()
-        self.bot_token = "<｜DSML｜tool_calls>"
-        self.eot_token = "</｜DSML｜tool_calls>"
-        self.function_calls_regex = r"<｜DSML｜tool_calls>(.*?)</｜DSML｜tool_calls>"
+    tool_calls_block_name = "tool_calls"
 
     def get_structural_tag_name(self) -> str:
         return "deepseek_v4"

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -19,6 +19,7 @@ from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
 from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
 from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.srt.function_call.deepseekv41_detector import DeepSeekV41Detector
 from sglang.srt.function_call.dots_detector import DotsToolDetector
 from sglang.srt.function_call.gemma4_detector import Gemma4Detector
 from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
@@ -72,6 +73,7 @@ class FunctionCallParser:
         "deepseekv31": DeepSeekV31Detector,
         "deepseekv32": DeepSeekV32Detector,
         "deepseekv4": DeepSeekV4Detector,
+        "deepseekv41": DeepSeekV41Detector,
         "dots": DotsToolDetector,
         "glm": Glm4MoeDetector,
         "glm45": Glm4MoeDetector,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -15,9 +15,15 @@ from typing import (
     Union,
 )
 
+import msgspec
 import torch
 import torch.nn.functional as F
 
+from sglang.kernels.ops.attention.dsv4 import (
+    topk_transform_paged,
+    topk_transform_paged_v2,
+    topk_transform_ragged_v2,
+)
 from sglang.kernels.ops.attention.dsv4.dequant_k_cache import (
     cast_q_fp8_for_q8kv8_prefill,
     dequantize_k_cache_paged,
@@ -26,13 +32,18 @@ from sglang.kernels.ops.attention.dsv4.dequant_k_cache import (
     q8kv8_padded_num_heads,
 )
 from sglang.kernels.ops.attention.dsv4.metadata_kernel import (
+    fill_all_compressed_indices,
+)
+from sglang.kernels.ops.attention.dsv4.metadata_kernel import (
     init_compression_metadata as _init_compression_metadata_triton,
 )
 from sglang.kernels.ops.attention.dsv4.online_c128_mtp import OnlineC128MTPController
+from sglang.kernels.ops.attention.dsv4.sm90_fp4_indexer import fp4_index_logits_decode
 from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     BuildCausalSwaPageIndices,
     BuildPageTablePositions,
     ExpandPrefillCausally,
+    late_layer_tail_layout,
 )
 from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     BuildBlockSeqLensCausal,
@@ -45,12 +56,20 @@ from sglang.srt.layers.attention.base_attn_backend import (
     SharedReadEnds,
 )
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
+from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     CompressorBackendMixin,
     FusedCompressMetadata,
     create_paged_compressor_data,
 )
-from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
+from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
+    _rope_fq4,
+    token_req_indices,
+)
+from sglang.srt.layers.attention.dsv4.indexer import (
+    C4IndexerBackendMixin,
+    select_candidate_blocks,
+)
 from sglang.srt.layers.attention.dsv4.metadata import (
     _LARGE_INDEXER_QUERY_THRESHOLD,
     PagedIndexerMetadata,
@@ -66,7 +85,19 @@ from sglang.srt.layers.attention.verify_mask import (
     VerifyMask,
     maybe_create_verify_mask,
 )
-from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.cp.interleave import (
+    InterleaveContextParallelMetadata,
+    interleave_rows_per_request,
+)
+from sglang.srt.layers.cp.utils import (
+    cp_materialize_global_token_order,
+    is_cp_v2_active,
+)
+from sglang.srt.layers.dp_attention import (
+    get_local_dp_buffer_len,
+    set_local_dp_buffer_len,
+)
+from sglang.srt.mem_cache.deepseek_v4_compress_state import KVAndScore
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import (
@@ -99,6 +130,12 @@ logger = logging.getLogger(__name__)
 SWA_WINDOW = 128
 C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
+
+
+@functools.lru_cache(maxsize=None)
+def _is_sm100_or_newer() -> bool:
+    """The DeepGEMM fp8_fp4 mqa-logits kernels need SM100/SM120; Hopper takes the torch indexer."""
+    return torch.cuda.get_device_capability()[0] >= 10
 
 
 def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -153,6 +190,255 @@ def _create_flashmla_metadata():
     return flash_mla.get_mla_metadata()[0]
 
 
+def _expand_index_page_table(
+    page_table: torch.Tensor,
+    *,
+    full_page_size: int,
+    compress_ratio: int,
+    index_page_size: int,
+) -> torch.Tensor:
+    """Expand the FULL page table into the block table of a low-ratio indexer-K
+    pool, which pages at `index_page_size` slots rather than a FULL page.
+
+    The kernel resolves compressed slot j through
+    page_table[b, j // index_page_size] * index_page_size + j % index_page_size,
+    which with this expansion is the c1/c2 KV pool slot of the same position.
+    [bs, n_full_pages] -> [bs, n_full_pages * blocks_per_page], int32.
+    """
+    slots_per_page = full_page_size // compress_ratio
+    assert slots_per_page % index_page_size == 0, (
+        f"{full_page_size = } / {compress_ratio = } must be a multiple of "
+        f"{index_page_size = }"
+    )
+    blocks_per_page = slots_per_page // index_page_size
+    if blocks_per_page == 1:
+        return page_table
+    bs, n = page_table.shape
+    base = page_table.to(torch.int64) * blocks_per_page
+    offsets = torch.arange(blocks_per_page, device=page_table.device, dtype=torch.int64)
+    expanded = base.unsqueeze(-1) + offsets  # [bs, n, blocks_per_page]
+    return expanded.reshape(bs, n * blocks_per_page).to(torch.int32)
+
+
+def _fp4_paged_mqa_logits(
+    q_fp4: Tuple[torch.Tensor, torch.Tensor],
+    k_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """DeepGEMM paged fp4 logits for the low-ratio indexer. No hadamard: the
+    reference does not apply one."""
+    from deep_gemm import fp8_fp4_paged_mqa_logits as fn
+
+    sl = seq_lens.to(torch.int32)
+    if sl.dim() == 1:
+        sl = sl.unsqueeze(-1)
+    return fn(
+        q_fp4,
+        k_cache,
+        weights,
+        sl,
+        page_table,
+        deep_gemm_metadata,
+        max_seq_len,
+        False,
+    )
+
+
+def two_level_decode_logits(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    is_candidate_source: bool,
+    uses_candidates: bool,
+    topk_blocks: int,
+    block_size: int,
+    published: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Apply candidate-block filtering and return logits plus an optional published mask.
+
+    Mask columns past each sequence length to -inf before selection: the paged
+    logits kernel leaves that tail uninitialized, and an all -inf block means
+    unreachable. This path is graph-captured and must not synchronize with the host.
+    Work scales with allocated page-table capacity, not live sequence length.
+    """
+    if not (is_candidate_source or uses_candidates):
+        return logits, None
+
+    from sglang.srt.model_executor.runner_utils.capture_mode import (
+        get_capture_dsa_variant,
+    )
+
+    if get_capture_dsa_variant() in (
+        "candidate_all",
+        "candidate_c2_all",
+        "candidate_unfiltered",
+    ):
+        # All requests fit the candidate budget; paged top-k masks their tails.
+        return logits, None
+
+    lens_col = seq_lens if seq_lens.dim() > 1 else seq_lens.unsqueeze(-1)
+    reachable = torch.arange(logits.shape[-1], device=logits.device) < lens_col
+    logits = logits.float().masked_fill(~reachable, -torch.inf)
+
+    if is_candidate_source:
+        # The source scores over every reachable position itself and only publishes,
+        # which is what the reference does.
+        return logits, select_candidate_blocks(
+            logits, lens_col, topk_blocks=topk_blocks, block_size=block_size
+        )
+
+    assert torch.is_tensor(published) and published.shape[0] == logits.shape[0], (
+        "candidate mask missing for decode"
+    )
+    return logits.masked_fill(~published[:, : logits.shape[-1]], -torch.inf), None
+
+
+# Arbitrary cap on one bf16 [rows, heads, lc] score chunk; transients run ~3x this.
+_TORCH_INDEXER_SCORE_BUDGET_BYTES = 1 << 30
+
+
+def _mask_topk_scores(
+    scores: torch.Tensor,
+    indices: torch.Tensor,
+    offsets: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Keep masked indexer scores out of attention even when top-k underfills."""
+    columns = indices.to(torch.int64)
+    if offsets is not None:
+        columns = columns - offsets[:, None]
+    selected_scores = scores.gather(1, columns.clamp(0, scores.shape[1] - 1))
+    valid = (
+        (columns >= 0) & (columns < scores.shape[1]) & (selected_scores > -torch.inf)
+    )
+    return indices.masked_fill(~valid, -1)
+
+
+@functools.cache
+def _has_dense_fp4_indexer() -> bool:
+    if not torch.cuda.is_available() or torch.version.cuda is None:
+        return False
+    try:
+        import deep_gemm
+    except ImportError:
+        return False
+    return hasattr(deep_gemm, "fp8_fp4_mqa_logits")
+
+
+def _dense_fp4_mqa_logits(
+    q_fp4: Tuple[torch.Tensor, torch.Tensor],
+    kv_fp4: Tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+    max_seqlen_k: int,
+) -> torch.Tensor:
+    from deep_gemm import fp8_fp4_mqa_logits as fn
+
+    # q (int8 [T, H, 64], int32 [T, H]) x kv (int8 [L, 64], int32 [L]) -> fp32
+    # [T, max_seqlen_k]; row t's column j is k[ks_t + j], valid for j < ke_t - ks_t
+    # (the rest is garbage: the kernel rejects clean_logits).
+    return fn(q_fp4, kv_fp4, weights, ks, ke, False, max_seqlen_k)
+
+
+def _low_ratio_source_projections(layer, x, q_lora, positions, bufs):
+    """Projections of a ratio-1/2 source layer, run as an eager break on the
+    live rows into static buffers: the compressor's kv / score and the indexer's
+    query and head weights. These GEMMs pick their algorithm by M, so at the
+    bucket size their rows differ from eager; everything downstream is
+    row-independent. Padded rows are zeroed."""
+    from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+        get_tc_piecewise_forward_context,
+    )
+
+    real = get_tc_piecewise_forward_context().forward_batch.num_token_non_padded_cpu
+    if real is None:
+        real = x.shape[0]
+
+    def put(name, value):
+        buf = bufs[name]
+        buf[:real].copy_(value)
+        buf[real:].zero_()
+
+    if real == 0:
+        # An idle DP-attention rank replays on fabricated rows with no live
+        # token; a zero-row GEMM is a launch error, so only zero the buffers.
+        for buf in bufs.values():
+            buf.zero_()
+        return
+
+    if layer.compressor is not None:
+        kv, score = layer.compressor.project(x[:real])
+        put("kv", kv)
+        if score is not None:
+            put("score", score)
+    if layer.indexer is not None:
+        indexer = layer.indexer
+        put("q", indexer.queries(q_lora[:real], layer.freqs_cis[positions[:real]]))
+        put("w", indexer.head_weights(x[:real]))
+
+
+def _bcg_low_ratio_source_projections(*args):
+    from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
+        eager_on_graph,
+    )
+
+    global _bcg_low_ratio_source_projections_fn
+    if _bcg_low_ratio_source_projections_fn is None:
+        _bcg_low_ratio_source_projections_fn = eager_on_graph(True)(
+            _low_ratio_source_projections
+        )
+    return _bcg_low_ratio_source_projections_fn(*args)
+
+
+_bcg_low_ratio_source_projections_fn = None
+
+
+def _as_int_list(values) -> Optional[List[int]]:
+    if values is None:
+        return None
+    if isinstance(values, torch.Tensor):
+        if values.device.type != "cpu":
+            return None
+        values = values.tolist()
+    return [int(v) for v in values]
+
+
+def _low_ratio_compression_metadata(
+    compress_ratio: int, seq_lens_casual: torch.Tensor, raw_out_loc: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Ratio 1/2 counterpart of the triton c4/c128 metadata; a completed group's
+    latent lives at raw_out_loc // ratio, -1 for a token that completes none."""
+    num_write_tokens = raw_out_loc.shape[0]
+    completes_group = seq_lens_casual[:num_write_tokens] % compress_ratio == 0
+    out_loc = torch.where(
+        completes_group, raw_out_loc.to(torch.int64) // compress_ratio, -1
+    )
+    topk_lengths_clamp1 = (seq_lens_casual // compress_ratio).clamp_min(1)
+    return out_loc, topk_lengths_clamp1.to(torch.int32)
+
+
+def _low_ratio_sparse_buffers(
+    topk_lengths_clamp1: torch.Tensor, topk: int, is_prefill: bool
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Fixed-shape top-k buffers the index_source layers fill in place. The
+    extra_topk_length the kernel reads comes from positions, not from the indexer."""
+    sparse_topk_lengths = torch.clamp(topk_lengths_clamp1, max=topk)
+    page_indices = _pad_last_dim(
+        torch.full(
+            (topk_lengths_clamp1.size(0), topk),
+            -1,
+            dtype=torch.int32,
+            device=topk_lengths_clamp1.device,
+        )
+    )
+    raw_indices = torch.empty_like(page_indices) if is_prefill else None
+    return sparse_topk_lengths, page_indices, raw_indices
+
+
 def _create_dummy_paged_compress_data(compress_ratio: int):
     return None
 
@@ -177,10 +463,14 @@ class DSV4AttnMetadata:
     swa_page_indices: torch.Tensor
     swa_topk_lengths: torch.Tensor
 
-    c4_sparse_topk: int
+    index_topk: int
     # SWA KV-store write target (out_cache_loc translated to SWA space), computed
     # once per iteration in make_core_attn_metadata and read by the store path.
+    request_window_layout: Optional[object] = None
     swa_out_cache_loc: Optional[torch.Tensor] = None
+    # Sorted compress ratios present in this stage; absent ratios keep no buffers
+    # or schedules. The default (4, 128) supports V4 metadata constructed by hand.
+    present_ratios: Tuple[int, ...] = (4, 128)
     c4_out_loc: Optional[torch.Tensor] = None
     c4_topk_lengths_raw: Optional[torch.Tensor] = None
     c4_topk_lengths_clamp1: Optional[torch.Tensor] = None
@@ -192,7 +482,28 @@ class DSV4AttnMetadata:
     c128_page_indices: Optional[torch.Tensor] = None
     c128_topk_lengths_clamp1: Optional[torch.Tensor] = None
 
-    c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
+    # The (1, 2) subset of present_ratios (DeepSeek V4.1): one latent per ratio
+    # tokens at slot raw_out_loc // ratio of the c1 / c2 pool, attended through
+    # the FlashMLA extra cache like c4.
+    low_ratios: Tuple[int, ...] = ()
+    c1_out_loc: Optional[torch.Tensor] = None
+    c1_topk_lengths_clamp1: Optional[torch.Tensor] = None
+    c1_sparse_topk_lengths: Optional[torch.Tensor] = field(init=False, default=None)
+    c1_sparse_page_indices: Optional[torch.Tensor] = field(init=False, default=None)
+    c1_sparse_raw_indices: Optional[torch.Tensor] = field(init=False, default=None)
+    c2_out_loc: Optional[torch.Tensor] = None
+    c2_topk_lengths_clamp1: Optional[torch.Tensor] = None
+    c2_sparse_topk_lengths: Optional[torch.Tensor] = field(init=False, default=None)
+    c2_sparse_page_indices: Optional[torch.Tensor] = field(init=False, default=None)
+    c2_sparse_raw_indices: Optional[torch.Tensor] = field(init=False, default=None)
+
+    c0_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
+    c1_flashmla_metadata: Optional[FlashMLASchedMeta] = field(
+        init=False, default=None, repr=False
+    )
+    c2_flashmla_metadata: Optional[FlashMLASchedMeta] = field(
+        init=False, default=None, repr=False
+    )
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c128_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
 
@@ -200,9 +511,13 @@ class DSV4AttnMetadata:
     def positions(self) -> torch.Tensor:
         return self.positions_casual
 
-    def get_flashmla_metadata(self, compress_ratio: Literal[0, 4, 128]):
+    def get_flashmla_metadata(self, compress_ratio: Literal[0, 1, 2, 4, 128]):
         if compress_ratio == 0:
+            return self.c0_flashmla_metadata
+        elif compress_ratio == 1:
             return self.c1_flashmla_metadata
+        elif compress_ratio == 2:
+            return self.c2_flashmla_metadata
         elif compress_ratio == 4:
             return self.c4_flashmla_metadata
         elif compress_ratio == 128:
@@ -210,14 +525,48 @@ class DSV4AttnMetadata:
         else:
             raise ValueError(f"invalid {compress_ratio=}")
 
+    def sparse_page_indices(self, compress_ratio: Literal[1, 2, 4]) -> torch.Tensor:
+        """Top-k slots into the ratio's extra cache, -1 padded; the indexer fills them."""
+        if compress_ratio == 1:
+            return self.c1_sparse_page_indices
+        elif compress_ratio == 2:
+            return self.c2_sparse_page_indices
+        elif compress_ratio == 4:
+            return self.c4_sparse_page_indices
+        raise ValueError(f"invalid {compress_ratio=}")
+
+    def sparse_raw_indices(
+        self, compress_ratio: Literal[1, 2, 4]
+    ) -> Optional[torch.Tensor]:
+        """The same top-k as request-local compressed positions, for the sparse
+        prefill workspace; allocated for prefill metadata only."""
+        if compress_ratio == 1:
+            return self.c1_sparse_raw_indices
+        elif compress_ratio == 2:
+            return self.c2_sparse_raw_indices
+        elif compress_ratio == 4:
+            return self.c4_sparse_raw_indices
+        raise ValueError(f"invalid {compress_ratio=}")
+
+    def sparse_topk_lengths(self, compress_ratio: Literal[1, 2, 4]) -> torch.Tensor:
+        if compress_ratio == 1:
+            return self.c1_sparse_topk_lengths
+        elif compress_ratio == 2:
+            return self.c2_sparse_topk_lengths
+        elif compress_ratio == 4:
+            return self.c4_sparse_topk_lengths
+        raise ValueError(f"invalid {compress_ratio=}")
+
     def copy_(self, other: DSV4AttnMetadata) -> None:
         copy_metadata(
             src=other,
             dst=self,
             check_eq_fields=[
-                "c4_sparse_topk",
+                "index_topk",
                 "page_size",
                 "cuda_int32_kwargs",
+                "present_ratios",
+                "low_ratios",
             ],
             copy_fields=[
                 "raw_out_loc",
@@ -235,21 +584,36 @@ class DSV4AttnMetadata:
                 "c4_sparse_topk_lengths",
                 "c4_sparse_page_indices",
                 "c4_sparse_raw_indices",
+                "c1_out_loc",
+                "c1_topk_lengths_clamp1",
+                "c1_sparse_topk_lengths",
+                "c1_sparse_page_indices",
+                "c1_sparse_raw_indices",
+                "c2_out_loc",
+                "c2_topk_lengths_clamp1",
+                "c2_sparse_topk_lengths",
+                "c2_sparse_page_indices",
+                "c2_sparse_raw_indices",
             ],
             assign_fields=[
                 # Recomputed by the recorded init_forward_metadata_in_graph op
                 # each forward; not copied across replays.
                 "swa_out_cache_loc",
+                "request_window_layout",
+                "c0_flashmla_metadata",
                 "c1_flashmla_metadata",
+                "c2_flashmla_metadata",
                 "c4_flashmla_metadata",
                 "c128_flashmla_metadata",
             ],
         )
 
     def refresh_for_breakable_cuda_graph_replay_(self, other: DSV4AttnMetadata) -> None:
-        assert self.c4_sparse_topk == other.c4_sparse_topk
+        assert self.index_topk == other.index_topk
         assert self.page_size == other.page_size
         assert self.cuda_int32_kwargs == other.cuda_int32_kwargs
+        assert self.present_ratios == other.present_ratios
+        assert self.low_ratios == other.low_ratios
 
         tensor_copy_fields = [
             "raw_out_loc",
@@ -260,6 +624,12 @@ class DSV4AttnMetadata:
             "c4_topk_lengths_raw",
             "c4_topk_lengths_clamp1",
             "c4_sparse_topk_lengths",
+            "c1_out_loc",
+            "c1_topk_lengths_clamp1",
+            "c1_sparse_topk_lengths",
+            "c2_out_loc",
+            "c2_topk_lengths_clamp1",
+            "c2_sparse_topk_lengths",
         ]
         reference_assign_fields = [
             "page_table",
@@ -267,7 +637,9 @@ class DSV4AttnMetadata:
             "swa_topk_lengths",
             "c128_page_indices",
             "c128_topk_lengths_clamp1",
+            "c0_flashmla_metadata",
             "c1_flashmla_metadata",
+            "c2_flashmla_metadata",
             "c4_flashmla_metadata",
             "c128_flashmla_metadata",
         ]
@@ -298,27 +670,52 @@ class DSV4AttnMetadata:
             f"{self.raw_out_loc.shape=}, {num_tokens=}"
         )
 
-        (
-            self.c4_out_loc,
-            _,
-            self.c4_topk_lengths_raw,
-            self.c4_topk_lengths_clamp1,
-            self.c128_out_loc,
-            _,
-            _,
-            self.c128_topk_lengths_clamp1,
-            self.c128_page_indices,
-        ) = _init_compression_metadata_triton(
-            self.seq_lens_casual,
-            self.positions_casual,
-            self.raw_out_loc,
-            self.page_table,
-            self.page_size,
-            compute_page_indices=True,
-        )
+        has_c4 = 4 in self.present_ratios
+        has_c128 = 128 in self.present_ratios
+        if has_c4 or has_c128:
+            # One kernel produces both ratios; compute_page_indices=False only
+            # drops the [T, max_c128_len] table, which is c128-only.
+            (
+                c4_out_loc,
+                _,
+                c4_topk_lengths_raw,
+                c4_topk_lengths_clamp1,
+                c128_out_loc,
+                _,
+                _,
+                c128_topk_lengths_clamp1,
+                c128_page_indices,
+            ) = _init_compression_metadata_triton(
+                self.seq_lens_casual,
+                self.positions_casual,
+                self.raw_out_loc,
+                self.page_table,
+                self.page_size,
+                compute_page_indices=has_c128,
+            )
+            if has_c4:
+                self.c4_out_loc = c4_out_loc
+                self.c4_topk_lengths_raw = c4_topk_lengths_raw
+                self.c4_topk_lengths_clamp1 = c4_topk_lengths_clamp1
+            if has_c128:
+                self.c128_out_loc = c128_out_loc
+                self.c128_topk_lengths_clamp1 = c128_topk_lengths_clamp1
+                self.c128_page_indices = _pad_last_dim(c128_page_indices)
 
-        self.c128_page_indices = _pad_last_dim(self.c128_page_indices)
         self.swa_page_indices = _pad_last_dim(self.swa_page_indices)
+
+        if 1 in self.low_ratios:
+            self.c1_out_loc, self.c1_topk_lengths_clamp1 = (
+                _low_ratio_compression_metadata(
+                    1, self.seq_lens_casual, self.raw_out_loc
+                )
+            )
+        if 2 in self.low_ratios:
+            self.c2_out_loc, self.c2_topk_lengths_clamp1 = (
+                _low_ratio_compression_metadata(
+                    2, self.seq_lens_casual, self.raw_out_loc
+                )
+            )
 
     # Cache-write locations stay in global logical order and are intentionally
     # excluded from CP reindexing.
@@ -328,28 +725,43 @@ class DSV4AttnMetadata:
         "swa_page_indices",
         "swa_topk_lengths",
         "page_table",
+    ]
+    # Same treatment, None for models without that compress ratio.
+    _CP_REINDEX_OPTIONAL_FIELDS = [
         "c4_topk_lengths_raw",
         "c4_topk_lengths_clamp1",
         "c128_page_indices",
         "c128_topk_lengths_clamp1",
+        "c1_topk_lengths_clamp1",
+        "c2_topk_lengths_clamp1",
     ]
     _CP_GLOBAL_FIELDS = [
         "raw_out_loc",
         "swa_out_cache_loc",
         "c4_out_loc",
         "c128_out_loc",
+        "c1_out_loc",
+        "c2_out_loc",
     ]
 
-    def apply_cp_reindex(self, num_tokens: Optional[int] = None) -> None:
+    def apply_cp_reindex(
+        self,
+        num_tokens: Optional[int] = None,
+        local_index: Optional[torch.Tensor] = None,
+    ) -> None:
         cp_rank = get_parallel().attn_cp_rank
         cp_size = get_parallel().attn_cp_size
-        idx = slice(cp_rank, None, cp_size)
         pre_global_len = self.seq_lens_casual.shape[0]
-        assert pre_global_len % cp_size == 0, (
-            f"apply_cp_reindex: global token count {pre_global_len} is not divisible by cp_size={cp_size}. "
-            "CP round-robin requires padding to ensure divisibility."
-        )
-        expected_local_len = pre_global_len // cp_size
+        if local_index is not None:
+            idx = local_index
+            expected_local_len = local_index.shape[0]
+        else:
+            idx = slice(cp_rank, None, cp_size)
+            assert pre_global_len % cp_size == 0, (
+                f"apply_cp_reindex: global token count {pre_global_len} is not divisible by cp_size={cp_size}. "
+                "CP round-robin requires padding to ensure divisibility."
+            )
+            expected_local_len = pre_global_len // cp_size
         if num_tokens is None:
             num_tokens = pre_global_len
         for field_name in self._CP_REINDEX_FIELDS:
@@ -358,9 +770,15 @@ class DSV4AttnMetadata:
                 f"CP reindex: {field_name} is {type(val)}, expected Tensor"
             )
             setattr(self, field_name, val[idx].contiguous())
-
-        for field_name in self._CP_REINDEX_FIELDS:
+        for field_name in self._CP_REINDEX_OPTIONAL_FIELDS:
             val = getattr(self, field_name)
+            if val is not None:
+                setattr(self, field_name, val[idx].contiguous())
+
+        for field_name in self._CP_REINDEX_FIELDS + self._CP_REINDEX_OPTIONAL_FIELDS:
+            val = getattr(self, field_name)
+            if val is None:
+                continue
             assert val.shape[0] == expected_local_len, (
                 f"apply_cp_reindex post-condition: {field_name}.shape[0]={val.shape[0]} "
                 f"!= expected_local_len={expected_local_len} (cp_size={cp_size})"
@@ -375,28 +793,106 @@ class DSV4AttnMetadata:
             )
 
     def init_flashmla_related(self, is_prefill: bool = False):
-        # c4_sparse_topk is set from model_config.index_topk per-model
-        # (small model: 512, large model: 1024).
-        assert self.c4_sparse_topk in (512, 1024), (
-            f"unexpected c4_sparse_topk={self.c4_sparse_topk}; "
+        assert self.index_topk in (512, 1024), (
+            f"unexpected index_topk={self.index_topk}; "
             "supported: 512 (small) or 1024 (large)"
         )
-        assert self.c4_topk_lengths_clamp1 is not None
-        self.c4_sparse_topk_lengths = torch.clamp(
-            self.c4_topk_lengths_clamp1, max=self.c4_sparse_topk
+        has_c4 = 4 in self.present_ratios
+        has_c128 = 128 in self.present_ratios
+        if has_c4:
+            assert self.c4_topk_lengths_clamp1 is not None
+            self.c4_sparse_topk_lengths = torch.clamp(
+                self.c4_topk_lengths_clamp1, max=self.index_topk
+            )
+            self.c4_sparse_page_indices = torch.full(
+                (self.c4_topk_lengths_clamp1.size(0), self.index_topk),
+                -1,
+                dtype=torch.int32,
+                device=self.c4_topk_lengths_clamp1.device,
+            )
+            self.c4_sparse_page_indices = _pad_last_dim(self.c4_sparse_page_indices)
+            if is_prefill:
+                self.c4_sparse_raw_indices = torch.empty_like(
+                    self.c4_sparse_page_indices
+                )
+        else:
+            self.c4_sparse_topk_lengths = None
+            self.c4_sparse_page_indices = None
+            self.c4_sparse_raw_indices = None
+        self.c0_flashmla_metadata = _create_flashmla_metadata()
+        self.c4_flashmla_metadata = _create_flashmla_metadata() if has_c4 else None
+        self.c128_flashmla_metadata = _create_flashmla_metadata() if has_c128 else None
+        if 1 in self.low_ratios:
+            (
+                self.c1_sparse_topk_lengths,
+                self.c1_sparse_page_indices,
+                self.c1_sparse_raw_indices,
+            ) = _low_ratio_sparse_buffers(
+                self.c1_topk_lengths_clamp1, self.index_topk, is_prefill
+            )
+            self.c1_flashmla_metadata = _create_flashmla_metadata()
+        if 2 in self.low_ratios:
+            (
+                self.c2_sparse_topk_lengths,
+                self.c2_sparse_page_indices,
+                self.c2_sparse_raw_indices,
+            ) = _low_ratio_sparse_buffers(
+                self.c2_topk_lengths_clamp1, self.index_topk, is_prefill
+            )
+            self.c2_flashmla_metadata = _create_flashmla_metadata()
+
+
+class LateLayerTail(msgspec.Struct, frozen=True):
+    """The token subset the layers after the last kv_source layer run over under
+    decoder SWA bounded replay: the last tail tokens of every request in the
+    extend. Consumers that would otherwise read the extend layout off the
+    forward_batch read these instead."""
+
+    token_indices: torch.Tensor
+    positions: torch.Tensor
+    extend_seq_lens: torch.Tensor
+    extend_seq_lens_cpu: List[int]
+    swa_out_cache_loc: torch.Tensor
+    # Set when the tail is the extend's last rows (one request): row selection
+    # is then a view, not a gather.
+    contiguous_start: Optional[int] = None
+    # prefill CP: this rank's tail rows padded to the largest share; cp_metadata is that layout
+    pad_rows: int = 0
+    cp_metadata: Optional[InterleaveContextParallelMetadata] = None
+    local_lens_cpu: Optional[List[int]] = None
+    req_global: Optional[torch.Tensor] = None
+    pos_global: Optional[torch.Tensor] = None
+
+    def rows(self, t: torch.Tensor) -> torch.Tensor:
+        rows = self.real_rows(t)
+        if self.pad_rows:
+            rows = torch.cat([rows, rows.new_zeros((self.pad_rows, *rows.shape[1:]))])
+        return rows
+
+    def real_rows(self, t: torch.Tensor) -> torch.Tensor:
+        return _tail_rows(
+            t, token_indices=self.token_indices, contiguous_start=self.contiguous_start
         )
-        self.c4_sparse_page_indices = torch.full(
-            (self.c4_topk_lengths_clamp1.size(0), self.c4_sparse_topk),
-            -1,
-            dtype=torch.int32,
-            device=self.c4_topk_lengths_clamp1.device,
-        )
-        self.c4_sparse_page_indices = _pad_last_dim(self.c4_sparse_page_indices)
-        if is_prefill:
-            self.c4_sparse_raw_indices = torch.empty_like(self.c4_sparse_page_indices)
-        self.c1_flashmla_metadata = _create_flashmla_metadata()
-        self.c4_flashmla_metadata = _create_flashmla_metadata()
-        self.c128_flashmla_metadata = _create_flashmla_metadata()
+
+
+def _tail_rows(
+    t: torch.Tensor, *, token_indices: torch.Tensor, contiguous_start: Optional[int]
+) -> torch.Tensor:
+    if contiguous_start is not None:
+        return t[contiguous_start:]
+    return t[token_indices]
+
+
+# Prefill CUDA graph: the ratio-1/2 indexer scores through the paged kernel on
+# a static logits width of cuda_graph_config[prefill].max_seq_len positions
+# (batches with a longer context replay eagerly), in chunks of this many rows.
+_PREFILL_GRAPH_INDEXER_ROW_CHUNK = 2048
+
+
+def _prefill_graph_max_seq_len() -> Optional[int]:
+    from sglang.srt.runtime_context import get_exec
+
+    return get_exec().graph.cuda_graph_config.prefill.max_seq_len
 
 
 @dataclass
@@ -404,13 +900,31 @@ class DSV4Metadata:
     core_attn_metadata: DSV4AttnMetadata
     indexer_metadata: Optional[PagedIndexerMetadata]
 
+    # Low-ratio paged indexer metadata for decode and prefill graph replay.
+    # Ratio 4 uses indexer_metadata above.
+    c1_indexer_metadata: Optional[PagedIndexerMetadata] = None
+    c2_indexer_metadata: Optional[PagedIndexerMetadata] = None
+
     c4_compress_metadata: Optional[FusedCompressMetadata] = None
     c128_compress_metadata: Optional[FusedCompressMetadata] = None
+
+    # Shared by all low-ratio source layers in this step;
+    # graph replay refreshes these tensors from live request metadata.
+    low_ratio_req_indices: Optional[torch.Tensor] = None
+    low_ratio_pos_i64: Optional[torch.Tensor] = None
+
+    # Per-step scratch for TP-padded query heads, zeroed by the first user.
+    # Later layers overwrite real heads and preserve the zero padding.
+    q_pad_buffer: Optional[torch.Tensor] = None
 
     # Built at the runner's prefill WAR boundary when the fast path is on,
     # otherwise lazily by ``_forward_prefill_sparse``.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
     prefill_shared_reads_snapshotted: bool = False
+
+    # Set only on the metadata built for the late layers under decoder SWA
+    # bounded replay; None everywhere else.
+    late_layer_tail: Optional[LateLayerTail] = None
 
     @property
     def core_metadata(self) -> DSV4AttnMetadata:
@@ -419,6 +933,8 @@ class DSV4Metadata:
     def copy_(self, other: DSV4Metadata):
         self.core_attn_metadata.copy_(other.core_attn_metadata)
         maybe_copy_inplace(self.indexer_metadata, src=other.indexer_metadata)
+        maybe_copy_inplace(self.c1_indexer_metadata, src=other.c1_indexer_metadata)
+        maybe_copy_inplace(self.c2_indexer_metadata, src=other.c2_indexer_metadata)
         maybe_copy_inplace(self.c4_compress_metadata, src=other.c4_compress_metadata)
         maybe_copy_inplace(
             self.c128_compress_metadata, src=other.c128_compress_metadata
@@ -431,6 +947,18 @@ class DSV4Metadata:
             static_metadata.core_attn_metadata
         )
         maybe_copy_inplace(self.indexer_metadata, src=static_metadata.indexer_metadata)
+        maybe_copy_inplace(
+            self.c1_indexer_metadata, src=static_metadata.c1_indexer_metadata
+        )
+        maybe_copy_inplace(
+            self.c2_indexer_metadata, src=static_metadata.c2_indexer_metadata
+        )
+        maybe_copy_inplace(
+            self.low_ratio_req_indices, src=static_metadata.low_ratio_req_indices
+        )
+        maybe_copy_inplace(
+            self.low_ratio_pos_i64, src=static_metadata.low_ratio_pos_i64
+        )
         maybe_copy_inplace(
             self.c4_compress_metadata, src=static_metadata.c4_compress_metadata
         )
@@ -539,6 +1067,7 @@ class DeepseekV4AttnBackend(
     ):
         super().__init__()
         self.model_runner = model_runner
+        self.encoder_replay = False
         self.device = torch.device(model_runner.device)
         self.max_context_len = model_runner.model_config.context_len
         head_dim = model_runner.model_config.head_dim
@@ -558,16 +1087,36 @@ class DeepseekV4AttnBackend(
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        # The distinct ratios this stage has, sorted -- (4, 128) for V4, (1, 2)
+        # for V4.1 -- not the per-layer hf_config.compress_ratios list. Nothing
+        # is built for a ratio outside this set.
+        self.present_ratios: Tuple[int, ...] = tuple(
+            sorted(self.token_to_kv_pool.kv_pools)
+        )
+        self.low_ratios: Tuple[int, ...] = tuple(
+            ratio for ratio in (1, 2) if ratio in self.present_ratios
+        )
+        self.has_c4: bool = 4 in self.present_ratios
+        self.has_c128: bool = 128 in self.present_ratios
+        # Per-request candidate masks the candidate_source layer publishes for the
+        # index_source layers after it (torch indexer scratch).
+        self.candidate_masks: Optional[List[torch.Tensor]] = None
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
 
         assert isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
-        self.c4_topk = getattr(
+        self.index_topk = getattr(
             model_runner.model_config.hf_text_config, "index_topk", C4_TOPK
         )
 
         self.enable_deepseek_v4_fp4_indexer: bool = (
             model_runner.server_args.enable_deepseek_v4_fp4_indexer
         )
+        self.enable_decoder_swa_bounded_replay: bool = (
+            model_runner.server_args.enable_decoder_swa_bounded_replay
+        )
+        # Built with the regular prefill metadata; the model switches onto it
+        # after the last kv_source layer (enter_late_layer_tail).
+        self.tail_forward_metadata: Optional[DSV4Metadata] = None
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
         self.dsv4_prefill_backend: str = getattr(
             model_runner.server_args, "dsv4_prefill_backend", "auto"
@@ -673,7 +1222,7 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool,
         online_c128_state_slot_offset: int,
     ) -> Optional[FusedCompressMetadata]:
-        if not self.online_c128_mtp.enabled():
+        if not self.has_c128 or not self.online_c128_mtp.enabled():
             return None
 
         assert seq_lens_cpu is not None
@@ -698,12 +1247,36 @@ class DeepseekV4AttnBackend(
         self,
         core_attn_metadata: DSV4AttnMetadata,
         *,
+        compress_ratio: int = 4,
         use_prefill_cuda_graph: bool = False,
     ):
+        page_table = core_attn_metadata.page_table
+        index_page_size = 0
+        if compress_ratio == 4:
+            c_seq_lens = core_attn_metadata.c4_topk_lengths_raw
+        elif compress_ratio in (1, 2):
+            c_seq_lens = (
+                core_attn_metadata.c1_topk_lengths_clamp1
+                if compress_ratio == 1
+                else core_attn_metadata.c2_topk_lengths_clamp1
+            )
+            # The low-ratio indexer-K pool pages at 64 slots, not page_size //
+            # ratio, so the kernel needs a block table at that granularity.
+            index_page_size = self.token_to_kv_pool.get_index_k_page_size(
+                compress_ratio
+            )
+            page_table = _expand_index_page_table(
+                page_table,
+                full_page_size=self.page_size,
+                compress_ratio=compress_ratio,
+                index_page_size=index_page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported indexer {compress_ratio = }")
         return PagedIndexerMetadata(
             page_size=self.page_size,
-            page_table=core_attn_metadata.page_table,
-            c4_seq_lens=core_attn_metadata.c4_topk_lengths_raw,
+            page_table=page_table,
+            c4_seq_lens=c_seq_lens,
             use_topk_v2=self.dsa_topk_backend.should_use_topk_v2() and not _is_xpu,
             # The SM120 FP4 kernel schedules split_kv=128, while the generic
             # JIT metadata planner encodes split_kv=256.
@@ -711,6 +1284,8 @@ class DeepseekV4AttnBackend(
                 self.enable_deepseek_v4_fp4_indexer and get_platform().is_sm120
             ),
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            compress_ratio=compress_ratio,
+            index_page_size=index_page_size,
         )
 
     def init_forward_metadata_decode(
@@ -746,13 +1321,25 @@ class DeepseekV4AttnBackend(
         online_c128_state_slot_offset: int = 0,
         dspark_block_size: Optional[int] = None,
         forward_batch: Optional[ForwardBatch] = None,
+        swa_replay_start: Optional[torch.Tensor] = None,
+        cp_metadata: Optional[InterleaveContextParallelMetadata] = None,
+        dspark_swa_buffers: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> DSV4Metadata:
         padded_num_tokens = out_cache_loc.shape[0]
         cp_v2_active = forward_batch is not None and is_cp_v2_active(forward_batch)
         if cp_v2_active:
-            cp_metadata = forward_batch.attn_cp_metadata
+            if cp_metadata is None:
+                cp_metadata = forward_batch.attn_cp_metadata
             assert cp_metadata is not None
             padded_num_tokens = sum(cp_metadata.per_rank_actual_token)
+            if (
+                swa_replay_start is not None
+                and swa_replay_start.shape[0] < padded_num_tokens
+            ):
+                swa_replay_start = torch.nn.functional.pad(
+                    swa_replay_start,
+                    (0, padded_num_tokens - swa_replay_start.shape[0]),
+                )
 
         seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
             num_tokens=num_tokens,
@@ -773,17 +1360,22 @@ class DeepseekV4AttnBackend(
             need_compress=need_compress,
             is_prefill=True,
             dspark_block_size=dspark_block_size,
+            dspark_swa_buffers=dspark_swa_buffers,
             num_tokens=num_tokens if cp_v2_active else None,
+            swa_replay_start=swa_replay_start,
+            num_groups=len(extend_seq_lens_cpu),
         )
         if cp_v2_active:
-            core_attn_metadata.apply_cp_reindex(num_tokens=num_tokens)
+            core_attn_metadata.apply_cp_reindex(
+                num_tokens=num_tokens, local_index=cp_metadata.local_index
+            )
             core_attn_metadata.init_flashmla_related(is_prefill=True)
         indexer_metadata = (
             self.init_forward_metadata_indexer(
                 core_attn_metadata,
                 use_prefill_cuda_graph=use_prefill_cuda_graph,
             )
-            if need_compress
+            if need_compress and self.has_c4
             else None
         )
         if not need_compress:
@@ -826,14 +1418,297 @@ class DeepseekV4AttnBackend(
                     online_state_slot_offset=online_c128_state_slot_offset,
                 )
 
-        c4_compress_metadata = create(compress_ratio=4)
-        c128_compress_metadata = create(compress_ratio=128)
-        return DSV4Metadata(
+        metadata = DSV4Metadata(
             core_attn_metadata,
             indexer_metadata,
-            c4_compress_metadata=c4_compress_metadata,
-            c128_compress_metadata=c128_compress_metadata,
+            c4_compress_metadata=create(compress_ratio=4) if self.has_c4 else None,
+            c128_compress_metadata=(
+                create(compress_ratio=128) if self.has_c128 else None
+            ),
         )
+        if use_prefill_cuda_graph and self.low_ratio_prefill_graph:
+            low = core_attn_metadata.low_ratios
+            metadata.c1_indexer_metadata = (
+                self._low_ratio_prefill_indexer_metadata(core_attn_metadata, 1)
+                if 1 in low
+                else None
+            )
+            metadata.c2_indexer_metadata = (
+                self._low_ratio_prefill_indexer_metadata(core_attn_metadata, 2)
+                if 2 in low
+                else None
+            )
+            metadata.low_ratio_req_indices = req_pool_indices_repeated.to(torch.int64)
+            metadata.low_ratio_pos_i64 = core_attn_metadata.positions_casual.to(
+                torch.int64
+            )
+        return metadata
+
+    def _low_ratio_prefill_indexer_metadata(
+        self, core: DSV4AttnMetadata, compress_ratio: int
+    ) -> PagedIndexerMetadata:
+        """Per-token paged indexer metadata for the prefill CUDA graph, capped at
+        the graph's max_seq_len so the logits width is static and bounded."""
+        num_pages = core.page_table.shape[1]
+        max_seq_len = _prefill_graph_max_seq_len()
+        if max_seq_len is not None:
+            num_pages = min(max_seq_len // self.page_size, num_pages)
+        index_page_size = self.token_to_kv_pool.get_index_k_page_size(compress_ratio)
+        page_table = _expand_index_page_table(
+            core.page_table[:, :num_pages],
+            full_page_size=self.page_size,
+            compress_ratio=compress_ratio,
+            index_page_size=index_page_size,
+        )
+        # Unclamped: a token with no completed group scores nothing (-1 rows),
+        # matching the eager extend indexer.
+        c_seq_lens = (core.seq_lens_casual // compress_ratio).to(torch.int32)
+        row_chunk = _PREFILL_GRAPH_INDEXER_ROW_CHUNK
+        return PagedIndexerMetadata(
+            page_size=self.page_size,
+            page_table=page_table,
+            c4_seq_lens=c_seq_lens,
+            use_topk_v2=False,
+            use_prefill_cuda_graph=True,
+            compress_ratio=compress_ratio,
+            index_page_size=index_page_size,
+            row_chunk=row_chunk if row_chunk < c_seq_lens.shape[0] else 0,
+        )
+
+    @property
+    def low_ratio_prefill_graph(self) -> bool:
+        """The ratio-1/2 sources can run inside the prefill CUDA graph."""
+        return (
+            bool(self.low_ratios) and _has_dense_fp4_indexer() and _is_sm100_or_newer()
+        )
+
+    def can_run_prefill_cuda_graph(self, forward_batch: ForwardBatch) -> bool:
+        max_seq_len = _prefill_graph_max_seq_len()
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        if max_seq_len is None or seq_lens_cpu is None or seq_lens_cpu.numel() == 0:
+            return True
+        return int(seq_lens_cpu.max().item()) <= max_seq_len
+
+    def _build_late_layer_tail_metadata(
+        self, forward_batch: ForwardBatch
+    ) -> DSV4Metadata:
+        """Metadata for the layers after the last kv_source layer under decoder
+        SWA bounded replay: each request contributes only its last SWA_WINDOW
+        extend tokens, and their window is floored at the tail start because
+        window KV before it is never written at those layers."""
+        extend_lens_cpu = forward_batch.extend_seq_lens_cpu
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        assert extend_lens_cpu is not None and seq_lens_cpu is not None
+        device = forward_batch.out_cache_loc.device
+        token_indices, tail_lens_cpu, swa_replay_start = late_layer_tail_layout(
+            extend_lens_cpu=extend_lens_cpu,
+            seq_lens_cpu=seq_lens_cpu.tolist(),
+            tail_len=SWA_WINDOW,
+            device=device,
+        )
+        contiguous_start = (
+            extend_lens_cpu[0] - tail_lens_cpu[0] if len(extend_lens_cpu) == 1 else None
+        )
+        out_cache_loc = _tail_rows(
+            forward_batch.out_cache_loc,
+            token_indices=token_indices,
+            contiguous_start=contiguous_start,
+        )
+        tail_lens = torch.tensor(tail_lens_cpu, dtype=torch.int32, device=device)
+        cp_tail = (
+            self._late_layer_tail_cp_layout(forward_batch, token_indices, tail_lens)
+            if is_cp_v2_active(forward_batch)
+            else None
+        )
+
+        metadata = self.init_forward_metadata_prefill(
+            max_seq_len=int(seq_lens_cpu.max().item()),
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens.to(torch.int32),
+            seq_lens_cpu=seq_lens_cpu.tolist(),
+            out_cache_loc=out_cache_loc,
+            num_tokens=sum(tail_lens_cpu),
+            extend_seq_lens=tail_lens,
+            extend_seq_lens_cpu=tail_lens_cpu,
+            extend_start_loc=torch.cumsum(tail_lens, dim=0) - tail_lens,
+            swa_replay_start=swa_replay_start,
+            forward_batch=forward_batch if cp_tail is not None else None,
+            cp_metadata=cp_tail["cp_metadata"] if cp_tail is not None else None,
+        )
+        swa_out_cache_loc = (
+            metadata.core_attn_metadata.request_window_layout.write_loc
+            if self.token_to_kv_pool.request_window is not None
+            else self.token_to_kv_pool.translate_loc_from_full_to_swa(out_cache_loc).to(
+                torch.int32
+            )
+        )
+        metadata.core_attn_metadata.swa_out_cache_loc = swa_out_cache_loc
+        metadata.low_ratio_req_indices = torch.repeat_interleave(
+            forward_batch.req_pool_indices.to(torch.int64), tail_lens.to(torch.int64)
+        )
+        positions = _tail_rows(
+            forward_batch.positions,
+            token_indices=token_indices,
+            contiguous_start=contiguous_start,
+        )
+        metadata.low_ratio_pos_i64 = positions.to(torch.int64)
+        if cp_tail is None:
+            # Without CP, tail rows index the full extend on this rank.
+            metadata.late_layer_tail = LateLayerTail(
+                token_indices=token_indices,
+                positions=positions,
+                extend_seq_lens=tail_lens,
+                extend_seq_lens_cpu=tail_lens_cpu,
+                swa_out_cache_loc=swa_out_cache_loc,
+                contiguous_start=contiguous_start,
+            )
+        else:
+            # With CP, select from this rank's extend and pad for collectives.
+            metadata.late_layer_tail = LateLayerTail(
+                token_indices=cp_tail["local_token_indices"],
+                positions=cp_tail["local_positions"],
+                extend_seq_lens=tail_lens,
+                extend_seq_lens_cpu=tail_lens_cpu,
+                swa_out_cache_loc=swa_out_cache_loc,
+                pad_rows=cp_tail["pad_rows"],
+                cp_metadata=cp_tail["cp_metadata"],
+                local_lens_cpu=cp_tail["local_lens_cpu"],
+                req_global=metadata.low_ratio_req_indices,
+                pos_global=metadata.low_ratio_pos_i64,
+            )
+        return metadata
+
+    def _late_layer_tail_cp_layout(
+        self,
+        forward_batch: ForwardBatch,
+        token_indices: torch.Tensor,
+        tail_lens: torch.Tensor,
+    ) -> dict:
+        """Keep bounded-replay tail rows on their original CP ranks, with padding."""
+        cp_rank = get_parallel().attn_cp_rank
+        cp_size = get_parallel().attn_cp_size
+        device = token_indices.device
+        total = token_indices.shape[0]
+        owner_rank = token_indices % cp_size
+        counts = torch.bincount(owner_rank, minlength=cp_size).tolist()
+        max_local = max(counts)
+        order = torch.argsort(owner_rank, stable=True)
+        rank_starts = torch.tensor(
+            [sum(counts[:r]) for r in range(cp_size)],
+            dtype=torch.int64,
+            device=device,
+        )
+        slot = torch.empty_like(owner_rank)
+        slot[order] = (
+            torch.arange(total, device=device) - rank_starts[owner_rank[order]]
+        )
+        gather_index = owner_rank * max_local + slot
+
+        local_tail_rows = (owner_rank == cp_rank).nonzero().squeeze(1)
+        pad_rows = max_local - counts[cp_rank]
+        # Give each rank distinct padding rows in the compact tail metadata.
+        pad_start = total + sum(max_local - c for c in counts[:cp_rank])
+        local_metadata_rows = torch.cat(
+            [
+                local_tail_rows,
+                torch.arange(pad_start, pad_start + pad_rows, device=device),
+            ]
+        )
+        tail_request_ids = torch.repeat_interleave(
+            torch.arange(forward_batch.batch_size, device=device),
+            tail_lens.to(torch.int64),
+            output_size=total,
+        )
+        local_positions = torch.cat(
+            [
+                forward_batch.positions[token_indices[local_tail_rows]],
+                forward_batch.positions.new_zeros(pad_rows),
+            ]
+        )
+        cp_metadata = InterleaveContextParallelMetadata(
+            per_rank_actual_token=[max_local] * cp_size,
+            max_rank_len=[max_local] * cp_size,
+            total_seq_lens=total,
+            bs=forward_batch.batch_size,
+            per_rank_logical_token=counts,
+            gather_index=gather_index,
+            local_index=local_metadata_rows,
+        )
+        return dict(
+            cp_metadata=cp_metadata,
+            local_token_indices=(token_indices[local_tail_rows] - cp_rank) // cp_size,
+            local_positions=local_positions,
+            local_lens_cpu=torch.bincount(
+                tail_request_ids[local_tail_rows], minlength=forward_batch.batch_size
+            ).tolist(),
+            pad_rows=pad_rows,
+        )
+
+    def enter_late_layer_tail(self, forward_batch: ForwardBatch) -> tuple:
+        """Switch the late layers onto the tail; hand the return value back to
+        exit_late_layer_tail. The candidate-source layer published its masks over
+        the full extend, so each request's mask is cut to its tail rows."""
+        tail_metadata = self.tail_forward_metadata
+        assert tail_metadata is not None, "no tail metadata for this forward"
+        saved = (
+            self.forward_metadata,
+            self.candidate_masks,
+            forward_batch.attn_cp_metadata,
+            get_local_dp_buffer_len(),
+        )
+        tail = tail_metadata.late_layer_tail
+        tail_lens_cpu = (
+            tail.local_lens_cpu
+            if tail.cp_metadata is not None
+            else tail.extend_seq_lens_cpu
+        )
+        if isinstance(self.candidate_masks, list) and self.candidate_masks:
+            self.candidate_masks = [
+                mask[mask.shape[0] - t :]
+                for mask, t in zip(self.candidate_masks, tail_lens_cpu)
+            ]
+        # The last index-source layer before the switch published its top-k into
+        # the full metadata's buffers; the consumer layers after the switch read
+        # the tail metadata's, so carry the tail rows over (padding stays -1).
+        full_core = saved[0].core_attn_metadata
+        tail_core = tail_metadata.core_attn_metadata
+        for ratio in tail_core.low_ratios:
+            for full_buf, tail_buf in (
+                (
+                    full_core.sparse_page_indices(ratio),
+                    tail_core.sparse_page_indices(ratio),
+                ),
+                (
+                    full_core.sparse_topk_lengths(ratio),
+                    tail_core.sparse_topk_lengths(ratio),
+                ),
+                (
+                    full_core.sparse_raw_indices(ratio),
+                    tail_core.sparse_raw_indices(ratio),
+                ),
+            ):
+                if full_buf is None or tail_buf is None:
+                    continue
+                rows = tail.real_rows(full_buf)
+                tail_buf[: rows.shape[0]].copy_(rows)
+        self.forward_metadata = tail_metadata
+        if self.token_to_kv_pool.request_window is not None:
+            self.token_to_kv_pool.request_window.activate(
+                tail_core.request_window_layout
+            )
+        if tail.cp_metadata is not None:
+            forward_batch.attn_cp_metadata = tail.cp_metadata
+            set_local_dp_buffer_len(sum(tail.cp_metadata.per_rank_actual_token))
+        return saved
+
+    def exit_late_layer_tail(self, saved: tuple, forward_batch: ForwardBatch) -> None:
+        (
+            self.forward_metadata,
+            self.candidate_masks,
+            forward_batch.attn_cp_metadata,
+            local_dp_buffer_len,
+        ) = saved
+        set_local_dp_buffer_len(local_dp_buffer_len)
 
     def init_forward_metadata_target_verify(
         self,
@@ -894,6 +1769,7 @@ class DeepseekV4AttnBackend(
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: torch.Tensor,
         block_size: int,
+        dspark_swa_buffers: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> DSV4Metadata:
         if seq_lens_cpu is None:
             seq_lens_cpu_list = seq_lens.tolist()
@@ -918,6 +1794,7 @@ class DeepseekV4AttnBackend(
             need_compress=False,
             use_prefill_cuda_graph=False,
             dspark_block_size=block_size,
+            dspark_swa_buffers=dspark_swa_buffers,
         )
 
     def make_forward_metadata_from_raw_verify(
@@ -967,7 +1844,11 @@ class DeepseekV4AttnBackend(
             out_loc=out_cache_loc,
             need_compress=True,
         )
-        indexer_metadata = self.init_forward_metadata_indexer(core_attn_metadata)
+        indexer_metadata = (
+            self.init_forward_metadata_indexer(core_attn_metadata)
+            if self.has_c4
+            else None
+        )
         create = functools.partial(
             create_paged_compressor_data,
             is_prefill=True,
@@ -983,12 +1864,23 @@ class DeepseekV4AttnBackend(
             online_state_slot_offset=online_c128_state_slot_offset,
         )
         c128_compress_metadata = raw_metadata.c128_compress_metadata
-        if c128_compress_metadata is None:
+        if c128_compress_metadata is None and self.has_c128:
             c128_compress_metadata = create(compress_ratio=128)
+        low = core_attn_metadata.low_ratios
         return DSV4Metadata(
             core_attn_metadata,
             indexer_metadata,
-            c4_compress_metadata=create(compress_ratio=4),
+            c1_indexer_metadata=(
+                self.init_forward_metadata_indexer(core_attn_metadata, compress_ratio=1)
+                if 1 in low
+                else None
+            ),
+            c2_indexer_metadata=(
+                self.init_forward_metadata_indexer(core_attn_metadata, compress_ratio=2)
+                if 2 in low
+                else None
+            ),
+            c4_compress_metadata=create(compress_ratio=4) if self.has_c4 else None,
             c128_compress_metadata=c128_compress_metadata,
         )
 
@@ -1008,7 +1900,23 @@ class DeepseekV4AttnBackend(
             out_loc=out_cache_loc,
             need_compress=True,
         )
-        indexer_metadata = self.init_forward_metadata_indexer(core_attn_metadata)
+        indexer_metadata = (
+            self.init_forward_metadata_indexer(core_attn_metadata)
+            if self.has_c4
+            else None
+        )
+
+        low = core_attn_metadata.low_ratios
+        c1_indexer_metadata = (
+            self.init_forward_metadata_indexer(core_attn_metadata, compress_ratio=1)
+            if 1 in low
+            else None
+        )
+        c2_indexer_metadata = (
+            self.init_forward_metadata_indexer(core_attn_metadata, compress_ratio=2)
+            if 2 in low
+            else None
+        )
 
         create = functools.partial(
             create_paged_compressor_data,
@@ -1022,8 +1930,12 @@ class DeepseekV4AttnBackend(
         return DSV4Metadata(
             core_attn_metadata,
             indexer_metadata,
-            c4_compress_metadata=create(compress_ratio=4),
-            c128_compress_metadata=create(compress_ratio=128),
+            c1_indexer_metadata=c1_indexer_metadata,
+            c2_indexer_metadata=c2_indexer_metadata,
+            c4_compress_metadata=create(compress_ratio=4) if self.has_c4 else None,
+            c128_compress_metadata=(
+                create(compress_ratio=128) if self.has_c128 else None
+            ),
         )
 
     def init_forward_metadata_draft_extend(
@@ -1039,9 +1951,12 @@ class DeepseekV4AttnBackend(
         if swa_out_cache_loc is None and out_cache_loc is not None:
             # Eager-only miss (no graph state / oversized batch): translate once
             # per step instead of per layer at store time.
-            swa_out_cache_loc = self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                out_cache_loc
-            ).to(torch.int32)
+            if self.token_to_kv_pool.request_window is None:
+                swa_out_cache_loc = (
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        out_cache_loc
+                    ).to(torch.int32)
+                )
         if out_cache_loc is None:
             out_cache_loc = seq_lens.new_zeros(num_tokens)
 
@@ -1095,6 +2010,10 @@ class DeepseekV4AttnBackend(
         return buf[:n]
 
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        from sglang.srt.model_executor.runner_utils.capture_mode import (
+            skip_low_ratio_indexer,
+        )
+
         # Upgrade Raw->Full so the c4/c128 compress + core_attn + indexer
         # materialization is recorded inside the cuda graph; a no-op (Full
         # already) when PREP_IN_CUDA_GRAPH=0.
@@ -1108,12 +2027,26 @@ class DeepseekV4AttnBackend(
                 raw_metadata=self.forward_metadata,
             )
 
+        metadata = self.forward_metadata
+        if isinstance(metadata, DSV4Metadata):
+            core = metadata.core_metadata
+            for ratio in core.low_ratios:
+                if skip_low_ratio_indexer(ratio):
+                    # Share the full-position indices across layers of this ratio.
+                    fill_all_compressed_indices(
+                        core.page_table,
+                        core.sparse_topk_lengths(ratio),
+                        core.sparse_page_indices(ratio),
+                        compress_ratio=ratio,
+                        page_size=core.page_size,
+                        raw_indices=core.sparse_raw_indices(ratio),
+                    )
+
         # Compute the SWA KV-store write target once per forward and cache it on
         # the metadata for every layer's store. This is recorded inside the cuda
         # graph, so replay re-reads the live out_cache_loc buffer (spec-v2 and DP
         # padding rebind out_cache_loc after out-graph metadata prep). flash_mla
         # kernels require int32 indices.
-        metadata = self.forward_metadata
         if (
             isinstance(metadata, DSV4Metadata)
             and forward_batch.out_cache_loc is not None
@@ -1132,13 +2065,26 @@ class DeepseekV4AttnBackend(
                     self.topk,
                     self.speculative_num_steps,
                 )[self.speculative_step_id]
-            metadata.core_attn_metadata.swa_out_cache_loc = (
-                self.token_to_kv_pool.translate_loc_from_full_to_swa(out_cache_loc).to(
-                    torch.int32
+            if self.token_to_kv_pool.request_window is None:
+                metadata.core_attn_metadata.swa_out_cache_loc = (
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        out_cache_loc
+                    ).to(torch.int32)
                 )
-            )
 
-            if self.is_dspark_draft and forward_batch.forward_mode.is_target_verify():
+            # Refresh low-ratio source metadata from the live decode inputs.
+            if (
+                metadata.core_metadata.low_ratios
+                and forward_batch.forward_mode.is_decode()
+            ):
+                metadata.low_ratio_req_indices = token_req_indices(forward_batch)
+                metadata.low_ratio_pos_i64 = forward_batch.positions.to(torch.int64)
+
+            if (
+                self.is_dspark_draft
+                and forward_batch.forward_mode.is_target_verify()
+                and self.token_to_kv_pool.request_window is None
+            ):
                 block_size = int(forward_batch.spec_info.draft_token_num)
                 seq_lens_casual = self._dspark_seq_lens_casual(
                     seq_lens=forward_batch.seq_lens, block_size=block_size
@@ -1261,6 +2207,15 @@ class DeepseekV4AttnBackend(
                 req_pool_indices,
                 seq_lens,
             )
+            dspark_swa_buffers = None
+            captured_metadata = self.cuda_graph_metadata_of_bucket_and_bs[bucket].get(
+                bs
+            )
+            if not in_capture and captured_metadata is not None:
+                # Reuse only storage: the draft graph rebuilds both tensors from
+                # live inputs before attention. copy_ onto itself is a no-op.
+                core = captured_metadata.core_attn_metadata
+                dspark_swa_buffers = (core.swa_page_indices, core.swa_topk_lengths)
             temp_metadata = self.init_forward_metadata_dspark_draft_block(
                 max_seq_len=chosen_max_seq_len,
                 req_pool_indices=req_pool_indices,
@@ -1268,6 +2223,7 @@ class DeepseekV4AttnBackend(
                 seq_lens_cpu=seq_lens_cpu,
                 out_cache_loc=out_cache_loc_padded,
                 block_size=block_size,
+                dspark_swa_buffers=dspark_swa_buffers,
             )
         elif bucket == _GraphBucket.TARGET_VERIFY:
             verify_bs = _get_target_verify_bs(forward_batch)
@@ -1358,8 +2314,20 @@ class DeepseekV4AttnBackend(
             self.online_c128_mtp.clear()
             return
 
+        self.encoder_replay = forward_batch.encoder_swa_replay
         self.forward_metadata = self._build_forward_metadata(forward_batch)
         self.init_forward_metadata_in_graph(forward_batch)
+        self.tail_forward_metadata = (
+            self._build_late_layer_tail_metadata(forward_batch)
+            if self.enable_decoder_swa_bounded_replay
+            and forward_batch.forward_mode.is_extend_without_speculative()
+            else None
+        )
+
+        if self.token_to_kv_pool.request_window is not None:
+            self.token_to_kv_pool.request_window.activate(
+                self.forward_metadata.core_attn_metadata.request_window_layout
+            )
 
     def prepare_prefill_shared_read_snapshot(
         self, forward_batch: ForwardBatch, *, num_qo_tokens: int
@@ -1368,6 +2336,8 @@ class DeepseekV4AttnBackend(
         # first layer. DFLASH/DSPARK have no later prefill draft-extend reader;
         # CP-v2 shards the query layout that this global snapshot assumes.
         metadata = self.forward_metadata
+        if self.token_to_kv_pool.request_window is not None:
+            return
         if isinstance(metadata, DSV4Metadata):
             metadata.prefill_shared_reads_snapshotted = False
         snapshot_shared_prefill_reads = (
@@ -1380,23 +2350,37 @@ class DeepseekV4AttnBackend(
             return
 
         assert isinstance(metadata, DSV4Metadata)
-        use_sparse_prefill = not get_platform().is_sm120 and (
-            num_qo_tokens > _LARGE_INDEXER_QUERY_THRESHOLD
-            or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+        # The tail never takes the sparse path (see the dispatch in forward_extend),
+        # so its metadata carries no chunk cache.
+        use_sparse_prefill = (
+            not get_platform().is_sm120
+            and metadata.late_layer_tail is None
+            and (
+                num_qo_tokens > _LARGE_INDEXER_QUERY_THRESHOLD
+                or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+            )
         )
         if use_sparse_prefill:
             metadata.sparse_prefill_cache = self._build_sparse_prefill_chunk_cache(
-                forward_batch, num_qo_tokens=num_qo_tokens
+                forward_batch, metadata.core_attn_metadata, num_qo_tokens=num_qo_tokens
             )
         # Marked for dense prefill too: that path reads only core_attn_metadata,
         # which init_forward_metadata already snapshotted.
         metadata.prefill_shared_reads_snapshotted = True
 
     def _build_sparse_prefill_chunk_cache(
-        self, forward_batch: ForwardBatch, *, num_qo_tokens: int
+        self,
+        forward_batch: ForwardBatch,
+        core_attn_metadata: DSV4AttnMetadata,
+        *,
+        num_qo_tokens: int,
     ) -> SparsePrefillChunkCache:
         seq_lens_cpu = forward_batch.seq_lens_cpu
         assert seq_lens_cpu is not None
+        # The chunk cache gathers the W-1 positions before the chunk; under the
+        # tail those are late-layer window slots this prefill never wrote.
+        assert self.forward_metadata.late_layer_tail is None
+        extend_seq_lens = forward_batch.extend_seq_lens
         extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
         assert extend_seq_lens_cpu is not None
         seq_lens_cpu_list = seq_lens_cpu.tolist()
@@ -1406,11 +2390,29 @@ class DeepseekV4AttnBackend(
                 seq_lens_cpu_list, extend_seq_lens_cpu, strict=True
             )
         )
+        if is_cp_v2_active(forward_batch):
+            query_lens = torch.tensor(
+                interleave_rows_per_request(
+                    _as_int_list(extend_seq_lens_cpu),
+                    get_parallel().attn_cp_rank,
+                    get_parallel().attn_cp_size,
+                ),
+                dtype=torch.int32,
+                device=extend_seq_lens.device,
+            )
+        else:
+            query_lens = extend_seq_lens.to(torch.int32)
+        # padding rows are never combined
+        query_pos = core_attn_metadata.seq_lens_casual[:num_qo_tokens] - 1
+        if query_pos.shape[0] < num_qo_tokens:
+            query_pos = _pad_tensor_to_size(query_pos, num_qo_tokens, value=0)
         # ``swa_window_size`` on the pool is its storage page size, not the
         # model's SWA window, so pass both explicitly.
         return SparsePrefillChunkCache.build(
             seq_lens=forward_batch.seq_lens.to(torch.int32),
-            extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
+            extend_seq_lens=extend_seq_lens.to(torch.int32),
+            query_lens=query_lens,
+            query_pos=query_pos,
             req_pool_indices=forward_batch.req_pool_indices.to(torch.int32),
             req_to_token=self.req_to_token,
             full_to_swa=self.token_to_kv_pool.full_to_swa_index_mapping,
@@ -1537,7 +2539,42 @@ class DeepseekV4AttnBackend(
             max_seq_len_override=self.MAX_SEQ_LEN_FOR_CAPTURE,
             use_prefill_cuda_graph=True,
         )
+        if self.low_ratio_prefill_graph and forward_batch.forward_mode.is_extend():
+            for ratio in self.low_ratios:
+                self._source_projection_buffers(
+                    forward_batch.out_cache_loc.shape[0], ratio
+                )
         return self.forward_metadata
+
+    def _source_projection_buffers(self, num_tokens: int, ratio: int) -> dict:
+        """Reuse static source-projection buffers across prefill graph buckets.
+
+        Growing a buffer set must keep previous allocations alive for captured graphs.
+        """
+        cfg = self.model_runner.model_config.hf_text_config
+        heads, dim = int(cfg.index_n_heads), int(cfg.index_head_dim)
+        sets = getattr(self, "_source_proj_bufs", None) or {}
+        have = sets.get(ratio)
+        if have is None or have[0]["q"].shape[0] < num_tokens:
+            latent = self.model_runner.model_config.head_dim
+            zeros = lambda *shape, dtype: torch.zeros(
+                *shape, dtype=dtype, device=self.device
+            )
+            bufs = {
+                "q": zeros(num_tokens, heads, dim, dtype=torch.bfloat16),
+                "w": zeros(num_tokens, heads, dtype=torch.bfloat16),
+                "kv": zeros(
+                    num_tokens,
+                    latent,
+                    dtype=torch.bfloat16 if ratio == 1 else torch.float32,
+                ),
+            }
+            if ratio == 2:
+                bufs["score"] = zeros(num_tokens, latent, dtype=torch.float32)
+            sets[ratio] = [bufs] + (have or [])
+            self._source_proj_bufs = sets
+        bufs = sets[ratio][0]
+        return {name: buf[:num_tokens] for name, buf in bufs.items()}
 
     def prepare_forward_metadata_for_breakable_cuda_graph_replay(
         self,
@@ -1622,15 +2659,854 @@ class DeepseekV4AttnBackend(
             metadata.core_attn_metadata, DSV4AttnMetadata
         ):
             core = metadata.core_attn_metadata
-            core.c1_flashmla_metadata = _create_flashmla_metadata()
-            core.c4_flashmla_metadata = _create_flashmla_metadata()
-            core.c128_flashmla_metadata = _create_flashmla_metadata()
+            core.c0_flashmla_metadata = _create_flashmla_metadata()
+            if 4 in core.present_ratios:
+                core.c4_flashmla_metadata = _create_flashmla_metadata()
+            if 128 in core.present_ratios:
+                core.c128_flashmla_metadata = _create_flashmla_metadata()
+            if 1 in core.low_ratios:
+                core.c1_flashmla_metadata = _create_flashmla_metadata()
+            if 2 in core.low_ratios:
+                core.c2_flashmla_metadata = _create_flashmla_metadata()
 
         # PREP_IN_CUDA_GRAPH=True: warmup upgraded raw->full on the host;
         # restore raw so capture re-runs the upgrade inside the graph.
         current_raw = getattr(self, "_current_capture_raw", None)
         if current_raw is not None:
             self.forward_metadata = current_raw
+
+    # ---- DeepSeek V4.1 ratio 1/2 compressor and indexer, torch bring-up path ----
+
+    def forward_low_ratio_sources(
+        self,
+        *,
+        layer,
+        x,
+        q_lora,
+        positions,
+        forward_batch: ForwardBatch,
+        run_compressor: bool = True,
+        run_indexer: bool = True,
+    ) -> None:
+        """Runs on every ratio 1/2 layer before its attention; the metadata and
+        latents it writes are what the layers after it attend through."""
+        if forward_batch.forward_mode.is_idle():
+            return
+        if forward_batch.encoder_swa_replay:
+            run_compressor = False
+        if dsa_use_prefill_cp(forward_batch) and forward_batch.forward_mode.is_extend():
+            self._forward_low_ratio_sources_cp(
+                layer=layer,
+                x=x,
+                q_lora=q_lora,
+                positions=positions,
+                forward_batch=forward_batch,
+                run_compressor=run_compressor,
+                run_indexer=run_indexer,
+            )
+            return
+        meta = self.forward_metadata
+        hoisted_req = getattr(meta, "low_ratio_req_indices", None)
+        hoisted_pos = getattr(meta, "low_ratio_pos_i64", None)
+        if (
+            hoisted_req is not None
+            and hoisted_pos is not None
+            and hoisted_pos.shape[0] == positions.shape[0]
+        ):
+            # Bucket-sized under the prefill graph; an eager break sees the
+            # live rows only and falls through.
+            req, pos = hoisted_req, hoisted_pos
+        else:
+            req = token_req_indices(forward_batch, num_tokens=positions.shape[0])
+            pos = positions.to(torch.int64)
+        if (
+            forward_batch.forward_mode.is_extend()
+            and self._low_ratio_in_prefill_graph()
+        ):
+            bufs = self._source_projection_buffers(x.shape[0], layer.compress_ratio)
+            _bcg_low_ratio_source_projections(layer, x, q_lora, pos, bufs)
+            if run_compressor and layer.compressor is not None:
+                self._low_ratio_compress_torch(
+                    layer, x, req, pos, projected=(bufs["kv"], bufs.get("score"))
+                )
+            if run_indexer and layer.indexer is not None:
+                self._low_ratio_index_topk_prefill_graph(
+                    layer, pos, bufs["q"], bufs["w"]
+                )
+            return
+        if run_compressor and layer.compressor is not None:
+            self._low_ratio_compress(layer, x, req, pos, forward_batch)
+        if run_indexer and layer.indexer is not None:
+            self._low_ratio_index_topk(layer, x, q_lora, req, pos, forward_batch)
+
+    def _forward_low_ratio_sources_cp(
+        self, *, layer, x, q_lora, positions, forward_batch, run_compressor, run_indexer
+    ) -> None:
+        """Every rank writes the whole prompt's compressed state and scores its own rows."""
+        cp_meta = forward_batch.attn_cp_metadata
+        total = int(cp_meta.total_seq_lens)
+        tail = self.forward_metadata.late_layer_tail
+        if tail is not None:
+            q_lens_cpu = tail.local_lens_cpu
+            req_global, pos_global = tail.req_global, tail.pos_global
+        else:
+            q_lens_cpu = interleave_rows_per_request(
+                _as_int_list(forward_batch.extend_seq_lens_cpu),
+                get_parallel().attn_cp_rank,
+                get_parallel().attn_cp_size,
+            )
+            req_global = token_req_indices(forward_batch, num_tokens=total)
+            pos_global = forward_batch.positions[:total].to(torch.int64)
+        num_local = sum(q_lens_cpu)
+        if run_compressor and layer.compressor is not None:
+            x_global = cp_materialize_global_token_order(
+                x.contiguous(), forward_batch, torch.cuda.current_stream()
+            )[:total]
+            self._low_ratio_compress_torch(layer, x_global, req_global, pos_global)
+        if run_indexer and layer.indexer is not None:
+            self._low_ratio_index_topk_dense(
+                layer,
+                x[:num_local],
+                q_lora[:num_local],
+                positions[:num_local].to(torch.int64),
+                forward_batch,
+                torch.tensor(q_lens_cpu, dtype=torch.int32, device=x.device),
+                q_lens_cpu,
+            )
+
+    def _low_ratio_compress(self, layer, x, req, pos, forward_batch) -> None:
+        if forward_batch.forward_mode.is_decode():
+            self._low_ratio_compress_decode(layer, x, req, pos)
+        else:
+            self._low_ratio_compress_torch(layer, x, req, pos)
+
+    def _low_ratio_in_prefill_graph(self) -> bool:
+        from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
+            is_in_breakable_cuda_graph,
+        )
+
+        return self.low_ratio_prefill_graph and is_in_breakable_cuda_graph()
+
+    def _low_ratio_compress_decode(self, layer, x, req, pos) -> None:
+        # Projection layout and fused-write support are fixed together at load time;
+        # HIP and pre-Blackwell use split projections.
+        if layer.compressor.use_fused_compress:
+            self._low_ratio_compress_decode_fused(layer, x, req, pos)
+            return
+        if layer.compress_ratio == 1:
+            core = self.forward_metadata.core_metadata
+            kv, _ = layer.compressor.project(x)
+            slots = torch.where(
+                core.c1_out_loc >= 0, core.c1_out_loc, torch.zeros_like(core.c1_out_loc)
+            )
+            self._low_ratio_write_group(
+                layer,
+                kv,
+                slots,
+                pos,
+                fuse_index_store=(
+                    x.is_cuda
+                    and torch.version.cuda is not None
+                    and _is_sm100_or_newer()
+                ),
+            )
+            return
+        if not (x.is_cuda and torch.version.cuda):
+            self._low_ratio_compress_torch(layer, x, req, pos)
+            return
+
+        from sglang.kernels.ops.attention.dsv4.pair_pool_decode import pair_pool_decode
+
+        core = self.forward_metadata.core_metadata
+        state = self.token_to_kv_pool.get_attention_compress_states(layer.layer_id)
+        kv, score = layer.compressor.project(x)
+        pooled, group_pos, slots = pair_pool_decode(
+            kv,
+            score,
+            pos,
+            core.raw_out_loc,
+            core.c2_out_loc,
+            req,
+            state.kv_score_buffer.kv,
+            state.kv_score_buffer.score,
+            state.kv_score_buffer.shape[0] - 1,
+            ring_size=state.ring_size,
+        )
+        self._low_ratio_write_group(
+            layer,
+            pooled,
+            slots,
+            group_pos,
+            fuse_index_store=_is_sm100_or_newer(),
+        )
+
+    def _low_ratio_compress_decode_fused(self, layer, x, req, pos) -> None:
+        """Fused compressor write, index-key projection, then fused index-key write.
+        Both write kernels consume metadata dtypes directly and suppress padded stores.
+        """
+        from sglang.kernels.ops.attention.dsv4.c1 import c1_decode_norm_rope_store
+        from sglang.kernels.ops.attention.dsv4.c2 import c2_decode_norm_rope_store
+        from sglang.kernels.ops.attention.dsv4.fp4_rope import (
+            index_k_norm_rope_pack_store,
+        )
+
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        compressor = layer.compressor
+        layer_id = layer.layer_id
+        # Contiguous complex64 freqs_cis gives a real/imag-interleaved view without copying.
+        freqs_cis = torch.view_as_real(layer.freqs_cis).flatten(-2)
+        kv_cache = pool.get_extra_key_buffer(layer_id)
+        page_size = pool.get_extra_key_page_size(layer_id)
+        assert kv_cache is not None
+
+        if layer.compress_ratio == 1:
+            # At ratio 1, c1_out_loc equals the int64 raw_out_loc supplied by the scheduler.
+            latent = c1_decode_norm_rope_store(
+                compressor.wkv(x),
+                compressor.norm.weight.data,
+                pos,
+                core.raw_out_loc,
+                compressor.norm.eps,
+                freqs_cis,
+                kv_cache,
+                page_size=page_size,
+            )
+            out_loc = core.c1_out_loc
+        else:
+            # CompressStatePool stores each request's pending pairs in a position ring.
+            # KVAndScore rows use | kv | score |, addressed as req * ring_size + pos % ring_size.
+            state = pool.get_attention_compress_states(layer_id)
+            latent = c2_decode_norm_rope_store(
+                compressor.project_fused(x),
+                state.kv_score_buffer.kv_score,
+                compressor.norm.weight.data,
+                pos,
+                req,
+                core.raw_out_loc,
+                compressor.norm.eps,
+                freqs_cis,
+                kv_cache,
+                page_size=page_size,
+                ring_size=state.ring_size,
+            )
+            out_loc = core.c2_out_loc
+
+        indexer = layer.indexer
+        if indexer is not None and indexer.owns_k:
+            # out_loc is -1 for an incomplete group and 0 for padding;
+            # the kernel suppresses both stores.
+            assert out_loc is not None
+            index_k_norm_rope_pack_store(
+                indexer.forward_wk(latent),
+                indexer.k_norm.weight.data,
+                indexer.k_norm.eps,
+                freqs_cis,
+                pos,
+                out_loc,
+                pool.get_index_k_with_scale_buffer(layer_id),
+                ratio=layer.compress_ratio,
+            )
+
+    def _low_ratio_compress_torch(self, layer, x, req, pos, projected=None) -> None:
+        core = self.forward_metadata.core_metadata
+        num_tokens = pos.shape[0]
+        kv, score = projected if projected is not None else layer.compressor.project(x)
+        if not num_tokens:
+            return
+        if layer.compress_ratio == 1:
+            self._low_ratio_write_group(layer, kv, core.c1_out_loc[:num_tokens], pos)
+            return
+
+        partner_kv, partner_score = self._low_ratio_pair_partners(
+            layer_id=layer.layer_id,
+            kv=kv,
+            score=score,
+            req=req,
+            pos=pos,
+            pad=core.raw_out_loc[:num_tokens] == 0,
+        )
+        pooled = layer.compressor.pool_pairs(
+            torch.stack([partner_kv, kv], dim=1),
+            torch.stack([partner_score, score], dim=1),
+        )
+        group_pos = torch.where(pos % 2 == 1, pos - 1, pos)
+        out_loc = core.c2_out_loc[:num_tokens]
+        slots = torch.where(out_loc >= 0, out_loc, torch.zeros_like(out_loc))
+        self._low_ratio_write_group(layer, pooled, slots, group_pos)
+
+    def _low_ratio_pair_partners(
+        self, *, layer_id, kv, score, req, pos, pad
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Read the preceding token, then publish this batch's trailing ring window.
+
+        Each request occupies consecutive rows and positions. Keeping only its
+        last ring_size rows gives every write a distinct live slot, including
+        when a prefill chunk is longer than the ring. Reads precede all writes
+        so wrapping cannot overwrite a cross-chunk partner.
+        """
+        state = self.token_to_kv_pool.get_attention_compress_states(layer_id)
+        ring = state.ring_size
+        num_tokens = pos.shape[0]
+        if not num_tokens:
+            return kv, score
+
+        read_pos = (pos - 1).masked_fill(pad, -1)
+        carried = state.get_state_by_state_loc(
+            state.translate_from_req_position_to_state_loc(req, read_pos)
+        )
+        in_batch = torch.zeros_like(pad)
+        in_batch[1:] = (
+            (req[1:] == req[:-1]) & (pos[1:] == pos[:-1] + 1) & ~pad[1:] & ~pad[:-1]
+        )
+        partner_kv = torch.where(in_batch[:, None], torch.roll(kv, 1, 0), carried.kv)
+        partner_score = torch.where(
+            in_batch[:, None], torch.roll(score, 1, 0), carried.score
+        )
+
+        keep = ~pad
+        if num_tokens > ring:
+            keep[:-ring] &= (req[:-ring] != req[ring:]) | pad[ring:]
+        write_pos = pos.masked_fill(~keep, -1)
+        state.set_state_by_state_loc(
+            state.translate_from_req_position_to_state_loc(req, write_pos),
+            KVAndScore.from_kv_score(kv=kv, score=score),
+        )
+        return partner_kv, partner_score
+
+    def _low_ratio_write_group(
+        self, layer, pooled, slots, group_pos, *, fuse_index_store=False
+    ) -> None:
+        pool = self.token_to_kv_pool
+        latent = layer.compressor.finish(pooled)
+        freqs = layer.freqs_cis[group_pos]
+        # Index keys come from the pre-RoPE latent, so publish them first. Stored
+        # as fp4 (per-32 ue8m0, no hadamard), matching the reference indexer.
+        if layer.indexer is not None and layer.indexer.owns_k:
+            if (
+                fuse_index_store
+                and latent.is_cuda
+                and torch.version.cuda is not None
+                and latent.dtype == torch.bfloat16
+                and layer.indexer.index_head_dim == 128
+            ):
+                from sglang.kernels.ops.attention.dsv4.rope_pack_indexer import (
+                    rope_fake_quant_pack_indexer,
+                )
+
+                indexer = layer.indexer
+                k = indexer.k_norm(indexer.forward_wk(latent))
+                rope_fake_quant_pack_indexer(
+                    k,
+                    freqs,
+                    indexer.rope_head_dim,
+                    cache=pool.get_index_k_with_scale_buffer(layer.layer_id),
+                    loc=slots,
+                )
+            else:
+                pool.set_index_k_fp4(
+                    layer_id=layer.layer_id,
+                    loc=slots,
+                    cache_k=layer.indexer.index_keys(latent, freqs),
+                )
+        # The FlashMLA cache requantizes the FP4/E4M3 latent into its FP8 layout.
+        latent = _rope_fq4(latent, freqs, layer.rope_head_dim, compressed_kv=True)
+        pool.set_extra_key_buffer_fused(
+            layer_id=layer.layer_id, loc=slots, cache_k=latent
+        )
+
+    def _low_ratio_index_topk(self, layer, x, q_lora, req, pos, forward_batch) -> None:
+        is_decode_or_verify = (
+            forward_batch.forward_mode.is_decode()
+            or forward_batch.forward_mode.is_target_verify()
+        )
+        if is_decode_or_verify and _is_sm100_or_newer():
+            self._low_ratio_index_topk_decode(layer, x, q_lora, pos)
+        elif (
+            self._use_dense_fp4_prefill_indexer(forward_batch) and _is_sm100_or_newer()
+        ):
+            self._low_ratio_index_topk_extend(layer, x, q_lora, pos, forward_batch)
+        elif is_decode_or_verify:
+            self._low_ratio_index_topk_sm90_decode(layer, x, q_lora, req, pos)
+        else:
+            self._low_ratio_index_topk_torch(layer, x, q_lora, req, pos)
+
+    @staticmethod
+    def _use_dense_fp4_prefill_indexer(forward_batch) -> bool:
+        return (
+            not envs.SGLANG_DSV41_TORCH_PREFILL_INDEXER.get()
+            and _has_dense_fp4_indexer()
+            and forward_batch.forward_mode.is_extend()
+            and forward_batch.seq_lens_cpu is not None
+            and forward_batch.extend_seq_lens_cpu is not None
+        )
+
+    def _low_ratio_index_topk_extend(
+        self, layer, x, q_lora, pos, forward_batch
+    ) -> None:
+        tail = self.forward_metadata.late_layer_tail
+        if tail is not None:
+            q_lens, q_lens_cpu = tail.extend_seq_lens, tail.extend_seq_lens_cpu
+        else:
+            q_lens = forward_batch.extend_seq_lens
+            q_lens_cpu = _as_int_list(forward_batch.extend_seq_lens_cpu)
+        assert q_lens_cpu is not None
+        self._low_ratio_index_topk_dense(
+            layer, x, q_lora, pos, forward_batch, q_lens, q_lens_cpu
+        )
+
+    def _low_ratio_index_topk_dense(
+        self, layer, x, q_lora, pos, forward_batch, q_lens, q_lens_cpu
+    ) -> None:
+        """Dense fp4 indexer over rows laid out request after request, `q_lens[b]` each."""
+        from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
+            quantize_fp4_indexer_tensor,
+        )
+
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        ratio = layer.compress_ratio
+        indexer = layer.indexer
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        page_indices.fill_(-1)
+        if raw_indices is not None:
+            raw_indices.fill_(-1)
+
+        seq_lens_cpu = _as_int_list(forward_batch.seq_lens_cpu)
+        assert seq_lens_cpu is not None
+        device = pos.device
+        # Visible compressed positions per request at its newest token; the
+        # per-token count (pos + 1) // ratio bounds each row below.
+        lc_per_req = [s // ratio for s in seq_lens_cpu]
+        req_pool_indices = forward_batch.req_pool_indices.to(torch.int64)
+        slot_chunks, starts, start = [], [], 0
+        for r, lc in enumerate(lc_per_req):
+            starts.append(start)
+            if lc == 0:
+                continue
+            j = torch.arange(lc, device=device)
+            slot_chunks.append(
+                self.req_to_token[req_pool_indices[r], j * ratio].to(torch.int64)
+                // ratio
+            )
+            start += lc
+        empty_mask = torch.zeros(0, 0, dtype=torch.bool, device=device)
+        num_tokens = pos.shape[0]
+        if not slot_chunks or num_tokens == 0:
+            if indexer.is_candidate_source:
+                self.candidate_masks = [empty_mask for _ in lc_per_req]
+            return
+        k_slots = torch.cat(slot_chunks)
+        k_fp4, k_sf = pool.get_low_ratio_index_k_fp4(layer.layer_id, k_slots)
+
+        q = indexer.queries(q_lora, layer.freqs_cis[pos])  # [T, H, 128] fp4 grid
+        num_heads = q.shape[1]
+        q_fp4, q_sf = quantize_fp4_indexer_tensor(q.flatten(0, 1), rne=True)
+        q_fp4 = q_fp4.view(num_tokens, num_heads, 64)
+        q_sf = q_sf.view(num_tokens, num_heads)
+        weights = indexer.head_weights(x).float()
+        compress_lens = ((pos + 1) // ratio).to(torch.int32)
+        ks = torch.repeat_interleave(
+            torch.tensor(starts, dtype=torch.int32, device=device),
+            q_lens.to(torch.int64),
+            output_size=num_tokens,
+        )
+        logits = _dense_fp4_mqa_logits(
+            (q_fp4, q_sf),
+            (k_fp4, k_sf),
+            weights,
+            ks,
+            ks + compress_lens,
+            # the fused top-k reads score rows through 16-byte vectors
+            ceil_align(max(lc_per_req), 4),
+        )
+        if indexer.is_candidate_source or indexer.uses_candidates:
+            self._publish_or_consume_candidates(
+                indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask
+            )
+        topk = indexer.index_topk
+        selected = torch.empty((num_tokens, topk), dtype=torch.int32, device=device)
+        topk_transform_ragged_v2(
+            logits, compress_lens, out_offsets=ks, out_indices=selected
+        )
+        if indexer.uses_candidates and not indexer.is_candidate_source:
+            selected = _mask_topk_scores(logits, selected, ks)
+        # ascending positions, padding last: the layout the consumers expect
+        unselected = torch.iinfo(torch.int32).max
+        selected = selected.masked_fill(selected < 0, unselected).sort(dim=-1).values
+        chosen = selected != unselected
+        page_indices[:num_tokens, :topk] = torch.where(
+            chosen, k_slots[selected.clamp_max(k_slots.shape[0] - 1)], -1
+        ).to(torch.int32)
+        if raw_indices is not None:
+            raw_indices[:num_tokens, :topk] = torch.where(
+                chosen, selected - ks[:, None], -1
+            )
+
+    def _publish_or_consume_candidates(
+        self, indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask
+    ) -> None:
+        """Level one of the two-level top-k: publish block masks, or sink non-candidates."""
+        publish = [] if indexer.is_candidate_source else None
+        j = torch.arange(logits.shape[1], device=logits.device)
+        tok_start = 0
+        for b, (lc, t_len) in enumerate(zip(lc_per_req, q_lens_cpu)):
+            rows = slice(tok_start, tok_start + t_len)
+            tok_start += t_len
+            if lc == 0 or t_len == 0:
+                if publish is not None:
+                    publish.append(empty_mask)
+                continue
+            scores = logits[rows, :lc]
+            if publish is None:
+                scores.masked_fill_(~self.candidate_masks[b], -torch.inf)
+                continue
+            lens = compress_lens[rows, None]
+            # the block selection tells unreachable positions apart by -inf
+            scores.masked_fill_(j[None, :lc] >= lens, -torch.inf)
+            # the block selection pads and pools a copy of its rows; bound that copy
+            step = max(1, _TORCH_INDEXER_SCORE_BUDGET_BYTES // (lc * 4))
+            masks = [
+                select_candidate_blocks(
+                    scores[start : start + step],
+                    lens[start : start + step],
+                    topk_blocks=indexer.candidate_topk_blocks,
+                    block_size=indexer.candidate_block_size,
+                )
+                for start in range(0, t_len, step)
+            ]
+            publish.append(masks[0] if len(masks) == 1 else torch.cat(masks))
+        if publish is not None:
+            self.candidate_masks = publish
+
+    def _low_ratio_index_topk_prefill_graph(self, layer, pos, q, w) -> None:
+        """q/w come from live rows; metadata fixes the graph's context width."""
+        from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
+            quantize_fp4_indexer_tensor,
+        )
+
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        ratio = layer.compress_ratio
+        indexer = layer.indexer
+        metadata = (
+            self.forward_metadata.c1_indexer_metadata
+            if ratio == 1
+            else self.forward_metadata.c2_indexer_metadata
+        )
+        assert metadata is not None, f"no prefill graph indexer metadata for {ratio = }"
+        assert indexer.n_local_heads == indexer.n_heads
+        width = metadata.max_c4_seq_len
+        if indexer.uses_candidates or indexer.is_candidate_source:
+            # Every reachable block is a candidate inside the window, so the
+            # two-level selection collapses to the plain top-k below.
+            assert (
+                width <= indexer.candidate_topk_blocks * indexer.candidate_block_size
+            ), f"prefill graph indexer width {width} exceeds the candidate window"
+
+        num_tokens, num_heads = q.shape[0], q.shape[1]
+        q_fp4, q_sf = quantize_fp4_indexer_tensor(q.flatten(0, 1), rne=True)
+        q_fp4 = q_fp4.view(num_tokens, 1, num_heads, 64)
+        q_sf = q_sf.view(num_tokens, 1, num_heads)
+        weights = w.float()
+
+        k_cache = pool.get_index_k_with_scale_buffer(layer.layer_id)
+        assert k_cache.dim() == 2
+        page_size = metadata.c4_page_size
+        k_cache = k_cache.view(k_cache.shape[0], page_size, 1, 68)
+
+        lens = metadata.c4_seq_lens
+        page_table = metadata.page_table
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        topk = min(indexer.index_topk, width)
+        columns = torch.arange(width, device=lens.device)
+        for rows, plan in metadata.row_chunks():
+            logits = _fp4_paged_mqa_logits(
+                (q_fp4[rows], q_sf[rows]),
+                k_cache,
+                weights[rows],
+                lens[rows],
+                page_table[rows],
+                plan,
+                width,
+            )
+            lens_c = lens[rows].unsqueeze(-1)
+            # Columns past a row's length hold garbage.
+            s = logits.masked_fill(columns[None, :] >= lens_c, -torch.inf)
+            idx = s.topk(topk, dim=-1, sorted=False).indices.sort(dim=-1).values
+            reach = idx < lens_c
+            slots = page_table[rows].gather(-1, idx // page_size) * page_size + (
+                idx % page_size
+            )
+            page_indices[rows, :topk] = torch.where(reach, slots, -1).to(torch.int32)
+            if raw_indices is not None:
+                raw_indices[rows, :topk] = torch.where(reach, idx, -1).to(torch.int32)
+
+    def _low_ratio_index_topk_decode(self, layer, x, q_lora, pos) -> None:
+        from sglang.srt.model_executor.runner_utils.capture_mode import (
+            skip_low_ratio_indexer,
+        )
+
+        if skip_low_ratio_indexer(layer.compress_ratio):
+            # The compressor still writes index K for later, longer contexts.
+            return
+
+        from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
+            quantize_fp4_indexer_tensor,
+        )
+
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        ratio = layer.compress_ratio
+        indexer = layer.indexer
+        metadata = (
+            self.forward_metadata.c1_indexer_metadata
+            if ratio == 1
+            else self.forward_metadata.c2_indexer_metadata
+        )
+        assert metadata is not None, f"no decode indexer metadata for {ratio = }"
+
+        # fp4 query as (payload, scale), kernel layout [bs, 1, n_heads, dim]. The
+        # kernel sums head scores locally, so the indexer heads must be replicated.
+        assert indexer.n_local_heads == indexer.n_heads
+        if (
+            x.is_cuda
+            and torch.version.cuda is not None
+            and x.dtype == torch.bfloat16
+            and indexer.index_head_dim == 128
+        ):
+            from sglang.kernels.ops.attention.dsv4.fp4_rope import (
+                index_q_rope_pack_weights,
+            )
+
+            q, _ = indexer.wq_b(q_lora)
+            q = q.view(q.shape[0], indexer.n_local_heads, indexer.index_head_dim)
+            # The fused query pack also computes head_weights(x).float(), preserving
+            # the fp32 multiply and bf16 rounding. freqs_cis stays a real/imag view.
+            q_fp4, q_sf, weights = index_q_rope_pack_weights(
+                q,
+                torch.view_as_real(layer.freqs_cis).flatten(-2),
+                pos,
+                indexer.head_weights_raw(x),  # [bs, n_local] bf16, n32k5120
+                indexer.head_weight_scale,
+            )
+        else:
+            q = indexer.queries(q_lora, layer.freqs_cis[pos])
+            q_fp4, q_sf = quantize_fp4_indexer_tensor(q.flatten(0, 1), rne=True)
+            weights = indexer.head_weights(x).float()  # [bs, n_local]
+        bs = q.shape[0]
+        q_fp4 = q_fp4.view(bs, 1, indexer.n_local_heads, 64)
+        q_sf = q_sf.view(bs, 1, indexer.n_local_heads)
+
+        k_cache = pool.get_index_k_with_scale_buffer(layer.layer_id)
+        assert k_cache.dim() == 2
+        # Index pool page (64 slots); metadata.page_table is expanded to match.
+        page_size = metadata.c4_page_size
+        k_cache = k_cache.view(
+            k_cache.shape[0], page_size, 1, 68
+        )  # fp4: 64 payload + 4 scale
+
+        logits = _fp4_paged_mqa_logits(
+            (q_fp4, q_sf),
+            k_cache,
+            weights,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            metadata.deep_gemm_metadata,
+            metadata.max_c4_seq_len,
+        )
+
+        logits, published = two_level_decode_logits(
+            logits,
+            metadata.c4_seq_lens,
+            is_candidate_source=indexer.is_candidate_source,
+            uses_candidates=indexer.uses_candidates,
+            topk_blocks=indexer.candidate_topk_blocks,
+            block_size=indexer.candidate_block_size,
+            published=self.candidate_masks,
+        )
+        if published is not None:
+            self.candidate_masks = published
+
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        filter_candidates = indexer.uses_candidates and not indexer.is_candidate_source
+        selected = torch.empty_like(page_indices) if filter_candidates else raw_indices
+        if metadata.use_topk_v2 and raw_indices is None:
+            topk_transform_paged_v2(
+                logits,
+                metadata.c4_seq_lens,
+                None if filter_candidates else metadata.page_table,
+                selected if filter_candidates else page_indices,
+                page_size,
+                metadata.topk_metadata,
+            )
+        else:
+            topk_transform_paged(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                page_size,
+                selected,
+            )
+        if filter_candidates:
+            selected = _mask_topk_scores(logits, selected)
+            columns = selected.clamp_min(0).to(torch.int64)
+            slots = metadata.page_table.gather(1, columns // page_size) * page_size
+            slots = slots + columns % page_size
+            page_indices.copy_(torch.where(selected >= 0, slots, -1))
+            if raw_indices is not None:
+                raw_indices.copy_(selected)
+
+    def _low_ratio_index_topk_sm90_decode(self, layer, x, q_lora, req, pos) -> None:
+        """Hopper decode indexer: one token per request, every request scored at
+        once against its visible compressed positions straight off the fp4 page
+        table (Triton), then the same candidate / top-k contract as the DeepGEMM
+        path: level-one candidate blocks where the layer publishes or consumes them,
+        and -1 padded slots with the valid prefix first."""
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        ratio = layer.compress_ratio
+        indexer = layer.indexer
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        page_indices.fill_(-1)
+        if raw_indices is not None:
+            raw_indices.fill_(-1)
+        bs = req.shape[0]
+        assert pos.shape[0] == bs, (
+            f"decode expects one token per request, {pos.shape=} {bs=}"
+        )
+        if bs == 0:
+            return
+        lens = (pos + 1) // ratio
+        metadata = (
+            self.forward_metadata.c1_indexer_metadata
+            if ratio == 1
+            else self.forward_metadata.c2_indexer_metadata
+        )
+        assert metadata is not None
+        # V4 reserves the replay bound in metadata; visibility stays on device.
+        # A capture-time length read would both synchronize and truncate replay.
+        lmax = min(metadata.max_c4_seq_len, self.req_to_token.shape[1] // ratio)
+        if lmax == 0:
+            return
+        q = indexer.queries(q_lora, layer.freqs_cis[pos])
+        weights = indexer.head_weights(x)
+        j = torch.arange(lmax, device=pos.device)
+        valid = j[None, :] < lens[:, None]
+        slots = (
+            self.req_to_token[req[:, None], (j * ratio)[None, :]].to(torch.int64)
+            // ratio
+        )
+        slots = slots.masked_fill(~valid, 0)
+        table = pool.get_index_k_with_scale_buffer(layer.layer_id)
+        s = fp4_index_logits_decode(
+            q, weights, slots, lens, table, table.shape[1] // 68
+        )
+        if indexer.is_candidate_source:
+            self.candidate_masks = select_candidate_blocks(
+                s,
+                lens[:, None],
+                topk_blocks=indexer.candidate_topk_blocks,
+                block_size=indexer.candidate_block_size,
+            )
+        elif indexer.uses_candidates:
+            # Published this step by the candidate-source layer's decode pass above.
+            consume = self.candidate_masks
+            assert torch.is_tensor(consume) and consume.shape[0] == bs, (
+                "candidate mask missing for decode"
+            )
+            s = s.masked_fill(~consume[:, :lmax], -torch.inf)
+        k = min(indexer.index_topk, lmax)
+        idx = s.topk(k, dim=-1, sorted=False).indices
+        if indexer.uses_candidates and not indexer.is_candidate_source:
+            idx = _mask_topk_scores(s, idx)
+            idx = idx.masked_fill(idx < 0, lmax)
+        idx = idx.sort(dim=-1).values
+        reach = idx < lens[:, None]
+        page_indices[:bs, :k] = torch.where(
+            reach, slots.gather(1, idx.clamp_max(lmax - 1)), -1
+        ).to(torch.int32)
+        if raw_indices is not None:
+            raw_indices[:bs, :k] = torch.where(reach, idx, -1).to(torch.int32)
+
+    def _low_ratio_index_topk_torch(self, layer, x, q_lora, req, pos) -> None:
+        pool = self.token_to_kv_pool
+        core = self.forward_metadata.core_metadata
+        ratio = layer.compress_ratio
+        indexer = layer.indexer
+        # Attention scans sparse_topk_lengths slots and skips -1 entries.
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        page_indices.fill_(-1)
+        if raw_indices is not None:
+            raw_indices.fill_(-1)
+        q = indexer.queries(q_lora, layer.freqs_cis[pos])
+        weights = indexer.head_weights(x)
+        # A compressed position is visible once the query has passed its last token.
+        compress_lens = (pos + 1) // ratio
+        topk = indexer.index_topk
+        publish = [] if indexer.is_candidate_source else None
+        consume = self.candidate_masks if indexer.uses_candidates else None
+        for b, r in enumerate(torch.unique_consecutive(req).tolist()):
+            tok = (req == r).nonzero().squeeze(1)
+            lens = compress_lens[tok]
+            lc = int(lens.max().item())
+            if lc == 0:
+                # Consumers address masks by request position, including empty requests.
+                if publish is not None:
+                    publish.append(
+                        torch.zeros(0, 0, dtype=torch.bool, device=pos.device)
+                    )
+                continue
+            j = torch.arange(lc, device=pos.device)
+            slots_j = self.req_to_token[r, j * ratio].to(torch.int64) // ratio
+            # Dequantize only this request's visible K rows; the full table is
+            # pool-sized.
+            index_k = pool.get_low_ratio_index_k_dequant(layer.layer_id, slots_j)
+            k = min(topk, lc)
+            # Every step below is per query row; chunk rows so the [rows, heads, lc]
+            # bf16 scores stay under the budget (16 GiB at once for a 16k-token prompt).
+            rows_per_chunk = max(
+                1,
+                _TORCH_INDEXER_SCORE_BUDGET_BYTES // (q.shape[1] * lc * 2),
+            )
+            masks = [] if publish is not None else None
+            for start in range(0, tok.numel(), rows_per_chunk):
+                rows = slice(start, start + rows_per_chunk)
+                tok_c, lens_c = tok[rows], lens[rows]
+                s = indexer.scores(q[tok_c], index_k, weights[tok_c])
+                s = s.masked_fill(j[None, :] >= lens_c[:, None], -torch.inf)
+                if masks is not None:
+                    masks.append(
+                        select_candidate_blocks(
+                            s,
+                            lens_c[:, None],
+                            topk_blocks=indexer.candidate_topk_blocks,
+                            block_size=indexer.candidate_block_size,
+                        )
+                    )
+                elif consume is not None:
+                    s = s.masked_fill(~consume[b][rows], -torch.inf)
+                idx = s.topk(k, dim=-1, sorted=False).indices
+                if consume is not None and masks is None:
+                    idx = _mask_topk_scores(s, idx)
+                    idx = idx.masked_fill(idx < 0, lc)
+                idx = idx.sort(dim=-1).values
+                reach = idx < lens_c[:, None]
+                page_indices[tok_c, :k] = torch.where(
+                    reach, slots_j[idx.clamp_max(lc - 1)], -1
+                ).to(torch.int32)
+                if raw_indices is not None:
+                    raw_indices[tok_c, :k] = torch.where(reach, idx, -1).to(torch.int32)
+            if masks is not None:
+                publish.append(torch.cat(masks) if len(masks) > 1 else masks[0])
+        if publish is not None:
+            self.candidate_masks = publish
 
     def get_swa_out_cache_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:
         """Resolve the SWA KV-store write target for the current forward.
@@ -1642,6 +3518,15 @@ class DeepseekV4AttnBackend(
         always falls back: its metadata may be stale, and
         translating the zero-padded out_cache_loc writes to the dummy slot.
         """
+        metadata = self.forward_metadata
+        if self.token_to_kv_pool.request_window is not None:
+            layout = metadata.core_attn_metadata.request_window_layout
+            self.token_to_kv_pool.request_window.activate(layout)
+            return layout.write_loc
+        if isinstance(metadata, DSV4Metadata) and metadata.late_layer_tail is not None:
+            # The tail's q rows are a subset of the extend, so the full
+            # out_cache_loc below would be the wrong length; the tail owns its own.
+            return metadata.late_layer_tail.swa_out_cache_loc
         out_cache_loc = forward_batch.out_cache_loc
         core = getattr(self.forward_metadata, "core_attn_metadata", None)
         cached = core.swa_out_cache_loc if core is not None else None
@@ -1665,14 +3550,25 @@ class DeepseekV4AttnBackend(
             cache_k=swa_k,
         )
 
-    def forward(
+    def forward(self, q, k, v, layer, forward_batch, *args, **kwargs):
+        result = self._forward_attention(q, k, v, layer, forward_batch, *args, **kwargs)
+        window = self.token_to_kv_pool.request_window
+        if (
+            window is not None
+            and not self.is_dspark_draft
+            and not forward_batch.forward_mode.is_idle()
+        ):
+            window.commit(self.token_to_kv_pool._swa_local_layer_id(layer.layer_id))
+        return result
+
+    def _forward_attention(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
         layer: RadixAttention,
         forward_batch: ForwardBatch,
-        compress_ratio: Literal[0, 4, 128],
+        compress_ratio: Literal[0, 1, 2, 4, 128],
         save_kv_cache: bool = True,
         attn_sink: Optional[torch.Tensor] = None,
         **_,
@@ -1695,10 +3591,12 @@ class DeepseekV4AttnBackend(
             swa_k_cache = token_to_kv_pool.get_swa_key_buffer_radix(layer_id)
 
             extra_k_cache, extra_indices, extra_topk_lengths = None, None, None
-            if compress_ratio == 4:
+            if compress_ratio in (1, 2, 4):
                 extra_k_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
-                extra_indices = core_attn_metadata.c4_sparse_page_indices
-                extra_topk_lengths = core_attn_metadata.c4_sparse_topk_lengths
+                extra_indices = core_attn_metadata.sparse_page_indices(compress_ratio)
+                extra_topk_lengths = core_attn_metadata.sparse_topk_lengths(
+                    compress_ratio
+                )
             elif compress_ratio == 128:
                 extra_k_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
                 extra_indices = core_attn_metadata.c128_page_indices
@@ -1706,21 +3604,22 @@ class DeepseekV4AttnBackend(
 
             swa_window_size = token_to_kv_pool.swa_window_size
             assert swa_k_cache.ndim == 2
-            k_cache_total_dim = token_to_kv_pool.swa_kv_pool.kv_cache_total_dim
+            k_cache_total_dim = (
+                token_to_kv_pool.qk_nope_head_dim
+                + token_to_kv_pool.qk_rope_head_dim * 2
+                + 8
+            )
             swa_k_cache = swa_k_cache[:, : swa_window_size * k_cache_total_dim].view(
                 swa_k_cache.shape[0], swa_window_size, 1, k_cache_total_dim
             )
 
             if extra_k_cache is not None:
-                page_sizes = {
-                    4: token_to_kv_pool.page_size // 4,
-                    128: token_to_kv_pool.page_size // 128,
-                }
+                extra_page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
                 extra_k_cache = extra_k_cache[
-                    :, : page_sizes[compress_ratio] * k_cache_total_dim
+                    :, : extra_page_size * k_cache_total_dim
                 ].view(
                     extra_k_cache.shape[0],
-                    page_sizes[compress_ratio],
+                    extra_page_size,
                     1,
                     k_cache_total_dim,
                 )
@@ -1758,10 +3657,14 @@ class DeepseekV4AttnBackend(
                     f"{extra_indices.shape=}'s last dimension is not aligned to 64"
                 )
 
-            # sparse_prefill_fwd does not support SM120.
+            # sparse_prefill_fwd does not support SM120. The late-layer tail stays
+            # on the dense path: its window floor lives in swa_page_indices, which
+            # the sparse chunk cache does not read.
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
                 and not get_platform().is_sm120
+                and self.forward_metadata.late_layer_tail is None
+                and token_to_kv_pool.request_window is None
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
@@ -1848,7 +3751,7 @@ class DeepseekV4AttnBackend(
         self,
         q: torch.Tensor,
         layer_id: int,
-        compress_ratio: Literal[0, 4, 128],
+        compress_ratio: Literal[0, 1, 2, 4, 128],
         forward_batch: ForwardBatch,
         token_to_kv_pool: DeepSeekV4TokenToKVPool,
         core_attn_metadata: DSV4AttnMetadata,
@@ -1873,7 +3776,7 @@ class DeepseekV4AttnBackend(
         cache = self.forward_metadata.sparse_prefill_cache
         if cache is None:
             cache = self._build_sparse_prefill_chunk_cache(
-                forward_batch, num_qo_tokens=q_flat.shape[0]
+                forward_batch, core_attn_metadata, num_qo_tokens=q_flat.shape[0]
             )
             self.forward_metadata.sparse_prefill_cache = cache
 
@@ -1898,16 +3801,18 @@ class DeepseekV4AttnBackend(
                 combined_indices = cache.c128_combined_indices
                 combined_lens = cache.c128_combined_lens
             else:
-                assert core_attn_metadata.c4_sparse_raw_indices is not None, (
-                    "sparse-prefill c4 path requires c4_sparse_raw_indices "
-                    "(allocated in init_flashmla_related when is_prefill=True)"
+                raw_indices = core_attn_metadata.sparse_raw_indices(compress_ratio)
+                assert raw_indices is not None, (
+                    f"sparse-prefill c{compress_ratio} path requires the raw "
+                    "top-k indices (allocated in init_flashmla_related when "
+                    "is_prefill=True)"
                 )
-                cache.ensure_c4(core_attn_metadata.page_table, extra_page_size)
-                flat_token_ids = cache.c4_flat_token_ids
-                combined_indices, combined_lens = cache.combine_c4_layer(
-                    c4_sparse_raw_indices=core_attn_metadata.c4_sparse_raw_indices[
-                        : cache.num_qo_tokens
-                    ],
+                gather = cache.ensure_compressed(
+                    compress_ratio, core_attn_metadata.page_table, extra_page_size
+                )
+                flat_token_ids = gather.flat_token_ids
+                combined_indices, combined_lens = cache.combine_compressed(
+                    compress_ratio, raw_indices[: cache.num_qo_tokens]
                 )
             n_compressed = flat_token_ids.shape[0]
             workspace = self.sparse_prefill_workspace.get(
@@ -1998,7 +3903,7 @@ class DeepseekV4AttnBackend(
         self,
         q: torch.Tensor,
         layer_id: int,
-        compress_ratio: Literal[0, 4, 128],
+        compress_ratio: Literal[0, 1, 2, 4, 128],
         forward_batch: ForwardBatch,
         token_to_kv_pool: DeepSeekV4TokenToKVPool,
         core_attn_metadata: DSV4AttnMetadata,
@@ -2076,16 +3981,18 @@ class DeepseekV4AttnBackend(
                 combined_indices = cache.c128_combined_indices
                 combined_lens = cache.c128_combined_lens
             else:
-                assert core_attn_metadata.c4_sparse_raw_indices is not None, (
-                    "Q8KV8 sparse-prefill c4 path requires c4_sparse_raw_indices "
-                    "(allocated in init_flashmla_related when is_prefill=True)"
+                raw_indices = core_attn_metadata.sparse_raw_indices(compress_ratio)
+                assert raw_indices is not None, (
+                    f"Q8KV8 sparse-prefill c{compress_ratio} path requires the raw "
+                    "top-k indices (allocated in init_flashmla_related when "
+                    "is_prefill=True)"
                 )
-                cache.ensure_c4(core_attn_metadata.page_table, extra_page_size)
-                flat_token_ids = cache.c4_flat_token_ids
-                combined_indices, combined_lens = cache.combine_c4_layer(
-                    c4_sparse_raw_indices=core_attn_metadata.c4_sparse_raw_indices[
-                        : cache.num_qo_tokens
-                    ],
+                gather = cache.ensure_compressed(
+                    compress_ratio, core_attn_metadata.page_table, extra_page_size
+                )
+                flat_token_ids = gather.flat_token_ids
+                combined_indices, combined_lens = cache.combine_compressed(
+                    compress_ratio, raw_indices[: cache.num_qo_tokens]
                 )
 
             n_compressed = flat_token_ids.shape[0]
@@ -2207,6 +4114,9 @@ class DeepseekV4AttnBackend(
         is_prefill: bool = False,
         dspark_block_size: Optional[int] = None,
         num_tokens: Optional[int] = None,
+        swa_replay_start: Optional[torch.Tensor] = None,
+        num_groups: Optional[int] = None,
+        dspark_swa_buffers: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> DSV4AttnMetadata:
         assert self.swa_page_size == SWA_WINDOW
 
@@ -2221,7 +4131,30 @@ class DeepseekV4AttnBackend(
         seq_lens_casual = prep.seq_lens_casual
 
         raw_positions = prep.positions_casual
-        if dspark_block_size is not None:
+        request_layout = None
+        if self.token_to_kv_pool.request_window is not None:
+            from sglang.srt.mem_cache.dsv41_request_window import window_layout
+
+            if self.encoder_replay:
+                starts = torch.ones_like(raw_positions, dtype=torch.bool)
+                starts[1:] = (
+                    req_pool_indices_repeated[1:] != req_pool_indices_repeated[:-1]
+                )
+                offset = torch.arange(
+                    raw_positions.numel(), device=raw_positions.device
+                )
+                group_first = torch.cummax(torch.where(starts, offset, 0), dim=0).values
+                swa_replay_start = raw_positions - (offset - group_first)
+            request_layout = window_layout(
+                req_pool_indices_repeated,
+                raw_positions,
+                capacity=self.token_to_kv_pool.request_window.capacity,
+                floor=swa_replay_start,
+                num_groups=num_groups,
+            )
+            swa_page_indices = _pad_last_dim(request_layout.indices)
+            swa_topk_lengths = request_layout.lengths
+        elif dspark_block_size is not None:
             assert (
                 self.is_dspark_draft
                 and dspark_block_size == self.speculative_num_draft_tokens - 1
@@ -2231,12 +4164,18 @@ class DeepseekV4AttnBackend(
                 f"and is only valid on the DSpark draft backend "
                 f"(is_dspark_draft={self.is_dspark_draft})."
             )
-            swa_page_indices, swa_topk_lengths = self.get_dspark_swa_page_indices(
-                seq_lens_casual=seq_lens_casual,
-                req_pool_indices_repeated=req_pool_indices_repeated,
-                out_loc=out_loc,
-                block_size=dspark_block_size,
+            assert swa_replay_start is None, (
+                "swa_replay_start is not wired for the DSpark draft window"
             )
+            if dspark_swa_buffers is None:
+                swa_page_indices, swa_topk_lengths = self.get_dspark_swa_page_indices(
+                    seq_lens_casual=seq_lens_casual,
+                    req_pool_indices_repeated=req_pool_indices_repeated,
+                    out_loc=out_loc,
+                    block_size=dspark_block_size,
+                )
+            else:
+                swa_page_indices, swa_topk_lengths = dspark_swa_buffers
         else:
             swa_page_indices = BuildCausalSwaPageIndices.execute(
                 req_to_token=self.req_to_token,
@@ -2245,8 +4184,15 @@ class DeepseekV4AttnBackend(
                 seq_lens_casual=seq_lens_casual,
                 swa_window=SWA_WINDOW,
                 page_index_aligned_size=PAGE_INDEX_ALIGNED_SIZE,
+                swa_replay_start=swa_replay_start,
             )
             swa_topk_lengths = prep.swa_topk_lengths
+            if swa_replay_start is not None:
+                # Slots below the floor are -1; the valid count shrinks to match.
+                floored = raw_positions - swa_replay_start.to(raw_positions.dtype) + 1
+                swa_topk_lengths = torch.minimum(
+                    swa_topk_lengths, floored.clamp_min(0).to(swa_topk_lengths.dtype)
+                )
 
         page_table = prep.page_table
 
@@ -2259,7 +4205,13 @@ class DeepseekV4AttnBackend(
             page_table=page_table,
             swa_page_indices=swa_page_indices,
             swa_topk_lengths=swa_topk_lengths,
-            c4_sparse_topk=self.c4_topk,
+            index_topk=self.index_topk,
+            present_ratios=self.present_ratios,
+            low_ratios=self.low_ratios,
+            request_window_layout=request_layout,
+            swa_out_cache_loc=(
+                request_layout.write_loc if request_layout is not None else None
+            ),
         )
 
         if need_compress:
@@ -2269,7 +4221,7 @@ class DeepseekV4AttnBackend(
             core_attn_metadata.c4_sparse_topk_lengths = None
             core_attn_metadata.c4_sparse_page_indices = None
             core_attn_metadata.c4_sparse_raw_indices = None
-            core_attn_metadata.c1_flashmla_metadata = _create_flashmla_metadata()
+            core_attn_metadata.c0_flashmla_metadata = _create_flashmla_metadata()
             core_attn_metadata.c4_flashmla_metadata = None
             core_attn_metadata.c128_flashmla_metadata = None
         return core_attn_metadata

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -280,6 +280,36 @@ def two_level_decode_logits(
         # All requests fit the candidate budget; paged top-k masks their tails.
         return logits, None
 
+    if (
+        logits.is_cuda
+        and torch.version.cuda is not None
+        and logits.ndim == 2
+        and logits.stride(1) == 1
+        and seq_lens.device == logits.device
+        and seq_lens.dtype in (torch.int32, torch.int64)
+        and seq_lens.is_contiguous()
+        and seq_lens.shape in ((logits.shape[0],), (logits.shape[0], 1))
+        and logits.numel() > 0
+        and 0 < block_size <= 1024
+    ):
+        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+            candidate_block_logits,
+        )
+
+        if not is_candidate_source:
+            assert (
+                torch.is_tensor(published)
+                and published.shape[0] == logits.shape[0]
+                and published.shape[1] >= logits.shape[1]
+            ), "candidate mask missing for decode"
+        return candidate_block_logits(
+            logits,
+            seq_lens,
+            topk_blocks=topk_blocks,
+            block_size=block_size,
+            published=None if is_candidate_source else published,
+        )
+
     lens_col = seq_lens if seq_lens.dim() > 1 else seq_lens.unsqueeze(-1)
     reachable = torch.arange(logits.shape[-1], device=logits.device) < lens_col
     logits = logits.float().masked_fill(~reachable, -torch.inf)
@@ -2778,7 +2808,16 @@ class DeepseekV4AttnBackend(
         if forward_batch.forward_mode.is_decode():
             self._low_ratio_compress_decode(layer, x, req, pos)
         else:
-            self._low_ratio_compress_torch(layer, x, req, pos)
+            self._low_ratio_compress_torch(
+                layer,
+                x,
+                req,
+                pos,
+                fuse_index_store=(
+                    forward_batch.forward_mode.is_target_verify()
+                    and layer.compressor.use_fused_compress
+                ),
+            )
 
     def _low_ratio_in_prefill_graph(self) -> bool:
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
@@ -2908,14 +2947,22 @@ class DeepseekV4AttnBackend(
                 ratio=layer.compress_ratio,
             )
 
-    def _low_ratio_compress_torch(self, layer, x, req, pos, projected=None) -> None:
+    def _low_ratio_compress_torch(
+        self, layer, x, req, pos, projected=None, *, fuse_index_store=False
+    ) -> None:
         core = self.forward_metadata.core_metadata
         num_tokens = pos.shape[0]
         kv, score = projected if projected is not None else layer.compressor.project(x)
         if not num_tokens:
             return
         if layer.compress_ratio == 1:
-            self._low_ratio_write_group(layer, kv, core.c1_out_loc[:num_tokens], pos)
+            self._low_ratio_write_group(
+                layer,
+                kv,
+                core.c1_out_loc[:num_tokens],
+                pos,
+                fuse_index_store=fuse_index_store,
+            )
             return
 
         partner_kv, partner_score = self._low_ratio_pair_partners(
@@ -2933,7 +2980,9 @@ class DeepseekV4AttnBackend(
         group_pos = torch.where(pos % 2 == 1, pos - 1, pos)
         out_loc = core.c2_out_loc[:num_tokens]
         slots = torch.where(out_loc >= 0, out_loc, torch.zeros_like(out_loc))
-        self._low_ratio_write_group(layer, pooled, slots, group_pos)
+        self._low_ratio_write_group(
+            layer, pooled, slots, group_pos, fuse_index_store=fuse_index_store
+        )
 
     def _low_ratio_pair_partners(
         self, *, layer_id, kv, score, req, pos, pad
@@ -2975,7 +3024,13 @@ class DeepseekV4AttnBackend(
         return partner_kv, partner_score
 
     def _low_ratio_write_group(
-        self, layer, pooled, slots, group_pos, *, fuse_index_store=False
+        self,
+        layer,
+        pooled,
+        slots,
+        group_pos,
+        *,
+        fuse_index_store=False,
     ) -> None:
         pool = self.token_to_kv_pool
         latent = layer.compressor.finish(pooled)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -160,7 +160,7 @@ class DSV4AttnMetadata:
     swa_page_indices: torch.Tensor
     swa_topk_lengths: torch.Tensor
 
-    c4_sparse_topk: int
+    index_topk: int
     # SWA KV-store write target (out_cache_loc translated to SWA space), computed
     # once per iteration in make_core_attn_metadata and read by the store path.
     swa_out_cache_loc: Optional[torch.Tensor] = None
@@ -180,7 +180,7 @@ class DSV4AttnMetadata:
     # unified-kv metadata
     unified: Optional[UnifiedKvMetadata] = None
 
-    c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
+    c0_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c128_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
 
@@ -190,7 +190,7 @@ class DSV4AttnMetadata:
 
     def get_flashmla_metadata(self, compress_ratio: Literal[0, 4, 128]):
         if compress_ratio == 0:
-            return self.c1_flashmla_metadata
+            return self.c0_flashmla_metadata
         elif compress_ratio == 4:
             return self.c4_flashmla_metadata
         elif compress_ratio == 128:
@@ -203,7 +203,7 @@ class DSV4AttnMetadata:
             src=other,
             dst=self,
             check_eq_fields=[
-                "c4_sparse_topk",
+                "index_topk",
                 "page_size",
                 "cuda_int32_kwargs",
             ],
@@ -231,7 +231,7 @@ class DSV4AttnMetadata:
                 # Recomputed by the recorded init_forward_metadata_in_graph op
                 # each forward; not copied across replays.
                 "swa_out_cache_loc",
-                "c1_flashmla_metadata",
+                "c0_flashmla_metadata",
                 "c4_flashmla_metadata",
                 "c128_flashmla_metadata",
             ],
@@ -323,22 +323,20 @@ class DSV4AttnMetadata:
             )
 
     def init_flashmla_related(self, is_prefill: bool = False):
-        # c4_sparse_topk is set from model_config.index_topk per-model
-        # (small model: 512, large model: 1024).
-        assert self.c4_sparse_topk in (512, 1024), (
-            f"unexpected c4_sparse_topk={self.c4_sparse_topk}; "
+        assert self.index_topk in (512, 1024), (
+            f"unexpected index_topk={self.index_topk}; "
             "supported: 512 (small) or 1024 (large)"
         )
         assert self.c4_topk_lengths_clamp1 is not None
         self.c4_sparse_topk_lengths = torch.clamp(
-            self.c4_topk_lengths_clamp1, max=self.c4_sparse_topk
+            self.c4_topk_lengths_clamp1, max=self.index_topk
         )
         assert self.c4_topk_lengths_raw is not None
         self.c4_sparse_topk_lengths_raw = torch.clamp(
-            self.c4_topk_lengths_raw, max=self.c4_sparse_topk
+            self.c4_topk_lengths_raw, max=self.index_topk
         )
         self.c4_sparse_page_indices = torch.full(
-            (self.c4_topk_lengths_clamp1.size(0), self.c4_sparse_topk),
+            (self.c4_topk_lengths_clamp1.size(0), self.index_topk),
             -1,
             dtype=torch.int32,
             device=self.c4_topk_lengths_clamp1.device,
@@ -346,7 +344,7 @@ class DSV4AttnMetadata:
         self.c4_sparse_page_indices = _pad_last_dim(self.c4_sparse_page_indices)
         if is_prefill:
             self.c4_sparse_raw_indices = torch.empty_like(self.c4_sparse_page_indices)
-        self.c1_flashmla_metadata = _create_flashmla_metadata()
+        self.c0_flashmla_metadata = _create_flashmla_metadata()
         self.c4_flashmla_metadata = _create_flashmla_metadata()
         self.c128_flashmla_metadata = _create_flashmla_metadata()
 
@@ -470,7 +468,7 @@ class DeepseekV4HipRadixBackend(
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
 
         assert isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
-        self.c4_topk = getattr(
+        self.index_topk = getattr(
             model_runner.model_config.hf_text_config, "index_topk", C4_TOPK
         )
         self.enable_deepseek_v4_fp4_indexer: bool = (
@@ -1214,7 +1212,7 @@ class DeepseekV4HipRadixBackend(
             metadata.core_attn_metadata, DSV4AttnMetadata
         ):
             core = metadata.core_attn_metadata
-            core.c1_flashmla_metadata = _create_flashmla_metadata()
+            core.c0_flashmla_metadata = _create_flashmla_metadata()
             core.c4_flashmla_metadata = _create_flashmla_metadata()
             core.c128_flashmla_metadata = _create_flashmla_metadata()
 
@@ -1804,7 +1802,7 @@ class DeepseekV4HipRadixBackend(
             page_table=page_table,
             swa_page_indices=swa_page_indices,
             swa_topk_lengths=swa_topk_lengths,
-            c4_sparse_topk=self.c4_topk,
+            index_topk=self.index_topk,
         )
 
         if need_compress:
@@ -1817,7 +1815,7 @@ class DeepseekV4HipRadixBackend(
             core_attn_metadata.c4_sparse_topk_lengths_raw = None
             core_attn_metadata.c4_sparse_page_indices = None
             core_attn_metadata.c4_sparse_raw_indices = None
-            core_attn_metadata.c1_flashmla_metadata = _create_flashmla_metadata()
+            core_attn_metadata.c0_flashmla_metadata = _create_flashmla_metadata()
             core_attn_metadata.c4_flashmla_metadata = None
             core_attn_metadata.c128_flashmla_metadata = None
         return core_attn_metadata

--- a/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
+++ b/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
@@ -1,0 +1,288 @@
+"""DeepSeek V4.1 ratio-1/2 compressors and indexers.
+
+Only kv_source layers own compressed latents; later layers with the same ratio
+share that storage. Index sources score the latents and publish top-k slots
+for subsequent attention layers.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+from sglang.kernels.ops.attention.dsv4 import linear_bf16_fp32
+from sglang.kernels.ops.attention.dsv4.rmsnorm_fp32 import rmsnorm_fp32
+from sglang.srt.layers.attention.dsv4.torch_quant import (
+    fake_quant_compressed_kv,
+    fake_quant_fp4,
+)
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.utils import add_prefix
+
+
+def _rope_fq4(x, freqs, rope_dim, *, compressed_kv=False):
+    """RoPE plus fake FP4 quantization, fused for CUDA BF16 inputs."""
+    if x.is_cuda and torch.version.cuda is not None and x.dtype == torch.bfloat16:
+        from sglang.kernels.ops.attention.dsv4.rope_fake_quant_fp4 import (
+            rope_tail_fake_quant_fp4,
+        )
+
+        return rope_tail_fake_quant_fp4(x, freqs, rope_dim, compressed_kv=compressed_kv)
+    quant = fake_quant_compressed_kv if compressed_kv else fake_quant_fp4
+    return quant(rope_tail(x, freqs, rope_dim))
+
+
+class RMSNorm(nn.Module):
+    """fp32 statistics and fp32 weight multiply, cast back at the very end."""
+
+    def __init__(self, dim: int, eps: float):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if (
+            x.is_cuda
+            and torch.version.cuda is not None
+            and x.dtype in (torch.bfloat16, torch.float32)
+            and self.weight.dtype in (torch.bfloat16, torch.float32)
+            and x.shape[-1] in (128, 512)
+            and x.numel() <= 64 * x.shape[-1]
+            and x.is_contiguous()
+            and self.weight.is_contiguous()
+        ):
+            return rmsnorm_fp32(x, self.weight, self.eps)
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+def token_req_indices(forward_batch, *, num_tokens=None) -> torch.Tensor:
+    """req_pool_indices repeated once per token of the batch."""
+    req = forward_batch.req_pool_indices.to(torch.int64)
+    if forward_batch.forward_mode.is_decode():
+        return req
+    if forward_batch.forward_mode.is_target_verify():
+        return torch.repeat_interleave(
+            req, int(forward_batch.spec_info.draft_token_num), output_size=num_tokens
+        )
+    assert forward_batch.forward_mode.is_extend(), (
+        "the V4.1 torch attention path serves extend, target-verify and decode"
+    )
+    return torch.repeat_interleave(
+        req, forward_batch.extend_seq_lens.to(torch.int64), output_size=num_tokens
+    )
+
+
+def rope_tail(
+    x: torch.Tensor, freqs: torch.Tensor, rope_dim: int, inverse: bool = False
+) -> torch.Tensor:
+    """Rotate the last rope_dim features of x [T, ..., D] with complex freqs [T, rope_dim // 2]."""
+    head, tail = x[..., :-rope_dim], x[..., -rope_dim:]
+    tc = torch.view_as_complex(tail.float().unflatten(-1, (-1, 2)).contiguous())
+    f = freqs.conj() if inverse else freqs
+    f = f.view(x.shape[0], *([1] * (x.ndim - 2)), rope_dim // 2)
+    rotated = torch.view_as_real(tc * f).flatten(-2).to(x.dtype)
+    return torch.cat([head, rotated], dim=-1)
+
+
+def fused_low_ratio_compress_supported() -> bool:
+    """Whether the fused c1 / c2 / index-K decode kernels can serve this process.
+
+    They pack fp4 with `cvt.rn.satfinite.e2m1x2`, a Blackwell (sm100+) CUDA
+    instruction, so HIP and pre-Blackwell parts keep the split projection and the
+    unfused write. Decided once at load time: the choice also fixes the weight
+    layout of the ratio-2 projection (one `wkv_gate` or `wkv` plus `wgate`)."""
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        return False
+    return torch.cuda.get_device_capability()[0] >= 10
+
+
+class DeepseekV41Compressor(nn.Module):
+    """Pool consecutive tokens into one pre-RoPE KV latent.
+
+    Ratio 1 uses a bf16 projection. Ratio 2 keeps checkpoint weights in bf16 but
+    accumulates projections and softmax pooling in fp32; finish rounds to bf16
+    before RMSNorm. The fp32 reference can differ in GEMM reduction order.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        compress_ratio: int,
+        eps: float,
+        *,
+        fused_compress: Optional[bool] = None,
+    ):
+        super().__init__()
+        self.compress_ratio = compress_ratio
+        self.norm = RMSNorm(head_dim, eps)
+        # The loader concatenates ratio-2 wkv/wgate when it finds wkv_gate.weight;
+        # ratio 1 must retain wkv.weight because there is no gate half to load.
+        self.use_fused_compress = (
+            fused_low_ratio_compress_supported()
+            if fused_compress is None
+            else bool(fused_compress)
+        )
+        self.use_fused_gate = compress_ratio > 1 and self.use_fused_compress
+        if self.use_fused_gate:
+            self.wkv_gate = nn.Linear(
+                hidden_size, 2 * head_dim, bias=False, dtype=torch.bfloat16
+            )
+        else:
+            self.wkv = nn.Linear(
+                hidden_size, head_dim, bias=False, dtype=torch.bfloat16
+            )
+            if compress_ratio > 1:
+                self.wgate = nn.Linear(
+                    hidden_size, head_dim, bias=False, dtype=torch.bfloat16
+                )
+
+    def project(self, x: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if self.compress_ratio == 1:
+            return self.wkv(x), None
+        if self.use_fused_gate:
+            # Extend accepts strided column views; pair_pool_decode requires contiguous
+            # halves and is reachable only when the fused projection is disabled.
+            fused = self.project_fused(x)
+            head_dim = fused.shape[-1] // 2
+            return fused[..., :head_dim], fused[..., head_dim:]
+        # Two GEMMs rather than one fused [2D, K] projection: the decode epilogue
+        # kernel (pair_pool_decode) reads kv and score as contiguous [n, D] fp32
+        # rows, which column slices of a fused output are not.
+        kv = linear_bf16_fp32(x, self.wkv.weight)
+        score = linear_bf16_fp32(x, self.wgate.weight)
+        return kv, score
+
+    def project_fused(self, x: torch.Tensor) -> torch.Tensor:
+        """`[n, 2D]` fp32, `| kv | score |`, for the fused decode kernel."""
+        return linear_bf16_fp32(x, self.wkv_gate.weight)
+
+    def finish(self, kv: torch.Tensor) -> torch.Tensor:
+        return self.norm(kv.to(torch.bfloat16))
+
+    @staticmethod
+    def pool_pairs(kv2: torch.Tensor, score2: torch.Tensor) -> torch.Tensor:
+        """kv2, score2 [n, 2, D] fp32 -> [n, D]"""
+        return (kv2 * score2.softmax(dim=1)).sum(dim=1)
+
+
+def _small_weights_proj_max_m(n_heads: int, hidden_size: int) -> int:
+    """Maximum decode rows for the small head-weight GEMM;
+    -1 means the device or checkpoint shape requires the linear fallback.
+    """
+    if not torch.cuda.is_available() or torch.version.hip is not None:
+        return -1
+    from sglang.kernels.ops.gemm.n32k5120 import MAX_M, can_use_n32k5120_gemm
+
+    return MAX_M if can_use_n32k5120_gemm(n_heads, hidden_size, 1) else -1
+
+
+class DeepseekV41Indexer(nn.Module):
+    """Scores compressed positions with a small fp4 side attention. Only a
+    kv_source layer owns index keys; the other index sources read the source's.
+
+    The projections are replicated across TP, as in the c4 indexer: every rank
+    scores with all heads, so the decode kernel path needs no cross-rank
+    reduction and every rank selects the same top-k."""
+
+    def __init__(
+        self,
+        config,
+        layer_id: int,
+        head_dim: int,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str,
+    ):
+        super().__init__()
+        self.n_heads = config.index_n_heads
+        self.n_local_heads = self.n_heads
+        self.index_head_dim = config.index_head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = config.index_topk
+        self.owns_k = layer_id in config.kv_source_layer_ids
+        self.is_candidate_source = layer_id == config.candidate_source_layer_id
+        self.uses_candidates = 0 <= config.candidate_source_layer_id < layer_id
+        self.candidate_topk_blocks = config.candidate_topk_blocks
+        self.candidate_block_size = config.candidate_block_size
+        self.softmax_scale = self.index_head_dim**-0.5
+        self.wq_b = ReplicatedLinear(
+            config.q_lora_rank,
+            self.n_heads * self.index_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            params_dtype=torch.bfloat16,
+            prefix=add_prefix("wq_b", prefix),
+        )
+        self.weights_proj = ReplicatedLinear(
+            config.hidden_size,
+            self.n_heads,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            quant_config=None,
+            prefix=add_prefix("weights_proj", prefix),
+        )
+        # The decode GEMM matches tiny_gemm's reduction order, not cuBLAS's;
+        # wider batches use the linear path.
+        self.weights_proj_small_max_m = _small_weights_proj_max_m(
+            self.n_heads, config.hidden_size
+        )
+        if self.owns_k:
+            self.wk = nn.Linear(
+                head_dim, self.index_head_dim, bias=False, dtype=torch.bfloat16
+            )
+            self.k_norm = RMSNorm(self.index_head_dim, config.rms_norm_eps)
+
+    def forward_wk(self, latent: torch.Tensor) -> torch.Tensor:
+        from sglang.kernels.ops.gemm.n128k512 import (
+            can_use_n128k512_gemm,
+            n128k512_gemm_bf16,
+        )
+
+        # Use the shared admission check: the JIT kernel requires supported shapes and
+        # hardware, and raises instead of falling back when either condition is violated.
+        if can_use_n128k512_gemm(
+            self.index_head_dim, latent.shape[-1], latent.shape[0]
+        ):
+            return n128k512_gemm_bf16(latent, self.wk.weight)
+        return self.wk(latent)
+
+    def index_keys(self, latent: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+        """Pre-RoPE latents [n, D] -> fp4-rounded index keys [n, index_head_dim]."""
+        k = self.k_norm(self.forward_wk(latent))
+        return _rope_fq4(k, freqs, self.rope_head_dim)
+
+    def queries(self, q_lora: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+        q, _ = self.wq_b(q_lora)
+        q = q.view(q.shape[0], self.n_local_heads, self.index_head_dim)
+        return _rope_fq4(q, freqs, self.rope_head_dim)
+
+    def head_weights_raw(self, x: torch.Tensor) -> torch.Tensor:
+        """`weights_proj(x)` before the scale, [tokens, n_heads] bf16."""
+        if 0 < x.shape[0] <= self.weights_proj_small_max_m and x.is_cuda:
+            from sglang.kernels.ops.gemm.n32k5120 import n32k5120_gemm_bf16
+
+            return n32k5120_gemm_bf16(x, self.weights_proj.weight)
+        w, _ = self.weights_proj(x)
+        return w
+
+    @property
+    def head_weight_scale(self) -> float:
+        return self.softmax_scale * self.n_heads**-0.5
+
+    def head_weights(self, x: torch.Tensor) -> torch.Tensor:
+        return self.head_weights_raw(x) * self.head_weight_scale
+
+    def scores(
+        self, q: torch.Tensor, k: torch.Tensor, weights: torch.Tensor
+    ) -> torch.Tensor:
+        """q [t, H, d], k [n, d], weights [t, H] -> [t, n], summed over all heads;
+        bf16 up to the reduction, as the reference does."""
+        s = torch.einsum("bhd,nd->bhn", q, k)
+        s = (s.relu() * weights.unsqueeze(-1)).sum(dim=1)
+        return s.float()

--- a/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
+++ b/python/sglang/srt/layers/attention/dsv4/dsv41_sparse.py
@@ -50,7 +50,6 @@ class RMSNorm(nn.Module):
             and x.dtype in (torch.bfloat16, torch.float32)
             and self.weight.dtype in (torch.bfloat16, torch.float32)
             and x.shape[-1] in (128, 512)
-            and x.numel() <= 64 * x.shape[-1]
             and x.is_contiguous()
             and self.weight.is_contiguous()
         ):

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -1126,3 +1126,30 @@ class C4Indexer(nn.Module):
             q_lora_ready=q_lora_ready,
             skip_compressor=skip_compressor,
         )
+
+
+def select_candidate_blocks(
+    logits: torch.Tensor,
+    compress_lens: torch.Tensor | int,
+    topk_blocks: int,
+    block_size: int,
+) -> torch.Tensor:
+    """Level one of the two-level top-k: a bool mask over positions keeping the
+    topk_blocks best-scoring blocks per query. Unreachable positions are already -inf
+    in logits, so an all -inf block means not reachable yet; the block holding the
+    query's newest position is always kept."""
+    width = logits.size(-1)
+    scores = F.pad(logits, (0, -width % block_size), value=-torch.inf)
+    scores = scores.unflatten(-1, (-1, block_size)).amax(dim=-1)
+    num_blocks = scores.size(-1)
+
+    last = (compress_lens - 1) // block_size
+    scores = scores.masked_fill(
+        torch.arange(num_blocks, device=logits.device) == last, torch.inf
+    )
+
+    top = scores.topk(min(topk_blocks, num_blocks), dim=-1)
+    keep = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, top.indices, top.values > -torch.inf
+    )
+    return keep.repeat_interleave(block_size, dim=-1)[..., :width]

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -119,6 +119,15 @@ class PagedIndexerMetadata:
     use_topk_v2: bool
     force_deep_gemm_metadata: bool = False
     use_prefill_cuda_graph: bool = False
+    # Compression ratio of the indexer source: 4 for c4, 1/2 for the dsv41
+    # low-ratio sources. Drives the compressed-domain page size and seq lens.
+    compress_ratio: int = 4
+    # Compressed-domain page size; 0 derives page_size // compress_ratio (the c4
+    # rule). The low-ratio indexer-K pool pages at 64 and passes it explicitly.
+    index_page_size: int = 0
+    # Rows per logits chunk for the prefill CUDA graph low-ratio indexer; 0 plans
+    # all rows at once. Chunk plans are stacked so replay can copy them in place.
+    row_chunk: int = 0
     deep_gemm_metadata: Any = field(init=False, repr=False)
     topk_metadata: torch.Tensor = field(init=False, repr=False)
     nonpaged_plan: Optional[NonPagedIndexerPlan] = field(
@@ -147,7 +156,18 @@ class PagedIndexerMetadata:
             _c4 = self.c4_seq_lens.to(torch.int32)
             if _c4.dim() == 1:
                 _c4 = _c4.unsqueeze(-1)
-            if _IS_SM120 and _c4.shape[0] > _SM120_INDEXER_M_CHUNK:
+            if self.row_chunk > 0:
+                self.deep_gemm_metadata = torch.stack(
+                    [
+                        get_paged_mqa_logits_metadata(
+                            _c4[_s : _s + self.row_chunk],
+                            self.c4_page_size,
+                            deep_gemm.get_num_sms(),
+                        )
+                        for _s in range(0, _c4.shape[0], self.row_chunk)
+                    ]
+                )
+            elif _IS_SM120 and _c4.shape[0] > _SM120_INDEXER_M_CHUNK:
                 # Chunk metadata is identical for every layer in the forward
                 # pass; compute the per-chunk list once here instead of per
                 # layer in the indexer.
@@ -176,10 +196,13 @@ class PagedIndexerMetadata:
             self.topk_metadata = torch.empty((0,))
 
         assert self.page_size == 256, "the system hardcodes page_size=256"
+        assert self.page_size % self.compress_ratio == 0, (
+            f"{self.page_size = } must divide {self.compress_ratio = }"
+        )
 
     @property
     def c4_page_size(self) -> int:
-        return self.page_size // 4
+        return self.index_page_size or self.page_size // self.compress_ratio
 
     @property
     def max_seq_len(self) -> int:
@@ -188,6 +211,18 @@ class PagedIndexerMetadata:
     @property
     def max_c4_seq_len(self) -> int:
         return self.page_table.shape[1] * self.c4_page_size
+
+    def row_chunks(self):
+        """(rows, plan) per logits chunk; one chunk when row_chunk is 0."""
+        num_rows = self.c4_seq_lens.shape[0]
+        if self.row_chunk <= 0:
+            return [(slice(0, num_rows), self.deep_gemm_metadata)]
+        return [
+            (slice(start, min(start + self.row_chunk, num_rows)), plan)
+            for start, plan in zip(
+                range(0, num_rows, self.row_chunk), self.deep_gemm_metadata
+            )
+        ]
 
     def copy_(self, other: PagedIndexerMetadata):
         if is_hip():
@@ -202,6 +237,9 @@ class PagedIndexerMetadata:
             dst=self,
             check_eq_fields=[
                 "page_size",
+                "compress_ratio",
+                "index_page_size",
+                "row_chunk",
                 "force_deep_gemm_metadata",
                 "use_prefill_cuda_graph",
                 "use_topk_v2",

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -34,7 +34,7 @@ compressed branch becomes a no-op) and any ``compress_ratio >= 1``.
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 import triton
@@ -114,6 +114,7 @@ def combined_topk_width(topk: int, window_size: int) -> int:
 def combine_topk_swa_indices(
     topk_indices: torch.Tensor,
     query_start_loc: torch.Tensor,
+    query_pos: torch.Tensor,
     seq_lens: torch.Tensor,
     gather_lens: torch.Tensor,
     compressed_base: torch.Tensor,
@@ -124,43 +125,22 @@ def combine_topk_swa_indices(
     out_indices: Optional[torch.Tensor] = None,
     out_lens: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Combine topk + SWA indices into a single ``flash_mla_sparse_fwd`` row.
+    """Combine top-k and SWA indices for flash_mla_sparse_fwd.
 
-    Args:
-        topk_indices: (num_tokens, K) int32. Per-query indices into the
-            compressed-cache region, **already in request-local space** —
-            i.e. in ``[0, compressed_gather_len[r])`` for the request that
-            owns each token. Pad entries can be any value; they are ignored
-            beyond ``topk_len``.
-        query_start_loc: (num_reqs+1,) int32. Cumulative query lengths; may
-            be in global (cross-chunk) space — kernel rebases by subtracting
-            ``query_start_loc[0]``.
-        seq_lens: (num_reqs,) int32. Each request's full sequence length.
-        gather_lens: (num_reqs,) int32. Trailing tokens dequanted into the
-            SWA region for that request.
-        compressed_base: (num_reqs,) int32. Flat workspace offset where
-            request r's compressed region begins. Pass all-zeros (or any
-            value) for SWA-only layers since topk=0 disables this branch.
-        swa_base: (num_reqs,) int32. Flat workspace offset where request
-            r's SWA region begins.
-        window_size: SWA window size.
-        compress_ratio: must be ``>= 1`` even when topk==0.
-        topk: configured topk; pass 0 for SWA-only layers.
-        out_indices: optional preallocated ``(num_tokens, combined_topk)``
-            int32 buffer. If provided, the kernel writes the per-query prefix
-            ``[0, topk_len + swa_len)``; positions beyond are not touched.
-            Caller must pre-fill with ``-1`` sentinels (and the chunk-invariant
-            valid-prefix length must hold across reuses).
-        out_lens: optional preallocated ``(num_tokens,)`` int32 buffer; the
-            kernel fully overwrites it, so any dtype-correct buffer works.
+    Top-k indices are int32 [num_tokens, K] in each request's compressed region.
+    Invalid entries within topk_len must be -1; later entries are ignored.
+    query_start_loc can include a cross-chunk offset; query_pos is absolute.
+    compressed_base and swa_base address the flat workspace. SWA-only layers use
+    topk == 0, but compress_ratio must still be positive.
 
-    Returns:
-        combined_indices: (num_tokens, padded_topk_swa) int32, padded to a
-            multiple of 128 with -1 sentinels.
-        combined_lens: (num_tokens,) int32, valid prefix length per token.
+    Returns int32 indices [num_tokens, padded_topk_swa] and per-token scanned-prefix
+    lengths, including -1 entries skipped by attention. Width is padded to 128.
+    Preallocated out_indices must contain -1 outside the written prefix;
+    reuse requires chunk-invariant scanned-prefix lengths. out_lens is overwritten.
     """
     assert topk_indices.dtype == torch.int32
     assert query_start_loc.dtype == torch.int32
+    assert query_pos.dtype == torch.int32
     assert seq_lens.dtype == torch.int32
     assert gather_lens.dtype == torch.int32
     assert compressed_base.dtype == torch.int32
@@ -201,6 +181,7 @@ def combine_topk_swa_indices(
         topk_indices,
         topk_indices.stride(0),
         query_start_loc,
+        query_pos,
         seq_lens,
         gather_lens,
         compressed_base,
@@ -284,13 +265,25 @@ def build_swa_token_ids(
 
 
 @dataclass
-class SparsePrefillChunkCache:
-    """Chunk-invariant scaffolding for ``_forward_prefill_sparse``.
+class CompressedGather:
+    """Positional layout of one top-k compressed cache inside the workspace."""
 
-    The fields here depend only on the prefill chunk (forward_batch,
-    req_to_token, full_to_swa_index_mapping, and the c4/c128 page tables)
-    and not on the per-layer k_cache. Reused across every layer in the
-    chunk to avoid rebuilding tiny tensors 61 times per forward pass.
+    flat_token_ids: torch.Tensor  # (num_reqs * c_max,) int32
+    page_size: int
+    compressed_base: torch.Tensor  # (num_reqs,) int32
+    swa_base: torch.Tensor  # (num_reqs,) int32
+    # Tail stays at the -1 sentinel because the valid prefix length is
+    # chunk-invariant per request; subsequent layers only overwrite that prefix.
+    combined_indices: Optional[torch.Tensor] = None
+    combined_lens: Optional[torch.Tensor] = None
+
+
+@dataclass
+class SparsePrefillChunkCache:
+    """Cache prefill-chunk metadata shared across layers.
+
+    Fields depend on request/token mappings and compressed page tables,
+    not per-layer k_cache; layer-specific top-k combinations are not cached.
     """
 
     # Geometry computed once per chunk.
@@ -309,7 +302,8 @@ class SparsePrefillChunkCache:
     # ``page_size`` so that ``slot // page_size`` recovers the right page.
     swa_page_size: int
     seq_lens: torch.Tensor  # (num_reqs,) int32
-    query_start_loc: torch.Tensor  # (num_reqs+1,) int32
+    query_start_loc: torch.Tensor  # (num_reqs+1,) int32, query rows per request
+    query_pos: torch.Tensor  # (num_qo_tokens,) int32, sequence position per row
 
     # SWA-side (every layer needs these, all chunk-invariant).
     swa_token_ids: torch.Tensor  # (total_swa,) int32
@@ -325,21 +319,16 @@ class SparsePrefillChunkCache:
     c128_combined_indices: Optional[torch.Tensor] = None
     c128_combined_lens: Optional[torch.Tensor] = None
 
-    # c4: positional layout of the c4 cache (combine output is per-layer).
-    c4_flat_token_ids: Optional[torch.Tensor] = None  # (num_reqs * c4_max,) int32
-    c4_page_size: Optional[int] = None
-    c4_compressed_base: Optional[torch.Tensor] = None  # (num_reqs,) int32
-    c4_swa_base: Optional[torch.Tensor] = None  # (num_reqs,) int32
-    # Tail stays at the -1 sentinel because the valid prefix length is
-    # chunk-invariant per request — subsequent layers only overwrite that prefix.
-    c4_combined_indices: Optional[torch.Tensor] = None
-    c4_combined_lens: Optional[torch.Tensor] = None
+    # Top-k compressed caches (c1 / c2 / c4), keyed by compress ratio.
+    compressed: Dict[int, CompressedGather] = field(default_factory=dict)
 
     @classmethod
     def build(
         cls,
         seq_lens: torch.Tensor,
         extend_seq_lens: torch.Tensor,
+        query_lens: torch.Tensor,
+        query_pos: torch.Tensor,
         req_pool_indices: torch.Tensor,
         req_to_token: torch.Tensor,
         full_to_swa: torch.Tensor,
@@ -349,11 +338,13 @@ class SparsePrefillChunkCache:
         max_seq_len: int,
         total_swa: int,
     ) -> "SparsePrefillChunkCache":
+        """``query_lens`` / ``query_pos``: the rows this forward runs (the extend, or
+        a CP rank's interleaved share of it); the SWA gather spans the whole extend."""
         device = seq_lens.device
         num_reqs = seq_lens.shape[0]
 
         query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
-        query_start_loc[1:] = torch.cumsum(extend_seq_lens, dim=0).to(torch.int32)
+        query_start_loc[1:] = torch.cumsum(query_lens, dim=0).to(torch.int32)
 
         swa_token_ids, swa_first_pos, swa_gather_lens, swa_offsets = (
             build_swa_token_ids(
@@ -375,6 +366,7 @@ class SparsePrefillChunkCache:
             swa_page_size=swa_page_size,
             seq_lens=seq_lens,
             query_start_loc=query_start_loc,
+            query_pos=query_pos,
             swa_token_ids=swa_token_ids,
             swa_first_pos=swa_first_pos,
             swa_gather_lens=swa_gather_lens,
@@ -389,6 +381,7 @@ class SparsePrefillChunkCache:
         cache.c0_combined_indices, cache.c0_combined_lens = combine_topk_swa_indices(
             topk_indices=zero_topk,
             query_start_loc=query_start_loc,
+            query_pos=query_pos,
             seq_lens=seq_lens,
             gather_lens=swa_gather_lens,
             compressed_base=zero_compressed_base,
@@ -420,7 +413,8 @@ class SparsePrefillChunkCache:
             f"live c128 extent {c128_max} exceeds metadata capacity "
             f"{c128_page_indices.shape[-1]}"
         )
-        last_q_per_req = (self.query_start_loc[1:] - 1).long()
+        # a request without rows on this rank gathers into a region nothing reads
+        last_q_per_req = (self.query_start_loc[1:] - 1).clamp_min(0).long()
         per_req_c128 = c128_page_indices.narrow(1, 0, c128_max).index_select(
             0, last_q_per_req
         )
@@ -443,6 +437,7 @@ class SparsePrefillChunkCache:
         combined_indices, combined_lens = combine_topk_swa_indices(
             topk_indices=topk_indices,
             query_start_loc=self.query_start_loc,
+            query_pos=self.query_pos,
             seq_lens=self.seq_lens,
             gather_lens=self.swa_gather_lens,
             compressed_base=compressed_base,
@@ -456,85 +451,90 @@ class SparsePrefillChunkCache:
         self.c128_combined_indices = combined_indices
         self.c128_combined_lens = combined_lens
 
-    def ensure_c4(
+    def ensure_compressed(
         self,
+        compress_ratio: int,
         page_table: torch.Tensor,
-        c4_page_size: int,
-    ) -> None:
-        """Populate c4-side fields from the per-query page table.
-
-        ``page_table`` is (num_qo_tokens, max_blocks); rows within a request
+        c_page_size: int,
+    ) -> CompressedGather:
+        """``page_table`` is (num_qo_tokens, max_blocks); rows within a request
         are duplicates. The combine output is per-layer (depends on the
         layer's remapped topk_indices), so we only cache the gather-side
         scaffolding plus compressed/swa bases.
         """
-        if self.c4_flat_token_ids is not None:
-            return
+        gather = self.compressed.get(compress_ratio)
+        if gather is not None:
+            return gather
         device = self.seq_lens.device
-        c4_max = max(self.max_seq_len // 4, 1)
-        c4_capacity = page_table.shape[-1] * c4_page_size
-        assert c4_max <= c4_capacity, (
-            f"live c4 extent {c4_max} exceeds metadata capacity {c4_capacity}"
+        c_max = max(self.max_seq_len // compress_ratio, 1)
+        c_capacity = page_table.shape[-1] * c_page_size
+        assert c_max <= c_capacity, (
+            f"live c{compress_ratio} extent {c_max} exceeds metadata capacity {c_capacity}"
         )
-        first_q_per_req = self.query_start_loc[:-1].long()
-        num_blocks = (c4_max + c4_page_size - 1) // c4_page_size
+        first_q_per_req = (
+            self.query_start_loc[:-1].clamp_max(self.num_qo_tokens - 1).long()
+        )
+        num_blocks = (c_max + c_page_size - 1) // c_page_size
         assert num_blocks <= page_table.shape[1]
         per_req_page_table = page_table.narrow(1, 0, num_blocks).index_select(
             0, first_q_per_req
         )
 
-        k_arange = torch.arange(c4_max, dtype=torch.int32, device=device)
-        block_idx = (k_arange // c4_page_size).long()
-        in_page = (k_arange % c4_page_size).to(torch.int32)
-        c4_token_ids_2d = (
-            per_req_page_table.index_select(1, block_idx) * c4_page_size + in_page
+        k_arange = torch.arange(c_max, dtype=torch.int32, device=device)
+        block_idx = (k_arange // c_page_size).long()
+        in_page = (k_arange % c_page_size).to(torch.int32)
+        token_ids_2d = (
+            per_req_page_table.index_select(1, block_idx) * c_page_size + in_page
         ).to(torch.int32)
-        flat_c4_ids = c4_token_ids_2d.reshape(-1).clamp_min(0)
-        total_compressed = self.num_reqs * c4_max
+        flat_ids = token_ids_2d.reshape(-1).clamp_min(0)
+        total_compressed = self.num_reqs * c_max
         compressed_base = (
-            torch.arange(self.num_reqs, dtype=torch.int32, device=device) * c4_max
+            torch.arange(self.num_reqs, dtype=torch.int32, device=device) * c_max
         ).to(torch.int32)
         swa_base = (total_compressed + self.swa_offsets[:-1]).to(torch.int32)
 
-        self.c4_flat_token_ids = flat_c4_ids
-        self.c4_page_size = c4_page_size
-        self.c4_compressed_base = compressed_base
-        self.c4_swa_base = swa_base
+        gather = CompressedGather(
+            flat_token_ids=flat_ids,
+            page_size=c_page_size,
+            compressed_base=compressed_base,
+            swa_base=swa_base,
+        )
+        self.compressed[compress_ratio] = gather
+        return gather
 
-    def combine_c4_layer(
+    def combine_compressed(
         self,
-        c4_sparse_raw_indices: torch.Tensor,
+        compress_ratio: int,
+        sparse_raw_indices: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Per-layer combine for c4. ``c4_sparse_raw_indices`` is the topk
-        kernel's positional output (``block_in_seq * c_page_size + in_page``)
-        — already in the request-local workspace coordinate that
-        ``combine_topk_swa_indices`` expects, so no remap is needed.
-
-        Reuses preallocated ``c4_combined_indices`` / ``c4_combined_lens``
-        buffers across layers — the kernel only overwrites the valid prefix.
+        """``sparse_raw_indices`` is the top-k as request-local compressed
+        positions, already the workspace coordinate ``combine_topk_swa_indices``
+        expects, so no remap is needed.
         """
-        topk = c4_sparse_raw_indices.shape[-1]
-        if self.c4_combined_indices is None:
+        gather = self.compressed[compress_ratio]
+        topk = sparse_raw_indices.shape[-1]
+        if gather.combined_indices is None:
             device = self.seq_lens.device
-            self.c4_combined_indices = torch.full(
+            gather.combined_indices = torch.full(
                 (self.num_qo_tokens, combined_topk_width(topk, self.swa_window_size)),
                 -1,
                 dtype=torch.int32,
                 device=device,
             )
-            self.c4_combined_lens = torch.zeros(
+            gather.combined_lens = torch.zeros(
                 self.num_qo_tokens, dtype=torch.int32, device=device
             )
         return combine_topk_swa_indices(
-            topk_indices=c4_sparse_raw_indices,
+            topk_indices=sparse_raw_indices,
             query_start_loc=self.query_start_loc,
+            query_pos=self.query_pos,
             seq_lens=self.seq_lens,
             gather_lens=self.swa_gather_lens,
-            compressed_base=self.c4_compressed_base,
-            swa_base=self.c4_swa_base,
+            compressed_base=gather.compressed_base,
+            swa_base=gather.swa_base,
             window_size=self.swa_window_size,
-            compress_ratio=4,
+            compress_ratio=compress_ratio,
             topk=topk,
-            out_indices=self.c4_combined_indices,
-            out_lens=self.c4_combined_lens,
+            out_indices=gather.combined_indices,
+            out_lens=gather.combined_lens,
         )

--- a/python/sglang/srt/layers/attention/dsv4/torch_quant.py
+++ b/python/sglang/srt/layers/attention/dsv4/torch_quant.py
@@ -1,0 +1,62 @@
+"""Pure-torch FP4 fake quantization for DeepSeek-V4.1.
+
+Indexer values use per-32 UE8M0 scales; compressed KV uses per-16 E4M3 scales.
+Both paths round to the E2M1 grid with ties to even.
+"""
+
+import torch
+
+FP8_MAX = 448.0
+FP4_MAX = 6.0
+FP8_BLOCK_SIZE = 32
+FP4_BLOCK_SIZE = 32
+FP4_AMAX_FLOOR = 6 * 2.0**-126
+
+
+def ceil_pow2(x: torch.Tensor) -> torch.Tensor:
+    """2 ** ceil(log2(x)) for positive fp32 x, computed on the IEEE bits so the
+    result is exact at powers of two."""
+    bits = x.contiguous().view(torch.int32)
+    exponent = ((bits >> 23) & 0xFF) - 127
+    has_mantissa = (bits & 0x7FFFFF) != 0
+    exponent = exponent + has_mantissa.to(torch.int32)
+    return ((exponent + 127) << 23).view(torch.float32)
+
+
+def block_scale(x: torch.Tensor, block_size: int, fmax: float, amax_floor: float):
+    """Per-block ue8m0 scale, as fp32 powers of two, shape [..., N // block_size]."""
+    amax = x.float().unflatten(-1, (-1, block_size)).abs().amax(dim=-1)
+    amax = amax.clamp_min(amax_floor)
+    # The kernel multiplies by the fp32 reciprocal rather than dividing. A Python
+    # scalar keeps this free of host tensors, so it can run under CUDA graph capture.
+    return ceil_pow2(amax * (1.0 / fmax))
+
+
+def round_fp4(x: torch.Tensor) -> torch.Tensor:
+    """Round fp32 values in [-6, 6] onto the e2m1 grid with round-to-nearest-even."""
+    magnitude = x.abs()
+    step = torch.where(magnitude < 2.0, 0.5, torch.where(magnitude < 4.0, 1.0, 2.0))
+    return torch.round(magnitude / step) * step * torch.sign(x)
+
+
+def fake_quant_fp4(x: torch.Tensor, block_size: int = FP4_BLOCK_SIZE) -> torch.Tensor:
+    """Quantize to fp4 (per-block ue8m0 scale) and back, in x's dtype."""
+    scale = block_scale(x, block_size, FP4_MAX, FP4_AMAX_FLOOR)
+    scaled = x.float().unflatten(-1, (-1, block_size)) / scale.unsqueeze(-1)
+    deq = round_fp4(scaled.clamp(-FP4_MAX, FP4_MAX)) * scale.unsqueeze(-1)
+    return deq.flatten(-2).to(x.dtype)
+
+
+def fake_quant_compressed_kv(x: torch.Tensor) -> torch.Tensor:
+    """FP4 round-trip with one E4M3FN scale per 16 compressed-KV elements.
+
+    Round amax / 6 to E4M3 with ties to even, clamping the scale to its
+    positive finite range [2**-9, 448]. Zero blocks remain zero.
+    """
+    blocks = x.float().unflatten(-1, (-1, 16))
+    amax = blocks.abs().amax(dim=-1, keepdim=True)
+    scale = (amax * (1.0 / FP4_MAX)).clamp(min=2**-9, max=FP8_MAX)
+    scale = scale.to(torch.float8_e4m3fn).float()
+    scaled = (blocks / scale).clamp(-FP4_MAX, FP4_MAX)
+    deq = round_fp4(scaled) * scale
+    return deq.flatten(-2).to(x.dtype)

--- a/python/sglang/srt/layers/cp/interleave.py
+++ b/python/sglang/srt/layers/cp/interleave.py
@@ -55,6 +55,9 @@ class InterleaveContextParallelMetadata(BaseContextParallelMetadata):
     per_rank_actual_token: Optional[List[int]] = None
     max_rank_len: Optional[List[int]] = None
     per_rank_logical_token: Optional[List[int]] = None
+    # Tail row -> packed all-gather slot; local tail metadata rows include padding.
+    gather_index: Optional[torch.Tensor] = None
+    local_index: Optional[torch.Tensor] = None
 
 
 class InterleaveCPStrategy(ContextParallelStrategy):
@@ -205,6 +208,8 @@ class InterleaveCPStrategy(ContextParallelStrategy):
             gathered = x.new_empty((self.cp_size * physical_rank_len, *x.shape[1:]))
         attn_cp_all_gather_into_tensor(gathered, padded_x.contiguous())
 
+        if metadata.gather_index is not None:
+            return gathered.index_select(0, metadata.gather_index)
         flat_indices = torch.arange(total_tokens, device=x.device)
         gather_indices = (
             flat_indices % self.cp_size
@@ -270,3 +275,15 @@ class InterleaveCPStrategy(ContextParallelStrategy):
         k_nope = full_latent[..., :kv_lora_rank].unsqueeze(1)
         k_rope = full_latent[..., kv_lora_rank:].unsqueeze(1)
         return k_nope, k_rope
+
+
+def interleave_rows_per_request(
+    extend_lens: List[int], cp_rank: int, cp_size: int
+) -> List[int]:
+    """Rows of each request an interleave CP rank holds (batch index congruent to the rank)."""
+    counts, start = [], 0
+    for n in extend_lens:
+        end = start + n
+        counts.append((end - 1 - cp_rank) // cp_size - (start - 1 - cp_rank) // cp_size)
+        start = end
+    return counts

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -1,0 +1,954 @@
+"""Engram: gated n-gram hash memory added to the hc residual stream.
+
+Predecessors come from the live batch and per-request history of the n - 1
+previous tokens. The token map, hash multipliers and prime layout must match
+sglang.kernels.ops.embeddings.engram_hash to produce identical hash ids.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import glob
+import logging
+import mmap
+import os
+import re
+import time
+from typing import Optional
+
+import msgspec
+import numpy as np
+import torch
+from torch import nn
+
+from sglang.kernels.ops.embeddings.engram_gate import fused_engram_gate
+from sglang.kernels.ops.embeddings.engram_gather import engram_gather
+from sglang.kernels.ops.embeddings.engram_hash import (
+    MODE_DECODE,
+    MODE_EXTEND,
+    MODE_VERIFY,
+    engram_commit_history,
+    engram_hash_ids,
+)
+from sglang.srt.distributed import tensor_model_parallel_all_reduce
+from sglang.srt.distributed.parallel_state import get_tp_group
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsv4.torch_quant import FP8_BLOCK_SIZE
+from sglang.srt.layers.dp_attention import (
+    attn_cp_all_gather_into_tensor,
+    dp_gather_replicate,
+    dp_reduce_scatter_tensor,
+    dp_scatter,
+    get_attention_dp_size,
+    get_global_dp_buffer_len,
+    is_dp_gatherv_active,
+)
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.runtime_context import get_model, get_parallel, get_serving
+from sglang.srt.utils import add_prefix
+from sglang.srt.utils.hf_transformers.tokenizer import get_tokenizer
+
+logger = logging.getLogger(__name__)
+
+
+def _find_next_prime(start: int, seen_primes: set[int]) -> int:
+    from sympy import isprime
+
+    candidate = start + 1
+    while not isprime(candidate) or candidate in seen_primes:
+        candidate += 1
+    return candidate
+
+
+def build_compressed_token_map(tokenizer) -> tuple[list[int], int]:
+    """Token id -> compressed id, plus the compressed vocab size. The size feeds every
+    hash multiplier, so a mismatch rehashes the whole table."""
+    from tokenizers import Regex, normalizers
+
+    # A private-use sentinel keeps a lone-space token from collapsing to "" under Strip().
+    sentinel = "\ue000"
+    normalizer = normalizers.Sequence(
+        [
+            normalizers.NFKC(),
+            normalizers.NFD(),
+            normalizers.StripAccents(),
+            normalizers.Lowercase(),
+            normalizers.Replace(Regex(r"[ \t\r\n]+"), " "),
+            normalizers.Replace(Regex(r"^ $"), sentinel),
+            normalizers.Strip(),
+            normalizers.Replace(sentinel, " "),
+        ]
+    )
+    backend = tokenizer.backend_tokenizer
+    key_to_new: dict[str, int] = {}
+    lookup = [0] * len(tokenizer)
+    for token_id in range(len(tokenizer)):
+        text = backend.decode([token_id], skip_special_tokens=False)
+        if "\ufffd" in text:
+            # A partial UTF-8 byte token has nothing to normalize; key it by its raw form.
+            key = backend.id_to_token(token_id)
+        else:
+            normalized = normalizer.normalize_str(text)
+            key = normalized if normalized else text
+        new_id = key_to_new.get(key)
+        if new_id is None:
+            new_id = len(key_to_new)
+            key_to_new[key] = new_id
+        lookup[token_id] = new_id
+    return lookup, len(key_to_new)
+
+
+def compute_hash_multipliers(
+    layer_ids: tuple[int, ...], max_ngram_size: int, vocab_size: int
+) -> torch.Tensor:
+    """One odd multiplier per (layer, lookback) from a per-layer RNG, bounded so that
+    token_id * multiplier fits in int64."""
+    max_long = np.iinfo(np.int64).max
+    multiplier_bound = max(1, (max_long // vocab_size) // 2)
+    rows = []
+    for layer_id in layer_ids:
+        generator = np.random.default_rng(10007 * layer_id)
+        values = generator.integers(
+            low=0, high=multiplier_bound, size=(max_ngram_size,), dtype=np.int64
+        )
+        rows.append(torch.tensor(values * 2 + 1))
+    return torch.stack(rows)
+
+
+class EngramLayout(msgspec.Struct, frozen=True):
+    max_ngram_size: int
+    layer_ids: tuple[int, ...]
+    num_embeddings: tuple[int, ...]
+    primes: tuple[tuple[tuple[int, ...], ...], ...]  # [layer][n-gram size][head]
+    n_heads: int
+    head_dim: int
+
+    @classmethod
+    def build(
+        cls,
+        layer_ids: tuple[int, ...],
+        num_embeddings: tuple[int, ...],
+        max_ngram_size: int,
+        n_heads: int,
+        head_dim: int,
+        vocab_size: int,
+    ) -> EngramLayout:
+        """Primes are drawn in (layer, n-gram size, head) order from one shared
+        ascending sequence starting above vocab_size - 1."""
+        primes, seen = [], set()
+        for _ in layer_ids:
+            per_ngram = []
+            for _ in range(max_ngram_size - 1):
+                sizes, current = [], vocab_size - 1
+                for _ in range(n_heads):
+                    current = _find_next_prime(current, seen)
+                    seen.add(current)
+                    sizes.append(current)
+                per_ngram.append(tuple(sizes))
+            primes.append(tuple(per_ngram))
+        return cls(
+            max_ngram_size=max_ngram_size,
+            layer_ids=layer_ids,
+            num_embeddings=num_embeddings,
+            primes=tuple(primes),
+            n_heads=n_heads,
+            head_dim=head_dim,
+        )
+
+
+def build_engram_layout(config) -> Optional[EngramLayout]:
+    layer_ids = tuple(config.engram_layer_ids)
+    if not layer_ids:
+        return None
+    return EngramLayout.build(
+        layer_ids=layer_ids,
+        num_embeddings=tuple(config.engram_num_embeddings),
+        max_ngram_size=config.engram_max_ngram_size,
+        n_heads=config.engram_n_heads,
+        head_dim=config.engram_head_dim,
+        vocab_size=config.engram_vocab_size,
+    )
+
+
+def compute_engram_hash_ids(
+    tokens: torch.Tensor,
+    blocked: torch.Tensor,
+    pad_id: int,
+    token_map: torch.Tensor,
+    multipliers: torch.Tensor,
+    primes: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    """tokens [T, n]: column 0 is the token itself, column s its s-th predecessor;
+    blocked [T, n] marks look-back that ran off the sequence start. Returns
+    [T, n_engram_layers, (n - 1) * n_heads] row ids into each layer's table."""
+    compressed = torch.where(blocked, pad_id, token_map[tokens])
+    products = compressed.unsqueeze(1) * multipliers
+    # XOR the multiplied ids one look-back at a time: after step i the running value
+    # is the (i + 1)-gram hash, bucketed by that n-gram size's primes.
+    rolling, hashes = products[..., 0], []
+    for i in range(1, tokens.shape[-1]):
+        rolling = torch.bitwise_xor(rolling, products[..., i])
+        hashes.append(rolling.unsqueeze(-1) % primes[:, i - 1])
+    return torch.cat(hashes, dim=-1) + offsets
+
+
+class EngramHasher(nn.Module):
+    """Hash ids for every token of a forward batch, [T, n_engram_layers, n_hash_cols]."""
+
+    def __init__(
+        self,
+        layout: EngramLayout,
+        tokenizer,
+        pad_id: int,
+        compressed_vocab_size: int,
+    ):
+        super().__init__()
+        self.max_ngram_size = layout.max_ngram_size
+        token_map, vocab_size = build_compressed_token_map(tokenizer)
+        assert vocab_size == compressed_vocab_size, (
+            f"the tokenizer normalizes to {vocab_size} distinct tokens but the config "
+            f"expects {compressed_vocab_size}; every hash multiplier depends on it"
+        )
+        self.pad_id = token_map[pad_id]
+        flat = [
+            [p for per_ngram in layer for p in per_ngram] for layer in layout.primes
+        ]
+        offsets = np.array([np.cumsum([0, *sizes[:-1]]) for sizes in flat])
+        multipliers = compute_hash_multipliers(
+            layout.layer_ids, layout.max_ngram_size, vocab_size
+        )
+        self.register_buffer("token_map", torch.tensor(token_map), persistent=False)
+        self.register_buffer("multipliers", multipliers, persistent=False)
+        self.register_buffer("primes", torch.tensor(layout.primes), persistent=False)
+        self.register_buffer("offsets", torch.tensor(offsets), persistent=False)
+        self.image_token_id: Optional[int] = None
+        self.history: Optional[torch.Tensor] = None
+        self.pad_row = 0
+
+    def init_history(self, num_req_slots: int, device) -> None:
+        """Allocate oldest-first history with a spare row for graph padding.
+
+        Extend reads scheduler-provided predecessors after prefix hits or
+        retraction. Decode commits in forward; verify commits after acceptance.
+        """
+        self.history = torch.zeros(
+            num_req_slots + 1,
+            self.max_ngram_size - 1,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.pad_row = num_req_slots
+
+    @classmethod
+    def from_config(cls, config, layout: EngramLayout) -> EngramHasher:
+        # The compressed token map is built with the HF normalizers, so the HF
+        # tokenizer backend is used here whatever the serving backend is.
+        tokenizer = get_tokenizer(
+            get_serving().tokenizer_path,
+            tokenizer_mode=get_serving().tokenizer_mode,
+            trust_remote_code=get_model().trust_remote_code,
+            revision=get_model().revision,
+            tokenizer_backend="huggingface",
+        )
+        result = cls(
+            layout,
+            tokenizer,
+            config.engram_pad_token_id,
+            config.engram_compressed_vocab_size,
+        )
+        result.image_token_id = (
+            config.image_token_id
+            if config.model_type == "deepseek_v41" and config.vision_n_layers > 0
+            else None
+        )
+        return result
+
+    def forward(
+        self, input_ids: torch.Tensor, forward_batch: ForwardBatch
+    ) -> torch.Tensor:
+        assert self.history is not None, "EngramHasher.init_history was not called"
+        n = self.max_ngram_size
+        num_tokens = input_ids.shape[0]
+        if num_tokens == 0:
+            return torch.empty(
+                (0, self.primes.shape[0], self.offsets.shape[1]),
+                dtype=torch.int64,
+                device=input_ids.device,
+            )
+        mode = forward_batch.forward_mode
+        req_slots = forward_batch.req_pool_indices.to(torch.int64)
+        bs = req_slots.shape[0]
+        device = input_ids.device
+        # Which request each token belongs to and where its run starts; tokens at or
+        # past num_real are graph padding. History rows come from self.history via
+        # req_slots unless the scheduler supplied this extend's predecessors.
+        num_real, block, row, starts = num_tokens, 1, None, None
+        history, hist_via_slots = self.history, True
+        if mode.is_decode():
+            kmode = MODE_DECODE
+            commit_rows, commit_last = req_slots, None
+        elif mode.is_target_verify():
+            block = int(forward_batch.spec_info.draft_token_num)
+            assert num_tokens == bs * block, (
+                "engram target-verify expects one equal block per request, got "
+                f"{num_tokens} tokens for {bs} requests of {block}"
+            )
+            kmode = MODE_VERIFY
+            commit_rows = commit_last = None
+        else:
+            assert mode.is_extend(), (
+                f"engram serves extend, target-verify and decode, not {mode}"
+            )
+            lens = forward_batch.extend_seq_lens.to(torch.int64)
+            starts = forward_batch.extend_start_loc.to(torch.int64)
+            row = torch.repeat_interleave(torch.arange(bs, device=device), lens)
+            num_real = row.shape[0]
+            kmode = MODE_EXTEND
+            if forward_batch.ngram_history is not None:
+                history, hist_via_slots = forward_batch.ngram_history, False
+            commit_rows = torch.where(lens > 0, req_slots, self.pad_row)
+            commit_last = (starts + lens - 1).clamp(0, num_tokens - 1)
+
+        if input_ids.is_cuda and torch.version.cuda is not None:
+            hash_ids, tokens = engram_hash_ids(
+                input_ids,
+                forward_batch.positions,
+                mode=kmode,
+                history=history,
+                token_map=self.token_map,
+                multipliers=self.multipliers,
+                primes=self.primes,
+                offsets=self.offsets,
+                pad_id=self.pad_id,
+                num_real=num_real,
+                req_slots=req_slots if hist_via_slots else None,
+                block=block,
+                row=row,
+                starts=starts,
+                image_token_id=self.image_token_id,
+                mm_pad_shift=MM_PAD_SHIFT_VALUE,
+            )
+        else:
+            hash_ids, tokens = self._torch_hash_ids(
+                input_ids,
+                forward_batch.positions,
+                kmode,
+                history[req_slots] if hist_via_slots else history,
+                num_real,
+                block,
+                row,
+                starts,
+            )
+        if commit_rows is not None:
+            # Padded rows must not overwrite a live request's history.
+            last_tokens = tokens if commit_last is None else tokens[commit_last]
+            out_loc = forward_batch.out_cache_loc
+            if out_loc is not None:
+                if commit_last is not None:
+                    out_loc = out_loc[commit_last]
+                commit_rows = torch.where(out_loc == 0, self.pad_row, commit_rows)
+            self.history[commit_rows] = (
+                last_tokens[:, : n - 1].flip(-1).to(self.history.dtype)
+            )
+        return hash_ids
+
+    def _torch_hash_ids(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kmode: int,
+        history: torch.Tensor,
+        num_real: int,
+        block: int,
+        row: Optional[torch.Tensor],
+        starts: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Non-CUDA fallback of the hash kernel: predecessor table [T, n] and hash ids.
+        ``history`` is already the per-request [bs, n - 1] rows of this batch."""
+        n = self.max_ngram_size
+        num_tokens = input_ids.shape[0]
+        device = input_ids.device
+        input_ids = input_ids.to(torch.int64)
+        shifts = torch.arange(n, device=device)
+        if kmode == MODE_DECODE:
+            tokens = torch.cat(
+                [input_ids.unsqueeze(-1), history.to(torch.int64).flip(-1)], dim=-1
+            )
+        else:
+            t = torch.arange(num_real, device=device)
+            if kmode == MODE_VERIFY:
+                row = t // block
+                offset = t - row * block
+            else:
+                offset = t - starts[row]
+            # Predecessor at shift s of token t: an earlier token of the same run
+            # when s <= offset, else history[row, -(s - offset)].
+            from_batch = shifts.unsqueeze(0) <= offset.unsqueeze(-1)
+            in_batch = input_ids[(t.unsqueeze(-1) - shifts).clamp_min(0)]
+            hist_col = (n - 2 - (shifts.unsqueeze(0) - offset.unsqueeze(-1) - 1)).clamp(
+                0, n - 2
+            )
+            from_hist = history.to(torch.int64)[row].gather(1, hist_col)
+            tokens = torch.where(from_batch, in_batch, from_hist)
+        if num_real < num_tokens:
+            tokens = torch.cat([tokens, tokens.new_zeros(num_tokens - num_real, n)])
+        positions = positions.to(torch.int64)
+        blocked = positions.unsqueeze(-1) < shifts
+        if num_real < num_tokens:
+            blocked[num_real:] = True
+        if self.image_token_id is not None:
+            # Scheduler-provided history still carries the multimodal pad ids.
+            tokens = tokens.masked_fill(
+                tokens >= MM_PAD_SHIFT_VALUE, self.image_token_id
+            )
+            # Once a lookback hits an image, every older predecessor is PAD.
+            blocked = (
+                (blocked | (tokens == self.image_token_id))
+                .to(torch.int32)
+                .cummax(-1)
+                .values.bool()
+            )
+        hash_ids = compute_engram_hash_ids(
+            tokens,
+            blocked,
+            self.pad_id,
+            self.token_map,
+            self.multipliers,
+            self.primes,
+            self.offsets,
+        )
+        return hash_ids, tokens
+
+    def commit_after_verify(
+        self,
+        verify_ids_2d: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        commit_lens: torch.Tensor,
+    ) -> None:
+        """Commit anchor + accepted drafts; the bonus is the next block's anchor."""
+        assert self.history is not None, "EngramHasher.init_history was not called"
+        if self.history.is_cuda:
+            engram_commit_history(
+                self.history, verify_ids_2d, req_pool_indices, commit_lens
+            )
+            return
+        n1 = self.max_ngram_size - 1
+        req = req_pool_indices.to(torch.int64)
+        window = torch.cat(
+            [self.history[req], verify_ids_2d.to(self.history.dtype)], dim=1
+        )
+        cols = commit_lens.to(torch.int64).unsqueeze(-1) + torch.arange(
+            n1, device=window.device
+        )
+        self.history[req] = window.gather(1, cols)
+
+
+_THP_DIR = "/sys/kernel/mm/transparent_hugepage"
+
+
+def _thp_mode(knob: str) -> str:
+    """Active mode of a transparent_hugepage sysfs knob ("" if unreadable)."""
+    try:
+        with open(f"{_THP_DIR}/{knob}") as f:
+            m = re.search(r"\[(\w+)\]", f.read())
+        return m.group(1) if m else ""
+    except OSError:
+        return ""
+
+
+def _huge_pages_backing(addr: int) -> tuple[int, int]:
+    """(mapped_kB, huge_kB) of the VMA holding addr, from /proc/self/smaps.
+    The only evidence that the kernel really handed out huge pages."""
+    mapped = huge = 0
+    inside = False
+    try:
+        with open("/proc/self/smaps") as f:
+            for line in f:
+                m = re.match(r"^([0-9a-f]+)-([0-9a-f]+) ", line)
+                if m:
+                    if inside:
+                        break
+                    inside = int(m.group(1), 16) <= addr < int(m.group(2), 16)
+                elif inside:
+                    key, _, rest = line.partition(":")
+                    if key == "Rss":
+                        mapped = int(rest.split()[0])
+                    elif key in ("AnonHugePages", "ShmemPmdMapped", "FilePmdMapped"):
+                        huge += int(rest.split()[0])
+    except OSError:
+        pass
+    return mapped, huge
+
+
+_page_cache_dropped = False
+
+
+def drop_checkpoint_page_cache(model_path: Optional[str] = None) -> tuple[int, int]:
+    """Drop checkpoint page cache with posix_fadvise(DONTNEED); return (files, bytes).
+
+    Cached checkpoint pages can prevent 512 MiB huge-page allocation,
+    so drop them before pre-faulting private host tables.
+    """
+    if model_path is None:
+        try:
+            model_path = get_model().model_path
+        except (ValueError, AttributeError):
+            # No published runtime context (unit tests, offline tools): nothing to drop.
+            return 0, 0
+    files, nbytes = 0, 0
+    for f in sorted(glob.glob(os.path.join(model_path, "*.safetensors"))):
+        try:
+            fd = os.open(f, os.O_RDONLY)
+        except OSError:
+            continue
+        try:
+            nbytes += os.fstat(fd).st_size
+            os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+            files += 1
+        finally:
+            os.close(fd)
+    return files, nbytes
+
+
+def _drop_page_cache_once(reason: str) -> None:
+    global _page_cache_dropped
+    if _page_cache_dropped or not envs.SGLANG_ENABLE_DSV41_ENGRAM_DROP_PAGE_CACHE.get():
+        return
+    _page_cache_dropped = True
+    files, nbytes = drop_checkpoint_page_cache()
+    logger.info(
+        "engram host table: dropped the page cache of %d checkpoint files (%.0f GiB) %s",
+        files,
+        nbytes / 2**30,
+        reason,
+    )
+
+
+class _HostTable:
+    """Host-memory backing for one engram table.
+
+    Layouts:
+      shared   one memfd holding every row, mapped by all ranks of the group;
+               rank 0 creates it, the others open it through /proc/<pid>/fd.
+               No all-reduce. Huge pages need transparent_hugepage/shmem_enabled.
+      private  one anonymous mapping per rank holding only its own rows, so the
+               lookup keeps the sharded all-reduce. Huge pages come from
+               transparent_hugepage/enabled (madvise or always).
+    """
+
+    def __init__(self, layout: str, nbytes: int, name: str, group, pin: bool):
+        assert layout in ("shared", "private"), layout
+        self.layout = layout
+        self.nbytes = nbytes
+        self.group = group
+        self.dirty = False
+        self.registered = False
+        if layout == "shared":
+            self.fd = self._open_shared_fd(nbytes, name)
+            self.mm = mmap.mmap(
+                self.fd,
+                nbytes,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+            )
+        else:
+            self.fd = None
+            self.mm = mmap.mmap(
+                -1,
+                nbytes,
+                flags=mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+            )
+        # Advisory before the first touch: pages are allocated huge at fault time.
+        self.mm.madvise(mmap.MADV_HUGEPAGE)
+        self.bytes = torch.frombuffer(self.mm, dtype=torch.uint8)
+        if layout == "private":
+            # Fault the shard in now, on a host whose page cache has just been
+            # emptied: cached checkpoint pages left by a previous server, or by
+            # the loader itself, make the 512 MiB huge-page faults fall back.
+            _drop_page_cache_once("before pre-faulting the private shard")
+            np.frombuffer(self.mm, dtype=np.uint8)[:: mmap.PAGESIZE] = 0
+        if layout == "shared":
+            # Every rank holds the fd before rank 0 continues; the /proc path only
+            # resolves while rank 0 keeps its descriptor.
+            group.barrier()
+        if pin:
+            err = torch.cuda.cudart().cudaHostRegister(self.bytes.data_ptr(), nbytes, 0)
+            if int(err) != 0:
+                raise RuntimeError(f"cudaHostRegister({nbytes} bytes) failed: {err}")
+            self.registered = True
+
+    @staticmethod
+    def choose_layout(requested: str) -> str:
+        if requested != "auto":
+            return requested
+        if _thp_mode("shmem_enabled") in ("advise", "always", "within_size", "force"):
+            return "shared"
+        if _thp_mode("enabled") in ("madvise", "always"):
+            return "private"
+        return "shared"
+
+    def _open_shared_fd(self, nbytes: int, name: str) -> int:
+        owner = None
+        if self.group.rank_in_group == 0:
+            fd = os.memfd_create(name, 0)
+            os.ftruncate(fd, nbytes)
+            owner = (os.getpid(), fd)
+        pid, owner_fd = self.group.broadcast_object(owner, src=0)
+        if self.group.rank_in_group == 0:
+            return fd
+        try:
+            return os.open(f"/proc/{pid}/fd/{owner_fd}", os.O_RDWR)
+        except OSError as e:
+            raise RuntimeError(
+                "engram host table: cannot open rank 0's memfd through /proc; the "
+                "TP ranks must share a PID namespace"
+            ) from e
+
+    def _collapse(self, tries: int = 3) -> None:
+        """madvise(MADV_COLLAPSE): synchronously fold whatever is still on base pages
+        into huge pages. Anonymous memory only; shmem obeys shmem_enabled and
+        refuses. EAGAIN means compaction ran out of time, so it is retried a few
+        times; anything else is logged and left."""
+        MADV_COLLAPSE = 25  # Linux >= 6.1; not in Python's mmap module
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.madvise.argtypes = (ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int)
+        for attempt in range(tries):
+            rc = libc.madvise(
+                ctypes.c_void_p(self.bytes.data_ptr()),
+                ctypes.c_size_t(self.nbytes),
+                MADV_COLLAPSE,
+            )
+            if rc == 0:
+                return
+            err = ctypes.get_errno()
+            if (
+                err != 11 or attempt == tries - 1
+            ):  # EAGAIN is the only one worth retrying
+                logger.info("engram host table: MADV_COLLAPSE errno %d", err)
+                return
+            time.sleep(1.0)
+
+    def finish_load(self, label: str):
+        if not self.dirty:
+            return
+        self.dirty = False
+        if self.layout == "shared":
+            self.group.barrier()
+        mapped_kb, huge_kb = _huge_pages_backing(self.bytes.data_ptr())
+        if self.layout == "private" and huge_kb < mapped_kb * 0.98:
+            # The loader's own reads refilled the page cache; empty it again so the
+            # collapse can find contiguous memory.
+            if envs.SGLANG_ENABLE_DSV41_ENGRAM_DROP_PAGE_CACHE.get():
+                drop_checkpoint_page_cache()
+            self._collapse()
+            mapped_kb, huge_kb = _huge_pages_backing(self.bytes.data_ptr())
+        pct = 100.0 * huge_kb / mapped_kb if mapped_kb else 0.0
+        msg = (
+            f"engram host table {label}: layout={self.layout}, "
+            f"{mapped_kb / 2**10:.0f} MiB resident, {huge_kb / 2**10:.0f} MiB in huge pages "
+            f"({pct:.0f}%){', pinned' if self.registered else ', unpinned (ATS)'}"
+        )
+        if huge_kb == 0:
+            knob = "shmem_enabled" if self.layout == "shared" else "enabled"
+            logger.warning(
+                "%s. No huge pages: expect ~10x slower lookups (one TLB miss per row); "
+                "transparent_hugepage/%s is '%s'",
+                msg,
+                knob,
+                _thp_mode(knob) or "unreadable",
+            )
+        else:
+            logger.info(msg)
+
+
+class EngramEmbedding(nn.Module):
+    """One layer's fp8 hash table with e8m0 block scales, dequantized on lookup.
+
+    Default: rows sharded over the TP group in device memory; each rank gathers
+    the rows it owns, zeroes the rest and the all-reduce reassembles the lookup.
+    With SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE the table lives in host memory and
+    the GPU gathers rows over the CPU link -- either one shared copy with no
+    all-reduce, or one private shard per rank (see _HostTable). Loading is
+    sharded in every layout: a rank writes only its own row range.
+    """
+
+    def __init__(self, num_embeddings: int, dim: int, layer_id: int):
+        super().__init__()
+        self.dim = dim
+        self.tp_size = get_parallel().tp_size
+        tp_rank = get_parallel().tp_rank
+        self.row_start = num_embeddings * tp_rank // self.tp_size
+        row_end = num_embeddings * (tp_rank + 1) // self.tp_size
+        self.rows = row_end - self.row_start
+        self.host_table: Optional[_HostTable] = None
+        if envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.get():
+            self._init_host_table(num_embeddings, dim, layer_id)
+        else:
+            self.weight = nn.Parameter(
+                torch.empty(self.rows, dim, dtype=torch.float8_e4m3fn),
+                requires_grad=False,
+            )
+            self.scale = nn.Parameter(
+                torch.empty(
+                    self.rows, dim // FP8_BLOCK_SIZE, dtype=torch.float8_e8m0fnu
+                ),
+                requires_grad=False,
+            )
+        self.weight.weight_loader = self._load_rows
+        self.scale.weight_loader = self._load_rows
+
+    def _init_host_table(self, num_embeddings: int, dim: int, layer_id: int):
+        layout = _HostTable.choose_layout(
+            envs.SGLANG_DSV41_ENGRAM_HOST_TABLE_LAYOUT.get()
+        )
+        n = num_embeddings if layout == "shared" else self.rows
+        w_bytes = n * dim
+        s_bytes = n * (dim // FP8_BLOCK_SIZE)
+        self.host_table = _HostTable(
+            layout,
+            max(1, w_bytes + s_bytes),  # mmap requires storage even for an empty shard.
+            f"sglang_engram_{layer_id}",
+            get_tp_group(),
+            pin=envs.SGLANG_DSV41_ENGRAM_HOST_TABLE_PIN.get(),
+        )
+        raw = self.host_table.bytes[: w_bytes + s_bytes]
+        weight = raw[:w_bytes].view(torch.float8_e4m3fn).view(n, dim)
+        scale = raw[w_bytes:].view(torch.float8_e8m0fnu).view(n, dim // FP8_BLOCK_SIZE)
+        self.weight = nn.Parameter(weight, requires_grad=False)
+        self.scale = nn.Parameter(scale, requires_grad=False)
+
+    @property
+    def _shared(self) -> bool:
+        return self.host_table is not None and self.host_table.layout == "shared"
+
+    def _load_rows(self, param: nn.Parameter, loaded_weight: torch.Tensor):
+        rows = slice(self.row_start, self.row_start + self.rows)
+        if self._shared:
+            param.data[rows].copy_(loaded_weight[rows])
+        else:
+            param.data.copy_(loaded_weight[rows])
+        if self.host_table is not None:
+            self.host_table.dirty = True
+
+    def finish_load(self, label: str = ""):
+        """Barrier (shared layout) once every rank has written its rows; log how
+        the table ended up backed."""
+        if self.host_table is not None:
+            self.host_table.finish_load(label)
+
+    def forward(
+        self,
+        indices: torch.Tensor,
+        forward_batch: Optional[ForwardBatch] = None,
+        *,
+        cp_all_tokens: bool = False,
+    ) -> torch.Tensor:
+        if self._shared:
+            if indices.shape[0] == 0:
+                return self._empty(indices)
+            out = self._empty(indices)
+            engram_gather(
+                self.weight.data_ptr(),
+                self.scale.data_ptr(),
+                indices.reshape(-1),
+                out.view(-1, self.dim),
+                self.dim,
+                FP8_BLOCK_SIZE,
+            )
+            return out
+        if cp_all_tokens and self.tp_size > 1:
+            # Prefill CP: gather the hash ids over the CP group first so every
+            # TP rank looks up the same indices, then keep this rank's slice.
+            parallel = get_parallel()
+            local_rows = indices.shape[0]
+            all_indices = indices.new_empty(
+                (parallel.attn_cp_size * local_rows, *indices.shape[1:])
+            )
+            attn_cp_all_gather_into_tensor(all_indices, indices.contiguous())
+            start = parallel.attn_cp_rank * local_rows
+            return self._lookup(all_indices)[start : start + local_rows]
+        if self.tp_size > 1 and get_attention_dp_size() > 1:
+            return self._dp_sharded_lookup(indices, forward_batch)
+        return self._lookup(indices)
+
+    def _lookup(self, indices: torch.Tensor) -> torch.Tensor:
+        """Lookup when every TP rank holds the same indices: the device and
+        private host shards zero unowned rows and the all-reduce reassembles."""
+        if indices.shape[0] == 0:
+            return self._empty(indices)
+        values = self._owned_rows(indices)
+        if self.tp_size > 1:
+            values = tensor_model_parallel_all_reduce(values)
+        return values
+
+    def _empty(self, indices: torch.Tensor) -> torch.Tensor:
+        return torch.empty(
+            *indices.shape, self.dim, dtype=torch.bfloat16, device=indices.device
+        )
+
+    def _owned_rows(self, indices: torch.Tensor) -> torch.Tensor:
+        """Rows of `indices` this rank's shard holds, zero for the rest."""
+        if self.rows == 0:
+            return self._empty(indices).zero_()
+        if self.host_table is None and (
+            not indices.is_cuda or torch.version.cuda is None
+        ):
+            local = indices - self.row_start
+            owned = (local >= 0) & (local < self.rows)
+            local = local.masked_fill(~owned, 0)
+            rows = self.weight[local].float().unflatten(-1, (-1, FP8_BLOCK_SIZE))
+            values = (rows * self.scale[local].float().unsqueeze(-1)).flatten(-2)
+            return values.to(torch.bfloat16).masked_fill(~owned.unsqueeze(-1), 0)
+        out = self._empty(indices)
+        engram_gather(
+            self.weight.data_ptr(),
+            self.scale.data_ptr(),
+            indices.reshape(-1),
+            out.view(-1, self.dim),
+            self.dim,
+            FP8_BLOCK_SIZE,
+            row_lo=self.row_start,
+            row_hi=self.row_start + self.rows,
+        )
+        return out
+
+    def _dp_sharded_lookup(
+        self, indices: torch.Tensor, forward_batch: Optional[ForwardBatch]
+    ) -> torch.Tensor:
+        """Gather DP ranks' indices before looking up TP-sharded rows.
+
+        Every rank joins, including idle ranks with zero rows; the reduced result
+        is sliced back to each rank's local tokens.
+        """
+        assert forward_batch is not None, "the DP engram lookup needs the batch"
+        rows = get_global_dp_buffer_len()
+        ids_global = torch.empty(
+            (rows, *indices.shape[1:]), dtype=indices.dtype, device=indices.device
+        )
+        # The MAX_LEN gather may zero its local input in place, hence the clone.
+        dp_gather_replicate(ids_global, indices.clone(), forward_batch)
+        if rows == 0:
+            return self._empty(indices)
+        values = self._owned_rows(ids_global).view(rows, -1)
+        local = torch.empty(
+            (indices.shape[0], values.shape[1]),
+            dtype=values.dtype,
+            device=values.device,
+        )
+        # MAX_LEN or gatherv-sized slices use reduce-scatter;
+        # otherwise scatter the summed buffer to the DP ranks.
+        padding = forward_batch.dp_padding_mode
+        if (
+            padding is not None
+            and padding.is_max_len()
+            and self.tp_size == get_attention_dp_size()
+            and rows == self.tp_size * local.shape[0]
+        ) or is_dp_gatherv_active():
+            dp_reduce_scatter_tensor(local, values)
+        else:
+            dp_scatter(local, tensor_model_parallel_all_reduce(values), forward_batch)
+        return local.view(*indices.shape, self.dim)
+
+
+def engram_gate(
+    x: torch.Tensor,
+    kv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+    clamp_value: float,
+) -> torch.Tensor:
+    """x [T, hc_mult, dim]; kv [T, (hc_mult + 1) * dim] holds one key per hc copy
+    followed by the shared value. Adds the gated value to every copy.
+
+    The fused kernel serves every token count on CUDA; the torch path below is the
+    non-CUDA fallback and materializes fp32 copies of x, key and value."""
+    if (
+        x.is_cuda
+        and torch.version.cuda is not None
+        and x.ndim == 3
+        and kv.shape == (x.shape[0], (x.shape[1] + 1) * x.shape[2])
+        and x.dtype == kv.dtype
+        and x.dtype in (torch.bfloat16, torch.float32)
+        and q_weight.dtype in (torch.bfloat16, torch.float32)
+        and k_weight.dtype in (torch.bfloat16, torch.float32)
+        and all(t.is_contiguous() for t in (x, kv, q_weight, k_weight))
+    ):
+        return fused_engram_gate(x, kv, q_weight, k_weight, eps, clamp_value)
+    hc_mult, dim = x.shape[-2:]
+    key, value = kv.split([hc_mult * dim, dim], dim=-1)
+    key = key.float().unflatten(-1, (hc_mult, dim))
+    weight = q_weight.float() * k_weight.float()
+    h = x.float()
+    # Normalized per (token, hc copy) over dim, not jointly over the copies.
+    rstd = torch.rsqrt(h.square().mean(-1) + eps) * torch.rsqrt(
+        key.square().mean(-1) + eps
+    )
+    dot = (h * weight * key).sum(-1) * rstd * dim**-0.5
+    # Signed square root before the sigmoid, matching the training kernel.
+    gate = torch.sigmoid(torch.copysign(dot.abs().clamp_min(clamp_value).sqrt(), dot))
+    return (h + gate.unsqueeze(-1) * value.float().unsqueeze(-2)).to(x.dtype)
+
+
+class Engram(nn.Module):
+    def __init__(
+        self,
+        config,
+        layer_id: int,
+        layout: EngramLayout,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.layer_hash_index = layout.layer_ids.index(layer_id)
+        self.eps = config.rms_norm_eps
+        self.clamp_value = 1e-6
+        dim, hc_mult = config.hidden_size, config.hc_mult
+        self.embed = EngramEmbedding(
+            layout.num_embeddings[self.layer_hash_index], layout.head_dim, layer_id
+        )
+        n_hash_cols = (layout.max_ngram_size - 1) * layout.n_heads
+        self.wkv = ReplicatedLinear(
+            n_hash_cols * layout.head_dim,
+            dim * (hc_mult + 1),
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("wkv", prefix),
+        )
+        self.q_weight = nn.Parameter(torch.ones(hc_mult, dim), requires_grad=False)
+        self.k_weight = nn.Parameter(torch.ones(hc_mult, dim), requires_grad=False)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        hash_ids: torch.Tensor,
+        forward_batch: Optional[ForwardBatch] = None,
+        *,
+        cp_all_tokens: bool = False,
+    ) -> torch.Tensor:
+        """x [T, hc_mult, dim]; hash_ids [T, n_hash_cols] for this layer."""
+        # The lookup runs first even for an idle DP-attention batch: under DP
+        # attention it is a collective every rank has to join.
+        emb = self.embed(hash_ids, forward_batch, cp_all_tokens=cp_all_tokens)
+        if x.shape[0] == 0:
+            # Nothing to gate, and the MXFP8 quantize behind wkv rejects an
+            # empty M.
+            return x
+        kv, _ = self.wkv(emb.flatten(-2))
+        return self.apply_gate(x, kv)
+
+    def project(
+        self, hash_ids: torch.Tensor, *, cp_all_tokens: bool = False
+    ) -> torch.Tensor:
+        kv, _ = self.wkv(self.embed(hash_ids, cp_all_tokens=cp_all_tokens).flatten(-2))
+        return kv
+
+    def apply_gate(self, x: torch.Tensor, kv: torch.Tensor) -> torch.Tensor:
+        return engram_gate(
+            x, kv, self.q_weight, self.k_weight, self.eps, self.clamp_value
+        )

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -922,6 +922,15 @@ def can_use_flashinfer_allreduce(
     # Dynamo, so statically-off configs must short-circuit before reaching them
     # (same ordering rule as apply_flashinfer_allreduce_fusion).
     token_num, hidden_dim = input_.shape
+
+    # MNNVL requires float4-aligned widths and hard-fails instead of falling back
+    # (FlashInfer csrc/trtllm_mnnvl_allreduce.cu). Shape and dtype are rank-invariant.
+    if (
+        workspace_manager.backend == "mnnvl"
+        and hidden_dim % (16 // input_.element_size()) != 0
+    ):
+        return False
+
     if torch.compiler.is_compiling():
         # Don't call into the flashinfer workspace object while tracing. The
         # workspace was allocated for (max_token_num, hidden_dim, dtype) and

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -184,6 +184,9 @@ class LogitsProcessorOutput:
     # The last hidden layers
     hidden_states: Optional[torch.Tensor] = None
 
+    # Original flattened token indices when only a subset of hidden rows is captured.
+    hidden_states_token_indices: Optional[torch.Tensor] = None
+
     ## Part 2: This part will be assigned in python/sglang/srt/layers/sampler.py::Sampler
     # he log probs of output tokens, if SGLANG_RETURN_ORIGINAL_LOGPROB = True, will get the log probs before applying temperature. If False, will get the log probs before applying temperature.
     next_token_logprobs: Optional[torch.Tensor] = None

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1487,7 +1487,7 @@ class FusedMoE(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
-        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         if self._use_ascend_fuseep:
             from sglang.srt.hardware_backend.npu.moe.fuseep import forward_fuseep
@@ -1528,7 +1528,7 @@ class FusedMoE(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
-        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         origin_hidden_states_dim = hidden_states.shape[-1]
         assert self.quant_method is not None
@@ -1537,21 +1537,9 @@ class FusedMoE(torch.nn.Module):
             dwdp_mgr = get_global_dwdp_manager()
             dwdp_mgr.wait_prefetch(self.layer_id)
 
-        dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
+        dispatch_output = self._dispatch_with_pre_quant(
+            hidden_states, topk_output, pre_quant_input
         )
-        if (
-            pre_quant_input is not None
-            and dispatch_output.format.is_standard()
-            and dispatch_output.hidden_states_scale is None
-        ):
-            # SGLANG_OPT_MOE_QUANT_ONCE: the standard dispatch was a pure
-            # passthrough, so the caller's pre-quantized (q, scale) pair still
-            # matches dispatch_output.hidden_states; attach it for the triton
-            # fused runner to skip its own activation quant.
-            dispatch_output = dispatch_output._replace(
-                hidden_states_pre_quant=pre_quant_input
-            )
 
         combine_input = self.run_moe_core(
             dispatch_output=dispatch_output,
@@ -1575,16 +1563,46 @@ class FusedMoE(torch.nn.Module):
 
         return final_hidden_states
 
+    def _dispatch_with_pre_quant(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        pre_quant_input: Optional[Tuple],
+    ) -> DispatchOutput:
+        dispatch_output = self.dispatcher.dispatch(
+            hidden_states=hidden_states, topk_output=topk_output
+        )
+        if (
+            pre_quant_input is not None
+            and dispatch_output.format.is_standard()
+            and dispatch_output.hidden_states_scale is None
+        ):
+            # The standard dispatch was a pure passthrough, so the caller's
+            # pre-quantized activation still matches dispatch_output.hidden_states;
+            # attach it so the runner skips its own activation quant. Either the
+            # SGLANG_OPT_MOE_QUANT_ONCE (q, scale) pair for the triton fused
+            # runner, or Mxfp8RoutedInputPreQuant for the flashinfer_mxfp4
+            # TRT-LLM method (quantized on a side stream, joined on its event --
+            # dropping it here would leave that stream unjoined under CUDA-graph
+            # capture).
+            dispatch_output = dispatch_output._replace(
+                hidden_states_pre_quant=pre_quant_input
+            )
+        return dispatch_output
+
     def forward_deferred_finalize(
-        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        pre_quant_input: Optional[Tuple] = None,
     ):
         assert self.quant_method is not None
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
             flashinfer_trtllm_deferred_finalize_context,
         )
 
-        dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
+        dispatch_output = self._dispatch_with_pre_quant(
+            hidden_states, topk_output, pre_quant_input
         )
 
         with flashinfer_trtllm_deferred_finalize_context():

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -76,6 +76,11 @@ def flashinfer_trtllm_deferred_finalize_context(
         _deferred_finalize_enabled.reset(token)
 
 
+def is_deferred_finalize_enabled() -> bool:
+    """Whether the caller asked for the ``do_finalize=False`` output ABI."""
+    return _deferred_finalize_enabled.get()
+
+
 def finalize_flashinfer_trtllm_deferred_output(
     deferred_output: FlashInferTrtllmDeferredFinalizeOutput,
     shared_output: torch.Tensor,

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -68,11 +68,14 @@ class StandardDispatchOutput(NamedTuple):
     hidden_states: torch.Tensor
     hidden_states_scale: Optional[torch.Tensor]
     topk_output: TopKOutput
-    # SGLANG_OPT_MOE_QUANT_ONCE: optional pre-quantized (q, scale) pair for
-    # ``hidden_states`` (per-token-group-128 fp8, q rows possibly padded to a
-    # multiple of 4). Consumed by the standard->triton fused runner so it can
-    # skip its own activation quant; ``hidden_states`` itself stays bf16.
-    hidden_states_pre_quant: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    # Optional pre-quantized activation for ``hidden_states`` (which itself
+    # stays bf16), so the runner skips its own activation quant. Either the
+    # SGLANG_OPT_MOE_QUANT_ONCE (q, scale) pair (per-token-group-128 fp8, q
+    # rows possibly padded to a multiple of 4) consumed by the standard->triton
+    # fused runner, or ``Mxfp8RoutedInputPreQuant`` (x_q, x_sf, ready event;
+    # MXFP8 linear scale layout, quantized on a side stream) consumed by
+    # ``Mxfp4FlashinferTrtllmMoEMethod.apply``.
+    hidden_states_pre_quant: Optional[Tuple] = None
 
     @property
     def format(self) -> DispatchOutputFormat:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -272,14 +272,10 @@ class TopKConfig:
 class TopKOutputChecker:
     @staticmethod
     def format_is_standard(topk_output: TopKOutput) -> TypeGuard[StandardTopKOutput]:
-        # ===== TO BE REFACTORED ====
-        # The experimental fused topk+pack carrier only exists under the master switch.
-        if _SGLANG_EXPERIMENTAL_LORA_OPTI:
-            return isinstance(
-                topk_output, (StandardTopKOutput, StandardTopKOutputPacked)
-            )
-        # ===== END TO BE REFACTORED ====
-        return isinstance(topk_output, StandardTopKOutput)
+        # StandardTopKOutputPacked is the standard (weights, ids, logits) triple
+        # plus the FlashInfer routed-MoE packed ids the router emitted alongside
+        # them; every standard-format consumer reads it by field name.
+        return isinstance(topk_output, (StandardTopKOutput, StandardTopKOutputPacked))
 
     @staticmethod
     def format_is_triton_kernels(
@@ -325,11 +321,13 @@ class StandardTopKOutput(NamedTuple):
         return TopKOutputFormat.STANDARD
 
 
-# ===== TO BE REFACTORED ====
-# Experimental fused topk+pack (SGLANG_OPT_LORA_FUSED_TOPK_PACK) carrier: the FlashInfer
-# routed-MoE packed topk produced fused in the gating kernel. Kept a SEPARATE type rather
-# than a 4th StandardTopKOutput field so the OSS `a, b, _ = topk_output` 3-tuple unpack
-# stays valid; only the gated experimental MoE dispatch reads .packed_topk_ids (getattr).
+# Standard top-k output carrying, in addition, the FlashInfer routed-MoE packed
+# topk ``(id << 16) | bf16_bits(weight)`` that the gating kernel produced in the
+# same launch (the sqrtsoftplus Triton router under the flashinfer_mxfp4 runner
+# backend, and the experimental Qwen3 fused topk+pack). Kept a SEPARATE type
+# rather than a 4th StandardTopKOutput field so the `a, b, _ = topk_output`
+# 3-tuple unpack in runners that never see it stays valid; consumers read
+# .packed_topk_ids via _get_packed_topk_ids_for_flashinfer_routed (getattr).
 class StandardTopKOutputPacked(NamedTuple):
     topk_weights: torch.Tensor
     topk_ids: torch.Tensor
@@ -339,9 +337,6 @@ class StandardTopKOutputPacked(NamedTuple):
     @property
     def format(self) -> TopKOutputFormat:
         return TopKOutputFormat.STANDARD
-
-
-# ===== END TO BE REFACTORED ====
 
 
 class TritonKernelTopKOutput(NamedTuple):
@@ -1365,10 +1360,12 @@ def biased_topk_jit_kernel_impl(
     num_token_non_padded: Optional[torch.Tensor] = None,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     apply_routed_scaling_factor_on_output: Optional[bool] = False,
+    packed_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
 
     if _use_aiter and scoring_func == "sqrtsoftplus" and num_fused_shared_experts == 0:
+        assert packed_out is None, "aiter topk_gating cannot emit packed ids"
         from aiter import topk_gating
 
         num_tokens = gating_output.shape[0]
@@ -1407,6 +1404,17 @@ def biased_topk_jit_kernel_impl(
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+            # The router masks rows >= num_token_non_padded itself (id -1,
+            # weight 0), saving the post-process mask launch; see
+            # _fused_gate_masks_padded_rows for why this is sqrtsoftplus-only.
+            num_token_non_padded=(
+                num_token_non_padded
+                if _fused_gate_masks_padded_rows(scoring_func)
+                else None
+            ),
+            # Optional FlashInfer routed-MoE packed ids, written in the same
+            # launch (see _fused_gate_emits_packed_ids).
+            packed_out=packed_out,
         )
         topk_weights, topk_ids = (
             topk_weights.to(torch.float32),
@@ -1559,6 +1567,48 @@ def _eplb_remap_enabled() -> bool:
         get_exec().moe.enable_eplb
         or get_exec().moe.init_expert_location != "trivial"
         or get_exec().moe.ep_num_redundant_experts > 0
+    )
+
+
+def _fused_gate_masks_padded_rows(scoring_func: str) -> bool:
+    """Whether the CUDA sqrtsoftplus router masks its own padded rows.
+
+    ``moe_fused_gate``'s Triton kernel already implements ``num_token_non_padded``
+    (rows >= it get id -1 and weight 0, ``HAS_PADDING``), so on this path the
+    count is handed to the router and :func:`_post_process_topk_ids` skips the
+    separate ``mask_topk_ids_padded_region`` launch. Live rows are bitwise
+    unchanged (the kernel only adds a final ``tl.where``); padded rows get the
+    same -1 ids and a 0 weight instead of a stale one, which every consumer of
+    a -1 id ignores. Restricted to sqrtsoftplus (DeepSeek-V4): on the sigmoid
+    path a padding count would bypass the Kimi-K3 radix fast path, which does
+    not take one, and on HIP the post-process fills padded ids with 0, not -1.
+    """
+    return _is_cuda and not _use_aiter and scoring_func == "sqrtsoftplus"
+
+
+def _fused_gate_emits_packed_ids(
+    scoring_func: str,
+    num_fused_shared_experts: int,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo],
+    routing_overridden: bool,
+) -> bool:
+    """Whether the sqrtsoftplus router also writes the FlashInfer routed-MoE
+    packed ids ``(id << 16) | bf16_bits(weight)``, replacing the separate
+    ``PackTopkIds`` launch in ``Mxfp4FlashinferTrtllmMoEMethod.apply``.
+
+    Same admission as the Qwen3 fused topk+pack precedent: the pack is taken
+    from the router's final (renormalized, scaled, padding-masked) values, so
+    nothing may rewrite ids or weights afterwards -- no EPLB logical->physical
+    remap, no fused shared-expert slots (which also implies waterfill is off),
+    no benchmark routing override. Only the flashinfer_mxfp4 runner backend
+    consumes the packed form.
+    """
+    return (
+        _fused_gate_masks_padded_rows(scoring_func)
+        and get_moe_runner_backend().is_flashinfer_mxfp4()
+        and expert_location_dispatch_info is None
+        and num_fused_shared_experts == 0
+        and not routing_overridden
     )
 
 
@@ -2113,7 +2163,13 @@ def _post_process_topk_ids(
     layer_id: int,
     num_token_non_padded: Optional[torch.Tensor] = None,
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    padded_rows_masked: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """``padded_rows_masked``: the router already wrote id -1 / weight 0 into
+    rows >= ``num_token_non_padded`` (see :func:`_fused_gate_masks_padded_rows`),
+    so the CUDA identity-remap branch skips its mask launch. Every branch that
+    remaps ids keeps the mask: a remap table indexed by -1 aliases its last
+    entry, so the mask must run after it."""
     num_fused_shared_experts = topk_config.num_fused_shared_experts
     use_per_rank_shared_slots = has_per_rank_fused_shared_slots(
         num_fused_shared_experts
@@ -2160,7 +2216,13 @@ def _post_process_topk_ids(
             recorder_topk_ids = routed_cols
         else:
             topk_ids = _biased_grouped_topk_postprocess(
-                topk_ids, expert_location_dispatch_info, num_token_non_padded
+                topk_ids,
+                expert_location_dispatch_info,
+                (
+                    None
+                    if padded_rows_masked and expert_location_dispatch_info is None
+                    else num_token_non_padded
+                ),
             )
     elif _is_hip:
         # On AMD HIP the aiter MoE kernels do not handle topk_ids=-1 safely
@@ -2320,8 +2382,20 @@ def select_experts(
 
     scoring_func = topk_config.scoring_func
 
-    # Set by the fused-gating+pack branch below; None everywhere else.
+    # Set by the fused-gating+pack branches below; None everywhere else.
     packed_topk = None
+    # True when the router itself masked rows >= num_token_non_padded, so the
+    # post-process can skip its mask launch (see _fused_gate_masks_padded_rows).
+    padded_rows_masked = False
+
+    simulate_uniform_experts = envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
+    simulate_round_robin_experts = envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
+    if simulate_uniform_experts and simulate_round_robin_experts:
+        raise ValueError(
+            "SGLANG_SIMULATE_UNIFORM_EXPERTS and "
+            "SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS are mutually exclusive"
+        )
+    routing_overridden = simulate_uniform_experts or simulate_round_robin_experts
 
     (
         router_logits,
@@ -2404,6 +2478,19 @@ def select_experts(
             scoring_func == "sqrtsoftplus" or scoring_func == "sigmoid"
         ):
             _biased_topk = biased_topk_xpu if _is_xpu else biased_topk_jit_kernel_impl
+            _packed_kwargs = {}
+            if _fused_gate_emits_packed_ids(
+                scoring_func,
+                num_fused_shared_experts,
+                expert_location_dispatch_info,
+                routing_overridden,
+            ):
+                packed_topk = torch.empty(
+                    (hidden_states.shape[0], top_k),
+                    dtype=torch.int32,
+                    device=hidden_states.device,
+                )
+                _packed_kwargs = dict(packed_out=packed_topk)
             topk_weights, topk_ids = _biased_topk(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
@@ -2416,7 +2503,9 @@ def select_experts(
                 num_token_non_padded=num_token_non_padded,
                 expert_location_dispatch_info=expert_location_dispatch_info,
                 apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                **_packed_kwargs,
             )
+            padded_rows_masked = _fused_gate_masks_padded_rows(scoring_func)
         elif (
             get_moe_runner_backend().is_flashinfer_trtllm_routed()
             and scoring_func == "softmax"
@@ -2445,8 +2534,7 @@ def select_experts(
                 and correction_bias is None
                 and expert_location_dispatch_info is None
                 and num_fused_shared_experts == 0
-                and not envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
-                and not envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
+                and not routing_overridden
             ):
                 num_experts = router_logits.shape[-1]
                 if num_experts & (num_experts - 1) == 0 and num_experts <= 512:
@@ -2492,15 +2580,7 @@ def select_experts(
             renormalize=renormalize,
         )
 
-    simulate_uniform_experts = envs.SGLANG_SIMULATE_UNIFORM_EXPERTS.get()
-    simulate_round_robin_experts = envs.SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS.get()
-    if simulate_uniform_experts and simulate_round_robin_experts:
-        raise ValueError(
-            "SGLANG_SIMULATE_UNIFORM_EXPERTS and "
-            "SGLANG_SIMULATE_ROUND_ROBIN_EXPERTS are mutually exclusive"
-        )
-
-    if simulate_uniform_experts or simulate_round_robin_experts:
+    if routing_overridden:
         # Benchmark-only: override gating with a balanced expert assignment (so
         # dummy/random benchmark tokens don't skew MoE load) via a single fused
         # Triton kernel — one launch instead of the ~5-7 small elementwise ops it
@@ -2523,6 +2603,8 @@ def select_experts(
             token_shard_rank=token_shard_rank,
             num_token_shards=num_token_shards,
         )
+        # The override rewrote every row, including the router-masked ones.
+        padded_rows_masked = False
 
     topk_ids, topk_weights, recorder_topk_ids = _post_process_topk_ids(
         topk_ids=topk_ids,
@@ -2532,18 +2614,17 @@ def select_experts(
         num_token_non_padded=num_token_non_padded,
         layer_id=layer_id,
         expert_location_dispatch_info=expert_location_dispatch_info,
+        padded_rows_masked=padded_rows_masked,
     )
 
     get_global_expert_distribution_recorder().on_select_experts(
         topk_ids=recorder_topk_ids
     )
 
-    # ===== TO BE REFACTORED ====
     if packed_topk is not None:
         return StandardTopKOutputPacked(
             topk_weights, topk_ids, router_logits, packed_topk
         )
-    # ===== END TO BE REFACTORED ====
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)
 
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -55,15 +55,19 @@ from sglang.srt.layers.quantization.base_config import (
 from sglang.srt.layers.quantization.fp8_utils import (
     _use_aiter_bpreshuffle_gfx95,
     apply_fp8_linear,
+    block_fp8_scale_to_mxfp8_e8m0,
     can_auto_enable_marlin_fp8,
+    can_serve_block_fp8_as_mxfp8,
     cutlass_fp8_supported,
     deepgemm_w8a8_block_fp8_linear_with_fallback,
+    dispatch_block_fp8_mxfp8_linear,
     dispatch_w8a8_block_fp8_linear,
     dispatch_w8a8_mxfp8_linear,
     input_to_float8,
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_block_scale_ue8m0_for_deepgemm,
+    resolve_block_fp8_mxfp8_backend,
     resolve_mxfp8_dense_gemm_backend,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -173,7 +177,7 @@ DSV4_DEQUANT_FP4_TABLE = torch.tensor(
         3.0,
         4.0,
         6.0,
-        0.0,
+        -0.0,
         -0.5,
         -1.0,
         -1.5,
@@ -244,6 +248,7 @@ class Fp8Config(QuantizationConfig):
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
         kv_cache_quant_algo: Optional[str] = None,
+        scale_fmt: Optional[str] = None,
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
@@ -268,6 +273,8 @@ class Fp8Config(QuantizationConfig):
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.use_mxfp8 = use_mxfp8
         self.kv_cache_quant_algo = kv_cache_quant_algo
+        # "ue8m0" checkpoints quantize activations with power-of-two scales.
+        self.scale_fmt = scale_fmt
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -335,6 +342,7 @@ class Fp8Config(QuantizationConfig):
         kv_cache_quant_algo = cls.get_from_keys_or(
             config, ["kv_cache_quant_algo"], None
         )
+        scale_fmt = cls.get_from_keys_or(config, ["scale_fmt"], None)
         if use_mxfp8:
             # MXFP8 (OCP) spec fixes block size to [1, 32]; ckpt field is metadata only.
             if weight_block_size is not None and weight_block_size != [1, 32]:
@@ -351,6 +359,7 @@ class Fp8Config(QuantizationConfig):
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=use_mxfp8,
             kv_cache_quant_algo=kv_cache_quant_algo,
+            scale_fmt=scale_fmt,
         )
 
     def get_quant_method(
@@ -483,7 +492,21 @@ class Fp8LinearMethod(LinearMethodBase):
             self.mxfp8_dense_backend = resolve_mxfp8_dense_gemm_backend()
             self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
         else:
-            self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
+            self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear(
+                weight_block_size=self.weight_block_size,
+                act_scale_ue8m0=isinstance(self.quant_config, Fp8Config)
+                and self.quant_config.scale_fmt == "ue8m0",
+            )
+        # 32-wide-K ue8m0 blocks can use FlashInfer MXFP8 on Blackwell;
+        # Triton is the fallback when no supported FlashInfer backend is selected.
+        self.block_fp8_as_mxfp8 = not self.use_mxfp8 and can_serve_block_fp8_as_mxfp8(
+            self.weight_block_size, getattr(self.quant_config, "scale_fmt", None)
+        )
+        if self.block_fp8_as_mxfp8:
+            self.mxfp8_dense_backend = resolve_block_fp8_mxfp8_backend()
+            self.w8a8_mxfp8_linear = dispatch_block_fp8_mxfp8_linear(
+                self.mxfp8_dense_backend
+            )
         self.is_checkpoint_fp8_serialized = (
             self.quant_config.is_checkpoint_fp8_serialized
         )
@@ -723,6 +746,8 @@ class Fp8LinearMethod(LinearMethodBase):
 
         layer.weight.data = weight.data
         layer.weight_scale_inv.data = weight_scale.data
+        if self.block_fp8_as_mxfp8:
+            self._prepare_block_fp8_as_mxfp8(layer)
 
         # The preshuffle rewrites the weight into a layout only
         # aiter_w8a8_block_fp8_linear can read, so it is correct exactly when
@@ -748,8 +773,32 @@ class Fp8LinearMethod(LinearMethodBase):
                 # instead of silently reading a permuted weight.
                 layer.aiter_bpreshuffled = True
 
-    def _process_mxfp8_linear_weight_scale(self, layer: Module) -> None:
-        if not self.use_mxfp8:
+    def _prepare_block_fp8_as_mxfp8(self, layer: Module) -> None:
+        """Derive the MXFP8 scale layout of a 32-wide-K ue8m0 block weight. The block
+        scales stay in place for the Triton fallback and for consumers that read them."""
+        layer.block_fp8_mxfp8_ready = False
+        if getattr(layer, "skip_aiter_bpreshuffle", False):
+            # The model reads .weight / .weight_scale_inv directly (DeepSeek-V4 wo_a);
+            # the trtllm backend would shuffle the weight in place.
+            return
+        n, k = layer.weight.shape
+        backend = self.mxfp8_dense_backend
+        if k % 32 != 0 or (backend.is_flashinfer_trtllm() and (k // 32) % 4 != 0):
+            return
+        try:
+            scale_u8 = block_fp8_scale_to_mxfp8_e8m0(
+                layer.weight_scale_inv.data, (n, k), self.weight_block_size
+            )
+        except ValueError as e:
+            logger.warning("Block-fp8 layer stays on the Triton kernel: %s", e)
+            return
+        self._process_mxfp8_linear_weight_scale(layer, scale_u8=scale_u8)
+        layer.block_fp8_mxfp8_ready = True
+
+    def _process_mxfp8_linear_weight_scale(
+        self, layer: Module, scale_u8: Optional[torch.Tensor] = None
+    ) -> None:
+        if not (self.use_mxfp8 or scale_u8 is not None):
             return
 
         backend = self.mxfp8_dense_backend
@@ -757,7 +806,8 @@ class Fp8LinearMethod(LinearMethodBase):
             from flashinfer import shuffle_matrix_a, shuffle_matrix_sf_a
 
             weight = layer.weight.data
-            scale_u8 = layer.weight_scale_inv.data
+            if scale_u8 is None:
+                scale_u8 = layer.weight_scale_inv.data
             n, k = weight.shape
             epilogue_tile_m = 128
             sf_cols = k // 32
@@ -797,7 +847,8 @@ class Fp8LinearMethod(LinearMethodBase):
         elif backend.is_flashinfer_cutlass() or backend.is_flashinfer_cutedsl():
             from flashinfer import block_scale_interleave
 
-            scale_u8 = layer.weight_scale_inv.data
+            if scale_u8 is None:
+                scale_u8 = layer.weight_scale_inv.data
             # block_scale_interleave may pad and/or reshape scales,
             # so store swizzled scales separately to keep weight update working
             copy_or_rebind_param(
@@ -811,7 +862,8 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
             n, k = layer.weight.shape
-            scale_u8 = layer.weight_scale_inv.data
+            if scale_u8 is None:
+                scale_u8 = layer.weight_scale_inv.data
             layer.weight_scale_inv_swizzled = None
             if n % 64 != 0 or k % 128 != 0:
                 if not (get_platform().is_blackwell and is_flashinfer_available()):
@@ -992,7 +1044,11 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
             )
 
-        if self.use_mxfp8:
+        if self.use_mxfp8 or (
+            self.block_fp8_as_mxfp8
+            and getattr(layer, "block_fp8_mxfp8_ready", False)
+            and not isinstance(x, tuple)
+        ):
             backend = self.mxfp8_dense_backend
             extra_kwargs = {}
             if backend.is_flashinfer_cutlass() or backend.is_flashinfer_cutedsl():
@@ -1013,7 +1069,7 @@ class Fp8LinearMethod(LinearMethodBase):
                     bias=bias,
                     **extra_kwargs,
                 )
-            return self.w8a8_mxfp8_linear(
+            out = self.w8a8_mxfp8_linear(
                 input=x,
                 weight=layer.weight,
                 weight_scale=weight_scale,
@@ -1021,6 +1077,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
                 **extra_kwargs,
             )
+            return out
 
         if self.block_quant:
             if use_intel_amx_backend(layer):

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -553,7 +553,10 @@ if get_platform().is_sm90 and is_flashinfer_available():
     from flashinfer.gemm import fp8_blockscale_gemm_sm90
 
 
-def dispatch_w8a8_block_fp8_linear() -> Callable:
+def dispatch_w8a8_block_fp8_linear(
+    weight_block_size: Optional[List[int]] = None,
+    act_scale_ue8m0: bool = False,
+) -> Callable:
     """
     Dispatch to the appropriate FP8 block linear implementation.
 
@@ -561,6 +564,14 @@ def dispatch_w8a8_block_fp8_linear() -> Callable:
     1. The --fp8-gemm-backend server argument (preferred)
     2. Auto-detection based on hardware capabilities
     """
+    if weight_block_size is not None and weight_block_size != [128, 128]:
+        # DeepGEMM, FlashInfer groupwise and CUTLASS take 128x128 blocks only;
+        # the Triton kernel reads the block size at launch. With an explicit
+        # --fp8-gemm-backend flashinfer_* on Blackwell, Fp8LinearMethod routes 32-wide K
+        # blocks with ue8m0 scales to the MXFP8 dense kernels instead
+        # (can_serve_block_fp8_as_mxfp8) and keeps this Triton path as the fallback.
+        return partial(triton_w8a8_block_fp8_linear, act_scale_ue8m0=act_scale_ue8m0)
+
     backend = get_fp8_gemm_runner_backend()
 
     # Handle explicit backend selection via --fp8-gemm-backend
@@ -635,6 +646,86 @@ def _unsupported_mxfp8_linear(*args, **kwargs) -> torch.Tensor:
         "requires Blackwell (SM100/SM103/SM110/SM120) with FlashInfer, Hopper (SM90) "
         "with DeepGEMM, or ROCm gfx95."
     )
+
+
+def resolve_block_fp8_mxfp8_backend() -> Mxfp8DenseGemmBackend:
+    """Resolve the FlashInfer MXFP8 backend for 32-wide-K ue8m0 block-fp8 weights.
+    Requires Blackwell; unresolved auto and Triton settings keep the block kernel.
+    """
+    backend = get_fp8_gemm_runner_backend()
+    if not (
+        backend.is_flashinfer_cutedsl()
+        or backend.is_flashinfer_cutlass()
+        or backend.is_flashinfer_trtllm()
+    ):
+        return Mxfp8DenseGemmBackend.UNSUPPORTED
+    if not (_is_cuda and get_platform().is_blackwell and is_flashinfer_available()):
+        return Mxfp8DenseGemmBackend.UNSUPPORTED
+    resolved = resolve_mxfp8_dense_gemm_backend()
+    return resolved if resolved.is_flashinfer() else Mxfp8DenseGemmBackend.UNSUPPORTED
+
+
+def can_serve_block_fp8_as_mxfp8(
+    weight_block_size: Optional[List[int]], scale_fmt: Optional[str]
+) -> bool:
+    """Whether a block-fp8 linear can run on the MXFP8 dense GEMMs instead of Triton.
+
+    A weight quantized with a 32-wide K block and ue8m0 (power-of-two) scales, paired
+    with per-32 ue8m0 activation scales, is an MXFP8 operand: repeating each block scale
+    over its rows gives the per-row [N, K // 32] e8m0 layout the MXFP8 kernels read, so
+    the GEMM consumes exactly the same fp8 values and scales.
+    """
+    if weight_block_size is None or len(weight_block_size) != 2:
+        return False
+    if weight_block_size[1] != 32 or scale_fmt != "ue8m0":
+        return False
+    return not resolve_block_fp8_mxfp8_backend().is_unsupported()
+
+
+def dispatch_block_fp8_mxfp8_linear(backend: Mxfp8DenseGemmBackend) -> Callable:
+    """The MXFP8 linear for the block-fp8 route, with the FlashInfer autotuner kept out
+    of the kernel choice (see `flashinfer_mxfp8_blockscaled_linear`)."""
+    if backend.is_flashinfer_trtllm():
+        return partial(
+            flashinfer_mxfp8_blockscaled_linear, backend="trtllm", pin_tactic=True
+        )
+    if backend.is_flashinfer_cutlass():
+        return partial(
+            flashinfer_mxfp8_blockscaled_linear, backend="cutlass", pin_tactic=True
+        )
+    if backend.is_flashinfer_cutedsl():
+        return partial(
+            flashinfer_mxfp8_blockscaled_linear, backend="cute-dsl", pin_tactic=True
+        )
+    return _unsupported_mxfp8_linear
+
+
+def block_fp8_scale_to_mxfp8_e8m0(
+    weight_scale: torch.Tensor,
+    weight_shape: Tuple[int, int],
+    weight_block_size: List[int],
+) -> torch.Tensor:
+    """Expand fp32 power-of-two block scales [ceil(N / bn), K // 32] into the MXFP8
+    per-row e8m0 layout [N, K // 32] (uint8 exponent bytes), bit-exact."""
+    n, k = weight_shape
+    block_n, block_k = weight_block_size
+    if block_k != 32 or k % 32 != 0:
+        raise ValueError(
+            f"MXFP8 needs a 32-wide K block and K % 32 == 0, got {block_k=} {k=}"
+        )
+    scale = weight_scale.detach().float().contiguous()
+    if tuple(scale.shape) != (ceil_div(n, block_n), k // 32):
+        raise ValueError(
+            f"unexpected block scale shape {tuple(scale.shape)} for weight {weight_shape}"
+        )
+    bits = scale.view(torch.int32)
+    # A positive normal power of two has a zero mantissa; its exponent field is the e8m0 code.
+    if not bool(torch.all((bits & 0x7FFFFF) == 0)) or not bool(torch.all(scale > 0)):
+        raise ValueError(
+            "block scales are not positive powers of two; cannot encode as e8m0"
+        )
+    e8m0 = (bits >> 23).to(torch.uint8)
+    return e8m0.repeat_interleave(block_n, dim=0)[:n].contiguous()
 
 
 def dispatch_w8a8_mxfp8_linear() -> Callable:
@@ -1064,8 +1155,9 @@ def deepgemm_w8a8_block_fp8_linear_with_fallback(
 
     # TODO: https://github.com/sgl-project/sglang/pull/6890#issuecomment-2943395737
     shape_supported = weight.shape[0] % 64 == 0 and weight.shape[1] % 128 == 0
+    block_supported = block_size == [128, 128]
 
-    if not (shape_supported and dtype_supported):
+    if not (shape_supported and dtype_supported and block_supported):
         # fall back to triton
         # If weight_scale is in UE8M0 packed format (int32), convert back to float32
         # UE8M0 format has shape (N, K//block_k//4) with dtype int32
@@ -1250,6 +1342,7 @@ def triton_w8a8_block_fp8_linear(
     weight_scale: torch.Tensor,
     input_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
+    act_scale_ue8m0: bool = False,
 ) -> torch.Tensor:
     if input_scale is not None:
         # Pre-quantized input: ``input`` is already fp8 and ``input_scale`` is
@@ -1264,9 +1357,15 @@ def triton_w8a8_block_fp8_linear(
         input_2d = input.view(-1, input.shape[-1])
         output_dtype = input_2d.dtype
         output_shape = [*input.shape[:-1], weight.shape[0]]
-        q_input, x_scale = per_token_group_quant_fp8(
-            input_2d, block_size[1], column_major_scales=False
-        )
+        if act_scale_ue8m0:
+            # Power-of-two scales in fp32 storage, as ue8m0 checkpoints quantize.
+            q_input, x_scale = sglang_per_token_group_quant_fp8(
+                input_2d, block_size[1], scale_ue8m0=True
+            )
+        else:
+            q_input, x_scale = per_token_group_quant_fp8(
+                input_2d, block_size[1], column_major_scales=False
+            )
 
     output = w8a8_block_fp8_matmul_triton(
         q_input, weight, x_scale, weight_scale, block_size, output_dtype=output_dtype
@@ -1312,9 +1411,14 @@ def flashinfer_mxfp8_blockscaled_linear(
     bias: Optional[torch.Tensor] = None,
     output_dtype: Optional[torch.dtype] = None,
     backend: str = "cutlass",
+    pin_tactic: bool = False,
 ) -> torch.Tensor:
     """MXFP8 dense linear via FlashInfer mm_mxfp8. `weight_scale` must be the layout
-    the backend expects, prepared at load time."""
+    the backend expects, prepared at load time.
+
+    pin_tactic skips autotuning and uses the backend heuristic to preserve row-wise
+    batch invariance; tactics tuned per M bucket can change the fp32 reduction order.
+    """
     input_2d = input.view(-1, input.shape[-1])
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
@@ -1346,15 +1450,29 @@ def flashinfer_mxfp8_blockscaled_linear(
     else:
         weight_scale_t = weight_scale.t() if weight_scale.ndim == 2 else weight_scale
 
-    output = flashinfer_mm_mxfp8(
-        q_input,
-        weight.t(),
-        x_scale_u8,
-        weight_scale_t,
-        out_dtype=output_dtype,
-        use_8x4_sf_layout=False,
-        backend=backend,
-    )
+    if pin_tactic:
+        from flashinfer.autotuner import autotune
+
+        with autotune(False, skip_ops={"mxfp8_gemm"}):
+            output = flashinfer_mm_mxfp8(
+                q_input,
+                weight.t(),
+                x_scale_u8,
+                weight_scale_t,
+                out_dtype=output_dtype,
+                use_8x4_sf_layout=False,
+                backend=backend,
+            )
+    else:
+        output = flashinfer_mm_mxfp8(
+            q_input,
+            weight.t(),
+            x_scale_u8,
+            weight_scale_t,
+            out_dtype=output_dtype,
+            use_8x4_sf_layout=False,
+            backend=backend,
+        )
 
     if bias is not None:
         output += bias

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -23,7 +23,7 @@ from sglang.srt.utils import (
     log_info_on_rank0,
     set_weight_attrs,
 )
-from sglang.srt.utils.common import next_power_of_2
+from sglang.srt.utils.common import next_power_of_2, print_warning_once
 
 _MXFP8_QUANTIZE_BACKEND = "cute-dsl" if get_platform().is_sm100 else "cuda"
 
@@ -46,6 +46,56 @@ from sglang.srt.utils.common import get_bool_env_var
 _USE_OFFICIAL_SHUFFLE = get_bool_env_var(
     "SGLANG_MXFP4_USE_OFFICIAL_SHUFFLE", default="true"
 )
+
+
+def _pad_intermediate_size(layer: Module) -> None:
+    intermediate_size = layer.w13_weight.shape[1] // 2
+    padded_size = (intermediate_size + 127) // 128 * 128
+    if padded_size == intermediate_size:
+        return
+
+    # Pad after TP loading so checkpoint shard offsets retain the original width.
+    # Gate and up occupy separate halves and must each get their own zero tail.
+    for name, fill_value in (
+        ("w13_weight", 0),
+        ("w13_weight_scale_inv", 1),
+    ):
+        param = getattr(layer, name)
+        num_experts, _, width = param.shape
+        padded = torch.full(
+            (num_experts, 2 * padded_size, width),
+            fill_value,
+            dtype=param.dtype,
+            device=param.device,
+        )
+        padded[:, :intermediate_size] = param[:, :intermediate_size]
+        padded[:, padded_size : padded_size + intermediate_size] = param[
+            :, intermediate_size:
+        ]
+        param.data = padded
+
+    for name, elements_per_column, fill_value in (
+        ("w2_weight", 2, 0),
+        ("w2_weight_scale_inv", 32, 1),
+    ):
+        param = getattr(layer, name)
+        num_experts, hidden_size, width = param.shape
+        padded = torch.full(
+            (num_experts, hidden_size, padded_size // elements_per_column),
+            fill_value,
+            dtype=param.dtype,
+            device=param.device,
+        )
+        padded[:, :, :width] = param
+        param.data = padded
+
+    print_warning_once(
+        f"flashinfer_mxfp4 MoE padded the local intermediate size from "
+        f"{intermediate_size} to {padded_size} for 128-element kernel alignment "
+        "after TP weight loading. Padding adds unused channels and may waste "
+        "compute and memory. Use this TP MoE configuration with caution and "
+        "benchmark it against a TP/EP configuration that avoids padding."
+    )
 
 
 class Mxfp4FlashinferTrtllmMoEMethod:
@@ -150,6 +200,8 @@ class Mxfp4FlashinferTrtllmMoEMethod:
 
         if getattr(layer, "_mega_moe_weights_built", False):
             return
+
+        _pad_intermediate_size(layer)
 
         w13_w, w13_s = reorder_w1w3_to_w3w1(
             layer.w13_weight.data, layer.w13_weight_scale_inv.data

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple
 
 import torch
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
-from sglang.kernels.ops.moe.pack_topk_ids import PackTopkIds
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
@@ -96,6 +95,27 @@ def _pad_intermediate_size(layer: Module) -> None:
         "compute and memory. Use this TP MoE configuration with caution and "
         "benchmark it against a TP/EP configuration that avoids padding."
     )
+
+
+def routed_hidden_size(layer: Module) -> int:
+    """Hidden size the routed GEMM1 expects (uint8 weights hold two fp4/row)."""
+    w13 = layer.w13_weight
+    return w13.shape[2] * 2 if w13.dtype == torch.uint8 else w13.shape[2]
+
+
+class Mxfp8RoutedInputPreQuant(NamedTuple):
+    """MXFP8 linear-layout quant of the routed MoE input, produced ahead of
+    :meth:`Mxfp4FlashinferTrtllmMoEMethod.apply` by
+    :meth:`Mxfp4FlashinferTrtllmMoEMethod.quantize_routed_input` -- e.g. on a
+    side stream while the gate GEMM and the router run on the main stream.
+    ``ready`` is the event recorded on the producing stream after the quant;
+    ``apply`` makes its stream wait on it right before the routed MoE op, whose
+    first kernel (routing) precedes the GEMM that reads ``x_q``/``x_sf``.
+    Carried in ``StandardDispatchOutput.hidden_states_pre_quant``."""
+
+    x_q: torch.Tensor
+    x_sf: torch.Tensor
+    ready: Optional[torch.cuda.Event]
 
 
 class Mxfp4FlashinferTrtllmMoEMethod:
@@ -312,6 +332,28 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                 persistent=False,
             )
 
+    def quantize_routed_input(
+        self, hidden_states: torch.Tensor, hidden_size: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """MXFP8 quant of the routed input in the linear scale layout the
+        routed MoE op requires (``hidden_states_scale`` [tokens, hidden // 32]),
+        on the current stream. This is the only front-end kernel that depends
+        on ``hidden_states`` alone, so callers may run it on a side stream and
+        hand the result to :meth:`apply` as :class:`Mxfp8RoutedInputPreQuant`;
+        ``apply`` runs the identical call inline otherwise."""
+        from sglang.srt.layers.quantization.fp8_utils import flashinfer_mxfp8_quantize
+
+        x_quant, x_scale = flashinfer_mxfp8_quantize(
+            hidden_states,
+            False,
+            alignment=hidden_size,
+            backend=_MXFP8_QUANTIZE_BACKEND,
+        )
+        x_scale = x_scale.view(torch.float8_e4m3fn).reshape(
+            *hidden_states.shape[:-1], -1
+        )
+        return x_quant, x_scale
+
     def apply(
         self,
         layer: Module,
@@ -322,6 +364,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
 
         hidden_states = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
+        pre_quant = getattr(dispatch_output, "hidden_states_pre_quant", None)
 
         w13 = layer.w13_weight
         w2 = layer.w2_weight
@@ -329,7 +372,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         w2_scale = layer.w2_weight_scale_inv
 
         intermediate_size = w2.shape[2] * 2 if w2.dtype == torch.uint8 else w2.shape[2]
-        hidden_size = w13.shape[2] * 2 if w13.dtype == torch.uint8 else w13.shape[2]
+        hidden_size = routed_hidden_size(layer)
 
         num_local_experts = layer.num_local_experts
         if w13_scale.dim() == 2:
@@ -337,19 +380,23 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         if w2_scale.dim() == 2:
             w2_scale = w2_scale.reshape(num_local_experts, hidden_size, -1)
 
-        if TopKOutputChecker.format_is_standard(topk_output):
-            topk_ids = topk_output.topk_ids
-            topk_weights = topk_output.topk_weights
-        elif TopKOutputChecker.format_is_bypassed(topk_output):
+        if TopKOutputChecker.format_is_bypassed(topk_output):
             raise NotImplementedError(
                 "the old code in this branch is WRONG. e.g. it does not consider HashTopK, and may miss args"
             )
-        else:
+        if not TopKOutputChecker.format_is_standard(topk_output):
             raise ValueError(f"Unsupported topk output format: {topk_output.format}")
 
-        packed_topk = PackTopkIds.execute(topk_ids, topk_weights)
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            _get_packed_topk_ids_for_flashinfer_routed,
+        )
+
+        # The sqrtsoftplus router emits the packed ids in its own launch
+        # (StandardTopKOutputPacked); pack here only when it did not.
+        packed_topk = _get_packed_topk_ids_for_flashinfer_routed(topk_output)
 
         precision = self.flashinfer_mxfp4_moe_precision
+        input_ready: Optional[torch.cuda.Event] = None
         if precision == "bf16":
             assert hidden_states.dtype == torch.bfloat16
             x_quant = hidden_states
@@ -363,40 +410,54 @@ class Mxfp4FlashinferTrtllmMoEMethod:
                     value=0.0,
                 )
         elif precision == "default":
-            from sglang.srt.layers.quantization.fp8_utils import (
-                flashinfer_mxfp8_quantize,
-            )
-
-            x_quant, x_scale = flashinfer_mxfp8_quantize(
-                hidden_states,
-                False,
-                alignment=hidden_size,
-                backend=_MXFP8_QUANTIZE_BACKEND,
-            )
-            x_scale = x_scale.view(torch.float8_e4m3fn).reshape(
-                *hidden_states.shape[:-1], -1
-            )
+            if isinstance(pre_quant, Mxfp8RoutedInputPreQuant):
+                # Quantized ahead of time (on a side stream) by the caller via
+                # quantize_routed_input on the same hidden_states.
+                assert pre_quant.x_q.shape[0] == hidden_states.shape[0]
+                x_quant, x_scale, input_ready = pre_quant
+            else:
+                x_quant, x_scale = self.quantize_routed_input(
+                    hidden_states, hidden_size
+                )
         else:
             raise NotImplementedError(f"Unsupported mxfp4 moe precision: {precision}")
 
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            _make_deferred_finalize_output,
+            is_deferred_finalize_enabled,
             trtllm_moe_enable_pdl,
         )
 
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            num_tokens = x_quant.shape[0]
-            out_hidden_size = (
-                x_quant.shape[-1] * 2
-                if x_quant.dtype == torch.uint8
-                else x_quant.shape[-1]
-            )
-            symm_output = torch.empty(
-                num_tokens, out_hidden_size, dtype=torch.bfloat16, device=x_quant.device
-            )
+        num_tokens = x_quant.shape[0]
+        # Deferred finalize (flashinfer_trtllm_deferred_finalize_context): hand
+        # back FlashInfer's permuted GEMM2 output + routing triple instead of
+        # the finalized [T, hidden] tensor, for a caller that fuses the
+        # finalize into its shared add / all-reduce
+        # (kernels.ops.communication.all_reduce_fusion).
+        defer_finalize = is_deferred_finalize_enabled()
+        symm_output = None
+        if not defer_finalize:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                out_hidden_size = (
+                    x_quant.shape[-1] * 2
+                    if x_quant.dtype == torch.uint8
+                    else x_quant.shape[-1]
+                )
+                symm_output = torch.empty(
+                    num_tokens,
+                    out_hidden_size,
+                    dtype=torch.bfloat16,
+                    device=x_quant.device,
+                )
 
-        output = trtllm_fp4_block_scale_routed_moe(
+        if input_ready is not None:
+            # The routing kernel is launched inside the op below, so the
+            # cross-stream join for x_quant/x_scale must precede the op call.
+            torch.cuda.current_stream().wait_event(input_ready)
+
+        result = trtllm_fp4_block_scale_routed_moe(
             topk_ids=packed_topk,
             routing_bias=None,
             hidden_states=x_quant,
@@ -422,11 +483,15 @@ class Mxfp4FlashinferTrtllmMoEMethod:
             local_num_experts=num_local_experts,
             routed_scaling_factor=1.0,
             routing_method_type=int(RoutingMethodType.TopK),
-            do_finalize=True,
-            tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
+            do_finalize=not defer_finalize,
+            tune_max_num_tokens=next_power_of_2(num_tokens),
             output=symm_output,
             enable_pdl=trtllm_moe_enable_pdl(num_tokens),
-        )[0]
+        )
+        if defer_finalize:
+            output = _make_deferred_finalize_output(result, top_k=packed_topk.shape[1])
+        else:
+            output = result[0]
 
         return StandardCombineInput(hidden_states=output)
 
@@ -470,3 +535,68 @@ def maybe_fuse_routed_scale_and_shared_add(
     if shared is not None:
         routed += shared
     return routed
+
+
+# Fused finalize + shared add + TP all-reduce
+_fused_finalize_all_reduce_world_size: Optional[int] = None
+_fused_finalize_all_reduce_probed = False
+
+
+def _fused_finalize_all_reduce_comm_world_size() -> Optional[int]:
+    """Register the TP group's CustomAllReduceV2 push plane with the fused
+    kernel once; None when the TP group has no usable v2 communicator."""
+    global _fused_finalize_all_reduce_world_size, _fused_finalize_all_reduce_probed
+    if not _fused_finalize_all_reduce_probed:
+        _fused_finalize_all_reduce_probed = True
+        from sglang.kernels.ops.communication import all_reduce_fusion
+        from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
+            CustomAllReduceV2,
+        )
+
+        ca_comm = get_tp_group().ca_comm
+        if isinstance(ca_comm, CustomAllReduceV2) and not ca_comm.disabled:
+            all_reduce_fusion.register_comm(ca_comm.obj)
+            _fused_finalize_all_reduce_world_size = ca_comm.world_size
+        else:
+            log_info_on_rank0(
+                logger,
+                "Fused MoE finalize: TP group has no "
+                "CustomAllReduceV2 push plane; keeping the unfused finalize path",
+            )
+    return _fused_finalize_all_reduce_world_size
+
+
+def should_use_fuse_finalize_all_reduce(
+    experts, num_tokens: int, hidden_dim: int
+) -> bool:
+    """Whether ``moe_finalize_all_reduce`` can replace finalize + shared add +
+    TP all-reduce for this layer and batch.
+
+    Capability only, no routing policy (the batch-size cap lives at the call
+    site): this MXFP4 TRT-LLM method (its deferred-finalize
+    ABI, expert weights already carrying the routed scaling factor -- the
+    kernel never rescales), a hidden width the kernel has a geometry for, a
+    CustomAllReduceV2 push plane on the TP group, and a batch that fits one of
+    its push slots.
+    """
+    if not isinstance(experts.quant_method, Mxfp4FlashinferTrtllmMoEMethod):
+        return False
+    if experts.quant_method.flashinfer_mxfp4_moe_precision != "default":
+        return False
+    if not experts.should_fuse_routed_scaling_factor_in_topk:
+        return False
+    if num_tokens <= 0:
+        return False
+    from sglang.kernels.ops.communication import all_reduce_fusion
+
+    if not all_reduce_fusion.valid_cluster_sizes(hidden_dim):
+        return False
+    tp_group = get_tp_group()
+    if _fused_finalize_all_reduce_comm_world_size() != tp_group.world_size:
+        return False
+    # one push phase counter per row (the plane has num_sm of them)
+    if num_tokens > tp_group.ca_comm.config.num_push_blocks:
+        return False
+    return all_reduce_fusion.fits_push_slot(
+        tp_group.ca_comm.max_push_size, num_tokens, hidden_dim
+    )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -4,6 +4,7 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
     get_disagg,
+    get_exec,
     get_parallel,
     get_schedule,
     get_serving,
@@ -2253,6 +2254,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Mask marking chunked (not-yet-finished) prefill requests whose sampled
     # pseudo next-token must NOT be written into the ngram token table.
     ne_skip_token_table_update: torch.Tensor = None
+    # DeepSeek-V4.1 engram, extend batches only: [bs, n - 1] int32 predecessors
+    # of each request's first extend token (NgramEmbeddingManager).
+    ne_history: Optional[torch.Tensor] = None
+    encoder_swa_reset: Optional[List[bool]] = None
 
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
@@ -2589,6 +2594,26 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_cpu = seq_lens_cpu
         self.extend_num_tokens = extend_num_tokens
 
+        if get_exec().features.enable_encoder_swa_bounded_replay:
+            for req in reqs:
+                if (
+                    req.multimodal_inputs is not None
+                    or req.input_embeds is not None
+                    or req.positional_embed_overrides is not None
+                ):
+                    raise ValueError(
+                        "encoder SWA replay currently supports token-only text requests"
+                    )
+                if req.return_logprob and req.logprob_start_len not in (
+                    -1,
+                    len(req.origin_input_ids),
+                ):
+                    raise ValueError(
+                        "encoder SWA replay cannot return cached prompt logprobs"
+                    )
+            self.encoder_swa_reset = [
+                r.kv.req_pool_idx is None or r.is_retracted for r in reqs
+            ]
         # Allocate memory
         out_cache_loc, req_pool_indices_tensor, req_pool_indices_cpu = alloc_for_extend(
             self

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -7,6 +7,7 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.prefill_delayer import PrefillDelayerSinglePassExecutor
 from sglang.srt.runtime_context import (
     get_disagg,
+    get_exec,
     get_schedule,
 )
 from sglang.srt.utils import get_bool_env_var, is_hip
@@ -524,6 +525,7 @@ class PrefillAdder:
         self.log_storage_hit_tokens = 0
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
+        self.log_replay_tokens = 0
         self.reprocessed_log_input_tokens = 0
 
         if running_batch is not None:
@@ -876,6 +878,14 @@ class PrefillAdder:
             self.reprocessed_log_input_tokens += extend_input_len
 
     def _account_prefill_cache_admission(self, req: Req, prefix_len: int) -> None:
+        if get_exec().features.enable_encoder_swa_bounded_replay and (
+            req.kv.req_pool_idx is None or req.is_retracted
+        ):
+            replay_tokens = min(prefix_len, 128)
+            self.log_replay_tokens += replay_tokens
+            self.rem_input_tokens -= replay_tokens
+            if self.rem_chunk_tokens is not None:
+                self.rem_chunk_tokens -= replay_tokens
         if req.retracted_stain:
             # Retraction attribution is intentionally omitted for now; discard
             # its lifecycle state so a later abort cannot report it as a drop.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1638,11 +1638,6 @@ class Scheduler(
             self.tp_worker.model_runner.ngram_embedding_manager
         )
         self.use_ngram_embedding = self.tp_worker.model_config.use_ngram_embedding
-        if self.use_ngram_embedding:
-            self.token_table = self.tp_worker.model_runner.ngram_embedding_manager.table
-            hf_config = self.tp_worker.model_config.hf_config
-            self.ngram_embedding_n = hf_config.ngram_embedding_n
-            self.ngram_embedding_k = hf_config.ngram_embedding_k
 
     def init_deterministic_inference_config(self):
         """Initialize deterministic inference configuration for different attention backends."""

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -98,6 +98,7 @@ class PrefillStats:
     log_host_hit_tokens: int = 0
     log_storage_hit_tokens: int = 0
     num_pending_tokens: int = 0
+    log_replay_tokens: int = 0
 
     @classmethod
     def from_adder(
@@ -109,6 +110,7 @@ class PrefillStats:
     ):
         return cls(
             log_input_tokens=adder.log_input_tokens,
+            log_replay_tokens=adder.log_replay_tokens,
             log_hit_tokens=adder.log_hit_tokens,
             reprocessed_log_input_tokens=adder.reprocessed_log_input_tokens,
             reprocessed_log_hit_tokens=adder.reprocessed_log_hit_tokens,
@@ -611,7 +613,10 @@ class SchedulerMetricsReporter:
         gap_latency = now - self.last_prefill_stats_tic
         self.last_prefill_stats_tic = now
         self.last_input_throughput = (
-            prefill_stats.log_input_tokens / gap_latency if gap_latency > 0 else 0.0
+            (prefill_stats.log_input_tokens + prefill_stats.log_replay_tokens)
+            / gap_latency
+            if gap_latency > 0
+            else 0.0
         )
 
         pool_stats = self.scheduler.pool_stats_observer.get_pool_stats()
@@ -636,6 +641,8 @@ class SchedulerMetricsReporter:
             f"#pending-token: {prefill_stats.num_pending_tokens}, "
         )
 
+        if prefill_stats.log_replay_tokens:
+            msg += f"#replay-token: {prefill_stats.log_replay_tokens}, "
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
             msg += f"#bootstrap-req: {len(self.scheduler.disagg_prefill_bootstrap_queue.queue)}, "
             msg += (
@@ -679,7 +686,9 @@ class SchedulerMetricsReporter:
                 value=can_run_cuda_graph
             )
             self.metrics_collector.increment_realtime_tokens(
-                prefill_compute_tokens=prefill_stats.log_input_tokens,
+                prefill_compute_tokens=(
+                    prefill_stats.log_input_tokens + prefill_stats.log_replay_tokens
+                ),
                 prefill_cache_tokens=prefill_stats.log_hit_tokens,
                 dp_cooperation_info=dp_cooperation_info,
             )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1170,6 +1170,28 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ) -> None:
         """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
         # FIXME: unify the length validation logic with the one in the scheduler.
+        if get_exec().features.enable_encoder_swa_bounded_replay:
+            if any(
+                value is not None
+                for value in (
+                    obj.image_data,
+                    obj.video_data,
+                    obj.audio_data,
+                    obj.input_embeds,
+                    obj.positional_embed_overrides,
+                )
+            ):
+                raise ValueError(
+                    "encoder SWA replay currently supports token-only text requests"
+                )
+            if (
+                isinstance(obj, GenerateReqInput)
+                and obj.return_logprob
+                and obj.logprob_start_len not in (None, -1, len(input_ids))
+            ):
+                raise ValueError(
+                    "encoder SWA replay cannot return cached prompt logprobs"
+                )
         _max_req_len = self.context_len
         input_token_num = len(input_ids) if input_ids is not None else 0
         input_token_num += self.num_reserved_tokens

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -600,6 +600,12 @@ class TpModelWorker(BaseTpWorker):
         *,
         capture_hidden_mode: Optional[CaptureHiddenMode] = None,
     ) -> GenerationBatchResult:
+        if batch is not None and get_exec().features.enable_encoder_swa_bounded_replay:
+            from sglang.srt.model_executor.encoder_swa_replay import (
+                run_encoder_swa_replay,
+            )
+
+            run_encoder_swa_replay(self, batch)
         # Get forward batch from schedule batch
         if batch is not None:
             # update the consumer index of hicache to the running batch

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -132,13 +132,9 @@ class CompressStatePool:
             dtype=dtype, device=device, enable_memory_saver=enable_memory_saver
         )
         if not online:
-            if _is_hip and ratio == 128:
-                # Request-scoped C128 state is addressed by req_pool_idx (or a
-                # per-request ring).  The pool is allocated with torch.empty(),
-                # so a cold server can otherwise read uninitialized partial
-                # states before a request slot has been written for the first
-                # time.  Initialize all C128 rows to the empty-state sentinel;
-                # C4 keeps the historical last-row sentinel behavior.
+            if ratio == 2 or (_is_hip and ratio == 128):
+                # Initialize all request-scoped rows to the empty-state sentinel before reuse;
+                # C4 initializes only its last-row sentinel.
                 self.kv_score_buffer.clear()
             else:
                 self.kv_score_buffer[-1].clear()
@@ -200,15 +196,17 @@ class CompressStatePool:
     ) -> torch.Tensor:
         swa_pages = swa_loc // self.swa_page_size
         state_loc = swa_pages * self.ring_size + (swa_loc % self.ring_size)
-        state_loc = torch.where(swa_loc < 0, -1, state_loc)
-        return state_loc
+        # masked_fill_, not where(cond, -1, ...): a Scalar branch is passed by
+        # value, while the scalar overload of where may stage a host tensor and
+        # so cannot run inside a CUDA graph capture.
+        return state_loc.masked_fill_(swa_loc < 0, -1)
 
     def translate_from_req_position_to_state_loc(
         self, req_pool_indices: torch.Tensor, positions: torch.Tensor
     ) -> torch.Tensor:
         state_loc = req_pool_indices * self.ring_size + positions % self.ring_size
-        state_loc = torch.where(positions < 0, -1, state_loc)
-        return state_loc
+        # A negative position means "no slot"; it lands on the empty row -1.
+        return state_loc.masked_fill_(positions < 0, -1)
 
     def get_state_by_state_loc(self, state_loc: torch.Tensor) -> KVAndScore:
         return self.kv_score_buffer[state_loc]

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
-from typing import List, Literal, NamedTuple, Optional, Tuple
+from typing import List, Literal, NamedTuple, Optional, Sequence, Tuple
 
 import torch
 
@@ -39,9 +39,18 @@ def get_dsv4_indexer_bytes_per_token(index_head_dim: int, use_fp4_indexer: bool)
 
 
 def get_compress_state_ring_size(
-    compress_ratio: int, is_speculative: bool = False
+    compress_ratio: int, is_speculative: bool = False, num_draft_tokens: int = 0
 ) -> int:
-    assert compress_ratio in [4, 128], f"Unsupported {compress_ratio = }"
+    assert compress_ratio in [2, 4, 128], f"Unsupported {compress_ratio = }"
+    if compress_ratio == 2:
+        # Ratio 2 keeps one pending even token per request, addressed by
+        # position % ring_size; two positions are one pair. A speculative ring
+        # must stay wider than the draft window so that regenerating a rejected
+        # position overwrites its own slot before the position after it reads
+        # the slot before it: smallest power of two >= 2 + draft tokens.
+        if not is_speculative:
+            return 2
+        return 1 << (num_draft_tokens + 1).bit_length()
     # Online c128 keeps a single (max, sum, kv) state per index instead of a
     # 128-slot ring buffer of raw tokens, so ring_size collapses to 1. Online
     # is incompatible with speculative decode for now.
@@ -58,7 +67,8 @@ def get_compress_state_ring_size(
 def get_compress_state_write_pad(compress_ratio: int, ring_size: int) -> int:
     """Largest draft-token count this ring can serve; mirrors `mtp_pad` in `c_plan.cuh`
     (the bound is derived there). Zero for a non-speculative ring, which is exactly one
-    window wide."""
+    window wide. Ratio 2's window is the pair itself, so its speculative ring serves
+    ring_size draft tokens."""
     window_size = compress_ratio * (2 if compress_ratio == 4 else 1)
     return ring_size - window_size + 2 if ring_size > window_size else 0
 
@@ -263,6 +273,11 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         raise NotImplementedError("HiSparseC4DevicePool does not support load_cpu_copy")
 
 
+# Low-ratio indexer-K pool page, in compressed slots: the DeepGEMM indexer reads
+# K in blocks of at most 128 and sglang's JIT metadata builder asserts 64.
+DSV41_INDEX_PAGE_SIZE = 64
+
+
 class DeepSeekV4IndexerPool(KVCache):
     quant_block_size = 128
     index_k_with_scale_buffer_dtype = torch.uint8
@@ -278,6 +293,7 @@ class DeepSeekV4IndexerPool(KVCache):
         enable_memory_saver: bool,
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
+        use_fp4_indexer: Optional[bool] = None,
     ):
         super().__init__(
             size,
@@ -290,8 +306,13 @@ class DeepSeekV4IndexerPool(KVCache):
             end_layer,
         )
         self.index_head_dim = index_head_dim
-        self.use_fp4_indexer = get_exec().kernel.enable_deepseek_v4_fp4_indexer
+        if use_fp4_indexer is None:
+            use_fp4_indexer = get_exec().kernel.enable_deepseek_v4_fp4_indexer
+        self.use_fp4_indexer = use_fp4_indexer
         self.uses_aiter_fp4_layout = _is_hip and self.use_fp4_indexer
+        # Low-ratio pools round to nearest even, as the reference does; c4 keeps
+        # the threshold rounding.
+        self.index_k_rne = False
 
         self._create_buffer()
 
@@ -432,11 +453,62 @@ class DeepSeekV4IndexerPool(KVCache):
             cache=self.index_k_with_scale_buffer[layer_id - self.start_layer],
             loc=loc,
             page_size=self.page_size,
+            rne=self.index_k_rne,
         )
+
+    def get_index_k_fp4(
+        self, layer_id: int, slots: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Packed fp4 rows at `slots`: (payload int8 [n, 64], scales int32 [n]).
+        Inverse of the store_fp4_index_k_cache page layout
+        [page_size * 64 payload | page_size * 4 scale bytes]."""
+        assert self.use_fp4_indexer, "packed readback only applies to the fp4 layout"
+        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        slots = slots.to(torch.int64)
+        p = self.page_size
+        page, off = (slots // p).unsqueeze(-1), slots % p
+        payload_cols = (off * 64).unsqueeze(-1) + torch.arange(64, device=buf.device)
+        scale_cols = (p * 64 + off * 4).unsqueeze(-1) + torch.arange(
+            4, device=buf.device
+        )
+        payload = buf[page, payload_cols].view(torch.int8)  # [n, 64]
+        scales = buf[page, scale_cols].contiguous().view(torch.int32).squeeze(-1)
+        return payload, scales
+
+    def get_index_k_dequant(
+        self, layer_id: int, slots: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Dequantized bf16 [n, index_head_dim] index K at `slots` (every slot when
+        None); pass the slots you need, the full table is pool-sized."""
+        from sglang.srt.layers.quantization.fp8 import DSV4_DEQUANT_FP4_TABLE
+
+        assert self.use_fp4_indexer, "dequant readback only applies to the fp4 layout"
+        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        if slots is None:
+            slots = torch.arange(self.size, device=buf.device)
+        slots = slots.to(torch.int64)
+        # A page is [page_size * 64 payload bytes | page_size * 4 scale bytes]
+        # (store_fp4_index_k_cache layout).
+        p = self.page_size
+        page, off = (slots // p).unsqueeze(-1), slots % p
+        payload_cols = (off * 64).unsqueeze(-1) + torch.arange(64, device=buf.device)
+        scale_cols = (p * 64 + off * 4).unsqueeze(-1) + torch.arange(
+            4, device=buf.device
+        )
+        u = buf[page, payload_cols].view(torch.uint8)  # [n, 64]
+        codes = torch.stack([u & 0x0F, (u >> 4) & 0x0F], dim=-1)  # [n, 64, 2]
+        vals = DSV4_DEQUANT_FP4_TABLE.to(buf.device)[codes.long()].flatten(
+            1
+        )  # [n, 128]
+        exps = buf[page, scale_cols].to(torch.int32) & 0xFF  # [n, 4]
+        scales = torch.exp2(exps.float() - 127).repeat_interleave(32, dim=-1)
+        return (vals * scales).to(torch.bfloat16)
 
 
 class DeepSeekV4LayerItem(NamedTuple):
-    compress_ratio: Literal[0, 4, 128]
+    compress_ratio: Literal[0, 1, 2, 4, 128]
+    # Layer index inside compress_kv_pool. Ratios 1/2 share a pool layer across the
+    # kv_source layer that writes it and the layers that read it.
     compress_layer_id: int
     compress_kv_pool: Optional[DeepSeekV4SingleKVPool] = None
 
@@ -534,6 +606,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
         num_req_slots: Optional[int] = None,
+        kv_source_layers: Sequence[int] = (),
+        full_size: Optional[int] = None,
     ):
         super().__init__(
             swa_size,
@@ -614,10 +688,6 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.indexer_head_dim = indexer_head_dim
 
         stage_layer_num = len(stage_ratios)
-        c4_layer_num = sum(1 for r in stage_ratios if r == 4)
-        c128_layer_num = sum(1 for r in stage_ratios if r == 128)
-        c4_page_size = page_size // 4
-        c128_page_size = page_size // 128
 
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
             is_unified_kv_triton,
@@ -625,10 +695,37 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
         self._unified_kv = is_unified_kv_triton()
 
-        if self._unified_kv:
+        self.request_window = None
+        if get_exec().features.enable_encoder_swa_bounded_replay:
+            from sglang.srt.mem_cache.dsv41_request_window import RequestWindow
+
+            def make_window_pool(size, layers):
+                return self._make_kv_pool(
+                    size=size,
+                    page_size=swa_page_size,
+                    dtype=dtype,
+                    layer_num=layers,
+                    device=device,
+                    enable_memory_saver=enable_memory_saver,
+                    global_page_size=swa_page_size,
+                )
+
             self.swa_kv_pool = None
-            self.c4_kv_pool = None
-            self.c128_kv_pool = None
+            self.unified_kv_pool = None
+            from sglang.srt.runtime_context import get_schedule
+
+            chunk = get_schedule().chunked_prefill_size or 0
+            self.request_window = RequestWindow(
+                make_window_pool,
+                num_slots=self.num_req_slots,
+                layers=stage_layer_num,
+                page_size=swa_page_size,
+                capacity=self.sliding_window + (online_mtp_max_draft_tokens or 0),
+                workspace_rows=(self.num_req_slots + 1) * self.sliding_window
+                + max(chunk, self.num_req_slots + 1),
+            )
+        elif self._unified_kv:
+            self.swa_kv_pool = None
             spec_extra = (
                 (get_spec().speculative_num_draft_tokens - 1)
                 if get_spec().speculative_algorithm is not None
@@ -662,41 +759,23 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 global_page_size=swa_page_size,
             )
 
-            c4_kv_pool_type = DeepSeekV4SingleKVPool
-            if enable_hisparse:
-                c4_kv_pool_type = HiSparseC4DevicePool
-            self.c4_kv_pool = self._make_kv_pool(
-                size=c4_size,
-                page_size=c4_page_size,
-                dtype=dtype,
-                layer_num=c4_layer_num,
-                device=device,
-                enable_memory_saver=enable_memory_saver,
-                global_page_size=page_size,
-                cls=c4_kv_pool_type,
-            )
-
-            self.c128_kv_pool = self._make_kv_pool(
-                size=c128_size,
-                page_size=c128_page_size,
-                dtype=dtype,
-                layer_num=c128_layer_num,
-                device=device,
-                enable_memory_saver=enable_memory_saver,
-                global_page_size=page_size,
-            )
-
-        indexer_size = self.c4_logical_size
-        self.c4_indexer_kv_pool = self._make_indexer_pool(
-            indexer_size,
-            c4_page_size,
-            dtype,
-            indexer_head_dim,
-            c4_layer_num,
-            device,
-            enable_memory_saver,
+        self.kv_source_layers = list(kv_source_layers)
+        self.sources_by_ratio = self._collect_sources_by_ratio()
+        self._init_compressed_pools(
+            c4_size=c4_size,
+            c128_size=c128_size,
+            full_size=full_size,
+            page_size=page_size,
+            dtype=dtype,
+            device=device,
+            enable_memory_saver=enable_memory_saver,
+            enable_hisparse=enable_hisparse,
         )
-
+        # HiSparse, the HiCache pool assemblers and the NPU pool read the compressed
+        # pools by these names; everything in this file goes through the registries.
+        self.c4_kv_pool = self.kv_pools.get(4)
+        self.c128_kv_pool = self.kv_pools.get(128)
+        self.c4_indexer_kv_pool = self.index_pools.get(4)
         self._init_compressed_layer_mapping()
 
         self._init_paged_compress_states(enable_memory_saver)
@@ -711,8 +790,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
 
     def get_ring_size(self, compress_ratio: int) -> int:
-        is_speculative = get_spec().speculative_algorithm is not None
-        return get_compress_state_ring_size(compress_ratio, is_speculative)
+        spec = get_spec()
+        return get_compress_state_ring_size(
+            compress_ratio,
+            spec.speculative_algorithm is not None,
+            spec.speculative_num_draft_tokens or 0,
+        )
 
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
         assert self.full_to_swa_index_mapping is not None
@@ -758,18 +841,34 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
             return data_ptrs, data_lens, item_lens
 
-        buf_groups = [
-            self.c4_kv_pool.kv_buffer,
-            self.c4_indexer_kv_pool.contiguous_page_row_buffers(),
-            self.c128_kv_pool.kv_buffer,
-        ]
-
-        for bufs in buf_groups:
-            for buf in bufs:
+        # Fixed ratio order, so the receiver's PP ptr-slicing stays valid. The
+        # transfer addresses every buffer by FULL page id, so one item is one
+        # FULL page: a KV pool row already is one, while an index pool row is one
+        # of its own pages (DSV41_INDEX_PAGE_SIZE slots for the low ratios), so
+        # there a FULL page is the run of adjacent index pages that hold its
+        # page_size // ratio slots.
+        for ratio in (4, 128, 1, 2):
+            if ratio not in self.kv_pools:
+                continue
+            for buf in self.kv_pools[ratio].kv_buffer:
                 assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
                 data_ptrs.append(buf.data_ptr())
                 data_lens.append(buf.nbytes)
                 item_lens.append(buf[0].nbytes)
+            index_pool = self.index_pools.get(ratio)
+            if index_pool is None:
+                continue
+            slots_per_full_page = self.page_size // ratio
+            assert slots_per_full_page % index_pool.page_size == 0, (
+                f"ratio-{ratio} index pages of {index_pool.page_size} slots do not "
+                f"tile a FULL page of {slots_per_full_page} slots"
+            )
+            index_pages_per_full_page = slots_per_full_page // index_pool.page_size
+            for buf in index_pool.contiguous_page_row_buffers():
+                assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
+                data_ptrs.append(buf.data_ptr())
+                data_lens.append(buf.nbytes)
+                item_lens.append(buf[0].nbytes * index_pages_per_full_page)
 
         return data_ptrs, data_lens, item_lens
 
@@ -833,7 +932,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         data_lens: List[int] = []
         item_lens: List[int] = []
 
-        if not self._unified_kv:
+        if self.swa_kv_pool is not None:
             for buf in self.swa_kv_pool.kv_buffer:
                 assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
                 data_ptrs.append(buf.data_ptr())
@@ -847,7 +946,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             for pool in pools:
                 if pool is None:
                     continue
-                if pool.ratio == 128:
+                # Request-scoped state ships as C128_STATE, not with the SWA ring.
+                if pool.ratio in (2, 128):
                     continue
                 t = pool.kv_score_buffer.kv_score
                 assert t.ndim == 2, f"expected 2D buffer, got {t.ndim}D"
@@ -860,17 +960,23 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_c128_state_buf_infos(
         self,
     ) -> Tuple[List[int], List[int], List[int]]:
+        """The request-scoped state component, named after its first member: the
+        c128 raw-token ring (or its single online row) and the ratio-2
+        pending-pair ring. One item is one c128 page / one request's pair ring."""
         data_ptrs: List[int] = []
         data_lens: List[int] = []
         item_lens: List[int] = []
         for pool in self.compress_state_pools:
-            if pool is None or pool.ratio != 128:
+            if pool is None or pool.ratio not in (2, 128):
                 continue
             t = pool.kv_score_buffer.kv_score
             assert t.ndim == 2, f"expected 2D buffer, got {t.ndim}D"
             data_ptrs.append(t.data_ptr())
             data_lens.append(t.nbytes)
-            item_lens.append(t[0].nbytes if ONLINE_C128 else t[0].nbytes * 128)
+            if pool.ratio == 2:
+                item_lens.append(t[0].nbytes * pool.ring_size)
+            else:
+                item_lens.append(t[0].nbytes if ONLINE_C128 else t[0].nbytes * 128)
         return data_ptrs, data_lens, item_lens
 
     def _make_kv_pool(
@@ -911,10 +1017,28 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_num: int,
         device: str,
         enable_memory_saver: bool,
+        force_fp4: bool = False,
     ) -> DeepSeekV4IndexerPool:
         """Build the c4 lightning-indexer K pool (packed CUDA layout).
         Overridden by :class:`DSV4NPUTokenToKVPool` to swap in the
-        dedicated-buffer NPU variant (int8 K + fp16 scale)."""
+        dedicated-buffer NPU variant (int8 K + fp16 scale).
+
+        ``force_fp4`` ignores the deployment flag: the low-ratio indexer is fp4 by
+        design, and sizing it off the flag would mis-size the buffer."""
+        if force_fp4:
+            pool = DeepSeekV4IndexerPool(
+                size,
+                page_size,
+                dtype,
+                index_head_dim,
+                layer_num,
+                device,
+                enable_memory_saver,
+                use_fp4_indexer=True,
+            )
+            # The dsv41 low-ratio indexer rounds to nearest even (reference rounding).
+            pool.index_k_rne = True
+            return pool
         return DeepSeekV4IndexerPool(
             size,
             page_size,
@@ -966,18 +1090,43 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             swa_page_size=self.swa_page_size,
         )
 
+    def _make_pair_state_pool(self, enable_memory_saver: bool) -> CompressStatePool:
+        """Ratio-2 pending-pair state: one position ring per request slot, holding
+        the fp32 (kv, score) of an even token until its odd partner arrives. Sized
+        from num_req_slots, not from a token budget -- the state is request-scoped."""
+        ring_size = self.get_ring_size(2)
+        return CompressStatePool(
+            size=self.num_req_slots * ring_size,
+            ring_size=ring_size,
+            overlap=False,
+            head_dim=self.qk_nope_head_dim + self.qk_rope_head_dim,
+            dtype=torch.float32,
+            device=self.device,
+            enable_memory_saver=enable_memory_saver,
+            ratio=2,
+            online=False,
+        )
+
     def _init_paged_compress_states(self, enable_memory_saver: bool):
-        c4_state_pool_size = self.c4_state_pool_size
-        c128_state_pool_size = self.c128_state_pool_size
         total_L = len(self.compression_ratios)
         self.compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
         self.indexer_compress_state_pools: List[Optional[CompressStatePool]] = [
             None
         ] * total_L
+        pair_sources = self.sources_by_ratio.get(2, [])
 
         for idx in range(self._stage_start, self._stage_end):
             ratio = self.compression_ratios[idx]
-            if ratio == 0:
+            if ratio in (0, 1):
+                continue
+
+            if ratio == 2:
+                # Only a kv_source layer compresses; the ratio-2 layers after it
+                # read its latents and so need no pending-pair state of their own.
+                if idx in pair_sources:
+                    self.compress_state_pools[idx] = self._make_pair_state_pool(
+                        enable_memory_saver
+                    )
                 continue
 
             self.compress_state_pools[idx] = self._make_attn_state_pool(
@@ -989,8 +1138,112 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                     ratio, enable_memory_saver
                 )
 
+    def _collect_sources_by_ratio(self) -> dict[int, List[int]]:
+        """Layers owning compressed storage, per ratio present in this PP stage:
+        every layer of ratios 4/128, the kv_source layers of ratios 1/2."""
+        stage = range(self._stage_start, self._stage_end)
+        for idx in stage:
+            ratio = self.compression_ratios[idx]
+            if ratio not in (0, 1, 2, 4, 128):
+                raise ValueError(f"Unsupported compression ratio: {ratio}")
+
+        sources_by_ratio: dict[int, List[int]] = {}
+        for ratio in (4, 128, 1, 2):
+            if ratio in (1, 2):
+                layers = [
+                    l
+                    for l in self.kv_source_layers
+                    if l in stage and self.compression_ratios[l] == ratio
+                ]
+            else:
+                layers = [l for l in stage if self.compression_ratios[l] == ratio]
+            if layers:
+                sources_by_ratio[ratio] = layers
+        return sources_by_ratio
+
+    def source_layer_of(self, layer_id: int) -> int:
+        """The layer owning this layer's compressed storage: itself for ratios 4/128,
+        the nearest preceding kv_source layer for ratios 1/2 -- the layer whose
+        latents, index keys and pair state this layer reads."""
+        ratio = self.compression_ratios[layer_id]
+        sources = [l for l in self.sources_by_ratio[ratio] if l <= layer_id]
+        assert sources, f"layer {layer_id} (ratio {ratio}) has no kv_source layer"
+        return max(sources)
+
+    def _init_compressed_pools(
+        self,
+        *,
+        c4_size: int,
+        c128_size: int,
+        full_size: Optional[int],
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        enable_memory_saver: bool,
+        enable_hisparse: bool,
+    ) -> None:
+        """One FlashMLA-layout KV pool per compress ratio present in this stage, plus
+        the packed indexer-K pool every ratio but 128 carries: slot = full-pool token
+        loc // ratio, page = page_size // ratio rows, so the pages line up with the
+        full pool's."""
+        self.kv_pools: dict[int, DeepSeekV4SingleKVPool] = {}
+        self.index_pools: dict[int, DeepSeekV4IndexerPool] = {}
+        if any(ratio in (1, 2) for ratio in self.sources_by_ratio):
+            assert full_size is not None, "low compress ratios need the full pool size"
+            assert not self._unified_kv, "unified_kv has no low compress ratio layout"
+
+        kv_pool_size = {4: c4_size, 128: c128_size}
+        if not self._unified_kv:
+            for ratio, sources in self.sources_by_ratio.items():
+                self.kv_pools[ratio] = self._make_kv_pool(
+                    size=(
+                        kv_pool_size[ratio]
+                        if ratio in kv_pool_size
+                        else full_size // ratio
+                    ),
+                    page_size=page_size // ratio,
+                    dtype=dtype,
+                    layer_num=len(sources),
+                    device=device,
+                    enable_memory_saver=enable_memory_saver,
+                    global_page_size=page_size,
+                    cls=(
+                        HiSparseC4DevicePool
+                        if ratio == 4 and enable_hisparse
+                        else DeepSeekV4SingleKVPool
+                    ),
+                )
+
+        for ratio, sources in self.sources_by_ratio.items():
+            if ratio == 128:
+                continue
+            if ratio == 4:
+                self.index_pools[ratio] = self._make_indexer_pool(
+                    self.c4_logical_size,
+                    page_size // 4,
+                    dtype,
+                    self.indexer_head_dim,
+                    len(sources),
+                    device,
+                    enable_memory_saver,
+                )
+                continue
+            # Slots remain loc // ratio, with DSV41_INDEX_PAGE_SIZE packed-buffer pages.
+            # Reserved FULL page 0 extends real slots past full_size; one index padding
+            # page is too small to cover that gap.
+            self.index_pools[ratio] = self._make_indexer_pool(
+                (full_size + page_size) // ratio,
+                DSV41_INDEX_PAGE_SIZE,
+                dtype,
+                self.indexer_head_dim,
+                len(sources),
+                device,
+                enable_memory_saver,
+                force_fp4=True,
+            )
+
     def _init_compressed_layer_mapping(self):
-        c1_cnt = c4_cnt = c128_cnt = 0
+        full_cnt = 0
         total_L = len(self.compression_ratios)
         self.layer_mapping: List[Optional[DeepSeekV4LayerItem]] = [None] * total_L
 
@@ -999,25 +1252,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             if ratio == 0:
                 self.layer_mapping[idx] = DeepSeekV4LayerItem(
                     compress_ratio=0,
-                    compress_layer_id=c1_cnt,
+                    compress_layer_id=full_cnt,
                 )
-                c1_cnt += 1
-            elif ratio == 4:
-                self.layer_mapping[idx] = DeepSeekV4LayerItem(
-                    compress_ratio=4,
-                    compress_layer_id=c4_cnt,
-                    compress_kv_pool=self.c4_kv_pool,
-                )
-                c4_cnt += 1
-            elif ratio == 128:
-                self.layer_mapping[idx] = DeepSeekV4LayerItem(
-                    compress_ratio=128,
-                    compress_layer_id=c128_cnt,
-                    compress_kv_pool=self.c128_kv_pool,
-                )
-                c128_cnt += 1
-            else:
-                raise ValueError(f"Unsupported compression ratio: {ratio}")
+                full_cnt += 1
+                continue
+
+            sources = self.sources_by_ratio[ratio]
+            self.layer_mapping[idx] = DeepSeekV4LayerItem(
+                compress_ratio=ratio,
+                compress_layer_id=sources.index(self.source_layer_of(idx)),
+                compress_kv_pool=self.kv_pools.get(ratio),
+            )
 
     def wait_layer_transfer(self, layer_id: int) -> None:
         if self.layer_transfer_counter is not None:
@@ -1027,7 +1272,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.wait_layer_transfer(layer_id)
         compress_state_pool = self.compress_state_pools[layer_id]
         assert compress_state_pool is not None, (
-            "Only c4/c128 layers have attention states."
+            "Only c4/c128 layers and ratio-2 kv_source layers have attention states."
         )
         return compress_state_pool
 
@@ -1051,23 +1296,21 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         return self.online_c128_mtp_pending_seq_lens
 
     def clear_c128_req_state(self, req_pool_idx: int) -> None:
-        """Reset request-scoped C128 state for one req slot."""
+        """Reset request-scoped state for one req slot: the C128 ring and the
+        ratio-2 pending-pair ring."""
         for pool in self.compress_state_pools:
-            if pool is None or pool.ratio != 128:
+            if pool is None or pool.ratio not in (2, 128):
                 continue
 
-            state = pool.kv_score_buffer.kv_score
-            if ONLINE_C128:
-                row = state[req_pool_idx]
+            if pool.ratio == 128 and ONLINE_C128:
+                row = pool.kv_score_buffer.kv_score[req_pool_idx]
                 head_dim = row.shape[-1] // 3
                 row[:head_dim].fill_(float("-inf"))
                 row[head_dim:].zero_()
-            else:
-                start = req_pool_idx * pool.ring_size
-                rows = state[start : start + pool.ring_size]
-                half = rows.shape[-1] // 2
-                rows[:, :half].zero_()
-                rows[:, half:].fill_(float("-inf"))
+                continue
+
+            start = req_pool_idx * pool.ring_size
+            pool.kv_score_buffer[start : start + pool.ring_size].clear()
 
     def clear_unaccepted_c128_draft_states(
         self,
@@ -1107,10 +1350,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         return layer_id - self._stage_start
 
     def get_swa_raw_buffer(self, layer_id: int) -> torch.Tensor:
+        if self.request_window is not None:
+            return self.request_window.buffer(self._swa_local_layer_id(layer_id))
         return self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)]
 
     def get_swa_key_buffer(self, layer_id: int) -> torch.Tensor:
         self.wait_layer_transfer(layer_id)
+        if self.request_window is not None:
+            return self.get_swa_raw_buffer(layer_id).view(
+                self.request_window.state.dtype
+            )
         return self.swa_kv_pool.get_key_buffer(self._swa_local_layer_id(layer_id))
 
     def set_swa_key_buffer(
@@ -1119,9 +1368,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     ) -> None:
-        self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack
-        )
+        if self.request_window is not None:
+            dsv4_index_buf_accessor.SetKAndS.execute(
+                pool=self.request_window.state,
+                buf=self.get_swa_raw_buffer(layer_id),
+                loc=loc,
+                nope_fp8_rope_bf16_pack=cache_nope_fp8_rope_bf16_pack,
+            )
+        else:
+            self.swa_kv_pool.set_key_buffer(
+                self._swa_local_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack
+            )
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
         _, _, compress_kv_pool = self.layer_mapping[layer_id]
@@ -1146,26 +1403,55 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             compress_layer_id, loc, cache_nope_fp8_rope_bf16_pack
         )
 
-    def get_index_k_page_size(self) -> int:
-        return self.c4_indexer_kv_pool.page_size
+    def _indexer_pool(self, compress_ratio: int) -> DeepSeekV4IndexerPool:
+        pool = self.index_pools.get(compress_ratio)
+        assert pool is not None, f"no indexer pool for {compress_ratio = }"
+        return pool
+
+    def get_low_ratio_index_k_dequant(
+        self, layer_id: int, slots: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Index-K rows at `slots` from the layer's latent source; see
+        get_index_k_dequant."""
+        compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
+        return self._indexer_pool(compress_ratio).get_index_k_dequant(
+            compress_layer_id, slots
+        )
+
+    def get_low_ratio_index_k_fp4(
+        self, layer_id: int, slots: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Packed fp4 index-K rows at `slots` from the layer's latent source:
+        (payload int8 [n, 64], ue8m0 scales packed int32 [n]), the kernel input
+        layout of quantize_fp4_indexer_tensor."""
+        compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
+        return self._indexer_pool(compress_ratio).get_index_k_fp4(
+            compress_layer_id, slots
+        )
+
+    def get_index_k_page_size(self, compress_ratio: int = 4) -> int:
+        return self._indexer_pool(compress_ratio).page_size
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
         self.wait_layer_transfer(layer_id)
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.get_index_k_with_scale_buffer(compress_layer_id)
+        return self._indexer_pool(compress_ratio).get_index_k_with_scale_buffer(
+            compress_layer_id
+        )
 
     def get_index_k_fp4_payload_buffer(self, layer_id: int) -> torch.Tensor:
         self.wait_layer_transfer(layer_id)
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.get_index_k_fp4_payload_buffer(compress_layer_id)
+        return self._indexer_pool(compress_ratio).get_index_k_fp4_payload_buffer(
+            compress_layer_id
+        )
 
     def get_index_k_fp4_scale_buffer(self, layer_id: int) -> torch.Tensor:
         self.wait_layer_transfer(layer_id)
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.get_index_k_fp4_scale_buffer(compress_layer_id)
+        return self._indexer_pool(compress_ratio).get_index_k_fp4_scale_buffer(
+            compress_layer_id
+        )
 
     def get_index_k_scale_buffer(
         self,
@@ -1177,8 +1463,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         self.wait_layer_transfer(layer_id)
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.get_index_k_scale_buffer(
+        return self._indexer_pool(compress_ratio).get_index_k_scale_buffer(
             compress_layer_id,
             seq_len_tensor,
             page_indices,
@@ -1194,8 +1479,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         index_k_scale: torch.Tensor,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        self.c4_indexer_kv_pool.set_index_k_scale_buffer(
+        self._indexer_pool(compress_ratio).set_index_k_scale_buffer(
             compress_layer_id, loc, index_k, index_k_scale
         )
 
@@ -1217,12 +1501,14 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         swa_loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     ) -> None:
-        self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), swa_loc, cache_nope_fp8_rope_bf16_pack
-        )
+        self.set_swa_key_buffer(layer_id, swa_loc, cache_nope_fp8_rope_bf16_pack)
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
         self.wait_layer_transfer(layer_id)
+        if self.request_window is not None:
+            return self.get_swa_raw_buffer(layer_id).view(
+                self.request_window.state.dtype
+            )
         return self.swa_kv_pool.get_key_buffer(self._swa_local_layer_id(layer_id))
 
     def set_swa_key_buffer_radix_fused(
@@ -1231,8 +1517,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         swa_loc: torch.Tensor,
         cache_k: torch.Tensor,
     ) -> None:
-        return self.swa_kv_pool.set_key_buffer_fused(
-            self._swa_local_layer_id(layer_id), swa_loc, cache_k
+        return fused_store_cache(
+            input=cache_k,
+            cache=self.get_swa_raw_buffer(layer_id),
+            indices=swa_loc,
+            page_size=self.swa_page_size,
+            type="flashmla",
         )
 
     def set_swa_key_buffer_radix_fused_norm_rope(
@@ -1252,8 +1542,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             freqs_cis=freqs_cis,
             positions=positions,
             out_loc=swa_loc,
-            kvcache=self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)],
-            page_size=self.swa_kv_pool.page_size,
+            kvcache=self.get_swa_raw_buffer(layer_id),
+            page_size=self.swa_page_size,
         )
 
     def set_unified_key_buffer_radix_fused_norm_rope(
@@ -1301,8 +1591,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         cache_k: torch.Tensor,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.set_index_fused(compress_layer_id, loc, cache_k)
+        return self._indexer_pool(compress_ratio).set_index_fused(
+            compress_layer_id, loc, cache_k
+        )
 
     def set_index_k_fp4(
         self,
@@ -1311,5 +1602,6 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         cache_k: torch.Tensor,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
-        assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
-        return self.c4_indexer_kv_pool.set_index_fp4(compress_layer_id, loc, cache_k)
+        return self._indexer_pool(compress_ratio).set_index_fp4(
+            compress_layer_id, loc, cache_k
+        )

--- a/python/sglang/srt/mem_cache/dsv41_request_window.py
+++ b/python/sglang/srt/mem_cache/dsv41_request_window.py
@@ -1,0 +1,234 @@
+from typing import Optional
+
+import msgspec
+import torch
+
+
+class WindowLayout(msgspec.Struct, frozen=True):
+    req: torch.Tensor
+    pos: torch.Tensor
+    write_loc: torch.Tensor
+    indices: torch.Tensor
+    lengths: torch.Tensor
+    history_req: torch.Tensor
+    history_pos: torch.Tensor
+    history_loc: torch.Tensor
+    history_valid: torch.Tensor
+    commit_mask: torch.Tensor
+    size: int
+
+
+def _first_row_offsets(
+    req: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    n = req.numel()
+    offset = torch.arange(n, device=req.device)
+    starts = torch.ones(n, dtype=torch.bool, device=req.device)
+    starts[1:] = req[1:] != req[:-1]
+    group = starts.cumsum(0) - 1
+    group_first = torch.cummax(torch.where(starts, offset, 0), dim=0).values
+    ends = torch.ones(n, dtype=torch.bool, device=req.device)
+    ends[:-1] = starts[1:]
+    group_last = torch.cummin(
+        torch.where(ends, offset, n - 1).flip(0), dim=0
+    ).values.flip(0)
+    return group, group_first, group_last
+
+
+def window_layout(
+    req,
+    pos,
+    *,
+    window: int = 128,
+    capacity: int = 256,
+    floor: Optional[torch.Tensor] = None,
+    num_groups: Optional[int] = None,
+):
+    n = pos.numel()
+    if n == 0:
+        raise ValueError("request-window layout needs at least one query")
+    req = req.to(torch.int64)
+    pos = pos.to(torch.int64)
+    device = pos.device
+    groups = n if num_groups is None else int(num_groups)
+    offset = torch.arange(n, device=device)
+    group, group_first, group_last = _first_row_offsets(req)
+    first_pos = pos - (offset - group_first)
+    history_rows = groups * window
+
+    write_loc = (history_rows + offset).to(torch.int32)
+    lookback = torch.arange(window, device=device)
+    seen_pos = pos[:, None] - lookback
+    old = seen_pos < first_pos[:, None]
+    old_loc = group[:, None] * window + (seen_pos - (first_pos[:, None] - window))
+    new_loc = history_rows + group_first[:, None] + seen_pos - first_pos[:, None]
+    valid = seen_pos >= 0
+    if floor is not None:
+        floor = floor.to(torch.int64)
+        valid &= seen_pos >= floor[:, None]
+    indices = torch.where(valid, torch.where(old, old_loc, new_loc), -1).to(torch.int32)
+    lengths = valid.sum(-1).to(torch.int32)
+
+    g_req = torch.zeros(groups, dtype=torch.int64, device=device).scatter_(
+        0, group, req
+    )
+    g_first = torch.zeros(groups, dtype=torch.int64, device=device).scatter_(
+        0, group, first_pos
+    )
+    g_live = torch.zeros(groups, dtype=torch.bool, device=device).scatter_(
+        0, group, torch.ones_like(group, dtype=torch.bool)
+    )
+    history_pos = (g_first[:, None] - window + lookback[None, :]).flatten()
+    history_valid = (history_pos >= 0) & g_live.repeat_interleave(window)
+    if floor is not None:
+        g_floor = torch.zeros(groups, dtype=torch.int64, device=device).scatter_(
+            0, group, floor
+        )
+        history_valid &= history_pos >= g_floor.repeat_interleave(window)
+    history_req = g_req.repeat_interleave(window)
+    history_loc = torch.arange(history_rows, device=device)
+
+    commit_mask = (group_last - offset) < capacity
+    return WindowLayout(
+        req,
+        pos,
+        write_loc,
+        indices,
+        lengths,
+        history_req,
+        history_pos,
+        history_loc,
+        history_valid,
+        commit_mask,
+        history_rows + n,
+    )
+
+
+def copy_packed_tokens(src, dst, src_loc, dst_loc, *, page_size):
+    if not src_loc.numel():
+        return
+    src_loc, dst_loc = src_loc.long(), dst_loc.long()
+    for width, base in ((576, 0), (8, page_size * 576)):
+        cols = torch.arange(width, device=src.device)
+        values = src[
+            src_loc[:, None] // page_size,
+            base + (src_loc[:, None] % page_size) * width + cols,
+        ]
+        dst[
+            dst_loc[:, None] // page_size,
+            base + (dst_loc[:, None] % page_size) * width + cols,
+        ] = values
+
+
+def _capturing() -> bool:
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+class RequestWindow:
+    def __init__(
+        self,
+        pool_factory,
+        *,
+        num_slots,
+        layers,
+        page_size,
+        capacity,
+        workspace_rows: Optional[int] = None,
+    ):
+        self.capacity = ((capacity + page_size - 1) // page_size) * page_size
+        self.page_size = page_size
+        self.pool_factory = pool_factory
+        self.num_slots = num_slots
+        self.rows = num_slots * self.capacity
+
+        self.state = pool_factory(self.rows + page_size, layers)
+        self.zero_row = self.rows
+        self.sink_row = self.rows + 1
+        self.tags = torch.full(
+            (layers, self.rows + page_size),
+            -1,
+            dtype=torch.int64,
+            device=self.state.kv_buffer[0].device,
+        )
+        self.workspace = None
+        if workspace_rows:
+            self._ensure_workspace(workspace_rows)
+        self.layout = None
+        self.prepared = None
+
+    def _ensure_workspace(self, rows: int) -> None:
+        if self.workspace is not None and self.workspace.size >= rows:
+            return
+        assert not _capturing(), "request-window workspace must be sized before capture"
+        size = ((rows + self.page_size - 1) // self.page_size) * self.page_size
+        self.workspace = self.pool_factory(size, 1)
+
+    def reset(self, slots):
+        loc = slots.to(torch.int64)[:, None] * self.capacity + torch.arange(
+            self.capacity, device=slots.device
+        )
+        self.tags[:, loc.flatten()] = -1
+        self.prepared = None
+
+    def activate(self, layout):
+        if self.layout is layout:
+            return
+        self.layout = layout
+        self.prepared = None
+        self._ensure_workspace(layout.size)
+
+    def initialize_dummy_history(self):
+        layout = self.layout
+        self.tags.fill_(-1)
+        loc = layout.history_req * self.capacity + layout.history_pos % self.capacity
+        for buf in self.state.kv_buffer:
+            buf.zero_()
+        self.tags[:, loc] = layout.history_pos
+        self.prepared = None
+
+    def _history_src(self, layout):
+        return torch.where(
+            layout.history_valid,
+            layout.history_req * self.capacity + layout.history_pos % self.capacity,
+            self.zero_row,
+        )
+
+    def buffer(self, layer):
+        if self.prepared != layer:
+            layout = self.layout
+            if layout is None:
+                raise RuntimeError("request-window metadata was not activated")
+            src = self._history_src(layout)
+            if not _capturing():
+                valid = layout.history_valid
+                if not torch.equal(
+                    self.tags[layer, src][valid], layout.history_pos[valid]
+                ):
+                    raise RuntimeError(
+                        "SWA history is missing: replay or window ownership is invalid"
+                    )
+            copy_packed_tokens(
+                self.state.kv_buffer[layer],
+                self.workspace.kv_buffer[0],
+                src,
+                layout.history_loc,
+                page_size=self.page_size,
+            )
+            self.prepared = layer
+        return self.workspace.kv_buffer[0]
+
+    def commit(self, layer):
+        layout = self.layout
+        dst = torch.where(
+            layout.commit_mask,
+            layout.req * self.capacity + layout.pos % self.capacity,
+            self.sink_row,
+        )
+        copy_packed_tokens(
+            self.buffer(layer),
+            self.state.kv_buffer[layer],
+            layout.write_loc,
+            dst,
+            page_size=self.page_size,
+        )
+        self.tags[layer, dst] = layout.pos

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -64,6 +64,12 @@ class PoolName(str, Enum):
     INDEXER = "indexer"
     # TODO(hzh0425): Current DeepSeek V4 pool naming is verbose; will be normalized to
     # 'COMPRESSED_KV / COMPRESSED_INDEXER / COMPRESSED_STATE' in the next PR.
+    DEEPSEEK_V4_C1 = "deepseek_v4_c1"
+    DEEPSEEK_V4_C1_INDEXER = "deepseek_v4_c1_indexer"
+    DEEPSEEK_V4_C1_INDEXER_SCALE = "deepseek_v4_c1_indexer_scale"
+    DEEPSEEK_V4_C2 = "deepseek_v4_c2"
+    DEEPSEEK_V4_C2_INDEXER = "deepseek_v4_c2_indexer"
+    DEEPSEEK_V4_C2_INDEXER_SCALE = "deepseek_v4_c2_indexer_scale"
     DEEPSEEK_V4_C4 = "deepseek_v4_c4"
     DEEPSEEK_V4_C4_INDEXER = "deepseek_v4_c4_indexer"
     # FP4 indexer splits the indexer cache into separate payload/scale buffers,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -536,6 +536,88 @@ def _dsv4_indexer_regions(kvcache: Any, page_size: int) -> list[_IndexerRegion]:
     ]
 
 
+def _dsv4_low_ratio_entries(kvcache: Any, page_size: int, num_host_pages: int):
+    """Mirror each shared source once, in FULL-page units, before its first use.
+
+    Prefixes end at an even page boundary. Ratio-2 compression starts a new
+    pair there, so its request-scoped ring is rebuilt rather than cached.
+    """
+    import torch
+
+    entries = []
+    transfer_layer_num = kvcache.end_layer - kvcache.start_layer
+    for ratio, names in (
+        (
+            1,
+            (
+                PoolName.DEEPSEEK_V4_C1,
+                PoolName.DEEPSEEK_V4_C1_INDEXER,
+                PoolName.DEEPSEEK_V4_C1_INDEXER_SCALE,
+            ),
+        ),
+        (
+            2,
+            (
+                PoolName.DEEPSEEK_V4_C2,
+                PoolName.DEEPSEEK_V4_C2_INDEXER,
+                PoolName.DEEPSEEK_V4_C2_INDEXER_SCALE,
+            ),
+        ),
+    ):
+        sources = getattr(kvcache, "sources_by_ratio", {}).get(ratio, [])
+        if not sources:
+            continue
+        kv_pool = kvcache.kv_pools[ratio]
+        index_pool = kvcache.index_pools[ratio]
+        assert page_size % ratio == 0
+        slots_per_page = page_size // ratio
+        assert slots_per_page % index_pool.page_size == 0
+        index_pages_per_full_page = slots_per_page // index_pool.page_size
+        layer_mapping = {
+            source - kvcache.start_layer: index for index, source in enumerate(sources)
+        }
+        regions = [(names[0], kv_pool, kv_pool.kv_buffer)]
+        if index_pool.index_k_with_scale_buffer is not None:
+            index_regions = [(names[1], index_pool.index_k_with_scale_buffer)]
+        else:
+            index_regions = [
+                (names[1], index_pool.index_k_payload_buffer),
+                (names[2], index_pool.index_k_scale_buffer),
+            ]
+        for name, buffers in index_regions:
+            # A FULL page contains several contiguous 64-slot FP4 index pages.
+            # Drop only the extra partial padding row beyond the FULL address space.
+            rows = []
+            for buffer in buffers:
+                full_pages = buffer.shape[0] // index_pages_per_full_page
+                rows.append(
+                    buffer[: full_pages * index_pages_per_full_page]
+                    .view(torch.uint8)
+                    .reshape(full_pages, -1)
+                )
+            regions.append((name, index_pool, rows))
+        for name, device_pool, buffers in regions:
+            entries.append(
+                build_pool_entry(
+                    name=name,
+                    host_pool=DeepSeekV4PagedHostPool(
+                        pool_name=str(name),
+                        device_buffers=buffers,
+                        item_bytes=buffers[0].shape[1] * buffers[0].element_size(),
+                        num_host_pages=num_host_pages,
+                        slot_page_size=page_size,
+                        layout=get_memory().hicache_mem_layout,
+                        allocator_type=_get_allocator_type(),
+                        page_aligned_only=True,
+                    ),
+                    device_pool=device_pool,
+                    layer_mapping=layer_mapping,
+                    transfer_layer_num=transfer_layer_num,
+                )
+            )
+    return entries
+
+
 def build_deepseek_v4_hicache_stack(
     *,
     params: CacheInitParams,
@@ -745,6 +827,8 @@ def build_deepseek_v4_hicache_stack(
                 ),
             ]
         )
+
+    entries.extend(_dsv4_low_ratio_entries(kvcache, page_size, num_host_pages))
 
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
@@ -1338,6 +1422,12 @@ class _DeepSeekV4Strategy(StackStrategy):
                 ),
             )
             for name, src in (
+                (PoolName.DEEPSEEK_V4_C1, PoolName.KV),
+                (PoolName.DEEPSEEK_V4_C1_INDEXER, PoolName.KV),
+                (PoolName.DEEPSEEK_V4_C1_INDEXER_SCALE, PoolName.KV),
+                (PoolName.DEEPSEEK_V4_C2, PoolName.KV),
+                (PoolName.DEEPSEEK_V4_C2_INDEXER, PoolName.KV),
+                (PoolName.DEEPSEEK_V4_C2_INDEXER_SCALE, PoolName.KV),
                 (PoolName.DEEPSEEK_V4_C4, PoolName.KV),
                 (PoolName.DEEPSEEK_V4_C4_INDEXER, PoolName.KV),
                 (PoolName.DEEPSEEK_V4_C4_INDEXER_SCALE, PoolName.KV),

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -44,6 +44,7 @@ from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.runtime_context import (
     get_context,
     get_disagg,
+    get_exec,
     get_memory,
     get_parallel,
     get_schedule,
@@ -219,7 +220,10 @@ def build_kv_cache(
     )
 
     # Hybrid memory pool
-    is_hybrid_swa = tp_worker.is_hybrid_swa
+    is_hybrid_swa = (
+        tp_worker.is_hybrid_swa
+        and not get_exec().features.enable_encoder_swa_bounded_replay
+    )
     is_hybrid_ssm = uses_ssm_state(tp_worker.model_runner.model_config)
     is_dsa = is_deepseek_dsa(model_config.hf_config)
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1178,6 +1178,7 @@ class KVCacheConfigurator:
         if is_dsv4_model:
             token_to_kv_pool = self._build_dsv4_kv_pool(
                 max_running_requests=sizes.max_running_requests,
+                full_max_total_num_tokens=sizes.full_max_total_num_tokens,
                 swa_max_total_num_tokens=sizes.swa_max_total_num_tokens,
                 c4_max_total_num_tokens=sizes.c4_max_total_num_tokens,
                 c128_max_total_num_tokens=sizes.c128_max_total_num_tokens,
@@ -1280,6 +1281,7 @@ class KVCacheConfigurator:
         self,
         *,
         max_running_requests: int,
+        full_max_total_num_tokens: int,
         swa_max_total_num_tokens: Optional[int],
         c4_max_total_num_tokens: int,
         c128_max_total_num_tokens: int,
@@ -1301,8 +1303,10 @@ class KVCacheConfigurator:
             compression_ratios = [
                 COMPRESS_RATIO_NEXTN_LAYER
             ] * self.layer_info.num_effective_layers
+            kv_source_layers = []
         else:
             compression_ratios = self.model_config.compress_ratios
+            kv_source_layers = list(self.model_config.hf_config.kv_source_layer_ids)
 
         # NPU keeps its PA_ND KV-pool subclass, while Compressor state sizing
         # follows the same fixed ring ownership as GPU. Do not replace the
@@ -1344,6 +1348,8 @@ class KVCacheConfigurator:
             end_layer=self.layer_info.end_layer,
             enable_hisparse=get_memory().enable_hisparse,
             online_mtp_max_draft_tokens=(max_speculative_num_draft_tokens() or 0),
+            kv_source_layers=kv_source_layers,
+            full_size=full_max_total_num_tokens,
         )
         return token_to_kv_pool
 
@@ -1923,7 +1929,16 @@ class KVCacheConfigurator:
                         need_sort=need_sort,
                     )
             else:
-                if self.is_hybrid_swa and sizes.full_max_total_num_tokens == 0:
+                if get_exec().features.enable_encoder_swa_bounded_replay:
+                    token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
+                        sizes.full_max_total_num_tokens,
+                        page_size=get_schedule().page_size,
+                        dtype=self.kv_cache_dtype,
+                        device=self.device,
+                        kvcache=token_to_kv_pool,
+                        need_sort=need_sort,
+                    )
+                elif self.is_hybrid_swa and sizes.full_max_total_num_tokens == 0:
                     token_to_kv_pool_allocator = PureSWATokenToKVPoolAllocator(
                         sizes.swa_max_total_num_tokens,
                         page_size=get_schedule().page_size,
@@ -1992,7 +2007,10 @@ class KVCacheConfigurator:
 
         else:
             assert self.is_draft_worker
-            if self.is_hybrid_swa:
+            if (
+                self.is_hybrid_swa
+                and not get_exec().features.enable_encoder_swa_bounded_replay
+            ):
                 if isinstance(
                     token_to_kv_pool_allocator,
                     DeepSeekV4HiSparseTokenToKVPoolAllocator,

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -69,7 +69,7 @@ from sglang.srt.mem_cache.multi_ended_allocator import (
     UnifiedMambaTokenToKVPoolAllocator,
     UnifiedSWATokenToKVPoolAllocator,
 )
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel
 
 
 class KVReadTables(msgspec.Struct, frozen=True):
@@ -159,6 +159,7 @@ class KVIndexTranslator:
             self._swa_write_loc_from_full = (
                 token_to_kv_pool.translate_loc_from_full_to_swa
                 if isinstance(token_to_kv_pool, BaseSWAKVPool)
+                and not get_exec().features.enable_encoder_swa_bounded_replay
                 else None
             )
 

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -18,7 +18,7 @@ from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.srt.runtime_context import get_disagg, get_memory, get_serving
+from sglang.srt.runtime_context import get_disagg, get_exec, get_memory, get_serving
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -162,7 +162,7 @@ def _create_unified_radix_cache(
     from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
     tree_components = [ComponentType.FULL]
-    if ctx.is_hybrid_swa:
+    if ctx.is_hybrid_swa and not get_exec().features.enable_encoder_swa_bounded_replay:
         tree_components.append(ComponentType.SWA)
     if ctx.is_hybrid_ssm:
         tree_components.append(ComponentType.MAMBA)

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -796,6 +796,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         elif pool_name in (
             PoolName.INDEXER,
             PoolName.DRAFT_INDEXER,
+            PoolName.DEEPSEEK_V4_C1,
+            PoolName.DEEPSEEK_V4_C1_INDEXER,
+            PoolName.DEEPSEEK_V4_C1_INDEXER_SCALE,
+            PoolName.DEEPSEEK_V4_C2,
+            PoolName.DEEPSEEK_V4_C2_INDEXER,
+            PoolName.DEEPSEEK_V4_C2_INDEXER_SCALE,
             PoolName.DEEPSEEK_V4_C4,
             PoolName.DEEPSEEK_V4_C4_INDEXER,
             PoolName.DEEPSEEK_V4_C4_INDEXER_SCALE,

--- a/python/sglang/srt/model_executor/cuda_graph_config.py
+++ b/python/sglang/srt/model_executor/cuda_graph_config.py
@@ -82,6 +82,7 @@ ALLOWED_KEYS_PER_PHASE = {
         "tc_compiler",
         "full_prefill_max_req",
         "full_prefill_prefix_chunk_tokens",
+        "max_seq_len",
     ),
 }
 
@@ -107,6 +108,10 @@ class PhaseConfig:
     # chunk variants and chooses the smallest one covering a batch. None uses
     # the scheduler's aggregate chunked_prefill_size token budget.
     full_prefill_prefix_chunk_tokens: Optional[int] = None
+    # Prefill only: a batch whose longest sequence exceeds this replays eagerly,
+    # and a backend that captures context-wide work sizes it by this. None
+    # leaves the admission to the token buckets.
+    max_seq_len: Optional[int] = None
 
 
 def default_prefill_backend() -> str:

--- a/python/sglang/srt/model_executor/encoder_swa_replay.py
+++ b/python/sglang/srt/model_executor/encoder_swa_replay.py
@@ -1,0 +1,77 @@
+from copy import copy
+
+import torch
+
+
+def run_encoder_swa_replay(worker, batch):
+    from sglang.srt.model_executor.forward_batch_info import (
+        CaptureHiddenMode,
+        ForwardBatch,
+    )
+
+    runner = worker.model_runner
+    window = runner.token_to_kv_pool.request_window
+    if window is None or not batch.forward_mode.is_extend_without_speculative():
+        return
+    for i, reset in enumerate(batch.encoder_swa_reset):
+        if not reset:
+            continue
+        slot = batch.req_pool_indices[i : i + 1]
+        window.reset(slot)
+        end = batch.prefix_lens[i]
+        if not end:
+            continue
+        if end % 2:
+            raise ValueError(
+                "encoder SWA replay requires an even cached-prefix boundary"
+            )
+        start = max(0, end - 128)
+        req = batch.reqs[i]
+        replay = copy(batch)
+        replay.reqs = [req]
+        replay.input_ids = torch.tensor(
+            list(req.full_untruncated_fill_ids[start:end]),
+            dtype=torch.int64,
+            device=runner.device,
+        )
+        replay.prefill_input_ids_cpu = None
+        replay.req_pool_indices = slot
+        replay.req_pool_indices_cpu = batch.req_pool_indices_cpu[i : i + 1]
+        replay.prefix_lens = [start]
+        replay.extend_lens = [end - start]
+        replay.extend_num_tokens = end - start
+        replay.seq_lens = torch.tensor([end], dtype=torch.int64, device=runner.device)
+        replay.seq_lens_cpu = torch.tensor([end], dtype=torch.int64)
+        replay.seq_lens_sum = end
+        replay.orig_seq_lens = replay.seq_lens
+        replay.out_cache_loc = runner.req_to_token_pool.req_to_token[
+            slot[0], start:end
+        ].long()
+        replay.return_logprob = False
+        replay.top_logprobs_nums = None
+        replay.token_ids_logprobs = None
+        replay.extend_logprob_start_lens = [end - start]
+        replay.extend_input_logprob_token_ids = None
+        replay.is_prefill_only = True
+        replay.spec_info = None
+        replay.sampling_info = None
+        replay.has_grammar = False
+        replay.multimodal_inputs = [None]
+        replay.ne_history = None
+        hasher = runner.model.model.engram_hasher
+        if hasher is not None:
+            n = hasher.max_ngram_size - 1
+            ids = list(req.full_untruncated_fill_ids[max(0, start - n) : start])
+            replay.ne_history = torch.tensor(
+                [[0] * (n - len(ids)) + ids],
+                dtype=torch.int32,
+                device=runner.device,
+            )
+        fb = ForwardBatch.init_new(
+            replay,
+            runner,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            return_hidden_states_before_norm=False,
+        )
+        fb.encoder_swa_replay = True
+        runner.forward(fb)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -586,6 +586,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
     # For ngram embedding
     ngram_embedding_info: Optional[NgramEmbeddingInfo] = None
+    # DeepSeek-V4.1 engram, extend only: the n - 1 tokens before each request's
+    # first extend token, oldest first, [bs, n - 1] int32 (see EngramHasher).
+    encoder_swa_replay: bool = False
+
+    ngram_history: Optional[torch.Tensor] = None
 
     # For dumper: int-hashed request / bootstrap-room IDs (derived from rids)
     rids_int: Optional[torch.Tensor] = None
@@ -788,6 +793,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             seq_lens_cpu=seq_lens_cpu,
             orig_seq_lens=batch.orig_seq_lens,
             out_cache_loc_dsv4=batch.out_cache_loc_dsv4,
+            ngram_history=batch.ne_history,
             mamba_track_indices=batch.mamba_track_indices,
             mamba_track_mask=batch.mamba_track_mask,
             mamba_track_seqlens=batch.mamba_track_seqlens,

--- a/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
+++ b/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
@@ -23,7 +23,8 @@ class NgramEmbeddingManager:
     enabled: bool
     table: Optional[torch.Tensor]
     n: int
-    k: int
+    # Draft runners have no hasher even when their config has engram layers.
+    engram_hasher: Optional[torch.nn.Module] = None
 
     @classmethod
     def from_model(
@@ -36,8 +37,6 @@ class NgramEmbeddingManager:
         device: str,
     ):
         token_table = None
-        ngram_embedding_n = 0
-        ngram_embedding_k = 0
         use_ngram_embedding = model_config.use_ngram_embedding
         if use_ngram_embedding:
             from sglang.srt.layers.n_gram_embedding import NgramEmbedding
@@ -58,14 +57,20 @@ class NgramEmbeddingManager:
                     module.init_buffers(
                         max_running_requests, chunked_prefill_size, device
                     )
-            hf_config = model_config.hf_config
-            ngram_embedding_n = hf_config.ngram_embedding_n
-            ngram_embedding_k = hf_config.ngram_embedding_k
+        engram_hasher = None
+        if model_config.engram_ngram_size > 0:
+            from sglang.srt.layers.engram import EngramHasher
+
+            for module in model.modules():
+                if isinstance(module, EngramHasher):
+                    assert engram_hasher is None, "one engram hasher per model"
+                    module.init_history(req_to_token_pool.req_to_token.shape[0], device)
+                    engram_hasher = module
         return cls(
             enabled=use_ngram_embedding,
             table=token_table,
-            n=ngram_embedding_n,
-            k=ngram_embedding_k,
+            n=model_config.ngram_context_size,
+            engram_hasher=engram_hasher,
         )
 
     def update_after_decode(
@@ -85,14 +90,30 @@ class NgramEmbeddingManager:
             batch_size=forward_batch.batch_size,
         )
 
+    def update_after_verify(
+        self,
+        *,
+        verify_ids_2d: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        commit_lens: torch.Tensor,
+    ) -> None:
+        if self.engram_hasher is None:
+            return
+        self.engram_hasher.commit_after_verify(
+            verify_ids_2d, req_pool_indices, commit_lens
+        )
+
     def prepare_for_forward(
         self,
         batch: Optional[ScheduleBatch],
         *,
         chunked_req: Optional[Req],
     ) -> Optional[ScheduleBatch]:
-        """Fill the token table for ngram embedding before a forward pass."""
-        if batch is None or not self.enabled:
+        if batch is None:
+            return batch
+        if self.engram_hasher is not None:
+            self._prepare_engram_history(batch)
+        if not self.enabled:
             return batch
         batch.ne_token_table = self.table
         if batch.forward_mode == ForwardMode.EXTEND:
@@ -143,6 +164,42 @@ class NgramEmbeddingManager:
                     else None
                 )
         return batch
+
+    def _prepare_engram_history(self, batch: ScheduleBatch) -> None:
+        """Refresh extend predecessors after prefix hits, retraction, or slot reuse,
+        and seed the history row of a request whose prefill ran on another server."""
+        n1 = self.engram_hasher.max_ngram_size - 1
+        if batch.forward_mode.is_prebuilt():
+            # PD decode runs no EXTEND for this request, so the row its first
+            # DECODE reads is written here: the n - 1 tokens before the one
+            # prefill sampled, which is the token decode feeds next.
+            history = self.engram_hasher.history
+            rows = []
+            for req in batch.reqs:
+                fill_ids = req.origin_input_ids + req.output_ids
+                end = len(fill_ids) - 1
+                ids = fill_ids[max(0, end - n1) : end]
+                rows.append([0] * (n1 - len(ids)) + list(ids))
+            slots = torch.tensor(
+                [req.kv.req_pool_idx for req in batch.reqs],
+                dtype=torch.int64,
+                device=history.device,
+            )
+            history[slots] = torch.tensor(
+                rows, dtype=history.dtype, device=history.device
+            ).view(len(rows), n1)
+            return
+        if not batch.forward_mode.is_extend_without_speculative():
+            return
+        rows = []
+        for req in batch.reqs:
+            start = req.extend_range.start
+            lo = max(0, start - n1)
+            ids = req.full_untruncated_fill_ids[lo:start]
+            rows.append([0] * (n1 - len(ids)) + list(ids))
+        batch.ne_history = torch.tensor(
+            rows, dtype=torch.int32, device=self.engram_hasher.history.device
+        ).view(len(rows), n1)
 
 
 def update_ngram_token_table_after_sampling(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -701,6 +701,50 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         return self._solve_pool_sizes(max_total_num_tokens, page_size)
 
 
+def compute_swa_request_cap(*, page_size: int, window: int, attn_dp_size: int) -> int:
+    """Worst-case SWA slots the scheduler holds live at max_running_requests.
+
+    Per request: the trailing window the eviction interval lets grow past it,
+    plus what the next decode step allocates. On top of that the prefill chunks
+    in flight, or on a PD decode rank the pre-allocated extra slots.
+    """
+    draft_tokens = get_spec().speculative_num_draft_tokens or 1
+    eviction_interval = max(1, envs.SGLANG_SWA_EVICTION_INTERVAL.get())
+
+    # __________[padding][eviction_interval][window]
+    # Padding to make sure eviction point is page-aligned.
+    trailing_tokens = window + eviction_interval * draft_tokens + page_size
+    if get_spec().speculative_algorithm is None:
+        decode_alloc = page_size
+    elif get_schedule().disable_overlap_schedule:
+        # spec-v1: new_tokens_required_next_decode per request.
+        decode_alloc = spec_decode_alloc_len_per_request(
+            page_size=page_size,
+            speculative_num_steps=get_spec().speculative_num_steps,
+            speculative_eagle_topk=get_spec().speculative_eagle_topk,
+            speculative_num_draft_tokens=get_spec().speculative_num_draft_tokens,
+        )
+    else:
+        # spec-v2: the overlap allocator keeps 2 * alloc_len outstanding
+        # (eagle_utils.eagle_prepare_for_decode: kv_committed_len + 2 * alloc_len).
+        decode_alloc = 2 * get_alloc_len_per_decode()
+    per_request = trailing_tokens + decode_alloc
+
+    num_reqs = get_schedule().max_running_requests // attn_dp_size
+    if get_disagg().disaggregation_mode == "decode":
+        return (
+            per_request * num_reqs
+            + (window + page_size) * get_disagg().disaggregation_decode_extra_slots
+        )
+    else:
+        chunks_in_flight = 1 if get_schedule().disable_overlap_schedule else 2
+        return (
+            per_request * num_reqs
+            + chunks_in_flight * get_schedule().chunked_prefill_size
+            + page_size
+        )
+
+
 class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
     """Hybrid SWA configurator with the SWA pool sized from a fixed token cap.
 
@@ -715,45 +759,11 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         super().__init__(kvc)
         assert self._full_layers_num > 0
 
-        page_size = kvc.page_size
-        window = kvc.sliding_window_size
-        draft_tokens = get_spec().speculative_num_draft_tokens or 1
-        eviction_interval = max(1, envs.SGLANG_SWA_EVICTION_INTERVAL.get())
-
-        """
-        __________[padding][eviction_interval][window]
-        Padding to make sure eviction point is page-aligned.
-        """
-        trailing_tokens = window + eviction_interval * draft_tokens + page_size
-        if get_spec().speculative_algorithm is None:
-            decode_alloc = page_size
-        elif get_schedule().disable_overlap_schedule:
-            # spec-v1: new_tokens_required_next_decode per request.
-            decode_alloc = spec_decode_alloc_len_per_request(
-                page_size=page_size,
-                speculative_num_steps=get_spec().speculative_num_steps,
-                speculative_eagle_topk=get_spec().speculative_eagle_topk,
-                speculative_num_draft_tokens=get_spec().speculative_num_draft_tokens,
-            )
-        else:
-            # spec-v2: the overlap allocator keeps 2 * alloc_len outstanding
-            # (eagle_utils.eagle_prepare_for_decode: kv_committed_len + 2 * alloc_len).
-            decode_alloc = 2 * get_alloc_len_per_decode()
-        per_request = trailing_tokens + decode_alloc
-
-        num_reqs = get_schedule().max_running_requests // kvc.ps.attn_dp_size
-        if get_disagg().disaggregation_mode == "decode":
-            self._swa_cap = (
-                per_request * num_reqs
-                + (window + page_size) * get_disagg().disaggregation_decode_extra_slots
-            )
-        else:
-            chunks_in_flight = 1 if get_schedule().disable_overlap_schedule else 2
-            self._swa_cap = (
-                per_request * num_reqs
-                + chunks_in_flight * get_schedule().chunked_prefill_size
-                + page_size
-            )
+        self._swa_cap = compute_swa_request_cap(
+            page_size=kvc.page_size,
+            window=kvc.sliding_window_size,
+            attn_dp_size=kvc.ps.attn_dp_size,
+        )
 
     @staticmethod
     def is_applicable(kvc: KVCacheConfigurator) -> bool:
@@ -818,6 +828,19 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         )
 
 
+# Applied when the operator left --swa-full-tokens-ratio at the CLI default and
+# the request cap is not usable; cap mode governs whenever it is.
+DSV4_DEFAULT_SWA_FULL_TOKENS_RATIO = 0.1
+
+
+def _operator_swa_full_tokens_ratio() -> Optional[float]:
+    """The operator's --swa-full-tokens-ratio, or None if it is still the default."""
+    from sglang.srt.server_args import ServerArgs
+
+    ratio = get_schedule().swa_full_tokens_ratio
+    return None if ratio == ServerArgs.swa_full_tokens_ratio else ratio
+
+
 @dataclass
 class _DSV4PoolSizes:
     full_max_total_num_tokens: int
@@ -842,6 +865,9 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.qk_nope_head_dim = cfg.qk_nope_head_dim
         self.qk_rope_head_dim = cfg.qk_rope_head_dim
         self.indexer_head_dim = cfg.index_head_dim
+        self.attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        # One FlashMLA-layout latent slot, in bytes.
+        self.kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
         # HIP takes the FP4-accurate byte count here. The NVIDIA FP4 path
         # keeps the FP8 estimate.
         self.indexer_bytes_per_token = get_dsv4_indexer_bytes_per_token(
@@ -860,9 +886,17 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"local={len(self.compression_ratios)}/{len(cfg.compress_ratios)}"
             )
         self.swa_page_size = cfg.window_size
-        self.swa_ratio = get_schedule().swa_full_tokens_ratio
+        self.operator_swa_ratio = _operator_swa_full_tokens_ratio()
+        self.swa_ratio = (
+            self.operator_swa_ratio
+            if self.operator_swa_ratio is not None
+            else DSV4_DEFAULT_SWA_FULL_TOKENS_RATIO
+        )
+        self.sliding_window_size = kvc.sliding_window_size
+        self.page_size = kvc.page_size
         self.is_speculative = get_spec().speculative_algorithm is not None
         self.online_c128_mtp_max_draft_tokens = max_speculative_num_draft_tokens() or 0
+        self.attn_dp_size = kvc.ps.attn_dp_size
         self.requested_max_running_requests_per_worker = (
             get_schedule().max_running_requests // kvc.ps.attn_dp_size
             if get_schedule().max_running_requests is not None
@@ -888,6 +922,19 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_total = len(self.compression_ratios)
         self.num_layers_ca4 = sum(1 for r in self.compression_ratios if r == 4)
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
+        # Ratio 1/2 kv_source layers keep one FlashMLA-layout latent and one packed
+        # index key per compressed position. The low-ratio indexer pools are built
+        # with force_fp4=True (deepseek_v4_memory_pool._init_low_ratio_pools), so
+        # they are fp4 whatever dtype the c4 indexer runs at.
+        low_ratio_index_bytes = get_dsv4_indexer_bytes_per_token(
+            self.indexer_head_dim, use_fp4_indexer=True
+        )
+        self.low_ratio_bytes_per_full_token = sum(
+            (self.kv_bytes + low_ratio_index_bytes) / cfg.compress_ratios[l]
+            for l in cfg.hf_config.kv_source_layer_ids
+            if kvc.layer_info.start_layer <= l < kvc.layer_info.end_layer
+            and cfg.compress_ratios[l] in (1, 2)
+        )
 
         if self.is_speculative:
             # Ring is sized once here, so it must serve the largest adaptive tier.
@@ -895,6 +942,36 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 max_speculative_num_draft_tokens() or 0
             )
 
+        from sglang.srt.runtime_context import get_exec
+
+        self.encoder_replay = get_exec().features.enable_encoder_swa_bounded_replay
+        self.request_window_bytes = 0
+        if self.encoder_replay:
+            slots = self.requested_max_running_requests_per_worker + 1
+            capacity = ceil_align(
+                self.sliding_window_size + self.online_c128_mtp_max_draft_tokens,
+                self.page_size,
+            )
+            layers = self.num_layers_total
+            scratch = (
+                max(
+                    get_schedule().chunked_prefill_size,
+                    slots * max(128, self.online_c128_mtp_max_draft_tokens),
+                )
+                + slots * 128
+                + self.page_size
+            )
+            self.request_window_bytes = (
+                (slots * capacity + self.page_size) * layers * (self.kv_bytes + 16)
+                + 4 * scratch * (self.kv_bytes + 16)
+                + slots * 3 * 16 * self.attn_head_dim * 8
+            )
+            self.swa_ratio = 0
+        self.swa_prefix_tails = self._resolve_swa_prefix_tails()
+        self.swa_cap_tokens = (
+            0 if self.encoder_replay else self._resolve_swa_cap_tokens()
+        )
+        self.bytes_per_swa_token = self._get_bytes_per_swa_token()
         self.bytes_per_full_token = self._get_bytes_per_full_token()
         if self.is_speculative:
             # Reserve memory for the speculative draft worker by inflating
@@ -903,7 +980,9 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
             draft_layers = 1
             target_layers = self.num_layers_total
-            self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
+            draft_scale = (target_layers + draft_layers) / target_layers
+            self.bytes_per_full_token *= draft_scale
+            self.bytes_per_swa_token *= draft_scale
 
         # Online c128 keeps a single in-progress (max, sum, kv) state per index
         # and assumes a strict forward-only schedule. Speculative decode (MTP)
@@ -955,46 +1034,124 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"get_compress_state_ring_size()."
             )
 
-    def _get_bytes_per_full_token(self) -> float:
-        kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
+    def _resolve_swa_prefix_tails(self) -> int:
+        """Cached prefix tails cap mode keeps addressable in the SWA pool.
 
-        attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-        c4_state_dtype_size, c128_state_dtype_size = (
-            _get_dsv4_compress_state_dtype_sizes()
+        A radix-cached prefix is reusable only while its last sliding_window
+        tokens still hold SWA slots, so SWA capacity bounds how many cached
+        prefixes stay hot. --swa-prefix-tails overrides the count.
+        """
+        prefix_tails = get_schedule().swa_prefix_tails
+        if prefix_tails is not None:
+            return prefix_tails
+        if get_memory().disable_radix_cache:
+            # Nothing is kept for reuse, so the request cap alone bounds the pool.
+            return 0
+        max_running_requests = self.requested_max_running_requests_per_worker
+        return 4 * max_running_requests if max_running_requests is not None else 0
+
+    def _resolve_swa_cap_tokens(self) -> Optional[int]:
+        """SWA slots to reserve in cap mode, or None to keep ratio sizing.
+
+        Cap mode replaces "swa_tokens = full_tokens * ratio" with a request-cap
+        budget plus radix headroom, so the SWA pool stops growing with the KV
+        budget. An explicit --swa-full-tokens-ratio opts back into ratio sizing.
+        """
+        if self.operator_swa_ratio is not None:
+            return None
+        max_running_requests = self.requested_max_running_requests_per_worker
+        if max_running_requests is None or self.sliding_window_size is None:
+            return None
+        chunked_prefill_size = get_schedule().chunked_prefill_size
+        if self.disaggregation_mode != "decode" and (
+            chunked_prefill_size is None or chunked_prefill_size <= 0
+        ):
+            return None
+
+        cap = compute_swa_request_cap(
+            page_size=self.page_size,
+            window=self.sliding_window_size,
+            attn_dp_size=self.attn_dp_size,
         )
-        c4_state_bytes = 2 * 2 * attn_head_dim * c4_state_dtype_size
+        headroom = self.swa_prefix_tails * (self.sliding_window_size + self.page_size)
+        return ceil_align(cap + headroom, self.page_size)
+
+    def _get_bytes_per_swa_token(self) -> float:
+        """Bytes one SWA slot costs across the whole stage.
+
+        The c4 compress state follows swa_tokens (c4_state_pool_size =
+        swa_tokens / swa_page_size * ring), so it is priced per SWA slot too.
+        """
+        c4_state_dtype_size, _ = _get_dsv4_compress_state_dtype_sizes()
+        c4_state_bytes = 2 * 2 * self.attn_head_dim * c4_state_dtype_size
+        c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * c4_state_dtype_size
+
+        c4_state_ratio = self.c4_ring_size / self.swa_page_size
+        return (
+            self.kv_bytes * self.num_layers_total
+            + c4_state_ratio
+            * (c4_state_bytes + c4_indexer_state_bytes)
+            * self.num_layers_ca4
+        )
+
+    def _get_bytes_per_full_token(self) -> float:
+        _, c128_state_dtype_size = _get_dsv4_compress_state_dtype_sizes()
         # Online c128 stores (max, sum, kv) per slot (3*head_dim) instead of
         # raw (kv, score) (2*head_dim). Combined with ring_size=1 this still
         # nets a large reduction (~3/256x) but the per-slot bytes go up.
         c128_online = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
         c128_state_bytes = (
-            (3 if c128_online else 2 * 1) * attn_head_dim * c128_state_dtype_size
+            (3 if c128_online else 2 * 1) * self.attn_head_dim * c128_state_dtype_size
         )
-        c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * c4_state_dtype_size
 
-        c4_state_ratio = self.c4_ring_size / self.swa_page_size
         # C128 state is request-scoped and is finalized after
         # max_running_requests is known, so it should not scale with
         # full-token capacity here.
         c128_state_ratio = 0
+        # Cap mode holds swa_tokens fixed, so the SWA pool and the c4 state that
+        # follows it become bias bytes (_get_swa_fixed_bytes) instead of coeff.
+        swa_ratio = 0 if self.swa_cap_tokens is not None else self.swa_ratio
 
         c4_frac = 1 / (4 * self.c4_shrink_factor)
         return (
-            self.swa_ratio * kv_bytes * self.num_layers_total
-            + c4_frac * kv_bytes * self.num_layers_ca4
-            + 1 / 128 * kv_bytes * self.num_layers_ca128
+            swa_ratio * self.bytes_per_swa_token
+            + self.low_ratio_bytes_per_full_token
+            + c4_frac * self.kv_bytes * self.num_layers_ca4
+            + 1 / 128 * self.kv_bytes * self.num_layers_ca128
             + 1 / 4 * self.indexer_bytes_per_token * self.num_layers_ca4
-            + self.swa_ratio * c4_state_ratio * c4_state_bytes * self.num_layers_ca4
             + c128_state_ratio * c128_state_bytes * self.num_layers_ca128
-            + self.swa_ratio
-            * c4_state_ratio
-            * c4_indexer_state_bytes
-            * self.num_layers_ca4
         )
+
+    def _get_swa_fixed_bytes(self) -> float:
+        """Bias bytes the SWA pool takes in cap mode; 0 when sizing by ratio."""
+        if self.encoder_replay:
+            return self.request_window_bytes
+        if self.swa_cap_tokens is None:
+            return 0
+        return self.swa_cap_tokens * self.bytes_per_swa_token
+
+    def _get_swa_tokens(self, full_token: int, page_size: int) -> int:
+        # swa_cap_tokens was page-aligned at resolve time; page_size here is the
+        # same get_schedule().page_size that self.page_size holds.
+        if self.swa_cap_tokens is None:
+            return int(full_token * self.swa_ratio) // page_size * page_size
+        return self.swa_cap_tokens
 
     def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
-        swa_tokens = int(full_token * self.swa_ratio) // page_size * page_size
+        swa_tokens = self._get_swa_tokens(full_token, page_size)
+        if self.swa_cap_tokens is None:
+            source = "explicit" if self.operator_swa_ratio is not None else "default"
+            logger.info(
+                f"DSV4 SWA sizing: mode=ratio ({source}), swa_tokens={swa_tokens}, "
+                f"swa_full_tokens_ratio={self.swa_ratio}"
+            )
+        else:
+            logger.info(
+                f"DSV4 SWA sizing: mode=cap, swa_tokens={swa_tokens}, "
+                f"request_cap+headroom={self.swa_cap_tokens}, "
+                f"prefix_tails={self.swa_prefix_tails}"
+            )
         return _DSV4PoolSizes(
             full_max_total_num_tokens=full_token,
             swa_max_total_num_tokens=swa_tokens,
@@ -1014,18 +1171,17 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             return 0
 
         _, c128_state_dtype_size = _get_dsv4_compress_state_dtype_sizes()
-        attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
         num_req_slots = self._get_num_req_slots(max_running_requests)
 
         if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
             state_rows = num_req_slots + self.c128_ring_size + 1
             state_rows *= 1 + self.online_c128_mtp_max_draft_tokens
-            state_last_dim = 3 * attn_head_dim
+            state_last_dim = 3 * self.attn_head_dim
         else:
             state_pool_size = num_req_slots * self.c128_ring_size
             state_rows = state_pool_size + self.c128_ring_size + 1
             state_rows = ceil_div(state_rows, 128) * 128
-            state_last_dim = 2 * attn_head_dim
+            state_last_dim = 2 * self.attn_head_dim
 
         return (
             state_rows * state_last_dim * c128_state_dtype_size * self.num_layers_ca128
@@ -1092,8 +1248,18 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 self._get_c128_state_fixed_bytes_for_token_capacity(full_token)
             )
 
-        available_bytes_for_tokens = max(available_bytes - c128_state_fixed_bytes, 0)
+        swa_fixed_bytes = self._get_swa_fixed_bytes()
+        fixed_bytes = c128_state_fixed_bytes + swa_fixed_bytes
+        available_bytes_for_tokens = max(available_bytes - fixed_bytes, 0)
         full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
+        if full_token <= 0 and self.swa_cap_tokens is not None:
+            raise RuntimeError(
+                f"The DSV4 SWA pool cap ({self.swa_cap_tokens} tokens, "
+                f"{swa_fixed_bytes / (1 << 30):.2f} GB) leaves no room for the full "
+                f"KV pool within the available {available_bytes / (1 << 30):.2f} GB. "
+                f"Reduce --max-running-requests, lower --swa-prefix-tails "
+                f"or SGLANG_SWA_EVICTION_INTERVAL, or increase --mem-fraction-static."
+            )
 
         sizes = self._compute_dsv4_sizes(full_token, page_size)
         logger.info(
@@ -1101,6 +1267,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
             f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
+            f"swa_fixed={swa_fixed_bytes / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -38,6 +38,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     NgramEmbeddingInfo,
     PPProxyTensors,
+    enable_num_token_non_padded,
     get_server_return_hidden_states_mode,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
@@ -623,7 +624,12 @@ class BaseRunner(ABC):
             spec_algorithm=mr.spec_algorithm,
             spec_info=spec_info,
             capture_hidden_mode=capture_hidden_mode,
-            num_token_non_padded=buffers.num_token_non_padded,
+            # The slot is only maintained under expert parallelism; hand out
+            # None otherwise, like the eager batch, so routing does not mask
+            # every row against a never-filled zero count.
+            num_token_non_padded=(
+                buffers.num_token_non_padded if enable_num_token_non_padded() else None
+            ),
             global_forward_mode=capture_forward_mode,
             lora_ids=lora_ids,
         )
@@ -637,6 +643,8 @@ class BaseRunner(ABC):
 
         forward_batch = mr.prepare_dummy_forward_batch(forward_batch)
         mr.attn_backend.init_forward_metadata(forward_batch)
+        if get_exec().features.enable_encoder_swa_bounded_replay:
+            mr.token_to_kv_pool.request_window.initialize_dummy_history()
 
         def run_once():
             # Reused dummy batches may carry DP-local lazy caches from a prior

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -248,10 +248,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             model_runner.server_args.enable_two_batch_overlap
         )
         self.use_ngram_embedding = model_runner.ngram_embedding_manager.enabled
-        if self.use_ngram_embedding:
-            hf_config = model_runner.model_config.hf_config
-            self.ngram_embedding_n = hf_config.ngram_embedding_n
-            self.ngram_embedding_k = hf_config.ngram_embedding_k
         self.speculative_algorithm = get_spec().speculative_algorithm
         self.enable_profile_cuda_graph = (
             model_runner.server_args.enable_profile_cuda_graph
@@ -331,6 +327,38 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.capture_forward_mode = ForwardMode.TARGET_VERIFY
         elif self.is_dllm:
             self.capture_forward_mode = ForwardMode.DLLM_EXTEND
+
+        self.candidate_filter_span = None
+        self.candidate_graph_limits = []
+        text_config = model_runner.model_config.hf_text_config
+        if (
+            self.capture_forward_mode == ForwardMode.DECODE
+            and model_runner.device == "cuda"
+            and not is_hip()
+            and torch.cuda.get_device_capability(model_runner.gpu_id)[0] >= 10
+            and getattr(text_config, "model_type", None) == "deepseek_v41"
+            and getattr(text_config, "candidate_source_layer_id", -1) >= 0
+        ):
+            span = text_config.candidate_topk_blocks * text_config.candidate_block_size
+            if span > 0:
+                self.candidate_filter_span = span
+                ratios = set(text_config.compress_ratios) & {1, 2}
+                topk = text_config.index_topk
+                variants = []
+                if topk > 0 and ratios:
+                    variants.append(("candidate_all", topk * min(ratios)))
+                    if ratios == {1, 2}:
+                        variants.append(("candidate_c2_all", topk * 2))
+                variants.append(("candidate_unfiltered", span))
+                for variant, limit in variants:
+                    self.candidate_graph_limits.append((variant, min(limit, span)))
+                    if limit >= span:
+                        break
+                logger.info(
+                    "Candidate indexer graph limits: %s; use full filtering above %s.",
+                    self.candidate_graph_limits,
+                    span,
+                )
 
         # --- bucket sizes ---------------------------------------------
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
@@ -580,10 +608,22 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         return num_tokens if self.ragged_verify_mode else bs
 
     def _resolve_dsa_variant(self, forward_batch: ForwardBatch) -> Optional[str]:
-        """Host dispatch: pick which pre-captured DSA decode graph to replay
-        from the batch-max kv_len. If any request has kv_len > index_topk
-        the dense (k-only) graph would be wrong for it, so the whole batch uses
-        the sparse (full indexer) graph. Returns None when dual-graph is off."""
+        """Select the indexer graph for the longest request, or None without variants."""
+        candidate_span = getattr(self, "candidate_filter_span", None)
+        if candidate_span is not None:
+            # Without the scheduler's CPU lengths, use the full graph without D2H.
+            lengths = getattr(forward_batch, "seq_lens_cpu", None)
+            has_host_lengths = (
+                lengths is not None
+                and lengths.device.type == "cpu"
+                and lengths.numel() > 0
+            )
+            if has_host_lengths:
+                max_seq_len = int(lengths.max())
+                for variant, limit in self.candidate_graph_limits:
+                    if max_seq_len <= limit:
+                        return variant
+            return "candidate_filtered"
         if not getattr(self, "dsa_dual_graph", False):
             return None
         seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
@@ -1008,7 +1048,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
             capture_hidden_mode=self.capture_hidden_mode,
-            num_token_non_padded=buffers.num_token_non_padded,
+            # The slot is only maintained under expert parallelism; hand out
+            # None otherwise, like the eager batch, so routing does not mask
+            # every row against a never-filled zero count.
+            num_token_non_padded=(
+                buffers.num_token_non_padded if enable_num_token_non_padded() else None
+            ),
             global_forward_mode=self.capture_forward_mode,
             lora_ids=lora_ids,
             rids_int=rids_int,
@@ -1121,6 +1166,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         dsa_variants = (
             ["dense", "sparse"] if getattr(self, "dsa_dual_graph", False) else [None]
         )
+        if getattr(self, "candidate_filter_span", None) is not None:
+            dsa_variants = [variant for variant, _ in self.candidate_graph_limits]
+            dsa_variants.append("candidate_filtered")
         for bs in capture_range:
             if get_parallel().tp_rank == 0:
                 avail_mem = get_available_gpu_memory(

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -82,6 +82,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
     ForwardMode,
+    NgramEmbeddingInfo,
     PPProxyTensors,
     compute_local_num_token_non_padded,
     enable_num_token_non_padded,
@@ -1239,6 +1240,12 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 is None
             ):
                 return False
+        # A backend may keep batches its captured metadata cannot describe eager.
+        backend_can_run = getattr(
+            self.model_runner.attn_backend, "can_run_prefill_cuda_graph", None
+        )
+        if backend_can_run is not None and not backend_can_run(forward_batch):
+            return False
         # Multi-req replay is supported by body-capture backends via the
         # layer_model.forward monkey-patch in replay(): the captured graph runs
         # the transformer stack, then the outer model.forward runs
@@ -1397,6 +1404,15 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 lora_ids=([None] * bs if self._capture_lora else None),
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
+            ngram_manager = self.model_runner.ngram_embedding_manager
+            if ngram_manager.enabled:
+                forward_batch.ngram_embedding_info = NgramEmbeddingInfo.create(
+                    ngram_manager.table,
+                    bs,
+                    self.device,
+                    column_starts=0,
+                    req_lens=shape_inputs["extend_seq_lens"],
+                )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
         return forward_batch, self.model_runner.attn_backend
 
@@ -1676,6 +1692,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 or forward_batch.return_pooled_hidden_states
             ),
         )
+        # The n-gram hasher runs outside the graph and reads this at replay.
+        static_forward_batch.ngram_embedding_info = forward_batch.ngram_embedding_info
+        static_forward_batch.ngram_history = forward_batch.ngram_history
         if self._is_full_backend:
             forward_batch.next_token_logits_buffer = (
                 static_forward_batch.next_token_logits_buffer
@@ -1749,6 +1768,30 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         return static_forward_batch
 
+    def _fill_input_embeds_slot(self, args, layer_kwargs, static_num_tokens: int):
+        """Refresh the captured input_embeds slot from this batch.
+
+        For text-only batches, compute embeddings from input_ids to avoid replaying
+        stale embeddings from the previous batch.
+        """
+        ie_idx = self._input_embeds_arg_idx
+        ie = layer_kwargs.get("input_embeds")
+        if ie is None and ie_idx is not None and len(args) > ie_idx:
+            ie = args[ie_idx]
+        if ie is None:
+            input_ids = layer_kwargs.get("input_ids")
+            if input_ids is None and len(args) > 0:
+                input_ids = args[0]
+            embed = getattr(self.model_runner.model, "get_input_embeddings", None)
+            assert input_ids is not None and embed is not None, (
+                "prefill CUDA graph replay needs input_embeds for the static "
+                "slot, and the model exposes no get_input_embeddings()"
+            )
+            ie = embed()(input_ids)
+        self.buffer_registry.get_slot("input_embeds").slice_for(1, static_num_tokens)[
+            : ie.shape[0]
+        ].copy_(ie)
+
     def _execute_body_capture(
         self,
         forward_batch: ForwardBatch,
@@ -1761,7 +1804,6 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         # BCG / Full: replay the captured body, run the LM head +
         # logits_processor eagerly.
         full_path = self._is_full_backend
-        ie_idx = self._input_embeds_arg_idx
 
         def replay_layer_forward(*args, **layer_kwargs):
             # The captured body graph reads activations from the static
@@ -1773,13 +1815,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             # Copy them into the slot before replay so the graph sees the
             # current request's embeddings (mirrors main's BCG closure).
             if self.buffer_registry.has_slot("input_embeds"):
-                ie = layer_kwargs.get("input_embeds")
-                if ie is None and ie_idx is not None and len(args) > ie_idx:
-                    ie = args[ie_idx]
-                if ie is not None:
-                    self.buffer_registry.get_slot("input_embeds").slice_for(
-                        1, static_num_tokens
-                    )[: ie.shape[0]].copy_(ie)
+                self._fill_input_embeds_slot(args, layer_kwargs, static_num_tokens)
             hs = self.backend.replay(shape_key, static_forward_batch, **kwargs)
             return _slice_output_rows(hs, raw_num_tokens) if full_path else hs
 

--- a/python/sglang/srt/model_executor/runner/shape_key.py
+++ b/python/sglang/srt/model_executor/runner/shape_key.py
@@ -30,9 +30,10 @@ class ShapeKey:
     variant_label: optional execution variant (for example, "lora",
         "nolora", or "chunked_prefix"), or None for runners that don't
         record per-variant graphs.
-    dsa_variant: DSA decode dual-graph variant ("dense" / "sparse"), or None
-        when DSA dual-graph capture is not enabled. Composes with variant_label
-        so LoRA and DSA variants can be captured independently.
+    dsa_variant: DSA indexer ("dense" / "sparse") or V4.1 indexer variant
+        ("candidate_all", "candidate_c2_all", "candidate_unfiltered",
+        "candidate_filtered"), or None.
+        Composes with variant_label so LoRA and DSA variants are independent.
     """
 
     size: int

--- a/python/sglang/srt/model_executor/runner_utils/capture_mode.py
+++ b/python/sglang/srt/model_executor/runner_utils/capture_mode.py
@@ -37,11 +37,8 @@ is_capture_mode = False
 # None = not dual, "lora" = capturing lora variant, "nolora" = capturing nolora variant.
 _capture_lora_variant: Optional[str] = None
 
-# When capturing dual DSA decode graphs (dense/sparse), tracks which variant is
-# being captured. Read by the DSA indexer's capture-time skip-logits branch to
-# force k-only ("dense") vs full indexer ("sparse").
-# None = not dual-capturing; the indexer then bakes in the full-indexer path,
-# which is correct for any kv_len.
+# Capture-time indexer variant for DSA and V4.1; None records the full path.
+# V4.1 variants can bypass scoring or candidate filtering for short histories.
 _capture_dsa_variant: Optional[str] = None
 
 
@@ -73,9 +70,15 @@ def _set_capture_lora_variant(variant: Optional[str]) -> None:
 
 
 def get_capture_dsa_variant() -> Optional[str]:
-    """Return the DSA decode variant being captured ("dense"/"sparse"), or None
-    when dual-variant capture is not active."""
+    """Return the indexer or candidate-filter variant being captured, or None."""
     return _capture_dsa_variant
+
+
+def skip_low_ratio_indexer(compress_ratio: int) -> bool:
+    """Whether this captured variant selects every position for this ratio."""
+    return _capture_dsa_variant == "candidate_all" or (
+        _capture_dsa_variant == "candidate_c2_all" and compress_ratio == 2
+    )
 
 
 def _set_capture_dsa_variant(variant: Optional[str]) -> None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager, nullcontext
+from functools import cached_property
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -128,7 +129,11 @@ from sglang.srt.layers.quantization.fp8_utils import (
     view_aiter_fused_rms_transposed_fp8_scale,
 )
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
+    Mxfp4FlashinferTrtllmMoEMethod,
+    Mxfp8RoutedInputPreQuant,
     maybe_fuse_routed_scale_and_shared_add,
+    routed_hidden_size,
+    should_use_fuse_finalize_all_reduce,
 )
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -568,6 +573,14 @@ class MoEGate(nn.Module):
         return logits
 
 
+# Fused finalize + shared add + TP all-reduce:
+# batch cap for routing onto the fused kernel. It stages the whole [T, hidden]
+# row view through one CustomAllReduceV2 push slot; 96 rows of 5120 bf16 fit
+# the 1 MiB slot the plane allocates, and larger batches keep the unfused
+# finalize + all-reduce chain (the slot fit itself is re-checked in the gate).
+_FUSED_FINALIZE_ALL_REDUCE_MAX_TOKENS = 96
+
+
 class DeepseekV2MoE(nn.Module):
     def __init__(
         self,
@@ -576,6 +589,7 @@ class DeepseekV2MoE(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
+        routed_quant_stream: Optional[torch.cuda.Stream] = None,
         is_nextn: bool = False,
         is_deepseek_v4: bool = False,
         dsa_enable_prefill_cp: bool = False,
@@ -617,7 +631,11 @@ class DeepseekV2MoE(nn.Module):
         self.config = config
         self.layer_id = layer_id
         self.alt_stream = alt_stream
+        self.routed_quant_stream = routed_quant_stream
         self.is_nextn = is_nextn
+        self._fuse_finalize_all_reduce = (
+            is_deepseek_v4 and get_platform().is_blackwell and self.tp_size == 4
+        )
 
         n_hash_layers = getattr(config, "num_hash_layers", 0)
         self.is_hash = layer_id < n_hash_layers and not (is_deepseek_v4 and is_nextn)
@@ -973,7 +991,8 @@ class DeepseekV2MoE(nn.Module):
         # - no stream explosion: main (routed) issued before alt block -> capture reuses 1 alt stream;
         # - PDL overlap: routed is the last main-stream kernel (fuses w/ residual add);
         # - dispose_tensor: disabled during capture (CaptureFlags.disable_dispose_tensor) so the routed
-        #   deep_gemm does not free hidden_states, which the shared expert reads on the alt stream.
+        #   deep_gemm does not free hidden_states, which the shared expert reads on the alt stream
+        #   (and the routed-input pre-quant reads on its own stream).
         use_flashinfer_trtllm_bypass = get_forward().flashinfer_trtllm_bypass
         current_stream = torch.cuda.current_stream()
         # Quantize-once (SGLANG_OPT_MOE_QUANT_ONCE) must happen on the main
@@ -984,6 +1003,13 @@ class DeepseekV2MoE(nn.Module):
             else self._maybe_quant_moe_input_once(hidden_states)
         )
         self.alt_stream.wait_stream(current_stream)
+        should_quant_routed_input_mxfp8 = (
+            not use_flashinfer_trtllm_bypass
+            and pre_quant_input is None
+            and self._should_quant_routed_input_mxfp8(hidden_states)
+        )
+        if should_quant_routed_input_mxfp8:
+            self.routed_quant_stream.wait_stream(current_stream)
         has_shared_output = (
             hidden_states.shape[0] > 0 and self.num_fused_shared_experts == 0
         )
@@ -992,8 +1018,22 @@ class DeepseekV2MoE(nn.Module):
             if get_exec().moe.enable_eplb and not self.is_nextn
             else None
         )
+
         # router_logits: (num_tokens, n_experts)
         router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+        # What the routed experts receive as their pre-quantized input: the
+        # quant-once fp8 pair when that is on (also fed to the shared expert),
+        # otherwise the MXFP8 pre-quant issued on routed_quant_stream, whose
+        # layout the shared expert cannot take, or None.
+        routed_pre_quant_input = pre_quant_input
+        if should_quant_routed_input_mxfp8:
+            with torch.cuda.stream(self.routed_quant_stream):
+                x_q, x_sf = self.experts.quant_method.quantize_routed_input(
+                    hidden_states, routed_hidden_size(self.experts)
+                )
+                ready = self.routed_quant_stream.record_event()
+            routed_pre_quant_input = Mxfp8RoutedInputPreQuant(x_q, x_sf, ready)
+
         if use_flashinfer_trtllm_bypass:
             topk_output = BypassedTopKOutput(
                 hidden_states=hidden_states,
@@ -1021,24 +1061,37 @@ class DeepseekV2MoE(nn.Module):
                     expert_location_dispatch_info=dispatch_info,
                     **topk_kwargs,
                 )
-        deferred_finalize = (
+        # The mHC post-split consumes the reduced row without an RMSNorm.
+        use_fused_finalize_all_reduce = (
+            self._fuse_finalize_all_reduce
+            and has_shared_output
+            and hidden_states.shape[-1] == 5120
+            and not self._shared_expert_tp1
+            and self.tp_size > 1
+            and hidden_states.shape[0] <= _FUSED_FINALIZE_ALL_REDUCE_MAX_TOKENS
+            and not should_skip_post_experts_all_reduce(is_tp_path=True)
+            and should_use_fuse_finalize_all_reduce(
+                self.experts, hidden_states.shape[0], hidden_states.shape[-1]
+            )
+        )
+        deferred_finalize = use_fused_finalize_all_reduce or (
             has_shared_output
             and not self._shared_expert_tp1
             and topk_output.format == TopKOutputFormat.BYPASSED
             and self.experts.supports_deferred_finalize
         )
         if deferred_finalize:
+            # carries the routed pre-quant: the apply joins routed_quant_stream on
+            # its event, which the CUDA-graph capture requires
             final_hidden_states = self.experts.forward_deferred_finalize(
-                hidden_states, topk_output
+                hidden_states, topk_output, pre_quant_input=routed_pre_quant_input
             )
         elif use_flashinfer_trtllm_bypass:
             final_hidden_states = self.experts.forward_impl(hidden_states, topk_output)
-        elif pre_quant_input is not None:
-            final_hidden_states = self.experts(
-                hidden_states, topk_output, pre_quant_input=pre_quant_input
-            )
         else:
-            final_hidden_states = self.experts(hidden_states, topk_output)
+            final_hidden_states = self.experts(
+                hidden_states, topk_output, pre_quant_input=routed_pre_quant_input
+            )
         if (
             not _is_cuda
             and not _is_musa
@@ -1048,6 +1101,7 @@ class DeepseekV2MoE(nn.Module):
             final_hidden_states *= self.routed_scaling_factor
 
         # Shared expert on alt stream, issued AFTER the main (routed) branch. See note above.
+        # Only the quant-once fp8 pair is shared with it; the routed MXFP8 pre-quant is not.
         with torch.cuda.stream(self.alt_stream):
             shared_output = self._forward_shared_experts(
                 hidden_states,
@@ -1055,17 +1109,42 @@ class DeepseekV2MoE(nn.Module):
                 pre_quant_input=pre_quant_input,
             )
 
+        # Joins the shared expert; the routed-input pre-quant on its own stream
+        # was already joined by the event wait inside the routed MoE apply.
         current_stream.wait_stream(self.alt_stream)
 
+        all_reduce_done = False
         if deferred_finalize:
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
                 finalize_flashinfer_trtllm_deferred_output,
             )
 
-            final_hidden_states = finalize_flashinfer_trtllm_deferred_output(
-                final_hidden_states,
-                shared_output,
-            )
+            deferred = final_hidden_states
+            if (
+                use_fused_finalize_all_reduce
+                and deferred.gemm2_out.shape[1] == hidden_states.shape[-1]
+            ):
+                from sglang.kernels.ops.communication.all_reduce_fusion import (
+                    moe_finalize_all_reduce,
+                )
+
+                final_hidden_states = moe_finalize_all_reduce(
+                    deferred.gemm2_out,
+                    deferred.expanded_idx_to_permuted_idx,
+                    deferred.expert_weights,
+                    deferred.top_k,
+                    shared_output,
+                    world_size=self.tp_size,
+                    hidden_dim=hidden_states.shape[-1],
+                    # Routing metadata must be ready before it is consumed.
+                    prefetch_metadata=False,
+                )
+                all_reduce_done = True
+            else:
+                final_hidden_states = finalize_flashinfer_trtllm_deferred_output(
+                    deferred,
+                    shared_output,
+                )
         else:
             final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
                 self.experts,
@@ -1074,8 +1153,10 @@ class DeepseekV2MoE(nn.Module):
                 self.routed_scaling_factor,
             )
 
-        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
-            is_tp_path=True,
+        if (
+            self.tp_size > 1
+            and not all_reduce_done
+            and not should_skip_post_experts_all_reduce(is_tp_path=True)
         ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         # TP1 shared experts are replicated, so add them after all-reduce to
@@ -1652,6 +1733,59 @@ class DeepseekV2MoE(nn.Module):
 
         q, s = sglang_per_token_group_quant_fp8_row_padded(hidden_states, 128)
         return q, s
+
+    @cached_property
+    def _routed_mxfp8_prequant_static_enabled(self) -> bool:
+        """Whether forward_normal_dual_stream may quantize the routed MoE input
+        (MXFP8, linear scale layout) on ``routed_quant_stream`` ahead of
+        Mxfp4FlashinferTrtllmMoEMethod.apply instead of inline on the main
+        stream. Cached per layer; see _compute_routed_mxfp8_prequant_enabled."""
+        return self._compute_routed_mxfp8_prequant_enabled()[0]
+
+    def _compute_routed_mxfp8_prequant_enabled(self) -> Tuple[bool, str]:
+        """Returns (eligible, reason); reason names the first failing check."""
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+
+        if not _is_cuda:
+            return False, "not CUDA"
+        if self.routed_quant_stream is None:
+            return False, "no routed_quant_stream"
+        if self._enable_a2a_moe or self._fuse_shared_experts_inside_sbo:
+            return False, "a2a MoE or SBO shared-expert fusion"
+        if not get_moe_runner_backend().is_flashinfer_mxfp4():
+            return False, "MoE runner backend not flashinfer_mxfp4"
+        experts = self.experts
+        if not isinstance(experts, FusedMoE):
+            return False, "experts not FusedMoE"
+        quant_method = experts.quant_method
+        if not isinstance(quant_method, Mxfp4FlashinferTrtllmMoEMethod):
+            return False, "experts quant method not Mxfp4FlashinferTrtllmMoEMethod"
+        if quant_method.flashinfer_mxfp4_moe_precision != "default":
+            return False, "flashinfer_mxfp4_moe_precision not default (no MXFP8 quant)"
+        # The pre-quant must describe exactly the tensor apply() receives: the
+        # standard dispatcher passes hidden_states through unchanged (the mxfp4
+        # backend keeps global expert ids), the fp4 all-gather does not.
+        if not isinstance(experts.dispatcher, StandardDispatcher):
+            return False, "dispatcher not StandardDispatcher"
+        if should_use_flashinfer_cutlass_moe_fp4_allgather():
+            return False, "flashinfer cutlass fp4 all-gather dispatch"
+        return True, "ok"
+
+    def _should_quant_routed_input_mxfp8(self, hidden_states: torch.Tensor) -> bool:
+        """Per-call gate for the routed-input pre-quant on ``routed_quant_stream``:
+        only while the current stream is being captured (this path is
+        capture-only; the graph then replays the side-stream quant and its event
+        join, and the tensors come from the graph pool, so no ``record_stream``
+        is needed), never inside a piecewise TC graph (its MoE op drops
+        ``pre_quant_input``), and only for a non-empty bf16 batch on a layer the
+        static check admits."""
+        return (
+            torch.cuda.is_current_stream_capturing()
+            and not is_in_tc_piecewise_cuda_graph()
+            and hidden_states.shape[0] > 0
+            and hidden_states.dtype == torch.bfloat16
+            and self._routed_mxfp8_prequant_static_enabled
+        )
 
     def op_gate(self, state):
         if state.hidden_states_mlp_input.shape[0] > 0:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -196,6 +196,7 @@ from sglang.srt.models.deepseek_common.utils import (
     quant_blocks_shared_experts_fusion,
     tiny_router_gemm_max_tokens,
 )
+from sglang.srt.multimodal.dsv41.vl_routing import vision_topk
 from sglang.srt.runtime_context import (
     attention_backends,
     get_device,
@@ -498,6 +499,12 @@ class MoEGate(nn.Module):
             self.e_score_correction_bias = nn.Parameter(correction_bias)
         else:
             self.e_score_correction_bias = None
+        self.e_score_correction_bias_vl = None
+        if config.model_type == "deepseek_v41" and config.vision_n_layers > 0:
+            self.e_score_correction_bias_vl = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
         if _is_cpu and _is_cpu_amx_available:
             self.quant_method = PackWeightMethod(weight_names=["weight"])
         self.use_dsa = is_deepseek_dsa(config)
@@ -914,6 +921,9 @@ class DeepseekV2MoE(nn.Module):
                 input_ids_global=input_ids_global,
             )
 
+        num_token_non_padded = (
+            forward_batch.num_token_non_padded if forward_batch is not None else None
+        )
         if not self._enable_a2a_moe:
             if self._can_dual_stream_graph(hidden_states):
                 fwd = get_forward()
@@ -928,12 +938,14 @@ class DeepseekV2MoE(nn.Module):
                 and self.num_fused_shared_experts == 0
                 and hidden_states.shape[0] > 0
                 and get_is_capture_mode()
+                and not is_in_breakable_cuda_graph()
             ):
                 return self.forward_normal_dual_stream(
                     hidden_states,
                     gemm_output_zero_allocator,
                     input_ids,
                     input_ids_global=input_ids_global,
+                    num_token_non_padded=num_token_non_padded,
                 )
             else:
                 return self.forward_normal(
@@ -942,6 +954,7 @@ class DeepseekV2MoE(nn.Module):
                     input_ids,
                     input_ids_global=input_ids_global,
                     skip_shared_experts=skip_shared_experts,
+                    num_token_non_padded=num_token_non_padded,
                 )
         else:
             return self.forward_deepep(
@@ -954,6 +967,7 @@ class DeepseekV2MoE(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
+        num_token_non_padded: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Note(kpham-sgl): issue order satisfies 3 constraints:
         # - no stream explosion: main (routed) issued before alt block -> capture reuses 1 alt stream;
@@ -992,12 +1006,21 @@ class DeepseekV2MoE(nn.Module):
                 if getattr(self, "is_hash", False)
                 else {}
             )
-            topk_output = self.topk(
-                hidden_states,
-                router_logits,
-                expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
-            )
+            if self.gate.e_score_correction_bias_vl is not None:
+                topk_output = vision_topk(
+                    self,
+                    router_logits,
+                    input_ids_global,
+                    num_token_non_padded=num_token_non_padded,
+                )
+            else:
+                topk_output = self.topk(
+                    hidden_states,
+                    router_logits,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=dispatch_info,
+                    **topk_kwargs,
+                )
         deferred_finalize = (
             has_shared_output
             and not self._shared_expert_tp1
@@ -1068,6 +1091,7 @@ class DeepseekV2MoE(nn.Module):
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
         skip_shared_experts: bool = False,
+        num_token_non_padded: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
@@ -1108,12 +1132,21 @@ class DeepseekV2MoE(nn.Module):
                 if getattr(self, "is_hash", False)
                 else {}
             )
-            topk_output = self.topk(
-                hidden_states,
-                router_logits,
-                expert_location_dispatch_info=dispatch_info,
-                **topk_kwargs,
-            )
+            if self.gate.e_score_correction_bias_vl is not None:
+                topk_output = vision_topk(
+                    self,
+                    router_logits,
+                    input_ids_global,
+                    num_token_non_padded=num_token_non_padded,
+                )
+            else:
+                topk_output = self.topk(
+                    hidden_states,
+                    router_logits,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=dispatch_info,
+                    **topk_kwargs,
+                )
         else:
             pre_quant_input = None
             shared_output = None

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -454,26 +454,51 @@ if _is_hip:
 
 
 def _apply_wo_a_bf16_matmul(
-    o: torch.Tensor, wo_a: torch.Tensor, is_decode: bool
+    o: torch.Tensor, wo_a: torch.Tensor, is_decode: bool, is_target_verify: bool = False
 ) -> torch.Tensor:
     """Compute bf16 wo_a: o [T, G, D] @ wo_a [G, R, D] -> [T, G, R].
 
-    Single-token Blackwell decode uses a GEMV for the validated TP4 shape.
-    ROCm decode can use aiter batched GEMM; its first runtime failure disables
-    that path for the process. Other cases use torch.einsum.
+    Single-token decode uses a GEMV for the validated TP4 shape. Blackwell
+    verify batches up to 384 rows write token-major output directly to avoid
+    the layout copy before wo_b. ROCm decode can use aiter batched GEMM;
+    other cases use torch.einsum.
     """
     global _wo_a_aiter_batched_gemm_disabled
     if (
-        is_decode
-        and _is_cuda
-        and (get_platform().is_blackwell or get_platform().is_sm90)
-        and o.shape == (1, 2, 4096)
+        _is_cuda
+        and (
+            (
+                is_decode
+                and o.shape[0] == 1
+                and (get_platform().is_blackwell or get_platform().is_sm90)
+            )
+            or (
+                is_target_verify
+                and 0 < o.shape[0] <= 384
+                and get_platform().is_blackwell
+            )
+        )
+        and o.shape[1:] == (2, 4096)
         and wo_a.shape == (2, 1024, 4096)
         and o.dtype == wo_a.dtype == torch.bfloat16
-        and o.is_contiguous()
+        and o.stride(2) == 1
+        and o.stride(1) == 4096
+        and o.stride(0) >= 8192
         and wo_a.is_contiguous()
     ):
-        return wo_a_bf16_gemv(o, wo_a)
+        if is_decode and o.shape[0] == 1:
+            return wo_a_bf16_gemv(o, wo_a)
+        result = torch.empty(
+            (o.shape[0], wo_a.shape[0], wo_a.shape[1]), dtype=o.dtype, device=o.device
+        )
+        # cuBLAS accepts the strided destination, preserving the einsum
+        # reduction while producing the contiguous layout consumed by wo_b.
+        # Draft warmup/capture can enter with grad tracking enabled.
+        with torch.no_grad():
+            torch.bmm(
+                o.transpose(0, 1), wo_a.transpose(1, 2), out=result.transpose(0, 1)
+            )
+        return result
     if (
         is_decode
         and _wo_a_aiter_batched_gemm_enabled
@@ -1498,7 +1523,15 @@ class MQALayer(MqaAttentionBase):
             and self.compress_ratio in (1, 2)
             and self.alt_streams is not None
             and (self.compressor is not None or self.indexer is not None)
-            and forward_batch.forward_mode.is_decode()
+            and (
+                forward_batch.forward_mode.is_decode()
+                or (
+                    forward_batch.forward_mode.is_target_verify()
+                    # Other MXFP8 backends may share mutable GEMM workspace.
+                    and getattr(self.wq_b.quant_method, "mxfp8_dense_backend", None)
+                    == Mxfp8DenseGemmBackend.FLASHINFER_CUTEDSL
+                )
+            )
         )
         src_stream = None
         if early_sources:
@@ -2065,7 +2098,10 @@ class MQALayer(MqaAttentionBase):
                 if wo_a_weight is not None:
                     wo_a = wo_a_weight.view(self.n_local_groups, self.o_lora_rank, -1)
                     o = _apply_wo_a_bf16_matmul(
-                        o, wo_a, is_decode=forward_batch.forward_mode.is_decode()
+                        o,
+                        wo_a,
+                        is_decode=forward_batch.forward_mode.is_decode(),
+                        is_target_verify=forward_batch.forward_mode.is_target_verify(),
                     )
                 else:
                     o = _apply_gguf_grouped_wo_a(
@@ -2125,6 +2161,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         compress_ratio_override: Optional[int] = None,
         engram_layout: Optional[EngramLayout] = None,
         hc_stats_stream: Optional[torch.cuda.Stream] = None,
+        moe_routed_quant_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
         self.hc_stats_stream = hc_stats_stream
@@ -2157,6 +2194,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=add_prefix("mlp", prefix),
             layer_id=self.layer_id,
             alt_stream=moe_alt_stream,
+            routed_quant_stream=moe_routed_quant_stream,
             is_nextn=is_nextn,
             is_deepseek_v4=True,
         )
@@ -2412,7 +2450,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             and self.hc_pre_from_prev_sublayer
             and self.hc_mult == 4
             and x.shape[1] == 5120
-            and x.shape[0] <= 64
+            and x.shape[0] <= 384
             and x.dtype == residual.dtype == torch.bfloat16
             and post.dtype == comb.dtype == torch.float32
             and all(t.is_contiguous() for t in (x, residual, post, comb))
@@ -2731,6 +2769,22 @@ class DeepseekV4DecoderLayer(nn.Module):
             y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
         return y, pre.squeeze(1), post.squeeze(1), comb.squeeze(1)
 
+    def _get_hc_stats_stream(self, hidden_states, forward_batch):
+        # Verify batches can also compute coefficients beside the
+        # sublayer; each branch joins before hc_post reads those coefficients.
+        return (
+            self.hc_stats_stream
+            if (
+                forward_batch.forward_mode.is_decode()
+                or (
+                    forward_batch.forward_mode.is_target_verify()
+                    and hidden_states.shape[0] > 0
+                )
+            )
+            and (not get_platform().is_sm90 or hidden_states.shape[0] == 1)
+            else None
+        )
+
     def forward_hc_pre_from_prev(
         self,
         positions: torch.Tensor,
@@ -2742,12 +2796,7 @@ class DeepseekV4DecoderLayer(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Layer forward where attention consumes the previous FFN's pre-mix and
         the FFN consumes this attention's. Returns (hidden_states, ffn_pre)."""
-        stats_stream = (
-            self.hc_stats_stream
-            if forward_batch.forward_mode.is_decode()
-            and (not get_platform().is_sm90 or hidden_states.shape[0] == 1)
-            else None
-        )
+        stats_stream = self._get_hc_stats_stream(hidden_states, forward_batch)
         residual = hidden_states
         x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
             hidden_states,
@@ -3334,6 +3383,14 @@ class DeepseekV4Model(nn.Module):
             if use_stream_pool
             else None
         )
+        # One stream for every layer's routed-MoE input pre-quant, separate from
+        # the attention/indexer streams and the shared expert's; each layer joins
+        # it (event wait) before its routed MoE op.
+        self.moe_routed_quant_stream = (
+            device_module.Stream()
+            if _is_cuda and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
+            else None
+        )
         # One shared stream for all layers, separate from attention/indexer and
         # shared-expert streams. Every sublayer joins before reusing its residual.
         self.hc_stats_stream = (
@@ -3355,6 +3412,7 @@ class DeepseekV4Model(nn.Module):
                 alt_streams=self.alt_streams,
                 engram_layout=self.engram_layout,
                 hc_stats_stream=self.hc_stats_stream,
+                moe_routed_quant_stream=self.moe_routed_quant_stream,
             ),
             pp_rank=self.pp_group.rank_in_group,
             pp_size=self.pp_group.world_size,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import time
 from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,7 +30,9 @@ from sglang.kernels.ops.attention.dsv4 import (
     fused_rope_inplace,
     sglang_per_token_group_quant_fp8_dsv4_wo_a,
 )
+from sglang.kernels.ops.attention.dsv4.wo_a_bf16_gemv import wo_a_bf16_gemv
 from sglang.kernels.ops.attention.flash_mla_sm120 import SM120_DECODE_MAX_TOKENS
+from sglang.kernels.ops.layernorm.mhc_post_split_h import mhc_post_split_h
 from sglang.kernels.ops.quantization.fp8_kernel import (
     sglang_per_token_group_quant_fp8,
 )
@@ -53,6 +56,10 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_prefill_cp_round_robin_split,
 )
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
+from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
+    DeepseekV41Compressor,
+    DeepseekV41Indexer,
+)
 from sglang.srt.layers.attention.dsv4.indexer import C4Indexer
 from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.communicator_dsa_cp import (
@@ -87,16 +94,24 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
     is_dp_gatherv_active,
 )
+from sglang.srt.layers.engram import (
+    Engram,
+    EngramHasher,
+    EngramLayout,
+    build_engram_layout,
+)
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
-from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.moe.utils import (
     is_shared_experts_fusion_disabled,
     uses_per_rank_fused_shared_slots,
 )
+from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_utils import (
+    Mxfp8DenseGemmBackend,
     view_aiter_fused_rms_transposed_fp8_scale,
 )
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
@@ -111,13 +126,21 @@ from sglang.srt.layers.utils.cp_utils import (
     prepare_context_parallel_metadata,
 )
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    embed_mm_inputs,
+)
+from sglang.srt.managers.schedule_batch import MM_PAD_SHIFT_VALUE, MultimodalInputs
 from sglang.srt.mem_cache.memory_pool import RadixAttention
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    PPProxyTensors,
+)
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
     get_token_to_kv_pool,
@@ -157,6 +180,11 @@ from sglang.srt.models.deepseek_v2 import (
     _is_npu,
     _is_xpu,
 )
+from sglang.srt.models.deepseek_v41_vit import Aligner, ViT
+from sglang.srt.multimodal.deepseek_v41_image_processing import (
+    image_token_types,
+    materialize_image_gpu,
+)
 from sglang.srt.runtime_context import (
     get_device,
     get_exec,
@@ -175,7 +203,6 @@ from sglang.srt.utils import (
     add_prefix,
     get_bool_env_var,
     is_gfx95_supported,
-    is_gfx942_supported,
     is_gfx1250_supported,
     is_sm120_supported,
     log_info_on_rank0,
@@ -246,6 +273,18 @@ def _get_mhc_ops() -> MhcOps:
 logger = logging.getLogger(__name__)
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
+
+
+def wo_a_fp8_gemm_enabled(quant_config: Optional[QuantizationConfig]) -> bool:
+    """The fp8 wo_a absorb GEMM (DeepGEMM fp8_einsum, aiter mxscale) takes 128x128
+    block scales only; any other layout dequantizes wo_a to bf16 at load."""
+    return (
+        _FP8_WO_A_GEMM
+        and isinstance(quant_config, Fp8Config)
+        and quant_config.weight_block_size == [128, 128]
+    )
+
+
 _MHC_POST_MULT_VALUE = 2.0
 _HC_PRENORM_DEEPGEMM_MIN_TOKENS = 1024
 
@@ -336,7 +375,6 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 # SGLANG_SHARED_EXPERT_TP1=1 (replicated shared expert). Default OFF.
 _SHARED_EXPERT_LOCAL = get_bool_env_var("SGLANG_DP_SHARED_EXPERT_LOCAL")
 _is_gfx95_supported = is_gfx95_supported()
-_is_gfx942_supported = is_gfx942_supported()
 _is_gfx1250_supported = is_gfx1250_supported()
 
 if _use_aiter:
@@ -418,20 +456,24 @@ if _is_hip:
 def _apply_wo_a_bf16_matmul(
     o: torch.Tensor, wo_a: torch.Tensor, is_decode: bool
 ) -> torch.Tensor:
-    """wo_a (attn output -> o_proj low-rank) bf16 batched matmul.
+    """Compute bf16 wo_a: o [T, G, D] @ wo_a [G, R, D] -> [T, G, R].
 
-    ``o`` is ``[T, G, D]`` (tokens, groups, head_dim) and ``wo_a`` is
-    ``[G, R, D]`` (groups, o_lora_rank, head_dim); the result is ``[T, G, R]``.
-
-    Dispatch contract: on the decode path, when the reroute is enabled
-    (``_wo_a_aiter_batched_gemm_enabled``, computed once at import) and has not
-    been disabled by a prior runtime failure, call the pre-imported aiter
-    ``batched_gemm_bf16`` (``Y[i] = X[i] @ W[i]^T``). Otherwise -- prefill, any
-    gate off, or after a failure -- use the numerically-equivalent
-    ``torch.einsum("tgd,grd->tgr", ...)``. The first runtime kernel failure
-    disables the reroute for the process (logged once).
+    Single-token Blackwell decode uses a GEMV for the validated TP4 shape.
+    ROCm decode can use aiter batched GEMM; its first runtime failure disables
+    that path for the process. Other cases use torch.einsum.
     """
     global _wo_a_aiter_batched_gemm_disabled
+    if (
+        is_decode
+        and _is_cuda
+        and (get_platform().is_blackwell or get_platform().is_sm90)
+        and o.shape == (1, 2, 4096)
+        and wo_a.shape == (2, 1024, 4096)
+        and o.dtype == wo_a.dtype == torch.bfloat16
+        and o.is_contiguous()
+        and wo_a.is_contiguous()
+    ):
+        return wo_a_bf16_gemv(o, wo_a)
     if (
         is_decode
         and _wo_a_aiter_batched_gemm_enabled
@@ -572,6 +614,7 @@ def _apply_gguf_grouped_wo_a(
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import (
         DeepseekV4AttnBackend,
+        LateLayerTail,
     )
     from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
         DeepseekV4HipRadixBackend,
@@ -628,12 +671,42 @@ def deepseek_v4_attention_with_output(
     )
 
     output[:real_num_tokens].view(ret.shape).copy_(ret)
+    output[real_num_tokens:].zero_()
     return
 
 
 bcg_deepseek_v4_attention_with_output = eager_on_graph(True)(
     deepseek_v4_attention_with_output
 )
+
+
+def deepseek_v4_low_ratio_sources(layer, x, q_lora, positions) -> None:
+    # The compressor and prefill indexer sync with the host: run them outside
+    # the prefill CUDA graph on the live batch, like the attention.
+    forward_batch = get_tc_piecewise_forward_context().forward_batch
+    real_num_tokens = forward_batch.num_token_non_padded_cpu
+    if real_num_tokens == 0:
+        return
+    get_attn_backend().forward_low_ratio_sources(
+        layer=layer,
+        x=x[:real_num_tokens],
+        q_lora=q_lora[:real_num_tokens],
+        positions=positions[:real_num_tokens],
+        forward_batch=forward_batch,
+    )
+
+
+bcg_deepseek_v4_low_ratio_sources = eager_on_graph(True)(deepseek_v4_low_ratio_sources)
+
+
+def deepseek_v4_engram_hash_ids(hasher, input_ids: torch.Tensor) -> torch.Tensor:
+    # The hasher reads per-request rows: run it outside the prefill CUDA graph
+    # on the live batch.
+    forward_batch = get_tc_piecewise_forward_context().forward_batch
+    return hasher(input_ids, forward_batch)
+
+
+bcg_deepseek_v4_engram_hash_ids = eager_on_graph(True)(deepseek_v4_engram_hash_ids)
 
 
 class MqaAttentionBase(nn.Module):
@@ -679,6 +752,7 @@ class MqaAttentionBase(nn.Module):
         self.o_lora_rank = config.o_lora_rank
         self.eps = config.rms_norm_eps
         self.softmax_scale = self.head_dim**-0.5
+        self.q_head_norm = config.q_head_norm
 
         self.compress_ratio: int = (
             compress_ratio
@@ -687,9 +761,13 @@ class MqaAttentionBase(nn.Module):
         )
         assert self.compress_ratio in (
             0,
+            1,
+            2,
             4,
             128,
-        ), f"V4 compress_ratio: expected one of (0, 4, 128), got {self.compress_ratio}"
+        ), (
+            f"compress_ratio: expected one of (0, 1, 2, 4, 128), got {self.compress_ratio}"
+        )
 
         assert self.head_dim == config.head_dim
         assert config.num_key_value_heads == 1
@@ -697,7 +775,9 @@ class MqaAttentionBase(nn.Module):
         fuse: bool = (
             envs.SGLANG_OPT_FUSE_WQA_WKV.get() if fuse_wqa_wkv is None else fuse_wqa_wkv
         )
-        fp8: bool = _FP8_WO_A_GEMM if wo_a_fp8 is None else wo_a_fp8
+        fp8: bool = (
+            wo_a_fp8_gemm_enabled(quant_config) if wo_a_fp8 is None else wo_a_fp8
+        )
         reduce_results: bool = (
             (self.attn_tp_size == get_parallel().tp_size and self.attn_tp_size > 1)
             if wo_b_reduce_results is None
@@ -716,6 +796,7 @@ class MqaAttentionBase(nn.Module):
             wo_a_quant_config = None
 
         self.fuse_wqa_wkv = fuse
+        self.wo_a_fp8 = fp8
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
         self._attn_sink_local: Optional[torch.Tensor] = None
@@ -891,7 +972,7 @@ class MQALayer(MqaAttentionBase):
         )
 
         active_rope_scaling = None
-        if self.compress_ratio in (4, 128):
+        if self.compress_ratio:
             active_rope_scaling = dict(self.rope_scaling or {})
             active_rope_scaling["rope_type"] = "deepseek_yarn"
         self.rotary_emb = get_rope_wrapper(
@@ -919,6 +1000,7 @@ class MQALayer(MqaAttentionBase):
             self.register_buffer("cos_cache", cos_cache, persistent=False)
             self.register_buffer("sin_cache", sin_cache, persistent=False)
 
+        self.is_dsv41 = getattr(config, "model_type", None) == "deepseek_v41"
         if alt_streams is not None and (
             (_is_cuda and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get())
             or (_is_npu and envs.SGLANG_NPU_USE_MULTI_STREAM.get())
@@ -962,6 +1044,24 @@ class MQALayer(MqaAttentionBase):
                     rotary_emb=self.rotary_emb,
                     fp4_cos=(self.cos_cache[:, 0, 0, :] if _is_hip else None),
                     fp4_sin=(self.sin_cache[:, 0, 0, :] if _is_hip else None),
+                )
+        elif self.compress_ratio in (1, 2):
+            # V4.1: only kv_source layers compress and only index_source layers
+            # score; the layers in between read both through the attention backend.
+            if self.layer_id in config.kv_source_layer_ids:
+                self.compressor = DeepseekV41Compressor(
+                    hidden_size=config.hidden_size,
+                    head_dim=self.head_dim,
+                    compress_ratio=self.compress_ratio,
+                    eps=config.rms_norm_eps,
+                )
+            if self.layer_id in config.index_source_layer_ids:
+                self.indexer = DeepseekV41Indexer(
+                    config,
+                    layer_id=self.layer_id,
+                    head_dim=self.head_dim,
+                    quant_config=quant_config,
+                    prefix=add_prefix("indexer", prefix),
                 )
 
         self.attn_mqa = RadixAttention(
@@ -1027,6 +1127,17 @@ class MQALayer(MqaAttentionBase):
     ) -> torch.Tensor:
         q, _ = self.wq_b(q)
         q = q.view(-1, self.n_local_heads, self.head_dim)
+        if not self.q_head_norm:
+            fused_rope_inplace(
+                q[..., -self.qk_rope_head_dim :],
+                None,
+                self.freqs_cis,
+                positions=positions,
+            )
+            if q_out is None:
+                return q
+            q_out.copy_(q)
+            return q_out
         if q_out is None:
             q_out = torch.empty_like(q)
         # Fused warp-per-(token, head) rmsnorm-self + RoPE + write to q_out.
@@ -1327,7 +1438,7 @@ class MQALayer(MqaAttentionBase):
             token_to_kv_pool = get_token_to_kv_pool()
             swa_loc = attn_backend.get_swa_out_cache_loc(forward_batch)
             swa_cache = token_to_kv_pool.get_swa_raw_buffer(self.layer_id)
-            swa_page_size = token_to_kv_pool.swa_kv_pool.page_size
+            swa_page_size = token_to_kv_pool.swa_page_size
 
             q = fused_qk_norm_rope_swa_store(
                 q=q,
@@ -1381,6 +1492,31 @@ class MQALayer(MqaAttentionBase):
         x_quant=None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         x_linear = x_quant if x_quant is not None else x
+        early_sources = (
+            _is_cuda
+            and get_platform().is_blackwell
+            and self.compress_ratio in (1, 2)
+            and self.alt_streams is not None
+            and (self.compressor is not None or self.indexer is not None)
+            and forward_batch.forward_mode.is_decode()
+        )
+        src_stream = None
+        if early_sources:
+            src_stream = self.alt_streams[-1]
+            x.record_stream(src_stream)
+            if self.compressor is not None:
+                # Compression depends only on x. Start before the Q/KV
+                # projection; keep its cache writes ordered before indexing.
+                src_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(src_stream):
+                    attn_backend.forward_low_ratio_sources(
+                        layer=self,
+                        x=x,
+                        q_lora=None,
+                        positions=positions,
+                        forward_batch=forward_batch,
+                        run_indexer=False,
+                    )
         # kv_score depends only on x, so its CP all-gather can start before the
         # projections and be collected inside forward_core_compressor below --
         # the projections are what hides it. No-op unless the CP+TBO path armed
@@ -1396,6 +1532,23 @@ class MQALayer(MqaAttentionBase):
         else:
             q_lora, _ = self.wq_a(x_linear)
             qkv_a = None
+
+        if early_sources:
+            q_lora = self.q_norm(q_lora)
+            if self.indexer is not None:
+                # The indexer consumes the NORMALIZED Q, not the view returned
+                # by wqkv_a. Join that producer before launching the indexer.
+                src_stream.wait_stream(torch.cuda.current_stream())
+                q_lora.record_stream(src_stream)
+                with torch.cuda.stream(src_stream):
+                    attn_backend.forward_low_ratio_sources(
+                        layer=self,
+                        x=x,
+                        q_lora=q_lora,
+                        positions=positions,
+                        forward_batch=forward_batch,
+                        run_compressor=False,
+                    )
 
         use_cp = self.dsa_enable_prefill_cp and dsa_use_prefill_cp(forward_batch)
         kv: Optional[torch.Tensor]
@@ -1428,7 +1581,8 @@ class MQALayer(MqaAttentionBase):
                 )
                 q, _ = self.wq_b(q_for_wqb)
             else:
-                q_lora = self.q_norm(q_lora)
+                if not early_sources:
+                    q_lora = self.q_norm(q_lora)
                 q, _ = self.wq_b(q_lora)
 
             kv = (
@@ -1465,10 +1619,10 @@ class MQALayer(MqaAttentionBase):
                 swa_loc = attn_backend.get_unified_swa_loc(forward_batch)
                 swa_page_size, bf16_store = 1, True
             else:
-                swa_cache = token_to_kv_pool.get_swa_raw_buffer(self.layer_id)
                 swa_loc = attn_backend.get_swa_out_cache_loc(forward_batch)
+                swa_cache = token_to_kv_pool.get_swa_raw_buffer(self.layer_id)
                 swa_page_size, bf16_store = (
-                    token_to_kv_pool.swa_kv_pool.page_size,
+                    token_to_kv_pool.swa_page_size,
                     False,
                 )
 
@@ -1543,7 +1697,8 @@ class MQALayer(MqaAttentionBase):
             if q_out is not None:
                 q_out.copy_(q)
         else:
-            q_lora = self.q_norm(q_lora)
+            if not early_sources:
+                q_lora = self.q_norm(q_lora)
             q = self._compute_q_b(q_lora, positions, q_out)
             if unified:
                 # unified_kv prefill: keep bf16 kv; the backend writes
@@ -1573,41 +1728,78 @@ class MQALayer(MqaAttentionBase):
                             torch.cuda.current_stream(),
                         )
             elif use_cp:
-                # NSA CP: keep bf16 kv around for the cross-rank all-gather, then
-                # write to the FlashMLA cache after gather.
-                kv = self._compute_kv_bf16(x_linear, positions, qkv_a=qkv_a)
+                # every rank writes the whole chunk's window KV with the fused fp32 store
+                if qkv_a is not None:
+                    kv = qkv_a[..., self.q_lora_rank :]
+                else:
+                    kv, _ = self.wkv(x_linear)
                 kv = cp_materialize_global_token_order(
                     kv.contiguous(),
                     forward_batch,
                     torch.cuda.current_stream(),
                 )
-                attn_backend.store_cache(
-                    layer_id=self.layer_id,
-                    swa_k=kv,
-                    forward_batch=forward_batch,
+                tail = attn_backend.forward_metadata.late_layer_tail
+                global_positions = (
+                    tail.pos_global
+                    if tail is not None
+                    else forward_batch.positions[: kv.shape[0]]
                 )
+                get_token_to_kv_pool().set_swa_key_buffer_radix_fused_norm_rope(
+                    layer_id=self.layer_id,
+                    swa_loc=attn_backend.get_swa_out_cache_loc(forward_batch),
+                    kv=kv,
+                    kv_weight=self.kv_norm.weight.data,
+                    eps=self.eps,
+                    freqs_cis=self.freqs_cis,
+                    positions=global_positions,
+                )
+                kv = None
             else:
                 self._compute_kv_to_cache(
                     x_linear, positions, forward_batch, attn_backend, qkv_a=qkv_a
                 )
                 kv = None
 
-        del qkv_a
+        if src_stream is None:
+            del qkv_a
 
-        if self.indexer is not None:
-            self.indexer(
-                x=x,
-                q_lora=q_lora,
-                forward_batch=forward_batch,
-                attn_backend=attn_backend,
-            )
-        if self.compressor is not None:
-            attn_backend.forward_core_compressor(
-                x,
-                forward_batch,
-                self.layer_id,
-                self.compressor,
-            )
+        if self.compress_ratio in (1, 2) and (
+            self.compressor is not None or self.indexer is not None
+        ):
+            if (
+                forward_batch.forward_mode.is_extend()
+                and is_in_breakable_cuda_graph()
+                and not getattr(attn_backend, "low_ratio_prefill_graph", False)
+            ):
+                bcg_deepseek_v4_low_ratio_sources(self, x, q_lora, positions)
+            elif src_stream is not None:
+                # Joined right below, before this function returns; attention is
+                # the first reader of anything written here.
+                torch.cuda.current_stream().wait_stream(src_stream)
+                del qkv_a
+            else:
+                attn_backend.forward_low_ratio_sources(
+                    layer=self,
+                    x=x,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                )
+        else:
+            if self.indexer is not None:
+                self.indexer(
+                    x=x,
+                    q_lora=q_lora,
+                    forward_batch=forward_batch,
+                    attn_backend=attn_backend,
+                )
+            if self.compressor is not None:
+                attn_backend.forward_core_compressor(
+                    x,
+                    forward_batch,
+                    self.layer_id,
+                    self.compressor,
+                )
 
         if _is_hip and kv_handle is not None:
             kv = cp_all_gather_rerange_finish(kv_handle)
@@ -1641,6 +1833,7 @@ class MQALayer(MqaAttentionBase):
             )
             and not (self.dsa_enable_prefill_cp and dsa_use_prefill_cp(forward_batch))
             and not (_is_hip and self.compressor is None)
+            and self.compress_ratio not in (1, 2)
         ) or (
             _is_npu
             and envs.SGLANG_NPU_USE_MULTI_STREAM.get()
@@ -1663,14 +1856,28 @@ class MQALayer(MqaAttentionBase):
                 if skip_decode_pad
                 else (64 if self.n_local_heads <= 64 else self.n_heads)
             )
-            # Only [0:n_local_heads] is written below. Uninitialized padded TP
-            # heads inject NaN into attention on gfx942 (fnuz), so zero-init
-            # there; other archs tolerate new_empty and skip the per-forward
-            # memset.
-            if _is_gfx942_supported:
-                q_padded = x.new_zeros(x.shape[0], padded_num_heads, self.head_dim)
+            # The kernel reads all padded heads; uninitialized values can affect real-head
+            # outputs, so the padding must be zero even though only real heads are written.
+            if self.is_dsv41:
+                # Each layer overwrites real heads and leaves padding zero. Reuse requires
+                # all consumers on the layer's stream and no retained reference after return;
+                # a side-stream consumer would need an event before the next layer writes.
+                want = (x.shape[0], padded_num_heads, self.head_dim)
+                meta = getattr(attn_backend, "forward_metadata", None)
+                q_padded = getattr(meta, "q_pad_buffer", None)
+                if (
+                    q_padded is None
+                    or tuple(q_padded.shape) != want
+                    or q_padded.dtype != x.dtype
+                ):
+                    q_padded = x.new_zeros(*want)
+                    if meta is not None:
+                        try:
+                            meta.q_pad_buffer = q_padded
+                        except (AttributeError, TypeError):
+                            pass
             else:
-                q_padded = x.new_empty(x.shape[0], padded_num_heads, self.head_dim)
+                q_padded = x.new_zeros(x.shape[0], padded_num_heads, self.head_dim)
             tp_slice = slice(0, self.n_local_heads)
             q_out = q_padded[:, tp_slice, :]
         attn_sink = self._local_attn_sink()
@@ -1768,7 +1975,7 @@ class MQALayer(MqaAttentionBase):
                 )
             o = o[:, tp_slice, :]
         if (
-            _FP8_WO_A_GEMM
+            self.wo_a_fp8
             and _wo_a_fp8_mxscale_fused_invrope is not None
             and not _is_npu
         ):
@@ -1810,7 +2017,7 @@ class MQALayer(MqaAttentionBase):
 
             o = o.view(o.shape[0], self.n_local_groups, -1)
 
-            if _FP8_WO_A_GEMM and _wo_a_fp8_mxscale is not None:
+            if self.wo_a_fp8 and _wo_a_fp8_mxscale is not None:
                 # ROCm gfx950: same fp8 absorb GEMM as the DeepGEMM path below,
                 # but through aiter's e8m0 block-scale batched GEMM. The
                 # activation is quantized per token-group inside the helper.
@@ -1820,7 +2027,7 @@ class MQALayer(MqaAttentionBase):
                     self.wo_a.weight.view(G, self.o_lora_rank, D),
                     self.wo_a.weight_scale_inv.data,
                 )
-            elif _FP8_WO_A_GEMM:
+            elif self.wo_a_fp8:
                 import deep_gemm
 
                 from sglang.srt.layers import deep_gemm_wrapper
@@ -1890,6 +2097,21 @@ class MQALayer(MqaAttentionBase):
         )
 
 
+@contextmanager
+def _every_row_routed(forward_batch: ForwardBatch, num_rows: int):
+    """Route every all-gathered row: under CP the real rows are not a prefix."""
+    saved = forward_batch.num_token_non_padded, forward_batch.num_token_non_padded_cpu
+    if saved[0] is not None:
+        forward_batch.num_token_non_padded = torch.full_like(saved[0], num_rows)
+    forward_batch.num_token_non_padded_cpu = num_rows
+    try:
+        yield
+    finally:
+        forward_batch.num_token_non_padded, forward_batch.num_token_non_padded_cpu = (
+            saved
+        )
+
+
 class DeepseekV4DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -1901,8 +2123,11 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix: str = "",
         alt_streams: Optional[List[torch.cuda.Stream]] = None,
         compress_ratio_override: Optional[int] = None,
+        engram_layout: Optional[EngramLayout] = None,
+        hc_stats_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__()
+        self.hc_stats_stream = hc_stats_stream
         self.config = config
         self.hidden_size = config.hidden_size
         self.layer_id = layer_id
@@ -1957,6 +2182,20 @@ class DeepseekV4DecoderLayer(nn.Module):
         self.use_fused_mhc_post_pre = (
             is_cross_layer_mhc_fusion_enabled() or _is_fused_mhc_post_pre_enabled_xpu()
         )
+        # The fused post+pre boundary bakes in the same-sublayer pre-mix, which
+        # the predecessor-pre scheme cannot express.
+        self.hc_pre_from_prev_sublayer = config.hc_pre_from_prev_sublayer
+        if self.hc_pre_from_prev_sublayer:
+            self.use_fused_mhc_post_pre = False
+        self.engram = None
+        if engram_layout is not None and layer_id in engram_layout.layer_ids:
+            self.engram = Engram(
+                config,
+                layer_id,
+                engram_layout,
+                quant_config=quant_config,
+                prefix=add_prefix("engram", prefix),
+            )
         self._input_layernorm_weight_bf16 = None
         self._post_attention_layernorm_weight_bf16 = None
 
@@ -2167,12 +2406,39 @@ class DeepseekV4DecoderLayer(nn.Module):
         if _is_xpu:
             return _get_mhc_ops().mhc_post(x, residual, post, comb)
 
+        if (
+            _is_cuda
+            and get_platform().is_blackwell
+            and self.hc_pre_from_prev_sublayer
+            and self.hc_mult == 4
+            and x.shape[1] == 5120
+            and x.shape[0] <= 64
+            and x.dtype == residual.dtype == torch.bfloat16
+            and post.dtype == comb.dtype == torch.float32
+            and all(t.is_contiguous() for t in (x, residual, post, comb))
+        ):
+            return mhc_post_split_h(x, residual, post, comb)
+
         if envs.SGLANG_OPT_USE_FLASHINFER_MHC.get():
             from flashinfer.mhc import mhc_post
 
             return mhc_post(x, residual, post, comb)
 
         if envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
+            if (
+                get_platform().is_sm90
+                and x.is_cuda
+                and 1 <= x.shape[0] <= 64
+                and x.shape[1] == 5120
+                and residual.shape == (x.shape[0], 4, 5120)
+                and x.dtype == residual.dtype == torch.bfloat16
+                and post.dtype == comb.dtype == torch.float32
+                and post.numel() == x.shape[0] * 4
+                and comb.shape == (x.shape[0], 4, 4)
+                and all(t.is_contiguous() for t in (x, residual, post, comb))
+            ):
+                return mhc_post_split_h(x, residual, post, comb)
+
             from sglang.kernels.ops.layernorm.mhc import mhc_post
 
             return mhc_post(x, residual, post, comb)
@@ -2382,6 +2648,142 @@ class DeepseekV4DecoderLayer(nn.Module):
         # cross-layer fusion, and the final layer is completed in DeepseekV4Model.
         return hidden_states, residual, post, comb
 
+    def _hc_mix_and_combine(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        apply_pre: Optional[torch.Tensor],
+        stats_stream: Optional[torch.cuda.Stream] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Mixing coefficients come from x; the sublayer input is x collapsed with
+        apply_pre (None selects copy 0). Returns (y, pre, post, comb)."""
+        from sglang.kernels.ops.layernorm.mhc import (
+            hc_combine,
+            hc_mix_stats,
+            hc_mix_stats_sinkhorn,
+        )
+
+        dtype = x.dtype
+        x_flat = x.flatten(1)
+        if (
+            x.is_cuda
+            and torch.version.cuda is not None
+            and (
+                get_platform().is_blackwell
+                or (get_platform().is_sm90 and x.shape[0] == 1)
+            )
+            and x.dtype == torch.bfloat16
+        ):
+            # The split-K partial fixes the reduction order;
+            # fusing the reduction and sinkhorn preserves batch invariance.
+            main_stream = torch.cuda.current_stream()
+            if stats_stream is not None:
+                stats_stream.wait_stream(main_stream)
+                x.record_stream(stats_stream)
+            with (
+                torch.cuda.stream(stats_stream)
+                if stats_stream is not None
+                else nullcontext()
+            ):
+                pre, post, comb = hc_mix_stats_sinkhorn(
+                    x_flat,
+                    hc_fn,
+                    hc_scale,
+                    hc_base,
+                    self.hc_mult,
+                    self.hc_sinkhorn_iters,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                )
+            if stats_stream is not None:
+                # These allocations originate on the side stream and are read
+                # after the caller joins it, on the main stream.
+                for coefficient in (pre, post, comb):
+                    coefficient.record_stream(main_stream)
+            if apply_pre is None:
+                y = x[:, 0, :].contiguous()
+            else:
+                y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
+            return y, pre, post, comb
+        if x.is_cuda and torch.version.cuda is not None:
+            # Keep mixing and RMS reductions batch-invariant; cuBLAS/torch reductions can
+            # change order with num_tokens. Kernel upcasts let x_flat remain a bf16 view.
+            mixes = hc_mix_stats(x_flat, hc_fn, self.rms_norm_eps).unsqueeze(1)
+        else:
+            x_flat = x_flat.float()
+            rsqrt = torch.rsqrt(
+                x_flat.square().mean(-1, keepdim=True) + self.rms_norm_eps
+            )
+            mixes = (F.linear(x_flat, hc_fn) * rsqrt).unsqueeze(1)
+        pre, post, comb = _get_mhc_ops().hc_split_sinkhorn(
+            mixes,
+            hc_scale,
+            hc_base,
+            self.hc_mult,
+            self.hc_sinkhorn_iters,
+            self.hc_eps,
+        )
+        if apply_pre is None:
+            y = x[:, 0, :].contiguous()
+        else:
+            y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
+        return y, pre.squeeze(1), post.squeeze(1), comb.squeeze(1)
+
+    def forward_hc_pre_from_prev(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_ids_global: torch.Tensor,
+        prev_pre: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Layer forward where attention consumes the previous FFN's pre-mix and
+        the FFN consumes this attention's. Returns (hidden_states, ffn_pre)."""
+        stats_stream = (
+            self.hc_stats_stream
+            if forward_batch.forward_mode.is_decode()
+            and (not get_platform().is_sm90 or hidden_states.shape[0] == 1)
+            else None
+        )
+        residual = hidden_states
+        x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
+            hidden_states,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+            apply_pre=prev_pre,
+            stats_stream=stats_stream,
+        )
+        x = self.input_layernorm(x)
+        with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
+            x = self.self_attn(
+                x=x, positions=positions, forward_batch=forward_batch, x_quant=None
+            )
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
+        hidden_states = self.hc_post(x, residual, attn_post, attn_comb)
+
+        residual = hidden_states
+        x, ffn_pre, ffn_post, ffn_comb = self._hc_mix_and_combine(
+            hidden_states,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            apply_pre=attn_pre,
+            stats_stream=stats_stream,
+        )
+        x = self.post_attention_layernorm(x)
+        x = self._run_moe_ffn_dp_sync(
+            x, forward_batch, input_ids=input_ids, input_ids_global=input_ids_global
+        )
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
+        hidden_states = self.hc_post(x, residual, ffn_post, ffn_comb)
+        return hidden_states, ffn_pre
+
     def _run_moe_ffn_dp_sync(
         self,
         hidden_states: torch.Tensor,
@@ -2480,14 +2882,30 @@ class DeepseekV4DecoderLayer(nn.Module):
         # Skip the MoE-internal post-experts all_reduce when we will do the
         # reduce via reduce_scatterv/reduce_scatter at the combine below
         # (else double-reduce).
-        with get_forward().scoped(mlp_reduce_scatter=mlp_reduce_scatter):
-            hidden_states = self.mlp(
-                hidden_states,
-                forward_batch,
-                input_ids=input_ids,
-                input_ids_global=input_ids_global,
-                skip_shared_experts=_do_shared_local,
-            )
+        gathered_rows = (
+            _every_row_routed(forward_batch, hidden_states.shape[0])
+            if _use_cp and get_moe_a2a_backend().is_none()
+            else nullcontext()
+        )
+        # The MoE sees DP-gathered rows, so this rank's local count cannot mask them.
+        # The standard dispatcher masks padding in the gathered buffer.
+        saved_num_token_non_padded = forward_batch.num_token_non_padded
+        if _use_tp_moe_gather:
+            forward_batch.num_token_non_padded = None
+        try:
+            with (
+                get_forward().scoped(mlp_reduce_scatter=mlp_reduce_scatter),
+                gathered_rows,
+            ):
+                hidden_states = self.mlp(
+                    hidden_states,
+                    forward_batch,
+                    input_ids=input_ids,
+                    input_ids_global=input_ids_global,
+                    skip_shared_experts=_do_shared_local,
+                )
+        finally:
+            forward_batch.num_token_non_padded = saved_num_token_non_padded
         if _use_cp and get_moe_a2a_backend().is_none():
             hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         elif _use_tp_moe_gather:
@@ -2856,6 +3274,19 @@ class DeepseekV4DecoderLayer(nn.Module):
         state.hidden_states_mlp_output = state.pop("local_out")
 
 
+def _scatter_tail_rows(
+    tail: LateLayerTail, rows: torch.Tensor, num_tokens: int
+) -> torch.Tensor:
+    # Rows outside the tail are never read (see _check_late_layer_tail_readers),
+    # so the buffer is left uninitialized: one copy, no fill.
+    full = rows.new_empty((num_tokens, rows.shape[1]))
+    if tail.contiguous_start is not None:
+        full[tail.contiguous_start :].copy_(rows)
+    else:
+        full[tail.token_indices] = rows[: tail.token_indices.shape[0]]
+    return full
+
+
 class DeepseekV4Model(nn.Module):
     fall_back_to_pt_during_load = False
 
@@ -2866,6 +3297,7 @@ class DeepseekV4Model(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.config = config
         self.pp_group = get_pp_group()
         self.hidden_size = config.hidden_size
         if self.pp_group.is_first_rank:
@@ -2902,6 +3334,17 @@ class DeepseekV4Model(nn.Module):
             if use_stream_pool
             else None
         )
+        # One shared stream for all layers, separate from attention/indexer and
+        # shared-expert streams. Every sublayer joins before reusing its residual.
+        self.hc_stats_stream = (
+            device_module.Stream()
+            if _is_cuda
+            and (get_platform().is_blackwell or get_platform().is_sm90)
+            and envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
+            and config.hc_pre_from_prev_sublayer
+            else None
+        )
+        self.engram_layout = build_engram_layout(config)
         self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: DeepseekV4DecoderLayer(
@@ -2910,6 +3353,8 @@ class DeepseekV4Model(nn.Module):
                 quant_config=quant_config,
                 prefix=prefix,
                 alt_streams=self.alt_streams,
+                engram_layout=self.engram_layout,
+                hc_stats_stream=self.hc_stats_stream,
             ),
             pp_rank=self.pp_group.rank_in_group,
             pp_size=self.pp_group.world_size,
@@ -2923,12 +3368,37 @@ class DeepseekV4Model(nn.Module):
         self.hc_eps = config.hc_eps
         self.hc_mult = hc_mult = config.hc_mult
         self.norm_eps = config.rms_norm_eps
-        if self.pp_group.is_last_rank:
+        self.hc_pre_from_prev_sublayer = config.hc_pre_from_prev_sublayer
+        self.hc_head_fn = self.hc_head_base = self.hc_head_scale = None
+        if self.pp_group.is_last_rank and not self.hc_pre_from_prev_sublayer:
             (
                 self.hc_head_fn,
                 self.hc_head_base,
                 self.hc_head_scale,
             ) = make_hc_head_params(hc_mult, config.hidden_size)
+        self.engram_hasher = None
+        if self.engram_layout is not None:
+            self.engram_hasher = EngramHasher.from_config(config, self.engram_layout)
+
+        self.engram_prefetch_stream = None
+        if (
+            _is_cuda
+            and envs.SGLANG_ENABLE_DSV41_ENGRAM_KV_PREFETCH.get()
+            and self.pp_group.world_size == 1
+            and not is_dp_attention_enabled()
+            and config.vision_n_layers == 0
+            and config.hc_pre_from_prev_sublayer
+            and self.start_layer <= 14 < self.end_layer
+            and self.layers[14].engram is not None
+            and self.layers[14].engram.embed._shared
+            # Other backends may share mutable GEMM workspace across streams.
+            and getattr(
+                self.layers[14].engram.wkv.quant_method, "mxfp8_dense_backend", None
+            )
+            == Mxfp8DenseGemmBackend.FLASHINFER_CUTEDSL
+        ):
+            self.engram_prefetch_stream = torch.cuda.Stream()
+            logger.info("Engram layer 14 KV prefetch enabled for BS=1 decode")
 
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.use_fused_mhc_post_pre = (
@@ -2938,6 +3408,21 @@ class DeepseekV4Model(nn.Module):
             self.cp_size = get_parallel().attn_cp_size
 
         self.dspark_layers_to_capture: Optional[List[int]] = None
+
+        # Decoder SWA bounded replay: layers past the last kv_source layer run over
+        # each request's last SWA_WINDOW extend tokens only.
+        self.late_layer_start: Optional[int] = None
+        if get_exec().features.enable_decoder_swa_bounded_replay:
+            assert config.kv_source_layer_ids, (
+                "decoder SWA bounded replay needs kv_source_layer_ids"
+            )
+            self.late_layer_start = max(config.kv_source_layer_ids) + 1
+            late_ratios = set(
+                config.compress_ratios[self.late_layer_start : config.num_hidden_layers]
+            )
+            assert late_ratios <= {0, 1}, (
+                f"late layers must not compress on their own, got ratios {late_ratios}"
+            )
 
     def get_input_embeddings(self) -> nn.Module:
         return self.embed_tokens
@@ -2977,6 +3462,156 @@ class DeepseekV4Model(nn.Module):
             norm_eps=self.norm_eps,
             hc_eps=self.hc_eps,
         )
+
+    def _check_late_layer_tail_readers(self, forward_batch: ForwardBatch) -> None:
+        # Rows outside the tail are never computed past the last kv_source layer,
+        # so anything reading hidden states of earlier prompt tokens cannot be served.
+        if (
+            forward_batch.capture_hidden_mode == CaptureHiddenMode.FULL
+            and self.dspark_layers_to_capture is None
+        ):
+            raise ValueError(
+                "decoder SWA bounded replay cannot capture hidden states of all "
+                "prompt tokens"
+            )
+        if forward_batch.return_logprob and any(
+            start < n
+            for start, n in zip(
+                forward_batch.extend_logprob_start_lens_cpu,
+                forward_batch.extend_seq_lens_cpu,
+            )
+        ):
+            raise ValueError(
+                "decoder SWA bounded replay cannot return logprobs of prompt tokens; "
+                "set logprob_start_len to the prompt length"
+            )
+
+    def _forward_layers_hc_pre_from_prev(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_ids: torch.Tensor,
+        input_ids_global: torch.Tensor,
+        capture_dspark: bool,
+        dspark_aux_hidden_states: List[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[LateLayerTail]]:
+        assert self.pp_group.world_size == 1, "pre-mix hand-off across PP is not wired"
+        hash_ids = None
+        cp_extend = (
+            is_cp_v2_active(forward_batch) and forward_batch.forward_mode.is_extend()
+        )
+        if self.engram_hasher is not None:
+            if cp_extend:
+                # n-gram hashing needs each token's predecessors: hash the whole prompt
+                total = int(forward_batch.attn_cp_metadata.total_seq_lens)
+                hash_ids = self.engram_hasher(
+                    forward_batch.input_ids[:total], forward_batch
+                )
+                parallel = get_parallel()
+                hash_ids = hash_ids[parallel.attn_cp_rank :: parallel.attn_cp_size]
+                pad_rows = hidden_states.shape[0] - hash_ids.shape[0]
+                if pad_rows > 0:
+                    hash_ids = torch.cat(
+                        [hash_ids, hash_ids.new_zeros(pad_rows, *hash_ids.shape[1:])]
+                    )
+            elif (
+                forward_batch.forward_mode.is_extend() and is_in_breakable_cuda_graph()
+            ):
+                hash_ids = bcg_deepseek_v4_engram_hash_ids(
+                    self.engram_hasher, input_ids
+                )
+            else:
+                hash_ids = self.engram_hasher(input_ids, forward_batch)
+        prefetched_engram_kv = None
+        if (
+            self.engram_prefetch_stream is not None
+            and forward_batch.forward_mode.is_decode()
+            and hash_ids.shape[0] == 1
+        ):
+            prefetch_stream = self.engram_prefetch_stream
+            prefetch_stream.wait_stream(torch.cuda.current_stream())
+            engram = self.layers[14].engram
+            with torch.cuda.stream(prefetch_stream):
+                prefetched_engram_kv = engram.project(
+                    hash_ids[:, engram.layer_hash_index]
+                )
+            hash_ids.record_stream(prefetch_stream)
+        tail = None
+        if (
+            self.late_layer_start is not None
+            and forward_batch.forward_mode.is_extend_without_speculative()
+        ):
+            self._check_late_layer_tail_readers(forward_batch)
+            attn_backend = get_attn_backend()
+            tail = attn_backend.tail_forward_metadata.late_layer_tail
+        saved_full = None
+        prev_pre = None
+        for i in range(self.start_layer, self.end_layer):
+            if tail is not None and i == self.late_layer_start:
+                # Past the last kv_source layer a layer only owes its window KV,
+                # and decode reaches back at most SWA_WINDOW positions.
+                saved_full = attn_backend.enter_late_layer_tail(forward_batch)
+                hidden_states, prev_pre, input_ids, input_ids_global = (
+                    tail.rows(hidden_states),
+                    tail.rows(prev_pre),
+                    tail.rows(input_ids),
+                    tail.rows(input_ids_global),
+                )
+                positions = tail.positions
+                if hash_ids is not None:
+                    hash_ids = tail.rows(hash_ids)
+            engram = self.layers[i].engram
+            if engram is not None:
+                before_engram = hidden_states
+                if i == 14 and prefetched_engram_kv is not None:
+                    main_stream = torch.cuda.current_stream()
+                    main_stream.wait_stream(self.engram_prefetch_stream)
+                    prefetched_engram_kv.record_stream(main_stream)
+                    hidden_states = engram.apply_gate(
+                        hidden_states, prefetched_engram_kv
+                    )
+                    prefetched_engram_kv = None
+                else:
+                    hidden_states = engram(
+                        hidden_states,
+                        hash_ids[:, engram.layer_hash_index],
+                        forward_batch,
+                        cp_all_tokens=cp_extend,
+                    )
+                if (
+                    self.config.model_type == "deepseek_v41"
+                    and self.config.vision_n_layers > 0
+                ):
+                    hidden_states = torch.where(
+                        (input_ids == self.config.image_token_id)[:, None, None],
+                        before_engram,
+                        hidden_states,
+                    )
+            if capture_dspark and i in self.dspark_layers_to_capture:
+                # The draft head reads the attention input of its target layers.
+                aux = hidden_states
+                if tail is not None and i < self.late_layer_start:
+                    aux = tail.rows(aux)
+                dspark_aux_hidden_states.append(aux.mean(dim=1))
+            ctx = (
+                nullcontext()
+                if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
+                else get_global_expert_distribution_recorder().with_current_layer(i)
+            )
+            with ctx:
+                hidden_states, prev_pre = self.layers[i].forward_hc_pre_from_prev(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    input_ids=input_ids,
+                    forward_batch=forward_batch,
+                    input_ids_global=input_ids_global,
+                    prev_pre=prev_pre,
+                )
+        if saved_full is not None:
+            attn_backend.exit_late_layer_tail(saved_full, forward_batch)
+            return hidden_states, prev_pre, tail
+        return hidden_states, prev_pre, None
 
     def _cp_children_splittable(self, forward_batch: ForwardBatch) -> bool:
         children = forward_batch.tbo_children
@@ -3278,7 +3913,20 @@ class DeepseekV4Model(nn.Module):
         for _attr in ("freqs_cis_c4", "freqs_cis_c128"):
             if hasattr(forward_batch, _attr):
                 delattr(forward_batch, _attr)
-        if run_tbo:
+        last_pre = None
+        tail = None
+        if self.hc_pre_from_prev_sublayer:
+            assert not run_tbo, "two-batch overlap is not wired for this hc scheme"
+            hidden_states, last_pre, tail = self._forward_layers_hc_pre_from_prev(
+                positions,
+                hidden_states,
+                forward_batch,
+                input_ids,
+                input_ids_global,
+                capture_dspark,
+                dspark_aux_hidden_states,
+            )
+        elif run_tbo:
             # Two-batch-overlap prefill (EP / mori). Cross-layer mHC fusion is
             # disabled here (each layer self-contained), so no trailing hc_post.
             hidden_states = self._forward_layers_tbo(
@@ -3351,10 +3999,27 @@ class DeepseekV4Model(nn.Module):
 
         pre_hc_head = hidden_states.flatten(1)
 
-        hidden_states = self.hc_head(
-            hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base
-        )
+        if self.hc_pre_from_prev_sublayer:
+            from sglang.kernels.ops.layernorm.mhc import hc_combine
+
+            hidden_states = hc_combine(
+                pre_hc_head.float(), last_pre, self.hc_mult, hidden_states.dtype
+            )
+        else:
+            hidden_states = self.hc_head(
+                hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base
+            )
         hidden_states = self.norm(hidden_states)
+
+        if tail is not None and not capture_dspark:
+            # The logits processor indexes rows by the full extend layout.
+            num_tokens = input_ids.shape[0]
+            hidden_states = _scatter_tail_rows(
+                tail=tail, rows=hidden_states, num_tokens=num_tokens
+            )
+            pre_hc_head = _scatter_tail_rows(
+                tail=tail, rows=pre_hc_head, num_tokens=num_tokens
+            )
 
         if capture_dspark:
             return (hidden_states, pre_hc_head), dspark_aux_hidden_states
@@ -3363,6 +4028,8 @@ class DeepseekV4Model(nn.Module):
 
 
 class DeepseekV4ForCausalLM(nn.Module):
+    supports_cuda_vmm_feature_transport = True
+
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -3382,7 +4049,26 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.config = config
         self.tp_size = get_parallel().tp_size
         self.quant_config = quant_config
+        self.wo_a_fp8 = wo_a_fp8_gemm_enabled(quant_config)
         self.determine_num_fused_shared_experts()
+        self.vision = None
+        if config.model_type == "deepseek_v41" and config.vision_n_layers > 0:
+            if (
+                get_parallel().attn_dp_size != 1
+                or get_parallel().attn_cp_size != 1
+                or get_pp_group().world_size != 1
+                or not get_moe_a2a_backend().is_none()
+            ):
+                raise ValueError(
+                    "V4.1 vision currently supports TP/EP without DP, CP, PP or MoE A2A"
+                )
+
+            args = SimpleNamespace(**vars(config), dim=config.hidden_size)
+            self.vision = ViT(args)
+            self.aligner = Aligner(args)
+            self.image_start = nn.Parameter(torch.empty(config.hidden_size))
+            self.image_end = nn.Parameter(torch.empty(config.hidden_size))
+            self.image_newline = nn.Parameter(torch.empty(config.hidden_size))
         self.model = DeepseekV4Model(
             config, quant_config, prefix=add_prefix("model", prefix)
         )
@@ -3431,6 +4117,57 @@ class DeepseekV4ForCausalLM(nn.Module):
     @property
     def routed_experts_weights_of_layer(self):
         return self._routed_experts_weights_of_layer.value
+
+    def pad_input_ids(self, input_ids, mm_inputs):
+
+        return MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
+            input_ids, mm_inputs
+        )
+
+    def get_image_feature(self, items):
+        """Return complete spans for the shared MM cache and chunk scheduler."""
+
+        spans = []
+        device, dtype = self.image_start.device, self.image_start.dtype
+        for item in items:
+            item.reconstruct(device.index, ipc_consumer_count=self.tp_size)
+            h, w = int(item.n_vit_h), int(item.n_vit_w)
+            pixels = torch.as_tensor(item.feature, device=device)
+            plan = item.model_specific_data.get("dsv41_gpu_plan")
+            patches = (
+                materialize_image_gpu(pixels, plan).to(dtype)
+                if plan is not None
+                else pixels.to(dtype)
+            )
+            features = self.aligner(self.vision(patches, h, w), h, w)
+            r = self.config.vision_downsample_ratio
+            types = image_token_types((h + r - 1) // r, (w + r - 1) // r).to(device)
+            span = torch.empty(
+                (len(types), self.config.hidden_size), device=device, dtype=dtype
+            )
+            span[types == 0] = self.image_start
+            span[types == 1] = features.to(dtype)
+            span[types == 2] = self.image_newline
+            span[types == 3] = self.image_end
+            spans.append(span)
+        return spans
+
+    def _prepare_mm_embeddings(self, input_ids, forward_batch):
+
+        # Keep scheduler hash IDs intact: the shared embedder clamps its input in place.
+        input_embeds, _ = embed_mm_inputs(
+            mm_inputs_list=[
+                item if item is not None else MultimodalInputs(mm_items=[])
+                for item in forward_batch.mm_inputs
+            ],
+            extend_prefix_lens=forward_batch.extend_prefix_lens_cpu,
+            extend_seq_lens=forward_batch.extend_seq_lens_cpu,
+            input_ids=input_ids.clone(),
+            input_embedding=self.get_input_embeddings(),
+            multimodal_model=self,
+        )
+        forward_batch.mm_input_embeds = input_embeds
+        return input_embeds
 
     def get_input_embeddings(self) -> nn.Module:
         return self.model.get_input_embeddings()
@@ -3489,6 +4226,24 @@ class DeepseekV4ForCausalLM(nn.Module):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
+        if (
+            self.vision is not None
+            and not forward_batch.forward_mode.is_decode()
+            and forward_batch.mm_inputs is not None
+            and any(x is not None for x in forward_batch.mm_inputs)
+        ):
+            if input_embeds is not None:
+                raise ValueError("Cannot combine input_embeds and image inputs")
+            input_embeds = self._prepare_mm_embeddings(input_ids, forward_batch)
+        if self.vision is not None and not (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
+        ):
+            # Decode/verify IDs are already vocabulary IDs. Remap prompt image
+            # hashes for Engram and routing without changing the scheduler's IDs.
+            input_ids = input_ids.masked_fill(
+                input_ids >= MM_PAD_SHIFT_VALUE, self.config.image_token_id
+            )
         if self.dsa_enable_prefill_cp:
             if can_dsa_cp_split(len(input_ids), self.cp_size, True, forward_batch):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
@@ -3521,16 +4276,33 @@ class DeepseekV4ForCausalLM(nn.Module):
             hidden_states, aux_hidden_states = hidden_states
         hidden_states, pre_hc_head = hidden_states
 
-        return self.logits_processor(
+        logits_metadata = forward_batch
+        tail = None
+        if (
+            self.capture_aux_hidden_states
+            and self.model.late_layer_start is not None
+            and forward_batch.forward_mode.is_extend_without_speculative()
+        ):
+            tail = get_attn_backend().tail_forward_metadata.late_layer_tail
+            input_ids = tail.rows(input_ids)
+            logits_metadata = LogitsMetadata.from_forward_batch(forward_batch)
+            logits_metadata.extend_seq_lens = tail.extend_seq_lens
+            logits_metadata.extend_seq_lens_cpu = tail.extend_seq_lens_cpu
+            logits_metadata.extend_logprob_start_lens_cpu = tail.extend_seq_lens_cpu
+
+        output = self.logits_processor(
             input_ids,
             hidden_states,
             self.lm_head,
-            forward_batch,
+            logits_metadata,
             aux_hidden_states,
             hidden_states_before_norm=(
                 None if aux_hidden_states is not None else pre_hc_head
             ),
         )
+        if tail is not None:
+            output.hidden_states_token_indices = tail.token_indices
+        return output
 
     def _setup_fp8_wo_a_scales(self, is_nextn: bool) -> None:
         from sglang.srt.layers import deep_gemm_wrapper
@@ -3589,7 +4361,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                 attn.wo_a.weight_scale_inv.format_ue8m0 = False
 
     def post_load_weights(self, is_nextn=False, weight_names=None):
-        if _FP8_WO_A_GEMM:
+        if self.wo_a_fp8:
             self._setup_fp8_wo_a_scales(is_nextn)
 
         if is_nextn:
@@ -3615,6 +4387,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         is_nextn: bool = False,
         num_hidden_layers: Optional[int] = None,
     ) -> str:
+        if name.startswith("vision."):
+            return name.replace(".attn.wqkv.", ".attn.qkv_proj.").replace(
+                ".attn.wo.", ".attn.proj."
+            )
+        if name.startswith(("aligner.", "image_")):
+            return name
         if name.startswith("embed."):
             return "model.embed_tokens." + name.removeprefix("embed.")
         if name.startswith("head."):
@@ -3660,6 +4438,8 @@ class DeepseekV4ForCausalLM(nn.Module):
         name = name.replace(".ffn_norm.", ".post_attention_layernorm.")
 
         if "self_attn" in name and name.endswith(".scale"):
+            name = name.removesuffix(".scale") + ".weight_scale_inv"
+        if ".engram.wkv." in name and name.endswith(".scale"):
             name = name.removesuffix(".scale") + ".weight_scale_inv"
 
         name = name.replace(".gate.tid2eid", ".topk.tid2eid")
@@ -3756,7 +4536,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             else:
                 raise ValueError("num_nextn_predict_layers is not in the config")
 
-        if not _FP8_WO_A_GEMM:
+        if not self.wo_a_fp8:
             weights = _prepare_deepseek_v4_weights(weights, self.quant_config)
 
         stacked_params_mapping = DEEPSEEK_V4_STACKED_PARAMS_MAPPING
@@ -3778,6 +4558,10 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
         cache_wqkv_a_weight: dict[str, dict[str, torch.Tensor]] = {}
+        skipped_by_group: dict[str, int] = {}
+        # The skip list below is DeepSeek V4.1 only; V4 checkpoints must load
+        # every compressor / indexer tensor.
+        is_dsv41 = getattr(self.config, "model_type", None) == "deepseek_v41"
 
         def auto_weight_loader(module):
             return getattr(module, "weight_loader", default_weight_loader)
@@ -3806,7 +4590,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             weight_names = []
             for name, loaded_weight in weights:
                 if (
-                    _FP8_WO_A_GEMM
+                    self.wo_a_fp8
                     and name.endswith(".wo_a.weight")
                     and loaded_weight.dtype != torch.float8_e4m3fn
                 ):
@@ -3825,6 +4609,25 @@ class DeepseekV4ForCausalLM(nn.Module):
                         is_nextn=is_nextn,
                         num_hidden_layers=self.config.num_hidden_layers,
                     )
+
+                    # V4.1 checkpoint tensors with no module in the text model yet;
+                    # the per-group count is logged after loading.
+                    skip_group = None
+                    if not is_dsv41:
+                        pass
+                    elif self.vision is None and name.startswith(
+                        ("vision.", "aligner.", "image_")
+                    ):
+                        skip_group = "vision"
+                    elif self.vision is None and name.endswith(
+                        ".gate.e_score_correction_bias_vl"
+                    ):
+                        skip_group = "gate.bias_vl"
+                    if skip_group is not None:
+                        skipped_by_group[skip_group] = (
+                            skipped_by_group.get(skip_group, 0) + 1
+                        )
+                        continue
 
                     layer_id = get_layer_id(name)
                     if (
@@ -3954,7 +4757,14 @@ class DeepseekV4ForCausalLM(nn.Module):
                                 or name == "lm_head.weight"
                             ) and not self.pp_group.is_last_rank:
                                 continue
-                            elif COMPRESSOR_PART in name and ".wkv_gate." not in name:
+                            elif (
+                                COMPRESSOR_PART in name
+                                and ".wkv_gate." not in name
+                                and (name.rsplit(".", 2)[0] + ".wkv_gate.weight")
+                                in params_dict
+                            ):
+                                # Concatenate checkpoint wkv/wgate whenever the target owns wkv_gate;
+                                # modules with split projections use per-parameter loading.
                                 is_kv = name.endswith(".wkv.weight")
                                 is_wgate = name.endswith(".wgate.weight")
                                 assert is_kv != is_wgate
@@ -3986,15 +4796,20 @@ class DeepseekV4ForCausalLM(nn.Module):
                                     )
                                     loaded_params.add(param_name)
                                     cache_compressor_weight.pop(key)
-                            elif fuse_wqa_wkv and (
-                                name.endswith(".wq_a.weight")
-                                or name.endswith(".wq_a.weight_scale_inv")
-                                or name.endswith(".wkv.weight")
-                                or name.endswith(".wkv.weight_scale_inv")
-                                or name.endswith(".wq_a.qweight")
-                                or name.endswith(".wkv.qweight")
-                                or name.endswith(".wq_a.qweight_type")
-                                or name.endswith(".wkv.qweight_type")
+                            elif (
+                                fuse_wqa_wkv
+                                and ".compressor." not in name
+                                and ".engram." not in name
+                                and (
+                                    name.endswith(".wq_a.weight")
+                                    or name.endswith(".wq_a.weight_scale_inv")
+                                    or name.endswith(".wkv.weight")
+                                    or name.endswith(".wkv.weight_scale_inv")
+                                    or name.endswith(".wq_a.qweight")
+                                    or name.endswith(".wkv.qweight")
+                                    or name.endswith(".wq_a.qweight_type")
+                                    or name.endswith(".wkv.qweight_type")
+                                )
                             ):
                                 is_q = ".wq_a." in name
                                 param_name = name.replace(
@@ -4059,6 +4874,12 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         assert len(cache_compressor_weight) == 0
         assert len(cache_wqkv_a_weight) == 0, cache_wqkv_a_weight.keys()
+        if skipped_by_group:
+            log_info_on_rank0(
+                logger,
+                "Skipped checkpoint tensors not wired yet: "
+                + ", ".join(f"{k}={v}" for k, v in sorted(skipped_by_group.items())),
+            )
         unloaded_params = params_dict.keys() - loaded_params
 
         skipped_checking_patterns = [
@@ -4089,6 +4910,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
 
         if not is_nextn:
+            for i, layer in enumerate(self.model.layers):
+                if getattr(layer, "engram", None) is not None:
+                    layer.engram.embed.finish_load(label=f"layer {i}")
             self._prewarm_mhc_kernels()
 
     def get_embed_and_head(self):
@@ -4127,8 +4951,12 @@ def _dequant_fp8(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
         torch.float32,
     ), f"expected fp8_e8m0fnu or float32, got {scale.dtype}"
 
+    # Block size is per-checkpoint (V4 128x128, V4.1 32x32); take it from the
+    # weight/scale shapes.
+    bn = weight.shape[0] // scale.shape[0]
+    bk = weight.shape[1] // scale.shape[1]
     weight_f32 = rearrange(
-        weight.float(), "(sn bn) (sk bk) -> sn bn sk bk", bn=128, bk=128
+        weight.float(), "(sn bn) (sk bk) -> sn bn sk bk", bn=bn, bk=bk
     )
     result = rearrange(
         weight_f32 * scale.float()[:, None, :, None], "sn bn sk bk -> (sn bn) (sk bk)"

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4054,13 +4054,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.vision = None
         if config.model_type == "deepseek_v41" and config.vision_n_layers > 0:
             if (
-                get_parallel().attn_dp_size != 1
-                or get_parallel().attn_cp_size != 1
+                get_parallel().attn_cp_size != 1
                 or get_pp_group().world_size != 1
                 or not get_moe_a2a_backend().is_none()
             ):
                 raise ValueError(
-                    "V4.1 vision currently supports TP/EP without DP, CP, PP or MoE A2A"
+                    "V4.1 vision currently supports TP/EP/DP without CP, PP or MoE A2A"
                 )
 
             args = SimpleNamespace(**vars(config), dim=config.hidden_size)

--- a/python/sglang/srt/models/deepseek_v41_vit.py
+++ b/python/sglang/srt/models/deepseek_v41_vit.py
@@ -1,0 +1,160 @@
+"""Vision tower and aligner from the 260903 reference implementation."""
+
+from functools import lru_cache
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.layers.attention.vision import (
+    VisionAttention,
+    VisionAttentionMetadata,
+    prepare_vision_attention_metadata,
+)
+
+
+@lru_cache(8)
+def get_vision_cos_sin(n_h: int, n_w: int, dim: int, theta: float):
+    inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    hpos = torch.arange(n_h).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+
+
+def apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class PatchEmbed(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.proj = nn.Linear(3 * args.vision_patch_size**2, args.vision_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x.flatten(1))
+
+
+def apply_vision_rotary(q, k, position_embeddings, x_shape):
+    # The reference pairs the two halves of each head, with FP32 arithmetic.
+    cos, sin = position_embeddings
+    return apply_rotary(q, cos, sin), apply_rotary(k, cos, sin)
+
+
+class Attention(VisionAttention):
+    def __init__(self, args):
+        super().__init__(
+            embed_dim=args.vision_dim,
+            num_heads=args.vision_n_heads,
+            projection_size=args.vision_dim,
+            use_qkv_parallel=True,
+            use_data_parallel=True,
+            customized_position_embedding_applier=apply_vision_rotary,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        metadata: VisionAttentionMetadata,
+    ) -> torch.Tensor:
+        return (
+            super()
+            .forward(
+                x,
+                position_embeddings=(cos, sin),
+                forward_metadata=metadata,
+                max_seqlen=x.shape[0],
+            )
+            .squeeze(0)
+        )
+
+
+class MLP(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.w1 = nn.Linear(args.vision_dim, 2 * args.vision_inter_dim, bias=False)
+        self.w2 = nn.Linear(args.vision_inter_dim, args.vision_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate, up = self.w1(x).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class Block(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.norm1 = RMSNorm(args.vision_dim)
+        self.attn = Attention(args)
+        self.norm2 = RMSNorm(args.vision_dim)
+        self.mlp = MLP(args)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        metadata: VisionAttentionMetadata,
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin, metadata)
+        return x + self.mlp(self.norm2(x))
+
+
+class ViT(nn.Module):
+    """DeepSeek ViT: full bidirectional attention over one image with 2D RoPE."""
+
+    def __init__(self, args):
+        super().__init__()
+        self.rope_dim = args.vision_dim // args.vision_n_heads // 2
+        self.rope_theta = args.vision_rope_theta
+        self.patch_embed = PatchEmbed(args)
+        self.blocks = nn.ModuleList([Block(args) for _ in range(args.vision_n_layers)])
+        self.norm = RMSNorm(args.vision_dim)
+
+    def forward(self, patches: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        x = self.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(n_h, n_w, self.rope_dim, self.rope_theta)
+        cos, sin = cos.to(x.device), sin.to(x.device)
+        # One image is one full, bidirectional sequence. Supplying its known
+        # length avoids device-to-host length discovery in every encoder layer.
+        metadata = prepare_vision_attention_metadata(
+            torch.tensor([0, x.shape[0]], dtype=torch.int32),
+            x.device,
+            max_seqlen=x.shape[0],
+        )
+        for block in self.blocks:
+            x = block(x, cos, sin, metadata)
+        return self.norm(x)
+
+
+class Aligner(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.downsample_ratio = args.vision_downsample_ratio
+        in_dim = args.vision_dim * self.downsample_ratio**2
+        self.w1 = nn.Linear(in_dim, args.dim)
+        self.w2 = nn.Linear(args.dim, args.dim)
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.downsample_ratio
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(x)))

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -40,6 +40,7 @@ from sglang.srt.models.deepseek_v4 import (
     DeepseekV4DecoderLayer,
     DeepseekV4ForCausalLM,
     MqaAttentionBase,
+    _apply_wo_a_bf16_matmul,
     _dequant_fp8_wo_a_streaming,
     hc_head_torch,
     make_hc_head_params,
@@ -253,7 +254,6 @@ class DSparkAttention(MqaAttentionBase):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-
         if _is_npu and forward_batch.forward_mode.is_idle():
             return torch.zeros_like(hidden_states)
 
@@ -353,7 +353,12 @@ class DSparkAttention(MqaAttentionBase):
         )
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         if self._use_fast_kernel:
-            o = torch.einsum("bgd,grd->bgr", o, wo_a)
+            o = _apply_wo_a_bf16_matmul(
+                o,
+                wo_a,
+                is_decode=forward_batch.forward_mode.is_decode(),
+                is_target_verify=forward_batch.forward_mode.is_target_verify(),
+            )
         else:
             o = torch.einsum("bgd,grd->bgr", o.float(), wo_a.float()).to(q.dtype)
         out, _ = self.wo_b(o.reshape(o.shape[0], o.shape[1] * o.shape[2]))
@@ -572,6 +577,8 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         alt_streams: Optional[List[torch.cuda.Stream]] = None,
+        hc_stats_stream: Optional[torch.cuda.Stream] = None,
+        moe_routed_quant_stream: Optional[torch.cuda.Stream] = None,
     ) -> None:
         super().__init__(
             config=_dspark_stage_config(config),
@@ -580,6 +587,8 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             prefix=prefix,
             is_nextn=True,
             alt_streams=alt_streams,
+            hc_stats_stream=hc_stats_stream,
+            moe_routed_quant_stream=moe_routed_quant_stream,
         )
         self.stage_id = stage_id
         self.dim = config.hidden_size
@@ -685,6 +694,7 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         forward_batch: ForwardBatch,
         prev_pre: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        stats_stream = self._get_hc_stats_stream(hidden_states, forward_batch)
         residual = hidden_states
         x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
             hidden_states,
@@ -692,10 +702,13 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_attn_scale,
             self.hc_attn_base,
             apply_pre=prev_pre,
+            stats_stream=stats_stream,
         )
         x = self.input_layernorm(x)
         with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
             x = self.self_attn(positions, x, forward_batch)
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
         hidden_states = self.hc_post(x, residual, attn_post, attn_comb)
 
         residual = hidden_states
@@ -705,9 +718,12 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_ffn_scale,
             self.hc_ffn_base,
             apply_pre=attn_pre,
+            stats_stream=stats_stream,
         )
         x = self.post_attention_layernorm(x)
         x = self._run_ffn(x, forward_batch)
+        if stats_stream is not None:
+            torch.cuda.current_stream().wait_stream(stats_stream)
         hidden_states = self.hc_post(x, residual, ffn_post, ffn_comb)
         return hidden_states, ffn_pre
 
@@ -797,6 +813,19 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.alt_streams: Optional[List[torch.cuda.Stream]] = (
             [torch.cuda.Stream()] if use_multi_stream else None
         )
+        self.moe_routed_quant_stream = (
+            torch.cuda.Stream()
+            if use_multi_stream and torch.version.cuda is not None
+            else None
+        )
+        self.hc_stats_stream = (
+            torch.cuda.Stream()
+            if use_multi_stream
+            and torch.version.cuda is not None
+            and get_platform().is_blackwell
+            and getattr(config, "hc_pre_from_prev_sublayer", False)
+            else None
+        )
         self.stages = nn.ModuleList(
             [
                 DSparkV4Stage(
@@ -808,6 +837,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
                     quant_config=quant_config,
                     prefix=add_prefix(f"stages.{stage_id}", prefix),
                     alt_streams=self.alt_streams,
+                    hc_stats_stream=self.hc_stats_stream,
+                    moe_routed_quant_stream=self.moe_routed_quant_stream,
                 )
                 for stage_id in range(self.num_stages)
             ]

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Iterable, List, Optional, Tuple
 
@@ -189,6 +190,22 @@ class DSparkAttention(MqaAttentionBase):
         q = self.q_norm(q)
         q, _ = self.wq_b(q)
         q = q.view(-1, self.n_local_heads, self.head_dim)
+        if not self.q_head_norm:
+            if self._use_fast_kernel and not _is_npu:
+                fused_rope_inplace(
+                    q[..., -self.rope_head_dim :],
+                    None,
+                    self.freqs_cis,
+                    positions=positions,
+                )
+            else:
+                apply_rotary_emb(
+                    q[..., -self.rope_head_dim :], self.freqs_cis[positions]
+                )
+            if q_out is None:
+                return q
+            q_out.copy_(q)
+            return q_out
         if self._use_fast_kernel:
             if q_out is None:
                 q_out = torch.empty_like(q)
@@ -527,6 +544,23 @@ def build_dspark_v4_confidence_head(
     )
 
 
+def _dspark_stage_config(config: DeepSeekV4Config) -> DeepSeekV4Config:
+    """Apply draft expert counts and disable image routing for text-only stages."""
+    n_routed = int(getattr(config, "dspark_n_routed_experts", 0) or 0)
+    n_active = int(getattr(config, "dspark_num_experts_per_tok", 0) or 0)
+    has_vision = int(getattr(config, "vision_n_layers", 0) or 0) > 0
+    if not (n_routed or n_active or has_vision):
+        return config
+    stage_config = copy.copy(config)
+    if n_routed:
+        stage_config.n_routed_experts = n_routed
+    if n_active:
+        stage_config.num_experts_per_tok = n_active
+    if has_vision:
+        stage_config.vision_n_layers = 0
+    return stage_config
+
+
 class DSparkV4Stage(DeepseekV4DecoderLayer):
     def __init__(
         self,
@@ -540,7 +574,7 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         alt_streams: Optional[List[torch.cuda.Stream]] = None,
     ) -> None:
         super().__init__(
-            config=config,
+            config=_dspark_stage_config(config),
             layer_id=layer_id,
             quant_config=quant_config,
             prefix=prefix,
@@ -566,11 +600,16 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
 
         if stage_id == num_stages - 1:
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-            (
-                self.hc_head_fn,
-                self.hc_head_base,
-                self.hc_head_scale,
-            ) = make_hc_head_params(config.hc_mult, config.hidden_size)
+            if self.hc_pre_from_prev_sublayer:
+                # V4.1 collapses the head with the last FFN's pre-mix; the
+                # checkpoint carries no hc_head_* tensors for the stages.
+                self.hc_head_fn = self.hc_head_base = self.hc_head_scale = None
+            else:
+                (
+                    self.hc_head_fn,
+                    self.hc_head_base,
+                    self.hc_head_scale,
+                ) = make_hc_head_params(config.hc_mult, config.hidden_size)
 
     def _build_self_attn(
         self,
@@ -615,7 +654,12 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
-    ) -> torch.Tensor:
+        prev_pre: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if self.hc_pre_from_prev_sublayer:
+            return self._forward_hc_pre_from_prev(
+                positions, hidden_states, forward_batch, prev_pre
+            )
         residual = hidden_states
         x, post, comb = self._hc_pre_block(
             hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
@@ -632,7 +676,40 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
         x = self.post_attention_layernorm(x)
         x = self._run_ffn(x, forward_batch)
         x = self._hc_post_block(x, residual, post, comb)
-        return x
+        return x, None
+
+    def _forward_hc_pre_from_prev(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        prev_pre: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden_states
+        x, attn_pre, attn_post, attn_comb = self._hc_mix_and_combine(
+            hidden_states,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+            apply_pre=prev_pre,
+        )
+        x = self.input_layernorm(x)
+        with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
+            x = self.self_attn(positions, x, forward_batch)
+        hidden_states = self.hc_post(x, residual, attn_post, attn_comb)
+
+        residual = hidden_states
+        x, ffn_pre, ffn_post, ffn_comb = self._hc_mix_and_combine(
+            hidden_states,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            apply_pre=attn_pre,
+        )
+        x = self.post_attention_layernorm(x)
+        x = self._run_ffn(x, forward_batch)
+        hidden_states = self.hc_post(x, residual, ffn_post, ffn_comb)
+        return hidden_states, ffn_pre
 
     def _run_ffn(self, x: torch.Tensor, forward_batch: ForwardBatch) -> torch.Tensor:
         shape = x.shape
@@ -745,6 +822,9 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.hc_mult = int(config.hc_mult)
         self.norm_eps = float(config.rms_norm_eps)
         self.hc_eps = float(config.hc_eps)
+        self.hc_pre_from_prev_sublayer = bool(
+            getattr(config, "hc_pre_from_prev_sublayer", False)
+        )
 
         if self.uses_own_vocab_modules:
             self.embed_tokens = VocabParallelEmbedding(
@@ -842,12 +922,20 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         if input_embeds is None:
             input_embeds = self.forward_embed(input_ids)
         x = input_embeds
+        pre = None
         for stage in self.stages:
-            x = stage(positions, x, forward_batch)
+            x, pre = stage(positions, x, forward_batch, pre)
+        if self.hc_pre_from_prev_sublayer:
+            from sglang.kernels.ops.layernorm.mhc import hc_combine
+
+            x = hc_combine(x.flatten(1).float(), pre, self.hc_mult, x.dtype)
 
         return LogitsProcessorOutput(next_token_logits=None, hidden_states=x)
 
     def collapse_hc_head(self, x: torch.Tensor) -> torch.Tensor:
+        if self.hc_pre_from_prev_sublayer:
+            assert x.dim() == 2, "V4.1 draft hidden states leave forward() collapsed"
+            return x
         last = self.stages[-1]
         return hc_head_torch(
             x,
@@ -1014,6 +1102,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         stage_id, rest = parts[1], parts[2]
 
         if rest.startswith("markov_head."):
+            rest = rest.replace("markov_head.embed.", "markov_head.markov_w1.", 1)
+            rest = rest.replace("markov_head.head.", "markov_head.markov_w2.", 1)
             return f"markov_head.{rest[len('markov_head.') :]}"
 
         if rest.startswith("confidence_head."):
@@ -1030,6 +1120,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         mapped_rest = mapped_rest.replace(".w2.", ".down_proj.")
         mapped_rest = mapped_rest.replace(".w3.", ".up_proj.")
         mapped_rest = mapped_rest.replace(".gate.tid2eid", ".topk.tid2eid")
+        if mapped_rest.endswith(".gate.bias_vl"):
+            return None
         mapped_rest = mapped_rest.replace(".gate.bias", ".gate.e_score_correction_bias")
         mapped_rest = mapped_rest.replace(".scale", ".weight_scale_inv")
         return f"stages.{stage_id}.{mapped_rest}"

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -41,7 +41,11 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_attn_backend
-from sglang.srt.models.deepseek_v4 import DeepseekV4DecoderLayer, DeepseekV4ForCausalLM
+from sglang.srt.models.deepseek_v4 import (
+    DeepseekV4DecoderLayer,
+    DeepseekV4ForCausalLM,
+    wo_a_fp8_gemm_enabled,
+)
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix
 
@@ -232,6 +236,7 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
         self.tp_size = get_parallel().tp_size
         self.pp_group = get_pp_group()
         self.quant_config = quant_config
+        self.wo_a_fp8 = wo_a_fp8_gemm_enabled(quant_config)
         self.determine_num_fused_shared_experts()
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         if self.dsa_enable_prefill_cp:

--- a/python/sglang/srt/multimodal/deepseek_v41_image_processing.py
+++ b/python/sglang/srt/multimodal/deepseek_v41_image_processing.py
@@ -1,0 +1,239 @@
+"""Image preprocessing.
+
+An image becomes a `n_vit_h x n_vit_w` patch grid for the ViT and a `n_llm_h x n_llm_w` token grid
+after the 3x3 aligner downsample, which the LLM sees as
+
+    [IMAGE_START] + ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h + [IMAGE_END]
+
+Every one of those positions carries `image_token_id` in `input_ids`; only the token type tells them
+apart. The IMAGE slots are filled with aligner rows in reading order.
+"""
+
+import base64
+import io
+import math
+from urllib.request import urlopen
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image, ImageOps
+
+IMAGE_START, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(4)
+
+
+def num_image_tokens(n_llm_h: int, n_llm_w: int) -> int:
+    return n_llm_h * (n_llm_w + 1) + 2
+
+
+def llm_grid(best_height: int, best_width: int, patch_size: int, downsample_ratio: int):
+    """Token grid the aligner produces from a patch grid of this pixel size."""
+    return math.ceil((best_height // patch_size) / downsample_ratio), math.ceil(
+        (best_width // patch_size) / downsample_ratio
+    )
+
+
+def solve_resize_ratio(height, width, patch_size, downsample_ratio, max_n_token):
+    """Largest aspect-preserving pixel size whose token grid still fits in max_n_token."""
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    cell = patch_size * downsample_ratio
+    if max_w_float < 1.0:  # very tall: collapse to a single column
+        return (max_n_token - 2) // 2 * cell, cell
+    if max_h_float < 1.0:  # very wide: collapse to a single row
+        return cell, (max_n_token - 3) * cell
+    beta = min(
+        math.floor(max_w_float) * cell / width, math.floor(max_h_float) * cell / height
+    )
+    return math.floor(height * beta / patch_size) * patch_size, math.floor(
+        width * beta / patch_size
+    ) * patch_size
+
+
+def safe_resize(
+    height, width, best_height, best_width, patch_size, downsample_ratio, max_n_token
+):
+    """Shrink the pixel size until the image costs at most max_n_token LLM tokens."""
+    n_llm_h, n_llm_w = llm_grid(best_height, best_width, patch_size, downsample_ratio)
+    if num_image_tokens(n_llm_h, n_llm_w) > max_n_token:
+        best_height, best_width = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, max_n_token
+        )
+        n_llm_h, n_llm_w = llm_grid(
+            best_height, best_width, patch_size, downsample_ratio
+        )
+        assert num_image_tokens(n_llm_h, n_llm_w) <= max_n_token
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+def load_image_bytes(record) -> bytes:
+    """Load image bytes from raw/base64 data, an Anthropic source, URL, or path."""
+    data = record.get("data")
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return base64.b64decode(data)
+
+    source = record.get("source")
+    if isinstance(source, dict):
+        if source.get("data") is not None:
+            return base64.b64decode(source["data"])
+        if source.get("url"):
+            return load_image_bytes({"url": source["url"]})
+
+    url = record.get("url")
+    if isinstance(url, str) and url:
+        if url.startswith("data:"):
+            header, _, payload = url.partition(",")
+            if ";base64" not in header:
+                raise ValueError(f"Unsupported data URL encoding: {header}")
+            return base64.b64decode(payload)
+        if url.startswith(("http://", "https://")):
+            with urlopen(url, timeout=30) as response:
+                return response.read()
+        with open(url, "rb") as file:
+            return file.read()
+
+    raise ValueError(f"Cannot load image from record: {list(record.keys())}")
+
+
+def plan_image_grid(width: int, height: int, args):
+    """Resize plan for an image of the given original size; a pure function of its arguments."""
+    p = args.vision_patch_size
+    if (
+        args.vision_max_wh_ratio is not None
+        and width > height * args.vision_max_wh_ratio
+    ):
+        width = height * args.vision_max_wh_ratio
+    if 0 < width * height < args.vision_min_pixels:
+        ratio = (args.vision_min_pixels / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / p) * p
+    best_height = math.ceil(height / p) * p
+    return safe_resize(
+        height,
+        width,
+        best_height,
+        best_width,
+        p,
+        args.vision_downsample_ratio,
+        args.vision_max_n_token,
+    )
+
+
+def decode_image(record):
+    """Decode using the same RGB conversion for every preprocessing backend."""
+    if isinstance(record, Image.Image):
+        image = record.convert("RGB")
+    else:
+        with Image.open(io.BytesIO(load_image_bytes(record))) as source:
+            image = source.convert("RGB")
+    return image
+
+
+def load_image(record, args):
+    """Load and transform one image record into ViT patches."""
+    p = args.vision_patch_size
+    image = decode_image(record)
+    n_llm_h, n_llm_w, best_height, best_width = plan_image_grid(
+        image.width, image.height, args
+    )
+    n_vit_h, n_vit_w = best_height // p, best_width // p
+    if (
+        args.vision_max_wh_ratio is not None
+        and image.width >= args.vision_max_wh_ratio * image.height
+    ):
+        image = image.resize((best_width, best_height))
+    else:
+        image = ImageOps.pad(image, (best_width, best_height), color=(127, 127, 127))
+    x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+    patches = (
+        x.reshape(3, n_vit_h, p, n_vit_w, p)
+        .permute(1, 3, 0, 2, 4)
+        .reshape(n_vit_h * n_vit_w, 3, p, p)
+    )
+    return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+def image_token_types(n_llm_h: int, n_llm_w: int) -> torch.Tensor:
+    """Default layout: the aligner grid in reading order, one IMAGE_NEW_LINE per row."""
+    types = [IMAGE_START]
+    types += ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h
+    types.append(IMAGE_END)
+    return torch.tensor(types, dtype=torch.int64)
+
+
+def prepare_image(record, args):
+    image = decode_image(record)
+    lh, lw, height, width = plan_image_grid(image.width, image.height, args)
+    stretch = (
+        args.vision_max_wh_ratio is not None
+        and image.width >= args.vision_max_wh_ratio * image.height
+    )
+    resize_h, resize_w = height, width
+    if not stretch:
+        if image.width / image.height > width / height:
+            resize_h = round(image.height / image.width * width)
+        elif image.width / image.height < width / height:
+            resize_w = round(image.width / image.height * height)
+    plan = {
+        "height": height,
+        "width": width,
+        "resize_h": resize_h,
+        "resize_w": resize_w,
+        "top": round((height - resize_h) / 2),
+        "left": round((width - resize_w) / 2),
+        "patch_size": args.vision_patch_size,
+    }
+    return np.array(image, dtype=np.uint8), plan, lh, lw
+
+
+def load_image_rust(record, args, *, resize_patchify):
+    pixels, plan, lh, lw = prepare_image(record, args)
+    bits = resize_patchify(
+        pixels,
+        (plan["height"], plan["width"]),
+        (plan["resize_h"], plan["resize_w"]),
+        (plan["top"], plan["left"]),
+        plan["patch_size"],
+    )
+    p = plan["patch_size"]
+    h, w = plan["height"] // p, plan["width"] // p
+    patches = torch.from_numpy(bits).view(torch.bfloat16).view(h * w, 3, p, p)
+    return patches, h, w, lh, lw
+
+
+def prepare_image_gpu(record, args):
+    pixels, plan, lh, lw = prepare_image(record, args)
+    return torch.from_numpy(pixels).permute(2, 0, 1).contiguous(), plan, lh, lw
+
+
+def materialize_image_gpu(pixels: torch.Tensor, plan: dict) -> torch.Tensor:
+    """Resize, pad, normalize and patchify on the input tensor's device."""
+    x = pixels.unsqueeze(0).float()
+    target = (plan["resize_h"], plan["resize_w"])
+    # PIL uses separable passes, with uint8 rounding/clamping after each pass.
+    # Keep those boundaries; a single 2D float resize preserves overshoots
+    # between passes and can diverge substantially on high-contrast images.
+    for size in ((x.shape[-2], target[1]), target):
+        if x.shape[-2:] != size:
+            x = (
+                F.interpolate(
+                    x, size=size, mode="bicubic", align_corners=False, antialias=True
+                )
+                .round()
+                .clamp_(0, 255)
+            )
+    top, left = plan["top"], plan["left"]
+    x = F.pad(
+        x,
+        (left, plan["width"] - target[1] - left, top, plan["height"] - target[0] - top),
+        value=127,
+    )
+    x = ((x / 255 - 0.5) / 0.5).to(torch.bfloat16)
+    p = plan["patch_size"]
+    h, w = plan["height"] // p, plan["width"] // p
+    return x.reshape(3, h, p, w, p).permute(1, 3, 0, 2, 4).reshape(h * w, 3, p, p)

--- a/python/sglang/srt/multimodal/dsv41/__init__.py
+++ b/python/sglang/srt/multimodal/dsv41/__init__.py
@@ -1,0 +1,1 @@
+"""Vision tower, image preprocessing and VL expert routing for DeepSeek-V4.1."""

--- a/python/sglang/srt/multimodal/dsv41/vl_routing.py
+++ b/python/sglang/srt/multimodal/dsv41/vl_routing.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.topk import (
+    StandardTopKOutput,
+    _mask_topk_ids_padded_region,
+    _zero_topk_weights_padded_region,
+)
+from sglang.srt.utils import is_cuda
+
+
+def vision_topk(moe, logits, input_ids, num_token_non_padded=None):
+    config = moe.topk.topk_config
+    if is_cuda():
+        from sglang.kernels.ops.moe.moe_fused_gate import moe_fused_gate
+
+        weights, indices = moe_fused_gate(
+            logits,
+            moe.gate.e_score_correction_bias,
+            topk=config.top_k,
+            scoring_func="sqrtsoftplus",
+            bias_alt=moe.gate.e_score_correction_bias_vl,
+            input_ids=input_ids,
+            bias_alt_token_id=moe.config.image_token_id,
+            renormalize=config.renormalize and config.top_k > 1,
+            renormalize_epsilon=1e-20,
+            routed_scaling_factor=config.routed_scaling_factor,
+            apply_routed_scaling_factor_on_output=config.apply_routed_scaling_factor_on_output,
+            num_token_non_padded=num_token_non_padded,
+        )
+        return StandardTopKOutput(weights, indices, logits)
+    scores = F.softplus(logits.float()).sqrt()
+    if input_ids is None:
+        bias = moe.gate.e_score_correction_bias
+    else:
+        bias = torch.where(
+            (input_ids == moe.config.image_token_id)[:, None],
+            moe.gate.e_score_correction_bias_vl,
+            moe.gate.e_score_correction_bias,
+        )
+    indices = (scores + bias).topk(config.top_k, dim=-1).indices
+    weights = scores.gather(-1, indices)
+    if config.renormalize and config.top_k > 1:
+        weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
+    if config.apply_routed_scaling_factor_on_output:
+        weights = weights * config.routed_scaling_factor
+    weights, indices = weights.float(), indices.int()
+    if num_token_non_padded is not None:
+        _mask_topk_ids_padded_region(indices, num_token_non_padded)
+        _zero_topk_weights_padded_region(weights, num_token_non_padded)
+    return StandardTopKOutput(weights, indices, logits)

--- a/python/sglang/srt/multimodal/processors/deepseek_v41.py
+++ b/python/sglang/srt/multimodal/processors/deepseek_v41.py
@@ -1,0 +1,127 @@
+"""260903 image preprocessing, preserving raw token IDs for Engram."""
+
+import asyncio
+import logging
+from functools import partial
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalProcessorOutput,
+)
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+from sglang.srt.multimodal.deepseek_v41_image_processing import (
+    image_token_types,
+    load_image,
+    load_image_rust,
+    prepare_image_gpu,
+)
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+from sglang.srt.runtime_context import get_mm
+from sglang.srt.rust_extensions import load_rust_extension
+
+logger = logging.getLogger(__name__)
+
+
+class DeepseekV41ImageProcessor(BaseMultimodalProcessor):
+    models = [DeepseekV4ForCausalLM]
+    preserve_processor_input_ids = True
+    prefer_tokenized_input = True
+    gpu_image_decode = False
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        self.image_backend = "cpu"
+        self.cpu_image_loader = load_image
+        backend = get_mm().image_processor_backend
+        if backend == "pil" or get_mm().disable_fast_image_processor:
+            self.image_backend = "cpu"
+        elif envs.SGLANG_ENCODER_IMAGE_PROCESSOR_USE_GPU.get():
+            self.image_backend = "gpu"
+        elif backend == "auto":
+            # Resolve the optional extension once, before the base class builds
+            # the preprocessing cache fingerprint. Image-processing errors are
+            # not caught here or retried with a different backend.
+            try:
+                extension = load_rust_extension(
+                    "sglang.srt.rust_extensions._multimodal"
+                )
+                resize_patchify = extension.dsv41.resize_patchify
+            except (ImportError, OSError, RuntimeError, AttributeError) as error:
+                logger.warning(
+                    "V4.1 Rust image processor unavailable; using PIL: %s", error
+                )
+            else:
+                self.image_backend = "rust"
+                self.cpu_image_loader = partial(
+                    load_image_rust, resize_patchify=resize_patchify
+                )
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        self.image_token_id = hf_config.image_token_id
+        self.mm_tokens = MultimodalSpecialTokens(
+            image_token=_processor.convert_ids_to_tokens(self.image_token_id),
+            image_token_id=self.image_token_id,
+        ).build(_processor)
+
+    def preprocess_fingerprint_payload(self):
+        payload = super().preprocess_fingerprint_payload()
+        payload["dsv41_image_backend"] = self.image_backend
+        return payload
+
+    async def process_mm_data_async(
+        self, image_data, input_text, request_obj, *args, **kwargs
+    ):
+        base = await self.load_mm_data(
+            input_text, image_data=image_data, multimodal_tokens=self.mm_tokens
+        )
+        ids = (
+            input_text
+            if isinstance(input_text, list)
+            else self._processor.encode(input_text)
+        )
+        if ids.count(self.image_token_id) != len(base.images):
+            raise ValueError("Image placeholders and images must match")
+        images = iter(base.images)
+        tokens, items = [], []
+        for token in ids:
+            if token != self.image_token_id:
+                tokens.append(token)
+                continue
+            image = next(images)
+            plan = None
+            if self.image_backend == "gpu":
+                patches, plan, lh, lw = await asyncio.to_thread(
+                    prepare_image_gpu, image, self.hf_config
+                )
+                h = plan["height"] // plan["patch_size"]
+                w = plan["width"] // plan["patch_size"]
+            else:
+                patches, h, w, lh, lw = await asyncio.to_thread(
+                    self.cpu_image_loader, image, self.hf_config
+                )
+            if self.keep_mm_features_on_device:
+                patches = patches.to(torch.device("cuda", self.server_args.base_gpu_id))
+            metadata = {"n_vit_h": h, "n_vit_w": w}
+            if plan is not None:
+                metadata["dsv41_gpu_plan"] = plan
+            count = len(image_token_types(lh, lw))
+            start = len(tokens)
+            tokens.extend([self.image_token_id] * count)
+            items.append(
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    feature=patches,
+                    offsets=[(start, start + count - 1)],
+                    model_specific_data=metadata,
+                )
+            )
+        return MultimodalProcessorOutput(
+            input_ids=tokens,
+            mm_items=self._prepare_mm_items_for_transport(items),
+            im_token_id=self.image_token_id,
+        )

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -2025,6 +2025,7 @@ class ReasoningParser:
         "deepseek-r1": DeepSeekR1Detector,
         "deepseek-v3": _DeepSeekV3Detector,
         "deepseek-v4": DeepSeekV4Detector,
+        "deepseek-v41": DeepSeekV4Detector,
         "dots": Qwen3Detector,
         "glm45": Glm45Detector,
         "ling3": Ling3Detector,

--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -355,6 +355,10 @@ def _is_deepseek_v4(ctx):
     return ctx.has_text("<｜DSML｜tool_calls>")
 
 
+def _is_deepseek_v41(ctx):
+    return ctx.has_text("<｜DSML｜ calls>")
+
+
 def _is_hunyuan(ctx):
     # The shipping Hy3 tokenizer appends a shared suffix to each special token
     # (e.g. ``<tool_calls:opensource>``), so match the bare or suffixed form.
@@ -478,6 +482,9 @@ REASONING_PARSER_RULES = (
     DetectionRule(name="step3p5", value="step3p5", predicate=_is_step3p5),
     DetectionRule(name="step3", value="step3", predicate=_is_step3),
     DetectionRule(name="qwen3", value="qwen3", predicate=_is_qwen3),
+    DetectionRule(
+        name="deepseek_v41", value="deepseek-v41", predicate=_is_deepseek_v41
+    ),
     DetectionRule(name="deepseek_v4", value="deepseek-v4", predicate=_is_deepseek_v4),
     DetectionRule(name="deepseek_v3", value="deepseek-v3", predicate=_is_deepseek_v3),
     DetectionRule(
@@ -504,6 +511,7 @@ TOOL_CALL_PARSER_RULES = (
     DetectionRule(name="minimax", value="minimax-m2", predicate=_is_minimax),
     DetectionRule(name="interns1", value="interns1", predicate=_is_interns1),
     DetectionRule(name="mistral", value="mistral", predicate=_is_mistral),
+    DetectionRule(name="deepseek_v41", value="deepseekv41", predicate=_is_deepseek_v41),
     DetectionRule(name="deepseek_v4", value="deepseekv4", predicate=_is_deepseek_v4),
     DetectionRule(name="deepseek_v32", value="deepseekv32", predicate=_is_deepseek_v32),
     DetectionRule(name="deepseek_v31", value="deepseekv31", predicate=_is_deepseek_v31),
@@ -695,6 +703,7 @@ def _log_undetected_parser(attr: str, label: str) -> None:
 
 def _architecture_auto_parsers(server_args, needs: Tuple[str, ...]) -> Dict[str, str]:
     """The parsers the model architecture implies, for the fields still on auto."""
+    from sglang.srt.entrypoints.openai.chat_encoding import is_deepseek_v41_config
     from sglang.srt.utils.hf_transformers_utils import get_config
 
     cfg = resolving_view(server_args)
@@ -710,6 +719,8 @@ def _architecture_auto_parsers(server_args, needs: Tuple[str, ...]) -> Dict[str,
 
     if "KimiK3" in arch or model_type == "kimi_k3":
         reasoning_parser, tool_call_parser = "kimi_k3", "kimi_k3"
+    elif is_deepseek_v41_config(arch=arch, model_type=model_type):
+        reasoning_parser, tool_call_parser = "deepseek-v41", "deepseekv41"
     elif "DeepseekV4" in arch:
         reasoning_parser, tool_call_parser = "deepseek-v4", "deepseekv4"
     elif "DeepseekV3" in arch:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -827,6 +827,19 @@ class ServerArgs:
         ),
         NS("schedule"),
     ] = 0.8
+    swa_prefix_tails: A[
+        Optional[int],
+        Arg(
+            help=(
+                "When the SWA KV pool is sized from the request cap (DeepSeek-V4 "
+                "family), how many radix-cached prefix tails it keeps room for. "
+                "Each tail is one sliding window plus one page. Default: 4 x "
+                "max_running_requests per attention-DP rank, 0 when the radix "
+                "cache is disabled."
+            ),
+        ),
+        NS("schedule"),
+    ] = None
     disable_hybrid_swa_memory: A[
         bool,
         Arg(help="Disable the hybrid SWA memory pool.", resolvable=True),
@@ -1877,6 +1890,12 @@ class ServerArgs:
     cuda_graph_max_bs_prefill: A[
         Optional[int],
         "Maximum batch size captured for the prefill cuda graph.",
+        NS("exec.graph"),
+    ] = None
+    cuda_graph_max_seq_len_prefill: A[
+        Optional[int],
+        "Longest sequence a prefill cuda graph replay admits; longer batches "
+        "run eager prefill. Folds into cuda_graph_config[prefill].max_seq_len.",
         NS("exec.graph"),
     ] = None
     cuda_graph_bs_decode: A[
@@ -3615,6 +3634,17 @@ class ServerArgs:
     enable_return_indexer_topk: A[
         bool,
         "Enable returning indexer topk indices of layers with indexer with responses.",
+        NS("exec.features"),
+    ] = False
+    enable_encoder_swa_bounded_replay: A[
+        bool,
+        "DeepSeek-V4.1 encoder SWA bounded replay: cache Main KV and Indexer keys only, "
+        "rebuild request-owned SWA windows on prefix hits. Experimental; CUDA only.",
+        NS("exec.features"),
+    ] = False
+    enable_decoder_swa_bounded_replay: A[
+        bool,
+        "DeepSeek-V4.1 decoder SWA bounded replay: after the last kv_source layer, run the remaining layers over only the last window_size tokens of a prefill. Main and indexer KV stay exact; nothing is replayed. Deterministic for a fixed prompt and chunk size.",
         NS("exec.features"),
     ] = False
     disable_outlines_disk_cache: A[

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -479,6 +479,7 @@ class CommitInjectCtx(msgspec.Struct):
     block_pos_offsets: torch.Tensor
     resolve_pool: object
     resolve_req_to_token: object
+    kv_injector: Optional[TargetHiddenKvInjector] = None
 
 
 class AcceptOuts(msgspec.Struct):
@@ -530,15 +531,22 @@ class DsparkVerifyEpilogue:
         )
         self.strided_logits: Optional[torch.Tensor] = None
         self.strided_hidden: Optional[torch.Tensor] = None
+        self._static_step_state: Optional[tuple[int, bool]] = None
 
     def capture_hook(self, runner, out, forward_batch, num_tokens) -> None:
-        if runner.model_runner.is_draft_worker or not runner.ragged_verify_mode:
+        if (
+            runner.model_runner.is_draft_worker
+            or not forward_batch.forward_mode.is_target_verify()
+        ):
             return
         if (
             not isinstance(out, LogitsProcessorOutput)
             or out.next_token_logits is None
             or out.hidden_states is None
         ):
+            return
+        if not runner.ragged_verify_mode:
+            self._static_epilogue(out, forward_batch)
             return
         self(
             compact_logits=out.next_token_logits,
@@ -550,6 +558,7 @@ class DsparkVerifyEpilogue:
         )
 
     def begin_step(self, verify_lens, armed: bool) -> None:
+        self._static_step_state = None
         if verify_lens is None:
             self.verify_lens_buf.zero_()
         else:
@@ -558,6 +567,50 @@ class DsparkVerifyEpilogue:
             if bs < self.max_bs:
                 self.verify_lens_buf[bs:].zero_()
         self.inject_gate_buf.fill_(1 if armed else 0)
+
+    def begin_static_step(self, bs: int, armed: bool) -> None:
+        state = (bs, armed)
+        if self._static_step_state == state:
+            return
+        self.verify_lens_buf[:bs].fill_(self.stride)
+        self.verify_lens_buf[bs:].zero_()
+        self.inject_gate_buf.fill_(int(armed))
+        self._static_step_state = state
+
+    def _static_epilogue(self, out, forward_batch) -> None:
+        bs = forward_batch.batch_size
+        verify_lens = self.verify_lens_buf[:bs]
+        candidates = forward_batch.input_ids.view(bs, self.stride)
+        commit_lens = self._accept(
+            candidates=candidates,
+            logits=out.next_token_logits,
+            draft_tokens=candidates[:, 1:].contiguous(),
+            seq_lens=forward_batch.seq_lens,
+        )
+        if not self.folds_commit:
+            return
+        # Consume the same staged locations as target verify, not a second
+        # lookup through req_to_token. Padded and fallback rows never write KV.
+        gated_commit_lens = (
+            torch.minimum(commit_lens, verify_lens.to(torch.int32))
+            * self.inject_gate_buf
+        )
+        cache_loc = forward_batch.out_cache_loc
+        state_slot = None
+        if is_unified_kv_triton():
+            state_slot = (
+                forward_batch.req_pool_indices.view(-1, 1)
+                .expand(bs, self.stride)
+                .reshape(-1)
+            )
+        self.commit_ctx.kv_injector.inject_target_hidden(
+            target_hidden=out.hidden_states,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc.view(bs, self.stride),
+            positions=forward_batch.positions,
+            commit_lens=gated_commit_lens,
+            state_slot=state_slot,
+        )
 
     def read_accept(self, bs: int) -> AcceptOuts:
         return AcceptOuts(
@@ -610,7 +663,23 @@ class DsparkVerifyEpilogue:
         self.strided_hidden = self._ensure_out(self.strided_hidden, compact_hidden)
         verify_lens = self.verify_lens_buf[:bs]
         self._scatter(compact_logits, compact_hidden, verify_lens, bs)
-        commit_lens = self._accept(input_ids, seq_lens, verify_lens, bs)
+        candidates = torch.zeros(
+            (bs * self.stride, 1), dtype=input_ids.dtype, device=input_ids.device
+        )
+        scatter_compact_to_strided_into(
+            compact=input_ids.view(-1, 1),
+            verify_lens=verify_lens,
+            out=candidates,
+            stride=self.stride,
+            fill_value=0,
+        )
+        commit_lens = self._accept(
+            candidates=candidates.view(bs, self.stride),
+            logits=self.strided_logits[: bs * self.stride],
+            draft_tokens=self.draft_tokens_buf[: bs * self.gamma].view(bs, self.gamma),
+            seq_lens=seq_lens,
+            cutoff_verify_lens=verify_lens,
+        )
         if self.folds_commit:
             self._commit_inject(
                 commit_lens, verify_lens, seq_lens, req_pool_indices, bs
@@ -632,22 +701,15 @@ class DsparkVerifyEpilogue:
             fill_value=0.0,
         )
 
-    def _accept(self, input_ids, seq_lens, verify_lens, bs: int) -> torch.Tensor:
-        candidates = torch.zeros(
-            (bs * self.stride, 1), dtype=input_ids.dtype, device=input_ids.device
-        )
-        scatter_compact_to_strided_into(
-            compact=input_ids.view(-1, 1),
-            verify_lens=verify_lens,
-            out=candidates,
-            stride=self.stride,
-            fill_value=0,
-        )
+    def _accept(
+        self, *, candidates, logits, draft_tokens, seq_lens, cutoff_verify_lens=None
+    ) -> torch.Tensor:
+        bs = candidates.shape[0]
         correct_len, bonus, cap_trim_lens = accept_greedy_triton(
-            candidates=candidates.view(bs, self.stride),
-            target_logits=self.strided_logits[: bs * self.stride],
+            candidates=candidates,
+            target_logits=logits,
             verify_num_draft_tokens=self.stride,
-            cutoff_verify_lens=verify_lens,
+            cutoff_verify_lens=cutoff_verify_lens,
         )
         self._tp_sync.sync(SpecTpSyncSite.DSPARK_ACCEPT_GRAPH, correct_len)
         self._tp_sync.sync(SpecTpSyncSite.DSPARK_ACCEPT_GRAPH, bonus)
@@ -658,7 +720,7 @@ class DsparkVerifyEpilogue:
             prefix_lens=seq_lens[:bs],
         )
         out_tokens = BuildOutTokens.execute(
-            draft_tokens=self.draft_tokens_buf[: bs * self.gamma].view(bs, self.gamma),
+            draft_tokens=draft_tokens,
             correct_len=correct_len,
             bonus=bonus,
             verify_num_draft_tokens=self.stride,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -304,8 +304,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             dp_moe_sync=self._draft_is_moe and get_parallel().enable_dp_attention,
         )
         self._verify_epilogue = None
+        static_epilogue_supported = (
+            self._verify_planner.mode_value == "static"
+            and self._draft_is_moe
+            and not get_parallel().enable_dp_attention
+            and self.ps.pp_size == 1
+        )
         if (
-            self._verify_planner.is_compact_mode
+            (self._verify_planner.is_compact_mode or static_epilogue_supported)
             and self._decode_graph_allowed
             and is_cuda()
         ):
@@ -321,6 +327,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                     resolve_req_to_token=lambda: (
                         self.model_runner.req_to_token_pool.req_to_token
                     ),
+                    kv_injector=self._kv_injector,
                 ),
             )
             self.model_runner.capture_tail_hooks.append(
@@ -590,9 +597,17 @@ class DSparkWorkerV2(BaseSpecWorker):
             final_pos = torch.repeat_interleave(
                 (draft_seq_lens + ctx_lens - 1).to(torch.int64), repeats
             )
+        cache_loc = batch.out_cache_loc
+        token_indices = logits_output.hidden_states_token_indices
+        if token_indices is not None:
+            cache_loc = cache_loc[token_indices]
+            positions = positions[token_indices]
+            if state_slot is not None:
+                state_slot = state_slot[token_indices]
+                final_pos = final_pos[token_indices]
         self._kv_injector.inject_target_hidden(
             target_hidden=logits_output.hidden_states,
-            cache_loc=batch.out_cache_loc,
+            cache_loc=cache_loc,
             positions=positions,
             state_slot=state_slot,
             final_pos=final_pos,
@@ -600,6 +615,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
         # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
         logits_output.hidden_states = None
+        logits_output.hidden_states_token_indices = None
 
         batch_output.next_draft_input = make_next_draft_input(
             bonus_tokens=next_token_ids,
@@ -780,6 +796,11 @@ class DSparkWorkerV2(BaseSpecWorker):
                     inject_gate=fold_eligible,
                 )
             else:
+                if (
+                    self._verify_epilogue is not None
+                    and self._verify_planner.mode_value == "static"
+                ):
+                    self._verify_epilogue.begin_static_step(bs, fold_eligible)
                 target_verify = self._verify_executor.run_non_compact(
                     batch=batch,
                     draft_input=draft_input,
@@ -804,7 +825,11 @@ class DSparkWorkerV2(BaseSpecWorker):
                 grammar_mask.apply(logits_output.next_token_logits)
 
         epilogue = self._verify_executor.verify_epilogue
-        folded_accept = fold_eligible and run_compact and can_run_cuda_graph
+        folded_accept = (
+            fold_eligible
+            and can_run_cuda_graph
+            and (run_compact or self._verify_planner.mode_value == "static")
+        )
         accept = self._verify_executor.accept_and_finalize(
             folded_accept=folded_accept,
             bs=bs,
@@ -816,6 +841,11 @@ class DSparkWorkerV2(BaseSpecWorker):
             layout=layout,
             prefix_lens=prefix_lens,
             draft_tokens=draft_tokens,
+        )
+        self.model_runner.ngram_embedding_manager.update_after_verify(
+            verify_ids_2d=verify_ids_2d,
+            req_pool_indices=batch.req_pool_indices,
+            commit_lens=accept.commit_lens,
         )
         if batch.return_logprob:
             compute_spec_logprobs(

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -74,6 +74,10 @@ from sglang.srt.configs import (
     XllmConfig,
 )
 from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
+from sglang.srt.configs.deepseek_v41 import (
+    DEEPSEEK_V41_CONFIG_CLASSES,
+    normalize_deepseek_v4_fields,
+)
 from sglang.srt.configs.internvl import InternVLChatConfig
 from sglang.srt.utils import get_bool_env_var, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
@@ -163,9 +167,31 @@ try:
 
     class _DeepseekV4ConfigAlias(_HFDeepseekV3Config):
         model_type = "deepseek_v4"
+        hc_pre_from_prev_sublayer = False
+        # V4 normalizes each attention query head (weightless rmsnorm) before RoPE.
+        q_head_norm = True
+        kv_source_layer_ids = ()
+        index_source_layer_ids = ()
+        candidate_source_layer_id = -1
+        candidate_topk_blocks = 0
+        candidate_block_size = 0
+        engram_layer_ids = ()
+        engram_num_embeddings = ()
+        engram_max_ngram_size = 1
+        engram_vocab_size = 0
+        engram_n_heads = 0
+        engram_head_dim = 0
+        engram_pad_token_id = 2
+        engram_compressed_vocab_size = 0
+
+        def __init__(self, **kwargs):
+            super().__init__(**normalize_deepseek_v4_fields(kwargs))
 
     _CONFIG_REGISTRY["deepseek_v32"] = _DeepseekV32ConfigAlias
     _CONFIG_REGISTRY["deepseek_v4"] = _DeepseekV4ConfigAlias
+    _CONFIG_REGISTRY.update(
+        {cls.model_type: cls for cls in DEEPSEEK_V41_CONFIG_CLASSES}
+    )
 
     # For kimi_k25_eagle3
     class _KimiK2ConfigAlias(_HFDeepseekV3Config):

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -19,6 +19,10 @@ from typing import Optional
 from transformers import PretrainedConfig
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
+from sglang.srt.configs.deepseek_v41 import (
+    DeepseekV41Config,
+    normalize_deepseek_v41_config,
+)
 from sglang.srt.configs.model_config_parser_registry import (
     ModelConfigParserBase,
     get_model_config_parser,
@@ -136,6 +140,8 @@ class HfModelConfigParser(ModelConfigParserBase):
             _set_architectures(config, "DeepseekOCRForCausalLM")
             config = DeepseekVLV2Config.from_pretrained(model, revision=revision)
             _apply_deepseek_ocr_overrides(config, model)
+        elif isinstance(config, DeepseekV41Config):
+            config._name_or_path = model
         elif config.model_type in _CONFIG_REGISTRY:
             model_type = config.model_type
             if model_type == "deepseek_vl_v2" and is_ocr:
@@ -264,6 +270,8 @@ def get_config(
     )
 
     if model_override_args:
+        if isinstance(config, DeepseekV41Config):
+            model_override_args = normalize_deepseek_v41_config(model_override_args)
         # A plain update() setattrs a dict-valued override straight onto the
         # config, so '{"text_config": {...}}' on a VLM would replace the whole
         # sub-config with a dict and break attribute access downstream.

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -49,6 +49,7 @@ from .tokenizer import (
     _fix_added_tokens_encoding,
     _fix_special_tokens_pattern,
     _install_tokenizer_warnings_filter,
+    get_tokenizer,
 )
 
 _IMAGE_PROCESSOR_BACKENDS = {"auto", "torchvision", "pil"}
@@ -253,6 +254,10 @@ def get_processor(
             revision=revision,
             **kwargs,
         )
+    if config.model_type == "deepseek_v41" and config.vision_n_layers > 0:
+        return get_tokenizer(
+            tokenizer_name, trust_remote_code=trust_remote_code, revision=revision
+        )
     is_ocr2 = _is_deepseek_ocr2_model(config)
     if _is_deepseek_ocr_model(config) or is_ocr2:
         config.model_type = "deepseek-ocr"
@@ -355,8 +360,6 @@ def get_processor(
     # AutoProcessor may internally create a TokenizersBackend tokenizer
     # (same issue as get_tokenizer). Replace it with a properly loaded one.
     if type(tokenizer).__name__ == _TOKENIZERS_BACKEND:
-        from .tokenizer import get_tokenizer
-
         logger.warning(
             "Processor tokenizer for %s is TokenizersBackend, "
             "reloading via get_tokenizer",

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
@@ -282,6 +282,10 @@ class TinyDSV4ModelConfig:
             index_topk=DSV4_INDEX_TOPK,
             num_hidden_layers=len(compression_ratios),
             compress_ratios=list(compression_ratios),
+            # Ratio 1/2 layers are their own kv_source (one-layer fixtures).
+            kv_source_layer_ids=[
+                i for i, ratio in enumerate(compression_ratios) if ratio in (1, 2)
+            ],
         )
         self.hf_config.get_text_config = lambda: self.hf_config
         self.hf_text_config = self.hf_config
@@ -411,6 +415,10 @@ class MockDSV4ModelRunner:
             device=device,
             enable_memory_saver=False,
             compression_ratios=list(compression_ratios),
+            kv_source_layers=model_config.hf_config.kv_source_layer_ids,
+            # Full locs are the identity-mapped SWA locs below, so the c1/c2
+            # latent pools (slot = loc // ratio) only need to span swa_size.
+            full_size=swa_size,
         )
         # Register identity full->swa mapping over swa_size full locs.
         identity = torch.arange(swa_size, dtype=torch.int64, device=device)
@@ -1106,20 +1114,22 @@ def prepare_dsv4_runner_inputs(
     # reference needs to build that metadata itself. Stash the current batch
     # so `_pure_torch_dsv4_combined_reference` knows which one to use.
     fixture._current_batch = batch  # type: ignore[attr-defined]
-    if case.compress_ratio in (4, 128):
+    if case.compress_ratio in (1, 2, 4, 128):
         _populate_extra_kv_cache(fixture, layer_id=0, num_entries=_DSV4_EXTRA_ENTRIES)
 
 
 def _seed_c4_if_needed(
-    fixture: DSV4AttentionFixture, *, num_entries: int = _DSV4_EXTRA_ENTRIES
+    fixture: DSV4AttentionFixture, *, num_entries: int | None = None
 ) -> None:
     """For compress_ratio=4, seed the C4 metadata the exercised path consumes
     (the C4Indexer would normally populate it; the compact fixture skips the
     indexer): `c4_sparse_page_indices` for the dense extend path,
     `c4_sparse_raw_indices` for sparse prefill. No-op for other compress_ratios.
     """
-    if fixture.case.compress_ratio != 4:
+    if fixture.case.compress_ratio not in (1, 2, 4):
         return
+    if num_entries is None:
+        num_entries = getattr(fixture, "extra_entries", _DSV4_EXTRA_ENTRIES)
     if fixture.seed_c4_for_sparse_prefill:
         _seed_c4_sparse_prefill_indices(fixture, num_entries=num_entries)
     else:
@@ -1138,7 +1148,7 @@ def run_dsv4_fixture_eager(fixture: DSV4AttentionFixture) -> torch.Tensor:
     full_kv_locs_per_req = _populate_swa_kv_cache(
         fixture, max_context_len=max_context_len, device=runner.device
     )
-    if case.compress_ratio in (4, 128):
+    if case.compress_ratio in (1, 2, 4, 128):
         _populate_extra_kv_cache(fixture, layer_id=0, num_entries=_DSV4_EXTRA_ENTRIES)
     q_input, _ = fixture.actual_module.project(fixture.input_hidden)
     with torch.no_grad(), forward_context(ForwardContext(attn_backend=fixture.backend)):
@@ -1202,7 +1212,7 @@ def expected_dsv4_output_from_inputs(
     runner = fixture.runner
     max_context_len = runner.req_to_token_pool.req_to_token.shape[1]
     q_input, _ = fixture.actual_module.project(inputs["input_hidden"])
-    if case.compress_ratio in (4, 128):
+    if case.compress_ratio in (1, 2, 4, 128):
         return _pure_torch_dsv4_combined_reference(fixture, q_input).float()
     full_kv_locs_per_req = _full_kv_locs_per_req(
         case, max_context_len=max_context_len, device=runner.device
@@ -1256,10 +1266,10 @@ def _extra_metadata_indices(
     the upgraded `DSV4AttnMetadata`. Mirrors the dispatch in
     `DeepseekV4AttnBackend.forward(compress_ratio=...)`.
     """
-    if compress_ratio == 4:
+    if compress_ratio in (1, 2, 4):
         return (
-            core_metadata.c4_sparse_page_indices,
-            core_metadata.c4_sparse_topk_lengths,
+            core_metadata.sparse_page_indices(compress_ratio),
+            core_metadata.sparse_topk_lengths(compress_ratio),
         )
     if compress_ratio == 128:
         return core_metadata.c128_page_indices, core_metadata.c128_topk_lengths_clamp1
@@ -1323,7 +1333,7 @@ def _pure_torch_dsv4_combined_reference(
     swa_indices = md.swa_page_indices  # [num_q, padded_window], full-pool locs
     swa_topk_lengths = md.swa_topk_lengths  # [num_q]
 
-    if case.compress_ratio in (4, 128):
+    if case.compress_ratio in (1, 2, 4, 128):
         extra_indices, extra_topk_lengths = _extra_metadata_indices(
             md, case.compress_ratio
         )
@@ -1401,7 +1411,8 @@ def _seed_c4_sparse_indices(
     non-trivial extra contribution.
     """
     md = fixture.backend.forward_metadata.core_metadata
-    sparse_indices = md.c4_sparse_page_indices
+    ratio = fixture.case.compress_ratio
+    sparse_indices = md.sparse_page_indices(ratio)
     num_q, sparse_topk = sparse_indices.shape
     seed = torch.full(
         (num_q, sparse_topk),
@@ -1412,12 +1423,12 @@ def _seed_c4_sparse_indices(
     seed[:, :num_entries] = torch.arange(
         num_entries, dtype=sparse_indices.dtype, device=sparse_indices.device
     )
-    md.c4_sparse_page_indices = seed
-    md.c4_sparse_topk_lengths = torch.full(
-        (num_q,),
-        num_entries,
-        dtype=md.c4_sparse_topk_lengths.dtype,
-        device=md.c4_sparse_topk_lengths.device,
+    lengths = md.sparse_topk_lengths(ratio)
+    setattr(md, f"c{ratio}_sparse_page_indices", seed)
+    setattr(
+        md,
+        f"c{ratio}_sparse_topk_lengths",
+        torch.full((num_q,), num_entries, dtype=lengths.dtype, device=lengths.device),
     )
 
 
@@ -1438,15 +1449,16 @@ def _seed_c4_sparse_prefill_indices(
     asserted below.
     """
     md = fixture.backend.forward_metadata.core_metadata
-    raw_indices = md.c4_sparse_raw_indices
+    ratio = fixture.case.compress_ratio
+    raw_indices = md.sparse_raw_indices(ratio)
     assert raw_indices is not None, "requires init_flashmla_related(is_prefill=True)"
     num_q, width = raw_indices.shape
-    lens = (md.positions_casual + 1) // 4
+    lens = (md.positions_casual + 1) // ratio
     max_len = int(lens.max().item())
     pool = fixture.runner.token_to_kv_pool
-    c4_page_size = pool.get_extra_key_page_size(layer_id=0)
-    assert max_len <= min(num_entries, c4_page_size), (
-        f"case attends {max_len} c4 entries; only {min(num_entries, c4_page_size)} populated"
+    c_page_size = pool.get_extra_key_page_size(layer_id=0)
+    assert max_len <= min(num_entries, c_page_size), (
+        f"case attends {max_len} c{ratio} entries; only {min(num_entries, c_page_size)} populated"
     )
     assert (md.page_table[:, 0] == 0).all(), (
         "sparse seeding requires the raw==physical identity (first page 0)"
@@ -1457,9 +1469,10 @@ def _seed_c4_sparse_prefill_indices(
         .expand(num_q, -1)
     )
     seeded = torch.where(seq < lens.unsqueeze(1), seq, seq.new_full((), -1))
-    md.c4_sparse_raw_indices = seeded
-    md.c4_sparse_page_indices = seeded.clone()
-    md.c4_sparse_topk_lengths = lens.to(md.c4_sparse_topk_lengths.dtype)
+    lengths = md.sparse_topk_lengths(ratio)
+    setattr(md, f"c{ratio}_sparse_raw_indices", seeded)
+    setattr(md, f"c{ratio}_sparse_page_indices", seeded.clone())
+    setattr(md, f"c{ratio}_sparse_topk_lengths", lens.to(lengths.dtype))
 
 
 def run_dsv4_target_verify_attention_case(
@@ -1501,7 +1514,7 @@ def run_dsv4_target_verify_attention_case(
     testcase.assertEqual(fixture.backend.max_context_len, max_context_len)
 
     _populate_swa_kv_cache(fixture, max_context_len=max_context_len, device=device)
-    if case.compress_ratio in (4, 128):
+    if case.compress_ratio in (1, 2, 4, 128):
         _populate_extra_kv_cache(fixture, layer_id=0, num_entries=_DSV4_EXTRA_ENTRIES)
 
     _prepare_target_verify_batch(fixture.forward_batch, case, device)
@@ -1627,12 +1640,16 @@ def run_dsv4_compress_attention_case(
     dense `flash_mla_with_kvcache` extend path or `_forward_prefill_sparse`;
     the C4 seeding dispatches on the same flag.
     """
-    assert case.compress_ratio in (
-        4,
-        128,
-    ), (
-        f"DSV4 compact runner requires compress_ratio in (4, 128); got {case.compress_ratio}"
+    assert case.compress_ratio in (1, 2, 4, 128), (
+        f"DSV4 compact runner requires compress_ratio in (1, 2, 4, 128); "
+        f"got {case.compress_ratio}"
     )
+    # The sparse-prefill seeding attends (pos + 1) // ratio entries per query, so
+    # the low ratios need more populated entries than the default 32.
+    if case.compress_ratio in (1, 2):
+        extra_entries = max(
+            extra_entries, max(case.seq_lens) // case.compress_ratio + 1
+        )
     if sparse_prefill:
         assert case.forward_mode.is_extend_without_speculative(), (
             f"sparse prefill only serves extend; got {case.forward_mode}"
@@ -1645,6 +1662,7 @@ def run_dsv4_compress_attention_case(
         compression_ratios=[case.compress_ratio],
     )
     fixture.seed_c4_for_sparse_prefill = sparse_prefill
+    fixture.extra_entries = extra_entries  # type: ignore[attr-defined]
     runner = fixture.runner
     max_context_len = runner.req_to_token_pool.req_to_token.shape[1]
 

--- a/rust/sglang-mm/src/dsv41/mod.rs
+++ b/rust/sglang-mm/src/dsv41/mod.rs
@@ -1,0 +1,139 @@
+//! V4.1 PIL bicubic resize, centered padding and CHW patch packing.
+use crate::common::{par, resize};
+use half::bf16;
+
+pub struct ImagePlan {
+    pub out_h: usize,
+    pub out_w: usize,
+    pub resize_h: usize,
+    pub resize_w: usize,
+    pub top: usize,
+    pub left: usize,
+    pub patch_size: usize,
+}
+
+pub fn resize_patchify(
+    rgb: &[u8],
+    h: usize,
+    w: usize,
+    plan: ImagePlan,
+) -> Result<Vec<u16>, String> {
+    let ImagePlan {
+        out_h,
+        out_w,
+        resize_h,
+        resize_w,
+        top,
+        left,
+        patch_size: ps,
+    } = plan;
+    if ps == 0
+        || h == 0
+        || w == 0
+        || resize_h == 0
+        || resize_w == 0
+        || out_h == 0
+        || out_w == 0
+        || !out_h.is_multiple_of(ps)
+        || !out_w.is_multiple_of(ps)
+        || resize_h > out_h
+        || resize_w > out_w
+        || top > out_h - resize_h
+        || left > out_w - resize_w
+        || h.checked_mul(w).and_then(|n| n.checked_mul(3)) != Some(rgb.len())
+    {
+        return Err("invalid V4.1 image geometry".into());
+    }
+    let len = out_h
+        .checked_mul(out_w)
+        .and_then(|n| n.checked_mul(3))
+        .ok_or("V4.1 output size overflow")?;
+    let resized = resize::resize_rgb(
+        rgb,
+        h,
+        w,
+        resize_h,
+        resize_w,
+        resize::Resample::Pil(resize::Filter::Bicubic),
+    );
+    let lut: [u16; 256] =
+        core::array::from_fn(|i| bf16::from_f32(((i as f32 / 255.0) - 0.5) / 0.5).to_bits());
+    let mut out = vec![0u16; len];
+    let patch_len = 3 * ps * ps;
+    let grid_w = out_w / ps;
+    par::for_chunks_mut(&mut out, patch_len, |index, patch| {
+        let py = index / grid_w * ps;
+        let px = index % grid_w * ps;
+        for c in 0..3 {
+            for y in 0..ps {
+                for x in 0..ps {
+                    let iy = py + y;
+                    let ix = px + x;
+                    let value =
+                        if iy >= top && iy < top + resize_h && ix >= left && ix < left + resize_w {
+                            resized[((iy - top) * resize_w + ix - left) * 3 + c]
+                        } else {
+                            127
+                        };
+                    patch[(c * ps + y) * ps + x] = lut[value as usize];
+                }
+            }
+        }
+    });
+    Ok(out)
+}
+
+#[cfg(feature = "python")]
+mod python {
+    use numpy::{IntoPyArray, PyArray1, PyReadonlyArray3, PyUntypedArrayMethods};
+    use pyo3::{exceptions::PyValueError, prelude::*};
+
+    #[pyfunction]
+    fn resize_patchify<'py>(
+        py: Python<'py>,
+        arr: PyReadonlyArray3<'py, u8>,
+        output_size: (usize, usize),
+        resize_size: (usize, usize),
+        padding_start: (usize, usize),
+        patch_size: usize,
+    ) -> PyResult<Bound<'py, PyArray1<u16>>> {
+        let (out_h, out_w) = output_size;
+        let (resize_h, resize_w) = resize_size;
+        let (top, left) = padding_start;
+        let shape = arr.shape();
+        let (h, w) = (shape[0], shape[1]);
+        if shape[2] != 3 {
+            return Err(PyValueError::new_err("expected HWC RGB"));
+        }
+        let data = arr
+            .as_slice()
+            .map_err(|_| PyValueError::new_err("expected contiguous RGB"))?
+            .to_vec();
+        let bits = py
+            .detach(move || {
+                super::resize_patchify(
+                    &data,
+                    h,
+                    w,
+                    super::ImagePlan {
+                        out_h,
+                        out_w,
+                        resize_h,
+                        resize_w,
+                        top,
+                        left,
+                        patch_size,
+                    },
+                )
+            })
+            .map_err(PyValueError::new_err)?;
+        Ok(bits.into_pyarray(py))
+    }
+    pub fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
+        let m = PyModule::new(parent.py(), "dsv41")?;
+        m.add_function(wrap_pyfunction!(resize_patchify, &m)?)?;
+        parent.add_submodule(&m)
+    }
+}
+#[cfg(feature = "python")]
+pub use python::register;

--- a/rust/sglang-mm/src/lib.rs
+++ b/rust/sglang-mm/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod common;
 pub mod driver;
+pub mod dsv41;
 pub mod inkling;
 pub mod pipeline;
 pub mod qwen_vl;
@@ -21,6 +22,7 @@ use pyo3::prelude::*;
 fn _multimodal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     common::register(m)?;
     inkling::register(m)?;
+    dsv41::register(m)?;
     qwen_vl::register(m)?;
     Ok(())
 }

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
@@ -126,6 +126,47 @@ class TestDSV4AttentionBackendCorrectness(CustomTestCase):
             extend_lens=(16,),
             compress_ratio=128,
         ),
+        # DeepSeek V4.1 ratio 1 / 2: latents in the c1 / c2 FlashMLA-layout pools,
+        # attended through the same extra-cache path as C4.
+        DSV4AttentionCase(
+            name="dsv4_c1_extend",
+            backend="dsv4",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=64,
+            page_size=DSV4_PAGE_SIZE,
+            prefix_lens=(64,),
+            extend_lens=(16,),
+            compress_ratio=1,
+        ),
+        DSV4AttentionCase(
+            name="dsv4_c1_decode",
+            backend="dsv4",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=64,
+            page_size=DSV4_PAGE_SIZE,
+            prefix_lens=(64, 200),
+            compress_ratio=1,
+        ),
+        DSV4AttentionCase(
+            name="dsv4_c2_extend",
+            backend="dsv4",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=64,
+            page_size=DSV4_PAGE_SIZE,
+            # Odd lengths: the ratio-2 causal count (pos + 1) // 2 rounds down.
+            prefix_lens=(33,),
+            extend_lens=(7,),
+            compress_ratio=2,
+        ),
+        DSV4AttentionCase(
+            name="dsv4_c2_decode",
+            backend="dsv4",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=64,
+            page_size=DSV4_PAGE_SIZE,
+            prefix_lens=(65,),
+            compress_ratio=2,
+        ),
         DSV4AttentionCase(
             name="dsv4_c128_decode",
             backend="dsv4",
@@ -340,7 +381,7 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
                 [[base + 11, base + 12], [base + 13, base + 14]], dtype=torch.int32
             ),
             swa_topk_lengths=torch.tensor([base + 15, base + 16], dtype=torch.int32),
-            c4_sparse_topk=128,
+            index_topk=128,
         )
         metadata.c4_out_loc = torch.tensor([base + 17, base + 18], dtype=torch.int32)
         metadata.c128_out_loc = torch.tensor([base + 19, base + 20], dtype=torch.int32)
@@ -365,7 +406,7 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
         metadata.c128_topk_lengths_clamp1 = torch.tensor(
             [base + 39, base + 40], dtype=torch.int32
         )
-        metadata.c1_flashmla_metadata = object()
+        metadata.c0_flashmla_metadata = object()
         metadata.c4_flashmla_metadata = object()
         metadata.c128_flashmla_metadata = object()
         return metadata
@@ -519,7 +560,7 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
             "swa_topk_lengths",
             "c128_page_indices",
             "c128_topk_lengths_clamp1",
-            "c1_flashmla_metadata",
+            "c0_flashmla_metadata",
             "c4_flashmla_metadata",
             "c128_flashmla_metadata",
         ]
@@ -625,12 +666,10 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
         for max_seq_len in (3, 4, 255, 256, 259, 260):
             with self.subTest(max_seq_len=max_seq_len):
                 cache = self._make_sparse_prefill_cache(max_seq_len)
-                cache.ensure_c4(page_table, c4_page_size=64)
+                gather = cache.ensure_compressed(4, page_table, c_page_size=64)
                 expected_extent = max(max_seq_len // 4, 1)
-                self.assertEqual(cache.c4_flat_token_ids.numel(), 2 * expected_extent)
-                self.assertEqual(
-                    cache.c4_compressed_base.tolist(), [0, expected_extent]
-                )
+                self.assertEqual(gather.flat_token_ids.numel(), 2 * expected_extent)
+                self.assertEqual(gather.compressed_base.tolist(), [0, expected_extent])
 
     def test_sparse_prefill_c128_uses_live_extent(self):
         from sglang.srt.layers.attention.dsv4 import sparse_prefill_utils

--- a/test/registered/attention/unittests/dsv4/test_dsv41_fused_compress.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_fused_compress.py
@@ -1,0 +1,328 @@
+"""Check decode numerics and packed writes through the real cache pool."""
+
+import types
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+HIDDEN = 2048
+HEAD_DIM = 512
+# `[0] * 2 + [2] * 18 + [1] * 20` as the served model lays the ratios out; the
+# ratio-2 and ratio-1 source layers are read back off the pool rather than
+# assumed.
+RATIOS = [0] * 2 + [2] * 18 + [1] * 20
+KV_SOURCE_LAYERS = (2, 8, 14, 20)
+POOL_PAGE_SIZE = 256
+POOL_FULL_SIZE = 4 * POOL_PAGE_SIZE
+MAX_REQS = 256
+INDEX_HEAD_DIM = 128
+ROPE_DIM = 64
+EPS = 1e-6
+
+
+def _make_pool():
+    """The real `DeepSeekV4TokenToKVPool`, so the buffers, their dtypes, the page
+    sizes and the pair-state ring all come from the code under test."""
+    from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+
+    return DeepSeekV4TokenToKVPool(
+        max_num_reqs=MAX_REQS,
+        swa_size=POOL_FULL_SIZE,
+        c4_size=0,
+        c128_size=0,
+        c4_state_pool_size=0,
+        c128_state_pool_size=0,
+        page_size=POOL_PAGE_SIZE,
+        swa_page_size=128,
+        dtype=torch.float8_e4m3fn,
+        c4_state_dtype=torch.float32,
+        c128_state_dtype=torch.float32,
+        qk_nope_head_dim=HEAD_DIM - ROPE_DIM,
+        qk_rope_head_dim=ROPE_DIM,
+        indexer_head_dim=INDEX_HEAD_DIM,
+        layer_num=len(RATIOS),
+        device="cuda",
+        enable_memory_saver=False,
+        compression_ratios=RATIOS,
+        kv_source_layers=KV_SOURCE_LAYERS,
+        full_size=POOL_FULL_SIZE,
+    )
+
+
+def _build(n: int, ratio: int, seed: int):
+    """One decode step against the real pool."""
+    from sglang.srt.layers.attention.deepseek_v4_backend import (
+        _low_ratio_compression_metadata,
+    )
+    from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
+        DeepseekV41Compressor,
+        DeepseekV41Indexer,
+        RMSNorm,
+    )
+    from sglang.srt.model_loader.utils import set_default_torch_dtype
+
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    with set_default_torch_dtype(torch.bfloat16):
+        compressor = DeepseekV41Compressor(
+            HIDDEN, HEAD_DIM, ratio, EPS, fused_compress=True
+        ).cuda()
+        k_norm = RMSNorm(INDEX_HEAD_DIM, EPS).cuda()
+        wk = torch.nn.Linear(
+            HEAD_DIM, INDEX_HEAD_DIM, bias=False, dtype=torch.bfloat16
+        ).cuda()
+    # Not `ones` anywhere: a constant weight cannot catch a wrong element index.
+    with torch.no_grad():
+        for module in (compressor, k_norm, wk):
+            for param in module.parameters():
+                param.copy_(torch.randn(param.shape, generator=g, device="cuda") * 0.1)
+    x = torch.randn(n, HIDDEN, generator=g, device="cuda", dtype=torch.bfloat16)
+
+    # Every token is the last of its group, so every row completes and writes.
+    pos = torch.arange(n, device="cuda", dtype=torch.int64) * ratio + (ratio - 1)
+    raw_out_loc = (torch.arange(n, device="cuda", dtype=torch.int32) + 1) * ratio + (
+        ratio - 1
+    )
+    out_loc, _ = _low_ratio_compression_metadata(
+        ratio, raw_out_loc.to(torch.int64) + 1, raw_out_loc
+    )
+
+    ang = torch.randn(int(pos.max()) + 2, ROPE_DIM // 2, generator=g, device="cuda")
+    freqs = torch.polar(torch.ones_like(ang), ang)
+
+    pool = _make_pool()
+    layer_id = pool.sources_by_ratio[ratio][0]
+    # Use the real pool: get_extra_key_buffer exposes a uint8 store as an fp8 view.
+    kv_cache = pool.get_extra_key_buffer(layer_id)
+    compressed_page = pool.get_extra_key_page_size(layer_id)
+    index_cache = pool.get_index_k_with_scale_buffer(layer_id)
+    # Ratio 1 pools nothing, so it has no pair state -- the pool asserts on the
+    # accessor rather than returning an empty one.
+    state = pool.get_attention_compress_states(layer_id) if ratio == 2 else None
+    assert int(out_loc.max()) < kv_cache.shape[0] * compressed_page, (
+        "the test's slots must fit the pool"
+    )
+
+    indexer = types.SimpleNamespace(
+        owns_k=True,
+        wk=wk,
+        k_norm=k_norm,
+        rope_head_dim=ROPE_DIM,
+        index_head_dim=INDEX_HEAD_DIM,
+    )
+    # The real method, bound to the stand-in: it reads only `wk` and
+    # `index_head_dim`, and it is what decides whether the in-tree GEMM serves `wk`.
+    captured = {}
+
+    def forward_wk(latent):
+        projected = DeepseekV41Indexer.forward_wk(indexer, latent)
+        captured.update(latent=latent, projected=projected)
+        return projected
+
+    indexer.forward_wk = forward_wk
+
+    if state is not None:
+        # Seeded rather than zeroed, so a completing row that fails to read its
+        # partner shows up instead of pairing against zeros.
+        state.kv_score_buffer.kv_score.copy_(
+            torch.randn(
+                state.kv_score_buffer.kv_score.shape,
+                generator=g,
+                device="cuda",
+                dtype=torch.float32,
+            )
+        )
+    layer = types.SimpleNamespace(
+        compressor=compressor,
+        indexer=indexer,
+        layer_id=layer_id,
+        compress_ratio=ratio,
+        rope_head_dim=ROPE_DIM,
+        freqs_cis=freqs,
+    )
+    backend = types.SimpleNamespace(
+        token_to_kv_pool=pool,
+        forward_metadata=types.SimpleNamespace(
+            core_metadata=types.SimpleNamespace(
+                raw_out_loc=raw_out_loc, c1_out_loc=out_loc, c2_out_loc=out_loc
+            )
+        ),
+    )
+    return types.SimpleNamespace(
+        backend=backend,
+        layer=layer,
+        x=x,
+        pos=pos,
+        freqs=freqs,
+        out_loc=out_loc,
+        kv_cache=kv_cache,
+        index_cache=index_cache,
+        compressor=compressor,
+        k_norm=k_norm,
+        captured=captured,
+        pair_state=(
+            state.kv_score_buffer.kv_score.clone() if state is not None else None
+        ),
+        ring_size=state.ring_size if state is not None else 0,
+        compressed_page=compressed_page,
+        req=torch.arange(n, device="cuda", dtype=torch.int64),
+    )
+
+
+def _reference(t, ratio: int):
+    """Check numerics independently, then check byte-exact packing of actual latents."""
+    from sglang.kernels.ops.attention.dsv4.attn import fused_store_cache
+    from sglang.kernels.ops.attention.dsv4.rope_pack_indexer import (
+        rope_fake_quant_pack_indexer,
+    )
+    from sglang.srt.layers.attention.dsv4.dsv41_sparse import rope_tail
+    from sglang.srt.layers.attention.dsv4.torch_quant import fake_quant_compressed_kv
+
+    if ratio == 1:
+        pooled = t.compressor.wkv(t.x)
+    else:
+        fused = t.compressor.project_fused(t.x)
+        kv, score = fused[..., :HEAD_DIM], fused[..., HEAD_DIM:]
+        # `translate_from_req_position_to_state_loc` for the slot `pos - 1`
+        # left: the ring puts the read and the write on different rows.
+        read = t.req * t.ring_size + (t.pos - 1) % t.ring_size
+        partner_kv = t.pair_state[read, :HEAD_DIM]
+        partner_score = t.pair_state[read, HEAD_DIM:]
+        pooled = (
+            torch.stack([partner_kv, kv], dim=1)
+            * torch.stack([partner_score, score], dim=1).softmax(dim=1)
+        ).sum(dim=1)
+    live = t.out_loc > 0
+    latent = t.captured["latent"]
+    projected = t.captured["projected"]
+    if live.any():
+        normalized_input = pooled[live].bfloat16().double()
+        normalized = normalized_input * torch.rsqrt(
+            normalized_input.square().mean(dim=-1, keepdim=True) + EPS
+        )
+        expected_latent = normalized * t.compressor.norm.weight.double()
+        # Pooling and normalization may differ by up to two bf16 ULPs.
+        torch.testing.assert_close(
+            latent[live].float(), expected_latent.float(), rtol=2**-6, atol=2**-20
+        )
+        expected_projection = F.linear(
+            latent[live].float(), t.layer.indexer.wk.weight.float()
+        )
+        torch.testing.assert_close(
+            projected[live].float(), expected_projection, rtol=1e-2, atol=1e-2
+        )
+
+    group_pos = t.pos & ~(ratio - 1)
+    # fused_store_cache takes uint8, while the pool exposes an fp8 view;
+    # compare and call any() through uint8 views of both buffers.
+    kv_cache = torch.zeros(
+        t.kv_cache.shape, dtype=torch.uint8, device=t.kv_cache.device
+    )
+    if not live.any():
+        return kv_cache, torch.zeros_like(t.index_cache)
+    fused_store_cache(
+        input=fake_quant_compressed_kv(
+            rope_tail(latent[live], t.freqs[group_pos[live]], ROPE_DIM)
+        ),
+        cache=kv_cache,
+        indices=t.out_loc[live],
+        page_size=t.compressed_page,
+        type="flashmla",
+    )
+    index_cache = torch.zeros_like(t.index_cache)
+    rope_fake_quant_pack_indexer(
+        t.k_norm(projected[live]),
+        t.freqs[group_pos[live]],
+        ROPE_DIM,
+        cache=index_cache,
+        loc=t.out_loc[live],
+    )
+    return kv_cache, index_cache
+
+
+class TestFusedLowRatioCompress(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # The pool reads the scheduler's config bags (`spec`, for the pair-ring
+        # size), so they have to be published before one can be built.
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", page_size=POOL_PAGE_SIZE)
+        )
+
+    def _check_step(self, t, ratio: int):
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DeepseekV4AttnBackend,
+        )
+
+        DeepseekV4AttnBackend._low_ratio_compress_decode_fused(
+            t.backend, t.layer, t.x, t.req, t.pos
+        )
+        ref_kv, ref_index = _reference(t, ratio)
+        torch.cuda.synchronize()
+
+        got_kv = t.kv_cache.view(torch.uint8)
+        if (t.out_loc > 0).any():
+            self.assertTrue(got_kv.any(), "the main-KV write published nothing")
+            self.assertTrue(t.index_cache.any(), "the index-K write published nothing")
+        self.assertTrue(
+            torch.equal(got_kv, ref_kv),
+            f"{ratio=}: {int((got_kv != ref_kv).sum())} main-KV cache "
+            f"bytes differ from the unfused chain",
+        )
+        self.assertTrue(
+            torch.equal(t.index_cache, ref_index),
+            f"{ratio=}: {int((t.index_cache != ref_index).sum())} index-K "
+            f"cache bytes differ from the unfused chain",
+        )
+
+    def test_ratio_2_matches_exact_reference(self):
+        from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
+            DeepseekV41Compressor,
+        )
+
+        torch.manual_seed(0)
+        hidden, head_dim, n = 5120, 512, 37
+        comp = DeepseekV41Compressor(hidden, head_dim, compress_ratio=2, eps=1e-6)
+        comp = comp.cuda()
+        # Read wkv/wgate from either the fused [2D, K] layout or split projections;
+        # both must satisfy the same numerical contract.
+        if comp.use_fused_gate:
+            w = comp.wkv_gate.weight
+            w_kv, w_gate = w[:head_dim], w[head_dim:]
+        else:
+            w_kv, w_gate = comp.wkv.weight, comp.wgate.weight
+        self.assertEqual(w_kv.dtype, torch.bfloat16)
+        self.assertEqual(w_gate.dtype, torch.bfloat16)
+
+        x = torch.randn(n, hidden, device="cuda", dtype=torch.bfloat16)
+        kv, score = comp.project(x)
+
+        # bf16 x bf16 products are exact in fp32 and fp64, so an fp64 GEMM over
+        # the same inputs is the reference up to the fp32 accumulation order.
+        x64 = x.double().cpu()
+        ref_kv = x64 @ w_kv.double().cpu().t()
+        ref_score = x64 @ w_gate.double().cpu().t()
+
+        for out, ref in ((kv, ref_kv), (score, ref_score)):
+            self.assertEqual(out.dtype, torch.float32)
+            torch.testing.assert_close(out.double().cpu(), ref, rtol=1e-4, atol=1e-4)
+            # Well below what a bf16-rounded output could reach.
+            bf16_err = (out.bfloat16().double().cpu() - ref).abs().max()
+            self.assertLess((out.double().cpu() - ref).abs().max(), bf16_err)
+
+    def test_matches_the_unfused_chain(self):
+        for ratio in (1, 2):
+            for n in (1, 64):
+                with self.subTest(ratio=ratio, n=n):
+                    self._check_step(_build(n, ratio, seed=100 + n + ratio), ratio)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/unittests/dsv4/test_dsv41_indexer_prefill.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_indexer_prefill.py
@@ -1,0 +1,285 @@
+"""DeepSeek-V4.1 ratio-1/2 prefill indexer on the DeepGEMM dense fp4 kernel:
+logits vs a torch golden of the reference scoring, the top-k buffer contract, and
+selection on a mixed batch of requests.
+
+GPU only (deep_gemm.fp8_fp4_mqa_logits).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+FULL_PAGE_SIZE = 256
+INDEX_PAGE_SIZE = 64
+HEAD_DIM = 128
+N_HEADS = 32
+TOPK = 64
+
+
+def golden_scores(q, k, weights):
+    """q [t, H, d], k [n, d], weights [t, H] -> [t, n], fp32 reference scoring."""
+    s = torch.einsum("bhd,nd->bhn", q.float(), k.float())
+    return (s.relu() * weights.float().unsqueeze(-1)).sum(dim=1)
+
+
+class _Indexer:
+    """Supply precomputed queries and head weights to the real indexer backend."""
+
+    def __init__(self, q, weights, topk):
+        self.q, self.w = q, weights
+        self.index_topk = topk
+        self.is_candidate_source = False
+        self.uses_candidates = False
+        self.candidate_topk_blocks = 2
+        self.candidate_block_size = 32
+        self.owns_k = False
+        self.n_local_heads = self.n_heads = q.shape[1]
+
+    def queries(self, q_lora, freqs):
+        return self.q[q_lora]
+
+    def head_weights(self, x):
+        return self.w[x]
+
+
+def _backend(core, pool, req_to_token):
+    from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
+
+    backend = object.__new__(DeepseekV4AttnBackend)
+    backend.forward_metadata = SimpleNamespace(core_metadata=core, late_layer_tail=None)
+    backend.token_to_kv_pool = pool
+    backend.req_to_token = req_to_token
+    backend.candidate_masks = None
+    return backend
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA only")
+class _PrefillIndexerFixture(CustomTestCase):
+    def _setup(self, ratio, seq_lens, extend_lens):
+        """A batch of requests with random FULL page tables; the fp4 index-K pool
+        is written through store_fp4_index_k_cache exactly as production does."""
+        from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
+            store_fp4_index_k_cache,
+        )
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            _low_ratio_sparse_buffers,
+        )
+        from sglang.srt.layers.attention.dsv4.torch_quant import fake_quant_fp4
+
+        torch.manual_seed(ratio)
+        dev = "cuda"
+        bs = len(seq_lens)
+        slots_per_page = FULL_PAGE_SIZE // ratio
+        n_full_pages = max((s + FULL_PAGE_SIZE - 1) // FULL_PAGE_SIZE for s in seq_lens)
+        n_phys_pages = bs * n_full_pages + 2
+        total_slots = n_phys_pages * slots_per_page
+        full_page_table = (
+            torch.randperm(n_phys_pages, device=dev)[: bs * n_full_pages]
+            .view(bs, n_full_pages)
+            .to(torch.int32)
+        )
+        # req_to_token in FULL token ids: position p of request b lives at
+        # page_table[b, p // 256] * 256 + p % 256.
+        req_to_token = torch.zeros(
+            bs, n_full_pages * FULL_PAGE_SIZE, dtype=torch.int32, device=dev
+        )
+        p = torch.arange(n_full_pages * FULL_PAGE_SIZE, device=dev)
+        for b in range(bs):
+            req_to_token[b] = (
+                full_page_table[b, p // FULL_PAGE_SIZE].to(torch.int64) * FULL_PAGE_SIZE
+                + p % FULL_PAGE_SIZE
+            ).to(torch.int32)
+
+        k_all = fake_quant_fp4(
+            torch.randn(total_slots, HEAD_DIM, device=dev, dtype=torch.bfloat16)
+        )
+        k_cache = torch.zeros(
+            total_slots // INDEX_PAGE_SIZE,
+            INDEX_PAGE_SIZE * 68,
+            dtype=torch.uint8,
+            device=dev,
+        )
+        store_fp4_index_k_cache(
+            input=k_all,
+            cache=k_cache,
+            loc=torch.arange(total_slots, dtype=torch.int32, device=dev),
+            page_size=INDEX_PAGE_SIZE,
+            rne=True,
+        )
+
+        def get_fp4(layer_id, slots):
+            slots = slots.to(torch.int64)
+            page, off = (
+                (slots // INDEX_PAGE_SIZE).unsqueeze(-1),
+                slots % INDEX_PAGE_SIZE,
+            )
+            payload = k_cache[
+                page, (off * 64).unsqueeze(-1) + torch.arange(64, device=dev)
+            ]
+            sc = k_cache[
+                page,
+                (INDEX_PAGE_SIZE * 64 + off * 4).unsqueeze(-1)
+                + torch.arange(4, device=dev),
+            ]
+            return payload.view(torch.int8), sc.contiguous().view(torch.int32).squeeze(
+                -1
+            )
+
+        pool = SimpleNamespace(
+            get_low_ratio_index_k_fp4=get_fp4,
+        )
+
+        # Tokens of the batch: the extend tail of every request, in batch order.
+        pos_list = []
+        for s, e in zip(seq_lens, extend_lens):
+            pos_list += list(range(s - e, s))
+        pos = torch.tensor(pos_list, dtype=torch.int64, device=dev)
+        T = pos.numel()
+        q = fake_quant_fp4(
+            torch.randn(T, N_HEADS, HEAD_DIM, device=dev, dtype=torch.bfloat16)
+        )
+        weights = torch.rand(T, N_HEADS, device=dev, dtype=torch.float32)
+        tok_ids = torch.arange(T, device=dev)
+
+        lens_clamp1 = ((pos + 1) // ratio).clamp_min(1).to(torch.int32)
+
+        def buffers():
+            _, page_indices, raw_indices = _low_ratio_sparse_buffers(
+                lens_clamp1, TOPK, is_prefill=True
+            )
+            core = SimpleNamespace(
+                sparse_page_indices=lambda r: page_indices,
+                sparse_raw_indices=lambda r: raw_indices,
+            )
+            return core, page_indices, raw_indices
+
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: False, is_extend=lambda: True
+            ),
+            seq_lens_cpu=list(seq_lens),
+            extend_seq_lens_cpu=list(extend_lens),
+            extend_seq_lens=torch.tensor(extend_lens, dtype=torch.int32, device=dev),
+            req_pool_indices=torch.arange(bs, dtype=torch.int32, device=dev),
+        )
+        return SimpleNamespace(
+            ratio=ratio,
+            dev=dev,
+            pool=pool,
+            req_to_token=req_to_token,
+            k_all=k_all,
+            pos=pos,
+            q=q,
+            weights=weights,
+            tok_ids=tok_ids,
+            buffers=buffers,
+            forward_batch=forward_batch,
+            seq_lens=seq_lens,
+            extend_lens=extend_lens,
+        )
+
+    def _run(self, st):
+        core, page_indices, raw_indices = st.buffers()
+        backend = _backend(core, st.pool, st.req_to_token)
+        indexer = _Indexer(st.q, st.weights, TOPK)
+        layer = SimpleNamespace(
+            layer_id=0,
+            compress_ratio=st.ratio,
+            indexer=indexer,
+            freqs_cis=torch.zeros(4096, device=st.dev),
+        )
+        backend._low_ratio_index_topk_extend(
+            layer, st.tok_ids, st.tok_ids, st.pos, st.forward_batch
+        )
+        return page_indices, raw_indices
+
+    def _golden_logits(self, st):
+        """Per token: golden scores over its request's visible compressed keys."""
+        out = []
+        tok = 0
+        for b, (s, e) in enumerate(zip(st.seq_lens, st.extend_lens)):
+            lc = s // st.ratio
+            j = torch.arange(lc, device=st.dev)
+            slots = st.req_to_token[b, j * st.ratio].to(torch.int64) // st.ratio
+            g = golden_scores(
+                st.q[tok : tok + e], st.k_all[slots], st.weights[tok : tok + e]
+            )
+            lens = ((st.pos[tok : tok + e] + 1) // st.ratio)[:, None]
+            out.append((g.masked_fill(j[None, :] >= lens, -torch.inf), slots))
+            tok += e
+        return out
+
+
+class TestPrefillIndexerKernelPath(_PrefillIndexerFixture):
+    def test_head_weights_match_scaled_linear(self):
+        from sglang.srt.layers.attention.dsv4.dsv41_sparse import DeepseekV41Indexer
+
+        config = SimpleNamespace(
+            index_n_heads=N_HEADS,
+            index_head_dim=HEAD_DIM,
+            index_topk=TOPK,
+            qk_rope_head_dim=64,
+            q_lora_rank=16,
+            hidden_size=5120,
+            kv_source_layer_ids=[],
+            candidate_source_layer_id=-1,
+            candidate_topk_blocks=2,
+            candidate_block_size=32,
+        )
+        torch.manual_seed(0)
+        indexer = DeepseekV41Indexer(config, 0, 512, None, "indexer").cuda()
+        with torch.no_grad():
+            indexer.weights_proj.weight.normal_(std=0.02)
+            for rows in (1, 33):
+                x = torch.randn(rows, 5120, device="cuda", dtype=torch.bfloat16)
+                expected = torch.nn.functional.linear(x, indexer.weights_proj.weight)
+                expected *= HEAD_DIM**-0.5 * N_HEADS**-0.5
+                torch.testing.assert_close(
+                    indexer.head_weights(x), expected, atol=2e-4, rtol=1e-2
+                )
+
+    def test_kernel_path_contract_and_selection(self):
+        for ratio in (1, 2):
+            st = self._setup(ratio, seq_lens=[300, 45, 700], extend_lens=[300, 45, 700])
+            page_indices, raw_indices = self._run(st)
+            tok = 0
+            for b, (g, slots) in enumerate(self._golden_logits(st)):
+                e = st.extend_lens[b]
+                lens = (st.pos[tok : tok + e] + 1) // ratio
+                for i in range(0, e, max(1, e // 7)):
+                    n_valid = min(TOPK, int(lens[i]))
+                    row_raw = raw_indices[tok + i]
+                    row_slot = page_indices[tok + i]
+                    if n_valid == 0:  # ratio 2, position 0: nothing visible yet
+                        self.assertTrue(bool((row_raw == -1).all()))
+                        continue
+                    self.assertTrue(bool((row_raw[:n_valid] >= 0).all()))
+                    self.assertTrue(bool((row_raw[:n_valid] < lens[i]).all()))
+                    self.assertTrue(bool((row_raw[n_valid:] == -1).all()))
+                    self.assertTrue(
+                        torch.equal(
+                            row_slot[:n_valid].to(torch.int64),
+                            slots[row_raw[:n_valid].to(torch.int64)],
+                        )
+                    )
+                    ref_sel = g[i].topk(n_valid).indices
+                    overlap = (
+                        len(set(ref_sel.tolist()) & set(row_raw[:n_valid].tolist()))
+                        / n_valid
+                    )
+                    self.assertGreaterEqual(
+                        overlap,
+                        0.9,
+                        msg=f"{ratio=} request {b} row {i}: overlap {overlap}",
+                    )
+                tok += e
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/benchmark/attention/bench_topk.py
+++ b/test/registered/kernels/benchmark/attention/bench_topk.py
@@ -104,14 +104,16 @@ if not DISABLE_TORCH:
     PRROVIDERS.append("torch")
 
 
+@marker.parametrize("page_size", [1, 64], [1, 64])
 @marker.parametrize("k", [512, 1024, 2048], [512])
 @marker.parametrize("seq_len", [2**x for x in range(10, 19)], [4096, 65536])
 @marker.parametrize("batch_size", [2**x for x in range(13)], [1, 128, 1024])
-@marker.parametrize("page_size", [1, 64], [1, 64])
 @marker.benchmark("provider", PRROVIDERS)
 def benchmark_paged(
     seq_len: int, batch_size: int, k: int, page_size: int, provider: str
 ):
+    seed = seq_len ^ (batch_size << 16) ^ (k << 32) ^ (page_size << 48)
+    torch.random.manual_seed(seed)
     if k > seq_len:
         marker.skip("k cannot be larger than seq_len")
     if k == 2048 and provider == "jit_v1":
@@ -127,6 +129,8 @@ def benchmark_paged(
 @marker.parametrize("batch_size", [2**x for x in range(7, 14)], [128, 1024])
 @marker.benchmark("provider", PRROVIDERS)
 def benchmark_ragged(seq_len: int, batch_size: int, k: int, provider: str):
+    seed = seq_len ^ (batch_size << 16) ^ (k << 32)
+    torch.random.manual_seed(seed)
     if k > seq_len:
         marker.skip("k cannot be larger than seq_len")
     if k != 2048 and provider == "jit_v1":

--- a/test/registered/kernels/ops/attention/dsv4/test_compressed_kv_quant.py
+++ b/test/registered/kernels/ops/attention/dsv4/test_compressed_kv_quant.py
@@ -1,0 +1,115 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.torch_quant import (
+    fake_quant_compressed_kv,
+    fake_quant_fp4,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+class TestCompressedKVQuant(CustomTestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_cuda_compressor_scale_boundaries(self):
+        from sglang.kernels.ops.attention.dsv4.attn import fused_store_cache
+        from sglang.kernels.ops.attention.dsv4.c1 import c1_decode_norm_rope_store
+
+        maxima = torch.tensor(
+            [0, 2**-12, 6 * 2**-9, 6 * 1.0625, 6 * 1.1875, 6 * 448, 1e6, 8.25],
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        weight = maxima.repeat_interleave(16).repeat(4)
+        weight[112:116] = torch.tensor(
+            [8.25, 4.125, 3.4375, -4.8125], device="cuda", dtype=torch.bfloat16
+        )
+        quantized = (
+            torch.tensor(
+                [0, 0, 6 * 2**-9, 6, 7.5, 2688, 2688, 8.25],
+                device="cuda",
+                dtype=torch.bfloat16,
+            )
+            .repeat_interleave(16)
+            .repeat(4)
+        )
+        # Scale 1.375: ties at 2.5 and -3.5 round to 2 and -4.
+        quantized[112:116] = torch.tensor(
+            [8.25, 4.125, 2.75, -5.5], device="cuda", dtype=torch.bfloat16
+        )
+        x = torch.ones(1, 512, device="cuda", dtype=torch.bfloat16)
+        freqs = torch.view_as_real(
+            torch.ones(1, 32, device="cuda", dtype=torch.complex64)
+        )
+        positions = torch.zeros(1, device="cuda", dtype=torch.int64)
+        slots = torch.ones_like(positions)
+        page_size = 128
+        page_bytes = -(-page_size * 584 // 576) * 576
+        cache = torch.zeros(1, page_bytes, device="cuda", dtype=torch.uint8)
+        expected = torch.zeros_like(cache)
+        latent = c1_decode_norm_rope_store(
+            x,
+            weight,
+            positions,
+            slots,
+            0.0,
+            freqs.flatten(-2),
+            cache,
+            page_size=page_size,
+        )
+        self.assertTrue(torch.equal(latent, weight.unsqueeze(0)))
+        fused_store_cache(
+            quantized.unsqueeze(0),
+            expected,
+            slots,
+            page_size=page_size,
+            type="flashmla",
+        )
+        self.assertTrue(torch.equal(cache, expected))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_triton_matches_torch_for_both_quantization_rules(self):
+        from sglang.kernels.ops.attention.dsv4.rope_fake_quant_fp4 import (
+            rope_tail_fake_quant_fp4,
+        )
+        from sglang.srt.layers.attention.dsv4.dsv41_sparse import _rope_fq4, rope_tail
+
+        generator = torch.Generator(device="cuda").manual_seed(17)
+        for rows in (0, 1, 33, 129):
+            x = torch.randn(
+                rows, 512, generator=generator, device="cuda", dtype=torch.bfloat16
+            )
+            angles = torch.randn(rows, 32, generator=generator, device="cuda")
+            freqs = torch.polar(torch.ones_like(angles), angles)
+            for compressed_kv in (False, True):
+                with self.subTest(rows=rows, compressed_kv=compressed_kv):
+                    quant = (
+                        fake_quant_compressed_kv if compressed_kv else fake_quant_fp4
+                    )
+                    expected = quant(rope_tail(x, freqs, 64))
+                    actual = _rope_fq4(x, freqs, 64, compressed_kv=compressed_kv)
+                    self.assertTrue(torch.equal(actual, expected))
+
+        # Identity RoPE isolates quantization boundaries from trigonometric rounding.
+        maxima = torch.tensor(
+            [0, 2**-12, 6 * 2**-9, 6 * 1.0625, 6 * 1.1875, 6 * 448, 1e6],
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        x = maxima[:, None].expand(-1, 512).contiguous()
+        freqs = torch.ones(x.shape[0], 32, device="cuda", dtype=torch.complex64)
+        actual = rope_tail_fake_quant_fp4(x, freqs, 64, compressed_kv=True)
+        expected = torch.tensor(
+            [0, 0, 6 * 2**-9, 6, 7.5, 2688, 2688],
+            device="cuda",
+            dtype=torch.bfloat16,
+        )[:, None].expand_as(x)
+        self.assertTrue(torch.equal(actual, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/attention/dsv4/test_decode_projections.py
+++ b/test/registered/kernels/ops/attention/dsv4/test_decode_projections.py
@@ -1,0 +1,40 @@
+"""Numerical and input ownership checks for decode projections."""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.wo_a_bf16_gemv import wo_a_bf16_gemv
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=35, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestDecodeProjections(CustomTestCase):
+    def test_grouped_gemv(self):
+        for seed in (0, 17, 20260908):
+            with self.subTest(seed=seed):
+                torch.manual_seed(seed)
+                x = torch.randn(1, 2, 4096, device="cuda", dtype=torch.bfloat16)
+                w = torch.randn(2, 1024, 4096, device="cuda", dtype=torch.bfloat16)
+                original_x, original_w = x.clone(), w.clone()
+                result = wo_a_bf16_gemv(x, w)
+                reference = torch.einsum("tgd,grd->tgr", x, w)
+                self.assertEqual(result.dtype, torch.bfloat16)
+                self.assertTrue(result.is_contiguous())
+                torch.testing.assert_close(result, reference, atol=1e-3, rtol=8e-3)
+                # Sample both groups against CPU FP64 accumulation independently
+                # of the cuBLAS algorithm selected by the serving reference.
+                exact = torch.einsum(
+                    "tgd,grd->tgr", x.cpu().double(), w[:, ::31].cpu().double()
+                ).bfloat16()
+                torch.testing.assert_close(
+                    result[:, :, ::31].cpu(), exact, atol=1e-3, rtol=8e-3
+                )
+                self.assertTrue(torch.equal(x, original_x))
+                self.assertTrue(torch.equal(w, original_w))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/attention/dsv4/test_pair_pool_decode.py
+++ b/test/registered/kernels/ops/attention/dsv4/test_pair_pool_decode.py
@@ -1,0 +1,103 @@
+"""Pair-pooling must match torch bitwise, including graph padding and ring state;
+rounding differences can change the downstream indexer's top-k selection.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsv4.pair_pool_decode import pair_pool_decode
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.cuda is None,
+    reason="pair_pool_decode requires CUDA",
+)
+
+
+@pytest.mark.parametrize("ring_size", (2, 8))
+@pytest.mark.parametrize("n", (1, 3, 64))
+def test_request_ring_matches_backend_and_graph_replay(n, ring_size):
+    from types import SimpleNamespace
+
+    from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
+    from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
+
+    torch.manual_seed(43)
+    dim = 512
+    state = CompressStatePool(
+        size=n * ring_size,
+        ring_size=ring_size,
+        overlap=False,
+        head_dim=dim,
+        dtype=torch.float32,
+        device="cuda",
+        enable_memory_saver=False,
+        ratio=2,
+    )
+    initial = torch.randn_like(state.kv_score_buffer.kv_score)
+    initial[-1, :dim] = 0
+    initial[-1, dim:] = -torch.inf
+    reference = object.__new__(DeepseekV4AttnBackend)
+    reference.token_to_kv_pool = SimpleNamespace(
+        get_attention_compress_states=lambda layer_id: state
+    )
+    fused_state = initial.clone()
+    kv, score = (torch.randn(n, dim, device="cuda") for _ in range(2))
+    pos = torch.ones(n, device="cuda", dtype=torch.int64)
+    req = torch.arange(n, device="cuda", dtype=torch.int64)
+    raw_loc = torch.arange(256, 256 + n, device="cuda", dtype=torch.int32)
+    if n > 1:
+        # A padding row shares a live request index and must not touch its ring.
+        req[-1] = 0
+        raw_loc[-1] = 0
+    out_loc = raw_loc.clone()
+
+    def run_fused():
+        return pair_pool_decode(
+            kv,
+            score,
+            pos,
+            raw_loc,
+            out_loc,
+            req,
+            fused_state[:, :dim],
+            fused_state[:, dim:],
+            fused_state.shape[0] - 1,
+            ring_size=ring_size,
+        )
+
+    run_fused()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        got = run_fused()
+    fused_state.copy_(initial)
+    state.kv_score_buffer.kv_score.copy_(initial)
+    for step in range(2 * ring_size + 3):
+        kv.normal_()
+        score.normal_()
+        pos.fill_(step)
+        out_loc.copy_(torch.where(pos % 2 == 1, raw_loc // 2, -1))
+        partner_kv, partner_score = reference._low_ratio_pair_partners(
+            layer_id=0, kv=kv, score=score, req=req, pos=pos, pad=raw_loc == 0
+        )
+        pairs = torch.stack([partner_kv, kv], dim=1)
+        weights = torch.stack([partner_score, score], dim=1).softmax(dim=1)
+        expected = (
+            (pairs * weights).sum(dim=1),
+            torch.where(pos % 2 == 1, pos - 1, pos),
+            out_loc.clamp_min(0),
+        )
+        graph.replay()
+        for actual, wanted in zip(got, expected):
+            torch.testing.assert_close(actual, wanted, rtol=0, atol=0)
+        torch.testing.assert_close(
+            fused_state, state.kv_score_buffer.kv_score, rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
+++ b/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
@@ -25,6 +25,7 @@ from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
 )
 from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
 from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+    CompressedGather,
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
     use_dsv4_q8kv8_sparse_prefill,
@@ -166,7 +167,9 @@ def _make_backend(
     dsv4_prefill_backend: str = "auto",
 ) -> DeepseekV4AttnBackend:
     backend = DeepseekV4AttnBackend.__new__(DeepseekV4AttnBackend)
-    backend.forward_metadata = SimpleNamespace(sparse_prefill_cache=None)
+    backend.forward_metadata = SimpleNamespace(
+        sparse_prefill_cache=None, late_layer_tail=None
+    )
     backend.req_to_token = req_to_token
     backend.sparse_prefill_workspace = SparsePrefillWorkspace(device)
     backend.softmax_scale = 512**-0.5
@@ -219,7 +222,12 @@ def _make_sparse_prefill_case(
         * 0.05
     ).to(torch.bfloat16)
     attn_sink = torch.zeros(local_heads, dtype=torch.float32, device=device)
-    core_attn_metadata = SimpleNamespace()
+    # position + 1 of the five query rows: seq_lens [96, 144], extend [3, 2]
+    core_attn_metadata = SimpleNamespace(
+        seq_lens_casual=torch.tensor(
+            [94, 95, 96, 143, 144], dtype=torch.int32, device=device
+        )
+    )
     return backend, forward_batch, token_to_kv_pool, q, attn_sink, core_attn_metadata
 
 
@@ -236,6 +244,10 @@ def _populate_compress_metadata(
         core_attn_metadata.c4_sparse_raw_indices = torch.zeros(
             (16, 1), dtype=torch.int32, device=device
         )
+        # The sparse prefill path selects the ratio's raw top-k through this accessor.
+        core_attn_metadata.sparse_raw_indices = lambda ratio: (
+            core_attn_metadata.c4_sparse_raw_indices if ratio == 4 else None
+        )
     elif compress_ratio == 128:
         core_attn_metadata.c128_page_indices = torch.zeros(
             (16, 1), dtype=torch.int32, device=device
@@ -248,9 +260,9 @@ def _patched_compressed_sparse_cache_paths(compress_ratio: int):
         yield
         return
 
-    old_ensure_c4 = SparsePrefillChunkCache.ensure_c4
+    old_ensure_compressed = SparsePrefillChunkCache.ensure_compressed
     old_ensure_c128 = SparsePrefillChunkCache.ensure_c128
-    old_combine_c4_layer = SparsePrefillChunkCache.combine_c4_layer
+    old_combine_compressed = SparsePrefillChunkCache.combine_compressed
 
     def _with_compressed_prefix(cache: SparsePrefillChunkCache, n_compressed: int):
         shifted_swa = torch.where(
@@ -279,26 +291,35 @@ def _patched_compressed_sparse_cache_paths(compress_ratio: int):
             self, n_compressed
         )
 
-    def fake_ensure_c4(self, page_table, extra_page_size):
-        _ = page_table, extra_page_size
+    def fake_ensure_compressed(self, compress_ratio, page_table, extra_page_size):
+        _ = page_table
         n_compressed = 8
-        self.c4_flat_token_ids = torch.arange(
-            n_compressed, dtype=torch.int64, device=self.swa_token_ids.device
+        device = self.swa_token_ids.device
+        gather = CompressedGather(
+            flat_token_ids=torch.arange(n_compressed, dtype=torch.int64, device=device),
+            page_size=extra_page_size,
+            compressed_base=torch.zeros(
+                self.num_reqs, dtype=torch.int32, device=device
+            ),
+            swa_base=torch.zeros(self.num_reqs, dtype=torch.int32, device=device),
         )
+        self.compressed[compress_ratio] = gather
+        return gather
 
-    def fake_combine_c4_layer(self, c4_sparse_raw_indices):
-        _ = c4_sparse_raw_indices
-        return _with_compressed_prefix(self, self.c4_flat_token_ids.shape[0])
+    def fake_combine_compressed(self, compress_ratio, sparse_raw_indices):
+        _ = sparse_raw_indices
+        n_compressed = self.compressed[compress_ratio].flat_token_ids.shape[0]
+        return _with_compressed_prefix(self, n_compressed)
 
     SparsePrefillChunkCache.ensure_c128 = fake_ensure_c128
-    SparsePrefillChunkCache.ensure_c4 = fake_ensure_c4
-    SparsePrefillChunkCache.combine_c4_layer = fake_combine_c4_layer
+    SparsePrefillChunkCache.ensure_compressed = fake_ensure_compressed
+    SparsePrefillChunkCache.combine_compressed = fake_combine_compressed
     try:
         yield
     finally:
-        SparsePrefillChunkCache.ensure_c4 = old_ensure_c4
+        SparsePrefillChunkCache.ensure_compressed = old_ensure_compressed
         SparsePrefillChunkCache.ensure_c128 = old_ensure_c128
-        SparsePrefillChunkCache.combine_c4_layer = old_combine_c4_layer
+        SparsePrefillChunkCache.combine_compressed = old_combine_compressed
 
 
 def _make_q8kv8_kernel_args(

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -352,15 +352,7 @@ def test_topk_v2_ragged_window(name: str, rows, k: int, offset_shift: int) -> No
     ref_raw = _reference(windows, lengths.cpu(), k)
     _assert_topk_close(windows, ref_raw, our_raw, len(rows), lengths.cpu(), k)
 
-    # the only legal in-place write is the <=3 masked columns ahead of a window
-    # that the kernel actually reads (trivial rows read nothing)
-    changed = (scores != before).cpu()
-    for i, (start, length) in enumerate(rows):
-        allowed = torch.zeros(scores.shape[1], dtype=torch.bool)
-        if length > k:
-            allowed[start - start % 4 : start] = True
-        stray = (changed[i] & ~allowed).nonzero().flatten().tolist()
-        assert not stray, f"row {i} ({name}) wrote outside its masked head: {stray[:8]}"
+    assert torch.equal(scores, before)
 
 
 @pytest.mark.parametrize("k", [512, 2048])

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -352,7 +352,56 @@ def test_topk_v2_ragged_window(name: str, rows, k: int, offset_shift: int) -> No
     ref_raw = _reference(windows, lengths.cpu(), k)
     _assert_topk_close(windows, ref_raw, our_raw, len(rows), lengths.cpu(), k)
 
-    assert torch.equal(scores, before)
+
+def _assert_topk_values(window, indices, k):
+    indices = indices.cpu().long()
+    window = window.cpu()
+    assert indices.numel() == k
+    assert ((indices >= 0) & (indices < window.numel())).all(), indices
+    assert indices.unique().numel() == k
+    expected = window.topk(k).values.sort().values
+    actual = window[indices].sort().values
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("num_ties", [48, 96])
+@torch.inference_mode()
+def test_topk_v2_negative_infinity_ties(num_ties: int) -> None:
+    """Inactive entries must not displace valid -inf scores or leave slots unwritten."""
+    k = 16
+    length = num_ties + 3
+    scores = torch.full((1, (length + 3) & ~3), -torch.inf, device="cuda")
+    scores[0, :3] = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+    lengths = torch.tensor([length], dtype=torch.int32, device="cuda")
+    out = torch.full((1, k), -2, dtype=torch.int32, device="cuda")
+
+    topk_transform_paged_v2(scores, lengths, None, out, PAGE_SIZE, _plan(lengths))
+
+    _assert_topk_values(scores[0, :length], out[0], k)
+
+
+@pytest.mark.parametrize("length", [257, 8193, 16385])
+@torch.inference_mode()
+def test_topk_v2_ragged_negative_infinity(length: int) -> None:
+    """Columns before an unaligned window must never beat its valid -inf scores."""
+    k = 16
+    scores = torch.full((3, (length + 6) & ~3), OUTSIDE_SCORE, device="cuda")
+    starts = torch.tensor([1, 2, 3], dtype=torch.int32, device="cuda")
+    lengths = torch.full((3,), length, dtype=torch.int32, device="cuda")
+    offsets = starts + 1024
+    out = torch.full((3, k), -2, dtype=torch.int32, device="cuda")
+    for row, start in enumerate((1, 2, 3)):
+        scores[row, start : start + length] = -torch.inf
+        scores[row, start : start + 3] = torch.tensor([1.0, 2.0, 3.0], device="cuda")
+
+    topk_transform_ragged_v2(
+        scores, lengths, out_offsets=offsets, out_indices=out, row_starts=starts
+    )
+
+    for row, start in enumerate((1, 2, 3)):
+        _assert_topk_values(
+            scores[row, start : start + length], out[row] - offsets[row], k
+        )
 
 
 @pytest.mark.parametrize("k", [512, 2048])

--- a/test/registered/kernels/ops/embeddings/test_engram_gate.py
+++ b/test/registered/kernels/ops/embeddings/test_engram_gate.py
@@ -1,0 +1,59 @@
+"""The fused gate retains FP32 normalization and casts only the final result."""
+
+import itertools
+import unittest
+
+import torch
+
+from sglang.kernels.ops.embeddings.engram_gate import fused_engram_gate
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+def reference(x, kv, qw, kw, eps, clamp):
+    hc, dim = x.shape[-2:]
+    key, value = kv.split([hc * dim, dim], dim=-1)
+    h, key, value = x.float(), key.float().reshape_as(x), value.float()
+    rstd = torch.rsqrt(h.square().mean(-1) + eps) * torch.rsqrt(
+        key.square().mean(-1) + eps
+    )
+    dot = (h * (qw.float() * kw.float()) * key).sum(-1) * rstd * dim**-0.5
+    gate = torch.sigmoid(torch.copysign(dot.abs().clamp_min(clamp).sqrt(), dot))
+    return (h + gate.unsqueeze(-1) * value.unsqueeze(-2)).to(x.dtype)
+
+
+class TestEngramGate(CustomTestCase):
+    def test_numerics_and_ownership(self):
+        torch.manual_seed(23)
+        # Token counts span decode (1), a verify block (8) and a prefill chunk (4096).
+        for dtype, weight_dtype, batch, dim in itertools.product(
+            (torch.bfloat16, torch.float32),
+            (torch.bfloat16, torch.float32),
+            (0, 1, 8, 4096),
+            (128, 5120),
+        ):
+            with self.subTest(dtype=dtype, weights=weight_dtype, batch=batch, dim=dim):
+                x = torch.randn(batch, 4, dim, device="cuda", dtype=dtype)
+                kv = torch.randn(batch, 5 * dim, device="cuda", dtype=dtype)
+                qw = torch.randn(4, dim, device="cuda", dtype=weight_dtype)
+                kw = torch.randn_like(qw)
+                originals = [v.clone() for v in (x, kv, qw, kw)]
+                result = fused_engram_gate(x, kv, qw, kw, 1e-6, 1e-6)
+                # fp32: the 5120-wide reductions run in a different order than
+                # torch's, worth ~1e-5 absolute on a handful of elements at 4096 tokens.
+                torch.testing.assert_close(
+                    result,
+                    reference(x, kv, qw, kw, 1e-6, 1e-6),
+                    atol=1e-5 if dtype == torch.bfloat16 else 2e-5,
+                    rtol=8e-3 if dtype == torch.bfloat16 else 3e-5,
+                )
+                self.assertEqual(result.dtype, dtype)
+                self.assertTrue(result.is_contiguous())
+                for value, original in zip((x, kv, qw, kw), originals):
+                    self.assertTrue(torch.equal(value, original))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/embeddings/test_engram_hash.py
+++ b/test/registered/kernels/ops/embeddings/test_engram_hash.py
@@ -1,0 +1,233 @@
+"""Compare decode and multimodal extend hashes with a per-token reference."""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.embeddings.engram_hash import (
+    MODE_DECODE,
+    MODE_EXTEND,
+    engram_hash_ids,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.cuda is None,
+    reason="engram_hash_ids requires CUDA",
+)
+
+VOCAB = 1000
+COMPRESSED = 300
+N = 4
+L = 2
+H = 8
+COLS = (N - 1) * H
+IMAGE = 7
+MM_PAD_SHIFT = 1_000_000
+# (N - 1) * H primes per layer, all above COMPRESSED - 1, in ascending order.
+PRIMES = [
+    1009,
+    1013,
+    1019,
+    1021,
+    1031,
+    1033,
+    1039,
+    1049,
+    1051,
+    1061,
+    1063,
+    1069,
+    1087,
+    1091,
+    1093,
+    1097,
+    1103,
+    1109,
+    1117,
+    1123,
+    1129,
+    1151,
+    1153,
+    1163,
+    1171,
+    1181,
+    1187,
+    1193,
+    1201,
+    1213,
+    1217,
+    1223,
+    1229,
+    1231,
+    1237,
+    1249,
+    1259,
+    1277,
+    1279,
+    1283,
+    1289,
+    1291,
+    1297,
+    1301,
+    1303,
+    1307,
+    1319,
+    1321,
+]
+
+
+def _tables(seed=0):
+    g = torch.Generator().manual_seed(seed)
+    token_map = torch.randint(0, COMPRESSED, (VOCAB,), generator=g, dtype=torch.int64)
+    bound = (2**63 - 1) // COMPRESSED // 2
+    multipliers = (
+        torch.randint(0, bound, (L, N), generator=g, dtype=torch.int64) * 2 + 1
+    )
+    primes = torch.tensor(PRIMES, dtype=torch.int64).view(L, N - 1, H)
+    flat = primes.view(L, COLS)
+    offsets = torch.cumsum(torch.cat([flat.new_zeros(L, 1), flat[:, :-1]], 1), 1)
+    return token_map, multipliers, primes, offsets
+
+
+def naive(
+    ids,
+    pos,
+    *,
+    mode,
+    history,
+    token_map,
+    multipliers,
+    primes,
+    offsets,
+    pad_id,
+    num_real,
+    req_slots,
+    block,
+    row,
+    starts,
+    image_token_id,
+):
+    ids, pos, hist, tm = (
+        ids.tolist(),
+        pos.tolist(),
+        history.tolist(),
+        token_map.tolist(),
+    )
+    mult, pr, ofs = multipliers.tolist(), primes.tolist(), offsets.tolist()
+    slots = req_slots.tolist() if req_slots is not None else None
+    row = row.tolist() if row is not None else None
+    starts = starts.tolist() if starts is not None else None
+    T = len(ids)
+    out = torch.zeros(T, L, COLS, dtype=torch.int64)
+    toks = torch.zeros(T, N, dtype=torch.int32)
+    for t in range(T):
+        comp = [pad_id] * N
+        if t < num_real:
+            if mode == MODE_DECODE:
+                r, off = t, 0
+            else:
+                r = row[t]
+                off = t - starts[r]
+            hrow = slots[r] if slots is not None else r
+            blocked = False
+            for s in range(N):
+                tok = ids[t - s] if s <= off else hist[hrow][N - 2 - (s - off - 1)]
+                if image_token_id is not None:
+                    if tok >= MM_PAD_SHIFT:
+                        tok = image_token_id
+                    blocked = blocked or tok == image_token_id
+                blocked = blocked or pos[t] < s
+                toks[t, s] = tok
+                comp[s] = pad_id if blocked else tm[tok]
+        for l in range(L):
+            rolling = comp[0] * mult[l][0]
+            for i in range(1, N):
+                rolling ^= comp[i] * mult[l][i]
+                for h in range(H):
+                    out[t, l, (i - 1) * H + h] = (
+                        rolling % pr[l][i - 1][h] + ofs[l][(i - 1) * H + h]
+                    )
+    return out, toks
+
+
+def _check(ids, pos, **kw):
+    dev = {k: (v.cuda() if torch.is_tensor(v) else v) for k, v in kw.items()}
+    got_ids, got_toks = engram_hash_ids(
+        ids.cuda(), pos.cuda(), mm_pad_shift=MM_PAD_SHIFT, **dev
+    )
+    want_ids, want_toks = naive(ids, pos, **kw)
+    assert got_toks.dtype == torch.int32 and got_ids.dtype == torch.int64
+    assert torch.equal(got_toks.cpu(), want_toks), (got_toks.cpu(), want_toks)
+    assert torch.equal(got_ids.cpu(), want_ids)
+    return got_ids
+
+
+def _common(seed=0, image=False):
+    token_map, multipliers, primes, offsets = _tables(seed)
+    return dict(
+        token_map=token_map,
+        multipliers=multipliers,
+        primes=primes,
+        offsets=offsets,
+        pad_id=int(token_map[2]),
+        image_token_id=IMAGE if image else None,
+    )
+
+
+def test_decode_reads_history_through_req_slots():
+    g = torch.Generator().manual_seed(1)
+    bs, slots_total = 7, 12
+    ids = torch.randint(0, VOCAB, (bs,), generator=g)
+    pos = torch.randint(0, 50, (bs,), generator=g)
+    pos[0] = 0  # sequence start: only the token itself survives
+    history = torch.randint(
+        0, VOCAB, (slots_total + 1, N - 1), generator=g, dtype=torch.int32
+    )
+    req_slots = torch.randperm(slots_total, generator=g)[:bs]
+    _check(
+        ids,
+        pos,
+        mode=MODE_DECODE,
+        history=history,
+        num_real=bs,
+        req_slots=req_slots,
+        block=1,
+        row=None,
+        starts=None,
+        **_common(),
+    )
+
+
+def _extend_batch(g, lens, padded_to):
+    starts = torch.cumsum(torch.tensor([0] + lens[:-1]), 0)
+    row = torch.repeat_interleave(torch.arange(len(lens)), torch.tensor(lens))
+    num_real = int(row.numel())
+    ids = torch.randint(0, VOCAB, (padded_to,), generator=g)
+    first_pos = torch.tensor([0, 17, 0, 5])[: len(lens)]
+    pos = torch.zeros(padded_to, dtype=torch.int64)
+    pos[:num_real] = first_pos[row] + (torch.arange(num_real) - starts[row])
+    return ids, pos, row, starts, num_real
+
+
+def test_extend_with_scheduler_history_and_image_spans():
+    g = torch.Generator().manual_seed(4)
+    lens = [6, 0, 3, 9]
+    ids, pos, row, starts, num_real = _extend_batch(g, lens, padded_to=18)
+    ids[2] = IMAGE  # inside request 0: shifts reaching it and beyond are PAD
+    ids[12] = IMAGE
+    history = torch.randint(0, VOCAB, (4, N - 1), generator=g, dtype=torch.int32)
+    history[3, 1] = MM_PAD_SHIFT + 5  # multimodal pad id in the scheduler's history
+    _check(
+        ids,
+        pos,
+        mode=MODE_EXTEND,
+        history=history,
+        num_real=num_real,
+        req_slots=None,
+        block=1,
+        row=row,
+        starts=starts,
+        **_common(image=True),
+    )

--- a/test/registered/kernels/ops/layernorm/test_hc_mix_stats.py
+++ b/test/registered/kernels/ops/layernorm/test_hc_mix_stats.py
@@ -1,0 +1,44 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.layernorm.mhc import hc_mix_stats
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.cuda is None,
+    reason="hc_mix_stats requires CUDA",
+)
+
+EPS = 1e-6
+
+
+def _reference(x_flat: torch.Tensor, hc_fn: torch.Tensor) -> torch.Tensor:
+    x = x_flat.double()
+    rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
+    return (x @ hc_fn.double().T) * rsqrt
+
+
+@pytest.mark.parametrize("m", [1, 7, 64, 300, 1024, 4096])
+@pytest.mark.parametrize("k", [4096, 20480])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_hc_mix_stats_matches_reference(m: int, k: int, dtype: torch.dtype):
+    torch.manual_seed(0)
+    x_flat = torch.randn(m, k, device="cuda", dtype=dtype)
+    hc_fn = torch.randn(24, k, device="cuda", dtype=torch.float32) * 0.02
+
+    got = hc_mix_stats(x_flat, hc_fn, EPS)
+    ref = _reference(x_flat, hc_fn)
+
+    assert got.shape == (m, 24) and got.dtype == torch.float32
+    scale = ref.abs().max().clamp(min=1e-6)
+    err_kernel = (got.double() - ref).abs().max() / scale
+    # Bound FP32 accumulation error relative to the independent FP64 result.
+    assert err_kernel < 1e-4
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/kernels/ops/moe/test_dsv41_vl_router.py
+++ b/test/registered/kernels/ops/moe/test_dsv41_vl_router.py
@@ -1,0 +1,109 @@
+import itertools
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.multimodal.dsv41.vl_routing import vision_topk
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+
+def route(
+    logits,
+    text,
+    image,
+    tokens,
+    *,
+    image_token_id,
+    num_token_non_padded=None,
+    **config,
+):
+    moe = SimpleNamespace(
+        gate=SimpleNamespace(
+            e_score_correction_bias=text, e_score_correction_bias_vl=image
+        ),
+        config=SimpleNamespace(image_token_id=image_token_id),
+        topk=SimpleNamespace(topk_config=SimpleNamespace(**config)),
+    )
+    out = vision_topk(moe, logits, tokens, num_token_non_padded)
+    return out.topk_weights, out.topk_ids
+
+
+def reference(
+    logits,
+    text,
+    image,
+    tokens,
+    *,
+    image_token_id,
+    top_k,
+    renormalize,
+    routed_scaling_factor,
+    apply_routed_scaling_factor_on_output,
+    num_token_non_padded=None,
+):
+    scores = F.softplus(logits.float()).sqrt()
+    bias = (
+        text
+        if tokens is None
+        else torch.where((tokens == image_token_id)[:, None], image, text)
+    )
+    indices = (scores + bias).topk(top_k, dim=-1).indices
+    weights = scores.gather(-1, indices)
+    if renormalize and top_k > 1:
+        weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
+    if apply_routed_scaling_factor_on_output:
+        weights = weights * routed_scaling_factor
+    indices = indices.int()
+    if num_token_non_padded is not None:
+        pad = (
+            torch.arange(logits.shape[0], device=logits.device) >= num_token_non_padded
+        )
+        indices[pad] = -1
+        weights[pad] = 0
+    return weights, indices
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestV41VLRouter(unittest.TestCase):
+    def make_case(self, rows, experts, dtype, k=6):
+        logits = torch.randn(rows, experts * 2, device="cuda", dtype=dtype)[:, ::2]
+        text = torch.randn(experts * 2, device="cuda", dtype=dtype)[::2]
+        image = -text
+        tokens = (torch.arange(rows * 2, device="cuda", dtype=torch.int64) % 4)[::2]
+        kwargs = dict(
+            image_token_id=0,
+            top_k=k,
+            renormalize=True,
+            routed_scaling_factor=1.5,
+            apply_routed_scaling_factor_on_output=True,
+        )
+        return (logits, text, image, tokens), kwargs
+
+    def assert_parity(self, args, kwargs):
+        expected = reference(*args, **kwargs)
+        actual = route(*args, **kwargs)
+        torch.testing.assert_close(actual[1], expected[1], atol=0, rtol=0)
+        torch.testing.assert_close(actual[0], expected[0], atol=1e-6, rtol=3e-6)
+        return actual
+
+    def test_modality_dtype_padding(self):
+        torch.manual_seed(114)
+        for rows, experts, dtype, k in itertools.product(
+            (0, 1, 5, 17), (128, 384), (torch.float32, torch.bfloat16), (1, 3, 6)
+        ):
+            with self.subTest(rows=rows, experts=experts, dtype=dtype, k=k):
+                args, kwargs = self.make_case(rows, experts, dtype, k)
+                self.assert_parity(args, kwargs)
+                for real in (0, max(0, rows - 1)):
+                    kwargs["num_token_non_padded"] = torch.tensor(
+                        real, device="cuda", dtype=torch.int32
+                    )
+                    self.assert_parity(args, kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/test_mhc_post_split_h.py
+++ b/test/registered/kernels/ops/test_mhc_post_split_h.py
@@ -1,0 +1,48 @@
+"""Stress rounding and graph replay against the current TileLang post kernel."""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.layernorm.mhc import mhc_post
+from sglang.kernels.ops.layernorm.mhc_post_split_h import mhc_post_split_h
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestMhcPostSplitH(CustomTestCase):
+    def test_exact_eager_and_graph(self):
+        with get_parallel().override(attn_cp_size=1):
+            for batch in (1, 4, 7, 8, 16, 32, 64):
+                with self.subTest(batch_size=batch):
+                    x = torch.empty(batch, 5120, device="cuda", dtype=torch.bfloat16)
+                    residual = torch.empty(
+                        batch, 4, 5120, device="cuda", dtype=torch.bfloat16
+                    )
+                    post = torch.empty(batch, 4, device="cuda")
+                    comb = torch.empty(batch, 4, 4, device="cuda")
+                    inputs = (x, residual, post, comb)
+                    for value in inputs:
+                        value.normal_()
+                    mhc_post_split_h(*inputs)
+                    torch.cuda.synchronize()
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        captured = mhc_post_split_h(*inputs)
+                    for seed in range(30):
+                        torch.manual_seed(1000 + seed)
+                        for value in inputs:
+                            value.normal_()
+                        expected = mhc_post(*inputs)
+                        actual = mhc_post_split_h(*inputs)
+                        graph.replay()
+                        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                        torch.testing.assert_close(captured, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models_e2e/test_deepseek_v41.py
+++ b/test/registered/models_e2e/test_deepseek_v41.py
@@ -1,0 +1,137 @@
+"""Day-zero sanity for a V4.1 vision checkpoint with a bundled DSpark head.
+
+Set DSV41_MODEL_PATH to the checkpoint available on the test runner.
+"""
+
+import base64
+import io
+import os
+import unittest
+
+import requests
+from PIL import Image
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
+from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=300, stage="nightly", runner_config="4-gpu-gb300")
+
+
+class _DSV41Server(CustomTestCase):
+    dspark = False
+    process = None
+    base_url = DEFAULT_URL_FOR_TEST
+    sanity_max_new_tokens_short = 64
+    _decode_generate = BasicDecodeCorrectnessMixin._decode_generate
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = os.environ.get("DSV41_MODEL_PATH")
+        if not cls.model:
+            raise unittest.SkipTest("Set DSV41_MODEL_PATH to the V4.1 checkpoint")
+        args = [
+            "--trust-remote-code",
+            "--tp",
+            "4",
+            "--ep-size",
+            "4",
+            "--attention-backend",
+            "dsv4",
+            "--moe-runner-backend",
+            "flashinfer_mxfp4",
+            "--mem-fraction-static",
+            "0.80",
+            "--chunked-prefill-size",
+            "4096",
+            "--context-length",
+            "16384",
+            "--max-running-requests",
+            "8",
+            "--cuda-graph-max-bs",
+            "8",
+            "--random-seed",
+            "0",
+        ]
+        if cls.dspark:
+            args += [
+                "--speculative-algorithm",
+                "DSPARK",
+                "--speculative-dspark-block-size",
+                "5",
+                "--enable-decoder-swa-bounded-replay",
+            ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.process is not None:
+            kill_process_tree(cls.process.pid)
+            cls.process = None
+
+
+class TestDSV41Sanity(_DSV41Server):
+    test_generation = BasicDecodeCorrectnessMixin.test_capital_france
+    test_streaming = BasicSchedulerStressMixin.test_streaming_response
+
+    def test_image_input(self):
+        buffer = io.BytesIO()
+        Image.new("RGB", (224, 224), "red").save(buffer, format="PNG")
+        image = base64.b64encode(buffer.getvalue()).decode("ascii")
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:image/png;base64,{image}"},
+                            },
+                            {
+                                "type": "text",
+                                "text": "What color is the image? Reply with one color word.",
+                            },
+                        ],
+                    }
+                ],
+                "chat_template_kwargs": {"thinking": False},
+                "temperature": 0,
+                "max_tokens": 32,
+            },
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        text = response.json()["choices"][0]["message"]["content"]
+        self.assertIn("red", text.lower())
+
+
+class TestDSV41DSpark(_DSV41Server):
+    dspark = True
+
+    def test_generation_with_speculation(self):
+        BasicDecodeCorrectnessMixin.test_capital_france(self)
+        output = self._decode_generate("List the numbers from 1 to 20:", 64)
+        self.assertTrue(output.strip())
+        response = requests.get(self.base_url + "/server_info", timeout=30)
+        self.assertEqual(response.status_code, 200, response.text)
+        accept_length = response.json()["internal_states"][0]["avg_spec_accept_length"]
+        self.assertGreater(accept_length, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/quant/test_block_fp8_as_mxfp8.py
+++ b/test/registered/quant/test_block_fp8_as_mxfp8.py
@@ -1,0 +1,134 @@
+"""Check the MXFP8 linear layer against an FP32 dequantization reference."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization import fp8_utils
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8_utils import (
+    Fp8GemmRunnerBackend,
+    can_serve_block_fp8_as_mxfp8,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=120, stage="base-c", runner_config="4-gpu-gb300")
+
+BLOCK = 32
+DEVICE = "cuda"
+OPT_IN = Fp8GemmRunnerBackend.FLASHINFER_CUTEDSL
+SKIP_MSG = "MXFP8 dense kernels unavailable (needs Blackwell + FlashInfer)"
+
+
+def _opt_in():
+    """Select the FlashInfer cute-dsl MXFP8 kernel the way `--fp8-gemm-backend` would."""
+    return patch.object(fp8_utils, "FP8_GEMM_RUNNER_BACKEND", OPT_IN)
+
+
+def _mxfp8_available():
+    with _opt_in():
+        return can_serve_block_fp8_as_mxfp8([BLOCK, BLOCK], "ue8m0")
+
+
+def _quant_block32(w: torch.Tensor):
+    """fp8 e4m3 weight with one ue8m0 scale per 32x32 block (ceil rule), like the checkpoint."""
+    n, k = w.shape
+    blocks = w.float().view(n // BLOCK, BLOCK, k // BLOCK, BLOCK)
+    amax = blocks.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-30)
+    scale = torch.exp2(torch.ceil(torch.log2(amax / 448.0)))
+    q = (blocks / scale).clamp(-448, 448).to(torch.float8_e4m3fn).view(n, k)
+    return q, scale.view(n // BLOCK, k // BLOCK)
+
+
+def _dequant_block32(q: torch.Tensor, scale: torch.Tensor):
+    n, k = q.shape
+    return (
+        q.float().view(n // BLOCK, BLOCK, k // BLOCK, BLOCK)
+        * scale.view(n // BLOCK, 1, k // BLOCK, 1)
+    ).view(n, k)
+
+
+def _block32_config():
+    return Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[BLOCK, BLOCK],
+        scale_fmt="ue8m0",
+    )
+
+
+def _build_layer(method: Fp8LinearMethod, q: torch.Tensor, scale: torch.Tensor):
+    """Create the layer through the linear method and load the checkpoint tensors through
+    the parameters' own loaders (the scale arrives as e8m0, the way the checkpoint stores it)."""
+    n, k = q.shape
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer=layer,
+        input_size_per_partition=k,
+        output_partition_sizes=[n],
+        input_size=k,
+        output_size=n,
+        params_dtype=torch.bfloat16,
+        skip_block_quant_check=True,  # no parallel state in a unit test
+        weight_loader=lambda *a, **kw: None,
+    )
+    layer = layer.to(DEVICE)
+    layer.weight.load_column_parallel_weight(q, tp_rank=0)
+    layer.weight_scale_inv.load_column_parallel_weight(
+        scale.to(torch.float8_e8m0fnu), tp_rank=0
+    )
+    method.process_weights_after_loading(layer)
+    return layer
+
+
+class _OptInCase(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not _mxfp8_available():
+            raise unittest.SkipTest(SKIP_MSG)
+        cls._patch = _opt_in()
+        cls._patch.start()
+        torch.manual_seed(0)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_patch"):
+            cls._patch.stop()
+
+
+class TestLinearNumerics(_OptInCase):
+    """Check decode and prefill outputs at the deployed dense projection shapes."""
+
+    SHAPES = [(1792, 5120), (5120, 576)]
+    MS = [1, 17, 300]
+
+    def test_against_dequantized_reference(self):
+        from sglang.kernels.ops.quantization.fp8_kernel import (
+            sglang_per_token_group_quant_fp8,
+        )
+
+        method = Fp8LinearMethod(_block32_config())
+        for n, k in self.SHAPES:
+            w = torch.randn(n, k, device=DEVICE, dtype=torch.bfloat16) / (k**0.5)
+            q, s = _quant_block32(w)
+            layer = _build_layer(method, q, s)
+            w_deq = _dequant_block32(q, s)
+            for m in self.MS:
+                x = torch.randn(m, k, device=DEVICE, dtype=torch.bfloat16)
+                xq, xs = sglang_per_token_group_quant_fp8(x, BLOCK, scale_ue8m0=True)
+                x_deq = (
+                    xq.float().view(m, k // BLOCK, BLOCK)
+                    * xs.view(m, k // BLOCK, 1).float()
+                )
+                ref = x_deq.view(m, k) @ w_deq.t()
+                out = method.apply(layer, x)
+                self.assertEqual(out.dtype, torch.bfloat16)
+                amax = ref.abs().max().item()
+                error = (out.float() - ref).abs().max().item() / amax
+                self.assertLess(error, 1e-2, (n, k, m, error))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/quant/test_fp8_hopper_swapab.py
+++ b/test/registered/quant/test_fp8_hopper_swapab.py
@@ -1,0 +1,113 @@
+"""Small-M Hopper block-FP8 MMA transpose with nonuniform UE8M0 scales."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.kernels.ops.quantization import fp8_kernel
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0),
+    "Hopper required",
+)
+class TestHopperBlockFP8SwapAB(CustomTestCase):
+    def test_graph_replay_matches_original(self):
+        self._check_graph_replay(split_k=False)
+
+    def test_split_k_replay_matches_original(self):
+        self._check_graph_replay(split_k=True)
+
+    def _check_graph_replay(self, split_k):
+        original = dict(
+            BLOCK_SIZE_M=64,
+            BLOCK_SIZE_N=32,
+            BLOCK_SIZE_K=32,
+            GROUP_SIZE_M=32,
+            num_warps=4,
+            num_stages=3,
+        )
+        for n, k in [
+            (1152, 5120),
+            (1792, 5120),
+            (25600, 6144),
+            (4096, 1280),
+            (5120, 2048),
+            (5120, 576),
+            (8192, 1280),
+        ]:
+            with self.subTest(n=n, k=k):
+                torch.manual_seed(17)
+                a = torch.randn(1, k, device="cuda").to(torch.float8_e4m3fn)
+                b = torch.randn(n, k, device="cuda").to(torch.float8_e4m3fn)
+                sa = torch.exp2(
+                    torch.randint(-5, 3, (1, k // 32), device="cuda").float()
+                )
+                sb = torch.exp2(
+                    torch.randint(-5, 3, (n // 32, k // 32), device="cuda").float()
+                )
+                config = {
+                    **original,
+                    "BLOCK_SIZE_M": 16,
+                    "BLOCK_SIZE_N": 128 if n == 25600 or k == 576 else 64,
+                    "num_stages": 4,
+                    "SWAP_AB": True,
+                }
+
+                if split_k and n != 25600:
+                    splits = {
+                        (1152, 5120): 16,
+                        (1792, 5120): 8,
+                        (4096, 1280): 4,
+                        (5120, 2048): 8,
+                        (5120, 576): 4,
+                        (8192, 1280): 2,
+                    }
+                    config.update(SPLIT_K=splits[n, k], BLOCK_SIZE_N=64)
+
+                def run():
+                    return fp8_kernel.w8a8_block_fp8_matmul_triton(
+                        a, b, sa, sb, [32, 32], torch.bfloat16
+                    )
+
+                with patch.object(
+                    fp8_kernel, "get_w8a8_block_fp8_configs", return_value={1: original}
+                ):
+                    expected = run()
+                with patch.object(
+                    fp8_kernel, "get_w8a8_block_fp8_configs", return_value={1: config}
+                ):
+                    run()  # Compile outside graph capture.
+                    graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(graph):
+                        actual = run()
+                graph.replay()
+                torch.testing.assert_close(
+                    actual,
+                    expected,
+                    rtol=0.008 if split_k else 0,
+                    atol=0.0001 if split_k else 0,
+                )
+                # Replay must read fresh activation payload and scales.
+                a.copy_(torch.randn(1, k, device="cuda").to(a.dtype))
+                sa.mul_(2)
+                with patch.object(
+                    fp8_kernel, "get_w8a8_block_fp8_configs", return_value={1: original}
+                ):
+                    expected = run()
+                graph.replay()
+                torch.testing.assert_close(
+                    actual,
+                    expected,
+                    rtol=0.008 if split_k else 0,
+                    atol=0.0001 if split_k else 0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv41.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv41.py
@@ -1,0 +1,173 @@
+"""DeepSeek V4.1 Flash + HiCache + UnifiedRadixCache.
+
+V4.1 replaces the c4/c128 compressed layers with ratio-1/2 kv_source layers, so
+the HiCache stack mirrors the low-ratio latent and fp4 index-key pools
+(deepseek_v4_c1 / deepseek_v4_c2 and their indexers) next to KV and SWA.
+The device pool is capped so the L2 (host) and L3 (storage) paths actually run.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.unified_radix_cache_kit import (
+    AccuracyTwoPassMixin,
+    UnifiedRadixTreeTestMixin,
+)
+from sglang.test.kl_multiturn_utils import get_input_ids
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    terminate_and_kill_process_tree,
+    unified_radix_tree_server_env,
+)
+
+DSV41_FLASH_MODEL = "deepseek-ai/DeepSeek-V4.1-Flash"
+DSV41_FLASH_LAUNCH_TIMEOUT = 3600
+
+register_cuda_ci(est_time=3600, stage="nightly", runner_config="4-gpu-gb300")
+
+# A cached prefix may lose up to one 256-token page at the tail.
+DSV41_PAGE_SIZE = 256
+
+
+def _assert_dsv41_decode_cached_tokens(result, history_len, output_len, label):
+    expected = history_len + output_len
+    actual = result["meta_info"]["cached_tokens"]
+    lower = max(0, expected - DSV41_PAGE_SIZE)
+    assert actual >= lower, f"{label}: expected cached_tokens>={lower}, got {actual}"
+
+
+def _dsv41_base_args():
+    return [
+        "--trust-remote-code",
+        "--tp-size",
+        "4",
+        "--ep-size",
+        "4",
+        "--mem-fraction-static",
+        "0.8",
+        "--chunked-prefill-size",
+        "8192",
+        "--context-length",
+        "32768",
+        # Small enough that the radix tree evicts to host during the tests.
+        "--max-total-tokens",
+        "65536",
+        "--max-running-requests",
+        "8",
+        "--enable-cache-report",
+        "--enable-hierarchical-cache",
+        "--hicache-ratio",
+        "4",
+        "--hicache-write-policy",
+        "write_through",
+    ]
+
+
+class TestUnifiedDeepSeekV41FlashHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
+    """DeepSeek V4.1 Flash + HiCache L2 + UnifiedRadixCache."""
+
+    tree_core_backend = "python"
+    hicache_io_backend = "kernel"
+    hicache_mem_layout = "page_first"
+    # The dsv4 backend is not batch-invariant (deterministic inference is refused
+    # on it), so decode-vs-prefill KL has a floor with or without HiCache: the
+    # same server without --enable-hierarchical-cache measured 0.0063 on the
+    # decode-cache-hit helper (0.0062 with HiCache) and 0.0009 / 0.0022 on the
+    # prefill-cache-hit helper, 9 samples, 512 tokens, 4xGB300 TP4.
+    kl_threshold = 0.01
+    sampling_temperature = 0
+    decode_hit_request_batch_size = 3
+    decode_hit_inter_batch_delay_s = 0.5
+    decode_cache_assert = staticmethod(_assert_dsv41_decode_cached_tokens)
+    gsm8k_threshold = 0.90
+    num_gsm8k_questions = 100
+
+    @unittest.skipIf(is_in_ci(), "To reduce the CI execution time.")
+    def test_multiturn_logprobs_match(self):
+        pass
+
+    @classmethod
+    def _server_args(cls):
+        return _dsv41_base_args() + [
+            "--hicache-io-backend",
+            cls.hicache_io_backend,
+            "--hicache-mem-layout",
+            cls.hicache_mem_layout,
+        ]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DSV41_FLASH_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DSV41_FLASH_LAUNCH_TIMEOUT,
+            other_args=cls._server_args(),
+            env=unified_radix_tree_server_env(cls.tree_core_backend),
+        )
+        cls.input_ids = get_input_ids(cls.model, num_samples=18)
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
+
+
+class TestUnifiedDeepSeekV41FlashDSparkHiCacheL3(AccuracyTwoPassMixin, CustomTestCase):
+    """DeepSeek V4.1 Flash DSpark + HiCache L3 (file backend) + UnifiedRadixCache."""
+
+    tree_core_backend = "python"
+    l3_prefetch_page_size = DSV41_PAGE_SIZE
+    l3_prefetch_prompt_pages = 4
+    gsm8k_threshold = 0.90
+    num_gsm8k_questions = 100
+    gsm8k_parallel = 8
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DSV41_FLASH_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.hicache_dir = tempfile.mkdtemp(prefix="hicache_l3_dsv41_")
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DSV41_FLASH_LAUNCH_TIMEOUT,
+            other_args=_dsv41_base_args()
+            + [
+                "--hicache-io-backend",
+                "kernel",
+                "--hicache-mem-layout",
+                "page_first",
+                "--hicache-storage-backend",
+                "file",
+                "--hicache-storage-prefetch-policy",
+                "wait_complete",
+                "--speculative-algorithm",
+                "DSPARK",
+                "--speculative-dspark-block-size",
+                "5",
+            ],
+            env=unified_radix_tree_server_env(
+                cls.tree_core_backend,
+                SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR=cls.hicache_dir,
+            ),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
+        hicache_dir = getattr(cls, "hicache_dir", None)
+        if hicache_dir and os.path.isdir(hicache_dir):
+            shutil.rmtree(hicache_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_encoding_dsv41.py
+++ b/test/registered/unit/entrypoints/openai/test_encoding_dsv41.py
@@ -1,0 +1,71 @@
+"""Unit tests for the DeepSeek-V4.1 chat encoder -- no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.entrypoints.openai.encoding_dsv41 import (
+    encode_messages,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _tool() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Look up a value",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            },
+        },
+    }
+
+
+class TestDsmlTags(CustomTestCase):
+    def test_multiturn_prompt_preserves_reasoning_and_tool_results(self):
+        messages = [
+            {"role": "system", "content": "system", "tools": [_tool()]},
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "reasoning_content": "reason",
+                "content": "summary",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {"query": query}},
+                    }
+                    for call_id, query in (("a", "first"), ("b", "second"))
+                ],
+            },
+            {"role": "tool", "tool_call_id": "b", "content": "second result"},
+            {"role": "tool", "tool_call_id": "a", "content": "first result"},
+        ]
+        prompt = encode_messages(messages, thinking_mode="thinking")
+        expected = (
+            "<｜User｜>question<｜Assistant｜><think>reason</think>summary\n\n"
+            "<｜DSML｜ calls>\n"
+            '<｜DSML｜ invoke name="lookup">\n'
+            '<｜DSML｜ parameter name="query" string="true">first</｜DSML｜ parameter>\n'
+            "</｜DSML｜ invoke>\n"
+            '<｜DSML｜ invoke name="lookup">\n'
+            '<｜DSML｜ parameter name="query" string="true">second</｜DSML｜ parameter>\n'
+            "</｜DSML｜ invoke>\n"
+            "</｜DSML｜ calls><｜end▁of▁sentence｜>"
+            "<｜User｜><tool_result>first result</tool_result>\n\n"
+            "<tool_result>second result</tool_result><｜Assistant｜><think>"
+        )
+        self.assertEqual(prompt[prompt.index("<｜User｜>") :], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -52,7 +52,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 # Every spec resolve_chat_encoding_spec can return; pinned by the guard below.
-_ALL_CHAT_ENCODING_SPECS = ("dsv4", "dsv32", "inkling", "kimi_k3")
+_ALL_CHAT_ENCODING_SPECS = ("dsv41", "dsv4", "dsv32", "inkling", "kimi_k3")
 
 
 def _spec_result(index):

--- a/test/registered/unit/function_call/test_deepseekv41_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv41_detector.py
@@ -1,0 +1,140 @@
+"""Unit tests for DeepSeekV41Detector (spaced DSML tags) -- no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai import encoding_dsv41
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+CHUNK_SIZES = [1, 2, 3, 5, 7, 11, 23, 1000]
+
+
+def _tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="Get weather information",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            ),
+        ),
+        Tool(
+            type="function",
+            function=Function(
+                name="lookup",
+                description="Look up a value",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"},
+                        "flags": {"type": "array"},
+                    },
+                },
+            ),
+        ),
+    ]
+
+
+def _assemble(calls):
+    """Streamed ToolCallItems -> [(name, parsed arguments)] per tool_index."""
+    by_index = {}
+    for call in calls:
+        entry = by_index.setdefault(call.tool_index, {"name": None, "args": ""})
+        if call.name:
+            entry["name"] = call.name
+        entry["args"] += call.parameters or ""
+    return [
+        (entry["name"], json.loads(entry["args"]))
+        for _, entry in sorted(by_index.items())
+    ]
+
+
+class TestDeepSeekV41RoundTrip(CustomTestCase):
+    """Encoder-rendered assistant tool calls parse back to the same arguments,
+    in one shot and at every chunk size."""
+
+    ARGUMENTS = {"query": '{"a": 1}', "limit": 2, "flags": [1, True, None]}
+
+    def setUp(self):
+        self.tools = _tools()
+        self.completion = encoding_dsv41.render_message(
+            1,
+            [
+                {"role": "user", "content": "question"},
+                {
+                    "role": "assistant",
+                    "reasoning_content": "reason",
+                    "content": "summary",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": json.dumps(self.ARGUMENTS),
+                            },
+                        }
+                    ],
+                },
+            ],
+            thinking_mode="thinking",
+        )
+        self.completion = "<think>" + self.completion
+        self.expected = [("lookup", self.ARGUMENTS)]
+
+    def test_one_shot(self):
+        parser = FunctionCallParser(self.tools, "deepseekv41")
+        reasoning, content = ReasoningParser("deepseek-v41").parse_non_stream(
+            self.completion
+        )
+        self.assertEqual(reasoning, "reason")
+        normal, calls = parser.parse_non_stream(content)
+        self.assertEqual(normal, "summary")
+        self.assertEqual(
+            [(c.name, json.loads(c.parameters)) for c in calls], self.expected
+        )
+
+    def test_streaming_at_every_chunk_size(self):
+        for chunk_size in CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                reasoning_parser = ReasoningParser("deepseek-v41")
+                tool_parser = FunctionCallParser(self.tools, "deepseekv41")
+                reasoning, normal, calls = "", "", []
+                for i in range(0, len(self.completion), chunk_size):
+                    reason, content = reasoning_parser.parse_stream_chunk(
+                        self.completion[i : i + chunk_size]
+                    )
+                    reasoning += reason or ""
+                    text, delta = tool_parser.parse_stream_chunk(content or "")
+                    normal += text
+                    calls.extend(delta)
+                reason, content = reasoning_parser.parse_stream_end()
+                reasoning += reason or ""
+                text, delta = tool_parser.parse_stream_chunk(content or "")
+                normal += text
+                calls.extend(delta)
+                text, delta = tool_parser.parse_stream_end()
+                normal += text
+                calls.extend(delta)
+                self.assertEqual(reasoning, "reason")
+                # The blank line before the block is released or trimmed depending
+                # on where the chunk boundary falls; the shared base behaves the
+                # same for V4, so only the prose itself is pinned here.
+                self.assertEqual(normal.strip(), "summary")
+                self.assertEqual(_assemble(calls), self.expected)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_mxfp4_trtllm_padding.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_trtllm_padding.py
@@ -1,0 +1,133 @@
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.quantization import mxfp4_flashinfer_trtllm_moe as mxfp4
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="4-gpu-b200")
+
+
+def make_layer(weights):
+    layer = torch.nn.Module()
+    names = (
+        "w13_weight",
+        "w2_weight",
+        "w13_weight_scale_inv",
+        "w2_weight_scale_inv",
+    )
+    for name, tensor in zip(names, weights):
+        layer.register_parameter(name, torch.nn.Parameter(tensor, requires_grad=False))
+    layer.num_experts = weights[0].shape[0]
+    layer.num_local_experts = layer.num_experts
+    layer.moe_ep_rank = 0
+    return layer
+
+
+def make_weights(intermediate, hidden=256, device="cpu"):
+    experts = 8
+    w13 = torch.randint(
+        -128,
+        128,
+        (experts, 2 * intermediate, hidden // 2),
+        dtype=torch.int8,
+        device=device,
+    )
+    w2 = torch.randint(
+        -128,
+        128,
+        (experts, hidden, intermediate // 2),
+        dtype=torch.int8,
+        device=device,
+    )
+    s13 = (
+        torch.randint(-6, -3, (experts, 2 * intermediate, hidden // 32), device=device)
+        .float()
+        .exp2()
+    )
+    s2 = (
+        torch.randint(-6, -3, (experts, hidden, intermediate // 32), device=device)
+        .float()
+        .exp2()
+    )
+    return w13, w2, s13, s2
+
+
+class TestMxfp4TrtllmPadding(CustomTestCase):
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10,
+        "Requires Blackwell",
+    )
+    def test_tp4_matches_unsharded_experts(self):
+        torch.manual_seed(42)
+        weights = make_weights(2304, hidden=5120, device="cuda")
+
+        def prepare(tensors):
+            layer = make_layer(tensors)
+            method = object.__new__(mxfp4.Mxfp4FlashinferTrtllmMoEMethod)
+            method._fp8 = Mock()
+            method.prefix = "test.experts"
+            method.flashinfer_mxfp4_moe_precision = "default"
+            method.process_weights_after_loading(layer)
+            method.create_moe_runner(layer, SimpleNamespace(swiglu_limit=10.0))
+            return method, layer
+
+        full = prepare([tensor.clone() for tensor in weights])
+        shards = []
+        for rank in range(4):
+            start = rank * 576
+            end = start + 576
+            w13, w2, s13, s2 = weights
+            shard = (
+                torch.cat(
+                    (w13[:, start:end], w13[:, 2304 + start : 2304 + end]), dim=1
+                ),
+                w2[..., start // 2 : end // 2].contiguous(),
+                torch.cat(
+                    (s13[:, start:end], s13[:, 2304 + start : 2304 + end]), dim=1
+                ),
+                s2[..., start // 32 : end // 32].contiguous(),
+            )
+            shards.append(prepare(shard))
+
+        with (
+            patch.object(mxfp4, "get_tp_group", return_value=None),
+            patch.object(mxfp4, "is_allocation_symmetric", return_value=False),
+            patch.object(mxfp4, "use_symmetric_memory", return_value=nullcontext()),
+        ):
+            for tokens in (1, 16, 64):
+                with self.subTest(tokens=tokens):
+                    x = torch.randn(tokens, 5120, dtype=torch.bfloat16, device="cuda")
+                    logits = torch.randn(tokens, 8, device="cuda")
+                    scores, ids = logits.softmax(-1).topk(6, dim=-1)
+                    topk = StandardTopKOutput(scores, ids.to(torch.int32), logits)
+                    dispatch = StandardDispatchOutput(x, None, topk)
+                    reference = full[0].apply(full[1], dispatch).hidden_states.float()
+                    actual = sum(
+                        method.apply(layer, dispatch).hidden_states.float()
+                        for method, layer in shards
+                    )
+                    relative_rmse = (
+                        (
+                            (actual - reference).square().mean()
+                            / reference.square().mean()
+                        )
+                        .sqrt()
+                        .item()
+                    )
+                    self.assertTrue(torch.isfinite(actual).all())
+                    self.assertLess(relative_rmse, 0.01)
+                    print(
+                        f"tokens={tokens} TP4 vs unsharded relative_rmse={relative_rmse:.6f}",
+                        flush=True,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_engram_device_table.py
+++ b/test/registered/unit/layers/test_engram_device_table.py
@@ -1,0 +1,124 @@
+"""Sharded device embeddings must reconstruct the checkpoint lookup on each rank."""
+
+import os
+import socket
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.multiprocessing as mp
+
+from sglang.srt.distributed.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="2-gpu-large")
+
+ROWS = 2048
+DIM = 256
+BLK = 32
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _init(rank: int, world: int, port: int, backend: str) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    init_distributed_environment(
+        world_size=world,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend=backend,
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world, backend=backend)
+
+
+def _teardown() -> None:
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+def _checkpoint_table(seed: int = 0, rows: int = ROWS):
+    """The checkpoint tensors as the loader hands them over: identical on every rank."""
+    g = torch.Generator().manual_seed(seed)
+    weight = (torch.randn(rows, DIM, generator=g) * 3).to(torch.float8_e4m3fn)
+    scale = torch.randint(
+        100, 140, (rows, DIM // BLK), dtype=torch.uint8, generator=g
+    ).view(torch.float8_e8m0fnu)
+    # Exponent byte zero represents 2**-127, not zero. Keep it in a real lookup.
+    weight.view(torch.uint8)[0, :BLK] = (
+        torch.tensor(1.0).to(torch.float8_e4m3fn).view(torch.uint8)
+    )
+    scale.view(torch.uint8)[0, 0] = 0
+    return weight, scale
+
+
+def _reference(weight, scale, ids):
+    ids = ids.cpu()
+    rows = weight[ids].float().unflatten(-1, (-1, BLK))
+    return (rows * scale[ids].float().unsqueeze(-1)).flatten(-2).to(torch.bfloat16)
+
+
+def _build(rows: int):
+    from sglang.srt.layers.engram import EngramEmbedding
+
+    with (
+        envs.SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE.override(False),
+        torch.device("cuda"),
+    ):
+        return EngramEmbedding(rows, DIM, layer_id=1)
+
+
+def _load(embed, weight, scale) -> None:
+    embed.weight.weight_loader(embed.weight, weight)
+    embed.scale.weight_loader(embed.scale, scale)
+    embed.finish_load()
+
+
+def _tp_worker(rank: int, world: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    _init(rank, world, port, "nccl")
+    try:
+        for rows in (2049, 2048, 1):
+            weight, scale = _checkpoint_table(rows=rows)
+            with (
+                get_parallel().override(tp_size=world, tp_rank=rank),
+                patch("sglang.srt.layers.engram.get_attention_dp_size", return_value=1),
+            ):
+                embed = _build(rows)
+                # Each rank loads its own range, including uneven or empty shards.
+                _load(embed, weight, scale)
+                ids = torch.arange(rows, device="cuda", dtype=torch.int64).view(-1, 1)
+                out = embed(ids)
+            torch.cuda.synchronize()
+            assert torch.equal(out.cpu(), _reference(weight, scale, ids)), (
+                f"rank {rank}, rows {rows}: incorrect lookup"
+            )
+            assert out[0, 0, 0].item() == 2**-127, "zero exponent was decoded as zero"
+            torch.distributed.barrier()
+    finally:
+        _teardown()
+
+
+class TestEngramDeviceTable(CustomTestCase):
+    def test_sharded_lookup_matches_checkpoint(self):
+        world = min(2, torch.cuda.device_count())
+        if world < 2:
+            self.skipTest("needs two GPUs to run two TP ranks")
+        mp.spawn(_tp_worker, args=(world, _free_port()), nprocs=world, join=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -442,6 +442,8 @@ class TestDecodePrebuilt(unittest.TestCase):
         scheduler.policy = MagicMock()
         scheduler.schedule_stream = MagicMock()
         scheduler.forward_stream = MagicMock()
+        scheduler.ngram_embedding_manager = MagicMock()
+        scheduler.chunked_req = None
         return scheduler
 
     def test_waiting_queue_is_sorted_before_prebuilt_selection(self):

--- a/test/registered/unit/mem_cache/test_dsv4_compress_write_pad.py
+++ b/test/registered/unit/mem_cache/test_dsv4_compress_write_pad.py
@@ -19,7 +19,7 @@ class TestCompressStateWritePad(CustomTestCase):
 
     def test_pad_is_zero_without_speculation(self):
         """A non-speculative ring is exactly one window wide: nothing rolls back."""
-        for compress_ratio in (4, 128):
+        for compress_ratio in (2, 4, 128):
             ring_size = get_compress_state_ring_size(compress_ratio, False)
             with self.subTest(cr=compress_ratio, ring=ring_size):
                 self.assertEqual(

--- a/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
@@ -1,4 +1,4 @@
-"""Unit tests for LongCat ngram token table updates."""
+"""Unit tests for ngram token tables and Engram predecessor history."""
 
 import unittest
 from types import SimpleNamespace

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1599,17 +1599,11 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "attention_backend": "dsv4",
                     "moe_runner_backend": "flashinfer_mxfp4",
                     "page_size": 256,
-                    "swa_full_tokens_ratio": 0.1,
                 },
             )
         # NPU pool geometry
         self.assertEqual(
             _deepseek_v4_overrides(_args(device="npu"), hf)["page_size"], 128
-        )
-        # user-set window ratio survives
-        self.assertNotIn(
-            "swa_full_tokens_ratio",
-            _deepseek_v4_overrides(_args(swa_full_tokens_ratio=0.5), hf),
         )
         # An explicit user choice takes precedence over the model default.
         self.assertNotIn(


### PR DESCRIPTION
## Motivation

DeepSeek-V4.1 replaces the c4/c128 compressed layers with ratio-1/2 kv_source layers, and the HiCache stack mirrors their latent and fp4 index-key pools (`deepseek_v4_c1` / `deepseek_v4_c2` and their indexers) as KV-derived sidecars. Nothing in `test/registered` exercises that path on V4.1. This adds the HiCache L2 / L3 coverage for `deepseek-ai/DeepSeek-V4.1-Flash`, mirroring `test_unified_radix_cache_kl_dsv4.py`.

## Modifications

New file `test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv41.py`, registered as `nightly` on `4-gpu-gb300`:

- `TestUnifiedDeepSeekV41FlashHiCache`: L2 (host) HiCache, `--hicache-ratio 4 write_through`, kernel / page_first. Runs GSM8K and the three multi-turn KL helpers from `UnifiedRadixTreeTestMixin`.
- `TestUnifiedDeepSeekV41FlashDSparkHiCacheL3`: DSpark (block size 5) + file storage backend with `wait_complete` prefetch. Runs two-pass GSM8K and `test_l3_prefetch_full_prefix_hit_after_flush`.

Both classes cap the device pool with `--max-total-tokens 65536` so the L2 / L3 paths actually run instead of everything staying resident on the GPU.

`kl_threshold` is 0.01 rather than the 0.005 used for V4. The dsv4 backend is not batch-invariant (it refuses `--enable-deterministic-inference`), so the decode-vs-prefill KL has a floor with or without HiCache: the same server without `--enable-hierarchical-cache` measured 0.0063 on `test_multiturn_decode_cache_hit_branching` (0.0062 with HiCache) and 0.0009 / 0.0022 on the prefill-cache-hit helper. The measurement is recorded next to the attribute.

## Accuracy Tests

Run on 4x GB300, TP4 / EP4, against the `dsv4.1` branch:

- L2 class: GSM8K 0.94 (threshold 0.90); `test_multiturn_logprobs_match`, `test_multiturn_prefill_cache_hit_branching` (KL 0.0022 / 0.0042 over two runs) and `test_multiturn_decode_cache_hit_branching` (KL 0.0062 / 0.0045) pass at the 0.01 threshold.
- L3 + DSpark class: GSM8K 0.92 / 0.94 across the flush; `test_l3_prefetch_full_prefix_hit_after_flush` passes with the full 1024-token prompt restored from storage.
- With `--enable-metrics`, a 106k-token filler run against the 65536-token device pool showed `load_back_tokens_total` kv 110592 / swa 96256, and a 3840-token prefix evicted to host came back with `cached_tokens=3840`.

Note: launching with a long local checkpoint path instead of the HF id needs the file-backend temp-name fix (separate PR against `main`); with the HF id the names are short and the L3 class is unaffected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829757682](https://github.com/sgl-project/sglang/actions/runs/34829757682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829757553](https://github.com/sgl-project/sglang/actions/runs/34829757553)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829757681](https://github.com/sgl-project/sglang/actions/runs/34829757681)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->