### PR TITLE
[DSV4.1] Support raw-index output in TopK v2 (port of #33672)

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -30,8 +30,9 @@ namespace impl = device::topk;
 using impl::TopKProblem;
 
 enum class TopKMode {
-  INDICES,     ///< raw selected indices into `out`; `page_table` unused
-  PAGE_TABLE,  ///< page-table-transformed indices into `out`
+  INDICES,      ///< raw selected indices into `out`; `page_table` unused
+  PAGE_TABLE,   ///< page-table-transformed indices into `out`
+  DUAL_OUTPUT,  ///< page-table-transformed indices into `out` and raw indices into `raw_indices`
 };
 
 using Register2 = impl::TopKRegister<2>;  // <= 8192, register-resident, 1 read
@@ -61,6 +62,7 @@ static_assert(sizeof(GlobalMetadata) == 2 * sizeof(int32_t) && sizeof(PlanItem) 
 struct PageTransform {
   const int32_t* __restrict__ page_table;
   uint32_t page_bits;
+  int32_t* __restrict__ raw_out;  // the row's raw output, written in DUAL_OUTPUT only
 
   SGL_DEVICE int32_t page_to_indices(uint32_t i) const {
     const uint32_t mask = (1u << page_bits) - 1u;
@@ -73,6 +75,7 @@ struct TopKPagedParams {
   const int32_t* __restrict__ seq_lens;
   const int32_t* __restrict__ page_table;
   int32_t* __restrict__ page_indices;
+  int32_t* __restrict__ raw_indices;      // DUAL_OUTPUT only, nullptr otherwise
   const PlanItem* __restrict__ metadata;  // [0]=GlobalMetadata, [1+i]=PlanItem
   int64_t score_stride;
   int64_t page_table_stride;
@@ -94,7 +97,7 @@ struct TopKPagedParams {
     return page_indices + batch_id * static_cast<int64_t>(topk);
   }
   SGL_DEVICE PageTransform get_transform(uint32_t batch_id) const {
-    return {page_table + batch_id * page_table_stride, page_bits};
+    return {page_table + batch_id * page_table_stride, page_bits, raw_indices + batch_id * static_cast<int64_t>(topk)};
   }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id, uint32_t seq_len) const {
     const auto k = static_cast<int64_t>(topk);
@@ -142,11 +145,16 @@ SGL_DEVICE void trivial_transform(const TopKProblem& problem, const PageTransfor
       problem.out[tx] = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
     } else {
       problem.out[tx] = tx < problem.seq_len ? transform.page_to_indices(tx) : -1;
+      if constexpr (kMode == TopKMode::DUAL_OUTPUT) {
+        transform.raw_out[tx] = tx < problem.seq_len ? static_cast<int32_t>(tx) : -1;
+      }
     }
   });
 }
 
+template <TopKMode kMode>
 SGL_DEVICE void paged_transform(const TopKProblem& problem, int32_t* out, const PageTransform& transform) {
+  static_assert(kMode != TopKMode::INDICES, "paged_transform requires page-table output");
   static_assert(kMaxTopK % kBlockSize == 0);
   constexpr uint32_t kNumElems = kMaxTopK / kBlockSize;
   int32_t indices[kNumElems];
@@ -157,6 +165,7 @@ SGL_DEVICE void paged_transform(const TopKProblem& problem, int32_t* out, const 
   for_each_item(problem.topk, [&](uint32_t tx, uint32_t i) {
     // safe write to output
     out[tx] = indices[i] >= 0 ? transform.page_to_indices(indices[i]) : -1;
+    if constexpr (kMode == TopKMode::DUAL_OUTPUT) transform.raw_out[tx] = indices[i];
   });
 }
 
@@ -291,7 +300,7 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
         device::PDLWaitPrimary<kPDLFinal>();
         problem.out = params.get_output_ptr(bx);  // in-place transform
         device::PDLTriggerSecondary<kPDL>();
-        return paged_transform(problem, problem.out, params.get_transform(bx));
+        return paged_transform<kMode>(problem, problem.out, params.get_transform(bx));
       } else {
         return device::PDLTriggerSecondary<kPDL>();
       }
@@ -301,7 +310,7 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKPagedParams params
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
     __syncthreads();
-    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
+    paged_transform<kMode>(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
 
@@ -388,7 +397,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_cluster_kernel(const __grid_constant__
       cluster.sync();
       if (by != 0) return;
       problem.out = s_topk_indices;
-      return paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
+      return paged_transform<kMode>(problem, params.get_output_ptr(bx), params.get_transform(bx));
     } else {
       return device::PDLTriggerSecondary<kPDL>();
     }
@@ -397,7 +406,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_cluster_kernel(const __grid_constant__
   device::PDLTriggerSecondary<kPDL>();
   if constexpr (kNeedStaging) {
     __syncthreads();
-    paged_transform(problem, params.get_output_ptr(bx), params.get_transform(bx));
+    paged_transform<kMode>(problem, params.get_output_ptr(bx), params.get_transform(bx));
   }
 }
 
@@ -539,7 +548,8 @@ struct TopKKernel {
       const tvm::ffi::Optional<tvm::ffi::TensorView> page_table,
       const tvm::ffi::TensorView page_indices,
       const uint32_t page_size,
-      const tvm::ffi::TensorView metadata) {
+      const tvm::ffi::TensorView metadata,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> raw_indices) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
     auto L = SymbolicSize{"max_seq_len"};
@@ -578,6 +588,17 @@ struct TopKKernel {
         .with_dtype<int32_t>()
         .with_device(device_)
         .verify(metadata);
+    // Present means "both outputs": `page_indices` receives the page-table
+    // transform and `raw_indices` the selected raw indices, same -1 padding.
+    int32_t* raw_indices_ptr = nullptr;
+    if (raw_indices.has_value()) {
+      RuntimeCheck(page_table.has_value(), "raw_indices requires a page table");
+      TensorMatcher({B, K})  // raw_indices
+          .with_dtype<int32_t>()
+          .with_device(device_)
+          .verify(raw_indices.value());
+      raw_indices_ptr = static_cast<int32_t*>(raw_indices.value().data_ptr());
+    }
 
     RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
     RuntimeCheck(S.unwrap() % 4 == 0, "score_stride must be a multiple of 4 (16-byte vectorized load)");
@@ -606,6 +627,7 @@ struct TopKKernel {
         .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
         .page_table = page_table_ptr,
         .page_indices = static_cast<int32_t*>(page_indices.data_ptr()),
+        .raw_indices = raw_indices_ptr,
         .metadata = static_cast<const PlanItem*>(metadata.data_ptr()),
         .score_stride = S.unwrap(),
         .page_table_stride = page_table_stride,
@@ -618,12 +640,16 @@ struct TopKKernel {
     };
 
     const auto dispatch = [&]<typename F>(F&& f) {
-      const auto mode = page_table.has_value() ? TopKMode::PAGE_TABLE : TopKMode::INDICES;
+      const auto mode = raw_indices.has_value()  ? TopKMode::DUAL_OUTPUT
+                        : page_table.has_value() ? TopKMode::PAGE_TABLE
+                                                 : TopKMode::INDICES;
       switch (mode) {
         case TopKMode::INDICES:
           return f.template operator()<TopKMode::INDICES>();
         case TopKMode::PAGE_TABLE:
           return f.template operator()<TopKMode::PAGE_TABLE>();
+        case TopKMode::DUAL_OUTPUT:
+          return f.template operator()<TopKMode::DUAL_OUTPUT>();
         default:
           Panic("Invalid mode, this path should be unreachable");
       }

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -149,17 +149,20 @@ def topk_transform_paged_v2(
     out_page_indices: torch.Tensor,
     page_size: int,
     metadata: torch.Tensor,
+    out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
     """Fused top-k + optional page-table transform (DeepSeek-V4 top-k v2 kernel).
 
-    Two output modes, chosen by whether ``page_tables`` is given and resolved to
-    a device-side template parameter, so an unused page-table gather is compiled
-    out rather than skipped at runtime:
+    Output mode is chosen from ``page_tables`` and ``out_raw_indices`` and
+    resolved to a device-side template parameter, so an unused page-table gather
+    is compiled out rather than skipped at runtime:
 
     * ``page_tables=None`` -- ``out_page_indices`` receives the raw selected
       indices and no page table is read.
     * ``page_tables`` given -- ``out_page_indices`` receives the page-table
       transform of them.
+    * Both outputs given -- ``out_page_indices`` receives the page-table
+      transform and ``out_raw_indices`` receives the selected raw indices.
 
     NOTE: every entry of `seq_lens` must be NON-NEGATIVE, and `metadata` must
     come from :func:`plan_topk_v2` over the same `seq_lens` values.
@@ -167,6 +170,16 @@ def topk_transform_paged_v2(
     trivial path and the output is guaranteed to be all -1.
     """
     if is_xpu():
+        if out_raw_indices is not None:
+            topk_transform_paged(
+                scores,
+                seq_lens,
+                page_tables,
+                out_page_indices,
+                page_size,
+                out_raw_indices,
+            )
+            return
         torch.ops.sgl_kernel.topk_transform_paged(
             scores,
             seq_lens,
@@ -184,4 +197,5 @@ def topk_transform_paged_v2(
         out_page_indices,
         page_size,
         metadata,
+        out_raw_indices,
     )

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -837,14 +837,14 @@ class C4IndexerBackendMixin:
         )
 
         raw_indices = None
-        if capture_enabled:
+        if core_metadata.c4_sparse_raw_indices is not None:
+            raw_indices = core_metadata.c4_sparse_raw_indices
+        elif capture_enabled:
             raw_indices = torch.empty_like(c4_sparse_page_indices)
         elif hisparse_decode:
             raw_indices = hisparse_coordinator.raw_indices_buffer[
                 : c4_sparse_page_indices.size(0)
             ]
-        elif core_metadata.c4_sparse_raw_indices is not None:
-            raw_indices = core_metadata.c4_sparse_raw_indices
 
         all_rows = slice(0, _c4sl.shape[0])
 
@@ -868,7 +868,7 @@ class C4IndexerBackendMixin:
                     indexer_metadata.c4_page_size,
                     row_raw_indices,
                 )
-            elif self.dsa_topk_backend.should_use_topk_v2() and raw_indices is None:
+            elif self.dsa_topk_backend.should_use_topk_v2():
                 topk_transform_paged_v2(
                     logits,
                     c4_seq_lens[rows],
@@ -882,6 +882,7 @@ class C4IndexerBackendMixin:
                         if rows == all_rows or not is_hip()
                         else plan_topk_v2(c4_seq_lens[rows])
                     ),
+                    row_raw_indices,
                 )
             else:
                 topk_transform_paged(

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -183,6 +183,20 @@ def _run_raw(scores, seq_lens, k):
     return [[v for v in out_cpu[i] if v != -1] for i in range(batch)]
 
 
+def _run_dual(scores, seq_lens, page_table, inv_cpu, k):
+    batch = scores.shape[0]
+    metadata = _plan(seq_lens)
+    out = torch.full((batch, k), -1, dtype=torch.int32, device=scores.device)
+    raw = torch.full_like(out, -1)
+    topk_transform_paged_v2(scores, seq_lens, page_table, out, PAGE_SIZE, metadata, raw)
+    torch.cuda.synchronize()
+    out_cpu = out.cpu().tolist()
+    raw_cpu = raw.cpu().tolist()
+    transformed_raw = [_invert(out_cpu[i], inv_cpu[i]) for i in range(batch)]
+    direct_raw = [[v for v in raw_cpu[i] if v != -1] for i in range(batch)]
+    return transformed_raw, direct_raw
+
+
 @pytest.mark.parametrize("page_mode", ["identity", "perm"])
 @pytest.mark.parametrize("k", [512, 1024, 2048])
 @pytest.mark.parametrize("batch,seq", FIXED_CONFIGS)
@@ -268,6 +282,27 @@ def test_topk_v2_output_indices(batch: int, seq: int, k: int) -> None:
     our_raw = _run_raw(scores, seq_lens, k)
     ref_raw = _reference(scores, seq_lens, k)
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
+
+
+@pytest.mark.parametrize(
+    "batch,seq", [(8, 256), (8, 8192), (4, 32768), (2, 131072), (31, 131072)]
+)
+@torch.inference_mode()
+def test_topk_v2_dual_output(batch: int, seq: int) -> None:
+    """The dual mode returns the same selection before and after page transform."""
+    k = 512
+    torch.manual_seed(batch * 100003 + seq * 7 + k + 2)
+    device = "cuda"
+    scores = torch.randn(batch, seq, dtype=torch.float32, device=device)
+    seq_lens = torch.full((batch,), seq, dtype=torch.int32, device=device)
+    num_pages = (seq + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(batch, num_pages, "perm", device)
+
+    transformed_raw, direct_raw = _run_dual(scores, seq_lens, page_table, inv_cpu, k)
+    for row in range(batch):
+        assert sorted(transformed_raw[row]) == sorted(direct_raw[row])
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, direct_raw, batch, seq_lens.cpu(), k)
 
 
 # --- ragged entry point ------------------------------------------------------

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
 from sglang.srt.layers.attention.dsv4.indexer import (
     FP8_DTYPE,
     C4IndexerBackendMixin,
@@ -181,6 +182,78 @@ class TestDSV4FlashInferTopK(CustomTestCase):
                         "out_raw_indices": out_raw_indices,
                     },
                 )
+
+
+class TestDSV4TopKDispatch(CustomTestCase):
+    def test_v2_raw_output_uses_sparse_prefill_buffer_with_capture(self):
+        page_table = torch.zeros((1, 1), dtype=torch.int32)
+        c4_seq_lens = torch.ones(1, dtype=torch.int32)
+        page_indices = torch.full((1, 512), -1, dtype=torch.int32)
+        raw_indices = torch.full_like(page_indices, -1)
+        topk_metadata = torch.zeros((2, 2), dtype=torch.int32)
+
+        indexer_metadata = object.__new__(PagedIndexerMetadata)
+        indexer_metadata.page_size = 256
+        indexer_metadata.page_table = page_table
+        indexer_metadata.c4_seq_lens = c4_seq_lens
+        indexer_metadata.topk_metadata = topk_metadata
+
+        logits = torch.empty((1, 65), dtype=torch.float32)
+        backend = C4IndexerBackendMixin()
+        backend.dsa_topk_backend = DSATopKBackend.SGL_KERNEL
+        backend.token_to_kv_pool = SimpleNamespace(
+            layer_mapping={0: SimpleNamespace(compress_layer_id=7)}
+        )
+        backend.forward_metadata = SimpleNamespace(
+            indexer_metadata=indexer_metadata,
+            core_metadata=SimpleNamespace(
+                positions=torch.arange(1, dtype=torch.int64),
+                page_table=page_table,
+                c4_sparse_page_indices=page_indices,
+                c4_sparse_raw_indices=raw_indices,
+            ),
+        )
+        backend.hisparse_coordinator = None
+        backend._forward_prepare_normal = MagicMock(
+            return_value=(
+                torch.empty((1, 1, 128)),
+                torch.empty((1, 1, 1)),
+            )
+        )
+        backend._get_nonpaged_indexer_plan = MagicMock(return_value=object())
+        backend._forward_nonpaged_indexer = MagicMock(return_value=logits)
+
+        indexer_capturer = MagicMock()
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_INDEXER.override(False),
+            envs.SGLANG_OPT_USE_AITER_INDEXER.override(False),
+            envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.override(True),
+            envs.SGLANG_OPT_USE_TOPK_V2.override(True),
+            patch(
+                f"{_INDEXER}.get_global_indexer_capturer",
+                return_value=indexer_capturer,
+            ),
+            patch(f"{_INDEXER}.topk_transform_paged") as topk_v1,
+            patch(f"{_INDEXER}.topk_transform_paged_v2") as topk_v2,
+        ):
+            backend.forward_c4_indexer(
+                x=torch.empty((1, 1)),
+                q_lora=torch.empty((1, 1)),
+                c4_indexer=SimpleNamespace(use_fp4_indexer=False, layer_id=0),
+                forward_batch=SimpleNamespace(forward_mode=ForwardMode.EXTEND),
+            )
+
+        topk_v2.assert_called_once()
+        args = topk_v2.call_args.args
+        self.assertIs(args[0], logits)
+        torch.testing.assert_close(args[1], c4_seq_lens)
+        torch.testing.assert_close(args[2], page_table)
+        torch.testing.assert_close(args[3], page_indices)
+        self.assertEqual(args[4], 64)
+        self.assertIs(args[5], topk_metadata)
+        self.assertEqual(args[6].data_ptr(), raw_indices.data_ptr())
+        topk_v1.assert_not_called()
+        indexer_capturer.capture.assert_called_once_with(7, raw_indices)
 
 
 class TestDSV4NonPagedIndexer(CustomTestCase):


### PR DESCRIPTION
## Motivation

Port of #33672 (@weireweire, "Support raw-index output in TopK v2") onto the `dsv4.1` branch. The top-k v2 kernel could emit either raw indices or page-table-transformed indices, not both, so every caller that also needs raw positions (verify / sparse prefill) had to fall back to the v1 kernel. With both outputs from one launch the v1 fallback and its `raw_indices is None` dispatch conditions can go.

The commit is the original author's (cherry-picked from a103b0dfa9); the `topk_v2.cuh` part is re-implemented on this branch's reworked kernel structure (`PageTransform` / `trivial_transform` / `paged_transform`), the Python, indexer and test parts apply as they were.

## Modifications

- `TopKMode::DUAL_OUTPUT`: `page_indices` receives the page-table transform and `raw_indices` the selected raw indices, same `-1` padding. `PageTransform` carries the row's raw output pointer; `trivial_transform` and `paged_transform<kMode>` write it only in this mode, so the existing `INDICES` and `PAGE_TABLE` instantiations compile to the same code as before.
- Host `transform_paged(..., metadata, raw_indices: Optional)`, mode chosen from the two optional tensors.
- `topk_transform_paged_v2(..., out_raw_indices=None)`; the C4 indexer passes its raw-index buffer to v2 instead of falling back to v1 (XPU keeps the v1 path).
- Tests: `test_topk_v2_dual_output` (selection identical before and after the transform, checked against the reference) and a raw-index case in `test_dsv4_nonpaged_indexer.py`.

## Checks

- `test/registered/kernels/ops/attention/test_topk_v2.py`: 288 passed; `test/registered/unit/layers/test_dsv4_nonpaged_indexer.py`: 10 passed (B200).
- SASS of the JIT module before/after (sm100a): every existing instantiation (`topk_main_kernel` L0-L3 x {INDICES, PAGE_TABLE}, `topk_small_batch_cluster_kernel` c8/c16, `topk_persistent_cluster_kernel`, `topk_ragged_kernel`) has the same instruction count and register count; the only textual differences are the kernel-parameter constant-bank offsets (one pointer added to `TopKPagedParams`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34608847783](https://github.com/sgl-project/sglang/actions/runs/34608847783)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34608847395](https://github.com/sgl-project/sglang/actions/runs/34608847395)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34608847547](https://github.com/sgl-project/sglang/actions/runs/34608847547)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->