### PR TITLE
[Cookbook][AMD] Kimi-K3 MI350X/MI355X: pin a ROCm image with the DSPARK graph-capture fix, add measured cell numbers

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -30,7 +30,7 @@ Then run the **Python** output of the command panel below in that environment.
 
 ```bash Command
 docker pull lmsysorg/sglang:latest                                  # NVIDIA (CUDA)
-docker pull lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260903     # AMD MI350X / MI355X (ROCm)
+docker pull lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260910     # AMD MI350X / MI355X (ROCm)
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.

--- a/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx
@@ -91,4 +91,31 @@ export const benchmarks = [
         ttft_ms: 11664, tpot_ms: 22.17, tokens_per_sec_per_gpu: 1946 },
     ],
   },
+  {
+    // DSPARK acceptance pinned to 5 of 8 draft tokens (SGLANG_SIMULATE_ACC_LEN=5
+    // SGLANG_SIMULATE_ACC_METHOD=match-expected SGLANG_RAGGED_VERIFY_MODE=static), so the
+    // rows are independent of the benchmark's random prompts; measured accept length 5.00.
+    match: { hw: "mi350x", pdMode: "unified", strategy: "balanced", quant: "mxfp4", spec: "dspark" },
+    sglang_version: "v0.5.19 @ 12771786",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 604, tpot_ms: 5.39, tokens_per_sec_per_gpu: 186 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 6035, tpot_ms: 15.32, tokens_per_sec_per_gpu: 864 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 23720, tpot_ms: 31.45, tokens_per_sec_per_gpu: 913 },
+    ],
+  },
+  {
+    match: { hw: "mi350x", pdMode: "unified", strategy: "balanced", quant: "mxfp4", spec: "none" },
+    sglang_version: "v0.5.19 @ 12771786",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 590, tpot_ms: 18.55, tokens_per_sec_per_gpu: 58 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 6331, tpot_ms: 32.80, tokens_per_sec_per_gpu: 462 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64 },
+        ttft_ms: 18665, tpot_ms: 70.39, tokens_per_sec_per_gpu: 813 },
+    ],
+  },
 ];

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -470,8 +470,8 @@ export const config = {
     gb200:  "lmsysorg/sglang:kimi-k3",
     // 20260903 or newer: the AITER SiTU A4W4/A8W4 layout fix (sgl-project/sglang#33838,
     // merged Sep 3) and the fused gfx950 KDA decode boundary (#34198) first ship here.
-    mi350x: "lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260903",
-    mi355x: "lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260903",
+    mi350x: "lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260910",
+    mi355x: "lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260910",
     // NVFP4 needs a build with sgl-project/sglang#35077; the purpose-built dev
     // image is cut from that PR's head (CUDA 13).
     "b300|nvfp4":  "lmsysorg/sglang:dev-dev-kimi-k3-nvfp4",


### PR DESCRIPTION
## Motivation

Running the Kimi-K3 cookbook's `mi350x` / `mi355x` Unified-Balanced cell as generated (image `v0.5.18-rocm720-mi35x-20260903`, `--mem-fraction-static 0.85`, DSPARK overlay) on a single 8x MI350X node (gfx950, 288 GB) fails in two independent ways:

1. **DSPARK aborts HIP graph capture** on the pinned `20260903` image: the DSpark draft sampler's TP sync calls `GroupCoordinator.broadcast` inside the decode graph, which still used `torch.distributed.broadcast` in that image (`Fatal Python error: Aborted` in `spec_tp_sync.sync`). The fix (dispatch to PyNccl on HIP, `parallel_state.py`) merged in #37601 on 2026-09-06, so every ROCm image from `20260907` on carries it; the cookbook still pins `20260903`. The mdx also says these knobs "first ship in the `20260903` daily ROCm image", which is true for the env knobs but not for DSPARK.
2. **`--mem-fraction-static 0.85` OOMs** on the first 8k-token prefill chunk (aiter FlyDSL fused-MoE stage-2 workspace, then the attention-residual buffers): Kimi-K3's loaded weights are 70.5% of the 288 GB (~203 GB/rank incl. the DSpark draft), so 0.85 leaves ~33 GB after decode-graph capture while the K3 prefill working set on this stack is ~24-44 GB depending on chunk size. The `aiter` attention backend auto-scales `mem_fraction_static` by 0.85 for `context_len > 8192` (`attention_hook.py`), but the AMD cell pins `--attention-backend triton`, which gets no such scaling.

Both reproduce on the pinned `20260903` image and **neither reproduces on `v0.5.19-rocm720-mi35x-20260910`** (sglang `0.5.19.dev20260910`, main `12771786f2`, aiter `4ad998328`): with the cell exactly as generated (`--mem-fraction-static 0.85`, default 16384-token prefill chunks, DSPARK overlay incl. `--enable-linear-replayssm-spec`, no source changes) the server captures the DSpark graphs and runs the cookbook speed shape (`random` 8192->1024) at concurrency 1 / 16 / 64 to completion with zero scheduler exceptions. So this PR only moves the AMD image pin forward and records the measured cell numbers; the memory-budget change I first prototyped (0.80 + 4096-token chunks) is not needed on the newer image and is not included.

## Modifications

- `docs/src/snippets/configs/moonshotai/kimi-k3.jsx`: `mi350x` / `mi355x` image -> `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260910`.
- `docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx`: same image in the `docker pull` line.
- `docs/src/snippets/configs/moonshotai/kimi-k3-benchmarks.jsx`: measured `mi350x` Unified/Balanced rows (mxfp4, spec `dspark` with acceptance pinned to 5, and `none`), same client command as the B300 rows (`bench_serving --backend sglang`, `--random-range-ratio 1.0`, `--warmup-requests 64 --flush-cache`, 16/80/320 prompts at c1/c16/c64).

## Verification (8x MI350X VF, gfx950, 288 GB, TP8, `moonshotai/Kimi-K3` MXFP4 weights)

Image `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260910` (sglang `0.5.19.dev20260910+g908226fea2`, main `12771786f2`, aiter `4ad998328`, torch 2.9.1+rocm7.2.0). Cell exactly as the command generator emits it for `mi350x` / Unified / Balanced (`--mem-fraction-static 0.85`, default 16384-token prefill chunks, `--context-length 16384` added), no source changes. Client = the cookbook's own `bench_serving --backend sglang --dataset-name random --random-input-len 8192 --random-output-len 1024 --random-range-ratio 1.0 --warmup-requests 64 --flush-cache` with 16 / 80 / 320 prompts at concurrency 1 / 16 / 64. Zero scheduler exceptions across all six runs.

| overlay | conc | median TTFT | median TPOT | total tok/s per GPU | accept len |
| --- | ---: | ---: | ---: | ---: | ---: |
| DSPARK, acceptance pinned to 5 (`SGLANG_SIMULATE_ACC_LEN=5 SGLANG_SIMULATE_ACC_METHOD=match-expected SGLANG_RAGGED_VERIFY_MODE=static`) | 1 | 604 ms | 5.39 ms | 186 | 5.00 |
| DSPARK, pinned 5 | 16 | 6035 ms | 15.32 ms | 864 | 5.00 |
| DSPARK, pinned 5 | 64 | 23720 ms | 31.45 ms | 913 | 5.00 |
| Non-Spec (`SGLANG_MLA_DECODE_TUNE=1`) | 1 | 590 ms | 18.55 ms | 58 | - |
| Non-Spec | 16 | 6331 ms | 32.80 ms | 462 | - |
| Non-Spec | 64 | 18665 ms | 70.39 ms | 813 | - |

The DSPARK rows use SGLang's acceptance simulation (`match-expected` accepts exactly 5 of the 8 draft tokens per round; the verify-all schedule `SGLANG_RAGGED_VERIFY_MODE=static` is required by the DSpark worker for simulated acceptance), so they do not depend on the benchmark's random prompts. With the real drafter on those random prompts acceptance reads 7.2-7.4 of 8 (c1 608 ms / 3.80 ms / 249, c16 1230 ms / 16.69 ms / 879, c64 16656 ms / 35.21 ms / 1261), which real text will not reach; those rows are intentionally not in the file. Simulated acceptance disables the in-graph acceptance path, so generated text is not used for quality. `max_running_requests` resolves to 74 (non-spec) / 48 (DSPARK) at this memory budget, so the concurrency-64 rows are partly queue-bound. For comparison the B300 1x8 Balanced rows in this file are 1395 (none) / 1987 (dspark, real acceptance) tok/s per GPU at c64.

Failure evidence on the old `20260903` pin (same node, same cell): DSPARK -> `Fatal Python error: Aborted` inside `spec_tp_sync.sync -> parallel_state.broadcast -> torch.distributed.broadcast` during decode-graph capture; non-spec and DSPARK -> `torch.OutOfMemoryError: HIP out of memory` in `aiter fused_moe_2stages` / `attn_residual.__init__` on the first 8k prefill chunk at 0.85 (only 0.80 + 4096-token chunks survived there).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34656287321](https://github.com/sgl-project/sglang/actions/runs/34656287321)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34656287270](https://github.com/sgl-project/sglang/actions/runs/34656287270)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->