### PR TITLE
[NPU] Change npu.Dockerfile working directory to /sgl-workspace

### DIFF
--- a/docker/npu.Dockerfile
+++ b/docker/npu.Dockerfile
@@ -33,7 +33,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       echo "Unsupported TARGETARCH: $TARGETARCH"; exit 1; \
     fi
 
-WORKDIR /workspace
+WORKDIR /sgl-workspace
 
 # Define environments
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Motivation

The NPU Docker image currently uses `/workspace` as the working directory, which is inconsistent with the expected workspace path used by the NPU container setup. This change updates the working directory to `/sgl-workspace` to align the Dockerfile with the actual runtime workspace location.

## Modifications

- Updated `docker/npu.Dockerfile`
- Changed `WORKDIR` from `/workspace` to `/sgl-workspace`

## Accuracy Tests

Not applicable. This change only updates the container working directory and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime performance.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34548982165](https://github.com/sgl-project/sglang/actions/runs/34548982165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34548981999](https://github.com/sgl-project/sglang/actions/runs/34548981999)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->