### PR TITLE
DeepSeek V4.1: build the tool-call structural tag with the spaced DSML names

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2294,14 +2294,17 @@ class OpenAIServingChat(OpenAIServingBase):
                         return ToolCallProcessingResult(None, text, finish_reason)
 
                     tool_calls = []
-                    for call_info in call_info_list:
+                    for index, call_info in enumerate(call_info_list):
                         tool_id = self._process_tool_call_id(
                             call_info, history_tool_calls_cnt
                         )
+                        # index is the call's position in tool_calls, as in the
+                        # streaming deltas; tool_index is the tool's position
+                        # in the request for some detectors.
                         tool_calls.append(
                             ToolCall(
                                 id=tool_id,
-                                index=getattr(call_info, "tool_index", None),
+                                index=index,
                                 function=FunctionResponse(
                                     name=call_info.name,
                                     arguments=call_info.parameters,

--- a/python/sglang/srt/function_call/deepseekv41_detector.py
+++ b/python/sglang/srt/function_call/deepseekv41_detector.py
@@ -1,5 +1,7 @@
-from typing import Optional
+from typing import List, Literal, Optional, Union
 
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+from sglang.srt.function_call.base_format_detector import StructuralTag
 from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
 
 
@@ -13,7 +15,91 @@ class DeepSeekV41Detector(DeepSeekV32Detector):
     invoke_tag_name = " invoke"
     parameter_tag_name = " parameter"
 
+    # The encoder joins an assistant turn's content and its calls block with a
+    # blank line, and renders it even when there is no content.
+    tool_calls_prefix = "\n\n"
+    think_end_token = "</think>"
+
     def get_structural_tag_name(self) -> Optional[str]:
-        # xgrammar's builtin "deepseek_v4" tag is the unspaced grammar; fall
-        # back to structure_info so constrained decoding uses the spaced tags.
+        # xgrammar's builtin "deepseek_v4" tag hardcodes the unspaced names,
+        # so the V4.1 tag is assembled in get_structural_tag instead.
         return None
+
+    def get_structural_tag(
+        self,
+        tools: Union[List[Tool], None] = None,
+        tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
+        thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
+    ) -> Optional[StructuralTag]:
+        """The builtin "deepseek_v4" shape with the spaced tag names.
+
+        Bodies are JSON: xgrammar's "deepseek_xml" body style also hardcodes
+        the unspaced " parameter" name, and the V3.2-lineage parser accepts a
+        JSON body inside an invoke.
+        """
+        try:
+            from xgrammar.structural_tag import (
+                AnyTextFormat,
+                ConstStringFormat,
+                JSONSchemaFormat,
+                OrFormat,
+                SequenceFormat,
+                StructuralTag,
+                TagFormat,
+                TagsWithSeparatorFormat,
+                TriggeredTagsFormat,
+            )
+        except ImportError:
+            return None
+
+        tools = list(tools or [])
+        if isinstance(tool_choice, ToolChoice):
+            tools = [
+                tool for tool in tools if tool.function.name == tool_choice.function.name
+            ]
+            if len(tools) != 1:
+                return None
+        if not tools:
+            return None
+
+        def invoke_tag(tool: Tool) -> TagFormat:
+            function = tool.function
+            schema = function.parameters if function.strict else True
+            if schema is None:
+                schema = True
+            return TagFormat(
+                begin=f'{self.invoke_start_token} name="{function.name}">',
+                content=JSONSchemaFormat(json_schema=schema),
+                end=f"{self.invoke_end_token}\n",
+            )
+
+        tags = [invoke_tag(tool) for tool in tools]
+        if isinstance(tool_choice, ToolChoice):
+            calls = tags[0]
+        elif parallel_tool_calls:
+            calls = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+        else:
+            calls = OrFormat(elements=tags)
+        block_begin = f"{self.bot_token}\n"
+
+        if tool_choice == "auto":
+            body = TriggeredTagsFormat(
+                triggers=[self.bot_token],
+                tags=[TagFormat(begin=block_begin, content=calls, end=self.eot_token)],
+                excludes=["<think>", self.think_end_token],
+            )
+        else:
+            body = SequenceFormat(
+                elements=[
+                    ConstStringFormat(value=self.tool_calls_prefix + block_begin),
+                    calls,
+                    ConstStringFormat(value=self.eot_token),
+                ]
+            )
+        if not thinking_mode:
+            return StructuralTag(format=body)
+        reasoning = TagFormat(
+            begin="", content=AnyTextFormat(), end=self.think_end_token
+        )
+        return StructuralTag(format=SequenceFormat(elements=[reasoning, body]))

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1813,6 +1813,40 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertEqual(tool_calls[1].id, "functions.get_weather:2")
             self.assertEqual(tool_calls[1].function.name, "get_weather")
 
+    def test_non_streaming_tool_call_index_is_the_call_ordinal(self):
+        """Two calls to the same tool must be numbered 0 and 1, as the
+        streaming deltas number them; a detector's tool_index is the tool's
+        position in the request and is 0 for both."""
+        self.chat.tool_call_parser = "deepseekv41"
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
+        ) as ParserMock:
+            parser_instance = ParserMock.return_value
+            calls = []
+            for city in ("San Francisco", "London"):
+                call_info = Mock()
+                call_info.name = "get_weather"
+                call_info.parameters = json.dumps({"location": city})
+                call_info.tool_index = 0
+                calls.append(call_info)
+            parser_instance.has_tool_call.return_value = True
+            parser_instance.parse_non_stream.return_value = ("", calls)
+
+            tool_calls, _, finish_reason = self.chat._process_tool_calls(
+                text="<｜DSML｜ calls>...",
+                tools=tools,
+                finish_reason={"type": "stop", "matched": None},
+                history_tool_calls_cnt=0,
+            )
+
+        self.assertEqual([tc.index for tc in tool_calls], [0, 1])
+        self.assertEqual(
+            [tc.function.arguments for tc in tool_calls],
+            [json.dumps({"location": "San Francisco"}), json.dumps({"location": "London"})],
+        )
+        self.assertEqual(finish_reason["type"], "tool_calls")
+
     def test_required_tool_choice_skips_json_fallback_for_native_parser(self):
         """A structural-tag parser owns the output format, so a missing tool
         call must not be pushed through the json_schema array fallback."""

--- a/test/registered/unit/function_call/test_deepseekv41_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv41_detector.py
@@ -3,7 +3,13 @@
 import json
 
 from sglang.srt.entrypoints.openai import encoding_dsv41
-from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+    ToolChoice,
+    ToolChoiceFuncName,
+)
+from sglang.srt.function_call.deepseekv41_detector import DeepSeekV41Detector
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -12,6 +18,7 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 CHUNK_SIZES = [1, 2, 3, 5, 7, 11, 23, 1000]
+DSML = "｜DSML｜"
 
 
 def _tools():
@@ -132,6 +139,72 @@ class TestDeepSeekV41RoundTrip(CustomTestCase):
                 # same for V4, so only the prose itself is pinned here.
                 self.assertEqual(normal.strip(), "summary")
                 self.assertEqual(_assemble(calls), self.expected)
+
+
+class TestDeepSeekV41ConstrainedDecoding(CustomTestCase):
+    """A forced call must open the calls block before the first invoke; the
+    per-tool legacy tag started the grammar at the invoke trigger, the model
+    closed a block it had not opened, and the parser dropped the call."""
+
+    def setUp(self):
+        self.tools = _tools()
+        self.detector = DeepSeekV41Detector()
+
+    def test_no_builtin_structural_tag(self):
+        """xgrammar's builtin deepseek_v4 tag is the unspaced grammar."""
+        self.assertIsNone(self.detector.get_structural_tag_name())
+        self.assertIsNone(self.detector.get_structural_tag([], "required"))
+
+    def test_required_tag_wraps_invokes_in_the_calls_block(self):
+        tag = self.detector.get_structural_tag(
+            tools=self.tools, tool_choice="required"
+        )
+        opener, calls, closer = tag.format.elements
+        self.assertEqual(opener.value, f"\n\n<{DSML} calls>\n")
+        self.assertEqual(closer.value, f"</{DSML} calls>")
+        self.assertTrue(calls.at_least_one)
+        self.assertEqual(
+            [t.begin for t in calls.tags],
+            [f'<{DSML} invoke name="get_weather">', f'<{DSML} invoke name="lookup">'],
+        )
+        self.assertEqual({t.end for t in calls.tags}, {f"</{DSML} invoke>\n"})
+
+    def test_named_tool_choice_keeps_only_that_tool(self):
+        tag = self.detector.get_structural_tag(
+            tools=self.tools,
+            tool_choice=ToolChoice(function=ToolChoiceFuncName(name="lookup")),
+        )
+        _, call, _ = tag.format.elements
+        self.assertEqual(call.begin, f'<{DSML} invoke name="lookup">')
+        self.assertEqual(call.type, "tag")
+
+    def test_parallel_off_allows_one_invoke(self):
+        tag = self.detector.get_structural_tag(
+            tools=self.tools, tool_choice="required", parallel_tool_calls=False
+        )
+        _, calls, _ = tag.format.elements
+        self.assertEqual(calls.type, "or")
+        self.assertEqual(len(calls.elements), 2)
+
+    def test_auto_tag_triggers_on_the_calls_block(self):
+        tag = self.detector.get_structural_tag(tools=self.tools, tool_choice="auto")
+        self.assertEqual(tag.format.triggers, [f"<{DSML} calls>"])
+        self.assertEqual(tag.format.tags[0].begin, f"<{DSML} calls>\n")
+        self.assertEqual(tag.format.tags[0].end, f"</{DSML} calls>")
+
+    def test_thinking_mode_prefixes_the_reasoning_span(self):
+        tag = self.detector.get_structural_tag(
+            tools=self.tools, tool_choice="required", thinking_mode=True
+        )
+        reasoning, body = tag.format.elements
+        self.assertEqual(reasoning.end, "</think>")
+        self.assertEqual(body.elements[0].value, f"\n\n<{DSML} calls>\n")
+
+    def test_parser_uses_the_native_tag_for_required(self):
+        parser = FunctionCallParser(self.tools, "deepseekv41")
+        kind, tag = parser.get_structure_constraint("required")
+        self.assertEqual(kind, "structural_tag")
+        self.assertEqual(tag.format.elements[0].value, f"\n\n<{DSML} calls>\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tool_choice=required, a named tool, and strict auto went through the legacy per-tool structural tag, which starts the grammar at the invoke trigger. The model was never allowed to open the calls block, closed one it had not opened, and the detector dropped the call (tool_calls null, finish_reason stop, raw DSML as content). Assemble the builtin deepseek_v4 shape with the V4.1 spaced tag names instead: blank line, calls block, one or more invokes (exactly one for a named tool, one of the set when parallel calls are off), JSON bodies. xgrammar 0.2.1's deepseek_xml body style hardcodes the unspaced parameter name, so bodies stay JSON, which the V3.2-lineage parser accepts.

Verified on 4x B300 with DeepSeek-V4.1-Flash on this branch: required (strict and not), strict auto, a named tool, two tools with parallel calls on and off all emit a well-formed block and parse; unit tests cover the tag shape.


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34539303204](https://github.com/sgl-project/sglang/actions/runs/34539303204)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34539302955](https://github.com/sgl-project/sglang/actions/runs/34539302955)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34539303133](https://github.com/sgl-project/sglang/actions/runs/34539303133)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->