### PR TITLE
MiMoV2: do not force flashinfer_trtllm when an EP a2a backend is active

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/mimo_v2.py
+++ b/python/sglang/srt/arg_groups/model_overrides/mimo_v2.py
@@ -27,8 +27,14 @@ def _mimo_v2_overrides(server_args: Any, hf_config: Any) -> dict:
 
     # On Blackwell "auto" falls through to the triton fused-MoE runner, ~12%
     # slower at bs=1 decode. FP4 checkpoints use flashinfer_mxfp4 instead.
+    #
+    # Only when there is no EP all-to-all backend: flashinfer_trtllm has no fused
+    # func registered for deepep/deepep_v2, so forcing it there turns a working
+    # "auto" (which resolves to deep_gemm) into a NotImplementedError at model
+    # init. Same guard the glm4_moe / qwen3_moe / deepseek_v4 overrides carry.
     if (
         get_platform().is_sm100
+        and cfg.moe_a2a_backend == "none"
         and cfg.moe_runner_backend == "auto"
         and get_quantization_config(hf_config) == "fp8"
     ):


### PR DESCRIPTION
## Motivation

The MiMoV2 config-time override forces `moe_runner_backend=flashinfer_trtllm` on sm100 FP8
without checking whether an EP all-to-all backend is active:

```python
if (
    get_platform().is_sm100
    and cfg.moe_runner_backend == "auto"
    and get_quantization_config(hf_config) == "fp8"
):
    overrides["moe_runner_backend"] = "flashinfer_trtllm"
```

`FusedOpPool` has no `flashinfer_trtllm` fused func registered for `deepep` or `deepep_v2`,
and `flashinfer_trtllm` has no `runner_core` (fused path only), so `MoeRunner.__init__` hits
`runner_core is None and fused_func is None`:

```
NotImplementedError: Runner backend MoeRunnerBackend.FLASHINFER_TRTLLM requires a fused func
for a2a backend deepep_v2, but none is registered.
```

The user asked for `auto`. `auto` resolves to `deep_gemm`, which works. The override turns a
working default into a hard failure at model init, and because the substitution is silent the
traceback names a backend the command line never mentioned.

Sibling overrides already carry exactly this guard — `glm4_moe.py:39`, `qwen3_moe.py:43`,
`deepseek_v4.py:62`, `nemotron_h.py:86` all test `cfg.moe_a2a_backend == "none"` before
forcing a runner. `mimo_v2.py` is the one that does not, so this brings it in line rather
than introducing a new convention.

## Modifications

One condition, `and cfg.moe_a2a_backend == "none"`, plus a comment explaining why (the next
person to read this will otherwise wonder whether the guard is load-bearing). No behaviour
change without an a2a backend: the sm100 FP8 fast path is untouched for the plain-TP case
the override was written for.

## Accuracy Tests

No numerical change. With `--moe-a2a-backend none` the resolved runner is `flashinfer_trtllm`
before and after — verified via `/get_server_info` on 8× B200 with an FP8 MiMoV2 checkpoint.
With `--moe-a2a-backend deepep_v2 --moe-runner-backend auto` the resolved runner goes from
"init raises" to `deep_gemm`, whose numerics against the `deepep` (v1) path are 10/12 prompts
bit-identical on a fixed logprob set (details in the companion PR).

## Speed Tests and Profiling

Unchanged where the override still fires. Where it no longer fires, the comparison is
`NotImplementedError` versus a running server.

Worth stating plainly for anyone weighing it: `flashinfer_trtllm` really is the faster runner
where it is usable — on decode at global bs=32 it is 24.58 ms/token versus 34.90 for
`deep_gemm`, ~30%. That is an argument for registering a `deepep`/`deepep_v2` fused func, not
for forcing a runner that cannot load. (The one existing `deepep`+`flashinfer_cutedsl` fused
func takes `CuteDslFp4MoeQuantInfo`, i.e. NVFP4 only, so it does not help an FP8 checkpoint.)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — happy to add one asserting `_mimo_v2_overrides` returns no `moe_runner_backend` when `moe_a2a_backend != "none"`; it needs no GPU, say the word
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

I cannot add the `run-ci` label myself, so this needs someone with write access to start CI.

---

Companions, independent of each other: #39080 (enable `deepep_v2` for MiMoV2 — the PR that
makes this guard reachable), #39078 (ElasticBuffer vs CUDA graph capture), #37211
(`ep_scatter_from_psum` kernel args).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34590432083](https://github.com/sgl-project/sglang/actions/runs/34590432083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34590431824](https://github.com/sgl-project/sglang/actions/runs/34590431824)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34590431968](https://github.com/sgl-project/sglang/actions/runs/34590431968)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->