### PR TITLE
Fix stale DSV4 indexer metadata names in the TopK v2 dispatch test

### DIFF
--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -213,15 +213,16 @@ class TestDSV4FlashInferTopK(CustomTestCase):
 class TestDSV4TopKDispatch(CustomTestCase):
     def test_v2_raw_output_uses_sparse_prefill_buffer_with_capture(self):
         page_table = torch.zeros((1, 1), dtype=torch.int32)
-        c4_seq_lens = torch.ones(1, dtype=torch.int32)
+        compressed_seq_lens = torch.ones(1, dtype=torch.int32)
         page_indices = torch.full((1, 512), -1, dtype=torch.int32)
         raw_indices = torch.full_like(page_indices, -1)
         topk_metadata = torch.zeros((2, 2), dtype=torch.int32)
 
         indexer_metadata = object.__new__(PagedIndexerMetadata)
         indexer_metadata.page_size = 256
+        indexer_metadata.compressed_page_size = 64
         indexer_metadata.page_table = page_table
-        indexer_metadata.c4_seq_lens = c4_seq_lens
+        indexer_metadata.compressed_seq_lens = compressed_seq_lens
         indexer_metadata.topk_metadata = topk_metadata
 
         logits = torch.empty((1, 65), dtype=torch.float32)
@@ -272,7 +273,7 @@ class TestDSV4TopKDispatch(CustomTestCase):
         topk_v2.assert_called_once()
         args = topk_v2.call_args.args
         self.assertIs(args[0], logits)
-        torch.testing.assert_close(args[1], c4_seq_lens)
+        torch.testing.assert_close(args[1], compressed_seq_lens)
         torch.testing.assert_close(args[2], page_table)
         torch.testing.assert_close(args[3], page_indices)
         self.assertEqual(args[4], 64)


### PR DESCRIPTION
#38947 renamed `PagedIndexerMetadata.c4_seq_lens` to `compressed_seq_lens` and turned the derived `c4_page_size` property into an explicit `compressed_page_size` field. #33672 landed a new test built on a pre-rename base, so its hand-built metadata stub still sets the old names and `forward_c4_indexer` blows up on `main`.

```
AttributeError: 'PagedIndexerMetadata' object has no attribute 'compressed_seq_lens'. Did you mean: 'max_compressed_seq_len'?
ERROR: test_v2_raw_output_uses_sparse_prefill_buffer_with_capture (__main__.TestDSV4TopKDispatch)
Ran 10 tests in 1.887s
FAILED (errors=1)
```

After: `Ran 10 tests in 0.017s / OK`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34614847128](https://github.com/sgl-project/sglang/actions/runs/34614847128)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34614847087](https://github.com/sgl-project/sglang/actions/runs/34614847087)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34614847159](https://github.com/sgl-project/sglang/actions/runs/34614847159)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->