### PR TITLE
Fix disagg PP MTP for GLM5.2

### DIFF
--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -24,6 +24,37 @@ from sglang.srt.utils.runai_utils import is_runai_obj_uri
 logger = logging.getLogger(__name__)
 
 
+def check_pipeline_parallel_compat(cfg: Any) -> None:
+    """What pipeline parallelism rules out, for a config that already has pp_size > 1.
+
+    Speculative decoding is allowed: the draft is built on the last pipeline stage
+    only (``EAGLEWorkerV2._hosts_draft``) and every earlier stage forwards the
+    target's PP proxy tensors and returns, which is platform-neutral machinery. Only
+    the EAGLE (non-multi-layer) shape has been exercised, so that much is enforced.
+    """
+    assert cfg.disable_overlap_schedule, (
+        "Pipeline parallelism is not compatible with overlap schedule"
+    )
+    if cfg.speculative_algorithm is not None:
+        assert (
+            cfg.speculative_algorithm.upper() == "EAGLE"
+            and not cfg.enable_multi_layer_eagle
+        ), (
+            "Pipeline parallelism currently only supports EAGLE "
+            "(non-multi-layer) speculative decoding"
+        )
+        if get_platform().is_npu:
+            assert cfg.disaggregation_mode == "prefill", (
+                "NPU PP + speculative decoding (MTP) is only supported "
+                "on prefill nodes (disaggregation-mode=prefill)"
+            )
+    assert cfg.min_free_slots_delay is None, (
+        "--min-free-slots-delay is not supported with pipeline "
+        "parallelism: allocatable slots per microbatch are bounded by "
+        "pp-max-micro-batch-size, so the threshold may never be reached"
+    )
+
+
 def check_server_args(server_args: Any):
     from sglang.srt.arg_groups.lora_hook import check_lora_server_args
 
@@ -49,33 +80,7 @@ def check_server_args(server_args: Any):
     )
 
     if cfg.pp_size > 1:
-        if get_platform().is_npu:
-            # NPU: allow PP + EAGLE speculative decoding
-            assert cfg.disable_overlap_schedule, (
-                "Pipeline parallelism is not compatible with overlap schedule"
-            )
-            if cfg.speculative_algorithm is not None:
-                assert (
-                    cfg.speculative_algorithm.upper() == "EAGLE"
-                    and not cfg.enable_multi_layer_eagle
-                ), (
-                    "Pipeline parallelism currently only supports EAGLE "
-                    "(non-multi-layer) speculative decoding"
-                )
-                assert cfg.disaggregation_mode == "prefill", (
-                    "NPU PP + speculative decoding (MTP) is only supported "
-                    "on prefill nodes (disaggregation-mode=prefill)"
-                )
-        else:
-            # Non-NPU: PP + speculative decoding is not supported
-            assert cfg.disable_overlap_schedule and cfg.speculative_algorithm is None, (
-                "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
-            )
-        assert cfg.min_free_slots_delay is None, (
-            "--min-free-slots-delay is not supported with pipeline "
-            "parallelism: allocatable slots per microbatch are bounded by "
-            "pp-max-micro-batch-size, so the threshold may never be reached"
-        )
+        check_pipeline_parallel_compat(cfg)
 
     assert not (cfg.dp_size > 1 and cfg.nnodes != 1 and not cfg.enable_dp_attention), (
         "multi-node data parallel is not supported unless dp attention!"

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -986,11 +986,17 @@ class CommonKVManager(BaseKVManager):
             )
 
         # Regular MLA PP slicing
-        start_layer = self.kv_args.prefill_start_layer
-        end_layer = start_layer + len(src_kv_ptrs)
         # Decode pp size should be equal to prefill pp size or 1
+        start_layer, end_layer = self._mla_kv_entry_span_with_pp(len(src_kv_ptrs))
         sliced_dst_kv_ptrs = dst_kv_ptrs[start_layer:end_layer]
         return src_kv_ptrs, sliced_dst_kv_ptrs, len(src_kv_ptrs)
+
+    def _mla_kv_entry_span_with_pp(self, n_src: int) -> Tuple[int, int]:
+        # A plain MLA pool registers one region per layer ascending, addressed as
+        # layer_id - start_layer, so this stage occupies [start, start + n_src) of a
+        # peer that registered the whole model. Pointer view: get_mla_kv_ptrs_with_pp.
+        start_layer = self.kv_args.prefill_start_layer
+        return start_layer, start_layer + n_src
 
     def _mla_slice_ptrs_for_pp(
         self,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -962,6 +962,43 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             )
         peer_info.kv_xfer_segments = prepared_segments
 
+    def _pp_layer_offset_dst_indices(
+        self, *, peer_info: KVArgsRegisterInfo, n_src: int, n_dst: int
+    ) -> Optional[List[int]]:
+        # Index view of _mla_kv_entry_span_with_pp: the prepped path pre-registers
+        # descriptor lists, so it needs entry indices where the non-prepped path takes
+        # sliced pointers. None keeps the caller on its layer-id pairing.
+        if self.pp_size <= 1 or n_src == n_dst:
+            return None
+        if self.kv_args.kv_layer_ids or peer_info.dst_kv_layer_ids:
+            return None
+        # Only a plain MLA pool is one region per layer: MHA registers a K block then a
+        # V block, the hybrid pool is dense over full-attention layers, and compressed
+        # MLA groups regions by compression bucket.
+        if not self.is_mla_backend or self.is_hybrid_mla_backend:
+            return None
+        if self.kv_args.mla_compression_ratios:
+            return None
+
+        start, end = self._mla_kv_entry_span_with_pp(n_src)
+        # Bootstrap admits a peer running our pp or 1, so a peer that does not cover the
+        # span is a matched-pp stage above 0, whose entries start at its own index 0.
+        if end > n_dst:
+            return None
+
+        indices = list(range(start, end))
+        src_item_lens = list(self.kv_args.kv_item_lens)
+        dst_item_lens = [peer_info.dst_kv_item_lens[j] for j in indices]
+        if src_item_lens != dst_item_lens:
+            # Disagreeing cell sizes mean the peers did not build the same KV geometry;
+            # writing anyway would silently corrupt the peer's pool.
+            raise RuntimeError(
+                "PP-heterogeneous MLA transfer: decode KV cell geometry differs from "
+                f"prefill over layers [{start}, {end}): prefill item_lens="
+                f"{src_item_lens}, decode item_lens={dst_item_lens}"
+            )
+        return indices
+
     def _prepare_payload_xfer(self, peer_info: KVArgsRegisterInfo):
         # If prefill does not run speculative decoding (the usual case),
         # decode with speculative decoding will have more kv items.
@@ -1045,14 +1082,18 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 else self._num_slots_src
             )
 
-            pairs = build_transfer_entry_pairs(
-                self.kv_args.kv_layer_ids,
-                peer_info.dst_kv_layer_ids,
-                n_src,
-                n_dst,
-                allow_positional_fallback=self.pp_size == 1,
+            dst_indices = self._pp_layer_offset_dst_indices(
+                peer_info=peer_info, n_src=n_src, n_dst=n_dst
             )
-            dst_indices = [j for _, j in pairs]
+            if dst_indices is None:
+                pairs = build_transfer_entry_pairs(
+                    self.kv_args.kv_layer_ids,
+                    peer_info.dst_kv_layer_ids,
+                    n_src,
+                    n_dst,
+                    allow_positional_fallback=self.pp_size == 1,
+                )
+                dst_indices = [j for _, j in pairs]
             dst_kv_ptrs = [peer_info.dst_kv_ptrs[j] for j in dst_indices]
             dst_kv_item_lens = [peer_info.dst_kv_item_lens[j] for j in dst_indices]
             dst_kv_data_lens = [

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -778,6 +778,14 @@ class SchedulerPPMixin:
             tensor_dict["draft_topk_p"] = draft_input.topk_p.contiguous()
             tensor_dict["draft_topk_index"] = draft_input.topk_index.contiguous()
             tensor_dict["draft_hidden_states"] = draft_input.hidden_states.contiguous()
+            # The DSA IndexShare seed has to ride along for the same reason. It is
+            # relayed rather than left on the producing stage because the rebuild
+            # below replaces batch.spec_info on EVERY rank, the last one included:
+            # anything missing from the ring is lost, not merely un-shared.
+            if draft_input.dsa_topk_indices is not None:
+                tensor_dict["draft_dsa_topk_indices"] = (
+                    draft_input.dsa_topk_indices.contiguous()
+                )
 
         if batch.return_logprob:
             logprob_dict = get_logprob_dict_from_result(result)
@@ -934,6 +942,7 @@ class SchedulerPPMixin:
                 bonus_tokens=next_token_ids,
                 num_tokens_per_req=1,
                 num_tokens_for_logprob_per_req=1,
+                dsa_topk_indices=pp_outputs.tensors.get("draft_dsa_topk_indices"),
             )
             batch.spec_info = next_draft_input
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -677,7 +677,6 @@ class ModelRunner:
             model=self.model,
             model_config=self.model_config,
             is_draft_worker=self.is_draft_worker,
-            spec_algorithm=self.spec_algorithm,
         )
         adjust_hybrid_swa_layer_ids(
             model_config=self.model_config,

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -5,11 +5,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import msgspec
 from torch import nn
 
-from sglang.srt.utils import is_npu
-
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
-    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
 class AttentionAndMoeLayers(NamedTuple):
@@ -140,7 +137,6 @@ def resolve_layer_indices(
     model: Any,
     model_config: ModelConfig,
     is_draft_worker: bool,
-    spec_algorithm: SpeculativeAlgorithm,
 ) -> ModelLayerInfo:
     # For MTP models like DeepSeek-V3 or GLM-4.5, the MTP layer(s) are used separately as draft
     # models for speculative decoding. In those cases, `num_nextn_predict_layers` is used to
@@ -148,8 +144,6 @@ def resolve_layer_indices(
     model_num_layers = _compute_model_num_layers(
         model=model, model_config=model_config, is_draft_worker=is_draft_worker
     )
-    _nnpl = model_config.num_nextn_predict_layers
-    model_has_mtp_layers = _nnpl is not None and _nnpl > 0
     pp_range = _resolve_pp_layer_range(model=model, model_num_layers=model_num_layers)
     num_effective_layers = pp_range.end_layer - pp_range.start_layer
 
@@ -157,14 +151,6 @@ def resolve_layer_indices(
     loop_num = _get_loop_num(model_config.hf_config)
     if loop_num > 1:
         num_effective_layers = num_effective_layers * loop_num
-
-    if not is_npu():
-        _assert_pp_mtp_compat(
-            model_has_mtp_layers=model_has_mtp_layers,
-            spec_algorithm=spec_algorithm,
-            num_effective_layers=num_effective_layers,
-            model_num_layers=model_num_layers,
-        )
 
     return ModelLayerInfo(
         start_layer=pp_range.start_layer,
@@ -210,23 +196,6 @@ def _resolve_pp_layer_range(*, model: Any, model_num_layers: int) -> _PPLayerRan
         start_layer=getattr(model, "start_layer", 0),
         end_layer=getattr(model, "end_layer", model_num_layers),
     )
-
-
-def _assert_pp_mtp_compat(
-    *,
-    model_has_mtp_layers: bool,
-    spec_algorithm: SpeculativeAlgorithm,
-    num_effective_layers: int,
-    model_num_layers: int,
-) -> None:
-    assert (
-        (not model_has_mtp_layers)
-        or (spec_algorithm.is_none())
-        or (
-            (not spec_algorithm.is_none())
-            and (num_effective_layers == model_num_layers)
-        )
-    ), "PP is not compatible with MTP models."
 
 
 def adjust_hybrid_swa_layer_ids(

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -403,8 +403,13 @@ class DeepseekV2WeightLoaderMixin:
                         # Skip loading extra bias for GPTQ models.
                         if name.endswith(".bias") and name not in params_dict:
                             continue
-                        # Skip loading embed_tokens if not first rank in pipeline parallelism
-                        if ".embed_tokens." in name and not self.pp_group.is_first_rank:
+                        # Skip embed_tokens on a pipeline stage that has no embedding
+                        # module. Keying on the parameter rather than on the rank covers
+                        # the last stage, which materializes one for its NextN draft to
+                        # borrow and would otherwise hand the draft an uninitialized
+                        # torch.empty. A PPMissingLayer registers no parameters, so a
+                        # middle stage still skips.
+                        if ".embed_tokens." in name and name not in params_dict:
                             continue
                         # Skip loading norm if not last rank in pipeline parallelism
                         if ".norm." in name and not self.pp_group.is_last_rank:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2572,6 +2572,22 @@ class DeepseekV2DecoderLayer(nn.Module):
         return output
 
 
+def pp_stage_needs_embedding(pp_group, speculative_algorithm) -> bool:
+    """Does this pipeline stage need a real ``embed_tokens``?
+
+    The first stage does, because it embeds the input ids. The last stage does too
+    whenever speculative decoding is on, because that is where ``EAGLEWorkerV2``
+    builds the NextN draft and the draft owns no embedding of its own: the weight
+    loader skips ``embed_tokens`` and ``shared_head.head`` inside the MTP block, and
+    the checkpoint does not ship them there either, so the draft borrows the target's
+    through ``get_embed_and_head`` -> ``set_embed_and_head``. ``lm_head`` needs no
+    such help -- the target already builds it on the last stage.
+    """
+    return pp_group.is_first_rank or (
+        pp_group.is_last_rank and speculative_algorithm is not None
+    )
+
+
 class DeepseekV2Model(nn.Module):
     fall_back_to_pt_during_load = False
 
@@ -2589,7 +2605,7 @@ class DeepseekV2Model(nn.Module):
         self.first_k_dense_replace = config.first_k_dense_replace
         self.pp_group = get_pp_group()
 
-        if self.pp_group.is_first_rank or (_is_npu and self.pp_group.is_last_rank):
+        if pp_stage_needs_embedding(self.pp_group, get_spec().speculative_algorithm):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,

--- a/test/registered/unit/disaggregation/test_pp_mla_kv_transfer.py
+++ b/test/registered/unit/disaggregation/test_pp_mla_kv_transfer.py
@@ -1,0 +1,258 @@
+"""Unit tests for NIXL KV transfer from a prefill with pp_size > 1 to a decode
+peer that is not pipelined, on plain-MLA models (MLATokenToKVPool)."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+NUM_LAYERS = 78
+ITEM_LEN = 576
+
+
+def _pp_layer_split(total: int, pp: int) -> list:
+    """(start_layer, num_layers) per PP rank, remainder to the last ranks."""
+    base, rem = divmod(total, pp)
+    out, start = [], 0
+    for rank in range(pp):
+        num = base + (1 if rank >= pp - rem else 0)
+        out.append((start, num))
+        start += num
+    return out
+
+
+class _StubKVManager:
+    """Carries the real span primitive, so the cases exercise the shared mapping
+    rather than a reimplementation of it."""
+
+    _mla_kv_entry_span_with_pp = CommonKVManager._mla_kv_entry_span_with_pp
+    get_mla_kv_ptrs_with_pp = CommonKVManager.get_mla_kv_ptrs_with_pp
+
+    def __init__(
+        self,
+        *,
+        pp_size: int,
+        prefill_start_layer: int,
+        n_src: int,
+        is_mla_backend: bool = True,
+        is_hybrid_mla_backend: bool = False,
+        kv_layer_ids: list = (),
+        mla_compression_ratios=None,
+        item_len: int = ITEM_LEN,
+    ):
+        self.pp_size = pp_size
+        self.is_mla_backend = is_mla_backend
+        self.is_hybrid_mla_backend = is_hybrid_mla_backend
+        self.kv_args = SimpleNamespace(
+            prefill_start_layer=prefill_start_layer,
+            kv_layer_ids=list(kv_layer_ids),
+            kv_item_lens=[item_len] * n_src,
+            mla_compression_ratios=mla_compression_ratios,
+        )
+
+
+def _peer(*, n_dst: int, dst_kv_layer_ids: list = (), item_len: int = ITEM_LEN):
+    return SimpleNamespace(
+        dst_kv_layer_ids=list(dst_kv_layer_ids),
+        dst_kv_item_lens=[item_len] * n_dst,
+    )
+
+
+def _resolve(manager, peer, n_src, n_dst):
+    return NixlKVManager._pp_layer_offset_dst_indices(
+        manager, peer_info=peer, n_src=n_src, n_dst=n_dst
+    )
+
+
+class TestPpPrefillToUnpipelinedDecode(CustomTestCase):
+    """Bug regression: a pp>1 prefill paired with a pp=1 decode never transferred
+    KV on NIXL, and failed after /health was green so the request hung rather
+    than the launch failing. Each stage must write into its own layer range of
+    the peer's pool."""
+
+    def test_stages_tile_the_decode_pool_exactly_once(self):
+        covered = []
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                indices = _resolve(
+                    _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                    _peer(n_dst=NUM_LAYERS),
+                    num,
+                    NUM_LAYERS,
+                )
+                self.assertEqual(indices, list(range(start, start + num)))
+                covered += indices
+        self.assertEqual(sorted(covered), list(range(NUM_LAYERS)))
+        self.assertEqual(len(covered), len(set(covered)))
+
+    def test_decode_side_draft_regions_are_never_targeted(self):
+        """Decode-only speculative decoding appends draft buffers after the
+        target's, so the span must stay inside the target layer range."""
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[3]
+        indices = _resolve(
+            _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+            _peer(n_dst=NUM_LAYERS + 1),
+            num,
+            NUM_LAYERS + 1,
+        )
+        self.assertEqual(indices, list(range(start, start + num)))
+        self.assertNotIn(NUM_LAYERS, indices)
+
+    def test_cell_geometry_disagreement_raises(self):
+        """A per-layer item_len mismatch means the peers did not build the same
+        KV geometry, which must fail loudly instead of corrupting the pool."""
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[3]
+        with self.assertRaisesRegex(RuntimeError, "geometry differs"):
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=NUM_LAYERS, item_len=ITEM_LEN + 80),
+                num,
+                NUM_LAYERS,
+            )
+
+
+class TestExistingPairingIsUnchanged(CustomTestCase):
+    """Derived property: the span is reachable only from the geometry the layer-id
+    pairing cannot express. Every other deployment must fall through to
+    build_transfer_entry_pairs, which the resolver signals with None."""
+
+    def test_unpipelined_prefill_defers(self):
+        for n_dst in (NUM_LAYERS, NUM_LAYERS + 1):
+            with self.subTest(n_dst=n_dst):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(
+                            pp_size=1, prefill_start_layer=0, n_src=NUM_LAYERS
+                        ),
+                        _peer(n_dst=n_dst),
+                        NUM_LAYERS,
+                        n_dst,
+                    )
+                )
+
+    def test_matched_pp_defers(self):
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                        _peer(n_dst=num),
+                        num,
+                        num,
+                    )
+                )
+
+    def test_published_layer_ids_defer(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[2]
+        self.assertIsNone(
+            _resolve(
+                _StubKVManager(
+                    pp_size=4,
+                    prefill_start_layer=start,
+                    n_src=num,
+                    kv_layer_ids=range(start, start + num),
+                ),
+                _peer(n_dst=NUM_LAYERS),
+                num,
+                NUM_LAYERS,
+            )
+        )
+        self.assertIsNone(
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=NUM_LAYERS, dst_kv_layer_ids=range(NUM_LAYERS)),
+                num,
+                NUM_LAYERS,
+            )
+        )
+
+    def test_pools_that_are_not_one_region_per_layer_defer(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[2]
+        for label, kwargs, n_dst in (
+            ("mha", {"is_mla_backend": False}, 2 * NUM_LAYERS),
+            ("hybrid_mla", {"is_hybrid_mla_backend": True}, NUM_LAYERS),
+            (
+                "compressed_mla",
+                {"mla_compression_ratios": [4] * NUM_LAYERS},
+                2 * NUM_LAYERS,
+            ),
+        ):
+            with self.subTest(pool=label):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(
+                            pp_size=4,
+                            prefill_start_layer=start,
+                            n_src=num,
+                            **kwargs,
+                        ),
+                        _peer(n_dst=n_dst),
+                        num,
+                        n_dst,
+                    )
+                )
+
+
+class TestMatchedPpWithDraftRegions(CustomTestCase):
+    """Derived property: bootstrap admits a peer at our pp or at 1, so under
+    matched pp a decode-side draft buffer makes n_src != n_dst and reaches the
+    span. Stage 0 degenerates to the identity and stays correct; every stage
+    above it must be rejected by the bound rather than writing at an offset the
+    peer does not have."""
+
+    def test_rank0_identity_span_stays_correct(self):
+        start, num = _pp_layer_split(NUM_LAYERS, 4)[0]
+        self.assertEqual(start, 0)
+        self.assertEqual(
+            _resolve(
+                _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                _peer(n_dst=num + 1),
+                num,
+                num + 1,
+            ),
+            list(range(num)),
+        )
+
+    def test_later_ranks_are_rejected(self):
+        for start, num in _pp_layer_split(NUM_LAYERS, 4)[1:]:
+            with self.subTest(start_layer=start):
+                self.assertIsNone(
+                    _resolve(
+                        _StubKVManager(pp_size=4, prefill_start_layer=start, n_src=num),
+                        _peer(n_dst=num + 1),
+                        num,
+                        num + 1,
+                    )
+                )
+
+
+class TestPointerAndIndexViewsAgree(CustomTestCase):
+    """Derived property: get_mla_kv_ptrs_with_pp (pointer view) and
+    _pp_layer_offset_dst_indices (index view) read the same span, so a change to
+    one must not silently diverge from the other."""
+
+    def test_views_select_the_same_destination_entries(self):
+        dst_ptrs = [9000 + i for i in range(NUM_LAYERS)]
+        for start, num in _pp_layer_split(NUM_LAYERS, 4):
+            with self.subTest(start_layer=start):
+                manager = _StubKVManager(
+                    pp_size=4, prefill_start_layer=start, n_src=num
+                )
+                src_ptrs = [1000 + i for i in range(num)]
+
+                _, sliced_dst, count = manager.get_mla_kv_ptrs_with_pp(
+                    src_ptrs, dst_ptrs
+                )
+                indices = _resolve(manager, _peer(n_dst=NUM_LAYERS), num, NUM_LAYERS)
+
+                self.assertEqual(count, num)
+                self.assertEqual(sliced_dst, [dst_ptrs[j] for j in indices])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_pp_mtp_embedding.py
+++ b/test/registered/unit/models/test_deepseek_pp_mtp_embedding.py
@@ -1,0 +1,84 @@
+"""Where a DeepSeek/GLM pipeline stage keeps ``embed_tokens``, and why the last one
+sometimes has to.
+
+A NextN draft owns no embedding. ``DeepseekV2WeightLoaderMixin`` skips ``embed_tokens``
+and ``shared_head.head`` inside the MTP block, and the checkpoint does not carry them
+there either -- ``nvidia/GLM-5.2-NVFP4``'s ``model.layers.78.*`` has
+``shared_head.norm.weight`` and nothing else. So the draft borrows the target's tensors
+via ``get_embed_and_head`` -> ``set_embed_and_head``.
+
+Under pipeline parallelism that borrowing is asymmetric. ``lm_head`` is fine: the target
+builds it on the last stage, which is exactly where ``EAGLEWorkerV2`` builds the draft
+(``_hosts_draft = get_pp_group().is_last_rank``). ``embed_tokens`` is not: it is a
+first-stage tensor, so without help the draft reads ``.weight`` off a ``PPMissingLayer``.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.models.deepseek_v2 import pp_stage_needs_embedding
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _pp_group(*, rank: int, size: int) -> SimpleNamespace:
+    return SimpleNamespace(is_first_rank=rank == 0, is_last_rank=rank == size - 1)
+
+
+class TestDeepseekPPStageEmbedding(CustomTestCase):
+    def test_without_speculative_decoding_only_the_first_stage_embeds(self):
+        for rank in range(4):
+            with self.subTest(rank=rank):
+                self.assertEqual(
+                    pp_stage_needs_embedding(_pp_group(rank=rank, size=4), None),
+                    rank == 0,
+                )
+
+    def test_speculative_decoding_adds_the_last_stage(self):
+        """The extra copy is what the NextN draft borrows; the target's own forward
+        never reads it."""
+        wants = [
+            pp_stage_needs_embedding(_pp_group(rank=rank, size=4), "EAGLE")
+            for rank in range(4)
+        ]
+        self.assertEqual(wants, [True, False, False, True])
+
+    def test_middle_stages_never_embed(self):
+        self.assertFalse(pp_stage_needs_embedding(_pp_group(rank=2, size=4), "EAGLE"))
+
+    def test_without_pipeline_parallelism_the_single_stage_embeds_either_way(self):
+        for spec in (None, "EAGLE"):
+            with self.subTest(spec=spec):
+                self.assertTrue(
+                    pp_stage_needs_embedding(_pp_group(rank=0, size=1), spec)
+                )
+
+    def test_pp_missing_layer_registers_no_parameters(self):
+        """The invariant the weight loader's skip rests on.
+
+        ``DeepseekV2WeightLoaderMixin`` decides whether to load ``embed_tokens`` by
+        asking whether the parameter exists on this rank, rather than by asking whether
+        this is the first rank -- otherwise the last stage's copy is allocated by
+        ``torch.empty`` and handed to the draft uninitialized. That only skips the
+        middle stages correctly because a placeholder owns no parameters.
+        """
+        placeholder = PPMissingLayer()
+        self.assertEqual(dict(placeholder.named_parameters()), {})
+        self.assertFalse(hasattr(placeholder, "weight"))
+
+    def test_a_real_embedding_registers_weight_under_its_prefix(self):
+        """The other half of the same invariant: a materialized stage does show up in
+        ``named_parameters()`` under the name the checkpoint uses."""
+        model = torch.nn.Module()
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        params = dict(model.named_parameters())
+        self.assertIn("embed_tokens.weight", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -63,6 +63,7 @@ from sglang.srt.arg_groups.serving_hook import (
 )
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 from sglang.srt.arg_groups.validation_hook import (
+    check_pipeline_parallel_compat,
     check_two_batch_overlap,
 )
 from sglang.srt.entrypoints.sidecar import (
@@ -1793,6 +1794,91 @@ class TestCudaGraphConfigDataclassAccess(CustomTestCase):
 
         self.assertEqual(config.get_capture_sizes(), [32, 64])
         self.assertEqual(config.compiler, "eager")
+
+
+class TestPipelineParallelCompat(CustomTestCase):
+    """What `pipeline-parallel-size > 1` rules out.
+
+    Speculative decoding is NOT on that list. The draft is built on the last pipeline
+    stage only (`EAGLEWorkerV2._hosts_draft`) and every earlier stage forwards the
+    target's PP proxy tensors and returns; that machinery is platform-neutral, so the
+    check no longer keys on the platform.
+    """
+
+    @staticmethod
+    def _cfg(**overrides):
+        cfg = dict(
+            disable_overlap_schedule=True,
+            speculative_algorithm=None,
+            enable_multi_layer_eagle=False,
+            disaggregation_mode="prefill",
+            min_free_slots_delay=None,
+        )
+        cfg.update(overrides)
+        return SimpleNamespace(**cfg)
+
+    def _is_npu(self, value: bool):
+        return patch(
+            "sglang.srt.arg_groups.validation_hook.get_platform",
+            return_value=SimpleNamespace(is_npu=value),
+        )
+
+    def test_overlap_schedule_must_be_off(self):
+        with self._is_npu(False):
+            with self.assertRaisesRegex(AssertionError, "overlap schedule"):
+                check_pipeline_parallel_compat(
+                    self._cfg(disable_overlap_schedule=False)
+                )
+
+    def test_no_speculative_decoding_is_fine(self):
+        with self._is_npu(False):
+            check_pipeline_parallel_compat(self._cfg())
+
+    def test_eagle_is_allowed_off_npu(self):
+        for mode in ("prefill", "decode", "null"):
+            with self.subTest(disaggregation_mode=mode), self._is_npu(False):
+                check_pipeline_parallel_compat(
+                    self._cfg(speculative_algorithm="EAGLE", disaggregation_mode=mode)
+                )
+
+    def test_nextn_resolves_to_eagle_and_is_allowed(self):
+        """`--speculative-algorithm NEXTN` has collapsed to EAGLE by the time the
+        validation hook runs, so the check only ever sees the resolved name."""
+        with self._is_npu(False):
+            check_pipeline_parallel_compat(self._cfg(speculative_algorithm="eagle"))
+
+    def test_non_eagle_speculative_algorithms_are_rejected(self):
+        with self._is_npu(False):
+            with self.assertRaisesRegex(AssertionError, "only supports EAGLE"):
+                check_pipeline_parallel_compat(
+                    self._cfg(speculative_algorithm="EAGLE3")
+                )
+
+    def test_multi_layer_eagle_is_rejected(self):
+        with self._is_npu(False):
+            with self.assertRaisesRegex(AssertionError, "only supports EAGLE"):
+                check_pipeline_parallel_compat(
+                    self._cfg(
+                        speculative_algorithm="EAGLE", enable_multi_layer_eagle=True
+                    )
+                )
+
+    def test_npu_still_restricts_speculative_decoding_to_prefill_nodes(self):
+        with self._is_npu(True):
+            check_pipeline_parallel_compat(
+                self._cfg(speculative_algorithm="EAGLE", disaggregation_mode="prefill")
+            )
+            with self.assertRaisesRegex(AssertionError, "prefill nodes"):
+                check_pipeline_parallel_compat(
+                    self._cfg(
+                        speculative_algorithm="EAGLE", disaggregation_mode="decode"
+                    )
+                )
+
+    def test_min_free_slots_delay_is_rejected(self):
+        with self._is_npu(False):
+            with self.assertRaisesRegex(AssertionError, "min-free-slots-delay"):
+                check_pipeline_parallel_compat(self._cfg(min_free_slots_delay=4))
 
 
 class TestPipelineParallelPrefillCudaGraphPolicy(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR is based on #38853, which fixes disagg PP for MLA. This PR fixes disagg PP + MTP for GLM5.2.

There are hard errors when running PP prefill + DP decode on GLM5.2, caused by three things:
1. PP + speculative decoding is rejected outright on every non-NPU platform, by `check_server_args` in `arg_groups/validation_hook.py` and by `_assert_pp_mtp_compat` in `model_executor/model_runner_components/layer_setup.py`. The runtime underneath is already PP-aware and platform-neutral: `EAGLEWorkerV2` builds the draft on the last PP stage only (`_hosts_draft`) and every earlier stage forwards the target's PP proxy tensors and returns.
2. Token embeddings are only available on first PP rank, but draft model also need token embeddings
3. PP `scheduler_pp_mixin` drops the draft model's DSA IndexShare seed (`dsa_topk_indices`), so decode has to regenerate them. However, decode DP currently hangs if one rank receives nothing which will run cudagraph, and another rank receives a request with no topk indices which runs eagerly.

On (3): the last PP stage's draft proposal crosses the pipeline ring as `draft_topk_p` / `draft_topk_index` / `draft_hidden_states` (`_pp_prepare_tensor_dict`) and is rebuilt into a fresh `EagleDraftInput` on every rank, which is then rebound to `batch.spec_info`.

## Modifications

1. Allow PP + speculative decoding. `validation_hook` keeps the overlap-schedule and EAGLE-shape restrictions for all platforms and keeps NPU's extra prefill-only rule, but the platform branch is gone. Removed `_assert_pp_mtp_compat` and `spec_algorithm` argument to `resolve_layer_indices`.
2. When constructing models and loading weights, also allow last PP rank to have token embeddings.
3. Add `dsa_topk_indices` to the PP ring in `scheduler_pp_mixin`.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

GLM-5.2-NVFP4 on GB300 with Dynamo router.
Prefill PP4 + EAGLE(steps 1) with decode TP4 + EAGLE(steps 3).

GSM8K `--max-tokens 16384`:

| prefill | score |
|---|---|
| `PP4` (this PR) | 95.45% |
| `TP4`, no PP (control) | 95.75% |

Only the prefill's parallelism differs, and scores matches. AL on decode is 3.589, which looks healthy.

Unit tests (CPU, no GPU): 14 new cases + 9 subtests across
`test/registered/unit/models/test_deepseek_pp_mtp_embedding.py` and
`TestPipelineParallelCompat` in `test/registered/unit/server_args/test_server_args.py`.
Regression sweep over `test/registered/unit/{spec,server_args,model_executor,models,disaggregation}`:
1451 passed.

## Speed Tests and Profiling

Not a performance change. Everything modified were previously unrunnable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34576894508](https://github.com/sgl-project/sglang/actions/runs/34576894508)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34576894291](https://github.com/sgl-project/sglang/actions/runs/34576894291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34576894396](https://github.com/sgl-project/sglang/actions/runs/34576894396)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->