### PR TITLE
[Bugfix] Fix SM120 DeepGEMM grouped FP8 weight requantization

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1543,6 +1543,7 @@ def requant_block_scale_ue8m0_for_deepgemm(
             weight_block_size=weight_block_size,
             output_dtype=output_dtype,
             weight_shape=weight_shape,
+            is_grouped=weight.ndim == 3,
         )
     ):
         return False

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -263,7 +263,7 @@ def get_architecture_class_name(model_config: ModelConfig) -> str:
 
 
 def should_deepgemm_weight_requant_ue8m0(
-    weight_block_size, output_dtype=None, weight_shape=None
+    weight_block_size, output_dtype=None, weight_shape=None, *, is_grouped=False
 ):
     """Should we requant fp8 weights into UE8M0 format when loading the model.
 
@@ -280,7 +280,7 @@ def should_deepgemm_weight_requant_ue8m0(
         return False
     # SM120 routes dense block-FP8 GEMMs to CUTLASS/Triton (fp32 scales);
     # only the grouped MoE GEMM consumes DeepGEMM layouts there.
-    if get_device_sm() == 120:
+    if get_device_sm() == 120 and not is_grouped:
         return False
     if output_dtype is not None and output_dtype != torch.bfloat16:
         return False


### PR DESCRIPTION
## Motivation

Fixes #39063.

SM120 can enable DeepGEMM grouped FP8 GEMMs, but the weight-loading guard currently skips UE8M0 requantization for all SM120 weights. Non-power-of-two block scales then trigger the DeepGEMM scale-layout assertion.

## Modifications

- Add a keyword-only `is_grouped=False` argument to the existing eligibility helper.
- Pass `weight.ndim == 3` from the block-scale preparation helper, allowing grouped MoE weights through the SM120 guard.
- Keep dense SM120 Linear weights excluded and preserve backend, dtype, block-size, shape and already-converted checks.

No kernel changes, dependency upgrades, new backend flags, Quant Once changes, or MegaMoE integration.

## Accuracy Tests

- Local validation (test changes are not included in this PR): **8 tests passed**, including an SM120 case matrix (grouped success, dense rejection, non-DeepGEMM rejection, FP16 rejection, unaligned-shape rejection, and repeated-call behavior).
- The local regression case fails on the unpatched upstream source (`False != True` for supported grouped SM120 weights), and passes with this patch.
- RTX PRO 5000 72GB / SM120, PyTorch 2.13.0+cu130, DeepGEMM nv_dev `572557e7ae9ad5331b81a1c250f141fba2c57962`: the issue's unmodified preparation path reproduces the scale assertion. With this patch, the same reproduction returns `PREPARE True`, completes grouped GEMM, and produces finite output without explicitly forcing requantization.
- This is guard regression and operator execution validation, **not full-model E2E accuracy validation**. No claim of bitwise equivalence to the original FP32-scale representation.

The reproducible GPU script is included in #39063. The additional local regression cases are not part of this minimal production-code diff.

## Speed Tests and Profiling

Not run for this PR: this is a weight-loading correctness fix, with no performance claim. The prior unmodified path fails for the reproduced input.

## Checklist

- [x] Ruff 0.15.1 formatting and configured F401/F821/UP037 checks; `git diff --check`.
- Regression tests: executed locally; no test changes included in this PR.
- [x] Preserve unrelated architectures and dense SM120 behavior.
- [x] Document reproduction, scope, and validation limitations above.
- Documentation/API guide changes: not applicable; no user-facing flags are added.
- Full-model accuracy and speed benchmarks: not performed for this minimal fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34580250464](https://github.com/sgl-project/sglang/actions/runs/34580250464)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34580250083](https://github.com/sgl-project/sglang/actions/runs/34580250083)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34580250436](https://github.com/sgl-project/sglang/actions/runs/34580250436)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->