### PR TITLE
[Fix] Parse Hunyuan tool arguments with JSON Schema type arrays

### DIFF
--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -214,9 +214,13 @@ class HunyuanDetector(BaseFormatDetector):
     @staticmethod
     def _get_types(arg_schema: dict) -> Set[str]:
         schemas = HunyuanDetector._get_schema_options(arg_schema)
-        return {
-            HunyuanDetector._normalize_type(s.get("type", "string")) for s in schemas
-        } - {"null"}
+        types = set()
+        for schema in schemas:
+            raw_types = schema.get("type", "string")
+            if isinstance(raw_types, str):
+                raw_types = [raw_types]
+            types.update(HunyuanDetector._normalize_type(t) for t in raw_types)
+        return types - {"null"}
 
     @staticmethod
     def _is_only_string_type(

--- a/test/registered/unit/function_call/test_hunyuan_detector.py
+++ b/test/registered/unit/function_call/test_hunyuan_detector.py
@@ -682,6 +682,88 @@ class TestHunyuanDetectorStructureInfo(CustomTestCase):
         self.assertFalse(self.detector.supports_structural_tag())
 
 
+class TestHunyuanDetectorTypeArrays(CustomTestCase):
+    def test_type_arrays_preserve_arguments_in_both_modes(self):
+        cases = (
+            (["integer", "null"], "7", 7),
+            (["null", "integer"], "null", None),
+            (["number", "null"], "1.25", 1.25),
+            (["null", "boolean"], "false", False),
+            (["string", "null"], 'literal "quoted" text', 'literal "quoted" text'),
+            (["array", "null"], "[1,2]", [1, 2]),
+            (["object", "null"], '{"ok": true}', {"ok": True}),
+            (["string", "integer"], "7", 7),
+            (["integer", "string"], "plain text", "plain text"),
+            (["string", "array"], "[1,2]", [1, 2]),
+        )
+        for types, raw_value, expected in cases:
+            for schema in (
+                {"type": types},
+                {"anyOf": [{"type": types}]},
+                {"oneOf": [{"type": types}]},
+            ):
+                for chunk_size in (1, 7, 10000):
+                    with self.subTest(
+                        schema=schema, value=raw_value, chunk_size=chunk_size
+                    ):
+                        tools = [
+                            Tool(
+                                type="function",
+                                function=Function(
+                                    name="echo",
+                                    parameters={
+                                        "type": "object",
+                                        "properties": {"value": schema},
+                                    },
+                                ),
+                            )
+                        ]
+                        call = (
+                            "<tool_call>echo<tool_sep>"
+                            f"<arg_key>value</arg_key><arg_value>{raw_value}</arg_value>"
+                            "</tool_call>"
+                        )
+                        # Repeated calls must reset streaming argument state.
+                        text = "<tool_calls>" + call + call + "</tool_calls>"
+                        with self.subTest(mode="nonstream"):
+                            result = HunyuanDetector().detect_and_parse(text, tools)
+                            self.assertEqual(len(result.calls), 2)
+                            for parsed in result.calls:
+                                self.assertEqual(parsed.name, "echo")
+                                value = json.loads(parsed.parameters)["value"]
+                                self.assertEqual(value, expected)
+                                self.assertIs(type(value), type(expected))
+
+                        with self.subTest(mode="stream"):
+                            detector = HunyuanDetector()
+                            deltas = []
+                            for start in range(0, len(text), chunk_size):
+                                deltas.extend(
+                                    detector.parse_streaming_increment(
+                                        text[start : start + chunk_size], tools
+                                    ).calls
+                                )
+                            collected = _collect_streamed_tool_calls(deltas)
+                            self.assertEqual(len(collected), 2)
+                            for parsed in collected:
+                                self.assertEqual(parsed["name"], "echo")
+                                value = json.loads(parsed["parameters"])["value"]
+                                self.assertEqual(value, expected)
+                                self.assertIs(type(value), type(expected))
+
+    def test_type_array_normalization_matches_scalar_options(self):
+        schemas = (
+            {"type": ["int32", "null"]},
+            {"anyOf": [{"type": ["int32", "null"]}, {"type": "boolean"}]},
+            {"oneOf": [{"type": ["string", "array"]}]},
+        )
+        for schema, expected in zip(
+            schemas, ({"integer"}, {"integer", "boolean"}, {"string", "array"})
+        ):
+            with self.subTest(schema=schema):
+                self.assertEqual(HunyuanDetector._get_types(schema), expected)
+
+
 class TestHunyuanDetectorFunctionCallParser(CustomTestCase):
     """Test through the FunctionCallParser interface."""
 


### PR DESCRIPTION
## Motivation

A Hunyuan tool parameter declared with a valid JSON Schema type array, such as `{"type": ["integer", "null"]}`, raises `TypeError: unhashable type: 'list'` in `_get_types()`. The non-streaming exception handler returns no calls, and streaming cannot finish emitting the arguments. This happens on a CPU before model execution.

## Modifications

Expand scalar and array-valued `type` entries before applying the existing normalization. Preserve current type precedence, aliases, and null handling. Cover nullable primitives, arrays/objects, mixed string unions, reversed type order, and type arrays inside `anyOf`/`oneOf` options. Replay repeated calls as complete, seven-character, and single-character chunks.

This is separate from merged #36626, which resolves properties through top-level combinators; the failure here occurs after the property schema has been found.

## Accuracy Tests

Baseline: `a26273d668c82400e9e2a97ed328d4148a04e123`.

[Reproducible experiment, pinned environment, raw per-case results, and complete logs](https://github.com/justavibedev/sglang/tree/experiments/hunyuan-schema-type-arrays/experiments/hunyuan-schema-type-arrays).

- New regressions: 183 leaf assertions fail on baseline and pass with the fix (180 stream/nonstream checks, plus three normalization cases). There are 30 distinct schema/value fixtures; nonstream checks repeat across the three streaming schedules.
- 43 direct Hunyuan detector unittest methods pass, including existing tests.
- Changed-file pre-commit hooks pass; `git diff --check` passes.

Local validation used Python 3.12.11 on macOS ARM64, importing the actual protocol, detector, base class, environment, and JSON utilities. The source harness skips SGLang package startup and replaces only the GPU-oriented `CustomTestCase` lifecycle with `unittest.TestCase`. Four `FunctionCallParser` integration tests were excluded. Full server/GPU integration and upstream CI are pending; no model accuracy claim is made. The registered tests retain the standard imports/lifecycle for normal project CI.

## Speed Tests and Profiling

Not run; no serving performance claim. This change only normalizes tool-schema type metadata.

## Checklist

- [x] Format changed code and run changed-file pre-commit checks.
- [x] Add focused registered unit regressions.
- [x] Follow existing detector/test structure.
- [ ] Run full project CI and server integration (maintainer CI required).

Implementation and test preparation used Codex assistance. This PR requests review of the bounded parser fix; it does not claim maintainer agreement on a broader redesign.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34527785522](https://github.com/sgl-project/sglang/actions/runs/34527785522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34527785039](https://github.com/sgl-project/sglang/actions/runs/34527785039)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34527785326](https://github.com/sgl-project/sglang/actions/runs/34527785326)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

