### PR TITLE
feat(grpc): support bounded profiling with num_steps

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -310,6 +310,9 @@ message OpenAIResponse {
 
 message StartProfileRequest {
   optional string output_dir = 1;
+  // Positive number of forward steps to profile before stopping automatically.
+  // Omit to profile until StopProfile is called.
+  optional int32 num_steps = 2;
 }
 
 message StartProfileResponse {

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -524,11 +524,13 @@ class RuntimeHandle:
 
         self._submit_json_unary("continue_generation", _payload, chunk_callback)
 
-    def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
+    def start_profile(
+        self, output_dir: Optional[str], chunk_callback, num_steps: Optional[int] = None
+    ) -> None:
         async def _payload():
             from sglang.srt.managers.io_struct import ProfileReq
 
-            req = ProfileReq(output_dir=output_dir) if output_dir else ProfileReq()
+            req = ProfileReq(output_dir=output_dir or None, num_steps=num_steps)
             await self.tokenizer_manager.start_profile(req)
             return {"message": "Profiling started."}
 

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -377,9 +377,10 @@ impl PyBridge {
         &self,
         rid: &str,
         output_dir: Option<&str>,
+        num_steps: Option<i32>,
     ) -> PyResult<Receiver<ResponseChunk>> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
-            runtime_handle.call_method1(py, "start_profile", (output_dir, callback))?;
+            runtime_handle.call_method1(py, "start_profile", (output_dir, callback, num_steps))?;
             Ok(())
         })
     }

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -791,10 +791,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         request: Request<proto::StartProfileRequest>,
     ) -> Result<Response<proto::StartProfileResponse>, Status> {
         let req = request.into_inner();
+        if req.num_steps.is_some_and(|steps| steps <= 0) {
+            return Err(Status::invalid_argument("num_steps must be positive"));
+        }
         let rid = uuid::Uuid::new_v4().to_string();
         let receiver = self
             .bridge
-            .submit_start_profile(&rid, req.output_dir.as_deref())
+            .submit_start_profile(&rid, req.output_dir.as_deref(), req.num_steps)
             .map_err(|e| pyerr_to_status(e, "Failed to start profile"))?;
 
         let json_str =

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -73,3 +73,83 @@ fn resolve_max_message_size_honors_env_var() {
         std::env::remove_var(VAR);
     }
 }
+
+#[tokio::test]
+async fn start_profile_preserves_optional_steps_and_rejects_nonpositive_limits() {
+    use crate::proto::sglang_service_server::SglangService;
+    use prost::Message;
+    use pyo3::prelude::*;
+    use pyo3::types::PyModule;
+    use std::sync::Arc;
+    use tonic::Request;
+
+    Python::initialize();
+    let handle = Python::attach(|py| {
+        PyModule::from_code(
+            py,
+            c"
+class Runtime:
+    def __init__(self):
+        self.calls = []
+
+    def start_profile(self, output_dir, callback, num_steps):
+        self.calls.append((output_dir, num_steps))
+        callback(b'{\"message\": \"Profiling started.\"}', finished=True)
+",
+            c"profile_test.py",
+            c"profile_test",
+        )
+        .unwrap()
+        .getattr("Runtime")
+        .unwrap()
+        .call0()
+        .unwrap()
+        .unbind()
+    });
+    let service = super::SglangServiceImpl {
+        bridge: Arc::new(crate::bridge::PyBridge::new(
+            Python::attach(|py| handle.clone_ref(py)),
+            None,
+            1024,
+            16,
+            tokio::runtime::Handle::current(),
+        )),
+        response_timeout: std::time::Duration::from_secs(5),
+    };
+    // Empty bytes are a valid legacy request with no optional fields.
+    let legacy = crate::proto::StartProfileRequest::decode(&[][..]).unwrap();
+    assert_eq!(legacy.num_steps, None);
+    service.start_profile(Request::new(legacy)).await.unwrap();
+    for steps in [1, 10, i32::MAX] {
+        let request = crate::proto::StartProfileRequest {
+            output_dir: Some("/tmp/profile".into()),
+            num_steps: Some(steps),
+        };
+        let decoded =
+            crate::proto::StartProfileRequest::decode(request.encode_to_vec().as_slice()).unwrap();
+        service.start_profile(Request::new(decoded)).await.unwrap();
+    }
+    for steps in [0, -1, i32::MIN] {
+        let error = service
+            .start_profile(Request::new(crate::proto::StartProfileRequest {
+                output_dir: None,
+                num_steps: Some(steps),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+    Python::attach(|py| {
+        let calls: Vec<(Option<String>, Option<i32>)> =
+            handle.getattr(py, "calls").unwrap().extract(py).unwrap();
+        assert_eq!(
+            calls,
+            vec![
+                (None, None),
+                (Some("/tmp/profile".into()), Some(1)),
+                (Some("/tmp/profile".into()), Some(10)),
+                (Some("/tmp/profile".into()), Some(i32::MAX)),
+            ]
+        );
+    });
+}

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import CustomTestCase
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
@@ -41,6 +41,39 @@ def _make_runtime_handle(responses):
     handle = RuntimeHandle.__new__(RuntimeHandle)
     handle.tokenizer_manager = _FakeTokenizerManager(responses)
     return handle
+
+
+class TestNativeGrpcProfiling(CustomTestCase):
+    def test_profile_step_limit_reaches_tokenizer_manager(self):
+        from unittest.mock import AsyncMock
+
+        maybe_stub_sgl_kernel()
+        from sglang.srt.managers.io_struct import ProfileReq
+
+        for output_dir, num_steps in (
+            (None, None),
+            ("", None),
+            ("/tmp/profile", 1),
+            (None, 10),
+        ):
+            with self.subTest(output_dir=output_dir, num_steps=num_steps):
+                handle = RuntimeHandle.__new__(RuntimeHandle)
+                handle.tokenizer_manager = SimpleNamespace(start_profile=AsyncMock())
+                handle._submit_on_tm_loop = asyncio.run
+                callback = _RecordingCallback()
+                if num_steps is None:
+                    # Preserve the old two-argument Python call as well.
+                    handle.start_profile(output_dir, callback)
+                else:
+                    handle.start_profile(output_dir, callback, num_steps)
+                handle.tokenizer_manager.start_profile.assert_awaited_once()
+                req = handle.tokenizer_manager.start_profile.call_args.args[0]
+                self.assertIsInstance(req, ProfileReq)
+                self.assertEqual(req.num_steps, num_steps)
+                self.assertEqual(req.output_dir, output_dir or None)
+                self.assertEqual(
+                    callback.calls, [(b'{"message": "Profiling started."}', True, None)]
+                )
 
 
 class TestNativeGrpcParallelResponses(CustomTestCase):


### PR DESCRIPTION
## Motivation

Native gRPC clients can start profiling but cannot bound the capture to a number of forward steps: `StartProfileRequest` only exposes `output_dir`. This is useful for sidecar-driven diagnostics, including Dynamo, where a client should be able to request a short capture without coordinating a separate stop RPC.

Related: #38075.

## Modifications

Add optional `num_steps` to `StartProfileRequest` and forward it through the Rust and Python bridges to the existing `ProfileReq.num_steps`. For example, `num_steps=10` uses the scheduler's existing bounded profiling behavior. Omitting the field retains manual `StopProfile` behavior; explicit zero and negative values return `INVALID_ARGUMENT` before starting a profile.

The profiler and scheduling implementation are unchanged. Tests cover legacy protobuf decoding, presence-preserving serialization, Rust-to-Python argument forwarding, invalid limits, and Python-to-TokenizerManager forwarding.

## Accuracy Tests

- Rust gRPC crate: 14 tests passed (`cargo +1.96.1 test -p sglang-grpc --lib`). On macOS, the test executable was explicitly linked to Python 3.13 using `PYO3_PYTHON` and `RUSTFLAGS`.
- `cargo +1.96.1 clippy -p sglang-grpc --all-targets -- -D warnings` passed.
- Rustfmt, Ruff formatting/lint, isort, and `git diff --check` passed.
- Python bridge regression test added to the existing CPU CI module, but not executed locally: dependency downloads were stopped. No model-output changes.

## Speed Tests and Profiling

GPU profiling was not run locally. Actual automatic stopping and trace-file output still need a GPU smoke test. No inference-performance claim.

## Checklist

- [x] Format changed files and run targeted lint checks.
- [x] Add registered CPU regression coverage and Rust tests.
- [x] Document the optional field's behavior in the protobuf schema.
- [ ] Run the Python bridge tests in CI and a bounded GPU profiling smoke test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34575825465](https://github.com/sgl-project/sglang/actions/runs/34575825465)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34575825122](https://github.com/sgl-project/sglang/actions/runs/34575825122)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34575825289](https://github.com/sgl-project/sglang/actions/runs/34575825289)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->