### PR TITLE
fix(openai): honor named tool_choice in the Kimi K3 encode path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -586,12 +586,19 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
 
             effective_tools = self._effective_tools(request)
+            named_tool_choice = (
+                request.tool_choice
+                if isinstance(request.tool_choice, ToolChoice)
+                else None
+            )
             if (
                 effective_tools
                 and isinstance(request.tool_choice, str)
                 and request.tool_choice in ("required", "none")
             ):
                 template_kwargs.setdefault("tool_choice", request.tool_choice)
+            elif effective_tools and named_tool_choice is not None:
+                template_kwargs.setdefault("tool_choice", "required")
             if request.response_format is not None:
                 template_kwargs.setdefault(
                     "response_format",
@@ -600,12 +607,20 @@ class OpenAIServingChat(OpenAIServingBase):
                     ),
                 )
 
+            visible_tools = request.tools
+            if visible_tools and named_tool_choice is not None:
+                named = [
+                    tool
+                    for tool in visible_tools
+                    if tool.function.name == named_tool_choice.function.name
+                ]
+                visible_tools = named or visible_tools
             request_tools = (
                 [
                     tool.model_dump(exclude_unset=True, by_alias=True)
-                    for tool in request.tools
+                    for tool in visible_tools
                 ]
-                if request.tools
+                if visible_tools
                 else None
             )
             prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1360,17 +1360,13 @@ class ServingChatTestCase(unittest.TestCase):
             model="x",
             messages=[{"role": "user", "content": "Add two numbers"}],
             tools=tools,
-            tool_choice=ToolChoice(
-                function=ToolChoiceFuncName(name="calculate")
-            ),
+            tool_choice=ToolChoice(function=ToolChoiceFuncName(name="calculate")),
         )
 
         result = self.chat._process_messages(request, is_multimodal=True)
 
         call = self.tm.tokenizer.apply_chat_template.call_args
-        tool_names = [
-            tool["function"]["name"] for tool in call.kwargs["tools"]
-        ]
+        tool_names = [tool["function"]["name"] for tool in call.kwargs["tools"]]
         self.assertEqual(tool_names, ["calculate"])
         self.assertEqual(call.kwargs["tool_choice"], "required")
         self.assertEqual(result.prompt_ids, [7, 8, 9])

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1336,6 +1336,45 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(result.prompt_ids, [7, 8, 9])
         self.assertEqual(result.image_data[0].url, "image-1")
 
+    def test_kimi_k3_encoder_named_tool_choice_narrows_tools(self):
+        self.template_manager.chat_template_name = None
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.tokenizer.apply_chat_template.return_value = [7, 8, 9]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculate",
+                    "parameters": {"type": "object"},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "transform",
+                    "parameters": {"type": "object"},
+                },
+            },
+        ]
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Add two numbers"}],
+            tools=tools,
+            tool_choice=ToolChoice(
+                function=ToolChoiceFuncName(name="calculate")
+            ),
+        )
+
+        result = self.chat._process_messages(request, is_multimodal=True)
+
+        call = self.tm.tokenizer.apply_chat_template.call_args
+        tool_names = [
+            tool["function"]["name"] for tool in call.kwargs["tools"]
+        ]
+        self.assertEqual(tool_names, ["calculate"])
+        self.assertEqual(call.kwargs["tool_choice"], "required")
+        self.assertEqual(result.prompt_ids, [7, 8, 9])
+
     def test_kimi_k3_neutralizes_text_only_assistant_history(self):
         self.template_manager.chat_template_name = None
         self.chat.chat_encoding_spec = "kimi_k3"


### PR DESCRIPTION
## Problem

In the `chat_encoding_spec == "kimi_k3"` encode branch of `OpenAIServingChat._encode_messages`, a named `tool_choice` (`{"type": "function", "function": {"name": "..."}}`) is ignored in two ways:

1. `request_tools` is built from **all** of `request.tools`, unfiltered. The generic Jinja path narrows the template's tools to the named function when `tool_choice` is a named `ToolChoice`; the K3 path does not.
2. Only string `tool_choice` values (`"required"` / `"none"`) are mapped into `template_kwargs`. A named choice is never communicated to the template, so the model receives no instruction to call a specific function.

Net effect: the model sees every tool with no narrowing, and if the structural-tag constraint does not build (its exception path returns `None`, and the `json_schema` fallback is excluded for `kimi_k3`), the request is fully unconstrained and the model can freely call the wrong function.

## Fix

- Introduce `named_tool_choice` when `request.tool_choice` is a `ToolChoice` instance.
- Add an `elif` that renders `tool_choice: "required"` when a named choice is present alongside tools (the K3 encoder has no named-choice rendering; forcing `required` plus narrowed tools is the closest supported semantics).
- Narrow `request_tools` to the chosen function, falling back to the full list when the named tool came from message-embedded tools (which are not part of `request.tools`).

This mirrors the existing filtering the Jinja path applies for a named choice.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34539849834](https://github.com/sgl-project/sglang/actions/runs/34539849834)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34539849724](https://github.com/sgl-project/sglang/actions/runs/34539849724)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34539849633](https://github.com/sgl-project/sglang/actions/runs/34539849633)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->