### PR TITLE
[AMD][CI] Temporarily pause MI355X disaggregated nightly

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -5,8 +5,10 @@ name: Nightly Test (AMD MI355X 2N 1P1D Disagg)
 # load balancer, then an sglang.bench_serving concurrency sweep) via
 # scripts/ci/slurm/launch_mi355x.sh.
 on:
-  schedule:
-    - cron: '0 7 * * *'
+  # Temporarily paused while the DI CI nodes are unavailable. Uncomment the
+  # schedule below when the nodes return.
+  # schedule:
+  #   - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
## Summary

- temporarily pause the scheduled MI355X disaggregated nightly while the DI CI nodes are unavailable
- keep `workflow_dispatch` and the complete workflow intact for manual testing and easy restoration

To resume the nightly after the nodes return, uncomment the existing `schedule` block.

## Validation

- parsed `.github/workflows/nightly-amd-mi355x-disagg.yml` with PyYAML
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34562158060](https://github.com/sgl-project/sglang/actions/runs/34562158060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34562157985](https://github.com/sgl-project/sglang/actions/runs/34562157985)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->