### PR TITLE
[Bug] Name capture profile traces after the captured graph

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -767,18 +767,21 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             trace_dir = graph_capture_profile_dir()
             os.makedirs(trace_dir, exist_ok=True)
 
-            # Track which BS is currently being captured for trace file naming
-            self._profile_bs_list = list(reversed(self.capture_bs))
-            self._profile_bs_idx = 0
+            # Names the trace of the graph currently being captured. The capture
+            # loop sets it per graph rather than the callback walking the bs
+            # sequence, because a bs bucket can capture more than one graph.
+            self._profile_trace_label = None
 
             def on_trace_ready(prof):
-                bs = self._profile_bs_list[self._profile_bs_idx]
+                label = self._profile_trace_label
+                if label is None:
+                    # Flushed outside a capture, so there is no graph to name.
+                    return
                 trace_file = os.path.join(
-                    trace_dir, f"{runner_name}_bs_{bs}_rank{rank}.json.gz"
+                    trace_dir, f"{runner_name}_{label}_rank{rank}.json.gz"
                 )
                 prof.export_chrome_trace(trace_file)
-                logger.info(f"Saved trace for bs={bs} to {trace_file}")
-                self._profile_bs_idx += 1
+                logger.info(f"Saved trace for {label} to {trace_file}")
 
             profile_context = profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
@@ -803,6 +806,32 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         torch.cuda.memory._record_memory_history()
         return profile_context
+
+    def _set_profile_trace_label(
+        self,
+        bs: int,
+        stream_idx: Optional[int] = None,
+        variant_label: Optional[str] = None,
+        attention_variant: Optional[str] = None,
+    ) -> None:
+        """Name the per-bs capture trace after the graph about to be captured.
+
+        A bs bucket can capture several graphs -- LoRA / no-LoRA, and one per
+        attention graph variant -- and PDMUX repeats the whole sweep per stream
+        group, so the profiler flushes more often than there are bs values.
+        Keep ``bs_{bs}`` as the leading component so the file name is unchanged
+        when a bucket captures a single graph.
+        """
+        if getattr(self, "_profiler", None) is None:
+            return
+        parts = [f"bs_{bs}"]
+        if stream_idx is not None:
+            parts.append(f"stream_{stream_idx}")
+        if variant_label is not None:
+            parts.append(variant_label)
+        if attention_variant is not None:
+            parts.append(attention_variant)
+        self._profile_trace_label = "_".join(parts)
 
     def _post_process_after_profile(self, prof_context):
         torch.cuda.memory._dump_snapshot("cuda_graph_runner_memory_usage.pickle")
@@ -1093,6 +1122,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 _set_capture_lora_variant(variant_label)
                 for attention_variant in attention_variants:
                     _set_capture_attention_variant(attention_variant)
+                    self._set_profile_trace_label(
+                        bs=bs,
+                        stream_idx=stream_idx,
+                        variant_label=variant_label,
+                        attention_variant=attention_variant,
+                    )
                     with torch_compile_decoration.patch_model(
                         self.model_runner.model,
                         bs in self.compile_bs,

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -10,9 +10,11 @@ Two capture-trace modes plus their precedence:
   * **Per-batch-size traces** (``SGLANG_GRAPH_BATCH_CAPTURE``): a *scheduled*
     profiler (``wait=2, warmup=0, active=1, repeat=0``) with the trace-export
     knobs (record_shapes / with_stack / with_flops / profile_memory) and an
-    ``on_trace_ready`` hook that writes one trace per batch size to
+    ``on_trace_ready`` hook that writes one trace per captured graph to
     ``<SGLANG_TORCH_PROFILER_DIR>/graph_capture_profile/`` named
-    ``{runner_name}_bs_{bs}_rank{rank}.json.gz``.
+    ``{runner_name}_bs_{bs}_rank{rank}.json.gz``, with the stream group and the
+    LoRA / attention variant appended when a bs bucket captures more than one
+    graph.
   * **Precedence**: when both env vars are set, the original single-trace path
     wins (no per-bs schedule / dir / bookkeeping).
 
@@ -85,12 +87,11 @@ class TestInitProfileBatchMode(CustomTestCase):
             self._invoke(capture_bs=[1, 2, 4], profiler_dir=tmp)
             self.assertTrue(os.path.isdir(os.path.join(tmp, "graph_capture_profile")))
 
-    def test_primes_reversed_bs_list_and_zero_index(self):
+    def test_primes_empty_trace_label(self):
         with tempfile.TemporaryDirectory() as tmp:
             fake_self, *_ = self._invoke(capture_bs=[1, 2, 4, 8], profiler_dir=tmp)
-            # Capture iterates large -> small, so the bs list is reversed.
-            self.assertEqual(fake_self._profile_bs_list, [8, 4, 2, 1])
-            self.assertEqual(fake_self._profile_bs_idx, 0)
+            # The capture loop names each graph as it reaches it.
+            self.assertIsNone(fake_self._profile_trace_label)
 
     def test_profiler_built_with_trace_export_knobs(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -164,7 +165,7 @@ class TestInitProfileOriginalMode(CustomTestCase):
             self.assertIsNone(kwargs.get("on_trace_ready"))
             mock_schedule.assert_not_called()
             self.assertFalse(os.path.isdir(os.path.join(tmp, "graph_capture_profile")))
-            self.assertFalse(hasattr(fake_self, "_profile_bs_list"))
+            self.assertFalse(hasattr(fake_self, "_profile_trace_label"))
 
     def test_no_flags(self):
         self._invoke_original(env={})
@@ -195,9 +196,15 @@ class TestOnTraceReadyNaming(CustomTestCase):
             os.environ.pop(_CAPTURE_TRACE, None)
             DecodeCudaGraphRunner._init_profile_context_and_memory_record(fake_self)
         on_trace_ready = mock_profile.call_args.kwargs["on_trace_ready"]
+        # The capture loop owns the label, and _set_profile_trace_label keys off
+        # _profiler to tell the scheduled per-bs profiler from the original pass.
+        fake_self._profiler = mock_profile.return_value
+        fake_self._set_profile_trace_label = (
+            DecodeCudaGraphRunner._set_profile_trace_label.__get__(fake_self)
+        )
         return fake_self, on_trace_ready
 
-    def test_exports_one_named_trace_per_bs_and_advances_index(self):
+    def test_exports_one_named_trace_per_bs(self):
         with tempfile.TemporaryDirectory() as tmp:
             capture_bs = [1, 2, 4]  # reversed -> [4, 2, 1]
             fake_self, on_trace_ready = self._build_on_trace_ready(
@@ -208,6 +215,7 @@ class TestOnTraceReadyNaming(CustomTestCase):
 
             exported = []
             for expected_bs in [4, 2, 1]:
+                fake_self._set_profile_trace_label(bs=expected_bs)
                 prof = mock.Mock()
                 prof.export_chrome_trace.side_effect = lambda p: exported.append(p)
                 on_trace_ready(prof)
@@ -223,8 +231,79 @@ class TestOnTraceReadyNaming(CustomTestCase):
                     os.path.join(trace_dir, f"{runner}_bs_1_rank0.json.gz"),
                 ],
             )
-            # Index advanced once per flush.
-            self.assertEqual(fake_self._profile_bs_idx, 3)
+
+    def test_variant_graphs_get_one_trace_each(self):
+        # A bs bucket that captures LoRA / no-LoRA and two attention variants
+        # flushes the profiler four times, so the name cannot come from the bs
+        # sequence: it used to mislabel the extra flushes and then run off the
+        # end of the bs list.
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_self, on_trace_ready = self._build_on_trace_ready(
+                capture_bs=[2, 4], rank=0, tmp=tmp
+            )
+            trace_dir = os.path.join(tmp, "graph_capture_profile")
+            runner = type(fake_self).__name__
+
+            exported = []
+            for bs in [4, 2]:
+                for variant_label in ["lora", "nolora"]:
+                    for attention_variant in ["dense", "sparse"]:
+                        fake_self._set_profile_trace_label(
+                            bs=bs,
+                            variant_label=variant_label,
+                            attention_variant=attention_variant,
+                        )
+                        prof = mock.Mock()
+                        prof.export_chrome_trace.side_effect = lambda p: (
+                            exported.append(p)
+                        )
+                        on_trace_ready(prof)
+
+            expected = [
+                os.path.join(trace_dir, f"{runner}_bs_{bs}_{lora}_{dsa}_rank0.json.gz")
+                for bs in [4, 2]
+                for lora in ["lora", "nolora"]
+                for dsa in ["dense", "sparse"]
+            ]
+            self.assertEqual(exported, expected)
+            self.assertEqual(len(set(exported)), len(expected))
+
+    def test_stream_group_in_trace_filename(self):
+        # PDMUX repeats the whole bs sweep per stream group, which would
+        # otherwise have every group overwrite the first group's traces.
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_self, on_trace_ready = self._build_on_trace_ready(
+                capture_bs=[8], rank=0, tmp=tmp
+            )
+            runner = type(fake_self).__name__
+
+            exported = []
+            for stream_idx in [0, 1]:
+                fake_self._set_profile_trace_label(bs=8, stream_idx=stream_idx)
+                prof = mock.Mock()
+                prof.export_chrome_trace.side_effect = lambda p: exported.append(p)
+                on_trace_ready(prof)
+
+            self.assertEqual(
+                exported,
+                [
+                    os.path.join(
+                        tmp,
+                        "graph_capture_profile",
+                        f"{runner}_bs_8_stream_{i}_rank0.json.gz",
+                    )
+                    for i in [0, 1]
+                ],
+            )
+
+    def test_flush_without_a_captured_graph_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _, on_trace_ready = self._build_on_trace_ready(
+                capture_bs=[8], rank=0, tmp=tmp
+            )
+            prof = mock.Mock()
+            on_trace_ready(prof)
+            prof.export_chrome_trace.assert_not_called()
 
     def test_rank_in_trace_filename(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -232,6 +311,7 @@ class TestOnTraceReadyNaming(CustomTestCase):
                 capture_bs=[8], rank=3, tmp=tmp
             )
             runner = type(fake_self).__name__
+            fake_self._set_profile_trace_label(bs=8)
             prof = mock.Mock()
             on_trace_ready(prof)
             prof.export_chrome_trace.assert_called_once_with(


### PR DESCRIPTION
## Motivation

Fixes #39092.

`SGLANG_GRAPH_BATCH_CAPTURE` named each capture trace by walking
`reversed(capture_bs)` once per profiler flush, which assumes a bs bucket
captures exactly one graph. `_capture_one_stream` sweeps the LoRA / no-LoRA
and attention graph variants (DSA dense / sparse) inside the bs loop, and
PDMUX repeats the
whole sweep per stream group, so flushes outnumber batch sizes. The result is
mislabeled traces first and an `IndexError` inside the profiler second.

The mislabeling is the more dangerous half: it does not raise, it just
attributes one bucket's data to a different bucket.

## Modifications

Have the capture loop record what it is about to capture, and let
`on_trace_ready` name the trace from that. This removes the requirement that
flush count match bs count, so no future caller has to keep the two in sync.

- `_set_profile_trace_label(bs, stream_idx, variant_label, attention_variant)`
  composes the label; it is a no-op when the profiler is off.
- `_capture_one_stream` calls it immediately before each capture, inside the
  innermost variant loop.
- `on_trace_ready` reads the label. A flush with no label set -- one that
  does not correspond to a capture -- is ignored rather than named after
  whatever the cursor happened to point at.

`bs_{bs}` stays the leading component. A bucket that captures a single graph
keeps its existing file name byte for byte; only multi-graph buckets grow a
`_stream_N` / `_lora` / `_dense` suffix. This is not a rename for the common
configuration.

## Accuracy Tests

Verified on MI355X / ROCm by running the same workload against two images
built from one Dockerfile, identical torch wheel, differing only in an `ARG`
that decides whether this patch is applied. Each arm runs both sides back to
back on the same node.

### The bug, before and after

`amd/GLM-5.2-MXFP4` at TP8 -- `GlmMoeDsaForCausalLM` with `index_topk=2048`,
so `dsa_dual_graph` is on and every bs bucket captures two graphs. Same model
and same command as the reproduction in #39092, with
`--cuda-graph-bs-decode 11 7 5 3`.

**Before:** the server dies partway through the third bucket with
`IndexError`, having written four files of which three name the wrong bs.

**After:** the server starts normally and writes one file per captured graph:

```
bs_11_dense   ProfilerStep#2    launches=6775
bs_11_sparse  ProfilerStep#5    launches=7333
bs_7_dense    ProfilerStep#8    launches=6766
bs_7_sparse   ProfilerStep#11   launches=7333
bs_5_dense    ProfilerStep#14   launches=6766
bs_5_sparse   ProfilerStep#17   launches=7333
bs_3_dense    ProfilerStep#20   launches=6770
bs_3_sparse   ProfilerStep#23   launches=7333
```

Markers advance exactly one schedule cycle apart, every name maps to exactly
one graph, and each dense / sparse pair is confirmed distinct by launch count.
Trace identity is established without trusting file names; method and the
full before/after alignment are in a follow-up comment.

### No regression on the single-graph path

These arms exist only to show that a bucket capturing one graph is untouched.
All three produce byte-identical file name sets and identical launch counts
with and without this patch:

| model | TP | architecture |
| --- | --- | --- |
| `Qwen/Qwen3-8B` | 1 | `Qwen3ForCausalLM` |
| `deepseek-ai/DeepSeek-V4-Flash-0731` | 8 | `DeepseekV4ForCausalLM` |
| `amd/MiniMax-M3-MXFP4` | 8 | `MiniMaxM3SparseForConditionalGeneration` |

`DeepSeek-V4-Flash-0731` is worth calling out: it has `index_topk=512` but its
architecture is not on the `is_deepseek_dsa` whitelist, so it must stay on the
single-graph path. It does -- four files, names unchanged.

### Not covered

PDMUX. It is NVIDIA-only (`spatial.create_greenctx_stream_by_value`, gated on
compute capability) and I have ROCm hardware only. That path is covered by
unit tests and by reading `capture()`; a check on NVIDIA hardware would be
welcome.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34603123486](https://github.com/sgl-project/sglang/actions/runs/34603123486)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #34603123176](https://github.com/sgl-project/sglang/actions/runs/34603123176)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34603123433](https://github.com/sgl-project/sglang/actions/runs/34603123433)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
