### PR TITLE
[FLA] Keep sigmoid(beta) in fp32 in GDN packed decode and KDA replay decode kernels

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
@@ -252,7 +252,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     x = a_val + dt_bias_val
     softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
     g_val = -tl.exp(A_log_val) * softplus_x
-    beta_val = tl.sigmoid(b_val).to(b.dtype.element_ty).to(tl.float32)
+    beta_val = tl.sigmoid(b_val)
 
     b_h *= exp(g_val)
     b_v -= tl.sum(b_h * b_k[None, :], 1)

--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py
@@ -135,7 +135,7 @@ def fused_recurrent_linear_replayssm_decode_kernel(
     #   g = -exp(A_log) * softplus(a + dt_bias);  alpha = exp(g);  beta = sigmoid(b)
     A_log_val = tl.load(A_log + i_hv).to(tl.float32)
     b_val = tl.load(b + i_n * stride_b_tok + i_hv).to(tl.float32)
-    beta_val = tl.sigmoid(b_val).to(b.dtype.element_ty).to(tl.float32)
+    beta_val = tl.sigmoid(b_val)
     if not IS_KDA:
         a_val = tl.load(a + i_n * stride_a_tok + i_hv).to(tl.float32)
         dt_bias_val = tl.load(dt_bias + i_hv).to(tl.float32)

--- a/test/registered/attention/unittests/gdn/test_decode_keeps_beta_in_fp32.py
+++ b/test/registered/attention/unittests/gdn/test_decode_keeps_beta_in_fp32.py
@@ -1,0 +1,130 @@
+"""Regression tests: decode kernels must keep the sigmoid(beta) gate in fp32.
+
+Both kernels covered here computed
+``tl.sigmoid(b_val).to(b.dtype.element_ty).to(tl.float32)``: the fp32 sigmoid
+was rounded to the input dtype (bf16 in serving) and immediately cast back,
+discarding the low mantissa bits with no bf16 arithmetic in between. The
+rounded gate multiplies the value vector in the delta-rule update of the
+persistent SSM state, which is read and written on every decode step, so the
+per-token rounding error accumulates with context length (issue #38975). The
+same-origin vllm copy of the packed kernel had the identical line and fixed it
+in vllm-project/vllm#53877.
+
+Degenerate config (B=H=HV=K=V=1, zero initial state, unit q=k=v): the
+delta-rule correction vanishes on a zero state and the outer product v (x) k
+is 1, so the stored state after one decode step equals sigmoid(b) itself.
+Each test reads the gate straight out of the state pool and compares it with
+a torch fp32 reference (rtol/atol=1e-6, the vllm regression-test tolerance).
+With bf16 gating input the pre-fix state was 0.62109375 vs fp32
+0.622459352016449 (rel err 0.2194%, exactly one bf16 rounding); keeping beta
+in fp32 makes it bit-exact.
+
+The ReplaySSM test runs at L=1, where ``write_pos == L-1`` makes every step a
+flush, so the checkpoint state (not just the ring) is updated immediately and
+reduces to the same one-step delta-rule update. That kernel tiles its
+reconstruction around ``tl.dot`` and requires K, V >= 16, so its unit vectors
+are one-hot (q = 0, k = e_0, v = e_0) and the expected state is all zeros with
+sigmoid(b) in the single [0, 0] element.
+"""
+
+import unittest
+
+import torch
+
+# Mirror sibling GDN unittests: register for CUDA/AMD CI. Module-level calls
+# (the CI collector parses them statically; see test_linear_replayssm_decode).
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-large-amd")
+
+
+def _one_step_inputs(device, dtype):
+    """One token, B=H=HV=K=V=1, unit q=k=v, b=0.5 (sigmoid far from bf16 grid)."""
+    mixed_qkv = torch.ones((1, 3), device=device, dtype=dtype)
+    a = torch.zeros((1, 1), device=device, dtype=dtype)
+    b = torch.full((1, 1), 0.5, device=device, dtype=dtype)
+    params = torch.zeros((1,), device=device, dtype=dtype)
+    return mixed_qkv, a, b, params
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestDecodeKeepsBetaInFp32(CustomTestCase):
+    def test_gdn_packed_decode(self):
+        from sglang.kernels.ops.attention.fla.fused_recurrent import (
+            fused_recurrent_gated_delta_rule_packed_decode as packed_decode,
+        )
+
+        device, dtype = "cuda", torch.bfloat16
+        mixed_qkv, a, b, params = _one_step_inputs(device, dtype)
+        # 2-slot pool: state[1] stays zero and isolates the written slot.
+        state = torch.zeros((2, 1, 1, 1), device=device, dtype=torch.float32)
+        out = torch.empty((1, 1, 1, 1), device=device, dtype=dtype)
+        packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=params,
+            dt_bias=params,
+            scale=1.0,
+            initial_state=state,
+            out=out,
+            ssm_state_indices=torch.zeros((1,), device=device, dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            state[0].reshape(-1),
+            torch.sigmoid(b.float()).reshape(-1),
+            atol=1e-6,
+            rtol=1e-6,
+            msg="packed decode must keep sigmoid(beta) in fp32",
+        )
+
+    def test_linear_replayssm_decode(self):
+        from sglang.kernels.ops.attention.fla.fused_recurrent_linear_replayssm import (
+            fused_recurrent_linear_replayssm_decode as replayssm_decode,
+        )
+
+        device, dtype = "cuda", torch.bfloat16
+        # Same degenerate recurrence, sized for this kernel's tl.dot tiling
+        # (K, V >= 16): q = 0, k = e_0, v = e_0 puts sigmoid(b) alone in the
+        # state at [v=0, k=0]; every other element stays exactly zero.
+        K = V = 16
+        mixed_qkv = torch.zeros((1, 2 * K + V), device=device, dtype=dtype)
+        mixed_qkv[0, K] = 1.0  # k = e_0
+        mixed_qkv[0, 2 * K] = 1.0  # v = e_0
+        a = torch.zeros((1, 1), device=device, dtype=dtype)
+        b = torch.full((1, 1), 0.5, device=device, dtype=dtype)
+        params = torch.zeros((1,), device=device, dtype=dtype)
+        state = torch.zeros((1, 1, V, K), device=device, dtype=torch.float32)
+        out = torch.empty((1, 1, 1, V), device=device, dtype=dtype)
+        L = 1  # write_pos == L-1: this step is a flush
+        replayssm_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=params,
+            dt_bias=params,
+            scale=1.0,
+            initial_state=state,
+            d_cache=torch.zeros((1, 1, L, V), device=device, dtype=dtype),
+            k_cache=torch.zeros((1, 1, L, K), device=device, dtype=dtype),
+            g_cache=torch.zeros((1, 1, L), device=device, dtype=torch.float32),
+            out=out,
+            ssm_state_indices=torch.zeros((1,), device=device, dtype=torch.int32),
+            write_pos=torch.zeros((1,), device=device, dtype=torch.int32),
+            nk=1,  # BKT = BK/nk must stay >= 16 at BK=16
+        )
+        expected = torch.zeros((1, V, K), device=device, dtype=torch.float32)
+        expected[0, 0, 0] = torch.sigmoid(b.float()).item()
+        torch.testing.assert_close(
+            state[0],
+            expected,
+            atol=1e-6,
+            rtol=1e-6,
+            msg="replayssm decode must keep sigmoid(beta) in fp32",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernel/ops/attention/test_decode_keeps_beta_in_fp32.py
+++ b/test/registered/kernel/ops/attention/test_decode_keeps_beta_in_fp32.py
@@ -31,13 +31,13 @@ import unittest
 
 import torch
 
-# Mirror sibling GDN unittests: register for CUDA/AMD CI. Module-level calls
-# (the CI collector parses them statically; see test_linear_replayssm_decode).
+# Register for CUDA/AMD CI, kernel-kind suites (see sibling kernel tests).
+# Module-level calls: the CI collector parses them statically via AST.
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-large-amd")
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
 
 
 def _one_step_inputs(device, dtype):


### PR DESCRIPTION
## Motivation

Fixes #38975.

The GDN packed decode kernel and the KDA replay decode kernel round the fp32 sigmoid gate through the input dtype and back:

```python
# fused_recurrent.py:255, fused_recurrent_linear_replayssm.py:138
beta_val = tl.sigmoid(b_val).to(b.dtype.element_ty).to(tl.float32)
```

No bf16 arithmetic happens between the two casts, so the round-trip only discards the low mantissa bits of the fp32 sigmoid. The rounded gate feeds the delta-rule update of the persistent SSM state, which is read and written on every decode step, so the rounding error enters the state once per token and accumulates with context length.

Two references show fp32 is the intended behavior. The KDA packed decode kernel in the same file already keeps beta in fp32 on purpose (`fused_recurrent.py:490`, comment "Keep beta in fp32 (no bf16 round-trip) to match the generic decode kernel `fused_sigmoid_gating_delta_rule_update`, which is the reference validated against torch"). And the same-origin vllm copy of the packed kernel had the identical line and fixed it in vllm-project/vllm#53877 because "the beta rounding error accumulates with context length and can eventually degrade generation accuracy and stability"; that fix was never ported here.

## Modifications

One line per file, the same as vllm's fix:

```python
beta_val = tl.sigmoid(b_val)
```

- `python/sglang/kernels/ops/attention/fla/fused_recurrent.py:255` (GDN packed decode)
- `python/sglang/kernels/ops/attention/fla/fused_recurrent_linear_replayssm.py:138` (KDA replay decode)

Added `test/registered/kernel/ops/attention/test_decode_keeps_beta_in_fp32.py`, a port of the regression test added alongside the vllm fix (`test_packed_decode_keeps_beta_in_fp32`), extended to cover the replay decode kernel. Degenerate config (zero initial state, unit q=k=v), so the stored state after one decode step equals `sigmoid(b)` itself and the test reads the gate straight out of the state pool, asserted against a torch fp32 reference at rtol/atol 1e-6.

## Accuracy Tests

Verified on A100-PCIE-40GB, torch 2.9.0+cu129, at the parent commit (full data in #38975).

Single step: pre-fix state `0.62109375` vs fp32 reference `0.622459352016449` (rel err 0.2194%, exactly one bf16 rounding); post-fix bit-exact.

1000-step decode drift (B=1, H=16, HV=48, K=V=128, bf16 activations, fp32 state, vs an independent torch fp32 recurrence that keeps beta in fp32):

| variant | state rel-L2 @ step 1000 | max output rel-L2 |
| --- | --- | --- |
| pre-fix | 1.41e-3 | 2.19e-3 |
| post-fix | 1.05e-7 | 2.39e-7 |

The new unit test fails on the pre-fix kernels (both test methods) and passes post-fix. The existing `test_linear_replayssm_decode.py` kernel-consistency suite (6 tests) passes post-fix.

## Speed Tests and Profiling

The change removes two elementwise dtype casts on a scalar per program; no measurable impact is expected, so no benchmark was run.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidelines).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34571858915](https://github.com/sgl-project/sglang/actions/runs/34571858915)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34571858765](https://github.com/sgl-project/sglang/actions/runs/34571858765)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34571858901](https://github.com/sgl-project/sglang/actions/runs/34571858901)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
