### PR TITLE
Add TraceLab session replay benchmark

### DIFF
--- a/docs/docs/developer_guide/bench_serving.mdx
+++ b/docs/docs/developer_guide/bench_serving.mdx
@@ -56,6 +56,62 @@ python3 -m sglang.bench_serving \
   --model meta-llama/Llama-3.1-8B-Instruct
 ```
 
+### TraceLab session replay
+
+`python -m sglang.benchmark.tracelab` replays the request lengths and session
+ordering in [TraceLab](https://github.com/uw-syfi/TraceLab) JSONL or canonical
+session-runner CSV traces (also gzip) against SGLang's native `/generate` endpoint:
+
+```bash Command
+curl -L --fail -o syfi_coding_trace.jsonl.gz \
+  https://github.com/uw-syfi/TraceLab/releases/latest/download/syfi_coding_trace.jsonl.gz
+curl -L --fail -o enwik9.zip http://mattmahoney.net/dc/enwik9.zip
+unzip enwik9.zip
+
+python -m sglang.benchmark.tracelab \
+  --dataset-path syfi_coding_trace.jsonl.gz \
+  --tokenizer /path/to/model \
+  --text-file enwik9 \
+  --base-url http://127.0.0.1:30000 \
+  --output-file tracelab-results.jsonl \
+  --num-requests 128 --max-rounds-per-session 16 --concurrency 8 --request-rate 0.5 \
+  --min-input-len 32768 --max-input-len 131072 \
+  --min-output-len 128 --max-output-len 4096
+```
+
+Like TraceLab's official replay runner, `--text-file` supplies a tokenized corpus
+for new input while prior prompt and actual generated token IDs carry forward
+into the next round's retained prefix. Missing history at the start of a selected
+segment is filled from the corpus and reported as cold rather than a cache hit.
+Without `--text-file`, content uses random vocabulary IDs for length-only probes.
+The corpus can be a source tree exported to one UTF-8 file, a code dataset shard,
+or a large public text corpus such as enwik9. It must tokenize to at least the
+largest selected input length; the driver fails before sending requests when it
+is too short. The public trace does not disclose original prompts. This is a
+serving-load replay, not an agent-quality
+evaluation or a representative measurement of speculative acceptance or expert
+routing. For content-sensitive profiling, use separately attributed real prompts.
+
+Input/output length bounds filter complete requests; they do not truncate them.
+Input length includes the recorded prefix plus newly appended tokens. Requests
+within each selected session run serially, with up to `--concurrency` active
+sessions. `--request-rate` controls global request starts. Canonical CSV
+`arrival_time` and `tool_wait_after_ms` are replayed in milliseconds; absent
+timing fields default to zero. CSV `input_len` means newly appended tokens,
+so total prompt length is `prefix_len + input_len`.
+`--max-rounds-per-session` optionally limits selected rounds
+from each session, so an early long session does not fill the whole request
+budget. The output records the actual number of selected sessions.
+Output JSONL records configuration, per-request results and a
+summary, and refuses to overwrite an existing file.
+
+TTFT starts when the HTTP request is submitted. TBT is the observed inter-chunk
+gap divided by the number of newly reported completion tokens in that chunk;
+the first chunk is excluded because its internal token timings are unknown.
+This is client-observed chunk-normalized TBT, not exact individual token latency.
+Failures and incomplete output lengths are recorded separately from successful
+request latency statistics.
+
 ### Fair embedding comparison
 
 Use the two embedding backends with the same model, tokenizer, input length, prompt count, and concurrency. The benchmark reports input-token throughput and end-to-end latency; embeddings have no decode-side TTFT or TPOT.

--- a/python/sglang/benchmark/tracelab.py
+++ b/python/sglang/benchmark/tracelab.py
@@ -1,0 +1,615 @@
+"""Replay metadata from https://github.com/uw-syfi/TraceLab.
+
+The public corpus does not contain prompt text. Token lengths and session order
+are observed data; generated prompt content is synthetic, not a coding-quality
+or speculative-acceptance benchmark.
+
+Download the public trace, choose any sufficiently large UTF-8 code/text corpus,
+then run the replay::
+
+    curl -L --fail -o syfi_coding_trace.jsonl.gz \
+      https://github.com/uw-syfi/TraceLab/releases/latest/download/syfi_coding_trace.jsonl.gz
+    curl -L --fail -o enwik9.zip http://mattmahoney.net/dc/enwik9.zip
+    unzip enwik9.zip
+
+    python -m sglang.benchmark.tracelab \
+        --dataset-path syfi_coding_trace.jsonl.gz \
+        --tokenizer deepseek-ai/DeepSeek-V4.1-Flash \
+        --text-file enwik9 \
+        --min-input-len 131072 --max-input-len 262144 \
+        --min-output-len 128 --max-output-len 4096 \
+        --num-requests 128 --concurrency 8 --request-rate 0.5 \
+        --output-file tracelab-results.jsonl
+
+Length bounds select observed rounds without truncation. Requests within each
+selected session execute in round order, replaying canonical CSV arrival and
+tool-wait fields. The global request rate additionally controls start spacing.
+Different sessions run concurrently.
+Recorded token counts come from the source model's tokenizer and are used as
+target token counts, not retokenizations of unavailable original text. Prefix
+reuse retains preceding prompts and actual generated IDs. Missing history is
+filled from a supplied corpus, as in TraceLab's replay/src/tokens.rs. Cold first
+requests and skipped rounds are therefore distinguishable
+from trace cache counts in the output. Dataset attribution: UW SyFI TraceLab,
+CC BY 4.0, https://github.com/uw-syfi/TraceLab.
+"""
+
+import argparse
+import asyncio
+import csv
+import gzip
+import hashlib
+import json
+import math
+import random
+import statistics
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterator, Optional
+
+
+@dataclass(frozen=True)
+class TraceRound:
+    session_id: str
+    round_id: str
+    round_index: int
+    input_tokens: int
+    output_tokens: int
+    prefix_tokens: int
+    arrival_time_ms: float = 0
+    tool_wait_after_ms: float = 0
+
+
+@dataclass(frozen=True)
+class LengthBounds:
+    min_input: int = 1
+    max_input: Optional[int] = None
+    min_output: int = 1
+    max_output: Optional[int] = None
+
+    def __post_init__(self):
+        for lower, upper in (
+            (self.min_input, self.max_input),
+            (self.min_output, self.max_output),
+        ):
+            if lower < 1 or (upper is not None and upper < lower):
+                raise ValueError("Token bounds must be positive and ordered")
+
+    def accepts(self, row: TraceRound) -> bool:
+        return (
+            row.input_tokens >= self.min_input
+            and (self.max_input is None or row.input_tokens <= self.max_input)
+            and row.output_tokens >= self.min_output
+            and (self.max_output is None or row.output_tokens <= self.max_output)
+        )
+
+
+def _integer(record: dict, key: str) -> int:
+    value = record.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{key} must be a nonnegative integer")
+    return value
+
+
+def parse_round(record: dict) -> TraceRound:
+    """Validate the released TraceLab token accounting without adding cache twice."""
+    session = record.get("session_id")
+    round_id = record.get("round_id")
+    if not isinstance(session, str) or not session:
+        raise ValueError("session_id must be a nonempty string")
+    if not isinstance(round_id, str) or not round_id:
+        raise ValueError("round_id must be a nonempty string")
+    total = _integer(record, "input_tokens_total")
+    prefix = _integer(record, "prefix_tokens")
+    appended = _integer(record, "newly_append_tokens")
+    if total != prefix + appended:
+        raise ValueError(
+            "input_tokens_total must equal prefix_tokens + newly_append_tokens"
+        )
+    timing = {}
+    for key in ("arrival_time_ms", "tool_wait_after_ms"):
+        value = record.get(key, 0)
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (float, int))
+            or not math.isfinite(value)
+            or value < 0
+        ):
+            raise ValueError(f"{key} must be finite and nonnegative")
+        timing[key] = value
+    return TraceRound(
+        session_id=session,
+        round_id=round_id,
+        round_index=_integer(record, "round_index"),
+        input_tokens=total,
+        output_tokens=_integer(record, "output_tokens"),
+        prefix_tokens=prefix,
+        **timing,
+    )
+
+
+def iter_rounds(
+    path: str,
+    bounds: Optional[LengthBounds] = None,
+    limit: Optional[int] = None,
+    max_rounds_per_session: Optional[int] = None,
+) -> Iterator[TraceRound]:
+    """Filter, never truncate, observed lengths; report malformed rows explicitly."""
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be positive")
+    if max_rounds_per_session is not None and max_rounds_per_session < 1:
+        raise ValueError("max_rounds_per_session must be positive")
+    bounds = bounds or LengthBounds()
+    source = Path(path)
+    opener = gzip.open if source.suffix == ".gz" else open
+    accepted = 0
+    per_session = defaultdict(int)
+    with opener(source, "rt", encoding="utf-8") as stream:
+        is_csv = source.name.removesuffix(".gz").endswith(".csv")
+        records = csv.DictReader(stream) if is_csv else stream
+        for line_number, line in enumerate(records, 1):
+            if not is_csv and not line.strip():
+                continue
+            try:
+                record = parse_csv_record(line) if is_csv else json.loads(line)
+                if not isinstance(record, dict):
+                    raise ValueError("expected a JSON object")
+                row = parse_round(record)
+            except (ValueError, TypeError) as error:
+                raise ValueError(f"{source}:{line_number}: {error}") from error
+            if bounds.accepts(row):
+                if (
+                    max_rounds_per_session is not None
+                    and per_session[row.session_id] >= max_rounds_per_session
+                ):
+                    continue
+                yield row
+                per_session[row.session_id] += 1
+                accepted += 1
+                if limit is not None and accepted >= limit:
+                    return
+
+
+def parse_csv_record(record):
+    """Accept TraceLab's session-runner and canonical simulator CSV schemas."""
+    session = record.get("session_id") or record.get("id")
+    prefix, appended = int(record["prefix_len"]), int(record["input_len"])
+    return {
+        "session_id": session,
+        "round_id": f"{session}:{record['round_idx']}",
+        "round_index": int(record["round_idx"]),
+        "prefix_tokens": prefix,
+        "newly_append_tokens": appended,
+        "input_tokens_total": prefix + appended,
+        "output_tokens": int(record["output_len"]),
+        "arrival_time_ms": float(record.get("arrival_time") or 0),
+        "tool_wait_after_ms": float(record.get("tool_wait_after_ms") or 0),
+    }
+
+
+async def replay_sessions(rows, send, *, concurrency=1, request_rate=math.inf):
+    """Serialize each session, with a global start-rate cap across active sessions.
+
+    ``send`` is an async callable receiving a TraceRound. Its returned result is
+    paired with that row. Request exceptions cancel the replay rather than
+    silently fabricating a successful measurement. Rate waiting occurs before
+    the transport starts its service-latency clock.
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be positive")
+    if math.isnan(request_rate) or request_rate <= 0:
+        raise ValueError("request_rate must be positive")
+    sessions = defaultdict(list)
+    identities = set()
+    for row in rows:
+        identity = (row.session_id, row.round_index)
+        if identity in identities:
+            raise ValueError(f"Duplicate session round: {identity}")
+        identities.add(identity)
+        sessions[row.session_id].append(row)
+    for rounds in sessions.values():
+        rounds.sort(key=lambda row: row.round_index)
+
+    session_queue = asyncio.Queue()
+    for rounds in sorted(sessions.values(), key=lambda rows: rows[0].arrival_time_ms):
+        session_queue.put_nowait(rounds)
+    interval = 0.0 if math.isinf(request_rate) else 1.0 / request_rate
+    rate_lock = asyncio.Lock()
+    next_start = 0.0
+    results = []
+    replay_started = asyncio.get_running_loop().time()
+
+    async def consume():
+        nonlocal next_start
+        while True:
+            try:
+                rounds = session_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            delay = (
+                replay_started
+                + rounds[0].arrival_time_ms / 1000
+                - asyncio.get_running_loop().time()
+            )
+            if delay > 0:
+                await asyncio.sleep(delay)
+            for row in rounds:
+                async with rate_lock:
+                    now = asyncio.get_running_loop().time()
+                    if next_start > now:
+                        await asyncio.sleep(next_start - now)
+                    next_start = asyncio.get_running_loop().time() + interval
+                result = await send(row)
+                results.append((row, result))
+                if row.tool_wait_after_ms:
+                    await asyncio.sleep(row.tool_wait_after_ms / 1000)
+            session_queue.task_done()
+
+    tasks = [
+        asyncio.create_task(consume()) for _ in range(min(concurrency, len(sessions)))
+    ]
+    try:
+        await asyncio.gather(*tasks)
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+    return results
+
+
+@dataclass
+class StreamMetrics:
+    """Client-observed timing; multi-token chunk TBT is an estimate, not a trace."""
+
+    started: float
+    first_token_at: Optional[float] = None
+    last_token_at: Optional[float] = None
+    output_tokens: int = 0
+    chunk_gaps: list = field(default_factory=list)
+    chunk_token_counts: list = field(default_factory=list)
+
+    def observe(self, completion_tokens: int, arrived: float):
+        if isinstance(completion_tokens, bool) or not isinstance(
+            completion_tokens, int
+        ):
+            raise ValueError("completion_tokens must be an integer")
+        if completion_tokens < self.output_tokens:
+            raise ValueError("Cumulative completion token count regressed")
+        if arrived < (self.last_token_at or self.started):
+            raise ValueError("Stream timestamps regressed")
+        delta = completion_tokens - self.output_tokens
+        if not delta:
+            return
+        if self.first_token_at is None:
+            self.first_token_at = arrived
+        else:
+            self.chunk_gaps.append(arrived - self.last_token_at)
+            self.chunk_token_counts.append(delta)
+        self.last_token_at = arrived
+        self.output_tokens = completion_tokens
+
+    def result(self):
+        if self.first_token_at is None:
+            raise ValueError("Stream ended without output tokens")
+        measured_tokens = sum(self.chunk_token_counts)
+        return {
+            "output_tokens": self.output_tokens,
+            "ttft_s": self.first_token_at - self.started,
+            "generation_latency_s": self.last_token_at - self.started,
+            "mean_tbt_s": (
+                sum(self.chunk_gaps) / measured_tokens if measured_tokens else None
+            ),
+            "tbt_method": "client_chunk_gap_divided_by_new_tokens",
+            "chunk_gaps_s": self.chunk_gaps,
+            "chunk_token_counts": self.chunk_token_counts,
+        }
+
+
+async def iter_sse_data(content):
+    """Decode SSE events across transport chunks, including CRLF and comments."""
+    data = []
+    async for raw_line in content:
+        line = raw_line.decode("utf-8").rstrip("\r\n")
+        if not line:
+            if data:
+                yield "\n".join(data)
+                data = []
+        elif line.startswith("data:"):
+            value = line[5:]
+            data.append(value[1:] if value.startswith(" ") else value)
+    if data:
+        yield "\n".join(data)
+
+
+async def send_generate(client, base_url, row, input_ids):
+    """Measure native SGLang /generate streaming without retokenizing prompts."""
+    if len(input_ids) != row.input_tokens:
+        raise ValueError("Prompt token count differs from the selected trace round")
+    payload = {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": row.output_tokens,
+            "ignore_eos": True,
+        },
+        "stream": True,
+    }
+    clock = asyncio.get_running_loop().time
+    metrics = StreamMetrics(clock())
+    complete = False
+    cached_tokens = None
+    output_ids = []
+    async with client.post(
+        base_url.rstrip("/") + "/generate", json=payload
+    ) as response:
+        response.raise_for_status()
+        async for data in iter_sse_data(response.content):
+            if data == "[DONE]":
+                complete = True
+                break
+            event = json.loads(data)
+            if event.get("error"):
+                raise RuntimeError(f"Server stream error: {event['error']}")
+            meta = event.get("meta_info", {})
+            if "output_ids" in event:
+                ids = event["output_ids"]
+                total = meta.get("completion_tokens")
+                if not isinstance(ids, list) or any(
+                    type(token) is not int for token in ids
+                ):
+                    raise ValueError("Invalid generated token IDs")
+                if len(ids) == total:
+                    output_ids = ids
+                elif len(output_ids) + len(ids) == total:
+                    output_ids.extend(ids)
+                else:
+                    raise ValueError(
+                        "Generated token IDs disagree with completion count"
+                    )
+            if "completion_tokens" in meta:
+                metrics.observe(meta["completion_tokens"], clock())
+            cached_tokens = meta.get("cached_tokens", cached_tokens)
+    if not complete:
+        raise RuntimeError("SSE stream ended without [DONE]")
+    result = metrics.result()
+    result.update(
+        request_latency_s=clock() - metrics.started,
+        cached_tokens=cached_tokens,
+        requested_output_tokens=row.output_tokens,
+        output_length_matched=metrics.output_tokens == row.output_tokens,
+        output_ids=output_ids,
+    )
+    return result
+
+
+class SyntheticPrompts:
+    """Use vocabulary IDs for length-only probes, retaining committed history."""
+
+    def __init__(self, token_ids, seed=0):
+        if not token_ids:
+            raise ValueError("Tokenizer has no usable non-special tokens")
+        self.token_ids = sorted(token_ids)
+        self.seed = seed
+        self.previous = {}
+
+    def build(self, row):
+        previous = self.previous.get(row.session_id, [])
+        reused = min(row.prefix_tokens, len(previous), row.input_tokens)
+        identity = f"{self.seed}:{row.session_id}:{row.round_id}".encode()
+        rng = random.Random(int.from_bytes(hashlib.sha256(identity).digest(), "big"))
+        prompt = previous[:reused] + rng.choices(
+            self.token_ids, k=row.input_tokens - reused
+        )
+        return prompt, reused
+
+    def commit_output(self, row, prompt, output_ids):
+        if len(output_ids) != row.output_tokens:
+            raise ValueError(
+                "Exact generated token IDs are required for session replay"
+            )
+        self.previous[row.session_id] = prompt + output_ids
+
+
+class CorpusPrompts(SyntheticPrompts):
+    """TraceLab replay/src/tokens.rs: retained context plus new corpus tokens."""
+
+    def __init__(self, token_ids, seed=0):
+        super().__init__(token_ids, seed)
+        self.token_ids = list(token_ids)
+        self.cursors = {}
+
+    def build(self, row):
+        previous = self.previous.get(row.session_id, [])
+        reused = min(row.prefix_tokens, len(previous))
+        if row.session_id not in self.cursors:
+            digest = hashlib.sha256(f"{self.seed}:{row.session_id}".encode()).digest()
+            self.cursors[row.session_id] = int.from_bytes(digest, "big") % len(
+                self.token_ids
+            )
+        cursor = self.cursors[row.session_id]
+        count = row.input_tokens - reused
+        fresh = [
+            self.token_ids[(cursor + i) % len(self.token_ids)] for i in range(count)
+        ]
+        self.cursors[row.session_id] = (cursor + count) % len(self.token_ids)
+        return previous[:reused] + fresh, reused
+
+
+def summarize_results(results, elapsed):
+    """Aggregate successful requests; preserve failed counts in the denominator."""
+    successful = [result for _, result in results if result["success"]]
+
+    def distribution(values):
+        values = sorted(values)
+        if not values:
+            return None
+        return {
+            "mean": statistics.mean(values),
+            **{
+                f"p{p}": values[max(0, math.ceil(len(values) * p / 100) - 1)]
+                for p in (50, 90, 99)
+            },
+        }
+
+    tbt = [
+        gap / count
+        for result in successful
+        for gap, count in zip(result["chunk_gaps_s"], result["chunk_token_counts"])
+        for _ in range(count)
+    ]
+    output_tokens = sum(result["output_tokens"] for result in successful)
+    return {
+        "type": "summary",
+        "requests": len(results),
+        "successful": len(successful),
+        "failed": len(results) - len(successful),
+        "duration_s": elapsed,
+        "output_tokens": output_tokens,
+        "output_tok_s": output_tokens / elapsed if elapsed > 0 else None,
+        "ttft_s": distribution([result["ttft_s"] for result in successful]),
+        "estimated_tbt_s": distribution(tbt),
+        "percentile_method": "nearest_rank",
+    }
+
+
+async def run_trace(args):
+    import aiohttp
+    from transformers import AutoTokenizer
+
+    bounds = LengthBounds(
+        args.min_input_len, args.max_input_len, args.min_output_len, args.max_output_len
+    )
+    rows = list(
+        iter_rounds(
+            args.dataset_path, bounds, args.num_requests, args.max_rounds_per_session
+        )
+    )
+    if not rows:
+        raise ValueError("No trace rows satisfy the length bounds")
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+    excluded = set(tokenizer.all_special_ids)
+    prompts = SyntheticPrompts(
+        [value for value in tokenizer.get_vocab().values() if value not in excluded],
+        args.seed,
+    )
+    if args.text_file:
+        token_ids = []
+        with open(args.text_file, encoding="utf-8") as corpus:
+            for line in corpus:
+                token_ids.extend(tokenizer.encode(line, add_special_tokens=False))
+                if len(token_ids) >= args.token_pool_limit:
+                    token_ids = token_ids[: args.token_pool_limit]
+                    break
+        if len(token_ids) < max(row.input_tokens for row in rows):
+            raise ValueError(
+                "Text corpus must cover the longest selected prompt without repetition"
+            )
+        prompts = CorpusPrompts(token_ids, args.seed)
+    timeout = aiohttp.ClientTimeout(total=args.request_timeout)
+    headers = {}
+    if args.api_key:
+        headers["Authorization"] = f"Bearer {args.api_key}"
+    # Open exclusively before sending requests, so an output-path failure cannot
+    # discard an expensive completed serving run or overwrite earlier evidence.
+    with open(args.output_file, "x", encoding="utf-8") as output:
+        output.write(
+            json.dumps(
+                {
+                    "type": "configuration",
+                    "dataset_path": str(Path(args.dataset_path).resolve()),
+                    "bounds": asdict(bounds),
+                    "request_rate": (
+                        args.request_rate if math.isfinite(args.request_rate) else "inf"
+                    ),
+                    "concurrency": args.concurrency,
+                    "selected_rounds": len(rows),
+                    "selected_sessions": len({row.session_id for row in rows}),
+                    "max_rounds_per_session": args.max_rounds_per_session,
+                    "seed": args.seed,
+                    "content": (
+                        "corpus_tokens"
+                        if args.text_file
+                        else "synthetic_vocabulary_tokens"
+                    ),
+                    "text_file": args.text_file,
+                    "prefix_policy": "retain_prior_prompt_and_actual_generated_tokens",
+                    "speculative_acceptance_representative": False,
+                }
+            )
+            + "\n"
+        )
+        output.flush()
+        async with aiohttp.ClientSession(timeout=timeout, headers=headers) as client:
+
+            async def send(row):
+                input_ids, reused = prompts.build(row)
+                try:
+                    result = await send_generate(client, args.base_url, row, input_ids)
+                    result["success"] = result["output_length_matched"]
+                    if result["success"]:
+                        prompts.commit_output(row, input_ids, result.pop("output_ids"))
+                except (
+                    aiohttp.ClientError,
+                    asyncio.TimeoutError,
+                    ValueError,
+                    RuntimeError,
+                ) as error:
+                    result = {"success": False, "error": str(error)}
+                output.write(
+                    json.dumps(
+                        {
+                            "type": "request",
+                            **asdict(row),
+                            **result,
+                            "synthetic_reused_input_tokens": reused,
+                        }
+                    )
+                    + "\n"
+                )
+                output.flush()
+                return result
+
+            started = asyncio.get_running_loop().time()
+            results = await replay_sessions(
+                rows, send, concurrency=args.concurrency, request_rate=args.request_rate
+            )
+            elapsed = asyncio.get_running_loop().time() - started
+        summary = summarize_results(results, elapsed)
+        output.write(json.dumps(summary) + "\n")
+        print(json.dumps(summary))
+        return 1 if summary["failed"] else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-path", required=True)
+    parser.add_argument("--tokenizer", required=True)
+    parser.add_argument(
+        "--text-file", help="UTF-8 corpus for TraceLab-style token reconstruction"
+    )
+    parser.add_argument("--token-pool-limit", type=int, default=100_000_000)
+    parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    parser.add_argument("--output-file", required=True)
+    parser.add_argument("--api-key", default=None)
+    parser.add_argument("--num-requests", type=int, default=128)
+    parser.add_argument("--max-rounds-per-session", type=int)
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--request-rate", type=float, default=math.inf)
+    parser.add_argument("--request-timeout", type=float, default=3600)
+    parser.add_argument("--min-input-len", type=int, default=1)
+    parser.add_argument("--max-input-len", type=int)
+    parser.add_argument("--min-output-len", type=int, default=1)
+    parser.add_argument("--max-output-len", type=int)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+    if args.request_timeout <= 0 or not math.isfinite(args.request_timeout):
+        parser.error("request-timeout must be finite and positive")
+    if args.token_pool_limit < 1:
+        parser.error("token-pool-limit must be positive")
+    raise SystemExit(asyncio.run(run_trace(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/benchmark/test_tracelab.py
+++ b/test/registered/unit/benchmark/test_tracelab.py
@@ -1,3 +1,5 @@
+"""Unit tests for TraceLab serving replay semantics."""
+
 import asyncio
 import gzip
 import json

--- a/test/registered/unit/test_tracelab.py
+++ b/test/registered/unit/test_tracelab.py
@@ -18,6 +18,9 @@ from sglang.benchmark.tracelab import (
     run_trace,
     send_generate,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def test_canonical_replay_preserves_generated_context_and_corpus(tmp_path):

--- a/test/registered/unit/test_tracelab.py
+++ b/test/registered/unit/test_tracelab.py
@@ -1,0 +1,316 @@
+import asyncio
+import gzip
+import json
+from argparse import Namespace
+from dataclasses import replace
+
+import pytest
+
+from sglang.benchmark.tracelab import (
+    CorpusPrompts,
+    LengthBounds,
+    StreamMetrics,
+    SyntheticPrompts,
+    iter_rounds,
+    iter_sse_data,
+    parse_round,
+    replay_sessions,
+    run_trace,
+    send_generate,
+)
+
+
+def test_canonical_replay_preserves_generated_context_and_corpus(tmp_path):
+    source = tmp_path / "trace.csv"
+    source.write_text(
+        "id,round_idx,prefix_len,input_len,output_len,arrival_time,tool_wait_after_ms\n"
+        "a,0,0,4,2,10,20\n"
+        "a,1,6,2,1,10,0\n"
+    )
+    first, second = list(iter_rounds(str(source)))
+    assert (first.arrival_time_ms, first.tool_wait_after_ms) == (10, 20)
+    prompts = CorpusPrompts(list(range(10, 110)))
+    initial, reused = prompts.build(first)
+    assert reused == 0 and len(initial) == 4
+    assert initial[1:] == [token + 1 for token in initial[:-1]]
+    prompts.commit_output(first, initial, [7, 8])
+    following, reused = prompts.build(second)
+    assert following[:6] == initial + [7, 8]
+    assert reused == 6 and len(following) == 8
+
+
+def record(index, tokens=128, output=16):
+    return {
+        "session_id": "session-a",
+        "round_id": f"round-{index}",
+        "round_index": index,
+        "input_tokens_total": tokens,
+        "prefix_tokens": tokens // 2,
+        "newly_append_tokens": tokens - tokens // 2,
+        "output_tokens": output,
+    }
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_trace_filter_preserves_observed_lengths_and_identity(tmp_path, compressed):
+    source = tmp_path / ("trace.jsonl.gz" if compressed else "trace.jsonl")
+    opener = gzip.open if compressed else open
+    records = [record(0, 64), record(1, 128), record(2, 256), record(3, 512)]
+    with opener(source, "wt") as stream:
+        for item in records:
+            stream.write(json.dumps(item) + "\n")
+    rows = list(iter_rounds(str(source), LengthBounds(128, 256), limit=2))
+    assert [(r.round_index, r.input_tokens) for r in rows] == [(1, 128), (2, 256)]
+    assert [r.round_id for r in rows] == ["round-1", "round-2"]
+    assert all(r.session_id == "session-a" for r in rows)
+    with opener(source, "wt") as stream:
+        for session in ("session-a", "session-b"):
+            for item in records:
+                stream.write(json.dumps(dict(item, session_id=session)) + "\n")
+    rows = list(iter_rounds(str(source), LengthBounds(128, 512), 4, 2))
+    assert [(r.session_id, r.round_index) for r in rows] == [
+        ("session-a", 1),
+        ("session-a", 2),
+        ("session-b", 1),
+        ("session-b", 2),
+    ]
+
+
+def test_cache_accounting_is_not_added_to_total_again():
+    item = record(0)
+    item["claude_cache_read_input_tokens"] = 64
+    item["claude_cache_creation_input_tokens"] = 60
+    assert parse_round(item).input_tokens == 128
+    item["input_tokens_total"] += 1
+    with pytest.raises(ValueError):
+        parse_round(item)
+
+
+def test_synthetic_prefix_is_bounded_and_session_local():
+    generator = SyntheticPrompts(range(3, 100), seed=7)
+    first = parse_round(record(0, 128))
+    prompt, reused = generator.build(first)
+    assert len(prompt) == 128 and reused == 0
+    generator.commit_output(first, prompt, [7] * first.output_tokens)
+    second = parse_round(record(1, 256))
+    following, reused = generator.build(second)
+    assert len(following) == 256 and reused == 128
+    assert following[:128] == prompt
+    other, reused = generator.build(replace(second, session_id="other"))
+    assert reused == 0 and other != following
+    assert SyntheticPrompts(range(3, 100), seed=7).build(first)[0] == prompt
+
+
+@pytest.mark.parametrize("key,value", [("output_tokens", -1), ("round_index", True)])
+def test_invalid_counts_are_rejected(key, value):
+    item = record(0)
+    item[key] = value
+    with pytest.raises(ValueError):
+        parse_round(item)
+
+
+def test_bounds_reject_invalid_range():
+    with pytest.raises(ValueError):
+        LengthBounds(256, 128)
+
+
+def test_replay_orders_sessions_and_bounds_concurrency():
+    async def exercise():
+        rows = [parse_round(record(1)), parse_round(record(0))]
+        rows += [replace(row, session_id="session-b") for row in rows]
+        active = set()
+        order = []
+        peak = 0
+
+        async def send(row):
+            nonlocal peak
+            assert row.session_id not in active
+            active.add(row.session_id)
+            peak = max(peak, len(active))
+            await asyncio.sleep(0)
+            order.append((row.session_id, row.round_index))
+            active.remove(row.session_id)
+            return row.output_tokens
+
+        results = await replay_sessions(rows, send, concurrency=2)
+        assert peak == 2
+        assert len(results) == len(rows)
+        for session in ("session-a", "session-b"):
+            assert [index for sid, index in order if sid == session] == [0, 1]
+
+    asyncio.run(exercise())
+
+
+def test_stream_timing_handles_batched_tokens_and_metadata_only_events():
+    metrics = StreamMetrics(10.0)
+    metrics.observe(0, 10.1)
+    metrics.observe(3, 10.5)
+    metrics.observe(3, 10.6)
+    metrics.observe(5, 10.9)
+    metrics.observe(6, 11.0)
+    result = metrics.result()
+    assert result["ttft_s"] == pytest.approx(0.5)
+    assert result["mean_tbt_s"] == pytest.approx(0.5 / 3)
+    assert result["chunk_token_counts"] == [2, 1]
+    assert result["output_tokens"] == 6
+    with pytest.raises(ValueError):
+        metrics.observe(5, 11.1)
+
+
+def test_sse_preserves_multiline_events_and_ignores_comments():
+    async def exercise():
+        async def content():
+            for line in (
+                b": ping\r\n",
+                b"data: first\r\n",
+                b"data: second\r\n",
+                b"\r\n",
+                b"data: [DONE]\n",
+                b"\n",
+            ):
+                yield line
+
+        assert [data async for data in iter_sse_data(content())] == [
+            "first\nsecond",
+            "[DONE]",
+        ]
+
+    asyncio.run(exercise())
+
+
+def test_replay_rate_applies_across_sessions():
+    async def exercise():
+        rows = [replace(parse_round(record(0)), session_id=str(i)) for i in range(3)]
+        starts = []
+
+        async def send(row):
+            starts.append(asyncio.get_running_loop().time())
+
+        await replay_sessions(rows, send, concurrency=3, request_rate=20)
+        assert all(b - a >= 0.045 for a, b in zip(starts, starts[1:]))
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("terminal", [True, False])
+def test_generate_transport_reads_fragmented_stream_and_requires_completion(terminal):
+    import aiohttp
+    from aiohttp import web
+
+    async def exercise():
+        row = parse_round(record(0, tokens=4, output=2))
+
+        async def handler(request):
+            payload = await request.json()
+            assert payload["input_ids"] == [3, 4, 5, 6]
+            assert payload["sampling_params"]["max_new_tokens"] == 2
+            response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+            await response.prepare(request)
+            data = b'data: {"meta_info":{"completion_tokens":2,"cached_tokens":0}}\n\n'
+            for fragment in (data[:7], data[7:23], data[23:]):
+                await response.write(fragment)
+                await asyncio.sleep(0)
+            if terminal:
+                await response.write(b"data: [DONE]\n\n")
+            await response.write_eof()
+            return response
+
+        app = web.Application()
+        app.router.add_post("/generate", handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            site = web.TCPSite(runner, "127.0.0.1", 0)
+            await site.start()
+            port = runner.addresses[0][1]
+            async with aiohttp.ClientSession() as client:
+                if terminal:
+                    result = await send_generate(
+                        client, f"http://127.0.0.1:{port}", row, [3, 4, 5, 6]
+                    )
+                    assert result["output_tokens"] == 2
+                    assert result["output_length_matched"]
+                    assert result["ttft_s"] >= 0
+                    assert result["mean_tbt_s"] is None
+                else:
+                    with pytest.raises(RuntimeError):
+                        await send_generate(
+                            client, f"http://127.0.0.1:{port}", row, [3, 4, 5, 6]
+                        )
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(exercise())
+
+
+def test_driver_writes_measured_results_without_overwriting(tmp_path, monkeypatch):
+    from aiohttp import web
+    from transformers import AutoTokenizer
+
+    class Tokenizer:
+        all_special_ids = [0, 1, 2]
+
+        def get_vocab(self):
+            return {str(i): i for i in range(32)}
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", lambda _: Tokenizer())
+    source = tmp_path / "trace.jsonl"
+    source.write_text("\n".join(json.dumps(record(i, 8, 3)) for i in range(2)))
+    destination = tmp_path / "result.jsonl"
+
+    async def exercise():
+        requests = []
+
+        async def handler(request):
+            body = await request.json()
+            requests.append(body)
+            assert len(body["input_ids"]) == 8
+            assert not set(body["input_ids"]) & {0, 1, 2}
+            return web.Response(
+                text='data: {"output_ids":[7,8,9],"meta_info":{"completion_tokens":3}}\n\ndata: [DONE]\n\n',
+                content_type="text/event-stream",
+            )
+
+        app = web.Application()
+        app.router.add_post("/generate", handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        try:
+            await web.TCPSite(runner, "127.0.0.1", 0).start()
+            args = Namespace(
+                dataset_path=str(source),
+                tokenizer="fake",
+                text_file=None,
+                token_pool_limit=1000,
+                min_input_len=1,
+                max_input_len=10,
+                min_output_len=1,
+                max_output_len=4,
+                num_requests=2,
+                max_rounds_per_session=None,
+                seed=7,
+                request_timeout=10,
+                api_key=None,
+                output_file=str(destination),
+                concurrency=2,
+                request_rate=float("inf"),
+                base_url=f"http://127.0.0.1:{runner.addresses[0][1]}",
+            )
+            assert await run_trace(args) == 0
+            records = [
+                json.loads(line) for line in destination.read_text().splitlines()
+            ]
+            assert records[0]["selected_rounds"] == 2
+            requests_recorded = [r for r in records if r["type"] == "request"]
+            assert all(r["success"] for r in requests_recorded)
+            assert [r["round_index"] for r in requests_recorded] == [0, 1]
+            assert records[-1]["successful"] == 2
+            assert records[-1]["output_tokens"] == 6
+            assert records[-1]["ttft_s"]["p50"] >= 0
+            with pytest.raises(FileExistsError):
+                await run_trace(args)
+            assert len(requests) == 2
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Motivation

Add a request driver for the public [UW SyFI TraceLab](https://github.com/uw-syfi/TraceLab) agentic-coding trace metadata. This supports controlled long-context serving experiments without converting token-count traces into fabricated chat messages.

## Changes

- Replay JSONL or canonical TraceLab CSV (also gzip) through native streaming `/generate`, preserving session order, session arrivals, tool waits, concurrency and global request-start rate.
- Reconstruct new input from a supplied text corpus and retain prior prompts plus exact generated token IDs, following TraceLab's official replay semantics. Filter complete requests by token bounds without truncation.
- Record per-request TTFT, chunk-normalized TBT, output length, cache counts, errors, and aggregate serving metrics in non-overwriting JSONL output.
- Document invocation, source attribution, and measurement limitations.

**This follows TraceLab's corpus-based workload reconstruction, not private prompt recovery.** Source-model counts become target lengths under the selected tokenizer. Canonical CSV preserves exported tool waits and synthetic session arrivals; fields absent from JSONL default to zero. Content-sensitive speculative acceptance and expert routing require separate real-content validation.

**TBT is client-observed and chunk-normalized**, not a claim of exact server-side per-token timestamps. The first chunk is excluded from inter-token estimates; incomplete responses and failures are not mixed into successful latency statistics.

## Validation

```bash
PYTHONPATH=python python -m pytest test/registered/unit/benchmark/test_tracelab.py -q
```

15 tests passed, including real loopback streaming HTTP, generated-token prefix retention, canonical CSV accounting, chunk framing, request ordering, rate spacing, filtering, prefix isolation, and incomplete-response handling.

The corpus/history/timing implementation passed 28/28 live requests
using TraceLab's own CSV converter at commit
`11b8b14c6005808ab272b3431487066832582414` (834 rounds from 32 sessions),
then applying the documented request-length filters. A public SWE-smith prefix
export supplied UTF-8 corpus content. Generated output IDs were retained between
rounds and the server reported prefix-cache hits.

| Input band | Requests passed | Mean TTFT | Chunk-normalized mean TBT |
| --- | ---: | ---: | ---: |
| 32K-128K | 16/16 | 0.926 s | 7.527 ms |
| 128K-256K | 12/12 | 1.271 s | 7.390 ms |

These runs used four NVIDIA GB200 GPUs, TP4/EP4, no speculative decoding,
concurrency four, request-start cap 0.5/s, and memory fraction 0.8. The exported
600-second tool wait was preserved. Aggregate replay throughput includes such
waits and is not a server saturation throughput measurement.
The same CLI also completed live validation on four NVIDIA B300 SXM6 AC GPUs with TP4/EP4 and 4096-token chunked prefill. The 32K-128K band passed 16/16 requests at 2.465 s mean TTFT and 15.741 ms chunk-normalized mean TBT; the 128K-256K band passed 16/16 at 3.209 s mean TTFT and 15.109 ms mean TBT. Eight intact recorded coding-prefix requests also passed with output lengths matched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35310071136](https://github.com/sgl-project/sglang/actions/runs/35310071136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35310071142](https://github.com/sgl-project/sglang/actions/runs/35310071142)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35310071289](https://github.com/sgl-project/sglang/actions/runs/35310071289)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->