### PR TITLE
[AMD] [GLM-5.3-Flash Day 0] Map Quark weight names for mixed MXFP4 and block FP8

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1082,7 +1082,11 @@ class Glm5NextForConditionalGeneration(nn.Module):
         orig_to_new_substr={
             "model.language_model.": "model.",
             "model.visual": "visual",
-        }
+        },
+        # The vision tower ships a pre-fused ``qkv``; the runtime module is
+        # ``qkv_proj``. Quantization configs name layers by module, so the
+        # rename load_weights already does for tensors is needed here too.
+        orig_to_new_suffix={".attn.qkv": ".attn.qkv_proj"},
     )
 
     packed_modules_mapping = {
@@ -1241,9 +1245,9 @@ class Glm5NextForConditionalGeneration(nn.Module):
         )
         if self.num_fused_shared_experts == 0:
             return
-        assert self.num_fused_shared_experts == 1, (
-            f"Only 1 fused shared expert is supported for {type(self).__name__}"
-        )
+        assert (
+            self.num_fused_shared_experts == 1
+        ), f"Only 1 fused shared expert is supported for {type(self).__name__}"
         log_info_on_rank0(logger, "Shared experts fusion optimization enabled.")
 
     def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
@@ -1422,6 +1426,16 @@ class Glm5NextForConditionalGeneration(nn.Module):
             fused_cat_dim = 0
 
         params_dict = dict(self.named_parameters())
+
+        def maybe_map_fp8_block_scale_name(name: str) -> str:
+            # Quark serializes block-FP8 scales as ``.weight_scale`` while the
+            # FP8 linear method registers them as ``.weight_scale_inv``.
+            if name.endswith(".weight_scale"):
+                candidate = name.removesuffix(".weight_scale") + ".weight_scale_inv"
+                if candidate in params_dict:
+                    return candidate
+            return name
+
         weight_names = []
         for name, loaded_weight in weights:
             is_visual_weight = "visual" in name
@@ -1485,6 +1499,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 candidate = name.replace(weight_name, param_name)
+                candidate = maybe_map_fp8_block_scale_name(candidate)
                 if (
                     param_name
                     in {
@@ -1513,6 +1528,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                         continue
                     is_expert_weight = True
                     name = name.replace(weight_name, param_name)
+                    name = maybe_map_fp8_block_scale_name(name)
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
@@ -1564,6 +1580,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                                     "fused_qkv_a_proj_with_mqa",
                                 )
                             )
+                            target = maybe_map_fp8_block_scale_name(target)
                             if target in params_dict:
                                 param = params_dict[target]
                                 weight_loader = getattr(
@@ -1574,6 +1591,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                             cached_a_proj.pop(kv_a_proj_name, None)
                         continue
 
+                    name = maybe_map_fp8_block_scale_name(name)
                     if name not in params_dict:
                         continue
 

--- a/test/registered/unit/models/test_glm5_next_quark_weight_mapping.py
+++ b/test/registered/unit/models/test_glm5_next_quark_weight_mapping.py
@@ -1,0 +1,81 @@
+"""Weight-name mapping GLM-5.3-Flash needs for Quark checkpoints — CPU only."""
+
+import unittest
+
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_MAPPER = Glm5NextForConditionalGeneration.hf_to_sglang_mapper
+
+
+class TestHfToSglangMapper(CustomTestCase):
+    def test_language_tower_prefix_is_stripped(self):
+        self.assertEqual(
+            _MAPPER.apply_list(["model.language_model.layers.0.mlp.down_proj"]),
+            ["model.layers.0.mlp.down_proj"],
+        )
+
+    def test_vision_tower_prefix_is_rewritten(self):
+        self.assertEqual(
+            _MAPPER.apply_list(["model.visual.blocks.0.attn.proj"]),
+            ["visual.blocks.0.attn.proj"],
+        )
+
+    def test_fused_vision_qkv_maps_to_runtime_module_name(self):
+        # The checkpoint ships a pre-fused `qkv`; the runtime module is
+        # `qkv_proj`. Quantization configs address layers by module name, so an
+        # unmapped exclusion would silently fail to match.
+        self.assertEqual(
+            _MAPPER.apply_list(["model.visual.blocks.0.attn.qkv"]),
+            ["visual.blocks.0.attn.qkv_proj"],
+        )
+
+    def test_mapper_rewrites_dict_keys(self):
+        mapped = _MAPPER.apply_dict(
+            {"model.language_model.layers.7.self_attn.q_a_proj": {"marker": 1}}
+        )
+        self.assertEqual(mapped, {"model.layers.7.self_attn.q_a_proj": {"marker": 1}})
+
+
+class TestBlockFp8ScaleNameMapping(CustomTestCase):
+    """Quark writes `.weight_scale`; the FP8 linear method wants `.weight_scale_inv`."""
+
+    @staticmethod
+    def _mapper(params_dict):
+        def maybe_map_fp8_block_scale_name(name: str) -> str:
+            if name.endswith(".weight_scale"):
+                candidate = name.removesuffix(".weight_scale") + ".weight_scale_inv"
+                if candidate in params_dict:
+                    return candidate
+            return name
+
+        return maybe_map_fp8_block_scale_name
+
+    def test_scale_is_renamed_when_runtime_param_exists(self):
+        fn = self._mapper({"model.layers.7.self_attn.q_a_proj.weight_scale_inv": None})
+        self.assertEqual(
+            fn("model.layers.7.self_attn.q_a_proj.weight_scale"),
+            "model.layers.7.self_attn.q_a_proj.weight_scale_inv",
+        )
+
+    def test_scale_is_left_alone_when_runtime_param_absent(self):
+        # MXFP4 layers keep `.weight_scale`; renaming them would break loading.
+        fn = self._mapper({"model.layers.3.mlp.experts.0.up_proj.weight_scale": None})
+        self.assertEqual(
+            fn("model.layers.3.mlp.experts.0.up_proj.weight_scale"),
+            "model.layers.3.mlp.experts.0.up_proj.weight_scale",
+        )
+
+    def test_non_scale_names_are_untouched(self):
+        fn = self._mapper({"model.layers.7.self_attn.q_a_proj.weight_scale_inv": None})
+        self.assertEqual(
+            fn("model.layers.7.self_attn.q_a_proj.weight"),
+            "model.layers.7.self_attn.q_a_proj.weight",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Quark export of GLM-5.3-Flash is globally MXFP4 with some layers pinned to block FP8, and it names things the way the checkpoint does rather than the way the runtime does. `hf_to_sglang_mapper`, added by [#38621](https://github.com/sgl-project/sglang/pull/38621), did not rewrite the pre-fused vision `attn.qkv`; `load_weights` already does that rename for tensors, but quantization configs address layers by module, so the checkpoint's exclusions for that projection never matched. Quark also serializes block-FP8 scales as `.weight_scale` while the FP8 linear method registers `weight_scale_inv`.

What `amd/GLM-5.3-Flash-Quark-MXFP4` ships, against what the runtime expects:

| Checkpoint name | Count | Runtime name |
| --- | --- | --- |
| `model.visual.blocks.*.attn.qkv` in `exclude` | 24 | `visual.blocks.*.attn.qkv_proj` |
| `*.weight_scale` tensors | 37,338 | `*.weight_scale_inv`, block-FP8 layers only |

## Scope

`Glm5NextForConditionalGeneration` only, no hardware gate, no change to CUDA paths or to `load_weights`' existing tensor-name handling. Both renames are deliberately narrow. On its own this PR fixes the vision exclusions and the scale names; the `layer_quant_config` half of the same checkpoint needs the companion quantization PR [#38998](https://github.com/sgl-project/sglang/pull/38998). Neither breaks anything without the other and they can land in either order. [#38546](https://github.com/sgl-project/sglang/pull/38546) already owns the MXFP4 MoE weight path.

| Rename | Fires only when | So this is unaffected |
| --- | --- | --- |
| `.attn.qkv` → `.attn.qkv_proj` | The name ends in that suffix, which no non-vision layer produces | [#38621](https://github.com/sgl-project/sglang/pull/38621)'s ModelOpt NVFP4 exclusions — its `model.visual*` glob does not end in it |
| `.weight_scale` → `.weight_scale_inv` | The runtime exposes `weight_scale_inv` for that parameter | MXFP4 layers keep their own `.weight_scale`; non-Quark checkpoints load byte-identically |

## Test plan

Both PRs are needed together for the checkpoint to resolve, so accuracy is for the stack. The two rows below differ only in the checkpoint.

| | |
| --- | --- |
| Image | `rocm/sgl-dev:v0.5.19-rocm720-mi35x-20260909`, AITER `4ad99832` |
| Base | `main` `480b14eda` + [#38541](https://github.com/sgl-project/sglang/pull/38541)–[#38547](https://github.com/sgl-project/sglang/pull/38547) + [#38998](https://github.com/sgl-project/sglang/pull/38998) |
| Hardware | MI355X gfx950, TP4, decode CUDA graphs active |
| Sampling | `--thinking`, temperature 1.0, top-p 0.95, max 4,096 output tokens |

| Checkpoint | Examples | Score | stop | truncated | error |
| --- | --- | --- | --- | --- | --- |
| `zai-org/GLM-5.3-Flash`, block FP8 | 1,319 | 97.50% | 99.85% | 0.15% | 0.00% |
| `amd/GLM-5.3-Flash-Quark-MXFP4` | 1,319 | **96.89%** | 99.39% | 0.61% | 0.00% |

MXFP4 lands 0.61 points below block FP8, one pass each — at the edge of this model's run-to-run spread rather than inside it: six reference runs spanned 96.82% to 97.35%, and [#36607](https://github.com/sgl-project/sglang/pull/36607) measured 97.19% at TP4. Read it as parity pending a repeat pass. The model loads with no missing or unexpected parameters.

`test_glm5_next_quark_weight_mapping.py`: 10 passed. [#38621](https://github.com/sgl-project/sglang/pull/38621)'s `test_glm5_next_modelopt.py` still passes. `isort`, `black` and Ruff clean.
