### PR TITLE
[Test] Fix Q8KV8 sparse-prefill pool fixture after page-size rename

### DIFF
--- a/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
+++ b/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
@@ -76,7 +76,7 @@ class _TokenToKVPool:
             extra_key_buffer if extra_key_buffer is not None else swa_key_buffer
         )
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
-        self.swa_window_size = page_size
+        self.swa_page_size = page_size
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
         _ = layer_id
@@ -84,7 +84,7 @@ class _TokenToKVPool:
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
         _ = layer_id
-        return self.swa_window_size
+        return self.swa_page_size
 
     def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor:
         _ = layer_id


### PR DESCRIPTION
## Motivation

After #38954 renamed the pool field to `swa_page_size`, the Q8KV8 sparse-prefill tests still expose `swa_window_size` on their mock pool. The backend raises `AttributeError` before the workspace comparison can run.

## Modifications

Update the mock field and its `get_extra_key_page_size` getter to use `swa_page_size`. Two-line, test-only fix; no production changes.

## Accuracy Tests

Ran the existing test file on CUDA before and after the fix:

```bash
pytest -q test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py --tb=short --disable-warnings
```

- Before, on main `40a84d6dfc`: 3 failed, 9 passed, 2 skipped.
- After: 12 passed, 2 skipped. All three helper cases (compression ratios 0, 4, 128) pass.
- The two real-kernel tests require SM90 and were skipped on the available hardware; SM90 validation remains for CI.
- `pre-commit run --files test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py`: passed with the local base set to `upstream/main`.

## Speed Tests and Profiling

Not applicable: no runtime or kernel changes.

## Checklist

- [x] Formatting and applicable pre-commit checks pass.
- [x] Existing regression tests verified before and after the fix.
- [x] Test-only change; no documentation updates required.
- [x] Follows SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34565335083](https://github.com/sgl-project/sglang/actions/runs/34565335083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34565334771](https://github.com/sgl-project/sglang/actions/runs/34565334771)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34565335140](https://github.com/sgl-project/sglang/actions/runs/34565335140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->