### PR TITLE
[PD] Batch the decode-side KV preallocation and stage its lengths through pinned memory

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
+import msgspec
 import numpy as np
 import torch
 from torch.distributed import ProcessGroup
@@ -74,6 +75,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.base import pinned_int64_pair
 from sglang.srt.mem_cache.allocator.swa import is_swa_req_ring
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -305,6 +307,27 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
         self.mamba_allocator.clear()
 
 
+class _PreallocPlan(msgspec.Struct, kw_only=True):
+    """One request's KV preallocation, decided on the host before the batched
+    device allocation in `_alloc_planned` hands it its slots."""
+
+    req: Req
+    prefix_indices: Optional[torch.Tensor]
+    prefix_len: int  # device-resident (L1) prefix
+    total_prefix_len: int  # prefix promised to prefill (L1 + L2 + L3)
+    fill_len: int
+    delta_len: int  # fresh slots to allocate: fill_len - total_prefix_len
+    uses_swa_tail: bool
+    swa_tail_len: int
+    host_indices: Optional[torch.Tensor] = None  # hisparse: RDMA destination
+    kv_loc: Optional[torch.Tensor] = None  # set by _alloc_planned
+    # pop_preallocated bookkeeping carried from admission to transfer setup
+    decode_req: Optional[DecodeRequest] = None
+    queue_index: int = -1
+    origin_input_len: int = 0
+    prefix_match: Optional[DecodePrefixMatch] = None
+
+
 @dataclass
 class DecodeRequest:
     req: Req
@@ -435,16 +458,23 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             self.tree_cache.dec_lock_ref(req.last_node, req.lock_receipt)
 
     def _reclaim_swa_tail_capacity(
-        self, swa_tail_len: int, req_id: str
+        self, swa_tail_len: int, req_id: str, *, pending_swa_tokens: int = 0
     ) -> Optional[str]:
         page_size = self.token_to_kv_pool_allocator.page_size
         required = ceil_align(swa_tail_len, page_size)
-        available = self.token_to_kv_pool_allocator.swa_available_size()
+        # Planned requests have not taken their slots yet; their tails are
+        # spoken for.
+        available = (
+            self.token_to_kv_pool_allocator.swa_available_size() - pending_swa_tokens
+        )
         if available < required:
             self.tree_cache.evict_for_alloc(
                 EvictParams(swa_num_tokens=required - available)
             )
-            available = self.token_to_kv_pool_allocator.swa_available_size()
+            available = (
+                self.token_to_kv_pool_allocator.swa_available_size()
+                - pending_swa_tokens
+            )
 
         if available < required:
             return (
@@ -834,6 +864,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 count_retracted=False
             )
 
+        plans: List[_PreallocPlan] = []
+        pending_full_tokens = 0
+        pending_swa_tokens = 0
         for i, req in enumerate(self.retracted_queue):
             if rids_to_check is not None and req.rid not in rids_to_check:
                 continue
@@ -850,16 +883,28 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
-            self._pre_alloc(req)
+            plan = self._plan_prealloc(req, pending_full_tokens=pending_full_tokens)
+            plans.append(plan)
+            pending_full_tokens += self._required_alloc_tokens(
+                fill_len=plan.fill_len, prefix_len=plan.prefix_len
+            )
             full_allocatable_tokens -= full_required
             if uses_swa_tail_prealloc:
-                swa_allocatable_tokens = self._swa_tail_allocatable_token_budget(
-                    count_retracted=False,
-                    extra_reserved_reqs=len(resumed_reqs),
+                pending_swa_tokens += ceil_align(
+                    plan.swa_tail_len, self.token_to_kv_pool_allocator.page_size
+                )
+                swa_allocatable_tokens = (
+                    self._swa_tail_allocatable_token_budget(
+                        count_retracted=False,
+                        extra_reserved_reqs=len(resumed_reqs),
+                    )
+                    - pending_swa_tokens
                 )
 
+        self._alloc_planned(plans)
+        for plan in plans:
             retraction_restore(
-                req,
+                plan.req,
                 self.tree_cache,
                 self.req_to_token_pool,
                 self.token_to_kv_pool_allocator,
@@ -1178,7 +1223,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 - len(self.transfer_queue.queue),
             )
 
-        # Then, preallocate the remaining requests if possible
+        # Then, preallocate the remaining requests if possible. Admission and
+        # host bookkeeping run per request; the device allocation happens once
+        # for every admitted request (`_alloc_planned`), then the transfer
+        # metadata is published per request.
+        plans: List[_PreallocPlan] = []
+        pending_full_tokens = 0
+        pending_swa_tokens = 0
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
@@ -1252,18 +1303,24 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 # Matching may lock previously-evictable radix pages, so refresh
                 # the admission budget against the post-lock pool state before we
                 # decide whether this request still fits.
-                full_allocatable_tokens = self._allocatable_token_budgets(
-                    retractable_tokens=retractable_tokens,
-                    count_retracted=True,
-                    extra_reserved_reqs=len(preallocated_reqs),
-                    hicache_reserved_tokens=reserved_restore_tokens,
+                full_allocatable_tokens = (
+                    self._allocatable_token_budgets(
+                        retractable_tokens=retractable_tokens,
+                        count_retracted=True,
+                        extra_reserved_reqs=len(plans),
+                        hicache_reserved_tokens=reserved_restore_tokens,
+                    )
+                    - pending_full_tokens
                 )
                 if uses_swa_tail_prealloc:
-                    swa_allocatable_tokens = self._swa_tail_allocatable_token_budget(
-                        retractable_tokens=retractable_tokens,
-                        retractable_swa_tokens=retractable_swa_tokens,
-                        count_retracted=True,
-                        extra_reserved_reqs=len(preallocated_reqs),
+                    swa_allocatable_tokens = (
+                        self._swa_tail_allocatable_token_budget(
+                            retractable_tokens=retractable_tokens,
+                            retractable_swa_tokens=retractable_swa_tokens,
+                            count_retracted=True,
+                            extra_reserved_reqs=len(plans),
+                        )
+                        - pending_swa_tokens
                     )
             else:
                 prefix_indices = None
@@ -1315,7 +1372,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     break
 
                 reclaim_error = self._reclaim_swa_tail_capacity(
-                    swa_len, decode_req.req.rid
+                    swa_len,
+                    decode_req.req.rid,
+                    pending_swa_tokens=pending_swa_tokens,
                 )
                 if reclaim_error is not None:
                     if prefix_match is not None and prefix_match.l1_prefix_len > 0:
@@ -1334,34 +1393,65 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     failed_reqs.append(decode_req)
                     indices_to_remove.add(i)
                     continue
-            dst_kv_indices = self._pre_alloc(
+            plan = self._plan_prealloc(
                 decode_req.req,
                 prefix_indices,
                 prefix_len,
                 total_prefix_len,
+                pending_full_tokens=pending_full_tokens,
             )
-            decode_req.prefix_match = prefix_match
-            if self.scheduler.enable_decode_hicache:
-                self._start_hicache_prefetch(decode_req.req, prefix_match)
-            hisparse_req_budget -= 1
-            # Recompute from actual pool state for the next queue entry.
-            # This accounts for page rounding and newly locked evictable cache.
-            if prefix_match is not None:
-                reserved_restore_tokens += prefix_match.restore_token_count
-            full_allocatable_tokens = self._allocatable_token_budgets(
-                retractable_tokens=retractable_tokens,
-                count_retracted=True,
-                extra_reserved_reqs=len(preallocated_reqs) + 1,
-                hicache_reserved_tokens=reserved_restore_tokens,
+            plan.decode_req = decode_req
+            plan.queue_index = i
+            plan.origin_input_len = origin_input_len
+            plan.prefix_match = prefix_match
+            plans.append(plan)
+            pending_full_tokens += self._required_alloc_tokens(
+                fill_len=plan.fill_len, prefix_len=plan.prefix_len
             )
             if uses_swa_tail_prealloc:
-                swa_allocatable_tokens = self._swa_tail_allocatable_token_budget(
+                pending_swa_tokens += ceil_align(
+                    plan.swa_tail_len, self.token_to_kv_pool_allocator.page_size
+                )
+            decode_req.prefix_match = prefix_match
+            hisparse_req_budget -= 1
+            # Recompute from pool state for the next queue entry, minus what the
+            # planned requests will take. This accounts for page rounding and
+            # newly locked evictable cache.
+            if prefix_match is not None:
+                reserved_restore_tokens += prefix_match.restore_token_count
+            full_allocatable_tokens = (
+                self._allocatable_token_budgets(
                     retractable_tokens=retractable_tokens,
-                    retractable_swa_tokens=retractable_swa_tokens,
                     count_retracted=True,
-                    extra_reserved_reqs=len(preallocated_reqs) + 1,
+                    extra_reserved_reqs=len(plans),
+                    hicache_reserved_tokens=reserved_restore_tokens,
+                )
+                - pending_full_tokens
+            )
+            if uses_swa_tail_prealloc:
+                swa_allocatable_tokens = (
+                    self._swa_tail_allocatable_token_budget(
+                        retractable_tokens=retractable_tokens,
+                        retractable_swa_tokens=retractable_swa_tokens,
+                        count_retracted=True,
+                        extra_reserved_reqs=len(plans),
+                    )
+                    - pending_swa_tokens
                 )
             decode_req.req.kv.cache_protected_len = total_prefix_len
+
+        self._alloc_planned(plans)
+
+        for plan in plans:
+            i = plan.queue_index
+            decode_req = plan.decode_req
+            prefix_match = plan.prefix_match
+            prefix_len = plan.prefix_len
+            total_prefix_len = plan.total_prefix_len
+            origin_input_len = plan.origin_input_len
+            dst_kv_indices = self._prealloc_dst_indices(plan)
+            if self.scheduler.enable_decode_hicache:
+                self._start_hicache_prefetch(decode_req.req, prefix_match)
 
             page_size = self.token_to_kv_pool_allocator.page_size
             kv_transfer_page_size = page_size
@@ -1771,20 +1861,25 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         )
         return num_new_pages * page_size
 
-    def _pre_alloc(
+    def _plan_prealloc(
         self,
         req: Req,
         prefix_indices: Optional[torch.Tensor] = None,
         prefix_len: Optional[int] = None,
         total_prefix_len: Optional[int] = None,
-    ) -> torch.Tensor:
-        """Pre-allocate the memory for req_to_token and token_kv_pool.
+        *,
+        pending_full_tokens: int = 0,
+    ) -> _PreallocPlan:
+        """Host side of the preallocation: take the req_to_token row, settle the
+        request's KV lengths, evict for the slots it will need. The slots
+        themselves come from `_alloc_planned`, once for a whole batch of plans.
 
         ``prefix_len`` is the L1 device-resident prefix length (already
         backed by ``prefix_indices``). ``total_prefix_len`` is the full
         prefix committed to prefill as ``decode_prefix_len`` (L1 + L2 + L3);
         the ``[prefix_len, total_prefix_len)`` gap is filled later by HiCache
-        loadback.
+        loadback. ``pending_full_tokens`` are slots earlier plans of the same
+        batch will take, not yet visible in the pool.
         """
         if prefix_len is None:
             prefix_len = 0
@@ -1799,6 +1894,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         fill_len = self._pre_alloc_fill_len(req)
         req.kv.kv_committed_len = fill_len
+        req.kv.kv_allocated_len = fill_len
 
         if prefix_len > 0:
             self.req_to_token_pool.write(
@@ -1816,16 +1912,25 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         # Evict cached entries if the pool doesn't have enough free pages.
         if (
             get_disagg().disaggregation_decode_enable_radix_cache
-            and self._radix_full_available() < required_alloc_tokens
+            and self._radix_full_available() - pending_full_tokens
+            < required_alloc_tokens
         ):
-            num_to_evict = required_alloc_tokens - self._radix_full_available()
+            num_to_evict = (
+                required_alloc_tokens
+                + pending_full_tokens
+                - self._radix_full_available()
+            )
             result = self.tree_cache.evict_for_alloc(
                 EvictParams(num_tokens=num_to_evict)
             )
-            if self._radix_full_available() < required_alloc_tokens:
+            if (
+                self._radix_full_available() - pending_full_tokens
+                < required_alloc_tokens
+            ):
                 logger.warning(
                     f"Eviction insufficient: needed {required_alloc_tokens} tokens, "
                     f"available {self._radix_full_available()} "
+                    f"(pending {pending_full_tokens}) "
                     f"after evicting {result.num_tokens_evicted}/{num_to_evict} tokens. "
                     f"evictable_size={self._radix_full_evictable()}, "
                     f"protected_size={self._radix_full_protected()}, "
@@ -1835,25 +1940,26 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     f"req={req.rid}"
                 )
 
-        allocator = self.token_to_kv_pool_allocator
         uses_swa_tail = self._uses_swa_tail_prealloc()
         swa_tail_len = self._swa_tail_len(fill_len)
+        if uses_swa_tail:
+            # Full-attention layers reuse prefix KV; SWA layers allocate only
+            # the live window tail, so the head below it has no SWA peers.
+            swa_evicted_seqlen = fill_len - swa_tail_len
+            assert (
+                swa_evicted_seqlen >= 0
+                and swa_evicted_seqlen % self.token_to_kv_pool_allocator.page_size == 0
+            )
+            req.kv.swa_evicted_seqlen = swa_evicted_seqlen
+
+        host_indices = None
         if self.scheduler.enable_hisparse:
             # HiSparse is incompatible with decode-side L1 radix cache. Keep
             # this path on the upstream full-allocation semantics.
             assert prefix_len == 0
-
-            # Direct-to-host path: only allocate logical indices (no hisparse
-            # device indices) and allocate host indices for RDMA destination.
+            # Direct-to-host path: the device allocation covers logical indices
+            # only; the RDMA destination is a host row.
             coordinator = self.scheduler.hisparse_coordinator
-            kv_loc = alloc_for_decode_prealloc_hisparse(
-                allocator,
-                req=req,
-                fill_len=fill_len,
-                uses_swa_tail=uses_swa_tail,
-                swa_tail_len=swa_tail_len,
-            )
-            # Allocate host indices for the RDMA transfer target.
             host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(
                 coordinator.req_to_host_pool,
                 coordinator.req_to_host_pool_allocated_len,
@@ -1861,37 +1967,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 0,
                 coordinator.host_token_len(fill_len),
             )
-        else:
-            kv_loc = alloc_for_decode_prealloc(
-                allocator,
-                req=req,
-                fill_len=fill_len,
-                delta_len=delta_len,
-                prefix_len=prefix_len,
-                total_prefix_len=total_prefix_len,
-                prefix_indices=prefix_indices,
-                uses_swa_tail=uses_swa_tail,
-                swa_tail_len=swa_tail_len,
-                req_to_token_pool=self.req_to_token_pool,
-            )
-        assert kv_loc is not None, (
-            f"KV cache is full! Bug in memory estimation. "
-            f"available={self._radix_full_available()}, "
-            f"evictable={self._radix_full_evictable()}, "
-            f"protected={self._radix_full_protected()}, "
-            f"required_alloc={required_alloc_tokens}, delta={delta_len}, "
-            f"fill={fill_len}, prefix={prefix_len}, total_prefix={total_prefix_len}, "
-            f"page_size={self.token_to_kv_pool_allocator.page_size}, "
-            f"req={req.rid}"
-        )
-
-        self.req_to_token_pool.write(
-            (
-                req.kv.req_pool_idx,
-                slice(total_prefix_len, total_prefix_len + len(kv_loc)),
-            ),
-            kv_loc,
-        )
 
         # Truncate fill_len to kv_committed_len so cache_unfinished_req only
         # inserts committed KV into the radix tree. The last output token
@@ -1906,50 +1981,149 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         )
         req.set_extend_range(total_prefix_len, req.kv.kv_committed_len)
 
-        # Return the transfer destination indices:
-        if self.scheduler.enable_hisparse:
-            return host_indices
-        return kv_loc
-
-
-def alloc_for_decode_prealloc_hisparse(
-    allocator: BaseTokenToKVPoolAllocator,
-    *,
-    req: Req,
-    fill_len: int,
-    uses_swa_tail: bool,
-    swa_tail_len: int,
-) -> torch.Tensor:
-    req.kv.kv_allocated_len = fill_len
-    device = allocator.device
-    prefix_lens = torch.tensor([0], dtype=torch.int64, device=device)
-    prefix_lens_cpu = torch.tensor([0], dtype=torch.int64)
-    seq_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
-    seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
-    last_loc = torch.tensor([-1], dtype=torch.int64, device=device)
-    if uses_swa_tail:
-        kv_loc = allocator.alloc_extend_swa_tail(
-            prefix_lens=prefix_lens,
-            prefix_lens_cpu=prefix_lens_cpu,
-            seq_lens=seq_lens,
-            seq_lens_cpu=seq_lens_cpu,
-            last_loc=last_loc,
-            extend_num_tokens=fill_len,
+        return _PreallocPlan(
+            req=req,
+            prefix_indices=prefix_indices,
+            prefix_len=prefix_len,
+            total_prefix_len=total_prefix_len,
+            fill_len=fill_len,
+            delta_len=delta_len,
+            uses_swa_tail=uses_swa_tail,
             swa_tail_len=swa_tail_len,
+            host_indices=host_indices,
         )
-        swa_evicted_seqlen = fill_len - swa_tail_len
-        assert swa_evicted_seqlen >= 0 and swa_evicted_seqlen % allocator.page_size == 0
-        req.kv.swa_evicted_seqlen = swa_evicted_seqlen
-    else:
-        kv_loc = allocator.alloc_logical_only(
-            prefix_lens=prefix_lens,
-            prefix_lens_cpu=prefix_lens_cpu,
-            seq_lens=seq_lens,
-            seq_lens_cpu=seq_lens_cpu,
-            last_loc=last_loc,
-            extend_num_tokens=fill_len,
+
+    def _alloc_planned(self, plans: List[_PreallocPlan]) -> None:
+        """Allocate every plan's fresh KV slots in one allocator call and write
+        them into the req_to_token rows.
+
+        One call per batch keeps the per-request host->device argument copies
+        and allocator launches off the scheduler's critical path; the lengths
+        go up through pinned memory so nothing here synchronizes the stream.
+        """
+        if not plans:
+            return
+        allocator = self.token_to_kv_pool_allocator
+
+        if hasattr(allocator, "c128_attn_allocator"):
+            # NPU DSV4 carries per-request side tables through its own hooks.
+            for plan in plans:
+                plan.kv_loc = alloc_for_decode_prealloc(
+                    allocator,
+                    req=plan.req,
+                    fill_len=plan.fill_len,
+                    delta_len=plan.delta_len,
+                    prefix_len=plan.prefix_len,
+                    total_prefix_len=plan.total_prefix_len,
+                    prefix_indices=plan.prefix_indices,
+                    uses_swa_tail=plan.uses_swa_tail,
+                    swa_tail_len=plan.swa_tail_len,
+                    req_to_token_pool=self.req_to_token_pool,
+                )
+                self._write_prealloc_row(plan)
+            return
+
+        extend_num_tokens = sum(plan.delta_len for plan in plans)
+        if allocator.page_size == 1:
+            out = allocator.alloc(extend_num_tokens)
+        else:
+            device = allocator.device
+            uses_swa_tail = plans[0].uses_swa_tail
+            # The SWA-tail allocator reuses the device-resident prefix; the plain
+            # extend allocates from the end of the prefill-committed prefix.
+            prefix_lens_cpu, prefix_lens = pinned_int64_pair(
+                [
+                    plan.prefix_len if uses_swa_tail else plan.total_prefix_len
+                    for plan in plans
+                ],
+                device,
+            )
+            seq_lens_cpu, seq_lens = pinned_int64_pair(
+                [plan.fill_len for plan in plans], device
+            )
+            last_loc = self._planned_last_loc(plans, device)
+            if uses_swa_tail:
+                out = allocator.alloc_extend_swa_tail(
+                    prefix_lens=prefix_lens,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=extend_num_tokens,
+                    swa_tail_lens=[plan.swa_tail_len for plan in plans],
+                )
+            else:
+                out = allocator.alloc_extend(
+                    prefix_lens=prefix_lens,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=extend_num_tokens,
+                )
+        assert out is not None, (
+            f"KV cache is full! Bug in memory estimation. "
+            f"available={self._radix_full_available()}, "
+            f"evictable={self._radix_full_evictable()}, "
+            f"protected={self._radix_full_protected()}, "
+            f"extend_num_tokens={extend_num_tokens}, "
+            f"page_size={allocator.page_size}, "
+            f"reqs={[plan.req.rid for plan in plans]}"
         )
-    return kv_loc
+
+        # The allocator lays the requests out back to back, in order.
+        for plan, kv_loc in zip(
+            plans, torch.split(out, [plan.delta_len for plan in plans])
+        ):
+            plan.kv_loc = kv_loc
+            self._write_prealloc_row(plan)
+
+    @staticmethod
+    def _planned_last_loc(
+        plans: List[_PreallocPlan], device: torch.device | str
+    ) -> torch.Tensor:
+        # -1 for a request with no device-resident prefix; the prefix's last
+        # slot otherwise. All of it stays on the stream: no host reads.
+        _, no_prefix = pinned_int64_pair([-1] * len(plans), device)
+        if all(plan.prefix_len == 0 for plan in plans):
+            return no_prefix
+        return torch.cat(
+            [
+                (
+                    plan.prefix_indices[-1:].to(dtype=torch.int64, device=device)
+                    if plan.prefix_len > 0
+                    else no_prefix[i : i + 1]
+                )
+                for i, plan in enumerate(plans)
+            ]
+        )
+
+    def _write_prealloc_row(self, plan: _PreallocPlan) -> None:
+        self.req_to_token_pool.write(
+            (
+                plan.req.kv.req_pool_idx,
+                slice(plan.total_prefix_len, plan.total_prefix_len + plan.delta_len),
+            ),
+            plan.kv_loc,
+        )
+
+    def _prealloc_dst_indices(self, plan: _PreallocPlan) -> torch.Tensor:
+        """The transfer destination indices prefill writes into."""
+        if self.scheduler.enable_hisparse:
+            return plan.host_indices
+        return plan.kv_loc
+
+    def _pre_alloc(
+        self,
+        req: Req,
+        prefix_indices: Optional[torch.Tensor] = None,
+        prefix_len: Optional[int] = None,
+        total_prefix_len: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Preallocate one request on its own; the queue paths batch instead."""
+        plan = self._plan_prealloc(req, prefix_indices, prefix_len, total_prefix_len)
+        self._alloc_planned([plan])
+        return self._prealloc_dst_indices(plan)
 
 
 def alloc_for_decode_prealloc(
@@ -1973,7 +2147,7 @@ def alloc_for_decode_prealloc(
         last_loc = (
             prefix_indices[-1:].to(dtype=torch.int64, device=device)
             if prefix_len > 0
-            else torch.tensor([-1], dtype=torch.int64, device=device)
+            else pinned_int64_pair([-1], device)[1]
         )
         extra_kwargs = {}
         dsv4_unwrap_prealloc = None
@@ -1994,16 +2168,16 @@ def alloc_for_decode_prealloc(
         if uses_swa_tail:
             # Full-attention layers reuse prefix KV; SWA layers allocate only
             # the live window tail.
+            prefix_lens_cpu, prefix_lens = pinned_int64_pair([prefix_len], device)
+            seq_lens_cpu, seq_lens = pinned_int64_pair([fill_len], device)
             kv_loc = allocator.alloc_extend_swa_tail(
-                prefix_lens=torch.tensor(
-                    [prefix_len], dtype=torch.int64, device=device
-                ),
-                prefix_lens_cpu=torch.tensor([prefix_len], dtype=torch.int64),
-                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
                 last_loc=last_loc,
                 extend_num_tokens=delta_len,
-                swa_tail_len=swa_tail_len,
+                swa_tail_lens=[swa_tail_len],
                 **extra_kwargs,
             )
             swa_evicted_seqlen = fill_len - swa_tail_len
@@ -2013,13 +2187,13 @@ def alloc_for_decode_prealloc(
             )
             req.kv.swa_evicted_seqlen = swa_evicted_seqlen
         else:
+            prefix_lens_cpu, prefix_lens = pinned_int64_pair([total_prefix_len], device)
+            seq_lens_cpu, seq_lens = pinned_int64_pair([fill_len], device)
             kv_loc = allocator.alloc_extend(
-                prefix_lens=torch.tensor(
-                    [total_prefix_len], dtype=torch.int64, device=device
-                ),
-                prefix_lens_cpu=torch.tensor([total_prefix_len], dtype=torch.int64),
-                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
                 last_loc=last_loc,
                 extend_num_tokens=delta_len,
                 **extra_kwargs,

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
@@ -20,7 +20,7 @@ mem_cache/common.py unpacks ``out_full_loc`` and stashes the bundle on
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 
@@ -413,7 +413,7 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,
         extend_num_tokens: int,
-        swa_tail_len: int,
+        swa_tail_lens: Sequence[int],
         *,
         req_pool_indices: Optional[torch.Tensor] = None,
         req_to_token_pool=None,
@@ -431,7 +431,7 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             seq_lens_cpu,
             last_loc,
             extend_num_tokens,
-            swa_tail_len,
+            swa_tail_lens,
         )
         return self._wrap_full_alloc(
             out_full_loc,

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -16,7 +16,7 @@ limitations under the License.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, List, Protocol, Tuple
 
 import torch
 
@@ -36,6 +36,24 @@ class MambaFullCacheDonor(Protocol):
     def prepare_mamba_allocation(self, target_size: int) -> None:
         """Expose layout-specific reclaim so Mamba capacity is queryable."""
         ...
+
+
+def pinned_int64_pair(
+    values: List[int], device: torch.device | str
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """The (cpu, device) int64 pair the alloc_* APIs take.
+
+    ``torch.tensor(values, device=cuda)`` copies from pageable memory, which
+    aten runs as cudaMemcpyAsync plus cudaStreamSynchronize; on the scheduler
+    stream that parks the host until the in-flight forward drains. A pinned
+    source keeps the copy asynchronous and stream-ordered before the allocator
+    kernel that reads it.
+    """
+    if torch.device(device).type == "cpu":
+        host = torch.tensor(values, dtype=torch.int64)
+        return host, host
+    host = torch.tensor(values, dtype=torch.int64, pin_memory=True)
+    return host, host.to(device, non_blocking=True)
 
 
 class BaseTokenToKVPoolAllocator(abc.ABC):

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -1,4 +1,5 @@
 import weakref
+from typing import Sequence
 
 import torch
 
@@ -409,7 +410,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,
         extend_num_tokens: int,
-        swa_tail_len: int,
+        swa_tail_lens: Sequence[int],
     ):
         return self.logical_attn_allocator.alloc_extend_swa_tail(
             prefix_lens=prefix_lens,
@@ -418,7 +419,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             seq_lens_cpu=seq_lens_cpu,
             last_loc=last_loc,
             extend_num_tokens=extend_num_tokens,
-            swa_tail_len=swa_tail_len,
+            swa_tail_lens=swa_tail_lens,
         )
 
     def alloc_device_buffer(self, allocated_indices, need_size: int):

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -1,8 +1,12 @@
 import logging
+from typing import Sequence
 
 import torch
 
-from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.base import (
+    BaseTokenToKVPoolAllocator,
+    pinned_int64_pair,
+)
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
@@ -294,18 +298,22 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,  # last_loc for full layers
         extend_num_tokens: int,
-        swa_tail_len: int,
+        swa_tail_lens: Sequence[int],
     ):
-        """Allocate full KV for the whole extend and SWA KV only for the tail."""
+        """Allocate full KV for the whole extend and SWA KV only for each
+        request's tail (``swa_tail_lens[i]`` trailing tokens of request i)."""
         assert self.page_size > 1
-        assert len(seq_lens_cpu) == 1, "SWA tail allocation currently supports bs=1"
-        assert len(prefix_lens_cpu) == 1
-        assert 0 <= swa_tail_len <= extend_num_tokens
+        bs = len(seq_lens_cpu)
+        assert len(prefix_lens_cpu) == bs and len(swa_tail_lens) == bs
+        deltas = (seq_lens_cpu - prefix_lens_cpu).tolist()
+        assert sum(deltas) == extend_num_tokens
+        assert all(0 <= t <= d for t, d in zip(swa_tail_lens, deltas))
 
+        ps = self.page_size
         num_full_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu, page_size=self.page_size, prefix_lens=prefix_lens_cpu
+            seq_lens=seq_lens_cpu, page_size=ps, prefix_lens=prefix_lens_cpu
         )
-        num_swa_pages = (swa_tail_len + self.page_size - 1) // self.page_size
+        num_swa_pages = sum((t + ps - 1) // ps for t in swa_tail_lens)
         if not self.new_pages_available(num_full_pages, num_swa_pages):
             return None
 
@@ -332,15 +340,16 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         assert alloc_full_indices is not None
 
-        if swa_tail_len == 0:
+        tails = [t for t in swa_tail_lens if t > 0]
+        if not tails:
             return alloc_full_indices
 
         device = self.device
-        swa_prefix_lens = torch.zeros((1,), dtype=torch.int64, device=device)
-        swa_prefix_lens_cpu = torch.zeros((1,), dtype=torch.int64)
-        swa_seq_lens = torch.tensor([swa_tail_len], dtype=torch.int64, device=device)
-        swa_seq_lens_cpu = torch.tensor([swa_tail_len], dtype=torch.int64)
-        swa_last_loc = torch.tensor([-1], dtype=torch.int64, device=device)
+        n = len(tails)
+        swa_prefix_lens = torch.zeros((n,), dtype=torch.int64, device=device)
+        swa_prefix_lens_cpu = torch.zeros((n,), dtype=torch.int64)
+        swa_seq_lens_cpu, swa_seq_lens = pinned_int64_pair(tails, device)
+        _, swa_last_loc = pinned_int64_pair([-1] * n, device)
 
         alloc_swa_indices = self.swa_attn_allocator.alloc_extend(
             swa_prefix_lens,
@@ -348,16 +357,26 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             swa_seq_lens,
             swa_seq_lens_cpu,
             swa_last_loc,
-            swa_tail_len,
+            sum(tails),
             num_new_pages=num_swa_pages,
         )
         assert alloc_swa_indices is not None
 
-        self.set_full_to_swa_mapping(
-            alloc_full_indices[-swa_tail_len:], alloc_swa_indices
-        )
-        if swa_tail_len < extend_num_tokens:
-            self.clear_full_to_swa_mapping(alloc_full_indices[:-swa_tail_len])
+        # Per request the full extend is one contiguous run of the output; the
+        # tail is its last `swa_tail_lens[i]` tokens, the head has no SWA pair.
+        tail_parts = []
+        head_parts = []
+        offset = 0
+        for delta, tail in zip(deltas, swa_tail_lens):
+            run = alloc_full_indices[offset : offset + delta]
+            if tail > 0:
+                tail_parts.append(run[delta - tail :])
+            if tail < delta:
+                head_parts.append(run[: delta - tail])
+            offset += delta
+        self.set_full_to_swa_mapping(torch.cat(tail_parts), alloc_swa_indices)
+        if head_parts:
+            self.clear_full_to_swa_mapping(torch.cat(head_parts))
         return alloc_full_indices
 
     def alloc_decode(

--- a/test/registered/unit/disaggregation/test_decode_prealloc_no_host_sync.py
+++ b/test/registered/unit/disaggregation/test_decode_prealloc_no_host_sync.py
@@ -1,0 +1,159 @@
+"""Decode-side KV preallocation allocates one batch per `pop_preallocated`
+and stages its allocator arguments through pinned memory. Per-request
+`torch.tensor(..., device=cuda)` copies were a cudaStreamSynchronize each on
+the scheduler stream; behind the WAR barrier that parks the host for the
+whole in-flight forward.
+
+    python -m pytest test/registered/unit/disaggregation/test_decode_prealloc_no_host_sync.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.srt.managers.schedule_batch import ReqKvInfo
+from sglang.srt.mem_cache.allocator.base import pinned_int64_pair
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
+from sglang.srt.runtime_context import publish, reset_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PAGE_SIZE = 4
+
+
+def _sync_error(fn):
+    """The RuntimeError torch raises if `fn` synchronizes, or None."""
+    torch.cuda.synchronize()
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        fn()
+    except RuntimeError as exc:
+        return exc
+    finally:
+        torch.cuda.set_sync_debug_mode("default")
+        torch.cuda.synchronize()
+    return None
+
+
+class _RowPool:
+    """req_to_token stand-in: hands out rows and records the writes."""
+
+    def __init__(self):
+        self.next_row = 0
+        self.writes = []
+
+    def alloc(self, reqs):
+        for req in reqs:
+            req.kv.req_pool_idx = self.next_row
+            self.next_row += 1
+        return [r.kv.req_pool_idx for r in reqs]
+
+    def write(self, indices, values):
+        self.writes.append((indices, values))
+
+
+def _req(rid, num_tokens):
+    req = SimpleNamespace(
+        rid=rid,
+        origin_input_ids=list(range(num_tokens)),
+        output_ids=[],
+        kv=ReqKvInfo(),
+    )
+    req.set_extend_range = lambda start, end: setattr(
+        req, "extend_range", SimpleNamespace(start=start, end=end)
+    )
+    return req
+
+
+def _queue(allocator):
+    queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+    queue.req_to_token_pool = _RowPool()
+    queue.token_to_kv_pool_allocator = allocator
+    queue.tree_cache = MagicMock()
+    queue.scheduler = SimpleNamespace(enable_hisparse=False)
+    queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+    return queue
+
+
+class TestDecodePreallocBatch(CustomTestCase):
+    def setUp(self):
+        reset_context()
+        self.addCleanup(reset_context)
+        publish(ServerArgs(model_path="dummy"), role="tokenizer")
+
+    def test_cpu_device_needs_no_pinned_staging(self):
+        # pin_memory requires an accelerator; on a CPU allocator the pair is
+        # the one host tensor.
+        host, dev = pinned_int64_pair([3], "cpu")
+        self.assertIs(host, dev)
+        self.assertEqual(host.tolist(), [3])
+
+    def test_one_allocation_serves_every_plan_in_order(self):
+        allocator = TokenToKVPoolAllocator(
+            size=64, dtype=torch.float16, device="cpu", kvcache=None, need_sort=False
+        )
+        queue = _queue(allocator)
+        lens = [5, 3, 8]
+        plans = [queue._plan_prealloc(_req(f"r{i}", n)) for i, n in enumerate(lens)]
+        before = allocator.available_size()
+
+        with unittest.mock.patch.object(
+            allocator, "alloc", wraps=allocator.alloc
+        ) as alloc:
+            queue._alloc_planned(plans)
+        alloc.assert_called_once_with(sum(lens))
+
+        self.assertEqual(allocator.available_size(), before - sum(lens))
+        all_slots = torch.cat([plan.kv_loc for plan in plans])
+        self.assertEqual(len(torch.unique(all_slots)), sum(lens))
+        for plan, n, (indices, values) in zip(
+            plans, lens, queue.req_to_token_pool.writes
+        ):
+            self.assertEqual(plan.kv_loc.numel(), n)
+            self.assertEqual(indices, (plan.req.kv.req_pool_idx, slice(0, n)))
+            self.assertTrue(torch.equal(values, plan.kv_loc))
+            self.assertEqual(plan.req.kv.kv_allocated_len, n)
+            self.assertEqual(plan.req.kv.kv_committed_len, n)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "sync detection needs CUDA")
+    def test_batched_prealloc_does_not_synchronize(self):
+        allocator = PagedTokenToKVPoolAllocator(
+            size=64 * PAGE_SIZE,
+            page_size=PAGE_SIZE,
+            dtype=torch.float16,
+            device="cuda",
+            kvcache=None,
+            need_sort=False,
+        )
+        queue = _queue(allocator)
+
+        def prealloc(lens):
+            plans = [queue._plan_prealloc(_req(f"r{n}", n)) for n in lens]
+            queue._alloc_planned(plans)
+
+        # Warm up outside the window: a first-time cudaMalloc / pinned block
+        # can synchronize on its own, which the detector would blame on the call.
+        prealloc([2 * PAGE_SIZE, PAGE_SIZE + 1])
+
+        # Gate on the pre-fix form: a detector blind to pageable H2D copies would
+        # pass the assert below no matter how the arguments are staged.
+        if (
+            _sync_error(lambda: torch.tensor([1], dtype=torch.int64, device="cuda"))
+            is None
+        ):
+            self.skipTest("sync debug mode does not flag a pageable H2D copy here")
+
+        self.assertIsNone(
+            _sync_error(lambda: prealloc([3 * PAGE_SIZE - 1, 2, PAGE_SIZE]))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -8,6 +8,7 @@ from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
     DecodeTransferQueue,
     HiCacheRestoreResult,
+    _PreallocPlan,
 )
 from sglang.srt.disaggregation.fake.conn import FakeKVManager, FakeKVReceiver
 from sglang.srt.disaggregation.utils import DisaggregationMode
@@ -85,19 +86,39 @@ class TestDecodeQueueCleanup(CustomTestCase):
             side_effect=lambda **_: physical_available
         )
 
-        def pre_alloc(_req):
-            nonlocal physical_available
-            self.assertGreaterEqual(physical_available, physical_tokens_per_req)
-            physical_available -= physical_tokens_per_req
+        # Planning reserves on the host; the pool only drops when the batch is
+        # allocated, so the budget mock stays flat until `_alloc_planned`.
+        def plan_prealloc(req, **_):
+            return _PreallocPlan(
+                req=req,
+                prefix_indices=None,
+                prefix_len=0,
+                total_prefix_len=0,
+                fill_len=fill_len,
+                delta_len=fill_len,
+                uses_swa_tail=True,
+                swa_tail_len=fill_len,
+            )
 
-        queue._pre_alloc = MagicMock(side_effect=pre_alloc)
+        def alloc_planned(plans):
+            nonlocal physical_available
+            self.assertGreaterEqual(
+                physical_available, physical_tokens_per_req * len(plans)
+            )
+            physical_available -= physical_tokens_per_req * len(plans)
+
+        queue._plan_prealloc = MagicMock(side_effect=plan_prealloc)
+        queue._alloc_planned = MagicMock(side_effect=alloc_planned)
 
         resumed = queue.resume_retracted_reqs()
 
         self.assertEqual(resumed, reqs[:3])
         self.assertEqual(queue.retracted_queue, reqs[3:])
         self.assertEqual(physical_available, 3 * page_size)
-        self.assertEqual(queue._pre_alloc.call_count, 3)
+        self.assertEqual(queue._plan_prealloc.call_count, 3)
+        # One device allocation for the whole resumed batch.
+        queue._alloc_planned.assert_called_once()
+        self.assertEqual(len(queue._alloc_planned.call_args.args[0]), 3)
 
     def test_prealloc_abort_clears_receiver_before_removing_request(self):
         receiver = FakeReceiver()
@@ -231,7 +252,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             )
         )
         queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
-        queue._pre_alloc = MagicMock()
+        queue._plan_prealloc = MagicMock()
         queue.req_to_token_pool = MagicMock()
         queue.req_to_token_pool.available_size.return_value = 1
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
@@ -254,7 +275,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         self.assertTrue(receiver.clear_called)
         self.assertIsNone(decode_req.kv_receiver)
         self.assertIsInstance(req.finished_reason, FINISH_ABORT)
-        queue._pre_alloc.assert_not_called()
+        queue._plan_prealloc.assert_not_called()
         scheduler.output_streamer.stream_output.assert_called_once_with(
             [req], req.return_logprob
         )

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -11,6 +11,7 @@ import torch
 from sglang.srt.disaggregation.decode import (  # noqa: E402
     DecodePreallocQueue,
     SchedulerDisaggregationDecodeMixin,
+    _PreallocPlan,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode  # noqa: E402
 from sglang.srt.managers.schedule_batch import (  # noqa: E402
@@ -138,12 +139,24 @@ class TestDecodePreallocQueuePriority(unittest.TestCase):
         queue._update_handshake_waiters = MagicMock()
         queue._allocatable_tokens = MagicMock(return_value=1000)
 
-        def pre_alloc_mock(req, prefix_indices=None, prefix_len=0, total_prefix_len=0):
-            return torch.arange(
-                len(req.origin_input_ids) - prefix_len, dtype=torch.int64
+        def plan_prealloc_mock(
+            req, prefix_indices=None, prefix_len=0, total_prefix_len=0, **_
+        ):
+            fill_len = len(req.origin_input_ids)
+            return _PreallocPlan(
+                req=req,
+                prefix_indices=prefix_indices,
+                prefix_len=prefix_len or 0,
+                total_prefix_len=total_prefix_len or 0,
+                fill_len=fill_len,
+                delta_len=fill_len - (total_prefix_len or 0),
+                uses_swa_tail=False,
+                swa_tail_len=fill_len,
+                kv_loc=torch.arange(fill_len - (prefix_len or 0), dtype=torch.int64),
             )
 
-        queue._pre_alloc = MagicMock(side_effect=pre_alloc_mock)
+        queue._plan_prealloc = MagicMock(side_effect=plan_prealloc_mock)
+        queue._alloc_planned = MagicMock()
 
         queue.req_to_token_pool = MagicMock()
         queue.req_to_token_pool.available_size.return_value = 100

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -422,8 +422,8 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
                 last_device_node=req.last_node,
             )
         )
-        queue._pre_alloc = MagicMock(
-            side_effect=AssertionError("_pre_alloc should not run")
+        queue._plan_prealloc = MagicMock(
+            side_effect=AssertionError("_plan_prealloc should not run")
         )
         queue.transfer_queue = MagicMock(queue=[], enable_staging=False)
         queue.tree_cache = MagicMock()
@@ -465,7 +465,7 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
 
         self.assertEqual(preallocated, [])
         self.assertEqual(failed, [])
-        queue._pre_alloc.assert_not_called()
+        queue._plan_prealloc.assert_not_called()
         queue.tree_cache.dec_swa_lock_only.assert_called_once_with(
             req.last_node,
             DecLockRefParams(swa_uuid_for_lock=123),

--- a/test/registered/unit/mem_cache/test_hisparse_allocator.py
+++ b/test/registered/unit/mem_cache/test_hisparse_allocator.py
@@ -46,7 +46,7 @@ class TestDeepSeekV4HiSparseAllocator(CustomTestCase):
             seq_lens_cpu=seq_lens_cpu,
             last_loc=last_loc,
             extend_num_tokens=512,
-            swa_tail_len=128,
+            swa_tail_lens=[128],
         )
 
         self.assertIs(result, expected)
@@ -58,7 +58,7 @@ class TestDeepSeekV4HiSparseAllocator(CustomTestCase):
         self.assertIs(kwargs["seq_lens_cpu"], seq_lens_cpu)
         self.assertIs(kwargs["last_loc"], last_loc)
         self.assertEqual(kwargs["extend_num_tokens"], 512)
-        self.assertEqual(kwargs["swa_tail_len"], 128)
+        self.assertEqual(kwargs["swa_tail_lens"], [128])
 
     def test_hisparse_budget_uses_full_logical_capacity_for_swa_tail(self):
         from sglang.srt.disaggregation.decode import DecodePreallocQueue
@@ -157,7 +157,7 @@ class TestDeepSeekV4HiSparseAllocator(CustomTestCase):
         allocator.alloc_logical_only.assert_not_called()
         _, kwargs = allocator.alloc_extend_swa_tail.call_args
         self.assertEqual(kwargs["extend_num_tokens"], fill_len)
-        self.assertEqual(kwargs["swa_tail_len"], swa_tail_len)
+        self.assertEqual(kwargs["swa_tail_lens"], [swa_tail_len])
         self.assertEqual(req.kv.swa_evicted_seqlen, fill_len - swa_tail_len)
         self.assertEqual(req.kv.kv_allocated_len, fill_len)
         self.assertEqual(req.kv.kv_committed_len, fill_len)

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -91,19 +91,20 @@ _OWNER_SITES = {
         "SchedulerBatchResultProcessor.process_batch_result_prefill",
         "kv_committed_len",
     ): 1,
-    # disaggregation decode prealloc: kv_allocated_len is settled inside the
-    # owned-kv alloc_for_decode_prealloc(_hisparse) functions (op42).
+    # disaggregation decode prealloc: both lengths are settled on the host in
+    # _plan_prealloc before the batched device allocation; the NPU DSV4
+    # per-request path (alloc_for_decode_prealloc) restates kv_allocated_len.
     (
         "disaggregation/decode.py",
-        "DecodePreallocQueue._pre_alloc",
+        "DecodePreallocQueue._plan_prealloc",
         "kv_committed_len",
     ): 1,
-    ("disaggregation/decode.py", "alloc_for_decode_prealloc", "kv_allocated_len"): 1,
     (
         "disaggregation/decode.py",
-        "alloc_for_decode_prealloc_hisparse",
+        "DecodePreallocQueue._plan_prealloc",
         "kv_allocated_len",
     ): 1,
+    ("disaggregation/decode.py", "alloc_for_decode_prealloc", "kv_allocated_len"): 1,
     # Beam member rows alias the leader's decode region, so releasing them
     # rewinds the leader's watermarks to keep its own per-Req release from
     # freeing that region twice.


### PR DESCRIPTION
`pop_preallocated` / `resume_retracted_reqs` now decide admission per request on the host, allocate every admitted request's KV in one `alloc_extend` / `alloc_extend_swa_tail` call, and only then publish the transfer metadata. The per-request `torch.tensor(..., device=cuda)` copies that used to synchronize the scheduler stream on every arriving request are gone: lengths go up once through pinned memory (`pinned_int64_pair`). `alloc_extend_swa_tail` takes `swa_tail_lens` per request instead of a single `swa_tail_len` with a `bs == 1` assert.

Follows #38159; the DSV4 NPU allocator keeps its per-request hooks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829774543](https://github.com/sgl-project/sglang/actions/runs/34829774543)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829774291](https://github.com/sgl-project/sglang/actions/runs/34829774291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829774408](https://github.com/sgl-project/sglang/actions/runs/34829774408)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->