### PR TITLE
[NPU][Bugfix] Align DSV4 SWA cache boundaries

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/dsv4/c128_sidecar_component.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/c128_sidecar_component.py
@@ -24,6 +24,7 @@ from sglang.srt.mem_cache.unified_cache.components import (
     BASE_COMPONENT_TYPE,
     ComponentType,
     EvictLayer,
+    SWAComponent,
     TreeComponent,
 )
 
@@ -36,6 +37,23 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.unified_radix_cache import (
         UnifiedTreeNode,
     )
+
+
+class DSV4SWAComponent(SWAComponent):
+    """SWA component whose cache boundary is constrained by DSV4 C128 pages."""
+
+    def prepare_for_caching_req(
+        self,
+        req: Req,
+        insert_params: InsertParams,
+        token_ids_len: int,
+        is_finished: bool,
+    ) -> int | None:
+        # Preserve SWA branch metadata, but do not cap the shared tree at an
+        # arbitrary SWA page. C128 can only be cached at complete physical
+        # groups, so its component selects the common cache boundary.
+        super().prepare_for_caching_req(req, insert_params, token_ids_len, is_finished)
+        return None
 
 
 class C128SidecarComponent(TreeComponent):

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
@@ -475,6 +475,31 @@ class DSV4NPUTokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         row.zero_()
         self.get_kvcache().clear_c128_req_state(int(req_pool_idx))
 
+    def _coalesce_adjacent_page_segments(self, segments):
+        """Merge only contiguous row ranges that split one physical page."""
+        merged = []
+        for free_index, start_pos in segments:
+            if free_index.numel() == 0:
+                continue
+            if merged:
+                previous, previous_start = merged[-1]
+                previous_end = previous_start + previous.numel()
+                if (
+                    start_pos == previous_end
+                    and start_pos // self.page_size
+                    == (previous_end - 1) // self.page_size
+                ):
+                    merged[-1] = (torch.cat((previous, free_index)), previous_start)
+                    continue
+            merged.append((free_index, start_pos))
+        return merged
+
+    def free_segments(self, segments):
+        super().free_segments(self._coalesce_adjacent_page_segments(segments))
+
+    def free_full_segments(self, segments):
+        super().free_full_segments(self._coalesce_adjacent_page_segments(segments))
+
     def available_size(self):
         return min(
             super().available_size(),

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -170,12 +170,14 @@ def _create_unified_radix_cache(
     if hasattr(params.req_to_token_pool, "req_to_c128_sidecar"):
         from sglang.srt.hardware_backend.npu.dsv4.c128_sidecar_component import (
             C128SidecarComponent,
+            DSV4SWAComponent,
         )
 
         tree_components.append(ComponentType.C128)
         params.component_registry_override = {
             **(params.component_registry_override or {}),
             ComponentType.C128: C128SidecarComponent,
+            ComponentType.SWA: DSV4SWAComponent,
         }
 
     params.tree_components = tuple(tree_components)

--- a/test/registered/unit/npu/test_dsv4_cache_components.py
+++ b/test/registered/unit/npu/test_dsv4_cache_components.py
@@ -1,0 +1,53 @@
+"""Host-safe regression tests for DSV4 Unified Radix Cache extensions."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.hardware_backend.npu.dsv4.c128_sidecar_component import (
+    DSV4SWAComponent,
+)
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_allocator import (
+    DSV4NPUTokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=1, suite="base-a-test-1-npu-a2")
+
+
+def test_dsv4_swa_branch_keeps_the_c128_cache_boundary_authoritative():
+    component = DSV4SWAComponent.__new__(DSV4SWAComponent)
+    component.tree_core = SimpleNamespace(is_eagle=False)
+    req = SimpleNamespace(
+        kv=SimpleNamespace(cache_protected_len=96256, swa_evicted_seqlen=117376),
+        swa_branching_seqlen=117632,
+    )
+    params = InsertParams()
+
+    cache_len = component.prepare_for_caching_req(
+        req, params, token_ids_len=117633, is_finished=False
+    )
+
+    assert cache_len is None
+    assert params.swa_evicted_seqlen == 117376
+    assert params.swa_branching_seqlen == 117632
+
+
+def test_dsv4_full_free_coalesces_only_adjacent_segments_in_one_page():
+    allocator = DSV4NPUTokenToKVPoolAllocator.__new__(DSV4NPUTokenToKVPoolAllocator)
+    allocator.page_size = 128
+    segments = [
+        (torch.tensor([100], dtype=torch.int64), 129024),
+        (torch.tensor([101, 102, 103], dtype=torch.int64), 129025),
+    ]
+
+    with patch.object(SWATokenToKVPoolAllocator, "free_full_segments") as free:
+        allocator.free_full_segments(segments)
+
+    normalized = free.call_args.args[1]
+    assert len(normalized) == 1
+    assert normalized[0][1] == 129024
+    assert normalized[0][0].tolist() == [100, 101, 102, 103]


### PR DESCRIPTION
## Motivation

  DeepSeek-V4 on Ascend uses a DSV4 C128 sidecar whose cacheable prefix is constrained by complete C128 physical groups, while the generic SWA
  component may select a finer-grained SWA page boundary.

  During chunked prefill with long shared prefixes, this mismatch can produce a logical SWA branching prefix that is larger than the reusable C128-
  backed device prefix, for example:

  ```text
  new_prefix_len=117632, len(new_indices)=96256

  The same DSV4 flow can also emit two logically adjacent KV release ranges that split one physical page, causing the shared allocator's page-
  disjointness assertion:

  AssertionError: segment at 129025 shares a page with the one ending at 129025

  Both issues are specific to the Ascend DSV4 cache layout and should be handled in the NPU abstraction layer instead of changing generic
  SWAComponent or UnifiedRadixCache behavior.
```

  ## Modifications

  - Add DSV4SWAComponent, an Ascend DSV4-specific SWA component that preserves SWA branch metadata but leaves the effective cache boundary to the
    C128 component, which only exposes complete physical groups.

  - Register DSV4SWAComponent only when the request pool exposes the DSV4 C128 sidecar.
  - Normalize only contiguous DSV4 KV free segments that split the same physical page before calling the shared full/SWA allocator paths. Non-
    contiguous or genuinely overlapping ranges remain protected by the existing shared allocator checks.

  - Add CI-registered host-safe regression tests for:
      - SWA/C128 branch-boundary handling.
      - Coalescing adjacent same-page full-KV release segments.

  ## Accuracy Tests
```plaintext
  run_eval(args)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:34<00:00,  5.82it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 34.677 s
```

  ## Speed Tests and Profiling

```plaintext
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 64        
Successful requests:                     64        
Benchmark duration (s):                  85.06     
Total input tokens:                      8371764   
Total input text tokens:                 8371764   
Total generated tokens:                  65536     
Total generated tokens (retokenized):    64932     
Request throughput (req/s):              0.75      
Input token throughput (tok/s):          98423.83  
Output token throughput (tok/s):         770.48    
Peak output token throughput (tok/s):    3594.00   
Peak concurrent requests:                64        
Total token throughput (tok/s):          99194.31  
Concurrency:                             57.73     
Accept length:                           2.67      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   76720.73  
Median E2E Latency (ms):                 75663.25  
P90 E2E Latency (ms):                    81718.84  
P95 E2E Latency (ms):                    82180.76  
P99 E2E Latency (ms):                    83599.76  
---------------Time to First Token----------------
Mean TTFT (ms):                          40298.74  
Median TTFT (ms):                        40065.95  
P90 TTFT (ms):                           56113.40  
P95 TTFT (ms):                           64498.14  
P99 TTFT (ms):                           66018.23  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.60     
Median TPOT (ms):                        34.07     
P90 TPOT (ms):                           53.62     
P95 TPOT (ms):                           54.12     
P99 TPOT (ms):                           56.20     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.62     
Median ITL (ms):                         16.85     
P90 ITL (ms):                            25.21     
P95 ITL (ms):                            25.61     
P99 ITL (ms):                            51.41     
Max ITL (ms):                            20859.89  
----------------Cache Hit Details-----------------
Total prompt tokens:                     8371764   
Total cached tokens:                     7569408   
  Device:                                7569408   
  Host:                                  0         
Cache hit rate:                          90.4%
  Device:                                100.0%
  Host:                                  0.0%
==================================================
```

  ## Checklist

  - [ ] Format code with pre-commit.
  - [ ] Add or update unit tests.
  - [ ] Update documentation where needed.
  - [ ] Provide accuracy and speed benchmark results where applicable.
  - [ ] Follow the SGLang code-style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34575510131](https://github.com/sgl-project/sglang/actions/runs/34575510131)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34575509957](https://github.com/sgl-project/sglang/actions/runs/34575509957)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34575510194](https://github.com/sgl-project/sglang/actions/runs/34575510194)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->