### PR TITLE
[ROCm] Route per-head QK norm to the stride-aware JIT kernel instead of copying

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/qknorm.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/qknorm.cuh
@@ -11,8 +11,10 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#endif
 #include <type_traits>
 
 namespace sglang {

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -480,7 +480,7 @@ def apply_qk_norm(
     k_eps = k_norm.variance_epsilon
 
     if (
-        _is_cuda  # TODO(dark): have not tested on ROCm or other backends
+        (_is_cuda or _is_hip)  # TODO(dark): have not tested on other backends
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
         and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()

--- a/test/registered/kernel/jit/test_qknorm_strided.py
+++ b/test/registered/kernel/jit/test_qknorm_strided.py
@@ -1,0 +1,157 @@
+"""Fused in-place QK norm on a strided fused-QKV slice.
+
+`test_qknorm.py` only ever feeds the kernel standalone contiguous `q`/`k`, but
+`apply_qk_norm` hands it 3-D views of a packed QKV projection whose rows are
+strided over the K/V columns. The kernel takes `q_stride`/`k_stride` as
+parameters and indexes `token * stride + head * head_dim`, so that layout is
+supported by construction -- these tests pin it, since nothing in-tree covered
+it before.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.layernorm.norm import (
+    can_use_fused_inplace_qknorm,
+    fused_inplace_qknorm,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=25, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=25, stage="jit-kernel-unit", runner_config="amd")
+
+DEVICE = "cuda"
+EPS = 1e-6
+
+# (num_tokens, num_q_heads, num_kv_heads, head_dim)
+LAYOUTS = [
+    (4096, 32, 8, 128),  # Qwen3-8B: row stride 6144
+    (1024, 32, 4, 128),  # Qwen3-30B-A3B: row stride 5120
+    (17, 16, 8, 128),  # ragged, GQA 2:1
+    (512, 16, 16, 64),  # MHA, head_dim 64
+    (128, 8, 8, 256),  # head_dim 256 (CTA kernel path)
+]
+DTYPES = [torch.bfloat16, torch.float16]
+
+
+def _fused_qkv(num_tokens, num_q_heads, num_kv_heads, head_dim, dtype, v_fill=None):
+    """Build a packed QKV buffer and return 3-D strided views of q and k."""
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    qkv = torch.randn(
+        num_tokens, q_size + 2 * kv_size, device=DEVICE, dtype=torch.float32
+    ).to(dtype)
+    if v_fill is not None:
+        qkv[:, q_size + kv_size :] = v_fill
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+    q3 = q.view(num_tokens, num_q_heads, head_dim)
+    k3 = k.view(num_tokens, num_kv_heads, head_dim)
+    # The layout under test: rows strided over the K/V columns.
+    assert q3.stride(0) == q_size + 2 * kv_size
+    assert not q3.is_contiguous()
+    return qkv, q3, k3, v
+
+
+def _weights(head_dim, dtype):
+    return (
+        torch.randn(head_dim, device=DEVICE, dtype=dtype),
+        torch.randn(head_dim, device=DEVICE, dtype=dtype),
+    )
+
+
+def _reference(x, weight, eps=EPS):
+    """RMSNorm per head, in fp32, matching RMSNorm.forward_native."""
+    x32 = x.float()
+    var = x32.pow(2).mean(-1, keepdim=True)
+    return (x32 * torch.rsqrt(var + eps) * weight.float()).to(x.dtype)
+
+
+def _skip_unless_supported(head_dim, dtype):
+    if not can_use_fused_inplace_qknorm(head_dim, dtype):
+        pytest.skip(f"JIT QK-norm unavailable for head_dim={head_dim} {dtype}")
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_strided_matches_contiguous_bitwise(layout, dtype):
+    """A strided slice and a dense copy of the same data must produce
+    bit-identical output -- the property a single row stride cannot provide."""
+    torch.manual_seed(0)
+    head_dim = layout[-1]
+    _skip_unless_supported(head_dim, dtype)
+
+    _, q_strided, k_strided, _ = _fused_qkv(*layout, dtype)
+    q_dense, k_dense = q_strided.contiguous(), k_strided.contiguous()
+    q_weight, k_weight = _weights(head_dim, dtype)
+
+    fused_inplace_qknorm(
+        q_strided, k_strided, q_weight, k_weight, EPS, head_dim=head_dim
+    )
+    fused_inplace_qknorm(q_dense, k_dense, q_weight, k_weight, EPS, head_dim=head_dim)
+
+    assert torch.equal(q_strided, q_dense)
+    assert torch.equal(k_strided, k_dense)
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_strided_matches_reference(layout, dtype):
+    torch.manual_seed(0)
+    head_dim = layout[-1]
+    _skip_unless_supported(head_dim, dtype)
+
+    _, q, k, _ = _fused_qkv(*layout, dtype)
+    q_weight, k_weight = _weights(head_dim, dtype)
+    q_expected = _reference(q.clone(), q_weight)
+    k_expected = _reference(k.clone(), k_weight)
+
+    fused_inplace_qknorm(q, k, q_weight, k_weight, EPS, head_dim=head_dim)
+
+    torch.testing.assert_close(q, q_expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(k, k_expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_operates_in_place_without_copying(layout):
+    """The point of the strided path: no reallocation, and the V columns of the
+    shared buffer are left alone."""
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    head_dim = layout[-1]
+    _skip_unless_supported(head_dim, dtype)
+
+    sentinel = 3.0
+    qkv, q, k, v = _fused_qkv(*layout, dtype, v_fill=sentinel)
+    q_ptr, k_ptr = q.data_ptr(), k.data_ptr()
+    q_weight, k_weight = _weights(head_dim, dtype)
+
+    fused_inplace_qknorm(q, k, q_weight, k_weight, EPS, head_dim=head_dim)
+
+    assert q.data_ptr() == q_ptr
+    assert k.data_ptr() == k_ptr
+    # An out-of-column write would land in V.
+    assert torch.equal(v, torch.full_like(v, sentinel))
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_does_not_read_outside_its_columns(layout):
+    """Poison V with NaN: a row-major (single-stride) misread of a q row runs
+    past the K columns into V and would surface as NaN in the output."""
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    head_dim = layout[-1]
+    _skip_unless_supported(head_dim, dtype)
+
+    qkv, q, k, _ = _fused_qkv(*layout, dtype, v_fill=float("nan"))
+    q_weight, k_weight = _weights(head_dim, dtype)
+
+    fused_inplace_qknorm(q, k, q_weight, k_weight, EPS, head_dim=head_dim)
+
+    assert torch.isfinite(q).all()
+    assert torch.isfinite(k).all()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`apply_qk_norm`'s fused fast path is gated on `_is_cuda`, with a `TODO(dark)` saying it has not been tried elsewhere. On ROCm it therefore falls through to `_reshape_for_qk_norm`, i.e. `x.reshape(-1, head_dim)`. `q`/`k` are last-dim slices of the fused QKV projection, so their rows are strided over the K/V columns and that flatten is not expressible with the input's strides — `reshape` silently degrades to `.contiguous()`, a whole-tensor device copy every layer, every forward. It is paid whether or not AITER is enabled, because the flatten lives in the model layer rather than a kernel wrapper.

Qwen3-8B on 1xMI325X (gfx942):

```
q (T, 32, 128) stride=(6144, 128, 1) bf16   reshape(-1,128) shares storage: False
k (T,  8, 128) stride=(6144, 128, 1) bf16   reshape(-1,128) shares storage: False
```

`6144 = 32*128 + 8*128 + 8*128` is the fused-QKV row stride, which pins the mechanism exactly.

The kernel behind the gate already accepts that layout — `qknorm.cuh` takes `q_stride`/`k_stride` and indexes `token * stride + head * head_dim` — and the JIT toolchain already targets HIP. Enabling it gives **+2.02% on Qwen3-8B and +3.11% on Qwen3-30B-A3B end to end, 3.4x at the kernel level**.

## Modifications

- `qknorm.cuh`: wrap two redundant unguarded `cuda_bf16.h` / `cuda_fp16.h` includes in `#ifndef USE_ROCM`. `sgl_kernel/utils.cuh`, included four lines above, already maps them to `hip/hip_*.h` and defines an empty `__grid_constant__`. These two lines were the only thing blocking the ROCm build (`fatal error: 'cuda_bf16.h' file not found`).
- `models/utils.py`: widen the gate from `_is_cuda` to `(_is_cuda or _is_hip)`. The other five conditions are platform-independent and left as they are; `can_use_fused_inplace_qknorm` still degrades to the old path when the kernel cannot be built for a given `head_dim`/dtype (supported: 64, 128, 256, 512, 1024).
- New `test/registered/kernel/jit/test_qknorm_strided.py`, registered for AMD CI.

**Not #21734 again.** That was reverted by #23159 because a stride-preserving 3-D view was handed to **AITER**, whose RMSNorm kernels fault on strided input. Here the strided view goes only to the JIT kernel, which carries the strides in its signature; the AITER fallback still receives the flattened 2-D tensor.

**Scope.** The 13 models on the shared `apply_qk_norm`: `qwen3`, `qwen3_moe`, `glm4_moe`, `llama4`, `bailing_moe`, `dflash`, `laguna`, `llada2`, `mellum`, `muse_glimmer`, `sdar`, `sdar_moe`, `inkling`. Models with a *local* `_apply_qk_norm` are not reached, and they split into two groups:

- **The Qwen3.5 stack already has a stride-aware path and pays no copy.** `Qwen3_5AttentionDecoderLayer` defaults to `attn_output_gate=True`, so on HIP/XPU/CPU it takes `forward_prepare_fused_gate` → `fused_qk_gemma_rmsnorm_with_gate`, whose kernel already does two-level `token * stride + head * stride` indexing and whose wrapper uses `view()`, not `reshape()`. This covers Qwen3.5, Qwen3.6-397B, Qwen3.8-2.4T-A95B (ships as `Qwen3_5MoeForCausalLM`) and Qwen3.8-Flash-Next / Qwen4-Exp (`Qwen4ExpAttentionDecoderLayer` inherits it and hard-sets the gate). A dispatch probe on Qwen3.5-122B confirms it: 361 calls, all to the gated kernel, none to the shared helper.
- **Still copying, and genuine follow-ups:** `qwen3_next`, `afmoe`, `lfm2`, and `bailing_moe_linear` / `bailing_moe_v3` when `use_qk_norm` is on — these inline `reshape(-1, head_dim)` in the model file.

`olmo2` looks like a candidate but normalizes the full hidden width, not per head. **NVIDIA is unaffected by construction** — see the first comment below.

One latent issue this PR does *not* fix: the non-gated `fused_qk_gemma_rmsnorm` still does `q.reshape(-1, head_dim)` and then passes `q_flat.stride(0)` to a kernel that declares a row-stride parameter — a value that can only ever be `head_dim`, so the parameter is dead and the docstring's "without an extra `.contiguous()` copy" does not hold. No shipped Qwen3.5-family config reaches it (they all gate), so it is latent rather than costly today.

## Accuracy Tests

New test: **30/30 on MI325X**, over 5 geometries (GQA 4:1 / 2:1, MHA, `head_dim` 64/128/256) x {bf16, fp16}. It asserts strided vs dense output is **bit-identical** (`torch.equal`), matches an fp32 per-head reference at `atol=rtol=2e-2`, preserves `data_ptr`, leaves the V columns of the shared buffer untouched (sentinel), and stays finite with V poisoned to NaN. The existing `test_qknorm.py` only ever builds standalone contiguous `q`/`k`, so nothing in tree had fed this kernel a strided fused-QKV slice.

GSM8K, 500 questions, 5-shot, greedy, Qwen3-8B, base vs patched at the same commit: **0.920 vs 0.920**, 0 invalid on both.

## Speed Tests and Profiling

**Kernel level.** Per-call GPU time from replaying a captured graph of 20 calls over 4 rotating QKV buffers (timing the Python callable is dispatch-bound at ~30 us/call and hides the kernel), best of 3 x 50 replays, bf16, `SGLANG_USE_AITER=1`. `cur/slice` is today's ROCm path; `cur/dense` holds that provider fixed and only densifies the input so `reshape` becomes a free view, which isolates the copy.

| geometry | tokens | cur/slice | cur/dense | fused | speedup |
|---|---|---:|---:|---:|---:|
| Qwen3-8B 32q/8kv | 4096 | 123.4 us | 98.7 us | 39.0 us | 3.16x |
| Qwen3-8B 32q/8kv | 8192 | 234.8 us | 191.1 us | 56.1 us | 4.18x |
| Qwen3-30B-A3B 32q/4kv | 8192 | 211.8 us | 172.7 us | 60.1 us | 3.52x |
| **sum, 12 cases** | | **1184.7 us** | **938.9 us** | **349.7 us** | **3.39x** |

Median 3.21x. Of the 835.0 us saved, **245.8 us (29%) is the copy** and 589.1 us (71%) is AITER's two norm launches trailing the single fused kernel. The same 29/71 split was measured independently for the equivalent vLLM path on gfx942, which is a useful cross-check on both.

**End to end.** `sglang.benchmark.offline_throughput`, random 1024-in / 128-out, `--disable-radix-cache`, TP=1, 1xMI325X. Three interleaved base/patched pairs per model with the order alternated per repeat, so drift and thermal ramp are shared rather than charged to one arm; deltas are pairwise and the figure is the median. Both arms are the same tree at the same commit differing only in the gate, so weights, JIT cache and aiter build are shared.

| Model | pairwise | median | within-arm spread |
|---|---|---|---|
| Qwen3-8B | +2.02 / +1.99 / +3.20 % | **+2.02 %** | base 1.21 %, patch 0.92 % |
| Qwen3-30B-A3B | +2.73 / +3.40 / +3.11 % | **+3.11 %** | base 1.21 %, patch 1.85 % |
| Qwen3-0.6B | +4.46 / −0.08 / +3.83 % | +3.83 % | base 1.73 %, patch 3.74 % |
| Mistral-7B (control) | −0.21 / +1.23 / −0.38 % | **−0.21 %** | base 1.26 %, patch 1.51 % |

Mistral-7B has no `q_norm`/`k_norm`, never reaches the helper, and comes out flat within its own spread. Qwen3-0.6B is **not** load-bearing: one of its three pairs is negative and its patched spread exceeds its median delta, because at that size the run is scheduler-bound. Reported rather than dropped.

Tested on gfx942 (MI325X) only; gfx950 (MI355X) numbers to follow.

<details>
<summary>Dispatch coverage — which models actually change, measured not assumed</summary>

Instrumented both `fused_inplace_qknorm` and `_reshape_for_qk_norm` to record every distinct `(shape, stride, dtype, verdict)`, then ran one short generate per model on both trees. These are dispatch counts, so they do not depend on clean timing.

| Model | layout reaching `apply_qk_norm` | calls whose 2-D flatten would copy |
|---|---|---|
| Qwen3-8B | q `(T,32,128)` / k `(T,8,128)`, stride 6144 | **11018 / 11234** |
| Qwen3-0.6B | q `(T,16,128)` / k `(T,8,128)`, stride 4096 | **8570 / 8738** |
| Qwen3-30B-A3B | q `(T,32,128)` / k `(T,4,128)`, stride 5120 | **14690 / 14978** |
| lfm2-1.2b | never reaches it (local `_apply_qk_norm`) | — |
| Mistral-7B | never reaches it (no QK norm) | — |
| Olmo-3-7B | never reaches it (full-width norm) | — |

On base, the identical 11018/11234 calls go through `_reshape_for_qk_norm` and copy, so the correspondence is one-to-one. The residual 216 calls are the `T == 1` decode graphs, where the leading dim is degenerate and the flatten is already free — worth stating plainly: this is a prefill and multi-sequence-decode cost, not a universal per-forward cost.

</details>

<details>
<summary>Why the other five gate conditions are kept as-is</summary>

I read them one at a time rather than assuming they were all CUDA-specific:

| condition | why it is kept |
|---|---|
| `allow_inplace` | caller semantics, platform-independent |
| `q_eps == k_eps` | the kernel takes a single `eps` |
| `not SGLANG_ENABLE_DETERMINISTIC_INFERENCE` | platform-independent |
| `tc_compiler != "inductor"` | `tc_compiler` is a platform-agnostic knob defaulting to `"eager"`; when inductor PCG *is* on, letting it fuse the norm is the same call as on CUDA |
| `can_use_fused_inplace_qknorm(head_dim, q.dtype)` | the real capability check — `@cache_once`, catches build failures and returns `False` |

One pre-existing property, now more exposed: the kernel's `TensorMatcher` requires the norm weight dtype to equal the activation dtype, and `can_use_fused_inplace_qknorm` does not check the weight. A model arriving with an fp32 norm weight would fail the matcher — but the set of models calling `apply_qk_norm` is platform-independent and the gate is already open on CUDA, so this PR cannot introduce a new instance of it. The dispatch probe shows `w_dtype=bfloat16` for all three models measured.

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — N/A, no user-facing surface and no new flags.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

AI assistance was used in preparing this change; all measurements were run and reviewed by hand.
