### PR TITLE
Hicache fixed

### DIFF
--- a/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
+++ b/python/sglang/srt/mem_cache/buffer_mode/pipeline.py
@@ -1114,6 +1114,19 @@ class BufferModePipeline:
             # (init_load_back's degrade contract).
             return _drop("device_capacity")
 
+        # Buffer-only restores directly from L3. Router experts are not an L3
+        # storage pool yet, so fail closed: invalidate the newly allocated KV
+        # slots instead of exposing rows belonging to their previous owners.
+        routed_experts_cache = cache._get_routed_experts_host_cache()
+        if routed_experts_cache is not None and not routed_experts_cache.restore_from_hicache(
+            f.host_indices, device_indices
+        ):
+            logger.error(
+                "HiCache buffer-only restored KV for request %s without "
+                "routed-expert sidecar; affected HostCache slots remain invalid",
+                f.req_id,
+            )
+
         swa_dev = next(
             (
                 t.device_indices

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -797,6 +797,9 @@ class HiRadixCache(RadixCache):
         self.prefetch_loaded_tokens_by_reqid.clear()
         self.evictable_host_leaves.clear()
         super().reset()
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None:
+            routed_experts_cache.clear()
 
     def release_host_resources(self) -> None:
         if self.token_to_kv_pool_host is not None:
@@ -808,6 +811,16 @@ class HiRadixCache(RadixCache):
             node = node.parent
             height += 1
         return height
+
+    @staticmethod
+    def _get_routed_experts_host_cache():
+        # Lazy import avoids coupling cache construction to model-runner setup.
+        from sglang.srt.state_capturer.routed_experts import (
+            get_global_experts_capturer,
+        )
+
+        capturer = get_global_experts_capturer()
+        return None if capturer is None else capturer.host_cache
 
     def _get_extra_pools(self) -> dict:
         if not isinstance(self.cache_controller, HybridCacheController):
@@ -874,7 +887,11 @@ class HiRadixCache(RadixCache):
                 node_id=node.id,
                 **self._get_extra_pools(),
             )
+
         if host_indices is not None:
+            routed_experts_cache = self._get_routed_experts_host_cache()
+            if routed_experts_cache is not None:
+                routed_experts_cache.backup_to_hicache(node.value, host_indices)
             node.host_value = host_indices.clone()
             assert len(node.host_value) > 0
             self._track_write_through_node(node, len(node.key))
@@ -1445,6 +1462,16 @@ class HiRadixCache(RadixCache):
             )
             return None
 
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None and not routed_experts_cache.restore_from_hicache(
+            host_indices, device_indices
+        ):
+            logger.error(
+                "HiCache restored KV for node %d without routed-expert sidecar; "
+                "affected HostCache slots remain invalid",
+                last_hit_node.id,
+            )
+
         for n in nodes_to_load:
             n.release_host()
         self.ongoing_load_back[last_hit_node.id] = last_hit_node
@@ -1670,6 +1697,9 @@ class HiRadixCache(RadixCache):
         host_indices = operation.host_indices
         fetched_key = prefetch_key[:min_completed_tokens]
         written_indices = host_indices[:min_completed_tokens]
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None:
+            routed_experts_cache.invalidate_hicache(written_indices)
         matched_length = self._insert_helper_host(
             last_host_node,
             fetched_key,

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -1066,7 +1066,18 @@ class SWAComponent(TreeComponent):
                     # device exists, skip it
                     n_swa += len(cd.value)
                 else:
-                    # host only, collect it
+                    # Host only: load at most the missing tail of the sliding
+                    # window. A radix node can be much larger than the window;
+                    # split its prefix off before collecting so the component
+                    # and Full-KV node-length invariants remain intact.
+                    remaining = self.sliding_window_size - n_swa
+                    if len(cd.host_value) > remaining:
+                        _, action = self.tree_core._split_node(
+                            cur.key, cur, len(cd.host_value) - remaining
+                        )
+                        if action is not None:
+                            self.cache._apply_cache_actions([action])
+                        cd = cur.component_data[ct]
                     backed_up.append(cd.host_value)
                     nodes.append(cur)
                     n_swa += len(cd.host_value)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -340,10 +340,24 @@ class UnifiedRadixCache(BasePrefixCache):
         """Attach an external KV store directly to the device pools."""
         self.linker = UnifiedCacheLinkerWrapper(self, cache_linker)
 
+    @staticmethod
+    def _get_routed_experts_host_cache():
+        # Lazy import avoids coupling cache construction to model-runner setup.
+        from sglang.srt.state_capturer.routed_experts import (
+            get_global_experts_capturer,
+        )
+
+        capturer = get_global_experts_capturer()
+        return None if capturer is None else capturer.host_cache
+
     def reset(self) -> None:
         if self.linker is not None:
             self.linker.reset()
         self._reset_full()
+
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None:
+            routed_experts_cache.clear()
 
     def _reset_full(self) -> None:
         """Full reset: destroy entire tree and all state."""
@@ -1433,6 +1447,9 @@ class UnifiedRadixCache(BasePrefixCache):
             )
             if host_indices is None:
                 return 0
+            routed_experts_cache = self._get_routed_experts_host_cache()
+            if routed_experts_cache is not None:
+                routed_experts_cache.backup_to_hicache(device_value, host_indices)
             self.tree_core.commit_backup(node_id, host_indices, comp_xfers)
             lock_params = None
             if not write_back:
@@ -1622,6 +1639,16 @@ class UnifiedRadixCache(BasePrefixCache):
         if device_indices is None:
             self.dec_host_lock_ref(node_id, host_anchor_params)
             return False
+
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None and not routed_experts_cache.restore_from_hicache(
+            kv_xfer.host_indices, device_indices
+        ):
+            logger.error(
+                "HiCache restored KV for node %d without routed-expert sidecar; "
+                "affected HostCache slots remain invalid",
+                node_id,
+            )
 
         # Commit the loaded KV back onto the node + apply its emitted actions.
         self._apply_cache_actions(
@@ -2000,6 +2027,13 @@ class UnifiedRadixCache(BasePrefixCache):
             anchor_lock_params,
             comp_xfers,
         ) = self.ongoing_prefetch[req_id]
+
+        # Storage owns these host slots now. Drop any L2 router-expert rows
+        # left by an earlier owner before the slots enter either cache mode or
+        # buffer-only staging.
+        routed_experts_cache = self._get_routed_experts_host_cache()
+        if routed_experts_cache is not None:
+            routed_experts_cache.invalidate_hicache(host_indices[:completed_tokens])
 
         # All PP/TP ranks will get the same `min_completed_tokens`, because `completed_tokens`
         # and `pool_hits` in their operations are same.  No need to sync cross-rank here.

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -76,6 +76,8 @@ def verify_logits_adjustments_are_noop(sampling_info) -> bool:
 class TargetVerifyResult(msgspec.Struct, frozen=True):
     logits_output: object
     can_run_cuda_graph: bool
+    routed_experts_output: object = None
+    indexer_topk_output: object = None
 
 
 class TargetVerifyExecutor:
@@ -311,6 +313,8 @@ class TargetVerifyExecutor:
         return TargetVerifyResult(
             logits_output=target_out.logits_output,
             can_run_cuda_graph=target_out.can_run_cuda_graph,
+            routed_experts_output=target_out.routed_experts_output,
+            indexer_topk_output=target_out.indexer_topk_output,
         )
 
     def commit_hidden(

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -891,6 +891,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=int(self.verify_num_draft_tokens),
             new_seq_lens=accept.new_seq_lens,
+            routed_experts_output=target_verify.routed_experts_output,
+            indexer_topk_output=target_verify.indexer_topk_output,
         )
 
     def _commit_target_mamba_states_after_verify(

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -78,6 +78,76 @@ class BaseHostCache:
         self.topk_size = topk_size
         self.name = name
         self._log_allocation()
+        # L1 rows use reusable KV slots; L2 rows use stable HiCache host slots.
+        self.valid = torch.zeros(num_tokens, dtype=torch.bool, device="cpu")
+        self.must_be_valid = torch.zeros(num_tokens, dtype=torch.bool, device="cpu")
+        self._hicache_rows = {}
+
+    def store(self, cache_pool_idx: torch.Tensor, values: torch.Tensor) -> None:
+        """Publish routed-expert rows for the current KV-slot owners."""
+        cache_pool_idx = cache_pool_idx.cpu()
+        self.buffer[cache_pool_idx] = values.cpu()
+        self.valid[cache_pool_idx] = True
+
+    def backup_to_hicache(
+        self, device_indices: torch.Tensor, host_indices: torch.Tensor
+    ) -> None:
+        """Save L1 rows under the L2 KV host-slot identity."""
+        device_indices = device_indices.cpu()
+        host_indices = host_indices.cpu()
+        if len(device_indices) != len(host_indices):
+            raise ValueError("HiCache device/host routed-expert index length mismatch")
+        # HiCache transfers full KV pages. Some page slots are layout padding
+        # and therefore have no forward-time routed-expert capture; preserve
+        # their initialized rows instead of rejecting the whole page.
+        rows = self.buffer[device_indices].clone()
+        for host_idx, row in zip(host_indices.tolist(), rows):
+            self._hicache_rows[host_idx] = row
+
+    def restore_from_hicache(
+        self, host_indices: torch.Tensor, device_indices: torch.Tensor
+    ) -> bool:
+        """Remap L2 rows to freshly allocated KV slots without stale reads."""
+        host_indices = host_indices.cpu()
+        device_indices = device_indices.cpu()
+        self.must_be_valid[device_indices] = True
+        if len(host_indices) != len(device_indices):
+            raise ValueError("HiCache host/device routed-expert index length mismatch")
+
+        # Invalidate first so a missing sidecar never exposes a prior owner.
+        self.valid[device_indices] = False
+        missing = [idx for idx in host_indices.tolist() if idx not in self._hicache_rows]
+        if missing:
+            logger.error(
+                "Missing routed-expert HiCache rows for host slots %s", missing[:16]
+            )
+            return False
+
+        rows = torch.stack([self._hicache_rows[idx] for idx in host_indices.tolist()])
+        self.buffer[device_indices] = rows
+        self.valid[device_indices] = True
+        return True
+
+    def invalidate_hicache(self, host_indices: torch.Tensor) -> None:
+        """Forget L2 sidecar rows when host slots acquire non-L2 content."""
+        for host_idx in host_indices.cpu().tolist():
+            self._hicache_rows.pop(host_idx, None)
+
+    def invalidate(self, cache_pool_idx: torch.Tensor) -> None:
+        cache_pool_idx = cache_pool_idx.cpu()
+        self.must_be_valid[cache_pool_idx] = True
+        self.valid[cache_pool_idx] = False
+
+    def clear(self) -> None:
+        """Clear both reusable HostCache rows and HiCache L2 sidecar rows."""
+        self.buffer.zero_()
+        self.valid.zero_()
+        self.must_be_valid.zero_()
+        self._hicache_rows.clear()
+
+    def clear_hicache(self) -> None:
+        """Backward-compatible alias for callers added with HiCache support."""
+        self.clear()
 
     def destroy(self):
         if self.buffer is None:
@@ -115,7 +185,7 @@ class TopkCaptureOutput:
         self.topk = fn(self.topk)
 
     def finalize(self):
-        self.host_cache.buffer[self.out_cache_loc] = self.topk
+        self.host_cache.store(self.out_cache_loc, self.topk)
 
 
 class BaseTopkCapturer:
@@ -185,6 +255,16 @@ class BaseTopkCapturer:
             .cpu()
             .clone()
         )
+        invalid_mask = (
+            self.host_cache.must_be_valid[cache_pool_idx]
+            & ~self.host_cache.valid[cache_pool_idx]
+        )
+        if invalid_mask.any():
+            invalid = cache_pool_idx[invalid_mask].tolist()
+            raise RuntimeError(
+                "Routed-expert data is unavailable for KV slots "
+                f"{invalid[:16]}; refusing to return stale HostCache rows."
+            )
         return self.host_cache.buffer[cache_pool_idx]
 
     def on_forward_end(
@@ -209,5 +289,5 @@ class BaseTopkCapturer:
                 host_cache=self.host_cache,
             )
         out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
-        self.host_cache.buffer[out_cache_loc_cpu] = slice_gpu.cpu()
+        self.host_cache.store(out_cache_loc_cpu, slice_gpu)
         return None

--- a/test/registered/unit/mem_cache/test_swa_hicache_window_load.py
+++ b/test/registered/unit/mem_cache/test_swa_hicache_window_load.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.unified_cache.components.swa_component import SWAComponent
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    CacheTransferPhase,
+)
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+
+
+class _Key:
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+
+def _component_data():
+    return [SimpleNamespace(value=None, host_value=None) for _ in range(3)]
+
+
+def test_swa_load_back_splits_large_host_node_to_one_window():
+    root = SimpleNamespace(parent=None)
+    node = SimpleNamespace(
+        key=_Key(16), id=1, parent=root, component_data=_component_data()
+    )
+    node.component_data[ComponentType.SWA].host_value = torch.arange(16)
+
+    cache = SimpleNamespace(root_node=root, cache_controller=object())
+
+    def split_node(key, child, split_len):
+        parent = SimpleNamespace(
+            key=_Key(split_len),
+            parent=child.parent,
+            component_data=_component_data(),
+        )
+        old = child.component_data[ComponentType.SWA].host_value
+        parent.component_data[ComponentType.SWA].host_value = old[:split_len].clone()
+        child.component_data[ComponentType.SWA].host_value = old[split_len:].clone()
+        child.key = _Key(len(key) - split_len)
+        child.parent = parent
+        return parent, None
+
+    cache._split_node = split_node
+    component = SWAComponent.__new__(SWAComponent)
+    component.cache = cache
+    component.tree_core = SimpleNamespace(
+        root_node=root, has_swa_host_pool=True, enable_hicache=True, _split_node=split_node
+    )
+    component.sliding_window_size = 6
+    component._swa_kv_pool_host = object()
+
+    transfers = component.build_hicache_transfers(
+        node, CacheTransferPhase.LOAD_BACK
+    )
+
+    assert len(transfers) == 1
+    transfer = transfers[0]
+    assert transfer.nodes_to_load == [node.id]
+    torch.testing.assert_close(transfer.host_indices, torch.arange(10, 16))
+    assert len(node.key) == 6
+    assert len(node.parent.key) == 10

--- a/test/registered/unit/test_host_cache_hicache.py
+++ b/test/registered/unit/test_host_cache_hicache.py
@@ -12,7 +12,9 @@ from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
 
 def _cache(num_tokens=16, num_layers=2, topk=3):
-    return BaseHostCache(num_tokens, num_layers, topk, name="test")
+    # These tests exercise CPU-side metadata only; avoid leaking repeated
+    # cudaHostRegister allocations across short-lived cache instances.
+    return BaseHostCache(num_tokens, num_layers, topk, name="test", device="npu")
 
 
 def test_hicache_restore_remaps_experts_to_new_kv_slots():

--- a/test/registered/unit/test_host_cache_hicache.py
+++ b/test/registered/unit/test_host_cache_hicache.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.state_capturer.base import (
+    BaseHostCache,
+    BaseTopkCapturer,
+    TopkCaptureOutput,
+)
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+
+def _cache(num_tokens=16, num_layers=2, topk=3):
+    return BaseHostCache(num_tokens, num_layers, topk, name="test")
+
+
+def test_hicache_restore_remaps_experts_to_new_kv_slots():
+    cache = _cache()
+    old_slots = torch.tensor([1, 2])
+    host_slots = torch.tensor([10, 11])
+    new_slots = torch.tensor([7, 8])
+    expected = torch.arange(12, dtype=torch.int32).reshape(2, 2, 3)
+
+    cache.store(old_slots, expected)
+    cache.backup_to_hicache(old_slots, host_slots)
+
+    # Simulate a previous owner leaving unrelated data in the slots selected
+    # by HiCache load-back.
+    dirty = torch.full_like(expected, 999)
+    cache.store(new_slots, dirty)
+
+    assert cache.restore_from_hicache(host_slots, new_slots)
+    torch.testing.assert_close(cache.buffer[new_slots], expected)
+    assert cache.valid[new_slots].all()
+
+
+def test_missing_hicache_sidecar_invalidates_dirty_destination():
+    cache = _cache()
+    new_slot = torch.tensor([7])
+    cache.store(new_slot, torch.full((1, 2, 3), 999, dtype=torch.int32))
+
+    assert not cache.restore_from_hicache(torch.tensor([123]), new_slot)
+    assert not cache.valid[new_slot].any()
+
+    capturer = BaseTopkCapturer.__new__(BaseTopkCapturer)
+    capturer.host_cache = cache
+    req_pool = SimpleNamespace(
+        req_to_token=torch.tensor([[0, 7, 0]], dtype=torch.int64)
+    )
+    with pytest.raises(RuntimeError, match="refusing to return stale"):
+        capturer.get_topk(
+            req_pool_idx=0,
+            seqlen=3,
+            req_to_token_pool=req_pool,
+            start_len=1,
+        )
+
+
+def test_capture_finalize_marks_slots_valid():
+    cache = _cache()
+    slots = torch.tensor([3, 4])
+    values = torch.arange(12, dtype=torch.int32).reshape(2, 2, 3)
+
+    TopkCaptureOutput(slots, values, cache).finalize()
+
+    torch.testing.assert_close(cache.buffer[slots], values)
+    assert cache.valid[slots].all()
+
+
+def test_backup_preserves_uncaptured_padding_slots():
+    cache = _cache()
+
+    cache.backup_to_hicache(torch.tensor([5]), torch.tensor([9]))
+    torch.testing.assert_close(cache._hicache_rows[9], cache.buffer[5])
+
+
+def test_clear_hicache_removes_l1_validity_and_l2_rows():
+    cache = _cache()
+    cache.store(torch.tensor([1]), torch.ones((1, 2, 3), dtype=torch.int32))
+    cache.backup_to_hicache(torch.tensor([1]), torch.tensor([9]))
+
+    cache.clear_hicache()
+
+    assert not cache.valid.any()
+    assert not cache.restore_from_hicache(torch.tensor([9]), torch.tensor([2]))
+
+
+def test_clear_removes_host_cache_and_hicache_rows():
+    cache = _cache()
+    cache.store(torch.tensor([1]), torch.ones((1, 2, 3), dtype=torch.int32))
+    cache.backup_to_hicache(torch.tensor([1]), torch.tensor([9]))
+
+    cache.clear()
+
+    assert not cache.buffer.any()
+    assert not cache.valid.any()
+    assert cache._hicache_rows == {}
+    assert not cache.restore_from_hicache(torch.tensor([9]), torch.tensor([2]))
+
+
+def test_storage_owner_invalidates_reused_hicache_host_slots():
+    cache = _cache()
+    old_slots = torch.tensor([1, 2])
+    host_slots = torch.tensor([9, 10])
+    destination = torch.tensor([6, 7])
+    values = torch.arange(12, dtype=torch.int32).reshape(2, 2, 3)
+
+    cache.store(old_slots, values)
+    cache.backup_to_hicache(old_slots, host_slots)
+    cache.invalidate_hicache(host_slots)
+
+    assert not cache.restore_from_hicache(host_slots, destination)
+    assert not cache.valid[destination].any()
+
+
+def test_unified_cache_resolves_global_routed_experts_host_cache(monkeypatch):
+    from sglang.srt.state_capturer import routed_experts
+
+    host_cache = object()
+    capturer = SimpleNamespace(host_cache=host_cache)
+    monkeypatch.setattr(
+        routed_experts,
+        "get_global_experts_capturer",
+        lambda: capturer,
+    )
+
+    assert UnifiedRadixCache._get_routed_experts_host_cache() is host_cache


### PR DESCRIPTION
# Preserve Routed Experts Across HiCache Restore

## Summary

This change keeps routed-expert metadata consistent with KV-cache ownership when HiCache moves KV pages between GPU and host memory.

When a request was restored from HiCache, its KV cache was copied into newly allocated device slots, but the routed-expert HostCache still contained data associated with the previous owners of those slots. Returning those rows could therefore expose stale expert IDs.

The fix introduces a routed-expert sidecar keyed by HiCache host slots, restores that sidecar together with KV pages, and fails closed when matching metadata is unavailable.

## Changes

- Track validity and ownership of routed-expert HostCache rows.
- Back up routed-expert rows when KV pages are written to HiCache.
- Restore routed-expert rows when KV pages are loaded into new device slots.
- Invalidate affected rows before restore so missing sidecar data cannot expose stale values.
- Invalidate sidecar entries for data prefetched from storage, since routed experts are not currently persisted in the L3 storage backend.
- Clear routed-expert L1 and L2 metadata when HiCache is reset.
- Apply the restore path to hierarchical, unified, buffer-mode, and SWA cache flows.
- Propagate routed-expert and indexer outputs through the dSpark speculative verification path.
- Add unit coverage for HostCache backup, restore, invalidation, reset, unified-cache integration, and SWA window loading.

## Correctness and Safety

The implementation uses fail-closed semantics. Device rows are marked invalid before a restore. If any routed-expert sidecar row is missing, the cache refuses to return data from those slots instead of returning values left by their previous owners.

L3 storage restores explicitly invalidate routed-expert metadata because the storage backend currently stores KV data only. This prevents an L3-restored request from accidentally consuming an unrelated HostCache row.

## Validation

### Unit tests

```text
21 passed
```

The following suites were run in the SGLang v0.5.19 environment:

```bash
python -m pytest -q \
  test/registered/unit/test_host_cache_hicache.py \
  test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
```

### End-to-end HiCache restore

The server was started with hierarchical cache and routed-expert output enabled. A 4,096-token MoE request was issued, evicted from GPU KV cache by additional requests, and then replayed.

```text
Prompt tokens:                    4096
Tokens restored from HiCache:     4064
Restored routed-expert IDs:     390144
Mismatches in restored region:       0
```

The remaining 32 tokens were recomputed rather than restored and were excluded from the HiCache correctness comparison.

## Scope

This PR keeps routed-expert metadata in host memory as an HiCache sidecar. Persisting routed-expert metadata in an L3 storage backend is intentionally out of scope; L3-loaded rows are invalidated to preserve correctness.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34567651997](https://github.com/sgl-project/sglang/actions/runs/34567651997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34567651831](https://github.com/sgl-project/sglang/actions/runs/34567651831)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34567652089](https://github.com/sgl-project/sglang/actions/runs/34567652089)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->