### PR TITLE
Fix DeepSeek-V4.1 VL routing dropping the fused shared expert

### DIFF
--- a/python/sglang/srt/multimodal/dsv41/vl_routing.py
+++ b/python/sglang/srt/multimodal/dsv41/vl_routing.py
@@ -2,15 +2,33 @@ import torch
 import torch.nn.functional as F
 
 from sglang.srt.layers.moe.topk import (
+    _RENORMALIZE_SUM_EPSILON,
     StandardTopKOutput,
     _mask_topk_ids_padded_region,
     _zero_topk_weights_padded_region,
 )
+from sglang.srt.layers.moe.utils import has_per_rank_fused_shared_slots
 from sglang.srt.utils import is_cuda
+
+
+def _scale_fused_shared_weights(weights, num_fused_shared_experts, scaling_factor):
+    # Standard EP replicates the fused shared expert on every rank and
+    # all-reduces the outputs, so the shared columns carry a 1/ep_size factor
+    # (applied by _post_process_topk_ids on the paths that go through it).
+    if num_fused_shared_experts and scaling_factor is not None:
+        weights[:, -num_fused_shared_experts:] *= scaling_factor
+    return weights
 
 
 def vision_topk(moe, logits, input_ids, num_token_non_padded=None):
     config = moe.topk.topk_config
+    num_fused_shared_experts = config.num_fused_shared_experts
+    if num_fused_shared_experts:
+        # The per-rank shared-slot layout is appended by _post_process_topk_ids,
+        # which this routing path bypasses.
+        assert not has_per_rank_fused_shared_slots(num_fused_shared_experts), (
+            "VL routing does not support per-rank fused shared slots"
+        )
     if is_cuda():
         from sglang.kernels.ops.moe.moe_fused_gate import moe_fused_gate
 
@@ -19,14 +37,20 @@ def vision_topk(moe, logits, input_ids, num_token_non_padded=None):
             moe.gate.e_score_correction_bias,
             topk=config.top_k,
             scoring_func="sqrtsoftplus",
+            num_fused_shared_experts=num_fused_shared_experts,
             bias_alt=moe.gate.e_score_correction_bias_vl,
             input_ids=input_ids,
             bias_alt_token_id=moe.config.image_token_id,
             renormalize=config.renormalize and config.top_k > 1,
-            renormalize_epsilon=1e-20,
+            renormalize_epsilon=_RENORMALIZE_SUM_EPSILON,
             routed_scaling_factor=config.routed_scaling_factor,
             apply_routed_scaling_factor_on_output=config.apply_routed_scaling_factor_on_output,
             num_token_non_padded=num_token_non_padded,
+        )
+        weights = _scale_fused_shared_weights(
+            weights,
+            num_fused_shared_experts,
+            config.fused_shared_experts_scaling_factor,
         )
         return StandardTopKOutput(weights, indices, logits)
     scores = F.softplus(logits.float()).sqrt()
@@ -38,12 +62,29 @@ def vision_topk(moe, logits, input_ids, num_token_non_padded=None):
             moe.gate.e_score_correction_bias_vl,
             moe.gate.e_score_correction_bias,
         )
-    indices = (scores + bias).topk(config.top_k, dim=-1).indices
+    # topk for routed experts only; the shared expert slots are appended below
+    # with the same layout as biased_grouped_topk_gpu.
+    topk_routed = config.top_k - num_fused_shared_experts
+    indices = (scores + bias).topk(topk_routed, dim=-1).indices
     weights = scores.gather(-1, indices)
+    routed_sum = weights.sum(-1, keepdim=True, dtype=torch.float32)
+    if num_fused_shared_experts:
+        shared_ids = logits.shape[-1] + torch.arange(
+            num_fused_shared_experts, device=indices.device, dtype=indices.dtype
+        )
+        indices = torch.cat(
+            [indices, shared_ids.expand(indices.shape[0], -1)],
+            dim=-1,
+        )
+        weights = F.pad(weights, (0, num_fused_shared_experts))
+        weights[:, topk_routed:] = routed_sum / config.routed_scaling_factor
     if config.renormalize and config.top_k > 1:
-        weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
+        weights = weights / (routed_sum + _RENORMALIZE_SUM_EPSILON)
     if config.apply_routed_scaling_factor_on_output:
         weights = weights * config.routed_scaling_factor
+    weights = _scale_fused_shared_weights(
+        weights, num_fused_shared_experts, config.fused_shared_experts_scaling_factor
+    )
     weights, indices = weights.float(), indices.int()
     if num_token_non_padded is not None:
         _mask_topk_ids_padded_region(indices, num_token_non_padded)

--- a/test/registered/kernels/ops/moe/test_dsv41_vl_router.py
+++ b/test/registered/kernels/ops/moe/test_dsv41_vl_router.py
@@ -26,7 +26,13 @@ def route(
             e_score_correction_bias=text, e_score_correction_bias_vl=image
         ),
         config=SimpleNamespace(image_token_id=image_token_id),
-        topk=SimpleNamespace(topk_config=SimpleNamespace(**config)),
+        topk=SimpleNamespace(
+            topk_config=SimpleNamespace(
+                num_fused_shared_experts=0,
+                fused_shared_experts_scaling_factor=None,
+                **config,
+            )
+        ),
     )
     out = vision_topk(moe, logits, tokens, num_token_non_padded)
     return out.topk_weights, out.topk_ids

--- a/test/registered/unit/multimodal/test_dsv41_vl_routing.py
+++ b/test/registered/unit/multimodal/test_dsv41_vl_routing.py
@@ -1,0 +1,88 @@
+"""Unit tests for srt/multimodal/dsv41/vl_routing"""
+
+import unittest
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.topk import TopKConfig
+from sglang.srt.multimodal.dsv41.vl_routing import vision_topk
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+NUM_EXPERTS = 16
+NUM_ROUTED_TOPK = 4
+ROUTED_SCALING_FACTOR = 1.5
+
+
+def _make_moe(
+    num_fused_shared_experts: int,
+    fused_shared_experts_scaling_factor: Optional[float] = None,
+):
+    return SimpleNamespace(
+        gate=SimpleNamespace(
+            e_score_correction_bias=torch.zeros(NUM_EXPERTS),
+            e_score_correction_bias_vl=torch.zeros(NUM_EXPERTS),
+        ),
+        config=SimpleNamespace(image_token_id=0),
+        topk=SimpleNamespace(
+            topk_config=TopKConfig(
+                top_k=NUM_ROUTED_TOPK + num_fused_shared_experts,
+                renormalize=True,
+                num_fused_shared_experts=num_fused_shared_experts,
+                routed_scaling_factor=ROUTED_SCALING_FACTOR,
+                apply_routed_scaling_factor_on_output=True,
+                scoring_func="sqrtsoftplus",
+                fused_shared_experts_scaling_factor=fused_shared_experts_scaling_factor,
+            )
+        ),
+    )
+
+
+class TestDsv41VisionTopK(CustomTestCase):
+    @patch("sglang.srt.multimodal.dsv41.vl_routing.is_cuda", return_value=False)
+    def test_fused_shared_expert_slot(self, _mock_is_cuda):
+        torch.manual_seed(0)
+        logits = torch.randn(8, NUM_EXPERTS)
+
+        unfused = vision_topk(_make_moe(0), logits, None)
+        fused = vision_topk(_make_moe(1), logits, None)
+
+        self.assertEqual(fused.topk_ids.shape, (8, NUM_ROUTED_TOPK + 1))
+        # The shared expert occupies the slot past the routed experts and, with
+        # renormalization, contributes with weight 1.0.
+        torch.testing.assert_close(
+            fused.topk_ids[:, -1],
+            torch.full((8,), NUM_EXPERTS, dtype=fused.topk_ids.dtype),
+        )
+        torch.testing.assert_close(fused.topk_weights[:, -1], torch.ones(8))
+        # Routing of the non-shared slots is unchanged by fusion.
+        torch.testing.assert_close(fused.topk_ids[:, :-1], unfused.topk_ids)
+        torch.testing.assert_close(fused.topk_weights[:, :-1], unfused.topk_weights)
+
+    @patch("sglang.srt.multimodal.dsv41.vl_routing.is_cuda", return_value=False)
+    def test_fused_shared_expert_ep_scaling(self, _mock_is_cuda):
+        torch.manual_seed(0)
+        logits = torch.randn(8, NUM_EXPERTS)
+        ep_size = 8
+
+        fused = vision_topk(_make_moe(1), logits, None)
+        scaled = vision_topk(_make_moe(1, 1 / ep_size), logits, None)
+
+        # Standard EP replicates the shared expert per rank, so its weight is
+        # divided by ep_size while the routed slots are untouched.
+        torch.testing.assert_close(scaled.topk_ids, fused.topk_ids)
+        torch.testing.assert_close(
+            scaled.topk_weights[:, -1], fused.topk_weights[:, -1] / ep_size
+        )
+        torch.testing.assert_close(
+            scaled.topk_weights[:, :-1], fused.topk_weights[:, :-1]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Serving `deepseek-ai/DeepSeek-V4.1-Flash` (FP8 weights + mxfp4 experts, TP8, no EP, DSpark) with `--enforce-shared-experts-fusion` starts cleanly and logs `Shared experts fusion optimization enabled.`, but the target model's logits are garbage: closed-form QA 0/6, 2-character continuations, DSpark accept length collapses to 1.0.

Root cause is in the V4.1 VL routing path. `vision_topk` called `moe_fused_gate` with `topk=config.top_k` but never forwarded `num_fused_shared_experts`. With fusion on, `top_k` is 7 (6 routed + 1 shared), so the gate treated all 7 slots as routed experts: it never emitted the synthetic shared-expert id 384 and normalized over the wrong expert set, i.e. a 7th routed expert silently replaced the shared expert on every token.

Before (ids/weights, layer 6, fusion on):

```
ids = [343, 141, 178, 6, 118, 270, 89]      # no id 384
w   = [0.769, 0.128, 0.120, 0.120, 0.126, 0.120, 0.118]
```

After:

```
ids = [343, 178, 114, 6, 141, 378, 384]     # shared slot present
w   = [0.865, 0.127, 0.129, 0.123, 0.129, 0.127, 1.0]
```

## Modifications

- `vision_topk` forwards `num_fused_shared_experts` to `moe_fused_gate`, and asserts the per-rank fused shared-slot layout is not in use (that layout is appended by `_post_process_topk_ids`, which this path bypasses).
- The torch fallback now appends the shared slots with the same layout as `biased_grouped_topk_gpu` (`topk_routed = top_k - num_fused_shared_experts`, `F.pad` for the shared columns, shared weight `sum(routed) / routed_scaling_factor`) and uses the shared `_RENORMALIZE_SUM_EPSILON` constant instead of a literal.
- Both branches apply `fused_shared_experts_scaling_factor` (standard EP's `1/ep_size`) to the appended shared columns, matching `_post_process_topk_ids`.
- New CPU unit test `test/registered/unit/multimodal/test_dsv41_vl_routing.py` (registered for `base-a-test-cpu`): shared slot id/weight and routed-slot equivalence with the unfused path, plus the EP scaling case.

## Accuracy Tests

DeepSeek-V4.1-Flash, 8xB200 and 8xB300, TP8, DSpark block size 5, `--enforce-shared-experts-fusion`:

- before: closed-form QA 0/6, 2-char continuation, DSpark accept length 1.0
- after: 6/6, coherent 445-char continuation, DSpark accept length ~4.7-5.9 (matching the fusion-off baseline)

Unit test passes on both boxes (2/2).

## Speed Tests and Profiling

`bench_serving`, random 1024-in/512-out, warm server (after FlashInfer autotune + CUDA graph capture), patched fusion vs fusion off:

| HW | Concurrency | fusion tok/s | off tok/s | fusion TTFT | off TTFT |
|---|---:|---:|---:|---:|---:|
| B200 | 1 | 465.9 | 463.7 | 172.8 ms | 190.2 ms |
| B200 | 8 | 1723.6 | 1648.9 | 275.0 ms | 295.9 ms |
| B200 | 32 | 2961.2 | 2687.8 | 354.5 ms | 397.6 ms |
| B300 | 1 | 481.0 | 444.3 | 175.7 ms | 249.6 ms |
| B300 | 8 | 1706.1 | 1565.5 | 281.7 ms | 375.9 ms |
| B300 | 32 | 2806.1 | 2382.6 | 373.7 ms | 451.0 ms |

So with this fix fusion is a win on V4.1-Flash: +0.5/+4.5/+10.2% output tok/s on B200 and +8.3/+9.0/+17.8% on B300 at concurrency 1/8/32, with TTFT 7-30% lower.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34547031078](https://github.com/sgl-project/sglang/actions/runs/34547031078)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34547030961](https://github.com/sgl-project/sglang/actions/runs/34547030961)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34547031233](https://github.com/sgl-project/sglang/actions/runs/34547031233)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->