### PR TITLE
[ROCm] Fix HiCache kernel backend GPU fault by using hipHostMalloc for host KV pool

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -240,7 +240,7 @@ def alloc_with_pin_memory(
     dtype: torch.dtype,
     device: str,
     pin_memory: bool,
-    allocator: None,
+    allocator=None,
     registration_granularity_bytes: int | None = None,
 ) -> torch.Tensor:
     """
@@ -250,8 +250,26 @@ def alloc_with_pin_memory(
     return buffer
 
 
+def _default_alloc_func():
+    """On ROCm/HIP, hipHostRegister maps host memory at a device virtual address
+    that differs from the host virtual address. The JIT HiCache kernels store
+    data_ptr() (host VA) in pointer tables and dereference them from GPU code,
+    which faults on ROCm because the GPU sees a different mapping.
+
+    hipHostMalloc (used by torch pin_memory=True) allocates at the same virtual
+    address on both host and device, so GPU kernels can safely dereference the
+    host-side data_ptr().
+
+    CUDA is unaffected: cudaHostRegister already provides unified VA."""
+    from sglang.srt.utils import is_hip
+
+    if is_hip():
+        return alloc_with_pin_memory
+    return alloc_with_host_register
+
+
 ALLOC_MEMORY_FUNCS = defaultdict(
-    lambda: alloc_with_host_register,
+    _default_alloc_func,
     {
         "npu": alloc_with_pin_memory,
         "musa": alloc_with_pin_memory,


### PR DESCRIPTION
## Motivation

`--hicache-io-backend kernel` crashes on ROCm with GPU memory access faults during live serving:

```
Memory access fault by GPU node-6 on address 0x77aed92f5000. Reason: Unknown.
```

The JIT HiCache kernels dereference `data_ptrs` (host virtual addresses) from GPU code. On ROCm, `hipHostRegister` maps host memory at a device VA that differs from the host VA, so these dereferences fault. This blocks the `kernel` io backend for all MLA models on AMD GPUs.

**Related PRs:**
- #35233 addresses the same root cause via `hipHostGetDevicePointer` resolution at every launch boundary (~20 files). This PR takes a simpler approach: avoid the mismatch entirely at allocation time.
- #37152 enables JIT HiCache kernels for non-128B MLA rows (576B DSV4 fp8). Without this fix, #37152 compiles but faults at runtime on ROCm.

## Modifications

`python/sglang/srt/mem_cache/pool_host/common.py`:
1. `ALLOC_MEMORY_FUNCS` default returns `alloc_with_pin_memory` on HIP. `hipHostMalloc` (via `pin_memory=True`) guarantees host VA == device VA, so the existing `data_ptr()` pointer tables work unchanged from GPU code. CUDA behavior is unchanged.
2. `alloc_with_pin_memory` accepts optional `allocator` kwarg for caller compatibility.

## Accuracy Tests

- MI355X (gfx950), DeepSeek-V4-Pro FP4, TP=8, EAGLE MTP
- `page_first` + `kernel` backend: server starts, CUDA graphs captured, warmup + serving without crash (previously crashed on first H2D transfer)
- JIT kernel microbench: 33.8 GB/s for 576B MLA elements, correctness verified (exact match)

## Speed Tests and Profiling

- Full AgentX CONC=48 60-min bench in progress (will update with results)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).