### PR TITLE
fix(modelopt): dispatch NVFP4 MoE on the cached backend, not the live global

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2952,11 +2952,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         # tuple). Defer per-attribute access to the branches that actually
         # consume them.
         activation = self.moe_runner_config.activation
-        # Resolved once in create_weights and cached here. Dispatch MUST use this, not
-        # the live global: under speculative decoding the global is the draft model's
-        # backend (--speculative-moe-runner-backend), so a global read disagrees with
-        # this layer's own backend, falls through to the NotImplementedError below, and
-        # then reports this cached value -- naming the backend already in use.
+        # Use the cached backend: the global differs under speculative decoding.
         moe_runner_backend = getattr(
             self, "_moe_runner_backend", get_moe_runner_backend()
         )

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2952,6 +2952,11 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         # tuple). Defer per-attribute access to the branches that actually
         # consume them.
         activation = self.moe_runner_config.activation
+        # Resolved once in create_weights and cached here. Dispatch MUST use this, not
+        # the live global: under speculative decoding the global is the draft model's
+        # backend (--speculative-moe-runner-backend), so a global read disagrees with
+        # this layer's own backend, falls through to the NotImplementedError below, and
+        # then reports this cached value -- naming the backend already in use.
         moe_runner_backend = getattr(
             self, "_moe_runner_backend", get_moe_runner_backend()
         )
@@ -2985,7 +2990,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             return self.runner.run(dispatch_output, quant_info)
 
         # FlashInfer TRTLLM FP4 path
-        if self.enable_flashinfer_trtllm_moe and hasattr(layer, "g1_scale_c"):
+        if moe_runner_backend.is_flashinfer_trtllm() and hasattr(layer, "g1_scale_c"):
             from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
                 FlashInferTrtllmFp4MoeQuantInfo,
             )
@@ -3021,7 +3026,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
             return self.runner.run(dispatch_output, quant_info)
 
-        if self.enable_flashinfer_cutedsl_moe:
+        if moe_runner_backend.is_flashinfer_cutedsl():
             from sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl import (
                 CuteDslFp4MoeQuantInfo,
                 ensure_cutedsl_wrapper,
@@ -3077,7 +3082,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             )
             return self.runner.run(dispatch_output, quant_info)
 
-        if self.enable_flashinfer_cutlass_moe:
+        if moe_runner_backend.is_flashinfer_cutlass():
             from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
                 FlashInferCutlassMoeQuantInfo,
             )


### PR DESCRIPTION
## Motivation

Fixes #38795.

`ModelOptNvFp4FusedMoEMethod.apply` resolves the MoE backend twice from two different sources, and under speculative decoding they disagree.

`create_weights` caches it:

```python
self._moe_runner_backend = moe_runner_backend
```

`apply` reads that cache for the error message and for the marlin/megamoe checks:

```python
moe_runner_backend = getattr(self, "_moe_runner_backend", get_moe_runner_backend())
```

but the flashinfer dispatch guards re-read the **live global** instead:

```python
@property
def enable_flashinfer_cutlass_moe(self) -> bool:
    return get_moe_runner_backend().is_flashinfer_cutlass()
```

With `--speculative-moe-runner-backend`, the global is the *draft* model's backend while the target layer's cache is still the user's choice. Every flashinfer branch is skipped and the method falls through to:

```
NotImplementedError: Unsupported moe_runner_backend for NVFP4 MoE:
MoeRunnerBackend.FLASHINFER_CUTLASS. Use --moe-runner-backend flashinfer_cutlass instead.
```

The message names the backend already in use, because it prints the cache while the guard read the global.

## Repro

`nvidia/GLM-5.3-Flash-NVFP4`, 8×B300 (sm_103), TP8/EP8:

```
--quantization modelopt_fp4 --moe-runner-backend flashinfer_cutlass
--speculative-algorithm EAGLE --speculative-num-steps 5 --speculative-eagle-topk 1
--speculative-num-draft-tokens 6 --speculative-adaptive
--speculative-moe-runner-backend triton
```

Dies at `build_adaptive_runtime_state` -> `decode_cuda_graph_runner` -> `run_moe_core` -> `modelopt_quant.apply`. Dropping `--speculative-adaptive` (fixed-step EAGLE, everything else identical) boots healthy and serves, which is why this only surfaces on the adaptive path.

## Modifications

Point the three flashinfer guards at the local `moe_runner_backend` the function already computes, matching the `is_marlin()` and `is_flashinfer_megamoe()` checks a few lines above:

```diff
-        if self.enable_flashinfer_trtllm_moe and hasattr(layer, "g1_scale_c"):
+        if moe_runner_backend.is_flashinfer_trtllm() and hasattr(layer, "g1_scale_c"):
-        if self.enable_flashinfer_cutedsl_moe:
+        if moe_runner_backend.is_flashinfer_cutedsl():
-        if self.enable_flashinfer_cutlass_moe:
+        if moe_runner_backend.is_flashinfer_cutlass():
```

The branch taken and the backend reported are now the same value by construction. A comment at the local records the invariant so the global does not creep back in.

The properties are left in place; they have other callers outside this method.

## Checklist

- [x] Behaviour is unchanged when the global and the cache agree, which is every non-speculative path and every fixed-step speculative path.
- [x] No new lint or formatting findings on the changed lines (the file's existing black/ruff findings are pre-existing on `main`).
- [ ] I could not add a unit test that exercises this without a Blackwell GPU: the divergence only appears during adaptive CUDA-graph capture. Happy to add one if a maintainer can point me at the right harness.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35291501780](https://github.com/sgl-project/sglang/actions/runs/35291501780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #35360849765](https://github.com/sgl-project/sglang/actions/runs/35360849765)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35291501721](https://github.com/sgl-project/sglang/actions/runs/35291501721)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->