### PR TITLE
[Bugfix] Support MiniMax-M3 with MegaMoE

### DIFF
--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -179,6 +179,35 @@ def forward_mega_moe(
     return y
 
 
+def _compute_mega_moe_router_logits(moe, hidden_states, forward_batch):
+    if compute_router_logits := getattr(moe, "_compute_router_logits", None):
+        return compute_router_logits(hidden_states)
+    return moe.gate(hidden_states, forward_batch=forward_batch)
+
+
+def _get_moe_intermediate_size(config) -> int:
+    if intermediate_size := getattr(config, "moe_intermediate_size", None):
+        return intermediate_size
+    return config.intermediate_size
+
+
+def _get_mega_moe_activation_params(config):
+    if getattr(config, "hidden_act", None) == "swigluoai":
+        return (
+            "swigluoai",
+            float(config.swiglu_alpha),
+            1.0,
+            float(config.swiglu_limit),
+        )
+    return "swiglu", 1.0, 0.0, getattr(config, "swiglu_limit", None)
+
+
+def _get_mega_moe_routed_scaling_factor(moe) -> float:
+    if moe.experts.should_fuse_routed_scaling_factor_in_topk:
+        return 1.0
+    return float(moe.routed_scaling_factor)
+
+
 def _run_mega_routed(
     moe: DeepseekV2MoE,
     hidden_states: torch.Tensor,
@@ -193,7 +222,9 @@ def _run_mega_routed(
     hidden_size = moe.config.hidden_size
 
     if num_tokens > 0:
-        router_logits = moe.gate(hidden_states, forward_batch=forward_batch)
+        router_logits = _compute_mega_moe_router_logits(
+            moe, hidden_states, forward_batch
+        )
         topk_kwargs = {"input_ids": input_ids_global} if moe.is_hash else {}
         topk_output = moe.topk(
             hidden_states,
@@ -217,7 +248,16 @@ def _run_mega_routed(
     ep_group = get_moe_ep_group().device_group
     num_experts = moe.experts.num_experts
     top_k = moe.config.num_experts_per_tok + moe.num_fused_shared_experts
-    intermediate_size = moe.config.moe_intermediate_size
+    intermediate_size = _get_moe_intermediate_size(moe.config)
+    activation, activation_alpha, activation_up_bias, activation_clamp = (
+        _get_mega_moe_activation_params(moe.config)
+    )
+    routed_scaling_factor = _get_mega_moe_routed_scaling_factor(moe)
+    if activation == "swigluoai" and _device_sm != 90:
+        raise RuntimeError(
+            "MegaMoE OAI-SwiGLU is only supported on SM90; refusing to run "
+            "a backend that would change the model activation semantics."
+        )
     num_max_tokens_per_rank = (
         envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
     )
@@ -252,6 +292,11 @@ def _run_mega_routed(
             topk_weights_in,
             buf,
             num_tokens,
+            routed_scaling_factor=routed_scaling_factor,
+            activation=activation,
+            activation_alpha=activation_alpha,
+            activation_up_bias=activation_up_bias,
+            activation_clamp=activation_clamp,
         )
 
     mma_type = _mega_moe_mma_type()

--- a/python/sglang/srt/layers/moe/mega_moe_sm90.py
+++ b/python/sglang/srt/layers/moe/mega_moe_sm90.py
@@ -48,13 +48,13 @@ def run_sm90_mega_routed(
     topk_weights: torch.Tensor,
     buf: SymmBuffer,
     num_tokens: int,
+    routed_scaling_factor: float = 1.0,
+    activation: str = "swiglu",
+    activation_alpha: float = 1.0,
+    activation_up_bias: float = 0.0,
+    activation_clamp: float | None = None,
 ) -> torch.Tensor:
     import deep_gemm
-
-    if moe.experts.should_fuse_routed_scaling_factor_in_topk:
-        routed_scaling_factor = 1.0
-    else:
-        routed_scaling_factor = float(moe.routed_scaling_factor)
 
     deep_gemm.mega_moe_pre_dispatch_sm90(
         hidden_states,
@@ -80,8 +80,10 @@ def run_sm90_mega_routed(
         moe.experts.mega_l2_weights,
         buf,
         recipe=(128, 128, 128),
-        activation="swiglu",
-        activation_clamp=getattr(moe.config, "swiglu_limit", None),
+        activation=activation,
+        activation_alpha=activation_alpha,
+        activation_up_bias=activation_up_bias,
+        activation_clamp=activation_clamp,
         fast_math=True,
     )
     y = y[:num_tokens]

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -336,6 +336,8 @@ class MiniMaxM3MoE(nn.Module):
         prefix: str = "",
     ):
         super().__init__()
+        self.config = config
+        self.is_hash = False
         self.tp_size = get_parallel().tp_size
         self.alt_stream = alt_stream
         self.n_shared_experts = getattr(config, "n_shared_experts", None)
@@ -393,7 +395,9 @@ class MiniMaxM3MoE(nn.Module):
             intermediate_size = config.intermediate_size * self.n_shared_experts
             # DeepEP all-gathers (not all-reduces) the layer output, so a TP-sharded
             # shared MLP would leave an unreduced partial; replicate (tp_size=1), like GLM4 / DSV2.
-            shared_experts_tp1 = get_moe_a2a_backend().is_deepep()
+            shared_experts_tp1 = (
+                get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_megamoe()
+            )
             self.shared_experts = MiniMaxM3MLP(
                 config=config,
                 quant_config=quant_config,
@@ -433,7 +437,21 @@ class MiniMaxM3MoE(nn.Module):
         should_allreduce_fusion: bool = False,
         use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
-        if get_moe_a2a_backend().is_deepep():
+        backend = get_moe_a2a_backend()
+        if backend.is_megamoe():
+            from sglang.srt.layers.moe.mega_moe import (
+                forward_mega_moe,
+                should_use_mega_moe,
+            )
+
+            if not should_use_mega_moe(self, hidden_states):
+                raise RuntimeError(
+                    "MiniMax-M3 MegaMoE was requested but is unavailable; "
+                    "refusing to fall back to forward_normal because EP-sharded "
+                    "experts require MegaMoE dispatch/combine."
+                )
+            return forward_mega_moe(self, hidden_states, forward_batch)
+        if backend.is_deepep():
             return self.forward_deepep(hidden_states, forward_batch)
         else:
             return self.forward_normal(

--- a/test/registered/unit/layers/moe/test_mega_moe_deepgemm_api.py
+++ b/test/registered/unit/layers/moe/test_mega_moe_deepgemm_api.py
@@ -257,6 +257,163 @@ class TestDeepGemmMegaMoeApi(CustomTestCase):
 
         torch.testing.assert_close(actual, expected)
 
+    def test_model_adapter_reads_minimax_moe_contract(self):
+        expected_logits = torch.tensor([[1.0, 2.0]])
+        moe = SimpleNamespace(
+            config=SimpleNamespace(
+                hidden_act="swigluoai",
+                swiglu_alpha=1.702,
+                swiglu_limit=7.0,
+                intermediate_size=384,
+            ),
+            _compute_router_logits=MagicMock(return_value=expected_logits),
+            routed_scaling_factor=2.0,
+            experts=SimpleNamespace(
+                should_fuse_routed_scaling_factor_in_topk=True,
+            ),
+            topk=SimpleNamespace(
+                topk_config=SimpleNamespace(apply_routed_scaling_factor_on_output=True)
+            ),
+        )
+
+        actual_logits = mega_moe._compute_mega_moe_router_logits(
+            moe, torch.zeros(1, 3), forward_batch=object()
+        )
+
+        self.assertIs(actual_logits, expected_logits)
+        self.assertEqual(mega_moe._get_moe_intermediate_size(moe.config), 384)
+        self.assertEqual(
+            mega_moe._get_mega_moe_activation_params(moe.config),
+            ("swigluoai", 1.702, 1.0, 7.0),
+        )
+        self.assertEqual(mega_moe._get_mega_moe_routed_scaling_factor(moe), 1.0)
+
+    def test_deepseek_expert_scaling_contract_remains_authoritative(self):
+        moe = SimpleNamespace(
+            experts=SimpleNamespace(
+                should_fuse_routed_scaling_factor_in_topk=False,
+            ),
+            routed_scaling_factor=2.5,
+            topk=SimpleNamespace(
+                topk_config=SimpleNamespace(apply_routed_scaling_factor_on_output=True)
+            ),
+        )
+
+        self.assertEqual(mega_moe._get_mega_moe_routed_scaling_factor(moe), 2.5)
+
+    def test_non_sm90_rejects_parameterized_swiglu(self):
+        deep_gemm = ModuleType("deep_gemm")
+        deep_gemm.fp8_fp4_mega_moe = MagicMock()
+        buffer = SimpleNamespace(
+            x=object(), x_sf=object(), topk_idx=object(), topk_weights=object()
+        )
+        moe = SimpleNamespace(
+            config=SimpleNamespace(
+                hidden_size=4,
+                hidden_act="swigluoai",
+                swiglu_alpha=1.702,
+                swiglu_limit=7.0,
+                num_experts_per_tok=2,
+                intermediate_size=8,
+            ),
+            experts=SimpleNamespace(
+                num_experts=8,
+                mega_l1_weights=object(),
+                mega_l2_weights=object(),
+                should_fuse_routed_scaling_factor_in_topk=True,
+            ),
+            num_fused_shared_experts=0,
+            routed_scaling_factor=1.0,
+            topk=SimpleNamespace(
+                topk_config=SimpleNamespace(apply_routed_scaling_factor_on_output=True)
+            ),
+        )
+
+        with (
+            patch.dict(sys.modules, {"deep_gemm": deep_gemm}),
+            patch.object(mega_moe, "_device_sm", 100),
+            patch.object(mega_moe, "_mega_moe_mma_type", return_value="fp8xfp4"),
+            patch.object(mega_moe, "_get_mega_moe_symm_buffer", return_value=buffer),
+            patch.object(mega_moe, "mega_moe_pre_dispatch"),
+            patch.object(
+                mega_moe,
+                "_configure_mega_moe_deep_gemm_num_sms",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "sglang.srt.distributed.parallel_state.get_moe_ep_group",
+                return_value=SimpleNamespace(device_group=object()),
+            ),
+            self.assertRaisesRegex(RuntimeError, "only supported on SM90"),
+        ):
+            mega_moe._run_mega_routed(
+                moe,
+                torch.zeros((0, 4)),
+                forward_batch=None,
+                input_ids_global=None,
+                num_tokens=0,
+            )
+
+        deep_gemm.fp8_fp4_mega_moe.assert_not_called()
+
+    def test_sm90_forwards_parameterized_swiglu(self):
+        from sglang.srt.layers.moe import mega_moe_sm90
+
+        deep_gemm = ModuleType("deep_gemm")
+        deep_gemm.mega_moe_pre_dispatch_sm90 = MagicMock()
+        deep_gemm.fp8_mega_moe = MagicMock()
+        experts = SimpleNamespace(
+            mega_l1_weights=object(),
+            mega_l2_weights=object(),
+        )
+        moe = SimpleNamespace(
+            config=SimpleNamespace(hidden_size=4),
+            experts=experts,
+        )
+        buffer = SimpleNamespace(
+            x=object(),
+            x_sf=object(),
+            topk_idx=object(),
+            topk_weights=object(),
+        )
+
+        with patch.dict(sys.modules, {"deep_gemm": deep_gemm}):
+            mega_moe_sm90.run_sm90_mega_routed(
+                moe,
+                torch.zeros((1, 4)),
+                torch.tensor([[0, 1]], dtype=torch.int32),
+                torch.tensor([[0.6, 0.4]]),
+                buffer,
+                num_tokens=1,
+                routed_scaling_factor=1.0,
+                activation="swigluoai",
+                activation_alpha=1.702,
+                activation_up_bias=1.0,
+                activation_clamp=7.0,
+            )
+
+        call = deep_gemm.fp8_mega_moe.call_args
+        self.assertEqual(call.kwargs["activation"], "swigluoai")
+        self.assertEqual(call.kwargs["activation_alpha"], 1.702)
+        self.assertEqual(call.kwargs["activation_up_bias"], 1.0)
+        self.assertEqual(call.kwargs["activation_clamp"], 7.0)
+
+    def test_minimax_megamoe_fails_closed(self):
+        from sglang.srt.models import minimax_m3
+
+        backend = SimpleNamespace(
+            is_megamoe=lambda: True,
+            is_deepep=lambda: False,
+        )
+        moe = object.__new__(minimax_m3.MiniMaxM3MoE)
+
+        with (
+            patch.object(minimax_m3, "get_moe_a2a_backend", return_value=backend),
+            patch.object(mega_moe, "should_use_mega_moe", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "refusing to fall back"),
+        ):
+            moe.forward(torch.zeros(1, 1), forward_batch=object())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

MiniMax-M3 uses parameterized OAI-SwiGLU and model-specific router logits. The current MegaMoE path assumes the DeepSeek MoE interface and standard SwiGLU, so enabling MegaMoE for MiniMax-M3 either cannot enter the backend correctly or silently changes the activation semantics.

### Dependency and merge order

This PR depends on [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87), which adds the SM90 FP8 MegaMoE API and kernel support for `activation_alpha`, `activation_up_bias`, and `swigluoai`.

The SGLang-side model/backend design in this PR is ready for review now. Please merge it only after SGLang updates to a DeepGEMM revision that contains [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87).

## Modifications

- Generalize MegaMoE router-logit and intermediate-size access so the path is not tied to DeepSeek field names.
- Pass the activation name, alpha, up bias, clamp, and routed scaling explicitly to the SM90 MegaMoE wrapper.
- Add MiniMax-M3 MegaMoE dispatch while keeping shared experts replicated under EP.
- Fail closed when MegaMoE is requested but unavailable instead of falling back to a non-EP forward path.
- Preserve existing DeepSeek defaults: standard SwiGLU, `alpha=1.0`, and `up_bias=0.0`.

## Accuracy Tests

Validated with MiniMax-M3-FP8 on 8 Hopper GPUs using MegaMoE decode and the DeepGEMM patch from [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87).

- Deterministic English and Chinese generation passed.
- MMLU support gate passed in the P/D deployment matrix.
- No backend fallback was observed.
- [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87) reported `calc_diff = 0.0000` for OAI-SwiGLU on both swapAB and non-swapAB SM90 epilogues.

## Speed Tests and Profiling

In the validated P/D matrix, MegaMoE decode showed positive throughput gains for supported configurations. This PR focuses on correctness and model/backend integration rather than changing the MegaMoE scheduling policy.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not required: no public SGLang user-facing API is introduced.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Review the SGLang model/backend design in this PR.
2. Merge [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87).
3. Update SGLang to a DeepGEMM revision containing [sgl-project/DeepGEMM#87](https://github.com/sgl-project/DeepGEMM/pull/87) and run the final CI/integration validation.
4. Merge this PR after the dependency update, green CI, and required approvals.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35486406972](https://github.com/sgl-project/sglang/actions/runs/35486406972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35486406664](https://github.com/sgl-project/sglang/actions/runs/35486406664)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35486407034](https://github.com/sgl-project/sglang/actions/runs/35486407034)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->