### PR TITLE
fix(kv-events): retry replay batches under backpressure

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -24,7 +24,7 @@ import queue
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections import deque
+from collections import OrderedDict, deque
 from itertools import count
 from queue import Queue
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
@@ -345,10 +345,18 @@ class NullEventPublisher(EventPublisher):
         return
 
 
+class _ReplayState(msgspec.Struct):
+    batches: deque[tuple[int, bytes]]
+    last_progress: float
+
+
 class ZmqEventPublisher(EventPublisher):
     """Reliable PUB/ROUTER publisher with an in-memory replay buffer.
 
     Spawns a separate thread to handle publishing from a queue.
+    Replay sends are nonblocking and resume after backpressure. Pending replays
+    retain a bounded number of history snapshots and expire after 30 seconds
+    without send progress; abandoned replays do not send a completion marker.
 
     Parameters
     ----------
@@ -371,6 +379,9 @@ class ZmqEventPublisher(EventPublisher):
 
     SHUTDOWN_TIMEOUT: float = 1.0
     END_SEQ = (-1).to_bytes(8, "big", signed=True)
+    MAX_PENDING_REPLAYS = 16
+    REPLAY_SEND_BUDGET = 256
+    REPLAY_IDLE_TIMEOUT = 30.0
 
     def __init__(
         self,
@@ -385,6 +396,7 @@ class ZmqEventPublisher(EventPublisher):
         # Storage
         self._event_queue = Queue[Optional[EventBatch]](maxsize=max_queue_size)
         self._buffer = deque[tuple[int, bytes]](maxlen=buffer_steps)
+        self._pending_replays: OrderedDict[bytes, _ReplayState] = OrderedDict()
 
         # ZMQ sockets
         self._ctx = zmq.Context.instance()
@@ -484,6 +496,8 @@ class ZmqEventPublisher(EventPublisher):
         # 3) works in our non‑blocking poll loop alongside PUB
         if self._replay_endpoint is not None:
             self._replay = self._ctx.socket(zmq.ROUTER)
+            # Default ROUTER sends silently drop messages at the peer's HWM.
+            self._replay.setsockopt(zmq.ROUTER_MANDATORY, 1)
             logger.debug(
                 f"ZmqEventPublisher socket replay_endpoint bind to {self._replay_endpoint}"
             )
@@ -497,7 +511,7 @@ class ZmqEventPublisher(EventPublisher):
 
         while self._running or self._event_queue.qsize() > 0:
             # --- replay (non-critical) ---------------------------------
-            if self._replay is not None and self._replay.poll(0):
+            if self._replay is not None:
                 try:
                     self._service_replay()
                 except Exception as e:
@@ -527,7 +541,50 @@ class ZmqEventPublisher(EventPublisher):
                 time.sleep(0.1)
 
     def _service_replay(self) -> None:
-        """If a replay request is waiting, send buffered batches."""
+        """Advance bounded replay work without blocking live publication."""
+        assert self._replay is not None
+
+        if len(self._pending_replays) < self.MAX_PENDING_REPLAYS and self._replay.poll(
+            0, zmq.POLLIN
+        ):
+            self._receive_replay_request()
+
+        budget = self.REPLAY_SEND_BUDGET
+        for _ in range(len(self._pending_replays)):
+            if budget == 0:
+                break
+            client_id, state = self._pending_replays.popitem(last=False)
+            if time.monotonic() - state.last_progress >= self.REPLAY_IDLE_TIMEOUT:
+                logger.warning("Replay expired without send progress for %r", client_id)
+                continue
+
+            while budget > 0:
+                budget -= 1
+                if state.batches:
+                    seq, payload = state.batches[0]
+                    seq_bytes = seq.to_bytes(8, "big")
+                else:
+                    seq_bytes, payload = self.END_SEQ, b""
+                try:
+                    self._replay.send_multipart(
+                        (client_id, b"", seq_bytes, payload), flags=zmq.DONTWAIT
+                    )
+                except zmq.Again:
+                    # Keep the unsent batch (including the terminal marker).
+                    self._pending_replays[client_id] = state
+                    break
+                except zmq.ZMQError as error:
+                    logger.warning("Abandoning replay for %r: %s", client_id, error)
+                    break
+
+                state.last_progress = time.monotonic()
+                if not state.batches:
+                    break  # The terminal marker was accepted by the socket.
+                state.batches.popleft()
+            else:
+                self._pending_replays[client_id] = state
+
+    def _receive_replay_request(self) -> None:
         assert self._replay is not None  # narrows type for mypy
 
         frame = self._replay.recv_multipart()
@@ -537,17 +594,12 @@ class ZmqEventPublisher(EventPublisher):
         client_id, _, start_seq_bytes = frame
         start_seq = int.from_bytes(start_seq_bytes, "big")
 
-        for seq, buf in self._buffer:
-            if seq >= start_seq:
-                # [identity, empty_delim, seq_bytes, payload]
-                # (identity, empty_delim) are stripped off by the router
-                # receiving payload is (seq_bytes, payload)
-                self._replay.send_multipart(
-                    (client_id, b"", seq.to_bytes(8, "big"), buf)
-                )
-        # Send end of sequence marker
-        # receiving payload is (-1, b""")
-        self._replay.send_multipart((client_id, b"", self.END_SEQ, b""))
+        # Pin this request's retained payloads while live events rotate the buffer.
+        # Admission and idle limits bound the number and lifetime of snapshots.
+        self._pending_replays[client_id] = _ReplayState(
+            batches=deque((seq, buf) for seq, buf in self._buffer if seq >= start_seq),
+            last_progress=time.monotonic(),
+        )
 
     @staticmethod
     def offset_endpoint_port(

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -7,9 +7,14 @@ the router can subscribe per replica (the `dp_size` it reads from
 `/server_info`).
 """
 
+import time
 import unittest
+from collections import OrderedDict, deque
+from queue import Queue
+from unittest.mock import patch
 
 import msgspec
+import zmq
 
 from sglang.srt.disaggregation.kv_events import (
     BlockStored,
@@ -222,6 +227,171 @@ class TestBlockStoredWireFormat(CustomTestCase):
             msgspec.msgpack.encode(batch), type=KVEventBatch
         )
         self.assertEqual(round_tripped.events[0].block_hashes, [123])
+
+
+class TestZmqReplayBackpressure(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.ctx = zmq.Context()
+        self.addCleanup(self.ctx.destroy, linger=0)
+        # Exercise the real socket setup and replay loop on the test thread.
+        self.publisher = ZmqEventPublisher.__new__(ZmqEventPublisher)
+        self.publisher._ctx = self.ctx
+        self.publisher._pub = None
+        self.publisher._replay = None
+        self.publisher._endpoint = "inproc://live"
+        self.publisher._replay_endpoint = "inproc://replay"
+        self.publisher._hwm = 100
+        self.publisher._buffer = deque(maxlen=1024)
+        self.publisher._pending_replays = OrderedDict()
+        socket_factory = zmq.Context.socket
+
+        def low_hwm_socket(context, socket_type):
+            socket = socket_factory(context, socket_type)
+            if socket_type == zmq.ROUTER:
+                socket.setsockopt(zmq.SNDHWM, 1)
+            return socket
+
+        with patch.object(zmq.Context, "socket", low_hwm_socket):
+            self.publisher._socket_setup()
+
+    def _client(self, identity=b"reader"):
+        client = self.ctx.socket(zmq.DEALER)
+        client.setsockopt(zmq.IDENTITY, identity)
+        client.setsockopt(zmq.RCVHWM, 1)
+        client.connect("inproc://replay")
+        return client
+
+    def _request(self, client, start=0):
+        client.send_multipart((b"", start.to_bytes(8, "big")))
+        self.assertTrue(self.publisher._replay.poll(1000, zmq.POLLIN))
+        self.publisher._service_replay()
+
+    def _collect(self, client):
+        frames = []
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            while client.poll(0, zmq.POLLIN):
+                message = client.recv_multipart()
+                frames.append(message)
+                if message == [b"", self.publisher.END_SEQ, b""]:
+                    return frames
+            self.publisher._service_replay()
+            client.poll(1, zmq.POLLIN)
+        self.fail("Replay did not deliver its terminal marker")
+
+    def test_full_queue_retries_tail_and_pins_requested_history(self):
+        batches = [(seq, f"batch-{seq}".encode()) for seq in range(1024)]
+        self.publisher._buffer.extend(batches)
+        client = self._client()
+        self._request(client)
+        self.assertIn(b"reader", self.publisher._pending_replays)
+
+        # New live events can evict every original batch during a slow replay.
+        self.publisher._buffer.extend((seq, b"new") for seq in range(1024, 2048))
+        frames = self._collect(client)
+        self.assertEqual(
+            frames,
+            [[b"", seq.to_bytes(8, "big"), payload] for seq, payload in batches]
+            + [[b"", self.publisher.END_SEQ, b""]],
+        )
+        self.assertFalse(self.publisher._pending_replays)
+
+    def test_terminal_marker_is_retried_when_queue_is_full(self):
+        # Inproc capacity is the sender HWM + receiver HWM, both set to one.
+        self.publisher._buffer.extend([(0, b"first"), (1, b"second")])
+        client = self._client()
+        self._request(client)
+        self.assertIn(b"reader", self.publisher._pending_replays)
+        self.assertFalse(self.publisher._pending_replays[b"reader"].batches)
+        self.assertEqual(
+            self._collect(client),
+            [
+                [b"", (0).to_bytes(8, "big"), b"first"],
+                [b"", (1).to_bytes(8, "big"), b"second"],
+                [b"", self.publisher.END_SEQ, b""],
+            ],
+        )
+
+    def test_stalled_reader_does_not_block_another_reader(self):
+        self.publisher._buffer.extend((seq, b"data") for seq in range(16))
+        stalled = self._client(b"stalled")
+        self._request(stalled)
+        healthy = self._client(b"healthy")
+        self._request(healthy)
+        frames = self._collect(healthy)
+        self.assertEqual(len(frames), 17)
+        self.assertEqual(
+            [int.from_bytes(frame[1], "big") for frame in frames[:-1]],
+            list(range(16)),
+        )
+        self.assertIn(b"stalled", self.publisher._pending_replays)
+
+    def test_stalled_replay_does_not_block_live_publication(self):
+        self.publisher._buffer.extend((seq, b"data") for seq in range(16))
+        client = self._client()
+        self._request(client)
+        subscriber = self.ctx.socket(zmq.SUB)
+        subscriber.setsockopt(zmq.SUBSCRIBE, b"")
+        subscriber.connect("inproc://live")
+        publisher = self.publisher
+        publisher._running = True
+        publisher._seq_gen = iter([16])
+        publisher._topic_bytes = b""
+        publisher._event_queue = Queue()
+        publisher._event_queue.put(KVEventBatch(ts=1.0, events=[]))
+        publisher._event_queue.put(None)
+        publisher._publisher_thread()
+        self.assertTrue(subscriber.poll(1000, zmq.POLLIN))
+        frames = subscriber.recv_multipart()
+        self.assertEqual(frames[:2], [b"", (16).to_bytes(8, "big")])
+        self.assertEqual(msgspec.msgpack.decode(frames[2], type=KVEventBatch).ts, 1.0)
+        self.assertIn(b"reader", publisher._pending_replays)
+
+    def test_send_budget_yields_before_finishing_replay(self):
+        self.publisher.REPLAY_SEND_BUDGET = 1
+        self.publisher._buffer.extend([(0, b"old"), (1, b"first"), (2, b"second")])
+        client = self._client()
+        self._request(client, start=1)
+        self.assertEqual(
+            list(self.publisher._pending_replays[b"reader"].batches), [(2, b"second")]
+        )
+        self.assertEqual(
+            self._collect(client),
+            [
+                [b"", (1).to_bytes(8, "big"), b"first"],
+                [b"", (2).to_bytes(8, "big"), b"second"],
+                [b"", self.publisher.END_SEQ, b""],
+            ],
+        )
+
+    def test_idle_replay_expires_and_releases_admission_slot(self):
+        self.publisher.MAX_PENDING_REPLAYS = 1
+        self.publisher._buffer.extend((seq, b"data") for seq in range(16))
+        stalled = self._client(b"stalled")
+        self._request(stalled)
+        healthy = self._client(b"healthy")
+        self._request(healthy)
+        self.assertEqual(list(self.publisher._pending_replays), [b"stalled"])
+        state = self.publisher._pending_replays[b"stalled"]
+        with patch(
+            "sglang.srt.disaggregation.kv_events.time.monotonic",
+            return_value=state.last_progress + self.publisher.REPLAY_IDLE_TIMEOUT,
+        ):
+            self.publisher._service_replay()
+        self.assertNotIn(b"stalled", self.publisher._pending_replays)
+        self.assertEqual(len(self._collect(healthy)), 17)
+
+    def test_disconnected_reader_does_not_retain_replay(self):
+        self.publisher._buffer.extend((seq, b"data") for seq in range(16))
+        client = self._client()
+        self._request(client)
+        client.close(linger=0)
+        deadline = time.monotonic() + 1
+        while self.publisher._pending_replays and time.monotonic() < deadline:
+            self.publisher._service_replay()
+            time.sleep(0.001)
+        self.assertFalse(self.publisher._pending_replays)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prevent the KV-event replay publisher from silently dropping batches and its completion marker when a slow reader fills the outgoing queue.

## Motivation

The replay ROUTER socket uses ZeroMQ's default behavior: sends to a peer at its high-water mark silently discard messages. `_service_replay` previously sent the entire retained history and terminal marker without backpressure handling. Increasing the live PUB socket's `hwm` does not change this replay socket.

A local reproduction with 1,024 retained batches and deliberately small inproc socket queues delivered only 2 batches and no terminal marker on the unpatched source. [ZeroMQ documents this ROUTER behavior](https://libzmq.readthedocs.io/en/latest/zmq_setsockopt.html#zmq-router-mandatory-accept-only-routable-messages-on-router-sockets).

## Modifications

- Enable `ROUTER_MANDATORY` and use nonblocking replay sends. Preserve the next unsent batch on `EAGAIN`, including the terminal marker.
- Advance pending replays on subsequent publisher-loop iterations, with a shared 256-send budget and rotation between clients so replay yields to live publication.
- Retain references to each accepted request's history snapshot while live events rotate the replay buffer. Limit pending snapshots to 16; discard disconnected clients and expire replays after 30 seconds without send progress, without emitting a completion marker.
- Add seven CPU regression tests to the existing registered KV-events test module: queue saturation/history rotation, terminal retry, independent readers, continued live publication, send budget/nonzero start sequence, admission/idle expiry, and disconnect cleanup.

The existing replay request, response, and terminal wire formats are unchanged. This repair does not add recovery for history that expired before a replay request or receiver-side completeness certification.

## Validation

- Unpatched source reproduction: 2/1,024 batches received, no completion marker, with both inproc socket high-water marks set to one.
- Patched regression: all 1,024 batches arrive in order followed by the completion marker, even after the original history is evicted by live events.
- All 21 tests in `test/registered/unit/disaggregation/test_kv_events.py` pass in an isolated CPU harness using the actual publisher code and real ZeroMQ sockets. The harness bypassed SGLang package bootstrap and substituted `unittest.TestCase` for the CI retry/reporting base; the full installed SGLang test environment was not built or run. The committed tests retain normal `CustomTestCase` and CPU CI registration.
- All applicable pre-commit hooks pass for the two changed files; `git diff --check` passes. Repository-wide hooks were not run.

## Accuracy Tests

Not applicable: no model-forward or numerical changes.

## Speed Tests and Profiling

No model-serving benchmark run. The regression tests verify that a blocked replay reader does not prevent a live cache-event batch from being published.

## Checklist

- [x] Format changed files with pre-commit.
- [x] Add focused unit tests in the existing CPU-registered module.
- [x] Document replay backpressure and expiry behavior in the publisher docstring.
- [ ] Run full-environment tests / serving benchmarks (not run; see Validation).
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34532010028](https://github.com/sgl-project/sglang/actions/runs/34532010028)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34532009807](https://github.com/sgl-project/sglang/actions/runs/34532009807)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34532009951](https://github.com/sgl-project/sglang/actions/runs/34532009951)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->