### PR TITLE
fix(kv-events): support per-rank IPC publisher endpoints

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -558,7 +558,7 @@ class ZmqEventPublisher(EventPublisher):
 
         Args:
             endpoint: The endpoint string
-                (e.g., "tcp://*:5557" or "inproc://cache")
+                (e.g., "tcp://*:5557", "ipc:///tmp/cache", or "inproc://cache")
             data_parallel_rank: The data parallel rank to offset by
 
         Returns:
@@ -569,9 +569,9 @@ class ZmqEventPublisher(EventPublisher):
         if not endpoint or data_parallel_rank == 0:
             return endpoint
 
-        if "inproc" in endpoint:
+        if endpoint.startswith(("ipc://", "inproc://")):
             return f"{endpoint}_dp{data_parallel_rank}"
-        if "tcp" in endpoint:
+        if endpoint.startswith("tcp://"):
             if endpoint and ":" in endpoint:
                 # Get everything after the last colon (the port)
                 last_colon_idx = endpoint.rfind(":")
@@ -580,7 +580,9 @@ class ZmqEventPublisher(EventPublisher):
                 new_port = base_port + data_parallel_rank
                 return f"{base_addr}:{new_port}"
             return endpoint
-        raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
+        raise ValueError(
+            "Invalid endpoint: must start with 'ipc://', 'inproc://', or 'tcp://'"
+        )
 
 
 class KVEventsConfig(BaseModel):

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -7,11 +7,16 @@ the router can subscribe per replica (the `dp_size` it reads from
 `/server_info`).
 """
 
+import atexit
+import tempfile
+import time
 import unittest
 
 import msgspec
+import zmq
 
 from sglang.srt.disaggregation.kv_events import (
+    AllBlocksCleared,
     BlockStored,
     BlockStoredMetadata,
     BlockStoredWithMetadata,
@@ -183,6 +188,86 @@ class TestSelectKvPublisherDpRank(CustomTestCase):
                     for a in range(dp_size)
                 }
                 self.assertEqual(len(ranks), dp_size)
+
+
+class TestIpcPublisherEndpoints(unittest.TestCase):
+    def test_endpoint_offsets(self):
+        for endpoint, rank_one in (
+            ("ipc:///tmp/kv-events.sock", "ipc:///tmp/kv-events.sock_dp1"),
+            ("ipc:///tmp/tcp-events.sock", "ipc:///tmp/tcp-events.sock_dp1"),
+            ("ipc:///tmp/inproc-events.sock", "ipc:///tmp/inproc-events.sock_dp1"),
+            ("inproc://cache", "inproc://cache_dp1"),
+            ("tcp://*:5557", "tcp://*:5558"),
+        ):
+            with self.subTest(endpoint=endpoint):
+                self.assertEqual(
+                    ZmqEventPublisher.offset_endpoint_port(endpoint, 0), endpoint
+                )
+                self.assertEqual(
+                    ZmqEventPublisher.offset_endpoint_port(endpoint, 1), rank_one
+                )
+        self.assertIsNone(ZmqEventPublisher.offset_endpoint_port(None, 1))
+
+    @unittest.skipUnless(zmq.has("ipc"), "ZeroMQ IPC transport is unavailable")
+    def test_multiple_ranks_publish_and_replay_over_ipc(self):
+        # Keep paths short enough for Unix-domain sockets, including on macOS.
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="kv-ipc-") as directory:
+            endpoint = f"ipc://{directory}/events"
+            replay_endpoint = f"ipc://{directory}/replay"
+            publishers = []
+            sockets = []
+            try:
+                for rank in range(2):
+                    publisher = ZmqEventPublisher(
+                        attn_dp_rank=rank,
+                        endpoint=endpoint,
+                        replay_endpoint=replay_endpoint,
+                    )
+                    publishers.append(publisher)
+                    sub = zmq.Context.instance().socket(zmq.SUB)
+                    sockets.append(sub)
+                    sub.setsockopt(zmq.SUBSCRIBE, b"")
+                    sub.connect(endpoint if rank == 0 else f"{endpoint}_dp{rank}")
+                    replay = zmq.Context.instance().socket(zmq.DEALER)
+                    sockets.append(replay)
+                    replay.connect(
+                        replay_endpoint if rank == 0 else f"{replay_endpoint}_dp{rank}"
+                    )
+
+                for rank, publisher in enumerate(publishers):
+                    sub, replay = sockets[rank * 2 : rank * 2 + 2]
+                    deadline = time.monotonic() + 5
+                    # PUB/SUB has an asynchronous subscription handshake. Retry
+                    # within a deadline instead of relying on a startup sleep.
+                    while True:
+                        publisher.publish(
+                            KVEventBatch(ts=1.0, events=[AllBlocksCleared()])
+                        )
+                        if sub.poll(50):
+                            break
+                        self.assertLess(time.monotonic(), deadline)
+                    topic, seq, payload = sub.recv_multipart()
+                    self.assertEqual(topic, b"")
+                    batch = msgspec.msgpack.decode(payload, type=KVEventBatch)
+                    self.assertEqual(batch.attn_dp_rank, rank)
+                    self.assertEqual(batch.events, [AllBlocksCleared()])
+
+                    replay.send_multipart([b"", seq])
+                    replayed = []
+                    while True:
+                        self.assertTrue(replay.poll(5000), "Replay response timed out")
+                        delimiter, replay_seq, replay_payload = replay.recv_multipart()
+                        self.assertEqual(delimiter, b"")
+                        if replay_seq == ZmqEventPublisher.END_SEQ:
+                            break
+                        replayed.append((replay_seq, replay_payload))
+                    self.assertIn((seq, payload), replayed)
+            finally:
+                for sock in sockets:
+                    sock.close(linger=0)
+                for publisher in publishers:
+                    publisher.shutdown()
+                    atexit.unregister(publisher.shutdown)
 
 
 class TestBlockStoredWireFormat(CustomTestCase):


### PR DESCRIPTION
## Summary

KV-event publishers already bind IPC endpoints, but `offset_endpoint_port` rejects a normal `ipc://` path on nonzero DP ranks. For example, rank 0 accepts `ipc:///tmp/events.sock`, while rank 1 fails during publisher initialization.

Support per-rank IPC paths using the existing inproc suffix convention: rank 0 keeps the configured path and rank 1 uses `ipc:///tmp/events.sock_dp1`. This applies to both publishing and replay endpoints. Match transport prefixes explicitly so `tcp` or `inproc` inside a socket filename does not select the wrong transport.

Add regression coverage for endpoint mapping and two simultaneous IPC publishers, including rank attribution, event delivery, and replay completion.

## Validation

- Confirmed the endpoint regression test fails against the base implementation.
- 16 test methods passed on macOS using an isolated loader for the actual publisher/network modules and the test classes. This bypasses SGLang package initialization and replaces the existing `CustomTestCase` base with `unittest.TestCase`; it is not a full pytest/engine run. The IPC test uses real ZeroMQ PUB/SUB and ROUTER/DEALER sockets for ranks 0 and 1.
- Ruff format/lint, isort check, registered-test validation, bare-pytest-main check, and `git diff --check` passed.
- Full SGLang test collection and GPU inference were not run locally because the full model/GPU dependencies are unavailable. The tests are included in the existing CPU CI-registered test file.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34576803954](https://github.com/sgl-project/sglang/actions/runs/34576803954)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34576803663](https://github.com/sgl-project/sglang/actions/runs/34576803663)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34576804020](https://github.com/sgl-project/sglang/actions/runs/34576804020)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->