### PR TITLE
[mem_cache] Coalesce touching kv-row segments before free so an aborted mid-prefill request does not trip _page_disjoint

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -107,6 +107,34 @@ def free_swa_out_of_window_slots(
         req.kv.swa_evicted_seqlen = new_swa_evicted_seqlen
 
 
+def _coalesce_touching_segments(
+    segments: list[tuple[torch.Tensor, int]],
+) -> list[tuple[torch.Tensor, int]]:
+    """Merge ascending ``(kv_indices, start_pos)`` segments of one kv row that
+    touch end-to-start into single segments; drop empty ones.
+
+    ``UnifiedRadixCache.cache_finished_req`` frees a request truncated mid
+    prefill (an abort) as two ranges, ``[page_aligned_len, effective_len)``
+    and ``[effective_len, full_len)``, which touch at ``effective_len``.
+    Handed to the allocator separately, the second one starts mid-page and
+    ``_page_disjoint`` asserts on the shared boundary page. Slices of the
+    same row that touch are exactly the slice they were cut from, so merging
+    them keeps "one call frees a shared page once" without an assert.
+    """
+    merged: list[tuple[torch.Tensor, int]] = []
+    for kv_indices, start_pos in segments:
+        num_indices = kv_indices.numel()
+        if num_indices == 0:
+            continue
+        if merged:
+            prev_indices, prev_start = merged[-1]
+            if prev_start + prev_indices.numel() == start_pos:
+                merged[-1] = (torch.cat((prev_indices, kv_indices)), prev_start)
+                continue
+        merged.append((kv_indices, start_pos))
+    return merged
+
+
 def free_kv_row_segments(
     allocator: BaseTokenToKVPoolAllocator,
     segments: list[tuple[torch.Tensor, int]],
@@ -114,10 +142,11 @@ def free_kv_row_segments(
     swa_evicted_seqlen: int,
 ) -> None:
     """Free ascending disjoint ``(kv_indices, start_pos)`` segments of one
-    request's kv row, split at the SWA eviction floor."""
+    request's kv row, split at the SWA eviction floor. Touching segments are
+    coalesced first so a boundary that is not page-aligned is freed once."""
     swa_dead: list[tuple[torch.Tensor, int]] = []
     swa_alive: list[tuple[torch.Tensor, int]] = []
-    for kv_indices, start_pos in segments:
+    for kv_indices, start_pos in _coalesce_touching_segments(segments):
         num_indices = kv_indices.numel()
         if num_indices == 0:
             continue

--- a/test/registered/unit/mem_cache/test_free_kv_row_segments_touching.py
+++ b/test/registered/unit/mem_cache/test_free_kv_row_segments_touching.py
@@ -1,0 +1,119 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""`free_kv_row_segments` must coalesce touching segments of one kv row.
+
+`UnifiedRadixCache.cache_finished_req` frees a request truncated mid prefill
+(an abort) as two ranges, ``[page_aligned_len, effective_len)`` and
+``[effective_len, full_len)``, which touch at ``effective_len``. Handed to
+``allocator.free_segments`` as two segments, ``_page_disjoint`` asserts on the
+shared boundary page ("segment at N shares a page with the one ending at N")
+and every scheduler rank dies with the request. Observed on Kimi-K3 (TP8,
+DSPARK, page_size 64) three times in production in two days, each time right
+after an abort of a request with a 120-200K-character prompt.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.common import (
+    _coalesce_touching_segments,
+    free_kv_row_segments,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PAGE = 64
+ROW = torch.arange(10_000, 10_000 + 4096, dtype=torch.int64)
+
+
+class _PageCheckOnly:
+    """Just enough allocator for `BaseTokenToKVPoolAllocator._page_disjoint`."""
+
+    page_size = PAGE
+
+
+class _RecordingAllocator:
+    page_size = PAGE
+
+    def __init__(self):
+        self.full_calls: list[list[tuple[torch.Tensor, int]]] = []
+        self.alive_calls: list[list[tuple[torch.Tensor, int]]] = []
+
+    def free_full_segments(self, segments):
+        self.full_calls.append(list(segments))
+
+    def free_segments(self, segments):
+        # Run the real disjointness check so the test fails the way the
+        # scheduler did if the segments still touch mid-page.
+        list(BaseTokenToKVPoolAllocator._page_disjoint(_PageCheckOnly(), segments))
+        self.alive_calls.append(list(segments))
+
+
+def _abort_shape(page_aligned_len: int, effective_len: int, full_len: int):
+    """The two ranges cache_finished_req emits for a truncated request."""
+    return [
+        (ROW[page_aligned_len:effective_len], page_aligned_len),
+        (ROW[effective_len:full_len], effective_len),
+    ]
+
+
+class TestCoalesceTouchingSegments(unittest.TestCase):
+    def test_touching_slices_become_the_slice_they_were_cut_from(self):
+        out = _coalesce_touching_segments(_abort_shape(1024, 1100, 1216))
+        self.assertEqual(len(out), 1)
+        indices, start = out[0]
+        self.assertEqual(start, 1024)
+        self.assertTrue(torch.equal(indices, ROW[1024:1216]))
+
+    def test_gaps_stay_apart_and_empties_are_dropped(self):
+        segs = [(ROW[0:8], 0), (ROW[8:8], 8), (ROW[20:30], 20), (ROW[30:33], 30)]
+        out = _coalesce_touching_segments(segs)
+        self.assertEqual([(s, i.numel()) for i, s in out], [(0, 8), (20, 13)])
+
+
+class TestFreeKvRowSegmentsAbortShape(unittest.TestCase):
+    def test_the_raw_abort_shape_would_assert(self):
+        # Documents the failure this fixes: a boundary that is not page-aligned.
+        segs = _abort_shape(1024, 1100, 1216)
+        with self.assertRaisesRegex(AssertionError, "shares a page"):
+            list(BaseTokenToKVPoolAllocator._page_disjoint(_PageCheckOnly(), segs))
+
+    def test_mid_page_boundary_is_freed_as_one_segment(self):
+        alloc = _RecordingAllocator()
+        free_kv_row_segments(
+            alloc, _abort_shape(1024, 1100, 1216), swa_evicted_seqlen=0
+        )
+        self.assertEqual(alloc.full_calls, [])
+        self.assertEqual(len(alloc.alive_calls), 1)
+        [(indices, start)] = alloc.alive_calls[0]
+        self.assertEqual(start, 1024)
+        self.assertTrue(torch.equal(indices, ROW[1024:1216]))
+
+    def test_swa_floor_split_still_applies_after_coalescing(self):
+        alloc = _RecordingAllocator()
+        free_kv_row_segments(
+            alloc, _abort_shape(1024, 1100, 1216), swa_evicted_seqlen=1088
+        )
+        [(dead, dead_start)] = alloc.full_calls[0]
+        [(alive, alive_start)] = alloc.alive_calls[0]
+        self.assertEqual((dead_start, dead.numel()), (1024, 64))
+        self.assertEqual((alive_start, alive.numel()), (1088, 128))
+        self.assertTrue(torch.equal(torch.cat((dead, alive)), ROW[1024:1216]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #38981. On Kimi-K3 with the unified hybrid SWA cache, aborting a request while it is still being prefilled (client disconnect, or a proxy's TTFB deadline) kills **every scheduler rank**:

```
free_kv_row_segments -> allocator.free_segments(swa_alive) -> _page_disjoint
AssertionError: segment at 32704 shares a page with the one ending at 32704
```

`UnifiedRadixCache.cache_finished_req` frees a request truncated at `effective_cache_len` as two ranges that touch there — `[page_aligned_len, effective_len)` and `[effective_len, full_len)` (the "deferred tail" path). `free_kv_row_segments` passed them to the allocator as separate segments, and `_page_disjoint` requires the second one to start on a fresh page. `effective_cache_len` is not page-aligned in general, so the shared boundary page asserts. The comment above that code ("the tail free is deferred and batched with the unaligned tail below so a shared boundary page is emitted once") states the intent; nothing actually merged the ranges. Reproduced on `nightly-dev-cu13-20260906-09daea94` (three production crashes in two days) and `nightly-dev-cu13-20260910-00840301` (within 3 minutes of a real-traffic replay), always right after an `/abort_request` for a 120–200K-character prompt in chunked prefill. #38159 does not touch this path.

## Modifications

- `mem_cache/common.py`: `_coalesce_touching_segments()` merges ascending `(kv_indices, start_pos)` segments of one kv row that touch end-to-start (and drops empty ones); `free_kv_row_segments` runs it before the SWA dead/alive split. Touching slices of the same row are exactly the slice they were cut from, so every page is still freed exactly once and no boundary is checked twice. The SWA eviction-floor split is unchanged and still applies to the merged segment.
- `test/registered/unit/mem_cache/test_free_kv_row_segments_touching.py` (CPU): the exact abort shape asserts under the real `_page_disjoint` as two segments and is freed as one merged segment through `free_kv_row_segments`; the eviction-floor split still applies after coalescing; gaps stay apart and empties are dropped.

## Accuracy Tests

Not applicable — the change only merges two frees of adjacent ranges of the same kv row into one; the set of freed indices is identical.

## Benchmarking and Profiling

Running as a build-time patch on our Kimi-K3 production deployment (8×B300, TP8, DSPARK) since 2026-09-11 01:47 UTC: the same trigger (TTFB-deadline aborts of long prompts) is now survived; decode throughput by concurrency bucket is within ±7% of the unpatched baseline.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel if you need help or have questions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34556405708](https://github.com/sgl-project/sglang/actions/runs/34556405708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34556405567](https://github.com/sgl-project/sglang/actions/runs/34556405567)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34556405677](https://github.com/sgl-project/sglang/actions/runs/34556405677)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->