### PR TITLE
[Spec] Fix DSpark overlap lifetime and read ordering

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -44,6 +44,8 @@ from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 from sglang.srt.speculative.spec_tp_sync import SpecTpSync, SpecTpSyncSite
 from sglang.srt.speculative.spec_utils import (
     SIMULATE_ACC_METHOD,
+    record_stream_each,
+    record_stream_for_v2_verify,
     sample_simulated_acc_len,
 )
 from sglang.srt.utils import is_npu
@@ -76,6 +78,7 @@ def verify_logits_adjustments_are_noop(sampling_info) -> bool:
 class TargetVerifyResult(msgspec.Struct, frozen=True):
     logits_output: object
     can_run_cuda_graph: bool
+    verify_forward_batch: object
 
 
 class TargetVerifyExecutor:
@@ -215,6 +218,8 @@ class TargetVerifyExecutor:
             capture_hidden_mode=CaptureHiddenMode.FULL,
             ragged_verify_layout=idle_layout,
         )
+        forward_stream = torch.get_device_module(device).current_stream()
+        record_stream_for_v2_verify(batch, verify_input, forward_stream)
         batch.out_cache_loc = torch.zeros(
             (num_dummy_tokens,), dtype=torch.int64, device=device
         )
@@ -233,6 +238,7 @@ class TargetVerifyExecutor:
         verify_forward_batch, _ = verify_input.prepare_for_verify(
             batch, self.target_worker
         )
+        record_stream_each((batch.input_ids, batch.out_cache_loc), forward_stream)
         self.target_worker.forward_batch_generation(
             batch=None,
             forward_batch=verify_forward_batch,
@@ -261,6 +267,10 @@ class TargetVerifyExecutor:
             capture_hidden_mode=CaptureHiddenMode.FULL,
             live_seq_lens_cpu=batch.seq_lens_cpu,
         )
+        forward_stream = torch.get_device_module(
+            self.model_runner.device
+        ).current_stream()
+        record_stream_for_v2_verify(batch, verify_input, forward_stream)
         batch.out_cache_loc = verify_cache_loc
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
@@ -296,9 +306,13 @@ class TargetVerifyExecutor:
         seq_lens_cpu_backup,
         seq_lens_sum_backup,
     ) -> TargetVerifyResult:
+        forward_stream = torch.get_device_module(
+            self.model_runner.device
+        ).current_stream()
         verify_forward_batch, _ = verify_input.prepare_for_verify(
             batch, self.target_worker
         )
+        record_stream_each((batch.input_ids, batch.out_cache_loc), forward_stream)
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.seq_lens_sum = seq_lens_sum_backup
 
@@ -311,6 +325,7 @@ class TargetVerifyExecutor:
         return TargetVerifyResult(
             logits_output=target_out.logits_output,
             can_run_cuda_graph=target_out.can_run_cuda_graph,
+            verify_forward_batch=verify_forward_batch,
         )
 
     def commit_hidden(
@@ -374,6 +389,10 @@ class TargetVerifyExecutor:
             ragged_verify_layout=layout,
             live_seq_lens_cpu=batch.seq_lens_cpu,
         )
+        forward_stream = torch.get_device_module(
+            self.model_runner.device
+        ).current_stream()
+        record_stream_for_v2_verify(batch, verify_input, forward_stream)
         batch.out_cache_loc = ragged_window.verify_cache_loc
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -516,9 +516,14 @@ class DSparkWorkerV2(BaseSpecWorker):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            result = self._forward_prefill(batch, on_publish)
+        else:
+            result = self._forward_decode(batch, on_publish, grammar_barrier)
 
-        return self._forward_decode(batch, on_publish, grammar_barrier)
+        read_done = torch.get_device_module(self.device).Event()
+        read_done.record()
+        self.model_runner.shared_read_done_event = read_done
+        return result
 
     def _forward_prefill(
         self, batch: ScheduleBatch, on_publish
@@ -891,6 +896,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=int(self.verify_num_draft_tokens),
             new_seq_lens=accept.new_seq_lens,
+            extra_keep_alive_refs=[target_verify.verify_forward_batch],
         )
 
     def _commit_target_mamba_states_after_verify(

--- a/test/registered/unit/spec/test_dspark_verify_tensor_lifetime.py
+++ b/test/registered/unit/spec/test_dspark_verify_tensor_lifetime.py
@@ -1,0 +1,150 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.speculative.dspark_components.dspark_verify import (
+    TargetVerifyExecutor,
+)
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import DSparkWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSparkVerifyTensorLifetime(unittest.TestCase):
+    @staticmethod
+    def _executor():
+        executor = object.__new__(TargetVerifyExecutor)
+        executor.verify_num_draft_tokens = 6
+        executor.model_runner = SimpleNamespace(device=torch.device("cpu"))
+        return executor
+
+    @staticmethod
+    def _batch(old_cache_loc):
+        return SimpleNamespace(
+            input_ids=torch.tensor([1], dtype=torch.int64),
+            out_cache_loc=old_cache_loc,
+            req_pool_indices=torch.tensor([0], dtype=torch.int64),
+            seq_lens=torch.tensor([16], dtype=torch.int64),
+            seq_lens_cpu=None,
+            seq_lens_sum=16,
+        )
+
+    @patch("torch.get_device_module")
+    @patch(
+        "sglang.srt.speculative.dspark_components.dspark_verify."
+        "record_stream_for_v2_verify"
+    )
+    def test_records_tensors_before_rebind(self, record_stream, get_device_module):
+        executor = self._executor()
+        executor._verify_backend_self_adds_seq_lens = MagicMock(return_value=True)
+        old_cache_loc = torch.tensor([3], dtype=torch.int64)
+        verify_cache_loc = torch.tensor([4, 5], dtype=torch.int64)
+        batch = self._batch(old_cache_loc)
+        expected = object()
+
+        def assert_old_binding(batch_arg, *_):
+            self.assertIs(batch_arg.out_cache_loc, old_cache_loc)
+
+        def assert_new_binding(**_):
+            self.assertIs(batch.out_cache_loc, verify_cache_loc)
+            return expected
+
+        record_stream.side_effect = assert_old_binding
+        get_device_module.return_value.current_stream.return_value = object()
+        executor._forward_prepared_verify = MagicMock(side_effect=assert_new_binding)
+
+        result = executor.run_non_compact(
+            batch=batch,
+            draft_input=SimpleNamespace(nxt_kv_lens_cpu=None),
+            verify_ids_2d=torch.tensor([[7, 8]]),
+            verify_window=SimpleNamespace(
+                positions_2d=torch.tensor([[16, 17]]),
+                verify_cache_loc=verify_cache_loc,
+            ),
+            sampling_info=None,
+        )
+
+        self.assertIs(result, expected)
+        record_stream.assert_called_once()
+
+    def test_prepare_records_new_bindings_before_target_forward(self):
+        executor = self._executor()
+        forward_stream = object()
+        new_input_ids = torch.tensor([7, 8], dtype=torch.int64)
+        new_cache_loc = torch.tensor([4, 5], dtype=torch.int64)
+        batch = self._batch(torch.tensor([3], dtype=torch.int64))
+        batch.out_cache_loc = new_cache_loc
+        verify_forward_batch = object()
+        verify_input = MagicMock()
+
+        def prepare_for_verify(batch_arg, target_worker):
+            batch_arg.input_ids = new_input_ids
+            return verify_forward_batch, True
+
+        verify_input.prepare_for_verify.side_effect = prepare_for_verify
+        target_out = SimpleNamespace(logits_output=object(), can_run_cuda_graph=True)
+        executor.target_worker = MagicMock()
+        executor.target_worker.forward_batch_generation.return_value = target_out
+
+        with (
+            patch(
+                "sglang.srt.speculative.dspark_components.dspark_verify."
+                "record_stream_each"
+            ) as record_stream,
+            patch(
+                "torch.get_device_module",
+                return_value=SimpleNamespace(current_stream=lambda: forward_stream),
+            ),
+        ):
+            result = executor._forward_prepared_verify(
+                batch=batch,
+                verify_input=verify_input,
+                seq_lens_cpu_backup=None,
+                seq_lens_sum_backup=16,
+            )
+
+        self.assertIs(result.logits_output, target_out.logits_output)
+        self.assertTrue(result.can_run_cuda_graph)
+        self.assertIs(result.verify_forward_batch, verify_forward_batch)
+        record_stream.assert_called_once_with(
+            (new_input_ids, new_cache_loc), forward_stream
+        )
+
+    @patch(
+        "sglang.srt.speculative.dspark_components.dspark_worker_v2."
+        "torch.get_device_module"
+    )
+    def test_wrapper_publishes_final_shared_read_event(self, get_device_module):
+        for is_extend in (True, False):
+            with self.subTest(is_extend=is_extend):
+                calls = []
+                event = SimpleNamespace(record=lambda: calls.append("record"))
+                get_device_module.return_value = SimpleNamespace(Event=lambda: event)
+                worker = object.__new__(DSparkWorkerV2)
+                worker.device = torch.device("cpu")
+                worker.model_runner = SimpleNamespace(shared_read_done_event=object())
+                worker._verify_planner = MagicMock()
+                worker._observers = MagicMock()
+                worker._forward_prefill = MagicMock(
+                    side_effect=lambda *_: calls.append("forward") or "prefill"
+                )
+                worker._forward_decode = MagicMock(
+                    side_effect=lambda *_: calls.append("forward") or "decode"
+                )
+                batch = SimpleNamespace(
+                    forward_mode=SimpleNamespace(is_extend=lambda: is_extend),
+                    is_extend_in_batch=False,
+                )
+
+                result = worker.forward_batch_generation(batch)
+
+                self.assertEqual(calls, ["forward", "record"])
+                self.assertEqual(result, "prefill" if is_extend else "decode")
+                self.assertIs(worker.model_runner.shared_read_done_event, event)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DSpark target verify can rebind scheduler-owned tensors while kernels still consume the old allocations on the forward stream. Its backend read-done event can also precede wrapper-level tensor use. Under overlap scheduling, either gap can allow the scheduler or caching allocator to reuse storage too early.

## Modifications

- Record DSpark verify tensors on the forward stream before and after `prepare_for_verify`.
- Retain the verify `ForwardBatch` through the existing scheduler keep-alive ring.
- Publish the shared-read event after the complete DSpark wrapper forward.

Scope: extracted from #36347; this PR does not change platform WAR enablement (#36054) or pipeline-parallel plumbing (#37154).

## Accuracy Tests

No output algorithm changes. Added focused ordering and lifetime unit tests.

## Speed Tests and Profiling

No device synchronization is added; the patch uses `record_stream`, the existing bounded keep-alive ring, and a stream event.

## Checklist

- [x] Format code with repository pre-commit hooks.
- [x] Add focused unit tests.
- [x] No documentation change is required.
- [x] Follow the SGLang code style guidance.

Validation: `9 passed, 2 subtests passed` across the new tests, the adjacent target-hidden tests, and the speculative overlap constraint tests.