### PR TITLE
[engine] Report `enable_http2` on `/model_info`

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -772,6 +772,10 @@ async def model_info():
         "tool_call_parser": _global_state.tokenizer_manager.config_value(
             "tool_call_parser"
         ),
+        # The transport a client must speak to reach this server, alongside the
+        # tokenizer and sampling defaults it needs for the same reason.
+        # sgl-router reads it to pick a forwarding client per worker.
+        "enable_http2": get_serving().enable_http2,
         "has_image_understanding": model_config.is_image_understandable_model,
         "has_audio_understanding": model_config.is_audio_understandable_model,
         "model_type": getattr(model_config.hf_config, "model_type", None),

--- a/test/registered/unit/entrypoints/test_model_info.py
+++ b/test/registered/unit/entrypoints/test_model_info.py
@@ -1,0 +1,108 @@
+"""Endpoint-level tests for `/model_info`.
+
+`/model_info` reports the identity the server currently answers under, plus
+the handful of serving settings a client needs before it can send a request.
+Everything here is read from manager-owned state, which is what makes the
+endpoint answerable while the scheduler is still warming.
+
+Current coverage:
+
+* `TestModelInfoEnableHttp2Contract` — `enable_http2` as a wire contract
+  with sgl-router, which reads it to choose a forwarding client per worker.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints import http_server
+from sglang.srt.runtime_context import publish, reset_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+def _call_model_info_with(server_args: ServerArgs) -> dict:
+    """Invoke `http_server.model_info()` against a stub global state.
+
+    Bypasses the FastAPI HTTP layer: the handler is an `async def` reading
+    module-level `_global_state`, so a `SimpleNamespace` stub plus a published
+    context (for `get_serving()`) is enough to exercise it without booting a
+    model server.
+    """
+    tokenizer_manager = SimpleNamespace(
+        server_args=server_args,
+        model_path=server_args.model_path,
+        served_model_name=server_args.served_model_name,
+        is_generation=True,
+        config_value=lambda name: None,
+        model_config=SimpleNamespace(
+            is_image_understandable_model=False,
+            is_audio_understandable_model=False,
+            hf_config=SimpleNamespace(),
+        ),
+    )
+    prior_state = http_server.get_global_state()
+    http_server.set_global_state(SimpleNamespace(tokenizer_manager=tokenizer_manager))
+    try:
+        # Inside the try: a `publish` that raises must still restore the module
+        # global, or the stub leaks into every later test in this process.
+        publish(server_args, role="tokenizer")
+        return asyncio.run(http_server.model_info())
+    finally:
+        http_server.set_global_state(prior_state)
+        reset_context()
+
+
+class TestModelInfoEnableHttp2Contract(CustomTestCase):
+    """`enable_http2` is a wire contract with sgl-router, not just a flag.
+
+    The router reads this key to decide whether to forward to a worker over
+    cleartext h2c (`experimental/sgl-router/src/workers/manager.rs`,
+    `resolve_protocol`). Its parser treats the key as optional, because engines
+    predating the flag do not send it — so if the field is renamed, dropped, or
+    stops being a bool, the router reads `None`, silently leaves every worker on
+    HTTP/1.1, and nothing on either side fails.
+
+    It is pinned on `/model_info` specifically. `/server_info` also carries it
+    as part of the launch record, but that handler awaits a scheduler
+    round-trip, so on a warming engine it can fail while this one answers —
+    and a protocol the router reads late is a protocol it never applies.
+    """
+
+    def test_enable_http2_is_present_and_boolean_by_default(self):
+        info = _call_model_info_with(ServerArgs(model_path="dummy"))
+
+        self.assertIn(
+            "enable_http2",
+            info,
+            "sgl-router reads `enable_http2` from /model_info to enable h2c "
+            "forwarding; renaming or dropping it silently disables the feature",
+        )
+        self.assertIsInstance(
+            info["enable_http2"],
+            bool,
+            "the router parses `enable_http2` as Option<bool>; a non-bool "
+            "deserialises to None and reads as 'no h2c'",
+        )
+        self.assertFalse(info["enable_http2"], "default must be off")
+
+    def test_enable_http2_reports_the_launched_value(self):
+        """Presence is not enough — the value has to track the launch flag.
+
+        A field pinned to its default would pass the case above while telling
+        the router "no h2c" on every engine that enabled it.
+        """
+        info = _call_model_info_with(ServerArgs(model_path="dummy", enable_http2=True))
+
+        self.assertTrue(
+            info["enable_http2"],
+            "an engine launched with --enable-http2 must advertise it, or the "
+            "router will never upgrade that worker to h2c",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `enable_http2` to the `/model_info` response, so a client can learn that
an engine serves cleartext HTTP/2 before it dials one.

An engine launched with `--enable-http2` runs Granian in `HTTPModes.auto`,
which serves cleartext HTTP/2 (h2c) alongside HTTP/1.1. Nothing on the wire
advertises that today, so a client in front of the engine has no way to know it
may multiplex and opens one connection per request. The flag joins the
tokenizer and sampling defaults already on `/model_info` — the same class of
fact: what a client needs to know before it sends a request.

## Why `/model_info` and not `/server_info`

`/server_info` reports the same flag as part of the launch record, but that
handler awaits a scheduler IPC round-trip (`get_internal_state`), while
`/model_info` is served from manager-owned state. A warming engine answers the
second long before the first, so a client that reads the transport from the
slower endpoint can start sending to an engine whose transport it has not read
yet.

## Tests

New `test/registered/unit/entrypoints/test_model_info.py`, registered as a CPU
test (`base-a-test-cpu`, est. 8 s). It pins `enable_http2` as a **wire
contract**, not as one more field: the intended consumer parses the key as
optional (engines predating the flag do not send it), so a rename or a type
change reads as "no h2c" and silently disables the feature with nothing failing
on either side. The existing field-coverage test iterates whatever fields
happen to exist and so cannot catch that.

Two cases:

- the key is present and boolean by default (and defaults to off);
- it tracks the launched value — which is what a field frozen at its default
  would fail while still passing the first case.

The handler is exercised directly against a stubbed `_global_state` plus a
published runtime context, so it costs no model server and runs on CPU. Not
executed locally (no sglang import available on this machine); first runs in
CI.

## Stack

This is the engine half of adding h2c support to sgl-router. The router half is
independent — it parses the key as optional, so it does not need this to
merge — and lands in:

- #39004 — `[router] Resolve a wire protocol per worker at registration`
- #39006 — `[router] Speak cleartext h2c on both edges`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvuNbhw6V1hUUgxnZ2F6Y9
