### PR TITLE
[ROCm] Raise HiCache JIT block quota for mapped-host throughput

### DIFF
--- a/python/sglang/kernels/ops/kvcache/hicache.py
+++ b/python/sglang/kernels/ops/kvcache/hicache.py
@@ -3,14 +3,22 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_hip_runtime,
+    load_jit,
+    make_cpp_args,
+)
 from sglang.kernels.kernel_api_logging import debug_kernel_api
 
 if TYPE_CHECKING:
     import torch
     from tvm_ffi.module import Module
 
-DEFAULT_BLOCK_QUOTA = 2
+_is_hip = is_hip_runtime()
+
+# ROCm needs a wider grid to saturate mapped-host transfers; CUDA keeps the legacy quota.
+DEFAULT_BLOCK_QUOTA = 32 if _is_hip else 2
 
 
 @cache_once


### PR DESCRIPTION
## Summary

This PR is split from #35233 to keep each change focused and independently reviewable.

It contains only the ROCm-specific HiCache JIT block-quota setting.

## Changes

- Use a default JIT block quota of 32 on HIP runtimes.
- Keep the CUDA default unchanged at 2.

## Scope

This PR does not change kernel implementations, memory layouts, backend selection, or registered-host pointer handling.

The registered-host `kernel/page_first` capability is split into #39041. The complete implementation remains in #35233.

## Validation

- Repository pre-commit hooks passed.
- ROCm JIT compilation and correctness checks passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34570728333](https://github.com/sgl-project/sglang/actions/runs/34570728333)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34570727548](https://github.com/sgl-project/sglang/actions/runs/34570727548)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34570727941](https://github.com/sgl-project/sglang/actions/runs/34570727941)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->