### PR TITLE
Fix RunAI object-storage checkpoint index filtering

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -4115,7 +4115,11 @@ class RunaiModelStreamerLoader(BaseModelLoader):
         """Prepare weights for the model.
 
         If the model is not local, it will be downloaded."""
-        from sglang.srt.utils.runai_utils import is_runai_obj_uri, list_safetensors
+        from sglang.srt.utils.runai_utils import (
+            ObjectStorageModel,
+            is_runai_obj_uri,
+            list_safetensors,
+        )
 
         is_object_storage_path = is_runai_obj_uri(model_name_or_path)
         if self._is_distributed is None:
@@ -4156,6 +4160,10 @@ class RunaiModelStreamerLoader(BaseModelLoader):
                 index_file,
                 self.load_config.download_dir,
                 revision,
+            )
+        if is_object_storage_path:
+            index_file = os.path.abspath(
+                os.path.join(ObjectStorageModel.get_path(hf_folder), index_file)
             )
         hf_weights_files = filter_duplicate_safetensors_files(
             hf_weights_files, hf_folder, index_file

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -830,7 +830,10 @@ def filter_duplicate_safetensors_files(
             if any(fnmatch.fnmatch(rel_path, pattern) for pattern in allow_patterns):
                 files_to_validate.add(f)
 
-    missing_files = sorted(f for f in files_to_validate if not os.path.isfile(f))
+    if "://" in hf_folder:
+        missing_files = sorted(files_to_validate.difference(hf_weights_files))
+    else:
+        missing_files = sorted(f for f in files_to_validate if not os.path.isfile(f))
     if missing_files:
         raise RuntimeError(
             f"{index_file} references {len(missing_files)} shard file(s) missing "

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -879,7 +879,16 @@ def maybe_add_mtp_safetensors(
 
     # Check if mtp.safetensors exists and is not already in the file list
     mtp_path = os.path.join(hf_folder, "mtp.safetensors")
-    if not os.path.isfile(mtp_path) or mtp_path in hf_weights_files:
+    if mtp_path in hf_weights_files:
+        return hf_weights_files
+
+    from sglang.srt.utils.runai_utils import is_runai_obj_uri, list_safetensors
+
+    if is_runai_obj_uri(hf_folder):
+        mtp_exists = mtp_path in list_safetensors(hf_folder)
+    else:
+        mtp_exists = os.path.isfile(mtp_path)
+    if not mtp_exists:
         return hf_weights_files
 
     # mtp.safetensors exists but not in index - this is a bug

--- a/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
@@ -47,6 +47,7 @@ class TestRunaiModelStreamerLoader(CustomTestCase):
                     shard = "model-00001-of-00001.safetensors"
                     files = [
                         f"{model_path}/{shard}",
+                        f"{model_path}/mtp.safetensors",
                         f"{model_path}/unused.safetensors",
                     ]
                     cache_root = (
@@ -62,6 +63,11 @@ class TestRunaiModelStreamerLoader(CustomTestCase):
                         patch.object(
                             runai_utils, "list_safetensors", return_value=files
                         ) as list_safetensors,
+                        patch.object(
+                            weight_utils,
+                            "runai_safetensors_weights_iterator",
+                            return_value=iter(()),
+                        ) as streamer,
                     ):
                         metadata = runai_utils.ObjectStorageModel.get_path(model_path)
                         os.makedirs(metadata, exist_ok=True)
@@ -83,7 +89,24 @@ class TestRunaiModelStreamerLoader(CustomTestCase):
                             (model_path, [files[0]]),
                         )
 
-                        list_safetensors.return_value = [files[1]]
+                        loader.target_device_str = "cpu"
+                        source = loader_mod.RunaiModelStreamerLoader.Source(
+                            model_or_path=model_path,
+                            revision=None,
+                            model_config=cast(
+                                ModelConfig,
+                                SimpleNamespace(
+                                    hf_config=SimpleNamespace(
+                                        architectures=["Glm4MoeForCausalLMNextN"],
+                                        num_nextn_predict_layers=1,
+                                    )
+                                ),
+                            ),
+                        )
+                        list(loader._get_weights_iterator(source))
+                        streamer.assert_called_once_with(files[:2], True, "cpu")
+
+                        list_safetensors.return_value = [files[-1]]
                         with self.assertRaisesRegex(RuntimeError, shard):
                             loader._prepare_weights(model_path, revision=None)
 

--- a/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
@@ -1,5 +1,8 @@
 import concurrent.futures
+import json
+import os
 import sys
+import tempfile
 import threading
 import unittest
 from types import SimpleNamespace
@@ -20,6 +23,7 @@ from sglang.srt.models.deepseek_v4 import (
     _dequant_fp8_wo_a_streaming,
 )
 from sglang.srt.models.deepseek_v4_dspark import DeepseekV4ForCausalLMDSpark
+from sglang.srt.utils import runai_utils
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -32,6 +36,57 @@ class _FakeModel:
 
 
 class TestRunaiModelStreamerLoader(CustomTestCase):
+    def test_remote_checkpoint_index(self):
+        for scheme in ("s3", "gs", "az"):
+            for relative_cache in (False, True):
+                with (
+                    self.subTest(scheme=scheme, relative_cache=relative_cache),
+                    tempfile.TemporaryDirectory() as cache_dir,
+                ):
+                    model_path = f"{scheme}://bucket/model"
+                    shard = "model-00001-of-00001.safetensors"
+                    files = [
+                        f"{model_path}/{shard}",
+                        f"{model_path}/unused.safetensors",
+                    ]
+                    cache_root = (
+                        os.path.relpath(cache_dir) if relative_cache else cache_dir
+                    )
+                    with (
+                        patch.object(
+                            runai_utils.envs.SGLANG_CACHE_DIR,
+                            "get",
+                            return_value=cache_root,
+                        ),
+                        patch.object(loader_mod, "get_server_args", return_value=None),
+                        patch.object(
+                            runai_utils, "list_safetensors", return_value=files
+                        ) as list_safetensors,
+                    ):
+                        metadata = runai_utils.ObjectStorageModel.get_path(model_path)
+                        os.makedirs(metadata, exist_ok=True)
+                        loader = loader_mod.RunaiModelStreamerLoader(
+                            LoadConfig(load_format=LoadFormat.RUNAI_STREAMER)
+                        )
+                        self.assertEqual(
+                            loader._prepare_weights(model_path, revision=None),
+                            (model_path, files),
+                        )
+                        list_safetensors.assert_called_with(path=model_path)
+
+                        with open(
+                            os.path.join(metadata, "model.safetensors.index.json"), "w"
+                        ) as f:
+                            json.dump({"weight_map": {"weight": shard}}, f)
+                        self.assertEqual(
+                            loader._prepare_weights(model_path, revision=None),
+                            (model_path, [files[0]]),
+                        )
+
+                        list_safetensors.return_value = [files[1]]
+                        with self.assertRaisesRegex(RuntimeError, shard):
+                            loader._prepare_weights(model_path, revision=None)
+
     def test_passes_quant_config_to_model_init(self):
         quant_config = object()
         fake_model = _FakeModel()

--- a/test/registered/unit/model_loader/test_weight_utils.py
+++ b/test/registered/unit/model_loader/test_weight_utils.py
@@ -4,8 +4,14 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.srt.model_loader.weight_utils import filter_duplicate_safetensors_files
+from sglang.srt.model_loader.weight_utils import (
+    filter_duplicate_safetensors_files,
+    maybe_add_mtp_safetensors,
+)
+from sglang.srt.utils import runai_utils
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -147,6 +153,50 @@ class TestFilterDuplicateSafetensorsFiles(CustomTestCase):
             index_file=INDEX_NAME,
         )
         self.assertEqual(result, [single])
+
+
+class TestMaybeAddMtpSafetensors(CustomTestCase):
+    def test_remote_mtp_guards(self):
+        folder = "s3://bucket/model"
+        model = f"{folder}/model.safetensors"
+        mtp = f"{folder}/mtp.safetensors"
+        cases = (
+            ("Glm4MoeForCausalLM", 1, [model, mtp], [model, mtp], False),
+            ("Glm4MoeForCausalLM", 1, [model], [model], True),
+            ("Glm4MoeForCausalLM", 0, [model], [model, mtp], False),
+            ("LlamaForCausalLM", 1, [model], [model, mtp], False),
+        )
+        for arch, nextn, selected, available, may_list in cases:
+            with (
+                self.subTest(arch=arch, nextn=nextn, selected=selected),
+                patch.object(
+                    runai_utils, "list_safetensors", return_value=available
+                ) as listing,
+            ):
+                config = SimpleNamespace(
+                    architectures=[arch], num_nextn_predict_layers=nextn
+                )
+                self.assertEqual(
+                    maybe_add_mtp_safetensors(selected, folder, INDEX_NAME, config),
+                    selected,
+                )
+                if not may_list:
+                    listing.assert_not_called()
+
+    def test_local_unindexed_mtp(self):
+        with tempfile.TemporaryDirectory() as folder:
+            model = _touch(folder, "model.safetensors")
+            mtp = _touch(folder, "mtp.safetensors")
+            config = SimpleNamespace(
+                architectures=["Glm4MoeLiteForCausalLMNextN"],
+                num_nextn_predict_layers=1,
+            )
+            with patch.object(runai_utils, "list_safetensors") as listing:
+                self.assertEqual(
+                    maybe_add_mtp_safetensors([model], folder, INDEX_NAME, config),
+                    [model, mtp],
+                )
+                listing.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_weight_utils.py
+++ b/test/registered/unit/model_loader/test_weight_utils.py
@@ -85,17 +85,19 @@ class TestFilterDuplicateSafetensorsFiles(CustomTestCase):
                 "vit": "vision_encoder/model.safetensors",
             },
         )
-        transformer = _touch(
-            self.folder, "transformer/diffusion_pytorch_model.safetensors"
-        )
+        shard = "transformer/diffusion_pytorch_model.safetensors"
+        _touch(self.folder, shard)
 
-        result = filter_duplicate_safetensors_files(
-            hf_weights_files=[transformer],
-            hf_folder=self.folder,
-            index_file=INDEX_NAME,
-            allow_patterns=["transformer/*.safetensors"],
-        )
-        self.assertEqual(result, [transformer])
+        for folder in (self.folder, "s3://bucket/model"):
+            with self.subTest(folder=folder):
+                transformer = os.path.join(folder, shard)
+                result = filter_duplicate_safetensors_files(
+                    hf_weights_files=[transformer],
+                    hf_folder=folder,
+                    index_file=os.path.join(self.folder, INDEX_NAME),
+                    allow_patterns=["transformer/*.safetensors"],
+                )
+                self.assertEqual(result, [transformer])
 
     def test_missing_shard_inside_allow_patterns_raises(self):
         _write_index(
@@ -106,18 +108,34 @@ class TestFilterDuplicateSafetensorsFiles(CustomTestCase):
                 "vit": "vision_encoder/model.safetensors",
             },
         )
-        transformer = _touch(
-            self.folder, "transformer/model-00001-of-00002.safetensors"
-        )
+        shard = "transformer/model-00001-of-00002.safetensors"
+        _touch(self.folder, shard)
 
-        with self.assertRaises(RuntimeError) as cm:
-            filter_duplicate_safetensors_files(
-                hf_weights_files=[transformer],
-                hf_folder=self.folder,
-                index_file=INDEX_NAME,
-                allow_patterns=["transformer/*.safetensors"],
-            )
-        self.assertIn("model-00002-of-00002.safetensors", str(cm.exception))
+        for folder in (self.folder, "s3://bucket/model"):
+            with (
+                self.subTest(folder=folder),
+                self.assertRaisesRegex(
+                    RuntimeError, r"model-00002-of-00002\.safetensors"
+                ),
+            ):
+                filter_duplicate_safetensors_files(
+                    hf_weights_files=[os.path.join(folder, shard)],
+                    hf_folder=folder,
+                    index_file=os.path.join(self.folder, INDEX_NAME),
+                    allow_patterns=["transformer/*.safetensors"],
+                )
+
+    def test_local_index_allows_subset_of_existing_shards(self):
+        _write_index(
+            self.folder,
+            {"w1": "first.safetensors", "w2": "second.safetensors"},
+        )
+        first = _touch(self.folder, "first.safetensors")
+        _touch(self.folder, "second.safetensors")
+
+        result = filter_duplicate_safetensors_files([first], self.folder, INDEX_NAME)
+
+        self.assertEqual(result, [first])
 
     def test_single_file_model_no_index_returns_unchanged(self):
         # No index on disk (single-file / dummy / object-storage): early return.


### PR DESCRIPTION
## Why is this change needed?

RunAI caches checkpoint metadata locally but streams weights from object storage. Looking for the index under the remote URI skips filtering and can load stale shards. Read the cached index and validate its shards against the remote listing.

Preserve the existing GLM4Moe/GLM4MoeLite workaround for separately packaged MTP weights by checking the remote listing in `maybe_add_mtp_safetensors()`. For a checkpoint with NextN layers whose index references only `model.safetensors`, the selected files change from:

```diff
- ["model.safetensors", "mtp.safetensors", "unused.safetensors"]
+ ["model.safetensors", "mtp.safetensors"]
```

## Test Plan

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/model_loader/test_runai_model_streamer_loader.py \
  test/registered/unit/model_loader/test_weight_utils.py
```

20 tests and 14 subtests pass on CPU. Regression tests fail when restoring either the old index-filtering functions or the old MTP helper. Coverage includes S3/GCS/Azure, absolute and relative metadata-cache paths, missing shards, absent indexes, subfolder filtering, local shard subsets, and MTP eligibility.

Repository pre-commit checks pass. Validated with Python 3.13, PyTorch 2.11.0, and runai-model-streamer 0.15.8; no GPU/model accuracy run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34624954233](https://github.com/sgl-project/sglang/actions/runs/34624954233)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34624953959](https://github.com/sgl-project/sglang/actions/runs/34624953959)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34624954240](https://github.com/sgl-project/sglang/actions/runs/34624954240)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->