### PR TITLE
[DSV4.1] Bound Blackwell prefill workspace and score compact candidates

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
+++ b/python/sglang/kernels/ops/attention/dsv4/candidate_blocks.py
@@ -4,40 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-
-@triton.jit
-def _maximum_with_nan(a, b):
-    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
-
-
-@triton.jit
-def _candidate_scores_kernel(
-    X,
-    LENS,
-    OUT,
-    SCORES,
-    WIDTH: tl.constexpr,
-    STRIDE: tl.constexpr,
-    BLOCKS: tl.constexpr,
-    GROUP: tl.constexpr,
-    GROUP_PAD: tl.constexpr,
-    TILE: tl.constexpr,
-):
-    row = tl.program_id(0).to(tl.int64)
-    blocks = tl.program_id(1) * TILE + tl.arange(0, TILE)
-    offsets = tl.arange(0, GROUP_PAD)
-    cols = blocks[:, None] * GROUP + offsets[None, :]
-    length = tl.load(LENS + row)
-    in_bounds = (cols < WIDTH) & (offsets[None, :] < GROUP)
-    values = tl.load(
-        X + row * STRIDE + cols, in_bounds & (cols < length), other=-float("inf")
-    ).to(tl.float32)
-    tl.store(OUT + row * WIDTH + cols, values, in_bounds)
-    scores = tl.reduce(values, axis=1, combine_fn=_maximum_with_nan)
-    scores = tl.where(
-        (length > 0) & (blocks == (length - 1) // GROUP), float("inf"), scores
-    )
-    tl.store(SCORES + row * BLOCKS + blocks, scores, blocks < BLOCKS)
+from sglang.kernels.ops.attention.dsv4.candidate_fp4_indexer import (
+    _candidate_scores_kernel,
+)
 
 
 @triton.jit
@@ -103,6 +72,7 @@ def candidate_block_logits(
         scores,
         width,
         logits.stride(0),
+        width,
         blocks,
         block_size,
         group_pad,

--- a/python/sglang/kernels/ops/attention/dsv4/candidate_fp4_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsv4/candidate_fp4_indexer.py
@@ -1,0 +1,149 @@
+"""Score only the published candidate blocks with the original MXFP4 values."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _maximum_with_nan(a, b):
+    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit
+def _candidate_scores_kernel(
+    X,
+    LENS,
+    OUT,
+    SCORES,
+    WIDTH: tl.constexpr,
+    STRIDE: tl.constexpr,
+    OUT_STRIDE: tl.constexpr,
+    BLOCKS: tl.constexpr,
+    GROUP: tl.constexpr,
+    GROUP_PAD: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    blocks = tl.program_id(1) * TILE + tl.arange(0, TILE)
+    offsets = tl.arange(0, GROUP_PAD)
+    cols = blocks[:, None] * GROUP + offsets[None, :]
+    length = tl.load(LENS + row)
+    in_bounds = (cols < WIDTH) & (offsets[None, :] < GROUP)
+    values = tl.load(
+        X + row * STRIDE + cols, in_bounds & (cols < length), other=-float("inf")
+    ).to(tl.float32)
+    tl.store(OUT + row * OUT_STRIDE + cols, values, in_bounds)
+    scores = tl.reduce(values, axis=1, combine_fn=_maximum_with_nan)
+    scores = tl.where(
+        (length > 0) & (blocks == (length - 1) // GROUP), float("inf"), scores
+    )
+    tl.store(SCORES + row * BLOCKS + blocks, scores, blocks < BLOCKS)
+
+
+@triton.jit
+def _candidate_fp4_logits(
+    Q,
+    QS,
+    K,
+    KS,
+    W,
+    BLOCK_IDS,
+    LENS,
+    OUT,
+    H: tl.constexpr,
+    BLOCKS: tl.constexpr,
+    GROUP: tl.constexpr,
+    ID_STRIDE: tl.constexpr,
+    N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * N + tl.arange(0, N)
+    block = tl.load(
+        BLOCK_IDS + row * ID_STRIDE + cols // GROUP, cols < BLOCKS * GROUP, other=-1
+    )
+    pos = block * GROUP + cols % GROUP
+    valid = (cols < BLOCKS * GROUP) & (block >= 0) & (pos < tl.load(LENS + row))
+    h = tl.arange(0, H)
+    d = tl.arange(0, 64)
+    s = tl.arange(0, 4)
+    q = tl.load(Q + row * H * 64 + h[:, None] * 64 + d[None, :])
+    qs = tl.load(QS + row * H + h)
+    qs = ((qs[:, None] >> (s[None, :] * 8)) & 255).to(tl.uint8)
+    k = tl.load(K + pos[:, None] * 64 + d[None, :], valid[:, None], other=0)
+    ks = tl.load(KS + pos, valid, other=0)
+    ks = ((ks[:, None] >> (s[None, :] * 8)) & 255).to(tl.uint8)
+    acc = tl.dot_scaled(
+        q.to(tl.uint8), qs, "e2m1", tl.trans(k.to(tl.uint8)), ks, "e2m1"
+    )
+    weights = tl.load(W + row * H + h)
+    # DeepGEMM accumulates four interleaved head streams with FP32 FMA.
+    doubled = acc + tl.abs(acc)
+    sums = tl.full((4, N), 0, tl.float32)
+    lanes = tl.arange(0, 4)
+    for group in tl.static_range(H // 4):
+        scores = tl.gather(
+            doubled, tl.broadcast_to((group * 4 + lanes)[:, None], (4, N)), 0
+        )
+        w = tl.gather(weights, group * 4 + lanes, 0)
+        sums = tl.fma(scores, w[:, None], sums)
+    even = tl.sum(tl.where((lanes % 2)[:, None] == 0, sums, 0), 0)
+    odd = tl.sum(tl.where((lanes % 2)[:, None] == 1, sums, 0), 0)
+    logits = (even + odd) * 0.5
+    tl.store(
+        OUT + row * BLOCKS * GROUP + cols,
+        tl.where(valid, logits, -float("inf")),
+        cols < BLOCKS * GROUP,
+    )
+
+
+def candidate_fp4_mqa_logits(q_fp4, k_fp4, weights, block_ids, seq_lens, block_size):
+    rows, heads, _ = q_fp4[0].shape
+    blocks = block_ids.shape[1]
+    output = torch.empty(
+        (rows, blocks * block_size), dtype=torch.float32, device=weights.device
+    )
+    if rows and blocks:
+        _candidate_fp4_logits[(rows, triton.cdiv(output.shape[1], 64))](
+            *q_fp4,
+            *k_fp4,
+            weights,
+            block_ids,
+            seq_lens,
+            output,
+            heads,
+            blocks,
+            block_size,
+            block_ids.stride(0),
+            64,
+        )
+    return output
+
+
+def select_candidate_block_indices(logits, seq_lens, topk_blocks, block_size):
+    """Mask the unread tail in place and retain block IDs instead of position masks."""
+    rows, width = logits.shape
+    blocks = triton.cdiv(width, block_size)
+    scores = torch.empty((rows, blocks), dtype=torch.float32, device=logits.device)
+    group_pad = triton.next_power_of_2(block_size)
+    tile = max(1, 1024 // group_pad)
+    _candidate_scores_kernel[(rows, triton.cdiv(blocks, tile))](
+        logits,
+        seq_lens,
+        logits,
+        scores,
+        width,
+        logits.stride(0),
+        logits.stride(0),
+        blocks,
+        block_size,
+        group_pad,
+        tile,
+    )
+    top = scores.topk(min(topk_blocks, blocks), dim=-1)
+    # Ascending IDs put a partial final block and invalid padding last.
+    return (
+        top.indices.masked_fill(~(top.values > -torch.inf), blocks)
+        .sort(-1)
+        .values.to(torch.int32)
+    )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -329,6 +329,7 @@ def two_level_decode_logits(
 
 # Arbitrary cap on one bf16 [rows, heads, lc] score chunk; transients run ~3x this.
 _TORCH_INDEXER_SCORE_BUDGET_BYTES = 1 << 30
+_DENSE_INDEXER_SCORE_BUDGET_BYTES = 16 << 30
 
 
 def _mask_topk_scores(
@@ -3167,37 +3168,188 @@ class DeepseekV4AttnBackend(
             q_lens.to(torch.int64),
             output_size=num_tokens,
         )
-        logits = _dense_fp4_mqa_logits(
-            (q_fp4, q_sf),
-            (k_fp4, k_sf),
-            weights,
-            ks,
-            ks + compress_lens,
-            # the fused top-k reads score rows through 16-byte vectors
-            ceil_align(max(lc_per_req), 4),
-        )
-        if indexer.is_candidate_source or indexer.uses_candidates:
-            self._publish_or_consume_candidates(
-                indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask
+        width = ceil_align(max(lc_per_req), 4)
+        compact_candidates = (
+            indexer.is_candidate_source or indexer.uses_candidates
+        ) and max(
+            lc_per_req
+        ) >= 16 * indexer.candidate_topk_blocks * indexer.candidate_block_size
+        # Keep the batched dense path when neither workspace bounds nor candidate
+        # scoring saves work; per-request launches penalize short prefills.
+        if (
+            not compact_candidates
+            and num_tokens * width * 4 <= _DENSE_INDEXER_SCORE_BUDGET_BYTES
+        ):
+            logits = _dense_fp4_mqa_logits(
+                (q_fp4, q_sf),
+                (k_fp4, k_sf),
+                weights,
+                ks,
+                ks + compress_lens,
+                # the fused top-k reads score rows through 16-byte vectors
+                ceil_align(max(lc_per_req), 4),
             )
+            if indexer.is_candidate_source or indexer.uses_candidates:
+                self._publish_or_consume_candidates(
+                    indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask
+                )
+            topk = indexer.index_topk
+            selected = torch.empty((num_tokens, topk), dtype=torch.int32, device=device)
+            topk_transform_ragged_v2(
+                logits, compress_lens, out_offsets=ks, out_indices=selected
+            )
+            if indexer.uses_candidates and not indexer.is_candidate_source:
+                selected = _mask_topk_scores(logits, selected, ks)
+            # ascending positions, padding last: the layout the consumers expect
+            unselected = torch.iinfo(torch.int32).max
+            selected = (
+                selected.masked_fill(selected < 0, unselected).sort(dim=-1).values
+            )
+            chosen = selected != unselected
+            page_indices[:num_tokens, :topk] = torch.where(
+                chosen, k_slots[selected.clamp_max(k_slots.shape[0] - 1)], -1
+            ).to(torch.int32)
+            if raw_indices is not None:
+                raw_indices[:num_tokens, :topk] = torch.where(
+                    chosen, selected - ks[:, None], -1
+                )
+            return
+
+        from sglang.kernels.ops.attention.dsv4.candidate_fp4_indexer import (
+            candidate_fp4_mqa_logits,
+            select_candidate_block_indices,
+        )
+
+        publish = [] if indexer.is_candidate_source else None
+        consume = indexer.uses_candidates and not indexer.is_candidate_source
         topk = indexer.index_topk
-        selected = torch.empty((num_tokens, topk), dtype=torch.int32, device=device)
-        topk_transform_ragged_v2(
-            logits, compress_lens, out_offsets=ks, out_indices=selected
-        )
-        if indexer.uses_candidates and not indexer.is_candidate_source:
-            selected = _mask_topk_scores(logits, selected, ks)
-        # ascending positions, padding last: the layout the consumers expect
-        unselected = torch.iinfo(torch.int32).max
-        selected = selected.masked_fill(selected < 0, unselected).sort(dim=-1).values
-        chosen = selected != unselected
-        page_indices[:num_tokens, :topk] = torch.where(
-            chosen, k_slots[selected.clamp_max(k_slots.shape[0] - 1)], -1
-        ).to(torch.int32)
-        if raw_indices is not None:
-            raw_indices[:num_tokens, :topk] = torch.where(
-                chosen, selected - ks[:, None], -1
+        token_start = 0
+        for b, (lc, t_len) in enumerate(zip(lc_per_req, q_lens_cpu)):
+            # Candidate gathers pay off once the full scan is much wider than
+            # the candidate pool. Short requests keep dense scoring and masks.
+            compact = (
+                (consume or publish is not None)
+                and lc
+                >= 16 * indexer.candidate_topk_blocks * indexer.candidate_block_size
             )
+            if publish is not None:
+                publish.append(
+                    torch.empty(
+                        (
+                            t_len,
+                            min(
+                                indexer.candidate_topk_blocks,
+                                ceil_align(lc, indexer.candidate_block_size)
+                                // indexer.candidate_block_size,
+                            )
+                            if compact
+                            else lc,
+                        ),
+                        device=device,
+                        dtype=torch.int32 if compact else torch.bool,
+                    )
+                )
+            if lc == 0 or t_len == 0:
+                token_start += t_len
+                continue
+            width = ceil_align(lc, 4)
+            # Bound the dense FP32 score allocation to 16 GiB, without shrinking
+            # the token batch used by projections and MoE.
+            score_width = (
+                indexer.candidate_topk_blocks * indexer.candidate_block_size
+                if consume and compact
+                else width
+            )
+            step = max(1, _DENSE_INDEXER_SCORE_BUDGET_BYTES // (score_width * 4))
+            for start in range(0, t_len, step):
+                stop = min(start + step, t_len)
+                rows = slice(token_start + start, token_start + stop)
+                lens = compress_lens[rows]
+                if consume and compact:
+                    blocks = self.candidate_masks[b][start:stop]
+                    logits = candidate_fp4_mqa_logits(
+                        (q_fp4[rows], q_sf[rows]),
+                        (
+                            k_fp4[starts[b] : starts[b] + lc],
+                            k_sf[starts[b] : starts[b] + lc],
+                        ),
+                        weights[rows],
+                        blocks,
+                        lens,
+                        indexer.candidate_block_size,
+                    )
+                    lengths = torch.full_like(lens, logits.shape[1])
+                    offsets = torch.zeros_like(lens)
+                else:
+                    logits = _dense_fp4_mqa_logits(
+                        (q_fp4[rows], q_sf[rows]),
+                        (k_fp4, k_sf),
+                        weights[rows],
+                        ks[rows],
+                        ks[rows] + lens,
+                        width,
+                    )
+                    lengths, offsets = lens, ks[rows]
+                if publish is not None:
+                    if compact:
+                        publish[b][start:stop] = select_candidate_block_indices(
+                            logits[:, :lc],
+                            lens,
+                            indexer.candidate_topk_blocks,
+                            indexer.candidate_block_size,
+                        )
+                    else:
+                        scores = logits[:, :lc]
+                        scores.masked_fill_(
+                            torch.arange(lc, device=device)[None, :] >= lens[:, None],
+                            -torch.inf,
+                        )
+                        publish[b][start:stop] = select_candidate_blocks(
+                            scores,
+                            lens[:, None],
+                            indexer.candidate_topk_blocks,
+                            indexer.candidate_block_size,
+                        )
+                        del scores
+                elif consume and not compact:
+                    logits[:, :lc].masked_fill_(
+                        ~self.candidate_masks[b][start:stop], -torch.inf
+                    )
+                selected = torch.empty(
+                    (stop - start, topk), dtype=torch.int32, device=device
+                )
+                topk_transform_ragged_v2(
+                    logits, lengths, out_offsets=offsets, out_indices=selected
+                )
+                if consume:
+                    selected = _mask_topk_scores(logits, selected, offsets)
+                if consume and compact:
+                    columns = selected.clamp_min(0).to(torch.int64)
+                    logical = blocks.gather(1, columns // indexer.candidate_block_size)
+                    logical = (
+                        logical * indexer.candidate_block_size
+                        + columns % indexer.candidate_block_size
+                    )
+                    selected = torch.where(selected >= 0, logical + starts[b], -1).to(
+                        torch.int32
+                    )
+                unselected = torch.iinfo(torch.int32).max
+                selected = (
+                    selected.masked_fill(selected < 0, unselected).sort(dim=-1).values
+                )
+                chosen = selected != unselected
+                page_indices[rows, :topk] = torch.where(
+                    chosen, k_slots[selected.clamp_max(k_slots.shape[0] - 1)], -1
+                ).to(torch.int32)
+                if raw_indices is not None:
+                    raw_indices[rows, :topk] = torch.where(
+                        chosen, selected - ks[rows, None], -1
+                    )
+                # Release each slice before allocating its successor.
+                del logits
+            token_start += t_len
+        if publish is not None:
+            self.candidate_masks = publish
 
     def _publish_or_consume_candidates(
         self, indexer, logits, compress_lens, lc_per_req, q_lens_cpu, empty_mask

--- a/test/registered/kernels/ops/attention/test_fp4_indexer.py
+++ b/test/registered/kernels/ops/attention/test_fp4_indexer.py
@@ -22,6 +22,7 @@ from sglang.srt.utils import get_device, is_xpu
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 _is_xpu = is_xpu()
 if _is_xpu:
@@ -235,6 +236,216 @@ def test_fp4_fused_q_indexer_rope_hadamard_quant(batch_size: int) -> None:
     torch.testing.assert_close(q_fp4.view(torch.uint8), ref_fp4)
     torch.testing.assert_close(q_sf, ref_sf)
     torch.testing.assert_close(weights_out.squeeze(-1), weight.float() * weight_scale)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10,
+    reason="DeepGEMM MXFP4 requires Blackwell",
+)
+@pytest.mark.parametrize("width", [17, 65539, 1048579])
+def test_candidate_fp4_indexer(width):
+    from deep_gemm import fp8_fp4_mqa_logits
+
+    from sglang.kernels.ops.attention.dsv4.candidate_blocks import (
+        candidate_block_logits,
+    )
+    from sglang.kernels.ops.attention.dsv4.candidate_fp4_indexer import (
+        candidate_fp4_mqa_logits,
+        select_candidate_block_indices,
+    )
+    from sglang.srt.layers.attention.dsv4.indexer import select_candidate_blocks
+
+    torch.manual_seed(910)
+    rows, heads, group, budget = 9, 32, 8, 2048
+    q = quantize_fp4_indexer_tensor(
+        torch.randn(rows * heads, 128, device="cuda", dtype=torch.bfloat16), rne=True
+    )
+    q = (q[0].view(rows, heads, 64), q[1].view(rows, heads))
+    # Independent per-32 scales and negative head weights exercise the FP32
+    # reduction, rather than only checking selected positions on positive scores.
+    keys = torch.randn(width, 4, 32, device="cuda", dtype=torch.bfloat16)
+    keys *= torch.tensor([0.25, 0.5, 2, 4], device="cuda")[None, :, None]
+    k = quantize_fp4_indexer_tensor(keys.flatten(1), rne=True)
+    weights = torch.randn(rows, heads, device="cuda")
+    lens = torch.tensor(
+        [0, 1, 7, 8, 9, 16, width - 1, width, width], device="cuda", dtype=torch.int32
+    )
+    width_aligned = (width + 3) // 4 * 4
+    baseline = fp8_fp4_mqa_logits(
+        q, k, weights, torch.zeros_like(lens), lens, False, width_aligned
+    )
+    visible = torch.arange(width, device="cuda")[None, :] < lens[:, None]
+    reference = baseline[:, :width].masked_fill(~visible, -torch.inf)
+    # Keep the baseline block-selection tie behavior, including all-masked rows.
+    reference[1:6] = reference[1:6].masked_fill(visible[1:6], 0)
+    block_ids = select_candidate_block_indices(reference.clone(), lens, budget, group)
+    reference_mask = select_candidate_blocks(reference, lens[:, None], budget, group)
+    # The shared block reducer must retain the paged decode helper's behavior.
+    masked, published = candidate_block_logits(
+        reference, lens, topk_blocks=budget, block_size=group, published=None
+    )
+    torch.testing.assert_close(masked, reference)
+    torch.testing.assert_close(published, reference_mask)
+    positions = (
+        (block_ids[:, :, None] * group + torch.arange(group, device="cuda"))
+        .flatten(1)
+        .long()
+    )
+    actual_mask = torch.zeros(
+        (rows, ((width + group - 1) // group + 1) * group),
+        device="cuda",
+        dtype=torch.bool,
+    )
+    actual_mask.scatter_(1, positions, True)
+    torch.testing.assert_close(actual_mask[:, :width], reference_mask)
+
+    actual = candidate_fp4_mqa_logits(q, k, weights, block_ids, lens, group)
+    expected = baseline.gather(1, positions.clamp_max(width_aligned - 1))
+    expected.masked_fill_(positions >= lens[:, None], -torch.inf)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    # Replaying with changed causal lengths must not reuse scores or read padding.
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        replayed = candidate_fp4_mqa_logits(q, k, weights, block_ids, lens, group)
+    lens.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.isneginf(replayed).all()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10,
+    reason="DeepGEMM MXFP4 requires Blackwell",
+)
+@pytest.mark.parametrize("ratio", [1, 2])
+def test_candidate_prefill_mapping(ratio):
+    from types import SimpleNamespace as NS
+    from unittest import mock
+
+    from sglang.srt.layers.attention import deepseek_v4_backend as backend_module
+    from sglang.srt.layers.attention.dsv4.indexer import select_candidate_blocks
+
+    torch.manual_seed(910)
+    lengths, q_lengths = [262147 * ratio, 0, 1, 8197 * ratio], [33, 0, 1, 17]
+    tokens, topk = sum(q_lengths), 512
+    compressed = [length // ratio for length in lengths]
+    positions = torch.cat(
+        [torch.arange(s - t, s, device="cuda") for s, t in zip(lengths, q_lengths)]
+    )
+    lens = ((positions + 1) // ratio).int()
+    slots = sum(compressed)
+    keys = quantize_fp4_indexer_tensor(
+        torch.randn(slots, 128, device="cuda", dtype=torch.bfloat16), rne=True
+    )
+    request_map = torch.zeros(
+        len(lengths), max(lengths), device="cuda", dtype=torch.int64
+    )
+    physical = torch.randperm(slots, device="cuda")
+    starts, offset = [], 0
+    for b, count in enumerate(compressed):
+        starts.append(offset)
+        request_map[b, torch.arange(count, device="cuda") * ratio] = (
+            physical[offset : offset + count] * ratio
+        )
+        offset += count
+    q_lens = torch.tensor(q_lengths, device="cuda")
+    offsets = torch.repeat_interleave(
+        torch.tensor(starts, device="cuda", dtype=torch.int32), q_lens
+    )
+    batch = NS(
+        seq_lens_cpu=lengths, req_pool_indices=torch.arange(len(lengths), device="cuda")
+    )
+    indexer = NS(
+        queries=lambda q, freqs: q,
+        head_weights=lambda x: x,
+        index_topk=topk,
+        candidate_topk_blocks=2048,
+        candidate_block_size=8,
+    )
+    layer = NS(
+        compress_ratio=ratio,
+        indexer=indexer,
+        layer_id=0,
+        freqs_cis=torch.zeros(max(lengths), 1, device="cuda"),
+    )
+    backend = backend_module.DeepseekV4AttnBackend.__new__(
+        backend_module.DeepseekV4AttnBackend
+    )
+    pages = torch.empty(tokens, topk, device="cuda", dtype=torch.int32)
+    raw = torch.empty_like(pages)
+    backend.req_to_token = request_map
+    backend.token_to_kv_pool = NS(
+        get_low_ratio_index_k_fp4=lambda _, loc: (keys[0][loc], keys[1][loc])
+    )
+    backend.forward_metadata = NS(
+        core_metadata=NS(
+            sparse_page_indices=lambda r: pages, sparse_raw_indices=lambda r: raw
+        )
+    )
+    backend.candidate_masks = None
+    published = []
+    for source in [True, False, False]:
+        query = torch.randn(tokens, 32, 128, device="cuda", dtype=torch.bfloat16)
+        weights = torch.randn(tokens, 32, device="cuda")
+        indexer.is_candidate_source, indexer.uses_candidates = source, not source
+        packed_q = quantize_fp4_indexer_tensor(query.flatten(0, 1), rne=True)
+        scores = backend_module._dense_fp4_mqa_logits(
+            (packed_q[0].view(tokens, 32, 64), packed_q[1].view(tokens, 32)),
+            (keys[0][physical], keys[1][physical]),
+            weights,
+            offsets,
+            offsets + lens,
+            (max(compressed) + 3) // 4 * 4,
+        )
+        start = 0
+        for b, (count, q_len) in enumerate(zip(compressed, q_lengths)):
+            rows = slice(start, start + q_len)
+            local = scores[rows, :count]
+            local.masked_fill_(
+                torch.arange(count, device="cuda")[None, :] >= lens[rows, None],
+                -torch.inf,
+            )
+            if source:
+                published.append(
+                    select_candidate_blocks(local, lens[rows, None], 2048, 8)
+                    if count
+                    else None
+                )
+            elif count:
+                local.masked_fill_(~published[b], -torch.inf)
+            start += q_len
+        selected = torch.empty_like(raw)
+        backend_module.topk_transform_ragged_v2(
+            scores, lens, out_offsets=offsets, out_indices=selected
+        )
+        if not source:
+            selected = backend_module._mask_topk_scores(scores, selected, offsets)
+        sentinel = torch.iinfo(torch.int32).max
+        selected = selected.masked_fill(selected < 0, sentinel).sort(-1).values
+        chosen = selected != sentinel
+        expected_pages = torch.where(
+            chosen, physical[selected.clamp_max(slots - 1)], -1
+        ).int()
+        expected_raw = torch.where(chosen, selected - offsets[:, None], -1)
+        budget = ((max(compressed) + 3) // 4 * 4) * 4 * 7
+        dense_logits = backend_module._dense_fp4_mqa_logits
+
+        def bounded_logits(*args):
+            result = dense_logits(*args)
+            assert result.numel() * result.element_size() <= budget
+            return result
+
+        with (
+            mock.patch.object(
+                backend_module, "_DENSE_INDEXER_SCORE_BUDGET_BYTES", budget
+            ),
+            mock.patch.object(backend_module, "_dense_fp4_mqa_logits", bounded_logits),
+        ):
+            backend._low_ratio_index_topk_dense(
+                layer, weights, query, positions, batch, q_lens, q_lengths
+            )
+        torch.testing.assert_close(pages, expected_pages, rtol=0, atol=0)
+        torch.testing.assert_close(raw, expected_raw, rtol=0, atol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **2026-09-18 update:** The tested combined implementation is pushed as [Stelath/sglang@9a6af4c808](https://github.com/Stelath/sglang/commit/9a6af4c808cbe787616e4e5ec1d908d9db74cdb1). Reopening this PR is blocked because upstream deleted its `dsv4.1` base branch. The validation below applies to that pushed commit, not the legacy closed-PR diff. `main` diverges from the tested base, so this has not been blindly retargeted.

## Motivation

Bound Blackwell DSV4.1 dense-prefill workspace and avoid scanning the full context in long-context candidate consumers. This combines @harmya's #40015 memory-bounded source with this PR's compact MXFP4 scoring; both of his commits retain their authorship.

## Modifications

- Reuse #40015's 2 GiB dense-score tile budget and int32 candidate-block metadata, including replay-tail slicing.
- Score only published candidate blocks with the original MXFP4 values and DeepGEMM's FP32 accumulation order. Keep dense consumers below the measured 16x context/candidate-width crossover.
- Reuse existing block selection and top-k; delete the duplicate custom block-selection kernel. No new dependency, serving flag, or change to candidate budgets, decode, or attention policy.
- Extend the registered GPU suite for compact scoring and consumer integration.

## Accuracy Tests

On one **GB300**, PyTorch **2.13.0+cu130**, all **21 registered tests passed**:

```bash
PYTHONPATH=python python test/registered/unit/layers/test_dsv41_candidate_blocks.py  # 4
PYTHONPATH=python python test/registered/unit/layers/test_dsv4_nonpaged_indexer.py  # 11
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python python test/registered/kernel/attention/dsv4/test_dense_prefill_indexer.py  # 6
```

Covers bit-exact compact scores versus DeepGEMM, mixed scales and signed weights, invalid/partial candidates, both compact tile sizes, changed-length CUDA-graph replay, ties, empty/ragged requests, compression ratios 1/2, source/consumer filtering, replay tails, forced tiling and allocation stability. All applicable pre-commit hooks passed under Python 3.12.

These are kernel/helper and dispatch checks, **not full-model quality or serving validation**. Among exactly tied final scores, compact-column top-k may choose different valid members from dense-column top-k.

## Speed Tests and Profiling

Same GPU/runtime and seeded inputs; upstream `dsv4.1` at `0ee3dc4422`, #40015 rebased onto that base, and the combined implementation. One source plus four consumers; three warmups and seven alternating trials. 32 heads, dimension 128, top-512, 2,048 candidate blocks of 8 positions.

Backend-method replay includes GPU query packing, tensor-based KV gathers, scoring, candidate selection, top-k and physical mapping. Query projections, attention, generation and serving are excluded. CUDA-event times include possible host-submission gaps. Memory is peak allocated VRAM above the pre-call baseline, not total process memory.

Each cell is **chain ms / peak added GiB**:

| Query rows / context | Upstream | #40015 only | Combined |
|---|---:|---:|---:|
| 32 requests x 512 / 4,096 each | 35.91 / 0.551 | 51.36 / 0.512 | 51.42 / 0.512 |
| 256 / 32,768 | 5.56 / 0.070 | 6.18 / 0.053 | 6.14 / 0.053 |
| 256 / 262,144 | 8.12 / 0.556 | 8.72 / 0.400 | 7.48 / 0.346 |
| 256 / 1,048,576 | 24.30 / 2.223 | 25.68 / 1.593 | 14.13 / 1.374 |
| 4,096 / 131,072 | 29.82 / 3.396 | 32.42 / 3.059 | 32.40 / 3.059 |
| 16,384 / 131,072 | 107.45 / 12.046 | 119.80 / 3.201 | 119.72 / 3.201 |
| 16,384 / 524,288 | 404.88 / 48.082 | 475.83 / 3.234 | 319.39 / 2.797 |
| 16,384 / 1,048,576 | 801.08 / 96.131 | 939.11 / 3.279 | 478.30 / 2.842 |

At 16K/1M: source time is 352.48 -> 313.40 ms; four consumers are 448.66 -> 164.80 ms. The chain is **40.3% faster with 97.0% less peak temporary VRAM**. This is **not** a whole-model speedup claim.

**Tradeoff:** short single-request and many-request cases remain ~10% and ~43% slower than upstream; tested 128K cases are ~9–11% slower. This is not a regression-free or universally faster implementation. The multi-request timing uses uniform lengths; genuine ragged performance remains unmeasured. A native broadcast-mask variant did not resolve the short-case regression and is not included.

## Checklist

- [x] Format and lint with pre-commit.
- [x] Add and run registered regression coverage.
- [x] Provide kernel/indexer accuracy and speed results with limitations.
- [x] Follow SGLang code style; no new user-facing configuration.
- [ ] Full-model accuracy and end-to-end speed validation.
- [ ] Maintainer CI and codeowner approval.

## Review and Merge Process

Draft implementation for review of the explicit memory/speed tradeoff. The upstream `dsv4.1` branch was deleted, so reopening requires an agreed replacement base and any necessary port/revalidation. Full-model validation, CI and required approvals remain before merge. Raw verification logs and scripts are kept private; no public gist uploads.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34540976216](https://github.com/sgl-project/sglang/actions/runs/34540976216)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34540975889](https://github.com/sgl-project/sglang/actions/runs/34540975889)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34540976011](https://github.com/sgl-project/sglang/actions/runs/34540976011)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
