### PR TITLE
[Bugfix] Fail clearly when DCP decode hits the LSE-less aiter path

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -733,20 +733,13 @@ class DeepseekMLARocmForwardMixin:
                         "llama_4_scaling": llama_4_scaling,
                     }
                 if is_dcp_mla_decode_phase(forward_batch):
-                    # set return_lse=True to correct attn_output
-                    attn_output, lse = self.attn_mqa_for_dcp_decode(
-                        q_nope_out,
-                        k_nope,
-                        k_nope,
-                        forward_batch,
-                        q_rope=q_pe,
-                        k_rope=k_pe,
-                        **extra_args,
-                        **(
-                            dict(topk_indices=topk_indices)
-                            if topk_indices is not None
-                            else {}
-                        ),
+                    # aiter's decode kernels never return LSE, which DCP's
+                    # cross-rank merge below requires. sgl-project/sglang#38709.
+                    raise NotImplementedError(
+                        "DCP decode is not supported with the aiter MLA "
+                        "decode backend on ROCm: it does not return the "
+                        "log-sum-exp DCP's merge step needs "
+                        "(sgl-project/sglang#38709)."
                     )
                 else:
                     attn_output = self.attn_mqa(

--- a/test/registered/unit/models/test_deepseek_mla_dispatch.py
+++ b/test/registered/unit/models/test_deepseek_mla_dispatch.py
@@ -18,6 +18,12 @@ from sglang.srt.layers.cp import base as cp_base
 from sglang.srt.layers.cp.zigzag import ZigzagCPStrategy
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.models.deepseek_common import attention_backend_handler as abh
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla as fml,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla_rocm as fmr,
+)
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
     AttnForwardMethod,
 )
@@ -140,6 +146,81 @@ class TestCPMLADispatch(CustomTestCase):
                                 abh._handle_attention_backend(attn, batch, "fa3"),
                                 expected,
                             )
+
+
+class TestRocmDcpDecodeLseGuard(CustomTestCase):
+    """aiter's decode kernels never return LSE, which DCP's cross-rank merge
+    needs; forward_absorb_rocm_core must fail clearly instead of crashing on
+    "not enough values to unpack" inside attn_mqa_for_dcp_decode. See
+    sgl-project/sglang#38709."""
+
+    def test_dcp_decode_on_dsa_backend_raises_clear_error(self):
+        # "dsa" is in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS, matching the
+        # reported repro (glm_moe_dsa). _skip_rope_for_dsa_tilelang_fused=False
+        # routes past the tilelang fast path into the branch that calls
+        # attn_mqa_for_dcp_decode.
+        fake_self = SimpleNamespace(
+            current_attention_backend="dsa",
+            _skip_rope_for_dsa_tilelang_fused=lambda: False,
+            _fuse_rope_for_trtllm_mla=lambda forward_batch: False,
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: True, is_target_verify=lambda: False
+            )
+        )
+        with mock.patch.object(
+            fml, "get_parallel", lambda: SimpleNamespace(dcp_enabled=True)
+        ):
+            with self.assertRaises(NotImplementedError):
+                fmr.DeepseekMLARocmForwardMixin.forward_absorb_rocm_core(
+                    fake_self,
+                    q_pe=None,
+                    k_pe=None,
+                    q_nope_out=None,
+                    k_nope=None,
+                    forward_batch=forward_batch,
+                    zero_allocator=None,
+                    positions=None,
+                    topk_indices=None,
+                    llama_4_scaling=None,
+                )
+
+    def test_non_dcp_decode_on_dsa_backend_does_not_raise(self):
+        # Same backend, DCP disabled -- must reach attn_mqa unaffected by the
+        # guard.
+        fake_self = SimpleNamespace(
+            current_attention_backend="dsa",
+            _skip_rope_for_dsa_tilelang_fused=lambda: False,
+            _fuse_rope_for_trtllm_mla=lambda forward_batch: False,
+            attn_mqa=mock.Mock(return_value="attn_output"),
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: True, is_target_verify=lambda: False
+            )
+        )
+        with mock.patch.object(
+            fml, "get_parallel", lambda: SimpleNamespace(dcp_enabled=False)
+        ):
+            try:
+                fmr.DeepseekMLARocmForwardMixin.forward_absorb_rocm_core(
+                    fake_self,
+                    q_pe=None,
+                    k_pe=None,
+                    q_nope_out=None,
+                    k_nope=None,
+                    forward_batch=forward_batch,
+                    zero_allocator=None,
+                    positions=None,
+                    topk_indices=None,
+                    llama_4_scaling=None,
+                )
+            except NotImplementedError:
+                self.fail("guard raised even though DCP decode is disabled")
+            except Exception:
+                pass  # post-attn_mqa tensor plumbing is out of scope here
+        fake_self.attn_mqa.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

On ROCm, `--dcp-size > 1` crashes every rank on the first decode forward
(`forward_absorb_rocm_core`) with:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

Fixes #38709

## Root cause

`is_dcp_mla_decode_phase(forward_batch)` branches in `forward_absorb_rocm_core`
unconditionally do `attn_output, lse = self.attn_mqa_for_dcp_decode(...)`.
`attn_mqa_for_dcp_decode` is a `RadixAttention` instance; in decode mode this
delegates to `AiterAttnBackend.forward_decode()`, which (unlike its
`forward_extend()` sibling) never computes or returns an LSE — all three of
its `return` statements return a single tensor. DCP's cross-rank merge right
after this call (`dcp_a2a_lse_reduce` / `cp_lse_ag_out_rs_mla`) genuinely needs
that LSE to combine partial softmax results correctly; there is no safe
default to substitute.

I traced this down to the underlying `aiter.mla.mla_decode_fwd` (external
AMD library): it *does* already support `return_lse=True` and returns
`(logits, final_lse)` — the feature exists upstream in aiter, SGLang's
wrapper chain (`forward_decode` -> `_forward_mla_decode` ->
`_mla_decode_fwd_with_head_pad`) just never asks for it, and the head-padding
wrapper currently discards `mla_decode_fwd`'s return value entirely (it
assumes its own separately-allocated `o` buffer is filled in place, which
holds in some of `mla_decode_fwd`'s internal branches but not the
`num_kv_splits == 1` branch, which builds and returns a *different* tensor).

## Why this PR doesn't wire up the full fix

Making DCP decode actually correct on ROCm means:
1. Passing `return_lse=True` through the three wrapper layers.
2. Capturing `mla_decode_fwd`'s actual return value instead of discarding it.
3. Confirming, on real hardware, that `o` and the returned `logits`/`lse`
   alias correctly in every branch the head-padding wrapper can take.

Getting (3) wrong would replace a loud crash with **silently wrong attention
output** — worse than the current state. I don't have ROCm/aiter hardware to
verify that safely, so this PR only replaces the crash with a clear,
actionable `NotImplementedError` pointing at this issue, so the failure mode
is diagnosable instead of a bare unpack error. Happy to open a follow-up once
I (or someone with a ROCm box) can validate the full fix numerically.

## Not a duplicate

- `gh issue view 38709 --comments` — no comments, no assignee.
- Searched open PRs for `38709`, `attn_mqa_for_dcp_decode`,
  `forward_absorb_rocm_core` — none found.

## Test Plan / Test Result

Added two pure-Python, CPU-only tests to
`test/registered/unit/models/test_deepseek_mla_dispatch.py`, following that
file's existing `SimpleNamespace` + `mock.patch.object` pattern:

- `test_dcp_decode_on_dsa_backend_raises_clear_error`
- `test_non_dcp_decode_on_dsa_backend_does_not_raise`

```bash
PYTHONPATH=python pytest test/registered/unit/models/test_deepseek_mla_dispatch.py -v
# 9 passed, 3 warnings, 8 subtests passed
```

Verified the new case is a real regression guard, not a tautology: reverted
just the source change and reran — `test_dcp_decode_on_dsa_backend_raises_clear_error`
fails (reaches the removed `attn_mqa_for_dcp_decode` call and hits an
`AttributeError` on the test double instead of getting a clean
`NotImplementedError`); restoring the fix makes all 9 tests pass again.

No model-output or accuracy impact — this only turns an unsupported
configuration's crash into an explicit error at the same call site; it does
not change any numerical computation.

## AI assistance disclosure

Prepared with AI assistance (Claude Code). I reviewed every changed line and
ran the tests above myself before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt95xmcafe7Mnff5y8Ah1d

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34585099077](https://github.com/sgl-project/sglang/actions/runs/34585099077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34585098702](https://github.com/sgl-project/sglang/actions/runs/34585098702)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34585099092](https://github.com/sgl-project/sglang/actions/runs/34585099092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->