### PR TITLE
[Bugfix] Isolate auto-truncated token budgets in batched requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1206,9 +1206,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"exceeds the model's context length ({self.context_len} tokens). "
                     "Truncating max_new_tokens."
                 )
-                obj.sampling_params["max_new_tokens"] = max(
-                    0, _max_req_len - input_token_num
-                )
+                # Batch normalization may share this dict across requests. Keep
+                # the context-dependent limit local to the request being checked.
+                obj.sampling_params = {
+                    **obj.sampling_params,
+                    "max_new_tokens": max(0, _max_req_len - input_token_num),
+                }
             else:
                 total_tokens = max_new_tokens + input_token_num
                 error_msg = (

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,9 +1,11 @@
+import asyncio
 import copy
 import re
 import unittest
 import weakref
 from array import array
 from pathlib import Path
+from types import SimpleNamespace
 
 import msgspec
 import numpy as np
@@ -23,7 +25,11 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalInputFormat,
     MultimodalProcessorOutput,
 )
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
+from sglang.srt.runtime_context import publish, reset_context
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
 from sglang.srt.utils.msgpack_utils import _restore_torch_tensor, enc_hook, ext_hook
 from sglang.test.ci.ci_register import (
@@ -1139,6 +1145,66 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req[0].routed_dp_rank, 3)
         self.assertEqual(req[1].routed_dp_rank, 3)
+
+
+class TestGenerateReqInputTokenization(CustomTestCase):
+    def setUp(self):
+        reset_context()
+        self.addCleanup(reset_context)
+        publish(ServerArgs(model_path="dummy"), role="tokenizer")
+        self.manager = TokenizerManager.__new__(TokenizerManager)
+        self.manager.context_len = 10
+        self.manager.num_reserved_tokens = 0
+        self.manager.allow_auto_truncate = True
+        self.manager.validate_total_tokens = True
+        self.manager.is_generation = True
+        self.manager.model_config = SimpleNamespace(
+            vocab_size=32, hf_config=SimpleNamespace(architectures=[])
+        )
+        self.manager.tokenizer = None
+        self.manager.mm_processor = None
+        self.manager.preferred_sampling_params = None
+        self.manager.sampling_params_class = SamplingParams
+        self.manager.rid_to_state = {}
+
+    async def _tokenize(self, req):
+        self.manager.rid_to_state[req.rid] = SimpleNamespace(
+            time_stats=APIServerReqTimeStats()
+        )
+        return await self.manager._tokenize_one_request(req)
+
+    def test_batch_truncation_matches_independent_requests(self):
+        async def tokenize_requests():
+            prompts = [[1] * 8, [2] * 2]
+            independent = []
+            for prompt in prompts:
+                req = GenerateReqInput(
+                    input_ids=prompt, sampling_params={"max_new_tokens": 4}
+                )
+                req.normalize_batch_and_arguments()
+                independent.append(await self._tokenize(req))
+
+            batch = GenerateReqInput(
+                input_ids=prompts, sampling_params={"max_new_tokens": 4}
+            )
+            batch.normalize_batch_and_arguments()
+            batched = [await self._tokenize(batch[i]) for i in range(batch.batch_size)]
+            return independent, batched
+
+        independent, batched = asyncio.run(tokenize_requests())
+        self.assertEqual(
+            [req.sampling_params.max_new_tokens for req in independent], [2, 4]
+        )
+        self.assertEqual(
+            [
+                (list(req.input_ids), req.sampling_params.max_new_tokens)
+                for req in batched
+            ],
+            [
+                (list(req.input_ids), req.sampling_params.max_new_tokens)
+                for req in independent
+            ],
+        )
 
 
 class TestEmbeddingReqInputGetItem(CustomTestCase):


### PR DESCRIPTION
## Motivation

I fixed a batch-order dependency in automatic truncation. Normalized batch requests can share their sampling dictionary, so shortening one request's `max_new_tokens` also shortens later requests that still fit the context window.

## Modifications

I copy the sampling dictionary only when applying a request-specific truncation. The regression compares batched tokenization with independent requests.

## Accuracy Tests

- Original source: an 8-token prompt followed by a 2-token prompt, each requesting 4 new tokens in a 10-token context, produces budgets `[2, 2]` instead of `[2, 4]`.
- Patched source: both pre-tokenized requests and batched text using the real Qwen2.5 tokenizer produce `[2, 4]`, matching independent requests.
- `test/registered/unit/managers/test_io_struct.py`: 49 passed, 2 skipped.

These CPU checks use the repository's `maybe_stub_sgl_kernel` helper for unavailable kernel imports. Tokenization, request normalization, validation, and sampling-parameter conversion are real; no GPU inference or model-accuracy benchmark was run.

## Speed Tests and Profiling

No performance benchmark was run. The new dictionary allocation occurs only when automatic truncation changes a request's budget; model and kernel execution are unchanged.

## Checklist

- [x] Applicable pre-commit hooks pass.
- [x] The regression fails before the fix and passes afterward.
- [x] Existing request semantics are preserved; no public API documentation change is needed.
- [ ] GPU accuracy and speed benchmarks were not run.

I used AI assistance for the implementation and regression coverage. The checks above were run through that workflow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34551986418](https://github.com/sgl-project/sglang/actions/runs/34551986418)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34551986111](https://github.com/sgl-project/sglang/actions/runs/34551986111)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34551986271](https://github.com/sgl-project/sglang/actions/runs/34551986271)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->