### PR TITLE
[AMD][DSv4/DSpark]: Fuse the draft block's attention-metadata prologue to graph mode

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -534,6 +534,10 @@ class Envs:
     SGLANG_DSPARK_FOLDED_PROPOSAL = EnvBool(True)
     SGLANG_DSPARK_STACKED_CTX_KV = EnvBool(True)
     SGLANG_DSPARK_EMBED_IN_GRAPH = EnvBool(True)
+    # Build the DSpark draft block's attention metadata with one fused
+    # Triton kernel, recorded inside the draft decode graph, instead of the
+    # target's ~85-launch eager prologue. See dsv4/dspark_draft_meta.py.
+    SGLANG_DSPARK_FUSED_PROLOGUE = EnvBool(True)
     SGLANG_DSPARK_OPT_MARKOV_W2_BF16 = EnvBool(True)
     SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD = EnvBool(True)
     SGLANG_DSPARK_OPT_FUSED_GREEDY_MARKOV = EnvBool(False)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -28,6 +28,10 @@ from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     FusedCompressMetadata,
     create_paged_compressor_data,
 )
+from sglang.srt.layers.attention.dsv4.dspark_draft_meta import (
+    DSparkDraftMetaBuffers,
+    make_dspark_draft_metadata,
+)
 from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
 from sglang.srt.layers.attention.dsv4.metadata import (
     PagedIndexerMetadata,
@@ -500,6 +504,10 @@ class DeepseekV4HipRadixBackend(
             DSV4RawVerifyMetadata,
             DSV4RawDecodeMetadata,
         ] = None
+        # Per-(bs, gamma) persistent metadata for the fused DSpark draft
+        # prologue. Addresses stay pinned for the life of the backend so the
+        # fill can be recorded inside the draft decode graph.
+        self._dspark_draft_meta: Dict[tuple, tuple] = {}
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
@@ -841,7 +849,93 @@ class DeepseekV4HipRadixBackend(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
         )
 
+    # ------------------------------------------------------------------
+    # DSpark draft: fused, graph-recordable metadata prologue
+    # ------------------------------------------------------------------
+    def _dspark_fused_prologue_enabled(self) -> bool:
+        """True when this backend drives a DSpark draft block over unified KV.
+
+        Every DSparkV4Stage pins compress_ratio=0, so the unified-KV decode
+        path reads only the SWA index stream, its indptr, the ring write
+        target and the per-token req-slot map. The target's builder produces
+        all of that plus a compressor plan, an FP4 indexer workspace and two
+        unused index streams, at ~85 eager launches per step.
+        """
+        if not self.is_dspark_draft:
+            return False
+        if not envs.SGLANG_DSPARK_FUSED_PROLOGUE.get():
+            return False
+        if get_parallel().attn_cp_size != 1:
+            # apply_cp_reindex rewrites per-token metadata fields the lean
+            # build deliberately leaves empty; fall back to the full builder.
+            return False
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_triton,
+        )
+
+        return is_unified_kv_triton()
+
+    def _dspark_draft_metadata_for(self, *, bs: int) -> tuple:
+        # Same block width the eager builder uses (init_forward_metadata_
+        # target_verify_old's extend_seq_lens), so token counts and every
+        # downstream shape are bit-identical to the path this replaces.
+        gamma = self.target_verify_num_draft_tokens
+        key = (bs, gamma)
+        entry = self._dspark_draft_meta.get(key)
+        if entry is None:
+            pool = self.token_to_kv_pool
+            buffers = DSparkDraftMetaBuffers(
+                bs=bs,
+                gamma=gamma,
+                win=int(pool.unified_swa_window),
+                device=self.device,
+            )
+            metadata = make_dspark_draft_metadata(
+                buffers=buffers,
+                page_size=self.page_size,
+                c4_sparse_topk=self.c4_topk,
+                cuda_int32_kwargs=self.cuda_int32_kwargs,
+                metadata_cls=DSV4Metadata,
+                attn_metadata_cls=DSV4AttnMetadata,
+                unified_cls=UnifiedKvMetadata,
+            )
+            entry = (buffers, metadata)
+            self._dspark_draft_meta[key] = entry
+        return entry
+
+    def _bind_dspark_draft_metadata(self, forward_batch: ForwardBatch) -> tuple:
+        """Resolve (and allocate on first sight) this bucket's buffers.
+
+        Runs out of graph so no allocation happens under capture; the fill
+        itself is issued from init_forward_metadata_in_graph.
+        """
+        buffers, metadata = self._dspark_draft_metadata_for(bs=forward_batch.batch_size)
+        self.forward_metadata = metadata
+        return buffers, metadata
+
+    def _fill_dspark_draft_metadata(self, forward_batch: ForwardBatch) -> None:
+        bs = forward_batch.batch_size
+        buffers, _ = self._bind_dspark_draft_metadata(forward_batch)
+        buffers.fill(
+            seq_lens=forward_batch.seq_lens[:bs].contiguous(),
+            req_pool_indices=forward_batch.req_pool_indices[:bs].contiguous(),
+            ring_stride=int(self.token_to_kv_pool.unified_swa_ring_size),
+        )
+
     def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and self._dspark_fused_prologue_enabled()
+        ):
+            # Recorded inside the draft decode graph: one kernel over the
+            # runner's static seq_lens / req_pool_indices buffers, writing the
+            # pinned metadata the captured attention already binds. Nothing
+            # below applies -- the draft owns no compressor, no FP4 indexer,
+            # and stores its KV through the unified ring (get_unified_swa_loc),
+            # never through swa_out_cache_loc.
+            self._fill_dspark_draft_metadata(forward_batch)
+            return
+
         # Upgrade Raw->Full so the c4/c128 compress + core_attn + indexer
         # materialization is recorded inside the cuda graph; a no-op (Full
         # already) when PREP_IN_CUDA_GRAPH=0.
@@ -967,6 +1061,17 @@ class DeepseekV4HipRadixBackend(
         in_capture: bool = False,
     ) -> None:
         bucket = _GraphBucket.of(forward_batch.forward_mode)
+        if (
+            bucket == _GraphBucket.TARGET_VERIFY
+            and self._dspark_fused_prologue_enabled()
+        ):
+            # Bind (and allocate on first sight) the pinned buffers here, out
+            # of capture; the fill runs in graph. Replay-prep issues no kernel
+            # at all, which is what removes the eager-launch bubble.
+            self._bind_dspark_draft_metadata(forward_batch)
+            if in_capture:
+                self._current_capture_raw = None
+            return
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
@@ -1100,6 +1205,13 @@ class DeepseekV4HipRadixBackend(
 
     def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
         if self.mtp_enabled and forward_batch.forward_mode.is_idle():
+            return
+
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            and self._dspark_fused_prologue_enabled()
+        ):
+            self._fill_dspark_draft_metadata(forward_batch)
             return
 
         req_pool_indices = forward_batch.req_pool_indices

--- a/python/sglang/srt/layers/attention/dsv4/dspark_draft_meta.py
+++ b/python/sglang/srt/layers/attention/dsv4/dspark_draft_meta.py
@@ -1,0 +1,218 @@
+"""Fused attention-metadata build for the DSpark draft block.
+
+The DSpark draft head runs its ``(bs, gamma)`` block through the DSV4 HIP
+backend as a ``TARGET_VERIFY`` forward, so it used to reuse the target's
+metadata builder: ``expand_prefill_casually`` (a python loop of two launches
+per request), ``get_swa_page_indices`` (a 128-wide gather plus two masked
+fills), ``init_compression_metadata``, the C4/C128 compressor planners, the
+FP4 indexer workspace, and ``build_decode_streams`` for all three streams.
+Eighty-five tiny kernels, every one launched eagerly from python, and ~1.27 ms
+of pure GPU bubble per decode step at bs=8.
+
+Almost none of it is read. Every ``DSparkV4Stage`` pins ``compress_ratio=0``,
+so with the unified-KV triton path the draft forward touches exactly four
+tensors: ``unified.swa_indices``, ``unified.swa_indptr``, ``unified.swa_loc``
+and ``unified.verify_store_state_slot``. All four are pure functions of
+``seq_lens`` and ``req_pool_indices``, which means the whole build collapses
+into one Triton kernel over device tensors -- no host values, no allocations,
+so it can be recorded inside the draft CUDA graph instead of launched eagerly.
+
+Shapes are static for a given graph bucket: the block is always ``gamma`` wide
+and every request extends by exactly ``gamma``, so token ``t = b * gamma + j``
+has
+
+    seq_len_casual = seq_lens[b] + 1 + j      (the target builder's
+                                              seq_lens + gamma, expanded
+                                              causally over the block)
+    position       = seq_len_casual - 1
+    swa_len        = min(position + 1, win)
+    swa_loc        = req_pool_indices[b] * ring + position % ring
+
+and the ragged SWA index stream is the ``swa_len``-long run
+``slot * ring + (position - swa_len + 1 + i) % ring``, packed at the exclusive
+prefix sum of ``swa_len``. The kernel computes that prefix sum in-register
+(one block covers every token: ``bs * gamma`` is at most a few hundred) so no
+separate cumsum launch is needed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _dspark_draft_meta_kernel(
+    seq_lens_ptr,  # [bs] prefix lengths (int32/int64)
+    req_pool_indices_ptr,  # [bs] req-pool slot per request
+    seq_lens_casual_ptr,  # [N] int32 out
+    positions_casual_ptr,  # [N] int32 out
+    swa_len_ptr,  # [N] int32 out
+    state_slot_ptr,  # [N] int32 out
+    swa_loc_ptr,  # [N] int32 out
+    swa_indptr_ptr,  # [N + 1] int32 out
+    swa_indices_ptr,  # [N * win] int32 out
+    ring_stride,
+    N,
+    gamma: tl.constexpr,
+    win: tl.constexpr,
+    BLOCK_N: tl.constexpr,  # next_pow2(N)
+    BLOCK_W: tl.constexpr,  # next_pow2(win)
+):
+    """One program per block token; grid = (N,).
+
+    Every program re-derives the full ``[N]`` length vector so it can take the
+    exclusive prefix sum locally. ``N`` is ``bs * gamma`` (a few hundred at
+    most), so the redundant work is far cheaper than a second launch.
+    """
+    t = tl.program_id(0)
+
+    i = tl.arange(0, BLOCK_N)
+    live = i < N
+    b_all = i // gamma
+    j_all = i % gamma
+    # Clamp the gather so padded lanes stay in bounds; `live` masks them out.
+    sl_all = tl.load(seq_lens_ptr + b_all, mask=live, other=0).to(tl.int32)
+    # Padded graph slots carry seq_lens == 0; the eager builder padded
+    # seq_lens_casual with 1, so clamp to keep a single valid slot.
+    casual_all = tl.maximum(sl_all + 1 + j_all, 1)
+    len_all = tl.minimum(casual_all, win)
+    len_all = tl.where(live, len_all, 0)
+
+    # Exclusive prefix sum at t, and the total for indptr[N].
+    base = tl.sum(tl.where(i < t, len_all, 0))
+    total = tl.sum(len_all)
+
+    tl.store(swa_indptr_ptr + t, base)
+    if t == 0:
+        tl.store(swa_indptr_ptr + N, total)
+
+    b = t // gamma
+    j = t % gamma
+    seq_len = tl.load(seq_lens_ptr + b).to(tl.int32)
+    casual = tl.maximum(seq_len + 1 + j, 1)
+    pos = casual - 1
+    n = tl.minimum(casual, win)
+    slot = tl.load(req_pool_indices_ptr + b).to(tl.int32)
+
+    tl.store(seq_lens_casual_ptr + t, casual)
+    tl.store(positions_casual_ptr + t, pos)
+    tl.store(swa_len_ptr + t, n)
+    tl.store(state_slot_ptr + t, slot)
+    tl.store(swa_loc_ptr + t, slot * ring_stride + pos % ring_stride)
+
+    # Ragged SWA prefix: abs_pos in [pos - n + 1, pos].
+    w = tl.arange(0, BLOCK_W)
+    wmask = w < n
+    abs_pos = pos - n + 1 + w
+    paged = slot * ring_stride + abs_pos % ring_stride
+    tl.store(swa_indices_ptr + base + w, paged, mask=wmask)
+
+
+class DSparkDraftMetaBuffers:
+    """Persistent output buffers for one ``(bs, gamma)`` graph bucket.
+
+    Allocated once, outside any CUDA-graph capture, and refilled in place by
+    the kernel. Keeping the addresses pinned is what lets the fill be recorded
+    inside the draft decode graph: the captured node reads the same static
+    ``seq_lens`` / ``req_pool_indices`` buffers the runner refreshes per step,
+    and writes the same metadata tensors the captured attention already binds.
+    """
+
+    def __init__(self, *, bs: int, gamma: int, win: int, device: torch.device):
+        n = bs * gamma
+        self.bs = bs
+        self.gamma = gamma
+        self.win = win
+        self.n = n
+        kw = {"dtype": torch.int32, "device": device}
+        self.seq_lens_casual = torch.zeros(n, **kw)
+        self.positions_casual = torch.zeros(n, **kw)
+        self.swa_len = torch.zeros(n, **kw)
+        self.state_slot = torch.zeros(n, **kw)
+        self.swa_loc = torch.zeros(n, **kw)
+        self.swa_indptr = torch.zeros(n + 1, **kw)
+        self.swa_indices = torch.zeros(n * win, **kw)
+        # Placeholders for DSV4AttnMetadata fields the compress_ratio==0
+        # unified-KV path never reads. Zero-element so metadata copy_ is a
+        # no-op and nothing can silently consume a stale value.
+        self.empty = torch.zeros(0, **kw)
+        self.empty_2d = torch.zeros(0, 0, **kw)
+        self._block_n = max(16, triton.next_power_of_2(n))
+        self._block_w = max(16, triton.next_power_of_2(win))
+
+    def fill(
+        self,
+        *,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        ring_stride: int,
+    ) -> None:
+        _dspark_draft_meta_kernel[(self.n,)](
+            seq_lens,
+            req_pool_indices,
+            self.seq_lens_casual,
+            self.positions_casual,
+            self.swa_len,
+            self.state_slot,
+            self.swa_loc,
+            self.swa_indptr,
+            self.swa_indices,
+            ring_stride,
+            self.n,
+            gamma=self.gamma,
+            win=self.win,
+            BLOCK_N=self._block_n,
+            BLOCK_W=self._block_w,
+            num_warps=4,
+        )
+
+
+def make_dspark_draft_metadata(
+    *,
+    buffers: DSparkDraftMetaBuffers,
+    page_size: int,
+    c4_sparse_topk: int,
+    cuda_int32_kwargs: dict,
+    metadata_cls,
+    attn_metadata_cls,
+    unified_cls,
+):
+    """Wrap pre-allocated buffers in the DSV4 metadata objects.
+
+    Called once per bucket; the returned object is reused for every step so
+    the captured graph's bound addresses stay valid.
+    """
+    core = attn_metadata_cls(
+        page_size=page_size,
+        raw_out_loc=buffers.empty,
+        seq_lens_casual=buffers.seq_lens_casual,
+        cuda_int32_kwargs=cuda_int32_kwargs,
+        positions_casual=buffers.positions_casual,
+        page_table=buffers.empty_2d,
+        swa_page_indices=buffers.empty_2d,
+        swa_topk_lengths=buffers.swa_len,
+        c4_sparse_topk=c4_sparse_topk,
+    )
+    # init=False fields: the compress_ratio==0 draft owns no C4 stream and HIP
+    # has no flash_mla scheduler metadata, so pin them all to None rather than
+    # leaving them unset.
+    core.c4_sparse_topk_lengths = None
+    core.c4_sparse_topk_lengths_raw = None
+    core.c4_sparse_page_indices = None
+    core.c4_sparse_raw_indices = None
+    core.c1_flashmla_metadata = None
+    core.c4_flashmla_metadata = None
+    core.c128_flashmla_metadata = None
+
+    unified = unified_cls()
+    unified.swa_indices = buffers.swa_indices
+    unified.swa_indptr = buffers.swa_indptr
+    unified.swa_loc = buffers.swa_loc
+    unified.verify_store_state_slot = buffers.state_slot
+    core.unified = unified
+
+    return metadata_cls(core, None)


### PR DESCRIPTION
## Motivation

The DSpark draft head builds its `(bs, gamma)` block through the DSv4 HIP
backend as a `TARGET_VERIFY` forward, so it reuses the **target's** attention
metadata builder. That builder is sized for a 61-layer target with compressed
and sparse attention, and almost none of what it produces is readable by the
draft.

Per decode step at bs=8 it costs **85 eager kernel launches** ahead of the draft
CUDA graph:

- `expand_prefill_casually` â a Python loop issuing `arange` + `fill_` per
  request (16 launches at bs=8), with `arange` bounds read from host
  `seq_lens`, which also makes the prep uncapturable
- `get_swa_page_indices` â a 128-wide gather plus two `masked_fill_`s
- `init_compression_metadata`, five `cumsum`s, and both the C4 and C128
  paged-compressor planners
- the FP4 indexer workspace (`_prefill_schedule_prep`, `_prefill_cta_info`)
- all three unified-KV decode index streams (SWA + HCA + CSA)

They do ~383 Âµs of GPU work spread across a ~1926 Âµs span â **~1543 Âµs of pure
launch-latency bubble**, and the only meaningful GPU idle inside the draft
forward. Everything after it (the three `DSparkV4Stage`s and the Markov head)
already runs back-to-back from a single graph replay with zero idle.

Almost all of that work is dead for this model. Every `DSparkV4Stage` pins
`compress_ratio=0`, so on the unified-KV triton path the draft forward reads
exactly four tensors: `unified.swa_indices`, `unified.swa_indptr`,
`unified.swa_loc`, and `unified.verify_store_state_slot`. There is no C4 stream,
no compressor plan, and no indexer to schedule.

All four are closed-form in `seq_lens` and `req_pool_indices`. Every request in a
DSpark block extends by exactly `gamma`, so for token `t = b * gamma + j`:

    seq_len_casual = seq_lens[b] + 1 + j
    position       = seq_len_casual - 1
    swa_len        = min(position + 1, win)
    swa_loc        = req_pool_indices[b] * ring + position % ring

and the ragged SWA stream is the `swa_len`-long run
`slot * ring + (position - swa_len + 1 + i) % ring`, packed at the exclusive
prefix sum of `swa_len`. That collapses into **one Triton kernel over device
tensors** â no host values and no allocations, which is what lets it be recorded
*inside* the draft decode graph instead of launched eagerly.

### Result

Measured on a DeepSeek-V4-Pro 128k/1k, conc 64, DP8/TP8, MTP=DSpark capture on
one MI355X node, averaged per draft forward at bs=8:

| | before | after |
|---|---|---|
| prologue kernels | 108 | **8** |
| â eager launches | 85 | **5** (graph-runner `load_batch` staging only) |
| â graph-replayed | 23 | 3 |
| prologue busy | 383 Âµs | **30 Âµs** |
| **prologue GPU idle** | **1543 Âµs** | **74 Âµs** |
| prologue span | 1926 Âµs | **104 Âµs** |

Replay prep now issues **zero** kernels; the fused kernel (2.2 Âµs standalone)
runs inside the graph. Draft stage and Markov-head kernel counts are unchanged
(24/16/24/16/24/36 + 49), confirming the draft compute itself is untouched.

> The two captures differ in context depth and cross-rank prefill contention, so
> only the prologue rows above are a like-for-like comparison; the rest of the
> decode step is not claimed here.

## Summary of changes

3 files, +334 / â0. Base: `69777c4d36`.

| File | Â± | What |
|---|---|---|
| `python/sglang/srt/layers/attention/dsv4/dspark_draft_meta.py` | **+218** (new) | The fused builder. `_dspark_draft_meta_kernel` (Triton) derives per-token causal lengths, positions, SWA window lengths, ring write targets and the ragged SWA index stream in one launch, taking the stream's exclusive prefix sum **in-register** so no separate `cumsum` is needed. `DSparkDraftMetaBuffers` holds per-`(bs, gamma)` output buffers allocated once and refilled in place, so the addresses the captured attention binds stay pinned for the backend's lifetime. `make_dspark_draft_metadata` wraps them in `DSV4Metadata` / `DSV4AttnMetadata` / `UnifiedKvMetadata`, pinning the C4/flash-MLA fields to `None` rather than leaving the `init=False` slots unset. |
| `python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py` | +112 | Four private methods on `DeepseekV4HipRadixBackend` plus three hook sites. `init_forward_metadata_out_graph` only *binds* the buffers (no kernels), `init_forward_metadata_in_graph` issues the fill so it is recorded in the graph, and `init_forward_metadata` routes the eager path through the same code. The draft also skips `swa_out_cache_loc` in the in-graph init â it stores KV through the unified ring via `get_unified_swa_loc` and never reads it. |
| `python/sglang/srt/environ.py` | +4 | `SGLANG_DSPARK_FUSED_PROLOGUE` (`EnvBool(True)`). |

### Gating / fallback

The fused path engages only when **all** of the following hold; otherwise the
existing builder runs unchanged:

- the backend is a DSpark **draft** worker (`is_dspark_draft`)
- `SGLANG_DSPARK_FUSED_PROLOGUE` is on (default)
- `is_unified_kv_triton()` â the flash-MLA path still reads `swa_page_indices`
- attention CP is off (`attn_cp_size == 1`) â `apply_cp_reindex` rewrites
  per-token fields the lean build deliberately leaves empty

No new server CLI flags, and no change to any non-DSpark path.

### Testing

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->