### PR TITLE
[Bugfix] Respect parameterized SwiGLU in contiguous DeepGEMM MoE

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -485,6 +485,19 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                     scale_ue8m0=False,
                 )
                 del down_input
+        elif self.config.gemm1_alpha is not None:
+            assert self.config.gemm1_beta == 1.0, (
+                "The OAI-SwiGLU DeepGEMM kernel requires gemm1_beta=1.0, "
+                f"got {self.config.gemm1_beta}"
+            )
+            down_input_fp8, down_input_scale = _contiguous_deep_gemm_silu_mul_quant(
+                gateup_output,
+                group_size=scale_block_size,
+                topk=self.config.top_k,
+                gemm1_alpha=self.config.gemm1_alpha,
+                gemm1_clamp_limit=self.config.gemm1_clamp_limit,
+            )
+            del gateup_output
         elif self.use_swizzle:
             swiglu_limit_arg: Optional[float] = self.swiglu_limit
             use_contig_swizzle = self.use_swizzle and not running_state.get(
@@ -1505,6 +1518,30 @@ def _varlen_deep_gemm_situ_mul_quant(
         down_input_scale = down_input_scale.transpose(-1, -2)
 
     return down_input, down_input_scale
+
+
+def _contiguous_deep_gemm_silu_mul_quant(
+    gateup_output: torch.Tensor,
+    group_size: int,
+    topk: int,
+    gemm1_alpha: float,
+    gemm1_clamp_limit: Optional[float],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply OAI-SwiGLU to the contiguous DeepGEMM activation layout."""
+    num_tokens = gateup_output.shape[0]
+    masked_m = torch.tensor(
+        [num_tokens], dtype=torch.int32, device=gateup_output.device
+    )
+    output, output_scale = _varlen_deep_gemm_silu_mul_quant(
+        gateup_output.unsqueeze(0),
+        masked_m=masked_m,
+        group_size=group_size,
+        topk=topk,
+        gemm1_alpha=gemm1_alpha,
+        gemm1_clamp_limit=gemm1_clamp_limit,
+        num_real_tokens=num_tokens,
+    )
+    return output.squeeze(0), output_scale.squeeze(0)
 
 
 def _varlen_deep_gemm_silu_mul_quant(

--- a/test/registered/kernel/moe/test_deep_gemm_contiguous_activation.py
+++ b/test/registered/kernel/moe/test_deep_gemm_contiguous_activation.py
@@ -1,0 +1,35 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_contiguous_deep_gemm_respects_oai_swiglu():
+    from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+        _contiguous_deep_gemm_silu_mul_quant,
+    )
+
+    torch.manual_seed(0)
+    gate_up = torch.randn(8, 256, dtype=torch.bfloat16, device="cuda")
+    output, scale = _contiguous_deep_gemm_silu_mul_quant(
+        gate_up,
+        group_size=128,
+        topk=4,
+        gemm1_alpha=1.702,
+        gemm1_clamp_limit=7.0,
+    )
+
+    actual = output.float() * scale.repeat_interleave(128, dim=-1)
+    gate, up = gate_up.float().chunk(2, dim=-1)
+    gate = gate.clamp(max=7.0)
+    expected = gate * torch.sigmoid(1.702 * gate)
+    expected *= up.clamp(-7.0, 7.0) + 1.0
+
+    cosine = F.cosine_similarity(actual.flatten(), expected.flatten(), dim=0)
+    normalized_mae = (actual - expected).abs().mean() / expected.abs().mean()
+    assert cosine > 0.999
+    assert normalized_mae < 0.03


### PR DESCRIPTION
## Motivation

DeepEP normal uses the contiguous DeepGEMM path for FP8 MoE. The model passes parameterized OAI-SwiGLU settings through `MoeRunnerConfig`, but the contiguous path ignored `gemm1_alpha` and `gemm1_beta` and applied standard SwiGLU instead. This silently corrupts outputs for MiniMax-M3 (alpha=1.702, beta=1.0, clamp=7.0).

## Modifications

- Route contiguous OAI-SwiGLU activations through the existing varlen fused activation-and-quantization implementation.
- Preserve the contiguous DeepEP layout with a single synthetic expert dimension.
- Fail explicitly unless `gemm1_beta == 1.0`, which is the beta supported by the existing OAI-SwiGLU kernel.
- Keep standard SwiGLU and DSV4 swizzled paths unchanged.

## Accuracy Tests

Tested on the latest `main` with MiniMax-M3-FP8, TP=8, EP=8, DeepEP normal, and the DeepGEMM MoE runner.

Before this fix, the isolated activation comparison produced:

```text
cosine = 0.72746420
normalized MAE = 0.87262815
```

After this fix:

```text
cosine > 0.999
normalized MAE < 0.03
```

End-to-end deterministic generation also recovered from corrupted output to the expected results, with no backend fallback observed.

## Speed Tests and Profiling

No new kernel is introduced. The fix reuses the existing fused OAI-SwiGLU activation-and-quantization implementation.

## Checklist

- [x] Ran pre-commit on all changed source files.
- [x] Verified the numerical result against a PyTorch OAI-SwiGLU reference.
- [x] Verified MiniMax-M3-FP8 end to end with DeepEP normal.
- [x] Kept the PR limited to the DeepGEMM runner fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35486611212](https://github.com/sgl-project/sglang/actions/runs/35486611212)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35486611063](https://github.com/sgl-project/sglang/actions/runs/35486611063)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35486611142](https://github.com/sgl-project/sglang/actions/runs/35486611142)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->