### PR TITLE
[DeepSeek-V4.1] Optimize small DSpark batches on Blackwell (BS1 803 tok/s)

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/wo_a_bf16_small_batch.py
+++ b/python/sglang/kernels/ops/attention/dsv4/wo_a_bf16_small_batch.py
@@ -1,0 +1,55 @@
+"""Split-K grouped BF16 projection for small speculative batches."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _wo_a_partial(X, W, P, M: tl.constexpr, SX: tl.constexpr):
+    tile, group, split = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    m = tl.arange(0, 16)
+    n = tile * 64 + tl.arange(0, 64)
+    k = split * 512 + tl.arange(0, 128)
+    acc = tl.zeros((16, 64), tl.float32)
+    for i in range(4):
+        offsets = k + i * 128
+        x = tl.load(
+            X + m[:, None] * SX + group * 4096 + offsets[None, :], m[:, None] < M, 0
+        )
+        w = tl.load(W + (group * 1024 + n[None, :]) * 4096 + offsets[:, None])
+        acc += tl.dot(x, w)
+    tl.store(
+        P + ((split * M + m[:, None]) * 2 + group) * 1024 + n[None, :],
+        acc,
+        m[:, None] < M,
+    )
+
+
+@triton.jit
+def _wo_a_reduce(P, Y, E: tl.constexpr):
+    i = tl.program_id(0) * 256 + tl.arange(0, 256)
+    split = tl.arange(0, 8)
+    values = tl.load(P + split[:, None] * E + i[None, :], i[None, :] < E, 0)
+    tl.store(Y + i, tl.sum(values, 0), i < E)
+
+
+def wo_a_bf16_small_batch(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute ``einsum('tgd,grd->tgr', x, weight)`` for the TP4 WO-A shape.
+
+    Eight K partitions expose more CTAs than the small-M batched GEMM.
+    Partial sums stay in FP32 until the final BF16, token-major store.
+    """
+    m = x.shape[0]
+    assert 2 <= m <= 8 and x.shape[1:] == (2, 4096)
+    assert weight.shape == (2, 1024, 4096) and weight.is_contiguous()
+    assert x.dtype == weight.dtype == torch.bfloat16
+    assert x.is_cuda and x.device == weight.device
+    assert x.stride(2) == 1 and x.stride(1) == 4096 and x.stride(0) >= 8192
+    result = torch.empty((m, 2, 1024), dtype=x.dtype, device=x.device)
+    partial = torch.empty((8, m, 2, 1024), dtype=torch.float32, device=x.device)
+    _wo_a_partial[(16, 2, 8)](
+        x, weight, partial, m, x.stride(0), num_warps=4, num_stages=3
+    )
+    _wo_a_reduce[(triton.cdiv(m * 2048, 256),)](partial, result, m * 2048, num_warps=4)
+    return result

--- a/python/sglang/kernels/ops/layernorm/hc_combine_norm.py
+++ b/python/sglang/kernels/ops/layernorm/hc_combine_norm.py
@@ -1,0 +1,40 @@
+"""Collapse the hyper-connection streams and normalize the sublayer input."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _hc_combine_norm(X, P, W, Y, SX: tl.constexpr, SP: tl.constexpr, EPS: tl.constexpr):
+    row, part = tl.program_id(0), tl.program_id(1)
+    h = tl.arange(0, 8192)
+    value = tl.full((8192,), 0, tl.float32)
+    for c in tl.static_range(4):
+        pre = tl.load(P + row * SP + c).to(tl.float32)
+        x = tl.load(X + row * SX + c * 5120 + h, h < 5120, 0).to(tl.float32)
+        value += x * pre
+    # The unfused combine stores BF16 before RMSNorm reads it.
+    value = value.to(tl.bfloat16).to(tl.float32)
+    inv_rms = tl.rsqrt(tl.sum(value * value, 0) / 5120 + EPS)
+    mask = (h >= part * 1280) & (h < (part + 1) * 1280)
+    weight = tl.load(W + h, mask, 0).to(tl.float32)
+    tl.store(Y + row * 5120 + h, value * inv_rms * weight, mask)
+
+
+def hc_combine_norm(
+    x: torch.Tensor, pre: torch.Tensor, weight: torch.Tensor, eps: float
+) -> torch.Tensor:
+    """Fuse four-stream combine and RMSNorm for small BF16 batches of width 5120."""
+    m = x.shape[0]
+    assert 0 < m <= 8 and x.shape == (m, 20480)
+    assert pre.shape == (m, 4) and pre.stride(1) == 1
+    assert weight.shape == (5120,) and weight.is_contiguous()
+    assert x.dtype == weight.dtype == torch.bfloat16 and x.stride(1) == 1
+    y = torch.empty((m, 5120), dtype=x.dtype, device=x.device)
+    # Four CTAs per row trade redundant statistics for more concurrent loads
+    # when only a few speculative tokens are being processed.
+    _hc_combine_norm[(m, 4)](
+        x, pre, weight, y, x.stride(0), pre.stride(0), eps, num_warps=8
+    )
+    return y

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_draft_model.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_draft_model.py
@@ -424,7 +424,15 @@ def commit_kv_proj_fused(
     num_stages = len(wkv_linears)
     stacked = _stacked_wkv_weight(wkv_linears=wkv_linears)
 
-    if stacked.fp8_scale is not None:
+    if stacked.mxfp8_scale is not None:
+        kv_all = wkv_linears[0].quant_method.w8a8_mxfp8_linear(
+            input=main_x,
+            weight=stacked.weight,
+            weight_scale=stacked.mxfp8_scale,
+            input_scale=None,
+            bias=None,
+        )
+    elif stacked.fp8_scale is not None:
         quant_method = wkv_linears[0].quant_method
         kv_all = quant_method.w8a8_block_fp8_linear(
             input=main_x,
@@ -447,6 +455,7 @@ def commit_kv_proj_fused(
 class _StackedWkvWeight(msgspec.Struct):
     weight: torch.Tensor
     fp8_scale: Optional[torch.Tensor]
+    mxfp8_scale: Optional[torch.Tensor] = None
 
 
 def _stacked_wkv_weight(*, wkv_linears: list[torch.nn.Module]) -> _StackedWkvWeight:
@@ -500,6 +509,22 @@ def _build_stacked_wkv_weight(
 ) -> _StackedWkvWeight:
     if _block_quant_stack_applies(wkv_linears=wkv_linears):
         weight = torch.cat([linear.weight for linear in wkv_linears], dim=0)
+        backend = getattr(wkv_linears[0].quant_method, "mxfp8_dense_backend", None)
+        if (
+            backend is not None
+            and (backend.is_flashinfer_cutlass() or backend.is_flashinfer_cutedsl())
+            and all(
+                getattr(linear, "block_fp8_mxfp8_ready", False)
+                and linear.weight.shape[0] % 128 == 0
+                for linear in wkv_linears
+            )
+        ):
+            # Each projection ends on a 128-row scale tile, so concatenating
+            # the prepared tiles preserves FlashInfer's swizzled scale layout.
+            scale = torch.cat(
+                [linear.weight_scale_inv_swizzled.reshape(-1) for linear in wkv_linears]
+            )
+            return _StackedWkvWeight(weight=weight, fp8_scale=None, mxfp8_scale=scale)
         if wkv_linears[0].weight_scale_inv.dtype == torch.int32:
             from sglang.srt.layers.quantization.fp8_utils import (
                 inverse_transform_scale_ue8m0,

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -31,6 +31,9 @@ from sglang.kernels.ops.attention.dsv4 import (
     sglang_per_token_group_quant_fp8_dsv4_wo_a,
 )
 from sglang.kernels.ops.attention.dsv4.wo_a_bf16_gemv import wo_a_bf16_gemv
+from sglang.kernels.ops.attention.dsv4.wo_a_bf16_small_batch import (
+    wo_a_bf16_small_batch,
+)
 from sglang.kernels.ops.attention.flash_mla_sm120 import SM120_DECODE_MAX_TOKENS
 from sglang.kernels.ops.layernorm.mhc_post_split_h import mhc_post_split_h
 from sglang.kernels.ops.quantization.fp8_kernel import (
@@ -488,6 +491,8 @@ def _apply_wo_a_bf16_matmul(
     ):
         if is_decode and o.shape[0] == 1:
             return wo_a_bf16_gemv(o, wo_a)
+        if 2 <= o.shape[0] <= 8:
+            return wo_a_bf16_small_batch(o, wo_a)
         result = torch.empty(
             (o.shape[0], wo_a.shape[0], wo_a.shape[1]), dtype=o.dtype, device=o.device
         )
@@ -2693,10 +2698,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         hc_scale: torch.Tensor,
         hc_base: torch.Tensor,
         apply_pre: Optional[torch.Tensor],
+        norm: RMSNorm,
         stats_stream: Optional[torch.cuda.Stream] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Mixing coefficients come from x; the sublayer input is x collapsed with
-        apply_pre (None selects copy 0). Returns (y, pre, post, comb)."""
+        apply_pre (None selects copy 0), then RMS-normalized.
+        Returns (y, pre, post, comb)."""
         from sglang.kernels.ops.layernorm.mhc import (
             hc_combine,
             hc_mix_stats,
@@ -2705,6 +2712,31 @@ class DeepseekV4DecoderLayer(nn.Module):
 
         dtype = x.dtype
         x_flat = x.flatten(1)
+
+        def combine_and_norm():
+            if apply_pre is None:
+                return norm(x[:, 0, :].contiguous())
+            from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
+
+            if (
+                x.is_cuda
+                and get_platform().is_blackwell
+                and 0 < x.shape[0] <= 8
+                and self.hc_mult == 4
+                and x_flat.shape[1] == 20480
+                and x.dtype == norm.weight.dtype == torch.bfloat16
+                and apply_pre.stride(1) == 1
+                and not norm.cast_x_before_out_mul
+                and norm.variance_size_override is None
+                and not is_batch_invariant_mode_enabled()
+            ):
+                from sglang.kernels.ops.layernorm.hc_combine_norm import hc_combine_norm
+
+                return hc_combine_norm(
+                    x_flat, apply_pre, norm.weight, norm.variance_epsilon
+                )
+            return norm(hc_combine(x_flat, apply_pre, self.hc_mult, dtype))
+
         if (
             x.is_cuda
             and torch.version.cuda is not None
@@ -2717,6 +2749,13 @@ class DeepseekV4DecoderLayer(nn.Module):
             # The split-K partial fixes the reduction order;
             # fusing the reduction and sinkhorn preserves batch invariance.
             main_stream = torch.cuda.current_stream()
+            # Avoid competing with the statistics projection for a tiny input;
+            # the coefficients still overlap the attention or FFN that follows.
+            y = (
+                combine_and_norm()
+                if stats_stream is not None and 0 < x.shape[0] <= 8
+                else None
+            )
             if stats_stream is not None:
                 stats_stream.wait_stream(main_stream)
                 x.record_stream(stats_stream)
@@ -2740,10 +2779,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                 # after the caller joins it, on the main stream.
                 for coefficient in (pre, post, comb):
                     coefficient.record_stream(main_stream)
-            if apply_pre is None:
-                y = x[:, 0, :].contiguous()
-            else:
-                y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
+            if y is None:
+                y = combine_and_norm()
             return y, pre, post, comb
         if x.is_cuda and torch.version.cuda is not None:
             # Keep mixing and RMS reductions batch-invariant; cuBLAS/torch reductions can
@@ -2763,10 +2800,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             self.hc_sinkhorn_iters,
             self.hc_eps,
         )
-        if apply_pre is None:
-            y = x[:, 0, :].contiguous()
-        else:
-            y = hc_combine(x_flat, apply_pre, self.hc_mult, dtype)
+        y = combine_and_norm()
         return y, pre.squeeze(1), post.squeeze(1), comb.squeeze(1)
 
     def _get_hc_stats_stream(self, hidden_states, forward_batch):
@@ -2804,9 +2838,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             self.hc_attn_scale,
             self.hc_attn_base,
             apply_pre=prev_pre,
+            norm=self.input_layernorm,
             stats_stream=stats_stream,
         )
-        x = self.input_layernorm(x)
         with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
             x = self.self_attn(
                 x=x, positions=positions, forward_batch=forward_batch, x_quant=None
@@ -2822,9 +2856,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             self.hc_ffn_scale,
             self.hc_ffn_base,
             apply_pre=attn_pre,
+            norm=self.post_attention_layernorm,
             stats_stream=stats_stream,
         )
-        x = self.post_attention_layernorm(x)
         x = self._run_moe_ffn_dp_sync(
             x, forward_batch, input_ids=input_ids, input_ids_global=input_ids_global
         )

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -702,9 +702,9 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_attn_scale,
             self.hc_attn_base,
             apply_pre=prev_pre,
+            norm=self.input_layernorm,
             stats_stream=stats_stream,
         )
-        x = self.input_layernorm(x)
         with self.self_attn.maybe_use_decode_attn_tp(forward_batch):
             x = self.self_attn(positions, x, forward_batch)
         if stats_stream is not None:
@@ -718,9 +718,9 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
             self.hc_ffn_scale,
             self.hc_ffn_base,
             apply_pre=attn_pre,
+            norm=self.post_attention_layernorm,
             stats_stream=stats_stream,
         )
-        x = self.post_attention_layernorm(x)
         x = self._run_ffn(x, forward_batch)
         if stats_stream is not None:
             torch.cuda.current_stream().wait_stream(stats_stream)


### PR DESCRIPTION
## Motivation

DSpark's small target-verify and draft batches still spend time in small WO-A GEMMs, separate mHC combine/RMSNorm launches, and a stacked KV projection that bypasses the selected MXFP8 backend.

On 4x B300, BS1 output throughput increases from **762.41 to 803.25 tok/s (+5.36%)** with real DSpark acceptance.

## Modifications

- Add an eight-way split-K BF16 WO-A kernel for the TP4 shape and 2–8 token rows. Accumulate partials in FP32 and write the final BF16 result in token-major layout.
- Fuse four-stream mHC combine and RMSNorm for small batches, preserving the intermediate BF16 rounding. Schedule it before the side-stream statistics projection so the two short operations do not compete; statistics still overlap the following attention/FFN.
- Reuse the prepared MXFP8 weights and swizzled scales for stacked draft KV projections. Both FlashInfer CUTLASS and CuTe-DSL backends are covered.

Existing fallbacks remain for other shapes/backends. No new environment flags. Production changes only; benchmark and validation harnesses are outside the source diff.

## Accuracy Tests

Same checkpoint, five-shot GSM8K prompt and scorer; 1,314 held-out questions, concurrency 1, temperature 0, top-p 1, seed 0, max output 4096. The serial run exercises the small draft/verify kernels.

| | Baseline | This PR |
|---|---:|---:|
| GSM8K | 1266/1314 (96.35%) | 1271/1314 (96.73%) |
| Request errors / empty outputs / truncations | 0 / 0 / 0 | 0 / 0 / 0 |

Paired results: 10 correct-to-incorrect and 15 incorrect-to-correct. Outputs are not bitwise identical; no aggregate accuracy loss was observed in this evaluation.

AIME 2026, same checkpoint and serving settings as the benchmarks; baseline `824bb45e1bf7`, candidate `0669e3d9464c`. Both runs use the same MathArena prompt, thinking mode, reasoning effort `max`, top-p 0.95 and max output 65,536.

| AIME 2026 | Baseline | This PR | Budget truncations (base / PR) |
|---|---:|---:|---:|
| 30 questions, concurrency 1, temperature 0 | 27/30 (90.00%) | 27/30 (90.00%) | 3 / 3 |
| 30 questions × 16 samples, concurrency 64, temperature 1 | 445/480 (92.71%) | 451/480 (93.96%) | 13 / 15 |

All requested samples completed with zero request errors. Budget truncations stay in the score. The repeated score is correct samples / 480 (mean pass@1), not pass@16. Serial requests use seed 0; repeated requests leave the seed unset.

Serial paired results: 1 correct-to-incorrect and 1 incorrect-to-correct. Both flips involve a token-budget truncation in one arm and a correct completed answer in the other.

Evaluator: `sgl-eval==0.1.0`, vendored NeMo-Skills revision `645cf567ff08c0ae9cc3fc8e1edbb975b3067816`. Source files and installed serving packages were checked unchanged during each arm.

<details><summary>AIME input checksums</summary>

Dataset SHA256: `6a43e48d55eb7736003f53074fef041a3da2b78d902d3fcd0b1974b2523221fc`

Prompt SHA256: `12d8c6381b0191d2e8f6b1ecd39a65229f35af6f7aff21716bb951d456133afb`

</details>

<details>
<summary>AIME 2026 commands</summary>

The run uses `sgl-eval==0.1.0` with its bundled NeMo-Skills data/prompt (`645cf567ff08c0ae9cc3fc8e1edbb975b3067816`). The evaluator is installed outside the serving environment. Both arms use the same files and sampling settings.

```bash
# Run with the serving checkout on PYTHONPATH.
python -m pip install --target /tmp/sgl-eval-pinned --no-deps \
  sgl-eval==0.1.0 math-verify==0.9.0 latex2sympy2_extended==1.11.0 \
  antlr4-python3-runtime==4.9.3 editdistance==0.8.1
export PYTHONPATH="/tmp/sgl-eval-pinned:$PWD/python"
EVAL_DATA=/tmp/sgl-eval-pinned/sgl_eval/_vendored/nemo_skills/dataset/aime26/test.txt
EVAL_PROMPT=/tmp/sgl-eval-pinned/sgl_eval/_vendored/nemo_skills/prompts/matharena-aime.yaml
python -m sgl_eval.cli run aime26 \
  --base-url http://127.0.0.1:30021/v1 --model "$MODEL_PATH" \
  --from-dataset "$EVAL_DATA" --prompt "$EVAL_PROMPT" \
  --num-threads 1 --n-repeats 1 --thinking --reasoning-effort max \
  --temperature 0 --top-p 0.95 --max-tokens 65536 --seed 0 \
  --out-dir results/aime-serial30
python -m sgl_eval.cli run aime26 \
  --base-url http://127.0.0.1:30021/v1 --model "$MODEL_PATH" \
  --from-dataset "$EVAL_DATA" --prompt "$EVAL_PROMPT" \
  --num-threads 64 --n-repeats 16 --thinking --reasoning-effort max \
  --temperature 1 --top-p 0.95 --max-tokens 65536 \
  --out-dir results/aime-repeat16
```

The repeated lane leaves the request seed unset. Accuracy is the fraction of correct samples, not pass@16. Errors and token-budget truncations are counted separately.

</details>


Kernel validation:

- WO-A: 105 production-kernel comparisons against an FP64 reference, including cancellation, zero/large/small inputs, M=2–8 and strided rows; preceded by a 525-case sweep of five configurations.
- mHC combine/RMSNorm: 128 precision cases and 16 CUDA Graph replays with changed inputs.
- Stacked KV: M=1/2/5/6/8/64/320/384 on both MXFP8 backends; bitwise equal to separate MXFP8 projections. Packed scale concatenation checked against independent packing.
- Existing `commit_kv_proj` parity case and repository pre-commit hooks passed.

## Speed Tests and Profiling

Base: `824bb45e1bf7486e49034bfa4bcad59aba799540` on `dsv4.1`. Candidate: `0669e3d946`.

4x B300 SXM6 AC, TP4/EP4; PyTorch 2.13.0+cu130, FlashInfer 0.6.18, Triton 3.7.1, sglang-kernel 0.4.6.post1, sgl-deep-gemm 0.1.7, CUTLASS DSL 4.6.2. Same checkpoint and dependencies, DSpark block size 5. Checkpoint config aliases were normalized once in a separate directory for both arms; tensor values and weights were unchanged.

Two independent server launches per arm in baseline / candidate / candidate / baseline order. Each launch has one warmup, ten BS1 measurements and three BS64 measurements. All measurements are included in these medians. The candidate medians from each launch are 804.86 and 801.91 tok/s.

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| BS1, input 4096/output 1024, post-first-event output tok/s | 762.41 | **803.25** | +5.36% |
| BS1 median accept length | 5.802 | 5.818 | |
| BS64, input 4096/output 2048, stable decode output tok/s | 13,346.69 | 13,327.61 | -0.14% |
| BS64 median accept length | 5.387 | 5.335 | |
| BS64 full-request output tok/s, including prefill and drain | 6,356.42 | 6,242.74 | -1.79% |

The input is a fixed repeated weather-notes summarization prompt, with a different Notebook ID per BS64 request. It is easy to predict; these acceptance lengths are workload-specific. BS1 excludes the first streamed event. BS64 uses consecutive CUDA Graph decode log intervals with exactly 64 live requests, excluding prefill. Its acceptance length varies across runs; this PR targets BS1 and does not claim a BS64 speedup.

<details>
<summary>All unprofiled measurements</summary>

| Run | BS1 tok/s | BS64 decode tok/s |
|---|---|---|
| baseline-b | 755.17, 771.38, 760.03, 690.98, 764.89, 760.80, 760.86, 742.06, 766.89, 764.06 | 13697.46, 13597.03, 13244.87 |
| candidate-e | 806.88, 806.78, 807.71, 805.74, 803.97, 805.81, 798.66, 792.70, 800.94, 802.47 | 13005.09, 13133.16, 13672.64 |
| candidate-e2 | 804.04, 801.13, 805.95, 775.96, 798.45, 802.70, 798.73, 797.22, 803.79, 805.05 | 13320.66, 13847.63, 13334.57 |
| baseline-c | 763.96, 760.13, 764.22, 698.41, 764.83, 721.72, 759.97, 764.80, 768.34, 764.58 | 13216.57, 13027.36, 13448.51 |

</details>

TP0 GPU traces (20 target/draft cycles) confirm that WO-A changes from 11.22 us per cuBLAS call to 5.64 + 1.78 us for split-K and reduction. The stacked KV Triton matmul, previously 102.39 us per cycle, is replaced by the selected MXFP8 path. Scheduling the fused mHC combine/RMSNorm before statistics reduces its observed duration from 4.13 to 3.25 us. These are profiled kernel timings, separate from the unprofiled serving numbers above.

| GPU timeline metric | Baseline | This PR |
|---|---:|---:|
| Target verify graph, median | 6.933 ms | 6.568 ms |
| Draft graph, median | 0.709 ms | 0.697 ms |
| Target-start to next target-start, median | 7.812 ms | 7.425 ms |
| Target kernels per graph | 1965 | 1926 |
| Draft kernels per graph | 181 | 179 |

### Reproduce

Run each checkout with the same model and installed dependencies. Clear inherited `SGLANG_*` overrides.

```bash
MODEL_PATH=/path/to/DeepSeek-V4.1
CUDA_VISIBLE_DEVICES=4,5,6,7 PYTHONPATH="$PWD/python" MAX_JOBS=16 \
python -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --tp 4 --ep-size 4 --trust-remote-code \
  --mem-fraction-static 0.80 --max-total-tokens 33554432 \
  --chunked-prefill-size 4096 \
  --cuda-graph-bs-decode 1 2 4 8 16 32 64 \
  --max-running-requests 128 \
  --speculative-algorithm DSPARK --speculative-dspark-block-size 5 \
  --skip-server-warmup --reasoning-parser deepseek-v41 \
  --random-seed 42 --decode-log-interval 10 \
  --host 127.0.0.1 --port 30021
```

After startup, `POST /freeze_gc`; flush the request cache before each repetition. Client scripts below are the measured harnesses with the tokenizer path made configurable through `MODEL_PATH`.

```bash
export MODEL_PATH=/path/to/DeepSeek-V4.1
export PYTHONPATH="$PWD/python"
SERVER_LOG=/path/to/server.log
mkdir -p results/bs1 results/bs64 results/gsm
curl -f -X POST http://127.0.0.1:30021/freeze_gc
python bench_bs1.py --out results/bs1 --server-log "$SERVER_LOG" --repeat 10
python bench_bs64.py --out results/bs64 --server-log "$SERVER_LOG"
curl -f -X POST 'http://127.0.0.1:30021/flush_cache?timeout=30'
python gsm_eval.py --out results/gsm --count 1314 --threads 1
```

GSM8K data: `openai/grade-school-math`, `grade_school_math/data/test.jsonl`; save as `gsm8k-test.jsonl` beside `gsm_eval.py`. SHA256: `3730d312f6e3440559ace48831e51066acaca737f6eabec99bccb9e4b3c39d14`. The first five rows are demonstrations, excluded from scoring.

<details>
<summary>bench_bs1.py</summary>

```python
"""Fixed-input, real-acceptance BS1 measurements on the owned server only."""
import argparse
import os
import hashlib
import json
import re
import time
from pathlib import Path

import requests
from tokenizers import Tokenizer


def save(path, value):
    path.write_text(json.dumps(value, indent=2, ensure_ascii=False))


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--out', type=Path, required=True)
    parser.add_argument('--server-log', type=Path, required=True)
    parser.add_argument('--url', default='http://127.0.0.1:30021')
    parser.add_argument('--repeat', type=int, default=3)
    parser.add_argument('--profile', action='store_true')
    args = parser.parse_args()
    tok = Tokenizer.from_file(str(Path(os.environ['MODEL_PATH']) / 'tokenizer.json'))
    prefix = tok.encode('Read these notes and summarize them.\n', add_special_tokens=False).ids
    unit = tok.encode('The observatory records the temperature, wind, and rainfall each day. Researchers compare the measurements across seasons.\n', add_special_tokens=False).ids
    suffix = tok.encode('\nWrite a detailed summary of the notes above.\n', add_special_tokens=False).ids

    def post(route, body=None, timeout=1800):
        r = requests.post(args.url+route, json=body or {}, timeout=timeout)
        r.raise_for_status()
        return r

    def warm(ids, rate):
        # The final SSE response can precede scheduler request cleanup.
        # Use the server's bounded idle wait, outside the measured interval.
        post('/flush_cache?timeout=30', timeout=60)
        if rate:
            r = post('/generate', {'input_ids':ids[:int(len(ids)*rate)], 'sampling_params':{'temperature':0, 'max_new_tokens':1, 'ignore_eos':True}})
            assert r.json()['meta_info']['completion_tokens']==1

    results=[]
    for length, out_len, rate in ((4096,1024,0.),):
        n = length-len(prefix)-len(suffix)
        ids = prefix + (unit*((n+len(unit)-1)//len(unit)))[:n] + suffix
        assert len(ids)==length
        save(args.out/f'input-{length}.json',ids)
        input_hash=hashlib.sha256(json.dumps(ids).encode()).hexdigest()
        for rep in range(args.repeat+1):
            warm(ids,rate)
            log_offset=args.server_log.stat().st_size
            body={'input_ids':ids,'sampling_params':{'temperature':0,'max_new_tokens':out_len,'ignore_eos':True,'stream_interval':1},'stream':True}
            start=time.perf_counter();first=None;first_count=None;last=None
            with requests.post(args.url+'/generate',json=body,stream=True,timeout=(30,1800)) as r:
                r.raise_for_status()
                for line in r.iter_lines():
                    if not line.startswith(b'data: '):continue
                    raw=line[6:]
                    if raw==b'[DONE]':break
                    last=json.loads(raw)
                    if 'error' in last:raise RuntimeError(last)
                    count=last.get('meta_info',{}).get('completion_tokens',0)
                    if first is None and count>0:first=time.perf_counter();first_count=count
            end=time.perf_counter()
            assert last is not None and first is not None,last
            meta=last['meta_info']
            assert meta['completion_tokens']==out_len and meta['prompt_tokens']==length,meta
            # Required evidence of actual speculative execution and acceptance.
            assert meta.get('spec_verify_ct',0)>0 and meta.get('spec_accept_length',0)>0,meta
            with args.server_log.open() as f:f.seek(log_offset);log=f.read()
            samples=[float(v) for v in re.findall(r'gen throughput \(token/s\):\s*([0-9.]+)',log)]
            result=dict(input_tokens=length,output_tokens=out_len,requested_cache_hit_rate=rate,repeat=rep,warmup=(rep==0),input_sha256=input_hash,elapsed_s=end-start,ttft_s=first-start,first_stream_completion_tokens=first_count,post_first_event_tps=(out_len-first_count)/(end-first),full_request_tps=out_len/(end-start),decode_log_samples=samples,response=last)
            results.append(result);save(args.out/'performance.json',results)
            print('PERF',length,rep,result['post_first_event_tps'],'accept',meta['spec_accept_length'],'cached',meta.get('cached_tokens'),flush=True)

        if args.profile:
            for activities in (['GPU'],):
                if length==131072 and activities==['CPU','GPU']:continue
                warm(ids,rate)
                tag=f'{length}-'+('-'.join(activities)).lower()
                folder=args.out/('profile-'+tag);folder.mkdir()
                request=dict(output_dir=str(folder),num_steps=20,activities=activities,profile_by_stage=True,profile_stages=['decode'],with_stack=(activities==['CPU','GPU']),record_shapes=(activities==['CPU','GPU']),profile_id=args.out.name+'-'+tag)
                save(folder/'request.json',request)
                post('/start_profile',request,timeout=60)
                response=post('/generate',{'input_ids':ids,'sampling_params':{'temperature':0,'max_new_tokens':200,'ignore_eos':True}}).json()
                save(folder/'response.json',response)
                # At most six tokens per verify step: 200 output tokens
                # always cover the 20 requested decode steps. Export is automatic.
                traces=list(folder.rglob('*.trace.json*'))
                assert len(traces)>=4,(tag,'Missing TP traces',traces)
                save(folder/'trace-files.json',[str(p) for p in traces])
                print('PROFILE',tag,len(traces),flush=True)


if __name__=='__main__':
    main()

```

</details>

<details>
<summary>bench_bs64.py</summary>

```python
"""BS64 serving regression measurement; raw requests and log intervals retained."""
import argparse
import os
from concurrent.futures import ThreadPoolExecutor
import hashlib
import json
from pathlib import Path
import re
import statistics
import threading
import time
import urllib.request

from tokenizers import Tokenizer


def save(path, value):
    path.write_text(json.dumps(value, indent=2, ensure_ascii=False) + '\n')


def post(url, route, body=None):
    request = urllib.request.Request(url + route, data=json.dumps(body or {}).encode(),
                                     headers={'Content-Type': 'application/json'})
    with urllib.request.urlopen(request, timeout=1800) as response:
        if route.startswith(('/flush_cache', '/start_profile', '/stop_profile')):
            return response.read().decode()
        return json.load(response)


def decode_samples(log):
    rows = []
    previous_bs = None
    for line in log.replace('\r', '\n').splitlines():
        if 'Prefill batch' in line:
            previous_bs = None
        if 'Decode batch' not in line:
            continue
        bs = re.search(r'#running-req: (\d+)', line)
        tps = re.search(r'gen throughput \(token/s\): ([0-9.]+)', line)
        al = re.search(r'accept len: ([0-9.]+)', line)
        graph = re.search(r'(?:CUDA graph|cuda graph|cuda_graph|full graph): (True|False)', line)
        if not bs or not tps:
            continue
        batch = int(bs.group(1))
        rows.append(dict(batch_size=batch, tps=float(tps.group(1)),
                         accept_length=float(al.group(1)) if al else None,
                         graph=graph.group(1) == 'True' if graph else None,
                         eligible=(batch == 64 and previous_bs == 64), line=line))
        previous_bs = batch
    return rows


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--out', type=Path, required=True)
    parser.add_argument('--server-log', type=Path, required=True)
    parser.add_argument('--url', default='http://127.0.0.1:30021')
    parser.add_argument('--no-spec', action='store_true')
    args = parser.parse_args()
    tok = Tokenizer.from_file(str(Path(os.environ['MODEL_PATH']) / 'tokenizer.json'))
    unit = tok.encode('The observatory records the temperature, wind, and rainfall each day. Researchers compare the measurements across seasons.\n', add_special_tokens=False).ids
    suffix = tok.encode('\nWrite a detailed summary of the notes above.\n', add_special_tokens=False).ids
    inputs = []
    for i in range(64):
        prefix = tok.encode(f'Notebook {i:03d}. Read these notes and summarize them.\n', add_special_tokens=False).ids
        n = 4096 - len(prefix) - len(suffix)
        inputs.append(prefix + (unit * ((n + len(unit) - 1) // len(unit)))[:n] + suffix)
    assert len({tuple(ids) for ids in inputs}) == 64
    assert all(len(ids) == 4096 for ids in inputs)
    save(args.out/'inputs.json', inputs)
    input_hash = hashlib.sha256(json.dumps(inputs).encode()).hexdigest()
    waves = []
    for rep in range(4):
        warmup = rep == 0
        output_length = 256 if warmup else 2048
        post(args.url, '/flush_cache?timeout=30')
        offset = args.server_log.stat().st_size
        barrier = threading.Barrier(65)

        def request_one(i):
            body = {'input_ids': inputs[i], 'sampling_params': {
                'temperature': 0, 'max_new_tokens': output_length, 'ignore_eos': True}}
            barrier.wait()
            begin = time.perf_counter()
            response = post(args.url, '/generate', body)
            elapsed = time.perf_counter() - begin
            meta = response['meta_info']
            assert meta['completion_tokens'] == output_length, meta
            assert meta['prompt_tokens'] == 4096, meta
            if not args.no_spec:
                assert meta.get('spec_verify_ct', 0) > 0, meta
                assert meta.get('spec_accept_length', 0) > 0, meta
            return dict(index=i, elapsed_s=elapsed, response=response)

        with ThreadPoolExecutor(max_workers=64) as executor:
            futures = [executor.submit(request_one, i) for i in range(64)]
            start = time.perf_counter()
            barrier.wait()
            responses = [future.result() for future in futures]
            elapsed = time.perf_counter() - start
        save(args.out/f'wave-{rep}-responses.json', responses)
        # Drain scheduler request cleanup before the next cache flush.
        time.sleep(1)
        with args.server_log.open('rb') as log:
            log.seek(offset)
            text = log.read().decode(errors='replace')
        (args.out/f'wave-{rep}-server.log').write_text(text)
        rows = decode_samples(text)
        eligible = [row for row in rows if row['eligible']]
        if not warmup:
            assert len(eligible) >= 3, ('Insufficient actual BS64 intervals', rows)
            assert all(row['graph'] is True for row in eligible), eligible[:3]
        completed = sum(r['response']['meta_info']['completion_tokens'] for r in responses)
        verifies = sum(r['response']['meta_info'].get('spec_verify_ct', 0) for r in responses)
        wave = dict(repeat=rep, warmup=warmup, requests=64, input_tokens=4096,
                    output_tokens_per_request=output_length, input_sha256=input_hash,
                    elapsed_s=elapsed, aggregate_full_request_tps=completed/elapsed,
                    weighted_accept_length=completed/verifies if verifies else None,
                    bs64_decode_median_tps=statistics.median(row['tps'] for row in eligible) if eligible else None,
                    bs64_decode_intervals=len(eligible), decode_intervals=rows)
        waves.append(wave)
        save(args.out/'performance.json', waves)
        print('WAVE', rep, 'warmup', warmup, 'actual BS64 decode', wave['bs64_decode_median_tps'],
              'intervals', len(eligible), 'full-request', wave['aggregate_full_request_tps'],
              'AL', wave['weighted_accept_length'], flush=True)


if __name__ == '__main__':
    main()

```

</details>

<details>
<summary>gsm_eval.py</summary>

```python
"""Pinned legacy five-shot GSM8K prompts/scorer, with complete response/error records."""
import argparse,hashlib,json,time
from pathlib import Path
from concurrent.futures import ThreadPoolExecutor,as_completed
import requests
from sglang.test.simple_eval_mixed_prefix_gsm8k import get_few_shot_examples,get_one_example,get_answer_value

def main():
 p=argparse.ArgumentParser();p.add_argument('--out',type=Path,required=True);p.add_argument('--threads',type=int,required=True);p.add_argument('--count',type=int,default=1314);p.add_argument('--url',default='http://127.0.0.1:30021');a=p.parse_args()
 a.out.mkdir(exist_ok=True);data=Path(__file__).with_name('gsm8k-test.jsonl');rows=[json.loads(l) for l in data.read_text().splitlines()];assert len(rows)==1319
 prefix=get_few_shot_examples(rows,5);ids=list(range(5,min(1319,5+a.count)))
 models=requests.get(a.url+'/v1/models',timeout=30);models.raise_for_status();model=models.json()['data'][0]['id']
 def run(i):
  prompt=prefix+get_one_example(rows,i,False);start=time.perf_counter()
  rec=dict(index=i,prompt=prompt,prompt_sha256=hashlib.sha256(prompt.encode()).hexdigest(),expected=get_answer_value(rows[i]['answer']))
  try:
   r=requests.post(a.url+'/v1/chat/completions',json=dict(model=model,messages=[dict(role='user',content=prompt)],temperature=0,top_p=1,max_tokens=4096,seed=0,return_meta_info=True),timeout=(30,1800));r.raise_for_status();j=r.json();rec['response']=j
   ch=j['choices'][0];content=ch['message'].get('content') or '';rec.update(answer=get_answer_value(content),correct=get_answer_value(content)==rec['expected'],truncated=ch['finish_reason']=='length',empty=not bool(content.strip()))
  except Exception as e:rec.update(error=repr(e),correct=False,truncated=False,empty=True)
  rec['elapsed_s']=time.perf_counter()-start;return rec
 results=[];begin=time.perf_counter()
 with (a.out/'samples.jsonl').open('w') as f,ThreadPoolExecutor(max_workers=a.threads) as pool:
  futures=[pool.submit(run,i) for i in ids]
  for future in as_completed(futures):
   r=future.result();results.append(r);f.write(json.dumps(r,ensure_ascii=False)+'\n');f.flush()
   if len(results)%25==0 or len(results)==len(ids):print('GSM',len(results),'/',len(ids),'correct',sum(x['correct'] for x in results),'errors',sum('error' in x for x in results),flush=True)
 summary=dict(count=len(results),correct=sum(r['correct'] for r in results),score=sum(r['correct'] for r in results)/len(results),errors=sum('error' in r for r in results),truncated=sum(r['truncated'] for r in results),empty=sum(r['empty'] for r in results),threads=a.threads,elapsed_s=time.perf_counter()-begin,dataset_sha256=hashlib.sha256(data.read_bytes()).hexdigest(),num_shots=5,held_out_indices=ids,temperature=0,top_p=1,seed=0,max_tokens=4096)
 (a.out/'summary.json').write_text(json.dumps(summary,indent=2));print(json.dumps(summary),flush=True)
 assert summary['errors']==0,summary
 assert summary['score']>=.9,summary
if __name__=='__main__':main()

```

</details>

## Checklist

- [x] Repository pre-commit hooks passed.
- [x] Kernel correctness and model accuracy/speed checks completed.
- [x] Launch command and client harnesses included above.
- [ ] New CI test files (external validation harnesses retained; no test files in this diff).
