### PR TITLE
[AMD] Fix AITER DSA prefill with an FP8 KV cache

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -407,13 +407,15 @@ class DeepseekSparseAttnBackend(
                 16 // self.num_q_heads if self.num_q_heads < 16 else 1
             )
             self.num_head_padded = self.num_q_heads * self.head_repeat_factor
-            self.aiter_dsa_max_split_per_batch = 64
             self.aiter_dsa_metadata_capacity = 0
             self.aiter_dsa_metadata_max_seqlen_q = 0
             self.aiter_dsa_metadata_q_dtype = None
             self.aiter_dsa_metadata_kv_dtype = None
             self.aiter_dsa_kv_last_page_lens = None
             self.aiter_dsa_work_metadata = None
+            self.aiter_dsa_identity_scale = torch.ones(
+                (), dtype=torch.float32, device=self.device
+            )
 
             if (
                 self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
@@ -575,9 +577,8 @@ class DeepseekSparseAttnBackend(
             q_dtype,
             kv_dtype,
             is_sparse=True,
-            fast_mode=False,
-            num_kv_splits=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
+            fast_mode=True,
+            intra_batch_mode=False,
         )
 
         return (
@@ -662,7 +663,7 @@ class DeepseekSparseAttnBackend(
             kv_last_page_lens,
             self.num_head_padded,
             1,
-            False,
+            True,
             self.aiter_dsa_work_metadata,
             self.aiter_dsa_work_info_set,
             self.aiter_dsa_work_indptr,
@@ -673,10 +674,9 @@ class DeepseekSparseAttnBackend(
             kv_granularity=16,
             max_seqlen_qo=max_seqlen_q,
             uni_seqlen_qo=max_seqlen_q,
-            fast_mode=False,
-            topk=self.dsa_index_topk,
-            max_split_per_batch=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
+            fast_mode=True,
+            topk=-1,
+            intra_batch_mode=False,
             dtype_q=q_dtype,
             dtype_kv=kv_dtype,
         )
@@ -689,8 +689,6 @@ class DeepseekSparseAttnBackend(
             "reduce_indptr": self.aiter_dsa_reduce_indptr,
             "reduce_final_map": self.aiter_dsa_reduce_final_map,
             "reduce_partial_map": self.aiter_dsa_reduce_partial_map,
-            "intra_batch_mode": True,
-            "num_kv_splits": self.aiter_dsa_max_split_per_batch,
         }
 
     def _pad_trtllm_sparse_page_table(
@@ -3253,11 +3251,14 @@ class DeepseekSparseAttnBackend(
         bs: int,
     ) -> torch.Tensor:
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        o_dtype = torch.bfloat16 if q.dtype == fp8_dtype else q.dtype
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (q.shape[0], layer.tp_q_head_num * layer.v_head_dim), dtype=o_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=o_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -3268,7 +3269,8 @@ class DeepseekSparseAttnBackend(
                     q.shape[0],
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=o_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
@@ -3278,7 +3280,12 @@ class DeepseekSparseAttnBackend(
         kv_scale = None
         aiter_persistent_kwargs = {}
         if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+            q_scale = self.aiter_dsa_identity_scale
+            kv_scale = (
+                layer.k_scale.reshape(())
+                if isinstance(layer.k_scale, torch.Tensor)
+                else self.aiter_dsa_identity_scale
+            )
 
         kv_indptr = self.kv_indptr
 
@@ -3331,11 +3338,14 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         num_tokens = q_all.shape[0]
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        o_dtype = torch.bfloat16 if q.dtype == fp8_dtype else q.dtype
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((num_tokens, layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (num_tokens, layer.tp_q_head_num * layer.v_head_dim), dtype=o_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=o_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -3346,7 +3356,8 @@ class DeepseekSparseAttnBackend(
                     num_tokens,
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=o_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
@@ -3356,7 +3367,12 @@ class DeepseekSparseAttnBackend(
         kv_scale = None
         aiter_persistent_kwargs = {}
         if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+            q_scale = self.aiter_dsa_identity_scale
+            kv_scale = (
+                layer.k_scale.reshape(())
+                if isinstance(layer.k_scale, torch.Tensor)
+                else self.aiter_dsa_identity_scale
+            )
 
         non_minus1_mask = page_table_1 != -1
         non_minus1_counts = non_minus1_mask.sum(dim=1)

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -1249,7 +1249,7 @@ DSA_DECODE_IMPL_VARIANTS: tuple[str, ...] = (
 # take in FP8 deployments. The `flashmla_kv` decode kernel and *both*
 # flashmla prefill kernels are the production-relevant FP8 paths.
 DSA_FP8_COMPATIBLE_PREFILL_IMPLS: frozenset[str] = frozenset(
-    {"flashmla_sparse", "flashmla_kv", "flashmla_auto"}
+    {"aiter", "flashmla_sparse", "flashmla_kv", "flashmla_auto"}
 )
 DSA_FP8_COMPATIBLE_DECODE_IMPLS: frozenset[str] = frozenset(
     {"flashmla_kv", "flashmla_auto"}
@@ -1396,8 +1396,8 @@ def run_dsa_sparse_fp8_prefill_case(
     if dsa_prefill_backend not in DSA_FP8_COMPATIBLE_PREFILL_IMPLS:
         testcase.skipTest(
             f"DSA prefill impl `{dsa_prefill_backend}` does not support FP8 KV "
-            f"cache (only `flashmla_sparse`, `flashmla_kv`, and `flashmla_auto` "
-            f"read FP8 K directly; others require BF16 K)."
+            f"cache (only `aiter`, `flashmla_sparse`, `flashmla_kv`, and "
+            f"`flashmla_auto` read FP8 K directly; others require BF16 K)."
         )
     if not case.forward_mode.is_extend_without_speculative():
         raise ValueError("run_dsa_sparse_fp8_prefill_case expects an EXTEND case.")


### PR DESCRIPTION
# [AMD] Fix AITER DSA prefill with an FP8 KV cache

## Motivation

SGLang gathers the KV entries selected by DeepSeek Sparse Attention into a
compact buffer before calling AITER. Each query's range in that buffer is
described by `kv_indptr`.

The existing integration configures AITER as if the input still used a fixed
sparse top-k layout. It also forces 64 work splits, allocates FP8 output for an
operation that returns BF16, and replaces the KV-cache scale with `1.0`. These
assumptions can produce invalid work metadata and incorrect output at long
context.

## Modifications

- Select AITER's v1.2 metadata builder with `fast_mode=True`.
- Disable the legacy v1.0 path with `intra_batch_mode=False`.
- Pass `topk=-1` because the KV entries are already compact. This makes AITER
  use the ranges in `kv_indptr`; it does not disable DSA top-k selection.
- Remove the fixed `max_split_per_batch=64` value so AITER derives the split
  count from the workload.
- Allocate BF16 output when the query input is FP8.
- Pass query scale `1.0` and the layer's KV-cache scale to AITER.
- Add AITER to the existing DSA FP8-prefill test matrix.

Cross-layer metadata reuse is intentionally excluded and will be submitted
separately.

## Accuracy Tests

Hardware: AMD MI355X, TP4, FP8 KV cache.

The existing DSA attention test suite passed the AITER BF16 and FP8 sparse
prefill cases:

```bash
python3 test/registered/attention/unittests/dsa/test_dsa.py
```

For a long-context output test, the same two fixed-seed random prompts were run
once with AITER prefill and once with TileLang prefill. Each prompt used 60,000
input tokens and 64 output tokens, with `temperature=0` and `top_p=1`. The
generated texts matched for both prompts.

## Speed Tests and Profiling

This is a correctness fix. The metadata builder changes from a fixed split
policy to AITER's workload-adaptive policy, but this PR does not claim a
standalone serving-speed improvement.

## Checklist

- [x] Format and code-style checks pass.
- [x] Existing DSA accuracy tests cover the AITER FP8-prefill path.
- [x] Long-context output matches TileLang for both test prompts.
- [x] No user-facing documentation change is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35722134044](https://github.com/sgl-project/sglang/actions/runs/35722134044)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35722133863](https://github.com/sgl-project/sglang/actions/runs/35722133863)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35722134307](https://github.com/sgl-project/sglang/actions/runs/35722134307)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->