### PR TITLE
docs: clarify FLUX.2 Klein FP8 compatibility

### DIFF
--- a/docs/cookbook/diffusion/FLUX/FLUX.mdx
+++ b/docs/cookbook/diffusion/FLUX/FLUX.mdx
@@ -42,6 +42,18 @@ FLUX models are optimized for high-quality image generation. The recommended lau
 
 See [Performance Optimization](/docs/sglang-diffusion/performance-optimization) for acceleration features and their runtime requirements.
 
+<Warning>
+Do not load the official `black-forest-labs/FLUX.2-klein-4b-fp8` single-file
+checkpoint with `--transformer-weights-path`. Its converted split-QKV layout
+does not match the packed-QKV layout required by SGLang's FLUX.2 FP8 path. Use
+`black-forest-labs/FLUX.2-klein-4B` in BF16 or convert the FP8 file to an
+SGLang-compatible packed ModelOpt transformer override. The published
+`lmsys/flux2-dev-modelopt-fp8-sglang-transformer` override targets
+`black-forest-labs/FLUX.2-dev`, not Klein. See
+[Quantization](/docs/sglang-diffusion/quantization#modelopt-fp8) for the
+supported loading pattern.
+</Warning>
+
 - `--vae-path`: Path to a custom VAE model or HuggingFace model ID (e.g., fal/FLUX.2-Tiny-AutoEncoder). If not specified, the VAE will be loaded from the main model path.
 - `--num-gpus`: Number of GPUs to use
 - `--tp-size`: Tensor parallelism size (only for the encoder; should not be larger than 1 if text encoder offload is enabled, as layer-wise offload plus prefetch is faster)

--- a/docs/docs/sglang-diffusion/quantization.mdx
+++ b/docs/docs/sglang-diffusion/quantization.mdx
@@ -637,6 +637,21 @@ representative NVFP4 subset and includes
 
 ## ModelOpt FP8
 
+<Warning>
+The official `black-forest-labs/FLUX.2-klein-4b-fp8` repository contains a
+Diffusion Single File checkpoint, not an SGLang-ready ModelOpt transformer
+override. Do not pass its `.safetensors` file to
+`--transformer-weights-path`: the single-file conversion produces split QKV
+parameters, while SGLang's FLUX.2 FP8 path expects packed QKV parameters, so
+weight loading fails.
+
+For FLUX.2 [klein] 4B, use the BF16
+`black-forest-labs/FLUX.2-klein-4B` checkpoint or convert the FP8 file to an
+SGLang-compatible packed ModelOpt transformer override first. The published
+`lmsys/flux2-dev-modelopt-fp8-sglang-transformer` override is only compatible
+with `black-forest-labs/FLUX.2-dev`; do not pair it with a Klein base model.
+</Warning>
+
 ### Usage Examples
 
 Converted ModelOpt FP8 transformer repos should be loaded as transformer


### PR DESCRIPTION
## Motivation

The official `black-forest-labs/FLUX.2-klein-4b-fp8` artifact is a Diffusion Single File checkpoint, not an SGLang-ready ModelOpt transformer override. Without an explicit warning, users can pass it to `--transformer-weights-path` and encounter a confusing weight-loading failure.

Addresses the documentation portion of #38514.

## Modifications

- Add a compatibility warning to the canonical diffusion quantization guide.
- Add the same guidance to the FLUX cookbook deployment section.
- Document the safe BF16 or conversion paths.
- Clarify that `lmsys/flux2-dev-modelopt-fp8-sglang-transformer` targets FLUX.2-dev and must not be paired with a Klein base model.

## Accuracy Tests

Not applicable. This is a documentation-only change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This change does not affect inference performance.

## Validation

- `node docs/scripts/check_cookbook_configs.mjs`
- `mint broken-links --check-anchors --check-redirects`
- `git diff --check`

## Checklist

- [x] Format the changes according to the repository documentation conventions.
- [x] Update documentation.
- [x] Verify internal links and anchors.
- [x] Confirm that unit, accuracy, and speed tests are not applicable to this documentation-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34551266341](https://github.com/sgl-project/sglang/actions/runs/34551266341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34551266230](https://github.com/sgl-project/sglang/actions/runs/34551266230)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->