### PR TITLE
[Profiling] Profile the tokenizer manager process and stream large trace merges

### DIFF
--- a/benchmark/prefill_only/bench_embeddings.py
+++ b/benchmark/prefill_only/bench_embeddings.py
@@ -48,6 +48,9 @@ config.freeze_gc = True  # Enable GC freeze functionality
 # Profiler output directory - by default uses present working directory (pwd)
 # Uncomment and customize the line below to override the default location:
 # config.profiler_dir = "/sglang-oss-trace"
+# Uncomment to also profile the tokenizer manager process and merge its trace
+# with the scheduler traces:
+# config.profile_tokenizer = True
 
 # HTTP Configuration
 HTTP_URL = "http://localhost:30000/v1/embeddings"

--- a/benchmark/prefill_only/bench_score.py
+++ b/benchmark/prefill_only/bench_score.py
@@ -43,6 +43,9 @@ config.freeze_gc = True  # Enable GC freeze functionality
 # Profiler output directory - by default uses present working directory (pwd)
 # Uncomment and customize the line below to override the default location:
 # config.profiler_dir = "/sglang-oss-trace"
+# Uncomment to also profile the tokenizer manager process and merge its trace
+# with the scheduler traces:
+# config.profile_tokenizer = True
 
 # HTTP Configuration
 HTTP_URL = "http://localhost:30000/v1/score"  # Use score API directly

--- a/benchmark/prefill_only/util.py
+++ b/benchmark/prefill_only/util.py
@@ -30,6 +30,11 @@ class BenchmarkConfig:
         self.num_unique_requests = 100
         self.distribution = "POISSON"  # Options: "CONSTANT", "POISSON"
         self.profile = False
+        # Also profile the tokenizer manager process and merge its trace with
+        # the scheduler traces. Off by default: the scheduler traces alone are
+        # what most prefill/attention analysis needs, and the extra trace makes
+        # the merge noticeably slower.
+        self.profile_tokenizer = False
 
         # Garbage Collection Control
         self.freeze_gc = True  # Enable/disable garbage collection freezing
@@ -282,7 +287,10 @@ async def make_http_call(
 
 
 async def send_profile_request(
-    profile_text: str, http_url: str, session: Optional[aiohttp.ClientSession] = None
+    profile_text: str,
+    http_url: str,
+    session: Optional[aiohttp.ClientSession] = None,
+    profile_tokenizer: bool = False,
 ) -> None:
     """
     Send a profile request (START_PROFILE or STOP_PROFILE) and wait for completion.
@@ -291,6 +299,8 @@ async def send_profile_request(
         profile_text: "START_PROFILE" or "STOP_PROFILE"
         http_url: Base HTTP URL (will derive profile endpoints from this)
         session: Optional aiohttp session to use
+        profile_tokenizer: Also profile the tokenizer manager process
+            (START_PROFILE only)
     """
     try:
         if session:
@@ -311,8 +321,15 @@ async def send_profile_request(
                 return
 
             headers = {"Content-Type": "application/json"}
+            payload = (
+                {"profile_tokenizer": True}
+                if profile_text == "START_PROFILE" and profile_tokenizer
+                else None
+            )
 
-            async with session.post(endpoint_url, headers=headers) as resp:
+            async with session.post(
+                endpoint_url, headers=headers, json=payload
+            ) as resp:
                 resp_text = await resp.text()
                 if resp.status == 200:
                     print(f"{profile_text} request completed")
@@ -747,7 +764,12 @@ async def run_generic_benchmark(
     ) as session:
         # Send START_PROFILE if profiling is enabled
         if config.profile:
-            await send_profile_request("START_PROFILE", http_url, session=session)
+            await send_profile_request(
+                "START_PROFILE",
+                http_url,
+                session=session,
+                profile_tokenizer=config.profile_tokenizer,
+            )
 
         # Add progress bar for sending requests
         with tqdm(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2141,6 +2141,10 @@ class ProfileReq(BaseReq, kw_only=True):
     profile_stages: Optional[List[str]] = None
     # Add iteration-level annotations (KV / request aggregates) for roofline-style analysis
     detailed_annotations: bool = False
+    # Also profile the tokenizer manager process. Only meaningful on the
+    # START_PROFILE request received by the tokenizer manager; the scheduler
+    # ignores this field.
+    profile_tokenizer: bool = False
 
 
 class ProfileReqOutput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -390,10 +390,26 @@ class TokenizerControlMixin:
         )
         req.record_shapes = (req.record_shapes is not False) and env_record_shapes
         req.profile_id = req.profile_id or str(time.time())
+
+        if req.profile_tokenizer:
+            self.start_tokenizer_profile(
+                output_dir=req.output_dir,
+                activities=req.activities,
+                with_stack=req.with_stack,
+                record_shapes=req.record_shapes,
+                profile_id=req.profile_id,
+            )
+            # The tokenizer trace is only useful next to the scheduler traces,
+            # so merging is implied when it is requested.
+            req.merge_profiles = True
+
         return await self._execute_profile(req)
 
     async def stop_profile(self: TokenizerManager):
         self.auto_create_handle_loop()
+        # Export the tokenizer trace before the scheduler stops, so it is on
+        # disk by the time the scheduler merges the traces for this profile id.
+        self.stop_tokenizer_profile()
         req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
         return await self._execute_profile(req)
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -103,6 +103,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerScoreMixin
+from sglang.srt.managers.tokenizer_profiler_mixin import TokenizerProfilerMixin
 from sglang.srt.managers.utils import (
     compute_num_reserved_tokens,
     is_health_check_generate_req,
@@ -396,7 +397,9 @@ class InputFormat(Enum):
 _MANAGER_OWNED_FIELDS = ("model_path", "served_model_name")
 
 
-class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+class TokenizerManager(
+    TokenizerControlMixin, TokenizerManagerScoreMixin, TokenizerProfilerMixin
+):
     """TokenizerManager is a process that tokenizes the text."""
 
     @property
@@ -463,6 +466,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Init request dispatcher
         self.init_request_dispatcher()
+
+        # Init the (opt-in, default-off) tokenizer manager process profiler
+        self.init_tokenizer_profiler()
 
         # Construct this last so later initialization failures cannot orphan
         # the transport's recycler thread.

--- a/python/sglang/srt/managers/tokenizer_profiler_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_profiler_mixin.py
@@ -1,0 +1,133 @@
+"""Torch-profiler support for the TokenizerManager process.
+
+The scheduler profiler (``SchedulerProfilerManager``) only traces the scheduler /
+worker processes. The tokenizer manager runs in its own process and holds all
+pre-scheduler overhead (tokenization, multimodal preprocessing, request
+bookkeeping, the asyncio event loop), which is therefore invisible in a normal
+profile. This mixin adds an opt-in torch profiler for that process; traces are
+written with a ``TKN-0`` rank tag so ``ProfileMerger`` can merge them alongside
+the scheduler's ``TP-*`` traces.
+"""
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import List, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizerProfilerMixin:
+    """Mixin that adds torch profiling support to ``TokenizerManager``."""
+
+    def init_tokenizer_profiler(self):
+        """Initialize profiler state. Called from ``TokenizerManager.__init__``."""
+        self.tokenizer_torch_profiler = None
+        self.tokenizer_profiler_output_dir: Optional[Path] = None
+        self.tokenizer_profile_id: Optional[str] = None
+        self.tokenizer_profile_in_progress: bool = False
+
+    def start_tokenizer_profile(
+        self,
+        output_dir: Optional[str] = None,
+        activities: Optional[List[str]] = None,
+        with_stack: Optional[bool] = None,
+        record_shapes: Optional[bool] = None,
+        profile_id: Optional[str] = None,
+    ) -> bool:
+        """Start profiling the tokenizer manager process.
+
+        Args:
+            output_dir: Directory to save trace files. Defaults to
+                ``SGLANG_TORCH_PROFILER_DIR``.
+            activities: Activities to profile. Only "CPU" and "GPU" are
+                meaningful here; defaults to ``["CPU"]`` because the tokenizer
+                manager does not run device work.
+            with_stack: Whether to capture stack traces. Defaults to True.
+            record_shapes: Whether to record tensor shapes. Defaults to False.
+            profile_id: Identifier shared with the scheduler profile so both
+                traces land in the same merge group.
+
+        Returns:
+            True if profiling started, False otherwise.
+        """
+        if self.tokenizer_profile_in_progress:
+            logger.warning("Tokenizer profiling already in progress")
+            return False
+
+        if output_dir is None:
+            output_dir = os.getenv("SGLANG_TORCH_PROFILER_DIR", "/tmp")
+        if activities is None:
+            activities = ["CPU"]
+        if profile_id is None:
+            profile_id = str(time.time())
+
+        activity_map = {
+            "CPU": torch.profiler.ProfilerActivity.CPU,
+            "GPU": torch.profiler.ProfilerActivity.CUDA,
+        }
+        torchprof_activities = [
+            activity_map[a] for a in activities if a in activity_map
+        ]
+        if not torchprof_activities:
+            logger.warning(
+                "No valid profiler activities for the tokenizer manager: %s", activities
+            )
+            return False
+
+        self.tokenizer_profiler_output_dir = Path(output_dir).expanduser()
+        self.tokenizer_profiler_output_dir.mkdir(parents=True, exist_ok=True)
+        self.tokenizer_profile_id = profile_id
+
+        logger.info(
+            "Starting tokenizer manager profiling. Traces will be saved to: %s",
+            self.tokenizer_profiler_output_dir,
+        )
+
+        self.tokenizer_torch_profiler = torch.profiler.profile(
+            activities=torchprof_activities,
+            with_stack=with_stack if with_stack is not None else True,
+            record_shapes=record_shapes if record_shapes is not None else False,
+        )
+        self.tokenizer_torch_profiler.start()
+        self.tokenizer_profile_in_progress = True
+
+        return True
+
+    def stop_tokenizer_profile(self) -> Optional[str]:
+        """Stop profiling the tokenizer manager process.
+
+        Returns:
+            Path to the exported trace file, or None if profiling was not active.
+        """
+        if not self.tokenizer_profile_in_progress:
+            return None
+
+        trace_path = None
+        if self.tokenizer_torch_profiler is not None:
+            self.tokenizer_torch_profiler.stop()
+
+            filename = f"{self.tokenizer_profile_id}-TKN-0.trace.json.gz"
+            trace_path = os.path.join(self.tokenizer_profiler_output_dir, filename)
+
+            start = time.perf_counter()
+            self.tokenizer_torch_profiler.export_chrome_trace(trace_path)
+            trace_size_mb = (
+                os.path.getsize(trace_path) / (1024 * 1024)
+                if os.path.exists(trace_path)
+                else 0.0
+            )
+            logger.info(
+                "Tokenizer manager trace exported in %.2fs (%.1f MB) to: %s",
+                time.perf_counter() - start,
+                trace_size_mb,
+                trace_path,
+            )
+
+        self.tokenizer_torch_profiler = None
+        self.tokenizer_profile_in_progress = False
+
+        return trace_path

--- a/python/sglang/srt/utils/profile_merger.py
+++ b/python/sglang/srt/utils/profile_merger.py
@@ -1,4 +1,8 @@
-"""Merge Chrome trace files from multiple ranks (TP, DP, PP, EP) into a single trace."""
+"""Merge Chrome trace files from multiple ranks (TP, DP, PP, EP, TKN) into a single trace.
+
+Large traces are merged in streaming mode so the merge does not have to hold
+every event of every rank in memory at once.
+"""
 
 import glob
 import gzip
@@ -6,13 +10,16 @@ import json
 import logging
 import os
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Above this compressed size, merge in streaming mode instead of in memory.
+LARGE_FILE_THRESHOLD_BYTES = 50 * 1024 * 1024
+
 
 class ProfileMerger:
-    """Merge profile traces from all parallelism types: TP, DP, PP, EP."""
+    """Merge profile traces from all parallelism types: TP, DP, PP, EP, plus TKN."""
 
     def __init__(self, output_dir: str, profile_id: str):
         self.output_dir = output_dir
@@ -21,12 +28,15 @@ class ProfileMerger:
             output_dir, f"merged-{profile_id}.trace.json.gz"
         )
 
-        # Rank types in priority order (used for sorting and labeling)
-        self.rank_types = ["tp", "dp", "pp", "ep"]
+        # Rank types in priority order (used for sorting and labeling).
+        # TKN (tokenizer manager) is not a GPU rank; it is listed first so it
+        # shows up above the GPU ranks in the trace viewer.
+        self.rank_types = ["tkn", "tp", "dp", "pp", "ep"]
 
-        # Sort index multipliers: DP (highest) > EP > PP > TP (lowest)
+        # Sort index multipliers: TKN (highest) > DP > EP > PP > TP (lowest)
         # These ensure proper visual ordering in trace viewer
         self.sort_index_multipliers = {
+            "tkn_rank": 1_000_000_000,
             "dp_rank": 100_000_000,
             "ep_rank": 1_000_000,
             "pp_rank": 10_000,
@@ -51,6 +61,13 @@ class ProfileMerger:
 
         logger.info(f"Found {len(trace_files)} trace files to merge")
 
+        if any(os.path.getsize(f) > LARGE_FILE_THRESHOLD_BYTES for f in trace_files):
+            logger.info("Large trace files detected, using streaming merge")
+            return self._merge_streaming(trace_files)
+        return self._merge_in_memory(trace_files)
+
+    def _merge_in_memory(self, trace_files: List[str]) -> str:
+        """Merge by loading each trace fully into memory."""
         merged_trace = {"traceEvents": []}
         all_device_properties = []
 
@@ -81,8 +98,97 @@ class ProfileMerger:
 
         return self.merged_trace_path
 
+    def _merge_streaming(self, trace_files: List[str]) -> str:
+        """Merge by writing events out per rank instead of buffering all of them.
+
+        Only one rank's trace is resident at a time and the merged document is
+        never materialized, so peak memory is bounded by the largest single
+        input rather than by the sum of all inputs plus the merged copy.
+        """
+        all_device_properties = []
+        other_metadata: Dict[str, Any] = {}
+        total_events = 0
+
+        with gzip.open(self.merged_trace_path, "wt", encoding="utf-8") as out_f:
+            out_f.write('{"traceEvents": [')
+            first_event = True
+
+            for trace_file in sorted(trace_files, key=self._get_rank_sort_key):
+                rank_info = self._extract_rank_info(trace_file)
+                file_size_mb = os.path.getsize(trace_file) / (1024 * 1024)
+                logger.info(
+                    f"Streaming {trace_file} ({file_size_mb:.1f}MB) "
+                    f"with rank info: {rank_info}"
+                )
+
+                try:
+                    for event, metadata in self._stream_trace_file(
+                        trace_file, rank_info
+                    ):
+                        if event is not None:
+                            if not first_event:
+                                out_f.write(",")
+                            out_f.write(json.dumps(event))
+                            first_event = False
+                            total_events += 1
+                        elif metadata is not None:
+                            all_device_properties.extend(
+                                metadata.pop("deviceProperties", [])
+                            )
+                            for key, value in metadata.items():
+                                other_metadata.setdefault(key, value)
+                except Exception as e:
+                    logger.error(f"Failed to stream trace file {trace_file}: {e}")
+                    continue
+
+            out_f.write("]")
+
+            if all_device_properties:
+                out_f.write(',"deviceProperties":')
+                out_f.write(json.dumps(all_device_properties))
+
+            for key, value in other_metadata.items():
+                out_f.write(f",{json.dumps(key)}:")
+                out_f.write(json.dumps(value))
+
+            out_f.write("}")
+
+        logger.info(f"Merged profile saved to: {self.merged_trace_path}")
+        logger.info(f"Total events merged: {total_events}")
+
+        return self.merged_trace_path
+
+    def _stream_trace_file(
+        self, path: str, rank_info: Dict[str, int]
+    ) -> Generator[Tuple[Optional[Dict], Optional[Dict]], None, None]:
+        """Yield ``(event, None)`` per processed event, then ``(None, metadata)``."""
+        rank_label = self._create_rank_label(rank_info)
+
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            trace = json.load(f)
+
+        for event in trace.pop("traceEvents", []):
+            yield self._process_single_event(event, rank_info, rank_label), None
+
+        if trace:
+            yield None, trace
+
+    def _process_single_event(
+        self, event: Dict, rank_info: Dict[str, int], rank_label: str
+    ) -> Dict:
+        """Update ``sort_index`` and prefix the PID with the rank label."""
+        if event.get("name") == "process_sort_index":
+            pid = self._maybe_cast_int(event.get("pid"))
+            if pid is not None and pid < self.pid_sort_index_threshold:
+                event.setdefault("args", {})["sort_index"] = self._calculate_sort_index(
+                    rank_info, pid
+                )
+
+        event["pid"] = f"{rank_label} {event.get('pid', '')}"
+        return event
+
     def _discover_trace_files(self) -> List[str]:
-        """Discover trace files matching profile_id (supports TP/DP/PP/EP formats)."""
+        """Discover trace files matching profile_id (supports TP/DP/PP/EP/TKN formats)."""
         patterns = [f"{self.profile_id}*.trace.json.gz"]
 
         trace_files = []
@@ -95,7 +201,7 @@ class ProfileMerger:
             for f in trace_files
             if not f.endswith(f"merged-{self.profile_id}.trace.json.gz")
             and not f.endswith("-memory.pickle")
-            and "TP-" in f
+            and ("TP-" in f or "TKN-" in f)
         ]
         trace_files = list(set(trace_files))
         return trace_files
@@ -147,14 +253,7 @@ class ProfileMerger:
         rank_label = self._create_rank_label(rank_info)
 
         for event in events:
-            if event.get("name") == "process_sort_index":
-                pid = self._maybe_cast_int(event.get("pid"))
-                if pid is not None and pid < self.pid_sort_index_threshold:
-                    event["args"]["sort_index"] = self._calculate_sort_index(
-                        rank_info, pid
-                    )
-
-            event["pid"] = f"{rank_label} {event['pid']}"
+            self._process_single_event(event, rank_info, rank_label)
 
         return events
 
@@ -164,11 +263,15 @@ class ProfileMerger:
             sort_index += rank_info.get(rank_type, 0) * multiplier
         return sort_index
 
-    def _get_rank_sort_key(self, path: str) -> Tuple[int, int, int, int]:
+    def _get_rank_sort_key(self, path: str) -> Tuple[int, int, int, int, int]:
         rank_info = self._extract_rank_info(path)
-        return tuple(
-            rank_info.get(f"{rank_type}_rank", 0)
-            for rank_type in ["dp", "ep", "pp", "tp"]
+        # TKN traces sort before the GPU traces, then by DP, EP, PP, TP.
+        return (
+            -1 if "tkn_rank" in rank_info else 0,
+            rank_info.get("dp_rank", 0),
+            rank_info.get("ep_rank", 0),
+            rank_info.get("pp_rank", 0),
+            rank_info.get("tp_rank", 0),
         )
 
     def _maybe_cast_int(self, x) -> Optional[int]:

--- a/test/registered/unit/utils/test_profile_merger.py
+++ b/test/registered/unit/utils/test_profile_merger.py
@@ -79,15 +79,69 @@ class TestProfileMerger(CustomTestCase):
         self.assertEqual(sort_idx, 83)
 
     def test_rank_sort_key(self):
-        # Full ranks: TP-1, DP-2, PP-3, EP-4 → sorted as (DP, EP, PP, TP)
+        # Full ranks: TP-1, DP-2, PP-3, EP-4 → sorted as (TKN, DP, EP, PP, TP)
         filename = f"{self.profile_id}-TP-1-DP-2-PP-3-EP-4.trace.json.gz"
         sort_key = self.merger._get_rank_sort_key(filename)
-        self.assertEqual(sort_key, (2, 4, 3, 1))
+        self.assertEqual(sort_key, (0, 2, 4, 3, 1))
 
-        # Missing ranks: only TP-1 → sorted as (DP=0, EP=0, PP=0, TP=1)
+        # Missing ranks: only TP-1 → sorted as (TKN=0, DP=0, EP=0, PP=0, TP=1)
         filename = f"{self.profile_id}-TP-1.trace.json.gz"
         sort_key = self.merger._get_rank_sort_key(filename)
-        self.assertEqual(sort_key, (0, 0, 0, 1))
+        self.assertEqual(sort_key, (0, 0, 0, 0, 1))
+
+        # The tokenizer-manager trace sorts ahead of every GPU rank.
+        tkn_key = self.merger._get_rank_sort_key(
+            f"{self.profile_id}-TKN-0.trace.json.gz"
+        )
+        self.assertEqual(tkn_key, (-1, 0, 0, 0, 0))
+        self.assertLess(tkn_key, sort_key)
+
+    def test_tokenizer_trace_discovery_and_labeling(self):
+        filename = f"{self.profile_id}-TKN-0.trace.json.gz"
+        rank_info = self.merger._extract_rank_info(filename)
+        self.assertEqual(rank_info, {"tkn_rank": 0})
+        self.assertEqual(self.merger._create_rank_label(rank_info), "[TKN00]")
+
+        for name in (filename, f"{self.profile_id}-TP-0.trace.json.gz"):
+            with gzip.open(os.path.join(self.temp_dir, name), "wt") as f:
+                json.dump({"traceEvents": []}, f)
+
+        discovered = {os.path.basename(f) for f in self.merger._discover_trace_files()}
+        self.assertIn(filename, discovered)
+
+    def test_streaming_merge_matches_in_memory_merge(self):
+        for rank, name in enumerate(["TP-0", "TP-1"]):
+            payload = {
+                "traceEvents": [
+                    {
+                        "name": "process_sort_index",
+                        "pid": 1,
+                        "args": {"sort_index": 0},
+                    },
+                    {"name": f"op-{rank}", "pid": 1, "ts": rank},
+                ],
+                "deviceProperties": [{"id": rank}],
+                "schemaVersion": 1,
+            }
+            path = os.path.join(
+                self.temp_dir, f"{self.profile_id}-{name}.trace.json.gz"
+            )
+            with gzip.open(path, "wt") as f:
+                json.dump(payload, f)
+
+        trace_files = self.merger._discover_trace_files()
+
+        in_memory_path = self.merger._merge_in_memory(trace_files)
+        with gzip.open(in_memory_path, "rt") as f:
+            in_memory = json.load(f)
+
+        streamed_path = self.merger._merge_streaming(trace_files)
+        with gzip.open(streamed_path, "rt") as f:
+            streamed = json.load(f)
+
+        self.assertEqual(streamed["traceEvents"], in_memory["traceEvents"])
+        self.assertEqual(streamed["deviceProperties"], in_memory["deviceProperties"])
+        self.assertEqual(streamed["schemaVersion"], in_memory["schemaVersion"])
 
     def test_discover_trace_files(self):
         # Create mock trace files


### PR DESCRIPTION
## Motivation

**1. The tokenizer manager process is invisible in profiles.** `/start_profile` traces the scheduler / worker processes. The tokenizer manager runs in its own process and owns everything that happens before the scheduler sees a request — tokenization, multimodal preprocessing, request bookkeeping, and the asyncio event loop itself. In a trace today that time shows up only as an unexplained gap before the scheduler picks the request up, which makes pre-scheduler overhead very hard to attribute. This is especially visible on prefill-only / embedding / scoring workloads, where per-request tokenizer-side cost is a meaningful fraction of end-to-end latency.

**2. `ProfileMerger` can OOM on large traces.** The merger builds the entire merged document in memory (every event of every rank, plus the merged copy) before writing it out. Profiling a high-RPS or long run across many ranks produces multi-GB traces, and the merge can then take down the process right at the end of a profiling run — after all the expensive work is already done.

## Modifications

**Tokenizer-manager profiler (opt-in, default off)**

- New `python/sglang/srt/managers/tokenizer_profiler_mixin.py` — `TokenizerProfilerMixin`, a small torch-profiler wrapper for the tokenizer manager process. Traces are exported as `<profile_id>-TKN-0.trace.json.gz` so they join the scheduler's `TP-*` traces under the same profile id. Defaults to CPU-only activities, since this process does no device work.
- `ProfileReq.profile_tokenizer: bool = False` turns it on. The scheduler ignores the field; it is only consumed by the tokenizer manager that receives the `START_PROFILE`.
- `TokenizerControlMixin.start_profile` starts the tokenizer profiler with the **same** `profile_id` as the scheduler request, and implies `merge_profiles` (a tokenizer trace is only useful next to the scheduler traces).
- `TokenizerControlMixin.stop_profile` exports the tokenizer trace **before** sending `STOP_PROFILE`, so the file is on disk by the time the scheduler runs the merge for that profile id.

**Trace merger**

- `ProfileMerger` learns the `TKN` rank type: discovery, rank-label extraction, sort-index multiplier, and a sort key that places the tokenizer trace above the GPU ranks in the viewer.
- New streaming merge path, selected automatically when any input trace exceeds 50MB compressed. It holds one rank's trace at a time and writes events straight to the gzip output instead of materializing the merged document, so peak memory is bounded by the largest single input rather than the sum of all inputs plus the merged copy. `deviceProperties` and other top-level metadata are still aggregated and emitted.
- The in-memory path is unchanged for smaller traces; both paths now share one `_process_single_event` helper (this also fixes a latent `KeyError` when a `process_sort_index` event has no `args`).

**Benchmark harness**

- `benchmark/prefill_only`: new `config.profile_tokenizer` (default `False`), which sends `profile_tokenizer` on the `START_PROFILE` request. Documented as a commented-out line in `bench_score.py` / `bench_embeddings.py` next to the existing profiler settings.

**Backwards compatibility:** everything is default-off. With `profile_tokenizer` unset the tokenizer profiler is never instantiated, and merge output is byte-identical to `main`.

## Accuracy Tests

Not applicable — no model, kernel, or forward-path code is touched.

## Speed Tests and Profiling

No steady-state serving impact: the new code runs only inside `/start_profile` and `/stop_profile` handling. `init_tokenizer_profiler()` just zeroes four attributes at startup.

Merge-path behavior:

- `test_streaming_merge_matches_in_memory_merge` asserts the streaming and in-memory merges produce identical `traceEvents`, `deviceProperties`, and other metadata for the same inputs.
- The streaming path was exercised internally on a 189MB compressed trace with ~11.4M events, where the in-memory merge previously OOM'd.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (`test/registered/unit/utils/test_profile_merger.py`: TKN discovery/labeling/sorting, and streaming-vs-in-memory parity.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34570096889](https://github.com/sgl-project/sglang/actions/runs/34570096889)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34570096719](https://github.com/sgl-project/sglang/actions/runs/34570096719)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34570096759](https://github.com/sgl-project/sglang/actions/runs/34570096759)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->