### PR TITLE
[Diffusion][SenseNova] Build RoPE tables once per forward, not per layer

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
@@ -402,6 +402,15 @@ class Qwen3RotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
+def _build_neo_unify_rope_tables(rotary_emb, rotary_emb_hw, indexes, x):
+    """Temporal positions use ``rotary_emb``; height and width use ``rotary_emb_hw``."""
+    return (
+        rotary_emb(x, indexes[0].unsqueeze(0)),
+        rotary_emb_hw(x, indexes[1].unsqueeze(0)),
+        rotary_emb_hw(x, indexes[2].unsqueeze(0)),
+    )
+
+
 class Qwen3Attention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
@@ -503,6 +512,13 @@ class Qwen3Attention(nn.Module):
         hw_config.max_position_embeddings = config.max_position_embeddings_hw
         self.rotary_emb_hw = Qwen3RotaryEmbedding(config=hw_config)
 
+    def _resolve_rope_tables(self, hidden_states, indexes, rope_tables):
+        if rope_tables is not None:
+            return rope_tables
+        return _build_neo_unify_rope_tables(
+            self.rotary_emb, self.rotary_emb_hw, indexes, hidden_states
+        )
+
     def forward_und(
         self,
         hidden_states: torch.Tensor,
@@ -530,17 +546,15 @@ class Qwen3Attention(nn.Module):
 
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
+            hidden_states, indexes, kwargs.pop("rope_tables", None)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
-
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
-
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -705,17 +719,15 @@ class Qwen3Attention(nn.Module):
         )  # [B,H,S,D]
 
         # RoPE
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
+            hidden_states, indexes, kwargs.pop("rope_tables", None)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
-
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
-
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -982,17 +994,15 @@ class Qwen3Attention(nn.Module):
             )
         value_states = value_states.view(hidden_shape).transpose(1, 2)
 
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
+            hidden_states, indexes, kwargs.pop("rope_tables", None)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
-
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
-
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -1388,7 +1398,18 @@ class Qwen3Model(Qwen3PreTrainedModel):
 
         hidden_states = inputs_embeds
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        # RoPE depends only on `indexes`, which is fixed for every layer of this
+        # forward, so build the tables once instead of once per layer.
+        layers = self.layers[: self.config.num_hidden_layers]
+        first_attn = layers[0].self_attn
+        rope_tables = _build_neo_unify_rope_tables(
+            first_attn.rotary_emb,
+            first_attn.rotary_emb_hw,
+            indexes,
+            hidden_states,
+        )
+
+        for decoder_layer in layers:
             hidden_states = decoder_layer(
                 hidden_states,
                 image_gen_indicators=image_gen_indicators,
@@ -1400,6 +1421,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 cache_position=cache_position,
+                rope_tables=rope_tables,
                 **kwargs,
             )
         if not exist_image_gen_tokens:

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
@@ -402,13 +402,9 @@ class Qwen3RotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
-# Temporal positions use `rotary_emb`; height and width use `rotary_emb_hw`.
-def _build_neo_unify_rope_tables(rotary_emb, rotary_emb_hw, indexes, x):
-    return (
-        rotary_emb(x, indexes[0].unsqueeze(0)),
-        rotary_emb_hw(x, indexes[1].unsqueeze(0)),
-        rotary_emb_hw(x, indexes[2].unsqueeze(0)),
-    )
+# RoPE runs on three axes: temporal, height, width, each a `(cos, sin)` pair.
+RopeTable = tuple[torch.Tensor, torch.Tensor]
+PositionEmbeddings = tuple[RopeTable, RopeTable, RopeTable]
 
 
 class Qwen3Attention(nn.Module):
@@ -512,11 +508,19 @@ class Qwen3Attention(nn.Module):
         hw_config.max_position_embeddings = config.max_position_embeddings_hw
         self.rotary_emb_hw = Qwen3RotaryEmbedding(config=hw_config)
 
-    def _resolve_rope_tables(self, hidden_states, indexes, rope_tables):
-        if rope_tables is not None:
-            return rope_tables
-        return _build_neo_unify_rope_tables(
-            self.rotary_emb, self.rotary_emb_hw, indexes, hidden_states
+    def _resolve_rope_tables(
+        self,
+        indexes: torch.LongTensor,
+        hidden_states: torch.Tensor,
+        position_embeddings: Optional[PositionEmbeddings] = None,
+    ) -> PositionEmbeddings:
+        if position_embeddings is not None:
+            return position_embeddings
+        # Temporal positions use `rotary_emb`; height and width use `rotary_emb_hw`.
+        return (
+            self.rotary_emb(hidden_states, indexes[0].unsqueeze(0)),
+            self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0)),
+            self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0)),
         )
 
     def forward_und(
@@ -526,7 +530,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         assert self.config._attn_implementation == "eager"
@@ -548,7 +552,7 @@ class Qwen3Attention(nn.Module):
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, rope_tables
+            indexes, hidden_states, position_embeddings
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -689,7 +693,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         input_shape = hidden_states.shape[:-1]
@@ -722,7 +726,7 @@ class Qwen3Attention(nn.Module):
 
         # RoPE
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, rope_tables
+            indexes, hidden_states, position_embeddings
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -874,7 +878,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         if exist_non_image_gen_tokens and not exist_image_gen_tokens:
@@ -884,7 +888,7 @@ class Qwen3Attention(nn.Module):
                 attention_mask,
                 past_key_values,
                 cache_position,
-                rope_tables=rope_tables,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
         if not exist_non_image_gen_tokens and exist_image_gen_tokens:
@@ -894,7 +898,7 @@ class Qwen3Attention(nn.Module):
                 attention_mask,
                 past_key_values,
                 cache_position,
-                rope_tables=rope_tables,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -1000,7 +1004,7 @@ class Qwen3Attention(nn.Module):
         value_states = value_states.view(hidden_shape).transpose(1, 2)
 
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, rope_tables
+            indexes, hidden_states, position_embeddings
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -1104,7 +1108,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -1121,7 +1125,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
-            rope_tables=rope_tables,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1145,7 +1149,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -1162,7 +1166,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
-            rope_tables=rope_tables,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1187,7 +1191,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
+        position_embeddings: Optional[PositionEmbeddings] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         if exist_non_image_gen_tokens and not exist_image_gen_tokens:
@@ -1202,7 +1206,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
                 past_key_values,
                 use_cache,
                 cache_position,
-                rope_tables=rope_tables,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
         if not exist_non_image_gen_tokens and exist_image_gen_tokens:
@@ -1217,7 +1221,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
                 past_key_values,
                 use_cache,
                 cache_position,
-                rope_tables=rope_tables,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -1252,7 +1256,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
-            rope_tables=rope_tables,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1333,7 +1337,6 @@ class Qwen3Model(Qwen3PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
 
@@ -1412,16 +1415,14 @@ class Qwen3Model(Qwen3PreTrainedModel):
 
         hidden_states = inputs_embeds
 
-        # RoPE depends only on `indexes`, so one build serves every layer of this
-        # forward.
+        # The tables depend only on the positions, plus the activation dtype and
+        # device that `Qwen3RotaryEmbedding.forward` reads off `x`. All three are
+        # fixed for the whole forward, so one build serves every layer.
         layers = self.layers[: self.config.num_hidden_layers]
-        if rope_tables is None:
-            first_attn = layers[0].self_attn
-            rope_tables = _build_neo_unify_rope_tables(
-                first_attn.rotary_emb,
-                first_attn.rotary_emb_hw,
-                indexes,
-                hidden_states,
+        position_embeddings = None
+        if layers:
+            position_embeddings = layers[0].self_attn._resolve_rope_tables(
+                indexes, hidden_states
             )
 
         for decoder_layer in layers:
@@ -1436,7 +1437,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 cache_position=cache_position,
-                rope_tables=rope_tables,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
         if not exist_image_gen_tokens:

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
@@ -402,8 +402,8 @@ class Qwen3RotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
+# Temporal positions use `rotary_emb`; height and width use `rotary_emb_hw`.
 def _build_neo_unify_rope_tables(rotary_emb, rotary_emb_hw, indexes, x):
-    """Temporal positions use ``rotary_emb``; height and width use ``rotary_emb_hw``."""
     return (
         rotary_emb(x, indexes[0].unsqueeze(0)),
         rotary_emb_hw(x, indexes[1].unsqueeze(0)),
@@ -526,6 +526,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         assert self.config._attn_implementation == "eager"
@@ -547,7 +548,7 @@ class Qwen3Attention(nn.Module):
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, kwargs.pop("rope_tables", None)
+            hidden_states, indexes, rope_tables
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -688,6 +689,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         input_shape = hidden_states.shape[:-1]
@@ -720,7 +722,7 @@ class Qwen3Attention(nn.Module):
 
         # RoPE
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, kwargs.pop("rope_tables", None)
+            hidden_states, indexes, rope_tables
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -872,6 +874,7 @@ class Qwen3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         if exist_non_image_gen_tokens and not exist_image_gen_tokens:
@@ -881,6 +884,7 @@ class Qwen3Attention(nn.Module):
                 attention_mask,
                 past_key_values,
                 cache_position,
+                rope_tables=rope_tables,
                 **kwargs,
             )
         if not exist_non_image_gen_tokens and exist_image_gen_tokens:
@@ -890,6 +894,7 @@ class Qwen3Attention(nn.Module):
                 attention_mask,
                 past_key_values,
                 cache_position,
+                rope_tables=rope_tables,
                 **kwargs,
             )
 
@@ -995,7 +1000,7 @@ class Qwen3Attention(nn.Module):
         value_states = value_states.view(hidden_shape).transpose(1, 2)
 
         (cos_t, sin_t), (cos_h, sin_h), (cos_w, sin_w) = self._resolve_rope_tables(
-            hidden_states, indexes, kwargs.pop("rope_tables", None)
+            hidden_states, indexes, rope_tables
         )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
@@ -1099,6 +1104,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -1115,6 +1121,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
+            rope_tables=rope_tables,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1138,6 +1145,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -1154,6 +1162,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
+            rope_tables=rope_tables,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1178,6 +1187,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
         past_key_values: Optional[Cache] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> torch.Tensor:
         if exist_non_image_gen_tokens and not exist_image_gen_tokens:
@@ -1192,6 +1202,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
                 past_key_values,
                 use_cache,
                 cache_position,
+                rope_tables=rope_tables,
                 **kwargs,
             )
         if not exist_non_image_gen_tokens and exist_image_gen_tokens:
@@ -1206,6 +1217,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
                 past_key_values,
                 use_cache,
                 cache_position,
+                rope_tables=rope_tables,
                 **kwargs,
             )
 
@@ -1240,6 +1252,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
+            rope_tables=rope_tables,
             **kwargs,
         )
         hidden_states = residual + hidden_states
@@ -1320,6 +1333,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        rope_tables: Optional[tuple] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
 
@@ -1398,16 +1412,17 @@ class Qwen3Model(Qwen3PreTrainedModel):
 
         hidden_states = inputs_embeds
 
-        # RoPE depends only on `indexes`, which is fixed for every layer of this
-        # forward, so build the tables once instead of once per layer.
+        # RoPE depends only on `indexes`, so one build serves every layer of this
+        # forward.
         layers = self.layers[: self.config.num_hidden_layers]
-        first_attn = layers[0].self_attn
-        rope_tables = _build_neo_unify_rope_tables(
-            first_attn.rotary_emb,
-            first_attn.rotary_emb_hw,
-            indexes,
-            hidden_states,
-        )
+        if rope_tables is None:
+            first_attn = layers[0].self_attn
+            rope_tables = _build_neo_unify_rope_tables(
+                first_attn.rotary_emb,
+                first_attn.rotary_emb_hw,
+                indexes,
+                hidden_states,
+            )
 
         for decoder_layer in layers:
             hidden_states = decoder_layer(

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -894,23 +894,13 @@ def test_sensenova_u1_shared_rope_tables_match_per_layer_computation():
     derive identical tables from the same `indexes`. If the tables ever become
     layer-dependent, sharing them would silently change every attention output.
     """
-    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
-        _build_neo_unify_rope_tables,
-    )
-
     torch.manual_seed(0)
     first, other = _tiny_dense_attention(0), _tiny_dense_attention(1)
     x = torch.randn(1, 5, _HIDDEN_DIM)
     indexes = torch.arange(3 * 5).reshape(3, 5) % 3
 
-    shared = _build_neo_unify_rope_tables(
-        first.rotary_emb, first.rotary_emb_hw, indexes, x
-    )
-    reference_modules = (
-        other.rotary_emb,
-        other.rotary_emb_hw,
-        other.rotary_emb_hw,
-    )
+    shared = first._resolve_rope_tables(indexes, x)
+    reference_modules = (other.rotary_emb, other.rotary_emb_hw, other.rotary_emb_hw)
     for (cos_shared, sin_shared), module, axis in zip(
         shared, reference_modules, (0, 1, 2)
     ):
@@ -919,64 +909,46 @@ def test_sensenova_u1_shared_rope_tables_match_per_layer_computation():
         assert torch.equal(sin_shared, sin_ref), f"sin differs on axis {axis}"
 
 
-class _RopeRebuildDetector(torch.nn.Module):
-    """An nn.Module so it can take over a registered submodule slot."""
+class _CountingRotaryEmbedding(torch.nn.Module):
+    """Delegates to a real rope module and records one entry per table computed."""
 
-    def forward(self, *args, **kwargs):
-        pytest.fail("rope tables rebuilt")
+    def __init__(self, inner, builds: list[int]):
+        super().__init__()
+        self.inner = inner
+        self.builds = builds
 
-
-def test_sensenova_u1_attention_reuses_passed_rope_tables(monkeypatch):
-    """Passing tables down must skip the per-layer rebuild.
-
-    The failure mode is silent: reintroducing the rebuild keeps every output
-    correct, so only this case notices that the sharing stopped happening.
-    """
-    attn = _tiny_dense_attention()
-    shared = ("t", "h", "w")
-    detector = _RopeRebuildDetector()
-    monkeypatch.setattr(attn, "rotary_emb", detector)
-    monkeypatch.setattr(attn, "rotary_emb_hw", detector)
-
-    x = torch.randn(1, 5, _HIDDEN_DIM)
-    indexes = torch.zeros(3, 5, dtype=torch.long)
-
-    assert attn._resolve_rope_tables(x, indexes, shared) is shared
+    def forward(self, x, position_ids):
+        self.builds.append(1)
+        return self.inner(x, position_ids)
 
 
 @pytest.mark.parametrize("image_gen", [True, False], ids=["gen", "und"])
-def test_sensenova_u1_model_builds_once_and_shares_with_every_layer(
-    monkeypatch, image_gen
-):
+def test_sensenova_u1_model_builds_once_and_shares_with_every_layer(image_gen):
     """One build per forward, reaching every layer on both dispatch paths.
 
     Guards the optimization itself: a dropped link, or a build moved back inside
     the layer loop, leaves every output correct, so only the call count notices.
+    Every layer's rope modules are wrapped by a counter, so it counts the real
+    table computations however they are reached: one build is 3 entries (t, h, w),
+    and any more means some layer computed its own.
     """
-    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify import (
-        modeling_qwen3,
-    )
     from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
-        Qwen3Attention,
         Qwen3Model,
     )
 
     model = Qwen3Model(_tiny_dense_config()).eval()
-    received = []
-    builds = []
-    original_build = modeling_qwen3._build_neo_unify_rope_tables
-    original_resolve = Qwen3Attention._resolve_rope_tables
+    builds: list[int] = []
+    for layer in model.layers:
+        # Each slot keeps its own rope module: `rotary_emb` and `rotary_emb_hw`
+        # differ in head_dim, so sharing one wrapper across both builds h/w tables
+        # of the wrong width instead of failing this assertion.
+        for name in ("rotary_emb", "rotary_emb_hw"):
+            setattr(
+                layer.self_attn,
+                name,
+                _CountingRotaryEmbedding(getattr(layer.self_attn, name), builds),
+            )
 
-    def counting_build(*args, **kwargs):
-        builds.append(1)
-        return original_build(*args, **kwargs)
-
-    def spy(self, hidden_states, indexes, rope_tables):
-        received.append(rope_tables is not None)
-        return original_resolve(self, hidden_states, indexes, rope_tables)
-
-    monkeypatch.setattr(modeling_qwen3, "_build_neo_unify_rope_tables", counting_build)
-    monkeypatch.setattr(Qwen3Attention, "_resolve_rope_tables", spy)
     with torch.no_grad():
         model(
             inputs_embeds=torch.randn(1, 5, _HIDDEN_DIM),
@@ -985,9 +957,7 @@ def test_sensenova_u1_model_builds_once_and_shares_with_every_layer(
             attention_mask={"full_attention": None},
         )
 
-    assert builds == [1], f"rope tables built {len(builds)} times, want 1"
-    assert len(received) == _LAYERS, f"attention ran {len(received)} times"
-    assert all(received), f"layers that had to rebuild: {received}"
+    assert len(builds) == 3, f"expected one t/h/w build, got {len(builds)}"
 
 
 def test_sensenova_u1_rope_sharing_does_not_change_output(monkeypatch):
@@ -1022,8 +992,8 @@ def test_sensenova_u1_rope_sharing_does_not_change_output(monkeypatch):
     monkeypatch.setattr(
         Qwen3Attention,
         "_resolve_rope_tables",
-        lambda self, hidden_states, idx, tables: original(
-            self, hidden_states, idx, None
+        lambda self, indexes, hidden_states, embeddings=None: original(
+            self, indexes, hidden_states, None
         ),
     )
     per_layer = run()

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -944,36 +944,50 @@ def test_sensenova_u1_attention_reuses_passed_rope_tables(monkeypatch):
     assert attn._resolve_rope_tables(x, indexes, shared) is shared
 
 
-def test_sensenova_u1_model_shares_rope_tables_with_every_layer(monkeypatch):
-    """Guards the wiring from the model loop down to attention.
+@pytest.mark.parametrize("image_gen", [True, False], ids=["gen", "und"])
+def test_sensenova_u1_model_builds_once_and_shares_with_every_layer(
+    monkeypatch, image_gen
+):
+    """One build per forward, reaching every layer on both dispatch paths.
 
-    A dropped kwarg anywhere in that chain leaves every output correct, so
-    without this case the sharing could stop happening unnoticed.
+    Guards the optimization itself: a dropped link, or a build moved back inside
+    the layer loop, leaves every output correct, so only the call count notices.
     """
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify import (
+        modeling_qwen3,
+    )
     from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
         Qwen3Attention,
         Qwen3Model,
     )
 
     model = Qwen3Model(_tiny_dense_config()).eval()
-    seen = []
-    original = Qwen3Attention._resolve_rope_tables
+    received = []
+    builds = []
+    original_build = modeling_qwen3._build_neo_unify_rope_tables
+    original_resolve = Qwen3Attention._resolve_rope_tables
+
+    def counting_build(*args, **kwargs):
+        builds.append(1)
+        return original_build(*args, **kwargs)
 
     def spy(self, hidden_states, indexes, rope_tables):
-        seen.append(rope_tables is not None)
-        return original(self, hidden_states, indexes, rope_tables)
+        received.append(rope_tables is not None)
+        return original_resolve(self, hidden_states, indexes, rope_tables)
 
+    monkeypatch.setattr(modeling_qwen3, "_build_neo_unify_rope_tables", counting_build)
     monkeypatch.setattr(Qwen3Attention, "_resolve_rope_tables", spy)
     with torch.no_grad():
         model(
             inputs_embeds=torch.randn(1, 5, _HIDDEN_DIM),
-            image_gen_indicators=torch.ones(1, 5, dtype=torch.bool),
+            image_gen_indicators=torch.full((1, 5), image_gen, dtype=torch.bool),
             indexes=torch.zeros(3, 5, dtype=torch.long),
             attention_mask={"full_attention": None},
         )
 
-    assert len(seen) == _LAYERS, f"attention ran {len(seen)} times, want {_LAYERS}"
-    assert all(seen), f"layers that had to rebuild their own tables: {seen}"
+    assert builds == [1], f"rope tables built {len(builds)} times, want 1"
+    assert len(received) == _LAYERS, f"attention ran {len(received)} times"
+    assert all(received), f"layers that had to rebuild: {received}"
 
 
 def test_sensenova_u1_rope_sharing_does_not_change_output(monkeypatch):
@@ -1015,34 +1029,3 @@ def test_sensenova_u1_rope_sharing_does_not_change_output(monkeypatch):
     per_layer = run()
 
     assert torch.equal(shared, per_layer)
-
-
-def test_sensenova_u1_rope_tables_reach_the_understanding_path(monkeypatch):
-    """`forward_und` has its own pop site, so the gen-path cases do not cover it.
-
-    All-zeros indicators select the understanding path used by the text prefix.
-    """
-    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
-        Qwen3Attention,
-        Qwen3Model,
-    )
-
-    model = Qwen3Model(_tiny_dense_config()).eval()
-    seen = []
-    original = Qwen3Attention._resolve_rope_tables
-
-    def spy(self, hidden_states, indexes, rope_tables):
-        seen.append(rope_tables is not None)
-        return original(self, hidden_states, indexes, rope_tables)
-
-    monkeypatch.setattr(Qwen3Attention, "_resolve_rope_tables", spy)
-    with torch.no_grad():
-        model(
-            inputs_embeds=torch.randn(1, 5, _HIDDEN_DIM),
-            image_gen_indicators=torch.zeros(1, 5, dtype=torch.bool),
-            indexes=torch.zeros(3, 5, dtype=torch.long),
-            attention_mask={"full_attention": None},
-        )
-
-    assert len(seen) == _LAYERS, f"attention ran {len(seen)} times, want {_LAYERS}"
-    assert all(seen), f"layers that had to rebuild their own tables: {seen}"

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -849,3 +849,200 @@ def test_sensenova_u1_multi_output_entrypoint_mixed_failure_fails_parent(
     assert trace_ctx.started_slices == [("gpu_forward", 2)]
     assert trace_ctx.finished_slices == [("gpu_forward", 2)]
     assert trace_ctx.finish_count == 1
+
+
+# ===== Shared RoPE tables =====
+
+_HIDDEN_DIM, _HEADS, _KV_HEADS, _HEAD_DIM, _LAYERS, _INTER = 8, 2, 1, 8, 2, 16
+
+
+def _tiny_dense_config():
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.configuration_neo_chat import (
+        NEOLLMConfig,
+    )
+
+    config = NEOLLMConfig(
+        hidden_size=_HIDDEN_DIM,
+        intermediate_size=_INTER,
+        num_attention_heads=_HEADS,
+        num_key_value_heads=_KV_HEADS,
+        head_dim=_HEAD_DIM,
+        num_hidden_layers=_LAYERS,
+        rms_norm_eps=1e-6,
+        attention_dropout=0.0,
+        attention_bias=False,
+        vocab_size=32,
+    )
+    config.layer_types = ["full_attention"] * _LAYERS
+    # forward_und asserts eager; the understanding path is unreachable otherwise.
+    config._attn_implementation = "eager"
+    return config
+
+
+def _tiny_dense_attention(layer_idx=0):
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        Qwen3Attention,
+    )
+
+    return Qwen3Attention(_tiny_dense_config(), layer_idx)
+
+
+def test_sensenova_u1_shared_rope_tables_match_per_layer_computation():
+    """Qwen3Model builds RoPE once per forward and shares it across layers.
+
+    Guards the assumption that makes it valid: two identically configured layers
+    derive identical tables from the same `indexes`. If the tables ever become
+    layer-dependent, sharing them would silently change every attention output.
+    """
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        _build_neo_unify_rope_tables,
+    )
+
+    torch.manual_seed(0)
+    first, other = _tiny_dense_attention(0), _tiny_dense_attention(1)
+    x = torch.randn(1, 5, _HIDDEN_DIM)
+    indexes = torch.arange(3 * 5).reshape(3, 5) % 3
+
+    shared = _build_neo_unify_rope_tables(
+        first.rotary_emb, first.rotary_emb_hw, indexes, x
+    )
+    reference_modules = (
+        other.rotary_emb,
+        other.rotary_emb_hw,
+        other.rotary_emb_hw,
+    )
+    for (cos_shared, sin_shared), module, axis in zip(
+        shared, reference_modules, (0, 1, 2)
+    ):
+        cos_ref, sin_ref = module(x, indexes[axis].unsqueeze(0))
+        assert torch.equal(cos_shared, cos_ref), f"cos differs on axis {axis}"
+        assert torch.equal(sin_shared, sin_ref), f"sin differs on axis {axis}"
+
+
+class _RopeRebuildDetector(torch.nn.Module):
+    """An nn.Module so it can take over a registered submodule slot."""
+
+    def forward(self, *args, **kwargs):
+        pytest.fail("rope tables rebuilt")
+
+
+def test_sensenova_u1_attention_reuses_passed_rope_tables(monkeypatch):
+    """Passing tables down must skip the per-layer rebuild.
+
+    The failure mode is silent: reintroducing the rebuild keeps every output
+    correct, so only this case notices that the sharing stopped happening.
+    """
+    attn = _tiny_dense_attention()
+    shared = ("t", "h", "w")
+    detector = _RopeRebuildDetector()
+    monkeypatch.setattr(attn, "rotary_emb", detector)
+    monkeypatch.setattr(attn, "rotary_emb_hw", detector)
+
+    x = torch.randn(1, 5, _HIDDEN_DIM)
+    indexes = torch.zeros(3, 5, dtype=torch.long)
+
+    assert attn._resolve_rope_tables(x, indexes, shared) is shared
+
+
+def test_sensenova_u1_model_shares_rope_tables_with_every_layer(monkeypatch):
+    """Guards the wiring from the model loop down to attention.
+
+    A dropped kwarg anywhere in that chain leaves every output correct, so
+    without this case the sharing could stop happening unnoticed.
+    """
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        Qwen3Attention,
+        Qwen3Model,
+    )
+
+    model = Qwen3Model(_tiny_dense_config()).eval()
+    seen = []
+    original = Qwen3Attention._resolve_rope_tables
+
+    def spy(self, hidden_states, indexes, rope_tables):
+        seen.append(rope_tables is not None)
+        return original(self, hidden_states, indexes, rope_tables)
+
+    monkeypatch.setattr(Qwen3Attention, "_resolve_rope_tables", spy)
+    with torch.no_grad():
+        model(
+            inputs_embeds=torch.randn(1, 5, _HIDDEN_DIM),
+            image_gen_indicators=torch.ones(1, 5, dtype=torch.bool),
+            indexes=torch.zeros(3, 5, dtype=torch.long),
+            attention_mask={"full_attention": None},
+        )
+
+    assert len(seen) == _LAYERS, f"attention ran {len(seen)} times, want {_LAYERS}"
+    assert all(seen), f"layers that had to rebuild their own tables: {seen}"
+
+
+def test_sensenova_u1_rope_sharing_does_not_change_output(monkeypatch):
+    """The end-to-end claim: sharing must not move the output by one bit.
+
+    Ran with sharing and with sharing bypassed (each layer rebuilding its own
+    tables, as before the change) on identical inputs.
+    """
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        Qwen3Attention,
+        Qwen3Model,
+    )
+
+    torch.manual_seed(0)
+    model = Qwen3Model(_tiny_dense_config()).eval()
+    embeds = torch.randn(1, 5, _HIDDEN_DIM)
+    indicators = torch.ones(1, 5, dtype=torch.bool)
+    indexes = torch.zeros(3, 5, dtype=torch.long)
+
+    def run():
+        with torch.no_grad():
+            return model(
+                inputs_embeds=embeds,
+                image_gen_indicators=indicators,
+                indexes=indexes,
+                attention_mask={"full_attention": None},
+            ).last_hidden_state
+
+    shared = run()
+
+    original = Qwen3Attention._resolve_rope_tables
+    monkeypatch.setattr(
+        Qwen3Attention,
+        "_resolve_rope_tables",
+        lambda self, hidden_states, idx, tables: original(
+            self, hidden_states, idx, None
+        ),
+    )
+    per_layer = run()
+
+    assert torch.equal(shared, per_layer)
+
+
+def test_sensenova_u1_rope_tables_reach_the_understanding_path(monkeypatch):
+    """`forward_und` has its own pop site, so the gen-path cases do not cover it.
+
+    All-zeros indicators select the understanding path used by the text prefix.
+    """
+    from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+        Qwen3Attention,
+        Qwen3Model,
+    )
+
+    model = Qwen3Model(_tiny_dense_config()).eval()
+    seen = []
+    original = Qwen3Attention._resolve_rope_tables
+
+    def spy(self, hidden_states, indexes, rope_tables):
+        seen.append(rope_tables is not None)
+        return original(self, hidden_states, indexes, rope_tables)
+
+    monkeypatch.setattr(Qwen3Attention, "_resolve_rope_tables", spy)
+    with torch.no_grad():
+        model(
+            inputs_embeds=torch.randn(1, 5, _HIDDEN_DIM),
+            image_gen_indicators=torch.zeros(1, 5, dtype=torch.bool),
+            indexes=torch.zeros(3, 5, dtype=torch.long),
+            attention_mask={"full_attention": None},
+        )
+
+    assert len(seen) == _LAYERS, f"attention ran {len(seen)} times, want {_LAYERS}"
+    assert all(seen), f"layers that had to rebuild their own tables: {seen}"


### PR DESCRIPTION
## Motivation

`Qwen3Attention` computes the t/h/w RoPE cos/sin tables in every layer, although the positions and RoPE config are the same across layers. For the 42-layer dense backbone, this change reduces table construction from 126 calls to 3 per forward.

## Modifications

Build the tables once in `Qwen3Model.forward` using the first layer's RoPE modules, then pass them through the decoder layers to attention. Attention falls back to computing its own tables when none are supplied, preserving the existing MoE and direct-call paths.

## Accuracy Tests

- `python -m pytest python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py -q`: 57 passed. Tests cover matching tables across layers, construction counts on generation and understanding paths, and bit-identical model output with sharing enabled and bypassed.
- Fixed-seed image generation produced byte-identical PNGs before and after the change at all sizes and step counts below.

Generation command used for the comparison:

```bash
for size in 256 512 1024 2048; do
  for steps in 4 50; do
    sglang generate --model-path /path/to/SenseNova-U1.5-8B-MoT --prompt "a red cube on a table" \
      --height $size --width $size --num-inference-steps $steps --seed 42 --num-gpus 1 --save-output
  done
done
```

Runs alternated between the parent commit and this change; output PNG SHA-256 hashes were compared.

## Speed Tests and Profiling

RTX 4090 (48 GB), Xeon Gold 6530 (8 physical cores). Before/after runs were interleaved within one session, with 3 rounds per configuration; the table reports median times.

| Size | 4 steps, before → after | 50 steps, before → after | Latency reduction (50 steps) |
|---|---|---|---|
| 256×256 | 2.20 → 1.86 s | 11.01 → 7.34 s | 33% |
| 512×512 | 2.26 → 1.86 s | 11.00 → 7.34 s | 33% |
| 1024×1024 | 2.60 → 2.50 s | 14.90 → 14.68 s | 1.5% |
| 2048×2048 | 6.76 → 6.68 s | 61.58 → 61.47 s | 0.2% |

The improvement is concentrated at 256×256 and 512×512 on this setup. GPU utilization during denoising was 70–79% at 512×512 and 95–100% at 1024×1024, consistent with reduced CPU overhead helping more at smaller sizes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34830163669](https://github.com/sgl-project/sglang/actions/runs/34830163669)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34830163445](https://github.com/sgl-project/sglang/actions/runs/34830163445)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34830163604](https://github.com/sgl-project/sglang/actions/runs/34830163604)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->




