### PR TITLE
[CI] Fix stale pool attribute in Q8KV8 sparse prefill test fixture

### DIFF
--- a/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
+++ b/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
@@ -76,7 +76,7 @@ class _TokenToKVPool:
             extra_key_buffer if extra_key_buffer is not None else swa_key_buffer
         )
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
-        self.swa_window_size = page_size
+        self.swa_page_size = page_size
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
         _ = layer_id
@@ -84,7 +84,7 @@ class _TokenToKVPool:
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
         _ = layer_id
-        return self.swa_window_size
+        return self.swa_page_size
 
     def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor:
         _ = layer_id


### PR DESCRIPTION
#38954 renamed the pool's `swa_window_size` attribute to `swa_page_size`, but the test's fake pool still set the old name.

```
FAILED test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py::test_q8kv8_sparse_prefill_real_kernel_matches_bf16_sparse_path
  python/sglang/srt/layers/attention/deepseek_v4_backend.py:1493: in build_sparse_prefill_chunk_cache
    swa_page_size=self.token_to_kv_pool.swa_page_size,
E AttributeError: '_TokenToKVPool' object has no attribute 'swa_page_size'
```

After: `12 passed, 2 skipped`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34565448757](https://github.com/sgl-project/sglang/actions/runs/34565448757)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34565448284](https://github.com/sgl-project/sglang/actions/runs/34565448284)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34565448637](https://github.com/sgl-project/sglang/actions/runs/34565448637)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
