### PR TITLE
[Feature] Breakable prefill CUDA graphs under decode context parallelism

### DIFF
--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -80,6 +80,9 @@ from sglang.srt.model_executor.cuda_graph_buffer_registry import (
     build_prefill_registry,
 )
 from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
+    create_chunked_prefix_cache_kv_indices,
+)
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -89,7 +92,12 @@ from sglang.srt.model_executor.forward_batch_info import (
     enable_num_token_non_padded,
     prefill_graph_tolerates_sum_len,
 )
-from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.model_executor.forward_context import (
+    ForwardContext,
+    forward_context,
+    get_req_to_token_pool,
+    get_token_to_kv_pool,
+)
 from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
     BaseCudaGraphRunner,
     freeze_gc,
@@ -568,6 +576,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self._input_embeds_arg_idx = (
                 params.index("input_embeds") if "input_embeds" in params else None
             )
+
+        # DCP extend attention reads KV through a gather buffer in attn_dcp_metadata;
+        # capture keeps one bucket-sized buffer per shape and replay reuses it.
+        self._dcp_extend_active = model_runner.ps.attn_dcp_size > 1 and hasattr(
+            model_runner.model, "prepare_context_parallel_metadata_for_dcp"
+        )
+        self._dcp_kv_buffers: Dict[int, torch.Tensor] = {}
 
         # --- aiter chip info pre-warming (AMD) -------------------------
         maybe_pre_warm_aiter_chip_info()
@@ -1059,6 +1074,25 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             capture_batch, in_capture=False
         )
 
+    def _plan_dcp_metadata(self, forward_batch: ForwardBatch):
+        """Plan DCP extend metadata as the eager runner does; the planner needs a
+        forward context, which capture has not entered yet."""
+        model_runner = self.model_runner
+        with forward_context(ForwardContext(attn_backend=model_runner.attn_backend)):
+            return model_runner.model.prepare_context_parallel_metadata_for_dcp(
+                forward_batch.seq_lens,
+                forward_batch.extend_prefix_lens,
+                forward_batch.extend_prefix_lens_cpu,
+                forward_batch.extend_seq_lens,
+                forward_batch.req_pool_indices,
+                get_req_to_token_pool().req_to_token,
+                forward_batch.seq_lens_sum,
+                get_token_to_kv_pool().get_kv_buffer_shape()[0],
+                model_runner.kv_cache_dtype,
+                model_runner.device,
+                create_chunked_prefix_cache_kv_indices,
+            )
+
     def _init_forward_metadata_for_capture(
         self, forward_batch: ForwardBatch, num_tokens: int
     ) -> None:
@@ -1066,6 +1100,12 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         contract. For opt-in backends (DSV4), call the BCG-specific entry
         and stash the returned per-bucket metadata object; otherwise fall
         back to the generic eager init that BCG/TC_PIECEWISE use today."""
+        if self._dcp_extend_active:
+            # Zero-prefix capture batch: its gather buffer is bucket-sized, so
+            # it doubles as the replay buffer for this shape.
+            metadata = self._plan_dcp_metadata(forward_batch)
+            forward_batch.attn_dcp_metadata = metadata
+            self._dcp_kv_buffers[num_tokens] = metadata.dcp_kv_buffer
         attn_backend = self.model_runner.attn_backend
         with forward_context(ForwardContext(attn_backend=attn_backend)):
             if not self.use_captured_attn_metadata:
@@ -1092,6 +1132,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         capture-stable wrapper state planned at capture time with the
         real seq_lens / prefix_lens; the captured kernels read the
         updated state at replay."""
+        if self._dcp_extend_active:
+            # The gather and the attention are breaks reading the live batch: plan
+            # live indices, but use the bucket-sized buffer (k_nope/k_pe are padded).
+            metadata = self._plan_dcp_metadata(forward_batch)
+            metadata.dcp_kv_buffer = self._dcp_kv_buffers[num_tokens]
+            forward_batch.attn_dcp_metadata = metadata
+            static_forward_batch.attn_dcp_metadata = metadata
         attn_backend = self.model_runner.attn_backend
         if self._is_full_backend:
             # Slot-padded shallow view: plan() must see exactly req_slots
@@ -1175,6 +1222,10 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         # FullCG's chunked-prefix topology covers a bounded prefix. Its capture
         # flag is FullCG-only, so this is inert for the BreakableCG vote path.
         if self._has_uncapturable_chunked_prefix(prefix_lens):
+            return False
+        # Under DCP only fresh prefills replay; a prefix hit needs the cross-rank
+        # prefix KV all-gather with per-batch shapes, which stays eager.
+        if self._dcp_extend_active and prefix_lens is not None and any(prefix_lens):
             return False
         # tc_piecewise captures with ForwardMode.EXTEND and spec_info=None.
         if is_target_verify:

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -102,6 +102,39 @@ def is_mla_dcp_lse_base_on_e(attention_backend: Optional[str]) -> bool:
     return attention_backend in {"flashmla", "cutedsl_mla"}
 
 
+@eager_on_graph(True)
+def bcg_dcp_extend_kv_gather(
+    token_to_kv_pool,
+    attn_mqa,
+    forward_batch: ForwardBatch,
+    kv_lora_rank: int,
+    k_nope: torch.Tensor,
+    k_pe: torch.Tensor,
+) -> None:
+    """Assemble the DCP extend KV buffer; an eager break under breakable graphs.
+    Reads the live batch from the forward context: replay re-supplies the capture-time arg."""
+    context = get_tc_piecewise_forward_context()
+    if context is not None:
+        forward_batch = context.forward_batch
+    metadata = forward_batch.attn_dcp_metadata
+    if metadata.dcp_extend_prefix_lens_sum == 0:
+        # No prefix KV on any DCP rank: skip the collective.
+        metadata.dcp_kv_buffer[..., :kv_lora_rank] = k_nope
+        metadata.dcp_kv_buffer[..., kv_lora_rank:] = k_pe
+        return
+    all_gather_kv_cache_for_mla_extend(
+        token_to_kv_pool,
+        attn_mqa,
+        forward_batch.extend_prefix_lens_cpu,
+        metadata.dcp_local_prefix_kv_indices,
+        metadata.dcp_extend_prefix_lens_sum,
+        metadata.dcp_kv_buffer,
+        kv_lora_rank,
+        k_nope,
+        k_pe,
+    )
+
+
 if _is_cuda:
     from sglang.kernels.ops.gemm import bmm_fp8
 
@@ -634,13 +667,10 @@ class DeepseekMLAForwardMixin:
                     )
             elif forward_batch.forward_mode.is_extend():
                 # for extend, gather kv
-                all_gather_kv_cache_for_mla_extend(
+                bcg_dcp_extend_kv_gather(
                     get_token_to_kv_pool(),
                     self.attn_mqa,
-                    forward_batch.extend_prefix_lens_cpu,
-                    forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
-                    forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
-                    forward_batch.attn_dcp_metadata.dcp_kv_buffer,
+                    forward_batch,
                     self.kv_lora_rank,
                     k_nope,
                     k_pe,

--- a/test/registered/e2e/models/test_kimi_linear_unified_memory_dcp_blackwell.py
+++ b/test/registered/e2e/models/test_kimi_linear_unified_memory_dcp_blackwell.py
@@ -47,7 +47,7 @@ from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=161, stage="extra-b", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=330, stage="extra-b", runner_config="4-gpu-b200")
 
 KIMI_LINEAR_MODEL = "moonshotai/Kimi-Linear-48B-A3B-Instruct"
 
@@ -80,6 +80,18 @@ class TestKimiLinearUnifiedMemoryDCPCuteDsl(
         "--cuda-graph-max-bs-decode",
         "128",
         "--enable-unified-memory",
+    ]
+
+
+class TestKimiLinearUnifiedMemoryDCPCuteDslBreakablePrefill(
+    TestKimiLinearUnifiedMemoryDCPCuteDsl
+):
+    """Same server with breakable prefill CUDA graphs: capture used to crash
+    under DCP (attn_dcp_metadata is None on the capture batch)."""
+
+    other_args = TestKimiLinearUnifiedMemoryDCPCuteDsl.other_args + [
+        "--cuda-graph-backend-prefill",
+        "breakable",
     ]
 
 

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_dcp.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_dcp.py
@@ -1,0 +1,164 @@
+"""Breakable prefill CUDA graphs under decode context parallelism.
+
+Replay re-runs the break functions with their capture-time arguments, so the
+DCP extend gather must take the live batch from the forward context, and the
+runner must hand every replayed batch the bucket-sized gather buffer it
+captured. Prefix hits need the cross-rank all-gather and stay eager.
+
+    python -m pytest test/registered/unit/model_executor/test_prefill_cuda_graph_dcp.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.dcp.metadata import DecodeContextParallelMetadata
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    set_tc_piecewise_forward_context,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+KV_LORA_RANK = 4
+ROPE_DIM = 2
+
+
+def _metadata(num_tokens):
+    return DecodeContextParallelMetadata(
+        dcp_kv_indptr=torch.zeros(2, dtype=torch.int32),
+        dcp_kv_buffer=torch.zeros((num_tokens, 1, KV_LORA_RANK + ROPE_DIM)),
+        dcp_kv_indices=torch.arange(num_tokens, dtype=torch.int32),
+        dcp_local_prefix_kv_indices=torch.zeros(0, dtype=torch.int32),
+        dcp_extend_prefix_lens_sum=0,
+    )
+
+
+def _batch(num_tokens, prefix_lens):
+    return SimpleNamespace(
+        batch_size=len(prefix_lens),
+        input_ids=torch.zeros(num_tokens, dtype=torch.int64),
+        input_embeds=None,
+        replace_embeds=None,
+        forward_mode=SimpleNamespace(is_target_verify=lambda: False),
+        capture_hidden_mode=CaptureHiddenMode.NULL,
+        global_num_tokens_cpu=None,
+        return_logprob=False,
+        extend_prefix_lens_cpu=prefix_lens,
+        extend_prefix_lens=torch.tensor(prefix_lens),
+        seq_lens=torch.tensor([num_tokens]),
+        extend_seq_lens=torch.tensor([num_tokens]),
+        req_pool_indices=torch.zeros(1, dtype=torch.int64),
+        seq_lens_sum=num_tokens,
+        attn_dcp_metadata=None,
+    )
+
+
+def _runner(dcp_active):
+    runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+    runner._capture_req_slots = 4
+    runner.enable_lora = False
+    runner.capture_hidden_mode = CaptureHiddenMode.NULL
+    runner.max_num_tokens = 32
+    runner.capture_num_tokens = [8]
+    runner.backend = SimpleNamespace()
+    runner.prefill_backend_name = Backend.BREAKABLE
+    runner.has_mha_companion_layers = False
+    runner._is_full_backend = False
+    runner._capture_chunked_prefix = False
+    runner.use_captured_attn_metadata = False
+    runner._dcp_extend_active = dcp_active
+    runner._dcp_kv_buffers = {}
+    return runner
+
+
+class TestDcpAdmission(unittest.TestCase):
+    def test_prefix_hits_stay_eager_under_dcp(self):
+        fresh = _batch(8, [0])
+        prefix_hit = _batch(8, [4])
+        self.assertTrue(_runner(dcp_active=False).can_run_graph(prefix_hit))
+        runner = _runner(dcp_active=True)
+        self.assertTrue(runner.can_run_graph(fresh))
+        self.assertFalse(runner.can_run_graph(prefix_hit))
+
+
+class TestDcpReplayMetadata(unittest.TestCase):
+    def test_replay_reuses_the_captured_gather_buffer(self):
+        runner = _runner(dcp_active=True)
+        captured = torch.full((8, 1, KV_LORA_RANK + ROPE_DIM), 7.0)
+        runner._dcp_kv_buffers[8] = captured
+        planned = []
+
+        def plan(*args):
+            planned.append(args)
+            return _metadata(num_tokens=5)
+
+        attn_backend = SimpleNamespace(
+            req_to_token_pool=SimpleNamespace(req_to_token=torch.zeros((1, 8))),
+            token_to_kv_pool=SimpleNamespace(
+                get_kv_buffer_shape=lambda: (torch.Size([64, 1, 6]), None)
+            ),
+            init_forward_metadata=lambda batch: None,
+            prepare_prefill_shared_read_snapshot=lambda batch, num_qo_tokens: None,
+        )
+        runner.model_runner = SimpleNamespace(
+            attn_backend=attn_backend,
+            model=SimpleNamespace(prepare_context_parallel_metadata_for_dcp=plan),
+            kv_cache_dtype=torch.float32,
+            device="cpu",
+        )
+        live = _batch(5, [0])
+        static = _batch(8, [0])
+        runner._prepare_forward_metadata_for_replay(live, static, num_tokens=8)
+
+        self.assertEqual(len(planned), 1)
+        self.assertIs(static.attn_dcp_metadata, live.attn_dcp_metadata)
+        # Live indices, captured (bucket-sized) buffer.
+        self.assertIs(static.attn_dcp_metadata.dcp_kv_buffer, captured)
+        self.assertEqual(static.attn_dcp_metadata.dcp_kv_indices.numel(), 5)
+
+
+class TestDcpExtendGatherBreak(unittest.TestCase):
+    def test_gather_writes_the_forward_context_batch(self):
+        from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla import (
+            bcg_dcp_extend_kv_gather,
+        )
+
+        capture_batch = _batch(8, [0])
+        capture_batch.attn_dcp_metadata = _metadata(8)
+        live_batch = _batch(8, [0])
+        live_batch.attn_dcp_metadata = _metadata(8)
+        k_nope = torch.ones((8, 1, KV_LORA_RANK))
+        k_pe = torch.full((8, 1, ROPE_DIM), 2.0)
+        with set_tc_piecewise_forward_context(
+            live_batch,
+            attention_layers=[],
+            quant_config=None,
+            moe_layers=[],
+            moe_fusions=[],
+        ):
+            # Replay re-supplies the capture-time batch as the argument.
+            bcg_dcp_extend_kv_gather(
+                None, None, capture_batch, KV_LORA_RANK, k_nope, k_pe
+            )
+        self.assertTrue(
+            torch.all(
+                live_batch.attn_dcp_metadata.dcp_kv_buffer[..., :KV_LORA_RANK] == 1.0
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                live_batch.attn_dcp_metadata.dcp_kv_buffer[..., KV_LORA_RANK:] == 2.0
+            )
+        )
+        self.assertTrue(torch.all(capture_batch.attn_dcp_metadata.dcp_kv_buffer == 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--cuda-graph-backend-prefill breakable` with `--dcp-size > 1` crashes during capture: the dummy extend batch has no `attn_dcp_metadata`, and the MLA extend path dereferences it in `all_gather_kv_cache_for_mla_extend`. The auto-disable rule only covers the default backend, so an explicit selection (as in the documented Kimi-K3 recipe) fails to boot, and DCP deployments have had to run prefill eagerly.

## Modifications

Breakable-graph break functions are replayed with their capture-time arguments, so per-batch state has to come from somewhere stable rather than the batch object passed at capture.

- `forward_mla.py`: the DCP extend KV assembly becomes an `eager_on_graph` break, `bcg_dcp_extend_kv_gather`. It reads the live batch from the forward context, like the attention break. With no cached prefix there is nothing to gather from other ranks, so it copies the local `k_nope` / `k_pe` into the gather buffer and skips the collective; prefix hits keep the existing all-gather.
- `prefill_cuda_graph_runner.py`: capture plans DCP metadata for its zero-prefix batch and keeps that bucket-sized gather buffer per shape. Replay plans the live batch's indices eagerly and points them at the captured buffer.
- Under DCP only fresh prefills replay. Prefix-hit extends, including chunked-prefill continuations, fall back to eager via `can_replay_locally`. Replaying prefix hits is a follow-up.
- The auto-disable rule is unchanged; the feature is reached by selecting `breakable` explicitly.

Tests: `test_prefill_cuda_graph_dcp.py` covers the admission gate, the replay buffer contract and the live-batch gather (all fail on `main`). The Kimi-Linear cutedsl + DCP e2e test gains a breakable-prefill variant, which could not boot before.

## Accuracy Tests

Kimi-K3, `cutedsl_mla`, `--dcp-size 8`, 2 nodes, against the same server with prefill graphs disabled. Graph replay is deterministic (repeated fresh prefills are bitwise identical), graph-vs-eager logprob differences are no larger than the eager server's own batch-composition variation, and standard accuracy evals plus a paired agentic coding benchmark match the disabled baseline. Every fresh prefill replayed and every prefix hit went eager in the logs. Also checked with draft-model speculative decoding and at a 1M-token context.

## Speed Tests and Profiling

Prefill TTFT, sequential, one output token, median ms:

| prompt tokens | 22 | 301 | 1142 | 1996 | 4437 (above largest bucket) |
|---|---|---|---|---|---|
| disabled | 404 | 454 | 461 | 486 | 460 |
| breakable | 133 | 155 | 171 | 177 | 460 |

Short-prompt rolling benchmark: TPOT 38.0 -> 33.6 ms, output throughput +14%, decode throughput unchanged. Capture: 42 buckets in ~70 s, 3.6–4.8 GB per GPU.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34528396851](https://github.com/sgl-project/sglang/actions/runs/34528396851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34528396158](https://github.com/sgl-project/sglang/actions/runs/34528396158)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34528396567](https://github.com/sgl-project/sglang/actions/runs/34528396567)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->