### PR TITLE
Fix dataclasses.asdict on the msgspec ServerArgs

### DIFF
--- a/benchmark/simulator/bench_runner.py
+++ b/benchmark/simulator/bench_runner.py
@@ -4,10 +4,10 @@ import asyncio
 import atexit
 import json
 import os
-from dataclasses import asdict
 from typing import Iterator
 
 import numpy as np
+from msgspec.structs import asdict
 from sglang_simulator.compat import apply_simulator_server_args
 from sglang_simulator.dataset import BaseDataset, GenericRequest
 from sglang_simulator.simulation.benchmark import BaseBenchmarkRunner, BenchmarkConfig

--- a/examples/runtime/engine/offline_batch_inference.py
+++ b/examples/runtime/engine/offline_batch_inference.py
@@ -4,7 +4,8 @@ python3 offline_batch_inference.py  --model meta-llama/Llama-3.1-8B-Instruct
 """
 
 import argparse
-import dataclasses
+
+import msgspec
 
 import sglang as sgl
 from sglang.srt.server_args import ServerArgs
@@ -24,7 +25,7 @@ def main(
     sampling_params = {"temperature": 0.8, "top_p": 0.95}
 
     # Create an LLM.
-    llm = sgl.Engine(**dataclasses.asdict(server_args))
+    llm = sgl.Engine(**msgspec.structs.asdict(server_args))
 
     outputs = llm.generate(prompts, sampling_params)
     # Print the outputs.

--- a/examples/runtime/engine/offline_batch_inference_async.py
+++ b/examples/runtime/engine/offline_batch_inference_async.py
@@ -9,8 +9,9 @@ which is useful to implement an online-like generation with batched inference.
 
 import argparse
 import asyncio
-import dataclasses
 import time
+
+import msgspec
 
 import sglang as sgl
 from sglang.srt.server_args import ServerArgs
@@ -26,7 +27,7 @@ class InferenceEngine:
 
 
 async def run_server(server_args):
-    inference = InferenceEngine(**dataclasses.asdict(server_args))
+    inference = InferenceEngine(**msgspec.structs.asdict(server_args))
 
     # Sample prompts.
     prompts = [

--- a/examples/runtime/engine/offline_batch_inference_vlm.py
+++ b/examples/runtime/engine/offline_batch_inference_vlm.py
@@ -4,7 +4,8 @@ python offline_batch_inference_vlm.py --model-path Qwen/Qwen2-VL-7B-Instruct
 """
 
 import argparse
-import dataclasses
+
+import msgspec
 
 import sglang as sgl
 from sglang.srt.parser.conversation import chat_templates
@@ -14,7 +15,7 @@ from sglang.srt.server_args import ServerArgs
 def main(
     server_args: ServerArgs,
 ):
-    vlm = sgl.Engine(**dataclasses.asdict(server_args))
+    vlm = sgl.Engine(**msgspec.structs.asdict(server_args))
 
     conv = chat_templates[server_args.chat_template].copy()
     image_token = conv.image_token


### PR DESCRIPTION
`simulator-test-cpu` fails on main with `TypeError: asdict() should be called on dataclass instances`.

#38753 turned `ServerArgs` into a `msgspec.Struct`, so `dataclasses.asdict` no longer accepts it. `benchmark/simulator/bench_runner.py` is the call site CI catches; the three `examples/runtime/engine/offline_batch_inference*.py` scripts break the same way and are fixed here too.

Switched to `msgspec.structs.asdict`, which keeps the previous semantics — raw field values, the input `Engine(**kwargs)` reconstructs from — where `resolved_dict()` would substitute resolved ones.

failure example: https://github.com/sgl-project/sglang/actions/runs/34469837108/job/103081322835


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34543631447](https://github.com/sgl-project/sglang/actions/runs/34543631447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34543630496](https://github.com/sgl-project/sglang/actions/runs/34543630496)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->