### PR TITLE
[API] Fix DeepSeek V4.1 `/v1/responses` empty prompt routing

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -609,7 +609,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             else None
         )
 
-        if is_multimodal:
+        if is_multimodal and self.chat_encoding_spec != "dsv41":
             request_prompts = [processed_messages.prompt]
             engine_prompts = [processed_messages.prompt]
         else:

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -525,6 +525,41 @@ class FullResponseUsageTestCase(CustomTestCase):
 
 
 class MultimodalRequestTestCase(CustomTestCase):
+    def test_dsv41_multimodal_request_preserves_encoded_prompt_ids(self):
+        for with_image in (False, True):
+            with self.subTest(with_image=with_image):
+                serving = make_serving(is_multimodal=True)
+                serving.chat_encoding_spec = "dsv41"
+                serving.default_chat_template_kwargs = {}
+                serving.template_manager.chat_template_name = None
+                serving._dsv41_default_reasoning_effort = "high"
+                tokenizer = serving.tokenizer_manager.tokenizer
+                tokenizer.convert_ids_to_tokens.return_value = "<image>"
+                content = [{"type": "input_text", "text": "describe it"}]
+                images = []
+                if with_image:
+                    images = ["http://example.com/cat.png"]
+                    content.append({"type": "input_image", "image_url": images[0]})
+                request = ResponsesRequest(
+                    model="x",
+                    input=[{"role": "user", "content": content}],
+                    reasoning={"effort": "high"},
+                    store=False,
+                )
+
+                _, request_prompts, engine_prompts, processed = asyncio.run(
+                    serving._make_request(request, None, tokenizer)
+                )
+
+                self.assertEqual(processed.prompt, "")
+                self.assertEqual(request_prompts, [[1, 2, 3]])
+                self.assertEqual(engine_prompts, [[1, 2, 3]])
+                self.assertEqual(processed.image_data, images or None)
+                rendered_prompt = tokenizer.encode.call_args.args[0]
+                self.assertIn("describe it", rendered_prompt)
+                if with_image:
+                    self.assertIn("<image>", rendered_prompt)
+
     def test_text_only_create_responses_rejects_media_before_generation(self):
         serving = make_serving()
         serving._process_messages = Mock()


### PR DESCRIPTION
- Fix `/v1/responses` returning `400: texts cannot be empty and tokenizer must be initialized` for text requests on multimodal DeepSeek V4.1 checkpoints: forward the encoder's `prompt_ids`, matching Chat Completions.
- Target the `dsv4.1` branch from #38798; preserve image payloads and encoded image placeholders without requiring `--language-model-only` or changing PD configuration.
- Add regression coverage using the V4.1 encoder for text-only and image inputs; both cases reproduced empty prompt routing before the fix.
- Related: #35486 fixes the same routing issue on `main` for `kimi_k3` and `inkling`. The `dsv4.1` branch does not yet contain that helper; when integrating it, `dsv41` must also be included in `spec_renders_prompt_ids`.
- Validation: 45 tests passed across `test_serving_responses.py`, `test_serving_responses_stream.py`, and `test_encoding_dsv41.py`; pre-commit checks passed. Real PD GPU inference has not been run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34557724636](https://github.com/sgl-project/sglang/actions/runs/34557724636)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34557724152](https://github.com/sgl-project/sglang/actions/runs/34557724152)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34557724624](https://github.com/sgl-project/sglang/actions/runs/34557724624)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->