### PR TITLE
[Bug] Include DSA variant in exact-bucket graph admission

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -705,6 +705,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             cuda_graph_bs,
             stream_idx=get_current_stream_idx() if self.enable_pdmux else None,
             variant_label=self._resolve_lora_variant(forward_batch),
+            dsa_variant=(
+                self._resolve_dsa_variant(forward_batch)
+                if self.disable_padding
+                else None
+            ),
         )
 
         is_bs_supported = (


### PR DESCRIPTION
- Include the selected DSA variant when checking exact-bucket graph availability with `--disable-cuda-graph-padding`; captured dense/sparse graphs previously fell back to eager.
- Keep padded admission free of length reads and preserve the independent LoRA key.
- Split the behavior fix from the graph-variant refactor in #38993, split from #38962 for #38798.
- Validation: one-off CPU checks reproduced the original fallback and passed after the fix locally and on `lsyin-b300`; pre-commit passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #34559599370](https://github.com/sgl-project/sglang/actions/runs/34559599370)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34559599278](https://github.com/sgl-project/sglang/actions/runs/34559599278)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #34559599340](https://github.com/sgl-project/sglang/actions/runs/34559599340)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->