### PR TITLE
[AMD] Reuse AITER DSA prefill metadata across layers

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -407,13 +407,15 @@ class DeepseekSparseAttnBackend(
                 16 // self.num_q_heads if self.num_q_heads < 16 else 1
             )
             self.num_head_padded = self.num_q_heads * self.head_repeat_factor
-            self.aiter_dsa_max_split_per_batch = 64
             self.aiter_dsa_metadata_capacity = 0
             self.aiter_dsa_metadata_max_seqlen_q = 0
             self.aiter_dsa_metadata_q_dtype = None
             self.aiter_dsa_metadata_kv_dtype = None
             self.aiter_dsa_kv_last_page_lens = None
             self.aiter_dsa_work_metadata = None
+            self.aiter_dsa_identity_scale = torch.ones(
+                (), dtype=torch.float32, device=self.device
+            )
 
             if (
                 self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
@@ -575,9 +577,8 @@ class DeepseekSparseAttnBackend(
             q_dtype,
             kv_dtype,
             is_sparse=True,
-            fast_mode=False,
-            num_kv_splits=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
+            fast_mode=True,
+            intra_batch_mode=False,
         )
 
         return (
@@ -662,7 +663,7 @@ class DeepseekSparseAttnBackend(
             kv_last_page_lens,
             self.num_head_padded,
             1,
-            False,
+            True,
             self.aiter_dsa_work_metadata,
             self.aiter_dsa_work_info_set,
             self.aiter_dsa_work_indptr,
@@ -673,10 +674,9 @@ class DeepseekSparseAttnBackend(
             kv_granularity=16,
             max_seqlen_qo=max_seqlen_q,
             uni_seqlen_qo=max_seqlen_q,
-            fast_mode=False,
-            topk=self.dsa_index_topk,
-            max_split_per_batch=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
+            fast_mode=True,
+            topk=-1,
+            intra_batch_mode=False,
             dtype_q=q_dtype,
             dtype_kv=kv_dtype,
         )
@@ -689,8 +689,6 @@ class DeepseekSparseAttnBackend(
             "reduce_indptr": self.aiter_dsa_reduce_indptr,
             "reduce_final_map": self.aiter_dsa_reduce_final_map,
             "reduce_partial_map": self.aiter_dsa_reduce_partial_map,
-            "intra_batch_mode": True,
-            "num_kv_splits": self.aiter_dsa_max_split_per_batch,
         }
 
     def _pad_trtllm_sparse_page_table(
@@ -3253,11 +3251,14 @@ class DeepseekSparseAttnBackend(
         bs: int,
     ) -> torch.Tensor:
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        o_dtype = torch.bfloat16 if q.dtype == fp8_dtype else q.dtype
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (q.shape[0], layer.tp_q_head_num * layer.v_head_dim), dtype=o_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=o_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -3268,7 +3269,8 @@ class DeepseekSparseAttnBackend(
                     q.shape[0],
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=o_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
@@ -3278,7 +3280,12 @@ class DeepseekSparseAttnBackend(
         kv_scale = None
         aiter_persistent_kwargs = {}
         if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+            q_scale = self.aiter_dsa_identity_scale
+            kv_scale = (
+                layer.k_scale.reshape(())
+                if isinstance(layer.k_scale, torch.Tensor)
+                else self.aiter_dsa_identity_scale
+            )
 
         kv_indptr = self.kv_indptr
 
@@ -3331,11 +3338,14 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         num_tokens = q_all.shape[0]
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        o_dtype = torch.bfloat16 if q.dtype == fp8_dtype else q.dtype
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((num_tokens, layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (num_tokens, layer.tp_q_head_num * layer.v_head_dim), dtype=o_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=o_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -3346,7 +3356,8 @@ class DeepseekSparseAttnBackend(
                     num_tokens,
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=o_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
@@ -3356,7 +3367,12 @@ class DeepseekSparseAttnBackend(
         kv_scale = None
         aiter_persistent_kwargs = {}
         if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+            q_scale = self.aiter_dsa_identity_scale
+            kv_scale = (
+                layer.k_scale.reshape(())
+                if isinstance(layer.k_scale, torch.Tensor)
+                else self.aiter_dsa_identity_scale
+            )
 
         non_minus1_mask = page_table_1 != -1
         non_minus1_counts = non_minus1_mask.sum(dim=1)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -416,6 +416,9 @@ class DeepseekSparseAttnBackend(
             self.aiter_dsa_identity_scale = torch.ones(
                 (), dtype=torch.float32, device=self.device
             )
+            self.aiter_dsa_extend_metadata_owner = None
+            self.aiter_dsa_extend_kv_last_page_lens = None
+            self.aiter_dsa_extend_persistent_kwargs = None
 
             if (
                 self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
@@ -690,6 +693,35 @@ class DeepseekSparseAttnBackend(
             "reduce_final_map": self.aiter_dsa_reduce_final_map,
             "reduce_partial_map": self.aiter_dsa_reduce_partial_map,
         }
+
+    def _get_aiter_dsa_extend_metadata(
+        self,
+        metadata_owner: DSAMetadata,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        bs: int,
+        max_seqlen_q: int,
+        q_dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        if self.aiter_dsa_extend_metadata_owner is not metadata_owner:
+            prepared = self._prepare_aiter_dsa_decode_metadata(
+                qo_indptr,
+                kv_indptr,
+                bs,
+                max_seqlen_q,
+                q_dtype,
+                kv_dtype,
+            )
+            self.aiter_dsa_extend_kv_last_page_lens = prepared.pop("kv_last_page_lens")
+            self.aiter_dsa_extend_persistent_kwargs = prepared
+            self.aiter_dsa_extend_metadata_owner = metadata_owner
+
+        kv_last_page_lens = self.aiter_dsa_extend_kv_last_page_lens
+        persistent_kwargs = self.aiter_dsa_extend_persistent_kwargs
+        assert kv_last_page_lens is not None
+        assert persistent_kwargs is not None
+        return kv_last_page_lens, persistent_kwargs
 
     def _pad_trtllm_sparse_page_table(
         self, page_table_1: torch.Tensor
@@ -3395,15 +3427,17 @@ class DeepseekSparseAttnBackend(
         )
         kv_last_page_lens = cu_seqlens_q
         if kv_cache.dtype == fp8_dtype:
-            aiter_persistent_kwargs = self._prepare_aiter_dsa_decode_metadata(
-                cu_seqlens_q,
-                kv_indptr,
-                num_tokens,
-                1,
-                q_kernel.dtype,
-                kv_cache.dtype,
+            kv_last_page_lens, aiter_persistent_kwargs = (
+                self._get_aiter_dsa_extend_metadata(
+                    self.forward_metadata,
+                    cu_seqlens_q,
+                    kv_indptr,
+                    num_tokens,
+                    1,
+                    q_kernel.dtype,
+                    kv_cache.dtype,
+                )
             )
-            kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
 
         # TODO support more forward_mode
         mla_decode_fwd(

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -1249,7 +1249,7 @@ DSA_DECODE_IMPL_VARIANTS: tuple[str, ...] = (
 # take in FP8 deployments. The `flashmla_kv` decode kernel and *both*
 # flashmla prefill kernels are the production-relevant FP8 paths.
 DSA_FP8_COMPATIBLE_PREFILL_IMPLS: frozenset[str] = frozenset(
-    {"flashmla_sparse", "flashmla_kv", "flashmla_auto"}
+    {"aiter", "flashmla_sparse", "flashmla_kv", "flashmla_auto"}
 )
 DSA_FP8_COMPATIBLE_DECODE_IMPLS: frozenset[str] = frozenset(
     {"flashmla_kv", "flashmla_auto"}
@@ -1396,8 +1396,8 @@ def run_dsa_sparse_fp8_prefill_case(
     if dsa_prefill_backend not in DSA_FP8_COMPATIBLE_PREFILL_IMPLS:
         testcase.skipTest(
             f"DSA prefill impl `{dsa_prefill_backend}` does not support FP8 KV "
-            f"cache (only `flashmla_sparse`, `flashmla_kv`, and `flashmla_auto` "
-            f"read FP8 K directly; others require BF16 K)."
+            f"cache (only `aiter`, `flashmla_sparse`, `flashmla_kv`, and "
+            f"`flashmla_auto` read FP8 K directly; others require BF16 K)."
         )
     if not case.forward_mode.is_extend_without_speculative():
         raise ValueError("run_dsa_sparse_fp8_prefill_case expects an EXTEND case.")

--- a/test/registered/unit/layers/attention/test_dsa_backend.py
+++ b/test/registered/unit/layers/attention/test_dsa_backend.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import Mock
+
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestAiterDSAMetadataReuse(CustomTestCase):
+    def test_metadata_is_reused_only_within_one_forward(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.aiter_dsa_extend_metadata_owner = None
+        backend.aiter_dsa_extend_kv_last_page_lens = None
+        backend.aiter_dsa_extend_persistent_kwargs = None
+
+        prepared_results = [
+            {
+                "kv_last_page_lens": object(),
+                "work_meta_data": object(),
+            },
+            {
+                "kv_last_page_lens": object(),
+                "work_meta_data": object(),
+            },
+        ]
+        backend._prepare_aiter_dsa_decode_metadata = Mock(side_effect=prepared_results)
+
+        def get_metadata(owner):
+            return backend._get_aiter_dsa_extend_metadata(
+                owner,
+                object(),
+                object(),
+                1,
+                1,
+                None,
+                None,
+            )
+
+        first_forward = object()
+        first = get_metadata(first_forward)
+        reused = get_metadata(first_forward)
+
+        self.assertEqual(backend._prepare_aiter_dsa_decode_metadata.call_count, 1)
+        self.assertIs(first[0], reused[0])
+        self.assertIs(first[1], reused[1])
+
+        second = get_metadata(object())
+
+        self.assertEqual(backend._prepare_aiter_dsa_decode_metadata.call_count, 2)
+        self.assertIsNot(first[0], second[0])
+        self.assertIsNot(first[1], second[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [AMD] Reuse AITER DSA prefill metadata across layers

**Depends on:** #39083

## Motivation

During an EXTEND forward pass, every DSA layer builds the same AITER work and
reduction metadata. The metadata depends on the sequences in the current
forward pass, not on the transformer layer. Building it again in every layer
adds unnecessary CPU and GPU work.

## Modifications

- Use the current `DSAMetadata` object to identify the forward pass.
- Build AITER metadata when the first DSA layer runs.
- Reuse that metadata in later layers of the same forward pass.
- Build new metadata when the `DSAMetadata` object changes.
- Keep the existing buffer size, dtype, and device checks.

Decode metadata is unchanged. The reused metadata belongs only to the current
forward pass.

## Accuracy Tests

Hardware: AMD MI355X.

The registered unit test checks that:

- one forward pass builds metadata once;
- a new forward pass builds new metadata.

The reused tensors also completed graph capture and two graph replays on
MI355X. The existing AITER BF16 and FP8 DSA prefill tests pass.

## Speed Tests and Profiling

For the tested long-context workload, AITER metadata generation decreased from
28.27 ms to 0.36 ms per 1,000 tokens.

## Checklist

- [x] Format and code-style checks pass.
- [x] Tests cover reuse within a forward pass and rebuilding for a new pass.
- [x] Graph capture and replay pass with reused metadata.
- [x] No user-facing documentation change is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35722137902](https://github.com/sgl-project/sglang/actions/runs/35722137902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35722137852](https://github.com/sgl-project/sglang/actions/runs/35722137852)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35722137982](https://github.com/sgl-project/sglang/actions/runs/35722137982)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->