### PR TITLE
[BugFix] Fix speculative auxiliary capture after fused all-reduce

### DIFF
--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -753,10 +753,6 @@ class BailingMoEModel(nn.Module):
         aux_hidden_states = []
         for i in range(self.start_layer, self.end_layer):
             with get_global_expert_distribution_recorder().with_current_layer(i):
-                if i in self.layers_to_capture:
-                    aux_hidden_states.append(
-                        hidden_states if residual is None else hidden_states + residual
-                    )
                 layer = self.layers[i]
                 hidden_states, residual = layer(
                     positions,
@@ -765,7 +761,8 @@ class BailingMoEModel(nn.Module):
                     residual,
                     captured_last_layer_outputs=(
                         aux_hidden_states
-                        if getattr(layer, "_is_layer_to_capture", False)
+                        if i in self.layers_to_capture
+                        or getattr(layer, "_is_layer_to_capture", False)
                         else None
                     ),
                 )

--- a/python/sglang/srt/models/bailing_moe_v3.py
+++ b/python/sglang/srt/models/bailing_moe_v3.py
@@ -1057,10 +1057,16 @@ class BailingMoELinearDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
         zero_allocator: BumpAllocator,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+            )
         )
 
         if not forward_batch.forward_mode.is_idle():
@@ -1274,16 +1280,25 @@ class BailingMoELinearModel(nn.Module):
                     forward_batch=forward_batch,
                     residual=residual,
                     zero_allocator=zero_allocator,
+                    captured_last_layer_outputs=(
+                        dspark_aux_hidden_states
+                        if capture_aux
+                        and i - 1 in self.layers_to_capture
+                        and hidden_states.shape[0] != 0
+                        else None
+                    ),
                 )
-                if (
-                    capture_aux
-                    and i in self.layers_to_capture
-                    and hidden_states.shape[0] != 0
-                ):
-                    if residual is None:
-                        dspark_aux_hidden_states.append(hidden_states)
-                    else:
-                        dspark_aux_hidden_states.append(hidden_states + residual)
+
+        if (
+            capture_aux
+            and self.end_layer - 1 in self.layers_to_capture
+            and hidden_states.shape[0] != 0
+        ):
+            dspark_aux_hidden_states.append(
+                hidden_states + residual
+                if residual is not None
+                else hidden_states.clone()
+            )
 
         if not self.pp_group.is_last_rank:
             return PPProxyTensors(

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -909,13 +909,16 @@ class Glm4MoeDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> torch.Tensor:
-
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states,
-            residual,
-            forward_batch,
-            quant_format=self.attn_quant_format,
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+                quant_format=self.attn_quant_format,
+            )
         )
 
         hidden_states = self.self_attn(
@@ -1098,14 +1101,15 @@ class Glm4MoeModel(nn.Module):
         aux_hidden_states = []
         for i in range(normal_start_layer, normal_end_layer):
             with get_global_expert_distribution_recorder().with_current_layer(i):
-                if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states + residual)
                 layer = self.layers[i]
                 hidden_states, residual = layer(
                     positions,
                     hidden_states,
                     forward_batch,
                     residual,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
                 )
 
         if normal_end_layer != self.end_layer:

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -638,12 +638,16 @@ class Glm4MoeLiteDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
         zero_allocator: BumpAllocator,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> torch.Tensor:
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states,
-            residual,
-            forward_batch,
-            getattr(self, "_gfx95_quant_format", ""),
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+                quant_format=getattr(self, "_gfx95_quant_format", ""),
+            )
         )
 
         hidden_states = self.self_attn(
@@ -833,8 +837,6 @@ class Glm4MoeLiteModel(nn.Module):
         aux_hidden_states = []
         for i in range(normal_start_layer, normal_end_layer):
             with get_global_expert_distribution_recorder().with_current_layer(i):
-                if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states + residual)
                 layer = self.layers[i]
                 hidden_states, residual = layer(
                     positions,
@@ -842,6 +844,9 @@ class Glm4MoeLiteModel(nn.Module):
                     forward_batch,
                     residual,
                     zero_allocator,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
                 )
 
         if normal_end_layer != self.end_layer:

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -623,9 +623,15 @@ class GptOssDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+            )
         )
 
         if hidden_states.shape[0] != 0:
@@ -735,22 +741,24 @@ class GptOssModel(nn.Module):
         # Capture hidden-state boundaries: boundary 0 is the embedding output,
         # and boundary i + 1 is the output after transformer block i.
         aux_hidden_states = []
-        if self.start_layer in self.layers_to_capture:
-            aux_hidden_states.append(
-                hidden_states + residual if residual is not None else hidden_states
-            )
         for i in range(self.start_layer, self.end_layer):
             with get_global_expert_distribution_recorder().with_current_layer(i):
                 layer = self.layers[i]
                 hidden_states, residual = layer(
-                    positions, hidden_states, forward_batch, residual
+                    positions,
+                    hidden_states,
+                    forward_batch,
+                    residual,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
                 )
-                if i + 1 in self.layers_to_capture:
-                    aux_hidden_states.append(
-                        hidden_states + residual
-                        if residual is not None
-                        else hidden_states
-                    )
+        if self.end_layer in self.layers_to_capture:
+            aux_hidden_states.append(
+                hidden_states + residual
+                if residual is not None
+                else hidden_states.clone()
+            )
         if not self.pp_group.is_last_rank:
             return PPProxyTensors(
                 {

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -105,10 +105,9 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             self.layers[self.start_layer : self.end_layer]
         ):
             layer_idx += self.start_layer
-            if layer_idx in self.layers_to_capture:
-                aux_hidden_states.append(
-                    hidden_states + residual if residual is not None else hidden_states
-                )
+            captured_last_layer_outputs = (
+                aux_hidden_states if layer_idx in self.layers_to_capture else None
+            )
 
             if self.use_hf_deepstack_order:
                 # HF-order path (RL on-policy / FSDP). SGLang applies residual at the START of the
@@ -122,6 +121,7 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                     hidden_states,
                     forward_batch,
                     residual,
+                    captured_last_layer_outputs=captured_last_layer_outputs,
                     post_residual_addition=deepstack_embeds,
                 )
             else:
@@ -132,6 +132,7 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                     hidden_states,
                     forward_batch,
                     residual,
+                    captured_last_layer_outputs=captured_last_layer_outputs,
                 )
                 if (
                     input_deepstack_embeds is not None

--- a/test/registered/e2e/speculative/test_speculative_capture_reduction.py
+++ b/test/registered/e2e/speculative/test_speculative_capture_reduction.py
@@ -1,0 +1,290 @@
+"""Aux captures must include real TP collectives and survive later decoder work.
+
+Uses production model loops, decoder forwards, communicators and CUDA norms.
+Attention/MLP are deterministic small modules; this is a distributed regression
+test, not a pretrained-model acceptance or performance benchmark.
+"""
+
+import importlib
+import inspect
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace as NS
+
+import torch
+from torch import nn
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="2-gpu-large")
+
+MODELS = [
+    ("gpt_oss", "GptOssModel", "GptOssDecoderLayer"),
+    ("glm4_moe", "Glm4MoeModel", "Glm4MoeDecoderLayer"),
+    ("glm4_moe_lite", "Glm4MoeLiteModel", "Glm4MoeLiteDecoderLayer"),
+    ("qwen3_vl_moe", "Qwen3MoeLLMModel", "Qwen3MoeDecoderLayer"),
+    ("bailing_moe", "BailingMoEModel", "BailingMoEBlock"),
+    ("bailing_moe_v3", "BailingMoELinearModel", "BailingMoELinearDecoderLayer"),
+]
+
+
+class Attention(nn.Module):
+    def forward(self, hidden_states, **kwargs):
+        return hidden_states.roll(1, -1) / 16
+
+
+class MLP(nn.Module):
+    def forward(self, hidden_states, forward_batch=None):
+        from sglang.srt.runtime_context import get_parallel
+
+        return hidden_states.roll(-1, -1) * ((get_parallel().tp_rank + 1) / 8)
+
+
+def make_model(entry, dtype, hidden_dim):
+    from sglang.srt.layers.communicator import (
+        LayerCommunicator,
+        LayerScatterModes,
+        ScatterMode,
+    )
+    from sglang.srt.layers.layernorm import RMSNorm
+
+    name, model_name, decoder_name = entry
+    module = importlib.import_module("sglang.srt.models." + name)
+    model_cls, decoder_cls = getattr(module, model_name), getattr(module, decoder_name)
+    model = model_cls.__new__(model_cls)
+    nn.Module.__init__(model)
+    model.pp_group = NS(is_first_rank=True, is_last_rank=True)
+    model.start_layer, model.end_layer = 0, 3
+    model.first_k_dense_replace = 0
+    model.layers_to_capture = [0, 1] if name == "bailing_moe_v3" else [1, 2]
+    model.capture_aux_hidden_states = True
+    model.hidden_size = hidden_dim
+    model.use_hf_deepstack_order = False
+    model.deepstack_embed_to_decoder_layer = range(3)
+    model.norm = RMSNorm(hidden_dim, eps=1e-6).to(device="cuda", dtype=dtype)
+    layers = []
+    for index in range(3):
+        layer = decoder_cls.__new__(decoder_cls)
+        nn.Module.__init__(layer)
+        layer.layer_id = index
+        layer.attn_quant_format = ""
+        layer.attention_type = 0
+        layer.is_layer_sparse = True
+        layer.use_mla = False
+        layer.self_attn = Attention()
+        layer.attention = Attention()
+        layer.mlp = MLP()
+        layer.input_layernorm = RMSNorm(hidden_dim, eps=1e-6).to(
+            device="cuda", dtype=dtype
+        )
+        layer.post_attention_layernorm = RMSNorm(hidden_dim, eps=1e-6).to(
+            device="cuda", dtype=dtype
+        )
+        layer.layer_scatter_modes = LayerScatterModes(
+            layer_input_mode=ScatterMode.TP_ATTN_FULL,
+            attn_mode=ScatterMode.TP_ATTN_FULL,
+            mlp_mode=ScatterMode.FULL,
+            middle_residual_mode=ScatterMode.TP_ATTN_FULL,
+            layer_output_mode=ScatterMode.TP_ATTN_FULL,
+        )
+        layer.layer_communicator = LayerCommunicator(
+            layer_scatter_modes=layer.layer_scatter_modes,
+            input_layernorm=layer.input_layernorm,
+            post_attention_layernorm=layer.post_attention_layernorm,
+            allow_reduce_scatter=True,
+            is_last_layer=index == 2,
+        )
+        layers.append(layer)
+    model.layers = nn.ModuleList(layers)
+    return model
+
+
+def check_case(entry, dtype, rows, mode, fused, graph):
+    from sglang.srt.runtime_context import get_exec
+
+    with get_exec().comm.override(
+        flashinfer_allreduce_fusion_backend="trtllm" if fused else None
+    ):
+        return _check_case(entry, dtype, rows, mode, fused, graph)
+
+
+def _check_case(entry, dtype, rows, mode, fused, graph):
+    import torch.distributed as dist
+
+    from sglang.srt.distributed import get_moe_tp_group
+    from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
+    model = make_model(entry, dtype, 2880)
+    generator = torch.Generator(device="cuda").manual_seed(42)
+    inputs = torch.randn(rows, 2880, generator=generator, device="cuda", dtype=dtype)
+    positions = torch.arange(rows, device="cuda")
+    batch = NS(
+        input_ids=positions,
+        forward_mode=mode,
+        can_run_tbo=False,
+        attn_cp_metadata=None,
+        capture_hidden_mode=CaptureHiddenMode.FULL,
+    )
+    expected, markers, handles = [], [], []
+
+    def hook(layer, args, kwargs):
+        values = inspect.signature(layer.forward).bind(*args, **kwargs).arguments
+        hidden, residual = values["hidden_states"], values.get("residual")
+        pending = bool(getattr(hidden, "_sglang_needs_allreduce_fusion", False))
+        reference = hidden.float().clone()
+        if pending:
+            dist.all_reduce(reference, group=get_moe_tp_group().device_group)
+        if residual is not None:
+            reference = reference + residual.float()
+        expected.append(reference.to(dtype))
+        markers.append(pending)
+
+    for i in [1, 2]:
+        handles.append(
+            model.layers[i].register_forward_pre_hook(hook, with_kwargs=True)
+        )
+
+    def forward():
+        arg = "inputs_embeds" if entry[0] == "bailing_moe_v3" else "input_embeds"
+        return model(None, positions, batch, **{arg: inputs.clone()})
+
+    final, captures = forward()
+    for handle in handles:
+        handle.remove()
+    if graph:
+        for _ in range(3):
+            forward()
+        cuda_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(cuda_graph):
+            final, captures = forward()
+        cuda_graph.replay()
+        cuda_graph.replay()
+        torch.cuda.synchronize()
+
+    saved_ids = model.layers_to_capture
+    model.layers_to_capture = []
+    target_without_capture = forward()
+    model.layers_to_capture = saved_ids
+    errors = [
+        (actual.float() - reference.float()).abs().max().item()
+        for actual, reference in zip(captures, expected, strict=True)
+    ]
+    atol = 0.025 if dtype == torch.bfloat16 else 0.003
+    close = [
+        torch.allclose(actual, reference, atol=atol, rtol=0.01)
+        for actual, reference in zip(captures, expected, strict=True)
+    ]
+    return {
+        "model": entry[0],
+        "dtype": str(dtype),
+        "rows": rows,
+        "phase": mode.name,
+        "fused": fused,
+        "graph": graph,
+        "pending": markers,
+        "max_abs_errors": errors,
+        "captures_correct": bool(close) and all(close),
+        "target_unchanged": torch.equal(final, target_without_capture),
+        "fusion_covered": all(markers) if fused else not any(markers),
+    }
+
+
+def worker(output):
+    from sglang.srt.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        init_distributed_environment,
+        initialize_model_parallel,
+        set_custom_all_reduce,
+    )
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    set_global_server_args_for_scheduler(
+        ServerArgs(
+            model_path="dummy",
+            tp_size=world_size,
+            device="cuda",
+            flashinfer_allreduce_fusion_backend="trtllm",
+        )
+    )
+    set_custom_all_reduce(False)
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method="env://",
+        backend="nccl",
+        timeout=120,
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+    results = []
+    with torch.inference_mode():
+        for entry in MODELS:
+            for dtype in [torch.float16, torch.bfloat16]:
+                for rows, mode in [
+                    (1, ForwardMode.EXTEND),
+                    (8, ForwardMode.TARGET_VERIFY),
+                ]:
+                    for fused in [False, True] if world_size > 1 else [False]:
+                        row = check_case(
+                            entry, dtype, rows, mode, fused, graph=rows == 8
+                        )
+                        results.append(row)
+                        Path(output, f"rank{rank}.json").write_text(
+                            json.dumps(results, indent=2) + "\n"
+                        )
+                        if rank == 0:
+                            print(json.dumps(row), flush=True)
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+class TestSpeculativeCaptureReduction(CustomTestCase):
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "requires two CUDA GPUs")
+    def test_capture_matches_completed_layer_output(self):
+        if torch.cuda.get_device_capability(0)[0] != 9:
+            self.skipTest("this test exercises the Hopper trtllm fusion backend")
+        with tempfile.TemporaryDirectory() as output:
+            run = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "torch.distributed.run",
+                    "--standalone",
+                    "--nproc-per-node=2",
+                    str(Path(__file__).resolve()),
+                    "--worker",
+                    output,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=240,
+                check=False,
+            )
+            self.assertEqual(run.returncode, 0, run.stdout)
+            for rank in range(2):
+                rows = json.loads(Path(output, f"rank{rank}.json").read_text())
+                self.assertEqual(len(rows), len(MODELS) * 8)
+                for row in rows:
+                    with self.subTest(rank=rank, case=row):
+                        self.assertTrue(row["fusion_covered"])
+                        self.assertTrue(row["target_unchanged"])
+                        self.assertTrue(row["captures_correct"])
+
+
+if __name__ == "__main__":
+    if "--worker" in sys.argv:
+        worker(sys.argv[sys.argv.index("--worker") + 1])
+    else:
+        unittest.main()


### PR DESCRIPTION
## Motivation

With tensor parallelism and all-reduce fusion enabled, the MLP output can remain a per-rank partial sum until the next decoder's input normalization. Several models capture `hidden_states + residual` before that reduction completes, so speculative drafts receive incomplete intermediate activations.

This extends the existing communicator-based capture design used by Qwen MoE and the DeepSeek/Kimi fix in #28343 to the remaining implementations covered here. It corrects the auxiliary-state contract while retaining the fused execution path. The end-to-end effect depends on the model and draft pairing.

## Modifications

- Capture auxiliary hidden states after the pending all-reduce in GPT-OSS, GLM-4 MoE, GLM-4 MoE Lite, Qwen3-VL MoE, Bailing MoE and Bailing MoE V3, using the existing communicator helper.
- Add a distributed regression test checking that captures match complete layer outputs and leave target outputs unchanged.

## Accuracy Tests

2×H100, TP=2, FA3, AR fusion, temperature=0, max_new_tokens=8192, concurrency=16; GPT-OSS/DFlash and GLM/EAGLE3 with default thinking. All six regression paths pass. MT-Bench uses supplemental Qwen3-30B-A3B-Instruct-2507 ratings (/10); GLM LiveCodeBench is output-cap limited. Acceptance length includes target bonus tokens.

| Model / dataset | Score Before | Score After | Acc. Length Before | Acc. Length After |
| --- | ---: | ---: | ---: | ---: |
| GPT-OSS-20B / GSM8K | 480/500 | 480/500 | 4.366 | 4.576 |
| GPT-OSS-20B / MT-Bench | 9.188 | 8.688 | 4.007 | 4.269 |
| GPT-OSS-20B / HumanEval | 148/164 | 148/164 | 4.433 | 4.249 |
| GPT-OSS-20B / LiveCodeBench v6 increment | 100/175 | 98/175 | 3.460 | 3.494 |
| GLM-4.7-Flash / GSM8K | 472/500 | 476/500 | 2.883 | 2.848 |
| GLM-4.7-Flash / MT-Bench | 8.994 | 8.967 | 2.557 | 2.568 |
| GLM-4.7-Flash / HumanEval | 145/164 | 141/164 | 2.792 | 2.794 |
| GLM-4.7-Flash / LiveCodeBench v6 increment | 56/175 | 51/175 | 2.507 | 2.545 |

## Speed Tests and Profiling

2×H100, TP=2, same engine/draft settings as above. Fixed prompts, 256 output tokens per request, concurrency 1 and 16.

| Model / concurrent requests | Before tok/s | After tok/s |
| --- | ---: | ---: |
| GPT-OSS-20B / 1 | 500.4 | 504.1 |
| GPT-OSS-20B / 16 | 3522.5 | 3411.9 |
| GLM-4.7-Flash / 1 | 203.3 | 214.0 |
| GLM-4.7-Flash / 16 | 1104.3 | 1104.9 |

## Checklist

- [x] Code formatted.
- [x] Unit tests added.
- [x] No documentation update is needed.
- [x] Accuracy and speed benchmark results provided.
- [x] Follow the SGLang code style.

Assisted-by: OpenAI Codex

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34599181932](https://github.com/sgl-project/sglang/actions/runs/34599181932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34599181485](https://github.com/sgl-project/sglang/actions/runs/34599181485)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34599181578](https://github.com/sgl-project/sglang/actions/runs/34599181578)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->