### PR TITLE
[PD] Harden deferred decode KV release: keep the drain ack, defer all failures, hold prefill source pages

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -260,12 +260,7 @@ class AscendKVManager(MooncakeKVManager):
                 )
                 for (src_ptr, dst_ptr, item_len) in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for f in futures:
-                        f.cancel()
-                    return status
+            return self._await_transfer_futures(futures)
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -241,9 +241,11 @@ class CommonKVManager(BaseKVManager):
             )
             self.register_to_bootstrap()
             self.transfer_infos = {}
-            # Deferred KV release: aborted room -> (decode_ip, decode_port);
-            # ack held until the transfer drains.
-            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
+            # Deferred KV release: aborted room -> {(decode_ip, decode_port)};
+            # acks held until the transfer drains. A set because several decode
+            # ranks send ABORT for one room when the sender fans out (MLA with
+            # prefill TP < decode TP), and each of them must be acked.
+            self._deferred_ack_targets: Dict[int, Set[Tuple[str, int]]] = {}
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
@@ -429,14 +431,21 @@ class CommonKVManager(BaseKVManager):
         except Exception as e:
             logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
 
+    def has_outstanding_chunks(self, room: int) -> bool:
+        """True while the transfer worker holds a dequeued or in-flight chunk for
+        this room. Backends without chunk accounting never report outstanding."""
+        outstanding = getattr(self, "_staging_outstanding", None)
+        return outstanding is not None and outstanding.get(room, 0) > 0
+
     def _maybe_ack_drained_abort(self, room: int) -> None:
-        """Send the deferred ack once an aborted room's chunks have drained
-        (outstanding == 0). pop() makes it fire at most once."""
-        if self._staging_outstanding.get(room, 0) > 0:
+        """Send the deferred acks once an aborted room's chunks have drained
+        (outstanding == 0). pop() makes it fire at most once per target set."""
+        if self.has_outstanding_chunks(room):
             return
-        target = self._deferred_ack_targets.pop(room, None)
-        if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
+        targets = self._deferred_ack_targets.pop(room, None)
+        if targets:
+            for decode_ip, decode_port in targets:
+                self._send_abort_ack(decode_ip, decode_port, room)
 
     def register_deferred_ack_target(
         self, room: int, decode_ip: str, decode_port: int
@@ -444,7 +453,25 @@ class CommonKVManager(BaseKVManager):
         """Hold this room's ack until its transfer drains. Callers must mark the
         room Failed FIRST -- registering while it still accepts chunks lets the
         worker ack, then a new chunk writes pages the decode already released."""
-        self._deferred_ack_targets[room] = (decode_ip, decode_port)
+        self._deferred_ack_targets.setdefault(room, set()).add((decode_ip, decode_port))
+
+    def handle_deferred_abort_ack(
+        self, room: int, decode_ip: str, decode_port: int
+    ) -> None:
+        """Ack a decode-side ABORT for `room`, or hold the ack while a chunk is
+        still outstanding. Callers must mark the room Failed FIRST.
+
+        The decision is based only on outstanding chunks, not on whether the
+        room is still tracked: the scheduler can clear() a room whose chunk is
+        still inside the transfer engine, and acking then would let the decode
+        free pages that are still being written."""
+        if self.has_outstanding_chunks(room):
+            self.register_deferred_ack_target(room, decode_ip, decode_port)
+            # The worker may have drained between the check and the register
+            # and would never revisit this room; try once here.
+            self._maybe_ack_drained_abort(room)
+        else:
+            self._send_abort_ack(decode_ip, decode_port, room)
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:
@@ -1334,9 +1361,14 @@ class CommonKVSender(BaseKVSender):
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "_deferred_ack_targets"):
-            # Drop a held ack target if the room concluded without draining
-            # (e.g. aborted before any chunk enqueued); else it leaks on prefill.
-            self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
+            # The scheduler polls Failed and clears the room while the worker
+            # may still be inside the transfer engine for it. Keep the held ack
+            # targets in that case: the worker acks (and pops them) on drain. If
+            # nothing is outstanding, ack now so a target registered for a room
+            # that concluded without any chunk (or whose chunk was skipped) does
+            # not leak and the decode does not wait for its timeout.
+            if not self.kv_mgr.has_outstanding_chunks(self.bootstrap_room):
+                self.kv_mgr._maybe_ack_drained_abort(self.bootstrap_room)
 
     def abort(self):
         self.kv_mgr.record_failure(
@@ -1600,13 +1632,7 @@ class CommonKVReceiver(BaseKVReceiver):
         )
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.invalidate_cached_bootstrap_infos()
-        if (
-            not self.abort_notified
-            and hasattr(self, "bootstrap_infos")
-            and self.bootstrap_infos is not None
-        ):
-            self._send_abort_notification()
-            self.abort_notified = True
+        self.ensure_abort_notified()
         return KVPoll.Failed
 
     def clear(self) -> None:
@@ -1621,13 +1647,23 @@ class CommonKVReceiver(BaseKVReceiver):
         )
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
-        if (
-            not self.abort_notified
-            and hasattr(self, "bootstrap_infos")
-            and self.bootstrap_infos is not None
-        ):
-            self._send_abort_notification()
-            self.abort_notified = True
+        self.ensure_abort_notified()
+
+    def ensure_abort_notified(self) -> bool:
+        """Send ABORT to every prefill rank of this room once, and arm the
+        deferred drain-ack accounting at the same time so no ABORT path can
+        forget it (acks for an unarmed room are dropped by note_abort_ack).
+        Returns whether the prefill has been notified."""
+        if self.abort_notified:
+            return True
+        if getattr(self, "bootstrap_infos", None) is None:
+            return False
+        if self.kv_mgr.enable_deferred_decode_kv_release:
+            # Arm before sending so an ack that races back is not dropped.
+            self.kv_mgr.register_deferred_abort_room(self.bootstrap_room)
+        self._send_abort_notification()
+        self.abort_notified = True
+        return True
 
     def _send_abort_notification(self):
         for bootstrap_info in self.bootstrap_infos:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2354,12 +2354,17 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 if (
                     self.enable_deferred_kv_release
                     and decode_req.kv_receiver.kv_mgr.enable_deferred_decode_kv_release
-                    and decode_req.kv_receiver.abort_notified
+                    and decode_req.kv_receiver.ensure_abort_notified()
                 ):
-                    # Decode-initiated abort: a prefill write may still target
-                    # these pages, so hold them until the drain ack or timeout.
-                    # (A prefill-initiated failure has already stopped writing ->
-                    # immediate release below.)
+                    # Whatever the cause, a prefill write may still target these
+                    # pages: a failure raised by one sender is MIN-reduced onto
+                    # every decode rank while the other prefill ranks are still
+                    # writing, and with several senders per rank the others keep
+                    # writing too. Tell every prefill rank to stop (no-op if the
+                    # decode already did) and hold the pages until each acks its
+                    # drain, or the timeout fires. Ranks with nothing outstanding
+                    # ack immediately. Without bootstrap infos no prefill was
+                    # ever told where these pages are, so release right away.
                     self._defer_release(decode_req)
                     deferred_indices.add(i)
                     indices_to_remove.add(i)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -906,21 +906,27 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
     def _await_transfer_futures(self, futures) -> int:
         """Await a chunk's per-layer RDMA writes; return the first non-zero status.
-        cancel() is a no-op for a running future, so with deferred release on we
-        still drain the running ones before returning (no write may outlive this
-        call, which the drain-ack relies on). Off: original early-return."""
+
+        On the first failure the pending futures are cancelled, but cancel() is
+        a no-op for a running future, so every submitted future is drained
+        before returning: no write may outlive this call, since the caller
+        frees source and destination pages (and acks the decode's abort) on
+        the assumption that the chunk is quiescent. A worker exception is
+        normalized to a failure status instead of escaping and abandoning the
+        sibling transfers mid-write."""
         ret = 0
         for future in concurrent.futures.as_completed(futures):
             try:
                 status = future.result()
             except concurrent.futures.CancelledError:
                 continue
+            except Exception:
+                logger.exception("KV transfer worker raised")
+                status = -1
             if status != 0 and ret == 0:
                 ret = status
                 for f in futures:
                     f.cancel()
-                if not self.enable_deferred_decode_kv_release:
-                    return ret
         return ret
 
     def send_kvcache(
@@ -2143,31 +2149,22 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     )
                     if self.enable_deferred_decode_kv_release:
                         # Mark Failed FIRST (stops add_transfer_request enqueuing
-                        # new chunks), THEN register the ack target: registering
+                        # new chunks), THEN decide on the ack: registering
                         # first would let the worker drain+ack while the room is
                         # not yet Failed, so a newly enqueued chunk could still
-                        # write to the freed pages. The worker (not this thread)
-                        # acks once its in-flight write drains; if nothing is in
-                        # flight, decode falls back to the release timeout.
+                        # write to the freed pages. The ack is held while a
+                        # chunk is outstanding, whether or not the room is still
+                        # tracked (clear() can drop a room mid-transfer), and
+                        # sent by the worker once its in-flight write drains.
                         if room_active:
                             self.update_status(room_to_be_aborted, KVPoll.Failed)
-                            self.register_deferred_ack_target(
-                                room_to_be_aborted, decode_ip, decode_port
-                            )
-                            # Try once: the room may already be quiescent and
-                            # never revisited by the worker.
-                            self._maybe_ack_drained_abort(room_to_be_aborted)
                             logger.debug(
                                 f"Received abort notification for room {room_to_be_aborted}, "
-                                f"marked as Failed; ACK deferred until transfer drains"
+                                f"marked as Failed"
                             )
-                        elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                            # Concluded/unknown AND quiescent: ack now. A cleared
-                            # room is not automatically quiescent -- clear() can
-                            # drop a room whose chunk is still transferring.
-                            self._send_abort_ack(
-                                decode_ip, decode_port, room_to_be_aborted
-                            )
+                        self.handle_deferred_abort_ack(
+                            room_to_be_aborted, decode_ip, decode_port
+                        )
                         continue
                     # No need to abort the room if it has already succeeded
                     if room_active:
@@ -2514,10 +2511,16 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
             status = self.kv_mgr.check_status(self.bootstrap_room)
             # Hold Success until all staging chunks transferred: a deferred
             # chunk can still be pending, and concluding now would drop it.
+            # With deferred release, hold Failed the same way: the scheduler
+            # frees the source pages right after a terminal poll, and a chunk
+            # still inside the transfer engine would read reused pages.
             if (
                 status == KVPoll.Success
-                and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
-            ):
+                or (
+                    status == KVPoll.Failed
+                    and self.kv_mgr.enable_deferred_decode_kv_release
+                )
+            ) and self.kv_mgr.has_outstanding_chunks(self.bootstrap_room):
                 return KVPoll.Transferring
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2794,20 +2794,13 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 f"ignoring (already completed or unknown)"
             )
 
-        # Deferred KV release: register only after the status flip above (see
-        # register_deferred_ack_target), then try once -- the room may already be
-        # quiescent and never revisited by the worker. A concluded/unknown room is
-        # acked only when nothing is still counted for it: the ERR path abandons
-        # sibling handles that may still be writing and clear() then drops the
-        # room, so "unknown" alone does not imply quiescent.
+        # Deferred KV release: decide only after the status flip above (see
+        # register_deferred_ack_target). The ack is held while a chunk is still
+        # counted for the room, tracked or not: the ERR path abandons sibling
+        # handles that may still be writing and clear() then drops the room, so
+        # "unknown" alone does not imply quiescent.
         if self.enable_deferred_decode_kv_release and decode_port is not None:
-            if room_active:
-                self.register_deferred_ack_target(
-                    room_to_be_aborted, decode_ip, decode_port
-                )
-                self._maybe_ack_drained_abort(room_to_be_aborted)
-            elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                self._send_abort_ack(decode_ip, decode_port, room_to_be_aborted)
+            self.handle_deferred_abort_ack(room_to_be_aborted, decode_ip, decode_port)
 
         return True
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -947,6 +947,8 @@ class SchedulerDisaggregationPrefillMixin:
         Poll the requests in the middle of transfer. If done, return the request.
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
+        self.resolve_prefill_drain_releases()
+
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 
@@ -1067,7 +1069,7 @@ class SchedulerDisaggregationPrefillMixin:
         else:
             logger.warning(error_message)
         req.time_stats.trace_ctx.abort(abort_info={"reason": error_message})
-        release_kv_cache(req, self.tree_cache)  # unlock the tree
+        self.release_prefill_kv_after_drain(req)  # unlock the tree
         if not isinstance(req.finished_reason, FINISH_ABORT):
             prepare_abort(
                 req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
@@ -1075,6 +1077,41 @@ class SchedulerDisaggregationPrefillMixin:
         if self.metrics_reporter.enable_metrics:
             self.metrics_collector.increment_transfer_failed_reqs()
         return exc
+
+    def release_prefill_kv_after_drain(
+        self: Scheduler, req: Req, is_insert: bool = True
+    ) -> bool:
+        """Release a retired request's KV, or hold it while its sender still has
+        a chunk inside the transfer engine (deferred KV release only).
+
+        A terminal poll or abort() does not stop a chunk the transfer worker has
+        already dequeued; freeing the source pages now would let that chunk read
+        pages reused by another request. The hold is per rank and outside
+        `disagg_prefill_inflight_queue`, whose length must stay identical across
+        TP ranks for the poll all-reduce. Returns True if released now."""
+        sender = req.disagg_kv_sender
+        kv_mgr = getattr(sender, "kv_mgr", None)
+        if (
+            kv_mgr is not None
+            and kv_mgr.enable_deferred_decode_kv_release
+            and kv_mgr.has_outstanding_chunks(sender.bootstrap_room)
+        ):
+            self.disagg_prefill_drain_releases.append((req, is_insert))
+            return False
+        release_kv_cache(req, self.tree_cache, is_insert=is_insert)
+        return True
+
+    def resolve_prefill_drain_releases(self: Scheduler) -> None:
+        if not self.disagg_prefill_drain_releases:
+            return
+        still_held = []
+        for req, is_insert in self.disagg_prefill_drain_releases:
+            sender = req.disagg_kv_sender
+            if sender.kv_mgr.has_outstanding_chunks(sender.bootstrap_room):
+                still_held.append((req, is_insert))
+            elif req.kv.holds_kv or req.kv.holds_mamba:
+                release_kv_cache(req, self.tree_cache, is_insert=is_insert)
+        self.disagg_prefill_drain_releases = still_held
 
     def clear_pending_chunk_send(self: Scheduler, req: Req) -> None:
         """Drop `req` from the sent-but-unconcluded chunk set.
@@ -1111,7 +1148,7 @@ class SchedulerDisaggregationPrefillMixin:
         if self.enable_hicache_storage:
             self.tree_cache.release_aborted_request(req.rid)
         if req.kv.holds_kv or req.kv.holds_mamba:
-            release_kv_cache(req, self.tree_cache, is_insert=False)
+            self.release_prefill_kv_after_drain(req, is_insert=False)
         return True
 
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1582,6 +1582,9 @@ class Scheduler(
             self.disagg_prefill_inflight_queue: List[Req] = []
             # Requests with a sent chunk that are not yet on the inflight queue.
             self.disagg_prefill_pending_chunk_rids: Set[str] = set()
+            # Retired requests whose KV is held until the transfer worker drains
+            # their last outstanding chunk (deferred KV release only).
+            self.disagg_prefill_drain_releases: List[Tuple[Req, bool]] = []
 
             self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
 
@@ -3455,7 +3458,10 @@ class Scheduler(
             )
             req.pending_bootstrap = False
         self._release_aborted_request(req.rid)
-        release_kv_cache(req, self.tree_cache, is_insert=False)
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            self.release_prefill_kv_after_drain(req, is_insert=False)
+        else:
+            release_kv_cache(req, self.tree_cache, is_insert=False)
 
         self.chunked_req = None
         self._pending_chunked_abort_req = None
@@ -4721,6 +4727,9 @@ class Scheduler(
         deferred_pending = (
             self.disaggregation_mode == DisaggregationMode.DECODE
             and self.disagg_decode_transfer_queue.has_pending_deferred_releases()
+        ) or (
+            self.disaggregation_mode == DisaggregationMode.PREFILL
+            and bool(self.disagg_prefill_drain_releases)
         )
         with self.scheduler_stage_metrics.record(SCHEDULER_STAGE_SANITY_CHECK_CACHE):
             if not self.enable_hisparse and not deferred_pending:
@@ -4803,6 +4812,7 @@ class Scheduler(
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 idle &= len(self.disagg_prefill_inflight_queue) == 0
                 idle &= len(self.disagg_prefill_bootstrap_queue.queue) == 0
+                idle &= len(self.disagg_prefill_drain_releases) == 0
 
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
@@ -5283,21 +5293,9 @@ class Scheduler(
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    receiver = decode_req.kv_receiver
-                    receiver.abort()
-                    # Arm drain-ack accounting once the ABORT is sent, so acks
-                    # arriving before this req is deferred (e.g. during the next
-                    # forward step) are captured. A fresh set also drops stale acks
-                    # from a prior request that reused this bootstrap_room. A
-                    # redundant abort only re-wipes -- holds longer, never releases
-                    # early -- so no transition guard is needed.
-                    if (
-                        receiver.kv_mgr.enable_deferred_decode_kv_release
-                        and receiver.abort_notified
-                    ):
-                        receiver.kv_mgr.register_deferred_abort_room(
-                            decode_req.req.bootstrap_room
-                        )
+                    # abort() also arms the deferred drain-ack accounting for
+                    # this room when deferred KV release is enabled.
+                    decode_req.kv_receiver.abort()
 
             # Abort requests whose KV is already backed up for retraction.
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/test/registered/unit/disaggregation/test_deferred_kv_release_hardening.py
+++ b/test/registered/unit/disaggregation/test_deferred_kv_release_hardening.py
@@ -1,0 +1,591 @@
+"""Unit tests hardening the deferred KV release mechanism for PD aborts.
+
+Companion to test_deferred_decode_kv_release.py. Each test forces one of the
+interleavings that previously let a page be released while a transfer for it
+was still inside the transfer engine, or let the decode wait for the release
+timeout because the prefill's drain ack was lost:
+
+- prefill clear() dropping the held ack target before the worker drained
+- a second decode rank's ABORT overwriting the first rank's ack target
+- ABORT arriving for a room the scheduler already cleared mid-chunk
+- a prefill-initiated failure releasing decode pages without an abort round trip
+- the decode waiting-timeout abort never arming the drain-ack accounting
+- prefill source pages released while the sender still has a chunk in flight
+- per-layer transfer futures abandoned after the first failure
+
+All fakes; no GPU, no network.
+"""
+
+import concurrent.futures
+import threading
+import unittest
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.disaggregation import decode as decode_mod
+from sglang.srt.disaggregation import prefill as prefill_mod
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVManager,
+    CommonKVReceiver,
+    CommonKVSender,
+)
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager, MooncakeKVSender
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _make_prefill_manager(deferred=True):
+    """Prefill-side manager carrying only the drain-ack state; acks recorded."""
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.enable_deferred_decode_kv_release = deferred
+    mgr._deferred_ack_targets = {}
+    mgr._staging_outstanding = defaultdict(int)
+    mgr.request_status = {}
+    mgr.transfer_infos = {}
+    mgr.req_to_decode_prefix_len = {}
+    mgr.acks = []
+    mgr._send_abort_ack = lambda ip, port, room: mgr.acks.append((ip, port, room))
+    return mgr
+
+
+class _Sender(CommonKVSender):
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
+class _Receiver(CommonKVReceiver):
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
+def _make_sender(mgr, room):
+    sender = _Sender.__new__(_Sender)
+    sender.kv_mgr = mgr
+    sender.bootstrap_room = room
+    return sender
+
+
+class TestPrefillAckTargetSurvivesClear(CustomTestCase):
+    """A: clear() must not drop the ack target while a chunk is outstanding."""
+
+    def test_clear_keeps_target_while_chunk_outstanding_then_worker_acks(self):
+        mgr = _make_prefill_manager()
+        room = 10
+        mgr.request_status[room] = KVPoll.Failed
+        # Worker dequeued a chunk, then ABORT arrived and registered a target.
+        mgr._staging_outstanding[room] = 1
+        mgr.register_deferred_ack_target(room, "10.0.0.1", 5000)
+
+        # Scheduler polls Failed and clears the room while the chunk is in flight.
+        _make_sender(mgr, room).clear()
+        self.assertIn(room, mgr._deferred_ack_targets)
+        self.assertEqual(mgr.acks, [])
+
+        # Worker finishes the chunk: outstanding hits zero and it acks.
+        mgr._staging_outstanding[room] -= 1
+        mgr._maybe_ack_drained_abort(room)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+        self.assertNotIn(room, mgr._deferred_ack_targets)
+
+    def test_clear_with_nothing_outstanding_acks_and_does_not_leak(self):
+        mgr = _make_prefill_manager()
+        room = 11
+        mgr.request_status[room] = KVPoll.Failed
+        mgr.register_deferred_ack_target(room, "10.0.0.1", 5000)
+
+        _make_sender(mgr, room).clear()
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+        self.assertNotIn(room, mgr._deferred_ack_targets)
+
+    def test_clear_without_target_is_noop(self):
+        mgr = _make_prefill_manager()
+        _make_sender(mgr, 12).clear()
+        self.assertEqual(mgr.acks, [])
+        self.assertEqual(mgr._deferred_ack_targets, {})
+
+
+class TestMultipleAckTargetsPerRoom(CustomTestCase):
+    """B: fan-out registers one target per decode rank; every one is acked."""
+
+    def test_second_decode_rank_does_not_overwrite_first(self):
+        mgr = _make_prefill_manager()
+        room = 20
+        mgr._staging_outstanding[room] = 1
+        mgr.register_deferred_ack_target(room, "10.0.0.1", 5000)
+        mgr.register_deferred_ack_target(room, "10.0.0.2", 5000)
+        self.assertEqual(len(mgr._deferred_ack_targets[room]), 2)
+
+        mgr._staging_outstanding[room] = 0
+        mgr._maybe_ack_drained_abort(room)
+        self.assertEqual(
+            sorted(mgr.acks), [("10.0.0.1", 5000, room), ("10.0.0.2", 5000, room)]
+        )
+        self.assertNotIn(room, mgr._deferred_ack_targets)
+
+    def test_duplicate_target_acked_once(self):
+        mgr = _make_prefill_manager()
+        room = 21
+        mgr.register_deferred_ack_target(room, "10.0.0.1", 5000)
+        mgr.register_deferred_ack_target(room, "10.0.0.1", 5000)
+        mgr._maybe_ack_drained_abort(room)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+
+
+class TestAbortForClearedRoomWithOutstandingChunk(CustomTestCase):
+    """C: the ack decision depends on outstanding chunks, not on room_active."""
+
+    def test_cleared_room_with_outstanding_chunk_defers_ack(self):
+        mgr = _make_prefill_manager()
+        room = 30
+        # Room already cleared by the scheduler, chunk still in the engine.
+        mgr._staging_outstanding[room] = 1
+        mgr.handle_deferred_abort_ack(room, "10.0.0.1", 5000)
+        self.assertEqual(mgr.acks, [])
+        self.assertIn(room, mgr._deferred_ack_targets)
+
+        mgr._staging_outstanding[room] -= 1
+        mgr._maybe_ack_drained_abort(room)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+
+    def test_active_room_with_nothing_outstanding_acks_now(self):
+        mgr = _make_prefill_manager()
+        room = 31
+        mgr.request_status[room] = KVPoll.Failed
+        mgr.handle_deferred_abort_ack(room, "10.0.0.1", 5000)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+        self.assertNotIn(room, mgr._deferred_ack_targets)
+
+    def test_worker_draining_between_check_and_register_still_acks(self):
+        # The handler's post-register retry covers the worker popping the count
+        # (and finding no target) right after the handler observed it non-zero.
+        mgr = _make_prefill_manager()
+        room = 32
+        mgr._staging_outstanding[room] = 1
+        real_register = mgr.register_deferred_ack_target
+
+        def register_then_drain(*args):
+            real_register(*args)
+            mgr._staging_outstanding.pop(room, None)
+            mgr._maybe_ack_drained_abort(room)
+
+        mgr.register_deferred_ack_target = register_then_drain
+        mgr.handle_deferred_abort_ack(room, "10.0.0.1", 5000)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, room)])
+        self.assertNotIn(room, mgr._deferred_ack_targets)
+
+    def test_backend_without_chunk_accounting_acks_now(self):
+        mgr = _make_prefill_manager()
+        del mgr._staging_outstanding
+        mgr.handle_deferred_abort_ack(33, "10.0.0.1", 5000)
+        self.assertEqual(mgr.acks, [("10.0.0.1", 5000, 33)])
+
+
+def _make_decode_manager(deferred=True):
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.enable_deferred_decode_kv_release = deferred
+    mgr._deferred_abort_ack_tracker = {}
+    mgr.request_status = {}
+    mgr.required_prefill_response_num_table = {}
+    mgr.prefill_response_tracker = defaultdict(set)
+    mgr.failure_records = {}
+    mgr.failure_lock = threading.Lock()
+    mgr.waiting_timeout = 0.0
+    return mgr
+
+
+def _make_receiver(mgr, room, n_prefill_ranks=2, bootstrap_infos="default"):
+    receiver = _Receiver.__new__(_Receiver)
+    receiver.kv_mgr = mgr
+    receiver.bootstrap_room = room
+    receiver.conclude_state = None
+    receiver.abort_notified = False
+    receiver.init_time = 0.0
+    receiver._connection_pool_entries = {}
+    if bootstrap_infos == "default":
+        bootstrap_infos = [{"rank": r} for r in range(n_prefill_ranks)]
+    receiver.bootstrap_infos = bootstrap_infos
+    receiver.abort_sends = 0
+
+    def fake_send():
+        receiver.abort_sends += 1
+
+    receiver._send_abort_notification = fake_send
+    receiver.invalidate_cached_bootstrap_infos = lambda: None
+    return receiver
+
+
+class TestAbortNotificationArmsDrainAcks(CustomTestCase):
+    """E: every ABORT path arms drain-ack accounting through one helper."""
+
+    def test_waiting_timeout_registers_room(self):
+        mgr = _make_decode_manager()
+        receiver = _make_receiver(mgr, 40)
+        self.assertEqual(receiver._check_waiting_timeout(), KVPoll.Failed)
+        self.assertTrue(receiver.abort_notified)
+        self.assertEqual(receiver.abort_sends, 1)
+        self.assertIn(40, mgr._deferred_abort_ack_tracker)
+        # An ack racing back right after the ABORT is now counted.
+        mgr.note_abort_ack(40, 0)
+        mgr.note_abort_ack(40, 1)
+        self.assertTrue(mgr.is_abort_release_safe(40, required_acks=2))
+
+    def test_abort_registers_room(self):
+        mgr = _make_decode_manager()
+        receiver = _make_receiver(mgr, 41)
+        receiver.abort()
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertIn(41, mgr._deferred_abort_ack_tracker)
+
+    def test_redundant_abort_does_not_wipe_recorded_acks(self):
+        mgr = _make_decode_manager()
+        receiver = _make_receiver(mgr, 42)
+        receiver.abort()
+        mgr.note_abort_ack(42, 0)
+        receiver.abort()
+        self.assertEqual(receiver.abort_sends, 1)
+        self.assertTrue(mgr.is_abort_release_safe(42, required_acks=1))
+
+    def test_not_registered_when_deferred_release_disabled(self):
+        mgr = _make_decode_manager(deferred=False)
+        receiver = _make_receiver(mgr, 43)
+        receiver.abort()
+        self.assertEqual(receiver.abort_sends, 1)
+        self.assertNotIn(43, mgr._deferred_abort_ack_tracker)
+
+    def test_no_bootstrap_infos_means_not_notified(self):
+        mgr = _make_decode_manager()
+        receiver = _make_receiver(mgr, 44, bootstrap_infos=None)
+        self.assertFalse(receiver.ensure_abort_notified())
+        self.assertFalse(receiver.abort_notified)
+        self.assertNotIn(44, mgr._deferred_abort_ack_tracker)
+
+
+class _FakeIdxAllocator:
+    def __init__(self):
+        self.freed = []
+
+    def free(self, idx):
+        self.freed.append(idx)
+
+
+def _make_transfer_queue(polls):
+    q = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    q.queue = []
+    q.tp_rank = 0
+    q.enable_staging = False
+    q.staging_handler = None
+    q.enable_deferred_kv_release = True
+    q.deferred_kv_release_timeout = 30.0
+    q._deferred_releases = []
+    q.tree_cache = object()
+    q.metadata_buffers = SimpleNamespace(bootstrap_room={})
+    q.req_to_metadata_buffer_idx_allocator = _FakeIdxAllocator()
+    q.scheduler = SimpleNamespace(
+        enable_decode_hicache=False,
+        enable_hisparse=False,
+        output_streamer=SimpleNamespace(stream_output=lambda reqs, logprob: None),
+        metrics_reporter=SimpleNamespace(enable_metrics=False),
+    )
+    q._poll_with_metadata_gate = lambda: polls
+    q._clean_hicache_prefetch_resources = lambda decode_req: None
+    return q
+
+
+def _make_decode_req(mgr, room, idx, bootstrap_infos="default"):
+    receiver = _make_receiver(mgr, room, bootstrap_infos=bootstrap_infos)
+    mgr.request_status[room] = KVPoll.Failed
+    receiver.failure_exception = lambda: None
+    return SimpleNamespace(
+        req=SimpleNamespace(rid=f"r{room}", bootstrap_room=room, return_logprob=False),
+        kv_receiver=receiver,
+        hicache_restore_status=None,
+        metadata_buffer_index=idx,
+    )
+
+
+class TestNonDecodeInitiatedFailureDefers(CustomTestCase):
+    """D: any Failed defers when enabled, after telling every prefill rank."""
+
+    def test_prefill_initiated_failure_sends_abort_and_defers(self):
+        mgr = _make_decode_manager()
+        dreq = _make_decode_req(mgr, 50, idx=3)
+        q = _make_transfer_queue([KVPoll.Failed])
+        q.queue = [dreq]
+
+        with (
+            patch.object(decode_mod, "release_kv_cache") as rel,
+            patch.object(decode_mod, "prepare_abort"),
+        ):
+            self.assertEqual(q.pop_transferred(), [])
+
+        rel.assert_not_called()
+        self.assertEqual(dreq.kv_receiver.abort_sends, 1)
+        self.assertIn(50, mgr._deferred_abort_ack_tracker)
+        self.assertEqual(len(q._deferred_releases), 1)
+        held, _deadline, held_idx, required_acks = q._deferred_releases[0]
+        self.assertIs(held, dreq)
+        self.assertEqual(held_idx, 3)
+        self.assertEqual(required_acks, 2)
+        self.assertEqual(q.queue, [])
+        # Slot is held too: freed at resolve time, not here.
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [])
+
+        # Both prefill ranks ack their drain -> released exactly once.
+        mgr.note_abort_ack(50, 0)
+        mgr.note_abort_ack(50, 1)
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            q.resolve_deferred_releases()
+        rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [3])
+
+    def test_decode_initiated_abort_does_not_resend_abort(self):
+        mgr = _make_decode_manager()
+        dreq = _make_decode_req(mgr, 51, idx=4)
+        dreq.kv_receiver.abort()
+        self.assertEqual(dreq.kv_receiver.abort_sends, 1)
+        q = _make_transfer_queue([KVPoll.Failed])
+        q.queue = [dreq]
+
+        with (
+            patch.object(decode_mod, "release_kv_cache") as rel,
+            patch.object(decode_mod, "prepare_abort"),
+        ):
+            q.pop_transferred()
+
+        rel.assert_not_called()
+        self.assertEqual(dreq.kv_receiver.abort_sends, 1)
+        self.assertEqual(len(q._deferred_releases), 1)
+
+    def test_failure_without_bootstrap_infos_releases_immediately(self):
+        # No prefill was ever told about these pages, so nothing can write them.
+        mgr = _make_decode_manager()
+        dreq = _make_decode_req(mgr, 52, idx=5, bootstrap_infos=None)
+        q = _make_transfer_queue([KVPoll.Failed])
+        q.queue = [dreq]
+
+        with (
+            patch.object(decode_mod, "release_kv_cache") as rel,
+            patch.object(decode_mod, "prepare_abort"),
+        ):
+            q.pop_transferred()
+
+        rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+        self.assertEqual(q._deferred_releases, [])
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [5])
+
+    def test_backend_without_deferred_support_releases_immediately(self):
+        mgr = _make_decode_manager(deferred=False)
+        dreq = _make_decode_req(mgr, 53, idx=6)
+        receiver = dreq.kv_receiver
+        q = _make_transfer_queue([KVPoll.Failed])
+        q.queue = [dreq]
+
+        with (
+            patch.object(decode_mod, "release_kv_cache") as rel,
+            patch.object(decode_mod, "prepare_abort"),
+        ):
+            q.pop_transferred()
+
+        rel.assert_called_once()
+        self.assertEqual(receiver.abort_sends, 0)
+        self.assertIsNone(dreq.kv_receiver)
+        self.assertEqual(q._deferred_releases, [])
+
+
+def _make_mooncake_sender(mgr, room):
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender.kv_mgr = mgr
+    sender.bootstrap_room = room
+    sender.conclude_state = None
+    sender.init_time = None
+    sender.trace_ctx = SimpleNamespace(trace_req_finish=lambda: None)
+    return sender
+
+
+class TestPrefillSenderPollHoldsFailedWhileOutstanding(CustomTestCase):
+    """F(i): Failed is held as Transferring while a chunk is still in flight."""
+
+    def test_failed_held_until_drained(self):
+        mgr = _make_prefill_manager()
+        mgr.check_status = lambda room: mgr.request_status[room]
+        room = 60
+        mgr.request_status[room] = KVPoll.Failed
+        mgr._staging_outstanding[room] = 1
+        sender = _make_mooncake_sender(mgr, room)
+
+        self.assertEqual(sender.poll(), KVPoll.Transferring)
+        self.assertIsNone(sender.conclude_state)
+        mgr._staging_outstanding[room] = 0
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        self.assertEqual(sender.conclude_state, KVPoll.Failed)
+
+    def test_failed_not_held_when_deferred_release_disabled(self):
+        mgr = _make_prefill_manager(deferred=False)
+        mgr.check_status = lambda room: mgr.request_status[room]
+        room = 61
+        mgr.request_status[room] = KVPoll.Failed
+        mgr._staging_outstanding[room] = 1
+        self.assertEqual(_make_mooncake_sender(mgr, room).poll(), KVPoll.Failed)
+
+    def test_success_still_held_regardless_of_flag(self):
+        mgr = _make_prefill_manager(deferred=False)
+        mgr.check_status = lambda room: mgr.request_status[room]
+        room = 62
+        mgr.request_status[room] = KVPoll.Success
+        mgr._staging_outstanding[room] = 1
+        self.assertEqual(_make_mooncake_sender(mgr, room).poll(), KVPoll.Transferring)
+
+
+def _make_prefill_scheduler():
+    return SimpleNamespace(
+        tree_cache=object(),
+        disagg_prefill_drain_releases=[],
+        release_prefill_kv_after_drain=(
+            SchedulerDisaggregationPrefillMixin.release_prefill_kv_after_drain
+        ),
+        resolve_prefill_drain_releases=(
+            SchedulerDisaggregationPrefillMixin.resolve_prefill_drain_releases
+        ),
+    )
+
+
+def _make_prefill_req(mgr, room):
+    return SimpleNamespace(
+        rid=f"p{room}",
+        bootstrap_room=room,
+        disagg_kv_sender=SimpleNamespace(kv_mgr=mgr, bootstrap_room=room),
+        kv=SimpleNamespace(holds_kv=True, holds_mamba=False),
+    )
+
+
+class TestPrefillSourceReleaseWaitsForDrain(CustomTestCase):
+    """F(ii): direct release paths hold source pages while a chunk is in flight."""
+
+    def test_release_held_then_resolved_once_after_drain(self):
+        mgr = _make_prefill_manager()
+        sched = _make_prefill_scheduler()
+        req = _make_prefill_req(mgr, 70)
+        mgr._staging_outstanding[70] = 1
+
+        with patch.object(prefill_mod, "release_kv_cache") as rel:
+            self.assertFalse(
+                sched.release_prefill_kv_after_drain(sched, req, is_insert=False)
+            )
+            rel.assert_not_called()
+            self.assertEqual(sched.disagg_prefill_drain_releases, [(req, False)])
+
+            # Still in flight: held across a resolve.
+            sched.resolve_prefill_drain_releases(sched)
+            rel.assert_not_called()
+
+            # Drained: released exactly once, with the original is_insert.
+            mgr._staging_outstanding[70] = 0
+            sched.resolve_prefill_drain_releases(sched)
+            rel.assert_called_once_with(req, sched.tree_cache, is_insert=False)
+            self.assertEqual(sched.disagg_prefill_drain_releases, [])
+            sched.resolve_prefill_drain_releases(sched)
+            rel.assert_called_once()
+
+    def test_release_immediate_when_nothing_outstanding(self):
+        mgr = _make_prefill_manager()
+        sched = _make_prefill_scheduler()
+        req = _make_prefill_req(mgr, 71)
+        with patch.object(prefill_mod, "release_kv_cache") as rel:
+            self.assertTrue(sched.release_prefill_kv_after_drain(sched, req))
+        rel.assert_called_once_with(req, sched.tree_cache, is_insert=True)
+        self.assertEqual(sched.disagg_prefill_drain_releases, [])
+
+    def test_release_immediate_when_deferred_release_disabled(self):
+        mgr = _make_prefill_manager(deferred=False)
+        sched = _make_prefill_scheduler()
+        req = _make_prefill_req(mgr, 72)
+        mgr._staging_outstanding[72] = 1
+        with patch.object(prefill_mod, "release_kv_cache") as rel:
+            self.assertTrue(sched.release_prefill_kv_after_drain(sched, req))
+        rel.assert_called_once()
+
+    def test_release_immediate_without_sender(self):
+        sched = _make_prefill_scheduler()
+        req = _make_prefill_req(None, 73)
+        req.disagg_kv_sender = None
+        with patch.object(prefill_mod, "release_kv_cache") as rel:
+            self.assertTrue(sched.release_prefill_kv_after_drain(sched, req))
+        rel.assert_called_once()
+
+    def test_resolve_skips_request_already_released_elsewhere(self):
+        mgr = _make_prefill_manager()
+        sched = _make_prefill_scheduler()
+        req = _make_prefill_req(mgr, 74)
+        mgr._staging_outstanding[74] = 1
+        with patch.object(prefill_mod, "release_kv_cache") as rel:
+            sched.release_prefill_kv_after_drain(sched, req)
+            req.kv.holds_kv = False
+            mgr._staging_outstanding[74] = 0
+            sched.resolve_prefill_drain_releases(sched)
+        rel.assert_not_called()
+        self.assertEqual(sched.disagg_prefill_drain_releases, [])
+
+
+class TestAwaitTransferFuturesDrains(CustomTestCase):
+    """G: every submitted future terminates before the call returns."""
+
+    def setUp(self):
+        self.mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+    def tearDown(self):
+        self.executor.shutdown(wait=True)
+
+    def test_running_sibling_is_drained_after_first_failure(self):
+        release = threading.Event()
+        sibling_done = threading.Event()
+
+        def slow_ok():
+            release.wait(timeout=10)
+            sibling_done.set()
+            return 0
+
+        def fail_fast():
+            return 7
+
+        futures = [self.executor.submit(slow_ok), self.executor.submit(fail_fast)]
+        # Let the failure land first, then unblock the running sibling from a
+        # helper thread so the awaiting call has to wait for it.
+        futures[1].result()
+        threading.Timer(0.05, release.set).start()
+        self.assertEqual(self.mgr._await_transfer_futures(futures), 7)
+        self.assertTrue(sibling_done.is_set())
+        self.assertTrue(all(f.done() for f in futures))
+
+    def test_exception_is_normalized_to_failure_status(self):
+        def boom():
+            raise RuntimeError("rdma")
+
+        futures = [self.executor.submit(boom), self.executor.submit(lambda: 0)]
+        self.assertNotEqual(self.mgr._await_transfer_futures(futures), 0)
+        self.assertTrue(all(f.done() for f in futures))
+
+    def test_first_nonzero_status_is_returned(self):
+        futures = [self.executor.submit(lambda: 0), self.executor.submit(lambda: 3)]
+        concurrent.futures.wait(futures)
+        self.assertEqual(self.mgr._await_transfer_futures(futures), 3)
+
+    def test_all_success_returns_zero(self):
+        futures = [self.executor.submit(lambda: 0) for _ in range(3)]
+        self.assertEqual(self.mgr._await_transfer_futures(futures), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE` (#35049, #37454) is meant to keep a decode request's destination KV pages allocated until the prefill has stopped writing them after an abort. Reviewing the code paths, the mechanism is defeated in the common case and has no counterpart for the prefill's source pages:

1. **Ack target dropped before the drain.** The prefill scheduler polls `Failed` (not gated on outstanding chunks) on the next iteration after ABORT, calls `failure_exception()` -> `CommonKVSender.clear()`, which pops `_deferred_ack_targets[room]` while the transfer worker is still inside `batch_transfer_sync`. When the worker finishes, `_maybe_ack_drained_abort` finds no target and sends nothing. The decode waits the full timeout and releases anyway. The timeout path is the common path, and it is itself a use-after-free window.
2. **One ack target per room.** With MLA fan-out (prefill TP < decode TP) two decode ranks send ABORT for the same room; the second overwrites the first, so only one rank ever gets an ack.
3. **ABORT for a cleared room with a chunk outstanding is never acked.** The inactive-room branch acks only when nothing is outstanding and otherwise does nothing.
4. **Non-decode-initiated failures release immediately.** `pop_transferred` defers only when `abort_notified` is set, on the assumption that a prefill-initiated failure has already stopped writing. That holds for the one failing sender only. With decode TP > 1 the MIN-reduced `Failed` reaches every decode rank while the other prefill ranks are still writing; with multiple senders per decode rank the other senders are still writing.
5. **Waiting-timeout abort never arms the tracker.** `_check_waiting_timeout` sends ABORT and sets `abort_notified` but never calls `register_deferred_abort_room`, so `note_abort_ack` drops its acks.
6. **Prefill source pages have no protection.** `MooncakeKVSender.poll()` gates `Success` on outstanding chunks but returns `Failed` immediately, and the inflight-failure, retired-abort, and chunked-abort paths call `release_kv_cache` right after `sender.abort()`. A dequeued chunk keeps RDMA-reading pages that can be re-prefilled for another request.
7. **`_await_transfer_futures` returns on first failure** unless the flag is set; `Future.cancel()` is a no-op for running futures, so sibling layer transfers outlive the call and any cleanup.

## Modifications

All under `python/sglang/srt/disaggregation/` unless noted; behind the existing flag unless noted.

- **A.** `CommonKVSender.clear()` keeps ack targets while the manager reports outstanding chunks for the room, else acks immediately (no leak).
- **B.** `_deferred_ack_targets` becomes `Dict[int, Set[(ip, port)]]`; every target is acked.
- **C.** New `CommonKVManager.handle_deferred_abort_ack()`: register the target if a chunk is outstanding regardless of whether the room is still tracked, else ack now. Used by the Mooncake and NIXL ABORT handlers.
- **D.** `DecodeTransferQueue.pop_transferred` defers any `Failed` when the flag is on, after `ensure_abort_notified()`; releases immediately only when the receiver has no `bootstrap_infos`.
- **E.** New `CommonKVReceiver.ensure_abort_notified()` is the single ABORT path and arms `register_deferred_abort_room`; `abort()` and `_check_waiting_timeout()` use it. The duplicate registration in `scheduler.abort_request` is removed.
- **F.** `MooncakeKVSender.poll()` holds `Failed` as `Transferring` while a chunk is outstanding. New `release_prefill_kv_after_drain()` / `resolve_prefill_drain_releases()` keep a retired request's KV in a per-rank hold list and release once the room drains; used by `handle_inflight_transfer_failure`, `_retire_aborted_prefill_result`, `process_pending_chunked_abort`. The idle check and `is_fully_idle` account for held requests. A per-rank list is used instead of re-appending to `disagg_prefill_inflight_queue` because that queue's length is all-reduced across attention TP ranks and "this rank has an outstanding chunk" is a per-rank condition.
- **G.** `_await_transfer_futures` always drains running futures and normalizes non-`CancelledError` exceptions to a nonzero status with `logger.exception` (unconditional; `Future.cancel()` cannot stop a running transfer). Ascend uses the shared helper.

## Known limitations (not addressed here)

- `DecodeTransferQueue.release_memory_occupation` still clears `_deferred_releases` without waiting.
- An ack after a Mooncake `batch_transfer_sync` **timeout** does not prove RDMA quiescence: Mooncake leaves the batch busy with WRs posted (`transfer_engine_py.cpp` "early free ... known issue"). Closing that needs a transport-level cancel or quarantine.
- The Mori backend never sends `ABORT_ACK`, so every deferral there is a timeout release.

## Accuracy

No change to model forward or sampling.

## Speed

None with the flag off, other than the unconditional futures drain in G (failure latency becomes the slowest running layer future). With the flag on: one extra ABORT / ABORT_ACK round trip per aborted transfer; KV held until the prefill worker exits the native call, bounded by `SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT`.

## Tests

- New `test/registered/unit/disaggregation/test_deferred_kv_release_hardening.py`: 30 deterministic unit tests with fakes (no GPU, no network) covering A through F. Run against `main` without the functional commit: 20 fail / 10 pass.
- Existing `test_deferred_decode_kv_release.py` and `test_decode_queue_cleanup.py`: still pass.
- `pre-commit run --files <changed>`: clean.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel if you need help.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34546058231](https://github.com/sgl-project/sglang/actions/runs/34546058231)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34546058003](https://github.com/sgl-project/sglang/actions/runs/34546058003)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34546058258](https://github.com/sgl-project/sglang/actions/runs/34546058258)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->