### PR TITLE
[Fix] Disable NCCL graph buffer registration for the TP LM-head all-to-all (pure-DP decode hang under request bursts)

### DIFF
--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -226,6 +226,34 @@ def handle_data_parallelism(server_args: Any):
 
     run_post_process_pass(server_args, _tp_lm_head_all_to_all_default)
     run_post_process_pass(server_args, _dp_lm_head_validation)
+    if resolving_view(server_args).enable_tp_lm_head_all_to_all:
+        _disable_nccl_graph_buffer_registration()
+
+
+def _disable_nccl_graph_buffer_registration() -> None:
+    """Keep NCCL from registering the buffers of the graph-captured PyNccl
+    all-to-all.
+
+    NCCL_GRAPH_REGISTER (default on) registers the send/recv buffers of every
+    collective captured in a CUDA graph for the lifetime of the graph, and
+    peers then move data through those registrations directly. The TP LM-head
+    all-to-all is captured in the decode graphs on graph-pool temporaries,
+    whose addresses the pool also hands to other tensors, and the registered
+    exchange does not survive that: under a burst of new requests (DP ranks
+    ramping at different rates) one rank finishes its step while the others
+    spin in ncclDevKernel_SendRecv forever, and every DP rank hangs.
+    Reproduced on tp4/dp4/ep4 and on a multi-node tp16/dp16/ep16 PD decode
+    deployment; disabling the registration removes the hang while dedicated
+    all-to-all buffers alone do not. Must run before the schedulers create
+    their NCCL communicators, which inherit this environment. An explicit
+    setting wins.
+    """
+    if os.environ.setdefault("NCCL_GRAPH_REGISTER", "0") != "0":
+        logger.warning(
+            "NCCL_GRAPH_REGISTER=%s was set explicitly; the graph-captured TP "
+            "LM-head all-to-all can deadlock with registered buffers.",
+            os.environ["NCCL_GRAPH_REGISTER"],
+        )
 
 
 def handle_dwdp(server_args: Any):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -3321,5 +3321,59 @@ class TestNoneMeansUnset(CustomTestCase):
         self.assertIsNotNone(server_args.mamba_full_memory_ratio)
 
 
+class TestTpLmHeadAllToAllNcclGraphRegister(unittest.TestCase):
+    """The graph-captured TP LM-head all-to-all must not run with NCCL's
+    graph buffer registration: registered graph-pool temporaries deadlock the
+    exchange under DP-rank ramps."""
+
+    def _resolve(self, **kwargs):
+        # The handler reads the DP-adjusted prefill knobs the pipeline would
+        # have settled by then; the dummy-model pipeline itself returns early.
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_dp_attention=True,
+            tp_size=2,
+            dp_size=2,
+            chunked_prefill_size=8192,
+            cuda_graph_config=CudaGraphConfig(
+                prefill=PhaseConfig(backend=Backend.DISABLED)
+            ),
+            **kwargs,
+        )
+        parallel_hook.handle_data_parallelism(server_args)
+        return server_args
+
+    def test_pure_dp_decode_node_disables_nccl_graph_register(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NCCL_GRAPH_REGISTER", None)
+            server_args = self._resolve(disaggregation_mode="decode")
+            self.assertTrue(
+                resolution_result(server_args, "enable_tp_lm_head_all_to_all")
+            )
+            self.assertEqual(os.environ.get("NCCL_GRAPH_REGISTER"), "0")
+
+    def test_explicit_nccl_graph_register_is_kept(self):
+        with patch.dict(os.environ, {"NCCL_GRAPH_REGISTER": "1"}, clear=False):
+            with self.assertLogs(parallel_hook.logger, level="WARNING") as logs:
+                self._resolve(disaggregation_mode="decode")
+            self.assertEqual(os.environ["NCCL_GRAPH_REGISTER"], "1")
+            self.assertIn("NCCL_GRAPH_REGISTER=1", "\n".join(logs.output))
+
+    def test_without_all_to_all_env_is_untouched(self):
+        # Unified serving keeps the all-to-all off by default, and a decode
+        # node with the DP LM head never takes the all-to-all.
+        for kwargs in (
+            {},
+            {"disaggregation_mode": "decode", "enable_dp_lm_head": True},
+        ):
+            with self.subTest(**kwargs), patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("NCCL_GRAPH_REGISTER", None)
+                server_args = self._resolve(**kwargs)
+                self.assertFalse(
+                    resolution_result(server_args, "enable_tp_lm_head_all_to_all")
+                )
+                self.assertNotIn("NCCL_GRAPH_REGISTER", os.environ)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Pure-DP PD decode nodes (`tp_size == dp_size` with DP attention) auto-enable the TP LM-head all-to-all (`_tp_lm_head_all_to_all_default`), a PyNccl send/recv captured in the decode CUDA graphs. With NCCL's default graph-capture buffer registration (`NCCL_GRAPH_REGISTER=1`) that exchange deadlocks the first time a burst of new requests ramps the DP ranks at different rates: one rank leaves the step while the others spin in `ncclDevKernel_SendRecv` forever, the scheduler watchdog fires on every rank, and the whole gang restarts.

Reproduced deterministically on a tp4/dp4/ep4 unified launch with `--enable-tp-lm-head-all-to-all` (hang on the first ~240-request burst from idle, every launch) and on a multi-node tp16/dp16/ep16 PD decode deployment. `--enable-dp-lm-head`, which avoids the all-to-all, does not hang.

Experiment matrix on the tp4/dp4/ep4 repro:

| Run | Result |
|---|---|
| baseline | hang on round 0 |
| different MoE backend | hang on round 0 |
| dedicated non-pool all-to-all buffers (no env change) | hang on round 0 |
| `NCCL_GRAPH_REGISTER=0 NCCL_LOCAL_REGISTER=0` | 4/4 rounds pass |
| `NCCL_GRAPH_REGISTER=0` only | 5/5 rounds pass |
| plain gather path (all-to-all off), default env | 5/5 rounds pass |
| this PR, default env | 10/10 rounds pass |

At the hang, cuda-gdb showed three ranks resident in `ncclDevKernel_SendRecv` and the fourth already in the next step's first cross-rank MoE kernel; per-rank Python-level decisions (forward mode, graph replay, LM-head branch) were identical across ranks, so the divergence is inside the registered exchange. The exact NCCL-side mechanism (registration of graph-pool temporaries whose addresses the pool reuses) is inferred from the experiment matrix, not from NCCL internals.

## Modifications

- `handle_data_parallelism` now sets `NCCL_GRAPH_REGISTER=0` in the server environment whenever the TP LM-head all-to-all resolves to enabled, so the schedulers' NCCL communicators inherit it. An explicit user setting is kept and a warning is logged.
- Scope: only the all-to-all path. `attn_tp > 1` shapes never enable the all-to-all (it requires `tp_size == dp_size`), and `--enable-dp-lm-head` is mutually exclusive with it, so neither changes behavior. Eager NCCL ops are unaffected; only the two collectives captured in the decode graphs (the LM-head all-to-all and the DP gather feeding it) go through NCCL's staging buffers instead of registered zero-copy.
- Unit tests cover: pure-DP decode node sets the env, an explicit value is preserved with a warning, and unified serving / decode with `--enable-dp-lm-head` leave the env untouched.

## Original commits

- `53b0218449`
- `ca3830e652`

## Accuracy Tests

N/A (no numerics change).

## Benchmarking and Profiling

Verified on an internal tp4/dp4/ep4 setup: without this change every launch hung on the first burst of ~240 concurrent requests from idle; with it, 10 burst rounds (240-256 concurrent requests, 250-1000 input tokens, 20-400 output tokens) all completed with health 200 throughout and no watchdog. A tp4/dp2/ep4 scoping check resolves `enable_tp_lm_head_all_to_all=False`, leaves the environment untouched, and completes 10/10 rounds, i.e. no behavior change there.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.io/developer_guide/contribution_guide.html#accuracy-results).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel at https://slack.sglang.io to discuss your PR.

Testing: `python -m unittest registered.unit.server_args.test_server_args.TestTpLmHeadAllToAllNcclGraphRegister` (3 passed) and `pre-commit run --files` on the two changed files (all hooks passed). The existing 2-GPU `test_tp_lm_head_all_to_all_cuda_graph` test is left to CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34524372939](https://github.com/sgl-project/sglang/actions/runs/34524372939)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34524372773](https://github.com/sgl-project/sglang/actions/runs/34524372773)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34524373001](https://github.com/sgl-project/sglang/actions/runs/34524373001)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->