### PR TITLE
fix(responses): send prompt ids when a custom encoder leaves the text prompt empty

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -611,8 +611,14 @@ class OpenAIServingResponses(OpenAIServingChat):
         )
 
         if is_multimodal:
-            request_prompts = [processed_messages.prompt]
-            engine_prompts = [processed_messages.prompt]
+            # Custom encoders (the DSv4.1 encoder among them) render token ids
+            # and leave the string prompt empty, so a multimodal model would
+            # otherwise hand an empty text to the engine and fail with
+            # "texts cannot be empty and tokenizer must be initialized".
+            # Models that fill both keep using the string prompt.
+            prompt = processed_messages.prompt or processed_messages.prompt_ids
+            request_prompts = [prompt]
+            engine_prompts = [prompt]
         else:
             request_prompts = [processed_messages.prompt_ids]
             engine_prompts = [processed_messages.prompt_ids]

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -622,6 +622,65 @@ class MultimodalRequestTestCase(CustomTestCase):
         )
         self.assertEqual(captured["adapted_request"].modalities, ["image"])
 
+    def test_multimodal_custom_encoder_prompt_ids_reach_the_engine(self):
+        """A custom encoder (DSv4.1) renders token ids and leaves the string
+        prompt empty; the engine must receive the ids, not empty text.
+
+        Handing the empty string over made _tokenize_texts raise
+        "texts cannot be empty and tokenizer must be initialized" (400).
+        """
+        serving = make_serving(is_multimodal=True)
+        captured = {}
+
+        serving._process_messages = Mock(
+            return_value=MessageProcessingResult(
+                prompt="",
+                prompt_ids=[7, 8, 9],
+                image_data=None,
+                audio_data=None,
+                video_data=None,
+                modalities=None,
+                stop=[],
+            )
+        )
+
+        async def fake_generate(
+            request_id,
+            request_prompt,
+            adapted_request,
+            sampling_params,
+            context,
+            **kwargs,
+        ):
+            captured["request_prompt"] = request_prompt
+            captured["adapted_request"] = adapted_request
+            context.append_output(
+                {
+                    "text": "Paris",
+                    "meta_info": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 1,
+                        "cached_tokens": 0,
+                    },
+                }
+            )
+            yield context
+
+        serving._generate_with_builtin_tools = fake_generate
+        request = ResponsesRequest(
+            model="x",
+            input="The capital of France is",
+            request_id="resp_ids",
+            store=False,
+        )
+
+        response = asyncio.run(serving.create_responses(request))
+
+        self.assertEqual(response.status, "completed")
+        self.assertEqual(captured["request_prompt"], [7, 8, 9])
+        self.assertEqual(captured["adapted_request"].input_ids, [7, 8, 9])
+        self.assertIsNone(captured["adapted_request"].text)
+
 
 class OutputItemsTestCase(CustomTestCase):
     def setUp(self):


### PR DESCRIPTION
## Motivation

`/v1/responses` returns 400 for any **multimodal** model whose chat encoder renders token ids instead of a string prompt — DeepSeek-V4.1 is one:

```
POST /v1/responses  {"model": "...", "input": "hi"}
-> 400 {"error": {"message": "texts cannot be empty and tokenizer must be initialized"}}
```

while the same request through `/v1/chat/completions` returns 200. It is not a parameter-shape problem: five different `input` spellings (string, message list, `input_text` parts, `+ instructions`, `+ stream`) all fail.

`serving_responses._make_request()` branches on modality and takes the string prompt for multimodal models:

```python
if is_multimodal:
    request_prompts = [processed_messages.prompt]
    engine_prompts = [processed_messages.prompt]
else:
    request_prompts = [processed_messages.prompt_ids]
    engine_prompts = [processed_messages.prompt_ids]
```

But `_process_messages()` → `_apply_jinja_template()` **returns early as soon as `_encode_messages()` produces ids**, and for `chat_encoding_spec == "dsv41"` ids are the only output — the string prompt stays `""`. The engine is therefore handed an empty text and raises in `_tokenize_texts()`.

Non-multimodal models take the `prompt_ids` branch, which is why the chat endpoint works for the same request. Adding a Jinja chat template does not help either: `_encode_messages()` is consulted first and the template is never applied.

## Modifications

`python/sglang/srt/entrypoints/openai/serving_responses.py` — in the multimodal branch, fall back to the ids when the string prompt is empty:

```python
if is_multimodal:
    # Custom encoders (the DSv4.1 encoder among them) render token ids and
    # leave the string prompt empty ...
    prompt = processed_messages.prompt or processed_messages.prompt_ids
    request_prompts = [prompt]
    engine_prompts = [prompt]
```

Models that fill both keep using the string prompt, so existing multimodal behaviour is unchanged (the existing `test_multimodal_create_responses_sends_text_and_media_to_engine` covers that path and still asserts on the text prompt).

## Accuracy Tests

New unit test `test_multimodal_custom_encoder_prompt_ids_reach_the_engine` in `test/registered/unit/entrypoints/openai/test_serving_responses.py`, in the existing `MultimodalRequestTestCase` shape: `_process_messages` returns `prompt=""` / `prompt_ids=[7, 8, 9]` and the test asserts the engine receives the ids (`request_prompt == [7,8,9]`, `adapted_request.input_ids == [7,8,9]`, `adapted_request.text is None`).

**I could not execute it locally** — the only sglang environment available to me is a `dev-dsv41` container whose tree predates `sglang.srt.disaggregation`, so pytest fails at collection (`ModuleNotFoundError: No module named 'sglang.srt.disaggregation'`). Please let CI run it; I would rather flag this than claim a green run I did not get.

End-to-end verification on 8× RTX 6000D (SM120) serving `deepseek-ai/DeepSeek-V4.1-Flash` (multimodal, `chat_encoding_spec == "dsv41"`), with the change mounted into the container:

| case | before | after |
| --- | --- | --- |
| `{"input": "The capital of France is"}` | 400 | **200**, `status=completed`, output `The capital of France is **Paris**.` |
| `+ instructions + max_output_tokens` | 400 | **200** |
| `+ stream: true` | 400 | **200** (SSE, includes `response.completed`) |
| Responses API function tools | 400 | **200**, output contains a `function_call` item: `get_weather` with `{"city": "北京"}` |
| regression: `/v1/chat/completions` tool call | 200 | 200, unchanged |
| regression: chat determinism (`temperature=0`, thinking) | 5/5 identical | 5/5 identical, same hash as before the change |

## Speed Tests and Profiling

Not applicable — no generation-path change; the engine receives the same prompt, only as ids rather than as an empty string.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Formatted with the pinned `isort==7.0.0` / `ruff==0.15.1` from `.pre-commit-config.yaml`. No documentation page describes this branch, so none is updated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->