### PR TITLE
[Refactor] Share `ChatInputProcessor` across API handlers

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -43,6 +43,7 @@ from sglang.srt.entrypoints.anthropic.protocol import (
     ToolUseBlock,
     is_server_tool,
 )
+from sglang.srt.entrypoints.openai.chat_input_adapter import from_chat_request
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -1420,7 +1421,7 @@ class AnthropicServing:
         """Handle /v1/messages/count_tokens endpoint.
 
         Converts the request to a ChatCompletionRequest, applies the chat
-        template via the OpenAI handler to tokenize, and returns the count.
+        template via the shared input processor, and returns the count.
         """
         try:
             # Build a minimal AnthropicMessagesRequest so we can reuse conversion
@@ -1445,19 +1446,11 @@ class AnthropicServing:
             )
 
         try:
-            is_multimodal = (
-                self.openai_serving_chat.tokenizer_manager.model_config.is_multimodal
+            prepared = self.openai_serving_chat.input_processor.prepare(
+                from_chat_request(chat_request)
             )
-            processed = self.openai_serving_chat._process_messages(
-                chat_request, is_multimodal
-            )
-
-            if isinstance(processed.prompt_ids, list):
-                input_tokens = len(processed.prompt_ids)
-            else:
-                # prompt_ids is a string (multimodal case) — tokenize it
-                tokenizer = self.openai_serving_chat.tokenizer_manager.tokenizer
-                input_tokens = len(tokenizer.encode(processed.prompt_ids))
+            tokenizer = self.openai_serving_chat.tokenizer_manager.tokenizer
+            input_tokens = len(prepared.prompt.tokenize(tokenizer))
 
             return JSONResponse(
                 content=AnthropicCountTokensResponse(

--- a/python/sglang/srt/entrypoints/chat_input/config.py
+++ b/python/sglang/srt/entrypoints/chat_input/config.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+import math
+
+from sglang.srt.entrypoints.chat_input.types import ChatModelConfig
+from sglang.srt.entrypoints.openai import chat_encoding
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_chat_model_config(
+    *,
+    tokenizer,
+    template_manager,
+    hf_config,
+    model_path,
+    revision,
+    tool_call_parser,
+    reasoning_parser,
+    default_chat_template_kwargs,
+    is_multimodal,
+) -> ChatModelConfig:
+    spec = chat_encoding.resolve_chat_encoding_spec(
+        hf_config=hf_config, tokenizer=tokenizer, tool_call_parser=tool_call_parser
+    )
+    detector = None
+    if reasoning_parser:
+        try:
+            detector = ReasoningParser(
+                model_type=reasoning_parser, stream_reasoning=True, tokenizer=tokenizer
+            ).detector
+        except ValueError as error:
+            logger.warning(
+                "Failed to initialize reasoning detector for parser '%s': %s",
+                reasoning_parser,
+                error,
+            )
+    profile = (
+        chat_encoding.resolve_dsv4_reasoning_effort_profile(
+            model_path=model_path,
+            revision=revision,
+            override=hf_config.to_dict().get(
+                chat_encoding.DSV4_REASONING_EFFORT_PROFILE_OVERRIDE
+            ),
+        )
+        if spec == "dsv4"
+        else None
+    )
+    inkling_effort = (
+        get_inkling_default_reasoning_effort() if spec == "inkling" else None
+    )
+    try:
+        auto_adds_specials = len(tokenizer.encode("")) > 0
+    except Exception:
+        auto_adds_specials = True
+    return ChatModelConfig(
+        tokenizer=tokenizer,
+        template_manager=template_manager,
+        is_multimodal=is_multimodal,
+        model_name=model_path,
+        chat_encoding_spec=spec,
+        tool_call_parser=tool_call_parser,
+        reasoning_parser=reasoning_parser,
+        reasoning_detector=detector,
+        default_chat_template_kwargs=default_chat_template_kwargs or {},
+        dsv4_reasoning_effort_profile=profile,
+        inkling_default_reasoning_effort=inkling_effort,
+        tokenizer_auto_adds_specials=auto_adds_specials,
+        is_gpt_oss=getattr(hf_config, "model_type", None) == "gpt_oss",
+        is_gemma4=getattr(hf_config, "model_type", None)
+        in ("gemma4", "gemma4_unified"),
+    )
+
+
+def get_inkling_default_reasoning_effort() -> float:
+    """Read the default Inkling reasoning effort from the environment."""
+    from sglang.srt.environ import envs
+
+    val = envs.SGLANG_INKLING_DEFAULT_REASONING_EFFORT.get()
+    if not val:
+        return 0.9
+    try:
+        parsed = float(val)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            "SGLANG_INKLING_DEFAULT_REASONING_EFFORT must be numeric"
+        ) from exc
+    if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
+        raise ValueError(
+            "SGLANG_INKLING_DEFAULT_REASONING_EFFORT must be in [0.0, 0.99]"
+        )
+    return parsed

--- a/python/sglang/srt/entrypoints/chat_input/normalization.py
+++ b/python/sglang/srt/entrypoints/chat_input/normalization.py
@@ -1,0 +1,131 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Normalization shared by chat-shaped API inputs."""
+
+from typing import Any, Dict
+
+
+def _has_message_level_tools(messages: Any) -> bool:
+    if not isinstance(messages, list):
+        return False
+    return any(
+        isinstance(message, dict)
+        and isinstance(message.get("role"), str)
+        and message["role"].lower() in ("system", "developer")
+        and bool(message.get("tools"))
+        for message in messages
+    )
+
+
+def set_tool_choice_default(values):
+    if values.get("tool_choice") is None:
+        if values.get("tools") is None and not _has_message_level_tools(
+            values.get("messages")
+        ):
+            values["tool_choice"] = "none"
+        else:
+            values["tool_choice"] = "auto"
+    return values
+
+
+def validate_reasoning_effort_type(value):
+    if isinstance(value, bool):
+        raise ValueError("reasoning_effort must not be a boolean")
+    return value
+
+
+def normalize_reasoning_inputs(values: Dict):
+    r = values.get("reasoning")
+    thinking = None
+
+    if r is not None and isinstance(r, dict):
+        effort = r.get("effort")
+        if effort is None:
+            effort = r.get("reasoning_effort")
+        if isinstance(effort, str) and effort in {
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        }:
+            values["reasoning_effort"] = effort
+        elif isinstance(effort, (int, float)) and not isinstance(effort, bool):
+            values["reasoning_effort"] = float(effort)
+        elif isinstance(effort, str):
+            # Keep parity with the top-level reasoning_effort field, whose
+            # lax union coerces numeric strings; range checks then apply.
+            try:
+                values["reasoning_effort"] = float(effort)
+            except ValueError as exc:
+                raise ValueError(f"invalid reasoning effort: {effort!r}") from exc
+        elif effort is not None:
+            raise ValueError(f"invalid reasoning effort: {effort!r}")
+
+        enabled = (
+            r.get("enabled") if r.get("enabled") is not None else r.get("enable", False)
+        )
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() in {"1", "true", "yes", "y", "on"}
+        if enabled:
+            thinking = True
+
+    effort = values.get("reasoning_effort")
+    if effort is not None:
+        thinking = effort != "none"
+
+    if thinking is not None:
+        ctk = values.get("chat_template_kwargs")
+        if not isinstance(ctk, dict):
+            ctk = {}
+        # different models check different keys:
+        # - "thinking" for deepseek-v3, kimi_k2
+        # - "enable_thinking" for qwen3, glm45, nemotron_3, interns1
+        ctk.setdefault("thinking", thinking)
+        ctk.setdefault("enable_thinking", thinking)
+        values["chat_template_kwargs"] = ctk
+
+    return values
+
+
+def set_json_schema(values):
+    response_format = values.get("response_format")
+    if not response_format:
+        return values
+
+    if response_format.get("type") != "json_schema":
+        return values
+
+    schema = response_format.pop("schema", None)
+    json_schema = response_format.get("json_schema")
+
+    if json_schema:
+        return values
+
+    if schema:
+        name_ = schema.get("title", "Schema")
+        strict_ = None
+        if "properties" in schema and "strict" in schema["properties"]:
+            item = schema["properties"].pop("strict", None)
+            strict_ = bool(item and item.get("default", False))
+
+        response_format["json_schema"] = {
+            "name": name_,
+            "schema": schema,
+            "strict": strict_,
+        }
+
+    return values

--- a/python/sglang/srt/entrypoints/chat_input/processor.py
+++ b/python/sglang/srt/entrypoints/chat_input/processor.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Optional
+
+from sglang.srt.entrypoints.chat_input.renderers import ChatRenderer
+from sglang.srt.entrypoints.chat_input.schema import ToolChoice
+from sglang.srt.entrypoints.chat_input.types import (
+    ChatInput,
+    ChatModelConfig,
+    MessageRenderer,
+    PreparedChat,
+    RenderedPrompt,
+    TokenPrompt,
+)
+from sglang.srt.entrypoints.chat_input.validation import (
+    MediaInputError,
+    validate_chat_input,
+    validate_media_content,
+)
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.utils import get_json_schema_constraint
+from sglang.srt.parser.hunyuan_reasoning import normalize_hunyuan_reasoning_effort
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+logger = logging.getLogger(__name__)
+
+
+class ChatInputProcessor:
+    def __init__(
+        self, config: ChatModelConfig, renderer: Optional[MessageRenderer] = None
+    ):
+        self.config = config
+        self.renderer = renderer if renderer is not None else ChatRenderer(config)
+
+    def prepare(self, chat_input: ChatInput) -> PreparedChat:
+        request = self._resolve_input(chat_input)
+        thinking_mode = self._get_reasoning_from_request(request)
+        tools, tool_call_constraint, tool_call_stop = self._prepare_tools(
+            request, thinking_mode
+        )
+        if request.input_ids is not None:
+            result = RenderedPrompt(prompt=TokenPrompt(request.input_ids))
+        else:
+            result = self.renderer.render(request, tools, thinking_mode)
+
+        return PreparedChat(
+            prompt=result.prompt,
+            image_data=result.image_data,
+            audio_data=result.audio_data,
+            video_data=result.video_data,
+            modalities=result.modalities,
+            stop=self._resolve_stop(request, result.template_stop, tool_call_stop),
+            tool_call_constraint=tool_call_constraint,
+            require_reasoning=thinking_mode,
+            skip_special_tokens=request.skip_special_tokens,
+            reasoning_end_token_ids=self._reasoning_end_token_ids(
+                request, thinking_mode
+            ),
+            chat_template_kwargs=copy.deepcopy(request.chat_template_kwargs),
+            reasoning_effort=request.reasoning_effort,
+        )
+
+    def _resolve_input(self, chat_input: ChatInput) -> ChatInput:
+        request = chat_input.model_copy(deep=True)
+        self._validate_media(request)
+        error = validate_chat_input(request)
+        if error:
+            raise ValueError(error)
+        if self.config.default_chat_template_kwargs:
+            ctk = dict(request.chat_template_kwargs or {})
+            for k, v in self.config.default_chat_template_kwargs.items():
+                ctk.setdefault(k, copy.deepcopy(v))
+            request.chat_template_kwargs = ctk
+            effort = ctk.get("reasoning_effort")
+            if effort is not None and request.reasoning_effort is None:
+                request.reasoning_effort = effort
+
+        normalize_hunyuan_reasoning_effort(
+            request,
+            self.config.reasoning_parser,
+            self.config.template_manager.reasoning_config,
+        )
+
+        # GptOss model needs to keep special tokens for harmony parsing
+        if self.config.is_gpt_oss or self.config.is_gemma4:
+            request.skip_special_tokens = False
+
+        self._patch_reasoning_skip_special_tokens(request)
+
+        if request.effective_tools() and request.tool_choice != "none":
+            request.skip_special_tokens = False
+        return request
+
+    def _prepare_tools(self, request: ChatInput, thinking_mode: bool):
+        # SGLang's ReasonerGrammarBackend owns the reasoning prefix
+        # when --reasoning-parser is configured, so builtin xgrammar
+        # tags must describe only the post-reasoning tool-call suffix.
+        xgrammar_reasoning = thinking_mode and (self.config.reasoning_parser is None)
+        tool_call_constraint = None
+
+        tools = None
+        tool_call_stop = None
+        required_parsed_natively = False
+        effective_tools = request.effective_tools()
+        if effective_tools and request.tool_choice != "none":
+            if not isinstance(request.tool_choice, str):
+                tools = [
+                    item.model_dump()
+                    for item in request.tools or []
+                    if item.function.name == request.tool_choice.function.name
+                ] or None
+            elif request.tools:
+                tools = [item.model_dump() for item in request.tools]
+            if self.config.tool_call_parser:
+                parser = FunctionCallParser(
+                    effective_tools,
+                    self.config.tool_call_parser,
+                    tokenizer=self.config.tokenizer,
+                )
+                tool_call_constraint = parser.get_structure_constraint(
+                    request.tool_choice,
+                    parallel_tool_calls=request.parallel_tool_calls,
+                    thinking_mode=xgrammar_reasoning,
+                )
+                required_parsed_natively = parser.detector.parses_required_natively()
+                if self.config.chat_encoding_spec == "kimi_k3":
+                    tool_call_stop = parser.detector.eot_token
+            if (
+                tool_call_constraint is None
+                and not required_parsed_natively
+                and not (
+                    self.config.chat_encoding_spec == "kimi_k3"
+                    and self.config.tool_call_parser == "kimi_k3"
+                )
+                and (
+                    request.tool_choice == "required"
+                    or isinstance(request.tool_choice, ToolChoice)
+                )
+            ):
+                json_schema = get_json_schema_constraint(
+                    effective_tools,
+                    request.tool_choice,
+                    parallel_tool_calls=request.parallel_tool_calls,
+                )
+                tool_call_constraint = ("json_schema", json_schema)
+
+        return tools, tool_call_constraint, tool_call_stop
+
+    @staticmethod
+    def _resolve_stop(request: ChatInput, template_stop, tool_call_stop):
+        if request.input_ids is not None:
+            stop = request.stop or []
+        elif template_stop is None:
+            stop = request.stop
+        else:
+            stop = copy.copy(template_stop if not request.ignore_eos else [])
+            if request.stop:
+                if isinstance(request.stop, str):
+                    stop.append(request.stop)
+                else:
+                    stop.extend(request.stop)
+
+        if tool_call_stop is not None:
+            if isinstance(stop, str):
+                stop = [stop]
+            elif stop is None:
+                stop = []
+            else:
+                stop = list(stop)
+            if tool_call_stop not in stop:
+                stop.append(tool_call_stop)
+
+        return stop
+
+    def _reasoning_end_token_ids(
+        self, request: ChatInput, thinking_mode: bool
+    ) -> Optional[list[int]]:
+        reasoning_end_token_ids = None
+        if self.config.reasoning_parser == "k2_horizon" and thinking_mode:
+            parser = ReasoningParser(
+                model_type=self.config.reasoning_parser,
+                stream_reasoning=False,
+                force_reasoning=True,
+                request=request,
+                tokenizer=self.config.tokenizer,
+            )
+            token_ids = self.config.tokenizer.encode(
+                parser.detector.think_end_token,
+                add_special_tokens=False,
+            )
+            if hasattr(token_ids, "tolist"):
+                token_ids = token_ids.tolist()
+            if (
+                not isinstance(token_ids, list)
+                or not token_ids
+                or any(
+                    type(token_id) is not int or token_id < 0 for token_id in token_ids
+                )
+            ):
+                raise ValueError(
+                    "The selected K2 reasoning terminator could not be encoded"
+                )
+            reasoning_end_token_ids = list(token_ids)
+        return reasoning_end_token_ids
+
+    def _patch_reasoning_skip_special_tokens(self, request: ChatInput) -> None:
+        """Keep parser-specific reasoning markers in the decoded text.
+
+        Some reasoning parsers rely on special-token delimiters that would be
+        removed during detokenization when ``skip_special_tokens=True``.
+        """
+        if self.config.reasoning_parser == "apertus2509":
+            request.skip_special_tokens = False
+        if (
+            self.config.reasoning_parser == "kimi_k3"
+            or self.config.chat_encoding_spec == "kimi_k3"
+        ):
+            request.skip_special_tokens = False
+
+        if (
+            self.config.reasoning_parser in ["mistral"]
+            and request.reasoning_effort is not None
+            and request.reasoning_effort != "none"
+        ):
+            request.skip_special_tokens = False
+        elif self.config.reasoning_parser == "inkling":
+            request.skip_special_tokens = False
+        elif self.config.reasoning_parser == "muse":
+            request.skip_special_tokens = False
+
+    def _get_reasoning_from_request(self, request: ChatInput) -> bool:
+        """Determine whether reasoning mode should be enabled for this request.
+
+        NOTE: This is predefined based on model's chat template
+        """
+        if not self.config.reasoning_parser:
+            return False
+
+        if self.config.reasoning_parser == "minimax-m3":
+            # M3 template prefills <mm:think> for thinking_mode=enabled, so it never
+            # appears in output and reasoning must be forced. Mirrors reasoning_parser.py.
+            return (request.chat_template_kwargs or {}).get(
+                "thinking_mode"
+            ) == "enabled"
+
+        if self.config.reasoning_parser == "hunyuan":
+            config = self.config.template_manager.reasoning_config
+            if config is not None and config.special_case == "hunyuan_effort":
+                return request.reasoning_effort not in ("none", "no_think")
+            # Hy3-preview template emits no <think> when reasoning_effort is
+            # "no_think" / "none" / unset; forcing reasoning would route all
+            # output into reasoning_content.
+            return request.reasoning_effort not in (None, "none", "no_think")
+
+        config = self.config.template_manager.reasoning_config
+        if config is None:
+            # Fallback to parser-level defaults when template toggle config
+            # cannot be inferred (e.g., parser-only <think> templates).
+            mode = (
+                self.config.reasoning_detector.reasoning_default
+                if self.config.reasoning_detector is not None
+                else None
+            )
+            if mode is None:
+                return False
+            if mode == "always":
+                return True
+            if mode == "mistral":
+                return (
+                    request.reasoning_effort is not None
+                    and request.reasoning_effort != "none"
+                )
+            if mode in ("thinking", "enable_thinking"):
+                return (
+                    not request.chat_template_kwargs
+                    or request.chat_template_kwargs.get(mode) is not False
+                )
+            if mode in ("explicit_thinking", "explicit_enable_thinking"):
+                toggle = mode.replace("explicit_", "")
+                return (
+                    request.chat_template_kwargs is not None
+                    and request.chat_template_kwargs.get(toggle) is True
+                )
+            logger.warning(
+                "Unknown reasoning_default mode '%s', defaulting to reasoning disabled",
+                mode,
+            )
+            return False
+
+        if config.special_case == "always":
+            return True
+
+        if config.special_case == "mistral":
+            return (
+                request.reasoning_effort is not None
+                and request.reasoning_effort != "none"
+            )
+
+        if config.toggle_param is None or config.default_enabled is None:
+            return False
+
+        if config.default_enabled:
+            return (
+                not request.chat_template_kwargs
+                or request.chat_template_kwargs.get(config.toggle_param) is not False
+            )
+        return (
+            request.chat_template_kwargs is not None
+            and request.chat_template_kwargs.get(config.toggle_param) is True
+        )
+
+    def _validate_media(self, request: ChatInput) -> None:
+        error = validate_media_content(request, self.config.is_multimodal)
+        if error:
+            raise MediaInputError(error)

--- a/python/sglang/srt/entrypoints/chat_input/renderers.py
+++ b/python/sglang/srt/entrypoints/chat_input/renderers.py
@@ -1,0 +1,825 @@
+from __future__ import annotations
+
+import copy
+import logging
+import math
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+import jinja2
+import orjson
+
+from sglang.srt.entrypoints.chat_input.schema import (
+    ChatCompletionMessageGenericParam,
+)
+from sglang.srt.entrypoints.chat_input.types import (
+    ChatInput,
+    ChatModelConfig,
+    RenderedPrompt,
+    TextPrompt,
+    TokenPrompt,
+)
+from sglang.srt.entrypoints.openai import encoding_dsv4, encoding_dsv32
+from sglang.srt.environ import envs
+from sglang.srt.parser.conversation import generate_chat_conv
+from sglang.srt.parser.jinja_template_utils import (
+    MEDIA_URL_PART_TYPES,
+    process_content_for_template_format,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mistral_common.exceptions import MistralCommonException
+
+    _MISTRAL_COMMON_ERRORS: tuple[type[BaseException], ...] = (MistralCommonException,)
+except ImportError:
+    _MISTRAL_COMMON_ERRORS = ()
+
+_CHAT_TEMPLATE_CLIENT_ERRORS: tuple[type[BaseException], ...] = (
+    jinja2.TemplateError,
+    TypeError,
+) + _MISTRAL_COMMON_ERRORS
+
+
+class ThinkingMode(str, Enum):
+    """Mode for message encoding - chat vs thinking/reasoning."""
+
+    CHAT = "chat"
+    THINKING = "thinking"
+
+
+def normalize_tool_content(role: str, content):
+    """Normalize tool message content from OpenAI array format to plain string.
+
+    OpenAI clients may send tool content as a list of content parts
+    (e.g. [{"type":"text","text":"..."}]) but most chat templates expect
+    a plain string for tool messages. Only flatten when ALL items are
+    pure OpenAI text parts; preserve lists containing non-text-type items
+    that some templates intentionally iterate over.
+    """
+    if role != "tool" or not isinstance(content, list):
+        return content
+    parts = content
+    is_openai_text_parts = all(
+        (isinstance(p, dict) and p.get("type") == "text") or isinstance(p, str)
+        for p in parts
+    )
+    if is_openai_text_parts:
+        text_parts = [p.get("text", "") if isinstance(p, dict) else p for p in parts]
+        return " ".join(text_parts)
+    return content
+
+
+def parse_tool_call_arguments(arguments: str) -> Dict[str, Any]:
+    """Parse OpenAI tool call arguments for chat templates."""
+    try:
+        parsed_arguments = orjson.loads(arguments)
+    except orjson.JSONDecodeError as exc:
+        raise ValueError(
+            "Assistant tool call function.arguments must be valid JSON."
+        ) from exc
+
+    if not isinstance(parsed_arguments, dict):
+        raise ValueError(
+            "Assistant tool call function.arguments must be a JSON object."
+        )
+
+    return parsed_arguments
+
+
+def normalize_assistant_tool_call_arguments(
+    message: Dict[str, Any], *, strict: bool = True
+) -> None:
+    """Normalize assistant history tool call arguments in-place."""
+    if message.get("role") != "assistant" or not isinstance(
+        message.get("tool_calls"), list
+    ):
+        return
+
+    for item in message["tool_calls"]:
+        function = item.get("function") if isinstance(item, dict) else None
+        if not isinstance(function, dict):
+            continue
+        if "arguments" in function and isinstance(function["arguments"], str):
+            try:
+                function["arguments"] = parse_tool_call_arguments(function["arguments"])
+            except ValueError:
+                if strict:
+                    raise
+
+
+KIMI_K3_IMAGE_PLACEHOLDER = "<|kimi_image_placeholder|>"
+KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED = "<| kimi_image_placeholder |>"
+
+
+def neutralize_kimi_k3_image_placeholder(text: str) -> str:
+    return text.replace(KIMI_K3_IMAGE_PLACEHOLDER, KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED)
+
+
+def neutralize_kimi_k3_image_placeholder_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return neutralize_kimi_k3_image_placeholder(value)
+    if isinstance(value, list):
+        return [neutralize_kimi_k3_image_placeholder_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: neutralize_kimi_k3_image_placeholder_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+class ChatRenderer:
+    def __init__(self, config: ChatModelConfig):
+        self.config = config
+
+    def render(
+        self, request: ChatInput, tools: Optional[List[Dict]], require_reasoning: bool
+    ) -> RenderedPrompt:
+        if self.config.template_manager.chat_template_name is None:
+            return self._apply_jinja_template(request, tools, self.config.is_multimodal)
+        return self._apply_conversation_template(
+            request, self.config.is_multimodal, require_reasoning
+        )
+
+    def _handle_last_assistant_message(
+        self,
+        messages: List[Dict[str, Any]],
+        request: ChatInput,
+    ) -> tuple[List[Dict[str, Any]], Optional[str]]:
+        """
+        Handle continue_final_message feature: separate final assistant message.
+
+        If continue_final_message is enabled and the last message is from assistant,
+        extract its content and remove it from the message list.
+        If continue_final_message is False and the last message is from assistant,
+        convert it to a user message to ensure the last message is always from user.
+
+        Only processes text-based content (strings), ignoring multimodal content (lists).
+
+        Args:
+            messages: List of message dictionaries
+            request: ChatInput with continue_final_message flag
+
+        Returns:
+            Tuple of (processed_messages, assistant_prefix)
+            - processed_messages: Messages with last assistant message handled appropriately
+            - assistant_prefix: Content of the last assistant message (string only), or None
+        """
+        assistant_prefix = None
+        if messages and messages[-1].get("role") == "assistant":
+            last_content = messages[-1].get("content")
+            # Only process string content, ignore multimodal content (lists)
+            if isinstance(last_content, str):
+                if request.continue_final_message:
+                    # Extract content and remove the assistant message
+                    assistant_prefix = last_content
+                    messages = messages[:-1]
+                else:
+                    # Convert the last assistant message to user message
+                    messages[-1] = {"role": "user", "content": last_content}
+        return messages, assistant_prefix
+
+    def _append_assistant_prefix_to_prompt_ids(
+        self, prompt_ids: List[int], assistant_prefix: str
+    ) -> List[int]:
+        """
+        Append assistant prefix to prompt_ids.
+
+        Args:
+            prompt_ids: Current prompt token IDs
+            assistant_prefix: Assistant message content to append
+
+        Returns:
+            Updated prompt_ids with assistant prefix appended
+        """
+        encoded = self.config.tokenizer.encode(assistant_prefix)
+        if encoded and encoded[0] == self.config.tokenizer.bos_token_id:
+            encoded = encoded[1:]
+        return prompt_ids + encoded
+
+    def _prepare_kimi_k3_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        request: ChatInput,
+    ) -> tuple[List[Dict[str, Any]], int, Optional[str]]:
+        image_count = 0
+        for index, message in enumerate(messages):
+            content = message.get("content")
+            if isinstance(content, list):
+                parts = []
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    part_type = part.get("type")
+                    if part_type in ("text", "input_text"):
+                        parts.append(
+                            {
+                                "type": "text",
+                                "text": neutralize_kimi_k3_image_placeholder(
+                                    part["text"]
+                                ),
+                            }
+                        )
+                    elif part_type in ("image_url", "input_image"):
+                        image = part.get("image_url") or {}
+                        if isinstance(image, str):
+                            image = {"url": image, "detail": part.get("detail")}
+                        parts.append({"type": "image_url", "image_url": image})
+                        image_count += 1
+                message["content"] = parts
+            elif isinstance(content, str):
+                message["content"] = neutralize_kimi_k3_image_placeholder(content)
+            elif content is None:
+                message["content"] = ""
+
+            if message.get("role") == "assistant":
+                for key in ("reasoning_content", "reasoning"):
+                    if key in message:
+                        message[key] = neutralize_kimi_k3_image_placeholder_value(
+                            message[key]
+                        )
+                for tool_call in message.get("tool_calls") or []:
+                    function = (
+                        tool_call.get("function")
+                        if isinstance(tool_call, dict)
+                        else None
+                    )
+                    if isinstance(function, dict) and "arguments" in function:
+                        function["arguments"] = (
+                            neutralize_kimi_k3_image_placeholder_value(
+                                function["arguments"]
+                            )
+                        )
+
+            source = request.messages[index]
+            if (
+                isinstance(source, ChatCompletionMessageGenericParam)
+                and source.role in ("system", "developer")
+                and source.tools
+            ):
+                message["tools"] = [
+                    tool.model_dump(exclude_unset=True, by_alias=True)
+                    for tool in source.tools
+                ]
+            if message.get("role") == "developer":
+                message["role"] = "system"
+
+        assistant_prefix = None
+        if request.continue_final_message:
+            messages, assistant_prefix = self._handle_last_assistant_message(
+                messages, request
+            )
+        return messages, image_count, assistant_prefix
+
+    def _encode_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        request: ChatInput,
+        thinking_mode: ThinkingMode,
+        tools: Optional[List[Dict]] = None,
+    ) -> Optional[List[int]]:
+        """Encode messages for custom chat_encoding_spec values.
+
+        Returns prompt_ids if handled, None to use default encoding.
+        """
+        if self.config.chat_encoding_spec == "inkling":
+            # Inkling: render messages -> input_ids with framing tokens + ONE placeholder per
+            # media (encoding/expansion happens later in InklingMultimodalProcessor). The
+            # server's tokenizer is the base tiktoken backend; wrap it so encode_special
+            # supplies the framing-token overlay.
+            from sglang.srt.parser.inkling_renderer import render_inkling_messages
+            from sglang.srt.parser.inkling_tokenizer import (
+                CONTENT_TEXT,
+                MESSAGE_MODEL,
+                InklingTokenizer,
+            )
+
+            inkling_tokenizer = InklingTokenizer(tokenizer=self.config.tokenizer)
+            reasoning_effort = self._parse_inkling_reasoning_effort(
+                request.reasoning_effort
+            )
+            if reasoning_effort is None:
+                reasoning_effort = self.config.inkling_default_reasoning_effort
+            assistant_prefix = self._pop_inkling_assistant_prefix(messages, request)
+            prompt_ids = render_inkling_messages(
+                messages,
+                inkling_tokenizer,
+                add_generation_prompt=False,
+                tools=tools,
+                reasoning_effort=reasoning_effort,
+            )
+            if assistant_prefix is not None:
+                # Continue the final assistant message inside an OPEN model text
+                # block: header + payload, no <|end_message|> and no
+                # <|content_model_end_sampling|>, so the model resumes the turn.
+                prompt_ids += [
+                    inkling_tokenizer.encode_special(MESSAGE_MODEL),
+                    inkling_tokenizer.encode_special(CONTENT_TEXT),
+                    *inkling_tokenizer.encode_text(assistant_prefix),
+                ]
+            return prompt_ids
+        if self.config.chat_encoding_spec == "kimi_k3":
+            messages, image_count, assistant_prefix = self._prepare_kimi_k3_messages(
+                messages, request
+            )
+            template_kwargs = dict(request.chat_template_kwargs or {})
+            template_kwargs.pop("tokenize", None)
+            template_kwargs.pop("return_dict", None)
+            template_kwargs.pop("image_prompts", None)
+            if image_count:
+                template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
+
+            if (
+                request.reasoning_effort in ("low", "high", "max")
+                and "thinking_effort" not in template_kwargs
+            ):
+                template_kwargs["thinking_effort"] = request.reasoning_effort
+            elif request.reasoning_effort not in (
+                None,
+                "none",
+                "low",
+                "high",
+                "max",
+            ):
+                logger.warning(
+                    "Kimi K3 does not support reasoning_effort=%r; using the "
+                    "encoder default.",
+                    request.reasoning_effort,
+                )
+
+            effective_tools = request.effective_tools()
+            if (
+                effective_tools
+                and isinstance(request.tool_choice, str)
+                and request.tool_choice in ("required", "none")
+            ):
+                template_kwargs.setdefault("tool_choice", request.tool_choice)
+            if request.response_format is not None:
+                template_kwargs.setdefault(
+                    "response_format",
+                    request.response_format.model_dump(
+                        exclude_unset=True, by_alias=True
+                    ),
+                )
+
+            request_tools = (
+                [
+                    tool.model_dump(exclude_unset=True, by_alias=True)
+                    for tool in request.tools
+                ]
+                if request.tools
+                else None
+            )
+            prompt_ids = self.config.tokenizer.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                tools=request_tools,
+                return_dict=False,
+                **template_kwargs,
+            )
+            if assistant_prefix:
+                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
+                    prompt_ids, assistant_prefix
+                )
+            return prompt_ids
+        return None
+
+    @staticmethod
+    def _pop_inkling_assistant_prefix(
+        messages: List[Dict[str, Any]],
+        request: ChatInput,
+    ) -> Optional[str]:
+        """Extract the trailing assistant text for ``continue_final_message``.
+
+        Only a plain-string assistant message with no tool calls and no
+        reasoning content can be continued; anything else renders as a closed
+        historical turn. Mutates ``messages`` in place (callers pass a copy).
+        """
+        if not request.continue_final_message or not messages:
+            return None
+        last = messages[-1]
+        if (
+            last.get("role") != "assistant"
+            or not isinstance(last.get("content"), str)
+            or last.get("tool_calls")
+            or last.get("reasoning_content")
+        ):
+            return None
+        messages.pop()
+        return last["content"]
+
+    @staticmethod
+    def _parse_inkling_reasoning_effort(
+        value: Optional[Union[str, float]],
+    ) -> Optional[float]:
+        """Convert an OpenAI-style reasoning_effort to an Inkling float."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError("Inkling reasoning_effort must not be a boolean")
+        if isinstance(value, (int, float)):
+            parsed = float(value)
+            if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
+                raise ValueError("Inkling reasoning_effort must be in [0.0, 0.99]")
+            return parsed
+        _EFFORT_MAP = {
+            "none": 0.0,
+            "minimal": 0.1,
+            "low": 0.2,
+            "medium": 0.7,
+            "high": 0.9,
+            "xhigh": 0.99,
+            "max": 0.99,
+        }
+        if value in _EFFORT_MAP:
+            return _EFFORT_MAP[value]
+        try:
+            parsed = float(value)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"invalid Inkling reasoning_effort: {value!r}") from exc
+        if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
+            raise ValueError("Inkling reasoning_effort must be in [0.0, 0.99]")
+        return parsed
+
+    @staticmethod
+    def _sort_tool_message_run(
+        run: List[Dict[str, Any]], tool_calls: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Order a tool-message run by tool_call position.
+
+        Templates that associate results by tool_call_id render the run in
+        tool_calls order; sorting the run upfront keeps extraction order and
+        placeholder order the same. Runs the template itself would refuse to
+        associate (missing/duplicate/unknown ids) are left untouched, as are
+        text-only runs, whose order text-only templates may rely on.
+        """
+        if len(run) < 2:
+            return run
+        call_ids = [tc.get("id") for tc in tool_calls]
+        if any(call_id is None for call_id in call_ids) or len(set(call_ids)) != len(
+            call_ids
+        ):
+            return run
+        result_ids = [message.get("tool_call_id") for message in run]
+        if any(result_id not in call_ids for result_id in result_ids) or len(
+            set(result_ids)
+        ) != len(result_ids):
+            return run
+        has_media = any(
+            isinstance(message.get("content"), list)
+            and any(
+                isinstance(part, dict) and part.get("type") in MEDIA_URL_PART_TYPES
+                for part in message["content"]
+            )
+            for message in run
+        )
+        if not has_media:
+            return run
+        position = {call_id: index for index, call_id in enumerate(call_ids)}
+        return sorted(run, key=lambda message: position[message["tool_call_id"]])
+
+    @classmethod
+    def _canonicalize_tool_message_order(
+        cls, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        canonical = []
+        index = 0
+        while index < len(messages):
+            message = messages[index]
+            canonical.append(message)
+            index += 1
+            tool_calls = message.get("tool_calls") or []
+            if message.get("role") != "assistant" or not tool_calls:
+                continue
+            run = []
+            while index < len(messages) and messages[index].get("role") in (
+                "tool",
+                "function",
+            ):
+                run.append(messages[index])
+                index += 1
+            canonical.extend(cls._sort_tool_message_run(run, tool_calls))
+        return canonical
+
+    def _apply_jinja_template(
+        self,
+        request: ChatInput,
+        tools: Optional[List[Dict]],
+        is_multimodal: bool,
+    ) -> RenderedPrompt:
+        """Apply Jinja chat template"""
+        prompt = ""
+        prompt_ids = []
+        openai_compatible_messages = []
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        template_content_format = (
+            self.config.template_manager.jinja_template_content_format
+        )
+
+        # Try custom encoding first (override in subclass for custom renderers)
+        thinking_requested = (request.chat_template_kwargs or {}).get(
+            "thinking", envs.SGLANG_DEFAULT_THINKING.get()
+        )
+        thinking_mode = (
+            ThinkingMode.THINKING if thinking_requested else ThinkingMode.CHAT
+        )
+        messages = [msg.model_dump() for msg in request.messages]
+        for message in messages:
+            normalize_assistant_tool_call_arguments(
+                message, strict=self.config.chat_encoding_spec != "kimi_k3"
+            )
+
+        prompt_ids = self._encode_messages(
+            copy.deepcopy(messages),
+            request,
+            thinking_mode,
+            tools=tools,
+        )
+
+        if prompt_ids is not None:
+            engine_prompt = (
+                TextPrompt(prompt_ids)
+                if isinstance(prompt_ids, str)
+                else TokenPrompt(prompt_ids)
+            )
+            if self.config.chat_encoding_spec in ("inkling", "kimi_k3"):
+                for message in request.messages:
+                    msg_dict = message.model_dump()
+                    if msg_dict.get("content") is None:
+                        msg_dict["content"] = ""
+                    process_content_for_template_format(
+                        msg_dict,
+                        "openai",
+                        image_data,
+                        video_data,
+                        audio_data,
+                        modalities,
+                    )
+        elif self.config.chat_encoding_spec is not None:
+            # dsv4/dsv32 encoding path
+            messages = copy.deepcopy(messages)
+
+            # dsv4/dsv32 are text-only and consume string content; flatten
+            # OpenAI parts-list content here so the encoder sees a plain string.
+            for i, msg in enumerate(messages):
+                if isinstance(msg.get("content"), list):
+                    messages[i] = process_content_for_template_format(
+                        msg, "string", [], [], [], []
+                    )
+
+            for msg in messages:
+                if msg.get("content") is None:
+                    msg["content"] = ""
+                processed_msg = process_content_for_template_format(
+                    msg,
+                    template_content_format,
+                    image_data,
+                    video_data,
+                    audio_data,
+                    modalities,
+                    use_dpsk_v32_encoding=self.config.chat_encoding_spec == "dsv32",
+                )
+                msg.update(processed_msg)
+
+            # Handle continue_final_message: separate final assistant message
+            messages, assistant_prefix = self._handle_last_assistant_message(
+                messages, request
+            )
+
+            if messages[0]["role"] != "system":
+                # insert an empty system prompt to help render tool system prompt
+                messages.insert(0, {"role": "system", "content": ""})
+            if request.tools:
+                messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
+
+            # Default encoding (dsv4/dsv32)
+            if self.config.chat_encoding_spec == "dsv4":
+                effort_source = request.reasoning_effort
+                if effort_source is None:
+                    env_val = envs.SGLANG_DSV4_REASONING_EFFORT.get()
+                    if env_val:
+                        effort_source = env_val
+                reasoning_effort_profile = self.config.dsv4_reasoning_effort_profile
+                assert reasoning_effort_profile is not None
+                accepted_efforts = encoding_dsv4.REASONING_EFFORT_PROFILES[
+                    reasoning_effort_profile
+                ]
+                v4_reasoning_effort = (
+                    effort_source if effort_source in accepted_efforts else None
+                )
+                if request.task is not None:
+                    encoding_dsv4.attach_task_to_last_user_message(
+                        messages, request.task
+                    )
+                real_input = encoding_dsv4.encode_messages(
+                    messages,
+                    thinking_mode=thinking_mode,
+                    reasoning_effort=v4_reasoning_effort,
+                    reasoning_effort_profile=reasoning_effort_profile,
+                )
+                prompt_ids = self.config.tokenizer.encode(real_input)
+            else:
+                real_input = encoding_dsv32.encode_messages(
+                    messages, thinking_mode=thinking_mode
+                )
+                prompt_ids = self.config.tokenizer.encode(real_input)
+
+            # Append assistant prefix if continue_final_message is enabled
+            if assistant_prefix:
+                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
+                    prompt_ids, assistant_prefix
+                )
+            engine_prompt = (
+                TextPrompt(prompt_ids)
+                if isinstance(prompt_ids, str)
+                else TokenPrompt(prompt_ids)
+            )
+        else:
+            if self.config.template_manager.jinja_template_may_reorder_tool_results:
+                messages = self._canonicalize_tool_message_order(messages)
+            for msg_dict in copy.deepcopy(messages):
+                if msg_dict.get("content") is None:
+                    msg_dict["content"] = ""
+
+                # Process content based on detected template format
+                processed_msg = process_content_for_template_format(
+                    msg_dict,
+                    template_content_format,
+                    image_data,
+                    video_data,
+                    audio_data,
+                    modalities,
+                )
+
+                processed_msg["content"] = normalize_tool_content(
+                    processed_msg["role"], processed_msg.get("content")
+                )
+
+                openai_compatible_messages.append(processed_msg)
+
+            # Handle continue_final_message: separate final assistant message
+            openai_compatible_messages, assistant_prefix = (
+                self._handle_last_assistant_message(openai_compatible_messages, request)
+            )
+
+            extra_template_kwargs = {}
+            if request.reasoning_effort is not None:
+                extra_template_kwargs["reasoning_effort"] = request.reasoning_effort
+            if request.chat_template_kwargs:
+                extra_template_kwargs.update(request.chat_template_kwargs)
+
+            rc = self.config.template_manager.reasoning_config
+            if rc is not None and rc.effort_kwarg is not None:
+                if request.reasoning_effort == "low":
+                    extra_template_kwargs.setdefault(rc.effort_kwarg, True)
+                elif request.reasoning_effort in ("medium", "high", "max"):
+                    logger.warning(
+                        "Model '%s' supports only 'low' reasoning effort; "
+                        "requested '%s' treated as default thinking",
+                        self.config.model_name,
+                        request.reasoning_effort,
+                    )
+
+            # Split apply_chat_template(tokenize=True) into render + encode so we
+            # can skip add_special_tokens=False on tokenizers that don't auto-add
+            # specials (Kimi-like, OpenAI-chat analogue of #25265). Chat
+            # templates already include role/special tokens, so the encode must
+            # avoid double BOS on tokenizers that would add it.
+            encode_kwargs = (
+                {"add_special_tokens": False}
+                if self.config.tokenizer_auto_adds_specials
+                else {}
+            )
+            try:
+                rendered_prompt = self.config.tokenizer.apply_chat_template(
+                    openai_compatible_messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    tools=tools,
+                    return_dict=False,
+                    **extra_template_kwargs,
+                )
+                prompt_ids = self.config.tokenizer.encode(
+                    rendered_prompt, **encode_kwargs
+                )
+            except Exception:
+                # If the first attempt fails, try with flat function-only format.
+                # Some templates (e.g. Mistral) expect tools without the OpenAI wrapper.
+                tools = (
+                    [t["function"] if "function" in t else t for t in tools]
+                    if tools
+                    else None
+                )
+                try:
+                    rendered_prompt = self.config.tokenizer.apply_chat_template(
+                        openai_compatible_messages,
+                        tokenize=False,
+                        add_generation_prompt=True,
+                        tools=tools,
+                        return_dict=False,
+                        **extra_template_kwargs,
+                    )
+                    prompt_ids = self.config.tokenizer.encode(
+                        rendered_prompt, **encode_kwargs
+                    )
+                except _CHAT_TEMPLATE_CLIENT_ERRORS as template_error:
+                    # Template errors (e.g., from raise_exception in Jinja templates)
+                    # and TypeError (e.g., tojson filter on Jinja2 Undefined variables)
+                    # should be treated as client errors (400 BadRequest)
+                    raise ValueError(str(template_error)) from template_error
+
+            # Append assistant prefix if continue_final_message is enabled
+            if assistant_prefix:
+                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
+                    prompt_ids, assistant_prefix
+                )
+
+            if is_multimodal:
+                prompt = self.config.tokenizer.decode(prompt_ids)
+            engine_prompt = (
+                TextPrompt(
+                    prompt,
+                    cached_token_ids=prompt_ids if prompt_ids or not prompt else None,
+                )
+                if is_multimodal
+                else TokenPrompt(prompt_ids)
+            )
+
+        image_data = image_data if image_data else None
+        audio_data = audio_data if audio_data else None
+        video_data = video_data if video_data else None
+        modalities = modalities if modalities else []
+        return RenderedPrompt(
+            prompt=engine_prompt,
+            image_data=image_data,
+            video_data=video_data,
+            audio_data=audio_data,
+            modalities=modalities,
+        )
+
+    def _apply_conversation_template(
+        self,
+        request: ChatInput,
+        is_multimodal: bool,
+        require_reasoning: bool,
+    ) -> RenderedPrompt:
+        """Apply conversation template"""
+        prompt = ""
+        prompt_ids = []
+        conv = generate_chat_conv(
+            request, self.config.template_manager.chat_template_name
+        )
+
+        # If we should continue the final assistant message, adjust the conversation.
+        if (
+            request.continue_final_message
+            and request.messages
+            and request.messages[-1].role == "assistant"
+        ):
+            # Remove the auto-added blank assistant turn, if present.
+            if conv.messages and conv.messages[-1][1] is None:
+                conv.messages.pop()
+            # Rebuild the prompt from the conversation.
+            prompt = conv.get_prompt()
+            # Strip trailing stop tokens or separators that indicate end-of-assistant.
+            if isinstance(conv.stop_str, list):
+                for stop_token in conv.stop_str:
+                    if prompt.endswith(stop_token):
+                        prompt = prompt[: -len(stop_token)]
+            elif isinstance(conv.stop_str, str) and prompt.endswith(conv.stop_str):
+                prompt = prompt[: -len(conv.stop_str)]
+            if conv.sep and prompt.endswith(conv.sep):
+                prompt = prompt[: -len(conv.sep)]
+            if getattr(conv, "sep2", None) and prompt.endswith(conv.sep2):
+                prompt = prompt[: -len(conv.sep2)]
+        else:
+            prompt = conv.get_prompt()
+            if require_reasoning and (
+                self.config.reasoning_detector is None
+                or not self.config.reasoning_detector.thinks_internally
+            ):
+                # Models with thinks_internally=True think without a leading <think> token
+                prompt += "<think>"  # Note(Xinyuan): hard code thinking token
+
+        image_data = conv.image_data if conv.image_data else None
+        video_data = conv.video_data if conv.video_data else None
+        audio_data = conv.audio_data if conv.audio_data else None
+        modalities = conv.modalities if conv.modalities else []
+        if not is_multimodal:
+            prompt_ids = self.config.tokenizer.encode(prompt)
+
+        return RenderedPrompt(
+            prompt=TextPrompt(prompt) if is_multimodal else TokenPrompt(prompt_ids),
+            template_stop=copy.copy(conv.stop_str or []),
+            image_data=image_data,
+            video_data=video_data,
+            audio_data=audio_data,
+            modalities=modalities,
+        )

--- a/python/sglang/srt/entrypoints/chat_input/schema.py
+++ b/python/sglang/srt/entrypoints/chat_input/schema.py
@@ -1,0 +1,354 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Shared message, tool, and formatting schemas for chat input preparation."""
+
+from __future__ import annotations
+
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeAlias,
+    Union,
+    get_args,
+)
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Field,
+    StrictBool,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+from typing_extensions import Literal
+
+try:
+    from xgrammar import StructuralTag
+except:
+    StructuralTag = Any
+
+
+class JsonSchemaResponseFormat(BaseModel):
+    name: str
+    description: Optional[str] = None
+    # use alias to workaround pydantic conflict
+    schema_: Optional[Dict[str, object]] = Field(alias="schema", default=None)
+    # The OpenAI wire contract accepts JSON booleans only; StrictBool rejects
+    # the values lax pydantic would coerce ("yes", "on", 0, 1, ...), matching
+    # OpenAI's 422 behavior. Omitted (None) keeps its meaning.
+    strict: Optional[StrictBool] = None
+
+
+class ResponseFormat(BaseModel):
+    type: Literal["text", "json_object", "json_schema"]
+    json_schema: Optional[JsonSchemaResponseFormat] = None
+
+
+class StructuresResponseFormat(BaseModel):
+    begin: str
+    schema_: Optional[Dict[str, object]] = Field(alias="schema", default=None)
+    end: str
+
+
+# NOTE(dark): keep this for backward compatibility
+class LegacyStructuralTagResponseFormat(BaseModel):
+    type: Literal["structural_tag"]
+    structures: List[StructuresResponseFormat]
+    triggers: List[str]
+    at_least_one: bool = False
+
+
+StructuralTagResponseFormat: TypeAlias = Union[
+    LegacyStructuralTagResponseFormat, StructuralTag
+]
+
+ToolCallConstraint: TypeAlias = Union[
+    Tuple[Literal["structural_tag"], StructuralTagResponseFormat],
+    Tuple[Literal["json_schema"], Any],  # json_schema can be dict/str/None
+]
+
+
+class ChatCompletionMessageContentTextPart(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class ChatCompletionMessageContentThinkingPart(BaseModel):
+    type: Literal["thinking", "reasoning"]
+    thinking: Optional[str] = None
+    text: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_payload(self):
+        if (self.thinking is None) == (self.text is None):
+            raise ValueError(
+                "thinking parts require exactly one of 'thinking' or 'text'"
+            )
+        return self
+
+
+class ChatCompletionMessageContentImageURL(BaseModel):
+    url: str
+    detail: Optional[Literal["auto", "low", "high"]] = "auto"
+    max_dynamic_patch: Optional[int] = None
+    min_dynamic_patch: Optional[int] = None
+    content_hash: Optional[str] = None
+
+    @field_validator("content_hash")
+    @classmethod
+    def validate_content_hash(cls, value: Optional[str]) -> Optional[str]:
+        from sglang.srt.multimodal.cache import parse_content_hash
+
+        return parse_content_hash(value)
+
+
+class ChatCompletionMessageContentVideoURL(BaseModel):
+    url: str
+    max_dynamic_patch: Optional[int] = None
+    min_dynamic_patch: Optional[int] = None
+    fps: Optional[float] = None
+    max_frames: Optional[int] = None
+    max_tokens_per_frame: Optional[int] = None
+    max_image_tokens: Optional[int] = None
+
+
+class ChatCompletionMessageContentAudioURL(BaseModel):
+    url: str
+
+
+class ChatCompletionMessageContentImagePart(BaseModel):
+    type: Literal["image_url"]
+    image_url: ChatCompletionMessageContentImageURL
+    modalities: Optional[Literal["image", "multi-images", "video"]] = "image"
+
+
+class ChatCompletionMessageContentVideoPart(BaseModel):
+    type: Literal["video_url"]
+    video_url: ChatCompletionMessageContentVideoURL
+
+
+class ChatCompletionMessageContentInputAudio(BaseModel):
+    data: str
+    format: Literal["wav", "mp3"]
+
+
+_AUDIO_FORMAT_TO_MIME_TYPE = {
+    "wav": "audio/wav",
+    "mp3": "audio/mpeg",
+}
+
+
+class ChatCompletionMessageContentAudioURLPart(BaseModel):
+    type: Literal["audio_url"]
+    audio_url: ChatCompletionMessageContentAudioURL
+
+
+class ChatCompletionMessageContentAudioInlinePart(BaseModel):
+    type: Literal["input_audio"]
+    input_audio: ChatCompletionMessageContentInputAudio
+
+
+def _to_audio_url_part(
+    part: Union[
+        ChatCompletionMessageContentAudioURLPart,
+        ChatCompletionMessageContentAudioInlinePart,
+    ],
+) -> ChatCompletionMessageContentAudioURLPart:
+    if isinstance(part, ChatCompletionMessageContentAudioURLPart):
+        return part
+
+    audio = part.input_audio
+    return ChatCompletionMessageContentAudioURLPart(
+        type="audio_url",
+        audio_url=ChatCompletionMessageContentAudioURL(
+            url=f"data:{_AUDIO_FORMAT_TO_MIME_TYPE[audio.format]};base64,{audio.data}"
+        ),
+    )
+
+
+# Audio arrives by reference as `audio_url`, holding a URL or a data URI, or
+# inline as OpenAI's `input_audio`, holding base64. Inline audio is converted to
+# the equivalent data URI as it validates.
+ChatCompletionMessageContentAudioPart = Annotated[
+    Union[
+        ChatCompletionMessageContentAudioURLPart,
+        ChatCompletionMessageContentAudioInlinePart,
+    ],
+    AfterValidator(_to_audio_url_part),
+]
+
+
+class ChatCompletionMessageContentToolReferenceBlock(BaseModel):
+    # GLM-specific extension used alongside `defer_loading` tools. The chat
+    # template looks up `tools[*].function.name == tr.name` and renders the
+    # referenced tool schemas inline for the current turn. Not part of any
+    # OpenAI API; included here so Pydantic accepts the content through the
+    # Chat Completions path (the Anthropic endpoint translates its
+    # `tool_name` field to `name` before forwarding).
+    type: Literal["tool_reference"]
+    name: str
+
+
+ChatCompletionMessageContentPart = Union[
+    ChatCompletionMessageContentTextPart,
+    ChatCompletionMessageContentThinkingPart,
+    ChatCompletionMessageContentImagePart,
+    ChatCompletionMessageContentVideoPart,
+    ChatCompletionMessageContentAudioPart,
+    ChatCompletionMessageContentToolReferenceBlock,
+]
+
+
+class FunctionResponse(BaseModel):
+    """Function response."""
+
+    name: Optional[str] = None
+    arguments: Optional[str | Dict[str, Any]] = None
+
+
+class ToolCall(BaseModel):
+    """Tool call response."""
+
+    id: Optional[str] = None
+    index: Optional[int] = None
+    type: Literal["function"] = "function"
+    function: FunctionResponse
+
+
+_GenericMessageRole = Literal[
+    "system", "assistant", "tool", "function", "developer", "latest_reminder"
+]
+_GENERIC_MESSAGE_ROLES: Tuple[str, ...] = get_args(_GenericMessageRole)
+
+
+class ChatCompletionMessageGenericParam(BaseModel):
+    role: _GenericMessageRole
+    content: Union[str, List[ChatCompletionMessageContentPart], None] = Field(
+        default=None
+    )
+    tool_call_id: Optional[str] = None
+    name: Optional[str] = None
+    reasoning_content: Optional[str] = None
+    tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
+    tools: Optional[List[Tool]] = Field(default=None, examples=[None])
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def _normalize_role(cls, v):
+        if isinstance(v, str):
+            v_lower = v.lower()
+            if v_lower not in _GENERIC_MESSAGE_ROLES:
+                allowed = ", ".join(repr(r) for r in _GENERIC_MESSAGE_ROLES)
+                raise ValueError(f"'role' must be one of {allowed} (case-insensitive).")
+            return v_lower
+        raise ValueError("'role' must be a string")
+
+    @model_validator(mode="after")
+    def validate_thinking_parts_role(self):
+        if self.role != "assistant" and isinstance(self.content, list):
+            for part in self.content:
+                if isinstance(part, ChatCompletionMessageContentThinkingPart):
+                    raise ValueError(
+                        "thinking content parts are only valid in assistant messages"
+                    )
+        return self
+
+
+class ChatCompletionMessageUserParam(BaseModel):
+    role: Literal["user"]
+    content: Union[str, List[ChatCompletionMessageContentPart]]
+
+    @model_validator(mode="after")
+    def validate_thinking_parts_role(self):
+        if isinstance(self.content, list):
+            for part in self.content:
+                if isinstance(part, ChatCompletionMessageContentThinkingPart):
+                    raise ValueError(
+                        "thinking content parts are only valid in assistant messages"
+                    )
+        return self
+
+
+ChatCompletionMessageParam = Union[
+    ChatCompletionMessageGenericParam, ChatCompletionMessageUserParam
+]
+
+
+class Function(BaseModel):
+    """Function descriptions."""
+
+    description: Optional[str] = Field(default=None, examples=[None])
+    name: str
+    parameters: Optional[object] = None
+    strict: bool = False
+    defer_loading: Optional[bool] = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if self.defer_loading is None:
+            data.pop("defer_loading", None)
+        return data
+
+
+class Tool(BaseModel):
+    """Function wrapper."""
+
+    type: str = Field(default="function", examples=["function"])
+    function: Function
+    defer_loading: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _propagate_defer_loading(self) -> Tool:
+        if self.defer_loading is not None and self.function.defer_loading is None:
+            self.function.defer_loading = self.defer_loading
+        return self
+
+
+# Tool is defined after the message params that reference it, so the forward
+# reference has to be resolved explicitly.
+ChatCompletionMessageGenericParam.model_rebuild()
+
+
+class ToolChoiceFuncName(BaseModel):
+    """The name of tool choice function."""
+
+    name: Optional[str] = None
+
+
+class ToolChoice(BaseModel):
+    """The tool choice definition."""
+
+    function: ToolChoiceFuncName
+    type: Literal["function"] = Field(default="function", examples=["function"])
+
+
+ReasoningEffortTier = Literal[
+    "none", "minimal", "low", "medium", "high", "xhigh", "max"
+]
+# Chat Completions and /v1/tokenize additionally accept a fine-grained float in
+# [0.0, 0.99] as an sglang extension (not part of the OpenAI schema, so the
+# /v1/responses surface deliberately keeps the string tiers only). Single-sourced
+# so these surfaces cannot drift apart.
+ReasoningEffortType = Optional[
+    Union[
+        ReasoningEffortTier,
+        Annotated[float, Field(ge=0.0, le=0.99, allow_inf_nan=False)],
+    ]
+]

--- a/python/sglang/srt/entrypoints/chat_input/types.py
+++ b/python/sglang/srt/entrypoints/chat_input/types.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Protocol, Union
+
+from pydantic import BaseModel
+
+from sglang.srt.entrypoints.chat_input.schema import (
+    ChatCompletionMessageParam,
+    ReasoningEffortType,
+    ResponseFormat,
+    StructuralTagResponseFormat,
+    Tool,
+    ToolCallConstraint,
+    ToolChoice,
+)
+
+
+class ChatInput(BaseModel):
+    messages: List[ChatCompletionMessageParam]
+    tools: Optional[List[Tool]] = None
+    tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = "none"
+    parallel_tool_calls: bool = True
+    response_format: Optional[Union[ResponseFormat, StructuralTagResponseFormat]] = None
+    reasoning_effort: ReasoningEffortType = None
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
+    continue_final_message: bool = False
+    input_ids: Optional[List[int]] = None
+    stop: Optional[Union[str, List[str]]] = None
+    ignore_eos: bool = False
+    skip_special_tokens: bool = True
+    task: Optional[
+        Literal["action", "query", "authority", "domain", "title", "read_url"]
+    ] = None
+
+    def effective_tools(self) -> List[Tool]:
+        tools = list(self.tools or [])
+        for message in self.messages:
+            if message.role in ("system", "developer"):
+                tools.extend(getattr(message, "tools", None) or [])
+        return tools
+
+
+@dataclass(frozen=True)
+class TextPrompt:
+    text: str
+    cached_token_ids: Optional[List[int]] = None
+
+    def to_generate_kwargs(self) -> Dict[str, str]:
+        return {"text": self.text}
+
+    def tokenize(self, tokenizer) -> List[int]:
+        if self.cached_token_ids is not None:
+            return list(self.cached_token_ids)
+        return tokenizer.encode(self.text, add_special_tokens=False)
+
+
+@dataclass(frozen=True)
+class TokenPrompt:
+    token_ids: List[int]
+
+    def to_generate_kwargs(self) -> Dict[str, List[int]]:
+        return {"input_ids": list(self.token_ids)}
+
+    def tokenize(self, tokenizer) -> List[int]:
+        return list(self.token_ids)
+
+
+@dataclass(frozen=True)
+class RenderedPrompt:
+    prompt: Union[TextPrompt, TokenPrompt]
+    image_data: Optional[Any] = None
+    audio_data: Optional[Any] = None
+    video_data: Optional[Any] = None
+    modalities: List[str] = field(default_factory=list)
+    template_stop: Optional[Union[str, List[str]]] = None
+
+
+@dataclass(frozen=True)
+class PreparedChat:
+    prompt: Union[TextPrompt, TokenPrompt]
+    image_data: Optional[Any]
+    audio_data: Optional[Any]
+    video_data: Optional[Any]
+    modalities: List[str]
+    stop: Optional[Union[str, List[str]]]
+    tool_call_constraint: Optional[ToolCallConstraint]
+    skip_special_tokens: bool
+    require_reasoning: bool
+    reasoning_end_token_ids: Optional[List[int]]
+    chat_template_kwargs: Optional[Dict[str, Any]]
+    reasoning_effort: ReasoningEffortType
+
+
+class MessageRenderer(Protocol):
+    def render(
+        self, request: ChatInput, tools: Optional[List[Dict]], require_reasoning: bool
+    ) -> RenderedPrompt: ...
+
+
+@dataclass(frozen=True)
+class ChatModelConfig:
+    tokenizer: Any
+    template_manager: Any
+    is_multimodal: bool
+    model_name: str = ""
+    chat_encoding_spec: Optional[str] = None
+    tool_call_parser: Optional[str] = None
+    reasoning_parser: Optional[str] = None
+    reasoning_detector: Any = None
+    default_chat_template_kwargs: Dict[str, Any] = field(default_factory=dict)
+    dsv4_reasoning_effort_profile: Optional[str] = None
+    inkling_default_reasoning_effort: Optional[float] = 0.9
+    tokenizer_auto_adds_specials: bool = True
+    is_gpt_oss: bool = False
+    is_gemma4: bool = False

--- a/python/sglang/srt/entrypoints/chat_input/validation.py
+++ b/python/sglang/srt/entrypoints/chat_input/validation.py
@@ -1,0 +1,84 @@
+from typing import Optional
+
+from jsonschema import Draft202012Validator, SchemaError
+
+from sglang.srt.entrypoints.chat_input.schema import ChatCompletionMessageGenericParam
+from sglang.srt.entrypoints.chat_input.types import ChatInput
+from sglang.srt.function_call.utils import normalize_json_schema_types
+
+
+def validate_chat_input(request: ChatInput) -> Optional[str]:
+    if not request.messages:
+        return "Messages cannot be empty."
+
+    effective_tools = request.effective_tools()
+    has_message_tools = any(
+        isinstance(message, ChatCompletionMessageGenericParam)
+        and message.role in ("system", "developer")
+        and message.tools
+        for message in request.messages
+    )
+    if (
+        isinstance(request.tool_choice, str)
+        and request.tool_choice.lower() == "required"
+        and not effective_tools
+    ):
+        return "Tools cannot be empty if tool choice is set to required."
+
+    if request.tool_choice is not None and not isinstance(request.tool_choice, str):
+        if not effective_tools:
+            return "Tools cannot be empty if tool choice is set to a specific tool."
+        tool_name = request.tool_choice.function.name
+        tool_exists = any(tool.function.name == tool_name for tool in effective_tools)
+        if not tool_exists:
+            return f"Tool '{tool_name}' not found in tools list."
+
+    if has_message_tools:
+        names = [tool.function.name for tool in effective_tools]
+        if len(names) != len(set(names)):
+            return "Tool names must be unique across request and message tools."
+
+    # Validate tool definitions
+    for i, tool in enumerate(effective_tools):
+        if tool.function.parameters is None:
+            continue
+        try:
+            # Rewrite DB/ORM-style aliases (e.g. "varchar", "enum", "int")
+            # to standard JSON Schema types before validation. RecursionError
+            # guards against hand-crafted cyclic schemas so the request gets
+            # a 400 instead of crashing into a 500.
+            normalize_json_schema_types(tool.function.parameters)
+            Draft202012Validator.check_schema(tool.function.parameters)
+        except SchemaError as e:
+            return f"Tool {i} function has invalid 'parameters' schema: {str(e)}"
+        except RecursionError:
+            return (
+                f"Tool {i} function 'parameters' schema is too deeply nested "
+                "or contains a cycle."
+            )
+
+    if request.response_format and request.response_format.type == "json_schema":
+        schema = getattr(request.response_format.json_schema, "schema_", None)
+        if schema is None:
+            return "schema_ is required for json_schema response format request."
+
+    return None
+
+
+class MediaInputError(ValueError):
+    pass
+
+
+def validate_media_content(request: ChatInput, is_multimodal: bool) -> Optional[str]:
+    if is_multimodal:
+        return None
+    for message in request.messages:
+        if not isinstance(message.content, list):
+            continue
+        for part in message.content:
+            if part.type in ("image_url", "video_url", "audio_url"):
+                return (
+                    "Model only supports text input; "
+                    + f"received unsupported content type '{part.type}'."
+                )
+    return None

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -324,7 +324,9 @@ async def lifespan(fast_api_app: FastAPI):
         _global_state.tokenizer_manager, _global_state.template_manager
     )
     fast_api_app.state.openai_serving_tokenize = OpenAIServingTokenize(
-        _global_state.tokenizer_manager, _global_state.template_manager
+        _global_state.tokenizer_manager,
+        _global_state.template_manager,
+        input_processor=fast_api_app.state.openai_serving_chat.input_processor,
     )
     fast_api_app.state.openai_serving_detokenize = OpenAIServingDetokenize(
         _global_state.tokenizer_manager
@@ -367,6 +369,7 @@ async def lifespan(fast_api_app: FastAPI):
             _global_state.template_manager,
             enable_prompt_tokens_details=True,
             tool_server=tool_server,
+            input_processor=fast_api_app.state.openai_serving_chat.input_processor,
         )
     except Exception as e:
         # Optional endpoint; a load failure (e.g. the gpt-oss harmony vocab

--- a/python/sglang/srt/entrypoints/openai/chat_encoding.py
+++ b/python/sglang/srt/entrypoints/openai/chat_encoding.py
@@ -157,15 +157,6 @@ def spec_owns_reasoning_history(spec: Optional[str]) -> bool:
     return spec is not None
 
 
-def spec_renders_prompt_ids(spec: Optional[str]) -> bool:
-    """Whether the encoder for ``spec`` returns pre-tokenized prompt ids.
-
-    Token-first encoders leave the text prompt empty; the MM processor
-    expands their single placeholder ids rather than re-tokenizing text.
-    """
-    return spec in ("inkling", "kimi_k3")
-
-
 def encode_simple_chat(
     *,
     tokenizer: Any,

--- a/python/sglang/srt/entrypoints/openai/chat_encoding.py
+++ b/python/sglang/srt/entrypoints/openai/chat_encoding.py
@@ -133,7 +133,7 @@ def resolve_chat_encoding_spec(
 
     # Inkling has no Jinja chat_template and uses a tiktoken base + a special-token
     # overlay + negative MM placeholders, so it can't go through apply_chat_template;
-    # render input_ids directly via the Inkling renderer (serving_chat._encode_messages).
+    # render input_ids directly via the shared chat input renderer.
     if "InklingForConditionalGeneration" in arch:
         return "inkling"
 

--- a/python/sglang/srt/entrypoints/openai/chat_input_adapter.py
+++ b/python/sglang/srt/entrypoints/openai/chat_input_adapter.py
@@ -1,0 +1,139 @@
+import copy
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from sglang.srt.entrypoints.chat_input.config import resolve_chat_model_config
+from sglang.srt.entrypoints.chat_input.normalization import (
+    normalize_reasoning_inputs,
+    set_json_schema,
+    set_tool_choice_default,
+    validate_reasoning_effort_type,
+)
+from sglang.srt.entrypoints.chat_input.processor import ChatInputProcessor
+from sglang.srt.entrypoints.chat_input.schema import Function, Tool
+from sglang.srt.entrypoints.chat_input.types import ChatInput, PreparedChat
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ResponsesRequest,
+    TokenizeRequest,
+)
+from sglang.srt.runtime_context import get_model, get_serving
+
+
+def create_chat_input_processor(tokenizer_manager, template_manager):
+    config = resolve_chat_model_config(
+        tokenizer=tokenizer_manager.tokenizer,
+        template_manager=template_manager,
+        hf_config=tokenizer_manager.model_config.hf_config,
+        model_path=tokenizer_manager.model_path,
+        revision=get_model().revision,
+        tool_call_parser=tokenizer_manager.config_value("tool_call_parser"),
+        reasoning_parser=tokenizer_manager.config_value("reasoning_parser"),
+        default_chat_template_kwargs=get_serving().default_chat_template_kwargs,
+        is_multimodal=tokenizer_manager.model_config.is_multimodal,
+    )
+    return ChatInputProcessor(config)
+
+
+def from_chat_request(request: ChatCompletionRequest) -> ChatInput:
+    return ChatInput.model_validate(
+        {name: copy.deepcopy(getattr(request, name)) for name in ChatInput.model_fields}
+    )
+
+
+def _validate_input(data: Dict[str, Any]) -> ChatInput:
+    data = copy.deepcopy(data)
+    data = set_tool_choice_default(data)
+    data = normalize_reasoning_inputs(data)
+    data = set_json_schema(data)
+    validate_reasoning_effort_type(data.get("reasoning_effort"))
+    return ChatInput.model_validate(data)
+
+
+def from_responses_request(
+    request: ResponsesRequest, messages: List[Dict[str, Any]]
+) -> ChatInput:
+    tools = [
+        Tool(
+            type="function",
+            function=Function(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.parameters,
+                strict=tool.strict,
+            ),
+        )
+        for tool in request.tools or []
+        if tool.type == "function"
+    ]
+    choice = request.effective_tool_choice() if tools else "none"
+    if isinstance(choice, dict):
+        choice = {"type": "function", "function": {"name": choice["name"]}}
+    return _validate_input(
+        {
+            "messages": messages,
+            "tools": tools or None,
+            "tool_choice": choice,
+            "parallel_tool_calls": (
+                request.parallel_tool_calls
+                if request.parallel_tool_calls is not None
+                else True
+            ),
+            "stop": request.stop,
+            "reasoning_effort": request.reasoning.effort if request.reasoning else None,
+            "chat_template_kwargs": request.chat_template_kwargs,
+        }
+    )
+
+
+def from_tokenize_request(request: TokenizeRequest) -> ChatInput:
+    return _validate_input(
+        request.model_dump(exclude={"prompt", "add_special_tokens"}, exclude_none=True)
+    )
+
+
+def with_prepared_options(request, prepared: PreparedChat):
+    updates = {
+        "chat_template_kwargs": copy.deepcopy(prepared.chat_template_kwargs),
+        "skip_special_tokens": prepared.skip_special_tokens,
+        "reasoning_effort": prepared.reasoning_effort,
+    }
+    fields = type(request).model_fields
+    return request.model_copy(
+        deep=True,
+        update={key: value for key, value in updates.items() if key in fields},
+    )
+
+
+class _GenerationValidationOptions(BaseModel):
+    """Keep coercion for legacy generation fields accepted by TokenizeRequest."""
+
+    max_completion_tokens: Optional[int] = None
+    max_tokens: Optional[int] = None
+    return_sampling_mask: bool = False
+    return_meta_info: bool = False
+
+
+def validate_chat_generation_options(request):
+    options = _GenerationValidationOptions.model_validate(
+        {
+            name: getattr(request, name)
+            for name in _GenerationValidationOptions.model_fields
+            if hasattr(request, name)
+        }
+    )
+    if options.return_sampling_mask and not options.return_meta_info:
+        return "return_sampling_mask requires return_meta_info=true."
+    max_output_tokens = options.max_completion_tokens or options.max_tokens
+    server_context_length = get_model().context_length
+    if (
+        max_output_tokens
+        and server_context_length
+        and max_output_tokens > server_context_length
+    ) and not get_serving().allow_auto_truncate:
+        return (
+            f"max_completion_tokens is too large: {max_output_tokens}."
+            f"This model supports at most {server_context_length} completion tokens."
+        )
+    return None

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -2037,12 +2037,8 @@ class RequestResponseMetadata(BaseModel):
 
 @dataclass
 class MessageProcessingResult:
-    """Rendered messages with an explicit engine input.
-
-    ``prompt`` and ``prompt_ids`` remain available to the tokenization endpoint;
-    generation consumes only ``engine_prompt``, selected by the renderer.
-    """
-
+    # prompt and prompt_ids are for tokenization;
+    # only engine_prompt determines the input sent for generation.
     engine_prompt: Union[str, List[int]] = field(kw_only=True)
     prompt: str
     prompt_ids: Union[str, List[int]]

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     Annotated,
     Any,
@@ -2037,6 +2037,13 @@ class RequestResponseMetadata(BaseModel):
 
 @dataclass
 class MessageProcessingResult:
+    """Rendered messages with an explicit engine input.
+
+    ``prompt`` and ``prompt_ids`` remain available to the tokenization endpoint;
+    generation consumes only ``engine_prompt``, selected by the renderer.
+    """
+
+    engine_prompt: Union[str, List[int]] = field(kw_only=True)
     prompt: str
     prompt_ids: Union[str, List[int]]
     image_data: Optional[Any]

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Any,
     Dict,
     List,
@@ -31,7 +29,6 @@ from typing import (
     Tuple,
     TypeAlias,
     Union,
-    get_args,
     runtime_checkable,
 )
 
@@ -50,11 +47,9 @@ from openai.types.responses.response_format_text_json_schema_config import (
 )
 from openai.types.shared.response_format_json_object import ResponseFormatJSONObject
 from pydantic import (
-    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
-    StrictBool,
     field_serializer,
     field_validator,
     model_serializer,
@@ -67,11 +62,58 @@ try:
 except:
     StructuralTag = Any
 
+from sglang.srt.entrypoints.chat_input.normalization import (
+    normalize_reasoning_inputs,
+    set_json_schema,
+    set_tool_choice_default,
+    validate_reasoning_effort_type,
+)
+
+# Preserve the existing import path for shared input schemas.
+from sglang.srt.entrypoints.chat_input.schema import (  # noqa: F401
+    _AUDIO_FORMAT_TO_MIME_TYPE,
+    _GENERIC_MESSAGE_ROLES,
+    ChatCompletionMessageContentAudioInlinePart,
+    ChatCompletionMessageContentAudioPart,
+    ChatCompletionMessageContentAudioURL,
+    ChatCompletionMessageContentAudioURLPart,
+    ChatCompletionMessageContentImagePart,
+    ChatCompletionMessageContentImageURL,
+    ChatCompletionMessageContentInputAudio,
+    ChatCompletionMessageContentPart,
+    ChatCompletionMessageContentTextPart,
+    ChatCompletionMessageContentThinkingPart,
+    ChatCompletionMessageContentToolReferenceBlock,
+    ChatCompletionMessageContentVideoPart,
+    ChatCompletionMessageContentVideoURL,
+    ChatCompletionMessageGenericParam,
+    ChatCompletionMessageParam,
+    ChatCompletionMessageUserParam,
+    Function,
+    FunctionResponse,
+    JsonSchemaResponseFormat,
+    LegacyStructuralTagResponseFormat,
+    ReasoningEffortTier,
+    ReasoningEffortType,
+    ResponseFormat,
+    StructuralTagResponseFormat,
+    StructuresResponseFormat,
+    Tool,
+    ToolCall,
+    ToolCallConstraint,
+    ToolChoice,
+    ToolChoiceFuncName,
+    _GenericMessageRole,
+    _to_audio_url_part,
+)
 from sglang.utils import convert_json_schema_to_str
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = "default"
+
+# The Responses event schema accepts fewer effort tiers than request inputs.
+ECHOABLE_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
 
 
 class ModelCard(BaseModel):
@@ -214,46 +256,6 @@ class UsageInfo(BaseModel):
 class StreamOptions(BaseModel):
     include_usage: Optional[bool] = False
     continuous_usage_stats: Optional[bool] = False
-
-
-class JsonSchemaResponseFormat(BaseModel):
-    name: str
-    description: Optional[str] = None
-    # use alias to workaround pydantic conflict
-    schema_: Optional[Dict[str, object]] = Field(alias="schema", default=None)
-    # The OpenAI wire contract accepts JSON booleans only; StrictBool rejects
-    # the values lax pydantic would coerce ("yes", "on", 0, 1, ...), matching
-    # OpenAI's 422 behavior. Omitted (None) keeps its meaning.
-    strict: Optional[StrictBool] = None
-
-
-class ResponseFormat(BaseModel):
-    type: Literal["text", "json_object", "json_schema"]
-    json_schema: Optional[JsonSchemaResponseFormat] = None
-
-
-class StructuresResponseFormat(BaseModel):
-    begin: str
-    schema_: Optional[Dict[str, object]] = Field(alias="schema", default=None)
-    end: str
-
-
-# NOTE(dark): keep this for backward compatibility
-class LegacyStructuralTagResponseFormat(BaseModel):
-    type: Literal["structural_tag"]
-    structures: List[StructuresResponseFormat]
-    triggers: List[str]
-    at_least_one: bool = False
-
-
-StructuralTagResponseFormat: TypeAlias = Union[
-    LegacyStructuralTagResponseFormat, StructuralTag
-]
-
-ToolCallConstraint: TypeAlias = Union[
-    Tuple[Literal["structural_tag"], StructuralTagResponseFormat],
-    Tuple[Literal["json_schema"], Any],  # json_schema can be dict/str/None
-]
 
 
 class FileRequest(BaseModel):
@@ -544,136 +546,6 @@ class CompletionStreamResponse(BaseModel):
         return data
 
 
-class ChatCompletionMessageContentTextPart(BaseModel):
-    type: Literal["text"]
-    text: str
-
-
-class ChatCompletionMessageContentThinkingPart(BaseModel):
-    type: Literal["thinking", "reasoning"]
-    thinking: Optional[str] = None
-    text: Optional[str] = None
-
-    @model_validator(mode="after")
-    def validate_payload(self):
-        if (self.thinking is None) == (self.text is None):
-            raise ValueError(
-                "thinking parts require exactly one of 'thinking' or 'text'"
-            )
-        return self
-
-
-class ChatCompletionMessageContentImageURL(BaseModel):
-    url: str
-    detail: Optional[Literal["auto", "low", "high"]] = "auto"
-    max_dynamic_patch: Optional[int] = None
-    min_dynamic_patch: Optional[int] = None
-    content_hash: Optional[str] = None
-
-    @field_validator("content_hash")
-    @classmethod
-    def validate_content_hash(cls, value: Optional[str]) -> Optional[str]:
-        from sglang.srt.multimodal.cache import parse_content_hash
-
-        return parse_content_hash(value)
-
-
-class ChatCompletionMessageContentVideoURL(BaseModel):
-    url: str
-    max_dynamic_patch: Optional[int] = None
-    min_dynamic_patch: Optional[int] = None
-    fps: Optional[float] = None
-    max_frames: Optional[int] = None
-    max_tokens_per_frame: Optional[int] = None
-    max_image_tokens: Optional[int] = None
-
-
-class ChatCompletionMessageContentAudioURL(BaseModel):
-    url: str
-
-
-class ChatCompletionMessageContentImagePart(BaseModel):
-    type: Literal["image_url"]
-    image_url: ChatCompletionMessageContentImageURL
-    modalities: Optional[Literal["image", "multi-images", "video"]] = "image"
-
-
-class ChatCompletionMessageContentVideoPart(BaseModel):
-    type: Literal["video_url"]
-    video_url: ChatCompletionMessageContentVideoURL
-
-
-class ChatCompletionMessageContentInputAudio(BaseModel):
-    data: str
-    format: Literal["wav", "mp3"]
-
-
-_AUDIO_FORMAT_TO_MIME_TYPE = {
-    "wav": "audio/wav",
-    "mp3": "audio/mpeg",
-}
-
-
-class ChatCompletionMessageContentAudioURLPart(BaseModel):
-    type: Literal["audio_url"]
-    audio_url: ChatCompletionMessageContentAudioURL
-
-
-class ChatCompletionMessageContentAudioInlinePart(BaseModel):
-    type: Literal["input_audio"]
-    input_audio: ChatCompletionMessageContentInputAudio
-
-
-def _to_audio_url_part(
-    part: Union[
-        ChatCompletionMessageContentAudioURLPart,
-        ChatCompletionMessageContentAudioInlinePart,
-    ],
-) -> ChatCompletionMessageContentAudioURLPart:
-    if isinstance(part, ChatCompletionMessageContentAudioURLPart):
-        return part
-
-    audio = part.input_audio
-    return ChatCompletionMessageContentAudioURLPart(
-        type="audio_url",
-        audio_url=ChatCompletionMessageContentAudioURL(
-            url=f"data:{_AUDIO_FORMAT_TO_MIME_TYPE[audio.format]};base64,{audio.data}"
-        ),
-    )
-
-
-# Audio arrives by reference as `audio_url`, holding a URL or a data URI, or
-# inline as OpenAI's `input_audio`, holding base64. Inline audio is converted to
-# the equivalent data URI as it validates.
-ChatCompletionMessageContentAudioPart = Annotated[
-    Union[
-        ChatCompletionMessageContentAudioURLPart,
-        ChatCompletionMessageContentAudioInlinePart,
-    ],
-    AfterValidator(_to_audio_url_part),
-]
-
-
-class ChatCompletionMessageContentToolReferenceBlock(BaseModel):
-    # GLM-specific extension used alongside `defer_loading` tools. The chat
-    # template looks up `tools[*].function.name == tr.name` and renders the
-    # referenced tool schemas inline for the current turn. Not part of any
-    # OpenAI API; included here so Pydantic accepts the content through the
-    # Chat Completions path (the Anthropic endpoint translates its
-    # `tool_name` field to `name` before forwarding).
-    type: Literal["tool_reference"]
-    name: str
-
-
-ChatCompletionMessageContentPart = Union[
-    ChatCompletionMessageContentTextPart,
-    ChatCompletionMessageContentThinkingPart,
-    ChatCompletionMessageContentImagePart,
-    ChatCompletionMessageContentVideoPart,
-    ChatCompletionMessageContentAudioPart,
-    ChatCompletionMessageContentToolReferenceBlock,
-]
-
 # Rerank content types for multimodal reranking (e.g., Qwen3-VL-Reranker)
 # Can be a simple string (text-only) or a list of multimodal content parts
 RerankContentPart = Union[
@@ -682,162 +554,6 @@ RerankContentPart = Union[
     ChatCompletionMessageContentVideoPart,
 ]
 RerankContent = Union[str, List[RerankContentPart]]
-
-
-class FunctionResponse(BaseModel):
-    """Function response."""
-
-    name: Optional[str] = None
-    arguments: Optional[str | Dict[str, Any]] = None
-
-
-class ToolCall(BaseModel):
-    """Tool call response."""
-
-    id: Optional[str] = None
-    index: Optional[int] = None
-    type: Literal["function"] = "function"
-    function: FunctionResponse
-
-
-_GenericMessageRole = Literal[
-    "system", "assistant", "tool", "function", "developer", "latest_reminder"
-]
-_GENERIC_MESSAGE_ROLES: Tuple[str, ...] = get_args(_GenericMessageRole)
-
-
-class ChatCompletionMessageGenericParam(BaseModel):
-    role: _GenericMessageRole
-    content: Union[str, List[ChatCompletionMessageContentPart], None] = Field(
-        default=None
-    )
-    tool_call_id: Optional[str] = None
-    name: Optional[str] = None
-    reasoning_content: Optional[str] = None
-    tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
-    tools: Optional[List[Tool]] = Field(default=None, examples=[None])
-
-    @field_validator("role", mode="before")
-    @classmethod
-    def _normalize_role(cls, v):
-        if isinstance(v, str):
-            v_lower = v.lower()
-            if v_lower not in _GENERIC_MESSAGE_ROLES:
-                allowed = ", ".join(repr(r) for r in _GENERIC_MESSAGE_ROLES)
-                raise ValueError(f"'role' must be one of {allowed} (case-insensitive).")
-            return v_lower
-        raise ValueError("'role' must be a string")
-
-    @model_validator(mode="after")
-    def validate_thinking_parts_role(self):
-        if self.role != "assistant" and isinstance(self.content, list):
-            for part in self.content:
-                if isinstance(part, ChatCompletionMessageContentThinkingPart):
-                    raise ValueError(
-                        "thinking content parts are only valid in assistant messages"
-                    )
-        return self
-
-
-class ChatCompletionMessageUserParam(BaseModel):
-    role: Literal["user"]
-    content: Union[str, List[ChatCompletionMessageContentPart]]
-
-    @model_validator(mode="after")
-    def validate_thinking_parts_role(self):
-        if isinstance(self.content, list):
-            for part in self.content:
-                if isinstance(part, ChatCompletionMessageContentThinkingPart):
-                    raise ValueError(
-                        "thinking content parts are only valid in assistant messages"
-                    )
-        return self
-
-
-ChatCompletionMessageParam = Union[
-    ChatCompletionMessageGenericParam, ChatCompletionMessageUserParam
-]
-
-
-class Function(BaseModel):
-    """Function descriptions."""
-
-    description: Optional[str] = Field(default=None, examples=[None])
-    name: str
-    parameters: Optional[object] = None
-    strict: bool = False
-    defer_loading: Optional[bool] = None
-
-    @model_serializer(mode="wrap")
-    def _serialize(self, handler):
-        data = handler(self)
-        if self.defer_loading is None:
-            data.pop("defer_loading", None)
-        return data
-
-
-class Tool(BaseModel):
-    """Function wrapper."""
-
-    type: str = Field(default="function", examples=["function"])
-    function: Function
-    defer_loading: Optional[bool] = None
-
-    @model_validator(mode="after")
-    def _propagate_defer_loading(self) -> Tool:
-        if self.defer_loading is not None and self.function.defer_loading is None:
-            self.function.defer_loading = self.defer_loading
-        return self
-
-
-# Tool is defined after the message params that reference it, so the forward
-# reference has to be resolved explicitly.
-ChatCompletionMessageGenericParam.model_rebuild()
-
-
-class ToolChoiceFuncName(BaseModel):
-    """The name of tool choice function."""
-
-    name: Optional[str] = None
-
-
-class ToolChoice(BaseModel):
-    """The tool choice definition."""
-
-    function: ToolChoiceFuncName
-    type: Literal["function"] = Field(default="function", examples=["function"])
-
-
-# OpenAI-spec string tiers for reasoning effort (current Responses/Chat API):
-# none/minimal/low/medium/high/xhigh/max. Used as-is by /v1/responses.
-ReasoningEffortTier = Literal[
-    "none", "minimal", "low", "medium", "high", "xhigh", "max"
-]
-# The typed /v1/responses stream events validate against OpenAI's narrower
-# ``Reasoning.effort``; echoing a tier outside this set kills the stream.
-ECHOABLE_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
-# Chat Completions and /v1/tokenize additionally accept a fine-grained float in
-# [0.0, 0.99] as an sglang extension (not part of the OpenAI schema, so the
-# /v1/responses surface deliberately keeps the string tiers only). Single-sourced
-# so these surfaces cannot drift apart.
-ReasoningEffortType = Optional[
-    Union[
-        ReasoningEffortTier,
-        Annotated[float, Field(ge=0.0, le=0.99, allow_inf_nan=False)],
-    ]
-]
-
-
-def _has_message_level_tools(messages: Any) -> bool:
-    if not isinstance(messages, list):
-        return False
-    return any(
-        isinstance(message, dict)
-        and isinstance(message.get("role"), str)
-        and message["role"].lower() in ("system", "developer")
-        and bool(message.get("tools"))
-        for message in messages
-    )
 
 
 class ChatCompletionRequest(BaseModel):
@@ -986,111 +702,22 @@ class ChatCompletionRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_tool_choice_default(cls, values):
-        if values.get("tool_choice") is None:
-            if values.get("tools") is None and not _has_message_level_tools(
-                values.get("messages")
-            ):
-                values["tool_choice"] = "none"
-            else:
-                values["tool_choice"] = "auto"
-        return values
+        return set_tool_choice_default(values)
 
     @field_validator("reasoning_effort", mode="before")
     @classmethod
     def validate_reasoning_effort_type(cls, value):
-        if isinstance(value, bool):
-            raise ValueError("reasoning_effort must not be a boolean")
-        return value
+        return validate_reasoning_effort_type(value)
 
     @model_validator(mode="before")
     @classmethod
     def normalize_reasoning_inputs(cls, values: Dict):
-        r = values.get("reasoning")
-        thinking = None
-
-        if r is not None and isinstance(r, dict):
-            effort = r.get("effort")
-            if effort is None:
-                effort = r.get("reasoning_effort")
-            if isinstance(effort, str) and effort in {
-                "none",
-                "minimal",
-                "low",
-                "medium",
-                "high",
-                "xhigh",
-                "max",
-            }:
-                values["reasoning_effort"] = effort
-            elif isinstance(effort, (int, float)) and not isinstance(effort, bool):
-                values["reasoning_effort"] = float(effort)
-            elif isinstance(effort, str):
-                # Keep parity with the top-level reasoning_effort field, whose
-                # lax union coerces numeric strings; range checks then apply.
-                try:
-                    values["reasoning_effort"] = float(effort)
-                except ValueError as exc:
-                    raise ValueError(f"invalid reasoning effort: {effort!r}") from exc
-            elif effort is not None:
-                raise ValueError(f"invalid reasoning effort: {effort!r}")
-
-            enabled = (
-                r.get("enabled")
-                if r.get("enabled") is not None
-                else r.get("enable", False)
-            )
-            if isinstance(enabled, str):
-                enabled = enabled.strip().lower() in {"1", "true", "yes", "y", "on"}
-            if enabled:
-                thinking = True
-
-        effort = values.get("reasoning_effort")
-        if effort is not None:
-            thinking = effort != "none"
-
-        if thinking is not None:
-            ctk = values.get("chat_template_kwargs")
-            if not isinstance(ctk, dict):
-                ctk = {}
-            # different models check different keys:
-            # - "thinking" for deepseek-v3, kimi_k2
-            # - "enable_thinking" for qwen3, glm45, nemotron_3, interns1
-            ctk.setdefault("thinking", thinking)
-            ctk.setdefault("enable_thinking", thinking)
-            values["chat_template_kwargs"] = ctk
-
-        return values
+        return normalize_reasoning_inputs(values)
 
     @model_validator(mode="before")
     @classmethod
     def set_json_schema(cls, values):
-        response_format = values.get("response_format")
-        if not response_format:
-            return values
-
-        if response_format.get("type") != "json_schema":
-            return values
-
-        schema = response_format.pop("schema", None)
-        json_schema = response_format.get("json_schema")
-
-        if json_schema:
-            return values
-
-        if schema:
-            name_ = schema.get("title", "Schema")
-            strict_ = None
-            if "properties" in schema and "strict" in schema["properties"]:
-                item = schema["properties"].pop("strict", None)
-                strict_ = bool(item and item.get("default", False))
-
-            response_format["json_schema"] = {
-                "name": name_,
-                "schema": schema,
-                "strict": strict_,
-            }
-
-        return values
+        return set_json_schema(values)
 
     def to_sampling_params(
         self,
@@ -2033,24 +1660,6 @@ class RequestResponseMetadata(BaseModel):
 
     request_id: str
     final_usage_info: Optional[UsageInfo] = None
-
-
-@dataclass
-class MessageProcessingResult:
-    # prompt and prompt_ids are for tokenization;
-    # only engine_prompt determines the input sent for generation.
-    engine_prompt: Union[str, List[int]] = field(kw_only=True)
-    prompt: str
-    prompt_ids: Union[str, List[int]]
-    image_data: Optional[Any]
-    audio_data: Optional[Any]
-    video_data: Optional[Any]
-    modalities: List[str]
-    stop: List[str]
-    tool_call_constraint: Optional[ToolCallConstraint] = None
-    skip_special_tokens: bool = True
-    require_reasoning: bool = False
-    reasoning_end_token_ids: Optional[List[int]] = None
 
 
 class ToolCallProcessingResult(NamedTuple):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1,44 +1,27 @@
 from __future__ import annotations
 
-import copy
 import json
 import logging
-import math
 import time
 import uuid
-from enum import Enum
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
 
-from sglang.srt.runtime_context import get_model, get_serving
-
-
-class ThinkingMode(str, Enum):
-    """Mode for message encoding - chat vs thinking/reasoning."""
-
-    CHAT = "chat"
-    THINKING = "thinking"
-
-
-import jinja2
 import orjson
 from fastapi import Request
-
-try:
-    from mistral_common.exceptions import MistralCommonException
-
-    _MISTRAL_COMMON_ERRORS: tuple[type[BaseException], ...] = (MistralCommonException,)
-except ImportError:
-    _MISTRAL_COMMON_ERRORS = ()
-
-_CHAT_TEMPLATE_CLIENT_ERRORS: tuple[type[BaseException], ...] = (
-    jinja2.TemplateError,
-    TypeError,
-) + _MISTRAL_COMMON_ERRORS
 from fastapi.responses import ORJSONResponse, StreamingResponse
-from jsonschema import Draft202012Validator, SchemaError
 
-from sglang.srt.entrypoints.openai import chat_encoding, encoding_dsv4, encoding_dsv32
+from sglang.srt.entrypoints.chat_input.validation import (
+    validate_chat_input,
+    validate_media_content,
+)
+from sglang.srt.entrypoints.openai import chat_encoding
+from sglang.srt.entrypoints.openai.chat_input_adapter import (
+    create_chat_input_processor,
+    from_chat_request,
+    validate_chat_generation_options,
+    with_prepared_options,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageContentTextPart,
     ChatCompletionMessageContentVideoPart,
@@ -56,9 +39,7 @@ from sglang.srt.entrypoints.openai.protocol import (
     ErrorResponse,
     FunctionResponse,
     LogProbs,
-    MessageProcessingResult,
     PromptTokensDetails,
-    ResponseParserProtocol,
     SglExt,
     Tool,
     ToolCall,
@@ -78,7 +59,6 @@ from sglang.srt.entrypoints.openai.utils import (
     process_spec_tokens_details_from_ret,
     should_include_usage,
     spec_tokens_details_from_meta_info,
-    to_generate_prompt_kwargs,
     to_openai_style_logprobs,
 )
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
@@ -86,21 +66,12 @@ from sglang.srt.environ import envs
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
-from sglang.srt.function_call.utils import (
-    get_json_schema_constraint,
-    normalize_json_schema_types,
-)
 from sglang.srt.managers.io_struct import GenerateReqInput
-from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.hunyuan_reasoning import (
-    normalize_hunyuan_reasoning_effort,
     uses_hunyuan_reasoning_effort,
 )
-from sglang.srt.parser.jinja_template_utils import (
-    MEDIA_URL_PART_TYPES,
-    process_content_for_template_format,
-)
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.runtime_context import get_serving
 from sglang.srt.sampling.sampling_params import (
     set_request_reasoning_end_token_ids,
 )
@@ -111,68 +82,6 @@ if TYPE_CHECKING:
     from sglang.srt.parser.template_manager import TemplateManager
 
 logger = logging.getLogger(__name__)
-
-_MEDIA_CONTENT_PART_TYPES = frozenset({"image_url", "video_url", "audio_url"})
-
-
-def normalize_tool_content(role: str, content):
-    """Normalize tool message content from OpenAI array format to plain string.
-
-    OpenAI clients may send tool content as a list of content parts
-    (e.g. [{"type":"text","text":"..."}]) but most chat templates expect
-    a plain string for tool messages. Only flatten when ALL items are
-    pure OpenAI text parts; preserve lists containing non-text-type items
-    that some templates intentionally iterate over.
-    """
-    if role != "tool" or not isinstance(content, list):
-        return content
-    parts = content
-    is_openai_text_parts = all(
-        (isinstance(p, dict) and p.get("type") == "text") or isinstance(p, str)
-        for p in parts
-    )
-    if is_openai_text_parts:
-        text_parts = [p.get("text", "") if isinstance(p, dict) else p for p in parts]
-        return " ".join(text_parts)
-    return content
-
-
-def parse_tool_call_arguments(arguments: str) -> Dict[str, Any]:
-    """Parse OpenAI tool call arguments for chat templates."""
-    try:
-        parsed_arguments = orjson.loads(arguments)
-    except orjson.JSONDecodeError as exc:
-        raise ValueError(
-            "Assistant tool call function.arguments must be valid JSON."
-        ) from exc
-
-    if not isinstance(parsed_arguments, dict):
-        raise ValueError(
-            "Assistant tool call function.arguments must be a JSON object."
-        )
-
-    return parsed_arguments
-
-
-def normalize_assistant_tool_call_arguments(
-    message: Dict[str, Any], *, strict: bool = True
-) -> None:
-    """Normalize assistant history tool call arguments in-place."""
-    if message.get("role") != "assistant" or not isinstance(
-        message.get("tool_calls"), list
-    ):
-        return
-
-    for item in message["tool_calls"]:
-        function = item.get("function") if isinstance(item, dict) else None
-        if not isinstance(function, dict):
-            continue
-        if "arguments" in function and isinstance(function["arguments"], str):
-            try:
-                function["arguments"] = parse_tool_call_arguments(function["arguments"])
-            except ValueError:
-                if strict:
-                    raise
 
 
 def _extract_max_dynamic_patch(request: ChatCompletionRequest):
@@ -199,27 +108,6 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
     img_max_dynamic_patch = min(img_vals) if img_vals else None
     vid_max_dynamic_patch = min(vid_vals) if vid_vals else None
     return img_max_dynamic_patch, vid_max_dynamic_patch
-
-
-KIMI_K3_IMAGE_PLACEHOLDER = "<|kimi_image_placeholder|>"
-KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED = "<| kimi_image_placeholder |>"
-
-
-def neutralize_kimi_k3_image_placeholder(text: str) -> str:
-    return text.replace(KIMI_K3_IMAGE_PLACEHOLDER, KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED)
-
-
-def neutralize_kimi_k3_image_placeholder_value(value: Any) -> Any:
-    if isinstance(value, str):
-        return neutralize_kimi_k3_image_placeholder(value)
-    if isinstance(value, list):
-        return [neutralize_kimi_k3_image_placeholder_value(item) for item in value]
-    if isinstance(value, dict):
-        return {
-            key: neutralize_kimi_k3_image_placeholder_value(item)
-            for key, item in value.items()
-        }
-    return value
 
 
 def _extract_video_question(request: ChatCompletionRequest) -> Optional[str]:
@@ -264,29 +152,23 @@ class OpenAIServingChat(OpenAIServingBase):
         self,
         tokenizer_manager: TokenizerManager,
         template_manager: TemplateManager,
+        *,
+        input_processor=None,
     ):
         super().__init__(tokenizer_manager)
         self.template_manager = template_manager
-        self.tool_call_parser = self.tokenizer_manager.config_value("tool_call_parser")
-        self.reasoning_parser = self.tokenizer_manager.config_value("reasoning_parser")
-        self.default_chat_template_kwargs = (
-            get_serving().default_chat_template_kwargs or {}
+        self.input_processor = (
+            input_processor
+            if input_processor is not None
+            else create_chat_input_processor(tokenizer_manager, template_manager)
         )
-        self._reasoning_detector = None
-        if self.reasoning_parser:
-            try:
-                rp = ReasoningParser(
-                    model_type=self.reasoning_parser,
-                    stream_reasoning=True,
-                    tokenizer=self.tokenizer_manager.tokenizer,
-                )
-                self._reasoning_detector = rp.detector
-            except ValueError as e:
-                logger.warning(
-                    "Failed to initialize reasoning detector for parser '%s': %s",
-                    self.reasoning_parser,
-                    e,
-                )
+        config = self.input_processor.config
+        self.tool_call_parser = config.tool_call_parser
+        self.reasoning_parser = config.reasoning_parser
+        self._reasoning_detector = config.reasoning_detector
+        self.chat_encoding_spec = config.chat_encoding_spec
+        self.is_gpt_oss = config.is_gpt_oss
+        self.is_gemma4 = config.is_gemma4
 
         # Get default sampling parameters from model's generation config
         self.default_sampling_params = (
@@ -301,125 +183,6 @@ class OpenAIServingChat(OpenAIServingBase):
             )
             OpenAIServingChat._default_sampling_params_logged = True
 
-        # Check if the model is a GPT-OSS model
-        self.is_gpt_oss = (
-            hasattr(self.tokenizer_manager.model_config, "hf_config")
-            and hasattr(self.tokenizer_manager.model_config.hf_config, "model_type")
-            and self.tokenizer_manager.model_config.hf_config.model_type == "gpt_oss"
-        )
-        self.is_gemma4 = (
-            hasattr(self.tokenizer_manager.model_config, "hf_config")
-            and hasattr(self.tokenizer_manager.model_config.hf_config, "model_type")
-            and self.tokenizer_manager.model_config.hf_config.model_type
-            in ("gemma4", "gemma4_unified")
-        )
-
-        # Which Python-based chat encoder (if any) bypasses apply_chat_template.
-        # Values: "dsv32", "dsv4", or custom values set by subclass. None for default.
-        self.chat_encoding_spec = self._resolve_chat_encoding_spec()
-        self._dsv4_reasoning_effort_profile = (
-            chat_encoding.resolve_dsv4_reasoning_effort_profile(
-                model_path=self.tokenizer_manager.model_path,
-                revision=get_model().revision,
-                override=self.tokenizer_manager.model_config.hf_config.to_dict().get(
-                    chat_encoding.DSV4_REASONING_EFFORT_PROFILE_OVERRIDE
-                ),
-            )
-            if self.chat_encoding_spec == "dsv4"
-            else None
-        )
-
-        # Resolve the env-configured Inkling effort default once: the env var is
-        # frozen for the server's lifetime, and a misconfigured value should
-        # fail at boot, not 400 every request.
-        self._inkling_default_reasoning_effort: Optional[float] = (
-            self._get_inkling_default_reasoning_effort()
-            if self.chat_encoding_spec == "inkling"
-            else None
-        )
-
-        # Per-request response parser for custom decoding (set by _encode_messages)
-        self._response_parser: Optional[ResponseParserProtocol] = None
-
-        # Probe whether ``encode("")`` returns specials. If it does, we must
-        # keep ``add_special_tokens=False`` at the chat-template encode site
-        # to avoid double BOS; otherwise the kwarg is a no-op and dropping it
-        # lets slow tokenizers (e.g. Kimi's TikTokenTokenizer) stay on the
-        # fast internal path.
-        try:
-            self._tokenizer_auto_adds_specials = (
-                len(self.tokenizer_manager.tokenizer.encode("")) > 0
-            )
-        except Exception:
-            self._tokenizer_auto_adds_specials = True
-
-    def _handle_last_assistant_message(
-        self,
-        messages: List[Dict[str, Any]],
-        request: ChatCompletionRequest,
-    ) -> tuple[List[Dict[str, Any]], Optional[str]]:
-        """
-        Handle continue_final_message feature: separate final assistant message.
-
-        If continue_final_message is enabled and the last message is from assistant,
-        extract its content and remove it from the message list.
-        If continue_final_message is False and the last message is from assistant,
-        convert it to a user message to ensure the last message is always from user.
-
-        Only processes text-based content (strings), ignoring multimodal content (lists).
-
-        Args:
-            messages: List of message dictionaries
-            request: ChatCompletionRequest with continue_final_message flag
-
-        Returns:
-            Tuple of (processed_messages, assistant_prefix)
-            - processed_messages: Messages with last assistant message handled appropriately
-            - assistant_prefix: Content of the last assistant message (string only), or None
-        """
-        assistant_prefix = None
-        if messages and messages[-1].get("role") == "assistant":
-            last_content = messages[-1].get("content")
-            # Only process string content, ignore multimodal content (lists)
-            if isinstance(last_content, str):
-                if request.continue_final_message:
-                    # Extract content and remove the assistant message
-                    assistant_prefix = last_content
-                    messages = messages[:-1]
-                else:
-                    # Convert the last assistant message to user message
-                    messages[-1] = {"role": "user", "content": last_content}
-        return messages, assistant_prefix
-
-    def _append_assistant_prefix_to_prompt_ids(
-        self, prompt_ids: List[int], assistant_prefix: str
-    ) -> List[int]:
-        """
-        Append assistant prefix to prompt_ids.
-
-        Args:
-            prompt_ids: Current prompt token IDs
-            assistant_prefix: Assistant message content to append
-
-        Returns:
-            Updated prompt_ids with assistant prefix appended
-        """
-        encoded = self.tokenizer_manager.tokenizer.encode(assistant_prefix)
-        if encoded and encoded[0] == self.tokenizer_manager.tokenizer.bos_token_id:
-            encoded = encoded[1:]
-        return prompt_ids + encoded
-
-    def _resolve_chat_encoding_spec(self) -> Optional[str]:
-        """Determine which chat encoding spec to use.
-
-        Override in subclass to add custom encoding specs.
-        """
-        return chat_encoding.resolve_chat_encoding_spec(
-            hf_config=self.tokenizer_manager.model_config.hf_config,
-            tokenizer=self.tokenizer_manager.tokenizer,
-            tool_call_parser=self.tool_call_parser,
-        )
-
     def _request_id_prefix(self) -> str:
         return "chatcmpl-"
 
@@ -433,273 +196,6 @@ class OpenAIServingChat(OpenAIServingBase):
             ):
                 tools.extend(message.tools)
         return tools
-
-    def _prepare_kimi_k3_messages(
-        self,
-        messages: List[Dict[str, Any]],
-        request: ChatCompletionRequest,
-    ) -> tuple[List[Dict[str, Any]], int, Optional[str]]:
-        image_count = 0
-        for index, message in enumerate(messages):
-            content = message.get("content")
-            if isinstance(content, list):
-                parts = []
-                for part in content:
-                    if not isinstance(part, dict):
-                        continue
-                    part_type = part.get("type")
-                    if part_type in ("text", "input_text"):
-                        parts.append(
-                            {
-                                "type": "text",
-                                "text": neutralize_kimi_k3_image_placeholder(
-                                    part["text"]
-                                ),
-                            }
-                        )
-                    elif part_type in ("image_url", "input_image"):
-                        image = part.get("image_url") or {}
-                        if isinstance(image, str):
-                            image = {"url": image, "detail": part.get("detail")}
-                        parts.append({"type": "image_url", "image_url": image})
-                        image_count += 1
-                message["content"] = parts
-            elif isinstance(content, str):
-                message["content"] = neutralize_kimi_k3_image_placeholder(content)
-            elif content is None:
-                message["content"] = ""
-
-            if message.get("role") == "assistant":
-                for key in ("reasoning_content", "reasoning"):
-                    if key in message:
-                        message[key] = neutralize_kimi_k3_image_placeholder_value(
-                            message[key]
-                        )
-                for tool_call in message.get("tool_calls") or []:
-                    function = (
-                        tool_call.get("function")
-                        if isinstance(tool_call, dict)
-                        else None
-                    )
-                    if isinstance(function, dict) and "arguments" in function:
-                        function["arguments"] = (
-                            neutralize_kimi_k3_image_placeholder_value(
-                                function["arguments"]
-                            )
-                        )
-
-            source = request.messages[index]
-            if (
-                isinstance(source, ChatCompletionMessageGenericParam)
-                and source.role in ("system", "developer")
-                and source.tools
-            ):
-                message["tools"] = [
-                    tool.model_dump(exclude_unset=True, by_alias=True)
-                    for tool in source.tools
-                ]
-            if message.get("role") == "developer":
-                message["role"] = "system"
-
-        assistant_prefix = None
-        if request.continue_final_message:
-            messages, assistant_prefix = self._handle_last_assistant_message(
-                messages, request
-            )
-        return messages, image_count, assistant_prefix
-
-    def _encode_messages(
-        self,
-        messages: List[Dict[str, Any]],
-        request: ChatCompletionRequest,
-        thinking_mode: ThinkingMode,
-        tools: Optional[List[Dict]] = None,
-    ) -> Optional[List[int]]:
-        """Encode messages for custom chat_encoding_spec values.
-
-        Returns prompt_ids if handled, None to use default encoding.
-        """
-        if self.chat_encoding_spec == "inkling":
-            # Inkling: render messages -> input_ids with framing tokens + ONE placeholder per
-            # media (encoding/expansion happens later in InklingMultimodalProcessor). The
-            # server's tokenizer is the base tiktoken backend; wrap it so encode_special
-            # supplies the framing-token overlay.
-            from sglang.srt.parser.inkling_renderer import render_inkling_messages
-            from sglang.srt.parser.inkling_tokenizer import (
-                CONTENT_TEXT,
-                MESSAGE_MODEL,
-                InklingTokenizer,
-            )
-
-            inkling_tokenizer = InklingTokenizer(
-                tokenizer=self.tokenizer_manager.tokenizer
-            )
-            reasoning_effort = self._parse_inkling_reasoning_effort(
-                request.reasoning_effort
-            )
-            if reasoning_effort is None:
-                reasoning_effort = self._inkling_default_reasoning_effort
-            assistant_prefix = self._pop_inkling_assistant_prefix(messages, request)
-            prompt_ids = render_inkling_messages(
-                messages,
-                inkling_tokenizer,
-                add_generation_prompt=False,
-                tools=tools,
-                reasoning_effort=reasoning_effort,
-            )
-            if assistant_prefix is not None:
-                # Continue the final assistant message inside an OPEN model text
-                # block: header + payload, no <|end_message|> and no
-                # <|content_model_end_sampling|>, so the model resumes the turn.
-                prompt_ids += [
-                    inkling_tokenizer.encode_special(MESSAGE_MODEL),
-                    inkling_tokenizer.encode_special(CONTENT_TEXT),
-                    *inkling_tokenizer.encode_text(assistant_prefix),
-                ]
-            return prompt_ids
-        if self.chat_encoding_spec == "kimi_k3":
-            messages, image_count, assistant_prefix = self._prepare_kimi_k3_messages(
-                messages, request
-            )
-            template_kwargs = dict(request.chat_template_kwargs or {})
-            template_kwargs.pop("tokenize", None)
-            template_kwargs.pop("return_dict", None)
-            template_kwargs.pop("image_prompts", None)
-            if image_count:
-                template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
-
-            if (
-                request.reasoning_effort in ("low", "high", "max")
-                and "thinking_effort" not in template_kwargs
-            ):
-                template_kwargs["thinking_effort"] = request.reasoning_effort
-            elif request.reasoning_effort not in (
-                None,
-                "none",
-                "low",
-                "high",
-                "max",
-            ):
-                logger.warning(
-                    "Kimi K3 does not support reasoning_effort=%r; using the "
-                    "encoder default.",
-                    request.reasoning_effort,
-                )
-
-            effective_tools = self._effective_tools(request)
-            if (
-                effective_tools
-                and isinstance(request.tool_choice, str)
-                and request.tool_choice in ("required", "none")
-            ):
-                template_kwargs.setdefault("tool_choice", request.tool_choice)
-            if request.response_format is not None:
-                template_kwargs.setdefault(
-                    "response_format",
-                    request.response_format.model_dump(
-                        exclude_unset=True, by_alias=True
-                    ),
-                )
-
-            request_tools = (
-                [
-                    tool.model_dump(exclude_unset=True, by_alias=True)
-                    for tool in request.tools
-                ]
-                if request.tools
-                else None
-            )
-            prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
-                messages,
-                tokenize=True,
-                add_generation_prompt=True,
-                tools=request_tools,
-                return_dict=False,
-                **template_kwargs,
-            )
-            if assistant_prefix:
-                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
-                    prompt_ids, assistant_prefix
-                )
-            return prompt_ids
-        return None
-
-    @staticmethod
-    def _pop_inkling_assistant_prefix(
-        messages: List[Dict[str, Any]],
-        request: ChatCompletionRequest,
-    ) -> Optional[str]:
-        """Extract the trailing assistant text for ``continue_final_message``.
-
-        Only a plain-string assistant message with no tool calls and no
-        reasoning content can be continued; anything else renders as a closed
-        historical turn. Mutates ``messages`` in place (callers pass a copy).
-        """
-        if not request.continue_final_message or not messages:
-            return None
-        last = messages[-1]
-        if (
-            last.get("role") != "assistant"
-            or not isinstance(last.get("content"), str)
-            or last.get("tool_calls")
-            or last.get("reasoning_content")
-        ):
-            return None
-        messages.pop()
-        return last["content"]
-
-    @staticmethod
-    def _parse_inkling_reasoning_effort(
-        value: Optional[Union[str, float]],
-    ) -> Optional[float]:
-        """Convert an OpenAI-style reasoning_effort to an Inkling float."""
-        if value is None:
-            return None
-        if isinstance(value, bool):
-            raise ValueError("Inkling reasoning_effort must not be a boolean")
-        if isinstance(value, (int, float)):
-            parsed = float(value)
-            if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
-                raise ValueError("Inkling reasoning_effort must be in [0.0, 0.99]")
-            return parsed
-        _EFFORT_MAP = {
-            "none": 0.0,
-            "minimal": 0.1,
-            "low": 0.2,
-            "medium": 0.7,
-            "high": 0.9,
-            "xhigh": 0.99,
-            "max": 0.99,
-        }
-        if value in _EFFORT_MAP:
-            return _EFFORT_MAP[value]
-        try:
-            parsed = float(value)
-        except (ValueError, TypeError) as exc:
-            raise ValueError(f"invalid Inkling reasoning_effort: {value!r}") from exc
-        if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
-            raise ValueError("Inkling reasoning_effort must be in [0.0, 0.99]")
-        return parsed
-
-    @staticmethod
-    def _get_inkling_default_reasoning_effort() -> float:
-        """Read the default Inkling reasoning effort from the environment."""
-        from sglang.srt.environ import envs
-
-        val = envs.SGLANG_INKLING_DEFAULT_REASONING_EFFORT.get()
-        if not val:
-            return 0.9
-        try:
-            parsed = float(val)
-        except (ValueError, TypeError) as exc:
-            raise ValueError(
-                "SGLANG_INKLING_DEFAULT_REASONING_EFFORT must be numeric"
-            ) from exc
-        if not math.isfinite(parsed) or not 0.0 <= parsed <= 0.99:
-            raise ValueError(
-                "SGLANG_INKLING_DEFAULT_REASONING_EFFORT must be in [0.0, 0.99]"
-            )
-        return parsed
 
     def _decode_response(self, ret_item: Dict[str, Any]) -> Union[str, ErrorResponse]:
         """Extract text from response."""
@@ -737,66 +233,6 @@ class OpenAIServingChat(OpenAIServingBase):
             # reference API excludes it from billed/reported prompt tokens.
             prompt_tokens = max(0, prompt_tokens - self._KIMI_K3_GENERATION_STUB_TOKENS)
         return prompt_tokens
-
-    @staticmethod
-    def _sort_tool_message_run(
-        run: List[Dict[str, Any]], tool_calls: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Order a tool-message run by tool_call position.
-
-        Templates that associate results by tool_call_id render the run in
-        tool_calls order; sorting the run upfront keeps extraction order and
-        placeholder order the same. Runs the template itself would refuse to
-        associate (missing/duplicate/unknown ids) are left untouched, as are
-        text-only runs, whose order text-only templates may rely on.
-        """
-        if len(run) < 2:
-            return run
-        call_ids = [tc.get("id") for tc in tool_calls]
-        if any(call_id is None for call_id in call_ids) or len(set(call_ids)) != len(
-            call_ids
-        ):
-            return run
-        result_ids = [message.get("tool_call_id") for message in run]
-        if any(result_id not in call_ids for result_id in result_ids) or len(
-            set(result_ids)
-        ) != len(result_ids):
-            return run
-        has_media = any(
-            isinstance(message.get("content"), list)
-            and any(
-                isinstance(part, dict) and part.get("type") in MEDIA_URL_PART_TYPES
-                for part in message["content"]
-            )
-            for message in run
-        )
-        if not has_media:
-            return run
-        position = {call_id: index for index, call_id in enumerate(call_ids)}
-        return sorted(run, key=lambda message: position[message["tool_call_id"]])
-
-    @classmethod
-    def _canonicalize_tool_message_order(
-        cls, messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        canonical = []
-        index = 0
-        while index < len(messages):
-            message = messages[index]
-            canonical.append(message)
-            index += 1
-            tool_calls = message.get("tool_calls") or []
-            if message.get("role") != "assistant" or not tool_calls:
-                continue
-            run = []
-            while index < len(messages) and messages[index].get("role") in (
-                "tool",
-                "function",
-            ):
-                run.append(messages[index])
-                index += 1
-            canonical.extend(cls._sort_tool_message_run(run, tool_calls))
-        return canonical
 
     async def _generate_stream_content(
         self,
@@ -945,103 +381,13 @@ class OpenAIServingChat(OpenAIServingBase):
 
     def _validate_request(self, request: ChatCompletionRequest) -> Optional[str]:
         """Validate that the input is valid."""
-        if not request.messages:
-            return "Messages cannot be empty."
-
-        if request.return_sampling_mask and not request.return_meta_info:
-            return "return_sampling_mask requires return_meta_info=true."
-
-        media_error = self._validate_media_content(request)
-        if media_error:
-            return media_error
-
-        effective_tools = self._effective_tools(request)
-        has_message_tools = any(
-            isinstance(message, ChatCompletionMessageGenericParam)
-            and message.role in ("system", "developer")
-            and message.tools
-            for message in request.messages
-        )
-        if (
-            isinstance(request.tool_choice, str)
-            and request.tool_choice.lower() == "required"
-            and not effective_tools
-        ):
-            return "Tools cannot be empty if tool choice is set to required."
-
-        if request.tool_choice is not None and not isinstance(request.tool_choice, str):
-            if not effective_tools:
-                return "Tools cannot be empty if tool choice is set to a specific tool."
-            tool_name = request.tool_choice.function.name
-            tool_exists = any(
-                tool.function.name == tool_name for tool in effective_tools
-            )
-            if not tool_exists:
-                return f"Tool '{tool_name}' not found in tools list."
-
-        if has_message_tools:
-            names = [tool.function.name for tool in effective_tools]
-            if len(names) != len(set(names)):
-                return "Tool names must be unique across request and message tools."
-
-        # Validate tool definitions
-        for i, tool in enumerate(effective_tools):
-            if tool.function.parameters is None:
-                continue
-            try:
-                # Rewrite DB/ORM-style aliases (e.g. "varchar", "enum", "int")
-                # to standard JSON Schema types before validation. RecursionError
-                # guards against hand-crafted cyclic schemas so the request gets
-                # a 400 instead of crashing into a 500.
-                normalize_json_schema_types(tool.function.parameters)
-                Draft202012Validator.check_schema(tool.function.parameters)
-            except SchemaError as e:
-                return f"Tool {i} function has invalid 'parameters' schema: {str(e)}"
-            except RecursionError:
-                return (
-                    f"Tool {i} function 'parameters' schema is too deeply nested "
-                    "or contains a cycle."
-                )
-
-        max_output_tokens = request.max_completion_tokens or request.max_tokens
-        server_context_length = get_model().context_length
-        if (
-            max_output_tokens
-            and server_context_length
-            and max_output_tokens > server_context_length
-        ) and not get_serving().allow_auto_truncate:
-            return (
-                f"max_completion_tokens is too large: {max_output_tokens}."
-                f"This model supports at most {server_context_length} completion tokens."
-            )
-
-        if request.response_format and request.response_format.type == "json_schema":
-            schema = getattr(request.response_format.json_schema, "schema_", None)
-            if schema is None:
-                return "schema_ is required for json_schema response format request."
-
-        return None
-
-    def _validate_media_content(self, request: ChatCompletionRequest) -> Optional[str]:
-        if self.tokenizer_manager.model_config.is_multimodal:
-            return None
-
-        media_type = next(
-            (
-                part.type
-                for message in request.messages
-                if isinstance(message.content, list)
-                for part in message.content
-                if part.type in _MEDIA_CONTENT_PART_TYPES
-            ),
-            None,
-        )
-        if media_type is None:
-            return None
-
+        chat_input = from_chat_request(request)
         return (
-            "Model only supports text input; "
-            f"received unsupported content type '{media_type}'."
+            validate_chat_input(chat_input)
+            or validate_media_content(
+                chat_input, self.tokenizer_manager.model_config.is_multimodal
+            )
+            or validate_chat_generation_options(request)
         )
 
     def _convert_to_internal_request(
@@ -1049,6 +395,8 @@ class OpenAIServingChat(OpenAIServingBase):
         request: ChatCompletionRequest,
         raw_request: Request = None,
     ) -> tuple[GenerateReqInput, ChatCompletionRequest]:
+
+        request = request.model_copy(deep=True)
 
         # Header-based opt-in (same rationale as request_headers.py).
         if raw_request is not None and not request.return_input_ids_in_sglext:
@@ -1095,10 +443,8 @@ class OpenAIServingChat(OpenAIServingBase):
                     "Please set stream=false when using return_meta_info=true."
                 )
 
-        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-
-        # Process messages and apply chat template
-        processed_messages = self._process_messages(request, is_multimodal)
+        processed_messages = self.input_processor.prepare(from_chat_request(request))
+        request = with_prepared_options(request, processed_messages)
         # Build sampling parameters
         sampling_params = request.to_sampling_params(
             stop=processed_messages.stop,
@@ -1110,7 +456,7 @@ class OpenAIServingChat(OpenAIServingBase):
             sampling_params, processed_messages.reasoning_end_token_ids
         )
 
-        prompt_kwargs = to_generate_prompt_kwargs(processed_messages.engine_prompt)
+        prompt_kwargs = processed_messages.prompt.to_generate_kwargs()
 
         # Extract custom labels from raw request headers
         custom_labels = self.extract_custom_labels(raw_request)
@@ -1175,458 +521,6 @@ class OpenAIServingChat(OpenAIServingBase):
             apply_header_overrides(adapted_request, raw_request.headers)
 
         return adapted_request, request
-
-    def _process_messages(
-        self, request: ChatCompletionRequest, is_multimodal: bool
-    ) -> MessageProcessingResult:
-        """Process chat messages and apply chat template"""
-        if self.default_chat_template_kwargs:
-            ctk = dict(request.chat_template_kwargs or {})
-            for k, v in self.default_chat_template_kwargs.items():
-                ctk.setdefault(k, v)
-            request.chat_template_kwargs = ctk
-            effort = ctk.get("reasoning_effort")
-            if effort is not None and request.reasoning_effort is None:
-                request.reasoning_effort = effort
-
-        normalize_hunyuan_reasoning_effort(
-            request, self.reasoning_parser, self.template_manager.reasoning_config
-        )
-
-        # GptOss model needs to keep special tokens for harmony parsing
-        if self.is_gpt_oss or self.is_gemma4:
-            request.skip_special_tokens = False
-
-        self._patch_reasoning_skip_special_tokens(request)
-
-        thinking_mode = self._get_reasoning_from_request(request)
-        # SGLang's ReasonerGrammarBackend owns the reasoning prefix
-        # when --reasoning-parser is configured, so builtin xgrammar
-        # tags must describe only the post-reasoning tool-call suffix.
-        xgrammar_reasoning = thinking_mode and (self.reasoning_parser is None)
-        tool_call_constraint = None
-
-        # Apply chat template and its stop strings
-        tools = None
-        tool_call_stop = None
-        required_parsed_natively = False
-        effective_tools = self._effective_tools(request)
-        if effective_tools and request.tool_choice != "none":
-            request.skip_special_tokens = False
-            if not isinstance(request.tool_choice, str):
-                tools = [
-                    item.model_dump()
-                    for item in request.tools or []
-                    if item.function.name == request.tool_choice.function.name
-                ] or None
-            elif request.tools:
-                tools = [item.model_dump() for item in request.tools]
-            if self.tool_call_parser:
-                parser = FunctionCallParser(
-                    effective_tools,
-                    self.tool_call_parser,
-                    tokenizer=self.tokenizer_manager.tokenizer,
-                )
-                tool_call_constraint = parser.get_structure_constraint(
-                    request.tool_choice,
-                    parallel_tool_calls=request.parallel_tool_calls,
-                    thinking_mode=xgrammar_reasoning,
-                )
-                required_parsed_natively = parser.detector.parses_required_natively()
-                if self.chat_encoding_spec == "kimi_k3":
-                    tool_call_stop = parser.detector.eot_token
-            if (
-                tool_call_constraint is None
-                and not required_parsed_natively
-                and not (
-                    self.chat_encoding_spec == "kimi_k3"
-                    and self.tool_call_parser == "kimi_k3"
-                )
-                and (
-                    request.tool_choice == "required"
-                    or isinstance(request.tool_choice, ToolChoice)
-                )
-            ):
-                json_schema = get_json_schema_constraint(
-                    effective_tools,
-                    request.tool_choice,
-                    parallel_tool_calls=request.parallel_tool_calls,
-                )
-                tool_call_constraint = ("json_schema", json_schema)
-
-        # When input_ids are provided, skip template tokenization entirely;
-        # only stop tokens and tool_call_constraint are needed.
-        if request.input_ids is not None:
-            result = MessageProcessingResult(
-                engine_prompt=request.input_ids,
-                prompt="",
-                prompt_ids=request.input_ids,
-                image_data=None,
-                audio_data=None,
-                video_data=None,
-                modalities=[],
-                stop=request.stop or [],
-            )
-        elif self.template_manager.chat_template_name is None:
-            result = self._apply_jinja_template(request, tools, is_multimodal)
-        else:
-            result = self._apply_conversation_template(request, is_multimodal)
-
-        if tool_call_stop is not None:
-            if isinstance(result.stop, str):
-                result.stop = [result.stop]
-            elif result.stop is None:
-                result.stop = []
-            else:
-                result.stop = list(result.stop)
-            if tool_call_stop not in result.stop:
-                result.stop.append(tool_call_stop)
-
-        result.tool_call_constraint = tool_call_constraint
-        result.require_reasoning = thinking_mode
-        result.skip_special_tokens = request.skip_special_tokens
-        if self.reasoning_parser == "k2_horizon" and thinking_mode:
-            parser = ReasoningParser(
-                model_type=self.reasoning_parser,
-                stream_reasoning=False,
-                force_reasoning=True,
-                request=request,
-                tokenizer=self.tokenizer_manager.tokenizer,
-            )
-            token_ids = self.tokenizer_manager.tokenizer.encode(
-                parser.detector.think_end_token,
-                add_special_tokens=False,
-            )
-            if hasattr(token_ids, "tolist"):
-                token_ids = token_ids.tolist()
-            if (
-                not isinstance(token_ids, list)
-                or not token_ids
-                or any(
-                    type(token_id) is not int or token_id < 0 for token_id in token_ids
-                )
-            ):
-                raise ValueError(
-                    "The selected K2 reasoning terminator could not be encoded"
-                )
-            result.reasoning_end_token_ids = list(token_ids)
-        return result
-
-    def _apply_jinja_template(
-        self,
-        request: ChatCompletionRequest,
-        tools: Optional[List[Dict]],
-        is_multimodal: bool,
-    ) -> MessageProcessingResult:
-        """Apply Jinja chat template"""
-        prompt = ""
-        prompt_ids = []
-        openai_compatible_messages = []
-        image_data = []
-        video_data = []
-        audio_data = []
-        modalities = []
-
-        template_content_format = self.template_manager.jinja_template_content_format
-
-        # Try custom encoding first (override in subclass for custom renderers)
-        thinking_requested = (request.chat_template_kwargs or {}).get(
-            "thinking", envs.SGLANG_DEFAULT_THINKING.get()
-        )
-        thinking_mode = (
-            ThinkingMode.THINKING if thinking_requested else ThinkingMode.CHAT
-        )
-        messages = [msg.model_dump() for msg in request.messages]
-        for message in messages:
-            normalize_assistant_tool_call_arguments(
-                message, strict=self.chat_encoding_spec != "kimi_k3"
-            )
-
-        prompt_ids = self._encode_messages(
-            copy.deepcopy(messages),
-            request,
-            thinking_mode,
-            tools=tools,
-        )
-
-        if prompt_ids is not None:
-            engine_prompt = prompt_ids
-            if self.chat_encoding_spec in ("inkling", "kimi_k3"):
-                for message in request.messages:
-                    msg_dict = message.model_dump()
-                    if msg_dict.get("content") is None:
-                        msg_dict["content"] = ""
-                    process_content_for_template_format(
-                        msg_dict,
-                        "openai",
-                        image_data,
-                        video_data,
-                        audio_data,
-                        modalities,
-                    )
-        elif self.chat_encoding_spec is not None:
-            # dsv4/dsv32 encoding path
-            messages = copy.deepcopy(messages)
-
-            # dsv4/dsv32 are text-only and consume string content; flatten
-            # OpenAI parts-list content here so the encoder sees a plain string.
-            for i, msg in enumerate(messages):
-                if isinstance(msg.get("content"), list):
-                    messages[i] = process_content_for_template_format(
-                        msg, "string", [], [], [], []
-                    )
-
-            for msg in messages:
-                if msg.get("content") is None:
-                    msg["content"] = ""
-                processed_msg = process_content_for_template_format(
-                    msg,
-                    template_content_format,
-                    image_data,
-                    video_data,
-                    audio_data,
-                    modalities,
-                    use_dpsk_v32_encoding=self.chat_encoding_spec == "dsv32",
-                )
-                msg.update(processed_msg)
-
-            # Handle continue_final_message: separate final assistant message
-            messages, assistant_prefix = self._handle_last_assistant_message(
-                messages, request
-            )
-
-            if messages[0]["role"] != "system":
-                # insert an empty system prompt to help render tool system prompt
-                messages.insert(0, {"role": "system", "content": ""})
-            if request.tools:
-                messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
-
-            # Default encoding (dsv4/dsv32)
-            if self.chat_encoding_spec == "dsv4":
-                effort_source = request.reasoning_effort
-                if effort_source is None:
-                    env_val = envs.SGLANG_DSV4_REASONING_EFFORT.get()
-                    if env_val:
-                        effort_source = env_val
-                reasoning_effort_profile = self._dsv4_reasoning_effort_profile
-                assert reasoning_effort_profile is not None
-                accepted_efforts = encoding_dsv4.REASONING_EFFORT_PROFILES[
-                    reasoning_effort_profile
-                ]
-                v4_reasoning_effort = (
-                    effort_source if effort_source in accepted_efforts else None
-                )
-                if request.task is not None:
-                    encoding_dsv4.attach_task_to_last_user_message(
-                        messages, request.task
-                    )
-                real_input = encoding_dsv4.encode_messages(
-                    messages,
-                    thinking_mode=thinking_mode,
-                    reasoning_effort=v4_reasoning_effort,
-                    reasoning_effort_profile=reasoning_effort_profile,
-                )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
-            else:
-                real_input = encoding_dsv32.encode_messages(
-                    messages, thinking_mode=thinking_mode
-                )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
-
-            # Append assistant prefix if continue_final_message is enabled
-            if assistant_prefix:
-                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
-                    prompt_ids, assistant_prefix
-                )
-            engine_prompt = prompt_ids
-        else:
-            if self.template_manager.jinja_template_may_reorder_tool_results:
-                messages = self._canonicalize_tool_message_order(messages)
-            for msg_dict in copy.deepcopy(messages):
-                if msg_dict.get("content") is None:
-                    msg_dict["content"] = ""
-
-                # Process content based on detected template format
-                processed_msg = process_content_for_template_format(
-                    msg_dict,
-                    template_content_format,
-                    image_data,
-                    video_data,
-                    audio_data,
-                    modalities,
-                )
-
-                processed_msg["content"] = normalize_tool_content(
-                    processed_msg["role"], processed_msg.get("content")
-                )
-
-                openai_compatible_messages.append(processed_msg)
-
-            # Handle continue_final_message: separate final assistant message
-            openai_compatible_messages, assistant_prefix = (
-                self._handle_last_assistant_message(openai_compatible_messages, request)
-            )
-
-            extra_template_kwargs = {}
-            if request.reasoning_effort is not None:
-                extra_template_kwargs["reasoning_effort"] = request.reasoning_effort
-            if request.chat_template_kwargs:
-                extra_template_kwargs.update(request.chat_template_kwargs)
-
-            rc = self.template_manager.reasoning_config
-            if rc is not None and rc.effort_kwarg is not None:
-                if request.reasoning_effort == "low":
-                    extra_template_kwargs.setdefault(rc.effort_kwarg, True)
-                elif request.reasoning_effort in ("medium", "high", "max"):
-                    logger.warning(
-                        "Model '%s' supports only 'low' reasoning effort; "
-                        "requested '%s' treated as default thinking",
-                        self.tokenizer_manager.served_model_name,
-                        request.reasoning_effort,
-                    )
-
-            # Split apply_chat_template(tokenize=True) into render + encode so we
-            # can skip add_special_tokens=False on tokenizers that don't auto-add
-            # specials (Kimi-like, OpenAI-chat analogue of #25265). Chat
-            # templates already include role/special tokens, so the encode must
-            # avoid double BOS on tokenizers that would add it.
-            encode_kwargs = (
-                {"add_special_tokens": False}
-                if self._tokenizer_auto_adds_specials
-                else {}
-            )
-            try:
-                rendered_prompt = self.tokenizer_manager.tokenizer.apply_chat_template(
-                    openai_compatible_messages,
-                    tokenize=False,
-                    add_generation_prompt=True,
-                    tools=tools,
-                    return_dict=False,
-                    **extra_template_kwargs,
-                )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                    rendered_prompt, **encode_kwargs
-                )
-            except Exception:
-                # If the first attempt fails, try with flat function-only format.
-                # Some templates (e.g. Mistral) expect tools without the OpenAI wrapper.
-                tools = (
-                    [t["function"] if "function" in t else t for t in tools]
-                    if tools
-                    else None
-                )
-                try:
-                    rendered_prompt = (
-                        self.tokenizer_manager.tokenizer.apply_chat_template(
-                            openai_compatible_messages,
-                            tokenize=False,
-                            add_generation_prompt=True,
-                            tools=tools,
-                            return_dict=False,
-                            **extra_template_kwargs,
-                        )
-                    )
-                    prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                        rendered_prompt, **encode_kwargs
-                    )
-                except _CHAT_TEMPLATE_CLIENT_ERRORS as template_error:
-                    # Template errors (e.g., from raise_exception in Jinja templates)
-                    # and TypeError (e.g., tojson filter on Jinja2 Undefined variables)
-                    # should be treated as client errors (400 BadRequest)
-                    raise ValueError(str(template_error)) from template_error
-
-            # Append assistant prefix if continue_final_message is enabled
-            if assistant_prefix:
-                prompt_ids = self._append_assistant_prefix_to_prompt_ids(
-                    prompt_ids, assistant_prefix
-                )
-
-            if is_multimodal:
-                prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
-            engine_prompt = prompt if is_multimodal else prompt_ids
-
-        stop = request.stop
-        image_data = image_data if image_data else None
-        audio_data = audio_data if audio_data else None
-        video_data = video_data if video_data else None
-        modalities = modalities if modalities else []
-        return MessageProcessingResult(
-            engine_prompt=engine_prompt,
-            prompt=prompt,
-            prompt_ids=prompt_ids,
-            image_data=image_data,
-            video_data=video_data,
-            audio_data=audio_data,
-            modalities=modalities,
-            stop=stop,
-        )
-
-    def _apply_conversation_template(
-        self,
-        request: ChatCompletionRequest,
-        is_multimodal: bool,
-    ) -> MessageProcessingResult:
-        """Apply conversation template"""
-        prompt = ""
-        prompt_ids = []
-        conv = generate_chat_conv(request, self.template_manager.chat_template_name)
-
-        # If we should continue the final assistant message, adjust the conversation.
-        if (
-            request.continue_final_message
-            and request.messages
-            and request.messages[-1].role == "assistant"
-        ):
-            # Remove the auto-added blank assistant turn, if present.
-            if conv.messages and conv.messages[-1][1] is None:
-                conv.messages.pop()
-            # Rebuild the prompt from the conversation.
-            prompt = conv.get_prompt()
-            # Strip trailing stop tokens or separators that indicate end-of-assistant.
-            if isinstance(conv.stop_str, list):
-                for stop_token in conv.stop_str:
-                    if prompt.endswith(stop_token):
-                        prompt = prompt[: -len(stop_token)]
-            elif isinstance(conv.stop_str, str) and prompt.endswith(conv.stop_str):
-                prompt = prompt[: -len(conv.stop_str)]
-            if conv.sep and prompt.endswith(conv.sep):
-                prompt = prompt[: -len(conv.sep)]
-            if getattr(conv, "sep2", None) and prompt.endswith(conv.sep2):
-                prompt = prompt[: -len(conv.sep2)]
-        else:
-            prompt = conv.get_prompt()
-            if self._get_reasoning_from_request(request) and (
-                self._reasoning_detector is None
-                or not self._reasoning_detector.thinks_internally
-            ):
-                # Models with thinks_internally=True think without a leading <think> token
-                prompt += "<think>"  # Note(Xinyuan): hard code thinking token
-
-        image_data = conv.image_data if conv.image_data else None
-        video_data = conv.video_data if conv.video_data else None
-        audio_data = conv.audio_data if conv.audio_data else None
-        modalities = conv.modalities if conv.modalities else []
-        stop = copy.copy(conv.stop_str or [] if not request.ignore_eos else [])
-
-        if request.stop:
-            if isinstance(request.stop, str):
-                stop.append(request.stop)
-            else:
-                stop.extend(request.stop)
-
-        if not is_multimodal:
-            prompt_ids = self.tokenizer_manager.tokenizer.encode(prompt)
-
-        return MessageProcessingResult(
-            engine_prompt=prompt if is_multimodal else prompt_ids,
-            prompt=prompt,
-            prompt_ids=prompt_ids,
-            image_data=image_data,
-            video_data=video_data,
-            audio_data=audio_data,
-            modalities=modalities,
-            stop=stop,
-        )
 
     async def _handle_streaming_request(
         self,
@@ -2099,7 +993,9 @@ class OpenAIServingChat(OpenAIServingBase):
             if self.reasoning_parser and request.separate_reasoning:
                 force_reasoning = (
                     self.template_manager.force_reasoning
-                    or self._get_reasoning_from_request(request)
+                    or self.input_processor._get_reasoning_from_request(
+                        from_chat_request(request)
+                    )
                 )
                 try:
                     parser = ReasoningParser(
@@ -2440,7 +1336,9 @@ class OpenAIServingChat(OpenAIServingBase):
         if index not in reasoning_parser_dict:
             is_force_reasoning = (
                 self.template_manager.force_reasoning
-                or self._get_reasoning_from_request(request)
+                or self.input_processor._get_reasoning_from_request(
+                    from_chat_request(request)
+                )
             )
             reasoning_parser_dict[index] = ReasoningParser(
                 self.reasoning_parser,
@@ -2479,30 +1377,6 @@ class OpenAIServingChat(OpenAIServingBase):
                 tool_calls = getattr(msg, "tool_calls", None)
                 idx += len(list(tool_calls)) if tool_calls is not None else 0  # noqa
         return idx
-
-    def _patch_reasoning_skip_special_tokens(
-        self, request: ChatCompletionRequest
-    ) -> None:
-        """Keep parser-specific reasoning markers in the decoded text.
-
-        Some reasoning parsers rely on special-token delimiters that would be
-        removed during detokenization when ``skip_special_tokens=True``.
-        """
-        if self.reasoning_parser == "apertus2509":
-            request.skip_special_tokens = False
-        if self.reasoning_parser == "kimi_k3" or self.chat_encoding_spec == "kimi_k3":
-            request.skip_special_tokens = False
-
-        if (
-            self.reasoning_parser in ["mistral"]
-            and request.reasoning_effort is not None
-            and request.reasoning_effort != "none"
-        ):
-            request.skip_special_tokens = False
-        elif self.reasoning_parser == "inkling":
-            request.skip_special_tokens = False
-        elif self.reasoning_parser == "muse":
-            request.skip_special_tokens = False
 
     def supports_native_reasoning_history(self) -> bool:
         """Whether the chat encoder takes history as ``reasoning_content`` rather
@@ -2625,87 +1499,6 @@ class OpenAIServingChat(OpenAIServingBase):
         chat_template_kwargs = dict(request.chat_template_kwargs or {})
         chat_template_kwargs[toggle_param] = enabled
         request.chat_template_kwargs = chat_template_kwargs
-
-    def _get_reasoning_from_request(self, request: ChatCompletionRequest) -> bool:
-        """Determine whether reasoning mode should be enabled for this request.
-
-        NOTE: This is predefined based on model's chat template
-        """
-        if not self.reasoning_parser:
-            return False
-
-        if self.reasoning_parser == "minimax-m3":
-            # M3 template prefills <mm:think> for thinking_mode=enabled, so it never
-            # appears in output and reasoning must be forced. Mirrors reasoning_parser.py.
-            return (request.chat_template_kwargs or {}).get(
-                "thinking_mode"
-            ) == "enabled"
-
-        if self.reasoning_parser == "hunyuan":
-            config = self.template_manager.reasoning_config
-            if config is not None and config.special_case == "hunyuan_effort":
-                return request.reasoning_effort not in ("none", "no_think")
-            # Hy3-preview template emits no <think> when reasoning_effort is
-            # "no_think" / "none" / unset; forcing reasoning would route all
-            # output into reasoning_content.
-            return request.reasoning_effort not in (None, "none", "no_think")
-
-        config = self.template_manager.reasoning_config
-        if config is None:
-            # Fallback to parser-level defaults when template toggle config
-            # cannot be inferred (e.g., parser-only <think> templates).
-            mode = (
-                self._reasoning_detector.reasoning_default
-                if self._reasoning_detector is not None
-                else None
-            )
-            if mode is None:
-                return False
-            if mode == "always":
-                return True
-            if mode == "mistral":
-                return (
-                    request.reasoning_effort is not None
-                    and request.reasoning_effort != "none"
-                )
-            if mode in ("thinking", "enable_thinking"):
-                return (
-                    not request.chat_template_kwargs
-                    or request.chat_template_kwargs.get(mode) is not False
-                )
-            if mode in ("explicit_thinking", "explicit_enable_thinking"):
-                toggle = mode.replace("explicit_", "")
-                return (
-                    request.chat_template_kwargs is not None
-                    and request.chat_template_kwargs.get(toggle) is True
-                )
-            logger.warning(
-                "Unknown reasoning_default mode '%s', defaulting to reasoning disabled",
-                mode,
-            )
-            return False
-
-        if config.special_case == "always":
-            return True
-
-        if config.special_case == "mistral":
-            return (
-                request.reasoning_effort is not None
-                and request.reasoning_effort != "none"
-            )
-
-        if config.toggle_param is None or config.default_enabled is None:
-            return False
-
-        if config.default_enabled:
-            return (
-                not request.chat_template_kwargs
-                or request.chat_template_kwargs.get(config.toggle_param) is not False
-            )
-        return (
-            request.chat_template_kwargs is not None
-            and request.chat_template_kwargs.get(config.toggle_param) is True
-        )
 
     async def _process_tool_call_stream(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -78,6 +78,7 @@ from sglang.srt.entrypoints.openai.utils import (
     process_spec_tokens_details_from_ret,
     should_include_usage,
     spec_tokens_details_from_meta_info,
+    to_generate_prompt_kwargs,
     to_openai_style_logprobs,
 )
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
@@ -1043,22 +1044,6 @@ class OpenAIServingChat(OpenAIServingBase):
             f"received unsupported content type '{media_type}'."
         )
 
-    def _engine_prompt(
-        self, processed_messages: MessageProcessingResult, is_multimodal: bool
-    ) -> tuple[str, Any]:
-        """Standard VLMs render a text prompt (with placeholder strings) for
-        the MM processor to tokenize. Token-first encoders instead produce
-        pre-rendered input_ids with single placeholder ids and leave the text
-        empty; pass those through rather than re-tokenizing an empty prompt.
-        """
-        if is_multimodal and not chat_encoding.spec_renders_prompt_ids(
-            self.chat_encoding_spec
-        ):
-            return "text", processed_messages.prompt
-        if isinstance(processed_messages.prompt_ids, str):
-            return "text", processed_messages.prompt_ids
-        return "input_ids", processed_messages.prompt_ids
-
     def _convert_to_internal_request(
         self,
         request: ChatCompletionRequest,
@@ -1125,14 +1110,7 @@ class OpenAIServingChat(OpenAIServingBase):
             sampling_params, processed_messages.reasoning_end_token_ids
         )
 
-        # Handle single vs multiple requests
-        if request.input_ids is not None:
-            prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
-        else:
-            prompt_key, prompt_value = self._engine_prompt(
-                processed_messages, is_multimodal
-            )
-            prompt_kwargs = {prompt_key: prompt_value}
+        prompt_kwargs = to_generate_prompt_kwargs(processed_messages.engine_prompt)
 
         # Extract custom labels from raw request headers
         custom_labels = self.extract_custom_labels(raw_request)
@@ -1280,6 +1258,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # only stop tokens and tool_call_constraint are needed.
         if request.input_ids is not None:
             result = MessageProcessingResult(
+                engine_prompt=request.input_ids,
                 prompt="",
                 prompt_ids=request.input_ids,
                 image_data=None,
@@ -1371,6 +1350,7 @@ class OpenAIServingChat(OpenAIServingBase):
         )
 
         if prompt_ids is not None:
+            engine_prompt = prompt_ids
             if self.chat_encoding_spec in ("inkling", "kimi_k3"):
                 for message in request.messages:
                     msg_dict = message.model_dump()
@@ -1458,6 +1438,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 prompt_ids = self._append_assistant_prefix_to_prompt_ids(
                     prompt_ids, assistant_prefix
                 )
+            engine_prompt = prompt_ids
         else:
             if self.template_manager.jinja_template_may_reorder_tool_results:
                 messages = self._canonicalize_tool_message_order(messages)
@@ -1562,6 +1543,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
             if is_multimodal:
                 prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
+            engine_prompt = prompt if is_multimodal else prompt_ids
 
         stop = request.stop
         image_data = image_data if image_data else None
@@ -1569,6 +1551,7 @@ class OpenAIServingChat(OpenAIServingBase):
         video_data = video_data if video_data else None
         modalities = modalities if modalities else []
         return MessageProcessingResult(
+            engine_prompt=engine_prompt,
             prompt=prompt,
             prompt_ids=prompt_ids,
             image_data=image_data,
@@ -1635,6 +1618,7 @@ class OpenAIServingChat(OpenAIServingBase):
             prompt_ids = self.tokenizer_manager.tokenizer.encode(prompt)
 
         return MessageProcessingResult(
+            engine_prompt=prompt if is_multimodal else prompt_ids,
             prompt=prompt,
             prompt_ids=prompt_ids,
             image_data=image_data,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -38,6 +38,8 @@ from openai.types.responses.response_reasoning_summary_part_done_event import (
 )
 from openai_harmony import Message as OpenAIMessage
 
+from sglang.srt.entrypoints.chat_input.types import PreparedChat, TokenPrompt
+from sglang.srt.entrypoints.chat_input.validation import MediaInputError
 from sglang.srt.entrypoints.context import (
     ConversationContext,
     HarmonyContext,
@@ -54,11 +56,13 @@ from sglang.srt.entrypoints.harmony_utils import (
     parse_response_input,
     render_for_completion,
 )
+from sglang.srt.entrypoints.openai.chat_input_adapter import (
+    from_responses_request,
+    with_prepared_options,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageParam,
-    ChatCompletionRequest,
     Function,
-    MessageProcessingResult,
     PromptTokenUsageInfo,
     RequestResponseMetadata,
     ResponsesRequest,
@@ -69,7 +73,6 @@ from sglang.srt.entrypoints.openai.protocol import (
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
 from sglang.srt.entrypoints.openai.utils import (
-    to_generate_prompt_kwargs,
     to_openai_style_logprobs,
 )
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -87,10 +90,6 @@ if TYPE_CHECKING:
     from sglang.srt.parser.template_manager import TemplateManager
 
 logger = logging.getLogger(__name__)
-
-
-class _MediaInputValidationError(ValueError):
-    pass
 
 
 def _build_output_text_logprobs(meta_info: dict) -> list[Logprob]:
@@ -151,8 +150,11 @@ class OpenAIServingResponses(OpenAIServingChat):
         *,
         enable_prompt_tokens_details: bool = False,
         tool_server: Optional[ToolServer] = None,
+        input_processor=None,
     ) -> None:
-        super().__init__(tokenizer_manager, template_manager)
+        super().__init__(
+            tokenizer_manager, template_manager, input_processor=input_processor
+        )
 
         # template_manager is already set by parent class; reasoning_parser comes
         # from the parent, which reads the manager's control-plane overlay.
@@ -303,23 +305,22 @@ class OpenAIServingResponses(OpenAIServingChat):
         try:
             model_name = request.model
             tokenizer = self.tokenizer_manager.tokenizer
-            processed_messages: Optional[MessageProcessingResult] = None
+            processed_messages: Optional[PreparedChat] = None
 
             if self.use_harmony:
-                messages, request_prompts, engine_prompts = (
-                    self._make_request_with_harmony(request, prev_response)
+                messages, engine_prompt = self._make_request_with_harmony(
+                    request, prev_response
                 )
                 require_reasoning = self._is_thinking_enabled_for_request(request)
             else:
-                (
-                    messages,
-                    request_prompts,
-                    engine_prompts,
-                    processed_messages,
-                ) = await self._make_request(request, prev_response, tokenizer)
+                messages, processed_messages = await self._make_request(
+                    request, prev_response, tokenizer
+                )
+                engine_prompt = processed_messages.prompt
+                request = with_prepared_options(request, processed_messages)
                 require_reasoning = processed_messages.require_reasoning
 
-        except _MediaInputValidationError as e:
+        except MediaInputError as e:
             return self.create_error_response(str(e))
         except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
@@ -344,7 +345,6 @@ class OpenAIServingResponses(OpenAIServingChat):
             )
 
         # Schedule the request and get the result generator
-        generators: list[AsyncGenerator[Any, None]] = []
         tool_list = []
         if self.use_harmony:
             if self.supports_browsing:
@@ -366,124 +366,106 @@ class OpenAIServingResponses(OpenAIServingChat):
                 else:
                     assert len(tool_list) == 0
                     tool_sessions = {}
-                for i, engine_prompt in enumerate(engine_prompts):
-                    # Calculate default max tokens from context length minus prompt length
-                    if isinstance(engine_prompt, list):
-                        prompt_length = len(engine_prompt)
-                    elif isinstance(engine_prompt, str):
-                        prompt_length = len(tokenizer.encode(engine_prompt))
-                    else:
-                        prompt_length = 0
+                # Calculate default max tokens from context length minus prompt length
+                if isinstance(engine_prompt, TokenPrompt):
+                    prompt_length = len(engine_prompt.token_ids)
+                else:
+                    prompt_length = len(tokenizer.encode(engine_prompt.text))
 
-                    context_len = (
-                        self.tokenizer_manager.model_config.context_len
-                        if hasattr(self.tokenizer_manager.model_config, "context_len")
-                        else 4096
-                    )
-                    # Account for reserved tokens (e.g., EAGLE speculative decoding slots)
-                    # that the tokenizer_manager adds during validation
-                    num_reserved_tokens = self.tokenizer_manager.num_reserved_tokens
-                    default_max_tokens = max(
-                        context_len - prompt_length - num_reserved_tokens, 512
-                    )  # Ensure minimum 512 tokens
-                    sampling_params = request.to_sampling_params(
-                        default_max_tokens,
-                        self.default_sampling_params,
-                        stop=(
-                            processed_messages.stop
-                            if processed_messages
-                            else request.stop
-                        ),
-                        tool_call_constraint=(
-                            processed_messages.tool_call_constraint
-                            if processed_messages
-                            else None
-                        ),
-                    )
-                    if processed_messages is not None:
-                        set_request_reasoning_end_token_ids(
-                            sampling_params,
-                            processed_messages.reasoning_end_token_ids,
-                        )
-                    # _process_messages set skip_special_tokens on a chat_request
-                    # we then discard, so re-apply it to the engine sampling dict.
-                    if processed_messages is not None and (
-                        not processed_messages.skip_special_tokens
-                    ):
-                        sampling_params["skip_special_tokens"] = False
-
-                    context: ConversationContext
-                    if self.use_harmony:
-                        if request.stream:
-                            context = StreamingHarmonyContext(messages, tool_sessions)
-                        else:
-                            context = HarmonyContext(messages, tool_sessions)
-                    else:
-                        context = SimpleContext()
-
-                    # Create GenerateReqInput for SGLang
-                    prompt_kwargs = to_generate_prompt_kwargs(engine_prompt)
-
-                    logprob_kwargs = (
-                        {
-                            "return_logprob": True,
-                            "logprob_start_len": -1,
-                            "top_logprobs_num": request.top_logprobs or 0,
-                            "return_text_in_logprobs": True,
-                        }
-                        if request.is_include_output_logprobs()
-                        else {}
-                    )
-
-                    adapted_request = GenerateReqInput(
-                        **prompt_kwargs,
-                        **logprob_kwargs,
-                        image_data=(
-                            processed_messages.image_data
-                            if processed_messages
-                            else None
-                        ),
-                        video_data=(
-                            processed_messages.video_data
-                            if processed_messages
-                            else None
-                        ),
-                        audio_data=(
-                            processed_messages.audio_data
-                            if processed_messages
-                            else None
-                        ),
-                        modalities=(
-                            processed_messages.modalities
-                            if processed_messages
-                            else None
-                        ),
-                        sampling_params=sampling_params,
-                        stream=request.stream,
-                        rid=request.request_id,
-                        session_id=request.session_id,
-                        extra_key=request.extra_key,
-                        cache_salt=request.cache_salt,
-                        # background+stream streams on this connection, so don't detach.
-                        background=request.background and not request.stream,
-                        require_reasoning=require_reasoning,
-                    )
-
-                    generator = self._generate_with_builtin_tools(
-                        request.request_id,
-                        request_prompts[i],
-                        adapted_request,
+                context_len = (
+                    self.tokenizer_manager.model_config.context_len
+                    if hasattr(self.tokenizer_manager.model_config, "context_len")
+                    else 4096
+                )
+                # Account for reserved tokens (e.g., EAGLE speculative decoding slots)
+                # that the tokenizer_manager adds during validation
+                num_reserved_tokens = self.tokenizer_manager.num_reserved_tokens
+                default_max_tokens = max(
+                    context_len - prompt_length - num_reserved_tokens, 512
+                )  # Ensure minimum 512 tokens
+                sampling_params = request.to_sampling_params(
+                    default_max_tokens,
+                    self.default_sampling_params,
+                    stop=(
+                        processed_messages.stop if processed_messages else request.stop
+                    ),
+                    tool_call_constraint=(
+                        processed_messages.tool_call_constraint
+                        if processed_messages
+                        else None
+                    ),
+                )
+                if processed_messages is not None:
+                    set_request_reasoning_end_token_ids(
                         sampling_params,
-                        context,
-                        raw_request=raw_request,
-                        priority=request.priority,
+                        processed_messages.reasoning_end_token_ids,
                     )
-                    generators.append(generator)
+                if processed_messages is not None and (
+                    not processed_messages.skip_special_tokens
+                ):
+                    sampling_params["skip_special_tokens"] = False
+
+                context: ConversationContext
+                if self.use_harmony:
+                    if request.stream:
+                        context = StreamingHarmonyContext(messages, tool_sessions)
+                    else:
+                        context = HarmonyContext(messages, tool_sessions)
+                else:
+                    context = SimpleContext()
+
+                # Create GenerateReqInput for SGLang
+                prompt_kwargs = engine_prompt.to_generate_kwargs()
+
+                logprob_kwargs = (
+                    {
+                        "return_logprob": True,
+                        "logprob_start_len": -1,
+                        "top_logprobs_num": request.top_logprobs or 0,
+                        "return_text_in_logprobs": True,
+                    }
+                    if request.is_include_output_logprobs()
+                    else {}
+                )
+
+                adapted_request = GenerateReqInput(
+                    **prompt_kwargs,
+                    **logprob_kwargs,
+                    image_data=(
+                        processed_messages.image_data if processed_messages else None
+                    ),
+                    video_data=(
+                        processed_messages.video_data if processed_messages else None
+                    ),
+                    audio_data=(
+                        processed_messages.audio_data if processed_messages else None
+                    ),
+                    modalities=(
+                        processed_messages.modalities if processed_messages else None
+                    ),
+                    sampling_params=sampling_params,
+                    stream=request.stream,
+                    rid=request.request_id,
+                    session_id=request.session_id,
+                    extra_key=request.extra_key,
+                    cache_salt=request.cache_salt,
+                    # background+stream streams on this connection, so don't detach.
+                    background=request.background and not request.stream,
+                    require_reasoning=require_reasoning,
+                )
+
+                generator = self._generate_with_builtin_tools(
+                    request.request_id,
+                    adapted_request,
+                    sampling_params,
+                    context,
+                    raw_request=raw_request,
+                    priority=request.priority,
+                )
             except ValueError as e:
                 return self.create_error_response(str(e))
 
-            assert len(generators) == 1
-            (result_generator,) = generators
+            result_generator = generator
 
             # Store the input messages
             if request.store:
@@ -573,48 +555,10 @@ class OpenAIServingResponses(OpenAIServingChat):
     ):
         messages = self._construct_input_messages(request, prev_response)
 
-        chat_tools = self._response_tools_to_chat_tools(request)
-        chat_request = ChatCompletionRequest(
-            model=request.model,
-            messages=messages,
-            stream=request.stream,
-            tools=chat_tools or None,
-            tool_choice=(
-                self._chat_tool_choice(request.effective_tool_choice())
-                if chat_tools
-                else "none"
-            ),
-            parallel_tool_calls=(
-                request.parallel_tool_calls
-                if request.parallel_tool_calls is not None
-                else True
-            ),
-            stop=request.stop,
-            reasoning_effort=(request.reasoning.effort if request.reasoning else None),
-            chat_template_kwargs=request.chat_template_kwargs,
+        processed_messages = self.input_processor.prepare(
+            from_responses_request(request, messages)
         )
-
-        media_error = self._validate_media_content(chat_request)
-        if media_error:
-            raise _MediaInputValidationError(media_error)
-
-        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self._process_messages(chat_request, is_multimodal)
-        # ``_process_messages`` merges server defaults into the temporary Chat
-        # request before rendering. Response parsing happens later from the
-        # original request, so carry over the exact template kwargs that selected
-        # the wire-format delimiters.
-        request.chat_template_kwargs = (
-            dict(chat_request.chat_template_kwargs)
-            if chat_request.chat_template_kwargs is not None
-            else None
-        )
-
-        engine_prompt = processed_messages.engine_prompt
-        request_prompts = [engine_prompt]
-        engine_prompts = [engine_prompt]
-
-        return messages, request_prompts, engine_prompts, processed_messages
+        return messages, processed_messages
 
     def _make_request_with_harmony(
         self,
@@ -627,8 +571,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             )
         messages = self._construct_input_messages_with_harmony(request, prev_response)
         prompt_token_ids = render_for_completion(messages)
-        engine_prompt = prompt_token_ids
-        return messages, [prompt_token_ids], [engine_prompt]
+        return messages, TokenPrompt(prompt_token_ids)
 
     async def responses_full_generator(
         self,
@@ -2541,7 +2484,6 @@ class OpenAIServingResponses(OpenAIServingChat):
     async def _generate_with_builtin_tools(
         self,
         request_id: str,
-        request_prompt: Any,
         adapted_request: GenerateReqInput,
         sampling_params: Any,
         context: ConversationContext,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -68,7 +68,10 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
-from sglang.srt.entrypoints.openai.utils import to_openai_style_logprobs
+from sglang.srt.entrypoints.openai.utils import (
+    to_generate_prompt_kwargs,
+    to_openai_style_logprobs,
+)
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
@@ -419,10 +422,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         context = SimpleContext()
 
                     # Create GenerateReqInput for SGLang
-                    if isinstance(engine_prompt, str):
-                        prompt_kwargs = {"text": engine_prompt}
-                    else:
-                        prompt_kwargs = {"input_ids": engine_prompt}
+                    prompt_kwargs = to_generate_prompt_kwargs(engine_prompt)
 
                     logprob_kwargs = (
                         {
@@ -610,7 +610,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             else None
         )
 
-        _, engine_prompt = self._engine_prompt(processed_messages, is_multimodal)
+        engine_prompt = processed_messages.engine_prompt
         request_prompts = [engine_prompt]
         engine_prompts = [engine_prompt]
 

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -1,9 +1,15 @@
 import logging
 from http import HTTPStatus
-from typing import List, Optional, Union
+from typing import List, Union
 
 from fastapi import Request
 
+from sglang.srt.entrypoints.chat_input.validation import validate_chat_input
+from sglang.srt.entrypoints.openai.chat_input_adapter import (
+    create_chat_input_processor,
+    from_tokenize_request,
+    validate_chat_generation_options,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     DetokenizeRequest,
     DetokenizeResponse,
@@ -12,7 +18,6 @@ from sglang.srt.entrypoints.openai.protocol import (
     TokenizeResponse,
 )
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
-from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +25,18 @@ logger = logging.getLogger(__name__)
 class OpenAIServingTokenize(OpenAIServingBase):
     """Handler for /v1/tokenize requests"""
 
-    def __init__(self, tokenizer_manager, template_manager=None):
+    def __init__(
+        self, tokenizer_manager, template_manager=None, *, input_processor=None
+    ):
         super().__init__(tokenizer_manager)
-        self.chat_serving: Optional[OpenAIServingChat] = (
-            OpenAIServingChat(tokenizer_manager, template_manager)
-            if template_manager is not None
-            else None
+        self.input_processor = (
+            input_processor
+            if input_processor is not None
+            else (
+                create_chat_input_processor(tokenizer_manager, template_manager)
+                if template_manager is not None
+                else None
+            )
         )
 
     def _request_id_prefix(self) -> str:
@@ -90,34 +101,16 @@ class OpenAIServingTokenize(OpenAIServingBase):
             )
 
     def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
-        if self.chat_serving is None:
+        if self.input_processor is None:
             raise ValueError("Chat template tokenization requires a template manager.")
-
-        chat_request = request.to_chat_completion_request()
-        validation_error = self.chat_serving._validate_request(chat_request)
-        if validation_error:
-            raise ValueError(validation_error)
-
-        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self.chat_serving._process_messages(
-            chat_request, is_multimodal
+        chat_input = from_tokenize_request(request)
+        error = validate_chat_input(chat_input) or validate_chat_generation_options(
+            request
         )
-
-        prompt_ids = processed_messages.prompt_ids
-        if isinstance(prompt_ids, list) and (
-            prompt_ids or not processed_messages.prompt
-        ):
-            return prompt_ids
-        if isinstance(prompt_ids, str):
-            return self.tokenizer_manager.tokenizer.encode(
-                prompt_ids, add_special_tokens=False
-            )
-        if processed_messages.prompt:
-            return self.tokenizer_manager.tokenizer.encode(
-                processed_messages.prompt, add_special_tokens=False
-            )
-
-        raise ValueError("Failed to render chat messages into token ids.")
+        if error:
+            raise ValueError(error)
+        prepared = self.input_processor.prepare(chat_input)
+        return prepared.prompt.tokenize(self.tokenizer_manager.tokenizer)
 
 
 class OpenAIServingDetokenize(OpenAIServingBase):

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -15,6 +15,12 @@ from sglang.srt.entrypoints.openai.protocol import (
 logger = logging.getLogger(__name__)
 
 
+def to_generate_prompt_kwargs(
+    prompt: Union[str, List[int]],
+) -> Dict[str, Union[str, List[int]]]:
+    return {"text" if isinstance(prompt, str) else "input_ids": prompt}
+
+
 def to_openai_style_logprobs(
     input_token_logprobs=None,
     output_token_logprobs=None,

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -15,12 +15,6 @@ from sglang.srt.entrypoints.openai.protocol import (
 logger = logging.getLogger(__name__)
 
 
-def to_generate_prompt_kwargs(
-    prompt: Union[str, List[int]],
-) -> Dict[str, Union[str, List[int]]]:
-    return {"text" if isinstance(prompt, str) else "input_ids": prompt}
-
-
 def to_openai_style_logprobs(
     input_token_logprobs=None,
     output_token_logprobs=None,

--- a/test/registered/unit/entrypoints/openai/test_chat_input_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_chat_input_processor.py
@@ -1,0 +1,644 @@
+import asyncio
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from utils import engine_chunk, input_processor, make_serving, sync_serving
+
+from sglang.srt.entrypoints.anthropic.protocol import AnthropicCountTokensRequest
+from sglang.srt.entrypoints.anthropic.serving import AnthropicServing
+from sglang.srt.entrypoints.chat_input.processor import ChatInputProcessor
+from sglang.srt.entrypoints.chat_input.types import (
+    ChatInput,
+    ChatModelConfig,
+    RenderedPrompt,
+    TextPrompt,
+    TokenPrompt,
+)
+from sglang.srt.entrypoints.context import SimpleContext
+from sglang.srt.entrypoints.openai.chat_input_adapter import (
+    from_chat_request,
+    from_responses_request,
+    from_tokenize_request,
+    with_prepared_options,
+)
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ResponsesRequest,
+    TokenizeRequest,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.srt.entrypoints.openai.serving_tokenize import OpenAIServingTokenize
+from sglang.srt.parser.template_detection import ReasoningToggleConfig
+from sglang.srt.runtime_context import reset_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def make_processor(serving):
+    return input_processor(serving)
+
+
+class ChatInputProcessorTest(CustomTestCase):
+    def setUp(self):
+        reset_context()
+        self.addCleanup(reset_context)
+
+    def make_serving(self, spec=None, multimodal=False, template=None):
+        serving = make_serving(is_multimodal=multimodal)
+        serving.chat_encoding_spec = spec
+        serving._dsv4_reasoning_effort_profile = "official" if spec == "dsv4" else None
+        serving.template_manager.chat_template_name = template
+        serving.template_manager.jinja_template_content_format = "openai"
+        serving.default_chat_template_kwargs = {}
+        tokenizer = serving.tokenizer_manager.tokenizer
+        tokenizer.apply_chat_template.return_value = (
+            [4, -1, 6] if spec == "kimi_k3" else "rendered prompt"
+        )
+        tokenizer.decode.return_value = "decoded prompt"
+        return serving
+
+    def assert_preparation_matches(self, serving, request):
+        original = request.model_dump()
+        tokenizer = serving.tokenizer_manager.tokenizer
+        old_request = request.model_copy(deep=True)
+        tokenizer.reset_mock()
+        old, old_request = sync_serving(serving)._convert_to_internal_request(
+            old_request
+        )
+        old_calls = tokenizer.mock_calls[:]
+        tokenizer.reset_mock()
+        chat_input = from_chat_request(request)
+        new = make_processor(serving).prepare(chat_input)
+        self.assertEqual(request.model_dump(), original)
+        self.assertEqual(chat_input, from_chat_request(request))
+        self.assertEqual(tokenizer.mock_calls, old_calls)
+        self.assertEqual(
+            new.prompt.to_generate_kwargs(),
+            {key: getattr(old, key) for key in new.prompt.to_generate_kwargs()},
+        )
+        for field in (
+            "image_data",
+            "audio_data",
+            "video_data",
+            "modalities",
+            "require_reasoning",
+        ):
+            self.assertEqual(getattr(new, field), getattr(old, field), field)
+        self.assertEqual(new.stop, old.sampling_params["stop"])
+        self.assertEqual(
+            new.skip_special_tokens, old.sampling_params["skip_special_tokens"]
+        )
+        self.assertEqual(new.chat_template_kwargs, old_request.chat_template_kwargs)
+        self.assertEqual(new.reasoning_effort, old_request.reasoning_effort)
+        return new
+
+    def test_existing_renderers_preserve_payloads_and_tokenizer_calls(self):
+        messages = [{"role": "user", "content": "hi"}]
+        variants = (
+            {},
+            {"reasoning_effort": "high"},
+            {"input_ids": [11, 12], "stop": ["STOP"]},
+            {
+                "messages": messages + [{"role": "assistant", "content": "prefix"}],
+                "continue_final_message": True,
+            },
+        )
+        paths = (
+            (None, False, None),
+            (None, True, None),
+            (None, False, "chatml"),
+            (None, True, "chatml"),
+            ("dsv32", False, None),
+            ("dsv4", False, None),
+            ("inkling", True, None),
+            ("kimi_k3", True, None),
+        )
+        for spec, multimodal, template in paths:
+            for variant in variants:
+                with self.subTest(
+                    spec=spec, multimodal=multimodal, template=template, variant=variant
+                ):
+                    serving = self.make_serving(spec, multimodal, template)
+                    data = {"model": "x", "messages": messages, **variant}
+                    self.assert_preparation_matches(
+                        serving, ChatCompletionRequest(**data)
+                    )
+
+    def test_tool_constraints_and_media_order_match(self):
+        for spec in (None, "kimi_k3"):
+            for choice in (
+                "auto",
+                "required",
+                {"type": "function", "function": {"name": "lookup"}},
+            ):
+                with self.subTest(spec=spec, choice=choice):
+                    serving = self.make_serving(spec, multimodal=True)
+                    if spec == "kimi_k3":
+                        serving.tool_call_parser = "kimi_k3"
+                    request = ChatCompletionRequest(
+                        model="x",
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "compare"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "https://example.com/one.png"
+                                        },
+                                    },
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "https://example.com/two.png"
+                                        },
+                                    },
+                                ],
+                            }
+                        ],
+                        tools=[
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup",
+                                    "parameters": {"type": "object", "properties": {}},
+                                },
+                            }
+                        ],
+                        tool_choice=choice,
+                    )
+                    self.assert_preparation_matches(serving, request)
+
+    def test_responses_adapter_matches_existing_message_preparation(self):
+        for with_tools in (False, True):
+            with self.subTest(with_tools=with_tools):
+                serving = self.make_serving(multimodal=True)
+                serving.default_chat_template_kwargs = {"thinking": False}
+                request = ResponsesRequest(
+                    model="x",
+                    input="hi",
+                    reasoning={"effort": "high"},
+                    store=False,
+                    tools=[
+                        {
+                            "type": "function",
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        }
+                    ]
+                    if with_tools
+                    else [],
+                    tool_choice={"type": "function", "name": "lookup"}
+                    if with_tools
+                    else "auto",
+                )
+                original = request.model_dump()
+                messages = serving._construct_input_messages(request)
+                chat_input = from_responses_request(request, messages)
+                prepared = make_processor(serving).prepare(chat_input)
+                self.assertEqual(request.model_dump(), original)
+                baseline_request = request.model_copy(deep=True)
+                _, old = asyncio.run(
+                    serving._make_request(
+                        baseline_request, None, serving.tokenizer_manager.tokenizer
+                    )
+                )
+                self.assertEqual(
+                    prepared.prompt.to_generate_kwargs(),
+                    old.prompt.to_generate_kwargs(),
+                )
+                self.assertEqual(
+                    prepared.tool_call_constraint, old.tool_call_constraint
+                )
+                self.assertEqual(
+                    prepared.chat_template_kwargs, old.chat_template_kwargs
+                )
+
+    def test_tokenize_reuses_precomputed_ids_without_selecting_generation_input(self):
+        for template in (None, "chatml"):
+            with self.subTest(template=template):
+                serving = self.make_serving(multimodal=True, template=template)
+                request = TokenizeRequest(messages=[{"role": "user", "content": "hi"}])
+                prepared = make_processor(serving).prepare(
+                    from_tokenize_request(request)
+                )
+                self.assertIsInstance(prepared.prompt, TextPrompt)
+                tokenizer = serving.tokenizer_manager.tokenizer
+                tokenizer.reset_mock()
+                self.assertEqual(prepared.prompt.tokenize(tokenizer), [1, 2, 3])
+                if template is None:
+                    tokenizer.encode.assert_not_called()
+                else:
+                    tokenizer.encode.assert_called_once_with(
+                        prepared.prompt.text, add_special_tokens=False
+                    )
+                self.assertEqual(
+                    prepared.prompt.to_generate_kwargs(), {"text": prepared.prompt.text}
+                )
+
+    def test_tokenize_adapter_matches_legacy_protocol_normalization(self):
+        messages = [{"role": "user", "content": "hi"}]
+        variants = (
+            {},
+            {"reasoning_effort": "none"},
+            {"reasoning": {"effort": "low"}},
+            {"input_ids": [21, 22]},
+            {"response_format": {"type": "json_object"}},
+            {"tools": [{"type": "function", "function": {"name": "lookup"}}]},
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "Use tools",
+                        "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                    },
+                    *messages,
+                ]
+            },
+        )
+        for spec in (None, "kimi_k3", "inkling"):
+            for variant in variants:
+                with self.subTest(spec=spec, variant=variant):
+                    serving = self.make_serving(spec, multimodal=True)
+                    endpoint = object.__new__(OpenAIServingTokenize)
+                    endpoint.input_processor = make_processor(serving)
+                    endpoint.tokenizer_manager = serving.tokenizer_manager
+                    request = TokenizeRequest(**{"messages": messages, **variant})
+                    original = request.model_dump()
+                    tokenizer = serving.tokenizer_manager.tokenizer
+                    tokenizer.reset_mock()
+                    expected = (
+                        make_processor(serving)
+                        .prepare(
+                            from_chat_request(request.to_chat_completion_request())
+                        )
+                        .prompt.tokenize(tokenizer)
+                    )
+                    old_calls = tokenizer.mock_calls[:]
+                    tokenizer.reset_mock()
+                    actual = endpoint._tokenize_chat_request(request)
+                    self.assertEqual(actual, expected)
+                    self.assertEqual(tokenizer.mock_calls, old_calls)
+                    self.assertEqual(request.model_dump(), original)
+
+    def test_reasoning_options_match_parser_requirements(self):
+        for parser in ("k2_horizon", "hunyuan", "mistral", "inkling", "kimi_k3"):
+            for effort in (None, "none", "high"):
+                with self.subTest(parser=parser, effort=effort):
+                    serving = self.make_serving()
+                    serving.reasoning_parser = parser
+                    serving.template_manager.reasoning_config = ReasoningToggleConfig(
+                        toggle_param="thinking", default_enabled=True
+                    )
+                    if parser == "hunyuan":
+                        serving.template_manager.reasoning_config = (
+                            ReasoningToggleConfig(special_case="hunyuan_effort")
+                        )
+                    self.assert_preparation_matches(
+                        serving,
+                        ChatCompletionRequest(
+                            model="x",
+                            messages=[{"role": "user", "content": "hi"}],
+                            reasoning_effort=effort,
+                        ),
+                    )
+
+    def test_resolved_options_are_request_local_on_success_and_failure(self):
+        serving = self.make_serving()
+        serving.reasoning_parser = "deepseek-r1"
+        serving.template_manager.reasoning_config = ReasoningToggleConfig(
+            toggle_param="thinking", default_enabled=True
+        )
+        defaults = {"thinking": True, "nested": {"value": 1}}
+        serving.default_chat_template_kwargs = defaults
+        processor = make_processor(serving)
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"thinking": False},
+        )
+        before = request.model_dump()
+        chat_input = from_chat_request(request)
+        first = processor.prepare(chat_input)
+        self.assertFalse(first.require_reasoning)
+        self.assertEqual(request.model_dump(), before)
+        self.assertEqual(chat_input.chat_template_kwargs, {"thinking": False})
+        first.chat_template_kwargs["nested"]["value"] = 99
+        self.assertEqual(defaults["nested"]["value"], 1)
+        second = processor.prepare(ChatInput(messages=request.messages))
+        self.assertTrue(second.require_reasoning)
+        self.assertEqual(second.chat_template_kwargs["nested"]["value"], 1)
+        effective = with_prepared_options(request, second)
+        self.assertTrue(effective.chat_template_kwargs["thinking"])
+        self.assertEqual(request.model_dump(), before)
+        processor.renderer.render = Mock(side_effect=ValueError("render failed"))
+        with self.assertRaisesRegex(ValueError, "render failed"):
+            processor.prepare(chat_input)
+        self.assertEqual(chat_input.chat_template_kwargs, {"thinking": False})
+        self.assertEqual(defaults, {"thinking": True, "nested": {"value": 1}})
+
+    def test_new_renderer_requires_no_serving_model_registration(self):
+        config = ChatModelConfig(
+            tokenizer=Mock(),
+            template_manager=SimpleNamespace(reasoning_config=None),
+            is_multimodal=True,
+            chat_encoding_spec="unregistered",
+        )
+        renderer = Mock()
+        renderer.render.return_value = RenderedPrompt(
+            prompt=TokenPrompt([4, -1, 6]), image_data=["image"]
+        )
+        processor = ChatInputProcessor(config, renderer=renderer)
+        result = processor.prepare(
+            ChatInput(messages=[{"role": "user", "content": "hi"}])
+        )
+        self.assertEqual(result.prompt.to_generate_kwargs(), {"input_ids": [4, -1, 6]})
+        self.assertEqual(result.image_data, ["image"])
+        renderer.render.assert_called_once()
+
+    def test_text_only_media_rejection_does_not_render_or_mutate_input(self):
+        serving = self.make_serving()
+        processor = make_processor(serving)
+        processor.renderer.render = Mock()
+        request = ChatInput(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "image.png"}}
+                    ],
+                }
+            ]
+        )
+        original = request.model_dump()
+        with self.assertRaisesRegex(ValueError, "only supports text"):
+            processor.prepare(request)
+        processor.renderer.render.assert_not_called()
+
+        self.assertEqual(request.model_dump(), original)
+
+    def test_stop_policy_preserves_legacy_payloads(self):
+        for spec, template in ((None, None), (None, "chatml"), ("kimi_k3", None)):
+            for stop in (None, "USER_STOP", ["USER_STOP"]):
+                for ignore_eos in (False, True):
+                    for input_ids in (None, [31, 32]):
+                        with self.subTest(
+                            spec=spec,
+                            template=template,
+                            stop=stop,
+                            ignore_eos=ignore_eos,
+                            input_ids=input_ids,
+                        ):
+                            serving = self.make_serving(spec, True, template)
+                            if spec == "kimi_k3":
+                                serving.tool_call_parser = "kimi_k3"
+                            self.assert_preparation_matches(
+                                serving,
+                                ChatCompletionRequest(
+                                    messages=[{"role": "user", "content": "hi"}],
+                                    tools=[
+                                        {
+                                            "type": "function",
+                                            "function": {"name": "lookup"},
+                                        }
+                                    ],
+                                    stop=stop,
+                                    ignore_eos=ignore_eos,
+                                    input_ids=input_ids,
+                                ),
+                            )
+
+    def test_template_stops_are_not_mutated_by_request_policy(self):
+        config = ChatModelConfig(
+            tokenizer=Mock(),
+            template_manager=SimpleNamespace(reasoning_config=None),
+            is_multimodal=True,
+        )
+        rendered = RenderedPrompt(
+            prompt=TokenPrompt([4, -1, 6]), template_stop=["TEMPLATE_STOP"]
+        )
+        renderer = Mock()
+        renderer.render.return_value = rendered
+        processor = ChatInputProcessor(config, renderer)
+        request = ChatInput(
+            messages=[{"role": "user", "content": "hi"}], stop=["USER_STOP"]
+        )
+        first = processor.prepare(request)
+        self.assertEqual(first.stop, ["TEMPLATE_STOP", "USER_STOP"])
+        second = processor.prepare(request.model_copy(update={"ignore_eos": True}))
+        self.assertEqual(second.stop, ["USER_STOP"])
+        self.assertEqual(rendered.template_stop, ["TEMPLATE_STOP"])
+        self.assertEqual(request.stop, ["USER_STOP"])
+
+    def test_adapters_do_not_delegate_to_chat_endpoint_validation(self):
+        methods = (
+            "set_tool_choice_default",
+            "normalize_reasoning_inputs",
+            "set_json_schema",
+            "validate_reasoning_effort_type",
+        )
+        with ExitStack() as patches:
+            for method in methods:
+                patches.enter_context(
+                    patch.object(
+                        ChatCompletionRequest,
+                        method,
+                        side_effect=AssertionError("Chat endpoint validation invoked"),
+                    )
+                )
+            messages = [{"role": "user", "content": "hi"}]
+            tokenize_input = from_tokenize_request(
+                TokenizeRequest(messages=messages, reasoning_effort="none")
+            )
+            responses_input = from_responses_request(
+                ResponsesRequest(input="hi", reasoning={"effort": "none"}), messages
+            )
+        self.assertEqual(
+            tokenize_input.chat_template_kwargs, responses_input.chat_template_kwargs
+        )
+        self.assertFalse(responses_input.chat_template_kwargs["thinking"])
+
+    def test_input_contract_imports_without_openai_protocol(self):
+        code = """
+import importlib.abc
+import sys
+
+class BlockOpenAIProtocol(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'sglang.srt.entrypoints.openai.protocol':
+            raise AssertionError('Shared input contract depends on the API protocol')
+
+sys.meta_path.insert(0, BlockOpenAIProtocol())
+from sglang.srt.entrypoints.chat_input.types import ChatInput
+
+chat_input = ChatInput(messages=[{'role': 'user', 'content': 'hi'}])
+assert chat_input.messages[0].content == 'hi'
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_all_endpoints_share_the_custom_renderer_and_keep_token_input(self):
+        fixture = self.make_serving(multimodal=True)
+        manager = fixture.tokenizer_manager
+        renderer = Mock()
+        renderer.render.return_value = RenderedPrompt(
+            prompt=TokenPrompt([4, -1, 6]),
+            image_data=["image"],
+            template_stop=["END"],
+        )
+        processor = ChatInputProcessor(make_processor(fixture).config, renderer)
+        endpoints = [
+            cls(manager, fixture.template_manager, input_processor=processor)
+            for cls in (
+                OpenAIServingChat,
+                OpenAIServingResponses,
+                OpenAIServingTokenize,
+            )
+        ]
+        chat, responses, tokenize = endpoints
+        self.assertTrue(
+            all(endpoint.input_processor is processor for endpoint in endpoints)
+        )
+        captured = []
+
+        async def generate(request, raw_request):
+            captured.append(request)
+            yield engine_chunk("done", finish=True)
+
+        manager.generate_request = generate
+        manager.tokenizer.reset_mock()
+        messages = [{"role": "user", "content": "hi"}]
+        chat_request = ChatCompletionRequest(messages=messages)
+        original = chat_request.model_dump()
+        adapted, _ = chat._convert_to_internal_request(chat_request)
+        response = asyncio.run(
+            responses.create_responses(
+                ResponsesRequest(model="x", input="hi", store=False)
+            )
+        )
+        tokens = tokenize._tokenize_chat_request(TokenizeRequest(messages=messages))
+        self.assertFalse(hasattr(response, "body"), getattr(response, "body", None))
+        self.assertEqual(response.status, "completed")
+        self.assertEqual(tokens, [4, -1, 6])
+        for request in (adapted, captured[0]):
+            self.assertEqual(request.input_ids, tokens)
+            self.assertIsNone(request.text)
+            self.assertEqual(request.image_data, ["image"])
+            self.assertEqual(request.sampling_params["stop"], ["END"])
+        manager.tokenizer.encode.assert_not_called()
+        self.assertEqual(chat_request.model_dump(), original)
+        count_response = asyncio.run(
+            AnthropicServing(chat).handle_count_tokens(
+                AnthropicCountTokensRequest(model="x", messages=messages), None
+            )
+        )
+        self.assertEqual(count_response.status_code, 200)
+        self.assertEqual(json.loads(count_response.body)["input_tokens"], len(tokens))
+
+    def test_harmony_keeps_native_rendering_for_full_and_streaming_responses(self):
+        serving = self.make_serving()
+        serving.use_harmony = True
+        serving.input_processor.prepare = Mock(
+            side_effect=AssertionError("Unexpected chat rendering")
+        )
+        serving._construct_input_messages_with_harmony = Mock(
+            return_value=["native message"]
+        )
+        captured = []
+
+        async def generate(request, raw_request):
+            captured.append(request)
+            yield engine_chunk("done", finish=True)
+
+        async def finish(request, params, result_generator, *args, **kwargs):
+            async for _ in result_generator:
+                pass
+            return "completed"
+
+        async def stream(request, params, result_generator, *args, **kwargs):
+            async for _ in result_generator:
+                yield "completed"
+
+        serving.tokenizer_manager.generate_request = generate
+        serving.responses_full_generator = finish
+        serving.responses_stream_generator = stream
+        module = "sglang.srt.entrypoints.openai.serving_responses"
+        with (
+            patch(module + ".render_for_completion", return_value=[77, 88]) as render,
+            patch(
+                module + ".HarmonyContext", side_effect=lambda *args: SimpleContext()
+            ),
+            patch(
+                module + ".StreamingHarmonyContext",
+                side_effect=lambda *args: SimpleContext(),
+            ),
+        ):
+            for streaming in (False, True):
+                request = ResponsesRequest(
+                    model="x", input="hi", store=False, stream=streaming
+                )
+
+                async def run():
+                    response = await serving.create_responses(request)
+                    return (
+                        [chunk async for chunk in response] if streaming else response
+                    )
+
+                self.assertEqual(
+                    asyncio.run(run()), ["completed"] if streaming else "completed"
+                )
+            self.assertEqual(render.call_count, 2)
+            render.assert_called_with(["native message"])
+        self.assertEqual(
+            [request.input_ids for request in captured], [[77, 88], [77, 88]]
+        )
+        serving.input_processor.prepare.assert_not_called()
+
+    def test_tokenize_keeps_validation_without_constructing_a_chat_handler(self):
+        fixture = self.make_serving()
+        processor = make_processor(fixture)
+        tokenize = OpenAIServingTokenize(
+            fixture.tokenizer_manager,
+            fixture.template_manager,
+            input_processor=processor,
+        )
+        processor.renderer.render = Mock()
+        requests = (
+            TokenizeRequest(messages=[]),
+            TokenizeRequest(
+                messages=[{"role": "user", "content": "hi"}], tool_choice="required"
+            ),
+            TokenizeRequest(
+                messages=[{"role": "user", "content": "hi"}], return_sampling_mask=True
+            ),
+        )
+        for request in requests:
+            with (
+                self.subTest(request=request.model_dump()),
+                self.assertRaises(ValueError),
+            ):
+                tokenize._tokenize_chat_request(request)
+        processor.renderer.render.assert_not_called()
+
+        request = TokenizeRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            input_ids=[31, 32],
+            return_sampling_mask="false",
+            max_tokens="5",
+        )
+        self.assertEqual(tokenize._tokenize_chat_request(request), [31, 32])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -513,6 +513,7 @@ class ServingChatTestCase(unittest.TestCase):
                 [],
                 ["</s>"],
                 None,
+                engine_prompt=[1, 2, 3],
             )
 
             self.basic_req.return_sampling_mask = True
@@ -546,7 +547,7 @@ class ServingChatTestCase(unittest.TestCase):
         body = request.model_dump()
 
         processed_messages = MessageProcessingResult(
-            "Test prompt", [1, 2, 3], None, None, [], [], None
+            "Test prompt", [1, 2, 3], None, None, [], [], None, engine_prompt=[1, 2, 3]
         )
         with (
             envs.SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES.override(True),
@@ -694,6 +695,7 @@ class ServingChatTestCase(unittest.TestCase):
                 [],
                 None,
                 require_reasoning=True,
+                engine_prompt=[1, 2, 3],
             )
 
             adapted, _ = self.chat._convert_to_internal_request(req)
@@ -718,6 +720,7 @@ class ServingChatTestCase(unittest.TestCase):
             video_data=None,
             modalities=[],
             stop=[],
+            engine_prompt=[1, 2, 3],
         )
 
         with patch.object(
@@ -757,13 +760,7 @@ class ServingChatTestCase(unittest.TestCase):
 
         with patch.object(self.chat, "_process_messages") as proc_mock:
             proc_mock.return_value = MessageProcessingResult(
-                "",
-                [1, 2, 3],
-                None,
-                None,
-                [],
-                [],
-                None,
+                "", [1, 2, 3], None, None, [], [], None, engine_prompt=[1, 2, 3]
             )
 
             adapted, _ = self.chat._convert_to_internal_request(req)
@@ -3353,6 +3350,7 @@ class ServingChatTestCase(unittest.TestCase):
             [],
             ["</s>"],
             None,
+            engine_prompt=[1, 2, 3],
         )
 
         with patch.object(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1,3 +1,15 @@
+from utils import input_processor, prepared_chat, sync_serving
+
+from sglang.srt.entrypoints.chat_input.config import (
+    get_inkling_default_reasoning_effort,
+)
+from sglang.srt.entrypoints.chat_input.renderers import (
+    ChatRenderer,
+    normalize_tool_content,
+)
+from sglang.srt.entrypoints.chat_input.types import RenderedPrompt, TokenPrompt
+from sglang.srt.entrypoints.openai.chat_input_adapter import from_chat_request
+
 """
 Unit-tests for OpenAIServingChat -- rewritten to use only the std-lib 'unittest'.
 Run with either:
@@ -28,13 +40,11 @@ from sglang.srt.entrypoints.openai.chat_encoding import (
 )
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
-    MessageProcessingResult,
     ToolChoice,
     ToolChoiceFuncName,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
-    normalize_tool_content,
 )
 from sglang.srt.environ import envs
 from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE, TOOLS_OPEN
@@ -292,7 +302,9 @@ class ServingChatTestCase(unittest.TestCase):
             ["call-a", "call-b"], ["call-b", "call-a"]
         ) + self._tool_round(["call-c", "call-d"], ["call-d", "call-c"], "video_url")
 
-        canonical = self.chat._canonicalize_tool_message_order(messages)
+        canonical = input_processor(
+            self.chat
+        ).renderer._canonicalize_tool_message_order(messages)
 
         self.assertEqual(
             [
@@ -312,7 +324,9 @@ class ServingChatTestCase(unittest.TestCase):
         for name, (call_ids, result_ids) in cases.items():
             with self.subTest(name=name):
                 messages = self._tool_round(call_ids, result_ids)
-                canonical = self.chat._canonicalize_tool_message_order(messages)
+                canonical = input_processor(
+                    self.chat
+                ).renderer._canonicalize_tool_message_order(messages)
                 self.assertEqual(canonical, messages)
 
     def test_canonicalize_tool_message_order_keeps_text_only_runs(self):
@@ -320,7 +334,9 @@ class ServingChatTestCase(unittest.TestCase):
         for message in messages[1:]:
             message["content"] = [{"type": "text", "text": "done"}]
 
-        canonical = self.chat._canonicalize_tool_message_order(messages)
+        canonical = input_processor(
+            self.chat
+        ).renderer._canonicalize_tool_message_order(messages)
 
         self.assertEqual(canonical, messages)
 
@@ -367,7 +383,9 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        result = self.chat._apply_jinja_template(request, None, is_multimodal=True)
+        result = input_processor(self.chat).renderer._apply_jinja_template(
+            request, None, is_multimodal=True
+        )
 
         self.assertEqual(
             [item.url for item in result.image_data], ["image-a", "image-b"]
@@ -385,14 +403,18 @@ class ServingChatTestCase(unittest.TestCase):
             messages=request.messages[:2] + request.messages[2:][::-1],
         )
         self.tm.tokenizer.apply_chat_template.reset_mock()
-        self.chat._apply_jinja_template(ordered_request, None, is_multimodal=True)
+        input_processor(self.chat).renderer._apply_jinja_template(
+            ordered_request, None, is_multimodal=True
+        )
         self.assertEqual(
             rendered_messages, self.tm.tokenizer.apply_chat_template.call_args[0][0]
         )
 
         self.template_manager.jinja_template_may_reorder_tool_results = False
         self.tm.tokenizer.apply_chat_template.reset_mock()
-        result = self.chat._apply_jinja_template(request, None, is_multimodal=True)
+        result = input_processor(self.chat).renderer._apply_jinja_template(
+            request, None, is_multimodal=True
+        )
         self.assertEqual(
             [item.url for item in result.image_data], ["image-b", "image-a"]
         )
@@ -494,9 +516,9 @@ class ServingChatTestCase(unittest.TestCase):
     def test_convert_to_internal_request_single(self):
         with (
             patch(
-                "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+                "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
             ) as conv_mock,
-            patch.object(self.chat, "_process_messages") as proc_mock,
+            patch.object(input_processor(self.chat), "prepare") as proc_mock,
         ):
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
@@ -505,20 +527,20 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins.stop_str = ["</s>"]
             conv_mock.return_value = conv_ins
 
-            proc_mock.return_value = MessageProcessingResult(
-                "Test prompt",
+            proc_mock.return_value = prepared_chat(
                 [1, 2, 3],
-                None,
-                None,
-                [],
-                ["</s>"],
-                None,
-                engine_prompt=[1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=[],
+                modalities=["</s>"],
+                stop=None,
             )
 
             self.basic_req.return_sampling_mask = True
             self.basic_req.return_meta_info = True
-            adapted, processed = self.chat._convert_to_internal_request(self.basic_req)
+            adapted, processed = sync_serving(self.chat)._convert_to_internal_request(
+                self.basic_req
+            )
             self.assertIsInstance(adapted, GenerateReqInput)
             self.assertFalse(adapted.stream)
             self.assertTrue(adapted.return_sampling_mask)
@@ -546,13 +568,18 @@ class ServingChatTestCase(unittest.TestCase):
         }
         body = request.model_dump()
 
-        processed_messages = MessageProcessingResult(
-            "Test prompt", [1, 2, 3], None, None, [], [], None, engine_prompt=[1, 2, 3]
+        processed_messages = prepared_chat(
+            [1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=[],
+            modalities=[],
+            stop=None,
         )
         with (
             envs.SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES.override(True),
             patch.object(
-                self.chat, "_process_messages", return_value=processed_messages
+                input_processor(self.chat), "prepare", return_value=processed_messages
             ),
         ):
             response = get_or_create_event_loop().run_until_complete(
@@ -581,7 +608,9 @@ class ServingChatTestCase(unittest.TestCase):
                 **{field: True},
             )
             with self.subTest(field=field), self.assertRaisesRegex(ValueError, field):
-                self.chat._convert_to_internal_request(req, self.fastapi_request)
+                sync_serving(self.chat)._convert_to_internal_request(
+                    req, self.fastapi_request
+                )
 
     def test_validate_request_rejects_sampling_mask_without_meta_info(self):
         req = ChatCompletionRequest(
@@ -606,7 +635,9 @@ class ServingChatTestCase(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "return_meta_info is not supported with streaming"
         ):
-            self.chat._convert_to_internal_request(req, self.fastapi_request)
+            sync_serving(self.chat)._convert_to_internal_request(
+                req, self.fastapi_request
+            )
 
     def test_convert_to_internal_request_input_ids_bypasses_template(self):
         self.tm.tokenizer = None
@@ -621,9 +652,9 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
-            adapted, processed = self.chat._convert_to_internal_request(
+            adapted, processed = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -685,24 +716,22 @@ class ServingChatTestCase(unittest.TestCase):
             tool_choice="required",
         )
 
-        with patch.object(self.chat, "_process_messages") as proc_mock:
-            proc_mock.return_value = MessageProcessingResult(
-                "",
+        with patch.object(input_processor(self.chat), "prepare") as proc_mock:
+            proc_mock.return_value = prepared_chat(
                 [1, 2, 3],
-                None,
-                None,
-                [],
-                [],
-                None,
+                image_data=None,
+                audio_data=None,
+                video_data=[],
+                modalities=[],
+                stop=None,
                 require_reasoning=True,
-                engine_prompt=[1, 2, 3],
             )
 
-            adapted, _ = self.chat._convert_to_internal_request(req)
+            adapted, _ = sync_serving(self.chat)._convert_to_internal_request(req)
 
         self.assertTrue(adapted.require_reasoning)
 
-    def test_process_messages_records_template_reasoning_state(self):
+    def testprepare_records_template_reasoning_state(self):
         self.chat.default_chat_template_kwargs = {"thinking": True}
         self.template_manager.reasoning_config = ReasoningToggleConfig(
             toggle_param="thinking", default_enabled=False
@@ -712,21 +741,16 @@ class ServingChatTestCase(unittest.TestCase):
             model="x",
             messages=[{"role": "user", "content": "What is 2+2?"}],
         )
-        rendered = MessageProcessingResult(
-            prompt="prompt",
-            prompt_ids=[1, 2, 3],
-            image_data=None,
-            audio_data=None,
-            video_data=None,
-            modalities=[],
-            stop=[],
-            engine_prompt=[1, 2, 3],
-        )
+        rendered = RenderedPrompt(prompt=TokenPrompt([1, 2, 3]), template_stop=[])
 
         with patch.object(
-            self.chat, "_apply_conversation_template", return_value=rendered
+            input_processor(self.chat).renderer,
+            "_apply_conversation_template",
+            return_value=rendered,
         ):
-            processed = self.chat._process_messages(request, is_multimodal=False)
+            processed = input_processor(self.chat, is_multimodal=False).prepare(
+                from_chat_request(request)
+            )
 
         self.assertTrue(processed.require_reasoning)
 
@@ -758,12 +782,17 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": False},
         )
 
-        with patch.object(self.chat, "_process_messages") as proc_mock:
-            proc_mock.return_value = MessageProcessingResult(
-                "", [1, 2, 3], None, None, [], [], None, engine_prompt=[1, 2, 3]
+        with patch.object(input_processor(self.chat), "prepare") as proc_mock:
+            proc_mock.return_value = prepared_chat(
+                [1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=[],
+                modalities=[],
+                stop=None,
             )
 
-            adapted, _ = self.chat._convert_to_internal_request(req)
+            adapted, _ = sync_serving(self.chat)._convert_to_internal_request(req)
 
         self.assertFalse(adapted.require_reasoning)
 
@@ -778,7 +807,7 @@ class ServingChatTestCase(unittest.TestCase):
             messages=[{"role": "user", "content": "What is 2+2?"}],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertIs(kwargs["enable_thinking"], False)
@@ -795,7 +824,7 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"enable_thinking": True},
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertIs(kwargs["enable_thinking"], True)
@@ -811,9 +840,11 @@ class ServingChatTestCase(unittest.TestCase):
             messages=[{"role": "user", "content": "What is 2+2?"}],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        prepared = input_processor(self.chat, is_multimodal=False).prepare(
+            from_chat_request(req)
+        )
 
-        self.assertEqual(req.reasoning_effort, "high")
+        self.assertEqual(prepared.reasoning_effort, "high")
 
     def test_hunyuan_default_reasoning_effort_is_normalized_for_template(self):
         self.template_manager.chat_template_name = None
@@ -841,12 +872,16 @@ class ServingChatTestCase(unittest.TestCase):
                     reasoning_effort=request_effort,
                 )
 
-                self.chat._process_messages(req, is_multimodal=False)
+                prepared = input_processor(self.chat, is_multimodal=False).prepare(
+                    from_chat_request(req)
+                )
 
                 kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
-                self.assertEqual(req.reasoning_effort, normalized_effort)
+                self.assertEqual(prepared.reasoning_effort, normalized_effort)
                 self.assertEqual(kwargs["reasoning_effort"], normalized_effort)
-                self.assertNotIn("reasoning_effort", req.chat_template_kwargs)
+                self.assertNotIn(
+                    "reasoning_effort", prepared.chat_template_kwargs or {}
+                )
 
     def test_hunyuan_reasoning_effort_precedence_survives_conversion(self):
         self.template_manager.chat_template_name = None
@@ -872,12 +907,14 @@ class ServingChatTestCase(unittest.TestCase):
                     chat_template_kwargs={"reasoning_effort": template_effort},
                 )
 
-                self.chat._convert_to_internal_request(req)
+                _, effective = sync_serving(self.chat)._convert_to_internal_request(req)
 
                 kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
-                self.assertEqual(req.reasoning_effort, normalized_effort)
+                self.assertEqual(effective.reasoning_effort, normalized_effort)
                 self.assertEqual(kwargs["reasoning_effort"], normalized_effort)
-                self.assertNotIn("reasoning_effort", req.chat_template_kwargs)
+                self.assertNotIn(
+                    "reasoning_effort", effective.chat_template_kwargs or {}
+                )
 
     def test_non_hunyuan_default_reasoning_effort_is_unchanged(self):
         self.template_manager.chat_template_name = None
@@ -889,12 +926,14 @@ class ServingChatTestCase(unittest.TestCase):
             messages=[{"role": "user", "content": "What is 2+2?"}],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        prepared = input_processor(self.chat, is_multimodal=False).prepare(
+            from_chat_request(req)
+        )
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
-        self.assertEqual(req.reasoning_effort, "medium")
+        self.assertEqual(prepared.reasoning_effort, "medium")
         self.assertEqual(kwargs["reasoning_effort"], "medium")
-        self.assertEqual(req.chat_template_kwargs["reasoning_effort"], "medium")
+        self.assertEqual(prepared.chat_template_kwargs["reasoning_effort"], "medium")
 
     def test_k2_selected_terminator_reaches_sampling_params(self):
         self.tm._config_overrides["reasoning_parser"] = "k2_horizon"
@@ -911,11 +950,15 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"reasoning_effort": "medium"},
         )
 
-        processed = self.chat._process_messages(req, is_multimodal=False)
+        processed = input_processor(self.chat, is_multimodal=False).prepare(
+            from_chat_request(req)
+        )
         self.assertEqual(processed.reasoning_end_token_ids, [8, 9])
 
-        with patch.object(self.chat, "_process_messages", return_value=processed):
-            adapted, _ = self.chat._convert_to_internal_request(req)
+        with patch.object(
+            input_processor(self.chat), "prepare", return_value=processed
+        ):
+            adapted, _ = sync_serving(self.chat)._convert_to_internal_request(req)
         self.assertEqual(
             adapted.sampling_params["custom_params"][
                 REQUEST_REASONING_END_TOKEN_IDS_KEY
@@ -953,7 +996,7 @@ class ServingChatTestCase(unittest.TestCase):
             tool_choice="required",
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertNotIn("thinking", kwargs)
@@ -989,7 +1032,7 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": True},
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertTrue(kwargs["thinking"])
@@ -1025,7 +1068,7 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": False},
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertFalse(kwargs["thinking"])
@@ -1057,7 +1100,7 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         expected_tools = [tool.model_dump() for tool in req.tools]
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
@@ -1095,7 +1138,7 @@ class ServingChatTestCase(unittest.TestCase):
             [1, 2, 3],
         ]
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         first_tools = self.tm.tokenizer.apply_chat_template.call_args_list[0].kwargs[
             "tools"
@@ -1145,12 +1188,14 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
+            "sglang.srt.entrypoints.chat_input.processor.FunctionCallParser"
         ) as parser_cls:
             parser = parser_cls.return_value
             parser.get_structure_constraint.return_value = ("structural_tag", "tag")
 
-            self.chat._process_messages(req, is_multimodal=False)
+            input_processor(self.chat, is_multimodal=False).prepare(
+                from_chat_request(req)
+            )
 
             parser.get_structure_constraint.assert_called_once()
             self.assertFalse(
@@ -1186,7 +1231,7 @@ class ServingChatTestCase(unittest.TestCase):
             with (
                 self.subTest(request_stop=request_stop),
                 patch(
-                    "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
+                    "sglang.srt.entrypoints.chat_input.processor.FunctionCallParser"
                 ) as parser_cls,
             ):
                 parser = parser_cls.return_value
@@ -1206,7 +1251,9 @@ class ServingChatTestCase(unittest.TestCase):
                     else request.stop
                 )
 
-                result = self.chat._process_messages(request, is_multimodal=False)
+                result = input_processor(self.chat, is_multimodal=False).prepare(
+                    from_chat_request(request)
+                )
 
                 self.assertEqual(result.stop, expected)
                 self.assertEqual(request.stop, original_stop)
@@ -1233,7 +1280,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_choice="none",
         )
 
-        result = self.chat._process_messages(request, is_multimodal=False)
+        result = input_processor(self.chat, is_multimodal=False).prepare(
+            from_chat_request(request)
+        )
 
         self.assertIsNone(result.stop)
 
@@ -1298,7 +1347,9 @@ class ServingChatTestCase(unittest.TestCase):
             },
         )
 
-        result = self.chat._process_messages(request, is_multimodal=True)
+        result = input_processor(self.chat, is_multimodal=True).renderer.render(
+            from_chat_request(request), None, False
+        )
 
         call = self.tm.tokenizer.apply_chat_template.call_args
         rendered_messages = call.args[0]
@@ -1330,7 +1381,7 @@ class ServingChatTestCase(unittest.TestCase):
             {"type": "object"},
         )
         self.assertNotIn("schema_", call.kwargs["response_format"]["json_schema"])
-        self.assertEqual(result.prompt_ids, [7, 8, 9])
+        self.assertEqual(result.prompt.token_ids, [7, 8, 9])
         self.assertEqual(result.image_data[0].url, "image-1")
 
     def test_kimi_k3_neutralizes_text_only_assistant_history(self):
@@ -1359,7 +1410,9 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        self.chat._process_messages(request, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(
+            from_chat_request(request)
+        )
 
         messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
@@ -1446,7 +1499,9 @@ class ServingChatTestCase(unittest.TestCase):
                 )
 
                 with self.assertRaisesRegex(ValueError, "must be a JSON object"):
-                    self.chat._process_messages(req, is_multimodal=False)
+                    input_processor(self.chat, is_multimodal=False).prepare(
+                        from_chat_request(req)
+                    )
 
                 self.tm.tokenizer.apply_chat_template.assert_not_called()
 
@@ -1481,7 +1536,7 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        input_processor(self.chat, is_multimodal=False).prepare(from_chat_request(req))
 
         messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
         self.assertEqual(
@@ -1525,7 +1580,9 @@ class ServingChatTestCase(unittest.TestCase):
                 )
 
                 with self.assertRaisesRegex(ValueError, "must be a JSON object"):
-                    self.chat._process_messages(req, is_multimodal=False)
+                    input_processor(self.chat, is_multimodal=False).prepare(
+                        from_chat_request(req)
+                    )
 
     def test_dsv_encoders_accept_object_tool_call_arguments_string(self):
         """DeepSeek encoders accept object-shaped OpenAI JSON string arguments."""
@@ -1562,7 +1619,9 @@ class ServingChatTestCase(unittest.TestCase):
                     ],
                 )
 
-                self.chat._process_messages(req, is_multimodal=False)
+                input_processor(self.chat, is_multimodal=False).prepare(
+                    from_chat_request(req)
+                )
 
     def test_stop_str_isolation_between_requests(self):
         """Test that stop strings from one request don't affect subsequent requests.
@@ -1574,7 +1633,7 @@ class ServingChatTestCase(unittest.TestCase):
         initial_stop_str = ["\n"]
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             # Create a mock conversation object that will be returned by generate_chat_conv
             conv_ins = Mock()
@@ -1595,7 +1654,9 @@ class ServingChatTestCase(unittest.TestCase):
             )
 
             # Call the actual _apply_conversation_template method (not mocked)
-            result1 = self.chat._apply_conversation_template(req1, is_multimodal=False)
+            result1 = input_processor(self.chat, is_multimodal=False).prepare(
+                from_chat_request(req1)
+            )
 
             # Verify first request has both stop strings
             expected_stop1 = initial_stop_str + ["CUSTOM_STOP"]
@@ -1610,7 +1671,9 @@ class ServingChatTestCase(unittest.TestCase):
                 messages=[{"role": "user", "content": "Second request"}],
                 # No custom stop strings
             )
-            result2 = self.chat._apply_conversation_template(req2, is_multimodal=False)
+            result2 = input_processor(self.chat, is_multimodal=False).prepare(
+                from_chat_request(req2)
+            )
 
             # Verify second request only has original stop strings (no CUSTOM_STOP from req1)
             self.assertEqual(result2.stop, initial_stop_str)
@@ -2338,7 +2401,7 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
         messages = [m.model_dump() for m in req.messages]
-        # Mirror the boundary normalization _process_messages does for any
+        # Mirror the boundary normalization prepare does for any
         # non-None chat_encoding_spec.
         for i, msg in enumerate(messages):
             if isinstance(msg.get("content"), list):
@@ -2512,7 +2575,9 @@ class ServingChatTestCase(unittest.TestCase):
             messages=[{"role": "user", "content": "Hello"}],
             reasoning_effort="max",
         )
-        serving_chat._process_messages(request, is_multimodal=False)
+        input_processor(serving_chat, is_multimodal=False).prepare(
+            from_chat_request(request)
+        )
         prompt = tm.tokenizer.encode.call_args.args[0]
         self.assertIn("Reasoning Effort: Beyond maximum", prompt)
 
@@ -2531,7 +2596,9 @@ class ServingChatTestCase(unittest.TestCase):
             reasoning_effort="max",
         )
 
-        serving_chat._process_messages(request, is_multimodal=False)
+        input_processor(serving_chat, is_multimodal=False).prepare(
+            from_chat_request(request)
+        )
 
         prompt = tm.tokenizer.encode.call_args.args[0]
         self.assertIn("Reasoning Effort: Beyond maximum", prompt)
@@ -2582,14 +2649,14 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             # Create a mock conversation object
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -2663,13 +2730,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -2754,13 +2821,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
             chunks = self._run_chat_stream(adapted_request, req)
@@ -2952,12 +3019,12 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
             chunks = self._run_chat_stream(adapted_request, req)
@@ -3222,13 +3289,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -3342,21 +3409,19 @@ class ServingChatTestCase(unittest.TestCase):
             model="x",
             messages=[{"role": "user", "content": "Hi?"}],
         )
-        processed_messages = MessageProcessingResult(
-            "Test prompt",
+        processed_messages = prepared_chat(
             [1, 2, 3],
-            None,
-            None,
-            [],
-            ["</s>"],
-            None,
-            engine_prompt=[1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=[],
+            modalities=["</s>"],
+            stop=None,
         )
 
         with patch.object(
-            self.chat, "_process_messages", return_value=processed_messages
+            input_processor(self.chat), "prepare", return_value=processed_messages
         ):
-            _, processed_request = self.chat._convert_to_internal_request(
+            _, processed_request = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -3417,13 +3482,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
             chunks = self._run_chat_stream(adapted_request, req)
@@ -3555,13 +3620,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
             chunks = self._run_chat_stream(adapted_request, req)
@@ -3740,13 +3805,13 @@ class ServingChatTestCase(unittest.TestCase):
         )
 
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
+            adapted_request, _ = sync_serving(self.chat)._convert_to_internal_request(
                 req, self.fastapi_request
             )
 
@@ -3825,7 +3890,9 @@ class ServingChatTestCase(unittest.TestCase):
         for effort, expected in cases:
             with self.subTest(effort=effort):
                 req.reasoning_effort = effort
-                self.assertEqual(chat._get_reasoning_from_request(req), expected)
+                self.assertEqual(
+                    input_processor(chat)._get_reasoning_from_request(req), expected
+                )
 
     def _setup_nemotron_super(self):
         """Drive _apply_jinja_template (chat_template_name=None) with a
@@ -3850,14 +3917,20 @@ class ServingChatTestCase(unittest.TestCase):
             reasoning_effort=effort,
         )
         with (
-            patch.object(self.chat, "_encode_messages", return_value=None),
             patch.object(
-                self.chat,
+                input_processor(self.chat).renderer,
+                "_encode_messages",
+                return_value=None,
+            ),
+            patch.object(
+                input_processor(self.chat).renderer,
                 "_handle_last_assistant_message",
                 return_value=([{"role": "user", "content": "hi"}], None),
             ),
         ):
-            self.chat._process_messages(req, False)
+            input_processor(self.chat, is_multimodal=False).prepare(
+                from_chat_request(req)
+            )
         _, kwargs = self.tm.tokenizer.apply_chat_template.call_args
         return kwargs
 
@@ -3869,7 +3942,7 @@ class ServingChatTestCase(unittest.TestCase):
     def test_nemotron_super_high_effort_warns_without_kwarg(self):
         self._setup_nemotron_super()
         with self.assertLogs(
-            "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+            "sglang.srt.entrypoints.chat_input.renderers", level="WARNING"
         ) as logs:
             kwargs = self._run_jinja_with_effort("high")
         self.assertNotIn("low_effort", kwargs)
@@ -3936,8 +4009,12 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"enable_thinking": False},
         )
 
-        self.assertTrue(self.chat._get_reasoning_from_request(enabled_by_default))
-        self.assertFalse(self.chat._get_reasoning_from_request(disabled_explicitly))
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(enabled_by_default)
+        )
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(disabled_explicitly)
+        )
 
     def test_get_reasoning_from_request_default_false_toggle(self):
         self.tm.server_args.reasoning_parser = "deepseek-v3"
@@ -3955,8 +4032,12 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": True},
         )
 
-        self.assertFalse(self.chat._get_reasoning_from_request(disabled_by_default))
-        self.assertTrue(self.chat._get_reasoning_from_request(enabled_explicitly))
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(disabled_by_default)
+        )
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(enabled_explicitly)
+        )
 
     def test_get_reasoning_from_request_special_cases(self):
         self.tm.server_args.reasoning_parser = "mistral"
@@ -3968,14 +4049,14 @@ class ServingChatTestCase(unittest.TestCase):
         self.template_manager.reasoning_config = ReasoningToggleConfig(
             special_case="always"
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req))
+        self.assertTrue(input_processor(self.chat)._get_reasoning_from_request(req))
 
         self.template_manager.reasoning_config = ReasoningToggleConfig(
             special_case="mistral"
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req))
+        self.assertFalse(input_processor(self.chat)._get_reasoning_from_request(req))
         req.reasoning_effort = "medium"
-        self.assertTrue(self.chat._get_reasoning_from_request(req))
+        self.assertTrue(input_processor(self.chat)._get_reasoning_from_request(req))
 
     # --- fallback path tests (config=None, uses reasoning_default) ---
 
@@ -3991,63 +4072,79 @@ class ServingChatTestCase(unittest.TestCase):
         req = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req))
+        self.assertTrue(input_processor(self.chat)._get_reasoning_from_request(req))
 
     def test_fallback_mistral_mode(self):
         self._setup_fallback("mistral")
         req_no_effort = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req_no_effort))
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(req_no_effort)
+        )
 
         req_with_effort = ChatCompletionRequest(
             model="x",
             messages=[{"role": "user", "content": "Hi?"}],
             reasoning_effort="high",
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req_with_effort))
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(req_with_effort)
+        )
 
     def test_fallback_enable_thinking_mode_default_on(self):
         self._setup_fallback("qwen3")
         req_default = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req_default))
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(req_default)
+        )
 
         req_disabled = ChatCompletionRequest(
             model="x",
             messages=[{"role": "user", "content": "Hi?"}],
             chat_template_kwargs={"enable_thinking": False},
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req_disabled))
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(req_disabled)
+        )
 
     def test_fallback_explicit_thinking_mode_default_off(self):
         self._setup_fallback("deepseek-v3")
         req_default = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req_default))
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(req_default)
+        )
 
         req_enabled = ChatCompletionRequest(
             model="x",
             messages=[{"role": "user", "content": "Hi?"}],
             chat_template_kwargs={"thinking": True},
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req_enabled))
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(req_enabled)
+        )
 
     def test_fallback_explicit_enable_thinking_mode_default_off(self):
         self._setup_fallback("mimo")
         req_default = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req_default))
+        self.assertFalse(
+            input_processor(self.chat)._get_reasoning_from_request(req_default)
+        )
 
         req_enabled = ChatCompletionRequest(
             model="x",
             messages=[{"role": "user", "content": "Hi?"}],
             chat_template_kwargs={"enable_thinking": True},
         )
-        self.assertTrue(self.chat._get_reasoning_from_request(req_enabled))
+        self.assertTrue(
+            input_processor(self.chat)._get_reasoning_from_request(req_enabled)
+        )
 
     def test_fallback_ling3_default_on(self):
         """Ling3 public checkpoints default `thinking_option='on'` in the chat
@@ -4070,7 +4167,10 @@ class ServingChatTestCase(unittest.TestCase):
         for kwargs, expected in cases:
             with self.subTest(kwargs=kwargs):
                 req.chat_template_kwargs = kwargs
-                self.assertEqual(self.chat._get_reasoning_from_request(req), expected)
+                self.assertEqual(
+                    input_processor(self.chat)._get_reasoning_from_request(req),
+                    expected,
+                )
 
     def test_fallback_no_detector_returns_false(self):
         self.chat.reasoning_parser = "qwen3"
@@ -4079,7 +4179,7 @@ class ServingChatTestCase(unittest.TestCase):
         req = ChatCompletionRequest(
             model="x", messages=[{"role": "user", "content": "Hi?"}]
         )
-        self.assertFalse(self.chat._get_reasoning_from_request(req))
+        self.assertFalse(input_processor(self.chat)._get_reasoning_from_request(req))
 
     def test_build_chat_response_qwen3_thinking_forces_reasoning(self):
         self.tm.server_args.reasoning_parser = "qwen3-thinking"
@@ -4131,7 +4231,10 @@ class ServingChatTestCase(unittest.TestCase):
         for kwargs, expected in cases:
             with self.subTest(kwargs=kwargs):
                 req.chat_template_kwargs = kwargs
-                self.assertEqual(self.chat._get_reasoning_from_request(req), expected)
+                self.assertEqual(
+                    input_processor(self.chat)._get_reasoning_from_request(req),
+                    expected,
+                )
 
     def test_poolside_v1_does_not_double_prepend_think(self):
         """When `enable_thinking=True` for poolside_v1, the HF chat template
@@ -4146,7 +4249,7 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"enable_thinking": True},
         )
         with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            "sglang.srt.entrypoints.chat_input.renderers.generate_chat_conv"
         ) as conv_mock:
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "BASE_PROMPT"
@@ -4154,13 +4257,15 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins.modalities = []
             conv_ins.stop_str = []
             conv_mock.return_value = conv_ins
-            result = self.chat._apply_conversation_template(req, is_multimodal=False)
-        self.assertEqual(result.prompt, "BASE_PROMPT")
+            result = input_processor(self.chat).renderer._apply_conversation_template(
+                req, is_multimodal=False, require_reasoning=False
+            )
+        self.assertEqual(self.tm.tokenizer.encode.call_args.args[0], "BASE_PROMPT")
 
     # ------------- hook method tests -------------
     def test_encode_messages_returns_none_by_default(self):
         """Default _encode_messages returns None (use standard encoding)."""
-        result = self.chat._encode_messages([], Mock(), False)
+        result = input_processor(self.chat).renderer._encode_messages([], Mock(), False)
         self.assertIsNone(result)
 
     def test_decode_response_returns_text(self):
@@ -4313,7 +4418,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
     """Inkling reasoning-effort mapping and validation."""
 
     def test_named_levels(self):
-        parse = OpenAIServingChat._parse_inkling_reasoning_effort
+        parse = ChatRenderer._parse_inkling_reasoning_effort
         self.assertEqual(parse("none"), 0.0)
         self.assertEqual(parse("minimal"), 0.1)
         self.assertEqual(parse("low"), 0.2)
@@ -4325,7 +4430,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
         self.assertEqual(parse("max"), parse("xhigh"))
 
     def test_scalar_range_is_validated(self):
-        parse = OpenAIServingChat._parse_inkling_reasoning_effort
+        parse = ChatRenderer._parse_inkling_reasoning_effort
         self.assertEqual(parse(0.5), 0.5)
         self.assertEqual(parse(0.99), 0.99)
         for value in (1.0, "1.0", 2.0, "1.5", -1.0, float("nan"), True):
@@ -4333,7 +4438,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
                 parse(value)
 
     def test_invalid_and_none(self):
-        parse = OpenAIServingChat._parse_inkling_reasoning_effort
+        parse = ChatRenderer._parse_inkling_reasoning_effort
         self.assertIsNone(parse(None))
         with self.assertRaises(ValueError):
             parse("garbage")
@@ -4341,7 +4446,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
     def test_env_default(self):
         from sglang.srt.environ import envs
 
-        get = OpenAIServingChat._get_inkling_default_reasoning_effort
+        get = get_inkling_default_reasoning_effort
         env = envs.SGLANG_INKLING_DEFAULT_REASONING_EFFORT
         try:
             env.clear()  # unset -> EnvStr default "0.9"
@@ -4392,7 +4497,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
             messages=[{"role": "user", "content": "hello"}],
             reasoning_effort=0.5,
         )
-        prompt_ids = serving._encode_messages(
+        prompt_ids = input_processor(serving).renderer._encode_messages(
             [message.model_dump() for message in request.messages],
             request,
             thinking_mode=None,
@@ -4423,7 +4528,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
             reasoning_effort=0.5,
             continue_final_message=True,
         )
-        prompt_ids = serving._encode_messages(
+        prompt_ids = input_processor(serving).renderer._encode_messages(
             [message.model_dump() for message in request.messages],
             request,
             thinking_mode=None,
@@ -4469,7 +4574,7 @@ class InklingReasoningEffortTest(unittest.TestCase):
             reasoning_effort=0.5,
             continue_final_message=True,
         )
-        prompt_ids = serving._encode_messages(
+        prompt_ids = input_processor(serving).renderer._encode_messages(
             [message.model_dump() for message in request.messages],
             request,
             thinking_mode=None,

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -12,10 +12,12 @@ from utils import make_serving
 
 from sglang.srt.entrypoints.context import SimpleContext
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
     MessageProcessingResult,
     RequestResponseMetadata,
     ResponsesRequest,
 )
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.serving_responses import (
     OpenAIServingResponses,
     _build_output_text_logprobs,
@@ -174,6 +176,7 @@ class ChatToolForwardingTestCase(CustomTestCase):
                 modalities=[],
                 stop=["</s>"],
                 tool_call_constraint=("json_schema", {"type": "object"}),
+                engine_prompt=[1, 2, 3],
             )
 
         serving._process_messages = Mock(side_effect=fake_process)
@@ -301,6 +304,7 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
             modalities=[],
             stop=[],
             reasoning_end_token_ids=[41, 42],
+            engine_prompt=[1, 2, 3],
         )
         captured = {}
 
@@ -369,6 +373,7 @@ class SkipSpecialTokensForwardingTestCase(CustomTestCase):
             video_data=None,
             modalities=[],
             stop=[],
+            engine_prompt=[1, 2, 3],
         )
         captured = {}
 
@@ -567,6 +572,7 @@ class MultimodalRequestTestCase(CustomTestCase):
                 video_data=None,
                 modalities=["image"],
                 stop=[],
+                engine_prompt="rendered multimodal prompt",
             )
         )
 
@@ -626,21 +632,12 @@ class MultimodalRequestTestCase(CustomTestCase):
         """Bug regression: token-first encoders leave prompt == "" with
         non-empty prompt_ids; forwarding the empty text 400s in
         _tokenize_texts, so the multimodal branch must forward prompt_ids."""
-        for spec in ("inkling", "kimi_k3"):
+        for spec in ("inkling", "kimi_k3", "custom_encoder"):
             with self.subTest(spec=spec):
                 serving = make_serving(is_multimodal=True)
                 serving.chat_encoding_spec = spec
-                serving._process_messages = Mock(
-                    return_value=MessageProcessingResult(
-                        prompt="",
-                        prompt_ids=[4, 5, 6],
-                        image_data=None,
-                        audio_data=None,
-                        video_data=None,
-                        modalities=[],
-                        stop=[],
-                    )
-                )
+                serving.template_manager.chat_template_name = None
+                serving._encode_messages = Mock(return_value=[4, 5, 6])
                 request = ResponsesRequest(model="x", input="hi", store=False)
 
                 _, request_prompts, engine_prompts, _ = asyncio.run(
@@ -651,6 +648,80 @@ class MultimodalRequestTestCase(CustomTestCase):
 
                 self.assertEqual(engine_prompts, [[4, 5, 6]])
                 self.assertEqual(request_prompts, [[4, 5, 6]])
+
+
+class EnginePromptTestCase(CustomTestCase):
+    def test_renderers_select_the_same_input_for_both_endpoints(self):
+        for template_name in (None, "chatml"):
+            for is_multimodal in (False, True):
+                with self.subTest(
+                    template_name=template_name, is_multimodal=is_multimodal
+                ):
+                    serving = make_serving(is_multimodal=is_multimodal)
+                    serving.template_manager.chat_template_name = template_name
+                    tokenizer = serving.tokenizer_manager.tokenizer
+                    tokenizer.apply_chat_template.return_value = "rendered prompt"
+                    tokenizer.decode.return_value = "decoded prompt"
+                    request = ResponsesRequest(model="x", input="hi", store=False)
+
+                    _, request_prompts, engine_prompts, processed = asyncio.run(
+                        serving._make_request(request, None, tokenizer)
+                    )
+                    expected = processed.prompt if is_multimodal else [1, 2, 3]
+                    self.assertEqual(processed.engine_prompt, expected)
+                    self.assertEqual(request_prompts, [expected])
+                    self.assertEqual(engine_prompts, [expected])
+
+                    chat_request = ChatCompletionRequest(
+                        model="x", messages=[{"role": "user", "content": "hi"}]
+                    )
+                    adapted, _ = OpenAIServingChat._convert_to_internal_request(
+                        serving, chat_request
+                    )
+                    self.assertEqual(adapted.text, expected if is_multimodal else None)
+                    self.assertEqual(
+                        adapted.input_ids, None if is_multimodal else expected
+                    )
+
+    def test_endpoints_use_the_explicit_prompt_without_model_routing(self):
+        for engine_prompt in ("chosen text", [4, -1, 6]):
+            with self.subTest(engine_prompt=engine_prompt):
+                serving = make_serving(is_multimodal=True)
+                serving.chat_encoding_spec = "custom_encoder"
+                serving._process_messages = Mock(
+                    return_value=MessageProcessingResult(
+                        engine_prompt=engine_prompt,
+                        prompt="unused text",
+                        prompt_ids=[99],
+                        image_data=["image-data"],
+                        audio_data=None,
+                        video_data=None,
+                        modalities=["image"],
+                        stop=[],
+                    )
+                )
+                request = ResponsesRequest(model="x", input="hi", store=False)
+                _, request_prompts, engine_prompts, _ = asyncio.run(
+                    serving._make_request(
+                        request, None, serving.tokenizer_manager.tokenizer
+                    )
+                )
+                self.assertEqual(request_prompts, [engine_prompt])
+                self.assertEqual(engine_prompts, [engine_prompt])
+
+                chat_request = ChatCompletionRequest(
+                    model="x", messages=[{"role": "user", "content": "hi"}]
+                )
+                adapted, _ = OpenAIServingChat._convert_to_internal_request(
+                    serving, chat_request
+                )
+                if isinstance(engine_prompt, str):
+                    self.assertEqual(adapted.text, engine_prompt)
+                    self.assertIsNone(adapted.input_ids)
+                else:
+                    self.assertEqual(adapted.input_ids, engine_prompt)
+                    self.assertIsNone(adapted.text)
+                self.assertEqual(adapted.image_data, ["image-data"])
 
 
 class OutputItemsTestCase(CustomTestCase):

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -629,9 +629,8 @@ class MultimodalRequestTestCase(CustomTestCase):
         self.assertEqual(captured["adapted_request"].modalities, ["image"])
 
     def test_multimodal_token_first_specs_route_through_prompt_ids(self):
-        """Bug regression: token-first encoders leave prompt == "" with
-        non-empty prompt_ids; forwarding the empty text 400s in
-        _tokenize_texts, so the multimodal branch must forward prompt_ids."""
+        """Multimodal requests must preserve custom-encoder token IDs;
+        an empty text prompt must not replace them."""
         for spec in ("inkling", "kimi_k3", "custom_encoder"):
             with self.subTest(spec=spec):
                 serving = make_serving(is_multimodal=True)

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -8,12 +8,24 @@ from openai.types.responses import (
     ResponseReasoningItem,
 )
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
-from utils import make_serving
+from utils import (
+    input_processor,
+    make_serving,
+    prepared_chat,
+    prompt_value,
+    sync_serving,
+)
 
+from sglang.srt.entrypoints.chat_input.types import (
+    RenderedPrompt,
+    TokenPrompt,
+)
 from sglang.srt.entrypoints.context import SimpleContext
+from sglang.srt.entrypoints.openai.chat_input_adapter import (
+    with_prepared_options,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
-    MessageProcessingResult,
     RequestResponseMetadata,
     ResponsesRequest,
 )
@@ -163,23 +175,21 @@ class ChatToolForwardingTestCase(CustomTestCase):
         serving = make_serving()
         seen = {}
 
-        def fake_process(chat_request, is_multimodal):
+        def fake_process(chat_request):
             seen["tools"] = chat_request.tools
             seen["tool_choice"] = chat_request.tool_choice
             seen["parallel_tool_calls"] = chat_request.parallel_tool_calls
-            return MessageProcessingResult(
-                prompt="prompt",
-                prompt_ids=[1, 2, 3],
+            return prepared_chat(
+                [1, 2, 3],
                 image_data=None,
                 audio_data=None,
                 video_data=None,
                 modalities=[],
                 stop=["</s>"],
                 tool_call_constraint=("json_schema", {"type": "object"}),
-                engine_prompt=[1, 2, 3],
             )
 
-        serving._process_messages = Mock(side_effect=fake_process)
+        input_processor(serving).prepare = Mock(side_effect=fake_process)
         request = ResponsesRequest(
             model="x",
             input="call the tool",
@@ -195,13 +205,14 @@ class ChatToolForwardingTestCase(CustomTestCase):
             store=False,
         )
 
-        messages, request_prompts, engine_prompts, processed = asyncio.run(
-            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        messages, processed = asyncio.run(
+            sync_serving(serving)._make_request(
+                request, None, serving.tokenizer_manager.tokenizer
+            )
         )
 
         self.assertEqual(messages, [{"role": "user", "content": "call the tool"}])
-        self.assertEqual(request_prompts, [[1, 2, 3]])
-        self.assertEqual(engine_prompts, [[1, 2, 3]])
+        self.assertEqual([prompt_value(processed)], [[1, 2, 3]])
         self.assertEqual(seen["tools"][0].function.name, "lookup")
         self.assertEqual(seen["tool_choice"], "required")
         self.assertFalse(seen["parallel_tool_calls"])
@@ -216,7 +227,9 @@ class ChatToolForwardingTestCase(CustomTestCase):
             tools=[{"type": "web_search"}, {"type": "mcp"}],
             store=False,
         )
-        result = asyncio.run(serving.create_responses(request, raw_request=None))
+        result = asyncio.run(
+            sync_serving(serving).create_responses(request, raw_request=None)
+        )
         self.assertEqual(getattr(result, "status_code", None), 400)
 
     def test_kimi_k3_request_uses_chat_encoder_fields(self):
@@ -240,8 +253,10 @@ class ChatToolForwardingTestCase(CustomTestCase):
             store=False,
         )
 
-        _, request_prompts, engine_prompts, _ = asyncio.run(
-            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        _, processed = asyncio.run(
+            sync_serving(serving)._make_request(
+                request, None, serving.tokenizer_manager.tokenizer
+            )
         )
 
         call = serving.tokenizer_manager.tokenizer.apply_chat_template.call_args
@@ -251,8 +266,7 @@ class ChatToolForwardingTestCase(CustomTestCase):
         self.assertEqual(call.kwargs["thinking_effort"], "high")
         self.assertEqual(call.kwargs["tool_choice"], "required")
         self.assertEqual(call.kwargs["tools"][0]["function"]["name"], "lookup")
-        self.assertEqual(request_prompts, [[4, 5, 6]])
-        self.assertEqual(engine_prompts, [[4, 5, 6]])
+        self.assertEqual([prompt_value(processed)], [[4, 5, 6]])
 
     def test_k2_output_parser_reuses_effective_template_default(self):
         serving = make_serving()
@@ -269,10 +283,13 @@ class ChatToolForwardingTestCase(CustomTestCase):
             store=False,
         )
 
-        asyncio.run(
-            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        _, prepared = asyncio.run(
+            sync_serving(serving)._make_request(
+                request, None, serving.tokenizer_manager.tokenizer
+            )
         )
 
+        request = with_prepared_options(request, prepared)
         render_call = serving.tokenizer_manager.tokenizer.apply_chat_template.call_args
         self.assertEqual(render_call.kwargs["reasoning_effort"], "low")
         self.assertEqual(request.chat_template_kwargs["reasoning_effort"], "low")
@@ -295,22 +312,11 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
         serving.template_manager.reasoning_config = ReasoningToggleConfig(
             toggle_param="thinking", default_enabled=True
         )
-        rendered = MessageProcessingResult(
-            prompt="prompt",
-            prompt_ids=[1, 2, 3],
-            image_data=None,
-            audio_data=None,
-            video_data=None,
-            modalities=[],
-            stop=[],
-            reasoning_end_token_ids=[41, 42],
-            engine_prompt=[1, 2, 3],
-        )
+        rendered = RenderedPrompt(prompt=TokenPrompt([1, 2, 3]), template_stop=[])
         captured = {}
 
         async def fake_generate(
             request_id,
-            request_prompt,
             adapted_request,
             sampling_params,
             context,
@@ -339,14 +345,21 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
 
         with (
             patch.object(
-                serving, "_apply_conversation_template", return_value=rendered
+                input_processor(serving),
+                "_reasoning_end_token_ids",
+                return_value=[41, 42],
+            ),
+            patch.object(
+                input_processor(serving).renderer,
+                "_apply_conversation_template",
+                return_value=rendered,
             ),
             patch(
                 "sglang.srt.entrypoints.openai.serving_responses.ReasoningParser"
             ) as parser_cls,
         ):
             parser_cls.return_value.parse_non_stream.return_value = (None, "done")
-            response = asyncio.run(serving.create_responses(request))
+            response = asyncio.run(sync_serving(serving).create_responses(request))
 
         self.assertEqual(response.status, "completed")
         self.assertFalse(captured["adapted_request"].require_reasoning)
@@ -360,26 +373,16 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
 
 
 class SkipSpecialTokensForwardingTestCase(CustomTestCase):
-    """The skip_special_tokens override from _process_messages must reach the
+    """The skip_special_tokens override from prepare must reach the
     engine sampling params; muse's channel markers die in detok otherwise."""
 
     def _create_responses_sampling_params(self, serving):
         serving.default_chat_template_kwargs = None
-        rendered = MessageProcessingResult(
-            prompt="prompt",
-            prompt_ids=[1, 2, 3],
-            image_data=None,
-            audio_data=None,
-            video_data=None,
-            modalities=[],
-            stop=[],
-            engine_prompt=[1, 2, 3],
-        )
+        rendered = RenderedPrompt(prompt=TokenPrompt([1, 2, 3]), template_stop=[])
         captured = {}
 
         async def fake_generate(
             request_id,
-            request_prompt,
             adapted_request,
             sampling_params,
             context,
@@ -408,14 +411,16 @@ class SkipSpecialTokensForwardingTestCase(CustomTestCase):
 
         with (
             patch.object(
-                serving, "_apply_conversation_template", return_value=rendered
+                input_processor(serving).renderer,
+                "_apply_conversation_template",
+                return_value=rendered,
             ),
             patch(
                 "sglang.srt.entrypoints.openai.serving_responses.ReasoningParser"
             ) as parser_cls,
         ):
             parser_cls.return_value.parse_non_stream.return_value = (None, "done")
-            response = asyncio.run(serving.create_responses(request))
+            response = asyncio.run(sync_serving(serving).create_responses(request))
 
         self.assertEqual(response.status, "completed")
         return captured["sampling_params"]
@@ -534,7 +539,7 @@ class FullResponseUsageTestCase(CustomTestCase):
 class MultimodalRequestTestCase(CustomTestCase):
     def test_text_only_create_responses_rejects_media_before_generation(self):
         serving = make_serving()
-        serving._process_messages = Mock()
+        input_processor(serving).renderer.render = Mock()
         request = ResponsesRequest(
             model="x",
             input=[
@@ -552,39 +557,35 @@ class MultimodalRequestTestCase(CustomTestCase):
             store=False,
         )
 
-        response = asyncio.run(serving.create_responses(request))
+        response = asyncio.run(sync_serving(serving).create_responses(request))
 
         self.assertEqual(response.status_code, 400)
         self.assertIn(b"received unsupported content type 'image_url'", response.body)
-        serving._process_messages.assert_not_called()
+        input_processor(serving).renderer.render.assert_not_called()
         serving.tokenizer_manager.generate_request.assert_not_called()
 
     def test_multimodal_create_responses_sends_text_and_media_to_engine(self):
         serving = make_serving(is_multimodal=True)
         captured = {}
 
-        serving._process_messages = Mock(
-            return_value=MessageProcessingResult(
-                prompt="rendered multimodal prompt",
-                prompt_ids=[9, 9, 9],
+        input_processor(serving).prepare = Mock(
+            return_value=prepared_chat(
+                "rendered multimodal prompt",
                 image_data=["http://example.com/cat.png"],
                 audio_data=None,
                 video_data=None,
                 modalities=["image"],
                 stop=[],
-                engine_prompt="rendered multimodal prompt",
             )
         )
 
         async def fake_generate(
             request_id,
-            request_prompt,
             adapted_request,
             sampling_params,
             context,
             **kwargs,
         ):
-            captured["request_prompt"] = request_prompt
             captured["adapted_request"] = adapted_request
             context.append_output(
                 {
@@ -617,10 +618,9 @@ class MultimodalRequestTestCase(CustomTestCase):
             store=False,
         )
 
-        response = asyncio.run(serving.create_responses(request))
+        response = asyncio.run(sync_serving(serving).create_responses(request))
 
         self.assertEqual(response.status, "completed")
-        self.assertEqual(captured["request_prompt"], "rendered multimodal prompt")
         self.assertEqual(captured["adapted_request"].text, "rendered multimodal prompt")
         self.assertIsNone(captured["adapted_request"].input_ids)
         self.assertEqual(
@@ -636,17 +636,18 @@ class MultimodalRequestTestCase(CustomTestCase):
                 serving = make_serving(is_multimodal=True)
                 serving.chat_encoding_spec = spec
                 serving.template_manager.chat_template_name = None
-                serving._encode_messages = Mock(return_value=[4, 5, 6])
+                input_processor(serving).renderer._encode_messages = Mock(
+                    return_value=[4, 5, 6]
+                )
                 request = ResponsesRequest(model="x", input="hi", store=False)
 
-                _, request_prompts, engine_prompts, _ = asyncio.run(
-                    serving._make_request(
+                _, processed = asyncio.run(
+                    sync_serving(serving)._make_request(
                         request, None, serving.tokenizer_manager.tokenizer
                     )
                 )
 
-                self.assertEqual(engine_prompts, [[4, 5, 6]])
-                self.assertEqual(request_prompts, [[4, 5, 6]])
+                self.assertEqual([prompt_value(processed)], [[4, 5, 6]])
 
 
 class EnginePromptTestCase(CustomTestCase):
@@ -663,13 +664,12 @@ class EnginePromptTestCase(CustomTestCase):
                     tokenizer.decode.return_value = "decoded prompt"
                     request = ResponsesRequest(model="x", input="hi", store=False)
 
-                    _, request_prompts, engine_prompts, processed = asyncio.run(
-                        serving._make_request(request, None, tokenizer)
+                    _, processed = asyncio.run(
+                        sync_serving(serving)._make_request(request, None, tokenizer)
                     )
-                    expected = processed.prompt if is_multimodal else [1, 2, 3]
-                    self.assertEqual(processed.engine_prompt, expected)
-                    self.assertEqual(request_prompts, [expected])
-                    self.assertEqual(engine_prompts, [expected])
+                    expected = prompt_value(processed) if is_multimodal else [1, 2, 3]
+                    self.assertEqual(prompt_value(processed), expected)
+                    self.assertEqual([prompt_value(processed)], [expected])
 
                     chat_request = ChatCompletionRequest(
                         model="x", messages=[{"role": "user", "content": "hi"}]
@@ -687,11 +687,9 @@ class EnginePromptTestCase(CustomTestCase):
             with self.subTest(engine_prompt=engine_prompt):
                 serving = make_serving(is_multimodal=True)
                 serving.chat_encoding_spec = "custom_encoder"
-                serving._process_messages = Mock(
-                    return_value=MessageProcessingResult(
-                        engine_prompt=engine_prompt,
-                        prompt="unused text",
-                        prompt_ids=[99],
+                input_processor(serving).prepare = Mock(
+                    return_value=prepared_chat(
+                        engine_prompt,
                         image_data=["image-data"],
                         audio_data=None,
                         video_data=None,
@@ -700,13 +698,12 @@ class EnginePromptTestCase(CustomTestCase):
                     )
                 )
                 request = ResponsesRequest(model="x", input="hi", store=False)
-                _, request_prompts, engine_prompts, _ = asyncio.run(
-                    serving._make_request(
+                _, processed = asyncio.run(
+                    sync_serving(serving)._make_request(
                         request, None, serving.tokenizer_manager.tokenizer
                     )
                 )
-                self.assertEqual(request_prompts, [engine_prompt])
-                self.assertEqual(engine_prompts, [engine_prompt])
+                self.assertEqual([prompt_value(processed)], [engine_prompt])
 
                 chat_request = ChatCompletionRequest(
                     model="x", messages=[{"role": "user", "content": "hi"}]
@@ -993,7 +990,7 @@ class EnginePassthroughTestCase(CustomTestCase):
     silently."""
 
     def _capture(self, serving, request):
-        # Let the real _process_messages run: it is the hop that turns
+        # Let the real prepare run: it is the hop that turns
         # skip_special_tokens off, so mocking it would make that assertion vacuous.
         # chat_template_name=None routes it through the tokenizer's template
         # (mocked) instead of the conversation registry, which has no fixture entry.
@@ -1003,7 +1000,6 @@ class EnginePassthroughTestCase(CustomTestCase):
 
         async def fake_generate(
             request_id,
-            request_prompt,
             adapted_request,
             sampling_params,
             context,
@@ -1024,7 +1020,7 @@ class EnginePassthroughTestCase(CustomTestCase):
             yield context
 
         serving._generate_with_builtin_tools = fake_generate
-        asyncio.run(serving.create_responses(request))
+        asyncio.run(sync_serving(serving).create_responses(request))
         return captured
 
     def test_require_reasoning_forwarded_when_reasoning_parser_configured(self):
@@ -1071,7 +1067,7 @@ class EnginePassthroughTestCase(CustomTestCase):
         self.assertFalse(captured["adapted_request"].require_reasoning)
 
     def test_skip_special_tokens_disabled_for_tool_requests(self):
-        # _process_messages turns it off so tool-call markers survive detokenize;
+        # prepare turns it off so tool-call markers survive detokenize;
         # create_responses must re-apply it to the engine sampling dict.
         serving = make_serving()
         serving.tool_call_parser = "qwen25"
@@ -1130,7 +1126,7 @@ class StreamingLogprobsRejectionTestCase(CustomTestCase):
             stream=True,
             include=["message.output_text.logprobs"],
         )
-        result = asyncio.run(serving.create_responses(request))
+        result = asyncio.run(sync_serving(serving).create_responses(request))
         self.assertEqual(result.status_code, 400)
         body = orjson.loads(result.body)
         self.assertIn("streaming mode", body["error"]["message"])

--- a/test/registered/unit/entrypoints/openai/utils.py
+++ b/test/registered/unit/entrypoints/openai/utils.py
@@ -43,6 +43,7 @@ if torch is not None:
 
 class MockTokenizerManager:
     def __init__(self, *, is_multimodal: bool = False):
+        self.model_path = "dummy"
         self.model_config = Mock(is_multimodal=is_multimodal, context_len=4096)
         self.model_config.get_default_sampling_params.return_value = {}
         self.model_config.hf_config = Mock(
@@ -175,3 +176,96 @@ class StreamFixture:
         """``run`` plus (event type, payload) pairing, the common assertion shape."""
         events = self.run(chunks)
         return list(zip(event_types(events), event_payloads(events)))
+
+
+def input_processor(serving, **overrides):
+    from dataclasses import replace
+
+    from sglang.srt.entrypoints.chat_input.processor import ChatInputProcessor
+    from sglang.srt.entrypoints.chat_input.types import ChatModelConfig
+
+    processor = getattr(serving, "input_processor", None)
+    if processor is None:
+        config = ChatModelConfig(
+            tokenizer=serving.tokenizer_manager.tokenizer,
+            template_manager=getattr(
+                serving, "template_manager", Mock(reasoning_config=None)
+            ),
+            is_multimodal=False,
+        )
+        processor = ChatInputProcessor(config)
+        serving.input_processor = processor
+    aliases = {
+        "chat_encoding_spec": "chat_encoding_spec",
+        "tool_call_parser": "tool_call_parser",
+        "reasoning_parser": "reasoning_parser",
+        "reasoning_detector": "_reasoning_detector",
+        "default_chat_template_kwargs": "default_chat_template_kwargs",
+        "dsv4_reasoning_effort_profile": "_dsv4_reasoning_effort_profile",
+        "inkling_default_reasoning_effort": "_inkling_default_reasoning_effort",
+        "tokenizer_auto_adds_specials": "_tokenizer_auto_adds_specials",
+        "is_gpt_oss": "is_gpt_oss",
+        "is_gemma4": "is_gemma4",
+    }
+    values = {
+        name: vars(serving)[alias]
+        for name, alias in aliases.items()
+        if alias in vars(serving)
+    }
+    values["tokenizer"] = serving.tokenizer_manager.tokenizer
+    model_config = getattr(serving.tokenizer_manager, "model_config", None)
+    if model_config is not None and isinstance(model_config.is_multimodal, bool):
+        values["is_multimodal"] = model_config.is_multimodal
+    values.update(overrides)
+    processor.config = replace(processor.config, **values)
+    processor.renderer.config = processor.config
+    return processor
+
+
+def sync_serving(serving):
+    input_processor(serving)
+    return serving
+
+
+def prepared_chat(
+    prompt,
+    *,
+    image_data=None,
+    audio_data=None,
+    video_data=None,
+    modalities=None,
+    stop=None,
+    tool_call_constraint=None,
+    skip_special_tokens=True,
+    require_reasoning=False,
+    reasoning_end_token_ids=None,
+    chat_template_kwargs=None,
+    reasoning_effort=None,
+):
+    from sglang.srt.entrypoints.chat_input.types import (
+        PreparedChat,
+        TextPrompt,
+        TokenPrompt,
+    )
+
+    return PreparedChat(
+        prompt=TextPrompt(prompt) if isinstance(prompt, str) else TokenPrompt(prompt),
+        image_data=image_data,
+        audio_data=audio_data,
+        video_data=video_data,
+        modalities=modalities or [],
+        stop=stop,
+        tool_call_constraint=tool_call_constraint,
+        skip_special_tokens=skip_special_tokens,
+        require_reasoning=require_reasoning,
+        reasoning_end_token_ids=reasoning_end_token_ids,
+        chat_template_kwargs=chat_template_kwargs,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def prompt_value(result):
+    from sglang.srt.entrypoints.chat_input.types import TextPrompt
+
+    prompt = result.prompt
+    return prompt.text if isinstance(prompt, TextPrompt) else prompt.token_ids


### PR DESCRIPTION
## Summary

- Follow up on #35486 and the DeepSeek V4.1 hotfix #38985; target `main` without importing the V4.1 support branch.
- Extract shared input schemas, normalization, model configuration, rendering, and preparation into `chat_input`. Keep existing protocol schema imports compatible through reexports.
- Give renderers a `RenderedPrompt` contract; let `ChatInputProcessor` assemble the final `PreparedChat`, including stop conditions, reasoning options, tool constraints, and media.
- Represent generation input as `TextPrompt` or `TokenPrompt`, so token encoders retain their IDs under multimodal configurations without serving-layer model-name exceptions.
- Migrate Chat Completions, Responses, tokenize, and Anthropic token counting to the shared processor. Responses no longer constructs a Chat Completions request, and tokenize no longer constructs a Chat serving handler.
- Share one processor instance across the HTTP handlers, preserve the native Harmony path, and remove the old message-processing result and duplicated prompt assembly. Custom renderers now implement `MessageRenderer` and return `RenderedPrompt`.

## Validation

- 972 related unit tests passed across OpenAI and Anthropic entrypoints, protocol schemas, conversation templates, reasoning, and function-call parsing; pre-commit checks passed.
- 13 independent baseline-vs-refactor tests passed, comparing generation payloads, tokenization results, and tokenizer calls across Jinja, conversation, Inkling, Kimi-K3, explicit input IDs, and text-only/multimodal configurations.
- Cover custom encoders absent from any model-name list, explicit input precedence, shared-processor handoff across endpoints, request immutability, media validation, and Harmony streaming/non-streaming handoff.
- No GPU inference or real DeepSeek V4.1 + PD end-to-end run was performed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34562190701](https://github.com/sgl-project/sglang/actions/runs/34562190701)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34562190477](https://github.com/sgl-project/sglang/actions/runs/34562190477)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34562190643](https://github.com/sgl-project/sglang/actions/runs/34562190643)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->