### PR TITLE
[Refactor] Remove prerelease DeepSeek V4.1 config aliases

### DIFF
--- a/python/sglang/srt/configs/deepseek_v41.py
+++ b/python/sglang/srt/configs/deepseek_v41.py
@@ -80,15 +80,6 @@ class DeepseekV41TextConfig(DeepseekV41Config):
 class DeepseekV41VisionConfig(PretrainedConfig):
     model_type = "deepseek_v41_vision"
 
-    def __init__(self, **kwargs):
-        kwargs["model_type"] = "deepseek_v41_vision"
-        super().__init__(**kwargs)
-
-    def to_dict(self):
-        values = super().to_dict()
-        values["model_type"] = "deepseek_v41_vision"
-        return values
-
 
 DEEPSEEK_V41_CONFIG_CLASSES = (
     DeepseekV41Config,

--- a/python/sglang/srt/configs/deepseek_v41.py
+++ b/python/sglang/srt/configs/deepseek_v41.py
@@ -2,14 +2,6 @@
 
 from transformers import DeepseekV3Config, PretrainedConfig
 
-_FIELD_ALIASES = {
-    "dspark_n_activated_experts": "dspark_num_experts_per_tok",
-    "kv_source_layers": "kv_source_layer_ids",
-    "index_source_layers": "index_source_layer_ids",
-    "candidate_source_layer": "candidate_source_layer_id",
-    "engram_pad_id": "engram_pad_token_id",
-}
-
 _VISION_FIELDS = {
     "num_hidden_layers": "vision_n_layers",
     "hidden_size": "vision_dim",
@@ -24,40 +16,26 @@ _VISION_FIELDS = {
 }
 
 
-def normalize_deepseek_v4_fields(values):
-    values = dict(values)
-    for old, new in _FIELD_ALIASES.items():
-        if old in values:
-            legacy_value = values.pop(old)
-            values.setdefault(new, legacy_value)
-    return values
-
-
 def _config_dict(config):
     return config.to_dict() if isinstance(config, PretrainedConfig) else dict(config)
 
 
 def normalize_deepseek_v41_config(values):
-    values = normalize_deepseek_v4_fields(values)
+    values = dict(values)
     text = values.pop("text_config", None)
     vision = values.pop("vision_config", None)
     if text is not None:
-        text = normalize_deepseek_v4_fields(_config_dict(text))
+        text = _config_dict(text)
         text.pop("model_type", None)
         values = {**text, **values}
     if vision is not None:
         vision = _config_dict(vision)
-        if "max_num_tokens" in vision:
-            vision.setdefault("max_image_tokens", vision["max_num_tokens"])
         for source, target in _VISION_FIELDS.items():
             if source in vision:
                 values.setdefault(target, vision[source])
     if "model_type" in values:
         values["model_type"] = "deepseek_v41"
-    if values.get("architectures") in (
-        ["DeepseekV41ForCausalLM"],
-        ["DeepseekV41ForConditionalGeneration"],
-    ):
+    if values.get("architectures") == ["DeepseekV41ForCausalLM"]:
         values["architectures"] = ["DeepseekV4ForCausalLM"]
     return values
 
@@ -103,9 +81,6 @@ class DeepseekV41VisionConfig(PretrainedConfig):
     model_type = "deepseek_v41_vision"
 
     def __init__(self, **kwargs):
-        if "max_num_tokens" in kwargs:
-            legacy_value = kwargs.pop("max_num_tokens")
-            kwargs.setdefault("max_image_tokens", legacy_value)
         kwargs["model_type"] = "deepseek_v41_vision"
         super().__init__(**kwargs)
 
@@ -115,26 +90,8 @@ class DeepseekV41VisionConfig(PretrainedConfig):
         return values
 
 
-class LegacyDeepseekV41Config(DeepseekV41Config):
-    model_type = "deepseek_v4.1"
-    __init__ = DeepseekV41Config.__init__
-
-
-class LegacyDeepseekV41TextConfig(DeepseekV41TextConfig):
-    model_type = "deepseek_v4.1_text"
-    __init__ = DeepseekV41Config.__init__
-
-
-class LegacyDeepseekV41VisionConfig(DeepseekV41VisionConfig):
-    model_type = "deepseek_v4.1_vision"
-    __init__ = DeepseekV41VisionConfig.__init__
-
-
 DEEPSEEK_V41_CONFIG_CLASSES = (
     DeepseekV41Config,
     DeepseekV41TextConfig,
     DeepseekV41VisionConfig,
-    LegacyDeepseekV41Config,
-    LegacyDeepseekV41TextConfig,
-    LegacyDeepseekV41VisionConfig,
 )

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -74,10 +74,7 @@ from sglang.srt.configs import (
     XllmConfig,
 )
 from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
-from sglang.srt.configs.deepseek_v41 import (
-    DEEPSEEK_V41_CONFIG_CLASSES,
-    normalize_deepseek_v4_fields,
-)
+from sglang.srt.configs.deepseek_v41 import DEEPSEEK_V41_CONFIG_CLASSES
 from sglang.srt.configs.internvl import InternVLChatConfig
 from sglang.srt.utils import get_bool_env_var, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
@@ -183,9 +180,6 @@ try:
         engram_head_dim = 0
         engram_pad_token_id = 2
         engram_compressed_vocab_size = 0
-
-        def __init__(self, **kwargs):
-            super().__init__(**normalize_deepseek_v4_fields(kwargs))
 
     _CONFIG_REGISTRY["deepseek_v32"] = _DeepseekV32ConfigAlias
     _CONFIG_REGISTRY["deepseek_v4"] = _DeepseekV4ConfigAlias


### PR DESCRIPTION
- Stack on #38798 with base `dsv4.1`. The public [DeepSeek-V4.1-Flash config](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/dba1be0a40aa45a94ad051997016db3960a90277/config.json) uses the canonical names.
- Remove the three dotted `deepseek_v4.1*` registrations, five prerelease field aliases, `vision_config.max_num_tokens` fallback, and `DeepseekV41ForConditionalGeneration` alias. Old internal checkpoint configs must be migrated to the official names.
- Let the canonical vision config inherit construction and serialization from `PretrainedConfig` after removing its legacy conversion.
- Preserve canonical nested config flattening, vision field mapping, `DeepseekV41ForCausalLM` routing, config overrides, and save/reload behavior. Keep the existing V4/V3.2 registrations.
- Validation: 144 passed, 1 skipped, 25 subtests. The unmodified public config produces identical full config snapshots before and after this cleanup for main/DSpark draft construction, nested overrides, save/reload, text/vision subconfigs, and V4/V3.2 registration. Formatting and lint checks passed. GPU weight loading was not rerun for this cleanup.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34534472878](https://github.com/sgl-project/sglang/actions/runs/34534472878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34534472729](https://github.com/sgl-project/sglang/actions/runs/34534472729)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34534472990](https://github.com/sgl-project/sglang/actions/runs/34534472990)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->