### PR TITLE
[NPU][Diffusion] Add SenseNova-U1 request batching and fused denoise optimizations

### DIFF
--- a/benchmark/sensenova/NPU_ATTENTION_MICROBENCH.md
+++ b/benchmark/sensenova/NPU_ATTENTION_MICROBENCH.md
@@ -1,0 +1,107 @@
+# SenseNova NPU Attention 微基准
+
+这个测试绕过服务和完整模型，直接调用 SenseNova 当前 NPU 路径使用的
+`torch.nn.functional.scaled_dot_product_attention`。它回答三个问题：
+
+1. B2 Attention 相比 B1 是否获得吞吐提升；
+2. 显式 mask 本身有多少开销；
+3. 变长样本合批是否比两个紧凑的单样本 Attention 更快。
+
+## 1. 准备代码
+
+进入已经安装好 `torch_npu` 的环境：
+
+```bash
+cd /workspace/sglang
+export PYTHONPATH=/workspace/sglang/python:${PYTHONPATH:-}
+mkdir -p /workspace/sensenova-attention-results
+```
+
+运行测试时不要同时启动 SGLang 服务，避免模型占用显存和干扰计时。
+
+## 2. 先运行小尺寸冒烟测试
+
+```bash
+python3 benchmark/sensenova/bench_npu_attention.py \
+  --query-length 1024 \
+  --short-prefix-length 260 \
+  --long-prefix-length 286 \
+  --heads 32 \
+  --kv-heads 8 \
+  --head-dim 128 \
+  --warmup 3 \
+  --iterations 10 \
+  --output /workspace/sensenova-attention-results/attention-q1024.json
+```
+
+脚本末尾三个 `allclose` 都应为 `true`。否则先停止，不执行下一步。
+
+## 3. 运行 2048 图像分辨率对应的测试
+
+SenseNova 的 2048×2048 图像在 Attention 中对应 4096 个 image token。之前
+的服务日志显示最大 prefix 为 286，因此使用 `K=4096+286=4382`：
+
+```bash
+python3 benchmark/sensenova/bench_npu_attention.py \
+  --query-length 4096 \
+  --short-prefix-length 260 \
+  --long-prefix-length 286 \
+  --heads 32 \
+  --kv-heads 8 \
+  --head-dim 128 \
+  --warmup 5 \
+  --iterations 20 \
+  --native-fia \
+  --output /workspace/sensenova-attention-results/attention-q4096.json
+```
+
+这个测试只执行单层 Attention，不会加载 SenseNova 模型，也不会生成 profiler
+trace。结果文件通常只有几 KB。
+
+## 4. 查看结果
+
+```bash
+python3 - <<'PY'
+import json
+
+path = "/workspace/sensenova-attention-results/attention-q4096.json"
+data = json.load(open(path, encoding="utf-8"))
+print("correctness:", data["correctness"])
+for name, value in data["measurements"].items():
+    print(f'{name:28s} {value["median_ms"]:10.3f} ms')
+print("derived:")
+for name, value in data["derived"].items():
+    print(f"  {name}: {value:.4f}")
+PY
+```
+
+各项含义：
+
+- `b1_long_no_mask`：一个长 prompt 样本；
+- `b2_no_mask`：两个等长样本直接合批，不传 mask；
+- `b2_all_true_mask`：相同 B2 输入，传入全部为 True 的显式 mask；
+- `b2_mixed_padding_mask`：一个短 prefix 和一个长 prefix 合批，屏蔽 padding；
+- `two_compact_singletons`：将两个样本拆开，短样本移除 padding，顺序执行两次；
+- `native_fia_b2_right_padded`：把短样本排成“有效 prefix + image token + 尾部
+  padding”，再通过 `npu_fused_infer_attention_score` 的
+  `actual_seq_lengths_kv` 跳过无效 KV；
+- `native_fia_b2_left_padded`：把 prefix 右对齐并保持 image token 的统一写入
+  位置，传入单元素 `kv_padding_size=[0]` 和每样本有效 KV 长度；这个布局若
+  通过验证，正式接入时只需在去噪前重排一次 prefix cache；
+- `b2_throughput_speedup_vs_b1`：B2 相对连续两个 B1 的理论吞吐倍数；
+- `all_true_mask_overhead_pct`：仅进入显式 mask 路径产生的开销；
+- `mixed_mask_overhead_vs_all_true_pct`：mask 中存在 False 后的额外开销；
+- `batched_mixed_speedup_vs_compact_singletons`：当前变长合批相对两个紧凑
+  单样本调用的加速倍数。
+- `native_fia_right_*` 和 `native_fia_left_*`：两种原生 FIA 布局相对当前
+  SDPA 的加速倍数，以及 B2 吞吐相对当前 B1 SDPA 的倍数。
+
+判断标准：
+
+- `b2_throughput_speedup_vs_b1` 接近 1，说明单层 Attention 在 B2 下也几乎
+  没有吞吐收益；明显大于 1 才说明端到端损失发生在其他算子或调度阶段；
+- `all_true_mask_overhead_pct` 较大，说明 NPU 的显式 mask 路径本身较慢；
+- `mixed_mask_overhead_vs_all_true_pct` 较小，说明性能主要取决于 mask 的形状和
+  算子路径，而不是 False 元素的数量；
+- `batched_mixed_speedup_vs_compact_singletons` 小于或接近 1，说明当前 padding
+  合批没有优于顺序执行紧凑 KV，下一步应验证支持有效序列长度的 NPU 原生接口。

--- a/benchmark/sensenova/NPU_BATCHING_VALIDATION.md
+++ b/benchmark/sensenova/NPU_BATCHING_VALIDATION.md
@@ -1,0 +1,307 @@
+# SenseNova 910C 内网批处理验证手册
+
+本手册分两部分：①确认批处理路径可以执行；②测量不同 batch size 的端到端性能。
+面向 Linux + 单张 Ascend 910C，使用已有的 NPU 推理镜像与本地完整模型。
+Windows 机器只负责拷贝代码，不执行 NPU 验证。
+
+本次实现已在 910C 上完成可用性与性能验证，结果见 2.5 节。复测遇到错误请保留日志；不可将 HTTP 成功等同于真实合批成功。
+第一部分不证明数值精度与原模型完全一致，只证明执行与返回可用。
+
+## 0. 共同准备（只做一次）
+
+### 0.1 拷贝文件并进入环境
+
+将当前开发工作区完整复制到内网 `/workspace/sglang`，包含未提交的修改以及
+`benchmark/sensenova/validate_npu_batching.py`。只复制 Git 分支历史可能遗漏未提交代码。
+激活已有的 SGLang NPU 环境；该环境需要已有 torch、torch_npu、SGLang 推理依赖和 Pillow。
+不要在内网执行 pip 下载命令。模型目录需要包含权重、配置和 tokenizer 全部文件。
+
+以下所有命令使用 Bash。打开两个终端，均进入同一个已激活的推理环境。
+只需在下面修改一次 `MODEL_PATH`，其他路径按本手册固定。
+
+```bash
+mkdir -p /workspace/sensenova-validation
+cat > /workspace/sensenova-validation/env.sh <<'SH'
+export REPO=/workspace/sglang
+export MODEL_PATH=/model/ModelScope/SenseNova/SenseNova-U1.5-8B-MoT
+export RESULTS=/workspace/sensenova-validation/results
+export PYTHONPATH="$REPO/python${PYTHONPATH:+:$PYTHONPATH}"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+SH
+source /workspace/sensenova-validation/env.sh
+cd "$REPO"
+mkdir -p "$RESULTS"
+test -f "$MODEL_PATH/config.json" || { echo '模型路径错误'; exit 1; }
+test -f benchmark/sensenova/validate_npu_batching.py || exit 1
+npu-smi info | tee "$RESULTS/npu-info.txt"
+python3 - <<'PY' | tee "$RESULTS/environment.txt"
+import sys, torch, torch_npu, sglang
+from PIL import Image
+print('Python:', sys.version)
+print('Torch:', torch.__version__)
+print('torch_npu:', torch_npu.__version__)
+print('SGLang:', sglang.__file__)
+print('NPU available:', torch.npu.is_available())
+assert torch.npu.is_available()
+assert '/workspace/sglang/python/' in sglang.__file__
+PY
+```
+
+上一步出现导入失败或断言失败：先修复现有镜像/环境，再继续。若目录带 Git 信息，保存版本：
+
+```bash
+git rev-parse HEAD > "$RESULTS/commit.txt"
+git diff --binary > "$RESULTS/working-tree.patch"
+```
+
+这些命令不记录未跟踪文件；请同时保留本次复制的完整代码包。
+
+### 0.2 创建统一服务启动脚本
+
+```bash
+cat > /workspace/sensenova-validation/serve.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+source /workspace/sensenova-validation/env.sh
+cd "$REPO"
+BATCH=${1:?需要 batch size}
+TAG=${2:?需要日志名称}
+sglang serve \
+  --model-path "$MODEL_PATH" \
+  --num-gpus 1 \
+  --port 30000 \
+  --batching-max-size "$BATCH" \
+  --batching-delay-ms 100 \
+  --enable-batching-metrics \
+  2>&1 | tee "$RESULTS/server-${TAG}.log"
+SH
+```
+
+NPU 默认启用原生 FIA 去噪 Attention。做 A/B 测试时，在执行 `serve.sh` 前设置：
+
+```bash
+# FIA 组
+export SGLANG_SENSENOVA_NPU_FIA=1
+
+# SDPA 对照组
+export SGLANG_SENSENOVA_NPU_FIA=0
+```
+
+当前分支还默认启用 NPU fused RMSNorm 和 dense MLP gate/up 融合。复现未优化
+对照时，同时关闭以下三项：
+
+```bash
+export SGLANG_SENSENOVA_NPU_FUSED_NORM=0
+export SGLANG_SENSENOVA_NPU_FUSED_MLP=0
+```
+
+验证完整优化路径时设置：
+
+```bash
+export SGLANG_SENSENOVA_NPU_FIA=1
+export SGLANG_SENSENOVA_NPU_FUSED_NORM=1
+export SGLANG_SENSENOVA_NPU_FUSED_MLP=1
+```
+
+MLP 融合会在第一次 NPU 前向时整理权重布局。正式计时前必须完成一次相同分辨率、
+步数和 batch size 的完整预热请求。融合路径保留原 checkpoint 参数名，不需要转换
+模型文件。
+
+每次修改后必须停止并重新启动服务。FIA 组与 SDPA 组使用相同 batch size、
+请求、分辨率、步数和 CFG 参数。
+
+采用当前环境自动选择的 NPU 后端；不带 GPU 分支的 FA3/Triton 参数，不开启入图。
+默认 think mode 为 false，每请求一张图。第一轮保持模型默认精度和采样实现。
+如果现有环境必须添加 offload 等参数才能启动，请只修改 `serve.sh` 一次，所有 B1/B2/B4 使用同一版本。
+`--num-gpus 1` 是框架通用设备数量参数，NPU 同样使用它。
+100 ms 是本次统一实验的合批等待窗口，结果会包含该窗口的影响。
+
+每次服务切换：在终端 A 按 Ctrl+C，等待旧进程退出、设备内存释放，再启动新服务。
+不允许两个模型服务同时占用该设备；若端口已占用，不继续测试。
+
+## 1. 验证适配可用性：真实批处理路径走通
+
+### 1.1 启动 B2 服务（终端 A）
+
+```bash
+bash /workspace/sensenova-validation/serve.sh 2 smoke-b2
+```
+
+### 1.2 等待服务就绪（终端 B）
+
+终端 B 每次新开都执行 source：
+
+```bash
+source /workspace/sensenova-validation/env.sh
+cd "$REPO"
+python3 - <<'PY'
+import time, urllib.request
+for _ in range(600):
+    try:
+        with urllib.request.urlopen('http://127.0.0.1:30000/health', timeout=5) as r:
+            if r.status == 200:
+                print('服务已就绪'); break
+    except Exception:
+        pass
+    time.sleep(2)
+else:
+    raise SystemExit('服务未就绪，请检查终端 A 日志')
+PY
+```
+
+### 1.3 先验证单请求，再验证并发请求
+
+```bash
+python3 benchmark/sensenova/validate_npu_batching.py \
+  --model "$MODEL_PATH" --requests 1 --concurrency 1 \
+  --size 1024 --steps 5 --cfg 4 --warmup 0 --save-images \
+  --output "$RESULTS/smoke-single"
+
+python3 benchmark/sensenova/validate_npu_batching.py \
+  --model "$MODEL_PATH" --requests 4 --concurrency 4 \
+  --size 1024 --steps 5 --cfg 4 --warmup 0 --save-images \
+  --output "$RESULTS/smoke-b2-cfg4"
+
+python3 benchmark/sensenova/validate_npu_batching.py \
+  --model "$MODEL_PATH" --requests 4 --concurrency 4 \
+  --size 1024 --steps 5 --cfg 1 --warmup 0 --save-images \
+  --output "$RESULTS/smoke-b2-cfg1"
+
+grep -n 'Processed dynamic batch of 2/2' "$RESULTS/server-smoke-b2.log"
+```
+
+脚本输出目录必须不存在，防止覆盖结果。重跑时给 `--output` 加 `-retry1` 等后缀。
+每个目录包含 `result.json`、按请求编号保存的 PNG；JSON 包含对应 prompt 和 seed。
+
+通过标准：
+
+- 三次命令均以退出码 0 结束，分别成功 1、4、4 次，failed=0。
+- CFG=1 和 CFG=4 两轮均在对应时间的服务日志中出现真实 `2/2` 合批记录。
+- 图片可以打开，尺寸正确，未出现全部黑图或明显损坏。
+- 服务无 OOM、运行异常，测试后仍能接收请求。
+
+只有图片成功、没有 `2/2`：结论是“单请求可用，批处理未证实”。先检查复制的代码、实际启动参数和并发量。
+必要时只重跑并发测试。不要据此进入性能结论。
+1024/5 步仅用于路径检查，图片质量不是该阶段验收指标。
+
+## 2. 验证性能：B1 / B2 / B4
+
+### 2.1 固定实验条件
+
+采用 2048×2048、50 步、CFG=4、每请求一图、客户端并发 4。
+三种服务配置唯一变化是最大 batch size。B1 同样使用并发 4，是排队执行的吞吐基线。
+脚本使用固定内置 prompt 和 seed，不访问外网，不依赖 vbench。
+计时包括 HTTP、图片传输、JSON/base64 解码和图片校验，是客户端端到端吞吐，不是纯算子时间。
+正式轮不保存 PNG，结果写入发生在计时结束后。
+
+### 2.2 创建性能测试脚本（终端 B）
+
+```bash
+cat > /workspace/sensenova-validation/perf.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$REPO"
+BATCH=${1:?需要 batch size}
+# 完整并发预热：执行相同分辨率和步数，结果不纳入正式统计。
+python3 benchmark/sensenova/validate_npu_batching.py \
+  --model "$MODEL_PATH" --requests 4 --concurrency 4 \
+  --size 2048 --steps 20 --cfg 4 --warmup 0 \
+  --output "$RESULTS/perf-b${BATCH}-warmup"
+python3 benchmark/sensenova/validate_npu_batching.py \
+  --model "$MODEL_PATH" --requests 4 --concurrency 4 \
+  --size 2048 --steps 50 --cfg 4 --warmup 0 \
+  --output "$RESULTS/perf-b${BATCH}"
+SH
+```
+
+### 2.3 依次测试三个服务配置
+
+先停止第一部分服务。每一行都按“终端 A 启动 → 终端 B 执行 1.2 的就绪检查 → 终端 B 测试 → 停止服务”的顺序执行。
+
+| 配置 | 终端 A | 终端 B（就绪后执行） |
+|---|---|---|
+| B1 | `bash /workspace/sensenova-validation/serve.sh 1 perf-b1` | `bash /workspace/sensenova-validation/perf.sh 1` |
+| B2 | `bash /workspace/sensenova-validation/serve.sh 2 perf-b2` | `bash /workspace/sensenova-validation/perf.sh 2` |
+| B4 | `bash /workspace/sensenova-validation/serve.sh 4 perf-b4` | `bash /workspace/sensenova-validation/perf.sh 4` |
+
+B4 如 OOM，停止 B4，不更改分辨率或 offload 来强行与前两组比较，记录“该配置容量不足”。
+B1/B2 的结果仍可分析。所有轮次 failed 必须为 0；有失败的轮次不进入有效吞吐比较。
+
+完成 B2/B4 后检查真实批次：
+
+```bash
+grep -n 'Processed dynamic batch of' "$RESULTS/server-perf-b2.log"
+grep -n 'Processed dynamic batch of' "$RESULTS/server-perf-b4.log"
+npu-smi info | tee "$RESULTS/npu-info-after.txt"
+```
+
+最大 batch=4 不等于实际每次 B4。需要日志出现 `4/4`，否则标为“最大 B4，实际混合批次”。
+日志包含预热和正式轮，检查正式轮对应区间，不可仅凭预热的合批记录认定正式轮已合批。
+
+### 2.4 自动汇总单轮结果
+
+```bash
+python3 - <<'PY'
+import json, os
+from pathlib import Path
+root = Path(os.environ['RESULTS'])
+baseline = None
+print('| 最大Batch | 吞吐(images/s) | 相对B1提升 | Mean延迟(s) | P95延迟(s) | 报告峰值内存(MB) |')
+print('|---|---|---|---|---|---|')
+for b in (1, 2, 4):
+    path = root / f'perf-b{b}/result.json'
+    if not path.exists():
+        print(f'| {b} | 未完成 | — | — | — | — |'); continue
+    row = json.loads(path.read_text())
+    if row['failed'] or row['successful'] != 4:
+        print(f'| {b} | 有失败，结果无效 | — | — | — | — |'); continue
+    rate = row['outputs_per_s']
+    if b == 1: baseline = rate
+    gain = f'{(rate / baseline - 1) * 100:+.2f}%' if baseline else '缺少B1'
+    mean = row['mean_latency_s']
+    p95 = row['p95_latency_s']
+    mem = [r['peak_memory_mb'] for r in row['requests'] if r.get('peak_memory_mb') is not None]
+    print(f'| {b} | {rate:.5f} | {gain} | {mean:.2f} | {p95:.2f} | {max(mem) if mem else "未上报"} |')
+PY
+```
+
+服务上报的 peak memory 可能是进程累计峰值，不应解释为每请求独占显存，也不能累加。
+独立重启使不同 batch 配置的峰值更可比较；未上报表示缺失，不表示零。
+4 请求用于开发阶段的固定负载 A/B，P95 仅代表本轮最慢请求。正式 SLA 需要更大样本量。
+
+结论写法：
+
+- 第一部分通过：批处理路径可用（不代表完整数值正确性已通过）。
+- B2/B4 单轮成功且正式轮日志证实合批：可报告表中吞吐提升，并保留实际批次分布。
+- 提升 ≥10% 可作为本次开发目标达到的参考；接近零或波动大时保留数据，不宣称加速。
+- 必须随结果附上代码包、环境信息、全部 server 日志及结果 JSON。
+
+### 2.5 910C 实测结果
+
+以下结果使用单卡910C、4个并发请求、2048×2048、50步、CFG=4。优化配置开启
+FIA、fused RMSNorm 和 fused MLP；未启用未证明有实际价值的 QKV 与 token-type
+fast path。
+
+| 配置 | 总耗时(s) | 吞吐(images/s) | Mean延迟(s) | P95延迟(s) | 峰值内存(MB) |
+|---|---:|---:|---:|---:|---:|
+| B1，优化全关 | 234.28 | 0.01707 | 146.47 | 234.27 | 35698 |
+| B2，优化全关 | 234.83 | 0.01703 | 176.06 | 234.83 | 37870 |
+| B1，FIA+Norm+MLP | 205.94 | 0.01942 | 128.80 | 205.94 | 35718 |
+| B2，FIA+Norm+MLP | 195.02 | 0.02051 | 146.33 | 195.01 | 37850 |
+
+原始算子下 B2 相对 B1 吞吐变化为 -0.24%。最终优化配置下，B2 相对 B1 吞吐提升
+5.60%，总耗时降低5.31%。最终 B2 相对 B1 全关对照吞吐提升20.13%，总耗时和
+P95均降低16.76%，Mean延迟基本不变，峰值 reserved memory 增加约2.15 GB。
+因此该实现的主要收益来自 NPU 算子路径，动态批处理在优化路径上提供额外的吞吐收益。
+
+这些“优化全关”结果来自当前分支，不等同于上游 main 基线。
+
+### 2.6 导出报告包
+
+```bash
+cd /workspace/sensenova-validation
+tar -czf sensenova-batching-results.tar.gz env.sh serve.sh perf.sh results
+```
+
+本手册不要求运行 GPU 验证，也不包含入图、I2I 或多设备验证。

--- a/benchmark/sensenova/NPU_PROFILING.md
+++ b/benchmark/sensenova/NPU_PROFILING.md
@@ -1,0 +1,126 @@
+# SenseNova B1/B2 短步骤 NPU profiling
+
+目标：比较真实模型 B1/B2 的单步算子执行，定位批处理没有吞吐收益的原因。
+无需启动 HTTP 服务。每组执行 3 步预热、3 步正式生成，只记录正式生成第 2 步。
+捕获范围为图像特征提取开始，到下一步图像特征提取之前，包含条件/无条件
+forward、CFG 和图像更新；不包含 prefix、排队、HTTP、图片编码。
+这是短步数下的算子诊断，不能用 profiling 耗时替代 50 步端到端性能结果。
+
+## 1. 准备
+
+停止已有模型服务，释放 NPU。进入已有 torch_npu 推理环境。
+将当前分支代码（包含之前的 NPU mask 修复）及两个脚本复制到内网：
+
+- `benchmark/sensenova/profile_npu_batching.py`
+- `benchmark/sensenova/validate_npu_batching.py`（提供固定 prompt，放在同一目录）
+
+以下在 Bash 执行，只需根据实际位置修改 REPO 和 MODEL_PATH：
+
+```bash
+export REPO=/sgl-workspace/sglang
+export MODEL_PATH=/nas/disk1/SenseNova/SenseNova-U1.5-8B-MoT/
+export PYTHONPATH="$REPO/python${PYTHONPATH:+:$PYTHONPATH}"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+cd "$REPO"
+npu-smi info
+mkdir -p /workspace/sensenova-profile
+```
+
+脚本使用逻辑 NPU 0、BF16、CFG=4、timestep_shift=3、2048²，无 offload/入图。
+模型和 tokenizer 均只从本地读取。脚本没有在真实 NPU 上验证过，依赖当前镜像
+提供 `torch_npu.profiler.profile` 和 `export_chrome_trace`。
+
+## 2. 顺序执行 B1、B2
+
+```bash
+python3 benchmark/sensenova/profile_npu_batching.py \
+  --model "$MODEL_PATH" --batch-size 1 \
+  --output /workspace/sensenova-profile/b1
+
+python3 benchmark/sensenova/profile_npu_batching.py \
+  --model "$MODEL_PATH" --batch-size 2 \
+  --output /workspace/sensenova-profile/b2
+```
+
+每次进程退出会释放模型；不要并行运行。输出目录必须不存在。
+模型加载耗时另计，生成总工作量每组只有 6 步。不是 16 请求，也不需要 50 步。
+
+## 3. 文件大小和导出
+
+关闭调用栈和内存事件采集，保留 shape、CPU 和 NPU 时间线。
+每组只保存 `trace.json.gz` 与 `metadata.json`，每组硬限制 14,000,000 bytes，
+两组总量小于 28 MB，留出打包余量。完整事件不会被抽样或截断。
+限制针对最终压缩结果；profiler 采集期间的内存和临时原始 JSON 不受此限制。
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+p = Path('/workspace/sensenova-profile')
+files = [p/b/n for b in ('b1','b2') for n in ('trace.json.gz','metadata.json')]
+assert all(f.is_file() for f in files), '缺少结果，请检查脚本是否成功'
+total = sum(f.stat().st_size for f in files)
+assert total < 30_000_000, f'结果超限：{total}'
+print('结果总字节数:', total)
+PY
+tar -czf /workspace/sensenova-profile-results.tar.gz \
+  -C /workspace/sensenova-profile b1 b2
+python3 - <<'PY'
+from pathlib import Path
+p=Path('/workspace/sensenova-profile-results.tar.gz')
+assert p.stat().st_size < 30_000_000
+print(p, p.stat().st_size, 'bytes')
+PY
+```
+
+如果脚本报告超过 14 MB，不会保存残缺 trace。改为两组均加 `--size 1024`，
+使用新的输出父目录，再按相同方式检查打包。1024² 结果只用于该尺寸诊断，
+不能直接解释所有 2048² 性能现象。若仍超限，保留报错信息再调整采集范围。
+
+回传 `sensenova-profile-results.tar.gz`。重点对比 Attention、矩阵乘、图像特征
+提取、数据搬运/布局转换，以及 CPU 与 NPU 的空闲间隙。
+
+## 4. B2 等长前缀对照
+
+更新 `profile_npu_batching.py` 后，保持原环境，停止已有服务，执行：
+
+```bash
+cd "$REPO"
+python3 benchmark/sensenova/profile_npu_batching.py \
+  --model "$MODEL_PATH" --batch-size 2 --same-prompt \
+  --output /workspace/sensenova-profile/b2-same-long
+```
+
+两个样本均使用原 B2 的较长 prompt，seed 仍为 1000、1001。
+因此最大前缀长度与原 B2 相同，但不存在 padding，代码会选择无显式 mask 的路径。
+仍为 3 步预热、3 步生成、只抓第 2 步；单组文件上限仍为 14 MB。
+回传新目录中的 `trace.json.gz` 和 `metadata.json`。
+优先比较条件分支的 42 次主 FlashAttention 调用总时间；无条件分支作为参考。
+该实验同时改变了文本内容及 mask 路径，只能提供诊断证据，不能当成 mask 的严格独立因果实验。
+
+## 5. NPU 优化前后对照
+
+使用相同代码分别关闭和开启 FIA、fused RMSNorm 和 fused MLP。两组都使用 B2、
+相同 prompt、2048²、3 步，并只采集第 2 个去噪步。每次命令使用新进程，
+避免 lazy packed MLP 权重影响基线。
+
+```bash
+export SGLANG_SENSENOVA_NPU_FIA=0
+export SGLANG_SENSENOVA_NPU_FUSED_MLP=0
+export SGLANG_SENSENOVA_NPU_FUSED_NORM=0
+python3 benchmark/sensenova/profile_npu_batching.py \
+  --model "$MODEL_PATH" --batch-size 2 --same-prompt \
+  --output /workspace/sensenova-profile/dense-baseline-b2
+
+export SGLANG_SENSENOVA_NPU_FIA=1
+export SGLANG_SENSENOVA_NPU_FUSED_MLP=1
+export SGLANG_SENSENOVA_NPU_FUSED_NORM=1
+python3 benchmark/sensenova/profile_npu_batching.py \
+  --model "$MODEL_PATH" --batch-size 2 --same-prompt \
+  --output /workspace/sensenova-profile/dense-optimized-b2
+```
+
+先确认两次生成都成功且结果中没有 NaN/Inf。MLP gate/up 融合使每步 dense MatMul
+调用数预计由 588 降至约 504 次。算子名称可能随 CANN 版本变化，因此同时比较
+Attention、RMSNorm、MatMul 的总次数和总时间，以及完整 denoise step wall time。
+将这两个目录打包，压缩结果应小于30 MB。

--- a/benchmark/sensenova/bench_npu_attention.py
+++ b/benchmark/sensenova/bench_npu_attention.py
@@ -1,0 +1,287 @@
+"""Microbenchmark the NPU SDPA path used by SenseNova denoising."""
+
+import argparse
+import json
+import math
+import statistics
+import time
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query-length", type=int, default=4096)
+    parser.add_argument("--short-prefix-length", type=int, default=260)
+    parser.add_argument("--long-prefix-length", type=int, default=286)
+    parser.add_argument("--heads", type=int, default=32)
+    parser.add_argument("--kv-heads", type=int, default=8)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--atol", type=float, default=0.02)
+    parser.add_argument("--rtol", type=float, default=0.02)
+    parser.add_argument(
+        "--native-fia",
+        action="store_true",
+        help="Also benchmark npu_fused_infer_attention_score with right-padded KV.",
+    )
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    if not 0 < args.short_prefix_length < args.long_prefix_length:
+        parser.error("prefix lengths must satisfy 0 < short < long")
+    if args.query_length <= 0 or min(args.heads, args.kv_heads, args.head_dim) <= 0:
+        parser.error("query length, heads, and head dimension must be positive")
+    if args.heads % args.kv_heads:
+        parser.error("heads must be divisible by kv-heads")
+    if args.warmup < 0 or args.iterations <= 0:
+        parser.error("warmup must be nonnegative and iterations must be positive")
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        raise FileExistsError(f"Refusing to overwrite existing result: {output}")
+
+    import torch
+    import torch_npu
+
+    if not torch.npu.is_available():
+        raise RuntimeError("No NPU is available")
+    torch.npu.set_device(0)
+    torch.manual_seed(0)
+    torch.npu.manual_seed_all(0)
+
+    device = torch.device("npu:0")
+    dtype = torch.bfloat16
+    batch_size = 2
+    query_length = args.query_length
+    key_length = args.long_prefix_length + query_length
+    shape_q = (batch_size, args.heads, query_length, args.head_dim)
+    shape_kv = (batch_size, args.kv_heads, key_length, args.head_dim)
+    q = torch.randn(shape_q, device=device, dtype=dtype)
+    k = torch.randn(shape_kv, device=device, dtype=dtype)
+    v = torch.randn(shape_kv, device=device, dtype=dtype)
+
+    all_true_mask = torch.ones(
+        (batch_size, 1, query_length, key_length),
+        device=device,
+        dtype=torch.bool,
+    )
+    mixed_mask = all_true_mask.clone()
+    mixed_mask[0, :, :, args.short_prefix_length : args.long_prefix_length] = False
+
+    scale = 1.0 / math.sqrt(args.head_dim)
+
+    def attention(q_, k_, v_, mask=None):
+        if q_.shape[1] != k_.shape[1]:
+            repeats = q_.shape[1] // k_.shape[1]
+            k_ = k_.repeat_interleave(repeats, dim=1)
+            v_ = v_.repeat_interleave(repeats, dim=1)
+        return torch.nn.functional.scaled_dot_product_attention(
+            q_,
+            k_,
+            v_,
+            attn_mask=mask,
+            dropout_p=0.0,
+            is_causal=False,
+            scale=scale,
+        )
+
+    compact_k0 = torch.cat(
+        (k[0:1, :, : args.short_prefix_length], k[0:1, :, args.long_prefix_length :]),
+        dim=2,
+    )
+    compact_v0 = torch.cat(
+        (v[0:1, :, : args.short_prefix_length], v[0:1, :, args.long_prefix_length :]),
+        dim=2,
+    )
+
+    def two_compact_singletons():
+        attention(q[0:1], compact_k0, compact_v0)
+        attention(q[1:2], k[1:2], v[1:2])
+
+    cases = {
+        "b1_long_no_mask": lambda: attention(q[1:2], k[1:2], v[1:2]),
+        "b2_no_mask": lambda: attention(q, k, v),
+        "b2_all_true_mask": lambda: attention(q, k, v, all_true_mask),
+        "b2_mixed_padding_mask": lambda: attention(q, k, v, mixed_mask),
+        "two_compact_singletons": two_compact_singletons,
+    }
+
+    native_fia = None
+    native_fia_left = None
+    if args.native_fia:
+        short_key_length = args.short_prefix_length + query_length
+        right_padded_k = k.clone()
+        right_padded_v = v.clone()
+        right_padded_k[0, :, args.short_prefix_length : short_key_length].copy_(
+            k[0, :, args.long_prefix_length :]
+        )
+        right_padded_v[0, :, args.short_prefix_length : short_key_length].copy_(
+            v[0, :, args.long_prefix_length :]
+        )
+        right_padded_k[0, :, short_key_length:].zero_()
+        right_padded_v[0, :, short_key_length:].zero_()
+        actual_seq_lengths = [query_length] * batch_size
+        actual_seq_lengths_kv = [
+            short_key_length,
+            args.long_prefix_length + query_length,
+        ]
+
+        def native_fia():
+            result, _ = torch_npu.npu_fused_infer_attention_score(
+                q,
+                right_padded_k,
+                right_padded_v,
+                actual_seq_lengths=actual_seq_lengths,
+                actual_seq_lengths_kv=actual_seq_lengths_kv,
+                num_heads=args.heads,
+                num_key_value_heads=args.kv_heads,
+                scale=scale,
+                input_layout="BNSD",
+                sparse_mode=0,
+            )
+            return result
+
+        cases["native_fia_b2_right_padded"] = native_fia
+
+        left_padding = args.long_prefix_length - args.short_prefix_length
+        left_padded_k = k.clone()
+        left_padded_v = v.clone()
+        left_padded_k[0, :, :left_padding].zero_()
+        left_padded_v[0, :, :left_padding].zero_()
+        left_padded_k[0, :, left_padding : args.long_prefix_length].copy_(
+            k[0, :, : args.short_prefix_length]
+        )
+        left_padded_v[0, :, left_padding : args.long_prefix_length].copy_(
+            v[0, :, : args.short_prefix_length]
+        )
+        kv_padding_size = torch.zeros(1, device=device, dtype=torch.int64)
+
+        def native_fia_left():
+            result, _ = torch_npu.npu_fused_infer_attention_score(
+                q,
+                left_padded_k,
+                left_padded_v,
+                actual_seq_lengths=actual_seq_lengths,
+                actual_seq_lengths_kv=actual_seq_lengths_kv,
+                kv_padding_size=kv_padding_size,
+                num_heads=args.heads,
+                num_key_value_heads=args.kv_heads,
+                scale=scale,
+                input_layout="BNSD",
+                sparse_mode=0,
+            )
+            return result
+
+        cases["native_fia_b2_left_padded"] = native_fia_left
+
+    def measure(fn):
+        for _ in range(args.warmup):
+            fn()
+        torch.npu.synchronize()
+        samples = []
+        for _ in range(args.iterations):
+            start = time.perf_counter()
+            fn()
+            torch.npu.synchronize()
+            samples.append((time.perf_counter() - start) * 1000)
+        return {
+            "median_ms": statistics.median(samples),
+            "mean_ms": statistics.fmean(samples),
+            "min_ms": min(samples),
+            "max_ms": max(samples),
+        }
+
+    def error(reference, actual):
+        diff = (reference.float() - actual.float()).abs()
+        return {
+            "max_abs": diff.max().item(),
+            "mean_abs": diff.mean().item(),
+            "allclose": torch.allclose(
+                reference.float(), actual.float(), atol=args.atol, rtol=args.rtol
+            ),
+        }
+
+    with torch.inference_mode():
+        no_mask = attention(q, k, v)
+        all_true = attention(q, k, v, all_true_mask)
+        mixed = attention(q, k, v, mixed_mask)
+        compact0 = attention(q[0:1], compact_k0, compact_v0)
+        compact1 = attention(q[1:2], k[1:2], v[1:2])
+        correctness = {
+            "all_true_vs_no_mask": error(no_mask, all_true),
+            "mixed_short_vs_compact": error(compact0, mixed[0:1]),
+            "mixed_long_vs_compact": error(compact1, mixed[1:2]),
+        }
+        if native_fia is not None:
+            native = native_fia()
+            correctness["native_fia_short_vs_compact"] = error(compact0, native[0:1])
+            correctness["native_fia_long_vs_compact"] = error(compact1, native[1:2])
+            del native
+        if native_fia_left is not None:
+            native_left = native_fia_left()
+            correctness["native_fia_left_short_vs_compact"] = error(
+                compact0, native_left[0:1]
+            )
+            correctness["native_fia_left_long_vs_compact"] = error(
+                compact1, native_left[1:2]
+            )
+            del native_left
+        del no_mask, all_true, mixed, compact0, compact1
+
+        measurements = {}
+        for name, fn in cases.items():
+            measurements[name] = measure(fn)
+            print(json.dumps({"case": name, **measurements[name]}), flush=True)
+
+    b1 = measurements["b1_long_no_mask"]["median_ms"]
+    b2 = measurements["b2_no_mask"]["median_ms"]
+    all_true = measurements["b2_all_true_mask"]["median_ms"]
+    mixed = measurements["b2_mixed_padding_mask"]["median_ms"]
+    compact = measurements["two_compact_singletons"]["median_ms"]
+    derived = {
+        "b2_throughput_speedup_vs_b1": 2 * b1 / b2,
+        "b2_time_ratio_vs_b1": b2 / b1,
+        "all_true_mask_overhead_pct": (all_true / b2 - 1) * 100,
+        "mixed_mask_overhead_vs_no_mask_pct": (mixed / b2 - 1) * 100,
+        "mixed_mask_overhead_vs_all_true_pct": (mixed / all_true - 1) * 100,
+        "batched_mixed_speedup_vs_compact_singletons": compact / mixed,
+    }
+    if args.native_fia:
+        native_right = measurements["native_fia_b2_right_padded"]["median_ms"]
+        native_left = measurements["native_fia_b2_left_padded"]["median_ms"]
+        derived.update(
+            {
+                "native_fia_right_speedup_vs_masked_sdpa": mixed / native_right,
+                "native_fia_right_speedup_vs_unmasked_sdpa": b2 / native_right,
+                "native_fia_right_b2_throughput_speedup_vs_b1": 2 * b1 / native_right,
+                "native_fia_left_speedup_vs_masked_sdpa": mixed / native_left,
+                "native_fia_left_speedup_vs_unmasked_sdpa": b2 / native_left,
+                "native_fia_left_b2_throughput_speedup_vs_b1": 2 * b1 / native_left,
+            }
+        )
+    result = {
+        "config": {
+            **vars(args),
+            "dtype": str(dtype),
+            "device": torch.npu.get_device_name(0),
+            "torch": torch.__version__,
+            "torch_npu": torch_npu.__version__,
+            "q_shape": list(shape_q),
+            "kv_shape": list(shape_kv),
+        },
+        "correctness": correctness,
+        "measurements": measurements,
+        "derived": derived,
+    }
+    output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps({"correctness": correctness, "derived": derived}, indent=2))
+    print(f"Wrote {output}")
+
+    if not all(item["allclose"] for item in correctness.values()):
+        raise RuntimeError("Attention correctness check failed; see the JSON result")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/sensenova/profile_npu_batching.py
+++ b/benchmark/sensenova/profile_npu_batching.py
@@ -1,0 +1,148 @@
+"""Capture one SenseNova denoise step on NPU without a serving process."""
+
+import argparse
+import gzip
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--batch-size", type=int, choices=[1, 2, 4], required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--size", type=int, default=2048)
+    parser.add_argument(
+        "--same-prompt",
+        action="store_true",
+        help="Repeat the longer B2 prompt to remove padding while retaining its maximum prefix length.",
+    )
+    args = parser.parse_args()
+    output = Path(args.output)
+    output.mkdir(parents=True, exist_ok=False)
+
+    # Register the repository's native model classes.
+    import torch
+    import torch_npu
+    from transformers import AutoModel, AutoTokenizer
+    from validate_npu_batching import PROMPTS
+
+    import sglang.multimodal_gen.runtime.models.sensenova_u1  # noqa: F401
+
+    torch.npu.set_device(0)
+    tokenizer = AutoTokenizer.from_pretrained(args.model, local_files_only=True)
+    model = (
+        AutoModel.from_pretrained(
+            args.model, torch_dtype=torch.bfloat16, local_files_only=True
+        )
+        .eval()
+        .to("npu:0")
+    )
+    kwargs = dict(
+        image_size=(args.size, args.size),
+        batch_size=args.batch_size,
+        num_steps=3,
+        cfg_scale=4.0,
+        timestep_shift=3.0,
+        think_mode=False,
+        seed=[1000 + i for i in range(args.batch_size)],
+    )
+    prompts = (
+        [PROMPTS[1]] * args.batch_size
+        if args.same_prompt
+        else PROMPTS[: args.batch_size]
+    )
+    print(f"Prompt mode: {'same-long' if args.same_prompt else 'mixed'}", flush=True)
+    print("Warmup: 3 steps", flush=True)
+    with torch.inference_mode():
+        warmup = model.t2i_generate(tokenizer, prompts, **kwargs)
+    del warmup
+    torch.npu.synchronize()
+    original = model.extract_feature
+    calls = 0
+    active = False
+    finished = False
+    profiler = torch_npu.profiler.profile(
+        activities=[
+            torch_npu.profiler.ProfilerActivity.CPU,
+            torch_npu.profiler.ProfilerActivity.NPU,
+        ],
+        record_shapes=True,
+        with_stack=False,
+        profile_memory=False,
+    )
+
+    def extract(*a, **kw):
+        nonlocal calls, active, finished
+        calls += 1
+        if calls == 2:
+            torch.npu.synchronize()
+            profiler.start()
+            active = True
+        elif calls == 3:
+            torch.npu.synchronize()
+            profiler.stop()
+            active = False
+            finished = True
+        return original(*a, **kw)
+
+    model.extract_feature = extract
+    print("Capture: step 2 of 3", flush=True)
+    try:
+        with torch.inference_mode():
+            result = model.t2i_generate(tokenizer, prompts, **kwargs)
+        torch.npu.synchronize()
+        if not torch.isfinite(result).all().item():
+            raise RuntimeError("Generation returned nonfinite pixels")
+    finally:
+        model.extract_feature = original
+        if active:
+            torch.npu.synchronize()
+            profiler.stop()
+    if calls != 3 or not finished:
+        raise RuntimeError(f"Expected exactly three denoise feature calls, got {calls}")
+    # No tensorboard handler: keep CANN intermediate artifacts out of the result folder.
+    with tempfile.TemporaryDirectory(prefix="sensenova-profile-") as temp:
+        trace = Path(temp) / "trace.json"
+        profiler.export_chrome_trace(str(trace))
+        compressed = gzip.compress(trace.read_bytes(), compresslevel=9)
+    metadata = json.dumps(
+        dict(
+            batch_size=args.batch_size,
+            prompt_mode="same-long" if args.same_prompt else "mixed",
+            prompts=prompts,
+            size=args.size,
+            steps=3,
+            captured_step=2,
+            cfg_scale=4.0,
+            dtype="bfloat16",
+            torch=torch.__version__,
+            torch_npu=torch_npu.__version__,
+            model=args.model,
+            optimizations={
+                name: os.getenv(name, "1")
+                for name in (
+                    "SGLANG_SENSENOVA_NPU_FIA",
+                    "SGLANG_SENSENOVA_NPU_FUSED_MLP",
+                    "SGLANG_SENSENOVA_NPU_FUSED_NORM",
+                )
+            },
+            compressed_trace_bytes=len(compressed),
+            scope="one full denoise step; no prefill, HTTP or scheduler",
+        ),
+        indent=2,
+    ).encode()
+    if len(compressed) + len(metadata) > 14_000_000:
+        raise RuntimeError(
+            f"Complete compressed trace exceeds the per-run 14 MB budget ({len(compressed)} bytes). "
+            "No partial trace saved. Retry with --size 1024 for BOTH B1 and B2."
+        )
+    (output / "trace.json.gz").write_bytes(compressed)
+    (output / "metadata.json").write_bytes(metadata)
+    print(f"Saved {len(compressed) + len(metadata)} bytes in {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/sensenova/validate_npu_batching.py
+++ b/benchmark/sensenova/validate_npu_batching.py
@@ -1,0 +1,138 @@
+"""Offline HTTP smoke and throughput checks; no dataset downloads required."""
+
+import argparse
+import base64
+import concurrent.futures
+import io
+import json
+import math
+import statistics
+import time
+import urllib.request
+from pathlib import Path
+
+from PIL import Image
+
+PROMPTS = [
+    "A red apple on a wooden table, studio photography.",
+    "A cinematic mountain lake at sunrise with snow covered peaks reflected in "
+    "calm water, a small wooden cabin beside pine trees, soft golden light, "
+    "realistic photography with detailed textures and a wide composition.",
+    "A blue ceramic teapot on a white background.",
+    "A quiet street in an ancient Chinese town after rain, stone pavement, "
+    "warm lanterns reflected in puddles, traditional wooden buildings, "
+    "evening light, a detailed watercolor painting.",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="http://127.0.0.1:30000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--requests", type=int, default=4)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--size", type=int, default=1024)
+    parser.add_argument("--steps", type=int, default=5)
+    parser.add_argument("--cfg", type=float, default=4.0)
+    parser.add_argument("--warmup", type=int, default=4)
+    parser.add_argument("--save-images", action="store_true")
+    args = parser.parse_args()
+    if (
+        min(args.requests, args.concurrency, args.size, args.steps) < 1
+        or args.warmup < 0
+    ):
+        parser.error(
+            "counts, size and steps must be positive; warmup must be nonnegative"
+        )
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=False)
+
+    def request(index):
+        payload = dict(
+            model=args.model,
+            prompt=PROMPTS[index % len(PROMPTS)],
+            seed=1000 + index,
+            n=1,
+            size=f"{args.size}x{args.size}",
+            num_inference_steps=args.steps,
+            guidance_scale=args.cfg,
+            response_format="b64_json",
+            output_format="png",
+            generator_device="npu",
+        )
+        start = time.perf_counter()
+        try:
+            req = urllib.request.Request(
+                args.url + "/v1/images/generations",
+                data=json.dumps(payload).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=3600) as response:
+                body = json.load(response)
+            if len(body.get("data", [])) != 1:
+                raise ValueError("expected exactly one output")
+            raw = base64.b64decode(body["data"][0]["b64_json"], validate=True)
+            with Image.open(io.BytesIO(raw)) as im:
+                im.load()
+                if im.size != (args.size, args.size):
+                    raise ValueError(f"unexpected image dimensions: {im.size}")
+            result = dict(
+                index=index,
+                seed=payload["seed"],
+                prompt=payload["prompt"],
+                success=True,
+                latency_s=time.perf_counter() - start,
+                peak_memory_mb=body.get("peak_memory_mb"),
+            )
+            return result, raw
+        except Exception as exc:
+            return dict(
+                index=index,
+                success=False,
+                error=str(exc),
+                latency_s=time.perf_counter() - start,
+            ), None
+
+    def run(count):
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=args.concurrency
+        ) as pool:
+            return list(pool.map(request, range(count)))
+
+    warmup = run(args.warmup)
+    if any(not item[0]["success"] for item in warmup):
+        (out / "warmup_errors.json").write_text(
+            json.dumps([x[0] for x in warmup], indent=2)
+        )
+        raise SystemExit("Warmup failed; inspect warmup_errors.json")
+    del warmup
+    start = time.perf_counter()
+    results = run(args.requests)
+    duration = time.perf_counter() - start
+    records = [item[0] for item in results]
+    latencies = sorted(r["latency_s"] for r in records if r["success"])
+    summary = dict(
+        config=vars(args),
+        successful=len(latencies),
+        failed=args.requests - len(latencies),
+        duration_s=duration,
+        outputs_per_s=len(latencies) / duration,
+        mean_latency_s=statistics.mean(latencies) if latencies else None,
+        p95_latency_s=latencies[math.ceil(0.95 * len(latencies)) - 1]
+        if latencies
+        else None,
+        requests=records,
+    )
+    (out / "result.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    if args.save_images:
+        for record, raw in results:
+            if raw is not None:
+                (out / f"{record['index']:03d}.png").write_bytes(raw)
+    print(json.dumps({k: v for k, v in summary.items() if k != "requests"}, indent=2))
+    if summary["failed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/developer_guide/sensenova-u1-npu-batching.md
+++ b/docs/docs/developer_guide/sensenova-u1-npu-batching.md
@@ -1,0 +1,134 @@
+---
+title: "SenseNova-U1 NPU batching development plan"
+description: "Implementation checklist for homogeneous request batching of SenseNova-U1 on Ascend NPU."
+---
+
+This page tracks the implementation of homogeneous request-level batching for
+SenseNova-U1. It remains outside the public navigation while the feature is in
+development.
+
+## Scope
+
+- Single-device text-to-image inference on Ascend NPU. SenseNova-U1 dynamic
+  batching remains disabled on other platforms.
+- Different prompts and seeds in one batch.
+- Requests in a batch must share resolution, sampling steps, CFG settings, and
+  output options.
+- `think_mode=false` for batches larger than one.
+- Request-level batching through the existing SGLang-Diffusion scheduler.
+
+Image-to-image generation, multi-device execution, denoise-step continuous
+batching, and NPU graph capture are outside this change.
+
+## Implementation checklist
+
+- [x] Add regression tests for batched prompts, seeds, padding, and singleton
+  compatibility (execution pending).
+- [x] Pass merged prompts, per-request seeds, and the real batch size through
+  `SenseNovaU1GenerationStage`.
+- [x] Add batched tokenization with padding and per-sample prefix lengths.
+- [x] Make text and image position indexes batch-aware.
+- [x] Mask padded prefix tokens during prefix and denoise attention.
+- [x] Build independent condition KV caches and reuse the common unconditional
+  prefix cache.
+- [x] Generate initial noise from independent per-request RNG streams.
+- [x] Enable dynamic batching and add a SenseNova-specific request cost estimate.
+- [x] Keep sequential multi-output requests outside merged dynamic batches.
+- [x] Cover singleton, batch size two, unequal prompt lengths, CFG on/off, and
+  unsupported batched think mode in unit tests (execution pending).
+- [x] Add real attention-layer prefix KV and two-step denoise comparisons with
+  unequal prefix lengths and CFG on/off (execution pending).
+- [x] Add scheduler merge/split ordering, output-count mismatch, and incompatible
+  resolution tests (execution pending).
+- [ ] Extend equivalence coverage to the full model generation loop.
+- [x] Validate batched generation on 910C at 1024x1024 with 5 steps and inspect
+  the generated images.
+- [x] Benchmark batch sizes one and two at 2048x2048 with 50 steps; record
+  throughput, latency, and peak NPU memory.
+- [x] Profile the NPU attention path and add the native fused inference
+  attention path for padded request batches; validate it on 910C.
+- [x] Keep denoise KV buffers in FIA-native BNSD layout and precompute repeated
+  timestep/noise embeddings on NPU.
+- [x] Add an NPU fused RMSNorm path with an environment-variable fallback and
+  validate it on 910C.
+- [x] Fuse dense MLP gate/up projections into one matmul followed by NPU SwiGLU,
+  preserve checkpoint parameter names, and validate it on 910C.
+- [ ] Re-profile one complete denoise step before deciding whether TorchAir graph
+  capture is justified.
+- [ ] Add serving and benchmark commands to the SenseNova-U1 cookbook after NPU
+  validation.
+
+The optimization order follows the 910C traces. A CFG-enabled denoise step
+contains 84 attention calls and 588 dense matmuls: 42 transformer layers, two
+condition branches, and seven projections per layer. NPU FIA avoids the explicit
+padded SDPA mask, fused RMSNorm replaces the decomposed normalization, and dense
+MLP gate/up fusion removes 84 matmul launches per step. QKV fusion and a denoise
+token-type shortcut were evaluated and removed: they improved end-to-end
+throughput by only 0.76% and 0.02%, respectively, while QKV fusion increased the
+reported peak reserved memory by about 1.44 GB.
+
+## Acceptance criteria
+
+- Batched requests preserve prompt, seed, and output ordering.
+- A sample generated in a batch matches its singleton execution within the
+  agreed numerical tolerance.
+- Padding tokens do not participate in prefix or denoise attention.
+- Batch size one retains its existing behavior.
+- A failed or unsupported batch returns a clear error instead of silently using
+  incorrect inputs.
+- Batch size two improves output throughput by at least 10 percent at a validated
+  910C workload, or profiling evidence explains why the path should remain
+  correctness-only.
+
+## Validation status and next steps
+
+The serving path completed 910C smoke tests with generated-image inspection.
+Four-request tests at 2048x2048, 50 steps, CFG 4 produced the following results:
+
+| Configuration | Duration (s) | Throughput (images/s) | Mean latency (s) | Peak memory (MB) |
+|---|---:|---:|---:|---:|
+| B1, optimizations disabled | 234.28 | 0.01707 | 146.47 | 35698 |
+| B2, optimizations disabled | 234.83 | 0.01703 | 176.06 | 37870 |
+| B1, FIA + RMSNorm + MLP | 205.94 | 0.01942 | 128.80 | 35718 |
+| B2, FIA + RMSNorm + MLP | 195.02 | 0.02051 | 146.33 | 37850 |
+
+With the final NPU optimizations enabled, B2 improves throughput by 5.60% over
+B1. Final B2 improves throughput by 20.13% over the B1 disabled-optimization
+control while keeping mean latency effectively unchanged. The disabled control
+uses this branch and is not an upstream-main measurement.
+
+Python compilation, focused Ruff checks, and whitespace checks run on the
+Windows development host. PyTorch, Transformers, and pytest are unavailable
+there, so the tensor regression suite must run in the Linux inference environment.
+
+Run the regression suite in the existing Linux inference environment:
+
+```bash
+PYTHONPATH="$PWD/python${PYTHONPATH:+:$PYTHONPATH}" python3 -m pytest \
+  python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py -q
+```
+
+Attention-layer prefix-plus-denoise comparisons and scheduler output-order tests
+are present in the regression suite. Full model generation-loop equivalence is a
+follow-up; the completed serving smoke tests cover the integrated path.
+
+Dynamic batching is available only on Ascend NPU and is opt-in through the
+existing `--batching-max-size` flag (default: 1). For a B2 trial, add
+`--batching-max-size 2 --batching-delay-ms 20 --enable-batching-metrics` to the validated single-device
+launch command and send at least two concurrent compatible requests. Each request
+must ask for one output and disable think mode. Keep resolution, steps, CFG and
+other sampling settings identical. Use the same prompts and seeds with batch size
+one for the baseline, and verify the scheduler reports an actual merged batch.
+
+On Ascend NPU, SenseNova denoising uses
+`npu_fused_infer_attention_score` with a right-aligned prefix cache and per-sample
+KV lengths. Set `SGLANG_SENSENOVA_NPU_FIA=0` before starting the server to restore
+the SDPA plus explicit padding-mask path for A/B comparison. The native path is
+enabled by default on NPU and keeps the reusable KV cache in the FIA-native BNSD
+layout. SenseNova also enables `torch_npu.npu_rms_norm` and dense MLP gate/up
+projection fusion with `torch_npu.npu_swiglu` on NPU. Set
+`SGLANG_SENSENOVA_NPU_FUSED_NORM=0` or `SGLANG_SENSENOVA_NPU_FUSED_MLP=0` before
+server startup to isolate each fused operator. MLP weights are packed lazily on
+their first NPU forward, so performance runs require a full warmup request. The
+checkpoint-facing parameter names are unchanged. CUDA and CPU keep their original
+operators, and SenseNova-U1 request batching remains disabled on those platforms.

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sensenova_u1.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sensenova_u1.py
@@ -8,6 +8,10 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
 from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config import (
     ModelDeploymentConfig,
 )
+from sglang.multimodal_gen.configs.sensenova_u1 import (
+    SENSENOVA_U1_RESOLUTION_ALIGNMENT,
+)
+from sglang.multimodal_gen.runtime.platforms import current_platform
 
 
 def _is_runtime_option_requested(value) -> bool:
@@ -81,7 +85,19 @@ class SenseNovaU1PipelineConfig(PipelineConfig):
     supports_cfg_parallel: bool = False
 
     def supports_dynamic_batching(self):
-        return False
+        return current_platform.is_npu()
+
+    def estimate_request_cost(self, batch) -> float:
+        image_tokens = (int(batch.width) // SENSENOVA_U1_RESOLUTION_ALIGNMENT) * (
+            int(batch.height) // SENSENOVA_U1_RESOLUTION_ALIGNMENT
+        )
+        cfg_branches = 2 if float(batch.guidance_scale) > 1 else 1
+        return float(
+            image_tokens
+            * int(batch.num_inference_steps)
+            * cfg_branches
+            * int(batch.num_outputs_per_prompt)
+        )
 
     def supports_disaggregation(self) -> bool:
         return False

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -563,6 +563,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
         if base_req.is_warmup or candidate_req.is_warmup:
             return "warmup"
+        if self._requires_sequential_multi_output(base_req, candidate_req):
+            return "sequential_multi_output"
         if self._has_realtime_session(base_req) or self._has_realtime_session(
             candidate_req
         ):
@@ -593,9 +595,20 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
     def _has_realtime_session(req: Req) -> bool:
         return bool(req.realtime_session_id) or req.session is not None
 
+    def _requires_sequential_multi_output(self, *reqs: Req) -> bool:
+        pipeline_config = self.server_args.pipeline_config
+        return (
+            pipeline_config.supports_sequential_multi_output_inference()
+            and not pipeline_config.supports_sequential_dit_inference()
+            and any(max(1, int(req.num_outputs_per_prompt or 1)) > 1 for req in reqs)
+        )
+
     def _can_dynamic_batch(self, base_req: Req, candidate_req: Req) -> bool:
         """Return whether `candidate_req` can be merged into a batch with `base_req`."""
         if base_req.is_warmup or candidate_req.is_warmup:
+            return False
+
+        if self._requires_sequential_multi_output(base_req, candidate_req):
             return False
 
         if self._has_realtime_session(base_req) or self._has_realtime_session(

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_neo_chat.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_neo_chat.py
@@ -21,7 +21,11 @@ from .modeling_fm_modules import (
     TimestepEmbedder,
 )
 from .modeling_neo_vit import NEOVisionModel
-from .modeling_qwen3 import Qwen3ForCausalLM, create_block_causal_mask
+from .modeling_qwen3 import (
+    Qwen3ForCausalLM,
+    create_block_causal_mask,
+    npu_fia_enabled,
+)
 from .modeling_qwen3_moe import Qwen3MoeForCausalLM
 from .utils import SYSTEM_MESSAGE_FOR_GEN, load_image_native
 
@@ -37,19 +41,38 @@ def version_cmp(v1, v2, op="eq"):
     return op_func(version.parse(v1), version.parse(v2))
 
 
+def _copy_right_aligned_prefix_bnsd(destination, source, lengths):
+    prefix_width = source.shape[2]
+    for batch_index, length in enumerate(lengths):
+        destination[batch_index, :, prefix_width - length : prefix_width].copy_(
+            source[batch_index, :, :length]
+        )
+
+
 def prepare_flash_kv_cache(
     past_key_values,
     current_len: int,
     batch_size: int,
+    prefix_lengths: Optional[torch.Tensor] = None,
 ):
     """
-    Convert prefix cache from [B, H, S, D] to flash-attn friendly [B, S, H, D],
-    and preallocate full KV buffer for [prefix + current].
+    Preallocate the full KV buffer for [prefix + current]. CUDA/SDPA use
+    [B, S, H, D], while NPU FIA keeps the source [B, H, S, D] layout.
 
     This is done once before denoising loop.
     """
     if past_key_values is None:
         return
+
+    lengths = None
+    if prefix_lengths is not None:
+        lengths = [int(length) for length in prefix_lengths.reshape(-1).tolist()]
+        if len(lengths) == 1 and batch_size > 1:
+            lengths *= batch_size
+        if len(lengths) != batch_size:
+            raise ValueError(
+                f"Expected {batch_size} prefix lengths, got {len(lengths)}"
+            )
 
     for layer in past_key_values.layers:
         past_k = layer.keys
@@ -60,28 +83,60 @@ def prepare_flash_kv_cache(
             layer.flash_total_len = current_len
             layer.flash_k_cache = None
             layer.flash_v_cache = None
+            layer.flash_actual_seq_lengths_kv = None
+            layer.flash_kv_padding_size = None
+            layer.flash_cache_layout = None
             continue
 
-        # original cache layout assumed: [B, H, S, D]
-        past_k_flash = past_k.transpose(1, 2).contiguous()  # [B, S, H, D]
-        past_v_flash = past_v.transpose(1, 2).contiguous()  # [B, S, H, D]
-
-        prefix_len = past_k_flash.shape[1]
+        # original cache layout: [B, H, S, D]
+        prefix_len = past_k.shape[2]
         total_len = prefix_len + current_len
 
-        k_cache = torch.empty(
-            (batch_size, total_len, past_k_flash.shape[2], past_k_flash.shape[3]),
-            device=past_k_flash.device,
-            dtype=past_k_flash.dtype,
+        use_npu_fia = (
+            past_k.device.type == "npu" and lengths is not None and npu_fia_enabled()
         )
-        v_cache = torch.empty(
-            (batch_size, total_len, past_v_flash.shape[2], past_v_flash.shape[3]),
-            device=past_v_flash.device,
-            dtype=past_v_flash.dtype,
-        )
-
-        k_cache[:, :prefix_len].copy_(past_k_flash)
-        v_cache[:, :prefix_len].copy_(past_v_flash)
+        if use_npu_fia:
+            if any(length < 0 or length > prefix_len for length in lengths):
+                raise ValueError(
+                    f"Prefix lengths must be between 0 and {prefix_len}, got {lengths}"
+                )
+            k_cache = torch.empty(
+                (batch_size, past_k.shape[1], total_len, past_k.shape[3]),
+                device=past_k.device,
+                dtype=past_k.dtype,
+            )
+            v_cache = torch.empty(
+                (batch_size, past_v.shape[1], total_len, past_v.shape[3]),
+                device=past_v.device,
+                dtype=past_v.dtype,
+            )
+            _copy_right_aligned_prefix_bnsd(k_cache, past_k, lengths)
+            _copy_right_aligned_prefix_bnsd(v_cache, past_v, lengths)
+            layer.flash_actual_seq_lengths_kv = [
+                length + current_len for length in lengths
+            ]
+            layer.flash_kv_padding_size = torch.zeros(
+                1, dtype=torch.int64, device=past_k.device
+            )
+            layer.flash_cache_layout = "BNSD"
+        else:
+            past_k_flash = past_k.transpose(1, 2).contiguous()
+            past_v_flash = past_v.transpose(1, 2).contiguous()
+            k_cache = torch.empty(
+                (batch_size, total_len, past_k_flash.shape[2], past_k_flash.shape[3]),
+                device=past_k_flash.device,
+                dtype=past_k_flash.dtype,
+            )
+            v_cache = torch.empty(
+                (batch_size, total_len, past_v_flash.shape[2], past_v_flash.shape[3]),
+                device=past_v_flash.device,
+                dtype=past_v_flash.dtype,
+            )
+            k_cache[:, :prefix_len].copy_(past_k_flash)
+            v_cache[:, :prefix_len].copy_(past_v_flash)
+            layer.flash_actual_seq_lengths_kv = None
+            layer.flash_kv_padding_size = None
+            layer.flash_cache_layout = "BSND"
 
         layer.flash_prefix_len = prefix_len
         layer.flash_total_len = total_len
@@ -101,6 +156,12 @@ def clear_flash_kv_cache(past_key_values):
             delattr(layer, "flash_k_cache")
         if hasattr(layer, "flash_v_cache"):
             delattr(layer, "flash_v_cache")
+        if hasattr(layer, "flash_actual_seq_lengths_kv"):
+            delattr(layer, "flash_actual_seq_lengths_kv")
+        if hasattr(layer, "flash_kv_padding_size"):
+            delattr(layer, "flash_kv_padding_size")
+        if hasattr(layer, "flash_cache_layout"):
+            delattr(layer, "flash_cache_layout")
 
 
 def optimized_scale(positive_flat, negative_flat):
@@ -127,7 +188,21 @@ def optimized_scale(positive_flat, negative_flat):
     return st_star
 
 
-def _randn_with_seed(shape, *, device, dtype, seed: int) -> torch.Tensor:
+def _randn_with_seed(shape, *, device, dtype, seed: int | list[int]) -> torch.Tensor:
+    if isinstance(seed, list):
+        if len(shape) == 0 or len(seed) != shape[0]:
+            raise ValueError(
+                f"expected one seed per batch item, got {len(seed)} seeds for shape {shape}"
+            )
+        return torch.cat(
+            [
+                _randn_with_seed(
+                    (1, *shape[1:]), device=device, dtype=dtype, seed=item_seed
+                )
+                for item_seed in seed
+            ],
+            dim=0,
+        )
     try:
         generator = torch.Generator(device)
     except (RuntimeError, TypeError):
@@ -554,21 +629,81 @@ class NEOChatModel(PreTrainedModel):
             return template.get_prompt() + append_text
         return template.get_prompt()
 
-    def _build_t2i_text_inputs(self, tokenizer, query: str):
-        model_inputs = tokenizer(query, return_tensors="pt")
-        input_ids = model_inputs["input_ids"].to(self.device)
+    def _build_t2i_text_inputs(self, tokenizer, query: str | list[str]):
+        if isinstance(query, str):
+            input_ids = tokenizer(query, return_tensors="pt")["input_ids"].to(
+                self.device
+            )
+            text_length = input_ids.shape[1]
+            t_idx = torch.arange(text_length, dtype=torch.long, device=input_ids.device)
+            indexes = torch.stack(
+                [t_idx, torch.zeros_like(t_idx), torch.zeros_like(t_idx)]
+            )
+            key_valid_mask = torch.ones(
+                (1, text_length), dtype=torch.bool, device=self.device
+            )
+            return (
+                input_ids,
+                indexes,
+                {"full_attention": create_block_causal_mask(t_idx)},
+                key_valid_mask,
+                torch.tensor([text_length], dtype=torch.long, device=self.device),
+            )
+
+        queries = query
+        if not queries:
+            raise ValueError("query batch must not be empty")
+        encoded = [
+            tokenizer(item, return_tensors="pt")["input_ids"][0] for item in queries
+        ]
+        lengths = [item.shape[0] for item in encoded]
+        prefix_lengths = torch.tensor(lengths, dtype=torch.long, device=self.device)
+        max_length = max(lengths)
+        pad_token_id = getattr(tokenizer, "pad_token_id", None)
+        if pad_token_id is None:
+            pad_token_id = getattr(tokenizer, "eos_token_id", None)
+        if pad_token_id is None:
+            pad_token_id = 0
+
+        input_ids = torch.full(
+            (len(encoded), max_length),
+            int(pad_token_id),
+            dtype=encoded[0].dtype,
+            device=self.device,
+        )
+        key_valid_mask = torch.zeros(
+            (len(encoded), max_length), dtype=torch.bool, device=self.device
+        )
+        for batch_index, item in enumerate(encoded):
+            item = item.to(self.device)
+            item_length = item.shape[0]
+            input_ids[batch_index, :item_length] = item
+            key_valid_mask[batch_index, :item_length] = True
 
         t_idx = torch.arange(
-            0, input_ids.shape[1], dtype=torch.long, device=input_ids.device
-        )
+            max_length, dtype=torch.long, device=input_ids.device
+        ).expand(len(encoded), -1)
         h_idx = torch.zeros_like(t_idx)
         w_idx = torch.zeros_like(t_idx)
-        indexes = torch.stack([t_idx, h_idx, w_idx], dim=0)
+        batched_indexes = torch.stack([t_idx, h_idx, w_idx], dim=1)
+        indexes = batched_indexes[0] if len(encoded) == 1 else batched_indexes
 
-        attention_mask = {"full_attention": create_block_causal_mask(indexes[0])}
-        return input_ids, indexes, attention_mask
+        attention_mask = {
+            "full_attention": create_block_causal_mask(t_idx, key_valid_mask)
+        }
+        return input_ids, indexes, attention_mask, key_valid_mask, prefix_lengths
 
     def _build_t2i_image_indexes(self, token_h, token_w, text_len, device):
+        if isinstance(text_len, torch.Tensor):
+            text_len = text_len.to(device=device, dtype=torch.long).reshape(-1)
+            batch_size = text_len.shape[0]
+            image_len = token_h * token_w
+            t_image = text_len[:, None].expand(batch_size, image_len)
+            idx = torch.arange(image_len, device=device, dtype=torch.long)
+            h_image = (idx // token_w).expand(batch_size, -1)
+            w_image = (idx % token_w).expand(batch_size, -1)
+            return torch.stack([t_image, h_image, w_image], dim=1)
+
         t_image = torch.full(
             (token_h * token_w,), text_len, dtype=torch.long, device=device
         )
@@ -703,7 +838,6 @@ class NEOChatModel(PreTrainedModel):
         image_size=None,
     ):
         B, L = z.shape[0], z.shape[1]
-
         outputs = self.language_model.model(
             inputs_embeds=input_embeds,
             image_gen_indicators=torch.ones(
@@ -2140,6 +2274,16 @@ class NEOChatModel(PreTrainedModel):
             timesteps = self._apply_time_schedule(
                 timesteps, token_h * token_w, timestep_shift
             )
+        denoise_embeddings = None
+        if device.type == "npu":
+            denoise_embeddings = self.fm_modules["timestep_embedder"](timesteps[:-1])
+            if self.add_noise_scale_embedding:
+                noise_level = timesteps.new_tensor(
+                    [noise_scale / self.noise_scale_max_value]
+                )
+                denoise_embeddings = denoise_embeddings + self.fm_modules[
+                    "noise_scale_embedder"
+                ](noise_level)
 
         for step_i in range(num_steps):
             t = timesteps[step_i]
@@ -2157,18 +2301,20 @@ class NEOChatModel(PreTrainedModel):
                 gen_model=True,
                 grid_hw=grid_hw,
             ).view(batch_size, token_h * token_w, -1)
-            t_expanded = t.expand(batch_size * token_h * token_w)
-            timestep_embeddings = self.fm_modules["timestep_embedder"](t_expanded).view(
-                batch_size, token_h * token_w, -1
-            )
-            if self.add_noise_scale_embedding:
-                noise_scale_tensor = torch.full_like(
-                    t_expanded, noise_scale / self.noise_scale_max_value
-                )
-                noise_embeddings = self.fm_modules["noise_scale_embedder"](
-                    noise_scale_tensor
+            if denoise_embeddings is not None:
+                timestep_embeddings = denoise_embeddings[step_i].view(1, 1, -1)
+            else:
+                t_expanded = t.expand(batch_size * token_h * token_w)
+                timestep_embeddings = self.fm_modules["timestep_embedder"](
+                    t_expanded
                 ).view(batch_size, token_h * token_w, -1)
-                timestep_embeddings += noise_embeddings
+                if self.add_noise_scale_embedding:
+                    noise_scale_tensor = torch.full_like(
+                        t_expanded, noise_scale / self.noise_scale_max_value
+                    )
+                    timestep_embeddings += self.fm_modules["noise_scale_embedder"](
+                        noise_scale_tensor
+                    ).view(batch_size, token_h * token_w, -1)
             image_embeds = image_embeds + timestep_embeddings
 
             out_cond = self._t2i_predict_v(
@@ -2296,24 +2442,43 @@ class NEOChatModel(PreTrainedModel):
     ):
         assert self.concat_time_token_num == 0
         assert cfg_norm in ["cfg_zero_star", "global", "none", "channel"]
+        prompts = prompt if isinstance(prompt, list) else [prompt]
+        if not prompts:
+            raise ValueError("prompt batch must not be empty")
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if isinstance(prompt, list) and len(prompts) != batch_size:
+            raise ValueError(
+                f"batch_size={batch_size} does not match {len(prompts)} prompts"
+            )
+        if len(prompts) > 1 and think_mode:
+            raise ValueError(
+                "batched SenseNova-U1 generation does not support think_mode"
+            )
+        if len(prompts) > 1 and self.device.type != "npu":
+            raise ValueError(
+                "batched SenseNova-U1 generation is only supported on Ascend NPU"
+            )
         self._notify_layer_offload_phase("prefix")
         merge_size = int(1 / self.downsample_ratio)
 
         self.config.t_eps = t_eps
-        # question_condition = f"Please generate an image based on the following description: {prompt}"
-        question_condition = f"{prompt}"
-        # question_condition += f"\nThe resolution of the image should be {image_size}"
-
         think_text = ""
         needs_cfg = cfg_scale > 1
 
         think_content = (
             "<think>\n" if think_mode else "<think>\n\n</think>\n\n" + IMG_START_TOKEN
         )
-        query_condition = self._build_t2i_query(
-            question_condition,
-            system_message=SYSTEM_MESSAGE_FOR_GEN,
-            append_text=think_content,
+        query_conditions = [
+            self._build_t2i_query(
+                item,
+                system_message=SYSTEM_MESSAGE_FOR_GEN,
+                append_text=think_content,
+            )
+            for item in prompts
+        ]
+        query_condition = (
+            query_conditions[0] if len(query_conditions) == 1 else query_conditions
         )
         query_uncondition = (
             self._build_t2i_query("", append_text=IMG_START_TOKEN)
@@ -2321,19 +2486,26 @@ class NEOChatModel(PreTrainedModel):
             else None
         )
 
-        input_ids_condition, indexes_condition, attention_mask_condition_prefix = (
-            self._build_t2i_text_inputs(tokenizer, query_condition)
-        )
+        (
+            input_ids_condition,
+            indexes_condition,
+            attention_mask_condition_prefix,
+            condition_key_valid_mask,
+            condition_prefix_lengths,
+        ) = self._build_t2i_text_inputs(tokenizer, query_condition)
         if query_uncondition is not None:
             (
                 input_ids_uncondition,
                 indexes_uncondition,
                 attention_mask_uncondition_prefix,
+                _,
+                uncondition_prefix_lengths,
             ) = self._build_t2i_text_inputs(tokenizer, query_uncondition)
         else:
             input_ids_uncondition = indexes_uncondition = (
                 attention_mask_uncondition_prefix
             ) = None
+            uncondition_prefix_lengths = None
 
         token_h = image_size[1] // (self.patch_size * merge_size)
         token_w = image_size[0] // (self.patch_size * merge_size)
@@ -2341,14 +2513,18 @@ class NEOChatModel(PreTrainedModel):
         indexes_image_condition = self._build_t2i_image_indexes(
             token_h,
             token_w,
-            indexes_condition.shape[1],
+            (
+                int(condition_prefix_lengths[0].item())
+                if len(prompts) == 1
+                else condition_prefix_lengths
+            ),
             device=input_ids_condition.device,
         )
         indexes_image_uncondition = (
             self._build_t2i_image_indexes(
                 token_h,
                 token_w,
-                indexes_uncondition.shape[1],
+                int(uncondition_prefix_lengths[0].item()),
                 device=input_ids_uncondition.device,
             )
             if indexes_uncondition is not None
@@ -2436,12 +2612,16 @@ class NEOChatModel(PreTrainedModel):
             past_key_values_condition,
             current_len=token_h * token_w,
             batch_size=batch_size,
+            prefix_lengths=(condition_prefix_lengths if device.type == "npu" else None),
         )
         if past_key_values_uncondition is not None:
             prepare_flash_kv_cache(
                 past_key_values_uncondition,
                 current_len=token_h * token_w,
                 batch_size=batch_size,
+                prefix_lengths=(
+                    uncondition_prefix_lengths if device.type == "npu" else None
+                ),
             )
 
         # init noise image tokens
@@ -2465,6 +2645,27 @@ class NEOChatModel(PreTrainedModel):
         )
 
         attention_mask_condition = {"full_attention": None}
+        if device.type == "npu" and batch_size > 1:
+            condition_key_valid_mask = condition_key_valid_mask.expand(batch_size, -1)
+            image_key_valid_mask = torch.ones(
+                (batch_size, token_h * token_w),
+                dtype=torch.bool,
+                device=device,
+            )
+            denoise_key_valid_mask = torch.cat(
+                [condition_key_valid_mask, image_key_valid_mask], dim=1
+            )
+            if not npu_fia_enabled():
+                attention_mask_condition["full_attention"] = denoise_key_valid_mask[
+                    :, None, None, :
+                ]
+                # Ascend FlashAttention requires an explicit query dimension.
+                # Materialize once and reuse across all layers and denoise steps.
+                attention_mask_condition["full_attention"] = (
+                    attention_mask_condition["full_attention"]
+                    .expand(-1, -1, token_h * token_w, -1)
+                    .contiguous()
+                )
         attention_mask_uncondition = {"full_attention": None}
 
         timesteps = torch.linspace(0.0, 1.0, num_steps + 1, device=device)
@@ -2472,6 +2673,16 @@ class NEOChatModel(PreTrainedModel):
             timesteps = self._apply_time_schedule(
                 timesteps, token_h * token_w, timestep_shift
             )
+        denoise_embeddings = None
+        if device.type == "npu":
+            denoise_embeddings = self.fm_modules["timestep_embedder"](timesteps[:-1])
+            if self.add_noise_scale_embedding:
+                noise_level = timesteps.new_tensor(
+                    [noise_scale / self.noise_scale_max_value]
+                )
+                denoise_embeddings = denoise_embeddings + self.fm_modules[
+                    "noise_scale_embedder"
+                ](noise_level)
 
         for step_i in range(num_steps):
             t = timesteps[step_i]
@@ -2486,18 +2697,20 @@ class NEOChatModel(PreTrainedModel):
                 gen_model=True,
                 grid_hw=grid_hw,
             ).view(batch_size, token_h * token_w, -1)
-            t_expanded = t.expand(batch_size * token_h * token_w)
-            timestep_embeddings = self.fm_modules["timestep_embedder"](t_expanded).view(
-                batch_size, token_h * token_w, -1
-            )
-            if self.add_noise_scale_embedding:
-                noise_scale_tensor = torch.full_like(
-                    t_expanded, noise_scale / self.noise_scale_max_value
-                )
-                noise_embeddings = self.fm_modules["noise_scale_embedder"](
-                    noise_scale_tensor
+            if denoise_embeddings is not None:
+                timestep_embeddings = denoise_embeddings[step_i].view(1, 1, -1)
+            else:
+                t_expanded = t.expand(batch_size * token_h * token_w)
+                timestep_embeddings = self.fm_modules["timestep_embedder"](
+                    t_expanded
                 ).view(batch_size, token_h * token_w, -1)
-                timestep_embeddings += noise_embeddings
+                if self.add_noise_scale_embedding:
+                    noise_scale_tensor = torch.full_like(
+                        t_expanded, noise_scale / self.noise_scale_max_value
+                    )
+                    timestep_embeddings += self.fm_modules["noise_scale_embedder"](
+                        noise_scale_tensor
+                    ).view(batch_size, token_h * token_w, -1)
             image_embeds = image_embeds + timestep_embeddings
 
             v_pred_condition = self._t2i_predict_v(

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3.py
@@ -1,10 +1,12 @@
 # Modified for SGLang; see this directory's README.md for upstream source.
 
 import copy
+import os
 from typing import Callable, Optional, Union
 
 import torch
 import torch._dynamo
+import torch.nn.functional as F
 from torch import nn
 from transformers import Qwen3Config
 from transformers.activations import ACT2FN
@@ -55,6 +57,30 @@ _VALID_ATTN_BACKENDS = ("auto", "flash", "sdpa")
 _ATTN_BACKEND: str = "auto"
 
 
+def npu_fia_enabled() -> bool:
+    return os.getenv("SGLANG_SENSENOVA_NPU_FIA", "1").lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
+def npu_fused_norm_enabled() -> bool:
+    return os.getenv("SGLANG_SENSENOVA_NPU_FUSED_NORM", "1").lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
+def npu_fused_mlp_enabled() -> bool:
+    return os.getenv("SGLANG_SENSENOVA_NPU_FUSED_MLP", "1").lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
 def set_attn_backend(backend: str) -> str:
     """Choose the attention kernel used by the Qwen3 layers at runtime.
 
@@ -92,7 +118,13 @@ def effective_attn_backend() -> str:
 
 
 def _sdpa_attn_func(
-    q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal: bool = False
+    q,
+    k,
+    v,
+    dropout_p: float = 0.0,
+    softmax_scale=None,
+    causal: bool = False,
+    attention_mask: Optional[torch.Tensor] = None,
 ):
     """Drop-in SDPA fallback for ``flash_attn_func``.
 
@@ -127,6 +159,7 @@ def _sdpa_attn_func(
             q_bhsd,
             k_bhsd,
             v_bhsd,
+            attn_mask=attention_mask,
             dropout_p=dropout_p,
             is_causal=causal,
             scale=softmax_scale,
@@ -138,6 +171,7 @@ def _sdpa_attn_func(
                 q_bhsd,
                 k_bhsd,
                 v_bhsd,
+                attn_mask=attention_mask,
                 dropout_p=dropout_p,
                 is_causal=causal,
             )
@@ -146,6 +180,7 @@ def _sdpa_attn_func(
                 q_bhsd,
                 k_bhsd,
                 v_bhsd,
+                attn_mask=attention_mask,
                 dropout_p=dropout_p,
                 is_causal=causal,
             )
@@ -153,37 +188,113 @@ def _sdpa_attn_func(
 
 
 def _flash_or_sdpa(
-    q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal: bool = False
+    q,
+    k,
+    v,
+    dropout_p: float = 0.0,
+    softmax_scale=None,
+    causal: bool = False,
+    attention_mask: Optional[torch.Tensor] = None,
+    actual_seq_lengths_kv: Optional[list[int]] = None,
+    kv_padding_size: Optional[torch.Tensor] = None,
+    input_layout: str = "BSND",
 ):
     backend = effective_attn_backend()
     # flash-attn ships CUDA kernels only. On XPU / CPU we transparently fall
     # back to SDPA even if the user asked for ``flash`` — the alternative
     # (crashing on first forward) is worse, and ``set_attn_backend('flash')``
     # already guarded against the "package missing" case.
-    if backend == "flash" and q.device.type == "cuda":
+    if backend == "flash" and q.device.type == "cuda" and attention_mask is None:
         return flash_attn_func(
             q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal
         )
+    if (
+        q.device.type == "npu"
+        and not causal
+        and dropout_p == 0.0
+        and actual_seq_lengths_kv is not None
+        and npu_fia_enabled()
+    ):
+        import torch_npu
+
+        if input_layout == "BNSD":
+            q_bhsd, k_bhsd, v_bhsd = q, k, v
+            batch_size, num_heads, query_length, _ = q.shape
+            num_key_value_heads = k.shape[1]
+        elif input_layout == "BSND":
+            q_bhsd = q.transpose(1, 2).contiguous()
+            k_bhsd = k.transpose(1, 2).contiguous()
+            v_bhsd = v.transpose(1, 2).contiguous()
+            batch_size, query_length, num_heads, _ = q.shape
+            num_key_value_heads = k.shape[2]
+        else:
+            raise ValueError(f"Unsupported attention input layout: {input_layout}")
+        out, _ = torch_npu.npu_fused_infer_attention_score(
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            actual_seq_lengths=[query_length] * batch_size,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            kv_padding_size=kv_padding_size,
+            num_heads=num_heads,
+            num_key_value_heads=num_key_value_heads,
+            scale=q.shape[-1] ** -0.5 if softmax_scale is None else softmax_scale,
+            input_layout="BNSD",
+            sparse_mode=0,
+        )
+        return out.transpose(1, 2).contiguous()
+    if input_layout != "BSND":
+        raise RuntimeError("BNSD attention input requires the NPU FIA path")
     return _sdpa_attn_func(
-        q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal
+        q,
+        k,
+        v,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        attention_mask=attention_mask,
     )
 
 
-def create_block_causal_mask(index: torch.Tensor):
-    """
-    index: (L)
-    return: (1, 1, L, L) block-wise causal attention mask
-    """
-    L = index.size(0)
-    idx_i = index.unsqueeze(1).expand(L, L)
-    idx_j = index.unsqueeze(0).expand(L, L)
+def position_ids_from_indexes(indexes: torch.Tensor, coordinate: int) -> torch.Tensor:
+    """Return one coordinate as ``[batch, sequence]`` position IDs."""
+    if indexes.ndim == 2:
+        return indexes[coordinate].unsqueeze(0)
+    if indexes.ndim == 3:
+        return indexes[:, coordinate]
+    raise ValueError(f"indexes must have 2 or 3 dimensions, got {indexes.ndim}")
 
-    arange = torch.arange(L, device=index.device)
-    mask = (idx_j == idx_i) | (arange.unsqueeze(0) <= arange.unsqueeze(1))
 
-    return torch.where(
-        mask[None, None, :, :] > 0, torch.tensor(0.0), torch.tensor(float("-inf"))
-    )
+def create_block_causal_mask(
+    index: torch.Tensor, key_valid_mask: Optional[torch.Tensor] = None
+):
+    """
+    index: (L) or (B, L)
+    key_valid_mask: optional (B, L), where True marks a real token
+    return: (B, 1, L, L) block-wise causal attention mask
+    """
+    if index.ndim == 1:
+        index = index.unsqueeze(0)
+    if index.ndim != 2:
+        raise ValueError(f"index must have 1 or 2 dimensions, got {index.ndim}")
+
+    batch_size, seq_len = index.shape
+    idx_i = index.unsqueeze(2)
+    idx_j = index.unsqueeze(1)
+
+    arange = torch.arange(seq_len, device=index.device)
+    mask = (idx_j == idx_i) | (arange.view(1, 1, -1) <= arange.view(1, -1, 1))
+    if key_valid_mask is not None:
+        if key_valid_mask.shape != (batch_size, seq_len):
+            raise ValueError(
+                "key_valid_mask must match the batched index shape; "
+                f"got {tuple(key_valid_mask.shape)} and {(batch_size, seq_len)}"
+            )
+        mask = mask & key_valid_mask.to(torch.bool).unsqueeze(1)
+
+    output = torch.zeros(mask.shape, dtype=torch.float32, device=index.device)
+    output.masked_fill_(~mask, float("-inf"))
+    return output.unsqueeze(1)
 
 
 def visualize_mask(mask: torch.Tensor, i: int = 0, j: int = 12):
@@ -207,6 +318,13 @@ class Qwen3RMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if hidden_states.device.type == "npu" and npu_fused_norm_enabled():
+            import torch_npu
+
+            if hasattr(torch_npu, "npu_rms_norm"):
+                return torch_npu.npu_rms_norm(
+                    hidden_states, self.weight, self.variance_epsilon
+                )[0]
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
@@ -227,8 +345,52 @@ class Qwen3MLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
+        self._npu_gate_up_weight = None
+
+    def _pack_npu_gate_up_weights(self) -> torch.Tensor:
+        reference = self.gate_proj.weight
+        packed = self._npu_gate_up_weight
+        if (
+            packed is not None
+            and packed.device == reference.device
+            and packed.dtype == reference.dtype
+            and packed.untyped_storage().data_ptr()
+            == reference.untyped_storage().data_ptr()
+        ):
+            return packed
+
+        with torch.no_grad():
+            packed = torch.cat(
+                [self.gate_proj.weight, self.up_proj.weight], dim=0
+            ).contiguous()
+            self.gate_proj.weight.set_(packed[: self.intermediate_size])
+            self.up_proj.weight.set_(packed[self.intermediate_size :])
+        self._npu_gate_up_weight = packed
+        return packed
+
+    def _use_npu_fused_mlp(self, x: torch.Tensor) -> bool:
+        if (
+            x.device.type != "npu"
+            or self.training
+            or torch.is_grad_enabled()
+            or x.dtype != torch.bfloat16
+            or self.gate_proj.weight.dtype != x.dtype
+            or self.config.hidden_act != "silu"
+            or not npu_fused_mlp_enabled()
+        ):
+            return False
+        try:
+            import torch_npu
+        except ImportError:
+            return False
+        return hasattr(torch_npu, "npu_swiglu")
 
     def forward(self, x):
+        if self._use_npu_fused_mlp(x):
+            import torch_npu
+
+            gate_up = F.linear(x, self._pack_npu_gate_up_weights())
+            return self.down_proj(torch_npu.npu_swiglu(gate_up))
         down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         return down_proj
 
@@ -530,17 +692,23 @@ class Qwen3Attention(nn.Module):
 
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        cos_t, sin_t = self.rotary_emb(
+            hidden_states, position_ids_from_indexes(indexes, 0)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
 
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        cos_h, sin_h = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 1)
+        )
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
 
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        cos_w, sin_w = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 2)
+        )
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -705,17 +873,23 @@ class Qwen3Attention(nn.Module):
         )  # [B,H,S,D]
 
         # RoPE
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        cos_t, sin_t = self.rotary_emb(
+            hidden_states, position_ids_from_indexes(indexes, 0)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
 
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        cos_h, sin_h = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 1)
+        )
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
 
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        cos_w, sin_w = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 2)
+        )
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -736,61 +910,96 @@ class Qwen3Attention(nn.Module):
         #   current image tokens attend to [prefix + current image tokens]
         #   fully bidirectional inside current block => causal=False
         # ------------------------------------------------------------------
-        if attention_mask is None:
-            # Convert current q/k/v to flash layout [B, S, H, D]
-            q = query_states.transpose(1, 2).contiguous()
-            k_cur = key_states.transpose(1, 2).contiguous()
-            v_cur = value_states.transpose(1, 2).contiguous()
+        key_padding_mask = (
+            attention_mask is not None
+            and attention_mask.ndim == 4
+            and (attention_mask.shape[-2] == 1 or attention_mask.dtype == torch.bool)
+        )
+        if attention_mask is None or key_padding_mask:
+            actual_seq_lengths_kv = None
+            kv_padding_size = None
+            input_layout = "BSND"
+            layer = (
+                past_key_values.layers[self.layer_idx]
+                if past_key_values is not None and not update_cache
+                else None
+            )
+            use_bnsd_cache = (
+                layer is not None
+                and getattr(layer, "flash_cache_layout", None) == "BNSD"
+                and getattr(layer, "flash_k_cache", None) is not None
+                and getattr(layer, "flash_v_cache", None) is not None
+            )
 
-            if past_key_values is not None:
-                if update_cache:
-                    # Rare path, keep compatibility.
-                    # past_key_values.update expects [B,H,S,D]
-                    key_states, value_states = past_key_values.update(
-                        key_states, value_states, self.layer_idx, cache_kwargs=None
-                    )
-                    k = key_states.transpose(1, 2).contiguous()
-                    v = value_states.transpose(1, 2).contiguous()
-                else:
-                    # Optimized path:
-                    # use preallocated flash_k_cache / flash_v_cache
-                    layer = past_key_values.layers[self.layer_idx]
-
-                    if (
-                        hasattr(layer, "flash_k_cache")
-                        and layer.flash_k_cache is not None
-                        and hasattr(layer, "flash_v_cache")
-                        and layer.flash_v_cache is not None
-                    ):
-                        prefix_len = layer.flash_prefix_len
-                        cur_len = k_cur.shape[1]
-
-                        # overwrite current segment in-place
-                        layer.flash_k_cache[:, prefix_len : prefix_len + cur_len].copy_(
-                            k_cur
-                        )
-                        layer.flash_v_cache[:, prefix_len : prefix_len + cur_len].copy_(
-                            v_cur
-                        )
-
-                        k = layer.flash_k_cache[:, : prefix_len + cur_len]
-                        v = layer.flash_v_cache[:, : prefix_len + cur_len]
-                    else:
-                        # fallback if user forgot to prepare flash cache
-                        layer = past_key_values.layers[self.layer_idx]
-                        past_k, past_v = layer.keys, layer.values
-
-                        if past_k is not None:
-                            past_k = past_k.transpose(1, 2).contiguous()
-                            past_v = past_v.transpose(1, 2).contiguous()
-                            k = torch.cat([past_k, k_cur], dim=1)
-                            v = torch.cat([past_v, v_cur], dim=1)
-                        else:
-                            k = k_cur
-                            v = v_cur
+            if use_bnsd_cache:
+                # NPU FIA consumes BNSD directly. Keep q/k/v and the reusable
+                # cache in this layout to avoid two full transposes per layer.
+                q = query_states
+                k_cur = key_states
+                v_cur = value_states
+                prefix_len = layer.flash_prefix_len
+                cur_len = k_cur.shape[2]
+                layer.flash_k_cache[:, :, prefix_len : prefix_len + cur_len].copy_(
+                    k_cur
+                )
+                layer.flash_v_cache[:, :, prefix_len : prefix_len + cur_len].copy_(
+                    v_cur
+                )
+                k = layer.flash_k_cache[:, :, : prefix_len + cur_len]
+                v = layer.flash_v_cache[:, :, : prefix_len + cur_len]
+                actual_seq_lengths_kv = layer.flash_actual_seq_lengths_kv
+                kv_padding_size = layer.flash_kv_padding_size
+                input_layout = "BNSD"
             else:
-                k = k_cur
-                v = v_cur
+                # CUDA flash-attn and SDPA use [B, S, H, D] at this boundary.
+                q = query_states.transpose(1, 2).contiguous()
+                k_cur = key_states.transpose(1, 2).contiguous()
+                v_cur = value_states.transpose(1, 2).contiguous()
+
+                if past_key_values is not None:
+                    if update_cache:
+                        # Rare path, keep compatibility.
+                        # past_key_values.update expects [B,H,S,D]
+                        key_states, value_states = past_key_values.update(
+                            key_states, value_states, self.layer_idx, cache_kwargs=None
+                        )
+                        k = key_states.transpose(1, 2).contiguous()
+                        v = value_states.transpose(1, 2).contiguous()
+                    else:
+                        if (
+                            getattr(layer, "flash_k_cache", None) is not None
+                            and getattr(layer, "flash_v_cache", None) is not None
+                        ):
+                            prefix_len = layer.flash_prefix_len
+                            cur_len = k_cur.shape[1]
+                            layer.flash_k_cache[
+                                :, prefix_len : prefix_len + cur_len
+                            ].copy_(k_cur)
+                            layer.flash_v_cache[
+                                :, prefix_len : prefix_len + cur_len
+                            ].copy_(v_cur)
+                            k = layer.flash_k_cache[:, : prefix_len + cur_len]
+                            v = layer.flash_v_cache[:, : prefix_len + cur_len]
+                            actual_seq_lengths_kv = getattr(
+                                layer, "flash_actual_seq_lengths_kv", None
+                            )
+                            kv_padding_size = getattr(
+                                layer, "flash_kv_padding_size", None
+                            )
+                        else:
+                            # fallback if the cache was not prepared
+                            past_k, past_v = layer.keys, layer.values
+                            if past_k is not None:
+                                past_k = past_k.transpose(1, 2).contiguous()
+                                past_v = past_v.transpose(1, 2).contiguous()
+                                k = torch.cat([past_k, k_cur], dim=1)
+                                v = torch.cat([past_v, v_cur], dim=1)
+                            else:
+                                k = k_cur
+                                v = v_cur
+                else:
+                    k = k_cur
+                    v = v_cur
 
             # sanity checks
             assert q.ndim == 4 and k.ndim == 4 and v.ndim == 4
@@ -806,6 +1015,10 @@ class Qwen3Attention(nn.Module):
                 dropout_p=0.0 if not self.training else self.attention_dropout,
                 softmax_scale=self.scaling,
                 causal=False,
+                attention_mask=attention_mask,
+                actual_seq_lengths_kv=actual_seq_lengths_kv,
+                kv_padding_size=kv_padding_size,
+                input_layout=input_layout,
             )  # [B, S_q, H_q, D]
 
             attn_output = attn_output.reshape(*input_shape, -1).contiguous()
@@ -982,17 +1195,23 @@ class Qwen3Attention(nn.Module):
             )
         value_states = value_states.view(hidden_shape).transpose(1, 2)
 
-        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        cos_t, sin_t = self.rotary_emb(
+            hidden_states, position_ids_from_indexes(indexes, 0)
+        )
         query_states_t, key_states_t = apply_rotary_pos_emb(
             query_states_t, key_states_t, cos_t, sin_t
         )
 
-        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        cos_h, sin_h = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 1)
+        )
         query_states_h, key_states_h = apply_rotary_pos_emb(
             query_states_h, key_states_h, cos_h, sin_h
         )
 
-        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        cos_w, sin_w = self.rotary_emb_hw(
+            hidden_states, position_ids_from_indexes(indexes, 2)
+        )
         query_states_w, key_states_w = apply_rotary_pos_emb(
             query_states_w, key_states_w, cos_w, sin_w
         )
@@ -1375,11 +1594,13 @@ class Qwen3Model(Qwen3PreTrainedModel):
                 )
             else:
                 causal_mask_mapping = {
-                    "full_attention": create_block_causal_mask(indexes[0]),
+                    "full_attention": create_block_causal_mask(
+                        position_ids_from_indexes(indexes, 0)
+                    ),
                 }
-                self.current_index = indexes[0].max()
+                self.current_index = position_ids_from_indexes(indexes, 0).max()
         else:
-            self.current_index = indexes[0].max()
+            self.current_index = position_ids_from_indexes(indexes, 0).max()
             # raise NotImplementedError('not isinstance(causal_mask_mapping := attention_mask, dict)')
 
             # The sliding window alternating layers are not always activated depending on the config

--- a/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3_moe.py
+++ b/python/sglang/multimodal_gen/runtime/models/sensenova_u1/neo_unify/modeling_qwen3_moe.py
@@ -23,6 +23,7 @@ from .modeling_qwen3 import (
     Qwen3Attention,
     Qwen3RMSNorm,
     create_block_causal_mask,
+    position_ids_from_indexes,
 )
 from .transformers_compat import (
     causal_mask_kwargs,
@@ -499,11 +500,13 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
                 )
             else:
                 causal_mask_mapping = {
-                    "full_attention": create_block_causal_mask(indexes[0]),
+                    "full_attention": create_block_causal_mask(
+                        position_ids_from_indexes(indexes, 0)
+                    ),
                 }
-                self.current_index = indexes[0].max()
+                self.current_index = position_ids_from_indexes(indexes, 0).max()
         else:
-            self.current_index = indexes[0].max()
+            self.current_index = position_ids_from_indexes(indexes, 0).max()
 
         hidden_states = inputs_embeds
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sensenova_u1/stages/generation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sensenova_u1/stages/generation.py
@@ -21,6 +21,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
     Req,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 
 
@@ -71,7 +72,47 @@ class SenseNovaU1GenerationStage(PipelineStage):
                 "SenseNova-U1 expects output expansion before generation; "
                 f"got num_outputs_per_prompt={batch.num_outputs_per_prompt}."
             )
-        seed = batch.seed[0] if isinstance(batch.seed, list) else int(batch.seed)
+        if current_platform.is_npu():
+            prompts = batch.prompt if isinstance(batch.prompt, list) else [batch.prompt]
+            batch_size = len(prompts)
+            if batch_size == 0:
+                raise ValueError(
+                    "SenseNova-U1 dynamic batch must contain at least one prompt"
+                )
+            if batch_size > 1 and options.think_mode:
+                raise ValueError(
+                    "SenseNova-U1 dynamic batching does not support think_mode"
+                )
+
+            dynamic_seeds = batch.extra.get("dynamic_batch_seeds")
+            if dynamic_seeds is None:
+                dynamic_seeds = (
+                    batch.seed if isinstance(batch.seed, list) else [batch.seed]
+                )
+            elif not isinstance(dynamic_seeds, list):
+                dynamic_seeds = [dynamic_seeds]
+            seeds = []
+            for seed in dynamic_seeds:
+                if isinstance(seed, list):
+                    if len(seed) != 1:
+                        raise ValueError(
+                            "SenseNova-U1 dynamic batching requires one seed per request"
+                        )
+                    seed = seed[0]
+                seeds.append(int(seed))
+            if len(seeds) != batch_size:
+                raise ValueError(
+                    "SenseNova-U1 dynamic batch requires one seed per prompt; "
+                    f"got {len(seeds)} seeds for {batch_size} prompts"
+                )
+            seed = seeds[0] if batch_size == 1 else seeds
+        else:
+            if isinstance(batch.prompt, list):
+                raise ValueError(
+                    "SenseNova-U1 dynamic batching is only supported on Ascend NPU"
+                )
+            batch_size = 1
+            seed = batch.seed[0] if isinstance(batch.seed, list) else int(batch.seed)
 
         out = self.model.t2i_generate(
             self.tokenizer,
@@ -83,7 +124,7 @@ class SenseNovaU1GenerationStage(PipelineStage):
             enable_timestep_shift=options.enable_timestep_shift,
             cfg_interval=options.cfg_interval,
             num_steps=int(batch.num_inference_steps),
-            batch_size=1,
+            batch_size=batch_size,
             t_eps=options.t_eps,
             think_mode=options.think_mode,
             seed=seed,

--- a/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.nn.functional as F
+from transformers.cache_utils import DynamicCache
 
 from sglang.multimodal_gen.configs.pipeline_configs.sensenova_u1 import (
     SenseNovaU1PipelineConfig,
@@ -26,6 +29,10 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     process_generation_batch,
 )
 from sglang.multimodal_gen.runtime.managers.gpu_worker import GPUWorker
+from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.configuration_neo_chat import (
+    NEOLLMConfig,
+)
 from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.configuration_neo_vit import (
     NEOVisionConfig,
 )
@@ -33,7 +40,20 @@ from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.conversation im
     get_conv_template,
 )
 from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_neo_chat import (
+    NEOChatModel,
+    _copy_right_aligned_prefix_bnsd,
     _randn_with_seed,
+    prepare_flash_kv_cache,
+)
+from sglang.multimodal_gen.runtime.models.sensenova_u1.neo_unify.modeling_qwen3 import (
+    Qwen3Attention,
+    Qwen3MLP,
+    _sdpa_attn_func,
+    create_block_causal_mask,
+    npu_fia_enabled,
+    npu_fused_mlp_enabled,
+    npu_fused_norm_enabled,
+    position_ids_from_indexes,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.executors.pipeline_executor import (
     PipelineExecutor,
@@ -56,7 +76,7 @@ class _FakeSenseNovaModel:
 
     def t2i_generate(self, tokenizer, prompt, **kwargs):
         self.call_kwargs = {"tokenizer": tokenizer, "prompt": prompt, **kwargs}
-        return torch.tensor(
+        sample = torch.tensor(
             [
                 [
                     [[-1.0, 0.0], [0.5, 1.0]],
@@ -65,6 +85,17 @@ class _FakeSenseNovaModel:
                 ]
             ]
         )
+        return sample.repeat(kwargs["batch_size"], 1, 1, 1)
+
+
+class _FakeTokenizer:
+    pad_token_id = None
+    eos_token_id = 2
+
+    def __call__(self, text, return_tensors):
+        del return_tensors
+        token_count = len(text.split()) + 1
+        return {"input_ids": torch.arange(1, token_count + 1).unsqueeze(0)}
 
 
 class _RecordingTraceContext:
@@ -186,6 +217,305 @@ def test_sensenova_u1_randn_fallback_preserves_cpu_rng(monkeypatch):
 
     assert torch.equal(first, second)
     assert torch.equal(torch.get_rng_state(), rng_state)
+
+
+def test_sensenova_u1_randn_supports_per_sample_seeds():
+    actual = _randn_with_seed(
+        (2, 3, 4), device=torch.device("cpu"), dtype=torch.float32, seed=[7, 19]
+    )
+    expected = torch.cat(
+        [
+            _randn_with_seed(
+                (1, 3, 4),
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                seed=seed,
+            )
+            for seed in (7, 19)
+        ]
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_sensenova_u1_builds_padded_batched_text_inputs():
+    model = SimpleNamespace(device=torch.device("cpu"))
+
+    input_ids, indexes, attention_mask, valid_mask, prefix_lengths = (
+        NEOChatModel._build_t2i_text_inputs(
+            model, _FakeTokenizer(), ["short", "a much longer prompt"]
+        )
+    )
+
+    assert input_ids.shape == (2, 5)
+    assert indexes.shape == (2, 3, 5)
+    assert prefix_lengths.tolist() == [2, 5]
+    assert valid_mask.tolist() == [
+        [True, True, False, False, False],
+        [True, True, True, True, True],
+    ]
+    mask = attention_mask["full_attention"]
+    assert mask.shape == (2, 1, 5, 5)
+    assert torch.isneginf(mask[0, :, :, 2:]).all()
+    assert torch.isfinite(mask[0, :, :, :2]).any()
+
+
+def test_sensenova_u1_position_indexes_support_batched_inputs():
+    indexes = torch.tensor(
+        [
+            [[0, 1], [0, 0], [0, 0]],
+            [[4, 4], [0, 1], [0, 0]],
+        ]
+    )
+
+    assert torch.equal(position_ids_from_indexes(indexes, 0), indexes[:, 0])
+    assert torch.equal(
+        position_ids_from_indexes(indexes[0], 1), indexes[0, 1].unsqueeze(0)
+    )
+
+
+def test_sensenova_u1_singleton_text_matches_valid_batched_tokens():
+    model = SimpleNamespace(device=torch.device("cpu"))
+    tokenizer = _FakeTokenizer()
+    batched = NEOChatModel._build_t2i_text_inputs(
+        model, tokenizer, ["short", "a much longer prompt"]
+    )
+    for i, prompt in enumerate(["short", "a much longer prompt"]):
+        single = NEOChatModel._build_t2i_text_inputs(model, tokenizer, prompt)
+        length = single[0].shape[1]
+        assert torch.equal(batched[0][i, :length], single[0][0])
+        assert torch.equal(batched[1][i, :, :length], single[1])
+        assert torch.equal(
+            batched[2]["full_attention"][i, :, :length, :length],
+            single[2]["full_attention"][0],
+        )
+
+
+def test_sensenova_u1_block_causal_mask_rejects_padded_keys():
+    indexes = torch.tensor([[0, 1, 2], [0, 1, 2]])
+    valid = torch.tensor([[True, True, False], [True, True, True]])
+
+    mask = create_block_causal_mask(indexes, valid)
+
+    assert mask.shape == (2, 1, 3, 3)
+    assert torch.isneginf(mask[0, :, :, 2]).all()
+    assert mask[1, 0, 2, 2] == 0
+
+
+def test_sensenova_u1_builds_per_sample_image_indexes():
+    indexes = NEOChatModel._build_t2i_image_indexes(
+        SimpleNamespace(),
+        token_h=2,
+        token_w=2,
+        text_len=torch.tensor([2, 5]),
+        device=torch.device("cpu"),
+    )
+
+    assert indexes.shape == (2, 3, 4)
+    assert indexes[:, 0].tolist() == [[2, 2, 2, 2], [5, 5, 5, 5]]
+    assert indexes[:, 1].tolist() == [[0, 0, 1, 1], [0, 0, 1, 1]]
+    assert indexes[:, 2].tolist() == [[0, 1, 0, 1], [0, 1, 0, 1]]
+
+
+def test_sensenova_u1_sdpa_masks_padded_prefix_keys():
+    q = torch.tensor([[[[1.0, 0.0]]]])
+    k = torch.tensor([[[[1.0, 0.0]], [[0.0, 1.0]], [[1.0, 1.0]]]])
+    v = torch.tensor([[[[2.0, 0.0]], [[0.0, 4.0]], [[100.0, 100.0]]]])
+    key_mask = torch.tensor([[[[True, True, False]]]])
+
+    actual = _sdpa_attn_func(q, k, v, attention_mask=key_mask)
+    expected = _sdpa_attn_func(q, k[:, :2], v[:, :2])
+
+    assert torch.allclose(actual, expected)
+
+
+def test_sensenova_u1_right_aligns_bnsd_prefix_for_npu_fia():
+    source = torch.tensor(
+        [
+            [[[1], [2], [99], [99], [99]]],
+            [[[3], [4], [5], [6], [7]]],
+        ]
+    )
+    destination = torch.zeros(2, 1, 8, 1, dtype=source.dtype)
+
+    _copy_right_aligned_prefix_bnsd(destination, source, [2, 5])
+
+    assert destination[:, 0, :5, 0].tolist() == [
+        [0, 0, 0, 1, 2],
+        [3, 4, 5, 6, 7],
+    ]
+    assert destination[:, :, 5:].eq(0).all()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "off"])
+def test_sensenova_u1_npu_fia_can_be_disabled(monkeypatch, value):
+    monkeypatch.setenv("SGLANG_SENSENOVA_NPU_FIA", value)
+    assert not npu_fia_enabled()
+
+
+def test_sensenova_u1_npu_fia_is_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("SGLANG_SENSENOVA_NPU_FIA", raising=False)
+    assert npu_fia_enabled()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "enabled"),
+    [
+        ("SGLANG_SENSENOVA_NPU_FUSED_NORM", npu_fused_norm_enabled),
+        ("SGLANG_SENSENOVA_NPU_FUSED_MLP", npu_fused_mlp_enabled),
+    ],
+)
+@pytest.mark.parametrize("value", ["0", "false", "off"])
+def test_sensenova_u1_npu_fused_ops_can_be_disabled(
+    monkeypatch, env_name, enabled, value
+):
+    monkeypatch.setenv(env_name, value)
+    assert not enabled()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "enabled"),
+    [
+        ("SGLANG_SENSENOVA_NPU_FUSED_NORM", npu_fused_norm_enabled),
+        ("SGLANG_SENSENOVA_NPU_FUSED_MLP", npu_fused_mlp_enabled),
+    ],
+)
+def test_sensenova_u1_npu_fused_ops_are_enabled_by_default(
+    monkeypatch, env_name, enabled
+):
+    monkeypatch.delenv(env_name, raising=False)
+    assert enabled()
+
+
+@torch.no_grad()
+def test_sensenova_u1_fused_dense_mlp_matches_original(monkeypatch):
+    config = SimpleNamespace(
+        hidden_size=16,
+        intermediate_size=24,
+        hidden_act="silu",
+    )
+    with torch.random.fork_rng():
+        torch.manual_seed(37)
+        mlp = Qwen3MLP(config).eval()
+        hidden_states = torch.randn(2, 5, config.hidden_size)
+        expected = mlp(hidden_states)
+
+    monkeypatch.setattr(mlp, "_use_npu_fused_mlp", lambda _x: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "torch_npu",
+        SimpleNamespace(
+            npu_swiglu=lambda x, dim=-1: (
+                F.silu(x.chunk(2, dim=dim)[0]) * x.chunk(2, dim=dim)[1]
+            )
+        ),
+    )
+    actual = mlp(hidden_states)
+
+    torch.testing.assert_close(actual, expected)
+    assert set(mlp.state_dict()) == {
+        "gate_proj.weight",
+        "up_proj.weight",
+        "down_proj.weight",
+    }
+    assert (
+        mlp.gate_proj.weight.untyped_storage().data_ptr()
+        == mlp.up_proj.weight.untyped_storage().data_ptr()
+    )
+
+
+def test_sensenova_u1_batched_gqa_matches_unpadded_singletons():
+    generator = torch.Generator().manual_seed(17)
+    q = torch.randn(2, 3, 4, 8, generator=generator)
+    k = torch.randn(2, 8, 2, 8, generator=generator)
+    v = torch.randn(2, 8, 2, 8, generator=generator)
+    # Five prefix slots followed by three current image tokens.
+    valid = torch.ones(2, 8, dtype=torch.bool)
+    valid[0, 2:5] = False
+    actual = _sdpa_attn_func(q, k, v, attention_mask=valid[:, None, None, :])
+    for i in range(2):
+        expected = _sdpa_attn_func(
+            q[i : i + 1], k[i : i + 1, valid[i]], v[i : i + 1, valid[i]]
+        )
+        torch.testing.assert_close(actual[i : i + 1], expected)
+
+
+@pytest.mark.parametrize("cfg_scale", [1.0, 4.0])
+@pytest.mark.parametrize("expand_query_mask", [False, True])
+@torch.no_grad()
+def test_sensenova_u1_prefix_and_denoise_attention_match_singletons(
+    cfg_scale, expand_query_mask
+):
+    config = NEOLLMConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=128,
+    )
+    config._attn_implementation = "eager"
+    with torch.random.fork_rng():
+        torch.manual_seed(23)
+        attention = Qwen3Attention(config, layer_idx=0).eval()
+    generator = torch.Generator().manual_seed(31)
+    text = torch.randn(2, 5, 64, generator=generator)
+    image = torch.randn(2, 3, 64, generator=generator)
+    unconditional = torch.randn(1, 2, 64, generator=generator)
+    helper = SimpleNamespace(device=torch.device("cpu"))
+
+    def run(prefix, lengths, image_states):
+        batch_size, width, _ = prefix.shape
+        positions = torch.arange(width).expand(batch_size, -1)
+        indexes = torch.stack(
+            [positions, torch.zeros_like(positions), torch.zeros_like(positions)], dim=1
+        )
+        valid = positions < torch.tensor(lengths)[:, None]
+        cache = DynamicCache(config=config)
+        attention.forward_und(
+            prefix, indexes, create_block_causal_mask(positions, valid), cache
+        )
+        prefix_keys = cache.layers[0].keys.clone()
+        prepare_flash_kv_cache(cache, current_len=3, batch_size=batch_size)
+        image_indexes = NEOChatModel._build_t2i_image_indexes(
+            helper, 1, 3, torch.tensor(lengths), torch.device("cpu")
+        )
+        mask = torch.cat([valid, torch.ones(batch_size, 3, dtype=torch.bool)], dim=1)
+        mask = mask[:, None, None, :]
+        if expand_query_mask:
+            mask = mask.expand(-1, -1, 3, -1).contiguous()
+        outputs = []
+        for _ in range(2):
+            image_states, _ = attention.forward_gen(
+                image_states,
+                image_indexes,
+                mask,
+                cache,
+                update_cache=False,
+            )
+            outputs.append(image_states)
+        torch.testing.assert_close(cache.layers[0].keys, prefix_keys)
+        return prefix_keys, outputs
+
+    keys, batched = run(text, [2, 5], image)
+    if cfg_scale > 1:
+        _, uncond_batch = run(unconditional.expand(2, -1, -1), [2, 2], image)
+    for i, length in enumerate([2, 5]):
+        single_keys, single = run(text[i : i + 1, :length], [length], image[i : i + 1])
+        torch.testing.assert_close(keys[i : i + 1, :, :length], single_keys)
+        if cfg_scale > 1:
+            _, uncond_single = run(unconditional, [2], image[i : i + 1])
+        for step in range(2):
+            actual, expected = batched[step][i : i + 1], single[step]
+            if cfg_scale > 1:
+                actual = uncond_batch[step][i : i + 1] + cfg_scale * (
+                    actual - uncond_batch[step][i : i + 1]
+                )
+                expected = uncond_single[step] + cfg_scale * (
+                    expected - uncond_single[step]
+                )
+            torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
 
 
 def test_sensenova_u1_randn_fallback_preserves_device_rng(monkeypatch):
@@ -338,11 +668,104 @@ def test_sensenova_u1_accepts_openai_image_api_num_frames():
     assert params.data_type == DataType.IMAGE
 
 
-def test_sensenova_u1_scheduler_capabilities():
+def test_sensenova_u1_scheduler_capabilities(monkeypatch):
     config = SenseNovaU1PipelineConfig()
 
+    monkeypatch.setattr(current_platform, "is_npu", lambda: True)
+    assert config.supports_dynamic_batching()
+    monkeypatch.setattr(current_platform, "is_npu", lambda: False)
     assert not config.supports_dynamic_batching()
     assert config.supports_sequential_multi_output_inference()
+
+
+def test_sensenova_u1_rejects_batched_generation_off_npu():
+    model = SimpleNamespace(device=torch.device("cpu"), concat_time_token_num=0)
+
+    with pytest.raises(ValueError, match="only supported on Ascend NPU"):
+        NEOChatModel.t2i_generate(
+            model,
+            tokenizer=None,
+            prompt=["first", "second"],
+            batch_size=2,
+        )
+
+
+def test_sensenova_u1_batch_cost_tracks_resolution_steps_and_cfg():
+    config = SenseNovaU1PipelineConfig()
+    batch = SimpleNamespace(
+        width=1024,
+        height=1024,
+        num_inference_steps=5,
+        guidance_scale=4.0,
+        num_outputs_per_prompt=1,
+    )
+
+    assert config.estimate_request_cost(batch) == 32 * 32 * 5 * 2
+
+
+def test_sensenova_u1_multi_output_request_is_not_dynamically_batched():
+    scheduler = object.__new__(Scheduler)
+    scheduler.server_args = SimpleNamespace(pipeline_config=SenseNovaU1PipelineConfig())
+    sampling = SenseNovaU1SamplingParams(
+        prompt="a mountain lake", num_outputs_per_prompt=2
+    )
+    request = SimpleNamespace(
+        is_warmup=False,
+        realtime_session_id=None,
+        session=None,
+        prompt=sampling.prompt,
+        image_path=None,
+        return_file_paths_only=False,
+        num_outputs_per_prompt=2,
+        sampling_params=sampling,
+    )
+
+    assert not scheduler._can_dynamic_batch(request, request)
+    assert (
+        scheduler._get_dynamic_batch_reject_reason(request, request)
+        == "sequential_multi_output"
+    )
+
+
+def test_sensenova_u1_scheduler_merge_and_split_preserve_request_order():
+    scheduler = object.__new__(Scheduler)
+    scheduler.server_args = SimpleNamespace(pipeline_config=SenseNovaU1PipelineConfig())
+    requests = []
+    for i, (prompt, seed) in enumerate([("short", 7), ("a longer prompt", 19)]):
+        sampling = SenseNovaU1SamplingParams(prompt=prompt, seed=seed)
+        requests.append(
+            SimpleNamespace(
+                prompt=prompt,
+                seed=seed,
+                request_id=f"request-{i}",
+                sampling_params=sampling,
+                extra=sampling.build_request_extra(),
+                is_warmup=False,
+                realtime_session_id=None,
+                session=None,
+                image_path=None,
+                return_file_paths_only=False,
+                num_outputs_per_prompt=1,
+                profile=False,
+            )
+        )
+    merged = scheduler._try_merge_generation_reqs(requests)
+    assert merged.prompt == ["short", "a longer prompt"]
+    assert merged.extra["dynamic_batch_seeds"] == [7, 19]
+    assert requests[0].prompt == "short"
+    outputs = scheduler._split_batched_output(
+        OutputBatch(output=[torch.tensor([7]), torch.tensor([19])]), requests
+    )
+    assert [output.output[0].item() for output in outputs] == [7, 19]
+    assert (
+        scheduler._split_batched_output(
+            OutputBatch(output=[torch.tensor([7])]), requests
+        )
+        is None
+    )
+    requests[1].sampling_params.width = 1024
+    del requests[1]._dynamic_batch_sig
+    assert scheduler._try_merge_generation_reqs(requests) is None
 
 
 def test_sensenova_u1_rejects_multi_gpu_during_arg_validation():
@@ -624,6 +1047,73 @@ def test_sensenova_u1_generation_stage_uses_sglang_params_and_single_model_batch
     assert model.call_kwargs["num_steps"] == 30
     assert model.call_kwargs["batch_size"] == 1
     assert model.call_kwargs["seed"] == 123
+
+
+def test_sensenova_u1_generation_stage_passes_dynamic_batch_inputs(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_npu", lambda: True)
+    sampling = SenseNovaU1SamplingParams(
+        prompt="first prompt",
+        width=1024,
+        height=1024,
+        guidance_scale=4.0,
+        num_inference_steps=5,
+        seed=7,
+    )
+    batch = SimpleNamespace(
+        prompt=["first prompt", "a longer second prompt"],
+        width=sampling.width,
+        height=sampling.height,
+        guidance_scale=sampling.guidance_scale,
+        num_inference_steps=sampling.num_inference_steps,
+        seed=sampling.seed,
+        num_outputs_per_prompt=1,
+        extra={
+            **sampling.build_request_extra(),
+            "dynamic_batch_seeds": [7, 19],
+        },
+        metrics=None,
+    )
+    model = _FakeSenseNovaModel()
+    stage = SenseNovaU1GenerationStage(model=model, tokenizer="tok")
+
+    output = stage.forward(batch, server_args=SimpleNamespace())
+
+    assert len(output.output) == 2
+    assert model.call_kwargs["prompt"] == [
+        "first prompt",
+        "a longer second prompt",
+    ]
+    assert model.call_kwargs["batch_size"] == 2
+    assert model.call_kwargs["seed"] == [7, 19]
+
+
+def test_sensenova_u1_generation_stage_rejects_batched_think_mode(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_npu", lambda: True)
+    sampling = SenseNovaU1SamplingParams(
+        prompt="first prompt",
+        width=1024,
+        height=1024,
+        think_mode=True,
+    )
+    batch = SimpleNamespace(
+        prompt=["first prompt", "second prompt"],
+        width=sampling.width,
+        height=sampling.height,
+        guidance_scale=sampling.guidance_scale,
+        num_inference_steps=sampling.num_inference_steps,
+        seed=sampling.seed,
+        num_outputs_per_prompt=1,
+        extra={
+            **sampling.build_request_extra(),
+            "dynamic_batch_seeds": [7, 19],
+        },
+        metrics=None,
+    )
+
+    with pytest.raises(ValueError, match="think_mode"):
+        SenseNovaU1GenerationStage(
+            model=_FakeSenseNovaModel(), tokenizer="tok"
+        ).forward(batch, server_args=SimpleNamespace())
 
 
 def test_sensenova_u1_multi_output_request_expands_before_generation_stage():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR follows the SenseNova-U1 support and performance roadmap tracked in [#37742](https://github.com/sgl-project/sglang/issues/37742).

SenseNova-U1 previously processed serving requests one at a time on Ascend NPU. Simply enabling request batching provided almost no throughput improvement because padded SDPA attention, repeated normalization and MLP launches, KV layout conversions, and repeated timestep embedding work offset the batching benefit.

This change adds homogeneous request-level batching for SenseNova-U1 on Ascend NPU and optimizes the repeated denoising path using native NPU operators.

## Modifications

- Enable dynamic request batching for SenseNova-U1 on Ascend NPU.
  - Preserve prompt, seed, and output ordering.
  - Require requests in one batch to share resolution, sampling steps, CFG settings, and output options.
  - Add a request-cost estimate based on image tokens, denoising steps, CFG branches, and output count.
  - Keep sequential multi-output requests outside merged dynamic batches.
- Add variable-length prompt support.
  - Pad batched text inputs and track per-sample prefix lengths.
  - Make text and image position indexes batch-aware.
  - Prevent padded prefix tokens from participating in prefix or denoise attention.
  - Reuse the shared unconditional prefix cache for CFG while retaining per-sample conditional prefixes.
  - Generate initial noise from independent per-request RNG streams.
- Add the native Ascend fused inference attention path.
  - Use `torch_npu.npu_fused_infer_attention_score` with per-sample KV lengths.
  - Keep the reusable denoise KV cache in FIA-native BNSD layout.
  - Right-align variable-length prefixes so image tokens keep a common cache offset.
  - Fall back to the existing masked SDPA path when FIA is disabled.
- Optimize repeated NPU denoising work.
  - Use `torch_npu.npu_rms_norm` for RMSNorm.
  - Fuse dense MLP gate/up projections into one matmul followed by `torch_npu.npu_swiglu`.
  - Precompute timestep and noise-scale embeddings outside the denoising loop.
  - Preserve checkpoint-facing MLP parameter names.
- Add offline serving benchmarks, an NPU attention microbenchmark, a bounded-size profiling script, and validation documentation.

The optimized paths are enabled by default on NPU and can be isolated with:

```bash
SGLANG_SENSENOVA_NPU_FIA=0
SGLANG_SENSENOVA_NPU_FUSED_NORM=0
SGLANG_SENSENOVA_NPU_FUSED_MLP=0
```

Dynamic batching remains disabled for SenseNova-U1 on CPU and CUDA. Those platforms retain the existing single-request attention, normalization, MLP, KV-cache, and timestep paths.

Current batching scope:

- Text-to-image generation
- Single Ascend NPU
- One output per merged request
- `think_mode=false` for batches larger than one
- Homogeneous sampling parameters

Image-to-image batching, multi-device execution, CFG conditional/unconditional branch fusion, denoise-step continuous batching, and NPU graph capture are outside this PR.

## Accuracy Tests

The integrated serving path was tested on one Ascend 910C with four concurrent requests.

Smoke-test configuration:

- SenseNova-U1.5-8B-MoT
- 1024 × 1024
- 5 denoising steps
- Batch size 2
- CFG 1 and CFG 4
- Four requests per run

Results:

- All requests completed successfully.
- Server logs confirmed real `2/2` dynamic batches.
- Generated images had the expected dimensions.
- Generated images were visually inspected after enabling fused MLP; no visible quality regression was found.

The native FIA microbenchmark also compared the padded batch output against independently executed compact inputs:

| Comparison | Max absolute error | Mean absolute error | `allclose` |
|---|---:|---:|:---:|
| Masked SDPA, short sample | 0.0009766 | 3.76e-06 | Yes |
| FIA, short sample | 0.0009766 | 1.30e-05 | Yes |
| FIA, long sample | 0.0004883 | 1.29e-05 | Yes |
| Left-aligned FIA cache, short sample | 0.0009766 | 1.30e-05 | Yes |
| Left-aligned FIA cache, long sample | 0.0004883 | 1.29e-05 | Yes |

Tolerance: `atol=0.02`, `rtol=0.02`, BF16.

Unit coverage was added for:

- Per-request seed determinism
- Padded batched tokenization
- Batched position indexes
- Prefix and denoise padding masks
- GQA batch equivalence
- FIA cache alignment
- Fused MLP equivalence and state-dict compatibility
- Scheduler merge/split ordering
- Incompatible request rejection
- NPU-only batching enforcement
- Batched CFG on/off attention behavior

The complete pytest suite was not executed on the Windows development host because that environment does not contain the SGLang PyTorch test dependencies. The test command for CI or an existing Linux inference environment is:

```bash
PYTHONPATH="$PWD/python${PYTHONPATH:+:$PYTHONPATH}" python3 -m pytest \
  python/sglang/multimodal_gen/test/unit/test_sensenova_u1.py -q
```

Static validation completed locally:

- Python compilation
- Ruff error checks
- Ruff formatting
- isort
- codespell
- Git whitespace checks

## Speed Tests and Profiling

Hardware and workload:

- One Ascend 910C
- SenseNova-U1.5-8B-MoT
- Four concurrent requests
- Four generated images
- 2048 × 2048
- 50 denoising steps
- CFG 4
- BF16

| Configuration | Duration (s) | Throughput (images/s) | Mean latency (s) | P95 latency (s) | Peak reserved memory (MB) |
|---|---:|---:|---:|---:|---:|
| B1, optimizations disabled | 234.28 | 0.01707 | 146.47 | 234.27 | 35698 |
| B2, optimizations disabled | 234.83 | 0.01703 | 176.06 | 234.83 | 37870 |
| B1, FIA + RMSNorm + MLP | 205.94 | 0.01942 | 128.80 | 205.94 | 35718 |
| B2, FIA + RMSNorm + MLP | 195.02 | 0.02051 | 146.33 | 195.01 | 37850 |

Derived results:

- B2 without NPU optimizations versus B1 without optimizations: **-0.24% throughput**
- Optimized B1 versus unoptimized B1: **+13.76% throughput**
- Optimized B2 versus unoptimized B2: **+20.42% throughput**
- Optimized B2 versus optimized B1: **+5.60% throughput**
- Optimized B2 versus unoptimized B1: **+20.13% throughput**
- Optimized B2 reduced total duration by **16.76%** versus unoptimized B1.

The attention microbenchmark at query length 4096 measured:

| Attention path | Median latency |
|---|---:|
| B2 unmasked SDPA | 5.060 ms |
| B2 masked SDPA | 6.544 ms |
| B2 native FIA | 4.718 ms |

Native FIA was:

- **1.387× faster** than masked SDPA.
- **1.073× faster** than unmasked SDPA.
- **1.103× higher theoretical B2 throughput** than the measured B1 SDPA path.

Profiling showed that the main end-to-end gain comes from the NPU attention, RMSNorm, and MLP operator paths. Request batching adds another 5.60% throughput on top of those optimizations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34586963431](https://github.com/sgl-project/sglang/actions/runs/34586963431)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34586963191](https://github.com/sgl-project/sglang/actions/runs/34586963191)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34586963246](https://github.com/sgl-project/sglang/actions/runs/34586963246)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->