### PR TITLE
[AMD] Avoid wide page-table expansion in chunked DSA prefill

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -116,6 +116,50 @@ def transform_index_page_table_decode_kernel(
     tl.store(result_ptr + offset, -1, mask=~mask)
 
 
+# Row-map page tables are contiguous, so their row stride changes with the
+# exact context length. Treating it as constexpr creates one cubin per observed
+# length and grows the loaded-module set in long-lived processes.
+@triton.jit(do_not_specialize=["page_table_stride_0"])
+def transform_index_page_table_row_map_kernel(
+    page_table_ptr: torch.Tensor,
+    topk_indices_ptr: torch.Tensor,
+    row_to_batch_ptr: torch.Tensor,
+    result_ptr: torch.Tensor,
+    page_table_stride_0,
+    page_table_stride_1: tl.constexpr,
+    topk_indices_stride_0: tl.constexpr,
+    topk_indices_stride_1: tl.constexpr,
+    result_stride_0: tl.constexpr,
+    result_stride_1: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    topk_offsets = tl.program_id(1) * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    topk_mask = topk_offsets < TOPK
+    request_id = tl.load(row_to_batch_ptr + row)
+    logical_indices = tl.load(
+        topk_indices_ptr
+        + row * topk_indices_stride_0
+        + topk_offsets * topk_indices_stride_1,
+        mask=topk_mask,
+        other=-1,
+    )
+    valid_mask = topk_mask & (logical_indices >= 0)
+    physical_indices = tl.load(
+        page_table_ptr
+        + request_id * page_table_stride_0
+        + logical_indices * page_table_stride_1,
+        mask=valid_mask,
+        other=-1,
+    )
+    tl.store(
+        result_ptr + row * result_stride_0 + topk_offsets * result_stride_1,
+        physical_indices,
+        mask=topk_mask,
+    )
+
+
 # Expanded EAGLE page tables are contiguous, so their row stride changes with
 # the exact context length. Treating it as constexpr creates one cubin per
 # observed length and grows the loaded-module set in long-lived processes.
@@ -175,6 +219,43 @@ def transform_index_page_table_prefill_kernel(
         loaded_kv_indices,
         mask=mask,
     )
+
+
+def transform_index_page_table_row_map(
+    page_table: torch.Tensor,
+    topk_indices: torch.Tensor,
+    row_to_batch: torch.Tensor,
+) -> torch.Tensor:
+    assert page_table.ndim == 2
+    assert topk_indices.ndim == 2
+    assert row_to_batch.ndim == 1
+    assert topk_indices.shape[0] == row_to_batch.shape[0]
+
+    result = torch.empty_like(topk_indices, dtype=torch.int32)
+    if topk_indices.shape[0] == 0 or topk_indices.shape[1] == 0:
+        return result
+
+    block_topk = 256
+    grid = (
+        topk_indices.shape[0],
+        triton.cdiv(topk_indices.shape[1], block_topk),
+    )
+    transform_index_page_table_row_map_kernel[grid](
+        page_table,
+        topk_indices,
+        row_to_batch,
+        result,
+        page_table_stride_0=page_table.stride(0),
+        page_table_stride_1=page_table.stride(1),
+        topk_indices_stride_0=topk_indices.stride(0),
+        topk_indices_stride_1=topk_indices.stride(1),
+        result_stride_0=result.stride(0),
+        result_stride_1=result.stride(1),
+        TOPK=topk_indices.shape[1],
+        BLOCK_TOPK=block_topk,
+        num_warps=4,
+    )
+    return result
 
 
 def transform_index_page_table_decode_fast(

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -160,6 +160,22 @@ class DSATopKBackend(Enum):
             )
 
             if topk_transform_method == TopkTransformMethod.PAGED:
+                if batch_idx_list is not None:
+                    from sglang.kernels.ops.attention.dsa.transform_index import (
+                        transform_index_page_table_row_map,
+                    )
+
+                    logical_topk = self.topk_func(
+                        logits,
+                        lengths,
+                        topk,
+                        row_starts=row_starts,
+                    )
+                    return transform_index_page_table_row_map(
+                        attn_metadata.page_table_1,
+                        logical_topk,
+                        batch_idx_list,
+                    )
                 page_table_size_1 = (
                     attn_metadata.page_table_1[batch_idx_list]
                     if batch_idx_list is not None

--- a/test/registered/kernel/attention/test_dsa_prefill_rowmap.py
+++ b/test/registered/kernel/attention/test_dsa_prefill_rowmap.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import sglang.kernels.ops.attention.dsa.transform_index as transform_index_module
+from sglang.kernels.ops.attention.dsa.transform_index import (
+    transform_index_page_table_row_map,
+)
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
+    DSATopKBackend,
+    TopkTransformMethod,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=10, stage="jit-kernel-unit", runner_config="amd")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="A GPU is required for this test.",
+)
+
+
+@pytest.mark.parametrize(
+    "num_requests,num_rows,width,topk",
+    [
+        (3, 17, 257, 64),
+        (16, 32, 60003, 2048),
+    ],
+)
+def test_row_map_matches_pytorch(
+    num_requests: int,
+    num_rows: int,
+    width: int,
+    topk: int,
+) -> None:
+    torch.manual_seed(7)
+    page_table = torch.randint(
+        0,
+        2**30,
+        (num_requests, width),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    row_to_batch = torch.randint(
+        0,
+        num_requests,
+        (num_rows,),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    logical = torch.randint(
+        0,
+        width,
+        (num_rows, topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    logical[::3, -7:] = -1
+
+    actual = transform_index_page_table_row_map(page_table, logical, row_to_batch)
+    reference = page_table[
+        row_to_batch[:, None].to(torch.int64),
+        logical.clamp_min(0).to(torch.int64),
+    ]
+    reference = torch.where(logical >= 0, reference, -1)
+
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+
+
+def test_chunked_paged_topk_uses_row_map() -> None:
+    page_table = torch.arange(8, dtype=torch.int32, device="cuda").reshape(2, 4)
+    logical = torch.tensor([[3, 1], [0, 2]], dtype=torch.int32, device="cuda")
+    row_to_batch = torch.tensor([1, 0], dtype=torch.int32, device="cuda")
+    logits = torch.zeros((2, 4), dtype=torch.float32, device="cuda")
+    lengths = torch.full((2,), 4, dtype=torch.int32, device="cuda")
+    expected = torch.empty_like(logical)
+
+    with (
+        envs.SGLANG_DSA_FUSE_TOPK.override(True),
+        patch.object(DSATopKBackend, "topk_func", return_value=logical),
+        patch.object(
+            transform_index_module,
+            "transform_index_page_table_row_map",
+            return_value=expected,
+        ) as row_map,
+    ):
+        actual = DSATopKBackend.SGL_KERNEL.topk_transform(
+            logits=logits,
+            lengths=lengths,
+            topk=2,
+            topk_transform_method=TopkTransformMethod.PAGED,
+            attn_metadata=SimpleNamespace(page_table_1=page_table),
+            batch_idx_list=row_to_batch,
+        )
+
+    assert actual is expected
+    row_map.assert_called_once_with(page_table, logical, row_to_batch)


### PR DESCRIPTION
# [AMD] Avoid wide page-table expansion in chunked DSA prefill

## Motivation

Long-context DSA prefill splits the logits into row chunks when the full FP32
logits tensor would exceed the memory limit. For example, a 32,768 by 60,000
tensor needs about 7.9 GiB.

For each chunk, the PAGED path currently expands the page table with
`page_table_1[batch_idx_list]` before selecting top-k entries. This copies every
page-table column for every row, even though only the selected top-k indices are
needed.

## Modifications

- Select the logical top-k indices before reading the page table.
- Add a Triton row-map kernel that uses `batch_idx_list` to find the page-table
  row for each token.
- Map only the selected logical indices to physical KV-cache slots.
- Read the page-table row stride at runtime so different context lengths do not
  compile separate Triton modules.

At 60,000 tokens with top-k 2,048, this maps about 30 times less page-table data.
The decode path is unchanged.

[SGLang PR #37889](https://github.com/sgl-project/sglang/pull/37889) handles
eligible unchunked rows with the fused top-k v2 kernel. Its chunked fallback
still uses the wide page-table expansion. This PR handles that fallback when
`batch_idx_list` is present.

## Accuracy Tests

The row-map output matches direct PyTorch indexing for:

- 3 requests, 17 rows, page-table width 257, and top-k 64;
- 16 requests, 32 rows, page-table width 60,003, and top-k 2,048.

The tests also check that `batch_idx_list` selects the row-map path.

```bash
python3 -m pytest \
  test/registered/kernel/attention/test_dsa_prefill_rowmap.py -v
```

## Speed Tests and Profiling

Hardware: AMD MI355X, TP4, GLM-5.2-MXFP4, 60,000 input tokens, concurrency 16.

- Time in `aten::index` decreased from 1.584 seconds to 0.004 seconds.
- Total GPU kernel time decreased by 4.4%.
- Output throughput increased by 1.5%.
- Mean time to first token decreased by 2.3%.

## Checklist

- [x] Format and code-style checks pass.
- [x] Tests cover small and long-context page tables.
- [x] The test is registered for AMD and CUDA CI.
- [x] The fused decode top-k path is unchanged.
- [x] No user-facing documentation change is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34595925176](https://github.com/sgl-project/sglang/actions/runs/34595925176)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34595925028](https://github.com/sgl-project/sglang/actions/runs/34595925028)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34595925085](https://github.com/sgl-project/sglang/actions/runs/34595925085)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->