### PR TITLE
[NPU] Add an opt-in graph-compatible QuantLightningIndexer fallback

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -928,6 +928,8 @@ class Envs:
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
     SGLANG_NPU_USE_MLAPO = EnvBool(False)
     SGLANG_NPU_ENABLE_SPARSE_KV_OFFLOAD = EnvBool(False)
+    # Use the unfused QuantLightningIndexer implementation.
+    SGLANG_NPU_USE_QLI_FALLBACK = EnvBool(False)
     # Forward native implementation for activation gelu tanh for model Skywork-Reward-Gemma-2-27B-v0.2
     SGLANG_NPU_FORWARD_NATIVE_GELUTANH = EnvBool(False)
     # Forward native implementation for gemma rms norm for model Skywork-Reward-Gemma-2-27B-v0.2

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 # stored unquantized, so the kernels need both dimensions spelled out.
 _NPU_ARCH35_KV_TILE_SIZE = 64
 _NPU_ARCH35_KV_ROPE_HEAD_DIM = 64
+_NPU_QLI_FALLBACK_MAX_SCORE_ELEMENTS = 16 * 1024 * 1024
 
 
 def _sparse_attn_ops():
@@ -713,6 +714,31 @@ class C4IndexerAscendBackendMixin:
             li_kv_scale = self.token_to_kv_pool.get_compress_dequant_scale_buffer(
                 c4_indexer.layer_id, True
             )
+            if envs.SGLANG_NPU_USE_QLI_FALLBACK.get():
+                if li_kv_dtype != "int8":
+                    raise RuntimeError(
+                        "The NPU QLI fallback requires an INT8 KV cache, "
+                        f"but got {li_kv_dtype}."
+                    )
+                if not getattr(self, "_npu_qli_fallback_logged", False):
+                    logger.warning(
+                        "Using the NPU QuantLightningIndexer fallback; "
+                        "the fused QLI operator is disabled."
+                    )
+                    self._npu_qli_fallback_logged = True
+                fallback_forward = (
+                    self._forward_npu_int8_fallback_graph
+                    if self.graph_mode
+                    else self._forward_npu_int8_fallback
+                )
+                return fallback_forward(
+                    c4_indexer,
+                    q,
+                    li_cmp_kv,
+                    li_kv_scale,
+                    weights,
+                    forward_batch,
+                )
             return self._forward_npu_fused(
                 c4_indexer, q, li_cmp_kv, li_kv_scale, weights, forward_batch
             )
@@ -782,6 +808,186 @@ class C4IndexerAscendBackendMixin:
             )
             topk_idxs.append(topk_idx)
         return torch.cat(topk_idxs, dim=0).to(dtype=torch.int32)
+
+    def _forward_npu_int8_fallback(
+        self,
+        c4_indexer,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        """Eager fallback for runtimes that cannot use the fused QLI operator."""
+        fm = self.forward_metadata
+        cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
+        if isinstance(cu_q_cpu, torch.Tensor):
+            cu_q_cpu = cu_q_cpu.tolist()
+        if cu_q_cpu is None or int(cu_q_cpu[-1]) != q.shape[0]:
+            raise RuntimeError(
+                "Invalid query offsets for the NPU QLI fallback: "
+                f"offsets={cu_q_cpu}, query_tokens={q.shape[0]}"
+            )
+
+        kv_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
+        if kv_lens_cpu is None:
+            kv_lens_cpu = fm.actual_seq_lengths_kv.cpu().tolist()
+        elif isinstance(kv_lens_cpu, torch.Tensor):
+            kv_lens_cpu = kv_lens_cpu.tolist()
+        request_count = len(cu_q_cpu) - 1
+        if len(kv_lens_cpu) < request_count:
+            raise RuntimeError(
+                "Invalid KV lengths for the NPU QLI fallback: "
+                f"kv_lengths={kv_lens_cpu}, request_count={request_count}"
+            )
+
+        ratio = c4_indexer.compressor.ratio
+        page_table = fm.c4_page_table
+        page_size = k.shape[1]
+        flat_k = k.flatten(0, 1)
+        flat_scale = k_scale.flatten(0, 1)
+        output = torch.full(
+            (q.shape[0], self._dsv4_index_topk),
+            -1,
+            dtype=torch.int32,
+            device=q.device,
+        )
+
+        for request_idx in range(request_count):
+            query_start = int(cu_q_cpu[request_idx])
+            query_end = int(cu_q_cpu[request_idx + 1])
+            query_count = query_end - query_start
+            compressed_len = int(kv_lens_cpu[request_idx]) // ratio
+            if compressed_len == 0:
+                continue
+
+            kv_indices = _get_kv_indices(
+                forward_batch,
+                compressed_len,
+                page_table,
+                request_idx,
+                compressed_len,
+                page_size=page_size,
+            ).to(torch.int64)
+            kv = flat_k.index_select(0, kv_indices).squeeze(1).to(q.dtype)
+            scale = (
+                flat_scale.index_select(0, kv_indices)
+                .reshape(compressed_len, 1)
+                .to(q.dtype)
+            )
+            kv = kv * scale
+
+            score_elements_per_query = c4_indexer.n_heads * compressed_len
+            query_chunk_size = max(
+                1,
+                min(
+                    query_count,
+                    _NPU_QLI_FALLBACK_MAX_SCORE_ELEMENTS // score_elements_per_query,
+                ),
+            )
+            logical_k = torch.arange(compressed_len, device=q.device)
+            for chunk_start in range(query_start, query_end, query_chunk_size):
+                chunk_end = min(query_end, chunk_start + query_chunk_size)
+                index_score = torch.einsum("qhd,kd->qhk", q[chunk_start:chunk_end], kv)
+                index_score = (
+                    index_score.relu_() * weights[chunk_start:chunk_end].unsqueeze(-1)
+                ).sum(dim=1)
+                if getattr(c4_indexer, "enable_indexer_tp", False):
+                    parallel = get_parallel()
+                    if parallel.attn_tp_size > 1:
+                        parallel.attn_tp_group.all_reduce(index_score)
+
+                valid_len = torch.div(
+                    forward_batch.positions[chunk_start:chunk_end] + 1,
+                    ratio,
+                    rounding_mode="floor",
+                ).clamp(max=compressed_len)
+                valid_mask = logical_k.unsqueeze(0) < valid_len.unsqueeze(1)
+                index_score.masked_fill_(~valid_mask, float("-inf"))
+                selected_count = min(self._dsv4_index_topk, compressed_len)
+                topk_idx = index_score.topk(selected_count, dim=-1).indices
+                topk_idx = torch.where(topk_idx < valid_len.unsqueeze(1), topk_idx, -1)
+                topk_idx = F.pad(
+                    topk_idx,
+                    (0, self._dsv4_index_topk - selected_count),
+                    value=-1,
+                )
+                output[chunk_start:chunk_end].copy_(topk_idx.to(torch.int32))
+
+        return output
+
+    def _forward_npu_int8_fallback_graph(
+        self,
+        c4_indexer,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        """Fixed-shape indexer fallback for NPU graph capture and replay."""
+        fm = self.forward_metadata
+        page_table = fm.c4_page_table
+        batch_size, page_count = page_table.shape
+        if q.shape[0] % batch_size != 0:
+            raise RuntimeError(
+                "Invalid graph query layout for the NPU QLI fallback: "
+                f"tokens={q.shape[0]}, batch_size={batch_size}"
+            )
+
+        queries_per_request = q.shape[0] // batch_size
+        page_size = k.shape[1]
+        max_compressed_len = page_count * page_size
+        safe_pages = page_table.clamp_min(0).to(torch.int64).flatten()
+        kv = (
+            k.index_select(0, safe_pages)
+            .reshape(batch_size, max_compressed_len, k.shape[-1])
+            .to(q.dtype)
+        )
+        scale = (
+            k_scale.index_select(0, safe_pages)
+            .reshape(batch_size, max_compressed_len)
+            .to(q.dtype)
+        )
+
+        q = q.reshape(batch_size, queries_per_request, c4_indexer.n_heads, q.shape[-1])
+        weights = weights.reshape(batch_size, queries_per_request, c4_indexer.n_heads)
+        index_score = torch.bmm(q.flatten(1, 2), kv.transpose(1, 2)).reshape(
+            batch_size,
+            queries_per_request,
+            c4_indexer.n_heads,
+            max_compressed_len,
+        )
+        index_score = (index_score.relu_() * weights.unsqueeze(-1)).sum(dim=2)
+        index_score = index_score * scale.unsqueeze(1)
+        if getattr(c4_indexer, "enable_indexer_tp", False):
+            parallel = get_parallel()
+            if parallel.attn_tp_size > 1:
+                parallel.attn_tp_group.all_reduce(index_score)
+
+        ratio = c4_indexer.compressor.ratio
+        compressed_lens = torch.div(
+            fm.actual_seq_lengths_kv, ratio, rounding_mode="floor"
+        ).clamp(max=max_compressed_len)
+        valid_lens = torch.div(
+            forward_batch.positions.reshape(batch_size, queries_per_request) + 1,
+            ratio,
+            rounding_mode="floor",
+        )
+        valid_lens = torch.minimum(valid_lens, compressed_lens.unsqueeze(1))
+        logical_k = torch.arange(max_compressed_len, device=q.device)
+        valid_mask = logical_k < valid_lens.unsqueeze(-1)
+        index_score.masked_fill_(~valid_mask, float("-inf"))
+
+        selected_count = min(self._dsv4_index_topk, max_compressed_len)
+        topk_idx = index_score.topk(selected_count, dim=-1).indices
+        topk_idx = torch.where(topk_idx < valid_lens.unsqueeze(-1), topk_idx, -1)
+        topk_idx = topk_idx.reshape(q.shape[0] * q.shape[1], selected_count)
+        return F.pad(
+            topk_idx,
+            (0, self._dsv4_index_topk - selected_count),
+            value=-1,
+        ).to(torch.int32)
 
     def _ensure_npu_c4_indexer(self, c4_indexer, device: torch.device) -> None:
         # A5's lightning indexer consumes FP8 K + fp32 scales; pre-A5 stays int8.

--- a/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
@@ -67,6 +67,7 @@ from sglang.srt.hardware_backend.npu.attention.ascend_dsv4_backend import (
     _sparse_attn_ops,
     _walsh_hadamard_matrix,
 )
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     dsv4_state_payloads,
 )
@@ -378,6 +379,154 @@ class TestC4IndexerInitialization(unittest.TestCase):
         backend._ensure_npu_c4_indexer(indexer, torch.device("cpu"))
 
         self.assertEqual(indexer.compressor.li_kv_dtype, "float8")
+
+
+class TestC4IndexerCompatibility(unittest.TestCase):
+    @staticmethod
+    def _indexer(li_kv_dtype="int8"):
+        return SimpleNamespace(
+            n_heads=1,
+            head_dim=2,
+            layer_id=0,
+            compressor=SimpleNamespace(ratio=4, li_kv_dtype=li_kv_dtype),
+        )
+
+    def test_qli_fallback_dispatch_bypasses_fused_indexer(self):
+        backend = C4IndexerAscendBackendMixin.__new__(C4IndexerAscendBackendMixin)
+        backend.graph_mode = False
+        backend._dsv4_index_topk = 2
+        backend.token_to_kv_pool = MagicMock()
+        expected = torch.tensor([[1, 0]], dtype=torch.int32)
+        backend._forward_npu_int8_fallback = MagicMock(return_value=expected)
+        backend._forward_npu_fused = MagicMock()
+        forward_mode = MagicMock()
+        forward_mode.is_extend.return_value = False
+        forward_mode.is_target_verify.return_value = False
+        forward_mode.is_idle.return_value = False
+        forward_batch = SimpleNamespace(forward_mode=forward_mode)
+
+        with envs.SGLANG_NPU_USE_QLI_FALLBACK.override(True):
+            result = backend._forward_indexer(
+                self._indexer(),
+                torch.zeros((1, 2)),
+                torch.zeros((1, 1, 2)),
+                torch.ones((1, 1)),
+                forward_batch,
+            )
+
+        self.assertIs(result, expected)
+        backend._forward_npu_int8_fallback.assert_called_once()
+        backend._forward_npu_fused.assert_not_called()
+
+    def test_qli_fallback_rejects_non_int8_cache(self):
+        backend = C4IndexerAscendBackendMixin.__new__(C4IndexerAscendBackendMixin)
+        backend.graph_mode = False
+        backend.token_to_kv_pool = MagicMock()
+        backend._forward_npu_fused = MagicMock()
+        forward_mode = MagicMock()
+        forward_mode.is_idle.return_value = False
+
+        with (
+            envs.SGLANG_NPU_USE_QLI_FALLBACK.override(True),
+            self.assertRaisesRegex(RuntimeError, "requires an INT8 KV cache"),
+        ):
+            backend._forward_indexer(
+                self._indexer("float8"),
+                torch.zeros((1, 2)),
+                torch.zeros((1, 1, 2)),
+                torch.ones((1, 1)),
+                SimpleNamespace(forward_mode=forward_mode),
+            )
+
+        backend._forward_npu_fused.assert_not_called()
+
+    def test_qli_fallback_uses_logical_pages_and_masks_partial_tail(self):
+        backend = C4IndexerAscendBackendMixin.__new__(C4IndexerAscendBackendMixin)
+        backend._dsv4_index_topk = 4
+        backend.forward_metadata = SimpleNamespace(
+            actual_seq_lengths_q_pa_cpu=torch.tensor([0, 1], dtype=torch.int32),
+            actual_seq_lengths_kv=torch.tensor([15], dtype=torch.int32),
+            c4_page_table=torch.tensor([[1, 0]], dtype=torch.int32),
+        )
+        # Logical C4 order is physical page 1 followed by physical page 0.
+        # Logical index 3 has the highest raw score but belongs to the
+        # incomplete 4-token tail and must not be selected.
+        k = torch.tensor(
+            [
+                [[[3, 0]], [[100, 0]]],
+                [[[1, 0]], [[2, 0]]],
+            ],
+            dtype=torch.int8,
+        )
+        scale = torch.ones((2, 2, 1, 1), dtype=torch.float32)
+        q = torch.tensor([[[1.0, 0.0]]])
+        weights = torch.ones((1, 1))
+        forward_batch = SimpleNamespace(positions=torch.tensor([14]))
+
+        result = backend._forward_npu_int8_fallback(
+            self._indexer(), q, k, scale, weights, forward_batch
+        )
+
+        self.assertEqual(result.tolist(), [[2, 1, 0, -1]])
+        self.assertEqual(result.dtype, torch.int32)
+
+    def test_qli_fallback_graph_dispatch_bypasses_fused_indexer(self):
+        backend = C4IndexerAscendBackendMixin.__new__(C4IndexerAscendBackendMixin)
+        backend.graph_mode = True
+        backend._dsv4_index_topk = 2
+        backend.token_to_kv_pool = MagicMock()
+        expected = torch.tensor([[1, 0]], dtype=torch.int32)
+        backend._forward_npu_int8_fallback_graph = MagicMock(return_value=expected)
+        backend._forward_npu_int8_fallback = MagicMock()
+        backend._forward_npu_fused = MagicMock()
+        forward_mode = MagicMock()
+        forward_mode.is_extend.return_value = False
+        forward_mode.is_target_verify.return_value = False
+        forward_mode.is_idle.return_value = False
+
+        with envs.SGLANG_NPU_USE_QLI_FALLBACK.override(True):
+            result = backend._forward_indexer(
+                self._indexer(),
+                torch.zeros((1, 2)),
+                torch.zeros((1, 1, 2)),
+                torch.ones((1, 1)),
+                SimpleNamespace(forward_mode=forward_mode),
+            )
+
+        self.assertIs(result, expected)
+        backend._forward_npu_int8_fallback_graph.assert_called_once()
+        backend._forward_npu_int8_fallback.assert_not_called()
+        backend._forward_npu_fused.assert_not_called()
+
+    def test_qli_graph_fallback_uses_device_metadata(self):
+        backend = C4IndexerAscendBackendMixin.__new__(C4IndexerAscendBackendMixin)
+        backend._dsv4_index_topk = 4
+        backend.forward_metadata = SimpleNamespace(
+            actual_seq_lengths_kv=torch.tensor([15, 8], dtype=torch.int32),
+            c4_page_table=torch.tensor([[1, 0], [2, -1]], dtype=torch.int32),
+        )
+        k = torch.tensor(
+            [
+                [[[3, 0]], [[100, 0]]],
+                [[[1, 0]], [[2, 0]]],
+                [[[4, 0]], [[5, 0]]],
+            ],
+            dtype=torch.int8,
+        )
+        scale = torch.ones((3, 2, 1, 1), dtype=torch.float32)
+        q = torch.tensor([[[1.0, 0.0]]] * 4)
+        weights = torch.ones((4, 1))
+        forward_batch = SimpleNamespace(positions=torch.tensor([7, 14, 3, 7]))
+
+        result = backend._forward_npu_int8_fallback_graph(
+            self._indexer(), q, k, scale, weights, forward_batch
+        )
+
+        self.assertEqual(
+            result.tolist(),
+            [[1, 0, -1, -1], [2, 1, 0, -1], [0, -1, -1, -1], [1, 0, -1, -1]],
+        )
+        self.assertEqual(result.dtype, torch.int32)
 
 
 class TestWalshHadamardMatrix(unittest.TestCase):
@@ -732,6 +881,7 @@ class TestSparseAttentionMetadata(unittest.TestCase):
             with (
                 self.subTest(is_arch35=is_arch35),
                 patch(self._ARCH35_PATCH_TARGET, return_value=is_arch35),
+                envs.SGLANG_NPU_USE_QLI_FALLBACK.override(False),
                 patch("torch.ops.custom", MagicMock(), create=True) as custom_ops,
                 patch("torch.ops.npu", MagicMock(), create=True),
             ):

--- a/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_dsv4_backend.py
@@ -55,6 +55,7 @@ _eagle_stub.per_step_draft_out_cache_loc = _per_step_draft_out_cache_loc
 sys.modules.setdefault("sglang.srt.speculative", ModuleType("sglang.srt.speculative"))
 sys.modules.setdefault("sglang.srt.speculative.eagle_utils", _eagle_stub)
 
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.ascend_dsv4_backend import (
     C4IndexerAscendBackendMixin,
     CompressorAscendBackendMixin,
@@ -67,7 +68,6 @@ from sglang.srt.hardware_backend.npu.attention.ascend_dsv4_backend import (
     _sparse_attn_ops,
     _walsh_hadamard_matrix,
 )
-from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     dsv4_state_payloads,
 )


### PR DESCRIPTION
## Motivation
On Ascend 910B4 with CANN 2026.9.0, the fused QuantLightningIndexer reproducibly triggers a native segmentation fault during inference.
The relevant stack trace is:
```text
!!!!!! Segfault encountered !!!!!!!
File "<unknown>", line 0, in aclnnQuantLightningIndexerGetWorkspaceSize
File ".../custom_ops/csrc/ops_common.h", line 881, in auto call(...)
File ".../custom_ops/csrc/ops_common.h", line 887, in auto call(...)
File ".../custom_ops/csrc/npu_quant_lightning_indexer.cpp", line 143,
  in custom::npu_quant_lightning_indexer_npu(...)
```
The failure occurs while the custom operator queries its workspace size, before it can return an ACL error. As a result, the segmentation fault cannot be caught or recovered from
Python, preventing DeepSeek V4 inference from running in this environment.
The Compressor itself is not present in the failing stack. Its existing `cache_mode=2` state-cache path remains valid and is left unchanged.
## Changes
- Add an opt-in environment variable:
  ```bash
  SGLANG_NPU_USE_QLI_FALLBACK=1
  ```
- Bypass the fused QuantLightningIndexer when the fallback is enabled.
- Add an eager INT8 QLI fallback that:
  - gathers compressed K through the logical C4 page table;
  - applies per-token dequantization scales;
  - computes weighted ReLU query-key scores;
  - applies causal and sequence-length masks;
  - returns fixed-width logical top-k indices;
  - chunks large prefill computations to limit temporary memory usage.
- Add a fixed-shape NPU graph fallback using:
  - device-side sequence metadata;
  - paged KV gathering;
  - batched matrix multiplication;
  - causal and sequence-length masking;
  - fixed-width top-k selection.
- Fail explicitly when the fallback is enabled with a non-INT8 indexer cache, instead of silently returning to the fused operator.
- Keep the existing fused QLI path unchanged when the fallback is disabled.
## Usage
For affected Ascend 910B4 environments, enable the fallback before starting the server:
```bash
export SGLANG_NPU_USE_QLI_FALLBACK=1
```
The fallback supports both eager execution and NPU graph execution. `--disable-cuda-graph` is not required.
Example:
```bash
export SGLANG_NPU_USE_QLI_FALLBACK=1
sglang serve \
  --model-path /path/to/model \
  --device npu \
  --attention-backend dsv4
```
When enabled, the following warning is emitted once:
```text
Using the NPU QuantLightningIndexer fallback; the fused QLI operator is disabled.
```
## Scope
The issue has currently been reproduced on Ascend 910B4 with CANN 2026.9.0.
The environment variable and implementation use operator-based naming rather than hardware-specific naming, allowing the fallback to be used with other NPU runtime combinations
affected by the same fused QLI failure.
This change does not modify:
- Compressor `cache_mode`;
- Compressor state-cache allocation or layout;
- fused QuantLightningIndexer arguments;
- the default fused QLI execution path;
- A5/FP8 indexer behavior.
The fallback is opt-in and currently supports the INT8 indexer cache contract.
## Graph Compatibility
The graph fallback uses fixed-shape tensor operations and graph-owned metadata. It does not use:
- `.cpu()`;
- `.tolist()`;
- `.item()`;
- data-dependent Python loops;
- dynamically sized top-k outputs.
Invalid page-table entries are mapped to a safe physical page before gathering and excluded through device-side sequence-length masking.
## Testing
Added unit coverage for:
- dispatching to the fallback instead of fused QLI;
- rejecting unsupported non-INT8 caches;
- logical-to-physical C4 page mapping;
- masking incomplete compressed-token tails;
- graph-mode fallback dispatch;
- fixed-shape graph computation with device-side sequence metadata.
Validation performed:
- Ruff formatting and lint checks;
- Python syntax compilation;
- Git diff validation;
- CPU numerical comparison against the reference indexer calculation;
- manual eager-mode validation on Ascend 910B4 with CANN 2026.9.0;
- manual graph-mode validation on Ascend 910B4 with CANN 2026.9.0.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34569800924](https://github.com/sgl-project/sglang/actions/runs/34569800924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34569800676](https://github.com/sgl-project/sglang/actions/runs/34569800676)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34569800832](https://github.com/sgl-project/sglang/actions/runs/34569800832)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->