### PR TITLE
[Perf] DSV4: up to -34% prefill TTFT on 840K-token prompts (B=1) via query-dim top-K reuse

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1475,6 +1475,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--deepseek-v4-prefill-reuse`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Reuse the DeepSeek V4 indexer top-K across a window of prefill query rows, scoring only the first row of each window. `deep10-inf-w4` also lets the ten deepest C4 indexer layers share one selection per chunk. Only affects single-request prefill on the non-paged indexer fast path; other cases keep the default path.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>uniform-w4</code>, <code>deep10-inf-w4</code></td>
+    </tr>
+        <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--fp8-gemm-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the runner backend for Blockwise FP8 GEMM operations. For MXFP8 dense GEMM, <code>auto</code> selects <code>flashinfer_cutedsl</code> when FlashInfer reports support (currently SM100/SM103), and otherwise selects <code>flashinfer_cutlass</code> on supported Blackwell GPUs. Options also include 'deep_gemm' (JIT-compiled), 'flashinfer_trtllm' (FlashInfer TRTLLM backend; SM100/SM103 only), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cutedsl' (FlashInfer CuTe DSL MXFP8 backend; SM100/SM103 only), 'flashinfer_deepgemm' (Hopper SM90 only, uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for SM120 GPUs), 'triton' (fallback, widely compatible), and 'aiter' (ROCm only).</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>

--- a/python/sglang/srt/arg_groups/fields/exec_.py
+++ b/python/sglang/srt/arg_groups/fields/exec_.py
@@ -308,6 +308,20 @@ class ExecKernel(msgspec.Struct):
         bool,
         "Enable the experimental FP4 C4 indexer path for DeepSeek V4. Default keeps the existing indexer implementation.",
     ] = False
+    deepseek_v4_prefill_reuse: A[
+        Optional[str],
+        Arg(
+            help="Reuse the DeepSeek V4 indexer top-K across a window of prefill "
+            "query rows, scoring only the first row of each window. 'uniform-w4' "
+            "uses a window of 4 on every C4 indexer layer; 'deep10-inf-w4' also "
+            "lets the ten deepest C4 layers of DeepSeek-V4-Flash (24-42) share one "
+            "selection per chunk. Only the non-paged indexer fast path is affected "
+            "(a single request with at least "
+            "SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS query rows); other "
+            "cases and the torch/flashinfer top-k backends keep the default path.",
+            choices=["uniform-w4", "deep10-inf-w4"],
+        ),
+    ] = None
 
 
 class ExecMamba(msgspec.Struct):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1445,6 +1445,8 @@ class Envs:
     # Per-rank local query rows (after DP-attention sharding when enabled),
     # not request ISL.
     SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS = EnvInt(8192)
+    # Log the --deepseek-v4-prefill-reuse dose every N reuse calls per rank; 0 disables.
+    SGLANG_LOG_DSV4_PREFILL_REUSE_INTERVAL = EnvInt(0)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -57,6 +57,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
     copy_metadata,
     maybe_copy_inplace,
 )
+from sglang.srt.layers.attention.dsv4.prefill_reuse import resolve_prefill_reuse_preset
 from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
@@ -647,6 +648,9 @@ class DeepseekV4AttnBackend(
         kernel = get_exec().kernel
         self.enable_deepseek_v4_fp4_indexer = kernel.enable_deepseek_v4_fp4_indexer
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
+        self.prefill_reuse_preset = resolve_prefill_reuse_preset(
+            kernel.deepseek_v4_prefill_reuse
+        )
         self.dsv4_prefill_backend = getattr(kernel, "dsv4_prefill_backend", "auto")
         if use_dsv4_q8kv8_sparse_prefill(self.dsv4_prefill_backend):
             if not get_platform().is_sm90:

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -39,6 +39,10 @@ from sglang.srt.layers.attention.dsv4.metadata import (
     NonPagedIndexerPlan,
     PagedIndexerMetadata,
 )
+from sglang.srt.layers.attention.dsv4.prefill_reuse import (
+    ReusePreset,
+    maybe_apply_reuse,
+)
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
@@ -444,6 +448,7 @@ class C4IndexerBackendMixin:
         super().__init__()
         self.debug_use_external_c4_sparse_indices: bool = False
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.SGL_KERNEL
+        self.prefill_reuse_preset: Optional[ReusePreset] = None
         self.flashinfer_topk_transform: Callable[..., None] = (
             topk_transform_flashinfer_fused
             if envs.SGLANG_DSA_FUSE_TOPK.get()
@@ -895,14 +900,34 @@ class C4IndexerBackendMixin:
 
         if nonpaged_plan is not None:
             assert isinstance(q_indexer, torch.Tensor)
-            logits = self._forward_nonpaged_indexer(
-                q_indexer=q_indexer,
-                weights=weights,
-                c4_indexer=c4_indexer,
-                token_to_kv_pool=token_to_kv_pool,
-                plan=nonpaged_plan,
-            )
-            run_topk_transform(all_rows, logits)
+            # Capture needs per-row indices, which reuse does not produce.
+            if (
+                self.prefill_reuse_preset is None
+                or capture_enabled
+                or not maybe_apply_reuse(
+                    preset=self.prefill_reuse_preset,
+                    topk_backend=self.dsa_topk_backend,
+                    forward_nonpaged_indexer=self._forward_nonpaged_indexer,
+                    c4_indexer=c4_indexer,
+                    token_to_kv_pool=token_to_kv_pool,
+                    plan=nonpaged_plan,
+                    q_indexer=q_indexer,
+                    weights=weights,
+                    c4_seq_lens=c4_seq_lens,
+                    page_table=page_table,
+                    c4_sparse_page_indices=c4_sparse_page_indices,
+                    raw_indices=raw_indices,
+                    compressed_page_size=indexer_metadata.compressed_page_size,
+                )
+            ):
+                logits = self._forward_nonpaged_indexer(
+                    q_indexer=q_indexer,
+                    weights=weights,
+                    c4_indexer=c4_indexer,
+                    token_to_kv_pool=token_to_kv_pool,
+                    plan=nonpaged_plan,
+                )
+                run_topk_transform(all_rows, logits)
         elif use_aiter_fp4:
             q_fp4, q_scale = q
             is_decode = forward_batch.forward_mode.is_decode()

--- a/python/sglang/srt/layers/attention/dsv4/prefill_reuse.py
+++ b/python/sglang/srt/layers/attention/dsv4/prefill_reuse.py
@@ -38,26 +38,20 @@ logger = logging.getLogger(__name__)
 
 # DeepSeek-V4-Flash has C4 indexers on the even layers 2..42; these are the ten deepest.
 _DEEP10_LAYERS = (24, 26, 28, 30, 32, 34, 36, 38, 40, 42)
-# Wider than any prefill chunk, so the whole chunk shares its first row's selection.
-_WHOLE_CHUNK = 999_999
 
 
 class ReusePreset(msgspec.Struct, frozen=True, kw_only=True):
     window: int
-    deep_window: int = 0
+    # These layers share one selection per chunk instead of using `window`.
     deep_layers: tuple[int, ...] = ()
 
-    def window_for(self, layer_id: int) -> int:
-        if self.deep_window and layer_id in self.deep_layers:
-            return self.deep_window
-        return self.window
+    def window_for(self, *, layer_id: int, query_rows: int) -> int:
+        return query_rows if layer_id in self.deep_layers else self.window
 
 
 PRESETS: dict[str, ReusePreset] = {
     "uniform-w4": ReusePreset(window=4),
-    "deep10-inf-w4": ReusePreset(
-        window=4, deep_window=_WHOLE_CHUNK, deep_layers=_DEEP10_LAYERS
-    ),
+    "deep10-inf-w4": ReusePreset(window=4, deep_layers=_DEEP10_LAYERS),
 }
 
 
@@ -116,7 +110,7 @@ def maybe_apply_reuse(
     if topk_backend.is_torch() or topk_backend.is_flashinfer():
         return False
     query_rows = q_indexer.shape[0]
-    window = preset.window_for(c4_indexer.layer_id)
+    window = preset.window_for(layer_id=c4_indexer.layer_id, query_rows=query_rows)
     num_leaders = -(-query_rows // window)
     if num_leaders >= query_rows:
         return False
@@ -170,6 +164,8 @@ def maybe_apply_reuse(
             leader_raw,
         )
 
+    # Followers longer than their leader read its -1 padding as part of their top-K;
+    # flash_mla_sparse_fwd skips -1, and compressed_base is 0 on this single-request path.
     c4_sparse_page_indices.copy_(leader_pages.index_select(0, row_to_leader))
     # Raw indices are sequence positions, not row-relative, so they broadcast as-is.
     if leader_raw is not None:

--- a/python/sglang/srt/layers/attention/dsv4/prefill_reuse.py
+++ b/python/sglang/srt/layers/attention/dsv4/prefill_reuse.py
@@ -1,0 +1,178 @@
+"""Query-row top-K reuse for the DeepSeek-V4 C4 indexer on the prefill fast path.
+
+Adjacent prefill query rows select heavily overlapping top-K sets, so the
+non-paged fast path scores one leader row per window of rows and broadcasts its
+selection to the rest of the window. The leader is the first row of its window,
+so no row reuses a selection that saw later tokens.
+
+Presets are layer-tiered: the window is chosen per C4 indexer layer, and
+``deep10-inf-w4`` lets the deepest layers share one selection per chunk while
+the rest keep a window of 4. The same query-group sharing on DSA indexers is
+PIVOT-Reuse (arXiv:2607.24593).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from typing import TYPE_CHECKING, Callable, Optional
+
+import msgspec
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import (
+    plan_topk_v2,
+    topk_transform_paged,
+    topk_transform_paged_v2,
+)
+from sglang.srt.environ import envs
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
+    from sglang.srt.layers.attention.dsv4.indexer import C4Indexer
+    from sglang.srt.layers.attention.dsv4.metadata import NonPagedIndexerPlan
+    from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+
+logger = logging.getLogger(__name__)
+
+# DeepSeek-V4-Flash has C4 indexers on the even layers 2..42; these are the ten deepest.
+_DEEP10_LAYERS = (24, 26, 28, 30, 32, 34, 36, 38, 40, 42)
+# Wider than any prefill chunk, so the whole chunk shares its first row's selection.
+_WHOLE_CHUNK = 999_999
+
+
+class ReusePreset(msgspec.Struct, frozen=True, kw_only=True):
+    window: int
+    deep_window: int = 0
+    deep_layers: tuple[int, ...] = ()
+
+    def window_for(self, layer_id: int) -> int:
+        if self.deep_window and layer_id in self.deep_layers:
+            return self.deep_window
+        return self.window
+
+
+PRESETS: dict[str, ReusePreset] = {
+    "uniform-w4": ReusePreset(window=4),
+    "deep10-inf-w4": ReusePreset(
+        window=4, deep_window=_WHOLE_CHUNK, deep_layers=_DEEP10_LAYERS
+    ),
+}
+
+
+def resolve_prefill_reuse_preset(name: Optional[str]) -> Optional[ReusePreset]:
+    if name is None:
+        return None
+    preset = PRESETS[name]
+    logger.info("DeepSeek V4 prefill top-K reuse enabled: %s = %s", name, preset)
+    return preset
+
+
+# The fast path fails closed silently, so these counters are the only evidence
+# that reuse ran; rows_saved / rows_total should match the preset.
+_dose = {"calls": 0, "rows_total": 0, "rows_saved": 0}
+
+
+def _record_dose(*, query_rows: int, num_leaders: int) -> None:
+    _dose["calls"] += 1
+    _dose["rows_total"] += query_rows
+    _dose["rows_saved"] += query_rows - num_leaders
+    interval = envs.SGLANG_LOG_DSV4_PREFILL_REUSE_INTERVAL.get()
+    if interval > 0 and _dose["calls"] % interval == 0:
+        logger.info(
+            "[dsv4-prefill-reuse] pid=%d calls=%d rows_total=%d rows_saved=%d "
+            "frac=%.4f",
+            os.getpid(),
+            _dose["calls"],
+            _dose["rows_total"],
+            _dose["rows_saved"],
+            _dose["rows_saved"] / _dose["rows_total"],
+        )
+
+
+def maybe_apply_reuse(
+    *,
+    preset: ReusePreset,
+    topk_backend: DSATopKBackend,
+    forward_nonpaged_indexer: Callable[..., torch.Tensor],
+    c4_indexer: C4Indexer,
+    token_to_kv_pool: DeepSeekV4TokenToKVPool,
+    plan: NonPagedIndexerPlan,
+    q_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    c4_seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    c4_sparse_page_indices: torch.Tensor,
+    raw_indices: Optional[torch.Tensor],
+    compressed_page_size: int,
+) -> bool:
+    """Score only the window leaders and broadcast their top-K to every row.
+
+    Returns True once the page (and raw) indices of all rows are written, so the
+    caller must skip its own scoring and top-K; False means nothing was touched.
+    """
+    # Only the sgl-kernel transforms are mirrored below.
+    if topk_backend.is_torch() or topk_backend.is_flashinfer():
+        return False
+    query_rows = q_indexer.shape[0]
+    window = preset.window_for(c4_indexer.layer_id)
+    num_leaders = -(-query_rows // window)
+    if num_leaders >= query_rows:
+        return False
+
+    device = c4_sparse_page_indices.device
+    leader_rows = torch.arange(0, query_rows, window, device=device)
+    row_to_leader = torch.arange(query_rows, device=device) // window
+
+    # Rebuilding the plan would fail its row-count checks, so derive it; only ke is per row.
+    leader_ke = plan.ke.index_select(0, leader_rows)
+    leader_plan = dataclasses.replace(
+        plan, ks=torch.zeros_like(leader_ke), ke=leader_ke, query_rows=num_leaders
+    )
+    logits = forward_nonpaged_indexer(
+        q_indexer=q_indexer.index_select(0, leader_rows),
+        weights=weights.index_select(0, leader_rows),
+        c4_indexer=c4_indexer,
+        token_to_kv_pool=token_to_kv_pool,
+        plan=leader_plan,
+    )
+
+    leader_seq_lens = c4_seq_lens.index_select(0, leader_rows)
+    leader_page_table = page_table.index_select(0, leader_rows)
+    # -1 like the production buffer: the transform leaves unfilled slots alone,
+    # and the broadcast below copies whole rows.
+    leader_pages = torch.full(
+        (num_leaders, c4_sparse_page_indices.shape[1]),
+        -1,
+        dtype=c4_sparse_page_indices.dtype,
+        device=device,
+    )
+    if topk_backend.should_use_topk_v2() and raw_indices is None:
+        # The cached top-K plan covers all rows, so the leaders need their own.
+        topk_transform_paged_v2(
+            logits,
+            leader_seq_lens,
+            leader_page_table,
+            leader_pages,
+            compressed_page_size,
+            plan_topk_v2(leader_seq_lens),
+        )
+        leader_raw = None
+    else:
+        leader_raw = None if raw_indices is None else torch.empty_like(leader_pages)
+        topk_transform_paged(
+            logits,
+            leader_seq_lens,
+            leader_page_table,
+            leader_pages,
+            compressed_page_size,
+            leader_raw,
+        )
+
+    c4_sparse_page_indices.copy_(leader_pages.index_select(0, row_to_leader))
+    # Raw indices are sequence positions, not row-relative, so they broadcast as-is.
+    if leader_raw is not None:
+        raw_indices[:query_rows].copy_(leader_raw.index_select(0, row_to_leader))
+    _record_dose(query_rows=query_rows, num_leaders=num_leaders)
+    return True

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
     NonPagedIndexerPlan,
     PagedIndexerMetadata,
 )
+from sglang.srt.layers.attention.dsv4.prefill_reuse import PRESETS, maybe_apply_reuse
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -23,6 +24,7 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 _INDEXER = "sglang.srt.layers.attention.dsv4.indexer"
+_PREFILL_REUSE = "sglang.srt.layers.attention.dsv4.prefill_reuse"
 
 
 class TestDSV4PagedIndexerMetadata(CustomTestCase):
@@ -455,6 +457,97 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         torch.testing.assert_close(call.args[3], plan.ks)
         torch.testing.assert_close(call.args[4], plan.ke)
         self.assertEqual(call.kwargs, {"clean_logits": False, "max_seqlen_k": 128})
+
+
+def _fake_topk_transform(logits, seq_lens, page_table, out, page_size, raw_out):
+    # Fills slot 0 with the scored row id and leaves the other slots untouched,
+    # like a row with a single candidate.
+    out[:, 0] = logits[:, 0].to(out.dtype)
+    raw_out[:, 0] = logits[:, 0].to(raw_out.dtype) + 1000
+
+
+_SGL_KERNEL_TOPK = SimpleNamespace(
+    is_torch=lambda: False,
+    is_flashinfer=lambda: False,
+    should_use_topk_v2=lambda: False,
+)
+
+
+class TestDSV4PrefillReuse(CustomTestCase):
+    query_rows = 10
+
+    def _apply(self, *, layer_id, topk_backend):
+        n = self.query_rows
+        # Each query row carries its own row id, so the logits name the leader.
+        q_indexer = torch.arange(n, dtype=torch.float32).unsqueeze(1)
+        plan = NonPagedIndexerPlan(
+            page_table=torch.zeros((1, 1), dtype=torch.int32),
+            gather_seq_lens=torch.tensor([n], dtype=torch.int32),
+            ks=torch.zeros(n, dtype=torch.int32),
+            ke=torch.arange(1, n + 1, dtype=torch.int32),
+            seq_len_sum=n,
+            max_seq_len=n,
+            max_seqlen_k=64,
+            query_rows=n,
+        )
+        pages = torch.full((n, 3), 7, dtype=torch.int32)
+        raw = torch.full((n + 2, 3), 7, dtype=torch.int32)
+        forward = MagicMock(side_effect=lambda **kw: kw["q_indexer"].clone())
+        with patch(f"{_PREFILL_REUSE}.topk_transform_paged", _fake_topk_transform):
+            applied = maybe_apply_reuse(
+                preset=PRESETS["deep10-inf-w4"],
+                topk_backend=topk_backend,
+                forward_nonpaged_indexer=forward,
+                c4_indexer=SimpleNamespace(layer_id=layer_id),
+                token_to_kv_pool=MagicMock(),
+                plan=plan,
+                q_indexer=q_indexer,
+                weights=torch.ones((n, 2)),
+                c4_seq_lens=torch.arange(1, n + 1, dtype=torch.int32),
+                page_table=torch.zeros((n, 2), dtype=torch.int32),
+                c4_sparse_page_indices=pages,
+                raw_indices=raw,
+                compressed_page_size=64,
+            )
+        return applied, pages, raw, forward, plan
+
+    def test_every_row_takes_its_window_leader_selection(self):
+        n = self.query_rows
+        # Layer 22 keeps a window of 4; layer 24 is a deep layer sharing one
+        # selection per chunk.
+        cases = {22: [0, 0, 0, 0, 4, 4, 4, 4, 8, 8], 24: [0] * n}
+        for layer_id, leaders in cases.items():
+            with self.subTest(layer_id=layer_id):
+                applied, pages, raw, forward, plan = self._apply(
+                    layer_id=layer_id, topk_backend=_SGL_KERNEL_TOPK
+                )
+                expected = torch.tensor(leaders, dtype=torch.int32)
+                self.assertTrue(applied)
+                torch.testing.assert_close(pages[:, 0], expected)
+                # Unfilled slots must read as invalid pages, not stale memory.
+                self.assertTrue(bool((pages[:, 1:] == -1).all()))
+                # Sparse prefill attention reads raw indices, so they broadcast too.
+                torch.testing.assert_close(raw[:n, 0], expected + 1000)
+                self.assertTrue(bool((raw[n:] == 7).all()))
+                scored = torch.unique(expected).long()
+                leader_plan = forward.call_args.kwargs["plan"]
+                self.assertEqual(leader_plan.query_rows, scored.numel())
+                torch.testing.assert_close(leader_plan.ke, plan.ke[scored])
+
+    def test_unsupported_topk_backends_leave_outputs_untouched(self):
+        for name in ("torch", "flashinfer"):
+            topk_backend = SimpleNamespace(
+                is_torch=lambda name=name: name == "torch",
+                is_flashinfer=lambda name=name: name == "flashinfer",
+                should_use_topk_v2=lambda: False,
+            )
+            with self.subTest(topk_backend=name):
+                applied, pages, raw, forward, _ = self._apply(
+                    layer_id=22, topk_backend=topk_backend
+                )
+                self.assertFalse(applied)
+                self.assertTrue(bool((pages == 7).all()))
+                self.assertTrue(bool((raw == 7).all()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

In DeepSeek-V4 prefill, the C4 lightning indexer scores every query row against the whole compressed KV prefix. Adjacent query rows pick heavily overlapping top-K sets, so on long single-request prefills most of that scoring is redundant.

This PR adds an opt-in, training-free schedule that scores one leader row per window of query rows and broadcasts the leader's top-K to the rest of the window. The leader is the first row of its window, so no row reuses a selection that saw later tokens.

**Prior art.** The same query-group sharing was published as PIVOT-Reuse ([arXiv:2607.24593](https://arxiv.org/abs/2607.24593)) for DSA indexers with one uniform group size. This PR differs in two ways:

- **Layer-tiered schedule.** The window is chosen per indexer layer. `deep10-inf-w4` lets the ten deepest C4 layers share one selection per prefill chunk and keeps a window of 4 on the other eleven; `uniform-w4` is the uniform variant.
- **CSA, not DSA.** It targets DeepSeek-V4's CSA stack, where C4 indexers sit only on the even layers 2..42 (interleaved with HCA layers), and plugs into the existing non-paged indexer fast path.

A standalone demo (A/B script, dose checker) lives in [Wendy-Hamlet/Echelon](https://github.com/Wendy-Hamlet/Echelon).

## Modifications

- `--deepseek-v4-prefill-reuse {uniform-w4,deep10-inf-w4}` in `ExecKernel` (default: off).
- New `layers/attention/dsv4/prefill_reuse.py`: scores the leader rows through the existing `_forward_nonpaged_indexer`, runs the same sgl-kernel top-K transform (v1/v2) on them, and broadcasts both page indices and raw indices to every row.
- `dsv4/indexer.py`: one call site on the non-paged branch. `deepseek_v4_backend.py` resolves the preset once at init, next to `dsa_topk_backend`.
- Everything else keeps the existing path untouched: the torch/flashinfer top-K backends, indexer score capture, and any batch that does not take the non-paged fast path.
- `SGLANG_LOG_DSV4_PREFILL_REUSE_INTERVAL` (default 0 = off) logs the achieved dose `rows_saved / rows_total` per rank. The fast path fails closed silently, so this is how to confirm reuse actually ran.
- CPU unit tests (leader broadcast of page and raw indices, fallback contract) and a server-arguments docs row. No kernel changes.

## Speed Tests and Profiling

DeepSeek-V4-Flash-0731, 8x H100 80GB, TP=8 with DP attention (dp=8), `--chunked-prefill-size 65536`, fp8 KV cache, CUDA graph on, radix cache off. Single request, `max_new_tokens=1`, prompt from Echelon's `demo/bench_prefill.py`; median over repeated runs after one warmup.

| Prompt tokens | Baseline | `deep10-inf-w4` | Change | Dose (rows saved) |
|---:|---:|---:|---:|---:|
| 840,295 | 125.713 s (5 runs, spread 0.8%) | 82.945 s (5 runs, spread 2.4%) | **-34.0% (1.52x)** | 0.8684 |
| 105,862 | 8.628 s (10 runs, spread 3.1%) | 8.332 s (10 runs, spread 3.3%) | -3.4% | 0.8658 |

The gain grows with prompt length; near 100K tokens it is about the size of run-to-run spread.

<details><summary>Launch command</summary>

```bash
SGLANG_OPT_DSV4_NONPAGED_INDEXER=1 SGLANG_OPT_USE_TOPK_V2=1 \
FLASHINFER_USE_CUDA_NORM=1 `# our driver (575) cannot run the CuTe DSL path` \
python -m sglang.launch_server \
  --model-path <DeepSeek-V4-Flash-0731> --trust-remote-code \
  --tp-size 8 --enable-dp-attention --dp-size 8 \
  --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.50 \
  --context-length 1040384 --chunked-prefill-size 65536 \
  --moe-runner-backend flashinfer_mxfp4 --disable-radix-cache \
  [--deepseek-v4-prefill-reuse deep10-inf-w4]
python demo/bench_prefill.py --server 127.0.0.1:30000 --tokens <N> --repeat 5
```
The 105,862-token row used `--context-length 131072` and `--repeat 10`.
</details>

These numbers were measured on upstream `554f817948` with an earlier revision of this patch. That revision had the same leader/broadcast logic; this revision restructures it to the repo conventions and is rebased onto `2adb2e84`. I will post a re-measurement on the current base in this thread.

## Accuracy Tests

Reuse changes which KV pages attention reads, so it is lossy by construction; **we do not claim it is lossless**. Numbers below are paired per-item comparisons of `deep10-inf-w4` against the baseline on DeepSeek-V4-Flash-0731.

- **S**: the items the baseline solves (score >= 0.8).
- **b**: items in S that the reuse run breaks (score < 0.2).
- **c**: the reverse flips.
- **p**: exact two-sided McNemar.
- **MDE**: the smallest damage b/|S| that this instrument could flag at p < 0.05, given the observed c.
- **Baseline rerun b:c**: the same comparison between two identical baseline runs, for scale.

| Benchmark | \|S\| | b : c | Damage | p | MDE | Mean score (base -> reuse) | Baseline rerun b:c |
|---|---:|---:|---:|---:|---:|---|---:|
| InfiniteBench longbook_choice_eng (run A) | 86 | 6 : 3 | 7.0% | 0.51 | 14.0% | 0.86 -> 0.83 | 0 : 0 |
| InfiniteBench longbook_choice_eng (run B) | 84 | 5 : 4 | 6.0% | 1.00 | 15.5% | 0.84 -> 0.83 | 1 : 4 |
| RULER cwe | 100 | 7 : 0 | **7.0%** | 0.016 | 6.0% | 1.000 -> 0.602 | 0 : 0 |
| RULER vt | 100 | 11 : 0 | **11.0%** | 0.001 | 6.0% | 1.000 -> 0.880 | 0 : 0 |
| RULER fwe | 97 | 0 : 1 | 0.0% | 1.00 | 8.2% | 0.983 -> 0.970 | 3 : 1 |
| MRCR 8-needle | 24 | 3 : 3 | 12.5% | 1.00 | 50.0% | 0.315 -> 0.309 | 0 : 2 |
| LongBench (8 subsets pooled) | 53 | 2 : 1 | 3.8% | 1.00 | 15.1% | 0.396 -> 0.397 | 2 : 1 |

Damage is detectable on RULER `cwe` and `vt`. On the other benchmarks it is below what the instrument can resolve, which bounds it by the MDE and does not show it is zero. On `cwe` the mean-score drop (-0.398) is much larger than the binary damage suggests, because most affected items lose partial credit rather than breaking outright.

These were measured with our research implementation of the same schedule, a runtime patch on an older sglang tree, not with this PR's code. I will re-run them on this revision.

## Scope

- Only single-request prefill on the non-paged indexer fast path (`_can_use_nonpaged_indexer`): `batch_size == 1`, EXTEND mode, and at least `SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS` query rows per rank. Concurrent serving and short prompts are unaffected. The algorithm itself is batch-agnostic; the limit comes from the code path.
- sgl-kernel top-K backend only; `--dsa-topk-backend torch|flashinfer` falls back to the existing path.
- `deep10-inf-w4` names DeepSeek-V4-Flash's C4 layer ids.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Re-measurement on this revision is pending, as noted above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjQUVNNPbKkLvWHR3fSFsu

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34830570192](https://github.com/sgl-project/sglang/actions/runs/34830570192)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34830570078](https://github.com/sgl-project/sglang/actions/runs/34830570078)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34830570268](https://github.com/sgl-project/sglang/actions/runs/34830570268)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->