### PR TITLE
[AMD] [GLM-5.3-Flash Day 0] Support Quark checkpoints that mix MXFP4 with explicit block FP8

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -15,7 +15,7 @@ from sglang.srt.layers.quantization.base_config import (  # noqa: E501
     QuantizationConfig,
     QuantizeMethodBase,
 )
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod, Fp8MoEMethod
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.quark.schemes import (
     QuarkLinearScheme,
@@ -375,9 +375,65 @@ class QuarkConfig(QuantizationConfig):
                 expanded.append(name.removeprefix("language_model."))
         self.exclude_layers = list(dict.fromkeys(expanded))
 
+        layer_quant_config = self.quant_config.get("layer_quant_config")
+        if layer_quant_config:
+            self.quant_config["layer_quant_config"] = hf_to_sglang_mapper.apply_dict(
+                layer_quant_config
+            )
+
+        if self.kv_cache_group:
+            self.kv_cache_group = hf_to_sglang_mapper.apply_list(self.kv_cache_group)
+
+    @staticmethod
+    def _get_block_fp8_config(
+        layer_quant_config: Optional[dict[str, Any]],
+        packed_modules_mapping: dict[str, list[str]],
+    ) -> Optional[Fp8Config]:
+        """Build an Fp8Config for a layer explicitly pinned to block FP8.
+
+        A Quark checkpoint may be globally MXFP4 while listing individual
+        layers as block-quantized FP8 in ``layer_quant_config``. Those layers
+        must be served by the FP8 methods, not by the global MXFP4 scheme.
+        """
+        if layer_quant_config is None:
+            return None
+
+        weight_config = layer_quant_config.get("weight") or {}
+        input_config = layer_quant_config.get("input_tensors") or {}
+        block_size = weight_config.get("block_size")
+        if not (
+            weight_config.get("dtype") in {"fp8_e4m3", "fp8_e4m3fn"}
+            and weight_config.get("qscheme") == "per_block"
+            and weight_config.get("is_dynamic") is False
+            and isinstance(block_size, list)
+            and len(block_size) == 2
+            and input_config.get("dtype") in {"fp8_e4m3", "fp8_e4m3fn"}
+            and input_config.get("is_dynamic") is True
+        ):
+            return None
+
+        return Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=block_size,
+            packed_modules_mapping=packed_modules_mapping,
+        )
+
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional["QuantizeMethodBase"]:
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+        explicit_layer_config = self._find_matched_layer_config(prefix, layer)
+        block_fp8_config = self._get_block_fp8_config(
+            explicit_layer_config, self.packed_modules_mapping
+        )
+        if block_fp8_config is not None:
+            if isinstance(layer, LinearBase):
+                return Fp8LinearMethod(block_fp8_config)
+            if isinstance(layer, FusedMoE):
+                return Fp8MoEMethod(block_fp8_config)
+
         # Check if the layer is skipped for quantization.
         if should_ignore_layer(
             prefix,
@@ -405,8 +461,6 @@ class QuarkConfig(QuantizationConfig):
         if isinstance(layer, RadixAttention):
             self._online_quantized_layers.add(prefix)
             return QuarkKVCacheMethod(self)
-
-        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 
         if isinstance(layer, FusedMoE):
             self._online_quantized_layers.add(prefix)
@@ -782,9 +836,15 @@ class QuarkConfig(QuantizationConfig):
         )
         return is_mx_fp4_weight and is_static_fp8_activation
 
-    def _find_matched_config(
+    def _find_matched_layer_config(
         self, layer_name: str, module: torch.nn.Module
-    ) -> dict[str, Any]:
+    ) -> Optional[dict[str, Any]]:
+        """Resolve a layer's explicit config, or None when it has none.
+
+        Unlike ``_find_matched_config`` this does not fall back to the global
+        config, so callers can tell "this layer is explicitly pinned to a
+        scheme" apart from "this layer just inherits the global scheme".
+        """
 
         proj_name = layer_name.split(".")[-1]
         if proj_name in self.packed_modules_mapping:
@@ -796,9 +856,17 @@ class QuarkConfig(QuantizationConfig):
                 for shard_proj_name in shard_proj_names
             ]
             shard_configs = [
-                self._find_matched_config(shard_name, module)
+                self._find_matched_layer_config(shard_name, module)
                 for shard_name in shard_names
             ]
+            if all(q_config is None for q_config in shard_configs):
+                return None
+            if any(q_config is None for q_config in shard_configs):
+                raise ValueError(
+                    f"Found a partially specified quantization configuration for "
+                    f"{shard_proj_names} in {layer_name}. SGLang requires all "
+                    "fused shards to use the same scheme."
+                )
             if not all(
                 deep_compare(q_config, shard_configs[0]) for q_config in shard_configs
             ):
@@ -823,10 +891,19 @@ class QuarkConfig(QuantizationConfig):
             if layer_type in layer_type_quant_config:
                 return layer_type_quant_config[layer_type]
 
-            global_quant_config = cast(
-                dict[str, Any], self.quant_config.get("global_quant_config")
-            )
-            return global_quant_config
+            return None
+
+    def _find_matched_config(
+        self, layer_name: str, module: torch.nn.Module
+    ) -> dict[str, Any]:
+        layer_config = self._find_matched_layer_config(layer_name, module)
+        if layer_config is not None:
+            return layer_config
+
+        global_quant_config = cast(
+            dict[str, Any], self.quant_config.get("global_quant_config")
+        )
+        return global_quant_config
 
     def _get_scheme_from_config(self, config: dict[str, Any]) -> "QuarkLinearScheme":
         if config.get("output_tensors") or config.get("bias"):

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -55,6 +55,12 @@ def should_ignore_layer(
     # proj_name = qkv_proj
     proj_name = layer_name.split(".")[-1]
 
+    # Some checkpoints serialize an already-fused module (for example a
+    # vision ``qkv`` projection) and list that fused name in ``exclude``.
+    # Honor the direct match before expanding model-level packed mappings.
+    if check_equal_or_regex_match(layer_name=layer_name, targets=ignore):
+        return True
+
     # Fused layers like gate_up_proj or qkv_proj will not be fused
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that

--- a/test/registered/unit/layers/quantization/test_quark_config.py
+++ b/test/registered/unit/layers/quantization/test_quark_config.py
@@ -5,10 +5,13 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=12, suite="base-a-test-cpu")
 
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 import torch
 
+from sglang.srt.layers.linear import LinearBase
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
 from sglang.srt.layers.quantization.quark.quark import (
     QuarkConfig,
     _build_mixed_precision_layer_quant_config,
@@ -16,6 +19,7 @@ from sglang.srt.layers.quantization.quark.quark import (
     _parse_nvfp4_excludes,
 )
 from sglang.srt.layers.quantization.quark.utils import check_equal_or_regex_match
+from sglang.srt.models.utils import WeightsMapper
 from sglang.test.test_utils import CustomTestCase
 
 _GET_CAP = "sglang.srt.layers.quantization.quark.quark.get_device_capability"
@@ -205,6 +209,134 @@ class TestParseNvfp4Excludes(CustomTestCase):
         self.assertFalse(
             check_equal_or_regex_match("model.layers.0.mlp.experts", excludes)
         )
+
+
+class TestQuarkPerLayerBlockFp8(CustomTestCase):
+    """A globally-MXFP4 checkpoint that pins some layers to block FP8.
+
+    Quark writes these exceptions into ``layer_quant_config`` under the
+    checkpoint's own weight names, so they only resolve once the model's
+    weight-name mapper has been applied to that dict too.
+    """
+
+    _BLOCK_FP8_CONFIG = {
+        "weight": {
+            "dtype": "fp8_e4m3",
+            "qscheme": "per_block",
+            "block_size": [128, 128],
+            "is_dynamic": False,
+        },
+        "input_tensors": {
+            "dtype": "fp8_e4m3",
+            "qscheme": "per_group",
+            "group_size": 128,
+            "is_dynamic": True,
+        },
+        "output_tensors": None,
+        "bias": None,
+    }
+
+    # Stands in for any multimodal model that nests the text tower under a
+    # ``language_model.`` prefix and ships a pre-fused vision ``qkv``.
+    _MAPPER = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+            "model.visual.": "visual.",
+        },
+        orig_to_new_suffix={".attn.qkv": ".attn.qkv_proj"},
+    )
+
+    def _build_bare_config(self) -> QuarkConfig:
+        config = _bare_config()
+        config.quant_config = {
+            "layer_quant_config": {
+                "model.language_model.layers.0.mlp.down_proj": self._BLOCK_FP8_CONFIG
+            },
+            "layer_type_quant_config": {},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "fp4",
+                    "qscheme": "per_group",
+                    "group_size": 32,
+                    "is_dynamic": False,
+                    "scale_format": "e8m0",
+                },
+                "input_tensors": {
+                    "dtype": "fp4",
+                    "qscheme": "per_group",
+                    "group_size": 32,
+                    "is_dynamic": True,
+                    "scale_format": "e8m0",
+                },
+            },
+        }
+        config.exclude_layers = []
+        config.kv_cache_group = []
+        config.packed_modules_mapping = {}
+        config.excluded_fp8_config = None
+        config._online_quantized_layers = set()
+        return config
+
+    def test_mapper_rewrites_explicit_layer_config(self):
+        config = self._build_bare_config()
+
+        config.apply_weight_name_mapper(self._MAPPER)
+
+        self.assertIn(
+            "model.layers.0.mlp.down_proj",
+            config.quant_config["layer_quant_config"],
+        )
+        self.assertNotIn(
+            "model.language_model.layers.0.mlp.down_proj",
+            config.quant_config["layer_quant_config"],
+        )
+
+    def test_mapper_rewrites_fused_visual_exclusion(self):
+        config = self._build_bare_config()
+        config.exclude_layers = ["model.visual.blocks.0.attn.qkv"]
+
+        config.apply_weight_name_mapper(self._MAPPER)
+
+        self.assertEqual(config.exclude_layers, ["visual.blocks.0.attn.qkv_proj"])
+
+    def test_explicit_block_fp8_linear_uses_fp8_method(self):
+        config = self._build_bare_config()
+        config.apply_weight_name_mapper(self._MAPPER)
+        layer = LinearBase.__new__(LinearBase)
+
+        method = config.get_quant_method(layer, "model.layers.0.mlp.down_proj")
+
+        self.assertIsInstance(method, Fp8LinearMethod)
+        self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+        self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+
+    def test_dynamic_block_fp8_weight_is_not_treated_as_serialized(self):
+        layer_config = deepcopy(self._BLOCK_FP8_CONFIG)
+        layer_config["weight"]["is_dynamic"] = True
+
+        self.assertIsNone(QuarkConfig._get_block_fp8_config(layer_config, {}))
+
+    def test_unmatched_layer_still_uses_global_quark_config(self):
+        config = self._build_bare_config()
+        config.apply_weight_name_mapper(self._MAPPER)
+
+        matched = config._find_matched_config(
+            "model.layers.4.mlp.down_proj", torch.nn.Module()
+        )
+
+        self.assertEqual(matched["weight"]["dtype"], "fp4")
+
+    def test_partially_specified_fused_shards_are_rejected(self):
+        config = self._build_bare_config()
+        config.packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+        config.quant_config["layer_quant_config"] = {
+            "model.layers.0.self_attn.q_proj": self._BLOCK_FP8_CONFIG
+        }
+
+        with self.assertRaises(ValueError):
+            config._find_matched_layer_config(
+                "model.layers.0.self_attn.qkv_proj", torch.nn.Module()
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/quantization/test_quark_utils.py
+++ b/test/registered/unit/layers/quantization/test_quark_utils.py
@@ -8,7 +8,7 @@ import unittest
 
 import torch
 
-from sglang.srt.layers.quantization.quark.utils import e8m0_to_f32
+from sglang.srt.layers.quantization.quark.utils import e8m0_to_f32, should_ignore_layer
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -64,6 +64,20 @@ class TestE8M0ToF32(CustomTestCase):
         self.assertEqual(out[0].item(), 1.0)
         self.assertEqual(out[1].item(), 128.0)
         self.assertTrue(torch.isnan(out[2]).item())
+
+
+class TestShouldIgnoreLayer(CustomTestCase):
+    def test_direct_fused_module_exclusion_takes_precedence(self):
+        # Checkpoints that ship an already-fused vision qkv list that fused
+        # name in `exclude`; expanding the packed mapping first would look for
+        # q/k/v shards that the checkpoint never wrote.
+        self.assertTrue(
+            should_ignore_layer(
+                "visual.blocks.0.attn.qkv_proj",
+                ["visual.blocks.0.attn.qkv_proj"],
+                {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Quark can export a model whose global scheme is MXFP4 while pinning individual layers to block FP8 in `layer_quant_config`. `apply_weight_name_mapper` rewrote only `exclude_layers`, so that dict kept the checkpoint's own weight names, every lookup missed, and the layer silently fell back to global MXFP4 — wrong precision, no error. `_find_matched_config` could not express "no explicit entry" either, because a miss returned the global config. This splits out `_find_matched_layer_config`, which returns `None`, and routes pinned layers to `Fp8LinearMethod` / `Fp8MoEMethod`.

Resolved scheme for `amd/GLM-5.3-Flash-Quark-MXFP4`, queried with runtime layer names:

| Layer | before | after |
| --- | --- | --- |
| `model.layers.7.self_attn.q_a_proj` | `fp4` `per_group` | **`fp8_e4m3` `per_block` [128,128]** |
| `model.layers.45.mlp.experts.7.up_proj` | `fp4` `per_group` | **`fp8_e4m3` `per_block` [128,128]** |
| `model.layers.3.mlp.experts.0.up_proj` | `fp4` `per_group` | `fp4` `per_group` |
| `visual.blocks.0.attn.qkv_proj` | not excluded | **excluded** |

All 924 `layer_quant_config` entries in that checkpoint are block FP8.

## Scope

Quark checkpoints only, no hardware gate. Resolution is unchanged for a checkpoint with no `layer_quant_config` and for a model defining no `hf_to_sglang_mapper`: the new helper returns `None` and the wrapper falls back to the global config exactly as before. It does change for an existing Quark checkpoint that pins layers to `per_block` FP8 — those now reach the FP8 methods instead of the Quark scheme, which is the intent. Other quantization backends are untouched.

[#38546](https://github.com/sgl-project/sglang/pull/38546) owns the MXFP4 MoE weight and runner path; this PR only decides which quantization method each layer is given.

| Also changed | Fires when |
| --- | --- |
| Fused shards partially specified now raise | `layer_quant_config` names some but not all shards of one fused module |
| `should_ignore_layer` direct-name match | An `exclude` entry names an already-fused module, e.g. a pre-fused vision `qkv` |
| `kv_cache_group` routed through the mapper | The model defines `hf_to_sglang_mapper` and the checkpoint sets that group |

## Test plan

The resolution table above isolates this PR as the single variable; it and the companion model-side PR [#38999](https://github.com/sgl-project/sglang/pull/38999) are needed together, so accuracy is for the stack. Both rows below differ only in the checkpoint.

| | |
| --- | --- |
| Image | `rocm/sgl-dev:v0.5.19-rocm720-mi35x-20260909`, AITER `4ad99832` |
| Base | `main` `480b14eda` + [#38541](https://github.com/sgl-project/sglang/pull/38541)–[#38547](https://github.com/sgl-project/sglang/pull/38547) + [#38999](https://github.com/sgl-project/sglang/pull/38999) |
| Hardware | MI355X gfx950, TP4, decode CUDA graphs active |
| Sampling | `--thinking`, temperature 1.0, top-p 0.95, max 4,096 output tokens |

| Checkpoint | Examples | Score | stop | truncated | error |
| --- | --- | --- | --- | --- | --- |
| `zai-org/GLM-5.3-Flash`, block FP8 | 1,319 | 97.50% | 99.85% | 0.15% | 0.00% |
| `amd/GLM-5.3-Flash-Quark-MXFP4` | 1,319 | **96.89%** | 99.39% | 0.61% | 0.00% |

MXFP4 lands 0.61 points below block FP8, one pass each — at the edge of this model's run-to-run spread rather than inside it: six reference runs spanned 96.82% to 97.35%, and [#36607](https://github.com/sgl-project/sglang/pull/36607) measured 97.19% for this checkpoint at TP4. Read it as parity pending a repeat pass, not a demonstrated regression.

`test_quark_config.py` and `test_quark_utils.py`: 26 passed. `isort`, `black` and Ruff clean.
