### PR TITLE
[DeepSeek-V4.1] Handle null message content in chat encoding

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv41.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv41.py
@@ -282,7 +282,11 @@ def render_message(
             )
 
     elif role == "developer":
-        assert content, f"Invalid message for role `{role}`: {msg}"
+        # ValueError, not assert: serving_base maps ValueError to a 400 and an
+        # AssertionError to a 500, and an empty developer message is a client
+        # error (dsv32 raises DS32EncodingError for the same input).
+        if not content:
+            raise ValueError(f"Invalid message for role `{role}`: {msg}")
 
         content_developer = USER_SP_TOKEN
         content_developer += content
@@ -308,7 +312,10 @@ def render_message(
                 if block_type == "text":
                     parts.append(block.get("text", ""))
                 elif block_type == "tool_result":
-                    tool_content = block.get("content", "")
+                    # `or ""` because get's default only covers a *missing* key;
+                    # content=null (legal in OpenAI tool results) must not render
+                    # the literal string "None".
+                    tool_content = block.get("content") or ""
                     if isinstance(tool_content, list):
                         text_parts = []
                         for b in tool_content:
@@ -446,7 +453,8 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             tool_block = {
                 "type": "tool_result",
                 "tool_use_id": msg.get("tool_call_id", ""),
-                "content": msg.get("content", ""),
+                # `or ""` because get's default only covers a *missing* key.
+                "content": msg.get("content") or "",
             }
             # Merge into previous message if it's already a user (merged tool)
             if (
@@ -465,7 +473,9 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         elif role == "user":
             content_blocks = msg.get("content_blocks")
             if content_blocks is None:
-                content_blocks = [{"type": "text", "text": msg.get("content", "")}]
+                # `or ""` so a null content becomes an empty text block instead
+                # of a None the renderer crashes on.
+                content_blocks = [{"type": "text", "text": msg.get("content") or ""}]
             if (
                 merged
                 and merged[-1].get("role") == "user"

--- a/test/registered/unit/entrypoints/openai/test_encoding_dsv41.py
+++ b/test/registered/unit/entrypoints/openai/test_encoding_dsv41.py
@@ -12,6 +12,41 @@ from sglang.srt.entrypoints.openai.encoding_dsv41 import (
 from sglang.test.test_utils import CustomTestCase
 
 
+class TestNullContent(CustomTestCase):
+    """OpenAI content is `str | parts | None`; None must not surface as the
+    literal string "None", crash the encoder, or escape as an AssertionError
+    (which serving_base maps to a 500 instead of a 400)."""
+
+    def test_tool_message_null_content_renders_empty_result(self):
+        prompt = encode_messages(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "tool", "tool_call_id": "t1", "content": None},
+            ],
+            thinking_mode="thinking",
+        )
+        self.assertIn("<tool_result></tool_result>", prompt)
+        self.assertNotIn("<tool_result>None</tool_result>", prompt)
+
+    def test_user_message_null_content_encodes(self):
+        prompt = encode_messages(
+            [{"role": "user", "content": None}], thinking_mode="thinking"
+        )
+        self.assertIn("<｜User｜><｜Assistant｜>", prompt)
+
+    def test_developer_empty_content_raises_value_error(self):
+        # ValueError so serving_base answers 400 BadRequest, matching the dsv32
+        # encoder's DS32EncodingError; an AssertionError would surface as a 500.
+        for content in ("", None):
+            with self.subTest(content=content):
+                with self.assertRaises(ValueError) as ctx:
+                    encode_messages(
+                        [{"role": "developer", "content": content}],
+                        thinking_mode="thinking",
+                    )
+                self.assertIn("developer", str(ctx.exception))
+
+
 def _tool() -> dict:
     return {
         "type": "function",


### PR DESCRIPTION
## Motivation

The DeepSeek-V4.1 chat encoder does not handle explicit `content=None` consistently.

This can lead to three failure modes:

* A tool message with null content renders `<tool_result>None</tool_result>` into the model prompt.
* A user message with null content can raise `TypeError` during prompt rendering.
* An empty/null developer message raises `AssertionError`, which can surface as HTTP 500 instead of a client error.

## Changes

* Normalize null user/tool content to an empty string at the V4.1 merge/render boundaries.
* Replace the developer-message assertion with `ValueError`, allowing invalid input to be handled as a client error.
* Add regression tests covering null tool content, null user content, and empty/null developer content.

The change is scoped to the DeepSeek-V4.1 encoder.

## Tests

```bash
PYTHONPATH=$PWD/python:/tmp/sgl_stub \
python -m pytest -q \
  test/registered/unit/entrypoints/openai/test_encoding_dsv41.py
```

Result:

```text
4 passed, 2 subtests passed
```

The new regression cases were also verified to fail on the unmodified `dsv4.1` branch for the expected reasons.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34572846901](https://github.com/sgl-project/sglang/actions/runs/34572846901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34572846587](https://github.com/sgl-project/sglang/actions/runs/34572846587)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34572846887](https://github.com/sgl-project/sglang/actions/runs/34572846887)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->