### PR TITLE
[Bugfix] Fix batched cross-encoder tokenization for reranking

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1487,7 +1487,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     async def _batch_tokenize_and_process(
         self, batch_size: int, obj: Union[GenerateReqInput, EmbeddingReqInput]
     ) -> List[Union[TokenizedGenerateReqInput, TokenizedEmbeddingReqInput]]:
-        """Handle batch tokenization for text inputs only."""
+        """Handle batch tokenization for texts and cross-encoder pairs."""
         logger.debug(f"Starting batch tokenization for {batch_size} text requests")
 
         # If batch does not have text nothing to tokenize
@@ -1500,7 +1500,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Collect requests and texts
         requests = [obj[i] for i in range(batch_size)]
-        texts = [req.text for req in requests]
+        texts = [
+            req.text[0]
+            if isinstance(req, EmbeddingReqInput) and req.is_cross_encoder_request
+            else req.text
+            for req in requests
+        ]
 
         # Check if any request is a cross-encoder request
         is_cross_encoder_request = any(
@@ -1512,6 +1517,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         input_ids_list, token_type_ids_list = await self._tokenize_texts(
             texts, is_cross_encoder_request
         )
+        # _tokenize_texts removes the batch dimension for a single cross-encoder pair.
+        if is_cross_encoder_request and batch_size == 1:
+            input_ids_list = [input_ids_list]
+            if token_type_ids_list is not None:
+                token_type_ids_list = [token_type_ids_list]
 
         # Process all requests
         tokenized_objs = []

--- a/test/registered/unit/managers/test_tokenizer_batch_encode.py
+++ b/test/registered/unit/managers/test_tokenizer_batch_encode.py
@@ -1,0 +1,82 @@
+"""CPU regressions for tokenizer-manager batch encoding with a local tokenizer."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from transformers import BertTokenizerFast
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import EmbeddingReqInput  # noqa: E402
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+from sglang.srt.observability.req_time_stats import APIServerReqTimeStats  # noqa: E402
+from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: E402
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestCrossEncoderBatchTokenization(CustomTestCase):
+    def setUp(self):
+        self.tokenizer = BertTokenizerFast(
+            vocab={
+                "[PAD]": 0,
+                "[UNK]": 1,
+                "[CLS]": 2,
+                "[SEP]": 3,
+                "[MASK]": 4,
+                "query": 5,
+                "first": 6,
+                "second": 7,
+                "document": 8,
+            }
+        )
+        self.manager = TokenizerManager.__new__(TokenizerManager)
+        self.manager.tokenizer = self.tokenizer
+        self.manager.async_dynamic_batch_tokenizer = None
+        self.manager.is_generation = False
+        self.manager.model_config = SimpleNamespace(
+            is_embedding_gemma=False, vocab_size=len(self.tokenizer)
+        )
+        self.manager.context_len = 32
+        self.manager.num_reserved_tokens = 0
+        self.manager.allow_auto_truncate = False
+        self.manager.validate_total_tokens = True
+        self.manager.preferred_sampling_params = None
+        self.manager.sampling_params_class = SamplingParams
+        self.manager.rid_to_state = {}
+
+    def test_cross_encoder_pairs_keep_per_request_token_sequences(self):
+        """Batch reranking must not add a nesting level or flatten a one-pair batch."""
+        for pairs in (
+            [["query", "first document"]],
+            [["query", "first document"], ["query", "second document document"]],
+        ):
+            with self.subTest(batch_size=len(pairs)):
+                request = EmbeddingReqInput(text=pairs, is_cross_encoder_request=True)
+                request.normalize_batch_and_arguments()
+                self.manager.rid_to_state = {
+                    rid: SimpleNamespace(time_stats=APIServerReqTimeStats())
+                    for rid in request.rid
+                }
+
+                tokenized = asyncio.run(
+                    self.manager._batch_tokenize_and_process(
+                        request.batch_size, request
+                    )
+                )
+                expected = self.tokenizer(pairs, return_token_type_ids=True)
+                self.assertEqual(
+                    [list(req.input_ids) for req in tokenized], expected["input_ids"]
+                )
+                self.assertEqual(
+                    [req.token_type_ids for req in tokenized],
+                    expected["token_type_ids"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

I fixed `/v1/rerank` with `--enable-tokenizer-batch-encode`. Each normalized cross-encoder subrequest wraps its query/document pair in a singleton list. Collecting those lists unchanged adds an extra nesting level that the tokenizer rejects.

## Modifications

I unwrap the per-request pair before batch tokenization and restore the batch dimension when the shared tokenizer helper returns a single pair. Ordinary text batches and individual cross-encoder tokenization keep their existing behavior.

## Accuracy Tests

```bash
SGLANG_USE_CPU_ENGINE=1 python test/registered/unit/managers/test_tokenizer_batch_encode.py
pre-commit run --files python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_tokenizer_batch_encode.py
```

- The one-document and two-document regression cases both fail on the original source and pass with the fix.
- The regression plus the existing request I/O suite passes: 49 passed, 2 skipped.
- A local randomly initialized BERT CPU model produces matching scores from batched and independent tokenization, through real rerank request conversion and response assembly.
- Applicable pre-commit hooks pass.

The CPU checks use the repository's existing helper for unavailable kernel imports. Native SGLang scheduler/kernel inference was not run; this is not a model-accuracy benchmark.

## Speed Tests and Profiling

No throughput benchmark was run. Model and kernel math are unchanged.

I used AI assistance for the implementation and regression coverage. The checks above were run through that workflow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34551986349](https://github.com/sgl-project/sglang/actions/runs/34551986349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34551986171](https://github.com/sgl-project/sglang/actions/runs/34551986171)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34551986354](https://github.com/sgl-project/sglang/actions/runs/34551986354)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->