### PR TITLE
Fix NIXL backend device selection in initialization thread

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -50,7 +50,7 @@ from sglang.srt.disaggregation.utils import (
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils.common import run_with_deadline
+from sglang.srt.utils.common import get_device_module, run_with_deadline
 
 try:
     from nixl._bindings import (
@@ -459,8 +459,14 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 backend_params.setdefault("thread_count", str(num_threads))
             elif backend == "UCCL":
                 backend_params.setdefault("num_cpus", str(num_threads))
+
+        def create_backend():
+            # Device selection is thread-local; UCX must initialize on this rank's GPU.
+            get_device_module().set_device(self.kv_args.gpu_id)
+            self.agent.create_backend(backend, backend_params)
+
         run_with_deadline(
-            lambda: self.agent.create_backend(backend, backend_params),
+            create_backend,
             timeout_s=envs.SGLANG_DISAGGREGATION_ENGINE_INIT_TIMEOUT.get(),
             what=f"NIXL create_backend({backend!r}, {backend_params})",
         )

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -11,10 +11,11 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
 from sglang.srt.disaggregation.common.utils import pack_int_lists
+from sglang.srt.disaggregation.nixl import conn
 from sglang.srt.disaggregation.nixl.conn import (
     KVArgsRegisterInfo,
     NixlKVManager,
@@ -24,6 +25,7 @@ from sglang.srt.disaggregation.nixl.conn import (
     TransferKVChunk,
     TransferStatus,
 )
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -104,6 +106,60 @@ def _fake_staging_buffer_module(mock_gather=None):
     module.resolve_total_kv_heads = lambda kv_args, attn_tp_size: 2
     module.gather_all_layers_to_staging = mock_gather or MagicMock()
     return module
+
+
+class TestNixlBackendInitialization(CustomTestCase):
+    def test_backend_initialization_selects_worker_device(self):
+        device_state = threading.local()
+        device_state.index = 3
+        parent_thread = threading.get_ident()
+        observed = []
+
+        def set_device(index):
+            device_state.index = index
+
+        def create_backend(_backend, _params):
+            observed.append((threading.get_ident(), getattr(device_state, "index", 0)))
+
+        args = KVArgs()
+        args.gpu_id = 3
+        args.pp_rank = 0
+        args.engine_rank = 0
+        args.kv_data_ptrs = []
+        agent = MagicMock()
+        agent.create_backend.side_effect = create_backend
+        agent.get_plugin_list.return_value = ["UCX"]
+        nixl_api = MagicMock()
+        nixl_api.nixl_agent.return_value = agent
+        manager = NixlKVManager.__new__(NixlKVManager)
+        manager.kv_args = args
+        manager.disaggregation_mode = DisaggregationMode.DECODE
+        manager.enable_deferred_decode_kv_release = False
+
+        with (
+            patch.object(CommonKVManager, "__init__", return_value=None),
+            patch.object(conn, "get_parallel", return_value=SimpleNamespace(tp_size=4)),
+            patch.object(
+                conn,
+                "get_device_module",
+                return_value=SimpleNamespace(set_device=set_device),
+            ),
+            patch.dict(sys.modules, {"nixl._api": nixl_api}),
+            patch.object(NixlKVManager, "register_buffer_to_engine"),
+            patch.object(NixlKVManager, "_start_heartbeat_checker_thread"),
+            patch.object(
+                conn.envs.SGLANG_DISAGGREGATION_NIXL_BACKEND, "get", return_value="UCX"
+            ),
+            patch.object(
+                conn.envs.SGLANG_DISAGG_STAGING_BUFFER, "get", return_value=False
+            ),
+        ):
+            manager.__init__(args, DisaggregationMode.DECODE, MagicMock())
+
+        self.assertEqual(len(observed), 1)
+        self.assertNotEqual(observed[0][0], parent_thread)
+        self.assertEqual(observed[0][1], 3)
+        self.assertEqual(device_state.index, 3)
 
 
 class TestNixlTransferInfo(CustomTestCase):


### PR DESCRIPTION
## Motivation

NIXL backend creation runs inside `run_with_deadline`, which starts a new thread. CUDA device selection is thread-local, so selecting a nonzero GPU on the scheduler thread does not select it on the initialization thread. UCX can consequently initialize on GPU 0 and fail subsequent KV transfers with `cannot find remote protocol` and remote-disconnect errors.

## Modifications

Select `self.kv_args.gpu_id` inside the deadline callback before calling `create_backend`, preserving the initialization timeout.

Add a regression to the existing registered NIXL CPU test suite. It uses thread-local fake device state and the real deadline worker to check that a rank assigned GPU 3 initializes its backend on GPU 3 in a separate thread.

## Accuracy Tests

```bash
python test/registered/unit/disaggregation/test_nixl_backend_basic.py -v
```

All 45 tests pass. Removing the device-selection line makes the new regression fail with `AssertionError: 0 != 3`.

## Speed Tests and Profiling

Not applicable: this adds device selection during backend initialization only.

## Checklist

- [x] Format code with the repository's pre-commit checks.
- [x] Add a unit test in a registered CPU suite.
- [x] Follow the SGLang code style.
- Documentation and model accuracy/speed benchmarks: not applicable to this initialization fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34767463503](https://github.com/sgl-project/sglang/actions/runs/34767463503)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34767463363](https://github.com/sgl-project/sglang/actions/runs/34767463363)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34767463492](https://github.com/sgl-project/sglang/actions/runs/34767463492)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->