### PR TITLE
[PP+PD] Fix #38206 Reduce bootstrap consensus latency

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -9,6 +9,8 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
+
 import numpy as np
 import numpy.typing as npt
 import requests
@@ -216,7 +218,7 @@ class CommonKVManager(BaseKVManager):
         )
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
-        self.request_status: Dict[int, KVPoll] = {}
+        self.request_status: Union[Dict[int, KVPoll], PPConsensusStore] = {}
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_send_locks: Dict[str, threading.Lock] = {}
@@ -361,6 +363,12 @@ class CommonKVManager(BaseKVManager):
 
     def check_status(self, bootstrap_room: int) -> KVPoll:
         return self.request_status[bootstrap_room]
+
+    def check_status_pp_consensus(self, bootstrap_room: int) -> KVPoll:
+        statuses = self.request_status.get_all_ranks(bootstrap_room)
+        if any(status is None for status in statuses):
+            return KVPoll.Bootstrapping
+        return min(statuses)
 
     def update_status(self, bootstrap_room: int, status: KVPoll):
         if bootstrap_room not in self.request_status:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -9,8 +9,6 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
-
 import numpy as np
 import numpy.typing as npt
 import requests
@@ -28,6 +26,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVTransferMetric,
     StateType,
 )
+from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     filter_kv_indices_for_cp_rank,

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -248,6 +248,10 @@ class CommonKVManager(BaseKVManager):
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
+            if self.pp_size > 1:
+                self.request_status = PPConsensusStore(
+                    self.pp_size, self.pp_rank, self.pp_group
+                )
             # If a timeout happens on the prefill side, it means prefill instances
             # fail to receive the KV indices from the decode instance of this request.
             # These timeout requests should be aborted to release the tree cache.
@@ -364,7 +368,7 @@ class CommonKVManager(BaseKVManager):
         return self.request_status[bootstrap_room]
 
     def check_status_pp_consensus(self, bootstrap_room: int) -> KVPoll:
-        statuses = self.request_status.get_all_ranks(bootstrap_room)
+        statuses = self.request_status.collect(bootstrap_room)
         if any(status is None for status in statuses):
             return KVPoll.Bootstrapping
         return min(statuses)

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -61,6 +61,9 @@ class FakeKVSender(BaseKVSender):
         self.conclude_state = KVPoll.Success
         return KVPoll.Success
 
+    def poll_pp_consensus(self) -> KVPoll:
+        return self.poll()
+
     def get_transfer_metric(self) -> KVTransferMetric:
         return KVTransferMetric()
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -45,6 +45,7 @@ from sglang.srt.disaggregation.common.utils import (
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
 )
+from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_dsa_tail_transfer_blocks,
@@ -216,6 +217,10 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        if self.pp_size > 1 and disaggregation_mode == DisaggregationMode.PREFILL:
+            self.request_status = PPConsensusStore(
+                self.pp_size, self.pp_rank, self.pp_group
+            )
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -2530,6 +2535,29 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
             return status
         else:
             return self.conclude_state
+
+    def poll_pp_consensus(self) -> KVPoll:
+        if self.conclude_state is None:
+            status = self.kv_mgr.check_status_pp_consensus(self.bootstrap_room)
+            # Hold Success until all staging chunks transferred: a deferred
+            # chunk can still be pending, and concluding now would drop it.
+            if (
+                status == KVPoll.Success
+                and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
+            ):
+                return KVPoll.Transferring
+            if status in (KVPoll.Success, KVPoll.Failed):
+                self.conclude_state = status
+                self.trace_ctx.trace_req_finish()
+            elif status == KVPoll.Bootstrapping:
+                timeout_result = self._check_bootstrap_timeout()
+                if timeout_result is not None:
+                    return timeout_result
+
+            return status
+        else:
+            return self.conclude_state
+
 
     def _init_trace_ctx(self):
         if self.kv_mgr.enable_trace:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -45,7 +45,6 @@ from sglang.srt.disaggregation.common.utils import (
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
 )
-from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_dsa_tail_transfer_blocks,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -217,10 +217,6 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
-        if self.pp_size > 1 and disaggregation_mode == DisaggregationMode.PREFILL:
-            self.request_status = PPConsensusStore(
-                self.pp_size, self.pp_rank, self.pp_group
-            )
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2558,7 +2558,6 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         else:
             return self.conclude_state
 
-
     def _init_trace_ctx(self):
         if self.kv_mgr.enable_trace:
             self.trace_ctx = TraceReqContext(

--- a/python/sglang/srt/disaggregation/pp_consensus_store.py
+++ b/python/sglang/srt/disaggregation/pp_consensus_store.py
@@ -1,197 +1,172 @@
 from __future__ import annotations
 
 import logging
+import os
 import pickle
 import queue
 import threading
 from enum import Enum, auto
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional
 
-_Key = Union[int, str]
+import zmq
 
-from torch.distributed import TCPStore
-
-from sglang.srt.utils.network import get_free_port, get_local_ip_auto
+from sglang.srt.utils.network import (
+    NetworkAddress,
+    get_local_ip_auto,
+    get_zmq_socket,
+    get_zmq_socket_on_host,
+)
 
 logger = logging.getLogger(__name__)
-
-_FLUSH_DONE_PREFIX = "pp_consensus_flush_done"
 
 
 class _OpKind(Enum):
     PUT = auto()
     DELETE = auto()
-    FLUSH = auto()
-    SHUTDOWN = auto()
 
 
 class PPConsensusStore:
-    """Cross-PP-rank key/value store backed by TCPStore for bootstrap consensus."""
+    """A map that replicates metadata to PP rank 0.
+
+    All ranks may use this as a normal Dict, e.g. ``store["key"] = value`` or ``del store["key"]``.
+    All modifications done by all ranks are replicated to rank 0 in background.  Rank 0 calls
+    ``collect`` to retrieve values of all ranks for the specified key.
+    """
 
     def __init__(self, pp_size: int, pp_rank: int, pp_group) -> None:
-        self.pp_size = pp_size
-        self.pp_rank = pp_rank
-        self.pp_group = pp_group
-        self._local_cache: Dict[str, Any] = {}
+        self._pp_size = pp_size
+        self._pp_rank = pp_rank
+        self._pp_group = pp_group
+        self._local_map: Dict[Any, Any] = {}
+        self._peer_map: Dict[int, Dict[Any, Any]] = {}
         self._cache_lock = threading.Lock()
-        self._pending_queue: queue.Queue = queue.Queue()
-        self._flush_seq = 0
-        self._store, host, port = self._init_tcp_store()
-        logger.info(
-            "PPConsensusStore rank=%d connected to %s:%d",
-            pp_rank,
-            host,
-            port,
-        )
-        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
-        self._worker.start()
+        self._replication_queue: Optional[queue.Queue] = None
+        self._zmq_ctx: Optional[zmq.Context] = None
+        self._socket: Optional[zmq.Socket] = None
+        self._init_zmq()
+        if self._pp_rank > 0:
+            self._replication_queue = queue.Queue()
+        self._worker_thread = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker_thread.start()
 
-    def _init_tcp_store(self) -> Tuple[TCPStore, str, int]:
-        if self.pp_rank == 0:
+    def _init_zmq(self) -> None:
+        self._zmq_ctx = zmq.Context()
+        # PP0 listens.
+        if self._pp_rank == 0:
             host = get_local_ip_auto()
-            port = get_free_port()
-            store = TCPStore(
-                host_name=host,
-                port=port,
-                world_size=self.pp_size,
-                is_master=True,
-                wait_for_workers=False,
+            port, self._socket = get_zmq_socket_on_host(
+                self._zmq_ctx, zmq.PULL, host=host
             )
             store_info = (host, port)
+            logger.info("PPConsensusStore is listening at %s:%d", host, port)
         else:
             store_info = None
-        store_info = self.pp_group.broadcast_object(store_info, src=0)
-        host, port = store_info
-        if self.pp_rank > 0:
-            store = TCPStore(
-                host_name=host,
-                port=port,
-                world_size=self.pp_size,
-                is_master=False,
+
+        # Broadcast our zmq host and port to other ranks.
+        host, port = self._pp_group.broadcast_object(store_info, src=0)
+
+        # PP>0 connects to PP0.
+        if self._pp_rank > 0:
+            self._socket = get_zmq_socket(
+                self._zmq_ctx,
+                zmq.PUSH,
+                NetworkAddress(host, port).to_tcp(),
+                bind=False,
             )
-        return store, host, port
+            logger.info("PPConsensusStore connected to %s:%d", host, port)
 
-    @staticmethod
-    def _normalize_key(key: _Key) -> str:
-        return str(key)
+    def _maybe_replicate_to_rank0(self, op: tuple) -> None:
+        if self._pp_rank > 0:
+            self._replication_queue.put(op)
 
-    def _store_key(self, pp_rank: int, key: _Key) -> str:
-        return f"pp_{pp_rank}/{self._normalize_key(key)}"
-
-    def _worker_loop(self) -> None:
-        logger.debug("worker loop")
-        while True:
-            op = self._pending_queue.get()
-            try:
-                if op[0] == _OpKind.SHUTDOWN:
-                    return
-                if op[0] == _OpKind.PUT:
-                    _, key, value = op
-                    logger.debug(f"put {key} = {value}")
-                    self._store.set(
-                        self._store_key(self.pp_rank, key), pickle.dumps(value)
-                    )
-                elif op[0] == _OpKind.DELETE:
-                    _, key = op
-                    store_key = self._store_key(self.pp_rank, key)
-                    try:
-                        self._store.delete_key(store_key)
-                    except Exception:
-                        # Key may already be absent; treat as success.
-                        pass
-                elif op[0] == _OpKind.FLUSH:
-                    _, done_event = op
-                    self._run_flush_barrier()
-                    done_event.set()
-            finally:
-                self._pending_queue.task_done()
-
-    def _run_flush_barrier(self) -> None:
-        self._flush_seq += 1
-        seq = self._flush_seq
-        self._store.set(f"{_FLUSH_DONE_PREFIX}/{self.pp_rank}/{seq}", b"1")
-        wait_keys = [
-            f"{_FLUSH_DONE_PREFIX}/{rank}/{seq}" for rank in range(self.pp_size)
-        ]
-        self._store.wait(wait_keys)
-
-    def put(self, key: _Key, value: Any) -> None:
-        key = self._normalize_key(key)
+    def pop(self, key: Any, default: Any = None) -> Any:
         with self._cache_lock:
-            self._local_cache[key] = value
-            self._pending_queue.put((_OpKind.PUT, key, value))
-
-    def delete(self, key: _Key) -> None:
-        key = self._normalize_key(key)
-        with self._cache_lock:
-            self._local_cache.pop(key, None)
-            self._pending_queue.put((_OpKind.DELETE, key))
-
-    def pop(self, key: _Key, default: Any = None) -> Any:
-        key = self._normalize_key(key)
-        with self._cache_lock:
-            if key not in self._local_cache:
+            if key not in self._local_map:
                 return default
-            value = self._local_cache.pop(key)
-            self._pending_queue.put((_OpKind.DELETE, key))
+            value = self._local_map.pop(key)
+            self._maybe_replicate_to_rank0((_OpKind.DELETE, self._pp_rank, key))
         return value
 
-    def get(self, key: _Key, default: Any = None) -> Any:
-        key = self._normalize_key(key)
+    def get(self, key: Any, default: Any = None) -> Any:
         with self._cache_lock:
-            return self._local_cache.get(key, default)
+            return self._local_map.get(key, default)
 
-    def __contains__(self, key: object) -> bool:
-        if not isinstance(key, (int, str)):
-            return False
-        key = self._normalize_key(key)
+    def __contains__(self, key: Any) -> bool:
         with self._cache_lock:
-            return key in self._local_cache
+            return key in self._local_map
 
-    def flush(self) -> None:
-        done_event = threading.Event()
-        self._pending_queue.put((_OpKind.FLUSH, done_event))
-        done_event.wait()
-
-    def get_local_rank(self, key: _Key) -> Any:
-        key = self._normalize_key(key)
+    def __getitem__(self, key: Any) -> Any:
         with self._cache_lock:
-            return self._local_cache.get(key)
+            return self._local_map[key]
 
-    def get_all_ranks(self, key: _Key) -> List[Any]:
-        values: List[Any] = []
-        for rank in range(self.pp_size):
-            store_key = self._store_key(rank, key)
-            if not self._store.check([store_key]):
-                values.append(None)
-                continue
-            logger.debug(f"get {store_key}")
-            raw = self._store.get(store_key)
-            if not raw:
-                values.append(None)
-                continue
-            values.append(pickle.loads(raw))
-        return values
-
-    def multiget_all_ranks(self, keys: List[_Key]) -> Dict[str, List[Any]]:
-        return {self._normalize_key(key): self.get_all_ranks(key) for key in keys}
-
-    def __getitem__(self, key: _Key) -> Any:
-        key = self._normalize_key(key)
+    def __setitem__(self, key: Any, value: Any) -> None:
         with self._cache_lock:
-            if key not in self._local_cache:
+            self._local_map[key] = value
+            self._maybe_replicate_to_rank0((_OpKind.PUT, self._pp_rank, key, value))
+
+    def __delitem__(self, key: Any) -> None:
+        with self._cache_lock:
+            if key not in self._local_map:
                 raise KeyError(key)
-            return self._local_cache[key]
-
-    def __setitem__(self, key: _Key, value: Any) -> None:
-        self.put(key, value)
-
-    def __delitem__(self, key: _Key) -> None:
-        key = self._normalize_key(key)
-        if key not in self:
-            raise KeyError(key)
-        self.delete(key)
+            self._local_map.pop(key)
+            self._maybe_replicate_to_rank0((_OpKind.DELETE, self._pp_rank, key))
 
     def close(self) -> None:
-        self._pending_queue.put((_OpKind.SHUTDOWN,))
-        self._worker.join(timeout=5)
+        if self._pp_rank > 0:
+            self._replication_queue.put(None)
+        self._zmq_ctx.term()  # This blocks until all zmq socket closed.
+        self._worker_thread.join()
+
+    def _worker_loop(self) -> None:
+        try:
+            if self._pp_rank == 0:
+                self._recv_loop()
+            else:
+                self._send_loop()
+        except zmq.error.ContextTerminated:
+            pass  # Raised by close().
+        except Exception as e:
+            logger.critical(
+                "PPConsensusStore background thread crashed: %s",
+                e,
+            )
+            for handler in logger.handlers:
+                handler.flush()
+            os._exit(1)
+        finally:
+            self._socket.close(linger=0)
+
+    def _recv_once(self) -> None:
+        op = pickle.loads(self._socket.recv())
+        if op[0] == _OpKind.PUT:
+            _, rank, key, value = op
+            logger.debug("recv put rank=%s %s = %s", rank, key, value)
+            with self._cache_lock:
+                self._peer_map.setdefault(rank, {})[key] = value
+        elif op[0] == _OpKind.DELETE:
+            _, rank, key = op
+            logger.debug("recv delete rank=%s %s", rank, key)
+            with self._cache_lock:
+                self._peer_map.get(rank, {}).pop(key, None)
+
+    def _recv_loop(self) -> None:
+        assert self._pp_rank == 0
+        while True:
+            self._recv_once()
+
+    def _send_loop(self) -> None:
+        assert self._pp_rank > 0
+        while True:
+            op = self._replication_queue.get()
+            if op is None:  # A signal for shutdown.
+                return
+            logger.debug("send %s", op)
+            self._socket.send(pickle.dumps(op))
+
+    def collect(self, key: Any) -> List[Any]:
+        assert self._pp_rank == 0, "collect can only be used on PP rank 0"
+        with self._cache_lock:
+            values: List[Any] = [self._local_map.get(key)]
+            for rank in range(1, self._pp_size):
+                values.append(self._peer_map.get(rank, {}).get(key))
+            return values

--- a/python/sglang/srt/disaggregation/pp_consensus_store.py
+++ b/python/sglang/srt/disaggregation/pp_consensus_store.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import logging
+import pickle
+import queue
+import threading
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+_Key = Union[int, str]
+
+from torch.distributed import TCPStore
+
+from sglang.srt.utils.network import get_free_port, get_local_ip_auto
+
+logger = logging.getLogger(__name__)
+
+_FLUSH_DONE_PREFIX = "pp_consensus_flush_done"
+
+
+class _OpKind(Enum):
+    PUT = auto()
+    DELETE = auto()
+    FLUSH = auto()
+    SHUTDOWN = auto()
+
+
+class PPConsensusStore:
+    """Cross-PP-rank key/value store backed by TCPStore for bootstrap consensus."""
+
+    def __init__(self, pp_size: int, pp_rank: int, pp_group) -> None:
+        self.pp_size = pp_size
+        self.pp_rank = pp_rank
+        self.pp_group = pp_group
+        self._local_cache: Dict[str, Any] = {}
+        self._cache_lock = threading.Lock()
+        self._pending_queue: queue.Queue = queue.Queue()
+        self._flush_seq = 0
+        self._store, host, port = self._init_tcp_store()
+        logger.info(
+            "PPConsensusStore rank=%d connected to %s:%d",
+            pp_rank,
+            host,
+            port,
+        )
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
+    def _init_tcp_store(self) -> Tuple[TCPStore, str, int]:
+        if self.pp_rank == 0:
+            host = get_local_ip_auto()
+            port = get_free_port()
+            store = TCPStore(
+                host_name=host,
+                port=port,
+                world_size=self.pp_size,
+                is_master=True,
+                wait_for_workers=False,
+            )
+            store_info = (host, port)
+        else:
+            store_info = None
+        store_info = self.pp_group.broadcast_object(store_info, src=0)
+        host, port = store_info
+        if self.pp_rank > 0:
+            store = TCPStore(
+                host_name=host,
+                port=port,
+                world_size=self.pp_size,
+                is_master=False,
+            )
+        return store, host, port
+
+    @staticmethod
+    def _normalize_key(key: _Key) -> str:
+        return str(key)
+
+    def _store_key(self, pp_rank: int, key: _Key) -> str:
+        return f"pp_{pp_rank}/{self._normalize_key(key)}"
+
+    def _worker_loop(self) -> None:
+        logger.debug("worker loop")
+        while True:
+            op = self._pending_queue.get()
+            try:
+                if op[0] == _OpKind.SHUTDOWN:
+                    return
+                if op[0] == _OpKind.PUT:
+                    _, key, value = op
+                    logger.debug(f"put {key} = {value}")
+                    self._store.set(self._store_key(self.pp_rank, key), pickle.dumps(value))
+                elif op[0] == _OpKind.DELETE:
+                    _, key = op
+                    store_key = self._store_key(self.pp_rank, key)
+                    try:
+                        self._store.delete_key(store_key)
+                    except Exception:
+                        # Key may already be absent; treat as success.
+                        pass
+                elif op[0] == _OpKind.FLUSH:
+                    _, done_event = op
+                    self._run_flush_barrier()
+                    done_event.set()
+            finally:
+                self._pending_queue.task_done()
+
+    def _run_flush_barrier(self) -> None:
+        self._flush_seq += 1
+        seq = self._flush_seq
+        self._store.set(f"{_FLUSH_DONE_PREFIX}/{self.pp_rank}/{seq}", b"1")
+        wait_keys = [f"{_FLUSH_DONE_PREFIX}/{rank}/{seq}" for rank in range(self.pp_size)]
+        self._store.wait(wait_keys)
+
+    def put(self, key: _Key, value: Any) -> None:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            self._local_cache[key] = value
+            self._pending_queue.put((_OpKind.PUT, key, value))
+
+    def delete(self, key: _Key) -> None:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            self._local_cache.pop(key, None)
+            self._pending_queue.put((_OpKind.DELETE, key))
+
+    def pop(self, key: _Key, default: Any = None) -> Any:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            if key not in self._local_cache:
+                return default
+            value = self._local_cache.pop(key)
+            self._pending_queue.put((_OpKind.DELETE, key))
+        return value
+
+    def get(self, key: _Key, default: Any = None) -> Any:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            return self._local_cache.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, (int, str)):
+            return False
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            return key in self._local_cache
+
+    def flush(self) -> None:
+        done_event = threading.Event()
+        self._pending_queue.put((_OpKind.FLUSH, done_event))
+        done_event.wait()
+
+    def get_local_rank(self, key: _Key) -> Any:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            return self._local_cache.get(key)
+
+    def get_all_ranks(self, key: _Key) -> List[Any]:
+        values: List[Any] = []
+        for rank in range(self.pp_size):
+            store_key = self._store_key(rank, key)
+            if not self._store.check([store_key]):
+                values.append(None)
+                continue
+            logger.debug(f"get {store_key}")
+            raw = self._store.get(store_key)
+            if not raw:
+                values.append(None)
+                continue
+            values.append(pickle.loads(raw))
+        return values
+
+    def multiget_all_ranks(self, keys: List[_Key]) -> Dict[str, List[Any]]:
+        return {self._normalize_key(key): self.get_all_ranks(key) for key in keys}
+
+    def __getitem__(self, key: _Key) -> Any:
+        key = self._normalize_key(key)
+        with self._cache_lock:
+            if key not in self._local_cache:
+                raise KeyError(key)
+            return self._local_cache[key]
+
+    def __setitem__(self, key: _Key, value: Any) -> None:
+        self.put(key, value)
+
+    def __delitem__(self, key: _Key) -> None:
+        key = self._normalize_key(key)
+        if key not in self:
+            raise KeyError(key)
+        self.delete(key)
+
+    def close(self) -> None:
+        self._pending_queue.put((_OpKind.SHUTDOWN,))
+        self._worker.join(timeout=5)

--- a/python/sglang/srt/disaggregation/pp_consensus_store.py
+++ b/python/sglang/srt/disaggregation/pp_consensus_store.py
@@ -5,7 +5,7 @@ import pickle
 import queue
 import threading
 from enum import Enum, auto
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 _Key = Union[int, str]
 
@@ -88,7 +88,9 @@ class PPConsensusStore:
                 if op[0] == _OpKind.PUT:
                     _, key, value = op
                     logger.debug(f"put {key} = {value}")
-                    self._store.set(self._store_key(self.pp_rank, key), pickle.dumps(value))
+                    self._store.set(
+                        self._store_key(self.pp_rank, key), pickle.dumps(value)
+                    )
                 elif op[0] == _OpKind.DELETE:
                     _, key = op
                     store_key = self._store_key(self.pp_rank, key)
@@ -108,7 +110,9 @@ class PPConsensusStore:
         self._flush_seq += 1
         seq = self._flush_seq
         self._store.set(f"{_FLUSH_DONE_PREFIX}/{self.pp_rank}/{seq}", b"1")
-        wait_keys = [f"{_FLUSH_DONE_PREFIX}/{rank}/{seq}" for rank in range(self.pp_size)]
+        wait_keys = [
+            f"{_FLUSH_DONE_PREFIX}/{rank}/{seq}" for rank in range(self.pp_size)
+        ]
         self._store.wait(wait_keys)
 
     def put(self, key: _Key, value: Any) -> None:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -43,6 +43,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    _all_reduce_polls,
     build_kv_layer_ids,
     build_staging_slot_metadata,
     get_dsa_tail_state_indices,
@@ -51,7 +52,6 @@ from sglang.srt.disaggregation.utils import (
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
-    _all_reduce_polls,
     poll_and_all_reduce_attn_cp_tp_group,
     pp_sync_polls,
     prepare_abort,
@@ -446,9 +446,7 @@ class PrefillBootstrapQueue:
                     import random
 
                     polls = [
-                        int(KVPoll.Failed)
-                        if random.random() < failure_prob
-                        else poll
+                        int(KVPoll.Failed) if random.random() < failure_prob else poll
                         for poll in polls
                     ]
             else:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -51,8 +51,9 @@ from sglang.srt.disaggregation.utils import (
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
+    _all_reduce_polls,
     poll_and_all_reduce_attn_cp_tp_group,
-    poll_and_all_reduce_pp,
+    pp_sync_polls,
     prepare_abort,
     setup_state_kv_args,
 )
@@ -177,6 +178,7 @@ class PrefillBootstrapQueue:
             self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
         )
         self.transfer_backend = transfer_backend
+        self.pp_poll_sync_work_list: List = []
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get():
             if self.is_mla_backend:
                 raise RuntimeError(
@@ -422,16 +424,8 @@ class PrefillBootstrapQueue:
     def pop_bootstrapped(
         self,
         return_failed_reqs: bool = False,
-        pp_good_rids: Optional[List[str]] = None,
-        pp_bad_rids: Optional[List[str]] = None,
     ) -> List[Req] | tuple[List[Req], List[Req]]:
-        """
-        pop the reqs which has finished bootstrapping
-
-        return_failed_reqs: For PP, on rank 0, also return the failed reqs to notify the next rank
-        pp_good_rids: RIDs that PP consensus determined as WaitingForInput.
-        pp_bad_rids: RIDs that PP consensus determined as Failed.
-        """
+        """Pop the reqs which have finished bootstrapping."""
 
         bootstrapped_reqs = []
         failed_reqs = []
@@ -444,22 +438,28 @@ class PrefillBootstrapQueue:
                 return [], []
 
         if self.pp_size > 1:
-            polls = poll_and_all_reduce_pp(
-                (req.rid for req in self.queue),
-                KVPoll.WaitingForInput,
-                pp_good_rids,
-                pp_bad_rids,
+            if self.pp_rank == 0:
+                polls = [
+                    int(req.disagg_kv_sender.poll_pp_consensus()) for req in self.queue
+                ]
+                if (failure_prob := envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get()) > 0:
+                    import random
+
+                    polls = [
+                        int(KVPoll.Failed)
+                        if random.random() < failure_prob
+                        else poll
+                        for poll in polls
+                    ]
+            else:
+                polls = None
+            polls = pp_sync_polls(
+                polls,
+                self.scheduler.pp_group,
+                self.pp_rank,
+                self.pp_size,
+                self.pp_poll_sync_work_list,
             )
-            uncovered = [i for i, poll in enumerate(polls) if poll is None]
-            if uncovered:
-                local_polls = poll_and_all_reduce_attn_cp_tp_group(
-                    [self.queue[i].disagg_kv_sender for i in uncovered],
-                    self.scheduler.attn_cp_cpu_group,
-                    self.scheduler.attn_tp_cpu_group,
-                )
-                for i, local_poll in zip(uncovered, local_polls):
-                    if local_poll == KVPoll.Failed:
-                        polls[i] = KVPoll.Failed
         else:
             polls = poll_and_all_reduce_attn_cp_tp_group(
                 [req.disagg_kv_sender for req in self.queue],
@@ -467,10 +467,11 @@ class PrefillBootstrapQueue:
                 self.scheduler.attn_tp_cpu_group,
             )
 
-        for i, (req, poll) in enumerate(zip(self.queue, polls)):
-            if poll is None:
-                continue
+        if self.pp_size > 1:
+            polls = _all_reduce_polls(polls, self.scheduler.attn_tp_cpu_group)
+            polls = _all_reduce_polls(polls, self.scheduler.attn_cp_cpu_group)
 
+        for i, (req, poll) in enumerate(zip(self.queue, polls)):
             if poll == KVPoll.Failed:
                 self.scheduler.handle_bootstrap_failure(req)
                 indices_to_remove.add(i)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -43,7 +43,6 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
-    _all_reduce_polls,
     build_kv_layer_ids,
     build_staging_slot_metadata,
     get_dsa_tail_state_indices,
@@ -53,7 +52,7 @@ from sglang.srt.disaggregation.utils import (
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce_attn_cp_tp_group,
-    pp_sync_polls,
+    poll_and_all_reduce_pp2,
     prepare_abort,
     setup_state_kv_args,
 )
@@ -438,21 +437,10 @@ class PrefillBootstrapQueue:
                 return [], []
 
         if self.pp_size > 1:
-            if self.pp_rank == 0:
-                polls = [
-                    int(req.disagg_kv_sender.poll_pp_consensus()) for req in self.queue
-                ]
-                if (failure_prob := envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get()) > 0:
-                    import random
-
-                    polls = [
-                        int(KVPoll.Failed) if random.random() < failure_prob else poll
-                        for poll in polls
-                    ]
-            else:
-                polls = None
-            polls = pp_sync_polls(
-                polls,
+            polls = poll_and_all_reduce_pp2(
+                [req.disagg_kv_sender for req in self.queue],
+                self.scheduler.attn_cp_cpu_group,
+                self.scheduler.attn_tp_cpu_group,
                 self.scheduler.pp_group,
                 self.pp_rank,
                 self.pp_size,
@@ -464,10 +452,6 @@ class PrefillBootstrapQueue:
                 self.scheduler.attn_cp_cpu_group,
                 self.scheduler.attn_tp_cpu_group,
             )
-
-        if self.pp_size > 1:
-            polls = _all_reduce_polls(polls, self.scheduler.attn_tp_cpu_group)
-            polls = _all_reduce_polls(polls, self.scheduler.attn_cp_cpu_group)
 
         for i, (req, poll) in enumerate(zip(self.queue, polls)):
             if poll == KVPoll.Failed:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -106,6 +106,25 @@ def poll_and_all_reduce_pp(
     ]
 
 
+def poll_and_all_reduce_pp2(
+    pollers: List[CommonKVSender],
+    attn_cp_cpu_group: dist.ProcessGroup,
+    attn_tp_cpu_group: dist.ProcessGroup,
+    pp_group: dist.ProcessGroup,
+    pp_rank: int,
+    pp_size: int,
+    pp_poll_sync_work_list: List[torch.distributed.Work],
+) -> List[int]:
+    polls: List[int] = []
+    if pp_rank == 0:
+        polls = _poll_with_failure_injection_pp(pollers)
+        polls = _all_reduce_polls(polls, attn_tp_cpu_group)
+        polls = _all_reduce_polls(polls, attn_cp_cpu_group)
+    # Propagate PP0's data to other ranks
+    polls = pp_sync_polls(polls, pp_group, pp_rank, pp_size, pp_poll_sync_work_list)
+    return polls
+
+
 def get_dsa_seed_metadata_dim(hf_config) -> int:
     """Return the model-defined PD seed width, independent of local spec mode."""
     if not getattr(hf_config, "index_share_for_mtp_iteration", False):
@@ -236,6 +255,17 @@ def _poll_with_failure_injection(pollers) -> List[int]:
             for poller in pollers
         ]
     return [int(poller.poll()) for poller in pollers]
+
+
+def _poll_with_failure_injection_pp(pollers) -> List[int]:
+    if (failure_prob := envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get()) > 0:
+        return [
+            int(KVPoll.Failed)
+            if random.random() < failure_prob
+            else int(poller.poll_pp_consensus())
+            for poller in pollers
+        ]
+    return [int(poller.poll_pp_consensus()) for poller in pollers]
 
 
 def _is_fake_transfer(req: Req) -> bool:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -20,8 +20,8 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.configs.model_config import get_dsa_mtp_topk_width, is_deepseek_dsa
-from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
     get_disagg,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -20,6 +20,7 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.configs.model_config import get_dsa_mtp_topk_width, is_deepseek_dsa
+from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
@@ -47,6 +48,44 @@ if is_npu():
 #########################
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 _IS_HIP = is_hip()
+
+
+def pp_sync_polls(
+    polls: Optional[List[int]],
+    pp_group,
+    pp_rank: int,
+    pp_size: int,
+    sync_work_list: List,
+) -> List[int]:
+    """Synchronize poll states from PP0 through the PP pipeline.
+
+    PP0 provides the data. Each later PP rank receives it from the previous
+    rank and asynchronously forwards it to the next rank.
+    """
+    if pp_size <= 1:
+        assert polls is not None
+        return polls
+
+    for p2p_work in sync_work_list:
+        p2p_work.work.wait()
+    sync_work_list.clear()
+
+    data = polls
+    if pp_rank > 0:
+        data = pp_group.recv_object(
+            src=pp_rank - 1,
+            tag=P2PTag.DISAGG_BOOTSTRAP_PP_SYNC,
+        )
+    if pp_rank + 1 < pp_size:
+        sync_work_list.extend(
+            pp_group.send_object(
+                data,
+                dst=pp_rank + 1,
+                async_send=True,
+                tag=P2PTag.DISAGG_BOOTSTRAP_PP_SYNC,
+            )
+        )
+    return data
 
 
 def poll_and_all_reduce_pp(

--- a/python/sglang/srt/distributed/communication_tags.py
+++ b/python/sglang/srt/distributed/communication_tags.py
@@ -13,3 +13,4 @@ class P2PTag(IntEnum):
     DEFAULT = 0
     HIRADIX_PP_SYNC = int.from_bytes(b"PpHi", byteorder="big")
     GRAMMAR_PP_SYNC = int.from_bytes(b"PpGr", byteorder="big")
+    DISAGG_BOOTSTRAP_PP_SYNC = int.from_bytes(b"PpBs", byteorder="big")

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -179,18 +179,15 @@ class SchedulerPPMixin:
         ====================================================================
         Stage P
         recv ith req from previous stage
-        recv ith bootstrap req from previous stage
+        pop bootstrapped reqs (PPConsensusStore + pp_sync polls)
         recv ith transferred req from previous stage
         recv ith proxy from previous stage
         run ith batch
-        recv prev (i+1) % mb_size th consensus bootstrapped req from previous stage
-        local consensus on bootstrapped req
         recv prev (i+1) % mb_size th release req from previous stage
         local consensus on release req
         recv prev (i+1) % mb_size th outputs
         process batch result of prev (i+1)% mb_size th batch (can be run in parallel with the curr batch GPU computation)
         send ith req to next stage
-        send ith bootstrap req to next stage
         send ith transferred req to next stage
         send ith proxy to next stage
         send current stage's outputs to next stage (can be stashed and delayed to send later)
@@ -198,23 +195,17 @@ class SchedulerPPMixin:
         the above order can be optimized and reordered to minimize communication-related CPU stall and overhead bubbles.
         ====================================================================
 
-        There are two additional elements compared to the regular schedule:
-
-        Bootstrap Requests + Release Requests:
-        - Both can have local failure and need to be consensus on. PP needs to guarantee eventual consistency of local failure and flush malfunc requests out as soft error.
+        Release Requests still use the two-pass PP consensus. Bootstrap uses
+        PPConsensusStore instead of the legacy two-round RID sync.
 
         """
         self.init_pp_loop_state()
 
         # PD additional state initialization
-        bmbs = [None] * self.pp_loop_size
         tmbs = [None] * self.pp_loop_size
-        consensus_bootstrapped_rids: Optional[List[str]] = None
         transferred_rids: List[str] = []
         release_rids: Optional[List[str]] = None
-        send_bootstrapped_work = []
         send_transfer_work = []
-        send_consensus_bootstrapped_work = []
         send_release_work = []
 
         while True:
@@ -227,7 +218,6 @@ class SchedulerPPMixin:
 
                 next_pp_outputs = None
                 next_release_rids = None
-                next_consensus_bootstrapped_rids = None
                 d2h_event = None
                 next_batch_result = None
 
@@ -236,9 +226,7 @@ class SchedulerPPMixin:
                 if not self.pp_group.is_last_rank:
                     self._pp_commit_comm_work(self.send_req_work)
 
-                bootstrapped_rids = self._pp_pd_get_bootstrapped_ids()
-                bmbs[mb_id] = bootstrapped_rids
-                self._pp_commit_comm_work(send_bootstrapped_work)
+                self.process_bootstrapped_queue()
 
                 transferred_rids = self._pp_pd_get_prefill_transferred_ids()
                 self._pp_commit_comm_work(send_transfer_work)
@@ -285,28 +273,12 @@ class SchedulerPPMixin:
                             next_mb_id,
                         )
                     )
-                send_consensus_bootstrapped_work, consensus_bootstrapped_rids = (
-                    self._pp_pd_send_consensus_bootstrapped_ids(
-                        bmbs,
-                        next_first_rank_mb_id,
-                        consensus_bootstrapped_rids,
-                        bootstrapped_rids,
-                    )
-                )
                 send_release_work, release_rids = (
                     self._pp_pd_send_consensus_release_ids(
                         tmbs, next_first_rank_mb_id, release_rids, transferred_rids
                     )
                 )
 
-                if bmbs[next_mb_id] is not None:
-                    next_consensus_bootstrapped_rids = (
-                        self._pp_recv_pyobj_from_prev_stage()
-                    )
-                    next_consensus_bootstrapped_rids = self.process_bootstrapped_queue(
-                        next_consensus_bootstrapped_rids
-                    )
-                self._pp_commit_comm_work(send_consensus_bootstrapped_work)
                 if tmbs[next_mb_id] is not None:
                     next_release_rids = self._pp_recv_pyobj_from_prev_stage()
                 self._pp_commit_comm_work(send_release_work)
@@ -325,9 +297,6 @@ class SchedulerPPMixin:
                     self.send_req_work = self._pp_send_pyobj_to_next_stage(
                         recv_reqs, async_send=True
                     )
-                    send_bootstrapped_work = self._pp_send_pyobj_to_next_stage(
-                        bootstrapped_rids, async_send=True
-                    )
                     send_transfer_work = self._pp_send_pyobj_to_next_stage(
                         transferred_rids, async_send=True
                     )
@@ -343,7 +312,6 @@ class SchedulerPPMixin:
 
                 self.pp_outputs = next_pp_outputs
                 release_rids = next_release_rids
-                consensus_bootstrapped_rids = next_consensus_bootstrapped_rids
 
                 self.running_batch.batch_is_full = False
 
@@ -568,67 +536,9 @@ class SchedulerPPMixin:
             defaultdict(deque)
         )
 
-    def process_bootstrapped_queue(
-        self: Scheduler, bootstrapped_rids: Optional[List[str]]
-    ):
-        # finished consensus bootstrapped reqs and prepare the waiting queue
-        if bootstrapped_rids is not None:
-            (
-                good_consensus_bootstrapped_rids,
-                bad_consensus_bootstrapped_rids,
-            ) = bootstrapped_rids
-            good_reqs, failed_reqs = (
-                self.disagg_prefill_bootstrap_queue.pop_bootstrapped(
-                    return_failed_reqs=True,
-                    pp_good_rids=good_consensus_bootstrapped_rids,
-                    pp_bad_rids=bad_consensus_bootstrapped_rids,
-                )
-            )
-            self.waiting_queue.extend(good_reqs)
-            return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
-        return None
-
-    def _pp_pd_get_bootstrapped_ids(self: Scheduler):
-        # communicate pre-consensus bootstrapp reqs
-        if self.pp_group.is_first_rank:
-            # First rank, pop the bootstrap reqs from the bootstrap queue
-            good_bootstrapped_rids, bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
-            )
-        else:
-            # Other ranks, receive the bootstrap reqs info from the previous rank and ensure the consensus
-            prev_bootstrapped_rids = self._pp_recv_pyobj_from_prev_stage()
-            prev_good_bootstrapped_rids, prev_bad_bootstrapped_rids = (
-                prev_bootstrapped_rids
-            )
-            curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
-            )
-            good_bootstrapped_rids = list(
-                set(prev_good_bootstrapped_rids) & set(curr_good_bootstrapped_rids)
-            )
-            bad_bootstrapped_rids = list(
-                set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
-            )
-        # Route locally-aborted reqs through the bad-union consensus so every PP
-        # rank flushes them in the same consensus round, regardless of when the
-        # AbortReq reaches each rank and regardless of whether
-        # disagg_kv_sender.abort() drives the poll to Failed (it is optional).
-        aborted_rids = {
-            req.rid
-            for req in self.disagg_prefill_bootstrap_queue.queue
-            if isinstance(req.finished_reason, FINISH_ABORT)
-        }
-        good_bootstrapped_rids, bad_bootstrapped_rids = self._route_aborts_to_bad(
-            good_bootstrapped_rids, bad_bootstrapped_rids, aborted_rids
-        )
-        return [good_bootstrapped_rids, bad_bootstrapped_rids]
+    def process_bootstrapped_queue(self: Scheduler):
+        reqs = self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
+        self.waiting_queue.extend(reqs)
 
     def _pp_pd_get_prefill_transferred_ids(self: Scheduler):
         # get the current stage transfer success

--- a/test/registered/unit/disaggregation/test_pp_consensus_store.py
+++ b/test/registered/unit/disaggregation/test_pp_consensus_store.py
@@ -1,0 +1,192 @@
+"""Unit tests for srt/disaggregation/pp_consensus_store."""
+
+import time
+import unittest
+from collections.abc import Callable
+
+from sglang.srt.disaggregation.pp_consensus_store import PPConsensusStore
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _MockPPGroup:
+    def __init__(self):
+        self._obj = None
+
+    def broadcast_object(self, obj, src=0):
+        if obj is not None:
+            self._obj = obj
+        return self._obj
+
+
+class TestPPConsensusStore(CustomTestCase):
+    def _wait_until(self, condition: Callable[[], bool]) -> None:
+        now = time.time()
+        start = now
+        deadline = now + 1
+        delay_time = 0.01
+        while now < deadline and not condition():
+            time.sleep(delay_time)
+            now = time.time()
+            delay_time *= 2
+        self.assertTrue(
+            now < deadline, f"Condition not met after {now - start} seconds"
+        )
+
+    def test_setitem(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        store0["key"] = 10
+        self.assertEqual(store0["key"], 10)
+        store0.close()
+
+    def test_setitme_replicate_to_rank0(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(2, 0, group)
+        store1 = PPConsensusStore(2, 1, group)
+        store0["key"] = 10
+        store1["key"] = 11
+        self._wait_until(lambda: store0.collect("key") == [10, 11])
+        store0.close()
+        store1.close()
+
+    def test_contains(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        store0["key"] = 10
+        self.assertTrue("key" in store0)
+        self.assertFalse("no_such_key" in store0)
+        store0.close()
+
+    def test_get(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        store0["key"] = 10
+        self.assertEqual(store0.get("key"), 10)
+        store0.close()
+
+    def test_get_not_exist(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        self.assertIsNone(store0.get("no_such_key"))
+        self.assertEqual(store0.get("no_such_key", "default"), "default")
+        store0.close()
+
+    def test_get_default(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        self.assertEqual(store0.get("no_such_key", "default"), "default")
+        store0.close()
+
+    def test_getitem_not_exist(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        with self.assertRaises(KeyError):
+            store0["no_such_key"]
+        store0.close()
+
+    def test_delitem(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        store0["key"] = 10
+        del store0["key"]
+        self.assertFalse("key" in store0)
+        store0.close()
+
+    def test_delitem_not_exist(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        with self.assertRaises(KeyError):
+            del store0["no_such_key"]
+        store0.close()
+
+    def test_delitem_replicate_to_rank0(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(2, 0, group)
+        store1 = PPConsensusStore(2, 1, group)
+        store0["key"] = 10
+        store1["key"] = 11
+        self._wait_until(lambda: store0.collect("key") == [10, 11])
+        del store1["key"]
+        self._wait_until(lambda: store0.collect("key") == [10, None])
+        store0.close()
+        store1.close()
+
+    def test_pop(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        store0["key"] = 10
+        self.assertEqual(store0.pop("key"), 10)
+        self.assertFalse("key" in store0)
+        store0.close()
+
+    def test_pop_not_exist(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        self.assertIsNone(store0.pop("no_such_key"))
+        store0.close()
+
+    def test_pop_default(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        self.assertEqual(store0.pop("no_such_key", "default"), "default")
+        store0.close()
+
+    def test_pop_replicate_to_rank0(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(2, 0, group)
+        store1 = PPConsensusStore(2, 1, group)
+        store0["key"] = 10
+        store1["key"] = 11
+        self._wait_until(lambda: store0.collect("key") == [10, 11])
+        self.assertEqual(store1.pop("key"), 11)
+        self.assertFalse("key" in store1)
+        self._wait_until(lambda: store0.collect("key") == [10, None])
+        store0.close()
+        store1.close()
+
+    def test_collect(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(3, 0, group)
+        store1 = PPConsensusStore(3, 1, group)
+        store2 = PPConsensusStore(3, 2, group)
+        store0["key"] = 10
+        store1["key"] = 11
+        store2["key"] = 12
+        self._wait_until(lambda: store0.collect("key") == [10, 11, 12])
+        store0.close()
+        store1.close()
+        store2.close()
+
+    def test_collect_missing(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(3, 0, group)
+        store1 = PPConsensusStore(3, 1, group)
+        store2 = PPConsensusStore(3, 2, group)
+        store0["key"] = 10
+        store2["key"] = 12
+        self._wait_until(lambda: store0.collect("key") == [10, None, 12])
+        store0.close()
+        store1.close()
+        store2.close()
+
+    def test_collect_not_exist(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(1, 0, group)
+        self.assertEqual(store0.collect("no_such_key"), [None])
+        store0.close()
+
+    def test_collect_requires_pp0(self):
+        group = _MockPPGroup()
+        store0 = PPConsensusStore(2, 0, group)
+        store1 = PPConsensusStore(2, 1, group)
+        with self.assertRaises(AssertionError):
+            store1.collect("key")
+        store0.close()
+        store1.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In current implementation, PP+PD bootstrap ready takes a full round-trip from PP0 to PP(n-1).  This contributes to TTFT in large pipeline deployement, e.g. `pp_size=8`.

This has been reported in #34815 and analyzed in depth in #38206.   PR #36613 was a different solution to the issue.

This PR proposes an alternative approach.  It introduces `PPConsensusStore`, which is simply a `Dict` shared among PP ranks.  All PP ranks update their bootstrap status into the map.  PP0 collects others bootstrap status and determine bootstrap readiness.  PP0 broadcast its decision to other PP ranks using `pp_sync`.  This completely removes two-round consensus for bootstrap readiness.

This PR is working in progress.  Here are limitations:
- Only works with mooncake transfer engine.  Other transfer engine is not fixed yet.
- ~~`TCPStore` lacks of batch and non-blocking operation.  We may need to implement our own store.~~
- ~~Only bootstrap consensus is removed.  Other consensus processes are kept unchanged.~~. This will be done in follow-up PRs.

Discussion and advices are welcome.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. Add `PPConsensusStore`, which helps PP0 to gather boostrap ready events from other PP ranks.
2. Add `MooncakeKVSender.poll_pp_consensus`.  This function collects bootstrap events of other PP ranks, and
3. In `pop_bootstrapped`, PP0 calls `poll_pp_consensus` to collect bootstrap status from others, and then propagate decision to other PP ranks.
4. Remove two-round bootstrap consensus at prefill side.

## Accuracy Tests

Tested SWE bench verfieid with DSv4 flash, pd disaggregation, P pp_size=4 tp_size=1, D pp_size=1 tp_size=4.

Baseline: 387/500
This PR: 385/500

<details>

```
# router
nohup env HF_HUB_OFFLINE=1 \
  python -m sglang_router.launch_router \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --pd-disaggregation \
  --prefill http://127.0.0.1:30000 \
  --decode http://127.0.0.1:30001 \
  --host 0.0.0.0 \
  --port 9000 > router.log 2>&1 &

# prefill
nohup env CUDA_VISIBLE_DEVICES=0,1,2,3 \
HF_HUB_OFFLINE=1 \
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --pp-size=4 \
  --tp-size=1 \
  --moe-runner-backend marlin \
  --host 0.0.0.0 \
  --port 30000 \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --chunked-prefill-size=8192 \
  --enable-metrics \
  --disaggregation-mode=prefill \
  --enable-metrics \
  --log-level=debug > prefill.log 2>&1 &


# decode
nohup env CUDA_VISIBLE_DEVICES=4,5,6,7 \
HF_HUB_OFFLINE=1 \
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --tp-size=4 \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --moe-runner-backend marlin \
  --host 0.0.0.0 \
  --port 30001 \
  --enable-metrics \
  --disaggregation-mode=decode > decode.log 2>&1 &

# run swebench
env HF_HUB_OFFLINE=1 \
    OPENAI_API_KEY=dummy \
    OPENAI_BASE_URL=http://x.x.x.x:9000/v1  \
    MSWEA_COST_TRACKING=ignore_errors \
uv run python -m minisweagent.run.benchmarks.swebench \
    --subset verified \
    --split test \
    --shuffle \
    -c swebench.yaml \
    -c environment.container_timeout=72h \
    -c model.model_kwargs.timeout=3600 \
    -o /root/swe_test/pd_tp_baseline_20260915 \
    -m "openai/deepseek-ai/DeepSeek-V4-Flash-0731" \
    -w 64

# read results
cd /root/projects/SWE-bench
uv pip install -e .
env http_proxy=socks5://127.0.0.1:1080 https_proxy=socks5://127.0.0.1:1080 \
python -m swebench.harness.run_evaluation \
    --predictions_path /root/swe_test/pd_pp_baseline_20260913/preds.json \
    --dataset_name princeton-nlp/SWE-Bench_Verified \
    --split test \
    --max_workers 32 \
    --run_id test-mini-swe-agent-$(date +%s) \
    --namespace=mirrors-ssl.aliyuncs.com/swebench
```

</details>

## Speed Tests and Profiling

I tested dsv4 flash with PD and no HiCache.  The benchmark shows **reduciton on TTFT by a single round of prefill (~1.4s)**.

<img width="373" height="745" alt="image" src="https://github.com/user-attachments/assets/89badd5a-d7ae-4663-a6b6-dbbd4d7a3873" />

<details>

```
export HF_ENDPOINT=https://hf-mirror.com

# router
nohup env HF_HUB_OFFLINE=1 \
  python -m sglang_router.launch_router \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --pd-disaggregation \
  --prefill http://127.0.0.1:30000 \
  --decode http://127.0.0.1:30001 \
  --host 0.0.0.0 \
  --port 9000 > router.log 2>&1 &

# prefill
nohup env CUDA_VISIBLE_DEVICES=0,1,2,3 \
HF_HUB_OFFLINE=1 \
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --pp-size=4 \
  --tp-size=1 \
  --moe-runner-backend marlin \
  --host 0.0.0.0 \
  --port 30000 \
  --chunked-prefill-size=8192 \
  --enable-metrics \
  --disaggregation-mode=prefill \
  --enable-metrics \
  --log-level=debug > prefill.log 2>&1 &


# decode
nohup env CUDA_VISIBLE_DEVICES=4,5,6,7 \
HF_HUB_OFFLINE=1 \
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --tp-size=4 \
  --moe-runner-backend marlin \
  --host 0.0.0.0 \
  --port 30001 \
  --enable-metrics \
  --disaggregation-mode=decode > decode.log 2>&1 &

# test script
set -e
for c in 1 4 16; do
        for i in $(seq 1 5); do
            python -m sglang.bench_serving  \
                --backend sglang-oai \
                --base-url http://127.0.0.1:9000 \
                --flush-cache \
                --dataset-name random \
                --num-prompts 256 \
                --random-input 4096 \
                --random-output 1 \
                --random-range-ratio 1 \
                --model=deepseek-ai/DeepSeek-V4-Flash-0731 \
                --max-concurrency=$c
        done
done
```

</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
7. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35327003410](https://github.com/sgl-project/sglang/actions/runs/35327003410)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35327003124](https://github.com/sgl-project/sglang/actions/runs/35327003124)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35327003337](https://github.com/sgl-project/sglang/actions/runs/35327003337)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->