### PR TITLE
[Fix][KDA] Rebuild accepted-state lists during CUDA graph capture

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -319,6 +319,17 @@ class MambaAttnBackendBase(AttentionBackend):
             mamba_track_indices=getattr(forward_batch, "mamba_track_indices", None),
         )
 
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        super().init_forward_metadata_in_graph(forward_batch)
+        if self.accept_lens_pool is None or self.forward_metadata is None:
+            return
+        # KDA shares these lists across layers of one forward. Graph warmup and
+        # capture reuse the same metadata, so drop the warmup lists here to
+        # record their construction in the graph. Otherwise replay keeps using
+        # the warmup slot indices and accepted lengths.
+        self.forward_metadata.fused_accept_state_indices = None
+        self.forward_metadata.fused_accept_num_accepted = None
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         self.forward_metadata = self._forward_metadata(forward_batch)
 

--- a/test/registered/attention/unittests/hybrid_linear/test_kda_fused_accept_indices.py
+++ b/test/registered/attention/unittests/hybrid_linear/test_kda_fused_accept_indices.py
@@ -136,6 +136,58 @@ class TestFusedAcceptPerForwardCache(CustomTestCase):
         self.assertIsNone(metadata.fused_accept_state_indices)
         self.assertIsNone(metadata.fused_accept_num_accepted)
 
+    def test_capture_rebuilds_warmup_indices_and_accept_lengths(self):
+        """Warmup and capture share metadata, but each must build its own lists.
+
+        Use CPU tensors to make a skipped capture-time build observable without
+        recording a CUDA graph: update the inputs after warmup and require the
+        next build to read them through the real KDA backend.
+        """
+        from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+        from sglang.srt.layers.attention.mamba.mamba2_metadata import ForwardMetadata
+        from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+        cases = (
+            ([3, 5], [[12, 13, 14, 15], [20, 21, 22, 23]], [1, 2]),
+            ([6, 3], [[24, 25, 26, 27], [12, 13, 14, 15]], [3, 1]),
+        )
+        for capture_slots, expected_indices, expected_lengths in cases:
+            with self.subTest(capture_slots=capture_slots):
+                # Bypass model loading; these methods only need CPU metadata.
+                backend = KDAAttnBackend.__new__(KDAAttnBackend)
+                slots = torch.tensor([3, 5], dtype=torch.int32)
+                query_start_loc = torch.tensor([0, 4, 8], dtype=torch.int32)
+                backend.accept_lens_pool = torch.tensor(
+                    [1, 1, 1, 2, 1, 4, 1, 1], dtype=torch.int32
+                )
+                backend.forward_metadata = ForwardMetadata(
+                    query_start_loc=query_start_loc, mamba_cache_indices=slots
+                )
+                forward_batch = ForwardBatch.__new__(ForwardBatch)
+                build_args = dict(
+                    cache_indices=slots,
+                    query_start_loc=query_start_loc,
+                    intermediate_state_cache=torch.empty(8, 4, 1),
+                    draft_token_num=4,
+                )
+
+                # The runner invokes this hook before both warmups and capture.
+                for _ in range(2):
+                    backend.init_forward_metadata_in_graph(forward_batch)
+                    _, warmup_lengths = backend._fused_accept_indices(**build_args)
+                    self.assertEqual(warmup_lengths.tolist(), [2, 4])
+
+                # Keep the same metadata and input storage, as the runner does.
+                slots.copy_(torch.tensor(capture_slots, dtype=torch.int32))
+                backend.accept_lens_pool.copy_(
+                    torch.tensor([1, 1, 1, 1, 1, 2, 3, 1], dtype=torch.int32)
+                )
+                backend.init_forward_metadata_in_graph(forward_batch)
+                indices, lengths = backend._fused_accept_indices(**build_args)
+
+                self.assertEqual(indices.tolist(), expected_indices)
+                self.assertEqual(lengths.tolist(), expected_lengths)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Kimi Delta Attention (KDA) can reuse stale state indices and accepted token counts during CUDA graph replay. State indices select stored model states. A CUDA graph records GPU operations during capture and repeats them during replay.

The graph runner reuses one `ForwardMetadata` object across warmup and capture. Warmup populates `fused_accept_state_indices` and `fused_accept_num_accepted`. KDA's lazy builder skips construction during capture because these arrays already exist. Replay consequently keeps using warmup values after the input slots or accepted counts change.

This affects the fused-accept KDA path introduced in #33722.

## Modifications

- Clear the two cached references in `MambaAttnBackendBase.init_forward_metadata_in_graph` when the accepted-length pool and metadata exist. KDA inherits this method, so capture records the array construction and replay reads current inputs.
- Add a regression test using the actual KDA builder and preparation method. It reuses one metadata object and input storage across two warmups and the next preparation call, checking changed accepted counts and changed slots.

Two files changed: 11 production lines and 52 test lines added.

## Accuracy Tests

Before/after validation ran on an NVIDIA RTX PRO 6000 Blackwell Workstation Edition, driver 595.71.05, Python 3.12, PyTorch 2.13.0+cu130, CUDA 13.0, FlashInfer 0.6.18, and sgl_kernel 0.4.6.post1. Container: `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729`.

[Full logs, dependency versions, and extra check script](https://gist.github.com/jhuangsa/e853b4c209870bf28543ac00075f819c).

| Check | Original | Fixed |
| --- | --- | --- |
| Seven tests in the existing test file | Two expected subtest failures | All pass |
| Actual CUDA graph capture/replay: changed lengths, changed slots, padding, slot reuse | All four return stale values | All four pass |
| Two builder calls within one forward share tensor objects | Pass | Pass |
| Next preparation call rebuilds arrays | Fail | Pass |
| Missing accepted-length pool or metadata is handled | Pass | Pass |

For the first replay case, the expected accepted counts are `[1, 2]`; the original code returns `[2, 4]`. The failures are value assertions after successful capture. The standalone GPU script passed on four consecutive runs in this environment.

The GPU runs tested original commit `304c428d90f43c6aaf5b36b8fc85628fb36d6464` and fixed commit `9d49e28753dd129b16aa8b40d11e617becf8455d` in separate source archives from a private development repository. `PYTHONPATH` selected each archive, and the script printed the imported KDA source path. These hashes document the tested source; reviewers can use the attached script and logs without access to that repository.

This public PR applies the same patch to upstream base `b3dc0388ed`. The public branch has not had a new GPU run. Its seven tests passed locally with real production modules and CPU tensors using a launcher that substitutes unused import dependencies. All applicable pre-commit checks for its two changed files and `git diff --check` passed.

Run the included test from the repository root:

```bash
PYTHONPATH="$PWD/python" python test/registered/attention/unittests/hybrid_linear/test_kda_fused_accept_indices.py
```

### Validation limits

- Full model output accuracy was not measured. The GPU scripts test array preparation and replay; they do not load a KDA model or execute FlashInfer's recurrent KDA computation. Their success does not establish support for that computation on the test GPU.
- The GPU capture/replay script is attached below as a standalone reproducer. It has not been added to the registered automated test suite. The PR includes the CPU regression test.
- On the earlier development checkout, the full `pre-commit run --all-files` check encountered formatting changes in three existing documentation scripts outside this patch; those changes were reverted. Rust checks could not run because `cargo`/`rustup` were unavailable. The full repository check is therefore not reported as passing. Only checks for the changed files were rerun on this public branch.

## Speed Tests and Profiling

Not measured. No speed improvement is claimed.

## Checklist

- [x] Add a focused regression test using the existing test registration and `CustomTestCase`.
- [x] Run all applicable pre-commit checks on the changed files and check the diff for whitespace errors.
- [x] Follow the existing code style.
- [ ] Complete the full repository formatting/tool checks; limitations described above.
- [ ] Run a full model accuracy evaluation; not measured.
- Documentation: no public API or configuration changes.
- Speed benchmarks: not measured.

## Review and Merge Process

@yuan-luo, could you review the warmup/capture interaction in the KDA path introduced by #33722? Please advise on the model accuracy evaluation needed for this change. An authorized maintainer can start the required CI checks (the project's automated tests).

<details>
<summary>Standalone CUDA graph reproducer (save as validate_kda_graph.py)</summary>

Run against the original and fixed source with `PYTHONPATH="$PWD/python" python /path/to/validate_kda_graph.py`. The original should fail with stale output assertions; the fix should pass all four cases. Replay updates only the input buffers and runs the graph; it does not call the Python builder again.

```python
"""Standalone GPU evidence script; run against both base and fixed source trees."""
import inspect
import torch
from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
from sglang.srt.layers.attention.mamba.mamba2_metadata import ForwardMetadata
from sglang.srt.model_executor.forward_batch_info import ForwardBatch


def main():
    assert torch.cuda.is_available(), "A CUDA-enabled PyTorch installation and GPU are required"
    print("KDA source:", inspect.getfile(KDAAttnBackend), flush=True)
    print("PyTorch:", torch.__version__, "CUDA:", torch.version.cuda, flush=True)
    print("GPU:", torch.cuda.get_device_name(), flush=True)
    device = "cuda"
    slots = torch.tensor([3, 5], dtype=torch.int32, device=device)
    starts = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
    pool = torch.tensor([1, 1, 1, 2, 1, 4, 1, 1], dtype=torch.int32, device=device)
    backend = KDAAttnBackend.__new__(KDAAttnBackend)
    backend.accept_lens_pool = pool
    backend.forward_metadata = ForwardMetadata(query_start_loc=starts, mamba_cache_indices=slots)
    batch = ForwardBatch.__new__(ForwardBatch)
    args = dict(cache_indices=slots, query_start_loc=starts,
                intermediate_state_cache=torch.empty(8, 4, 1, device=device), draft_token_num=4)
    stream = torch.cuda.Stream()
    stream.wait_stream(torch.cuda.current_stream())
    with torch.cuda.stream(stream):
        for _ in range(2):
            backend.init_forward_metadata_in_graph(batch)
            backend._fused_accept_indices(**args)
    torch.cuda.current_stream().wait_stream(stream)
    torch.cuda.synchronize()
    graph = torch.cuda.CUDAGraph()
    with torch.cuda.graph(graph, stream=stream):
        backend.init_forward_metadata_in_graph(batch)
        indices, lengths = backend._fused_accept_indices(**args)
        # Keep output copying in the old graph too, so it is never empty.
        output_indices = indices.clone()
        output_lengths = lengths.clone()
    torch.cuda.synchronize()
    cases = [
        ("changed lengths", [3, 5], [1, 1, 1, 1, 1, 2, 3, 1],
         [[12, 13, 14, 15], [20, 21, 22, 23]], [1, 2]),
        ("changed slots", [6, 3], [1, 1, 1, 1, 1, 2, 3, 1],
         [[24, 25, 26, 27], [12, 13, 14, 15]], [3, 1]),
        ("padding", [5, -1], [1, 1, 1, 1, 1, 4, 3, 1],
         [[20, 21, 22, 23], [-4, -3, -2, -1]], [4, 1]),
        ("reused slot", [3, 6], [1, 1, 1, 4, 1, 2, 2, 1],
         [[12, 13, 14, 15], [24, 25, 26, 27]], [4, 2]),
    ]
    failures = []
    for name, new_slots, new_pool, expected_indices, expected_lengths in cases:
        slots.copy_(torch.tensor(new_slots, dtype=torch.int32, device=device))
        pool.copy_(torch.tensor(new_pool, dtype=torch.int32, device=device))
        # Replay only: never call the Python preparation methods here.
        graph.replay()
        torch.cuda.synchronize()
        actual_indices = output_indices.cpu().tolist()
        actual_lengths = output_lengths.cpu().tolist()
        passed = actual_indices == expected_indices and actual_lengths == expected_lengths
        print(name, "PASS" if passed else "FAIL", flush=True)
        print("  indices expected:", expected_indices, "actual:", actual_indices, flush=True)
        print("  lengths expected:", expected_lengths, "actual:", actual_lengths, flush=True)
        if not passed:
            failures.append(name)
    assert not failures, "Stale graph outputs: " + ", ".join(failures)
    print("PASS: all four CUDA graph replay cases", flush=True)


if __name__ == "__main__":
    main()
```

</details>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34559408599](https://github.com/sgl-project/sglang/actions/runs/34559408599)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34559408313](https://github.com/sgl-project/sglang/actions/runs/34559408313)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34559408582](https://github.com/sgl-project/sglang/actions/runs/34559408582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->