### PR TITLE
perf: compile grammars and apply vocab mask only on the entry TP rank

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -145,6 +145,26 @@ class BaseGrammarObject:
         raise NotImplementedError()
 
 
+class PlaceholderGrammarObject(BaseGrammarObject):
+    """Grammar placeholder carried by non-entry TP ranks.
+
+    With TP > 1 (and no speculative decoding), only the entry rank of the
+    DP/TP group compiles grammars and applies the vocab mask; the sampled
+    token ids are broadcast in the sampler. The other ranks carry this
+    placeholder so per-batch checks such as ``any(req.grammar)`` stay
+    identical across ranks, while grammar state tracking stays on the entry
+    rank. Requests finish via token-based checks (grammar backends force EOS
+    at termination), so the always-False ``is_terminated`` is consistent with
+    the entry rank's grammar-driven finish.
+    """
+
+    def accept_token(self, token: int) -> None:
+        pass
+
+    def rollback(self, k: int) -> None:
+        pass
+
+
 class GrammarMask(NamedTuple):
     """A filled vocab_mask plus the backend that applies it.
 

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -9,12 +9,18 @@ import torch
 
 from sglang.srt.constrained.base_grammar_backend import (
     InvalidGrammarObject,
+    PlaceholderGrammarObject,
     create_grammar_backend,
 )
 from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
 from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.environ import envs
-from sglang.srt.runtime_context import get_serving
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.runtime_context import (
+    get_parallel,
+    get_serving,
+    get_spec,
+)
 from sglang.srt.sampling.sampling_params import (
     get_request_reasoning_end_token_ids,
 )
@@ -53,6 +59,21 @@ class GrammarManager:
         self.grammar_sync_size = scheduler.dp_tp_group.world_size
         self.grammar_sync_entry = scheduler.dp_tp_group.first_rank
         self.is_grammar_sync_entry = scheduler.dp_tp_group.is_first_rank
+        # With TP > 1, no speculative decoding and no context parallelism,
+        # only the entry rank compiles grammars and applies the vocab mask;
+        # the sampled token ids are broadcast in the sampler. Speculative
+        # decoding drafts from per-rank grammar bitmasks, so it keeps the
+        # compile-everywhere behavior. Keep this condition identical to
+        # Sampler.tp_grammar_entry_only in layers/sampler.py.
+        cp_group = get_parallel().attn_cp_group if is_dp_attention_enabled() else None
+        cp_active = cp_group is not None and (
+            torch.distributed.get_world_size(cp_group.device_group) > 1
+        )
+        self.tp_grammar_entry_only = (
+            self.grammar_sync_size > 1
+            and get_spec().speculative_algorithm is None
+            and not cp_active
+        )
         self.pp_rank = scheduler.ps.pp_rank
         self.pp_size = scheduler.ps.pp_size
         self.pp_group = scheduler.pp_group
@@ -82,7 +103,8 @@ class GrammarManager:
         self,
         ready_req_idxs: set[int],
         failed_req_idxs: set[int],
-    ) -> tuple[set[int], set[int]]:
+        failed_reasons: dict[int, str],
+    ) -> tuple[set[int], set[int], dict[int, str]]:
         """
         Synchronize ready/failed grammar request indexes across the PP pipeline.
 
@@ -90,10 +112,10 @@ class GrammarManager:
         rank and asynchronously forwards it to the next rank.
         """
         if self.pp_size <= 1 or self.pp_group is None:
-            return ready_req_idxs, failed_req_idxs
+            return ready_req_idxs, failed_req_idxs, failed_reasons
 
         self._drain_pp_sync_work()
-        data = (ready_req_idxs, failed_req_idxs)
+        data = (ready_req_idxs, failed_req_idxs, failed_reasons)
         if self.pp_rank > 0:
             data = self.pp_group.recv_object(
                 src=self.pp_rank - 1,
@@ -164,24 +186,38 @@ class GrammarManager:
                 elif req.sampling_params.structural_tag is not None:
                     key = ("structural_tag", req.sampling_params.structural_tag)
 
-                value, cache_hit = self.grammar_backend.get_cached_or_future_value(
-                    key, req.require_reasoning
-                )
-                req.grammar = value
-
-                if not cache_hit:
+                if self.tp_grammar_entry_only and not self.is_grammar_sync_entry:
+                    # Non-entry ranks never compile; they carry a placeholder so
+                    # batch-level grammar checks stay rank-consistent and wait
+                    # for the entry rank's readiness broadcast below.
+                    req.grammar = PlaceholderGrammarObject()
                     req.grammar_key = key
                     add_to_grammar_queue = True
                 else:
-                    if isinstance(
-                        value, InvalidGrammarObject
-                    ):  # We hit a cached invalid grammar.
-                        error_msg = (
-                            f"Failed to compile {key[0]} grammar: {value.error_message}"
-                        )
-                        req.set_finish_with_abort(error_msg)
-                    else:
-                        self._apply_request_reasoning_config(req)
+                    value, cache_hit = self.grammar_backend.get_cached_or_future_value(
+                        key, req.require_reasoning
+                    )
+                    req.grammar = value
+
+                    if not cache_hit or self.tp_grammar_entry_only:
+                        # With entry-only compilation every rank queues the
+                        # request so the ready/failed sync moves them together;
+                        # the abort state of cached-invalid grammars is also
+                        # propagated through that sync instead of aborting
+                        # here on the entry rank only.
+                        req.grammar_key = key
+                        add_to_grammar_queue = True
+                    if cache_hit:
+                        if isinstance(
+                            value, InvalidGrammarObject
+                        ):  # We hit a cached invalid grammar.
+                            if not self.tp_grammar_entry_only:
+                                error_msg = f"Failed to compile {key[0]} grammar: {value.error_message}"
+                                req.set_finish_with_abort(error_msg)
+                            # With entry-only compilation the abort is applied
+                            # on every rank after the sync below.
+                        else:
+                            self._apply_request_reasoning_config(req)
         elif self._enable_strict_thinking:
             grammar_obj = self.grammar_backend.init_strict_reasoning_grammar(
                 req.require_reasoning
@@ -207,32 +243,80 @@ class GrammarManager:
         ready_reqs = intersect(ready_reqs_all)
         failed_reqs = union(failed_reqs_all)
 
+        Compile outcomes (invalid grammar, compile exception, timeout) are
+        reported per index in failure messages that travel with the same
+        sync, so every rank applies an identical abort state even though only
+        the entry rank compiles.
+
         PP0 then propagates the synced result to later PP ranks. Later PP
         ranks receive and apply the propagated ready/failed decision.
         """
         assert self.grammar_backend
         ready_req_idxs: set[int] = set()
         failed_req_idxs: set[int] = set()
+        failed_reasons: dict[int, str] = {}
 
         if self.pp_rank == 0:
             # Poll for ready requests
             start_time = time.perf_counter()
             while time.perf_counter() - start_time < self.SGLANG_GRAMMAR_POLL_INTERVAL:
                 for i, req in enumerate(self.grammar_queue):
-                    if i in ready_req_idxs:
+                    if i in ready_req_idxs or i in failed_req_idxs:
                         continue
 
-                    if (
-                        req.finished() or req.grammar is None
-                    ):  # It is aborted by AbortReq
+                    if req.finished() or req.grammar is None:
+                        # It is aborted by AbortReq
                         ready_req_idxs.add(i)
                         continue
 
-                    assert isinstance(req.grammar, futures.Future), f"{req=}"
+                    if isinstance(req.grammar, PlaceholderGrammarObject):
+                        # Non-entry ranks never compile; they are ready as
+                        # soon as the entry rank's decision arrives.
+                        ready_req_idxs.add(i)
+                        continue
+
+                    if isinstance(req.grammar, InvalidGrammarObject):
+                        # A cached-invalid grammar on the compiling rank.
+                        # Fail through the sync so every rank aborts the
+                        # request with the same message.
+                        failed_req_idxs.add(i)
+                        failed_reasons[i] = (
+                            f"Failed to compile {req.grammar_key[0]} grammar: "
+                            f"{req.grammar.error_message}"
+                        )
+                        continue
+
+                    if not isinstance(req.grammar, futures.Future):
+                        # A cache hit on the compiling rank: already resolved.
+                        ready_req_idxs.add(i)
+                        continue
+
                     if req.grammar.done():
+                        try:
+                            result = req.grammar.result()
+                        except Exception as e:
+                            logger.error(
+                                f"Grammar compilation raised an exception: {e}, "
+                                f"grammar_key={req.grammar_key}"
+                            )
+                            failed_req_idxs.add(i)
+                            failed_reasons[i] = (
+                                f"Failed to compile {req.grammar_key[0]} grammar: "
+                                f"Grammar compilation failed: {e}"
+                            )
+                            continue
+                        if isinstance(result, InvalidGrammarObject):
+                            failed_req_idxs.add(i)
+                            failed_reasons[i] = (
+                                f"Failed to compile {req.grammar_key[0]} grammar: "
+                                f"{result.error_message}"
+                            )
+                            continue
                         ready_req_idxs.add(i)
 
-                if len(ready_req_idxs) == len(self.grammar_queue):
+                if len(ready_req_idxs) + len(failed_req_idxs) == len(
+                    self.grammar_queue
+                ):
                     break
 
                 # Sleep a bit to avoid busy waiting
@@ -240,14 +324,11 @@ class GrammarManager:
 
             # Check failed requests
             for i, req in enumerate(self.grammar_queue):
-                if i not in ready_req_idxs:
+                if i not in ready_req_idxs and i not in failed_req_idxs:
                     # grammar_wait_ct is only updated on PP0; later PP ranks
                     # receive PP0's ready/failed decision through PP sync.
-                    self.grammar_queue[i].grammar_wait_ct += 1
-                    if (
-                        self.grammar_queue[i].grammar_wait_ct
-                        >= self.SGLANG_GRAMMAR_MAX_POLL_ITERATIONS
-                    ):
+                    req.grammar_wait_ct += 1
+                    if req.grammar_wait_ct >= self.SGLANG_GRAMMAR_MAX_POLL_ITERATIONS:
                         # Timeout after max poll iterations
                         # The actual waiting time is SGLANG_GRAMMAR_MAX_POLL_ITERATIONS * max(SGLANG_GRAMMAR_POLL_INTERVAL, GPU_forward_batch_latency)
                         failed_req_idxs.add(i)
@@ -260,13 +341,15 @@ class GrammarManager:
                 all_gather_output = [None] * self.grammar_sync_size
                 torch.distributed.all_gather_object(
                     all_gather_output,
-                    (ready_req_idxs, failed_req_idxs),
+                    (ready_req_idxs, failed_req_idxs, failed_reasons),
                     group=self.grammar_sync_group,
                 )
                 synced_ready_req_idxs = set.intersection(
                     *[x[0] for x in all_gather_output]
                 )
                 synced_failed_req_idxs = set.union(*[x[1] for x in all_gather_output])
+                for x in all_gather_output:
+                    failed_reasons.update(x[2])
         else:
             synced_ready_req_idxs = ready_req_idxs
             synced_failed_req_idxs = failed_req_idxs
@@ -275,9 +358,11 @@ class GrammarManager:
         (
             synced_ready_req_idxs,
             synced_failed_req_idxs,
+            failed_reasons,
         ) = self._pp_sync_ready_failed(
             synced_ready_req_idxs,
             synced_failed_req_idxs,
+            failed_reasons,
         )
 
         # Return ready requests
@@ -285,10 +370,21 @@ class GrammarManager:
         for i in synced_ready_req_idxs:
             req = self.grammar_queue[i]
             return_reqs.append(req)
-            if req.finished() or req.grammar is None:  # It is aborted by AbortReq
+            if (
+                req.finished()
+                or req.grammar is None
+                or isinstance(req.grammar, PlaceholderGrammarObject)
+            ):
+                # Aborted by AbortReq, or a non-entry-rank placeholder whose
+                # grammar state lives on the entry rank.
                 continue
 
-            assert isinstance(req.grammar, futures.Future) and req.grammar_key
+            if not isinstance(req.grammar, futures.Future):
+                # A cache hit resolved at arrival; the reasoning config was
+                # already applied when the cached value was fetched.
+                continue
+
+            assert req.grammar_key
             try:
                 req.grammar = req.grammar.result()
             except Exception as e:
@@ -307,13 +403,19 @@ class GrammarManager:
         for i in synced_failed_req_idxs:
             req = self.grammar_queue[i]
             return_reqs.append(req)
+            if req.finished():
+                continue
 
-            assert isinstance(req.grammar, futures.Future) and req.grammar_key
-            req.grammar.cancel()
-            self.grammar_backend.set_cache(
-                req.grammar_key, InvalidGrammarObject("Grammar preprocessing timed out")
+            if isinstance(req.grammar, futures.Future):
+                assert req.grammar_key
+                req.grammar.cancel()
+                self.grammar_backend.set_cache(
+                    req.grammar_key,
+                    InvalidGrammarObject("Grammar preprocessing timed out"),
+                )
+            error_msg = failed_reasons.get(
+                i, f"Grammar preprocessing timed out: {req.grammar_key=}"
             )
-            error_msg = f"Grammar preprocessing timed out: {req.grammar_key=}"
             req.set_finish_with_abort(error_msg)
 
         # Remove finished requests from grammar_queue

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -20,7 +20,12 @@ from sglang.srt.layers.logits_processor import (
 from sglang.srt.layers.logprob_processor import (
     OutputLogprobProcessor,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_parallel,
+    get_server_args,
+    get_spec,
+)
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.utils.async_probe import sanitize_nan_logits
@@ -109,11 +114,28 @@ def _select_sampling_mask_rows(
 class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
-        self.tp_sync_group = get_tp_group().device_group
+        tp_sync_group = (
+            get_parallel().attn_tp_group
+            if is_dp_attention_enabled()
+            else get_tp_group()
+        )
+        self.tp_sync_group = tp_sync_group.device_group
         self.cp_sync_group = None
         if is_dp_attention_enabled():
-            self.tp_sync_group = get_parallel().attn_tp_group.device_group
             self.cp_sync_group = get_parallel().attn_cp_group.device_group
+        # With grammar-constrained sampling, no speculative decoding and no
+        # context parallelism, only the entry rank of the sync group applies
+        # the grammar vocab mask and its sampled token ids are broadcast
+        # (see _sync_token_ids_across_tp).
+        cp_active = self.cp_sync_group is not None and (
+            dist.get_world_size(self.cp_sync_group) > 1
+        )
+        self.tp_grammar_entry_only = (
+            tp_sync_group.world_size > 1
+            and get_spec().speculative_algorithm is None
+            and not cp_active
+        )
+        self.is_tp_grammar_entry = tp_sync_group.rank_in_group == 0
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -647,7 +669,18 @@ class Sampler(nn.Module):
     def _sync_token_ids_across_tp(
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
-        if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+        if sampling_info.grammars and self.tp_grammar_entry_only:
+            # Only the entry rank of the TP group applies the grammar vocab
+            # mask, so its sampled token ids are authoritative: broadcast them
+            # instead of relying on bitwise-identical sampling kernels on
+            # every rank. Non-entry ranks carry placeholder grammar objects,
+            # which keeps `sampling_info.grammars` truthy here on all ranks.
+            torch.distributed.broadcast(
+                batch_next_token_ids,
+                group_src=0,
+                group=self.tp_sync_group,
+            )
+        elif SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
             # the last all-reduce, the last lm_head matmul, and all sampling kernels.

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1876,7 +1876,17 @@ class ModelRunner:
         #       was executed after we processed last batch's results.
 
         # Calculate logits bias and apply it to next_token_logits.
-        sampling_info.update_regex_vocab_mask()
+        if (
+            sampling_info.grammars
+            and self.sampler.tp_grammar_entry_only
+            and not self.sampler.is_tp_grammar_entry
+        ):
+            # With entry-only grammar compilation, non-entry TP ranks skip the
+            # vocab mask entirely; the entry rank's sampled token ids are
+            # broadcast in the sampler.
+            sampling_info.grammar_mask = None
+        else:
+            sampling_info.update_regex_vocab_mask()
         observer_state = None
         if observer is not None:
             observer_state = sampling_info.apply_logits_bias_with_observer(

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -11,6 +11,7 @@ from sglang.srt.constrained.base_grammar_backend import (
     BaseGrammarObject,
     GrammarMask,
     GrammarRow,
+    PlaceholderGrammarObject,
 )
 from sglang.srt.runtime_context import get_exec
 from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
@@ -258,8 +259,19 @@ class SamplingBatchInfo:
             self.grammar_mask = None
             return
 
-        # Find a grammar from the list
-        first_grammar = next(grammar for grammar in self.grammars if grammar)
+        # Find a grammar from the list. With entry-only grammar compilation,
+        # non-entry TP ranks only carry PlaceholderGrammarObject entries.
+        first_grammar = next(
+            (
+                grammar
+                for grammar in self.grammars
+                if grammar and not isinstance(grammar, PlaceholderGrammarObject)
+            ),
+            None,
+        )
+        if first_grammar is None:
+            self.grammar_mask = None
+            return
 
         vocab_mask = first_grammar.allocate_vocab_mask(
             vocab_size=self.vocab_size,
@@ -272,7 +284,10 @@ class SamplingBatchInfo:
         entries = [
             GrammarRow(row=row, grammar=grammar)
             for row, grammar in enumerate(self.grammars)
-            if grammar and not grammar.finished and not grammar.is_terminated()
+            if grammar
+            and not isinstance(grammar, PlaceholderGrammarObject)
+            and not grammar.finished
+            and not grammar.is_terminated()
         ]
         first_grammar.fill_vocab_mask_batched(entries, vocab_mask)
 

--- a/test/registered/constrained_decoding/test_constrained_decoding.py
+++ b/test/registered/constrained_decoding/test_constrained_decoding.py
@@ -1,6 +1,7 @@
 import unittest
 
 import openai
+import torch
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -24,6 +25,7 @@ register_amd_ci(est_time=220, suite="stage-b-test-1-gpu-small-amd")
 class ServerWithGrammar(CustomTestCase):
     backend = "xgrammar"
     disable_overlap = False
+    tp_size = 1
 
     @classmethod
     def setUpClass(cls):
@@ -35,6 +37,9 @@ class ServerWithGrammar(CustomTestCase):
             "--grammar-backend",
             cls.backend,
         ]
+
+        if cls.tp_size > 1:
+            launch_args += ["--tp-size", str(cls.tp_size)]
 
         if cls.disable_overlap:
             launch_args += ["--disable-overlap-schedule"]
@@ -77,6 +82,39 @@ class TestLLGuidanceBackend(
     RegexConstrainedMixin,
 ):
     backend = "llguidance"
+
+
+# With TP > 1 only the entry rank compiles grammars and applies the vocab
+# mask; the sampled token ids are broadcast in the sampler. These variants
+# exercise that path end to end.
+@unittest.skipIf(torch.cuda.device_count() < 2, "Requires at least 2 GPUs")
+class TestXGrammarBackendTP2(
+    ServerWithGrammar,
+    JSONConstrainedMixin,
+    JSONModeMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
+):
+    backend = "xgrammar"
+    tp_size = 2
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "Requires at least 2 GPUs")
+class TestOutlinesBackendTP2(ServerWithGrammar, JSONConstrainedMixin, JSONModeMixin):
+    backend = "outlines"
+    tp_size = 2
+
+
+@unittest.skipIf(torch.cuda.device_count() < 2, "Requires at least 2 GPUs")
+class TestLLGuidanceBackendTP2(
+    ServerWithGrammar,
+    JSONConstrainedMixin,
+    JSONModeMixin,
+    EBNFConstrainedMixin,
+    RegexConstrainedMixin,
+):
+    backend = "llguidance"
+    tp_size = 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> Supersedes #38392 (closed unintentionally when its head branch was recreated during a rebase onto latest `main` — same change, rebased, with an extra context-parallel safety gate). Discussion and earlier benchmarks: #38392.

## Motivation

With TP > 1 and no speculative decoding, every TP rank currently compiles the same grammar (the backend cache is per-process, so caches never converge across ranks) and computes/applies the grammar vocab mask at every decode step. The sampler then keeps ranks in sync via `all_reduce(MIN)`, which depends on bitwise-deterministic sampling kernels — the original motivation of the `sampling_info.grammars` special case.

Re-lands #13947 (reverted by #16845 because DP attention was broken), following up on the stalled #16874, ported to the current `GrammarManager` structure. Closes #13809. Credit to @raayandhar (#13947) and @hnyls2002 (#16874) for the original designs.

## What this does

1. **Compile once, not n×**: only the entry rank of the DP/TP group submits grammar compilation. Non-entry ranks carry a `PlaceholderGrammarObject` and never compile. (#16874 still compiled lazily on every rank: the grammar backend cache is per-process, so the re-fetch in its move-ready loop was a full re-compile.)
2. **Mask once per step**: only the entry rank computes and applies the grammar vocab mask; other ranks skip `update_regex_vocab_mask` entirely.
3. **Broadcast instead of trust**: when grammars are present, the sampler broadcasts the entry rank's token ids (`group_src=0` over the attention-TP group under DP attention), replacing `all_reduce(MIN)`.

## Why it is safe

- **Finish-state consistency**: grammar backends pass the model EOS as a stop token, so at termination the mask only allows EOS and every rank finishes via the same token-based check (which runs before the grammar-terminated check in `update_finish_state`). Placeholder objects report `is_terminated() == False`, matching the non-entry ranks' effective behavior in #16874 (their grammar objects never accepted tokens).
- **Failure consistency**: invalid grammars, compile exceptions, and timeouts are classified on the compiling rank and propagated through the existing ready/failed `all_gather_object` sync with per-index reasons, so every rank applies an identical abort state with the same message.
- **Group consistency**: the compile/mask entry rank is `dp_tp_group` rank 0, which equals the sampler's `tp_sync_group` root (attention-TP group under `--enable-dp-attention`) — the rank that applies the mask is exactly the rank whose tokens are broadcast.
- **Unchanged paths**: TP=1, `SYNC_TOKEN_IDS_ACROSS_TP`, speculative decoding (drafts from per-rank bitmasks), and context parallelism keep today's behavior; the optimization is gated off for them via identical conditions in `GrammarManager` and `Sampler`.

## Tests

- TP2 variants of `test_constrained_decoding` added (xgrammar / outlines / llguidance).
- Existing DP2TP2 grammar coverage in `test_dp_attention` exercises the DP-attention path.

## Benchmarks

2×H100, TP2, Qwen2.5-3B-Instruct, xgrammar, triton attention backend. 128 requests = 32 distinct deeply-nested JSON schemas × 4, concurrency 32, max_new_tokens 320. Scheduler-process CPU seconds (utime+stime) per rank during the run:

**TP2:**

| metric | main | this PR | delta |
| --- | --- | --- | --- |
| entry-rank scheduler CPU | 10.3 s | 10.4 s | ~0 |
| non-entry-rank scheduler CPU | 9.6 s | **5.0 s** | **-48%** |
| total scheduler CPU | 19.9 s | 15.4 s | **-23%** |
| wall time (128 reqs) | 17.35 s | 16.30 s | -6% |
| grammar violations | 0 / 128 | 0 / 128 | — |

**TP4 (4×H100, warm grammar cache = steady state):**

| metric | main | this PR | delta |
| --- | --- | --- | --- |
| total scheduler CPU | 26.5 s | 18.3 s | **-31%** |
| non-entry ranks CPU (×3) | ~6.7 s each | ~3.9 s each | **~-41% each** |
| entry-rank scheduler CPU | 6.7 s | 6.6 s | ~0 |
| nominal throughput | 6115 tok/s | 6329 tok/s | +3.5% |
| grammar violations | 0 / 128 | 0 / 128 | — |

The saving scales with TP size as expected (3/4 of ranks shed the work at TP4); the entry rank is unchanged and does not gate decode at this batch/grammar density. During the cold compile-burst phase, total scheduler CPU is ~45–50 s on main vs ~27 s with this PR (≈ -42%).

Note: measured on a driver-535 (CUDA 12.x) machine with the closest period-consistent stack (torch 2.9.0+cu128 + sgl-kernel 0.4.0), since current main's wheel stack is CUDA 13-only; CI runs the official stack. The changed code paths are pure Python and independent of that difference.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34577008197](https://github.com/sgl-project/sglang/actions/runs/34577008197)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34577008106](https://github.com/sgl-project/sglang/actions/runs/34577008106)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34577008146](https://github.com/sgl-project/sglang/actions/runs/34577008146)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->