### PR TITLE
[Bugfix] Defer the QSA indexer import in the EAGLE draft worker

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -390,8 +390,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
     def _configure_qsa_mtp_index_share(self) -> None:
         """Reuse the draft-extend QSA selection across the MTP decode steps;
         chain speculation only: with topk > 1 decode rows are not request-major."""
-        from sglang.srt.layers.attention.qsa.qsa_indexer import QSAIndexer
-
         hf_config = self.draft_runner.model_config.hf_config
         if (
             not _qsa_index_share_requested(hf_config)
@@ -401,6 +399,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             or not isinstance(self.draft_extend_attn_backend, QwenSparseAttnBackend)
         ):
             return
+
+        # Imported here rather than at function entry: the module pulls in
+        # tilelang, and every EAGLE/NEXTN model reaches this function, so a
+        # top-of-function import makes an unrelated tilelang import failure
+        # fatal to speculative decoding on models that never use QSA.
+        from sglang.srt.layers.attention.qsa.qsa_indexer import QSAIndexer
+
         if get_spec().speculative_adaptive:
             # Adaptive speculation switches SpecRuntimeState between the draft-extend
             # capture and the decode lookup; per-state index buffers would not match.


### PR DESCRIPTION
## Motivation

EAGLE/NEXTN speculative decoding fails to start on models that do not use Qwen sparse attention, in any image where `tilelang` does not import cleanly. This PR moves one import below an early return so those models never load tilelang at all.

`_configure_qsa_mtp_index_share` imports `QSAIndexer` at function entry, above the guard that returns for any model whose config does not set `index_share_for_mtp_iteration`. Every EAGLE/NEXTN draft worker calls the function during `init_attention_backends`, so every speculative model imports `qsa_indexer`, which imports `tilelang`.

Serving `amd/Qwen3.8-2.4T-A95B-Quark-MXFP4` with NEXTN (3/1/4, TP8) on an image built on `lmsysorg/sglang:v0.5.19-rocm10-mi35x` with sglang updated to main, the scheduler dies after the full weight load:

```
File "sglang/srt/speculative/eagle_worker_v2.py", line 393, in _configure_qsa_mtp_index_share
  from sglang.srt.layers.attention.qsa.qsa_indexer import QSAIndexer
File "sglang/srt/layers/attention/qsa/mqa.py", line 15, in <module>
  import tilelang
File "/opt/tilelang/3rdparty/tvm/python/tvm/ir/attrs.py", line 76, in <module>
  @tvm_ffi.register_object("ir.DictAttrs")
AttributeError: attribute '__dict__' of 'type' objects is not writable
```

That is image-side version skew, not an sglang bug, and ours to fix: reinstalling sglang on top of the released image re-resolves `apache-tvm-ffi` to a newer PyPI wheel than the one TileLang's bundled TVM was built against. The point here is that it should not be reachable at all. This model sets no `index_share_for_mtp_iteration`, so the function returns immediately and the import is the only thing that runs.

## Modifications

Move the import below the early return. Only `qsa_indexer`, and therefore tilelang, is deferred; `QwenSparseMultiStepDraftBackend` and `QwenSparseAttnBackend` stay at module scope.

The guard's `isinstance` checks already ensure only QSA backends reach the code that needs `QSAIndexer`, so every path that used the symbol still gets it and the guard's behaviour is unchanged.

This is the pattern the repo already applies to `tvm_ffi`-dependent imports: #35290 made the minimax_m2 all-reduce kernels lazy so the module loads on XPU without `tvm_ffi`, and #28531 guarded the DSv4 online-MTP `tvm_ffi` import for the same reason. #36914 did the same for aiter on CPU CI.

## Accuracy Tests

None run, because no output can change. QSA models evaluate the guard exactly as before and import `QSAIndexer` before first use; non-QSA models already returned at the same point, so the import was the only thing the change removes from them. NEXTN on the checkpoint above now starts and serves, where it previously could not initialise the draft worker.

## Speed Tests and Profiling

None applicable. The change removes one module import from startup on non-QSA speculative models and touches no runtime path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Not added: the only thing to assert is that `qsa_indexer` is absent from `sys.modules` after a non-QSA draft worker initialises. Happy to add that if a reviewer wants it.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing behaviour changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). No runtime path changes; see the two sections above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34834206622](https://github.com/sgl-project/sglang/actions/runs/34834206622)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34834206096](https://github.com/sgl-project/sglang/actions/runs/34834206096)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34834206383](https://github.com/sgl-project/sglang/actions/runs/34834206383)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->


