### PR TITLE
[DeepSeek-V4.1] Allow heterogeneous TP for DSpark PD with matching layouts

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -50,6 +50,7 @@ from sglang.srt.disaggregation.utils import (
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
     resolve_dcp_dst_entry_indices,
+    validate_dsv41_c2_state_layout,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
@@ -214,6 +215,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self.has_c2_state = 2 in (getattr(args, "mla_compression_ratios", None) or ())
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -1424,6 +1426,12 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     and len(dst_indices_local) == 0
                 ):
                     continue
+                if st == StateType.C128_STATE and self.has_c2_state:
+                    try:
+                        validate_dsv41_c2_state_layout(src_item_lens, dst_item_lens)
+                    except ValueError as error:
+                        logger.error("C2 state transfer rejected: %s", error)
+                        return -1
                 if len(src_indices) != len(dst_indices_local):
                     # These components are position- or request-indexed:
                     # truncating silently misaligns rows and corrupts KV.

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -44,6 +44,7 @@ from sglang.srt.disaggregation.utils import (
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
     resolve_dcp_dst_entry_indices,
+    validate_dsv41_c2_state_layout,
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_parallel, get_schedule
@@ -405,6 +406,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self.has_c2_state = 2 in (getattr(args, "mla_compression_ratios", None) or ())
         self.transfer_source_rank = (
             self.kv_args.pp_rank * get_parallel().tp_size + self.kv_args.engine_rank
         )
@@ -2334,6 +2336,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             )
             dst_lids = dst_state_layer_ids[i] if i < len(dst_state_layer_ids) else []
             comp_notif = f"{notif}_{i}"
+
+            if st == StateType.C128_STATE and self.has_c2_state:
+                validate_dsv41_c2_state_layout(src_lens, dst_lens)
 
             if st == StateType.MAMBA:
                 if self.attn_tp_size != decode_tp_size:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -99,6 +99,21 @@ def get_dsv4_c128_state_indices(
     return np.array([page], dtype=np.int32)
 
 
+def validate_dsv41_c2_state_layout(
+    src_item_lens: List[int], dst_item_lens: List[int]
+) -> None:
+    """C2 transfer addresses both endpoints using the sender's whole-ring stride.
+
+    Check nonempty payloads before writing with an incompatible peer stride.
+    """
+    if src_item_lens != dst_item_lens:
+        raise ValueError(
+            "DeepSeek-V4.1 PD requires matching C2 state layouts on prefill and decode "
+            f"(prefill item lengths={src_item_lens}, decode item lengths={dst_item_lens}); "
+            "configure the same DSpark ring size on both endpoints."
+        )
+
+
 def get_dsv4_request_state_indices(pool, req_pool_idx: int, seq_len: int) -> np.ndarray:
     """PD transfer indices of the request-scoped state component (C128_STATE).
 

--- a/test/registered/unit/disaggregation/test_dsv41_c2_layout.py
+++ b/test/registered/unit/disaggregation/test_dsv41_c2_layout.py
@@ -1,0 +1,21 @@
+"""Reject incompatible peer strides before a C2 state transfer is issued."""
+
+import unittest
+
+from sglang.srt.disaggregation.utils import validate_dsv41_c2_state_layout
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestC2Layout(unittest.TestCase):
+    def test_matching_layers(self):
+        validate_dsv41_c2_state_layout([32768, 32768, 32768], [32768, 32768, 32768])
+
+    def test_different_ring_strides(self):
+        with self.assertRaisesRegex(ValueError, "matching C2 state layouts"):
+            validate_dsv41_c2_state_layout([8192] * 3, [32768] * 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Allow DeepSeek-V4.1 DSpark PD with different P/D TP sizes when target/draft transfer layouts match. Remove the independent same-TP bootstrap rejection and reuse the existing MLA rank mapping. Preserve layout equality and C2 stride validation; no ring representation or transfer slicing changes are included.

Based on `dsv4.1@0d5e663b8`. V4.1's CUDA KV pools contain replicated vectors without a TP-sharded head axis. For P8/D4, decode rank r receives full KV/state from prefill rank 2r; rank 2r+1 receives dummy metadata and completes locally. Static verify, Mooncake, matching speculative/layout configuration and DP/CP1 restrictions remain. The C2 stride checks also cover non-speculative transfers.

## Validation

- Tested commit `a9cb223ea`, tree `a619db6c8453a91e9a694c6069d6a6d7dae52a5c`, on HPC8 in `llm-eng-dev`: P TP/EP8 on eight B300 GPUs, D TP/EP4 on four B300 GPUs on another node; Mooncake over IB; static DSpark block size 5; context 1048576; fraction 0.80; max running 72 on P and 48 on D.
- Engram host tables enabled on both. P decoder bounded replay and radix caching enabled, P CUDA graphs disabled; D radix caching disabled.
- Five C2/DSpark PD unit tests passed against the installed Linux runtime. `git diff --check` passed. Six relevant installed file hashes per role matched the tested tree.
- All 30 exact-length requests passed at concurrency 1 and 8, around 128, 256, 4096, 8192 and 16384 tokens. Answers and output token IDs matched across concurrency settings; normal stop and positive DSpark verify counts. P logs showed cache reuse.
- Three streaming cases passed. Cancellation after the first output token drained decode in approximately 1.012 seconds; the next request completed correctly.
- P, D and router remained Ready with zero restarts. Captured P/D logs contained no OOM, layout mismatch or transfer-failure matches.

Full GSM8K test split: **1282/1319 (97.1948%)**, zero request errors, invalid answers or truncated outputs. Temperature 0, thinking disabled, concurrency 8, output cap 16384. Draft acceptance rate 66.2904%; output tokens per verify step 4.31748. This is a P8/D4 evaluation, not a matched homogeneous-TP comparison. The historical P4/D4 score of 1283/1319 used an older source and different settings; the difference cannot be attributed to TP.

Not validated here: NIXL network transfers, forced retraction, cancellation during KV transfer, arbitrary heterogeneous TP ratios, full-1M requests, or bitwise equivalence against a colocated baseline. The independent decoder bounded replay/cache concern is not fixed by this change.
