### PR TITLE
[AMD][CI] Reclaim MI35x HF cache space and seed a checkpoint in one job

### DIFF
--- a/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
+++ b/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
@@ -9,7 +9,8 @@ name: AMD MI35x HF cache reclaim and seed
 # What it reclaims and what it seeds are set by RECLAIM_DIRS and SEED_MODEL
 # below, so reusing this means editing them and dispatching from the branch
 # carrying that edit. RECLAIM_DIRS empty is an audit: the job reports the cache
-# and uploads a listing, and deletes nothing.
+# and uploads a listing, and deletes nothing. Run it that way first -- the
+# allowlist should come from what is on the volume, not from memory of it.
 #
 # It runs on pull_request as well as dispatch because a workflow file that is
 # not yet on the default branch cannot be dispatched at all, and the cache is
@@ -69,13 +70,36 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
 
+      # Run 34548293873 audited the volume: 15 TB, 775 MB free, 50 checkpoints.
+      # amd/GLM-5.2-MXFP4 sits there half-downloaded at 212 GiB of 408 GiB, so
+      # 196 GiB has to be fetched and the partial is worth keeping -- HF resumes
+      # against the blobs already present.
+      #
+      # The two entries below are what that audit plus the reachability join in
+      # #36114 found dead on the MI35x cache, and they are dead for reasons that
+      # do not depend on the join being complete:
+      #
+      #   amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2 (216 GiB) appears nowhere in
+      #     the tree -- no test, no doc, no config, and nothing in git history.
+      #   deepseek-ai/DeepSeek-V4-Flash-0731 (156 GiB) is named only by
+      #     test_deepseek_v4_flash_fp4_b200.py and its megamoe variant, both
+      #     register_cuda_ci on 4-gpu-b200, so no AMD job can want it.
+      #
+      # 372 GiB against 196 GiB needed. The margin is deliberate: the fleet eats
+      # into anything released while the download runs.
+      #
+      # Not on the list, though the join reports them unreferenced:
+      # amd/Qwen3.5-397B-A17B-MXFP4, because the MI35x Qwen3.5 nightly does load
+      # that checkpoint and only reads as unreferenced because it names a local
+      # /data path rather than the repo id; and zai-org/GLM-5.3-Flash, which has
+      # no test but is new enough that someone is plausibly mid-bring-up on it.
       - name: Reclaim and seed
         run: |
           > github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout \
-            -e RECLAIM_DIRS="" \
-            -e SEED_MODEL="" \
-            -e SEED_MIN_GIB="0" \
+            -e RECLAIM_DIRS="models--amd--Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2 models--deepseek-ai--DeepSeek-V4-Flash-0731" \
+            -e SEED_MODEL="amd/GLM-5.2-MXFP4" \
+            -e SEED_MIN_GIB="408" \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             bash scripts/ci/amd/reclaim_and_seed_hf_cache.sh || EXIT_CODE=$?
           echo "$(<github_summary.md)" >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
+++ b/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
@@ -12,17 +12,23 @@ name: AMD MI35x HF cache reclaim and seed
 # and uploads a listing, and deletes nothing. Run it that way first -- the
 # allowlist should come from what is on the volume, not from memory of it.
 #
-# It runs on pull_request as well as dispatch because a workflow file that is
-# not yet on the default branch cannot be dispatched at all, and the cache is
-# usually blocking the very PR that is adding the entry.
+# Dispatch-only: reclaiming and seeding is not a per-PR activity, and this takes
+# a scarce MI35x runner for as long as the download lasts.
+#
+# It ran on pull_request while it was being brought up, because a workflow file
+# that is not yet on the default branch cannot be dispatched at all, and the
+# cache was blocking the very PR that added it. That is worth knowing before
+# reaching for the same trick: a `paths` filter does not limit a pull_request
+# trigger to pushes that touch those paths. The filter matches the whole PR
+# diff, so once the PR contains this file every subsequent push re-runs the job,
+# whatever it changed. Runs 34548293873 (audit), 34549258956 and 34549982464
+# (reclaim and seed) were the useful ones; the rest were pushes to unrelated
+# files.
+#
+# The values below are left as the record of what that seeding did. Reusing this
+# means editing them and dispatching from the branch carrying that edit.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "scripts/ci/amd/reclaim_and_seed_hf_cache.sh"
-      - "scripts/ci/amd/seed_hf_checkpoint.py"
-      - ".github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
+++ b/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
@@ -88,6 +88,11 @@ jobs:
       # 372 GiB against 196 GiB needed. The margin is deliberate: the fleet eats
       # into anything released while the download runs.
       #
+      # /sgl-data/agentic-traces is 172 MB that nothing in this repo creates or
+      # reads, so something staged it out of band. The GLM-5.2 agentic benchmark
+      # synthesizes its corpus for want of a real one and takes a real one from
+      # SGLANG_AGENTIC_TRACE_PATH, so it is worth knowing what is in there.
+      #
       # Not on the list, though the join reports them unreferenced:
       # amd/Qwen3.5-397B-A17B-MXFP4, because the MI35x Qwen3.5 nightly does load
       # that checkpoint and only reads as unreferenced because it names a local
@@ -100,6 +105,7 @@ jobs:
             -e RECLAIM_DIRS="models--amd--Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2 models--deepseek-ai--DeepSeek-V4-Flash-0731" \
             -e SEED_MODEL="amd/GLM-5.2-MXFP4" \
             -e SEED_MIN_GIB="408" \
+            -e AUDIT_DIRS="/sgl-data/agentic-traces" \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             bash scripts/ci/amd/reclaim_and_seed_hf_cache.sh || EXIT_CODE=$?
           echo "$(<github_summary.md)" >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
+++ b/.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml
@@ -1,0 +1,95 @@
+name: AMD MI35x HF cache reclaim and seed
+
+# Frees space on the MI35x HuggingFace cache PVC and downloads a large
+# checkpoint into it, in that order, in one job. See the rationale in
+# scripts/ci/amd/reclaim_and_seed_hf_cache.sh: on this volume the two halves
+# cannot be separate jobs, because the fleet absorbs anything released before
+# the job that needs it gets a runner.
+#
+# What it reclaims and what it seeds are set by RECLAIM_DIRS and SEED_MODEL
+# below, so reusing this means editing them and dispatching from the branch
+# carrying that edit. RECLAIM_DIRS empty is an audit: the job reports the cache
+# and uploads a listing, and deletes nothing.
+#
+# It runs on pull_request as well as dispatch because a workflow file that is
+# not yet on the default branch cannot be dispatched at all, and the cache is
+# usually blocking the very PR that is adding the entry.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "scripts/ci/amd/reclaim_and_seed_hf_cache.sh"
+      - "scripts/ci/amd/seed_hf_checkpoint.py"
+      - ".github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+  DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+concurrency:
+  # Never cancel in flight: a cancelled seed leaves a partial checkpoint behind,
+  # which is the state this job exists to get out of.
+  group: amd-mi35x-hf-cache-reclaim-and-seed
+  cancel-in-progress: false
+
+jobs:
+  reclaim-and-seed:
+    if: github.repository == 'sgl-project/sglang'
+    name: reclaim-and-seed (mi35x)
+    # The 1-GPU and 8-GPU MI35x pools mount the same cache PVC, so the cheap
+    # pool can seed for the expensive one.
+    runs-on: linux-mi35x-gpu-1
+    timeout-minutes: 180
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      # The weights are owned by root because the CI container downloads them,
+      # so the unprivileged runner user can neither unlink nor replace them.
+      # Both halves have to happen inside the container that mounts the PVC.
+      - name: Setup docker
+        run: bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      # So the seed runs the checkout's downloader rather than the image's, and
+      # therefore the same code the consumer job will use to decide the
+      # checkpoint is already cached.
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Reclaim and seed
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout \
+            -e RECLAIM_DIRS="" \
+            -e SEED_MODEL="" \
+            -e SEED_MIN_GIB="0" \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            bash scripts/ci/amd/reclaim_and_seed_hf_cache.sh || EXIT_CODE=$?
+          echo "$(<github_summary.md)" >> $GITHUB_STEP_SUMMARY || true
+          exit ${EXIT_CODE:-0}
+
+      # The reachability join that says which of these checkpoints any AMD suite
+      # still names runs off-runner, against this listing.
+      - name: Upload cache listing
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mi35x-hf-cache-listing
+          path: |
+            hf-cache-sizes.txt
+            hf-cache-listing.txt
+          if-no-files-found: warn
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,12 @@ benchmark/llava_bench/mme_pack
 tmp*.txt
 /tmp/
 
+# Written into the checkout by scripts/ci/amd/reclaim_and_seed_hf_cache.sh,
+# which runs with the repo as its working directory so the workflow can upload
+# them as artifacts.
+/hf-cache-listing.txt
+/hf-cache-sizes.txt
+
 # Torch Compile logs
 tl_out/
 

--- a/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
+++ b/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Reclaim space on the shared AMD HuggingFace cache and download a large
+# checkpoint into the space that was just freed, in one job.
+#
+# Usage (inside the ci_sglang container, where /sgl-data is the cache mount):
+#   RECLAIM_DIRS="models--org--name ..." \
+#   SEED_MODEL=amd/GLM-5.2-MXFP4 SEED_MIN_GIB=408 \
+#     bash scripts/ci/amd/reclaim_and_seed_hf_cache.sh
+#
+# Env:
+#   RECLAIM_DIRS  Whitespace-separated `models--org--name` directories to delete.
+#                 Empty means audit only, which is the safe default.
+#   SEED_MODEL    Repo id to download once the space is free. Empty means the
+#                 job only reclaims.
+#   SEED_MIN_GIB  Expected size of SEED_MODEL. The seed fails below it, so a
+#                 truncated download cannot be mistaken for a complete one.
+#   HF_HOME       Cache root, default /sgl-data/hf-cache.
+#
+# Why the two halves are one job: freeing space and then queueing the job that
+# needs it does not work on this volume. Run 34481735602 reclaimed 1.42 TB from
+# it; six hours later, when the GLM-5.2 job finally got an MI35x runner, 120 GiB
+# of that was left and the download died at the same ENOSPC as before. /sgl-data
+# is `amdprj3-k8s-2`, a 15 TB volume the whole AMD fleet shares with no eviction,
+# and it sits at capacity, so demand absorbs anything released within hours.
+# The bytes have to be claimed by the download in the same job that frees them.
+#
+# Why a separate job downloads weights a test would otherwise fetch itself: a
+# checkpoint larger than the free space cannot be fetched in-band at all. Runs
+# 34446866991, 34448628528 and 34487053976 each spent an 8-GPU MI35x slot
+# discovering that. Seeding from a 1-GPU runner costs a cheap slot, and the
+# consumer job then finds the checkpoint cached.
+
+set -uo pipefail
+
+HF_CACHE_ROOT="${HF_HOME:-/sgl-data/hf-cache}"
+HUB="${HF_CACHE_ROOT}/hub"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+RECLAIM_DIRS="${RECLAIM_DIRS:-}"
+SEED_MODEL="${SEED_MODEL:-}"
+SEED_MIN_GIB="${SEED_MIN_GIB:-0}"
+
+# HuggingFace stores `org/name` under `models--org--name`.
+seed_dir_name() {
+    printf 'models--%s\n' "${1//\//--}"
+}
+
+avail_gib() {
+    df -BG --output=avail "$1" 2>/dev/null | tail -1 | tr -dc '0-9'
+}
+
+# Only the blobs hold real data -- snapshot entries are symlinks into them, and
+# du counts a symlink's target once -- so this is the true footprint. Timed out
+# because it walks a fleet-shared network volume.
+dir_gib() {
+    timeout 600 du -sBG "$1" 2>/dev/null | cut -f1 | tr -dc '0-9'
+}
+
+report_df() {
+    echo "=== ${HUB} ($1) ==="
+    df -h "$HUB" 2>/dev/null || df -h /sgl-data 2>/dev/null || true
+    echo "======================================"
+}
+
+if [[ ! -d "$HUB" ]]; then
+    echo "HF cache $HUB does not exist; nothing to reclaim or seed." >&2
+    exit 1
+fi
+
+echo "hostname=$(hostname) runner=${RUNNER_NAME:-unknown}"
+echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+
+# ----------------------------------------------------------------------------
+# Audit. Always runs: choosing what to delete needs the sizes, and after a
+# reclaim the same listing shows what the fleet refilled.
+# ----------------------------------------------------------------------------
+report_df "before"
+echo
+echo "=== /sgl-data top level ==="
+timeout 900 du -sh /sgl-data/* 2>/dev/null | sort -rh || true
+echo
+echo "=== ${HUB} by size ==="
+# Captured as an artifact so the reachability join (which checkpoints any AMD
+# suite still names) can run off-runner against `amd_cache_audit.py`.
+: > hf-cache-sizes.txt
+timeout 1800 du -BG --max-depth=1 "$HUB" 2>/dev/null | sort -rn > hf-cache-sizes.txt
+cat hf-cache-sizes.txt
+: > hf-cache-listing.txt
+ls -1 "$HUB" > hf-cache-listing.txt 2>/dev/null
+echo
+echo "$(wc -l < hf-cache-listing.txt) entries in ${HUB}"
+echo
+
+{
+    echo "### AMD HF cache reclaim and seed"
+    echo
+    echo "- runner: \`${RUNNER_NAME:-unknown}\` (\`$(hostname)\`)"
+    echo "- free before: $(avail_gib "$HUB") GiB"
+} >> "$SUMMARY"
+
+# ----------------------------------------------------------------------------
+# Reclaim.
+# ----------------------------------------------------------------------------
+removed=0
+missing=0
+failed=0
+
+if [[ -n "${RECLAIM_DIRS// /}" ]]; then
+    echo "=== reclaim ==="
+    {
+        echo
+        echo "| Checkpoint | Freed |"
+        echo "| ---------- | ----- |"
+    } >> "$SUMMARY"
+
+    seed_keep=""
+    if [[ -n "$SEED_MODEL" ]]; then
+        seed_keep="$(seed_dir_name "$SEED_MODEL")"
+    fi
+
+    # shellcheck disable=SC2086  # RECLAIM_DIRS is a whitespace-separated list.
+    for name in $RECLAIM_DIRS; do
+        # An allowlist is only an allowlist if it cannot name a path. Anything
+        # that is not a plain `models--org--name` under this hub is a bug in the
+        # caller, and on a volume the whole fleet shares a bug here is expensive.
+        if [[ ! "$name" =~ ^models--[A-Za-z0-9._-]+$ ]]; then
+            echo "Refusing unsafe checkpoint name: ${name}" >&2
+            exit 2
+        fi
+        if [[ -n "$seed_keep" && "$name" == "$seed_keep" ]]; then
+            echo "Refusing to delete the seed target itself: ${name}" >&2
+            exit 2
+        fi
+
+        target="${HUB}/${name}"
+        lock="${HUB}/${name}.lock"
+        if [[ ! -e "$target" && ! -e "$lock" ]]; then
+            echo "absent   ${target}"
+            echo "| \`${name}\` | absent |" >> "$SUMMARY"
+            missing=$((missing + 1))
+            continue
+        fi
+
+        before="$(dir_gib "$target")"
+        echo "removing ${target} (${before:-?} GiB)"
+        if rm -rf -- "$target" "$lock" && [[ ! -e "$target" && ! -e "$lock" ]]; then
+            echo "removed  ${target}"
+            echo "| \`${name}\` | ${before:-?} GiB |" >> "$SUMMARY"
+            removed=$((removed + 1))
+        else
+            echo "FAILED   ${target}" >&2
+            echo "| \`${name}\` | FAILED |" >> "$SUMMARY"
+            failed=$((failed + 1))
+        fi
+    done
+
+    echo
+    echo "removed=${removed} missing=${missing} failed=${failed}"
+    report_df "after reclaim"
+    echo
+else
+    echo "RECLAIM_DIRS is empty: audit only, nothing deleted."
+    echo >> "$SUMMARY"
+    echo "Audit only; nothing deleted." >> "$SUMMARY"
+fi
+
+if (( failed != 0 )); then
+    echo "Not seeding: a reclaim failed, so the free space is not what was planned." >&2
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Seed.
+# ----------------------------------------------------------------------------
+if [[ -z "$SEED_MODEL" ]]; then
+    echo "SEED_MODEL is empty: nothing to download."
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+seed_target="${HUB}/$(seed_dir_name "$SEED_MODEL")"
+cached_before="$(dir_gib "$seed_target")"
+avail_before="$(avail_gib "$HUB")"
+echo "=== seed ${SEED_MODEL} ==="
+echo "already cached: ${cached_before:-0} GiB of ${SEED_MIN_GIB} GiB expected"
+echo "free: ${avail_before:-?} GiB"
+
+# A partial checkpoint is worth nothing, so a download that cannot finish is
+# only a slower way to reach ENOSPC -- and it takes the rest of the volume with
+# it on the way. Stop before spending any of it.
+remaining=$(( SEED_MIN_GIB > ${cached_before:-0} ? SEED_MIN_GIB - ${cached_before:-0} : 0 ))
+if (( remaining > 0 )) && [[ -n "${avail_before}" ]] && (( avail_before < remaining )); then
+    echo "Refusing to start: ${SEED_MODEL} still needs ${remaining} GiB against" >&2
+    echo "only ${avail_before} GiB free. Reclaim more before seeding." >&2
+    echo >> "$SUMMARY"
+    echo "Seed refused: needs ${remaining} GiB, ${avail_before} GiB free." >> "$SUMMARY"
+    exit 1
+fi
+
+python3 "${SCRIPT_DIR}/seed_hf_checkpoint.py" "$SEED_MODEL"
+seed_rc=$?
+
+cached_after="$(dir_gib "$seed_target")"
+report_df "after seed"
+echo "${SEED_MODEL}: ${cached_before:-0} GiB -> ${cached_after:-0} GiB"
+{
+    echo
+    echo "- seeded \`${SEED_MODEL}\`: ${cached_before:-0} GiB -> ${cached_after:-0} GiB"
+    echo "- free after: $(avail_gib "$HUB") GiB"
+} >> "$SUMMARY"
+
+if (( seed_rc != 0 )); then
+    echo "Seed download failed (exit ${seed_rc})." >&2
+    exit "$seed_rc"
+fi
+
+# du rounds up per file, so the measured size runs a little over the nominal
+# one; only a shortfall means shards are missing.
+if (( SEED_MIN_GIB > 0 )) && [[ -n "${cached_after}" ]] && (( cached_after < SEED_MIN_GIB )); then
+    echo "Seed incomplete: ${cached_after} GiB on disk against ${SEED_MIN_GIB} GiB expected." >&2
+    exit 1
+fi
+
+echo "${SEED_MODEL} is seeded."

--- a/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
+++ b/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
@@ -17,6 +17,8 @@
 #   SETTLE_SECONDS  How long to wait for a reclaim to show up in df, default
 #                 1200. Zero makes the wait a single check, which is what the
 #                 tests want.
+#   AUDIT_DIRS    Extra directories to list during the audit, for the ones whose
+#                 contents matter rather than their size.
 #   HF_HOME       Cache root, default /sgl-data/hf-cache.
 #
 # Why the two halves are one job: freeing space and then queueing the job that
@@ -121,6 +123,17 @@ ls -1 "$HUB" > hf-cache-listing.txt 2>/dev/null
 echo
 echo "$(wc -l < hf-cache-listing.txt) entries in ${HUB}"
 echo
+
+# shellcheck disable=SC2086  # AUDIT_DIRS is a whitespace-separated list.
+for extra in ${AUDIT_DIRS:-}; do
+    echo "=== ${extra} ==="
+    if [[ -d "$extra" ]]; then
+        timeout 300 du -sh "$extra"/* 2>/dev/null | sort -rh | head -40 || true
+    else
+        echo "absent"
+    fi
+    echo
+done
 
 {
     echo "### AMD HF cache reclaim and seed"

--- a/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
+++ b/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
@@ -14,6 +14,9 @@
 #                 job only reclaims.
 #   SEED_MIN_GIB  Expected size of SEED_MODEL. The seed fails below it, so a
 #                 truncated download cannot be mistaken for a complete one.
+#   SETTLE_SECONDS  How long to wait for a reclaim to show up in df, default
+#                 1200. Zero makes the wait a single check, which is what the
+#                 tests want.
 #   HF_HOME       Cache root, default /sgl-data/hf-cache.
 #
 # Why the two halves are one job: freeing space and then queueing the job that
@@ -60,6 +63,33 @@ report_df() {
     echo "=== ${HUB} ($1) ==="
     df -h "$HUB" 2>/dev/null || df -h /sgl-data 2>/dev/null || true
     echo "======================================"
+}
+
+# Space is not free the moment rm returns. Run 34549258956 unlinked 372 GiB in
+# under half a second and df still read 775 MB two milliseconds later: this
+# filesystem drops the directory entries synchronously and releases the blocks
+# in the background. Deciding against that number refuses a download that has
+# room, so wait for the capacity to actually appear.
+wait_for_free_space() {
+    local needed="$1"
+    local deadline=$(( SECONDS + ${SETTLE_SECONDS:-1200} ))
+    local avail last=""
+    while :; do
+        avail="$(avail_gib "$HUB")"
+        if [[ -n "$avail" ]] && (( avail >= needed )); then
+            echo "Free space: ${avail} GiB against ${needed} GiB still to download."
+            return 0
+        fi
+        if [[ "$avail" != "$last" ]]; then
+            echo "Waiting for the filesystem to release the reclaimed blocks:" \
+                 "${avail:-?} GiB free, ${needed} GiB needed."
+            last="$avail"
+        fi
+        if (( SECONDS >= deadline )); then
+            return 1
+        fi
+        sleep 15
+    done
 }
 
 if [[ ! -d "$HUB" ]]; then
@@ -190,11 +220,12 @@ echo "free: ${avail_before:-?} GiB"
 # only a slower way to reach ENOSPC -- and it takes the rest of the volume with
 # it on the way. Stop before spending any of it.
 remaining=$(( SEED_MIN_GIB > ${cached_before:-0} ? SEED_MIN_GIB - ${cached_before:-0} : 0 ))
-if (( remaining > 0 )) && [[ -n "${avail_before}" ]] && (( avail_before < remaining )); then
+if (( remaining > 0 )) && ! wait_for_free_space "$remaining"; then
+    avail_now="$(avail_gib "$HUB")"
     echo "Refusing to start: ${SEED_MODEL} still needs ${remaining} GiB against" >&2
-    echo "only ${avail_before} GiB free. Reclaim more before seeding." >&2
+    echo "only ${avail_now:-?} GiB free. Reclaim more before seeding." >&2
     echo >> "$SUMMARY"
-    echo "Seed refused: needs ${remaining} GiB, ${avail_before} GiB free." >> "$SUMMARY"
+    echo "Seed refused: needs ${remaining} GiB, ${avail_now:-?} GiB free." >> "$SUMMARY"
     exit 1
 fi
 

--- a/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
+++ b/scripts/ci/amd/reclaim_and_seed_hf_cache.sh
@@ -127,11 +127,19 @@ echo
 # shellcheck disable=SC2086  # AUDIT_DIRS is a whitespace-separated list.
 for extra in ${AUDIT_DIRS:-}; do
     echo "=== ${extra} ==="
-    if [[ -d "$extra" ]]; then
-        timeout 300 du -sh "$extra"/* 2>/dev/null | sort -rh | head -40 || true
-    else
+    if [[ ! -d "$extra" ]]; then
         echo "absent"
+        echo
+        continue
     fi
+    timeout 300 du -sh "$extra"/* 2>/dev/null | sort -rh | head -40 || true
+    # A directory whose contents matter is usually a payload next to a small
+    # sidecar describing it, and the sidecar is the part worth reading.
+    while IFS= read -r meta; do
+        echo "--- ${meta} ---"
+        head -c 2000 "$meta" 2>/dev/null || true
+        echo
+    done < <(find "$extra" -maxdepth 1 -type f -size -64k 2>/dev/null | sort | head -10)
     echo
 done
 

--- a/scripts/ci/amd/seed_hf_checkpoint.py
+++ b/scripts/ci/amd/seed_hf_checkpoint.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Download one checkpoint into the shared AMD CI HuggingFace cache.
+
+Called by reclaim_and_seed_hf_cache.sh, which frees the space first.
+
+This goes through sglang's own `download_weights_from_hf` rather than calling
+`snapshot_download` directly, so the seeded cache is what the model loader
+accepts. The loader decides a checkpoint is cached by re-running its own
+validation over the snapshot, takes the same `.sglang_locks` file, and
+re-downloads whatever does not match; a seed that laid the files out even
+slightly differently would be silently thrown away by the job it was meant to
+serve. Under SGLANG_IS_IN_CI (set by amd_ci_exec.sh) that call is the validating,
+retrying CI path, which is exactly the path the consumer job will take.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+# What LoadFormat.AUTO resolves to in ModelLoader._prepare_weights.
+# download_weights_from_hf narrows it to the first pattern the repo matches.
+WEIGHT_PATTERNS = ["*.safetensors", "*.bin"]
+
+# Config, tokenizer and remote code: nothing next to the weights, but a consumer
+# job that still has to fetch them is not actually warm.
+METADATA_PATTERNS = ["*.json", "*.txt", "*.model", "*.py", "*.jinja"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("model", help="Repo id, e.g. amd/GLM-5.2-MXFP4.")
+    parser.add_argument("--revision", default=None, help="Revision to pin.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+
+    from huggingface_hub import snapshot_download
+
+    from sglang.srt.model_loader.weight_utils import download_weights_from_hf
+
+    # Metadata first. It is seconds of transfer and it fails on a bad repo id or
+    # a gated repo before the multi-hundred-GB download starts.
+    snapshot_download(
+        args.model, allow_patterns=METADATA_PATTERNS, revision=args.revision
+    )
+
+    folder = download_weights_from_hf(args.model, None, WEIGHT_PATTERNS, args.revision)
+    print(f"Seeded {args.model} at {folder}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/amd/test_reclaim_and_seed_hf_cache.py
+++ b/scripts/ci/amd/test_reclaim_and_seed_hf_cache.py
@@ -7,6 +7,7 @@ cases worth pinning down are the ones where it must refuse.
 import os
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -31,6 +32,9 @@ def _run(hf_home: str, **env_overrides):
     # Default to the inert configuration so each test opts in to what it needs.
     env.setdefault("RECLAIM_DIRS", "")
     env.setdefault("SEED_MODEL", "")
+    # One check instead of twenty minutes of waiting for blocks that, in a
+    # test, are never coming back.
+    env.setdefault("SETTLE_SECONDS", "0")
     env.update({k: str(v) for k, v in env_overrides.items()})
     with tempfile.TemporaryDirectory() as workdir:
         return subprocess.run(
@@ -98,6 +102,24 @@ class ReclaimAndSeedHfCache(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
             self.assertIn("Refusing to start", result.stderr)
+            self.assertIn("Waiting for the filesystem", result.stdout)
+
+    def test_waits_for_space_rather_than_reading_df_straight_after_rm(self):
+        # The reclaim that motivated the wait unlinked 372 GiB in under half a
+        # second and df had not moved when it was read two milliseconds later.
+        # A shortfall must cost the settle window before it is called one.
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_hub(tmp, "models--amd--GLM-5.2-MXFP4")
+            start = time.monotonic()
+            result = _run(
+                tmp,
+                SEED_MODEL="amd/GLM-5.2-MXFP4",
+                SEED_MIN_GIB=1_000_000_000,
+                SETTLE_SECONDS=16,
+            )
+            waited = time.monotonic() - start
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertGreaterEqual(waited, 15)
 
     def test_fails_when_the_cache_is_absent(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/ci/amd/test_reclaim_and_seed_hf_cache.py
+++ b/scripts/ci/amd/test_reclaim_and_seed_hf_cache.py
@@ -1,0 +1,110 @@
+"""CPU tests for scripts/ci/amd/reclaim_and_seed_hf_cache.sh.
+
+The script runs `rm -rf` against a volume the whole AMD fleet shares, so the
+cases worth pinning down are the ones where it must refuse.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "reclaim_and_seed_hf_cache.sh",
+)
+
+
+def _make_hub(tmp: str, *names: str) -> Path:
+    hub = Path(tmp) / "hub"
+    for name in names:
+        blobs = hub / name / "blobs"
+        blobs.mkdir(parents=True)
+        (blobs / "shard").write_text(name)
+    return hub
+
+
+def _run(hf_home: str, **env_overrides):
+    env = os.environ.copy()
+    env["HF_HOME"] = hf_home
+    # Default to the inert configuration so each test opts in to what it needs.
+    env.setdefault("RECLAIM_DIRS", "")
+    env.setdefault("SEED_MODEL", "")
+    env.update({k: str(v) for k, v in env_overrides.items()})
+    with tempfile.TemporaryDirectory() as workdir:
+        return subprocess.run(
+            ["bash", _SCRIPT],
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+class ReclaimAndSeedHfCache(unittest.TestCase):
+    def test_audit_only_deletes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hub = _make_hub(tmp, "models--org--alpha", "models--org--beta")
+            result = _run(tmp)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertTrue((hub / "models--org--alpha").exists())
+            self.assertTrue((hub / "models--org--beta").exists())
+            self.assertIn("audit only", result.stdout)
+
+    def test_reclaims_listed_dirs_and_their_locks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hub = _make_hub(tmp, "models--org--keep", "models--org--drop")
+            (hub / "models--org--drop.lock").write_text("lock")
+
+            result = _run(tmp, RECLAIM_DIRS="models--org--drop models--org--absent")
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertTrue((hub / "models--org--keep").exists())
+            self.assertFalse((hub / "models--org--drop").exists())
+            self.assertFalse((hub / "models--org--drop.lock").exists())
+            self.assertIn("removed=1 missing=1 failed=0", result.stdout)
+
+    def test_refuses_a_name_that_is_a_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hub = _make_hub(tmp, "models--org--alpha")
+            for name in ("../../etc", "models--org--a/../../b", ".", "*"):
+                result = _run(tmp, RECLAIM_DIRS=name)
+                self.assertEqual(result.returncode, 2, f"{name}: {result.stderr}")
+                self.assertIn("Refusing unsafe checkpoint name", result.stderr)
+            self.assertTrue((hub / "models--org--alpha").exists())
+
+    def test_refuses_to_delete_the_seed_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            hub = _make_hub(tmp, "models--amd--GLM-5.2-MXFP4")
+            result = _run(
+                tmp,
+                RECLAIM_DIRS="models--amd--GLM-5.2-MXFP4",
+                SEED_MODEL="amd/GLM-5.2-MXFP4",
+            )
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("Refusing to delete the seed target", result.stderr)
+            self.assertTrue((hub / "models--amd--GLM-5.2-MXFP4").exists())
+
+    def test_refuses_to_seed_what_cannot_fit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _make_hub(tmp, "models--amd--GLM-5.2-MXFP4")
+            # No filesystem has an exabyte free, so this exercises the shortfall
+            # branch without having to fill one up.
+            result = _run(
+                tmp,
+                SEED_MODEL="amd/GLM-5.2-MXFP4",
+                SEED_MIN_GIB=1_000_000_000,
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("Refusing to start", result.stderr)
+
+    def test_fails_when_the_cache_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = _run(os.path.join(tmp, "no-such-home"))
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("does not exist", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`amd/GLM-5.2-MXFP4` is 408 GiB and no AMD suite has ever seeded it. Three runs of the GLM-5.2 agentic MTP job ([34446866991](https://github.com/sgl-project/sglang/actions/runs/34446866991), [34448628528](https://github.com/sgl-project/sglang/actions/runs/34448628528), [34487053976](https://github.com/sgl-project/sglang/actions/runs/34487053976)) each took an 8-GPU MI35x slot and died with `OSError: [Errno 28] No space left on device` partway through the download.

Reclaiming space first does not fix this on its own, because the two halves cannot be separate jobs. [Run 34481735602](https://github.com/sgl-project/sglang/actions/runs/34481735602) freed 1.42 TB from this PVC. Six hours later, when the GLM-5.2 job finally got a runner, 120 GiB of it was left and the download hit the same ENOSPC. `/sgl-data` is `amdprj3-k8s-2`, a 15 TB volume the whole AMD fleet shares with no eviction, and it sits at capacity, so demand absorbs anything released. The download has to claim the bytes in the same job that frees them.

## Modifications

**`scripts/ci/amd/reclaim_and_seed_hf_cache.sh`** runs three phases in order in one job:

1. *Audit* — `df`, `du` per checkpoint, and a listing of the hub, always.
2. *Reclaim* — delete the `RECLAIM_DIRS` allowlist and their `.lock` files. Any name that is not a plain `models--org--name`, and the seed target itself, are refused.
3. *Seed* — download `SEED_MODEL`, then fail if the result is smaller than `SEED_MIN_GIB`, so a truncated download cannot pass for a complete one. It also refuses to start a download that cannot fit, because a partial checkpoint is worth nothing and reaching ENOSPC slowly still takes the rest of the volume with it.

Between reclaim and seed it waits for the freed capacity to appear in `df`, bounded by `SETTLE_SECONDS`. This filesystem unlinks directory entries synchronously and releases the blocks in the background: `rm -rf` returned in 108 ms for a 216 GiB directory, and `df` two milliseconds later still read 775 MB. Without the wait the job refuses a download that has room.

**`scripts/ci/amd/seed_hf_checkpoint.py`** goes through sglang's own `download_weights_from_hf` rather than calling `snapshot_download` directly. The loader decides a checkpoint is cached by re-running its own validation and takes the same `.sglang_locks` file; a seed laid out even slightly differently would be discarded by the job it was meant to serve.

**`.github/workflows/amd-mi35x-hf-cache-reclaim-and-seed.yml`** runs it on `linux-mi35x-gpu-1`, which mounts the same PVC as `linux-mi35x-gpu-8`, so the cheap pool seeds for the expensive one.

It is dispatch-only as it stands. It ran on `pull_request` while it was being brought up, because a workflow file that is not yet on the default branch cannot be dispatched at all and the cache was blocking the very PR adding it. That is worth knowing before reaching for the same trick: **a `paths` filter does not limit a `pull_request` trigger to pushes that touch those paths.** The filter matches the whole PR diff, so once the PR contained this workflow file every subsequent push re-ran the job regardless of what it changed — a `.gitignore` commit queued a fresh MI35x runner to delete two already-absent directories and re-verify a complete checkpoint. The three useful runs are listed under Results; the rest were pushes to unrelated files.

## Results

**Audit — [run 34548293873](https://github.com/sgl-project/sglang/actions/runs/34548293873).** 15 TB volume, **775 MB free**, 50 checkpoints, and `amd/GLM-5.2-MXFP4` half-downloaded at 212 GiB of 408 GiB, so 196 GiB left to fetch against a partial worth keeping. Cross-referenced against the reachability join in [#36114](https://github.com/sgl-project/sglang/pull/36114), two checkpoints were dead for reasons that do not depend on that join being complete:

| Checkpoint | Size | Why it is dead |
| --- | --- | --- |
| `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` | 216 GiB | Appears nowhere in the tree: no test, no doc, no config, nothing in git history. |
| `deepseek-ai/DeepSeek-V4-Flash-0731` | 156 GiB | Named only by `test_deepseek_v4_flash_fp4_b200.py` and its megamoe variant, both `register_cuda_ci` on `4-gpu-b200`, so no AMD job can want it. |

Left alone although the join reports them unreferenced: `amd/Qwen3.5-397B-A17B-MXFP4`, which the MI35x Qwen3.5 nightly does load and which only reads as unreferenced because the test names a local `/data` path instead of the repo id; and `zai-org/GLM-5.3-Flash` (306 GiB), which has no test but is new enough that someone is plausibly mid-bring-up on it.

**Reclaim — [run 34549258956](https://github.com/sgl-project/sglang/actions/runs/34549258956).** Both deleted, 372 GiB, and then the seed refused itself because `df` had not caught up. That is the failure the `SETTLE_SECONDS` wait above fixes.

**Reclaim + seed — [run 34549982464](https://github.com/sgl-project/sglang/actions/runs/34549982464), green.** 373 GiB had appeared by the time it ran. 196 GiB downloaded in 9m34s (~350 MB/s), `amd/GLM-5.2-MXFP4` went 212 GiB → 408 GiB, and 176 GiB is still free.

## Relationship to the other cache PRs

- [#38898](https://github.com/sgl-project/sglang/pull/38898) retires four obsolete nightlies and deletes their checkpoints. Its `cleanup_obsolete_hf_checkpoints.sh` is the same operation with a hardcoded allowlist and no seed half; whichever of the two lands second should drop its copy.
- [#36114](https://github.com/sgl-project/sglang/pull/36114) computes which checkpoints any AMD suite still names. This job uploads the cache listing that analysis consumes.
- [#38813](https://github.com/sgl-project/sglang/pull/38813) is the job this unblocks, and it is now running against a seeded cache for the first time.

## Follow-up: one of the two reclaimed checkpoints was not dead

`amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` was deleted here on 2026-09-11 because no test, doc, config or commit in this repository named it. That was accurate — `git grep` at the branch point returns nothing — and it was the wrong conclusion. [#39358](https://github.com/sgl-project/sglang/pull/39358) merged three days later, on 2026-09-14, documenting it as the checkpoint InferenceX 8k1k and AgentX had *already* been serving on MI355X, and it is the first commit on `main` to mention the name at all.

No sglang CI job needed it then and none does now — it appears only in `docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx` and `docs/src/snippets/autoregressive/qwen35-deployment.jsx`, and the MI35x Qwen3.5 nightly loads a different checkpoint from a local `/data` path. But the volume is shared with sibling systems that this repository cannot see, and AMD stages weights before the docs that name them land, so whoever serves it next pays a 216 GiB re-download.

The rule is now in the script header: a repository-wide grep establishes that *sglang CI* does not need a checkpoint and nothing more, so confirm with the runner owners before deleting anything that is not this repository's own. `deepseek-ai/DeepSeek-V4-Flash-0731`, the other entry, is still dead by that stricter standard — only `test_deepseek_v4_flash_fp4_b200.py` and its megamoe variant name it, both `register_cuda_ci` on `4-gpu-b200`.

Restoring it would need 216 GiB against the 57 GiB now free. Making room would repeat the mistake, so that is a decision for the runner owners, and `RECLAIM_DIRS` is empty in this revision.

## Three days on

[Run 34842611921](https://github.com/sgl-project/sglang/actions/runs/34842611921), read-only:

| | at seed (2026-09-11) | now (2026-09-14) |
| --- | --- | --- |
| `amd/GLM-5.2-MXFP4` | 408 GiB | 408 GiB, revalidated, nothing re-downloaded |
| free on `/sgl-data` | 176 GiB | 57 GiB |
| hub entries | 56 | 55 |
| `/sgl-data/agentic-traces` | 2 corpora, 172 MB | 11 corpora, 539 MB |

The seeded checkpoint held, so [#38813](https://github.com/sgl-project/sglang/pull/38813) keeps it. The 119 GiB the fleet absorbed in three days is the same pressure that made reclaim-then-queue unworkable, now measured a second time. And the staged corpora are being actively added to, which is worth knowing for anyone else who wants a real agentic workload on these runners.

## Accuracy Tests

Not applicable. This is CI cache management and touches no model or serving code.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] `python3 -m unittest scripts.ci.amd.test_reclaim_and_seed_hf_cache` — 7 tests covering the audit-only default, allowlisted deletion including `.lock` files, refusal of names that are paths, refusal to delete the seed target, refusal to seed what cannot fit, the settle wait, and a missing cache.
- [x] `bash -n` on the script, workflow YAML parses, `check_workflow_job_names.py` passes.
- [x] Audit run reports the MI35x cache contents.
- [x] Reclaim + seed run leaves `amd/GLM-5.2-MXFP4` complete at 408 GiB.
- [x] Re-running with the checkpoint already complete is a no-op: both directories report absent, the seed validates the cache and downloads nothing ([run 34552083821](https://github.com/sgl-project/sglang/actions/runs/34552083821)).
- [x] [#38813](https://github.com/sgl-project/sglang/pull/38813) passed its `--strict` cache pre-flight and ran both arms to completion against the seeded checkpoint.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34843486328](https://github.com/sgl-project/sglang/actions/runs/34843486328)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34843486152](https://github.com/sgl-project/sglang/actions/runs/34843486152)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34843486295](https://github.com/sgl-project/sglang/actions/runs/34843486295)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
