### PR TITLE
[PD] Read nixl TransferInfo.is_dummy as a field in unit tests

### DIFF
--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -165,7 +165,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertFalse(info.is_dummy())
+        self.assertFalse(info.is_dummy)
 
     def test_empty_indices_without_decode_prefix_is_dummy(self):
         info = TransferInfo.from_zmq(
@@ -182,7 +182,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertTrue(info.is_dummy())
+        self.assertTrue(info.is_dummy)
 
     def test_explicit_dummy_frame_true_is_dummy(self):
         # msg[9] is the explicit is_dummy frame the sender writes
@@ -202,7 +202,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertTrue(info.is_dummy())
+        self.assertTrue(info.is_dummy)
 
     def test_explicit_dummy_frame_true_with_prefix_hit_stays_dummy(self):
         # A dummy rank whose request also has a decode-side prefix hit: the
@@ -223,7 +223,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertTrue(info.is_dummy())
+        self.assertTrue(info.is_dummy)
 
     def test_explicit_dummy_frame_false_with_empty_indices_is_real(self):
         # Full prefix hit as the sender encodes it: empty kv indices,
@@ -243,7 +243,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertFalse(info.is_dummy())
+        self.assertFalse(info.is_dummy)
 
     def test_explicit_dummy_frame_false_for_real_transfer(self):
         info = TransferInfo.from_zmq(
@@ -261,7 +261,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertFalse(info.is_dummy())
+        self.assertFalse(info.is_dummy)
 
     def test_fallback_without_dummy_frame_reads_prefix_hit_dummy_as_real(self):
         # Old-peer fallback: without msg[9], a dummy rank with a decode-side
@@ -281,7 +281,7 @@ class TestNixlTransferInfo(CustomTestCase):
             ]
         )
 
-        self.assertFalse(info.is_dummy())
+        self.assertFalse(info.is_dummy)
 
 
 class TestNixlKVArgsRegisterInfo(CustomTestCase):


### PR DESCRIPTION
## Motivation

> [!IMPORTANT]
> **Merge this only after #36612.** `TransferInfo.is_dummy` is still a method on `main` until that PR lands, so this PR is red on its own and turns green the moment #36612 is in. Merging it first would break `main` in the opposite direction.

#36612 turns `TransferInfo.is_dummy` from a method into a `bool` dataclass field computed once in `from_zmq()`. It converts the two call sites that existed when it was branched (2026-08-27):

```
test/registered/unit/disaggregation/test_nixl_backend_basic.py:168,185
```

`test_nixl_backend_basic.py` has since grown five more, added by #34977 (`2018c64e22`, 2026-09-11) — after #36612's last push on 2026-09-09:

```
test/registered/unit/disaggregation/test_nixl_backend_basic.py:205,226,246,264,284
```

These are not textual conflicts, so `git merge` succeeds silently and `base-a-test-cpu` then goes red with:

```
TypeError: 'bool' object is not callable
```

Verified with a local trial merge of #36612 into current `main`: `Automatic merge went well`, then five `is_dummy()` call sites remain.

## Modifications

Convert all seven `info.is_dummy()` assertions in `test_nixl_backend_basic.py` to field reads. No other change — the production `is_dummy()` call sites in `nixl/conn.py` are #36612's to convert.

All seven (not just the five #36612 misses) so the file is self-consistent whichever order the two land in; the two that overlap change to identical content, so the merge stays clean either way.

## Scope check

I audited the rest of the disaggregation unit tests against #36612's other behavioral changes (the rewritten `CommonKVManager.update_status` policy, the deleted NIXL `update_status` override, and the new settle-then-raise barrier in `transfer_worker`). Nothing else breaks:

- `TestNixlUpdateStatus` — both cases (Failed is terminal; a missing room is not resurrected by Failed) are exactly what the new shared policy implements.
- `TestNixlTransferWorker` — builds `TransferInfo` by keyword without `is_dummy`, which picks up the new `= False` default and matches the old computed value; its `check_xfer_state` stub returns `DONE`, so `_await_handles` settles on the first pass and the worker never enters the new failure path.
- `TestNixlNodeFailure`, `TestNixlNotifications`, `TestNixlReceiverPoll` — unaffected.
- `test_nixl_deferred_kv_release.py`, `test_receiver_connection_pool.py`, `test_decode_queue_cleanup.py`, `test_kv_transfer_replica_metric.py` — all mock or stub `update_status` / `failure_exception`.
- `test_nixl_sender_failure_cleanup.py` — covers `NixlKVSender.failure_exception`; #36612 only changes the *receiver*'s.
- `test_disaggregation_wire.py` — its `is_dummy` assertions are mooncake's, already a field.

## Checklist

- [x] Format check passes (whitespace-neutral: only `()` removed; every line stays well under the line limit)
- [x] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34615153783](https://github.com/sgl-project/sglang/actions/runs/34615153783)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34615153400](https://github.com/sgl-project/sglang/actions/runs/34615153400)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34615153703](https://github.com/sgl-project/sglang/actions/runs/34615153703)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->