### PR TITLE
[ROCm][Bugfix] Keep quantization for mixed Quark Qwen3.5 MTP checkpoints

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -91,6 +91,12 @@ def _mtp_quant_config(quant_config):
 
 
 class Qwen3_5ForCausalLMMTP(nn.Module):
+    # The loader reads this off the model class and hands it to the quant
+    # config, which needs it to expand fused module names (qkv_proj ->
+    # q/k/v_proj) before matching them against an exclude list. Without it an
+    # excluded attention projection is not recognised as excluded.
+    packed_modules_mapping = Qwen3_5ForCausalLM.packed_modules_mapping
+
     @staticmethod
     def shared_experts_fusion_disable_reason(hf_config, quant_config):
         return Qwen3_5ForCausalLM.shared_experts_fusion_disable_reason(

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -68,16 +68,24 @@ def _mtp_quant_config(quant_config):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:
         return None
-    # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in bf16;
-    # every `mtp.*` layer appears under the quantization exclude list. Detect
-    # that and skip quantization here so linear/MoE weight loaders allocate
-    # bf16 shapes (see sgl-project/sglang#23113).
+    # Some Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module
+    # entirely in bf16, listing every `mtp.*` layer under the quantization
+    # exclude list. Skip quantization for those so linear/MoE weight loaders
+    # allocate bf16 shapes (see sgl-project/sglang#23146).
+    #
+    # Others are mixed: the routed experts stay MXFP4 while attention, the
+    # shared expert and fc are excluded. Skipping there would make the MoE
+    # loader allocate bf16 experts that the MXFP4 checkpoint shards no longer
+    # fit. The routed experts are the bulk of the draft, so use them as the
+    # signal and skip only when they are excluded too; the per-layer
+    # exclusions keep the remaining bf16 modules bf16 on their own.
     if quant_config and quant_config.get_name() == "quark":
-        exclude_layers = getattr(quant_config, "exclude_layers", [])
-        if any(
-            isinstance(layer, str) and layer.startswith("mtp.")
-            for layer in exclude_layers
-        ):
+        mtp_excludes = [
+            layer
+            for layer in getattr(quant_config, "exclude_layers", [])
+            if isinstance(layer, str) and layer.startswith("mtp.")
+        ]
+        if mtp_excludes and any("mlp.experts" in layer for layer in mtp_excludes):
             return None
     return quant_config
 

--- a/test/registered/unit/models/test_qwen3_5_mtp_quant_config.py
+++ b/test/registered/unit/models/test_qwen3_5_mtp_quant_config.py
@@ -1,0 +1,107 @@
+import unittest
+
+from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
+from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP, _mtp_quant_config
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# The real `mtp.*` exclude entries of the two AMD Quark MXFP4 checkpoints.
+# Quark names layers in the checkpoint namespace, where the draft is prefixed
+# `mtp.`. The two lists are identical apart from the routed experts:
+# Qwen3.5-397B excludes all 512x3 draft expert projections, so its whole MTP
+# module is bf16; Qwen3.8-2.4T excludes none of them, so its draft experts stay
+# MXFP4 while attention, the shared expert and fc are bf16.
+_MIXED_EXCLUDES = [  # amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 (all 10 mtp.* entries)
+    "mtp.fc",
+    "mtp.layers.0.mlp.gate",
+    "mtp.layers.0.mlp.shared_expert.down_proj",
+    "mtp.layers.0.mlp.shared_expert.gate_proj",
+    "mtp.layers.0.mlp.shared_expert.up_proj",
+    "mtp.layers.0.mlp.shared_expert_gate",
+    "mtp.layers.0.self_attn.k_proj",
+    "mtp.layers.0.self_attn.o_proj",
+    "mtp.layers.0.self_attn.q_proj",
+    "mtp.layers.0.self_attn.v_proj",
+]
+_ALL_BF16_EXCLUDES = _MIXED_EXCLUDES + [  # amd/Qwen3.5-397B-A17B-MXFP4
+    f"mtp.layers.0.mlp.experts.{expert}.{proj}"
+    for expert in range(512)
+    for proj in ("gate_proj", "up_proj", "down_proj")
+]
+
+
+class _FakeQuantConfig:
+    def __init__(self, name, exclude_layers):
+        self._name = name
+        self.exclude_layers = list(exclude_layers)
+
+    def get_name(self):
+        return self._name
+
+
+class TestQwen3_5MTPQuantConfig(CustomTestCase):
+    def test_mixed_quark_checkpoint_keeps_quantization(self):
+        """Routed experts stay MXFP4, so the draft must stay quantized."""
+        quant_config = _FakeQuantConfig("quark", _MIXED_EXCLUDES)
+
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_fully_bf16_quark_checkpoint_skips_quantization(self):
+        """Regression guard for #23146: a bf16 draft must stay unquantized."""
+        quant_config = _FakeQuantConfig("quark", _ALL_BF16_EXCLUDES)
+
+        self.assertIsNone(_mtp_quant_config(quant_config))
+
+    def test_the_two_checkpoints_differ_only_in_the_routed_experts(self):
+        """Guards the premise of the fix, not the implementation."""
+        extra = set(_ALL_BF16_EXCLUDES) - set(_MIXED_EXCLUDES)
+
+        self.assertTrue(all("mlp.experts" in layer for layer in extra))
+        self.assertEqual(len(extra), 512 * 3)
+
+    def test_quark_checkpoint_without_mtp_excludes_keeps_quantization(self):
+        quant_config = _FakeQuantConfig("quark", ["model.layers.0.self_attn.q_proj"])
+
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_non_quark_quant_config_is_untouched(self):
+        quant_config = _FakeQuantConfig("fp8", _MIXED_EXCLUDES)
+
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_mtp_reuses_target_packed_modules_mapping(self):
+        self.assertEqual(
+            Qwen3_5ForCausalLMMTP.packed_modules_mapping,
+            Qwen3_5ForCausalLM.packed_modules_mapping,
+        )
+
+    def test_excluded_fused_attention_projection_is_ignored(self):
+        """The mapping has to expand qkv_proj before the exclude list matches.
+
+        Without it `should_ignore_layer` compares the fused name against
+        `q_proj`/`k_proj`/`v_proj` entries, finds nothing, and the layer is
+        quantized against bf16 checkpoint shards.
+        """
+        ignored = should_ignore_layer(
+            "mtp.layers.0.self_attn.qkv_proj",
+            ignore=_MIXED_EXCLUDES,
+            fused_mapping=Qwen3_5ForCausalLMMTP.packed_modules_mapping,
+        )
+
+        self.assertTrue(ignored)
+
+    def test_unexcluded_fused_attention_projection_is_not_ignored(self):
+        ignored = should_ignore_layer(
+            "model.layers.0.self_attn.qkv_proj",
+            ignore=_MIXED_EXCLUDES,
+            fused_mapping=Qwen3_5ForCausalLMMTP.packed_modules_mapping,
+        )
+
+        self.assertFalse(ignored)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Speculative decoding is currently not working for amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 (NEXTN, TP8, gfx950), because MTP does not load on mixed Quark MXFP4 Qwen3.5 checkpoints. This PR fixes the issue by addressing two separate problems:

`_mtp_quant_config` drops the draft's quant config as soon as any `mtp.*` layer appears in the Quark exclude list. That is correct for checkpoints whose MTP module is entirely bf16 (#23146), but here it builds the whole draft unquantized, so the MoE loader allocates bf16 experts that the MXFP4 checkpoint shards no longer fit.

`Qwen3_5ForCausalLMMTP` declares no `packed_modules_mapping`, which the loader reads off the model class so the quant config can expand `qkv_proj` into `q_proj`/`k_proj`/`v_proj` before matching the exclude list. Without it an excluded attention projection is allocated MXFP4 - half as wide once packed - against bf16 shards.

## Modifications

Two changes in `python/sglang/srt/models/qwen3_5_mtp.py`:

- `_mtp_quant_config`: the Quark branch now takes the whole-module skip only when the routed experts are excluded as well, rather than on any `mtp.*` entry. They are the bulk of the draft, and the ordinary per-layer exclusions keep attention, the shared expert and `fc` in bf16 on their own.
- `Qwen3_5ForCausalLMMTP`: declare `packed_modules_mapping`, aliasing the target model's as `Qwen3_5ForConditionalGeneration` already does. That is also what the `TODO` above the Quark block in `_get_quantization_config` asks for.

`test/registered/unit/models/test_qwen3_5_mtp_quant_config.py` is new, covered under Accuracy Tests below.

Nothing else changes behaviour. The `mtp.*` exclude lists of the two published AMD checkpoints are identical apart from the routed experts:

| checkpoint | `mtp.*` excludes | of which `mlp.experts` |
| --- | --- | --- |
| amd/Qwen3.5-397B-A17B-MXFP4 | 1546 | 1536 (= 512 x 3) |
| amd/Qwen3.8-2.4T-A95B-Quark-MXFP4 | 10 | 0 |

So the 397B still takes the skip and is unaffected. The only lists whose behaviour changes are Quark lists naming some `mtp.*` layers but not the routed experts, which is exactly the mixed case.

One side effect worth flagging: `_get_quantization_config` mutates the mapping it reads off the class, so a Quark run now adds `fused_qkv_a_proj_with_mqa` to `Qwen3_5ForCausalLM.packed_modules_mapping` process-wide. It is harmless here and `Qwen3_5ForConditionalGeneration` already aliases the same dict, but I can copy instead if you prefer.

## Accuracy Tests

The draft loads and serves on `amd/Qwen3.8-2.4T-A95B-Quark-MXFP4`, NEXTN 3/1/4, TP8, MI350X; without this change it fails at load. New CPU-only unit tests cover both checkpoint shapes, using the real exclude entries, including a regression guard for #23146.

## Speed Tests and Profiling

None; this only changes which weights are allocated quantized at load time.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing behaviour changes, so there is nothing to document; happy to add a note if you want one.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35745236127](https://github.com/sgl-project/sglang/actions/runs/35745236127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35745235874](https://github.com/sgl-project/sglang/actions/runs/35745235874)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:hourglass_flowing_sand: [Run #35745236230](https://github.com/sgl-project/sglang/actions/runs/35745236230)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->