### PR TITLE
[HiCache] Enable registered-host kernel/page_first transfers

### DIFF
--- a/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
+++ b/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
@@ -17,6 +17,24 @@
 #include "utils.h"  // WARP_SIZE
 #endif
 
+inline void* resolve_device_accessible_ptr(const at::Tensor& tensor) {
+  void* ptr = tensor.data_ptr();
+#if defined(USE_ROCM)
+  if (tensor.device().is_cpu()) {
+    void* device_ptr = nullptr;
+    C10_CUDA_CHECK(hipHostGetDevicePointer(&device_ptr, ptr, 0));
+    return device_ptr;
+  }
+#elif !defined(USE_MUSA)
+  if (tensor.device().is_cpu()) {
+    void* device_ptr = nullptr;
+    C10_CUDA_CHECK(cudaHostGetDevicePointer(&device_ptr, ptr, 0));
+    return device_ptr;
+  }
+#endif
+  return ptr;
+}
+
 #if !defined(USE_ROCM) && !defined(USE_MUSA)
 __device__ __forceinline__ void
 transfer_item_warp(int32_t lane_id, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
@@ -335,6 +353,10 @@ void transfer_kv_launcher(
   TORCH_CHECK(src_indices.numel() == dst_indices.numel(), "Source and destination indices must have the same length");
   TORCH_CHECK(item_size % 8 == 0, "Item byte size must be divisible by 8");
 
+#if !defined(USE_MUSA)
+  const at::cuda::OptionalCUDAGuard device_guard(src_indices.device());
+#endif
+
   auto div_up = [](int64_t x, int64_t y) { return (x + y - 1) / y; };
   const int64_t num_items = src_indices.numel();
   const int64_t items_per_warp = div_up(num_items, block_quota * num_warps_per_block);
@@ -342,10 +364,10 @@ void transfer_kv_launcher(
   dim3 grid_dim(num_blocks, 1, 1);
   const int32_t threads_per_block = num_warps_per_block * WARP_SIZE;
 
-  const void* src_k_ptr = src_k.defined() ? src_k.data_ptr() : nullptr;
-  void* dst_k_ptr = dst_k.defined() ? dst_k.data_ptr() : nullptr;
-  const void* src_v_ptr = IsMLA || !src_v.defined() ? nullptr : src_v.data_ptr();
-  void* dst_v_ptr = IsMLA || !dst_v.defined() ? nullptr : dst_v.data_ptr();
+  const void* src_k_ptr = src_k.defined() ? resolve_device_accessible_ptr(src_k) : nullptr;
+  void* dst_k_ptr = dst_k.defined() ? resolve_device_accessible_ptr(dst_k) : nullptr;
+  const void* src_v_ptr = IsMLA || !src_v.defined() ? nullptr : resolve_device_accessible_ptr(src_v);
+  void* dst_v_ptr = IsMLA || !dst_v.defined() ? nullptr : resolve_device_accessible_ptr(dst_v);
   const uintptr_t* src_k_tbl_ptr = src_k_layers.defined() ? src_k_layers.data_ptr<uintptr_t>() : nullptr;
   const uintptr_t* dst_k_tbl_ptr = dst_k_layers.defined() ? dst_k_layers.data_ptr<uintptr_t>() : nullptr;
   const uintptr_t* src_v_tbl_ptr = IsMLA || !src_v_layers.defined() ? nullptr : src_v_layers.data_ptr<uintptr_t>();

--- a/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
@@ -3,6 +3,7 @@
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
+#include <sgl_kernel/runtime.cuh>
 #include <sgl_kernel/utils.cuh>
 #include <sgl_kernel/vec.cuh>
 
@@ -318,17 +319,18 @@ struct HiCacheKernel {
     const auto element_bytes = D.unwrap() * dtype_size;
     RuntimeCheck(kElementSize == element_bytes, "HicacheKernel: cache dimension mismatch.");
 
-    const auto k_cache_dst_ptr = k_cache_dst.data_ptr();
-    const auto v_cache_dst_ptr = v_cache_dst.data_ptr();
-    const auto k_cache_src_ptr = k_cache_src.data_ptr();
-    const auto v_cache_src_ptr = v_cache_src.data_ptr();
+    const auto device = indices_device.unwrap();
+    runtime::DeviceGuard device_guard(device.device_id);
+    const auto k_cache_dst_ptr = runtime::device_accessible_ptr(k_cache_dst);
+    const auto v_cache_dst_ptr = runtime::device_accessible_ptr(v_cache_dst);
+    const auto k_cache_src_ptr = runtime::device_accessible_ptr(k_cache_src);
+    const auto v_cache_src_ptr = runtime::device_accessible_ptr(v_cache_src);
     const auto indices_dst_ptr = indices_dst.data_ptr();
     const auto indices_src_ptr = indices_src.data_ptr();
     const auto length = static_cast<uint32_t>(L.unwrap());
     const auto kv_cache_src_stride = static_cast<int64_t>(N.unwrap() * dtype_size);
     const auto kv_cache_dst_stride = static_cast<int64_t>(M.unwrap() * dtype_size);
     const auto use_int32 = indices_dtype.unwrap().bits == 32;
-    const auto device = indices_device.unwrap();
 
     constexpr auto kWorkersPerBlock = kBlockSize / (device::kWarpThreads / kUnroll);
     const auto num_blocks = std::min(div_ceil(length, kWorkersPerBlock), kBlockQuota);
@@ -440,15 +442,16 @@ struct HiCacheKernel {
     const auto element_bytes = D.unwrap() * dtype_size;
     RuntimeCheck(kElementSize == element_bytes, "HicacheKernel MLA: cache dimension mismatch.");
 
-    const auto cache_dst_ptr = cache_dst.data_ptr();
-    const auto cache_src_ptr = cache_src.data_ptr();
+    const auto device = indices_device.unwrap();
+    runtime::DeviceGuard device_guard(device.device_id);
+    const auto cache_dst_ptr = runtime::device_accessible_ptr(cache_dst);
+    const auto cache_src_ptr = runtime::device_accessible_ptr(cache_src);
     const auto indices_dst_ptr = indices_dst.data_ptr();
     const auto indices_src_ptr = indices_src.data_ptr();
     const auto length = static_cast<uint32_t>(L.unwrap());
     const auto cache_src_stride = static_cast<int64_t>(N.unwrap() * dtype_size);
     const auto cache_dst_stride = static_cast<int64_t>(M.unwrap() * dtype_size);
     const auto use_int32 = indices_dtype.unwrap().bits == 32;
-    const auto device = indices_device.unwrap();
 
     constexpr auto kWorkersPerBlock = kBlockSize / (device::kWarpThreads / kUnroll);
     const auto num_blocks = std::min(div_ceil(length, kWorkersPerBlock), kBlockQuota);

--- a/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
@@ -320,11 +320,10 @@ struct HiCacheKernel {
     RuntimeCheck(kElementSize == element_bytes, "HicacheKernel: cache dimension mismatch.");
 
     const auto device = indices_device.unwrap();
-    runtime::DeviceGuard device_guard(device.device_id);
-    const auto k_cache_dst_ptr = runtime::device_accessible_ptr(k_cache_dst);
-    const auto v_cache_dst_ptr = runtime::device_accessible_ptr(v_cache_dst);
-    const auto k_cache_src_ptr = runtime::device_accessible_ptr(k_cache_src);
-    const auto v_cache_src_ptr = runtime::device_accessible_ptr(v_cache_src);
+    const auto k_cache_dst_ptr = runtime::get_device_accessible_ptr(k_cache_dst);
+    const auto v_cache_dst_ptr = runtime::get_device_accessible_ptr(v_cache_dst);
+    const auto k_cache_src_ptr = runtime::get_device_accessible_ptr(k_cache_src);
+    const auto v_cache_src_ptr = runtime::get_device_accessible_ptr(v_cache_src);
     const auto indices_dst_ptr = indices_dst.data_ptr();
     const auto indices_src_ptr = indices_src.data_ptr();
     const auto length = static_cast<uint32_t>(L.unwrap());
@@ -443,9 +442,8 @@ struct HiCacheKernel {
     RuntimeCheck(kElementSize == element_bytes, "HicacheKernel MLA: cache dimension mismatch.");
 
     const auto device = indices_device.unwrap();
-    runtime::DeviceGuard device_guard(device.device_id);
-    const auto cache_dst_ptr = runtime::device_accessible_ptr(cache_dst);
-    const auto cache_src_ptr = runtime::device_accessible_ptr(cache_src);
+    const auto cache_dst_ptr = runtime::get_device_accessible_ptr(cache_dst);
+    const auto cache_src_ptr = runtime::get_device_accessible_ptr(cache_src);
     const auto indices_dst_ptr = indices_dst.data_ptr();
     const auto indices_src_ptr = indices_src.data_ptr();
     const auto length = static_cast<uint32_t>(L.unwrap());

--- a/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
@@ -50,6 +50,58 @@ namespace sglang {
 
 namespace host::runtime {
 
+class DeviceGuard {
+ public:
+  explicit DeviceGuard(int target_device) {
+#ifdef USE_ROCM
+    RuntimeDeviceCheck(::hipGetDevice(&original_device_));
+    if (original_device_ != target_device) {
+      RuntimeDeviceCheck(::hipSetDevice(target_device));
+      changed_ = true;
+    }
+#else
+    RuntimeDeviceCheck(::cudaGetDevice(&original_device_));
+    if (original_device_ != target_device) {
+      RuntimeDeviceCheck(::cudaSetDevice(target_device));
+      changed_ = true;
+    }
+#endif
+  }
+
+  ~DeviceGuard() {
+    if (changed_) {
+#ifdef USE_ROCM
+      (void)::hipSetDevice(original_device_);
+#else
+      (void)::cudaSetDevice(original_device_);
+#endif
+    }
+  }
+
+  DeviceGuard(const DeviceGuard&) = delete;
+  DeviceGuard& operator=(const DeviceGuard&) = delete;
+
+ private:
+  int original_device_ = 0;
+  bool changed_ = false;
+};
+
+inline void* device_accessible_ptr(const tvm::ffi::TensorView& tensor) {
+  void* ptr = tensor.data_ptr();
+  const auto tensor_device_type = tensor.device().device_type;
+  if (tensor_device_type != kDLCPU && tensor_device_type != kDLGPUHost) {
+    return ptr;
+  }
+
+  void* device_ptr = nullptr;
+#ifdef USE_ROCM
+  RuntimeDeviceCheck(::hipHostGetDevicePointer(&device_ptr, ptr, 0));
+#else
+  RuntimeDeviceCheck(::cudaHostGetDevicePointer(&device_ptr, ptr, 0));
+#endif
+  return device_ptr;
+}
+
 // Return the maximum number of active blocks per SM for the given kernel
 template <typename T>
 inline auto get_blocks_per_sm(T&& kernel, int32_t block_dim, std::size_t dynamic_smem = 0) -> uint32_t {

--- a/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
@@ -50,43 +50,7 @@ namespace sglang {
 
 namespace host::runtime {
 
-class DeviceGuard {
- public:
-  explicit DeviceGuard(int target_device) {
-#ifdef USE_ROCM
-    RuntimeDeviceCheck(::hipGetDevice(&original_device_));
-    if (original_device_ != target_device) {
-      RuntimeDeviceCheck(::hipSetDevice(target_device));
-      changed_ = true;
-    }
-#else
-    RuntimeDeviceCheck(::cudaGetDevice(&original_device_));
-    if (original_device_ != target_device) {
-      RuntimeDeviceCheck(::cudaSetDevice(target_device));
-      changed_ = true;
-    }
-#endif
-  }
-
-  ~DeviceGuard() {
-    if (changed_) {
-#ifdef USE_ROCM
-      (void)::hipSetDevice(original_device_);
-#else
-      (void)::cudaSetDevice(original_device_);
-#endif
-    }
-  }
-
-  DeviceGuard(const DeviceGuard&) = delete;
-  DeviceGuard& operator=(const DeviceGuard&) = delete;
-
- private:
-  int original_device_ = 0;
-  bool changed_ = false;
-};
-
-inline void* device_accessible_ptr(const tvm::ffi::TensorView& tensor) {
+inline void* get_device_accessible_ptr(const tvm::ffi::TensorView& tensor) {
   void* ptr = tensor.data_ptr();
   const auto tensor_device_type = tensor.device().device_type;
   if (tensor_device_type != kDLCPU && tensor_device_type != kDLGPUHost) {

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -78,6 +78,18 @@ def _pinned_host_pool(host_pool_cls, **kwargs):
         ALLOC_MEMORY_FUNCS[DEVICE] = original_alloc
 
 
+def _registered_host_pool(host_pool_cls, **kwargs):
+    return host_pool_cls(
+        host_to_device_ratio=2.0,
+        host_size=0,
+        page_size=PAGE_SIZE,
+        pin_memory=True,
+        device="cpu",
+        allocator_type="default",
+        **kwargs,
+    )
+
+
 def _fill_with_offset(tensor: torch.Tensor, offset: int) -> None:
     data = torch.arange(
         tensor.numel(), device=tensor.device, dtype=tensor.dtype
@@ -253,6 +265,96 @@ def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> 
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mla(element_dim: int, page_count: int) -> None:
     _run_mla(element_dim, page_count)
+
+
+@pytest.mark.parametrize("pool_kind", ["mha", "mla"])
+def test_registered_mmap_page_first_kernel_operands_and_graph(
+    pool_kind: str,
+) -> None:
+    if pool_kind == "mha":
+        device_pool = MHATokenToKVPool(
+            size=PAGE_SIZE * 4,
+            page_size=PAGE_SIZE,
+            head_num=1,
+            head_dim=128,
+            dtype=torch.bfloat16,
+            layer_num=1,
+            device=DEVICE,
+            enable_memory_saver=False,
+        )
+        host_pool = _registered_host_pool(
+            MHATokenToKVPoolHost,
+            device_pool=device_pool,
+            layout="page_first",
+        )
+        host_refs = [host_pool.k_data_refs[0], host_pool.v_data_refs[0]]
+        device_refs = [device_pool.k_buffer[0], device_pool.v_buffer[0]]
+    else:
+        device_pool = MLATokenToKVPool(
+            size=PAGE_SIZE * 4,
+            page_size=PAGE_SIZE,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            dtype=torch.bfloat16,
+            layer_num=1,
+            device=DEVICE,
+            enable_memory_saver=False,
+        )
+        host_pool = _registered_host_pool(
+            MLATokenToKVPoolHost,
+            device_pool=device_pool,
+            layout="page_first",
+        )
+        host_refs = [host_pool.data_refs[0]]
+        device_refs = [device_pool.kv_buffer[0]]
+
+    graph = None
+    try:
+        assert host_pool.can_use_jit
+        for index, host_ref in enumerate(host_refs):
+            _fill_with_offset(host_ref, index + 3)
+
+        host_indices = _token_indices_for_pages(torch.tensor([0]))
+        aot_device_indices = _token_indices_for_pages(torch.tensor([1]))
+        host_pool.can_use_jit = False
+        host_pool.load_to_device_per_layer(
+            device_pool, host_indices, aot_device_indices, 0, "kernel"
+        )
+        torch.cuda.synchronize()
+        for host_ref, device_ref in zip(host_refs, device_refs):
+            _assert_pages_equal(
+                host_ref,
+                device_ref,
+                torch.tensor([0]),
+                torch.tensor([1]),
+            )
+
+        graph_device_indices = _token_indices_for_pages(torch.tensor([2]))
+        host_pool.can_use_jit = True
+        capture_stream = torch.cuda.Stream()
+        capture_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(capture_stream):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                host_pool.load_to_device_per_layer(
+                    device_pool, host_indices, graph_device_indices, 0, "kernel"
+                )
+        torch.cuda.current_stream().wait_stream(capture_stream)
+        for device_ref in device_refs:
+            device_ref.index_fill_(0, graph_device_indices, 0)
+        graph.replay()
+        torch.cuda.synchronize()
+        for host_ref, device_ref in zip(host_refs, device_refs):
+            _assert_pages_equal(
+                host_ref,
+                device_ref,
+                torch.tensor([0]),
+                torch.tensor([2]),
+            )
+    finally:
+        torch.cuda.synchronize()
+        del graph
+        host_pool.destroy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR is split from #35233 to keep each change focused and independently reviewable.

It contains the minimal registered-host pointer handling required to keep MHA and MLA HiCache on the `kernel/page_first` path.

## Changes

- Resolve registered CPU/GPU-host tensor operands to device-accessible aliases in the AOT KV transfer launcher.
- Apply the same alias resolution and device guard to the one-layer MHA and MLA JIT launchers.
- Preserve the caller's current device after pointer resolution.
- Add registered-mmap page-first coverage for AOT, JIT, MHA, MLA, and graph replay.

## Scope

This PR is limited to direct MHA/MLA page-first kernel operands. It does not include block-quota tuning, all-layer pointer tables, Mamba, HiSparse, DSA, or DSV4 handling.

The block-quota change is split into #39036. The complete implementation remains in #35233.

## Validation

ROCm 7.2.4 / MI355X (`gfx950`), image `lmsysorg/sglang-rocm:v0.5.19-rocm724-mi35x-20260910`:

- Fresh AOT build passed.
- `test_hicache_page_first_write_back.py`: `14 passed`.
- Repository pre-commit hooks passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34840463395](https://github.com/sgl-project/sglang/actions/runs/34840463395)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34840463162](https://github.com/sgl-project/sglang/actions/runs/34840463162)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34840463324](https://github.com/sgl-project/sglang/actions/runs/34840463324)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
