### PR TITLE
[Bugfix] Infer the draft path for Qwen3.5 bundled MTP

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -874,6 +874,13 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         "HYV4ForCausalLM",
         # Qwen4-Exp ships its NEXTN draft layer inside the target checkpoint.
         "Qwen4ExpForConditionalGeneration",
+        # So does Qwen3.5: all four of these target loaders skip `mtp` weights,
+        # which are in the checkpoint only for the draft worker to pick up via
+        # the Qwen3_5ForCausalLMMTP rewrite in ModelConfig._config_draft_model.
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
     ]:
         if cfg.speculative_draft_model_path is None:
             declare_resolution(
@@ -892,7 +899,9 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "PixtralForConditionalGeneration",
             ]:
                 logger.warning(
-                    "DeepSeek MTP does not require setting speculative_draft_model_path."
+                    "%s bundles its MTP draft in the target checkpoint, so "
+                    "--speculative-draft-model-path is not required.",
+                    model_arch,
                 )
 
     if not cfg.speculative_adaptive and cfg.speculative_num_steps is None:


### PR DESCRIPTION
## Motivation

Qwen3.5 already bundles its MTP draft in the target checkpoint, so --speculative-draft-model-path is redundant, but omitting it currently fails the load. This PR adds the four Qwen3.5 architectures to the existing list of models that default the draft path to --model-path.

## Modifications

Add the four Qwen3.5 architectures next to `Qwen4ExpForConditionalGeneration`, which is listed for the same reason, and make the warning name the architecture it fired for. It read "DeepSeek MTP does not require setting speculative_draft_model_path", already wrong for the GLM, Bailing, HunYuan and Qwen4-Exp entries.

**This cannot regress an existing setup.** The new entries only take effect when `speculative_draft_model_path is None`, which previously could not work for these architectures. Callers that already pass the flag keep the path they passed.

`InternS2PreviewForConditionalGeneration`, `InternS2MobiusForConditionalGeneration` and `Qwen3MoeForCausalLM` have MTP remaps too and are absent for the same reason, one line each if their owners confirm the published checkpoints bundle the draft. Left out because I cannot test them.

## Accuracy Tests

None needed: this resolves a launch argument to the same path users pass by hand today. Checked on `amd/Qwen3.8-2.4T-A95B-Quark-MXFP4` (`Qwen3_5MoeForCausalLM`, NEXTN 3/1/4, TP8).

## Speed Tests and Profiling

None; argument resolution only, no runtime path changes.

Related: #39064, a separate fix for mixed Quark MXFP4 Qwen3.5 MTP checkpoints.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). `_handle_eagle_family` needs a resolved `ModelConfig`, so exercising it wants a real checkpoint config rather than a CPU unit test, and the change is four string literals. Happy to add one if you can point me at the preferred fixture.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Nothing to document: this removes a required flag, it does not add one.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable, as noted above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35715879331](https://github.com/sgl-project/sglang/actions/runs/35715879331)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35715879056](https://github.com/sgl-project/sglang/actions/runs/35715879056)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35715879284](https://github.com/sgl-project/sglang/actions/runs/35715879284)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->

