### PR TITLE
fix(kda): route NVIDIA prefill padding to the reserved Mamba slot

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia.py
@@ -357,9 +357,11 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
         alog_flat = self._flat_param(A_log)
         dtb_flat = self._flat_param(dt_bias)
 
-        all_slot_indices = torch.where(
-            cache_indices >= 0, cache_indices, ssm_states.shape[0] - 1
-        ).to(torch.int64)
+        # Slot 0 is reserved for padded rows; MambaSlotAllocator only allocates
+        # 1..size, so the trailing row is a valid request/checkpoint slot.
+        all_slot_indices = torch.where(cache_indices >= 0, cache_indices, 0).to(
+            torch.int64
+        )
         state_backup = ssm_states.index_select(0, all_slot_indices).clone()
         packed_output = torch.empty_like(v)
 


### PR DESCRIPTION
Addresses the NVIDIA KDA variant of the padding-slot aliasing discussed in
#36880 and #36885. This change targets `main`'s NVIDIA wrapper, not the Triton
wrapper discussed in #36885.

## The bug

`NvidiaKDAKernel.extend` remapped padded rows (`cache_indices == -1`) to
`ssm_states.shape[0] - 1`, described as the pool's trailing sentinel. That row
is not reserved:

- `MambaPool` allocates `size + 1` rows.
- `MambaSlotAllocator` reserves slot 0 as the dummy write target and hands out
  `1..size` inclusive.

Therefore `ssm_states.shape[0] - 1 == size` is the last allocatable slot. The
remapped index is reused for the initial-state gather, final-state scatter, and
exception rollback. If a live request or radix checkpoint owns the trailing
slot, a padded row can silently overwrite its SSM state.

## The fix

Map negative cache indices to reserved slot 0 instead:

```python
all_slot_indices = torch.where(cache_indices >= 0, cache_indices, 0).to(
    torch.int64
)
```

Unlike Triton's KDA path, the NVIDIA wrapper repacks requests into a dense
bucket and cannot pass `-1` to its native state interface. An explicit dummy
slot is therefore required, and slot 0 is the allocator-defined sink.

## Scope and status

The current ordinary padded-prefill path rejects zero-length rows before this
mapping, so the bug is latent under today's admission logic. The fix aligns the
NVIDIA wrapper with the Mamba allocator contract and prevents the alias if that
guard changes or another padded row reaches the dense path.

The change is limited to the sentinel mapping. It does not change supported
shapes, bucket selection, state layout conversion, or the Triton fallback.

## Validation

- `git diff --check`
- Python syntax compilation of `kda_nvidia.py`
- Code audit against `MambaSlotAllocator.clear()`, which allocates slots
  `1..size` and reserves slot 0

GPU validation has not been run, and no regression test is included. Ordinary
zero-length graph padding currently falls back before reaching this mapping,
so replaying that path alone would not exercise the changed code. A focused
test should exercise the mapping with a negative slot and positive sequence
length, keeping the trailing allocatable slot occupied, and verify both the
successful scatter and exception rollback without changing other live slots.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34560561135](https://github.com/sgl-project/sglang/actions/runs/34560561135)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34560560706](https://github.com/sgl-project/sglang/actions/runs/34560560706)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34560561038](https://github.com/sgl-project/sglang/actions/runs/34560561038)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->