### PR TITLE
[DSV4.1] Enable the two-level candidate indexer on DeepGEMM's paged sparse MQA logits

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/amax_copy.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/amax_copy.cuh
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace sglang {
+
+/// Level-one keys of the DeepSeek-V4.1 two-level indexer: one key per block of
+/// kBlockTokens consecutive scores, the block's maximum score (`amax` in the
+/// model code, a plain max). Row `b` has `ceil(seq_len[b] / kBlockTokens)` keys;
+/// its newest block is written as +inf so the block top-k can never drop it,
+/// which also makes the scores past `seq_len` inside that block irrelevant.
+/// Nothing is written past the key count: the consumer takes the same count as
+/// the row length. Rows with at most `topk` blocks are skipped entirely (every
+/// block is selected anyway; `topk = 0` disables the skip).
+struct AmaxConfig {
+  using DType = float;                         // TODO: support bf16
+  static constexpr uint32_t kBlockTokens = 8;  // scores per key
+  static constexpr uint32_t kBlockSize = 512;
+  static constexpr uint32_t kNumItems = 2;  // keys per thread
+  static constexpr uint32_t kOccupancy = 4;
+  static constexpr uint32_t kKeysPerCTA = kBlockSize * kNumItems;
+  // One block is 32 B: a single load on Blackwell, two 16 B loads before it.
+  static constexpr uint32_t kVecSize = device::kMaxVecBytes / sizeof(DType);
+  static constexpr uint32_t kVecsPerBlock = kBlockTokens / kVecSize;
+  static_assert(kVecsPerBlock * kVecSize == kBlockTokens);
+  using vec_t = device::AlignedVector<DType, kVecSize>;
+};
+
+struct AmaxParams {
+  const AmaxConfig::DType* __restrict__ scores;
+  AmaxConfig::DType* __restrict__ amax_scores;
+  const int32_t* __restrict__ seq_len;
+  int64_t stride_scores;       // in elements
+  int64_t stride_amax_scores;  // in elements
+  uint32_t topk;               // rows with <= topk blocks are skipped, 0 = never skip
+};
+
+/// grid = (rows, ceil(max_keys / kKeysPerCTA)); a CTA owns kKeysPerCTA consecutive
+/// keys of one row, a thread kNumItems keys kBlockSize apart (coalesced loads).
+template <bool kUsePDL>
+__global__ __launch_bounds__(AmaxConfig::kBlockSize, AmaxConfig::kOccupancy)  //
+    void amax8_varlen_kernel(const __grid_constant__ AmaxParams params) {
+  using namespace device;
+  using C = AmaxConfig;
+  using T = typename C::DType;
+  using vec_t = typename C::vec_t;
+  const auto bx = blockIdx.x;
+  const auto by = blockIdx.y;
+  const auto tx = threadIdx.x;
+
+  PDLWaitPrimary<kUsePDL>();  // seq_len and scores are the previous kernels' outputs
+  const auto seq_len = static_cast<uint32_t>(params.seq_len[bx]);
+  const auto num_keys = (seq_len + C::kBlockTokens - 1) / C::kBlockTokens;
+  const auto first_key = by * C::kKeysPerCTA;
+  if (num_keys <= params.topk || first_key >= num_keys) {
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+  const auto* __restrict__ in = params.scores + bx * params.stride_scores;
+  auto* __restrict__ out = params.amax_scores + bx * params.stride_amax_scores;
+
+  vec_t vec[C::kNumItems][C::kVecsPerBlock];
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto idx = first_key + tx + i * C::kBlockSize;
+    if (idx < num_keys) {
+#pragma unroll
+      for (uint32_t v = 0; v < C::kVecsPerBlock; ++v) {
+        vec[i][v].load(in, idx * C::kVecsPerBlock + v);
+      }
+    }
+  }
+  // The dependent grid may start its prologue now; its griddepcontrol.wait still
+  // covers every store below (it waits for this grid to complete).
+  PDLTriggerSecondary<kUsePDL>();
+
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto idx = first_key + tx + i * C::kBlockSize;
+    if (idx < num_keys) {
+      T key = vec[i][0][0];
+#pragma unroll
+      for (uint32_t v = 0; v < C::kVecsPerBlock; ++v) {
+#pragma unroll
+        for (uint32_t j = 0; j < C::kVecSize; ++j) {
+          key = fmaxf(key, vec[i][v][j]);  // a NaN score is ignored, torch.amax would propagate it
+        }
+      }
+      out[idx] = idx + 1 == num_keys ? std::numeric_limits<T>::infinity() : key;
+    }
+  }
+}
+
+/// Host entry: `amax_scores[b, i] = max(scores[b, 8 i : 8 i + 8])` for
+/// `i < ceil(seq_len[b] / 8)`, the last of them +inf; rows with at most `topk`
+/// blocks untouched. `scores` rows must stay 32 B aligned (stride % 8 == 0).
+/// The grid covers `amax_scores`' width, so the caller sizes it for the longest
+/// row: `seq_len[b] <= 8 * amax_scores.shape[1]` for every row (not checked).
+template <bool kPDL>
+struct AmaxCopyKernel {
+  static void amax8_varlen(
+      const tvm::ffi::TensorView scores,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView amax_scores,
+      const uint32_t topk) {
+    using namespace host;
+    using C = AmaxConfig;
+    auto B = SymbolicSize{"batch_size"};
+    auto L = SymbolicSize{"max_seq_len"};
+    auto S = SymbolicSize{"stride_scores"};
+    auto K = SymbolicSize{"max_keys"};
+    auto O = SymbolicSize{"stride_amax_scores"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+    TensorMatcher({B, L})  // scores
+        .with_strides({S, 1})
+        .with_dtype<typename C::DType>()
+        .with_device(device_)
+        .verify(scores);
+    TensorMatcher({B})  // seq_lens
+        .with_dtype<int32_t>()
+        .with_device(device_)
+        .verify(seq_lens);
+    TensorMatcher({B, K})  // amax_scores
+        .with_strides({O, 1})
+        .with_dtype<typename C::DType>()
+        .with_device(device_)
+        .verify(amax_scores);
+    RuntimeCheck(S.unwrap() % C::kBlockTokens == 0, "stride_scores must keep every block 32 B aligned");
+    RuntimeCheck(
+        reinterpret_cast<uintptr_t>(scores.data_ptr()) % (C::kBlockTokens * sizeof(typename C::DType)) == 0,
+        "scores must be 32 B aligned");
+    RuntimeCheck(K.unwrap() > 0, "amax_scores must hold at least one key per row");
+    const auto max_keys = K.unwrap();  // ceil(longest row / 8), sized by the caller
+    const auto params = AmaxParams{
+        .scores = static_cast<const typename C::DType*>(scores.data_ptr()),
+        .amax_scores = static_cast<typename C::DType*>(amax_scores.data_ptr()),
+        .seq_len = static_cast<const int32_t*>(seq_lens.data_ptr()),
+        .stride_scores = S.unwrap(),
+        .stride_amax_scores = O.unwrap(),
+        .topk = topk,
+    };
+    const auto grid = dim3(
+        static_cast<uint32_t>(B.unwrap()),
+        static_cast<uint32_t>(div_ceil(max_keys, static_cast<int64_t>(C::kKeysPerCTA))));
+    LaunchKernel(grid, C::kBlockSize, device_.unwrap())
+        .config({.use_pdl = kPDL})
+        .launch(amax8_varlen_kernel<kPDL>, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/sort_idx.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/sort_idx.cuh
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+#include <limits>
+
+namespace sglang {
+
+/// Finalises the block table layer 20 publishes for DeepGEMM's sparse indexer:
+/// the top-k block ids a row selected (any order, -1 padded) become, in place,
+/// the same ids ascending with INT32_MAX past the row's count, plus each block
+/// as a pool slot / 8 (`page_table[b, id / bpp] * bpp + id % bpp`, `bpp` blocks
+/// per index page). A row with at most `topk` blocks keeps every block and gets
+/// the identity table without reading its input.
+///
+/// Counting sort over a bitmap of the row's blocks (one bit per block, 16 KiB
+/// for the 128K blocks of a 1M-token row): set the selected bits, exclusive-scan
+/// the popcounts, emit every set bit at its rank. A word with a single bit is
+/// emitted by its owner (one `ffs`, no loop); a word with more goes to a
+/// block-wide queue that the warps drain one word per step, one lane per bit,
+/// so a dense cluster of selected blocks is spread over all warps.
+struct SortConfig {
+  static constexpr uint32_t kBlockSize = 1024;
+  static constexpr uint32_t kOccupancy = 2;
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static constexpr uint32_t kBlockTokens = 8;
+  static constexpr uint32_t kMaxSeqLen = 128 * 1024;  // blocks: 1M tokens / kBlockTokens
+  static constexpr uint32_t kMaxTopK = 2048;
+  static constexpr uint32_t kWordsPerThread = kMaxSeqLen / 32 / kBlockSize;
+  static_assert(kWordsPerThread == 4 && kNumWarps == device::kWarpThreads);
+  static constexpr int32_t kPad = std::numeric_limits<int32_t>::max();
+  using word_vec_t = device::AlignedVector<uint32_t, kWordsPerThread>;
+  struct WriteItem {
+    uint32_t start;  // rank of the word's first bit | word index << 16
+    uint32_t bits;
+  };
+  struct Smem {
+    uint32_t queue_size;
+    uint32_t warp_sum[kNumWarps];
+    union {
+      alignas(16) uint32_t bitmap[kMaxSeqLen / 32];
+      WriteItem write_queue[kMaxTopK];  // a queued word holds >= 2 of the topk bits
+    };
+  };
+};
+
+struct SortParams {
+  const uint32_t* __restrict__ seq_len;    // [rows] tokens
+  const int32_t* __restrict__ page_table;  // [rows, pages] index-pool pages
+  int32_t* __restrict__ indices;           // [rows, topk] blocks, -1 padded in, ascending + kPad out
+  int32_t* __restrict__ out_pages;         // [rows, topk] the same blocks as pool slots / 8
+  int64_t page_table_stride;
+  int64_t indices_stride;
+  int64_t out_pages_stride;
+  uint32_t topk;
+  uint32_t page_bits;  // log2(page_size / kBlockTokens)
+};
+
+/// One CTA per row.
+template <bool kUsePDL>
+__global__ __launch_bounds__(SortConfig::kBlockSize, SortConfig::kOccupancy)  //
+    void sort_128k_transform(const __grid_constant__ SortParams params) {
+  using namespace device;
+  using C = SortConfig;
+  __shared__ C::Smem smem;
+  const auto bx = blockIdx.x;
+  const auto tx = threadIdx.x;
+  const auto warp_id = tx / kWarpThreads;
+  const auto lane_id = tx % kWarpThreads;
+  const auto lanemask_lt = (1u << lane_id) - 1u;
+
+  PDLWaitPrimary<kUsePDL>();  // indices is the block top-k's output
+  const auto seq_len = params.seq_len[bx];
+  const auto nblocks = (seq_len + C::kBlockTokens - 1) / C::kBlockTokens;
+  const auto* __restrict__ table = params.page_table + bx * params.page_table_stride;
+  auto* __restrict__ indices = params.indices + bx * params.indices_stride;
+  auto* __restrict__ pages = params.out_pages + bx * params.out_pages_stride;
+  const auto bpp_mask = (1u << params.page_bits) - 1u;
+  const auto emit = [&](uint32_t rank, uint32_t id) {
+    indices[rank] = static_cast<int32_t>(id);
+    pages[rank] = (table[id >> params.page_bits] << params.page_bits) | static_cast<int32_t>(id & bpp_mask);
+  };
+  const auto pad = [&](uint32_t rank) {
+    indices[rank] = C::kPad;
+    pages[rank] = C::kPad;
+  };
+
+  if (nblocks <= params.topk) {  // every block is selected: the identity table
+    for (uint32_t t = tx; t < params.topk; t += C::kBlockSize) {
+      if (t < nblocks) {
+        emit(t, t);
+      } else {
+        pad(t);
+      }
+    }
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+
+  // 1. the selected blocks as a bitmap
+  C::word_vec_t words;
+  words.fill(0u);
+  words.store(smem.bitmap, tx);
+  if (tx == 0) smem.queue_size = 0;
+  __syncthreads();
+  for (uint32_t t = tx; t < params.topk; t += C::kBlockSize) {
+    const auto id = indices[t];
+    if (id >= 0) atomicOr(&smem.bitmap[id >> 5], 1u << (id & 31));
+  }
+  __syncthreads();
+
+  // 2. rank of every word's first bit: block-wide exclusive scan of the popcounts
+  words.load(smem.bitmap, tx);
+  uint32_t count[C::kWordsPerThread];
+  uint32_t local = 0;
+#pragma unroll
+  for (uint32_t j = 0; j < C::kWordsPerThread; ++j) {
+    count[j] = __popc(words[j]);
+    local += count[j];
+  }
+  const auto warp_inc = warp::inclusive_sum(lane_id, local);
+  if (lane_id == kWarpThreads - 1) smem.warp_sum[warp_id] = warp_inc;
+  __syncthreads();  // also: every thread holds its words, the bitmap may become the queue
+  const auto peer_sum = smem.warp_sum[lane_id];
+  const auto warp_prefix = warp::reduce_sum(lane_id < warp_id ? peer_sum : 0u);
+  const auto total = warp::reduce_sum(peer_sum);
+  uint32_t base = warp_prefix + warp_inc - local;
+  PDLTriggerSecondary<kUsePDL>();
+
+  // 3. single bits by their owner, denser words queued for the warps
+#pragma unroll
+  for (uint32_t j = 0; j < C::kWordsPerThread; ++j) {
+    const auto word_idx = tx * C::kWordsPerThread + j;
+    if (count[j] == 1) {
+      emit(base, word_idx * 32 + __ffs(words[j]) - 1);
+    } else if (count[j] >= 2) {
+      const auto slot = atomicAdd(&smem.queue_size, 1u);
+      smem.write_queue[slot] = {base | (word_idx << 16), words[j]};
+    }
+    base += count[j];
+  }
+  for (uint32_t t = total + tx; t < params.topk; t += C::kBlockSize) {
+    pad(t);
+  }
+  __syncthreads();
+
+  // 4. drain the queue: one word per warp step, one lane per bit
+  const auto queue_size = smem.queue_size;
+  for (uint32_t q = warp_id; q < queue_size; q += C::kNumWarps) {
+    const auto item = smem.write_queue[q];
+    if ((item.bits >> lane_id) & 1u) {
+      emit((item.start & 0xFFFFu) + __popc(item.bits & lanemask_lt), (item.start >> 16) * 32 + lane_id);
+    }
+  }
+}
+
+/// The page transform alone, for a block top-k that already emits its ids
+/// ascending (e.g. DeepSelect with `sorted_index`): `out_pages[t]` is the pool
+/// slot / 8 of `indices[t]` for `t < min(topk, ceil(seq_len / 8))`, INT32_MAX
+/// past that; `indices` is left as it is. Those first entries must be valid
+/// block ids of the row.
+template <bool kUsePDL>
+__global__ __launch_bounds__(SortConfig::kBlockSize, SortConfig::kOccupancy)  //
+    void page_transform_128k(const __grid_constant__ SortParams params) {
+  using namespace device;
+  using C = SortConfig;
+  const auto bx = blockIdx.x;
+  const auto tx = threadIdx.x;
+  PDLWaitPrimary<kUsePDL>();
+  const auto seq_len = params.seq_len[bx];
+  const auto nblocks = (seq_len + C::kBlockTokens - 1) / C::kBlockTokens;
+  const auto num_valid = min(nblocks, params.topk);
+  const auto* __restrict__ table = params.page_table + bx * params.page_table_stride;
+  const auto* __restrict__ indices = params.indices + bx * params.indices_stride;
+  auto* __restrict__ pages = params.out_pages + bx * params.out_pages_stride;
+  const auto bpp_mask = (1u << params.page_bits) - 1u;
+  for (uint32_t t = tx; t < params.topk; t += C::kBlockSize) {
+    if (t < num_valid) {
+      const auto id = static_cast<uint32_t>(indices[t]);
+      pages[t] = (table[id >> params.page_bits] << params.page_bits) | static_cast<int32_t>(id & bpp_mask);
+    } else {
+      pages[t] = C::kPad;
+    }
+  }
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+/// Host entry: `indices` is rewritten in place; `page_size` is the index pool's,
+/// a power of two >= 8, and the row's page table must cover its length.
+template <bool kPDL>
+struct SortIdxKernel {
+  /// Sort + page transform, in place on `indices`.
+  static void transform(
+      const tvm::ffi::TensorView indices,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView page_table,
+      const tvm::ffi::TensorView out_pages,
+      const uint32_t page_size) {
+    launch<sort_128k_transform<kPDL>>(indices, seq_lens, page_table, out_pages, page_size);
+  }
+
+  /// Page transform only, `indices` already ascending and left untouched.
+  static void transform_pages(
+      const tvm::ffi::TensorView indices,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView page_table,
+      const tvm::ffi::TensorView out_pages,
+      const uint32_t page_size) {
+    launch<page_transform_128k<kPDL>>(indices, seq_lens, page_table, out_pages, page_size);
+  }
+
+ private:
+  template <auto kKernel>
+  static void launch(
+      const tvm::ffi::TensorView indices,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView page_table,
+      const tvm::ffi::TensorView out_pages,
+      const uint32_t page_size) {
+    using namespace host;
+    using C = SortConfig;
+    auto B = SymbolicSize{"batch_size"};
+    auto K = SymbolicSize{"topk_blocks"};
+    auto Si = SymbolicSize{"indices_stride"};
+    auto Sp = SymbolicSize{"out_pages_stride"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+    TensorMatcher({B, K}).with_strides({Si, 1}).with_dtype<int32_t>().with_device(device_).verify(indices);
+    TensorMatcher({B}).with_dtype<int32_t>().with_device(device_).verify(seq_lens);
+    TensorMatcher({B, -1}).with_strides({-1, 1}).with_dtype<int32_t>().with_device(device_).verify(page_table);
+    TensorMatcher({B, K}).with_strides({Sp, 1}).with_dtype<int32_t>().with_device(device_).verify(out_pages);
+    RuntimeCheck(
+        std::has_single_bit(page_size) && page_size >= C::kBlockTokens,
+        "page_size must be a power of two of at least 8");
+    const auto topk = static_cast<uint32_t>(K.unwrap());
+    RuntimeCheck(topk > 0 && topk <= C::kMaxTopK, "topk_blocks must be in (0, kMaxTopK]");
+    const auto params = SortParams{
+        .seq_len = static_cast<const uint32_t*>(seq_lens.data_ptr()),
+        .page_table = static_cast<const int32_t*>(page_table.data_ptr()),
+        .indices = static_cast<int32_t*>(indices.data_ptr()),
+        .out_pages = static_cast<int32_t*>(out_pages.data_ptr()),
+        .page_table_stride = page_table.stride(0),
+        .indices_stride = Si.unwrap(),
+        .out_pages_stride = Sp.unwrap(),
+        .topk = topk,
+        .page_bits = static_cast<uint32_t>(std::countr_zero(page_size / C::kBlockTokens)),
+    };
+    LaunchKernel(static_cast<uint32_t>(B.unwrap()), C::kBlockSize, device_.unwrap())
+        .config({.use_pdl = kPDL})
+        .launch(kKernel, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_bf16_small.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_bf16_small.cuh
@@ -169,7 +169,8 @@ TOPK_BF16_KERNEL void topk_bf16_approx_kernel(const __grid_constant__ TopKBF16Pa
     auto* __restrict__ out = params.page_indices + bx * params.page_indices_stride;
     const auto page_mask = (1u << params.page_bits) - 1;
     for (uint32_t t = tx; t < params.topk; t += C::kBlockSize) {
-      out[t] = t < seq_len ? (table[t >> params.page_bits] << params.page_bits) | static_cast<int32_t>(t & page_mask) : -1;
+      out[t] =
+          t < seq_len ? (table[t >> params.page_bits] << params.page_bits) | static_cast<int32_t>(t & page_mask) : -1;
     }
     return PDLTriggerSecondary<kUsePDL>();
   }

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_bf16_small.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_bf16_small.cuh
@@ -1,0 +1,364 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+
+namespace sglang {
+
+struct TopKBF16Config {
+  static constexpr uint32_t kBlockSize = 1024;
+  static constexpr uint32_t kOccupancy = 2;
+  static constexpr uint32_t kMaxSeqLen = 16384;
+  static constexpr uint32_t kVecSize = device::kMaxVecBytes / sizeof(bf16_t);
+  static constexpr uint32_t kNumItems = kMaxSeqLen / (kVecSize * kBlockSize);
+  static constexpr uint32_t kMaxTopK = 4096;
+  static constexpr uint32_t kNumWarps = kBlockSize / device::kWarpThreads;
+  static_assert(kMaxSeqLen == kNumItems * kVecSize * kBlockSize);
+  using vec_t = device::AlignedVector<bf16x2_t, kVecSize / 2>;
+  struct SmemApprox {
+    static constexpr uint32_t kHistBits = 13;
+    static constexpr uint32_t kHistSize = 1 << kHistBits;
+    // The threshold search walks the histogram 16 B at a time: 4 bins per thread
+    // per round, warp w owning the bin range [w * 256, (w + 1) * 256).
+    static constexpr uint32_t kHistItems = 16 / sizeof(uint32_t);
+    static constexpr uint32_t kHistRounds = kHistSize / (kHistItems * kBlockSize);
+    using hist_vec_t = device::AlignedVector<uint32_t, kHistItems>;
+    static_assert(kHistRounds == 2 && kNumWarps == device::kWarpThreads);
+    uint32_t count_eq_gt;    // collect cursors, (gt << 16) | eq
+    uint32_t threshold_bin;  // the bin holding the k-th largest
+    uint32_t warp_sum[kNumWarps];
+    union {
+      alignas(16) uint32_t histogram[kHistSize];
+      int32_t stage_out_idxs[kMaxTopK];
+    };
+  };
+};
+
+#define TOPK_BF16_KERNEL __global__ __launch_bounds__(TopKBF16Config::kBlockSize, TopKBF16Config::kOccupancy)
+
+struct TopKBF16Params {
+  const bf16_t* __restrict__ scores;
+  const int32_t* __restrict__ seq_lens;
+  const int32_t* __restrict__ page_table;
+  int32_t* __restrict__ page_indices;
+  int64_t score_stride;
+  int64_t page_table_stride;
+  int64_t page_indices_stride;
+  uint32_t topk;
+  uint32_t page_bits;
+};
+
+SGL_DEVICE uint32_t extract_coarse_bin2(bf16x2_t pair) {
+  using device::cast;
+  const auto fp16_pair = cast<fp16x2_t>(cast<fp32x2_t>(pair));
+  const auto bits = reinterpret_cast<const uint32_t&>(fp16_pair);
+  const auto sign = ((bits >> 15) & 0x00010001u) * 0xFFFFu;
+  const auto key = bits ^ (sign | 0x80008000u);
+  return (key >> 3) & 0x1FFF1FFFu;  // 1 + 5 + 7 = 13 bit, drop 3 redundant bits
+}
+
+SGL_DEVICE uint32_t get_ptx_lane_id() {
+  uint32_t lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+}
+
+/// Locates the bin where `above < topk <= above + count`, `above` being the number
+/// of elements in the bins beyond it, and publishes both. `total` is what the
+/// histogram counted, so `topk <= total` or no bin qualifies (the caller passes
+/// min(topk, seq_len)). One bin passes, so exactly one thread writes. The
+/// counters are re-read for that bin rather than kept: the row is live in
+/// registers across this and 8 more would spill.
+SGL_DEVICE void topk_bf16_find_threshold(uint32_t topk, uint32_t total, TopKBF16Config::SmemApprox& smem) {
+  using S = TopKBF16Config::SmemApprox;
+  using hist_vec_t = S::hist_vec_t;
+  constexpr auto kItems = S::kHistItems;
+  constexpr auto kRounds = S::kHistRounds;
+  constexpr auto kWarpSize = device::kWarpThreads;
+  const auto tx = threadIdx.x;
+  const auto lane_id = tx % kWarpSize;
+  const auto warp_id = tx / kWarpSize;
+  const auto hist_vec_index = [&](uint32_t r) { return warp_id * kRounds * kWarpSize + lane_id + r * kWarpSize; };
+
+  uint32_t local_sum[kRounds];
+#pragma unroll
+  for (uint32_t r = 0; r < kRounds; ++r) {
+    hist_vec_t hist;
+    hist.load(smem.histogram, hist_vec_index(r));
+    local_sum[r] = 0;
+#pragma unroll
+    for (uint32_t j = 0; j < kItems; ++j) {
+      local_sum[r] += hist[j];
+    }
+  }
+
+  uint32_t warp_inc_sum[kRounds];
+#pragma unroll
+  for (uint32_t r = 0; r < kRounds; ++r) {
+    warp_inc_sum[r] = device::warp::inclusive_sum(lane_id, local_sum[r]);
+  }
+  if (lane_id == kWarpSize - 1) smem.warp_sum[warp_id] = warp_inc_sum[0] + warp_inc_sum[1];
+  // round 1 sits entirely above round 0 within the warp's range
+  const auto warp_half_sum = __shfl_sync(0xFFFFFFFFu, warp_inc_sum[0], kWarpSize - 1);
+  __syncthreads();
+
+  const auto peer_sum = smem.warp_sum[lane_id];
+  const auto warp_prefix_sum = device::warp::reduce_sum(lane_id < warp_id ? peer_sum : 0u);
+  // elements in every bin below this thread's bins of round r
+  const uint32_t exc_sum[kRounds] = {
+      warp_prefix_sum + warp_inc_sum[0] - local_sum[0],
+      warp_prefix_sum + warp_half_sum + warp_inc_sum[1] - local_sum[1],
+  };
+
+#pragma unroll
+  for (uint32_t r = 0; r < kRounds; ++r) {
+    // `above` only falls as the bin rises, so the threshold is inside this
+    // thread's bins exactly when it straddles their two ends.
+    const auto above_hi = total - exc_sum[r];
+    const auto above_lo = above_hi - local_sum[r];
+    if (above_lo >= topk || topk > above_hi) continue;
+    hist_vec_t hist;
+    hist.load(smem.histogram, hist_vec_index(r));
+    auto prefix = exc_sum[r];
+    const auto bin_base = hist_vec_index(r) * kItems;
+#pragma unroll
+    for (uint32_t j = 0; j < kItems; ++j) {
+      prefix += hist[j];
+      const auto above = total - prefix;
+      if (above < topk && above + hist[j] >= topk) {
+        smem.threshold_bin = bin_base + j;
+        smem.count_eq_gt = above;
+      }
+    }
+  }
+}
+
+/// TODO: this kernel is not optimized at all
+template <bool kUsePDL>
+TOPK_BF16_KERNEL void topk_bf16_approx_kernel(const __grid_constant__ TopKBF16Params params) {
+  using namespace device;
+  using C = TopKBF16Config;
+  using vec_t = C::vec_t;
+  const auto bx = blockIdx.x;
+  const auto tx = threadIdx.x;
+  const auto seq_len = static_cast<uint32_t>(params.seq_lens[bx]);
+  const auto* __restrict__ scores_row = params.scores + bx * params.score_stride;
+
+  using Smem = typename C::SmemApprox;
+  __shared__ Smem smem;
+
+  for (uint32_t i = 0; i < Smem::kHistSize / C::kBlockSize; ++i) {
+    smem.histogram[tx + i * C::kBlockSize] = 0;
+  }
+  __syncthreads();
+  PDLWaitPrimary<kUsePDL>();
+
+  if (seq_len <= params.topk) {
+    // every element is selected: the row's indices through the table, -1 past the row
+    const auto* __restrict__ table = params.page_table + bx * params.page_table_stride;
+    auto* __restrict__ out = params.page_indices + bx * params.page_indices_stride;
+    const auto page_mask = (1u << params.page_bits) - 1;
+    for (uint32_t t = tx; t < params.topk; t += C::kBlockSize) {
+      out[t] = t < seq_len ? (table[t >> params.page_bits] << params.page_bits) | static_cast<int32_t>(t & page_mask) : -1;
+    }
+    return PDLTriggerSecondary<kUsePDL>();
+  }
+
+  vec_t scores[C::kNumItems];
+  const auto num_full = div_ceil(seq_len, C::kVecSize);
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto vid = i * C::kBlockSize + tx;
+    if (vid < num_full) {
+      scores[i].load(scores_row, vid);
+    }
+  }
+
+  // 1 time 13-bit histogram, not 100% correct
+  uint32_t bins[C::kNumItems][C::kVecSize / 2];
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+#pragma unroll
+    for (uint32_t j = 0; j < C::kVecSize / 2; ++j) {
+      bins[i][j] = extract_coarse_bin2(scores[i][j]);
+    }
+  }
+
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto vid = i * C::kBlockSize + tx;
+    if (vid + 1 == num_full) [[unlikely]] {
+      // elements of the last vector that are inside the row
+      const auto tail_length = (seq_len - 1) % C::kVecSize + 1;
+#pragma unroll
+      for (uint32_t j = 0; j < C::kVecSize / 2; ++j) {
+        const auto lo = bins[i][j] & 0xFFFFu;
+        const auto hi = bins[i][j] >> 16;
+        const auto lo_valid = j * 2 + 0 < tail_length;
+        const auto hi_valid = j * 2 + 1 < tail_length;
+        // wish compiler can generate predicate instructions
+        if (lo_valid) atomicAdd(&smem.histogram[lo], 1);
+        if (hi_valid) atomicAdd(&smem.histogram[hi], 1);
+        // mask invalid bins to lowest (0): no real value keys below the -inf bin
+        // (0x7F), so they can never compare above or equal to the threshold
+        if (!hi_valid) bins[i][j] = lo;
+        if (!lo_valid) bins[i][j] = 0;
+      }
+    } else if (vid < num_full) [[likely]] {
+#pragma unroll
+      for (uint32_t j = 0; j < C::kVecSize / 2; ++j) {
+        const auto lo = bins[i][j] & 0xFFFFu;
+        const auto hi = bins[i][j] >> 16;
+        atomicAdd(&smem.histogram[lo], 1);
+        atomicAdd(&smem.histogram[hi], 1);
+      }
+    }
+  }
+
+  __syncthreads();
+  topk_bf16_find_threshold(params.topk, seq_len, smem);
+  __syncthreads();
+  const auto threshold_bin = smem.threshold_bin;
+  uint32_t local_eq = 0;
+  uint32_t local_gt = 0;
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto vid = i * C::kBlockSize + tx;
+    if (vid < num_full) {
+#pragma unroll
+      for (uint32_t j = 0; j < C::kVecSize / 2; ++j) {
+        const auto lo = bins[i][j] & 0xFFFFu;
+        const auto hi = bins[i][j] >> 16;
+        local_gt += lo > threshold_bin;
+        local_gt += hi > threshold_bin;
+        local_eq += lo == threshold_bin;
+        local_eq += hi == threshold_bin;
+      }
+    }
+  }
+  const auto lane_id = get_ptx_lane_id();
+  const auto local_payload = (local_gt << 16) | local_eq;
+  const auto warp_inc_payload = warp::inclusive_sum(lane_id, local_payload);
+  uint32_t warp_payload = 0;
+  if (lane_id == kWarpThreads - 1) {
+    warp_payload = atomicAdd(&smem.count_eq_gt, warp_inc_payload);
+  }
+  warp_payload = __shfl_sync(0xFFFFFFFFu, warp_payload, kWarpThreads - 1);
+  const auto exc_payload = warp_payload + warp_inc_payload - local_payload;
+  local_eq = exc_payload & 0xFFFFu;
+  local_gt = exc_payload >> 16;
+  const auto collect = [&](uint32_t bin, uint32_t idx) {
+    if (bin == threshold_bin) {
+      const auto pos = local_eq++;
+      if (pos < params.topk) smem.stage_out_idxs[pos] = idx;
+    } else if (bin > threshold_bin) {
+      const auto pos = local_gt++;
+      smem.stage_out_idxs[pos] = idx;
+    }
+  };
+
+#pragma unroll
+  for (uint32_t i = 0; i < C::kNumItems; ++i) {
+    const auto vid = i * C::kBlockSize + tx;
+    if (vid < num_full) {
+#pragma unroll
+      for (uint32_t j = 0; j < C::kVecSize / 2; ++j) {
+        const auto lo = bins[i][j] & 0xFFFFu;
+        const auto hi = bins[i][j] >> 16;
+        collect(lo, vid * C::kVecSize + j * 2 + 0);
+        collect(hi, vid * C::kVecSize + j * 2 + 1);
+      }
+    }
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+  __syncthreads();
+
+  // page-transform: a selected index i maps through this row's table to slot
+  // table[i >> page_bits] << page_bits | (i & mask); -1 past what the row has
+  const auto* __restrict__ table = params.page_table + bx * params.page_table_stride;
+  auto* __restrict__ out = params.page_indices + bx * params.page_indices_stride;
+  const auto page_mask = (1u << params.page_bits) - 1;
+  constexpr uint32_t kRounds = C::kMaxTopK / C::kBlockSize;
+#pragma unroll
+  for (uint32_t i = 0; i < kRounds; ++i) {
+    const auto t = i * C::kBlockSize + tx;
+    if (t < params.topk) {
+      const auto idx = static_cast<uint32_t>(smem.stage_out_idxs[t]);
+      out[t] = (table[idx >> params.page_bits] << params.page_bits) | static_cast<int32_t>(idx & page_mask);
+    }
+  }
+}
+
+/// Host entry: bf16 top-k over rows of at most kMaxSeqLen, selected indices
+/// written through a per-row table as `table[i >> log2(page_size)] << log2(page_size)
+/// | (i & mask)`, -1 past min(topk, seq_len).
+template <bool kPDL>
+struct TopKBF16Kernel {
+  static void transform(
+      const tvm::ffi::TensorView scores,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView page_table,
+      const tvm::ffi::TensorView page_indices,
+      const uint32_t page_size) {
+    using namespace host;
+    using C = TopKBF16Config;
+    auto B = SymbolicSize{"batch_size"};
+    auto L = SymbolicSize{"max_seq_len"};
+    auto S = SymbolicSize{"score_stride"};
+    auto K = SymbolicSize{"topk"};
+    auto O = SymbolicSize{"page_indices_stride"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+    TensorMatcher({B, L})  // scores
+        .with_strides({S, 1})
+        .with_dtype<bf16_t>()
+        .with_device(device_)
+        .verify(scores);
+    TensorMatcher({B})  // seq_lens
+        .with_dtype<int32_t>()
+        .with_device(device_)
+        .verify(seq_lens);
+    TensorMatcher({B, -1})  // page_table
+        .with_strides({-1, 1})
+        .with_dtype<int32_t>()
+        .with_device(device_)
+        .verify(page_table);
+    TensorMatcher({B, K})  // page_indices
+        .with_strides({O, 1})
+        .with_dtype<int32_t>()
+        .with_device(device_)
+        .verify(page_indices);
+    RuntimeCheck(std::has_single_bit(page_size), "page_size must be a power of 2");
+    RuntimeCheck(L.unwrap() <= C::kMaxSeqLen, "rows longer than kMaxSeqLen take the streaming top-k");
+    RuntimeCheck(S.unwrap() % C::kVecSize == 0, "score_stride must keep every row vector-aligned");
+    const auto topk = static_cast<uint32_t>(K.unwrap());
+    RuntimeCheck(topk > 0 && topk <= C::kMaxTopK, "topk must be in (0, kMaxTopK]");
+    const auto params = TopKBF16Params{
+        .scores = static_cast<const bf16_t*>(scores.data_ptr()),
+        .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
+        .page_table = static_cast<const int32_t*>(page_table.data_ptr()),
+        .page_indices = static_cast<int32_t*>(page_indices.data_ptr()),
+        .score_stride = S.unwrap(),
+        .page_table_stride = page_table.stride(0),
+        .page_indices_stride = O.unwrap(),
+        .topk = topk,
+        .page_bits = static_cast<uint32_t>(std::countr_zero(page_size)),
+    };
+    LaunchKernel(static_cast<uint32_t>(B.unwrap()), C::kBlockSize, device_.unwrap())
+        .config({.use_pdl = kPDL})
+        .launch(topk_bf16_approx_kernel<kPDL>, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -530,6 +530,10 @@ struct TopKKernel {
     RuntimeCheck(metadata.size(0) == B.unwrap() + 1, "invalid metadata shape");
 #if SUPPORT_CLUSTER
     const auto batch_size = static_cast<uint32_t>(B.unwrap());
+    // persistent cluster not supported
+    if (kNumPersistentClusters == 0) return;
+    // will not route to persistent cluster
+    if (batch_size <= kNumPersistentClusters || batch_size > kClusterMaxBatch) return;
     const auto device = device_.unwrap();
     LaunchKernel(1, kBlockSize, device)(  //
         topk_plan_cluster,

--- a/python/sglang/kernels/ops/attention/dsv4/attn.py
+++ b/python/sglang/kernels/ops/attention/dsv4/attn.py
@@ -43,7 +43,10 @@ def _jit_fused_store_module(
 
 
 def get_paged_mqa_logits_metadata(seq_lens: torch.Tensor, page_size: int, num_sm: int):
-    assert page_size == 64
+    # The schedule only depends on the sequence lengths (256-token splits), not
+    # on the page size; DeepGEMM takes 32 / 64 / 128 on SM100 and we page at 64
+    # or 128 slots.
+    assert page_size in (64, 128), page_size
     seq_lens = seq_lens.view(-1).to(torch.int32)
     bs = int(seq_lens.shape[0])
     metadata = seq_lens.new_empty(num_sm + 1, 2)

--- a/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
+++ b/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
@@ -4,6 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.kernels.jit.utils import is_arch_support_pdl
+
 
 @triton.jit
 def _maximum_with_nan(a, b):
@@ -147,3 +149,60 @@ def candidate_block_logits(
         num_warps=4,
     )
     return output, keep
+
+
+@triton.jit
+def _candidate_row_lens_kernel(
+    LENS,
+    NBLOCKS,
+    VALID,
+    ROWS,
+    TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+    TILE: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    rows = tl.program_id(0) * TILE + tl.arange(0, TILE)
+    mask = rows < ROWS
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()  # LENS is the previous kernel's output
+    length = tl.load(LENS + rows, mask, 0).to(tl.int32)
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+    nblocks = (length + (BLOCK - 1)) // BLOCK
+    kept = tl.minimum(nblocks, TOPK)
+    # the kept blocks laid out back to back, the newest one possibly partial
+    valid = BLOCK * (kept - 1) + (length - 1) % BLOCK + 1
+    valid = tl.where(length > 0, valid, 0)
+    tl.store(NBLOCKS + rows, nblocks, mask)
+    tl.store(VALID + rows, valid, mask)
+
+
+def candidate_row_lens(
+    seq_lens: torch.Tensor, topk_blocks: int, block_size: int = 8
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per row: its number of blocks ``ceil(seq_len / block_size)`` and the
+    length of its sparse logits row once the ``min(topk_blocks, blocks)`` kept
+    blocks are laid out back to back (the newest block possibly partial):
+    ``block_size * (kept - 1) + (seq_len - 1) % block_size + 1``. Both int32
+    ``[rows]``; a zero-length row gets 0 for both."""
+    assert seq_lens.dim() == 1 and seq_lens.is_contiguous()
+    rows = seq_lens.numel()
+    nblocks = torch.empty(rows, dtype=torch.int32, device=seq_lens.device)
+    valid = torch.empty_like(nblocks)
+    tile = 256
+    use_pdl = is_arch_support_pdl()
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
+    _candidate_row_lens_kernel[(triton.cdiv(rows, tile),)](
+        seq_lens,
+        nblocks,
+        valid,
+        rows,
+        topk_blocks,
+        block_size,
+        tile,
+        use_pdl,
+        num_warps=4,
+        **pdl_kwargs,
+    )
+    return nblocks, valid

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -61,6 +61,39 @@ def _jit_topk_v2_module():
     )
 
 
+@cache_once
+def _jit_topk_bf16_small_module():
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        make_name("topk_bf16_small"),
+        *args,
+        cuda_files=["deepseek_v4/topk_bf16_small.cuh"],
+        cuda_wrappers=[("topk_transform", f"TopKBF16Kernel<{args}>::transform")],
+    )
+
+
+def topk_transform_bf16_small(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+) -> None:
+    """bf16 top-k for rows of at most 16384 scores (the DeepSeek-V4.1 sparse
+    indexer's consumer rows), fused with a page-table transform.
+
+    Row ``b`` selects the ``k = out_page_indices.shape[1]`` best of its first
+    ``seq_lens[b]`` scores; a selected index ``i`` is written as
+    ``page_table[b, i // page_size] * page_size + i % page_size``, in no
+    particular order, and ``-1`` fills the slots past ``min(k, seq_lens[b])``.
+    Selection is by a 13-bit fp16-derived key, exact for bf16 in fp16's normal
+    range; ties within a key are broken arbitrarily.
+    """
+    _jit_topk_bf16_small_module().topk_transform(
+        scores, seq_lens, page_table, out_page_indices, page_size
+    )
+
+
 def topk_transform_paged(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -94,6 +94,102 @@ def topk_transform_bf16_small(
     )
 
 
+@cache_once
+def _jit_amax_copy_module():
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        make_name("amax_copy"),
+        *args,
+        cuda_files=["deepseek_v4/amax_copy.cuh"],
+        cuda_wrappers=[("amax8_varlen", f"AmaxCopyKernel<{args}>::amax8_varlen")],
+    )
+
+
+def amax8_varlen(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    topk: int = 0,
+    *,
+    max_seqlen: int = 0,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Level-one keys of the two-level indexer: ``out[b, i]`` is the max of
+    ``scores[b, 8 i : 8 i + 8]`` for ``i < ceil(seq_lens[b] / 8)``, the last of
+    them ``+inf`` (the newest block is always selected), nothing written past
+    that count. Rows with at most ``topk`` blocks are skipped (every block is
+    selected anyway); ``topk=0`` never skips. ``out`` is allocated as
+    ``[rows, ceil(max_seqlen / 8)]`` when not given, ``max_seqlen`` defaulting to
+    the width of ``scores``; every ``seq_lens[b]`` must fit in ``8 * out.shape[1]``.
+    fp32 only for now; ``scores`` rows must be 32-byte aligned (stride a multiple
+    of 8). Returns ``out``.
+    """
+    if out is None:
+        num_tokens, max_len = scores.shape
+        if max_seqlen == 0:
+            max_seqlen = max_len
+        out = scores.new_empty(num_tokens, (max_seqlen + 7) // 8)
+    _jit_amax_copy_module().amax8_varlen(scores, seq_lens, out, topk)
+    return out
+
+
+@cache_once
+def _jit_sort_idx_module():
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        make_name("sort_idx"),
+        *args,
+        cuda_files=["deepseek_v4/sort_idx.cuh"],
+        cuda_wrappers=[
+            ("transform", f"SortIdxKernel<{args}>::transform"),
+            ("transform_pages", f"SortIdxKernel<{args}>::transform_pages"),
+        ],
+    )
+
+
+def sort_candidate_blocks(
+    blocks: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    *,
+    out_pages: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """The block table of the two-level indexer from a row's selected blocks,
+    in place: ``blocks`` ``[rows, k]`` int32 block ids in any order, ``-1``
+    padded, become the same ids ascending with ``INT32_MAX`` past ``min(k,
+    ceil(seq_lens[b] / 8))``; the matching pool slots / 8 (``page_table[b, id //
+    bpp] * bpp + id % bpp``, ``bpp = page_size // 8``, same padding) go to
+    ``out_pages``. A row with at most ``k`` blocks gets the identity table
+    regardless of its input. Returns ``out_pages``.
+    """
+    if out_pages is None:
+        out_pages = torch.empty_like(blocks)
+    _jit_sort_idx_module().transform(blocks, seq_lens, page_table, out_pages, page_size)
+    return out_pages
+
+
+def transform_candidate_blocks(
+    blocks: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    *,
+    out_pages: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """The page transform of ``sort_candidate_blocks`` alone, for a block top-k
+    that already emits ascending ids: ``out_pages[b, t]`` is the pool slot / 8 of
+    ``blocks[b, t]`` for ``t < min(k, ceil(seq_lens[b] / 8))`` (which must be
+    valid block ids), ``INT32_MAX`` past that; ``blocks`` is not modified.
+    Returns ``out_pages``.
+    """
+    if out_pages is None:
+        out_pages = torch.empty_like(blocks)
+    _jit_sort_idx_module().transform_pages(
+        blocks, seq_lens, page_table, out_pages, page_size
+    )
+    return out_pages
+
+
 def topk_transform_paged(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1403,6 +1403,10 @@ class Envs:
     # Run the DeepSeek-V4.1 ratio-1/2 prefill indexer on the torch path instead
     # of the DeepGEMM dense fp4 logits kernel (test oracle / fallback).
     SGLANG_DSV41_TORCH_PREFILL_INDEXER = EnvBool(False)
+    # DeepSeek-V4.1 two-level indexer on DeepGEMM's paged sparse MQA logits for the
+    # index-source layers after the candidate source (decode). Needs a DeepGEMM
+    # with fp8_fp4_paged_sparse_mqa_logits on SM100; off = the torch masks.
+    SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER = EnvBool(False)
     # Keep the DeepSeek-V4.1 engram tables in host memory (layout below) and gather
     # rows from the GPU instead of sharding them over HBM.
     SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1407,6 +1407,8 @@ class Envs:
     # index-source layers after the candidate source (decode). Needs a DeepGEMM
     # with fp8_fp4_paged_sparse_mqa_logits on SM100; off = the torch masks.
     SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER = EnvBool(False)
+    # use multistream to overlap the publish-side with other computation
+    SGLANG_DSV41_DEEP_GEMM_CANDIDATE_OVERLAP = EnvBool(True)
     # Keep the DeepSeek-V4.1 engram tables in host memory (layout below) and gather
     # rows from the GPU instead of sharding them over HBM.
     SGLANG_ENABLE_DSV41_ENGRAM_HOST_TABLE = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -19,11 +19,7 @@ import msgspec
 import torch
 import torch.nn.functional as F
 
-from sglang.kernels.ops.attention.dsv4 import (
-    topk_transform_paged,
-    topk_transform_paged_v2,
-    topk_transform_ragged_v2,
-)
+from sglang.kernels.ops.attention.dsv4 import topk_transform_ragged_v2
 from sglang.kernels.ops.attention.dsv4.dequant_k_cache import (
     cast_q_fp8_for_q8kv8_prefill,
     dequantize_k_cache_paged,
@@ -79,6 +75,7 @@ from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
 from sglang.srt.layers.attention.dsv4.indexer import (
     C4IndexerBackendMixin,
     fp4_paged_mqa_logits,
+    fp32_jit_paged_topk,
     select_candidate_blocks,
 )
 from sglang.srt.layers.attention.dsv4.metadata import (
@@ -3347,24 +3344,7 @@ class DeepseekV4AttnBackend(
             metadata.max_c4_seq_len,
         )
         # TODO(dark): add bf16 topk
-        if metadata.use_topk_v2 and raw_indices is None:
-            topk_transform_paged_v2(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                page_size,
-                metadata.topk_metadata,
-            )
-        else:
-            topk_transform_paged(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                page_size,
-                raw_indices,
-            )
+        fp32_jit_paged_topk(logits, metadata, page_indices, raw_indices)
 
     # TODO(candidate): Hopper decode still publishes / consumes masks inline (torch
     # top-k); move into the candidate indexer with the prefill paths.

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -3018,7 +3018,10 @@ class DeepseekV4AttnBackend(
         )
         if is_decode_or_verify:
             if _is_sm100_or_newer():
-                self._low_ratio_index_topk_decode(layer, x, q_lora, pos)
+                # verify rows of one request share a request id (DeepGEMM pairs
+                # them); decode has one row per request, nothing to pair
+                req_ids = None if forward_batch.forward_mode.is_decode() else req
+                self._low_ratio_index_topk_decode(layer, x, q_lora, pos, req_ids)
             else:
                 self._low_ratio_index_topk_sm90_decode(layer, x, q_lora, req, pos)
         elif (
@@ -3253,7 +3256,7 @@ class DeepseekV4AttnBackend(
             if raw_indices is not None:
                 raw_indices[rows, :topk] = torch.where(reach, idx, -1).to(torch.int32)
 
-    def _low_ratio_index_topk_decode(self, layer, x, q_lora, pos) -> None:
+    def _low_ratio_index_topk_decode(self, layer, x, q_lora, pos, req=None) -> None:
         from sglang.srt.model_executor.runner_utils.capture_mode import (
             skip_low_ratio_indexer,
         )
@@ -3319,7 +3322,14 @@ class DeepseekV4AttnBackend(
 
         page_indices = core.sparse_page_indices(ratio)
         raw_indices = core.sparse_raw_indices(ratio)
-        inputs = IndexerInputs(q_fp4, q_sf, k_cache, weights, metadata)
+        inputs = IndexerInputs(
+            q_fp4,
+            q_sf,
+            k_cache,
+            weights,
+            metadata,
+            request_ids=req,  # one per query row; verify rows of a request share one
+        )
         candidate_layer = not _every_request_fits()
         # use special selection for candidate layers
         if indexer.uses_candidates and candidate_layer:

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -57,6 +57,16 @@ from sglang.srt.layers.attention.base_attn_backend import (
 )
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
 from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
+from sglang.srt.layers.attention.dsv4.candidate_indexer import (
+    CandidateMetadata,
+    IndexerInputs,
+    make_candidate_indexer,
+)
+from sglang.srt.layers.attention.dsv4.candidate_torch import (
+    CandidateMasks,
+    mask_topk_scores,
+    published_masks,
+)
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     CompressorBackendMixin,
     FusedCompressMetadata,
@@ -68,6 +78,7 @@ from sglang.srt.layers.attention.dsv4.dsv41_sparse import (
 )
 from sglang.srt.layers.attention.dsv4.indexer import (
     C4IndexerBackendMixin,
+    fp4_paged_mqa_logits,
     select_candidate_blocks,
 )
 from sglang.srt.layers.attention.dsv4.metadata import (
@@ -220,131 +231,23 @@ def _expand_index_page_table(
     return expanded.reshape(bs, n * blocks_per_page).to(torch.int32)
 
 
-def _fp4_paged_mqa_logits(
-    q_fp4: Tuple[torch.Tensor, torch.Tensor],
-    k_cache: torch.Tensor,
-    weights: torch.Tensor,
-    seq_lens: torch.Tensor,
-    page_table: torch.Tensor,
-    deep_gemm_metadata,
-    max_seq_len: int,
-) -> torch.Tensor:
-    """DeepGEMM paged fp4 logits for the low-ratio indexer. No hadamard: the
-    reference does not apply one."""
-    from deep_gemm import fp8_fp4_paged_mqa_logits as fn
-
-    sl = seq_lens.to(torch.int32)
-    if sl.dim() == 1:
-        sl = sl.unsqueeze(-1)
-    return fn(
-        q_fp4,
-        k_cache,
-        weights,
-        sl,
-        page_table,
-        deep_gemm_metadata,
-        max_seq_len,
-        False,
-    )
-
-
-def two_level_decode_logits(
-    logits: torch.Tensor,
-    seq_lens: torch.Tensor,
-    *,
-    is_candidate_source: bool,
-    uses_candidates: bool,
-    topk_blocks: int,
-    block_size: int,
-    published: Optional[torch.Tensor],
-) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-    """Apply candidate-block filtering and return logits plus an optional published mask.
-
-    Mask columns past each sequence length to -inf before selection: the paged
-    logits kernel leaves that tail uninitialized, and an all -inf block means
-    unreachable. This path is graph-captured and must not synchronize with the host.
-    Work scales with allocated page-table capacity, not live sequence length.
-    """
-    if not (is_candidate_source or uses_candidates):
-        return logits, None
-
-    from sglang.srt.model_executor.runner_utils.capture_mode import (
-        get_capture_dsa_variant,
-    )
-
-    if get_capture_dsa_variant() in (
-        "candidate_all",
-        "candidate_c2_all",
-        "candidate_unfiltered",
-    ):
-        # All requests fit the candidate budget; paged top-k masks their tails.
-        return logits, None
-
-    if (
-        logits.is_cuda
-        and torch.version.cuda is not None
-        and logits.ndim == 2
-        and logits.stride(1) == 1
-        and seq_lens.device == logits.device
-        and seq_lens.dtype in (torch.int32, torch.int64)
-        and seq_lens.is_contiguous()
-        and seq_lens.shape in ((logits.shape[0],), (logits.shape[0], 1))
-        and logits.numel() > 0
-        and 0 < block_size <= 1024
-    ):
-        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
-            candidate_block_logits,
-        )
-
-        if not is_candidate_source:
-            assert (
-                torch.is_tensor(published)
-                and published.shape[0] == logits.shape[0]
-                and published.shape[1] >= logits.shape[1]
-            ), "candidate mask missing for decode"
-        return candidate_block_logits(
-            logits,
-            seq_lens,
-            topk_blocks=topk_blocks,
-            block_size=block_size,
-            published=None if is_candidate_source else published,
-        )
-
-    lens_col = seq_lens if seq_lens.dim() > 1 else seq_lens.unsqueeze(-1)
-    reachable = torch.arange(logits.shape[-1], device=logits.device) < lens_col
-    logits = logits.float().masked_fill(~reachable, -torch.inf)
-
-    if is_candidate_source:
-        # The source scores over every reachable position itself and only publishes,
-        # which is what the reference does.
-        return logits, select_candidate_blocks(
-            logits, lens_col, topk_blocks=topk_blocks, block_size=block_size
-        )
-
-    assert torch.is_tensor(published) and published.shape[0] == logits.shape[0], (
-        "candidate mask missing for decode"
-    )
-    return logits.masked_fill(~published[:, : logits.shape[-1]], -torch.inf), None
-
-
 # Arbitrary cap on one bf16 [rows, heads, lc] score chunk; transients run ~3x this.
 _TORCH_INDEXER_SCORE_BUDGET_BYTES = 1 << 30
 
 
-def _mask_topk_scores(
-    scores: torch.Tensor,
-    indices: torch.Tensor,
-    offsets: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
-    """Keep masked indexer scores out of attention even when top-k underfills."""
-    columns = indices.to(torch.int64)
-    if offsets is not None:
-        columns = columns - offsets[:, None]
-    selected_scores = scores.gather(1, columns.clamp(0, scores.shape[1] - 1))
-    valid = (
-        (columns >= 0) & (columns < scores.shape[1]) & (selected_scores > -torch.inf)
+def _every_request_fits() -> bool:
+    """The captured decode variants where every request's positions fit the
+    candidate block budget (decode_cuda_graph_runner): the plain top-k is the
+    whole selection, and the candidate layers behave like any index source."""
+    from sglang.srt.model_executor.runner_utils.capture_mode import (
+        get_capture_dsa_variant,
     )
-    return indices.masked_fill(~valid, -1)
+
+    return get_capture_dsa_variant() in (
+        "candidate_all",
+        "candidate_c2_all",
+        "candidate_unfiltered",
+    )
 
 
 @functools.cache
@@ -947,6 +850,12 @@ class DSV4Metadata:
     # Later layers overwrite real heads and preserve the zero padding.
     q_pad_buffer: Optional[torch.Tensor] = None
 
+    # Two-level low-ratio indexer (dsv4/candidate_indexer.py): what the
+    # candidate-source layer published for the index-source layers after it, in
+    # the chosen implementation's own type. Written once per forward by that
+    # layer, read by those layers, never copied from the host.
+    candidate_metadata: Optional[CandidateMetadata] = None
+
     # Built at the runner's prefill WAR boundary when the fast path is on,
     # otherwise lazily by ``_forward_prefill_sparse``.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
@@ -1128,9 +1037,13 @@ class DeepseekV4AttnBackend(
         )
         self.has_c4: bool = 4 in self.present_ratios
         self.has_c128: bool = 128 in self.present_ratios
-        # Per-request candidate masks the candidate_source layer publishes for the
-        # index_source layers after it (torch indexer scratch).
-        self.candidate_masks: Optional[List[torch.Tensor]] = None
+        # Two-level low-ratio indexer, decided here for the model's block budget
+        # (dsv4/candidate_indexer.py).
+        cfg = model_runner.model_config.hf_text_config
+        self.candidate_indexer = make_candidate_indexer(
+            getattr(cfg, "candidate_topk_blocks", 0),
+            getattr(cfg, "candidate_block_size", 0),
+        )
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
 
         assert isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
@@ -1682,7 +1595,6 @@ class DeepseekV4AttnBackend(
         assert tail_metadata is not None, "no tail metadata for this forward"
         saved = (
             self.forward_metadata,
-            self.candidate_masks,
             forward_batch.attn_cp_metadata,
             get_local_dp_buffer_len(),
         )
@@ -1692,11 +1604,16 @@ class DeepseekV4AttnBackend(
             if tail.cp_metadata is not None
             else tail.extend_seq_lens_cpu
         )
-        if isinstance(self.candidate_masks, list) and self.candidate_masks:
-            self.candidate_masks = [
-                mask[mask.shape[0] - t :]
-                for mask, t in zip(self.candidate_masks, tail_lens_cpu)
-            ]
+        # TODO(candidate): goes away once the source publishes its tail rows straight
+        # onto the tail metadata (publish_prefill); until then cut the full masks.
+        full_masks = self.forward_metadata.candidate_metadata
+        if isinstance(full_masks, CandidateMasks) and full_masks.request_masks:
+            tail_metadata.candidate_metadata = CandidateMasks(
+                request_masks=[
+                    mask[mask.shape[0] - t :]
+                    for mask, t in zip(full_masks.request_masks, tail_lens_cpu)
+                ]
+            )
         # The last index-source layer before the switch published its top-k into
         # the full metadata's buffers; the consumer layers after the switch read
         # the tail metadata's, so carry the tail rows over (padding stays -1).
@@ -1734,7 +1651,6 @@ class DeepseekV4AttnBackend(
     def exit_late_layer_tail(self, saved: tuple, forward_batch: ForwardBatch) -> None:
         (
             self.forward_metadata,
-            self.candidate_masks,
             forward_batch.attn_cp_metadata,
             local_dp_buffer_len,
         ) = saved
@@ -3103,14 +3019,15 @@ class DeepseekV4AttnBackend(
             forward_batch.forward_mode.is_decode()
             or forward_batch.forward_mode.is_target_verify()
         )
-        if is_decode_or_verify and _is_sm100_or_newer():
-            self._low_ratio_index_topk_decode(layer, x, q_lora, pos)
+        if is_decode_or_verify:
+            if _is_sm100_or_newer():
+                self._low_ratio_index_topk_decode(layer, x, q_lora, pos)
+            else:
+                self._low_ratio_index_topk_sm90_decode(layer, x, q_lora, req, pos)
         elif (
             self._use_dense_fp4_prefill_indexer(forward_batch) and _is_sm100_or_newer()
         ):
             self._low_ratio_index_topk_extend(layer, x, q_lora, pos, forward_batch)
-        elif is_decode_or_verify:
-            self._low_ratio_index_topk_sm90_decode(layer, x, q_lora, req, pos)
         else:
             self._low_ratio_index_topk_torch(layer, x, q_lora, req, pos)
 
@@ -3176,9 +3093,12 @@ class DeepseekV4AttnBackend(
             start += lc
         empty_mask = torch.zeros(0, 0, dtype=torch.bool, device=device)
         num_tokens = pos.shape[0]
+        # TODO: move this to candidate indexer
         if not slot_chunks or num_tokens == 0:
             if indexer.is_candidate_source:
-                self.candidate_masks = [empty_mask for _ in lc_per_req]
+                self.forward_metadata.candidate_metadata = CandidateMasks(
+                    request_masks=[empty_mask for _ in lc_per_req]
+                )
             return
         k_slots = torch.cat(slot_chunks)
         k_fp4, k_sf = pool.get_low_ratio_index_k_fp4(layer.layer_id, k_slots)
@@ -3214,7 +3134,7 @@ class DeepseekV4AttnBackend(
             logits, compress_lens, out_offsets=ks, out_indices=selected
         )
         if indexer.uses_candidates and not indexer.is_candidate_source:
-            selected = _mask_topk_scores(logits, selected, ks)
+            selected = mask_topk_scores(logits, selected, ks)
         # ascending positions, padding last: the layout the consumers expect
         unselected = torch.iinfo(torch.int32).max
         selected = selected.masked_fill(selected < 0, unselected).sort(dim=-1).values
@@ -3227,11 +3147,18 @@ class DeepseekV4AttnBackend(
                 chosen, selected - ks[:, None], -1
             )
 
+    # TODO(candidate): dense-prefill level one / level two inline with masks; move
+    # into the candidate indexer as publish_prefill / select_prefill.
     def _publish_or_consume_candidates(
         self, indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask
     ) -> None:
         """Level one of the two-level top-k: publish block masks, or sink non-candidates."""
         publish = [] if indexer.is_candidate_source else None
+        consume = (
+            None
+            if publish is not None
+            else published_masks(self.forward_metadata.candidate_metadata)
+        )
         j = torch.arange(logits.shape[1], device=logits.device)
         tok_start = 0
         for b, (lc, t_len) in enumerate(zip(lc_per_req, q_lens_cpu)):
@@ -3243,7 +3170,7 @@ class DeepseekV4AttnBackend(
                 continue
             scores = logits[rows, :lc]
             if publish is None:
-                scores.masked_fill_(~self.candidate_masks[b], -torch.inf)
+                scores.masked_fill_(~consume.request_masks[b], -torch.inf)
                 continue
             lens = compress_lens[rows, None]
             # the block selection tells unreachable positions apart by -inf
@@ -3261,7 +3188,9 @@ class DeepseekV4AttnBackend(
             ]
             publish.append(masks[0] if len(masks) == 1 else torch.cat(masks))
         if publish is not None:
-            self.candidate_masks = publish
+            self.forward_metadata.candidate_metadata = CandidateMasks(
+                request_masks=publish
+            )
 
     def _low_ratio_index_topk_prefill_graph(self, layer, pos, q, w) -> None:
         """q/w come from live rows; metadata fixes the graph's context width."""
@@ -3306,7 +3235,7 @@ class DeepseekV4AttnBackend(
         topk = min(indexer.index_topk, width)
         columns = torch.arange(width, device=lens.device)
         for rows, plan in metadata.row_chunks():
-            logits = _fp4_paged_mqa_logits(
+            logits = fp4_paged_mqa_logits(
                 (q_fp4[rows], q_sf[rows]),
                 k_cache,
                 weights[rows],
@@ -3391,7 +3320,24 @@ class DeepseekV4AttnBackend(
             k_cache.shape[0], page_size, 1, 68
         )  # fp4: 64 payload + 4 scale
 
-        logits = _fp4_paged_mqa_logits(
+        page_indices = core.sparse_page_indices(ratio)
+        raw_indices = core.sparse_raw_indices(ratio)
+        inputs = IndexerInputs(q_fp4, q_sf, k_cache, weights, metadata)
+        candidate_layer = not _every_request_fits()
+        # use special selection for candidate layers
+        if indexer.uses_candidates and candidate_layer:
+            return self.candidate_indexer.select_decode(
+                self.forward_metadata.candidate_metadata,
+                inputs,
+                page_indices,
+                raw_indices,
+            )
+        if indexer.is_candidate_source and candidate_layer:
+            self.forward_metadata.candidate_metadata = (
+                self.candidate_indexer.publish_decode(inputs, page_indices, raw_indices)
+            )
+            return
+        logits = fp4_paged_mqa_logits(
             (q_fp4, q_sf),
             k_cache,
             weights,
@@ -3400,29 +3346,13 @@ class DeepseekV4AttnBackend(
             metadata.deep_gemm_metadata,
             metadata.max_c4_seq_len,
         )
-
-        logits, published = two_level_decode_logits(
-            logits,
-            metadata.c4_seq_lens,
-            is_candidate_source=indexer.is_candidate_source,
-            uses_candidates=indexer.uses_candidates,
-            topk_blocks=indexer.candidate_topk_blocks,
-            block_size=indexer.candidate_block_size,
-            published=self.candidate_masks,
-        )
-        if published is not None:
-            self.candidate_masks = published
-
-        page_indices = core.sparse_page_indices(ratio)
-        raw_indices = core.sparse_raw_indices(ratio)
-        filter_candidates = indexer.uses_candidates and not indexer.is_candidate_source
-        selected = torch.empty_like(page_indices) if filter_candidates else raw_indices
+        # TODO(dark): add bf16 topk
         if metadata.use_topk_v2 and raw_indices is None:
             topk_transform_paged_v2(
                 logits,
                 metadata.c4_seq_lens,
-                None if filter_candidates else metadata.page_table,
-                selected if filter_candidates else page_indices,
+                metadata.page_table,
+                page_indices,
                 page_size,
                 metadata.topk_metadata,
             )
@@ -3433,31 +3363,11 @@ class DeepseekV4AttnBackend(
                 metadata.page_table,
                 page_indices,
                 page_size,
-                selected,
+                raw_indices,
             )
-        if filter_candidates:
-            if logits.is_cuda and torch.version.cuda is not None:
-                from sglang.kernels.ops.attention.dsv4.indexer_postprocess import (
-                    filter_topk_pages,
-                )
 
-                filter_topk_pages(
-                    logits,
-                    selected,
-                    metadata.page_table,
-                    page_indices,
-                    page_size,
-                    raw_indices,
-                )
-            else:
-                selected = _mask_topk_scores(logits, selected)
-                columns = selected.clamp_min(0).to(torch.int64)
-                slots = metadata.page_table.gather(1, columns // page_size) * page_size
-                slots = slots + columns % page_size
-                page_indices.copy_(torch.where(selected >= 0, slots, -1))
-                if raw_indices is not None:
-                    raw_indices.copy_(selected)
-
+    # TODO(candidate): Hopper decode still publishes / consumes masks inline (torch
+    # top-k); move into the candidate indexer with the prefill paths.
     def _low_ratio_index_topk_sm90_decode(self, layer, x, q_lora, req, pos) -> None:
         """Hopper decode indexer: one token per request, every request scored at
         once against its visible compressed positions straight off the fp4 page
@@ -3505,15 +3415,16 @@ class DeepseekV4AttnBackend(
             q, weights, slots, lens, table, table.shape[1] // 68
         )
         if indexer.is_candidate_source:
-            self.candidate_masks = select_candidate_blocks(
+            mask = select_candidate_blocks(
                 s,
                 lens[:, None],
                 topk_blocks=indexer.candidate_topk_blocks,
                 block_size=indexer.candidate_block_size,
             )
+            self.forward_metadata.candidate_metadata = CandidateMasks(mask=mask)
         elif indexer.uses_candidates:
             # Published this step by the candidate-source layer's decode pass above.
-            consume = self.candidate_masks
+            consume = published_masks(self.forward_metadata.candidate_metadata).mask
             assert torch.is_tensor(consume) and consume.shape[0] == bs, (
                 "candidate mask missing for decode"
             )
@@ -3521,7 +3432,7 @@ class DeepseekV4AttnBackend(
         k = min(indexer.index_topk, lmax)
         idx = s.topk(k, dim=-1, sorted=False).indices
         if indexer.uses_candidates and not indexer.is_candidate_source:
-            idx = _mask_topk_scores(s, idx)
+            idx = mask_topk_scores(s, idx)
             idx = idx.masked_fill(idx < 0, lmax)
         idx = idx.sort(dim=-1).values
         reach = idx < lens[:, None]
@@ -3531,6 +3442,8 @@ class DeepseekV4AttnBackend(
         if raw_indices is not None:
             raw_indices[:bs, :k] = torch.where(reach, idx, -1).to(torch.int32)
 
+    # TODO(candidate): torch prefill still publishes / consumes masks inline; same
+    # move as above.
     def _low_ratio_index_topk_torch(self, layer, x, q_lora, req, pos) -> None:
         pool = self.token_to_kv_pool
         core = self.forward_metadata.core_metadata
@@ -3548,7 +3461,11 @@ class DeepseekV4AttnBackend(
         compress_lens = (pos + 1) // ratio
         topk = indexer.index_topk
         publish = [] if indexer.is_candidate_source else None
-        consume = self.candidate_masks if indexer.uses_candidates else None
+        consume = (
+            published_masks(self.forward_metadata.candidate_metadata).request_masks
+            if indexer.uses_candidates
+            else None
+        )
         for b, r in enumerate(torch.unique_consecutive(req).tolist()):
             tok = (req == r).nonzero().squeeze(1)
             lens = compress_lens[tok]
@@ -3591,7 +3508,7 @@ class DeepseekV4AttnBackend(
                     s = s.masked_fill(~consume[b][rows], -torch.inf)
                 idx = s.topk(k, dim=-1, sorted=False).indices
                 if consume is not None and masks is None:
-                    idx = _mask_topk_scores(s, idx)
+                    idx = mask_topk_scores(s, idx)
                     idx = idx.masked_fill(idx < 0, lc)
                 idx = idx.sort(dim=-1).values
                 reach = idx < lens_c[:, None]
@@ -3603,7 +3520,9 @@ class DeepseekV4AttnBackend(
             if masks is not None:
                 publish.append(torch.cat(masks) if len(masks) > 1 else masks[0])
         if publish is not None:
-            self.candidate_masks = publish
+            self.forward_metadata.candidate_metadata = CandidateMasks(
+                request_masks=publish
+            )
 
     def get_swa_out_cache_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:
         """Resolve the SWA KV-store write target for the current forward.

--- a/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
@@ -6,7 +6,9 @@ from typing import Optional
 import torch
 
 from sglang.kernels.ops.attention.dsv4.topk import (
+    amax8_varlen,
     plan_topk_v2,
+    sort_candidate_blocks,
     topk_transform_bf16_small,
     topk_transform_paged,
     topk_transform_paged_v2,
@@ -18,7 +20,6 @@ from sglang.srt.layers.attention.dsv4.candidate_indexer import (
 from sglang.srt.layers.attention.dsv4.indexer import fp4_paged_mqa_logits
 
 CANDIDATE_BLOCK_SIZE = 8  # positions per block; DeepGEMM accepts 8 or 16
-_INT32_MAX = torch.iinfo(torch.int32).max
 
 
 @dataclass
@@ -42,25 +43,31 @@ def valid_lens(seq_lens: torch.Tensor, topk_blocks: int) -> torch.Tensor:
     return block * (num - 1) + (seq_lens - 1) % block + 1
 
 
-# TODO: replace this naive implementation
 def amax_topk_blocks(
     logits: torch.Tensor,
     seq_lens: torch.Tensor,
     topk_blocks: int,
+    max_seq_len: Optional[int] = None,
 ) -> torch.Tensor:
-    rows, width = logits.shape
+    """Per row the ``topk_blocks`` blocks of 8 positions with the largest block
+    maximum among its first ``seq_lens[b]`` positions, the newest block always
+    included: block ids in no particular order, ``-1`` past the row's count
+    (``sort_candidate_blocks`` turns them into the published table)."""
+    rows = logits.shape[0]
     block = CANDIDATE_BLOCK_SIZE
-    nblocks = (seq_lens + block - 1) // block
-    newest = (seq_lens - 1).clamp_min(0) // block
-    ids = torch.arange(width // block, device=logits.device, dtype=torch.int32)
-    keys = logits.view(rows, width // block, block).amax(dim=-1)
+    if max_seq_len is None:
+        max_seq_len = logits.shape[1]
+    # TODO(candidate): nblocks and the plan are per-forward constants -> metadata
+    nblocks = (seq_lens + (block - 1)) // block
     # NOTE: plan cannot be the previous kernel of topk_transform_paged_v2
     plan = plan_topk_v2(nblocks)
-    keys.masked_fill_(ids[None, :] >= nblocks[:, None], -torch.inf)
-    keys.masked_fill_(ids[None, :] == newest[:, None], torch.inf)
+    # block maxima, the newest block +inf; the top-k reads each row up to nblocks
+    # only, so nothing past a row's keys is initialised (v2 needs stride % 4 == 0)
+    keys = logits.new_empty(rows, -(-max_seq_len // (4 * block)) * 4)
+    amax8_varlen(logits, seq_lens, out=keys)
     blocks = torch.empty(rows, topk_blocks, dtype=torch.int32, device=logits.device)
     topk_transform_paged_v2(keys, nblocks, None, blocks, 1, plan)
-    return torch.where(blocks < 0, _INT32_MAX, blocks).sort(dim=1).values
+    return blocks
 
 
 def build_schedule(
@@ -108,17 +115,6 @@ def sparse_logits(
         table.blocks.shape[1],
         CANDIDATE_BLOCK_SIZE,
     )
-
-
-def physical_blocks(
-    blocks: torch.Tensor, page_table: torch.Tensor, page_size: int
-) -> torch.Tensor:
-    """The published logical blocks as pool slots / 8: ``page_table[b, block //
-    bpp] * bpp + block % bpp`` with ``bpp = page_size / 8`` blocks per page. The
-    padding past a row's valid count maps to garbage no top-k ever picks."""
-    bpp = page_size // CANDIDATE_BLOCK_SIZE
-    page = (blocks // bpp).clamp_max(page_table.shape[1] - 1).to(torch.int64)
-    return page_table.gather(1, page) * bpp + blocks % bpp
 
 
 def topk_transform_sparse(
@@ -196,6 +192,13 @@ class DeepGemmCandidateIndexer:
                 raw_indices,
             )
         blocks = amax_topk_blocks(logits, seq_lens, self.topk_blocks)
+        # in place: ascending, INT32_MAX padded, plus the blocks as pool slots / 8
+        phys_blocks = sort_candidate_blocks(
+            blocks,
+            seq_lens,
+            metadata.page_table,
+            metadata.c4_page_size,
+        )
         schedule = build_schedule(
             blocks,
             seq_lens,
@@ -206,9 +209,7 @@ class DeepGemmCandidateIndexer:
         return SparseBlockTable(
             blocks=blocks,
             schedule=schedule,
-            phys_blocks=physical_blocks(
-                blocks, metadata.page_table, metadata.c4_page_size
-            ),
+            phys_blocks=phys_blocks,
         )
 
     def scores(self, table: SparseBlockTable, inputs: IndexerInputs) -> torch.Tensor:
@@ -233,6 +234,7 @@ class DeepGemmCandidateIndexer:
         published blocks, written ascending as slots through the page table with
         ``-1`` past the valid count (and as positions into ``raw_indices`` when
         given)."""
+        assert raw_indices is None
         table = candidate_metadata
         seq_lens = inputs.metadata.c4_seq_lens.reshape(-1)
         logits = self.scores(table, inputs)

--- a/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -13,6 +14,7 @@ from sglang.kernels.ops.attention.dsv4.topk import (
     topk_transform_bf16_small,
     topk_transform_paged_v2,
 )
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.candidate_indexer import (
     CandidateMetadata,
     IndexerInputs,
@@ -155,6 +157,11 @@ class DeepGemmCandidateIndexer:
         assert block_size == CANDIDATE_BLOCK_SIZE, block_size
         self.topk_blocks = topk_blocks
         self.block_size = block_size
+        self.alt_stream = None
+        self.need_wait = False
+        # TODO: maybe lower this priority
+        if envs.SGLANG_DSV41_DEEP_GEMM_CANDIDATE_OVERLAP.get():
+            self.alt_stream = torch.cuda.Stream()
 
     def publish_decode(
         self,
@@ -177,6 +184,16 @@ class DeepGemmCandidateIndexer:
             metadata.deep_gemm_metadata,
             metadata.max_c4_seq_len,
         )
+        if self.alt_stream is not None:
+            self.alt_stream.wait_stream(torch.cuda.current_stream())
+            # the level-one chain reads `logits` on the side stream while the main
+            # stream moves on: keep the allocator from handing its memory to a
+            # later main-stream allocation before those reads ran
+            logits.record_stream(self.alt_stream)
+            self.need_wait = True
+            stream_ctx = torch.cuda.stream(self.alt_stream)
+        else:
+            stream_ctx = contextlib.nullcontext()
         # TODO(candidate): one kernel for both selections below (dense logits read once)
         topk_transform_paged_v2(
             logits,
@@ -188,28 +205,29 @@ class DeepGemmCandidateIndexer:
             out_raw_indices=raw_indices,
         )
         # per row: block count for the block top-k, sparse-row length for the consumers
-        nblocks, row_valid_lens = candidate_row_lens(seq_lens, self.topk_blocks)
-        blocks = amax_topk_blocks(logits, seq_lens, nblocks, self.topk_blocks)
-        # in place: ascending, INT32_MAX padded, plus the blocks as pool slots / 8
-        phys_blocks = sort_candidate_blocks(
-            blocks,
-            seq_lens,
-            metadata.page_table,
-            metadata.c4_page_size,
-        )
-        schedule = build_sparse_indexer_schedule(
-            blocks,
-            seq_lens,
-            metadata.page_table,
-            metadata.c4_page_size,
-            inputs.q_fp4.dtype,
-        )
-        return SparseBlockTable(
-            blocks=blocks,
-            schedule=schedule,
-            phys_blocks=phys_blocks,
-            valid_lens=row_valid_lens,
-        )
+        with stream_ctx:
+            nblocks, row_valid_lens = candidate_row_lens(seq_lens, self.topk_blocks)
+            blocks = amax_topk_blocks(logits, seq_lens, nblocks, self.topk_blocks)
+            # in place: ascending, INT32_MAX padded, plus the blocks as pool slots / 8
+            phys_blocks = sort_candidate_blocks(
+                blocks,
+                seq_lens,
+                metadata.page_table,
+                metadata.c4_page_size,
+            )
+            schedule = build_sparse_indexer_schedule(
+                blocks,
+                seq_lens,
+                metadata.page_table,
+                metadata.c4_page_size,
+                inputs.q_fp4.dtype,
+            )
+            return SparseBlockTable(
+                blocks=blocks,
+                schedule=schedule,
+                phys_blocks=phys_blocks,
+                valid_lens=row_valid_lens,
+            )
 
     def scores(self, table: SparseBlockTable, inputs: IndexerInputs) -> torch.Tensor:
         """A consumer: bf16 logits ``[rows, topk_blocks * 8]`` of the published
@@ -235,6 +253,9 @@ class DeepGemmCandidateIndexer:
         given)."""
         assert raw_indices is None
         table = candidate_metadata
+        if self.alt_stream is not None and self.need_wait:
+            self.need_wait = False
+            torch.cuda.current_stream().wait_stream(self.alt_stream)
         logits = self.scores(table, inputs)
         # decode carries no raw_indices; the kernel writes slots only
         topk_transform_sparse(logits, table.valid_lens, table, page_indices)

--- a/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.topk import (
+    plan_topk_v2,
+    topk_transform_bf16_small,
+    topk_transform_paged,
+    topk_transform_paged_v2,
+)
+from sglang.srt.layers.attention.dsv4.candidate_indexer import (
+    CandidateMetadata,
+    IndexerInputs,
+)
+from sglang.srt.layers.attention.dsv4.indexer import fp4_paged_mqa_logits
+
+CANDIDATE_BLOCK_SIZE = 8  # positions per block; DeepGEMM accepts 8 or 16
+_INT32_MAX = torch.iinfo(torch.int32).max
+
+
+@dataclass
+class SparseBlockTable(CandidateMetadata):
+    # [rows, topk_blocks] int32: ascending logical block ids, valid for the first
+    # min(topk_blocks, ceil(seq_len / 8)) entries of a row; DeepGEMM reads only those
+    blocks: torch.Tensor
+    # DeepGEMM's schedule metadata (uint8) for them
+    schedule: torch.Tensor
+    # [rows, topk_blocks] int32: the same blocks as pool slots / 8, so a consumer's
+    # top-k maps column j of the sparse row to slot phys_blocks[b, j // 8] * 8 + j % 8
+    # with the plain page-table transform at page size 8
+    phys_blocks: torch.Tensor
+
+
+def valid_lens(seq_lens: torch.Tensor, topk_blocks: int) -> torch.Tensor:
+    """Length of each row of the sparse logits: the published blocks laid out
+    block by block, the newest (highest) block possibly partial."""
+    block = CANDIDATE_BLOCK_SIZE
+    num = ((seq_lens + block - 1) // block).clamp_max(topk_blocks)
+    return block * (num - 1) + (seq_lens - 1) % block + 1
+
+
+# TODO: replace this naive implementation
+def amax_topk_blocks(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    topk_blocks: int,
+) -> torch.Tensor:
+    rows, width = logits.shape
+    block = CANDIDATE_BLOCK_SIZE
+    nblocks = (seq_lens + block - 1) // block
+    newest = (seq_lens - 1).clamp_min(0) // block
+    ids = torch.arange(width // block, device=logits.device, dtype=torch.int32)
+    keys = logits.view(rows, width // block, block).amax(dim=-1)
+    # NOTE: plan cannot be the previous kernel of topk_transform_paged_v2
+    plan = plan_topk_v2(nblocks)
+    keys.masked_fill_(ids[None, :] >= nblocks[:, None], -torch.inf)
+    keys.masked_fill_(ids[None, :] == newest[:, None], torch.inf)
+    blocks = torch.empty(rows, topk_blocks, dtype=torch.int32, device=logits.device)
+    topk_transform_paged_v2(keys, nblocks, None, blocks, 1, plan)
+    return torch.where(blocks < 0, _INT32_MAX, blocks).sort(dim=1).values
+
+
+def build_schedule(
+    blocks: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+    q_dtype: torch.dtype,
+) -> torch.Tensor:
+    """DeepGEMM's schedule for the published blocks: ``seq_lens`` ``[rows]``
+    int32, ``page_table`` ``[rows, pages]`` int32 at the index pool's page size."""
+    import deep_gemm
+
+    # TODO(candidate): the request ids are shape-only; they belong in the metadata
+    request_ids = torch.arange(blocks.shape[0], dtype=torch.int32, device=blocks.device)
+    return deep_gemm.get_paged_sparse_mqa_logits_metadata(
+        seq_lens.contiguous(),
+        page_table,
+        request_ids,
+        page_size,
+        blocks,
+        q_dtype,
+        CANDIDATE_BLOCK_SIZE,
+    )
+
+
+def sparse_logits(
+    q_fp4: torch.Tensor,
+    q_sf: torch.Tensor,
+    k_cache: torch.Tensor,
+    weights: torch.Tensor,
+    table: SparseBlockTable,
+) -> torch.Tensor:
+    """bf16 logits ``[rows, topk_blocks * 8]`` of the published blocks: ``q_fp4``
+    ``[rows, 1, heads, 64]`` int8 with ``q_sf`` ``[rows, 1, heads]`` int32 (packed
+    ue8m0), ``k_cache`` ``[pages, page_size, 1, 68]`` uint8 whose page stride is
+    a multiple of 512 bytes, ``weights`` ``[rows, heads]`` bf16."""
+    import deep_gemm
+
+    return deep_gemm.fp8_fp4_paged_sparse_mqa_logits(
+        (q_fp4, q_sf),
+        k_cache,
+        weights,
+        table.schedule,
+        table.blocks.shape[1],
+        CANDIDATE_BLOCK_SIZE,
+    )
+
+
+def physical_blocks(
+    blocks: torch.Tensor, page_table: torch.Tensor, page_size: int
+) -> torch.Tensor:
+    """The published logical blocks as pool slots / 8: ``page_table[b, block //
+    bpp] * bpp + block % bpp`` with ``bpp = page_size / 8`` blocks per page. The
+    padding past a row's valid count maps to garbage no top-k ever picks."""
+    bpp = page_size // CANDIDATE_BLOCK_SIZE
+    page = (blocks // bpp).clamp_max(page_table.shape[1] - 1).to(torch.int64)
+    return page_table.gather(1, page) * bpp + blocks % bpp
+
+
+def topk_transform_sparse(
+    logits: torch.Tensor,
+    valid_lens: torch.Tensor,
+    table: SparseBlockTable,
+    page_indices: torch.Tensor,
+) -> None:
+    """Top-``k`` (``k = page_indices.shape[1]``) of every row of the sparse
+    ``logits`` (bf16 ``[rows, topk_blocks * 8]``) within its first ``valid_lens[b]``
+    columns, written as pool slots, ``-1`` where a row has fewer than ``k`` valid
+    columns, in no particular order. Column ``j`` is slot
+    ``phys_blocks[b, j // 8] * 8 + j % 8``: the bf16 top-k kernel's page-table
+    transform at page size 8 over the physical block table."""
+    topk_transform_bf16_small(
+        logits, valid_lens, table.phys_blocks, page_indices, CANDIDATE_BLOCK_SIZE
+    )
+
+
+def warmup(rows: int, topk_blocks: int, page_size: int, q_dtype: torch.dtype, device):
+    """Build one schedule so DeepGEMM allocates its per-stream metadata workspace
+    outside any CUDA-graph capture."""
+    seq_lens = torch.full(
+        (rows,), CANDIDATE_BLOCK_SIZE, dtype=torch.int32, device=device
+    )
+    blocks = torch.zeros(rows, topk_blocks, dtype=torch.int32, device=device)
+    page_table = torch.zeros(rows, 1, dtype=torch.int32, device=device)
+    build_schedule(blocks, seq_lens, page_table, page_size, q_dtype)
+
+
+class DeepGemmCandidateIndexer:
+    def __init__(self, topk_blocks: int, block_size: int):
+        assert block_size == CANDIDATE_BLOCK_SIZE, block_size
+        self.topk_blocks = topk_blocks
+        self.block_size = block_size
+
+    def publish_decode(
+        self,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> SparseBlockTable:
+        """Layer 20 end to end: dense logits, its own plain top-k into
+        ``page_indices`` (and ``raw_indices`` when given), the block table from
+        the same logits and DeepGEMM's schedule for it; the backend stores the
+        table on the forward metadata."""
+        metadata = inputs.metadata
+        seq_lens = metadata.c4_seq_lens.reshape(-1)
+        logits = fp4_paged_mqa_logits(
+            (inputs.q_fp4, inputs.q_sf),
+            inputs.k_cache,
+            inputs.weights,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            metadata.deep_gemm_metadata,
+            metadata.max_c4_seq_len,
+        )
+        # TODO(candidate): one kernel for both selections below (dense logits read once)
+        if metadata.use_topk_v2 and raw_indices is None:
+            topk_transform_paged_v2(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                metadata.c4_page_size,
+                metadata.topk_metadata,
+            )
+        else:
+            topk_transform_paged(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                metadata.c4_page_size,
+                raw_indices,
+            )
+        blocks = amax_topk_blocks(logits, seq_lens, self.topk_blocks)
+        schedule = build_schedule(
+            blocks,
+            seq_lens,
+            metadata.page_table,
+            metadata.c4_page_size,
+            inputs.q_fp4.dtype,
+        )
+        return SparseBlockTable(
+            blocks=blocks,
+            schedule=schedule,
+            phys_blocks=physical_blocks(
+                blocks, metadata.page_table, metadata.c4_page_size
+            ),
+        )
+
+    def scores(self, table: SparseBlockTable, inputs: IndexerInputs) -> torch.Tensor:
+        """A consumer: bf16 logits ``[rows, topk_blocks * 8]`` of the published
+        blocks only."""
+        return sparse_logits(
+            inputs.q_fp4,
+            inputs.q_sf,
+            inputs.k_cache,
+            inputs.weights.to(torch.bfloat16),
+            table,
+        )
+
+    def select_decode(
+        self,
+        candidate_metadata: SparseBlockTable,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        """A consumer: top-``k`` (``k = page_indices.shape[1]``) inside the
+        published blocks, written ascending as slots through the page table with
+        ``-1`` past the valid count (and as positions into ``raw_indices`` when
+        given)."""
+        table = candidate_metadata
+        seq_lens = inputs.metadata.c4_seq_lens.reshape(-1)
+        logits = self.scores(table, inputs)
+        # decode carries no raw_indices; the kernel writes slots only
+        topk_transform_sparse(
+            logits, valid_lens(seq_lens, self.topk_blocks), table, page_indices
+        )

--- a/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
@@ -5,19 +5,21 @@ from typing import Optional
 
 import torch
 
+from sglang.kernels.ops.attention.dsv4.candidate_blocks import candidate_row_lens
 from sglang.kernels.ops.attention.dsv4.topk import (
     amax8_varlen,
     plan_topk_v2,
     sort_candidate_blocks,
     topk_transform_bf16_small,
-    topk_transform_paged,
     topk_transform_paged_v2,
 )
 from sglang.srt.layers.attention.dsv4.candidate_indexer import (
     CandidateMetadata,
     IndexerInputs,
 )
-from sglang.srt.layers.attention.dsv4.indexer import fp4_paged_mqa_logits
+from sglang.srt.layers.attention.dsv4.indexer import (
+    fp4_paged_mqa_logits,
+)
 
 CANDIDATE_BLOCK_SIZE = 8  # positions per block; DeepGEMM accepts 8 or 16
 
@@ -33,11 +35,14 @@ class SparseBlockTable(CandidateMetadata):
     # top-k maps column j of the sparse row to slot phys_blocks[b, j // 8] * 8 + j % 8
     # with the plain page-table transform at page size 8
     phys_blocks: torch.Tensor
+    # [rows] int32: length of each row of the sparse logits (see `valid_lens`)
+    valid_lens: torch.Tensor
 
 
 def valid_lens(seq_lens: torch.Tensor, topk_blocks: int) -> torch.Tensor:
     """Length of each row of the sparse logits: the published blocks laid out
-    block by block, the newest (highest) block possibly partial."""
+    block by block, the newest (highest) block possibly partial. Torch reference
+    of ``candidate_row_lens``; the decode path takes the kernel's value."""
     block = CANDIDATE_BLOCK_SIZE
     num = ((seq_lens + block - 1) // block).clamp_max(topk_blocks)
     return block * (num - 1) + (seq_lens - 1) % block + 1
@@ -46,19 +51,19 @@ def valid_lens(seq_lens: torch.Tensor, topk_blocks: int) -> torch.Tensor:
 def amax_topk_blocks(
     logits: torch.Tensor,
     seq_lens: torch.Tensor,
+    nblocks: torch.Tensor,
     topk_blocks: int,
     max_seq_len: Optional[int] = None,
 ) -> torch.Tensor:
     """Per row the ``topk_blocks`` blocks of 8 positions with the largest block
     maximum among its first ``seq_lens[b]`` positions, the newest block always
     included: block ids in no particular order, ``-1`` past the row's count
-    (``sort_candidate_blocks`` turns them into the published table)."""
+    (``sort_candidate_blocks`` turns them into the published table). ``nblocks``
+    is ``ceil(seq_lens / 8)`` as int32, from ``candidate_row_lens``."""
     rows = logits.shape[0]
     block = CANDIDATE_BLOCK_SIZE
     if max_seq_len is None:
         max_seq_len = logits.shape[1]
-    # TODO(candidate): nblocks and the plan are per-forward constants -> metadata
-    nblocks = (seq_lens + (block - 1)) // block
     # NOTE: plan cannot be the previous kernel of topk_transform_paged_v2
     plan = plan_topk_v2(nblocks)
     # block maxima, the newest block +inf; the top-k reads each row up to nblocks
@@ -70,7 +75,7 @@ def amax_topk_blocks(
     return blocks
 
 
-def build_schedule(
+def build_sparse_indexer_schedule(
     blocks: torch.Tensor,
     seq_lens: torch.Tensor,
     page_table: torch.Tensor,
@@ -142,7 +147,7 @@ def warmup(rows: int, topk_blocks: int, page_size: int, q_dtype: torch.dtype, de
     )
     blocks = torch.zeros(rows, topk_blocks, dtype=torch.int32, device=device)
     page_table = torch.zeros(rows, 1, dtype=torch.int32, device=device)
-    build_schedule(blocks, seq_lens, page_table, page_size, q_dtype)
+    build_sparse_indexer_schedule(blocks, seq_lens, page_table, page_size, q_dtype)
 
 
 class DeepGemmCandidateIndexer:
@@ -173,25 +178,18 @@ class DeepGemmCandidateIndexer:
             metadata.max_c4_seq_len,
         )
         # TODO(candidate): one kernel for both selections below (dense logits read once)
-        if metadata.use_topk_v2 and raw_indices is None:
-            topk_transform_paged_v2(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                metadata.c4_page_size,
-                metadata.topk_metadata,
-            )
-        else:
-            topk_transform_paged(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                metadata.c4_page_size,
-                raw_indices,
-            )
-        blocks = amax_topk_blocks(logits, seq_lens, self.topk_blocks)
+        topk_transform_paged_v2(
+            logits,
+            seq_lens,
+            metadata.page_table,
+            page_indices,
+            metadata.c4_page_size,
+            metadata.topk_metadata,
+            out_raw_indices=raw_indices,
+        )
+        # per row: block count for the block top-k, sparse-row length for the consumers
+        nblocks, row_valid_lens = candidate_row_lens(seq_lens, self.topk_blocks)
+        blocks = amax_topk_blocks(logits, seq_lens, nblocks, self.topk_blocks)
         # in place: ascending, INT32_MAX padded, plus the blocks as pool slots / 8
         phys_blocks = sort_candidate_blocks(
             blocks,
@@ -199,7 +197,7 @@ class DeepGemmCandidateIndexer:
             metadata.page_table,
             metadata.c4_page_size,
         )
-        schedule = build_schedule(
+        schedule = build_sparse_indexer_schedule(
             blocks,
             seq_lens,
             metadata.page_table,
@@ -210,6 +208,7 @@ class DeepGemmCandidateIndexer:
             blocks=blocks,
             schedule=schedule,
             phys_blocks=phys_blocks,
+            valid_lens=row_valid_lens,
         )
 
     def scores(self, table: SparseBlockTable, inputs: IndexerInputs) -> torch.Tensor:
@@ -236,9 +235,6 @@ class DeepGemmCandidateIndexer:
         given)."""
         assert raw_indices is None
         table = candidate_metadata
-        seq_lens = inputs.metadata.c4_seq_lens.reshape(-1)
         logits = self.scores(table, inputs)
         # decode carries no raw_indices; the kernel writes slots only
-        topk_transform_sparse(
-            logits, valid_lens(seq_lens, self.topk_blocks), table, page_indices
-        )
+        topk_transform_sparse(logits, table.valid_lens, table, page_indices)

--- a/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_deep_gemm.py
@@ -77,19 +77,41 @@ def amax_topk_blocks(
     return blocks
 
 
+_ROW_IDS: dict = {}
+
+
+def _row_ids(rows: int, device: torch.device) -> torch.Tensor:
+    """``arange(rows)`` int32 from a cached buffer (grown in steps of 8192), so the
+    every-row-its-own-request case costs no launch."""
+    buf = _ROW_IDS.get(device)
+    if buf is None or buf.numel() < rows:
+        size = max(8192, -(-rows // 8192) * 8192)
+        buf = _ROW_IDS[device] = torch.arange(size, dtype=torch.int32, device=device)
+    return buf[:rows]
+
+
 def build_sparse_indexer_schedule(
     blocks: torch.Tensor,
     seq_lens: torch.Tensor,
     page_table: torch.Tensor,
     page_size: int,
     q_dtype: torch.dtype,
+    request_ids: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """DeepGEMM's schedule for the published blocks: ``seq_lens`` ``[rows]``
-    int32, ``page_table`` ``[rows, pages]`` int32 at the index pool's page size."""
+    int32, ``page_table`` ``[rows, pages]`` int32 at the index pool's page size.
+    ``request_ids`` ``[rows]``, one id per row with a request's rows consecutive
+    (verify: its draft tokens), lets DeepGEMM pair two rows of a request on one
+    KV pass; each row keeps its own block list and output layout. Paired rows
+    must share their page-table row. None: every row is its own request."""
     import deep_gemm
 
-    # TODO(candidate): the request ids are shape-only; they belong in the metadata
-    request_ids = torch.arange(blocks.shape[0], dtype=torch.int32, device=blocks.device)
+    rows = blocks.shape[0]
+    if request_ids is None:
+        request_ids = _row_ids(rows, blocks.device)  # cached, no launch
+    else:
+        # the scheduler keeps request indices as int64; one small cast per publish
+        request_ids = request_ids[:rows].to(torch.int32).contiguous()
     return deep_gemm.get_paged_sparse_mqa_logits_metadata(
         seq_lens.contiguous(),
         page_table,
@@ -221,6 +243,7 @@ class DeepGemmCandidateIndexer:
                 metadata.page_table,
                 metadata.c4_page_size,
                 inputs.q_fp4.dtype,
+                inputs.request_ids,
             )
             return SparseBlockTable(
                 blocks=blocks,

--- a/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
@@ -24,6 +24,9 @@ class IndexerInputs:
     k_cache: torch.Tensor  # [pages, page_size, 1, 68] uint8, the layer's index-K pool
     weights: torch.Tensor  # [rows, heads] bf16/fp32 head weights
     metadata: PagedIndexerMetadata  # this ratio's lengths, page table and plans
+    # [rows] int, one request id per query row, the rows of one request
+    # consecutive (verify: its draft tokens); None = every row its own request
+    request_ids: Optional[torch.Tensor] = None
 
     @property
     def num_rows(self) -> int:

--- a/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
@@ -41,16 +41,14 @@ class CandidateIndexer(Protocol, Generic[T]):
         inputs: IndexerInputs,
         page_indices: torch.Tensor,
         raw_indices: Optional[torch.Tensor] = None,
-    ) -> T:
-        ...
+    ) -> T: ...
     def select_decode(
         self,
         candidate_metadata: T,
         inputs: IndexerInputs,
         page_indices: torch.Tensor,
         raw_indices: Optional[torch.Tensor] = None,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 def make_candidate_indexer(topk_blocks: int, block_size: int) -> CandidateIndexer:

--- a/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_indexer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Optional, Protocol, TypeVar
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
+
+
+class CandidateMetadata:
+    """Base of an implementation's published state on
+    ``DSV4Metadata.candidate_metadata``."""
+
+
+@dataclass(frozen=True)
+class IndexerInputs:
+    """One index-source layer's operands on the paged fp4 decode path (one query
+    row per request, or per draft token under verify)."""
+
+    q_fp4: torch.Tensor  # [rows, 1, heads, 64] int8, packed fp4
+    q_sf: torch.Tensor  # [rows, 1, heads] int32, packed ue8m0
+    k_cache: torch.Tensor  # [pages, page_size, 1, 68] uint8, the layer's index-K pool
+    weights: torch.Tensor  # [rows, heads] bf16/fp32 head weights
+    metadata: PagedIndexerMetadata  # this ratio's lengths, page table and plans
+
+    @property
+    def num_rows(self) -> int:
+        return self.q_fp4.shape[0]
+
+
+T = TypeVar("T", bound=CandidateMetadata)
+
+
+# TODO(dark): support publish prefill/select prefill
+# TODO(dark): support fusion of publish + topk of publish layer
+class CandidateIndexer(Protocol, Generic[T]):
+    def publish_decode(
+        self,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> T:
+        ...
+    def select_decode(
+        self,
+        candidate_metadata: T,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        ...
+
+
+def make_candidate_indexer(topk_blocks: int, block_size: int) -> CandidateIndexer:
+    """Decided once, at backend init: DeepGEMM's sparse indexer when
+    ``SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER`` is set (the user vouches for the
+    kernel being there), the torch algorithm otherwise. A model without a
+    candidate source gets the torch one too; it is never asked to publish or
+    select."""
+    from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
+        DeepGemmCandidateIndexer,
+    )
+    from sglang.srt.layers.attention.dsv4.candidate_torch import (
+        TorchCandidateIndexer,
+    )
+
+    if envs.SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER.get():
+        return DeepGemmCandidateIndexer(topk_blocks, block_size)
+    return TorchCandidateIndexer(topk_blocks, block_size)

--- a/python/sglang/srt/layers/attention/dsv4/candidate_torch.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_torch.py
@@ -7,16 +7,13 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from sglang.kernels.ops.attention.dsv4 import (
-    topk_transform_paged,
-    topk_transform_paged_v2,
-)
 from sglang.srt.layers.attention.dsv4.candidate_indexer import (
     CandidateMetadata,
     IndexerInputs,
 )
 from sglang.srt.layers.attention.dsv4.indexer import (
     fp4_paged_mqa_logits,
+    fp32_jit_paged_topk,
     select_candidate_blocks,
 )
 
@@ -149,24 +146,7 @@ class TorchCandidateIndexer:
             block_size=self.block_size,
             published=None,
         )
-        if metadata.use_topk_v2 and raw_indices is None:
-            topk_transform_paged_v2(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                metadata.c4_page_size,
-                metadata.topk_metadata,
-            )
-        else:
-            topk_transform_paged(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                metadata.c4_page_size,
-                raw_indices,
-            )
+        fp32_jit_paged_topk(logits, metadata, page_indices, raw_indices)
         return CandidateMasks(mask=mask)
 
     def select_decode(
@@ -200,25 +180,10 @@ class TorchCandidateIndexer:
             block_size=self.block_size,
             published=candidate_metadata.mask,
         )
+        # raw positions into `selected`; `page_indices` gets the unfiltered slots
+        # here and is rewritten with the masked selection just below
         selected = torch.empty_like(page_indices)
-        if metadata.use_topk_v2 and raw_indices is None:
-            topk_transform_paged_v2(
-                logits,
-                metadata.c4_seq_lens,
-                None,
-                selected,
-                page_size,
-                metadata.topk_metadata,
-            )
-        else:
-            topk_transform_paged(
-                logits,
-                metadata.c4_seq_lens,
-                metadata.page_table,
-                page_indices,
-                page_size,
-                selected,
-            )
+        fp32_jit_paged_topk(logits, metadata, page_indices, raw_indices=selected)
         if logits.is_cuda and torch.version.cuda is not None:
             # fused: drop the selections the mask zeroed, page-transform the rest
             from sglang.kernels.ops.attention.dsv4.indexer_postprocess import (

--- a/python/sglang/srt/layers/attention/dsv4/candidate_torch.py
+++ b/python/sglang/srt/layers/attention/dsv4/candidate_torch.py
@@ -1,0 +1,243 @@
+# TODO(candidate): retire with the last path that still selects through masks
+# (Hopper decode, prefill); the paged fp4 decode path already has the DeepGEMM one.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import (
+    topk_transform_paged,
+    topk_transform_paged_v2,
+)
+from sglang.srt.layers.attention.dsv4.candidate_indexer import (
+    CandidateMetadata,
+    IndexerInputs,
+)
+from sglang.srt.layers.attention.dsv4.indexer import (
+    fp4_paged_mqa_logits,
+    select_candidate_blocks,
+)
+
+
+@dataclass
+class CandidateMasks(CandidateMetadata):
+    mask: Optional[torch.Tensor] = None  # decode: [rows, width] bool
+    request_masks: Optional[List[torch.Tensor]] = None  # prefill: [rows_b, lc_b] each
+
+
+def published_masks(candidate) -> CandidateMasks:
+    """The forward's ``candidate_metadata`` as the masks the source published."""
+    assert isinstance(candidate, CandidateMasks), "candidate masks missing"
+    return candidate
+
+
+def two_level_decode_logits(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    is_candidate_source: bool,
+    uses_candidates: bool,
+    topk_blocks: int,
+    block_size: int,
+    published: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Apply candidate-block filtering and return logits plus an optional published mask.
+
+    Mask columns past each sequence length to -inf before selection: the paged
+    logits kernel leaves that tail uninitialized, and an all -inf block means
+    unreachable. This path is graph-captured and must not synchronize with the host.
+    Work scales with allocated page-table capacity, not live sequence length.
+    """
+    if not (is_candidate_source or uses_candidates):
+        return logits, None
+
+    if (
+        logits.is_cuda
+        and torch.version.cuda is not None
+        and logits.ndim == 2
+        and logits.stride(1) == 1
+        and seq_lens.device == logits.device
+        and seq_lens.dtype in (torch.int32, torch.int64)
+        and seq_lens.is_contiguous()
+        and seq_lens.shape in ((logits.shape[0],), (logits.shape[0], 1))
+        and logits.numel() > 0
+        and 0 < block_size <= 1024
+    ):
+        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+            candidate_block_logits,
+        )
+
+        if not is_candidate_source:
+            assert (
+                torch.is_tensor(published)
+                and published.shape[0] == logits.shape[0]
+                and published.shape[1] >= logits.shape[1]
+            ), "candidate mask missing for decode"
+        return candidate_block_logits(
+            logits,
+            seq_lens,
+            topk_blocks=topk_blocks,
+            block_size=block_size,
+            published=None if is_candidate_source else published,
+        )
+
+    lens_col = seq_lens if seq_lens.dim() > 1 else seq_lens.unsqueeze(-1)
+    reachable = torch.arange(logits.shape[-1], device=logits.device) < lens_col
+    logits = logits.float().masked_fill(~reachable, -torch.inf)
+
+    if is_candidate_source:
+        # The source scores over every reachable position itself and only publishes,
+        # which is what the reference does.
+        return logits, select_candidate_blocks(
+            logits, lens_col, topk_blocks=topk_blocks, block_size=block_size
+        )
+
+    assert torch.is_tensor(published) and published.shape[0] == logits.shape[0], (
+        "candidate mask missing for decode"
+    )
+    return logits.masked_fill(~published[:, : logits.shape[-1]], -torch.inf), None
+
+
+def mask_topk_scores(
+    scores: torch.Tensor,
+    indices: torch.Tensor,
+    offsets: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Keep masked indexer scores out of attention even when top-k underfills."""
+    columns = indices.to(torch.int64)
+    if offsets is not None:
+        columns = columns - offsets[:, None]
+    selected_scores = scores.gather(1, columns.clamp(0, scores.shape[1] - 1))
+    valid = (
+        (columns >= 0) & (columns < scores.shape[1]) & (selected_scores > -torch.inf)
+    )
+    return indices.masked_fill(~valid, -1)
+
+
+class TorchCandidateIndexer:
+    def __init__(self, topk_blocks: int, block_size: int):
+        self.topk_blocks = topk_blocks
+        self.block_size = block_size
+
+    def publish_decode(
+        self,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> CandidateMasks:
+        """Layer 20 end to end: dense logits, its own plain top-k into
+        ``page_indices`` (and ``raw_indices`` when given), and the mask for the
+        layers after it; the backend stores the mask on the forward metadata."""
+        metadata = inputs.metadata
+        logits = fp4_paged_mqa_logits(
+            (inputs.q_fp4, inputs.q_sf),
+            inputs.k_cache,
+            inputs.weights,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            metadata.deep_gemm_metadata,
+            metadata.max_c4_seq_len,
+        )
+        logits, mask = two_level_decode_logits(
+            logits,
+            metadata.c4_seq_lens,
+            is_candidate_source=True,
+            uses_candidates=False,
+            topk_blocks=self.topk_blocks,
+            block_size=self.block_size,
+            published=None,
+        )
+        if metadata.use_topk_v2 and raw_indices is None:
+            topk_transform_paged_v2(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                metadata.c4_page_size,
+                metadata.topk_metadata,
+            )
+        else:
+            topk_transform_paged(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                metadata.c4_page_size,
+                raw_indices,
+            )
+        return CandidateMasks(mask=mask)
+
+    def select_decode(
+        self,
+        candidate_metadata: CandidateMasks,
+        inputs: IndexerInputs,
+        page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        """A consumer: dense logits, masked, top-k, written as slots through the
+        page table with ``-1`` past the valid count (and as positions into
+        ``raw_indices`` when given)."""
+        metadata = inputs.metadata
+        page_size = metadata.c4_page_size
+        assert isinstance(candidate_metadata, CandidateMasks)
+        logits = fp4_paged_mqa_logits(
+            (inputs.q_fp4, inputs.q_sf),
+            inputs.k_cache,
+            inputs.weights,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            metadata.deep_gemm_metadata,
+            metadata.max_c4_seq_len,
+        )
+        logits, _ = two_level_decode_logits(
+            logits,
+            metadata.c4_seq_lens,
+            is_candidate_source=False,
+            uses_candidates=True,
+            topk_blocks=self.topk_blocks,
+            block_size=self.block_size,
+            published=candidate_metadata.mask,
+        )
+        selected = torch.empty_like(page_indices)
+        if metadata.use_topk_v2 and raw_indices is None:
+            topk_transform_paged_v2(
+                logits,
+                metadata.c4_seq_lens,
+                None,
+                selected,
+                page_size,
+                metadata.topk_metadata,
+            )
+        else:
+            topk_transform_paged(
+                logits,
+                metadata.c4_seq_lens,
+                metadata.page_table,
+                page_indices,
+                page_size,
+                selected,
+            )
+        if logits.is_cuda and torch.version.cuda is not None:
+            # fused: drop the selections the mask zeroed, page-transform the rest
+            from sglang.kernels.ops.attention.dsv4.indexer_postprocess import (
+                filter_topk_pages,
+            )
+
+            filter_topk_pages(
+                logits,
+                selected,
+                metadata.page_table,
+                page_indices,
+                page_size,
+                raw_indices,
+            )
+        else:
+            selected = mask_topk_scores(logits, selected)
+            columns = selected.clamp_min(0).to(torch.int64)
+            slots = metadata.page_table.gather(1, columns // page_size) * page_size
+            slots = slots + columns % page_size
+            page_indices.copy_(torch.where(selected >= 0, slots, -1))
+            if raw_indices is not None:
+                raw_indices.copy_(selected)

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -1129,6 +1129,34 @@ class C4Indexer(nn.Module):
         )
 
 
+def fp4_paged_mqa_logits(
+    q_fp4: Tuple[torch.Tensor, torch.Tensor],
+    k_cache: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """DeepGEMM paged fp4 logits for the low-ratio indexer. No hadamard: the
+    reference does not apply one."""
+    from deep_gemm import fp8_fp4_paged_mqa_logits
+
+    sl = seq_lens.to(torch.int32)
+    if sl.dim() == 1:
+        sl = sl.unsqueeze(-1)
+    return fp8_fp4_paged_mqa_logits(
+        q_fp4,
+        k_cache,
+        weights,
+        sl,
+        page_table,
+        deep_gemm_metadata,
+        max_seq_len,
+        False,
+    )
+
+
 def select_candidate_blocks(
     logits: torch.Tensor,
     compress_lens: torch.Tensor | int,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -1157,6 +1157,36 @@ def fp4_paged_mqa_logits(
     )
 
 
+def fp32_jit_paged_topk(
+    logits: torch.Tensor,
+    metadata,
+    page_indices: torch.Tensor,
+    raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    """Plain top-k of the dense paged ``logits``: pool slots into ``page_indices``
+    (``-1`` past the valid count) and, when given, positions into ``raw_indices``;
+    ``metadata`` is the ratio's ``PagedIndexerMetadata``."""
+    if metadata.use_topk_v2:
+        topk_transform_paged_v2(
+            logits,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            page_indices,
+            metadata.c4_page_size,
+            metadata.topk_metadata,
+            raw_indices,
+        )
+    else:
+        topk_transform_paged(
+            logits,
+            metadata.c4_seq_lens,
+            metadata.page_table,
+            page_indices,
+            metadata.c4_page_size,
+            raw_indices,
+        )
+
+
 def select_candidate_blocks(
     logits: torch.Tensor,
     compress_lens: torch.Tensor | int,

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -275,7 +275,13 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
 
 # Low-ratio indexer-K pool page, in compressed slots: the DeepGEMM indexer reads
 # K in blocks of at most 128 and sglang's JIT metadata builder asserts 64.
-DSV41_INDEX_PAGE_SIZE = 64
+def dsv41_index_page_size() -> int:
+    if envs.SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER.get():
+        return 128
+    return 64
+
+
+DSV41_INDEX_PAGE_SIZE = dsv41_index_page_size()
 
 
 class DeepSeekV4IndexerPool(KVCache):

--- a/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
@@ -52,6 +52,23 @@ def _reference_blocks(logits, lens, block_size=8):
 
 class TestSparseIndexer(CustomTestCase):
     def test_amax_topk_blocks_matches_reference(self):
+        # short rows: the block top-k skips its plan; 40 rows of 300K tokens:
+        # 37500 keys per row on a batch above the persistent pool, plan needed
+        self._check_amax_topk_blocks(
+            torch.tensor(
+                [1, 37, 16384, 16389, 40000, 131072], dtype=torch.int32, device="cuda"
+            ),
+            131072,
+        )
+        self._check_amax_topk_blocks(
+            torch.randint(200000, 300001, (40,), dtype=torch.int32, device="cuda"),
+            300000,
+        )
+
+    def _check_amax_topk_blocks(self, lens, width):
+        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+            candidate_row_lens,
+        )
         from sglang.kernels.ops.attention.dsv4.topk import sort_candidate_blocks
         from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
             amax_topk_blocks,
@@ -59,10 +76,7 @@ class TestSparseIndexer(CustomTestCase):
         )
 
         torch.manual_seed(0)
-        lens = torch.tensor(
-            [1, 37, 16384, 16389, 40000, 131072], dtype=torch.int32, device="cuda"
-        )
-        bs, width = lens.numel(), 131072
+        bs = lens.numel()
         logits = torch.randn(bs, width, device="cuda")
         # the tail past the length is garbage in production: make it loud
         logits.masked_fill_(
@@ -72,9 +86,11 @@ class TestSparseIndexer(CustomTestCase):
         page_table = torch.stack(
             [torch.randperm(pages, device="cuda") for _ in range(bs)]
         ).to(torch.int32)
-        blocks = amax_topk_blocks(logits, lens, BLOCKS)
+        nblocks, valid = candidate_row_lens(lens, BLOCKS)
+        self.assertTrue(torch.equal(nblocks, (lens + 7) // 8))
+        self.assertTrue(torch.equal(valid, valid_lens(lens, BLOCKS)))
+        blocks = amax_topk_blocks(logits, lens, nblocks, BLOCKS)
         phys = sort_candidate_blocks(blocks, lens, page_table, PAGE)
-        valid = valid_lens(lens, BLOCKS)
         keys = logits.view(bs, -1, 8).amax(-1)
         bpp = PAGE // 8
         for b, ref in enumerate(_reference_blocks(logits, lens)):

--- a/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
@@ -1,0 +1,222 @@
+"""Decode two-level indexer on DeepGEMM's paged sparse MQA logits.
+
+The block table layer 20 publishes (``amax_topk_blocks``) is checked against
+the model code's ``select_candidate_blocks``; a consumer's sparse logits
+are checked against DeepGEMM's dense bf16 paged logits gathered at the published
+positions, which the kernel is documented to match bitwise; its selection is
+checked against a torch top-k of those. The kernel path needs a DeepGEMM with
+``fp8_fp4_paged_sparse_mqa_logits`` on an SM100 device; it skips elsewhere.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=120, stage="stage-b-test-small-1-gpu", runner_config="1-gpu")
+
+HEADS = 32
+HEAD_DIM = 128
+PAGE = 128  # index pool page on SM100: 128 * 68 bytes = 17 * 512
+TOPK = 512
+BLOCKS = 2048
+
+
+def _sparse_indexer_available() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 10:
+        return False
+    try:
+        import deep_gemm
+    except ImportError:
+        return False
+    return hasattr(deep_gemm, "fp8_fp4_paged_sparse_mqa_logits")
+
+
+def _reference_blocks(logits, lens, block_size=8):
+    """Block ids the model code keeps, per row, ascending."""
+    from sglang.srt.layers.attention.dsv4.indexer import select_candidate_blocks
+
+    width = logits.shape[1]
+    reach = torch.arange(width, device=logits.device)[None, :] < lens[:, None]
+    mask = select_candidate_blocks(
+        logits.masked_fill(~reach, -torch.inf),
+        lens[:, None],
+        topk_blocks=BLOCKS,
+        block_size=block_size,
+    )
+    return [m.view(-1, block_size).any(-1).nonzero().flatten() for m in mask]
+
+
+class TestSparseIndexer(CustomTestCase):
+    def test_amax_topk_blocks_matches_reference(self):
+        from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
+            amax_topk_blocks,
+            valid_lens,
+        )
+
+        torch.manual_seed(0)
+        lens = torch.tensor(
+            [1, 37, 16384, 16389, 40000, 131072], dtype=torch.int32, device="cuda"
+        )
+        bs, width = lens.numel(), 131072
+        logits = torch.randn(bs, width, device="cuda")
+        # the tail past the length is garbage in production: make it loud
+        logits.masked_fill_(
+            torch.arange(width, device="cuda")[None, :] >= lens[:, None], 1e4
+        )
+        blocks = amax_topk_blocks(logits, lens, BLOCKS)
+        valid = valid_lens(lens, BLOCKS)
+        keys = logits.view(bs, -1, 8).amax(-1)
+        for b, ref in enumerate(_reference_blocks(logits, lens)):
+            nb = (int(lens[b]) + 7) // 8
+            n = min(nb, BLOCKS)
+            got = blocks[b, :n].long()
+            self.assertTrue(torch.equal(got, got.sort().values), "not ascending")
+            self.assertEqual(got.unique().numel(), n)
+            self.assertIn(nb - 1, got.tolist(), "newest block not kept")
+            self.assertTrue(bool((got < nb).all()))
+            # equal keys may swap blocks: compare the key multiset (the forced
+            # block excluded, its key is arbitrary garbage)
+            keep = got != nb - 1
+            keep_ref = ref != nb - 1
+            self.assertTrue(
+                torch.equal(
+                    keys[b][got[keep]].sort().values,
+                    keys[b][ref[keep_ref]].sort().values,
+                ),
+                msg=f"row {b}",
+            )
+            # past the valid count nothing looks like a block DeepGEMM could read
+            self.assertTrue(bool((blocks[b, n:] >= nb).all()))
+            expect_valid = 8 * (n - 1) + ((int(lens[b]) - 1) % 8 + 1)
+            self.assertEqual(int(valid[b]), expect_valid)
+
+    @unittest.skipUnless(
+        _sparse_indexer_available(), "needs DeepGEMM's paged sparse MQA logits on SM100"
+    )
+    def test_sparse_chain_matches_dense_logits(self):
+        """Layer 20 publishes from its dense fp32 logits; a consumer's sparse bf16
+        logits equal the dense bf16 logits at the published positions bitwise."""
+        import deep_gemm
+
+        from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
+            DeepGemmCandidateIndexer,
+            valid_lens,
+        )
+        from sglang.srt.layers.attention.dsv4.candidate_indexer import IndexerInputs
+
+        torch.manual_seed(1)
+        lens = torch.tensor(
+            [300, 16384, 70000, 131072], dtype=torch.int32, device="cuda"
+        )
+        bs = lens.numel()
+        max_pages = (int(lens.max()) + PAGE - 1) // PAGE
+        num_pages = bs * max_pages
+        # fp4 index-K pool, the store kernel's page layout: PAGE * 64 payload bytes
+        # then PAGE * 4 packed-ue8m0 scale bytes. Random codes with small scales
+        # (2^-9 .. 2^-5) keep the logits inside the fp16 range the top-k's coarse
+        # keys resolve; production indexer logits are O(1-100).
+        pool = torch.randint(
+            0, 255, (num_pages, PAGE * 68), dtype=torch.uint8, device="cuda"
+        )
+        pool[:, PAGE * 64 :] = torch.randint(
+            118, 123, (num_pages, PAGE * 4), dtype=torch.uint8, device="cuda"
+        )
+        k_cache = pool.view(num_pages, PAGE, 1, 68)
+        self.assertEqual(k_cache.stride(0) % 512, 0)
+        page_table = (
+            torch.randperm(num_pages, device="cuda").view(bs, max_pages).to(torch.int32)
+        )
+        q_fp4 = torch.randint(
+            0, 255, (bs, 1, HEADS, HEAD_DIM // 2), dtype=torch.uint8, device="cuda"
+        ).view(torch.int8)
+        q_sf = (
+            torch.randint(118, 123, (bs, 1, HEADS, 4), dtype=torch.uint8, device="cuda")
+            .view(torch.int32)
+            .squeeze(-1)
+        )
+        weights = (torch.rand(bs, HEADS, device="cuda") * 0.05).to(torch.bfloat16)
+
+        sched = deep_gemm.get_paged_mqa_logits_metadata(
+            lens.view(-1, 1), PAGE, deep_gemm.get_num_sms()
+        )
+        dense = lambda dtype: deep_gemm.fp8_fp4_paged_mqa_logits(
+            (q_fp4, q_sf),
+            k_cache,
+            weights.float() if dtype == torch.float32 else weights,
+            lens.view(-1, 1),
+            page_table,
+            sched,
+            int(lens.max()),
+            False,
+            dtype,
+        )
+        from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
+
+        impl = DeepGemmCandidateIndexer(BLOCKS, 8)
+        inputs = IndexerInputs(
+            q_fp4,
+            q_sf,
+            k_cache,
+            weights.float(),
+            SimpleNamespace(
+                c4_seq_lens=lens,
+                page_table=page_table,
+                c4_page_size=PAGE,
+                deep_gemm_metadata=sched,
+                max_c4_seq_len=int(lens.max()),
+                use_topk_v2=True,
+                topk_metadata=plan_topk_v2(lens),
+            ),
+        )
+        source_slots = torch.empty(bs, TOPK, dtype=torch.int32, device="cuda")
+        table = impl.publish_decode(inputs, source_slots)
+        # the source's own selection: min(k, len) slots per row, the rest -1
+        for b in range(bs):
+            self.assertEqual(int((source_slots[b] >= 0).sum()), min(TOPK, int(lens[b])))
+        sparse = impl.scores(table, inputs)
+        self.assertEqual(sparse.shape, (bs, BLOCKS * 8))
+        dense16 = dense(torch.bfloat16)
+        reach = torch.arange(dense16.shape[1], device="cuda")[None, :] < lens[:, None]
+        seen = dense16.float()[reach]
+        self.assertTrue(
+            bool(torch.isfinite(seen).all()) and float(seen.max()) < 65504.0
+        )
+        cols = torch.arange(BLOCKS * 8, device="cuda")
+        pos = table.blocks.long().repeat_interleave(8, dim=1) * 8 + (cols % 8)[None, :]
+        row_valid = valid_lens(lens, BLOCKS)
+        valid = cols[None, :] < row_valid[:, None].long()
+        ref = dense16.gather(1, pos.clamp(max=dense16.shape[1] - 1))
+        self.assertTrue(
+            torch.equal(sparse[valid], ref[valid]), "sparse logits differ from dense"
+        )
+        # the consumer's selection: per row the top-k of the valid columns as
+        # slots (any order), -1 padded; bf16 ties may swap positions, so the picked
+        # scores are compared as a multiset. Slots invert through the page table.
+        page_indices = torch.empty(bs, TOPK, dtype=torch.int32, device="cuda")
+        impl.select_decode(table, inputs, page_indices)
+        slot_to_pos = torch.empty(bs, num_pages * PAGE, dtype=torch.int64, device="cuda")
+        for b in range(bs):
+            n_valid = min(TOPK, int(row_valid[b]))
+            chosen = page_indices[b] >= 0
+            self.assertEqual(int(chosen.sum()), n_valid)
+            slots = page_indices[b][chosen].long()
+            pages_b = page_table[b].long()
+            slot_to_pos[b].fill_(-1)
+            slot_to_pos[b][
+                (pages_b[:, None] * PAGE + torch.arange(PAGE, device="cuda")[None, :]).flatten()
+            ] = torch.arange(pages_b.numel() * PAGE, device="cuda")
+            p = slot_to_pos[b][slots]
+            self.assertTrue(bool((p >= 0).all()) and bool((p < lens[b]).all()))
+            self.assertEqual(p.unique().numel(), n_valid)
+            row = sparse[b].float().masked_fill(~valid[b], -torch.inf)
+            ref_vals = row.topk(n_valid).values.sort().values
+            got_vals = dense16[b].float()[p].sort().values
+            self.assertTrue(torch.equal(got_vals, ref_vals), f"row {b}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
@@ -52,6 +52,7 @@ def _reference_blocks(logits, lens, block_size=8):
 
 class TestSparseIndexer(CustomTestCase):
     def test_amax_topk_blocks_matches_reference(self):
+        from sglang.kernels.ops.attention.dsv4.topk import sort_candidate_blocks
         from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
             amax_topk_blocks,
             valid_lens,
@@ -67,9 +68,15 @@ class TestSparseIndexer(CustomTestCase):
         logits.masked_fill_(
             torch.arange(width, device="cuda")[None, :] >= lens[:, None], 1e4
         )
+        pages = (width + PAGE - 1) // PAGE
+        page_table = torch.stack(
+            [torch.randperm(pages, device="cuda") for _ in range(bs)]
+        ).to(torch.int32)
         blocks = amax_topk_blocks(logits, lens, BLOCKS)
+        phys = sort_candidate_blocks(blocks, lens, page_table, PAGE)
         valid = valid_lens(lens, BLOCKS)
         keys = logits.view(bs, -1, 8).amax(-1)
+        bpp = PAGE // 8
         for b, ref in enumerate(_reference_blocks(logits, lens)):
             nb = (int(lens[b]) + 7) // 8
             n = min(nb, BLOCKS)
@@ -91,6 +98,10 @@ class TestSparseIndexer(CustomTestCase):
             )
             # past the valid count nothing looks like a block DeepGEMM could read
             self.assertTrue(bool((blocks[b, n:] >= nb).all()))
+            # the same blocks as pool slots / 8 through the row's page table
+            ref_phys = page_table[b][got // bpp].long() * bpp + got % bpp
+            self.assertTrue(torch.equal(phys[b, :n].long(), ref_phys))
+            self.assertTrue(bool((phys[b, n:] == torch.iinfo(torch.int32).max).all()))
             expect_valid = 8 * (n - 1) + ((int(lens[b]) - 1) % 8 + 1)
             self.assertEqual(int(valid[b]), expect_valid)
 

--- a/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
@@ -198,7 +198,9 @@ class TestSparseIndexer(CustomTestCase):
         # scores are compared as a multiset. Slots invert through the page table.
         page_indices = torch.empty(bs, TOPK, dtype=torch.int32, device="cuda")
         impl.select_decode(table, inputs, page_indices)
-        slot_to_pos = torch.empty(bs, num_pages * PAGE, dtype=torch.int64, device="cuda")
+        slot_to_pos = torch.empty(
+            bs, num_pages * PAGE, dtype=torch.int64, device="cuda"
+        )
         for b in range(bs):
             n_valid = min(TOPK, int(row_valid[b]))
             chosen = page_indices[b] >= 0
@@ -207,7 +209,9 @@ class TestSparseIndexer(CustomTestCase):
             pages_b = page_table[b].long()
             slot_to_pos[b].fill_(-1)
             slot_to_pos[b][
-                (pages_b[:, None] * PAGE + torch.arange(PAGE, device="cuda")[None, :]).flatten()
+                (
+                    pages_b[:, None] * PAGE + torch.arange(PAGE, device="cuda")[None, :]
+                ).flatten()
             ] = torch.arange(pages_b.numel() * PAGE, device="cuda")
             p = slot_to_pos[b][slots]
             self.assertTrue(bool((p >= 0).all()) and bool((p < lens[b]).all()))

--- a/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
+++ b/test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py
@@ -248,6 +248,115 @@ class TestSparseIndexer(CustomTestCase):
             got_vals = dense16[b].float()[p].sort().values
             self.assertTrue(torch.equal(got_vals, ref_vals), f"row {b}")
 
+    @unittest.skipUnless(
+        _sparse_indexer_available(), "needs DeepGEMM's paged sparse MQA logits on SM100"
+    )
+    def test_paired_verify_rows_match_unpaired(self):
+        """Verify shape: each request has 6 consecutive rows (its draft tokens) with
+        lengths L, L+1, ..., sharing one page-table row. With request ids DeepGEMM
+        pairs the rows on one KV pass; the sparse logits must equal the unpaired
+        (every row its own request) result bitwise, row layout unchanged."""
+        import deep_gemm
+
+        from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+            candidate_row_lens,
+        )
+        from sglang.kernels.ops.attention.dsv4.topk import (
+            sort_candidate_blocks,
+        )
+        from sglang.srt.layers.attention.dsv4.candidate_deep_gemm import (
+            SparseBlockTable,
+            amax_topk_blocks,
+            build_sparse_indexer_schedule,
+            sparse_logits,
+            valid_lens,
+        )
+
+        torch.manual_seed(3)
+        draft = 6
+        base = torch.tensor([20000, 16385, 70000], dtype=torch.int32, device="cuda")
+        lens = (
+            base[:, None] + torch.arange(draft, device="cuda", dtype=torch.int32)
+        ).flatten()
+        request_ids = torch.repeat_interleave(
+            torch.tensor([7, 3, 11], dtype=torch.int64, device="cuda"), draft
+        )
+        rows = lens.numel()
+        max_pages = (int(lens.max()) + PAGE - 1) // PAGE
+        num_pages = base.numel() * max_pages
+        pool = torch.randint(
+            0, 255, (num_pages, PAGE * 68), dtype=torch.uint8, device="cuda"
+        )
+        pool[:, PAGE * 64 :] = torch.randint(
+            118, 123, (num_pages, PAGE * 4), dtype=torch.uint8, device="cuda"
+        )
+        k_cache = pool.view(num_pages, PAGE, 1, 68)
+        per_request = (
+            torch.randperm(num_pages, device="cuda")
+            .view(base.numel(), max_pages)
+            .to(torch.int32)
+        )
+        page_table = per_request.repeat_interleave(draft, dim=0)  # rows share theirs
+        q_fp4 = torch.randint(
+            0, 255, (rows, 1, HEADS, HEAD_DIM // 2), dtype=torch.uint8, device="cuda"
+        ).view(torch.int8)
+        q_sf = (
+            torch.randint(
+                118, 123, (rows, 1, HEADS, 4), dtype=torch.uint8, device="cuda"
+            )
+            .view(torch.int32)
+            .squeeze(-1)
+        )
+        weights = (torch.rand(rows, HEADS, device="cuda") * 0.05).to(torch.bfloat16)
+        sched = deep_gemm.get_paged_mqa_logits_metadata(
+            lens.view(-1, 1), PAGE, deep_gemm.get_num_sms()
+        )
+        dense = deep_gemm.fp8_fp4_paged_mqa_logits(
+            (q_fp4, q_sf),
+            k_cache,
+            weights.float(),
+            lens.view(-1, 1),
+            page_table,
+            sched,
+            int(lens.max()),
+            False,
+            torch.float32,
+        )
+        nblocks, row_valid = candidate_row_lens(lens, BLOCKS)
+        blocks = amax_topk_blocks(dense, lens, nblocks, BLOCKS)
+        phys = sort_candidate_blocks(blocks, lens, page_table, PAGE)
+        out = {}
+        for name, ids in (("paired", request_ids), ("unpaired", None)):
+            schedule = build_sparse_indexer_schedule(
+                blocks, lens, page_table, PAGE, q_fp4.dtype, ids
+            )
+            table = SparseBlockTable(
+                blocks=blocks, schedule=schedule, phys_blocks=phys, valid_lens=row_valid
+            )
+            out[name] = sparse_logits(q_fp4, q_sf, k_cache, weights, table)
+        cols = torch.arange(BLOCKS * 8, device="cuda")
+        valid = cols[None, :] < row_valid[:, None].long()
+        self.assertTrue(torch.equal(row_valid, valid_lens(lens, BLOCKS)))
+        self.assertTrue(
+            torch.equal(out["paired"][valid], out["unpaired"][valid]),
+            "pairing changed the sparse logits",
+        )
+        # and both equal the dense bf16 logits at the published positions
+        dense16 = deep_gemm.fp8_fp4_paged_mqa_logits(
+            (q_fp4, q_sf),
+            k_cache,
+            weights,
+            lens.view(-1, 1),
+            page_table,
+            sched,
+            int(lens.max()),
+            False,
+            torch.bfloat16,
+        )
+        pos = blocks.long().repeat_interleave(8, dim=1) * 8 + (cols % 8)[None, :]
+        ref = dense16.gather(1, pos.clamp(max=dense16.shape[1] - 1))
+        self.assertTrue(torch.equal(out["paired"][valid], ref[valid]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/kernels/ops/attention/test_amax_copy.py
+++ b/test/registered/kernels/ops/attention/test_amax_copy.py
@@ -1,0 +1,125 @@
+"""Correctness tests for the DeepSeek-V4.1 JIT block-max ("amax") copy.
+
+``amax8_varlen`` writes, per row, the maximum of each block of 8 consecutive
+fp32 scores for the first ``ceil(seq_lens[b] / 8)`` blocks, the last of them
+``+inf`` (the newest block is always selected), and leaves everything else
+untouched. It is the level-one key computation of the two-level sparse indexer:
+the keys feed a block top-k, which is why rows with at most ``topk`` blocks may
+be skipped (every block of such a row is selected anyway).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsv4.topk import amax8_varlen
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+BLOCK = 8
+SENTINEL = -12345.0
+CONFIGS = [
+    # (batch, seq): a single partial block, exact blocks, one CTA, many CTAs
+    (1, 1),
+    (1, 8),
+    (1, 9),
+    (3, 1000),
+    (4, 16389),
+    (8, 131072),
+    (2, 1048576),
+]
+
+
+def _keys_ref(scores: torch.Tensor, lens: torch.Tensor) -> torch.Tensor:
+    """Per row the block maxima of the first ceil(len / 8) blocks, the last +inf."""
+    batch, width = scores.shape
+    nblocks = (width + BLOCK - 1) // BLOCK
+    padded = torch.nn.functional.pad(
+        scores, (0, nblocks * BLOCK - width), value=-torch.inf
+    )
+    keys = padded.view(batch, nblocks, BLOCK).amax(-1)
+    last = (lens.long() + BLOCK - 1) // BLOCK - 1
+    keys[torch.arange(batch, device=scores.device), last] = torch.inf
+    return keys
+
+
+def _check(
+    out: torch.Tensor, scores: torch.Tensor, lens: torch.Tensor, skip=None
+) -> None:
+    ref = _keys_ref(scores, lens)
+    for b in range(scores.shape[0]):
+        n = (int(lens[b]) + BLOCK - 1) // BLOCK
+        if skip is not None and skip[b]:
+            assert torch.all(out[b] == SENTINEL), f"row {b} was skipped but written"
+            continue
+        assert torch.equal(out[b, :n], ref[b, :n]), f"row {b} keys differ"
+        assert torch.all(out[b, n:] == SENTINEL), f"row {b} written past its keys"
+
+
+def _inputs(batch: int, seq: int, ragged: bool, stride_pad: int = 0):
+    torch.manual_seed(batch * 977 + seq)
+    lens = torch.full((batch,), seq, dtype=torch.int32, device="cuda")
+    if ragged:
+        lens = torch.randint(1, seq + 1, (batch,), dtype=torch.int32, device="cuda")
+        lens[0] = seq
+    stride = (seq + BLOCK - 1) // BLOCK * BLOCK + stride_pad
+    storage = torch.randn(batch, stride, device="cuda") * 10
+    scores = storage[:, :seq]
+    return scores, lens
+
+
+@pytest.mark.parametrize("ragged", [False, True])
+@pytest.mark.parametrize("batch,seq", CONFIGS)
+def test_matches_block_max(batch: int, seq: int, ragged: bool):
+    scores, lens = _inputs(batch, seq, ragged)
+    out = torch.full((batch, (seq + BLOCK - 1) // BLOCK), SENTINEL, device="cuda")
+    assert amax8_varlen(scores, lens, out=out) is out
+    _check(out, scores, lens)
+
+
+def test_strided_views():
+    """Score rows padded past the row width and a key buffer wider than needed."""
+    scores, lens = _inputs(4, 16389, ragged=True, stride_pad=248)
+    nblocks = (16389 + BLOCK - 1) // BLOCK
+    out = torch.full((4, nblocks + 5), SENTINEL, device="cuda")
+    amax8_varlen(scores, lens, out=out[:, :nblocks])
+    _check(out, scores, lens)
+
+
+def test_allocates_output():
+    scores, lens = _inputs(3, 20000, ragged=True)
+    out = amax8_varlen(scores, lens)
+    assert out.shape == (3, (20000 + BLOCK - 1) // BLOCK) and out.dtype == torch.float32
+    ref = _keys_ref(scores, lens)
+    for b in range(3):
+        n = (int(lens[b]) + BLOCK - 1) // BLOCK
+        assert torch.equal(out[b, :n], ref[b, :n])
+
+
+def test_max_seqlen_sizes_output():
+    """A batch whose rows are all shorter than the padded width only needs
+    ceil(max_seqlen / 8) keys per row."""
+    scores, _ = _inputs(4, 65536, ragged=False)
+    lens = torch.tensor([40000, 1, 16384, 39999], dtype=torch.int32, device="cuda")
+    out = amax8_varlen(scores, lens, max_seqlen=40000)
+    assert out.shape == (4, 5000)
+    ref = _keys_ref(scores, lens)
+    for b in range(4):
+        n = (int(lens[b]) + BLOCK - 1) // BLOCK
+        assert torch.equal(out[b, :n], ref[b, :n])
+
+
+def test_topk_skips_rows_that_fit():
+    scores, _ = _inputs(4, 40000, ragged=False)
+    lens = torch.tensor([40000, 16384, 16385, 100], dtype=torch.int32, device="cuda")
+    out = torch.full((4, 5000), SENTINEL, device="cuda")
+    amax8_varlen(scores, lens, 2048, out=out)
+    _check(out, scores, lens, skip=[False, True, False, True])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernels/ops/attention/test_sort_idx.py
+++ b/test/registered/kernels/ops/attention/test_sort_idx.py
@@ -1,0 +1,140 @@
+"""Correctness tests for the DeepSeek-V4.1 JIT candidate block table sort.
+
+``sort_candidate_blocks`` turns a row's selected block ids (any order, ``-1``
+padded) in place into the ascending, ``INT32_MAX``-padded table DeepGEMM's
+sparse indexer schedule reads, and writes the same blocks as pool slots / 8
+through the row's index page table. Rows with at most ``k`` blocks get the
+identity table. The kernel is a bitmap counting sort whose dense words are
+drained by a block-wide queue, so the id distributions below cover sparse,
+clustered and completely full words.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsv4.topk import (
+    sort_candidate_blocks,
+    transform_candidate_blocks,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+BLOCK = 8
+PAD = torch.iinfo(torch.int32).max
+MAX_BLOCKS = 1 << 17
+
+
+def _select(nblocks: int, k: int, dist: str, gen: torch.Generator) -> torch.Tensor:
+    """k distinct block ids below nblocks (all of them if nblocks <= k), shuffled."""
+    n = min(k, nblocks)
+    if dist == "uniform":
+        ids = torch.randperm(nblocks, device="cuda", generator=gen)[:n]
+    elif dist == "clustered":  # runs of 64 consecutive blocks mixed with scattered ones
+        runs = max(n // 96, 1)
+        starts = torch.randint(
+            0, max(nblocks - 64, 1), (runs,), device="cuda", generator=gen
+        )
+        runs_ids = (
+            starts[:, None] + torch.arange(64, device="cuda")[None, :]
+        ).flatten()
+        rest = torch.randperm(nblocks, device="cuda", generator=gen)[:n]
+        ids = torch.unique(torch.cat([runs_ids, rest]))[:n]
+    elif dist == "newest":  # the tail of the row: every word full
+        ids = torch.arange(nblocks - n, nblocks, device="cuda")
+    else:
+        raise ValueError(dist)
+    ids = ids.to(torch.int32)
+    ids = ids[torch.randperm(ids.numel(), device="cuda", generator=gen)]
+    return torch.nn.functional.pad(ids, (0, k - n), value=-1)
+
+
+def _case(lens, k, dist, page_size, seed=0):
+    gen = torch.Generator(device="cuda").manual_seed(seed)
+    lens_t = torch.tensor(lens, dtype=torch.int32, device="cuda")
+    max_pages = (max(lens) + page_size - 1) // page_size
+    page_table = torch.stack(
+        [torch.randperm(max_pages, device="cuda", generator=gen) for _ in lens]
+    ).to(torch.int32)
+    blocks = torch.stack(
+        [_select((l + BLOCK - 1) // BLOCK, k, dist, gen) for l in lens]
+    )
+    return lens_t, page_table, blocks
+
+
+def _check(blocks, pages, selected, lens, page_table, page_size, k):
+    bpp = page_size // BLOCK
+    for b, seq in enumerate(lens):
+        nblocks = (seq + BLOCK - 1) // BLOCK
+        n = min(k, nblocks)
+        if nblocks <= k:
+            ref = torch.arange(n, device="cuda", dtype=torch.int32)
+        else:
+            ref = selected[b][selected[b] >= 0].sort().values
+        assert torch.equal(blocks[b, :n], ref), f"row {b} ids"
+        assert torch.all(blocks[b, n:] == PAD), f"row {b} padding"
+        ref_pages = page_table[b][ref // bpp] * bpp + ref % bpp
+        assert torch.equal(pages[b, :n], ref_pages), f"row {b} slots"
+        assert torch.all(pages[b, n:] == PAD), f"row {b} slot padding"
+
+
+@pytest.mark.parametrize("dist", ["uniform", "clustered", "newest"])
+@pytest.mark.parametrize("page_size", [64, 128])
+@pytest.mark.parametrize(
+    "lens,k",
+    [
+        # rows that fit (identity), rows just above k, long rows up to 1M tokens
+        ([1, 8, 16384, 16385, 16392], 2048),
+        ([40000, 131072, 65537, 1048576], 2048),
+        ([1048576, 1048571, 300000], 2048),
+        ([2049, 9000, 20000], 256),
+    ],
+)
+def test_matches_sorted_selection(lens, k, dist, page_size):
+    lens_t, page_table, blocks = _case(lens, k, dist, page_size)
+    selected = blocks.clone()
+    pages = sort_candidate_blocks(blocks, lens_t, page_table, page_size)
+    _check(blocks, pages, selected, lens, page_table, page_size, k)
+
+
+def test_dense_words_only():
+    """Every selected id inside k / 32 full words, in random order: the queue path only."""
+    lens = [MAX_BLOCKS * BLOCK, 100000]
+    lens_t, page_table, _ = _case(lens, 2048, "uniform", 128)
+    gen = torch.Generator(device="cuda").manual_seed(3)
+    rows = []
+    for seq in lens:
+        nblocks = (seq + BLOCK - 1) // BLOCK
+        start = (nblocks - 2048) // 2 // 32 * 32
+        ids = torch.arange(start, start + 2048, device="cuda", dtype=torch.int32)
+        rows.append(ids[torch.randperm(2048, device="cuda", generator=gen)])
+    blocks = torch.stack(rows)
+    selected = blocks.clone()
+    pages = torch.empty_like(blocks)
+    assert (
+        sort_candidate_blocks(blocks, lens_t, page_table, 128, out_pages=pages) is pages
+    )
+    _check(blocks, pages, selected, lens, page_table, 128, 2048)
+
+
+@pytest.mark.parametrize("page_size", [64, 128])
+def test_page_transform_of_sorted_ids(page_size):
+    """Ascending ids in, INT32_MAX past the row's count (a DeepSelect-style
+    input): the same pages as the sort, blocks untouched."""
+    lens = [1, 16384, 16385, 131072, 1048576]
+    k = 2048
+    lens_t, page_table, blocks = _case(lens, k, "clustered", page_size, seed=11)
+    ref_pages = sort_candidate_blocks(blocks.clone(), lens_t, page_table, page_size)
+    ascending = torch.where(blocks < 0, PAD, blocks).sort(dim=1).values
+    kept = ascending.clone()
+    pages = transform_candidate_blocks(ascending, lens_t, page_table, page_size)
+    assert torch.equal(ascending, kept)
+    assert torch.equal(pages, ref_pages)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernels/ops/attention/test_topk_bf16.py
+++ b/test/registered/kernels/ops/attention/test_topk_bf16.py
@@ -1,0 +1,135 @@
+"""Correctness tests for the DeepSeek-V4.1 JIT bf16 top-k transform.
+
+``topk_transform_bf16_small`` selects the per-row top-k of bf16 ``scores`` within each
+row's ``seq_lens`` (rows of at most 16384) and writes the page-table transform of
+the selected indices, ``-1`` past ``min(k, seq_len)``, in no particular order.
+It is the consumer selection of the two-level sparse indexer: there the "page
+table" is the per-row physical block table at page size 8.
+
+Selection uses a 13-bit fp16-derived key, exact for bf16 in fp16's normal
+range, so it is validated against ``torch.topk`` on the multiset of selected
+values (elements of equal value may swap).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsv4.topk import topk_transform_bf16_small
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+MAX_SEQ = 16384
+CONFIGS = [
+    # (batch, seq): short rows select everything, full rows the 16384 maximum
+    (1, 1),
+    (4, 300),
+    (8, 512),
+    (8, 513),
+    (16, 4097),
+    (32, 16000),
+    (32, MAX_SEQ),
+    (148, MAX_SEQ),
+    (300, MAX_SEQ),
+]
+
+
+def _rows(batch: int, seq: int, k: int, ties: bool, ragged: bool):
+    torch.manual_seed(batch * 131 + seq)
+    lens = torch.full((batch,), seq, dtype=torch.int32, device="cuda")
+    if ragged:
+        lens = torch.randint(1, seq + 1, (batch,), dtype=torch.int32, device="cuda")
+        lens[0] = seq
+    scores = torch.randn(batch, MAX_SEQ, device="cuda") * 2
+    if ties:
+        scores = (scores * 2).round() / 2  # a handful of distinct values per row
+    # everything past a row is garbage that must never be selected
+    scores.masked_fill_(
+        torch.arange(MAX_SEQ, device="cuda")[None, :] >= lens[:, None], 1e4
+    )
+    return scores.to(torch.bfloat16), lens
+
+
+def _check(scores, lens, table, page_size, out):
+    """Every row: min(k, len) valid slots, the rest -1; slots invert to unique
+    in-row indices whose values are torch's top-k values."""
+    k = out.shape[1]
+    nblocks = MAX_SEQ // page_size
+    inv = torch.empty_like(table)
+    inv.scatter_(
+        1,
+        table.long(),
+        torch.arange(nblocks, device="cuda", dtype=torch.int32).expand_as(table),
+    )
+    for b in range(scores.shape[0]):
+        n = min(k, int(lens[b]))
+        chosen = out[b] >= 0
+        assert int(chosen.sum()) == n, (
+            f"row {b}: {int(chosen.sum())} selected, want {n}"
+        )
+        slots = out[b][chosen].long()
+        idx = inv[b][slots // page_size].long() * page_size + slots % page_size
+        assert bool((idx < int(lens[b])).all()), f"row {b}: index past the row"
+        assert idx.unique().numel() == n, f"row {b}: duplicate index"
+        got = scores[b, idx].float().sort(descending=True).values
+        ref = scores[b, : int(lens[b])].float().topk(n).values
+        assert torch.equal(got, ref), f"row {b}: selected values differ from torch.topk"
+
+
+@pytest.mark.parametrize("page_mode", ["identity", "perm"])
+@pytest.mark.parametrize("ties", [False, True])
+@pytest.mark.parametrize("k", [512, 2048])
+@pytest.mark.parametrize("batch,seq", CONFIGS)
+def test_topk_bf16(
+    batch: int, seq: int, k: int, ties: bool, page_mode: str
+) -> None:
+    page_size = 8
+    scores, lens = _rows(batch, seq, k, ties, ragged=False)
+    nblocks = MAX_SEQ // page_size
+    if page_mode == "identity":
+        table = torch.arange(nblocks, device="cuda", dtype=torch.int32).repeat(batch, 1)
+    else:
+        table = torch.stack(
+            [torch.randperm(nblocks, device="cuda") for _ in range(batch)]
+        ).to(torch.int32)
+    out = torch.full((batch, k), -7, dtype=torch.int32, device="cuda")
+    topk_transform_bf16_small(scores, lens, table, out, page_size)
+    torch.cuda.synchronize()
+    _check(scores, lens, table, page_size, out)
+
+
+@pytest.mark.parametrize("page_size", [8, 64])
+def test_topk_bf16_ragged_lengths(page_size: int) -> None:
+    batch, k = 64, 512
+    scores, lens = _rows(batch, MAX_SEQ, k, ties=False, ragged=True)
+    nblocks = MAX_SEQ // page_size
+    table = torch.stack(
+        [torch.randperm(nblocks, device="cuda") for _ in range(batch)]
+    ).to(torch.int32)
+    out = torch.full((batch, k), -7, dtype=torch.int32, device="cuda")
+    topk_transform_bf16_small(scores, lens, table, out, page_size)
+    torch.cuda.synchronize()
+    _check(scores, lens, table, page_size, out)
+
+
+def test_topk_bf16_padded_output() -> None:
+    """The output may be a view whose last dimension was padded."""
+    batch, k, page_size = 3, 512, 8
+    scores, lens = _rows(batch, MAX_SEQ, k, ties=False, ragged=False)
+    table = torch.arange(MAX_SEQ // page_size, device="cuda", dtype=torch.int32).repeat(
+        batch, 1
+    )
+    buf = torch.full((batch, k + 64), -7, dtype=torch.int32, device="cuda")
+    out = buf[:, :k]
+    topk_transform_bf16_small(scores, lens, table, out, page_size)
+    torch.cuda.synchronize()
+    assert bool((buf[:, k:] == -7).all()), "wrote past the view"
+    _check(scores, lens, table, page_size, out)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/kernels/ops/attention/test_topk_bf16.py
+++ b/test/registered/kernels/ops/attention/test_topk_bf16.py
@@ -84,9 +84,7 @@ def _check(scores, lens, table, page_size, out):
 @pytest.mark.parametrize("ties", [False, True])
 @pytest.mark.parametrize("k", [512, 2048])
 @pytest.mark.parametrize("batch,seq", CONFIGS)
-def test_topk_bf16(
-    batch: int, seq: int, k: int, ties: bool, page_mode: str
-) -> None:
+def test_topk_bf16(batch: int, seq: int, k: int, ties: bool, page_mode: str) -> None:
     page_size = 8
     scores, lens = _rows(batch, seq, k, ties, ragged=False)
     nblocks = MAX_SEQ // page_size

--- a/test/registered/kernels/test_dsv4_indexer_postprocess.py
+++ b/test/registered/kernels/test_dsv4_indexer_postprocess.py
@@ -2,7 +2,10 @@ import unittest
 
 import torch
 
-from sglang.kernels.ops.attention.dsv4.candidate_blocks import candidate_block_logits
+from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+    candidate_block_logits,
+    candidate_row_lens,
+)
 from sglang.kernels.ops.attention.dsv4.indexer_postprocess import filter_topk_pages
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -21,6 +24,29 @@ def reference_pages(scores, indices, pages, page_size):
 
 
 class TestIndexerPostprocess(CustomTestCase):
+    def test_candidate_row_lens(self):
+        lens = torch.tensor(
+            [1, 7, 8, 9, 300, 16383, 16384, 16385, 16392, 40000, 1048576, 1048571],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        for topk in (2048, 256, 1):
+            nblocks, valid = candidate_row_lens(lens, topk)
+            ref_blocks = (lens + 7) // 8
+            kept = ref_blocks.clamp_max(topk)
+            ref_valid = 8 * (kept - 1) + (lens - 1) % 8 + 1
+            self.assertEqual(nblocks.dtype, torch.int32)
+            self.assertTrue(torch.equal(nblocks, ref_blocks))
+            self.assertTrue(torch.equal(valid, ref_valid))
+            # a row with all its blocks kept is the whole row
+            fits = ref_blocks <= topk
+            self.assertTrue(torch.equal(valid[fits], lens[fits]))
+        nblocks, valid = candidate_row_lens(
+            torch.zeros(3, dtype=torch.int32, device="cuda"), 2048
+        )
+        self.assertTrue(torch.equal(nblocks, torch.zeros_like(nblocks)))
+        self.assertTrue(torch.equal(valid, torch.zeros_like(valid)))
+
     def test_filter_and_page_mapping(self):
         torch.manual_seed(91)
         for rows in (1, 6, 64):


### PR DESCRIPTION
DeepSeek-V4.1's low-ratio indexer is two-level: the candidate-source layer (layer 20) scores every visible compressed position and publishes, per query row, the `candidate_topk_blocks` best `candidate_block_size`-position blocks; the index-source layers after it (24/28/32/36) select their top-k only inside those blocks. Until now the consumers still computed dense logits over the whole context and masked everything outside the candidates. This PR routes the consumers through DeepGEMM's new `fp8_fp4_paged_sparse_mqa_logits`, which scores only the published blocks.

## What this enables

- `SGLANG_DSV41_DEEP_GEMM_CANDIDATE_INDEXER=1` (default off) switches the paged fp4 decode path (SM100, decode and target-verify) to the DeepGEMM sparse indexer: layer 20 runs its own top-k and publishes an ascending logical block table plus DeepGEMM's schedule for it; layers 24/28/32/36 score the published blocks only and select inside that row. Requires a DeepGEMM that provides `get_paged_sparse_mqa_logits_metadata` / `fp8_fp4_paged_sparse_mqa_logits` (upstream `66081d4` or later); the user is responsible for that when turning the flag on.
- With the flag on, the SM100 low-ratio index-K pool pages at 128 slots instead of 64 (128 x 68 B is a multiple of 512 B, the sparse kernel's page-stride requirement); the JIT paged-logits metadata builder accepts both page sizes.
- Adds `topk_bf16_small`, a JIT bf16 top-k transform for rows of at most 16384 scores with a fused page-table transform, used to select inside the sparse row.

## Structure

- `dsv4/candidate_indexer.py`: the interface (`CandidateMetadata`, `IndexerInputs`, `make_candidate_indexer`, chosen once at backend init).
- `dsv4/candidate_torch.py`: the model code's algorithm (bool masks over positions), the default. `two_level_decode_logits` moves here from the backend, keeping the Triton `candidate_block_logits` fast path.
- `dsv4/candidate_deep_gemm.py`: the DeepGEMM implementation (`SparseBlockTable`: block table + schedule + physical blocks). The level-one block selection is still a torch composition (`amax_topk_blocks`, marked TODO).
- `DSV4Metadata.candidate_metadata`: one slot for whatever the source published, in the implementation's own type; written by layer 20, read by the layers after it, never copied from the host. The former backend-level `candidate_masks` state moves there.
- The backend's `_low_ratio_index_topk_decode` becomes: consumer -> `select_decode`; source -> `publish_decode`; everything else the plain top-k as before. The short-context CUDA-graph variants keep selecting every position and never touch the candidate path.

**Unchanged**: prefill and the Hopper decode path keep the existing mask-based selection (same results), only their state now lives on the forward metadata.

## Tests

- `test/registered/kernels/ops/attention/test_topk_bf16.py`: the bf16 top-k against `torch.topk` across row lengths, ties, page tables and padded outputs.
- `test/registered/attention/unittests/dsv4/test_dsv41_sparse_indexer.py`: level one against the model code's `select_candidate_blocks`; with a DeepGEMM that has the sparse kernel, the sparse logits against DeepGEMM's dense bf16 logits at the published positions (bitwise) and the consumer's selection against a torch reference.
- Existing dsv4 prefill / fused-compress tests unchanged and passing.

## Follow-ups

Level-one kernel (block amax + top-k) instead of the torch composition; prefill through the same implementations; end-to-end validation once the DeepGEMM dependency carries the sparse kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34632077104](https://github.com/sgl-project/sglang/actions/runs/34632077104)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34632076753](https://github.com/sgl-project/sglang/actions/runs/34632076753)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34632077042](https://github.com/sgl-project/sglang/actions/runs/34632077042)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->