### PR TITLE
Improve multimodal processor import diagnostics

### DIFF
--- a/python/sglang/srt/managers/multimodal_processor.py
+++ b/python/sglang/srt/managers/multimodal_processor.py
@@ -12,6 +12,7 @@ from sglang.srt.server_args import ServerArgs
 logger = logging.getLogger(__name__)
 
 PROCESSOR_MAPPING = {}
+PROCESSOR_IMPORT_FAILURES: dict[str, str] = {}
 
 
 def import_processors(package_name: str, overwrite: bool = False):
@@ -21,8 +22,10 @@ def import_processors(package_name: str, overwrite: bool = False):
             try:
                 module = importlib.import_module(name)
             except Exception as e:
+                PROCESSOR_IMPORT_FAILURES[name] = f"{type(e).__name__}: {e}"
                 logger.warning(f"Ignore import error when loading {name}: {e}")
                 continue
+            PROCESSOR_IMPORT_FAILURES.pop(name, None)
             all_members = inspect.getmembers(module, inspect.isclass)
             classes = [
                 member
@@ -82,8 +85,19 @@ def get_mm_processor(
 ) -> BaseMultimodalProcessor:
     processor_cls = get_mm_processor_cls(hf_config, model_config)
     if processor_cls is None:
+        import_failure_details = ""
+        if PROCESSOR_IMPORT_FAILURES:
+            failures = "\n".join(
+                f"- {name}: {failure}"
+                for name, failure in sorted(PROCESSOR_IMPORT_FAILURES.items())
+            )
+            import_failure_details = (
+                f"\nProcessor modules that failed to import:\n{failures}"
+            )
         raise ValueError(
             f"No processor registered for architecture: {hf_config.architectures}.\n"
-            f"Registered architectures: {[model_cls.__name__ for model_cls in PROCESSOR_MAPPING.keys()]}"
+            f"Registered architectures: "
+            f"{[model_cls.__name__ for model_cls in PROCESSOR_MAPPING.keys()]}"
+            f"{import_failure_details}"
         )
     return processor_cls(hf_config, server_args, processor, transport_mode, **kwargs)

--- a/test/registered/unit/managers/test_multimodal_processor_import_diagnostics.py
+++ b/test/registered/unit/managers/test_multimodal_processor_import_diagnostics.py
@@ -1,0 +1,75 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers import multimodal_processor as mm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMultimodalProcessorImportDiagnostics(CustomTestCase):
+    def test_import_failure_is_reported_and_cleared_after_retry(self):
+        package_name = "test_processors"
+        processor_module = f"{package_name}.broken"
+        package = SimpleNamespace(__path__=[])
+        module = SimpleNamespace(__name__=processor_module)
+        failures = mm.PROCESSOR_IMPORT_FAILURES
+        failures.clear()
+        self.addCleanup(failures.clear)
+
+        with (
+            patch.object(
+                mm.importlib,
+                "import_module",
+                side_effect=[
+                    package,
+                    ImportError("libavcodec.so.61: cannot open shared object file"),
+                ],
+            ),
+            patch.object(
+                mm.pkgutil,
+                "iter_modules",
+                return_value=[(None, processor_module, False)],
+            ),
+        ):
+            mm.import_processors(package_name)
+
+        hf_config = SimpleNamespace(architectures=["ExampleForConditionalGeneration"])
+        with (
+            patch.object(mm, "get_mm_processor_cls", return_value=None),
+            self.assertRaises(ValueError) as context,
+        ):
+            mm.get_mm_processor(
+                hf_config,
+                server_args=None,
+                processor=None,
+                transport_mode=None,
+            )
+
+        message = str(context.exception)
+        self.assertIn("No processor registered for architecture", message)
+        self.assertIn("Processor modules that failed to import:", message)
+        self.assertIn(processor_module, message)
+        self.assertIn("ImportError: libavcodec.so.61", message)
+
+        with (
+            patch.object(
+                mm.importlib,
+                "import_module",
+                side_effect=[package, module],
+            ),
+            patch.object(
+                mm.pkgutil,
+                "iter_modules",
+                return_value=[(None, processor_module, False)],
+            ),
+        ):
+            mm.import_processors(package_name)
+
+        self.assertNotIn(processor_module, failures)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

Multimodal processor discovery deliberately tolerates individual module import errors.
Although it emits a warning immediately, the later fatal `No processor registered`
exception drops those causes. The warning and final exception can be separated across
large or multiprocess logs, so a dependency or initialization failure looks like missing
model support.

This diagnostic gap has appeared in earlier reports such as #12830/#12874 and #12134.

Fixes #39073

## Modifications

- Retain a concise string summary for each failed processor import: module name,
  exception type and exception message.
- Remove a stale failure if that module imports successfully on a later retry.
- Append the sorted failure summaries only when processor lookup is already fatal.
- Add one registered CPU test covering the fatal diagnostic and successful retry.

This does not make optional processor dependencies mandatory, change registration
semantics, retain traceback/frame objects, or affect the normal request path.

## Accuracy Tests

Not applicable. Model selection and model outputs are unchanged.

## Speed Tests and Profiling

Not applicable. The new formatting path runs only when startup is already terminating
with an unregistered processor error.

## Tests

```bash
PYTHONPATH=python python3 test/registered/unit/managers/test_multimodal_processor_import_diagnostics.py
```

Result: 1 passed.

A black-box reproducer was also run against the exact upstream base and this branch.
The base reported `contains_module=False` and `contains_cause=False`; this branch
reported both as `True` and retained the original fatal exception type.

Validated against upstream base `822e73ccddc0297e9901042d4aab7fcccc11f1a6`;
the patch commit is `2b1ddcdd35bc1cdddcf890b01a9e99ef68c12ca0`.

The complete pre-commit set for both changed files also passes, including CI registry
validation.

## Checklist

- [x] Format your code according to the pre-commit guidance.
- [x] Add a focused registered CPU unit test.
- [x] Documentation is not required for this error-reporting-only change.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34585583670](https://github.com/sgl-project/sglang/actions/runs/34585583670)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34585583326](https://github.com/sgl-project/sglang/actions/runs/34585583326)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34585583620](https://github.com/sgl-project/sglang/actions/runs/34585583620)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->