### PR TITLE
[MoonEP] Use DeepGEMM psum layout, zero-copy shard and other optimization

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -131,6 +131,25 @@ def grouped_gemm_nt_bf16_masked(
         )
 
 
+_psum_layout_checked = False
+
+
+def _require_psum_layout() -> None:
+    global _psum_layout_checked
+    if _psum_layout_checked:
+        return
+    import inspect
+
+    params = inspect.signature(deep_gemm.m_grouped_fp8_gemm_nt_contiguous).parameters
+    if "use_psum_layout" not in params:
+        raise RuntimeError(
+            "This MoE path hands DeepGEMM a prefix-sum grouped layout "
+            "(m_grouped_fp8_gemm_nt_contiguous(use_psum_layout=...)), which the "
+            "installed DeepGEMM does not accept. Install DeepGEMM >= 0.1.5."
+        )
+    _psum_layout_checked = True
+
+
 def grouped_gemm_nt_f8f8bf16_contig(
     lhs: Tuple[torch.Tensor, torch.Tensor],
     rhs: Tuple[torch.Tensor, torch.Tensor],
@@ -138,6 +157,8 @@ def grouped_gemm_nt_f8f8bf16_contig(
     m_indices: torch.Tensor,
     recipe_a: Optional[Tuple[int, int]] = None,
     recipe_b: Optional[Tuple[int, int]] = None,
+    use_psum_layout: bool = False,
+    expected_m_for_psum_layout: Optional[int] = None,
 ):
     m, k = lhs[0].shape
     num_groups, n, _ = rhs[0].shape
@@ -154,6 +175,11 @@ def grouped_gemm_nt_f8f8bf16_contig(
         fp4_kwargs["recipe_a"] = recipe_a
     if recipe_b is not None:
         fp4_kwargs["recipe_b"] = recipe_b
+    if use_psum_layout:
+        _require_psum_layout()
+        fp4_kwargs["use_psum_layout"] = True
+        if expected_m_for_psum_layout is not None:
+            fp4_kwargs["expected_m_for_psum_layout"] = int(expected_m_for_psum_layout)
 
     with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -211,6 +211,8 @@ class DeepGemmRunnerInput(RunnerInput):
     masked_m: Optional[torch.Tensor] = None
     expected_m: Optional[int] = None
     m_indices: Optional[torch.Tensor] = None
+    psum_layout: bool = False
+    rows_end: Optional[torch.Tensor] = None
 
     @property
     def runner_backend(self) -> MoeRunnerBackend:
@@ -333,6 +335,14 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         if deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
             hidden_states_scale = tma_align_input_scale(hidden_states_scale)
 
+        psum_kwargs = (
+            dict(
+                use_psum_layout=True,
+                expected_m_for_psum_layout=runner_input.expected_m,
+            )
+            if runner_input.psum_layout
+            else {}
+        )
         deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
             (hidden_states, hidden_states_scale),
             w13_weight_fp8,
@@ -340,6 +350,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             m_indices,
             recipe_a=recipe_a,
             recipe_b=recipe_b,
+            **psum_kwargs,
         )
 
         dispose_tensor(hidden_states)
@@ -349,7 +360,16 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             situ_beta = self.config.gemm1_alpha
             situ_linear_beta = self.config.gemm1_clamp_limit
             assert situ_beta is not None and situ_linear_beta is not None
-            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 and runner_input.psum_layout:
+                down_input_fp8, down_input_scale = _moonep_situ_mul_quant_rows(
+                    gateup_output,
+                    runner_input.rows_end,
+                    scale_block_size,
+                    situ_beta,
+                    situ_linear_beta,
+                )
+                del gateup_output
+            elif deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
                 # Fused SiTU + per-group fp8 quant over the compacted rows,
                 # then the proven round-up e8m0 cast (mn-major packed layout).
                 rows = gateup_output.shape[0]
@@ -481,6 +501,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             m_indices,
             recipe_a=recipe_a,
             recipe_b=recipe_b,
+            **psum_kwargs,
         )
 
         return down_output
@@ -1295,6 +1316,269 @@ def _moonep_finalize_rows(
     )
 
 
+def _moonep_local_segments(
+    pool, cu_seqlens: torch.Tensor, plan, num_global_experts: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    epn = pool.num_local_experts
+    home = pool.ep_rank * epn
+    device = cu_seqlens.device
+    idx = torch.cat(
+        [
+            torch.arange(home, home + epn, device=device),
+            torch.arange(
+                num_global_experts,
+                num_global_experts + pool.num_prefetch_slots,
+                device=device,
+            ),
+        ]
+    )
+    ends = cu_seqlens[idx]
+    starts = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens[:-1]])[idx]
+    n_pad = plan.zero_fill_ranges[idx, 1]
+    return (
+        starts.to(torch.int32).contiguous(),
+        (ends - starts - n_pad).to(torch.int32).contiguous(),
+    )
+
+
+def _moonep_psum_layout(
+    seg_start: torch.Tensor, seg_len: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    psum = (seg_start + seg_len).to(torch.int32).contiguous()
+    rows_end = ((psum[-1:] + 127) // 128 * 128).to(torch.int32).contiguous()
+    return psum, rows_end
+
+
+_MOONEP_ROW_PROGRAMS = 304  # persistent row loops: 2 programs per SM on GB200
+
+
+@triton.jit
+def _e8m0_round_up(x):
+    bits = x.to(tl.int32, bitcast=True)
+    exp = (bits >> 23) & 0xFF
+    mant = bits & 0x7FFFFF
+    is_ru = (mant > 0) & (exp != 0xFE) & ~((exp == 0) & (mant <= 0x400000))
+    return exp + is_ru.to(tl.int32)
+
+
+@triton.jit
+def _pack_e8m0_bytes(e8):
+    shifts = tl.arange(0, 4)[None, :] * 8
+    return tl.sum(e8 << shifts, axis=1)
+
+
+@triton.jit
+def _moonep_quant_rows_kernel(
+    x_ptr,  # [rows, K] bf16
+    q_ptr,  # [rows, K] fp8 out
+    s_ptr,  # int32, column-major packed: (row, kg4) at kg4 * S_STRIDE + row
+    end_ptr,  # int32 [1]: rows to process
+    K,
+    S_STRIDE,
+    GROUP: tl.constexpr,
+    KG: tl.constexpr,
+    KG_POW2: tl.constexpr,
+    NUM_PROGRAMS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    end = tl.load(end_ptr)
+    rows2d = tl.arange(0, KG_POW2)[:, None]
+    cols = tl.arange(0, GROUP)[None, :]
+    offs = rows2d * GROUP + cols
+    mask = rows2d < KG
+    for row in range(pid, end, NUM_PROGRAMS):
+        r = row.to(tl.int64)
+        x = tl.load(x_ptr + r * K + offs, mask=mask, other=0.0).to(tl.float32)
+        amax = tl.clamp(tl.max(tl.abs(x), axis=1), min=1e-10, max=float("inf"))
+        # UE8M0: quantize with the power-of-two scale itself, so the packed
+        # exponent describes exactly the scale the values were divided by.
+        scale = tl.exp2(tl.ceil(tl.log2(amax / 448.0)))
+        q = tl.clamp(x / scale[:, None], -448.0, 448.0).to(tl.float8e4nv)
+        tl.store(q_ptr + r * K + offs, q, mask=mask)
+        e8 = tl.reshape(_e8m0_round_up(scale), [KG_POW2 // 4, 4])
+        packed = _pack_e8m0_bytes(e8)
+        g4 = tl.arange(0, KG_POW2 // 4)
+        tl.store(s_ptr + g4.to(tl.int64) * S_STRIDE + r, packed, mask=g4 < KG // 4)
+
+
+@triton.jit
+def _moonep_situ_mul_quant_rows_kernel(
+    g_ptr,  # [rows, 2N] bf16, non-interleaved [gate; up] halves
+    q_ptr,  # [rows, N] fp8 out
+    s_ptr,  # int32, column-major packed: (row, kg4) at kg4 * S_STRIDE + row
+    end_ptr,  # int32 [1]: rows to process
+    N,
+    S_STRIDE,
+    situ_beta,
+    situ_linear_beta,
+    GROUP: tl.constexpr,
+    KG: tl.constexpr,
+    KG_POW2: tl.constexpr,
+    NUM_PROGRAMS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    end = tl.load(end_ptr)
+    rows2d = tl.arange(0, KG_POW2)[:, None]
+    cols = tl.arange(0, GROUP)[None, :]
+    offs = rows2d * GROUP + cols
+    mask = rows2d < KG
+    for row in range(pid, end, NUM_PROGRAMS):
+        r = row.to(tl.int64)
+        gate = tl.load(g_ptr + r * 2 * N + offs, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(g_ptr + r * 2 * N + N + offs, mask=mask, other=0.0).to(tl.float32)
+        # tanh(x) == 2*sigmoid(2x) - 1 (avoids a libdevice dependency)
+        gate_t = 2.0 * tl.sigmoid(2.0 * gate / situ_beta) - 1.0
+        gate = situ_beta * gate_t * tl.sigmoid(gate)
+        up_t = 2.0 * tl.sigmoid(2.0 * up / situ_linear_beta) - 1.0
+        y = gate * situ_linear_beta * up_t
+        amax = tl.clamp(tl.max(tl.abs(y), axis=1), min=1e-10, max=float("inf"))
+        # Same quantization as _situ_mul_quant_contig_kernel followed by
+        # _cast_to_e8m0_with_rounding_up, fused: values scaled by 448/amax,
+        # scale byte the round-up exponent of amax/448.
+        q = (y * (448.0 / amax)[:, None]).to(tl.float8e4nv)
+        tl.store(q_ptr + r * N + offs, q, mask=mask)
+        e8 = tl.reshape(_e8m0_round_up(amax / 448.0), [KG_POW2 // 4, 4])
+        packed = _pack_e8m0_bytes(e8)
+        g4 = tl.arange(0, KG_POW2 // 4)
+        tl.store(s_ptr + g4.to(tl.int64) * S_STRIDE + r, packed, mask=g4 < KG // 4)
+
+
+@triton.jit
+def _moonep_finalize_shard_kernel(
+    down_ptr,  # [NvS, H] bf16, DeepGEMM's w2 output in NvS row order
+    shard_ptr,  # [NvS, H] bf16, MoonEP's dispatch/combine shard
+    w_ptr,  # [NvS] fp32 route weights
+    seg_start_ptr,  # [G] int32
+    seg_len_ptr,  # [G] int32
+    H,
+    HAS_WEIGHTS: tl.constexpr,
+    ROWS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    g = tl.program_id(0)
+    seg_len = tl.load(seg_len_ptr + g)
+    row0 = tl.program_id(1) * ROWS
+    if row0 >= seg_len:
+        return
+    seg_start = tl.load(seg_start_ptr + g)
+    col = tl.program_id(2) * BLOCK + tl.arange(0, BLOCK)
+    cmask = col < H
+    for i in range(ROWS):
+        rr = row0 + i
+        if rr < seg_len:
+            dst = (seg_start + rr).to(tl.int64)
+            x = tl.load(down_ptr + dst * H + col, mask=cmask).to(tl.float32)
+            if HAS_WEIGHTS:
+                x = x * tl.load(w_ptr + dst)
+            tl.store(
+                shard_ptr + dst * H + col, x.to(shard_ptr.dtype.element_ty), mask=cmask
+            )
+
+
+def _moonep_quant_rows(
+    hidden_states: torch.Tensor,
+    rows_end: torch.Tensor,
+    group_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        create_per_token_group_quant_fp8_output_scale,
+    )
+
+    rows, k = hidden_states.shape
+    kg = k // group_size
+    assert kg % 4 == 0, "packed e8m0 scales need K/group_size % 4 == 0"
+    x_q = torch.empty((rows, k), device=hidden_states.device, dtype=torch.float8_e4m3fn)
+    x_s = create_per_token_group_quant_fp8_output_scale(
+        x_shape=(rows, k),
+        device=hidden_states.device,
+        group_size=group_size,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    _moonep_quant_rows_kernel[(_MOONEP_ROW_PROGRAMS,)](
+        hidden_states,
+        x_q,
+        x_s,
+        rows_end,
+        k,
+        x_s.stride(1),
+        GROUP=group_size,
+        KG=kg,
+        KG_POW2=triton.next_power_of_2(kg),
+        NUM_PROGRAMS=_MOONEP_ROW_PROGRAMS,
+        num_warps=8,
+    )
+    return x_q, x_s
+
+
+def _moonep_situ_mul_quant_rows(
+    gateup_output: torch.Tensor,
+    rows_end: torch.Tensor,
+    group_size: int,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    rows, two_n = gateup_output.shape
+    half_n = two_n // 2
+    kg = half_n // group_size
+    assert kg % 4 == 0, "packed e8m0 scales need N/group_size % 4 == 0"
+    down_input_fp8 = torch.empty(
+        (rows, half_n), device=gateup_output.device, dtype=torch.float8_e4m3fn
+    )
+    # Same storage as _cast_to_e8m0_with_rounding_up returns: [kg/4, rows]
+    # int32 viewed as [rows, kg/4].
+    down_input_scale = torch.empty(
+        (kg // 4, rows), device=gateup_output.device, dtype=torch.int32
+    ).t()
+    _moonep_situ_mul_quant_rows_kernel[(_MOONEP_ROW_PROGRAMS,)](
+        gateup_output,
+        down_input_fp8,
+        down_input_scale,
+        rows_end,
+        half_n,
+        rows,
+        situ_beta,
+        situ_linear_beta,
+        GROUP=group_size,
+        KG=kg,
+        KG_POW2=triton.next_power_of_2(kg),
+        NUM_PROGRAMS=_MOONEP_ROW_PROGRAMS,
+        num_warps=8,
+    )
+    return down_input_fp8, down_input_scale
+
+
+def _moonep_finalize_into_shard(
+    down_output: torch.Tensor,
+    shard: torch.Tensor,
+    route_weights_nvs: Optional[torch.Tensor],
+    seg_start: torch.Tensor,
+    seg_len: torch.Tensor,
+    max_rows_per_group: int,
+) -> torch.Tensor:
+    rows, hidden_size = down_output.shape
+    ROWS, BLOCK = 32, 1024
+    grid = (
+        seg_start.numel(),
+        triton.cdiv(max_rows_per_group, ROWS),
+        triton.cdiv(hidden_size, BLOCK),
+    )
+    _moonep_finalize_shard_kernel[grid](
+        down_output,
+        shard,
+        route_weights_nvs,
+        seg_start,
+        seg_len,
+        hidden_size,
+        HAS_WEIGHTS=route_weights_nvs is not None,
+        ROWS=ROWS,
+        BLOCK=BLOCK,
+        num_warps=4,
+    )
+    return shard
+
+
 @register_pre_permute("moonep", "deep_gemm")
 def pre_permute_moonep_to_deep_gemm(
     dispatch_output: MoonEPDispatchOutput,
@@ -1334,44 +1618,60 @@ def pre_permute_moonep_to_deep_gemm(
             ),
             num_sms=get_moonep_num_sms(),
         )
-        quant_info.w13_weight = pool.ranges[moonep_weights.W13_WEIGHT].view(torch.int8)
-        quant_info.w2_weight = pool.ranges[moonep_weights.W2_WEIGHT].view(torch.int8)
-        quant_info.w13_scale = pool.ranges[moonep_weights.W13_SCALE].permute(0, 2, 1)
-        quant_info.w2_scale = pool.ranges[moonep_weights.W2_SCALE].permute(0, 2, 1)
-
-        expert_ids = moonep_weights.group_rows(
-            layer_id, expert_ids, runner_config.num_experts
+        quant_info.w13_weight = pool.block_view(
+            moonep_weights.W13_WEIGHT, layer_id
+        ).view(torch.int8)
+        quant_info.w2_weight = pool.block_view(moonep_weights.W2_WEIGHT, layer_id).view(
+            torch.int8
+        )
+        quant_info.w13_scale = pool.block_view(
+            moonep_weights.W13_SCALE, layer_id
+        ).permute(0, 2, 1)
+        quant_info.w2_scale = pool.block_view(
+            moonep_weights.W2_SCALE, layer_id
+        ).permute(0, 2, 1)
+        seg_start, seg_len = _moonep_local_segments(
+            pool,
+            dispatch_output.cu_seqlens,
+            dispatch_output.plan,
+            runner_config.num_experts,
+        )
+        psum, rows_end = _moonep_psum_layout(seg_start, seg_len)
+        running_state["moonep_segments"] = (
+            seg_start,
+            seg_len,
+            dispatch_output.hidden_states,
+            int(dispatch_output.capacity) * runner_config.top_k,
+        )
+        block_k = quant_info.block_shape[1] if quant_info.block_shape else 128
+        running_state["mxfp8_act_gran_k"] = block_k
+        hidden_states_fp8, hidden_states_scale = _moonep_quant_rows(
+            hidden_states, rows_end, block_k
+        )
+        return DeepGemmRunnerInput(
+            hidden_states=hidden_states_fp8,
+            hidden_states_scale=hidden_states_scale,
+            use_masked_gemm=False,
+            m_indices=psum,
+            psum_layout=True,
+            rows_end=rows_end,
+            expected_m=max(
+                1,
+                ceil_div(
+                    dispatch_output.num_tokens * runner_config.top_k * pool.ep_size,
+                    runner_config.num_experts,
+                ),
+            ),
         )
 
+    assert quant_info.w13_weight.dtype == torch.bfloat16, quant_info.w13_weight.dtype
     m_indices = _moonep_m_indices(dispatch_output.cu_seqlens, expert_ids, all_tokens)
     running_state["m_indices"] = m_indices
-
-    if quant_info.w13_weight.dtype == torch.bfloat16:
-        return DeepGemmRunnerInput(
-            hidden_states=hidden_states,
-            hidden_states_scale=torch.empty(
-                (all_tokens, 1), device=hidden_states.device, dtype=torch.float32
-            ),
-            use_masked_gemm=False,
-            m_indices=m_indices,
-        )
-
-    from sglang.kernels.ops.quantization.fp8_kernel import (
-        sglang_per_token_group_quant_fp8,
-    )
-
-    block_k = quant_info.block_shape[1] if quant_info.block_shape else 128
-    running_state["mxfp8_act_gran_k"] = block_k
-    hidden_states_fp8, hidden_states_scale = sglang_per_token_group_quant_fp8(
-        hidden_states,
-        block_k,
-        column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-        scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-    )
     return DeepGemmRunnerInput(
-        hidden_states=hidden_states_fp8,
-        hidden_states_scale=hidden_states_scale,
+        hidden_states=hidden_states,
+        hidden_states_scale=torch.empty(
+            (all_tokens, 1), device=hidden_states.device, dtype=torch.float32
+        ),
         use_masked_gemm=False,
         m_indices=m_indices,
     )
@@ -1388,7 +1688,21 @@ def post_permute_deep_gemm_to_moonep(
 
     hidden_states = runner_output.hidden_states
     route_weights_nvs = running_state["route_weights_nvs"]
-    _moonep_finalize_rows(hidden_states, running_state["m_indices"], route_weights_nvs)
+    segments = running_state.get("moonep_segments")
+    if segments is not None:
+        seg_start, seg_len, shard, max_rows_per_group = segments
+        hidden_states = _moonep_finalize_into_shard(
+            hidden_states,
+            shard,
+            route_weights_nvs,
+            seg_start,
+            seg_len,
+            max_rows_per_group,
+        )
+    else:
+        _moonep_finalize_rows(
+            hidden_states, running_state["m_indices"], route_weights_nvs
+        )
 
     return MoonEPCombineInput(
         hidden_states=hidden_states,

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -44,6 +44,7 @@ class MoonEPDispatchOutput(NamedTuple):
     plan: Any
     expert_ids: torch.Tensor
     num_tokens: int
+    capacity: Optional[int] = None
 
     @property
     def format(self) -> DispatchOutputFormat:
@@ -500,6 +501,16 @@ def run_moonep_bf16_expert(
     )
 
 
+_MIN_CAPACITY_RUNG = 8
+
+
+def _capacity_rung(num_tokens: int, decode_cap: int) -> int:
+    rung = _MIN_CAPACITY_RUNG
+    while rung < num_tokens and rung < decode_cap:
+        rung *= 2
+    return min(rung, decode_cap)
+
+
 def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
     override = envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.get()
     if override > 0:
@@ -551,21 +562,18 @@ class MoonEPDispatcher(BaseDispatcher):
         self.decode_max_dispatch_tokens_per_rank = _resolve_decode_capacity(
             self.num_max_dispatch_tokens_per_rank
         )
+        self._active_capacity = self.num_max_dispatch_tokens_per_rank
         self.num_prefetch_slots = None
 
     @staticmethod
     def _raise_unimplemented() -> NoReturn:
         raise NotImplementedError(_MOONEP_UNSUPPORTED_MESSAGE)
 
-    def _phase_capacity(self) -> int:
-        if self.decode_max_dispatch_tokens_per_rank is None:
+    def _phase_capacity(self, num_tokens: int) -> int:
+        decode_cap = self.decode_max_dispatch_tokens_per_rank
+        if decode_cap is None or num_tokens > decode_cap:
             return self.num_max_dispatch_tokens_per_rank
-
-        from sglang.srt.layers.dp_attention import get_is_extend_in_batch
-
-        if get_is_extend_in_batch():
-            return self.num_max_dispatch_tokens_per_rank
-        return self.decode_max_dispatch_tokens_per_rank
+        return _capacity_rung(num_tokens, decode_cap)
 
     def _get_buffer(self, capacity: int | None = None):
         if self.hidden_size is None or self.num_experts is None:
@@ -579,7 +587,7 @@ class MoonEPDispatcher(BaseDispatcher):
             router_topk=self.router_topk,
             num_experts=self.num_experts,
             num_max_dispatch_tokens_per_rank=(
-                self._phase_capacity() if capacity is None else capacity
+                self._active_capacity if capacity is None else capacity
             ),
             num_prefetch_slots=self.num_prefetch_slots,
         )
@@ -612,8 +620,18 @@ class MoonEPDispatcher(BaseDispatcher):
             return hidden_states, topk_ids, topk_weights, num_tokens
 
         pad_tokens = capacity - num_tokens
+        top_k = topk_ids.shape[1]
         hidden_pad = hidden_states.new_zeros(pad_tokens, hidden_states.shape[1])
-        id_pad = topk_ids.new_zeros(pad_tokens, topk_ids.shape[1])
+        assert self.num_experts is not None
+        id_pad = (
+            torch.arange(
+                num_tokens * top_k,
+                capacity * top_k,
+                device=topk_ids.device,
+                dtype=torch.int32,
+            )
+            % self.num_experts
+        ).view(pad_tokens, top_k)
         weight_pad = topk_weights.new_zeros(pad_tokens, topk_weights.shape[1])
         return (
             torch.cat((hidden_states, hidden_pad), dim=0).contiguous(),
@@ -675,7 +693,8 @@ class MoonEPDispatcher(BaseDispatcher):
         if self.num_experts is None:
             raise ValueError("MoonEPDispatcher requires num_experts.")
 
-        capacity = self._phase_capacity()
+        capacity = self._phase_capacity(int(hidden_states.shape[0]))
+        self._active_capacity = capacity
         hidden_states, topk_ids, topk_weights, num_tokens = self._pad_to_capacity(
             hidden_states,
             topk_output.topk_ids,
@@ -690,7 +709,9 @@ class MoonEPDispatcher(BaseDispatcher):
             topk_ids,
             tokens_per_expert,
             async_finish=False,
+            zero_copy=True,
         )
+        hidden_nvsh = hidden_nvsh.view(hidden_nvsh.shape)
         return MoonEPDispatchOutput(
             hidden_states=hidden_nvsh,
             route_weights_nvs=route_weights_nvs,
@@ -698,6 +719,7 @@ class MoonEPDispatcher(BaseDispatcher):
             plan=plan,
             expert_ids=self._expert_ids_from_plan(cu_seqlens, plan),
             num_tokens=num_tokens,
+            capacity=capacity,
         )
 
     def dispatch_a(
@@ -719,11 +741,14 @@ class MoonEPDispatcher(BaseDispatcher):
                 f"MoonEPDispatcher.combine expected MOONEP input, got "
                 f"{combine_input.format}"
             )
-        hidden_states, _route_weights_sk, _event = self._get_buffer().combine(
+        buffer = self._get_buffer()
+        shard = buffer._require_ctx()["hidden_buf_local"]
+        hidden_states, _route_weights_sk, _event = buffer.combine(
             plan=combine_input.plan,
             hidden_nvsh=combine_input.hidden_states,
             route_weights_nvs=None,
             async_finish=False,
+            zero_copy=combine_input.hidden_states.data_ptr() == shard.data_ptr(),
         )
         return hidden_states[: combine_input.num_tokens].contiguous()
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -98,6 +98,10 @@ class MoonEPWeightPool:
         start = self.chunk_start(self.ep_rank) + self.layer_offset(layer_id)
         return self.ranges[kind][start : start + self.num_local_experts]
 
+    def block_view(self, kind: str, layer_id: int) -> torch.Tensor:
+        start = self.chunk_start(self.ep_rank) + self.layer_offset(layer_id)
+        return self.ranges[kind][start : start + self.block_rows]
+
     def slot_view(self, kind: str, layer_id: int) -> torch.Tensor:
         start = (
             self.chunk_start(self.ep_rank)
@@ -231,27 +235,6 @@ def expert_rows(layer_id: int, expert_ids: torch.Tensor) -> torch.Tensor:
     chunk = (owner - _pool.ep_rank) % _pool.ep_size
     rows = chunk * _pool.chunk_rows + _pool.layer_offset(layer_id) + expert_ids % epn
     return torch.where(expert_ids < 0, expert_ids, rows).to(torch.int32)
-
-
-def group_rows(
-    layer_id: int, expert_ids: torch.Tensor, num_global_experts: int
-) -> torch.Tensor:
-    assert _pool is not None, "MoonEP expert pool was never created"
-    rows = expert_rows(layer_id, expert_ids)
-    tail = expert_ids[num_global_experts:]
-    slot_base = (
-        _pool.chunk_start(_pool.ep_rank)
-        + _pool.layer_offset(layer_id)
-        + _pool.num_local_experts
-    )
-    slots = torch.arange(
-        slot_base,
-        slot_base + tail.numel(),
-        device=expert_ids.device,
-        dtype=torch.int32,
-    )
-    rows[num_global_experts:] = torch.where(tail < 0, tail.to(torch.int32), slots)
-    return rows
 
 
 def prefetch_experts(layer_id: int, source_rows: torch.Tensor, num_sms: int) -> None:

--- a/test/registered/unit/layers/moe/test_moonep_weights.py
+++ b/test/registered/unit/layers/moe/test_moonep_weights.py
@@ -173,18 +173,50 @@ class TestMoonEPPoolRows(CustomTestCase):
                     specs={**SPECS, moonep_weights.W2_WEIGHT: ((4, 16), torch.uint8)},
                 )
 
-    def test_group_rows_keep_home_groups_and_remap_the_prefetch_tail(self):
-        num_global_experts = EP_SIZE * NUM_LOCAL_EXPERTS
-        expert_ids = torch.cat(
-            [torch.arange(num_global_experts), torch.tensor([12, -1])]
-        )
-        rows = moonep_weights.group_rows(7, expert_ids, num_global_experts)
 
-        home = moonep_weights.expert_rows(7, torch.arange(num_global_experts))
-        self.assertEqual(rows[:num_global_experts].tolist(), home.tolist())
-        # slot_base = this rank's chunk + this layer's block + its own experts.
-        self.assertEqual(rows[num_global_experts].item(), NUM_LOCAL_EXPERTS)
-        self.assertEqual(rows[num_global_experts + 1].item(), -1)
+class TestMoonEPLocalSegments(CustomTestCase):
+    """Per-group (start, real rows) of the local groups, and the psum layout built from them."""
+
+    def test_local_groups_come_out_in_block_order_with_pads_removed(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+            _moonep_local_segments,
+        )
+
+        # 8 global experts, 2 ranks x 4, rank 1 owns e4..e7, plus 2 slots;
+        # segments are padded to 4 rows. Non-empty on rank 1: e5 (2 real),
+        # e7 (1 real), slot0 (3 real). Every other group is empty.
+        pool = SimpleNamespace(num_local_experts=4, num_prefetch_slots=2, ep_rank=1)
+        lengths = [0, 0, 0, 0, 0, 4, 0, 4, 4, 0]  # padded, per cu_seqlens group
+        cu_seqlens = torch.tensor(lengths, dtype=torch.int32).cumsum(0).to(torch.int32)
+        n_pad = torch.tensor([0, 0, 0, 0, 0, 2, 0, 3, 1, 0], dtype=torch.int32)
+        zero_fill = torch.stack([torch.zeros_like(n_pad), n_pad], dim=1)
+        plan = SimpleNamespace(zero_fill_ranges=zero_fill)
+
+        seg_start, seg_len = _moonep_local_segments(
+            pool, cu_seqlens, plan, num_global_experts=8
+        )
+        # Block order: home experts e4..e7, then slots 0..1.
+        self.assertEqual(seg_start.tolist(), [0, 0, 4, 4, 8, 12])
+        self.assertEqual(seg_len.tolist(), [0, 2, 0, 1, 3, 0])
+        self.assertEqual(seg_start.dtype, torch.int32)
+        self.assertEqual(seg_len.dtype, torch.int32)
+
+    def test_psum_layout_ends_and_aligned_row_bound(self):
+        from sglang.srt.layers.moe.moe_runner.deep_gemm import _moonep_psum_layout
+
+        # Three groups, segments padded to 128: g0 rows 0..127 with 2 real,
+        # g1 empty, g2 rows 128..255 with 130 real -> spills into a second
+        # 128-row tile, so the bound is 384. DeepGEMM reads g as
+        # [align(psum[g-1], 128), psum[g]).
+        seg_start = torch.tensor([0, 128, 128], dtype=torch.int32)
+        seg_len = torch.tensor([2, 0, 130], dtype=torch.int32)
+        psum, rows_end = _moonep_psum_layout(seg_start, seg_len)
+        self.assertEqual(psum.tolist(), [2, 128, 258])
+        self.assertEqual(psum.dtype, torch.int32)
+        self.assertEqual(rows_end.tolist(), [384])
+        self.assertEqual(rows_end.dtype, torch.int32)
 
 
 class TestMoonEPMIndices(CustomTestCase):


### PR DESCRIPTION
This PR adds several optimization to improve MoonEP+DeepGEMM performance for Kimi K3:
1. Use DeepGEMM psum layout
2. Zero-copy dispatch/combine
3. Padding tokens no longer route to expert 0

## Result

Steady-state decode, greedy, 128 output tokens, `decode_bench.py`:

| concurrency | before (tok/s) | after (tok/s) | after + DSPARK γ=7 (tok/s) |
|---|---|---|---|
| 1 (per request) | 6.06 | 15.9 (2.6x) | 37.6 (6.2x) |
| 8 (aggregate) | 48.5 | 128.5 (2.65x) | 239 (4.9x) |
| 32 (aggregate) | 190 | 458 (2.4x) | 663 (3.5x) |

Decode step at c=8: 165 ms -> 62 ms. One MoE layer: 1.69 ms -> 0.62 ms.
gsm8k (200 questions, greedy): 0.995 before, 0.990 after, 0.995 with DSPARK.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829990237](https://github.com/sgl-project/sglang/actions/runs/34829990237)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829989726](https://github.com/sgl-project/sglang/actions/runs/34829989726)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829989732](https://github.com/sgl-project/sglang/actions/runs/34829989732)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->