### PR TITLE
Fix MUSA detection in compiled prefill path

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -115,13 +115,14 @@ def should_use_dsa_fused_topk(seed_dsa_topk_from_draft_extend: bool) -> bool:
 
 
 def is_dsa_enable_prefill_cp():
+    if get_parallel().attn_cp_size <= 1:
+        return False
+
     if is_hip() or is_npu() or is_musa():
         return False
 
     # Generic prefill CP derives activation from the runtime topology and model
     # architecture.
-    if get_parallel().attn_cp_size <= 1:
-        return False
     from sglang.srt.configs.model_config import is_deepseek_dsa, is_deepseek_v4
 
     hf_config = process_model_config().hf_config

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -220,13 +220,17 @@ def is_cpu() -> bool:
     return os.getenv("SGLANG_USE_CPU_ENGINE", "0") == "1" and is_host_cpu_supported
 
 
+try:
+    import torchada  # noqa: F401
+except ImportError:
+    _IS_MUSA = False
+else:
+    _IS_MUSA = hasattr(torch.version, "musa") and torch.version.musa is not None
+
+
 @lru_cache(maxsize=1)
 def is_musa() -> bool:
-    try:
-        import torchada  # noqa: F401
-    except ImportError:
-        return False
-    return hasattr(torch.version, "musa") and torch.version.musa is not None
+    return _IS_MUSA
 
 
 @lru_cache(maxsize=1)

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -121,6 +121,24 @@ class TestCPStrategyUnit(CustomTestCase):
         ):
             self.assertFalse(is_dsa_enable_prefill_cp())
 
+    def test_disabled_dsa_cp_skips_platform_probes(self):
+        parallel = SimpleNamespace(attn_cp_size=1)
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.dsa.utils.get_parallel",
+                return_value=parallel,
+            ),
+            patch("sglang.srt.layers.attention.dsa.utils.is_hip") as mock_is_hip,
+            patch("sglang.srt.layers.attention.dsa.utils.is_npu") as mock_is_npu,
+            patch("sglang.srt.layers.attention.dsa.utils.is_musa") as mock_is_musa,
+        ):
+            self.assertFalse(is_dsa_enable_prefill_cp())
+
+        mock_is_hip.assert_not_called()
+        mock_is_npu.assert_not_called()
+        mock_is_musa.assert_not_called()
+
 
 class TestPrefillCPBCGReplay(CustomTestCase):
     def tearDown(self):

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -7,12 +7,27 @@ from sglang.srt.utils.common import (
     flatten_arrays_to_int64_tensor,
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
+    is_musa,
 )
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
+
+
+class TestMusaDetection(CustomTestCase):
+    def test_is_musa_is_torch_compile_safe(self):
+        is_musa.cache_clear()
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def add_platform_offset(value):
+            return value + 1 if is_musa() else value - 1
+
+        value = torch.zeros(1)
+        actual = add_platform_offset(value)
+        expected = torch.ones(1) if is_musa() else -torch.ones(1)
+        torch.testing.assert_close(actual, expected)
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")


### PR DESCRIPTION
## Motivation

Fixes #39054.

`is_dsa_enable_prefill_cp()` is reachable from the TorchDynamo-traced prefill path. Its MUSA platform guard called `is_musa()`, which performed `import torchada` inside the function. On CUDA systems without `torchada`, Dynamo treats the import bytecode as an unsupported operation instead of raising a catchable Python `ImportError`. This graph break is fatal during `tc_piecewise` prefill CUDA-graph capture and prevents server startup.

## Modifications

- Resolve MUSA availability once when `sglang.srt.utils.common` is imported, preserving the existing `torch.version.musa` check and the cached `is_musa()` API.
- Return the resolved module-level boolean from `is_musa()` so Dynamo can constant-fold the result without tracing import bytecode.
- Short-circuit `is_dsa_enable_prefill_cp()` when attention CP is disabled before evaluating platform probes.
- Add regression tests covering full-graph `torch.compile` use of `is_musa()` and the disabled-CP platform-probe short circuit.

## Accuracy Tests

This change does not alter model math. The issue's end-to-end validation with the patch completed `tc_piecewise` prefill capture on all eight B200 ranks and reported GSM8K accuracy of 0.954, compared with 0.924 at the last-known-good commit.

The repository's pre-commit checks pass. The new PyTorch unit tests were not run on the local host because its Python environment does not include PyTorch; they are included for CI coverage.

## Speed Tests and Profiling

Not applicable. The change moves an optional-package probe out of the traced runtime path and does not modify inference kernels or tensor operations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation changes are needed for this internal platform-detection fix.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Existing end-to-end accuracy results are included above; speed testing is not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34646915185](https://github.com/sgl-project/sglang/actions/runs/34646915185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #34798174213](https://github.com/sgl-project/sglang/actions/runs/34798174213)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34646915208](https://github.com/sgl-project/sglang/actions/runs/34646915208)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->