### PR TITLE
[Simulator] Exclude predictor query time from offline latency

### DIFF
--- a/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/scheduler.py
+++ b/tools/sglang-simulator/src/sglang_simulator/simulation/sglang/scheduler.py
@@ -455,9 +455,8 @@ class C_SchedulerHook(BaseHook):
                         )
                     )
                     # Accumulate predictor execution time for performance analysis.
-                    C_SchedulerHook.TOTAL_PREDICTOR_TIME_COST += (
-                        time.perf_counter() - pred_start
-                    )
+                    predictor_time_cost = time.perf_counter() - pred_start
+                    C_SchedulerHook.TOTAL_PREDICTOR_TIME_COST += predictor_time_cost
                     predicted_latency = float(predicted_latency)
 
                     forward_latency = 0
@@ -468,6 +467,10 @@ class C_SchedulerHook(BaseHook):
                         StateManager.set_last_real_time_ts(now)
                     else:
                         forward_latency = predicted_latency
+                        # Predictor queries are simulation work, not scheduler CPU overhead.
+                        StateManager.set_last_real_time_ts(
+                            StateManager.get_last_real_time_ts() + predictor_time_cost
+                        )
 
                     StateManager.set_current_inference_dur(forward_latency)
 

--- a/tools/sglang-simulator/test/test_simulation_offline_blocking.py
+++ b/tools/sglang-simulator/test/test_simulation_offline_blocking.py
@@ -1,4 +1,6 @@
 import json
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from test_simulation_sglang_serving import (
@@ -81,3 +83,121 @@ def test_request_rate_offline_matches_blocking(tmp_path):
             error,
             tolerance,
         )
+
+
+@pytest.mark.parametrize("mode", ["OFFLINE", "BLOCKING"])
+@pytest.mark.parametrize("predictor_delays", [(0.0, 0.0), (0.25, 0.001), (0.001, 0.25)])
+@pytest.mark.parametrize("l2_load_duration", [0.0, 0.06])
+def test_predictor_query_time_in_token_latencies(
+    monkeypatch, mode, predictor_delays, l2_load_duration
+):
+    """Predictor query time must not inflate offline TTFT or later token latency.
+
+    Blocking mode still measures elapsed wall time, including predictor queries.
+    """
+    from sglang_simulator.simulation.sglang import scheduler
+    from sglang_simulator.simulation.types import SimulationMode
+
+    hook = scheduler.C_SchedulerHook
+    state = scheduler.StateManager
+    stats_manager = scheduler.request_stats_manager
+    clock = SimpleNamespace(now=100.0)
+
+    def advance(duration):
+        clock.now += duration
+
+    monkeypatch.setattr(
+        scheduler,
+        "time",
+        SimpleNamespace(
+            time=lambda: clock.now,
+            perf_counter=lambda: clock.now,
+            sleep=advance,
+        ),
+    )
+    monkeypatch.setattr(hook, "SIM_MODE", SimulationMode(mode))
+    monkeypatch.setattr(hook, "OVERLAP_SCHEDULE", False)
+    monkeypatch.setattr(hook, "ITERATION_STATS", [])
+    monkeypatch.setattr(hook, "TOTAL_PREDICTOR_TIME_COST", 0.0)
+    monkeypatch.setattr(hook, "SIMULATION_BATCH", None)
+
+    delays = iter(predictor_delays)
+    predicted_latencies = iter([0.1, 0.05])
+
+    def predict(batch):
+        advance(next(delays))
+        return next(predicted_latencies)
+
+    monkeypatch.setattr(
+        hook,
+        "INFERENCE_PREDICTOR",
+        SimpleNamespace(
+            predict_infer_time=predict,
+        ),
+    )
+    req = SimpleNamespace(
+        rid="r1", extend_input_len=4, prefix_indices=[], output_ids=[]
+    )
+    batch = SimpleNamespace(
+        reqs=[req],
+        forward_mode=SimpleNamespace(
+            is_extend=lambda: not req.output_ids, is_decode=lambda: bool(req.output_ids)
+        ),
+    )
+    monkeypatch.setattr(scheduler, "get_obj_from_args", lambda _type_name, obj: obj)
+
+    class GenerationBatchResult:
+        pass
+
+    def run_batch(_self, _batch):
+        advance(0.03)
+        return GenerationBatchResult()
+
+    def process_batch_result(_self, _batch):
+        advance(0.04)
+        req.output_ids.append(1)
+
+    target = SimpleNamespace(
+        _prefetch_kvcache=Mock(),
+        get_new_batch_prefill=Mock(),
+        run_batch=run_batch,
+        process_batch_result=process_batch_result,
+        event_loop_normal=Mock(),
+        init_request_dispatcher=Mock(),
+    )
+    hook.hook(target)
+    state.reset()
+    stats_manager.reset()
+    state.set_last_real_time_ts(clock.now)
+    req_stats = stats_manager.get_req_stats(req.rid)
+    req_stats.created_time = 0.0
+    req_stats.input_length = 4
+    req_stats.output_length = 2
+    req_stats.queue_start = req_stats.queue_end = 0.0
+
+    try:
+        for _ in predictor_delays:
+            advance(0.02)
+            state.inc_hicache_l2_load_dur(l2_load_duration)
+            target.run_batch(None, batch)
+            target.process_batch_result(None, batch)
+
+        expected_latencies = [0.19 + l2_load_duration, 0.14 + l2_load_duration]
+        if mode == "BLOCKING":
+            expected_latencies = [
+                latency + delay
+                for latency, delay in zip(expected_latencies, predictor_delays)
+            ]
+        assert req_stats.gen_token_latencies == pytest.approx(expected_latencies)
+        metrics = scheduler.calc_metrics([req_stats])
+        assert metrics["completed"] == 1
+        assert metrics["mean_ttft_ms"] == pytest.approx(expected_latencies[0] * 1000)
+        assert metrics["mean_itl_ms"] == pytest.approx(expected_latencies[1] * 1000)
+        assert state.get_global_clock() == pytest.approx(sum(expected_latencies))
+        assert [item["cpu_overhead"] for item in hook.ITERATION_STATS] == pytest.approx(
+            [0.09, 0.09] if mode == "OFFLINE" else [0.04, 0.04]
+        )
+        assert hook.TOTAL_PREDICTOR_TIME_COST == pytest.approx(sum(predictor_delays))
+    finally:
+        state.reset()
+        stats_manager.reset()


### PR DESCRIPTION
## Motivation

Fixes #39042. In OFFLINE mode, time spent querying the latency predictor is counted again as scheduler CPU overhead. A 250 ms predictor query can turn a simulated 190 ms TTFT into 440 ms even though the predicted inference latency is unchanged.

## Modifications

Reuse the measured predictor duration to advance the CPU interval's starting timestamp in OFFLINE mode. This excludes predictor work while retaining CPU work before and after the query. `predictor_time_cost` still records the query duration, and BLOCKING mode continues to measure elapsed wall time.

Extend the existing offline/blocking simulator test file with deterministic clock coverage for prefill and decode, cold and cached predictor calls, and L2 load delays. The tests run the scheduler hooks, StateManager, token latency recording, and final TTFT/ITL metric calculation; predictor and model execution are controlled boundaries.

## Accuracy Tests

No model forward or generated output changes. Regression target:

```bash
python -m pytest -q tools/sglang-simulator/test/test_simulation_offline_blocking.py -k predictor_query
```

- Before the fix: **4 failed, 8 passed**; only OFFLINE cases with nonzero predictor delay fail.
- After the fix: **12 passed**.
- Local validation used Python 3.12 on macOS with an import-only stub for the Linux-only AIConfigurator SDK. Scheduler timing and metrics ran from the source checkout. The existing server compatibility test was not run locally; the simulator CPU CI job already runs this test file with its full dependencies.

## Speed Tests and Profiling

No live model benchmark was run. Controlled clocks verify that a slower predictor changes BLOCKING elapsed latency and recorded predictor cost, while OFFLINE TTFT/ITL stay unchanged. No model weights or accelerator runtime were downloaded.

## Checklist

- [x] Formatting and pre-commit checks on both changed files; Ruff and isort checks passed. Full-repository checks were not run in the sparse checkout.
- [x] Add regression tests to the existing simulator CPU test target.
- [x] Follow SGLang code style.
- Documentation and model accuracy/speed benchmarks: not applicable to this timing-accounting fix.

AI assistance was used for implementation and testing. No duplicate fix was found in the issue timeline or open PR searches for the issue number and predictor timing terms.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34580872047](https://github.com/sgl-project/sglang/actions/runs/34580872047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34580871723](https://github.com/sgl-project/sglang/actions/runs/34580871723)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->