### PR TITLE
[AMD] Tune Triton sparse MLA on gfx950

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -26,6 +26,7 @@ _G = tl.constexpr(128)
 _PREFERRED_BLOCK_K = 64
 _MIN_BLOCK_K = 16
 _INDEX_ELEMENT_SIZE = 4
+_I32_MAX = (1 << 31) - 1
 
 _SUPPORTED_INPUT_DTYPES = (
     torch.bfloat16,
@@ -118,11 +119,21 @@ def _no_async_copy():
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=1)
-def _cu_count() -> int:
-    return torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).multi_processor_count
+@functools.lru_cache(maxsize=None)
+def _cu_count_for_device(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def _cu_count(device: torch.device | int | None = None) -> int:
+    if device is None:
+        device_index = torch.cuda.current_device()
+    elif isinstance(device, torch.device):
+        device_index = (
+            device.index if device.index is not None else torch.cuda.current_device()
+        )
+    else:
+        device_index = device
+    return _cu_count_for_device(device_index)
 
 
 @functools.lru_cache(maxsize=None)
@@ -185,6 +196,47 @@ def _kv_splits_heuristic(
         return 1
     splits_to_fill = max(1, target_wg // base_ctas)
     return _prev_pow2(min(splits_to_fill, max_kv_splits))
+
+
+@functools.lru_cache(maxsize=None)
+def _is_gfx950_device(device: int) -> bool:
+    properties = torch.cuda.get_device_properties(device)
+    arch = getattr(properties, "gcnArchName", "") or ""
+    return arch.split(":", 1)[0] == "gfx950"
+
+
+def _gfx950_sparse_mla_kv_splits(
+    base_ctas: int,
+    topk: int,
+    block_k: int,
+    num_cu: int,
+    kv_splits: int,
+    max_kv_splits: int,
+) -> int:
+    tiles_per_split = (topk + kv_splits * block_k - 1) // (kv_splits * block_k)
+    if 4 < base_ctas <= 8 and kv_splits == 32 and tiles_per_split == 1:
+        return kv_splits // 2
+
+    tokens_per_split = (topk + kv_splits - 1) // kv_splits
+    if (
+        topk >= 2048
+        and base_ctas <= num_cu
+        and tokens_per_split >= 1024
+        and kv_splits < max_kv_splits
+    ):
+        return min(kv_splits * 2, max_kv_splits)
+
+    return kv_splits
+
+
+def _gfx950_sparse_mla_num_warps(
+    base_ctas: int, active_splits: int, num_cu: int
+) -> int:
+    return 2 if base_ctas * active_splits > num_cu else 4
+
+
+def _page_offsets_fit_i32(num_pages: int, kv_dim: int) -> bool:
+    return num_pages * kv_dim <= _I32_MAX
 
 
 def _row_strides(x: torch.Tensor) -> tuple[torch.Tensor, int, int]:
@@ -504,6 +556,12 @@ def _next_pow2(n: int) -> int:
     return 1 << (n - 1).bit_length()
 
 
+def _reduce_d_chunk(active_splits: int, output_rows: int = 0) -> int:
+    if active_splits <= 4:
+        return 512 if output_rows >= 1536 else 128
+    return 64
+
+
 # ---------------------------------------------------------------------------
 # Split-K kernels (for short sequences: MTP verify/draft, decode)
 # grid=(seq, head_blocks, kv_splits) + reduce
@@ -516,6 +574,7 @@ def _sparse_mla_fused_kernel(
     q_rope_ptr,
     kv_ptr,
     idx_ptr,
+    topk_length_ptr,
     out_ptr,
     qk_scale,
     fp8_max,
@@ -530,8 +589,11 @@ def _sparse_mla_fused_kernel(
     STRIDE_QR_T: tl.constexpr,
     STRIDE_QR_H: tl.constexpr,
     USE_FP8_DOT: tl.constexpr,
+    USE_TOPK_LENGTH: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    USE_I64_PAGE: tl.constexpr = True,
+    PIPE_STAGES: tl.constexpr = 3,
 ):
     """Single-pass with head-block splitting. grid=(seq, head_blocks)."""
     t = tl.program_id(0)
@@ -585,17 +647,23 @@ def _sparse_mla_fused_kernel(
     if NUM_GROUPS >= 4:
         acc3 = tl.zeros((BLOCK_H, _G), dtype=tl.float32)
 
-    k_offs = tl.arange(0, BLOCK_K)
-    num_tiles = tl.cdiv(topk, BLOCK_K)
+    valid_topk = topk
+    if USE_TOPK_LENGTH:
+        valid_topk = tl.minimum(tl.maximum(tl.load(topk_length_ptr + t), 0), topk)
 
-    for j in tl.range(0, num_tiles, num_stages=3):
+    k_offs = tl.arange(0, BLOCK_K)
+    num_tiles = tl.cdiv(valid_topk, BLOCK_K)
+
+    for j in tl.range(0, num_tiles, num_stages=PIPE_STAGES):
         k_start = j * BLOCK_K
         k_pos = k_start + k_offs
-        valid = k_pos < topk
+        valid = k_pos < valid_topk
 
         slot = tl.load(idx_ptr + t * topk + k_pos, mask=valid, other=0)
         valid = valid & (slot >= 0)
-        page = tl.where(valid, slot, 0).to(tl.int64)
+        page = tl.where(valid, slot, 0)
+        if USE_I64_PAGE:
+            page = page.to(tl.int64)
 
         kv_base = kv_ptr + page[:, None] * KV_DIM
         kv0 = tl.load(kv_base + g[None, :], mask=valid[:, None], other=0.0).to(
@@ -607,11 +675,15 @@ def _sparse_mla_fused_kernel(
             ).to(input_type)
         if NUM_GROUPS >= 3:
             kv2 = tl.load(
-                kv_base + (2 * _G + g)[None, :], mask=valid[:, None], other=0.0
+                kv_base + (2 * _G + g)[None, :],
+                mask=valid[:, None],
+                other=0.0,
             ).to(input_type)
         if NUM_GROUPS >= 4:
             kv3 = tl.load(
-                kv_base + (3 * _G + g)[None, :], mask=valid[:, None], other=0.0
+                kv_base + (3 * _G + g)[None, :],
+                mask=valid[:, None],
+                other=0.0,
             ).to(input_type)
         kv_tail = tl.load(
             kv_base + (D_V + dt)[None, :], mask=valid[:, None], other=0.0
@@ -952,6 +1024,8 @@ def _triton_sparse_mla_fwd_splitk(
     sm_scale: float,
     d_v: int,
     kv_splits: int,
+    topk_length: torch.Tensor | None = None,
+    use_topk_length: bool = False,
 ) -> torch.Tensor:
     """Split-K path for short sequences."""
     is_fp8 = _validate_input_dtypes(q_nope, q_rope, kv)
@@ -962,6 +1036,15 @@ def _triton_sparse_mla_fwd_splitk(
     kv_dim = kv.shape[-1]
     topk = indices.shape[-1]
     idx_flat = indices.squeeze(1).contiguous() if indices.dim() == 3 else indices
+    if use_topk_length:
+        assert topk_length is not None
+        assert topk_length.dtype == torch.int32
+        assert topk_length.device == q_nope.device
+        assert topk_length.numel() >= seq
+        assert topk_length.is_contiguous()
+        topk_length_ptr = topk_length.reshape(-1)
+    else:
+        topk_length_ptr = idx_flat
     q_nope, stride_qn_t, stride_qn_h = _row_strides(q_nope)
     q_rope, stride_qr_t, stride_qr_h = _row_strides(q_rope)
 
@@ -969,6 +1052,19 @@ def _triton_sparse_mla_fwd_splitk(
     BLOCK_K = _sparse_mla_block_k(kv)
     n_head_blocks = (H + BLOCK_H - 1) // BLOCK_H
     h_padded = n_head_blocks * BLOCK_H
+    num_cu = _cu_count(q_nope.device)
+    base_ctas = seq * n_head_blocks
+    device_index = q_nope.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    optimize_gfx950_fp8 = (
+        use_fp8_dot
+        and H == 16
+        and d_v == 512
+        and d_tail == 64
+        and kv_dim == 576
+        and _is_gfx950_device(device_index)
+    )
 
     num_groups = d_v // 128
     assert num_groups <= 4, (
@@ -981,15 +1077,21 @@ def _triton_sparse_mla_fwd_splitk(
     # double its partial-buffer traffic merely because each tile is smaller.
     max_kv_splits = max(1, topk // _PREFERRED_BLOCK_K)
     kv_splits = min(kv_splits, max_kv_splits)
+    if use_topk_length:
+        kv_splits = 1
 
     out = torch.empty(seq, H, d_v, device=q_nope.device, dtype=torch.bfloat16)
 
     if kv_splits == 1:
+        fused_num_warps = 4
+        if optimize_gfx950_fp8:
+            fused_num_warps = _gfx950_sparse_mla_num_warps(base_ctas, 1, num_cu)
         _sparse_mla_fused_kernel[(seq, n_head_blocks)](
             q_nope,
             q_rope,
             kv,
             idx_flat,
+            topk_length_ptr,
             out,
             qk_scale,
             _FP8_MAX,
@@ -1004,9 +1106,17 @@ def _triton_sparse_mla_fwd_splitk(
             STRIDE_QR_T=stride_qr_t,
             STRIDE_QR_H=stride_qr_h,
             USE_FP8_DOT=use_fp8_dot,
+            USE_TOPK_LENGTH=use_topk_length,
             BLOCK_H=BLOCK_H,
             BLOCK_K=BLOCK_K,
-            num_warps=4,
+            USE_I64_PAGE=not (
+                optimize_gfx950_fp8
+                and fused_num_warps == 2
+                and topk >= 2048
+                and _page_offsets_fit_i32(kv.shape[0], kv_dim)
+            ),
+            PIPE_STAGES=1 if use_topk_length else 3,
+            num_warps=fused_num_warps,
             num_stages=2,
         )
         return out.unsqueeze(0)
@@ -1016,6 +1126,9 @@ def _triton_sparse_mla_fwd_splitk(
         tiles_per_split * BLOCK_K
     )
     active_splits = min(active_splits, kv_splits)
+    split_num_warps = 4
+    if optimize_gfx950_fp8:
+        split_num_warps = _gfx950_sparse_mla_num_warps(base_ctas, active_splits, num_cu)
 
     lse_partial = torch.empty(
         seq, kv_splits, h_padded, dtype=torch.float32, device=q_nope.device
@@ -1047,11 +1160,11 @@ def _triton_sparse_mla_fwd_splitk(
         KV_SPLITS=kv_splits,
         BLOCK_H=BLOCK_H,
         BLOCK_K=BLOCK_K,
-        num_warps=4,
+        num_warps=split_num_warps,
         num_stages=2,
     )
 
-    D_CHUNK = 64
+    D_CHUNK = _reduce_d_chunk(active_splits, seq * H) if optimize_gfx950_fp8 else 64
     _sparse_mla_reduce_kernel[(seq, H, (d_v + D_CHUNK - 1) // D_CHUNK)](
         lse_partial,
         acc_partial,
@@ -1080,24 +1193,73 @@ def triton_sparse_mla_fwd(
     indices: torch.Tensor,
     sm_scale: float,
     d_v: int = 512,
+    topk_length: torch.Tensor | None = None,
+    max_topk_length: int | None = None,
 ) -> torch.Tensor:
     """Unified sparse MLA forward. Auto-selects single-pass vs split-K.
 
     q_nope: [seq, H, d_v] fp8/bf16, q_rope: [seq, H, dim-d_v] fp8/bf16,
     kv: [num_pages, 1, dim] fp8/bf16, indices: [seq, 1, topk].
+    topk_length optionally bounds each row's packed valid-index prefix;
+    max_topk_length is its host-known batch maximum.
 
     Returns [1, seq, H, d_v] bf16 to match tilelang_sparse_fwd.
     """
     seq = q_nope.shape[0]
     H = q_nope.shape[1]
-    num_cu = _cu_count()
+    num_cu = _cu_count(q_nope.device)
     BLOCK_H = 16
     BLOCK_K = _sparse_mla_block_k(kv)
     topk = indices.shape[-1]
     max_kv_splits = max(1, topk // _PREFERRED_BLOCK_K)
     head_blocks = max(1, (H + BLOCK_H - 1) // BLOCK_H)
     base_ctas = seq * head_blocks
+    device_index = q_nope.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    optimize_gfx950_fp8 = (
+        kv.dtype != torch.bfloat16
+        and H == 16
+        and d_v == 512
+        and q_rope.shape[-1] == 64
+        and kv.shape[-1] == 576
+        and _is_gfx950_device(device_index)
+    )
+    use_topk_length = (
+        optimize_gfx950_fp8
+        and topk >= 2048
+        and topk % 128 == 0
+        and max_topk_length is not None
+        and max_topk_length <= 512
+    )
+    if use_topk_length:
+        if topk_length is None:
+            from sglang.kernels.ops.kvcache.cache_ops import (
+                q8kv8_topk_length_from_indices,
+            )
+
+            indices_2d = indices.squeeze(1) if indices.dim() == 3 else indices
+            if indices_2d.stride(1) != 1:
+                indices_2d = indices_2d.contiguous()
+            topk_length = q8kv8_topk_length_from_indices(indices_2d)
+        with _no_async_copy():
+            return _triton_sparse_mla_fwd_splitk(
+                q_nope,
+                q_rope,
+                kv,
+                indices,
+                sm_scale,
+                d_v,
+                kv_splits=1,
+                topk_length=topk_length,
+                use_topk_length=True,
+            )
     if base_ctas > num_cu:
+        if optimize_gfx950_fp8:
+            with _no_async_copy():
+                return _triton_sparse_mla_fwd_splitk(
+                    q_nope, q_rope, kv, indices, sm_scale, d_v, kv_splits=1
+                )
         return _triton_sparse_mla_fwd_single(q_nope, q_rope, kv, indices, sm_scale, d_v)
     kv_splits = min(
         _kv_splits_heuristic(
@@ -1105,6 +1267,15 @@ def triton_sparse_mla_fwd(
         ),
         max_kv_splits,
     )
+    if optimize_gfx950_fp8:
+        kv_splits = _gfx950_sparse_mla_kv_splits(
+            base_ctas,
+            topk,
+            BLOCK_K,
+            num_cu,
+            kv_splits,
+            max_kv_splits,
+        )
     return _triton_sparse_mla_fwd_splitk(
         q_nope, q_rope, kv, indices, sm_scale, d_v, kv_splits
     )

--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla_decode.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla_decode.py
@@ -11,15 +11,19 @@ Two variants:
   2. Split-K: adaptive split-K with fused fast path (adapted from DSv4)
 """
 
-import functools
-
 import torch
 import triton
 import triton.language as tl
 
 from sglang.kernels.ops.attention.dsa.triton_sparse_mla import (
     _PREFERRED_BLOCK_K,
+    _cu_count,
+    _gfx950_sparse_mla_kv_splits,
+    _gfx950_sparse_mla_num_warps,
+    _is_gfx950_device,
     _no_async_copy,
+    _page_offsets_fit_i32,
+    _reduce_d_chunk,
     _row_strides,
     _sparse_mla_block_k,
     _validate_input_dtypes,
@@ -30,7 +34,18 @@ _IS_FNUZ = is_fp8_fnuz()
 _FP8_MAX = 240.0 if _IS_FNUZ else 448.0
 _G = tl.constexpr(128)
 
-_splitk_bufs: dict[torch.device, tuple[torch.Tensor, torch.Tensor]] = {}
+_SplitKWorkspace = list[tuple[torch.Tensor, torch.Tensor]]
+_splitk_bufs: dict[tuple[torch.device, int], _SplitKWorkspace] = {}
+
+
+def _gfx950_sparse_mla_decode_tile_config(
+    base_ctas: int, topk: int, block_k: int, max_kv_splits: int
+) -> tuple[int, int]:
+    if topk == 2048 and base_ctas <= 2:
+        block_k = 32
+        if base_ctas == 1:
+            max_kv_splits = 64
+    return block_k, max_kv_splits
 
 
 def _get_splitk_bufs(
@@ -39,25 +54,25 @@ def _get_splitk_bufs(
     h_padded: int,
     d_v: int,
     device: torch.device,
+    workspace: _SplitKWorkspace | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    key = device
+    if workspace is None:
+        stream_id = int(torch.cuda.current_stream(device).cuda_stream)
+        workspace = _splitk_bufs.setdefault((device, stream_id), [])
+
     needed_lse = bs * kv_splits * h_padded
     needed_acc = bs * kv_splits * h_padded * d_v
-    if key in _splitk_bufs:
-        lse_buf, acc_buf = _splitk_bufs[key]
+    for lse_buf, acc_buf in reversed(workspace):
         if lse_buf.numel() >= needed_lse and acc_buf.numel() >= needed_acc:
             lse = lse_buf[:needed_lse].view(bs, kv_splits, h_padded)
             acc = acc_buf[:needed_acc].view(bs, kv_splits, h_padded, d_v)
             return lse, acc
-    cap_bs = max(bs, 128)
-    cap_splits = max(kv_splits, 32)
-    lse_buf = torch.empty(
-        cap_bs * cap_splits * h_padded, dtype=torch.float32, device=device
-    )
-    acc_buf = torch.empty(
-        cap_bs * cap_splits * h_padded * d_v, dtype=torch.bfloat16, device=device
-    )
-    _splitk_bufs[key] = (lse_buf, acc_buf)
+
+    # Keep old allocations alive because captured graphs retain their pointers.
+    capacity_lse = max(needed_lse, 2 * _cu_count(device) * 16)
+    lse_buf = torch.empty(capacity_lse, dtype=torch.float32, device=device)
+    acc_buf = torch.empty(capacity_lse * d_v, dtype=torch.bfloat16, device=device)
+    workspace.append((lse_buf, acc_buf))
     lse = lse_buf[:needed_lse].view(bs, kv_splits, h_padded)
     acc = acc_buf[:needed_acc].view(bs, kv_splits, h_padded, d_v)
     return lse, acc
@@ -68,13 +83,6 @@ def _get_splitk_bufs(
 # ---------------------------------------------------------------------------
 
 LOG2E = 1.4426950408889634
-
-
-@functools.lru_cache(maxsize=1)
-def _cu_count() -> int:
-    return torch.cuda.get_device_properties(
-        torch.cuda.current_device()
-    ).multi_processor_count
 
 
 def _prev_pow2(n: int) -> int:
@@ -130,6 +138,7 @@ def _sparse_mla_decode_fused_kernel(
     USE_FP8_DOT: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    USE_I64_PAGE: tl.constexpr = True,
 ):
     t = tl.program_id(0)
     pid_h = tl.program_id(1)
@@ -197,7 +206,9 @@ def _sparse_mla_decode_fused_kernel(
 
         slot = tl.load(idx_ptr + t * topk + k_pos, mask=valid, other=0)
         valid = valid & (slot >= 0)
-        page = tl.where(valid, slot, 0).to(tl.int64)
+        page = tl.where(valid, slot, 0)
+        if USE_I64_PAGE:
+            page = page.to(tl.int64)
 
         kv_base = kv_ptr + page[:, None] * KV_DIM
         kv0 = tl.load(
@@ -578,6 +589,7 @@ def triton_sparse_mla_decode_splitk(
     sm_scale: float,
     d_v: int = 512,
     kv_splits: int | None = None,
+    workspace: _SplitKWorkspace | None = None,
 ) -> torch.Tensor:
     """Split-K Triton sparse MLA decode (DSv4 pattern).
 
@@ -585,6 +597,7 @@ def triton_sparse_mla_decode_splitk(
     q_rope:  [bs, H, d_tail] fp8/bf16
     kv:      [num_pages, 1, DIM] fp8/bf16
     indices: [bs, 1, topk] int32
+    workspace: backend-owned grow-only split-K buffers for graph-safe reuse
     returns: [1, bs, H, d_v] bf16
     """
     is_fp8 = _validate_input_dtypes(q_nope, q_rope, kv)
@@ -614,9 +627,24 @@ def triton_sparse_mla_decode_splitk(
     # Keep the number of split partials independent of a smaller LDS-safe
     # BLOCK_K. This retains the existing reduction cost on 64 KiB devices.
     max_kv_splits = max(1, topk // _PREFERRED_BLOCK_K)
+    num_cu = _cu_count(q_nope.device)
+    base_ctas = max(1, bs * n_head_blocks)
+    device_index = q_nope.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    optimize_gfx950_fp8 = (
+        use_fp8_dot
+        and H == 16
+        and d_v == 512
+        and d_tail == 64
+        and kv_dim == 576
+        and _is_gfx950_device(device_index)
+    )
+    if optimize_gfx950_fp8:
+        BLOCK_K, max_kv_splits = _gfx950_sparse_mla_decode_tile_config(
+            base_ctas, topk, BLOCK_K, max_kv_splits
+        )
     if kv_splits is None:
-        num_cu = _cu_count()
-        base_ctas = max(1, bs * n_head_blocks)
         # Very sparse BF16 launches benefit from enough split-K work to queue
         # two workgroups per CU. Once token/head parallelism is less sparse, keep the
         # one-wave target to avoid paying extra partial-output reduction cost.
@@ -634,12 +662,24 @@ def triton_sparse_mla_decode_splitk(
             ),
             max_kv_splits,
         )
+        if optimize_gfx950_fp8:
+            kv_splits = _gfx950_sparse_mla_kv_splits(
+                base_ctas,
+                topk,
+                BLOCK_K,
+                num_cu,
+                kv_splits,
+                max_kv_splits,
+            )
     else:
         kv_splits = min(kv_splits, max_kv_splits)
 
     qk_scale = float(sm_scale) * LOG2E
 
     if kv_splits == 1:
+        fused_num_warps = 4
+        if optimize_gfx950_fp8:
+            fused_num_warps = _gfx950_sparse_mla_num_warps(base_ctas, 1, num_cu)
         out = torch.empty(bs, H, d_v, device=q_nope.device, dtype=torch.bfloat16)
         with _no_async_copy():
             _sparse_mla_decode_fused_kernel[(bs, n_head_blocks)](
@@ -663,7 +703,13 @@ def triton_sparse_mla_decode_splitk(
                 USE_FP8_DOT=use_fp8_dot,
                 BLOCK_H=BLOCK_H,
                 BLOCK_K=BLOCK_K,
-                num_warps=4,
+                USE_I64_PAGE=not (
+                    optimize_gfx950_fp8
+                    and fused_num_warps == 2
+                    and topk >= 2048
+                    and _page_offsets_fit_i32(kv.shape[0], kv_dim)
+                ),
+                num_warps=fused_num_warps,
                 num_stages=2,
             )
         return out.unsqueeze(0)
@@ -673,9 +719,12 @@ def triton_sparse_mla_decode_splitk(
         tiles_per_split * BLOCK_K
     )
     active_splits = min(active_splits, kv_splits)
+    split_num_warps = 4
+    if optimize_gfx950_fp8:
+        split_num_warps = _gfx950_sparse_mla_num_warps(base_ctas, active_splits, num_cu)
 
     lse_partial, acc_partial = _get_splitk_bufs(
-        bs, kv_splits, h_padded, d_v, q_nope.device
+        bs, kv_splits, h_padded, d_v, q_nope.device, workspace
     )
     out = torch.empty(bs, H, d_v, device=q_nope.device, dtype=torch.bfloat16)
 
@@ -704,11 +753,11 @@ def triton_sparse_mla_decode_splitk(
             KV_SPLITS=kv_splits,
             BLOCK_H=BLOCK_H,
             BLOCK_K=BLOCK_K,
-            num_warps=4,
+            num_warps=split_num_warps,
             num_stages=2,
         )
 
-    D_CHUNK = 64
+    D_CHUNK = _reduce_d_chunk(active_splits, bs * H) if optimize_gfx950_fp8 else 64
     grid_reduce = (bs, H, (d_v + D_CHUNK - 1) // D_CHUNK)
     _sparse_mla_decode_reduce_kernel[grid_reduce](
         lse_partial,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -368,6 +368,10 @@ class DeepseekSparseAttnBackend(
             self.flashmla_kv_num_q_heads = self.num_q_heads
         self.enable_auto_select_prefill_impl = self.dsa_prefill_impl == "flashmla_auto"
         self._sink_pad_cache: dict[tuple[int, int], torch.Tensor] = {}
+        # Keep graph-captured buffers alive per stream.
+        self._triton_sparse_mla_workspaces: dict[
+            int, list[tuple[torch.Tensor, torch.Tensor]]
+        ] = {}
 
         # Hoisted per-call imports of set_dsa_prefill_impl. Module-scope
         # imports would cycle through model_executor (which imports the
@@ -2140,6 +2144,12 @@ class DeepseekSparseAttnBackend(
                 indices=page_table_1.unsqueeze(1),
                 sm_scale=layer.scaling,
                 d_v=layer.v_head_dim,
+                topk_length=None,
+                max_topk_length=(
+                    min(metadata.max_seq_len_k, page_table_1.shape[-1])
+                    if self.dsa_index_kpool <= 1
+                    else None
+                ),
             )
         elif dsa_impl in ("flashmla_sparse", "flashmla_sparse_q8"):
             if topk_transform_method == TopkTransformMethod.RAGGED:
@@ -3117,6 +3127,8 @@ class DeepseekSparseAttnBackend(
             triton_sparse_mla_decode_splitk,
         )
 
+        stream_id = int(torch.cuda.current_stream(q_nope.device).cuda_stream)
+        workspace = self._triton_sparse_mla_workspaces.setdefault(stream_id, [])
         return triton_sparse_mla_decode_splitk(
             q_nope=q_nope,
             q_rope=q_rope,
@@ -3124,6 +3136,7 @@ class DeepseekSparseAttnBackend(
             indices=page_table_1.unsqueeze(1),
             sm_scale=sm_scale,
             d_v=v_head_dim,
+            workspace=workspace,
         )
 
     def _forward_intel_xpu_sparse_decode(

--- a/test/registered/kernels/ops/attention/test_triton_sparse_mla_hip.py
+++ b/test/registered/kernels/ops/attention/test_triton_sparse_mla_hip.py
@@ -1,0 +1,177 @@
+"""ROCm tests for Triton sparse MLA launch tuning."""
+
+import pytest
+import torch
+from sglang.kernels.ops.attention.dsa.triton_sparse_mla import (
+    _cu_count,
+    _cu_count_for_device,
+    _gfx950_sparse_mla_kv_splits,
+    _gfx950_sparse_mla_num_warps,
+    _page_offsets_fit_i32,
+    _reduce_d_chunk,
+    triton_sparse_mla_fwd,
+)
+from sglang.kernels.ops.attention.dsa.triton_sparse_mla_decode import (
+    _get_splitk_bufs,
+    _gfx950_sparse_mla_decode_tile_config,
+    _sparse_mla_decode_reduce_kernel,
+    _splitk_bufs,
+)
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
+pytestmark = pytest.mark.skipif(not is_hip(), reason="ROCm only")
+
+
+def test_cu_count_uses_tensor_device(monkeypatch):
+    requested = []
+
+    class Properties:
+        multi_processor_count = 123
+
+    def get_device_properties(device):
+        requested.append(device)
+        return Properties()
+
+    _cu_count_for_device.cache_clear()
+    monkeypatch.setattr(torch.cuda, "get_device_properties", get_device_properties)
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_device",
+        lambda: pytest.fail("current_device must not be used"),
+    )
+    assert _cu_count(torch.device("cuda:7")) == 123
+    assert requested == [7]
+    _cu_count_for_device.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("active_splits", "output_rows", "expected"),
+    [(2, 0, 128), (4, 1535, 128), (4, 1536, 512), (8, 2048, 64)],
+)
+def test_reduce_d_chunk(active_splits, output_rows, expected):
+    assert _reduce_d_chunk(active_splits, output_rows) == expected
+
+
+@pytest.mark.parametrize(
+    ("base_ctas", "topk", "initial", "expected"),
+    [
+        (4, 2048, 32, 32),
+        (5, 2048, 32, 16),
+        (65, 2048, 2, 4),
+        (256, 2048, 1, 2),
+        (257, 2048, 1, 1),
+        (160, 1024, 1, 1),
+    ],
+)
+def test_gfx950_kv_splits(base_ctas, topk, initial, expected):
+    assert (
+        _gfx950_sparse_mla_kv_splits(
+            base_ctas,
+            topk,
+            block_k=64,
+            num_cu=256,
+            kv_splits=initial,
+            max_kv_splits=max(1, topk // 64),
+        )
+        == expected
+    )
+
+
+def test_gfx950_launch_config():
+    assert _gfx950_sparse_mla_num_warps(64, 4, 256) == 4
+    assert _gfx950_sparse_mla_num_warps(65, 4, 256) == 2
+    assert _gfx950_sparse_mla_decode_tile_config(1, 2048, 64, 32) == (32, 64)
+    assert _gfx950_sparse_mla_decode_tile_config(3, 2048, 64, 32) == (64, 32)
+    max_pages = ((1 << 31) - 1) // 576
+    assert _page_offsets_fit_i32(max_pages, 576)
+    assert not _page_offsets_fit_i32(max_pages + 1, 576)
+
+
+def test_splitk_workspaces_are_graph_and_stream_safe():
+    workspace = []
+    device = torch.device("cuda")
+    _get_splitk_bufs(1, 1, 16, 4, device, workspace)
+    first = workspace[0]
+    _get_splitk_bufs(1024, 1, 16, 4, device, workspace)
+    assert len(workspace) == 2
+    assert workspace[0][0] is first[0]
+    assert workspace[0][1] is first[1]
+
+    _splitk_bufs.clear()
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    pointers = []
+    for stream in streams:
+        with torch.cuda.stream(stream):
+            lse, _ = _get_splitk_bufs(1, 1, 16, 4, device)
+            pointers.append(lse.data_ptr())
+    assert pointers[0] != pointers[1]
+    _splitk_bufs.clear()
+
+
+@pytest.mark.parametrize("topk", [2048, 2050])
+def test_short_prefill_index_bound_matches_explicit_bound(topk):
+    torch.manual_seed(29)
+    seq, heads, value_dim, tail_dim = 4, 16, 512, 64
+    q = torch.randn(
+        seq, heads, value_dim + tail_dim, device="cuda", dtype=torch.bfloat16
+    )
+    kv = (
+        torch.randn(256, 1, value_dim + tail_dim, device="cuda")
+        .clamp_(-2, 2)
+        .to(torch.float8_e4m3fn)
+    )
+    indices = torch.full((seq, 1, topk), -1, device="cuda", dtype=torch.int32)
+    for row in range(seq):
+        positions = torch.randperm(128, device="cuda")[: row + 1]
+        indices[row, 0, positions] = torch.randint(
+            0, kv.shape[0], (row + 1,), device="cuda", dtype=torch.int32
+        )
+
+    ramp = torch.arange(1, topk + 1, device="cuda", dtype=torch.int32)
+    topk_length = torch.where(indices.squeeze(1) >= 0, ramp, 0).amax(dim=1)
+    args = (
+        q[:, :, :value_dim],
+        q[:, :, value_dim:],
+        kv,
+        indices,
+        value_dim**-0.5,
+        value_dim,
+    )
+    expected = triton_sparse_mla_fwd(
+        *args, topk_length=topk_length, max_topk_length=seq
+    )
+    actual = triton_sparse_mla_fwd(*args, max_topk_length=seq)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("active_splits", [2, 4])
+def test_reduce_d_chunk_is_bitwise_identical(active_splits):
+    torch.manual_seed(active_splits)
+    batch, heads, value_dim = 7, 16, 512
+    lse = torch.randn(batch, active_splits, heads, device="cuda")
+    acc = torch.randn(
+        batch, active_splits, heads, value_dim, device="cuda", dtype=torch.bfloat16
+    )
+
+    def run(d_chunk):
+        out = torch.empty(batch, heads, value_dim, device="cuda", dtype=torch.bfloat16)
+        _sparse_mla_decode_reduce_kernel[(batch, heads, value_dim // d_chunk)](
+            lse,
+            acc,
+            out,
+            H=heads,
+            D_V=value_dim,
+            KV_SPLITS=active_splits,
+            ACTIVE_SPLITS=active_splits,
+            ACTIVE_SPLITS_POW2=active_splits,
+            D_CHUNK=d_chunk,
+            BLOCK_K=64,
+            num_warps=4,
+        )
+        return out
+
+    torch.testing.assert_close(
+        run(_reduce_d_chunk(active_splits)), run(64), rtol=0, atol=0
+    )


### PR DESCRIPTION
## Summary
- Tune split-K and reduction launch geometry for gfx950 FP8 sparse MLA.
- Reuse stream-local decode workspaces across graph capture and replay.

## Results
GLM-5.2-MXFP4 on MI355X, TP4/EP4, AgentX c14:
- Total throughput: 39,684 → 42,656 tok/s (+7.49%)
- Output throughput: 244.53 → 253.52 tok/s (+3.67%)
- Mean TPOT: 41.22 → 37.76 ms (-8.39%)
- Request errors: 0/365 → 0/392

GSM8K full test (1,319 examples):
- Strict exact match: 97.42% → 96.82%
- Flexible exact match: 97.42% → 96.89%
- Paired McNemar p=0.115

## Test
- 17 sparse MLA GPU tests passed on MI355X.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34575811867](https://github.com/sgl-project/sglang/actions/runs/34575811867)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34575811661](https://github.com/sgl-project/sglang/actions/runs/34575811661)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34575811779](https://github.com/sgl-project/sglang/actions/runs/34575811779)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->