### PR TITLE
fix(sm120): fall back to Triton per call when FlashInfer lacks the prefill shape

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -295,6 +295,35 @@ def flashinfer_dsv4_decode_supports_num_heads(num_heads: int, num_tokens: int) -
     return num_tokens <= decode_max_tokens and num_heads in supported_heads
 
 
+# FlashInfer's SM120 sparse-MLA prefill dispatcher (sparse_mla_prefill_dispatch
+# in csrc/sparse_mla_sm120.cu) instantiates a fixed envelope:
+#   * single cache: topk in {128, 192, 256, 512, 1024, 2048}
+#   * dual cache (hierarchical candidate pool, DSV4 only): topk == 128 and
+#     extra_page_block_size in {64, 2}
+# Any other shape returns false from the C++ and aborts the engine with
+# "Unsupported sparse-MLA prefill configuration". The Triton implementation has
+# no such constraint, so route the uncovered shapes to it for that call instead
+# of requiring the global SGLANG_SM120_FLASHMLA_BACKEND=triton override.
+_FLASHINFER_PREFILL_TOPK = frozenset({128, 192, 256, 512, 1024, 2048})
+_FLASHINFER_EXTRA_PAGE_BLOCK_SIZES = frozenset({64, 2})
+
+
+def _flashinfer_covers(q, indices, extra_k_cache, extra_indices) -> bool:
+    """Whether FlashInfer's SM120 kernels have an instantiation for this call."""
+    if q.shape[0] <= SM120_DECODE_MAX_TOKENS:
+        # Decode is dispatched from Python via the decode dispatch table and
+        # takes the (num_heads, topk) pairs this model uses; the extra cache
+        # does not change the decode dispatch.
+        return True
+    if int(indices.shape[-1]) not in _FLASHINFER_PREFILL_TOPK:
+        return False
+    if extra_k_cache is None or extra_indices is None:
+        return True
+    if extra_k_cache.ndim < 3:
+        return False
+    return int(extra_k_cache.shape[1]) in _FLASHINFER_EXTRA_PAGE_BLOCK_SIZES
+
+
 def flash_mla_with_kvcache_sm120(**kwargs):
     """SM120 FlashMLA sparse decode entry point.
 
@@ -313,7 +342,24 @@ def flash_mla_with_kvcache_sm120(**kwargs):
     extra_indices = kwargs.get("extra_indices_in_kvcache")
     extra_topk_length = kwargs.get("extra_topk_length")
 
-    if _sm120_default_backend == "flashinfer":
+    flashinfer_ok = _sm120_default_backend != "flashinfer" or _flashinfer_covers(
+        q, indices, extra_k_cache, extra_indices
+    )
+    if _sm120_default_backend == "flashinfer" and not flashinfer_ok:
+        logger.info(
+            "SM120 sparse-MLA: FlashInfer's dispatcher has no instantiation for "
+            "this call (num_tokens=%d, topk=%d, extra_page_block_size=%s); using "
+            "the Triton sparse-MLA implementation for this call.",
+            q.shape[0],
+            int(indices.shape[-1]),
+            (
+                int(extra_k_cache.shape[1])
+                if extra_k_cache is not None and extra_k_cache.ndim >= 3
+                else None
+            ),
+        )
+
+    if _sm120_default_backend == "flashinfer" and flashinfer_ok:
         if q.shape[0] > SM120_DECODE_MAX_TOKENS:
             return _flash_mla_sm120_prefill(
                 q,

--- a/test/registered/unit/test_flashinfer_sparse_mla.py
+++ b/test/registered/unit/test_flashinfer_sparse_mla.py
@@ -6,6 +6,9 @@ from unittest.mock import patch
 import torch
 
 from sglang.kernels.ops.attention.flash_mla_sm120 import (
+    _FLASHINFER_EXTRA_PAGE_BLOCK_SIZES,
+    _FLASHINFER_PREFILL_TOPK,
+    _flashinfer_covers,
     _validate_flashinfer_sparse_mla_backend,
     flashinfer_sparse_mla_forward,
 )
@@ -117,6 +120,66 @@ class TestFlashInferSparseMLABackendGate(unittest.TestCase):
         self.assertIn("model_arch='DeepseekV3ForCausalLM'", message)
         self.assertIn("sm_major=12", message)
         self.assertIn("kv_cache_dtype=torch.float8_e4m3fn", message)
+
+
+class TestFlashInferSM120PrefillEnvelope(unittest.TestCase):
+    """``_flashinfer_covers`` mirrors the C++ prefill instantiation envelope.
+
+    FlashInfer's ``sparse_mla_prefill_dispatch`` returns false outside it and
+    aborts the engine, so the SM120 wrapper must divert those calls to the
+    Triton implementation by itself.
+    """
+
+    @staticmethod
+    def _q(num_tokens):
+        return torch.zeros(num_tokens, 8, 512, dtype=torch.bfloat16)
+
+    @staticmethod
+    def _cache(pages, page_block_size):
+        if page_block_size is None:
+            return torch.zeros(pages, 584, dtype=torch.uint8)
+        return torch.zeros(pages, page_block_size, 1, 584, dtype=torch.uint8)
+
+    def test_decode_is_always_covered(self):
+        # Decode goes through the Python decode dispatch table, which only
+        # takes (num_heads, topk) pairs this model instantiates.
+        indices = torch.zeros(64, 1024, dtype=torch.int32)
+        self.assertTrue(
+            _flashinfer_covers(self._q(64), indices, self._cache(4, 1024), indices)
+        )
+
+    def test_prefill_topk_envelope(self):
+        extra = self._cache(4, 64)
+        for topk in sorted(_FLASHINFER_PREFILL_TOPK):
+            with self.subTest(topk=topk):
+                indices = torch.zeros(128, topk, dtype=torch.int32)
+                self.assertTrue(_flashinfer_covers(self._q(128), indices, None, None))
+        indices = torch.zeros(128, 384, dtype=torch.int32)
+        self.assertFalse(_flashinfer_covers(self._q(128), indices, None, None))
+
+    def test_dual_cache_page_block_envelope(self):
+        indices = torch.zeros(128, 128, dtype=torch.int32)
+        for pbs in sorted(_FLASHINFER_EXTRA_PAGE_BLOCK_SIZES):
+            with self.subTest(extra_page_block_size=pbs):
+                self.assertTrue(
+                    _flashinfer_covers(
+                        self._q(128), indices, self._cache(4, pbs), indices
+                    )
+                )
+        # DeepSeek-V4.1's hierarchical candidate pool pages at 128 and 256.
+        for pbs in (128, 256):
+            with self.subTest(extra_page_block_size=pbs):
+                self.assertFalse(
+                    _flashinfer_covers(
+                        self._q(128), indices, self._cache(4, pbs), indices
+                    )
+                )
+
+    def test_malformed_extra_cache_is_not_covered(self):
+        indices = torch.zeros(128, 128, dtype=torch.int32)
+        self.assertFalse(
+            _flashinfer_covers(self._q(128), indices, self._cache(4, None), indices)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`SGLANG_SM120_FLASHMLA_BACKEND` picks one sparse-MLA implementation for the whole process, and the default `flashinfer` backend has a fixed prefill instantiation envelope in C++ (`sparse_mla_prefill_dispatch`):

* single cache: `topk ∈ {128, 192, 256, 512, 1024, 2048}`
* dual cache (hierarchical candidate pool, DSV4 only): `topk == 128` and `extra_page_block_size ∈ {64, 2}`

Outside that envelope the C++ returns `false` and **aborts the engine**:

```
tvm.error.InternalError: Check failed: (ok) is false: Unsupported sparse-MLA prefill
configuration: model=DSV4 num_heads=8 topk=128 page_block_size=64 topk_extra=512
extra_page_block_size=128
```

DeepSeek-V4.1's hierarchical candidate pool pages its extra KV cache at 128 (and 256) tokens, so serving that model on SM120 currently requires the global `SGLANG_SM120_FLASHMLA_BACKEND=triton`, which gives up FlashInfer for *every* call — including the decode and single-cache shapes FlashInfer handles well.

## Modifications

* Add `_flashinfer_covers(q, indices, extra_k_cache, extra_indices)`, a predicate mirroring the C++ prefill envelope (decode short-circuits to `True`; the decode dispatch table already covers the `(num_heads, topk)` pairs this model uses).
* In `flash_mla_with_kvcache_sm120`, when the default backend is `flashinfer` and the shape is outside the envelope, log once per call at `info` and route **that call** to the existing Triton implementation.
* No change when the backend is explicitly `triton`/`torch`, and no change for shapes FlashInfer covers.

Companion change: flashinfer-ai/flashinfer#5121 instantiates `extra_page_block_size ∈ {128, 256}` for the dual-cache prefill. Once that lands, adding those two values to `_FLASHINFER_EXTRA_PAGE_BLOCK_SIZES` keeps those calls on FlashInfer; until then the fallback is what makes the model runnable with the default backend.

## Accuracy Tests

The predicate is pure Python and covered by new unit tests in `test/registered/unit/test_flashinfer_sparse_mla.py` (class `TestFlashInferSM120PrefillEnvelope`, CPU suite `base-a-test-cpu`): decode always covered, every supported prefill `topk` covered, an unsupported `topk` rejected, `extra_page_block_size` 64/2 covered, 128/256 rejected, malformed 2-D extra cache rejected.

End-to-end, on 8× RTX 6000D (SM120) with `deepseek-ai/DeepSeek-V4.1-Flash` and the flashinfer backend left at its default (no `SGLANG_SM120_FLASHMLA_BACKEND`): the server reaches `/health` 200, logs 29,792 per-call fallbacks, raises **zero** `Unsupported sparse-MLA prefill` errors, and chat completions are correct.

## Speed Tests and Profiling

This PR is a robustness fix, not a speed optimization — it keeps the previously-aborting shapes on the Triton implementation. End-to-end on 8× RTX 6000D (16k in / 512 out, c16, N=100, warmup 16), **prefix caching disabled on both sides**, 3 runs each:

| configuration | total tok/s | TTFT median | TTFT p99 | ITL median |
| --- | --- | --- | --- | --- |
| before (engine aborts with the default backend, radix OFF) | — | — | — | — |
| this PR alone (stock FlashInfer → candidate-pool prefill falls back to Triton, radix OFF) | 1,978 | 61,539 ms | — | 64.4 ms |
| this PR + flashinfer-ai/flashinfer#5121 (prefill stays on FlashInfer, radix OFF) | **5,850** | **19,148 ms** | 35,408 ms | 26.5 ms |

* **3.0× throughput and 3.2× TTFT** for the prefill path, caching held constant (FlashInfer side: 5,843.69 / 5,850.38 / 5,852.39; Triton side: 1,977.19 / 1,977.86).
* With prefix caching enabled — the serving configuration for agent traffic — the same protocol reaches 17,950 tok/s at 963 ms median TTFT; that extra gain is prefix reuse and is reported separately.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Formatted with the pinned `isort==7.0.0` / `ruff==0.15.1` (repo `.pre-commit-config.yaml`). No documentation page describes the SM120 sparse-MLA envelope, so none is updated; happy to add one if you want the envelope documented.
