### PR TITLE
perf: serialize completion stream chunks directly

### DIFF
--- a/rust/sglang-server/src/api_server/openai/completions.rs
+++ b/rust/sglang-server/src/api_server/openai/completions.rs
@@ -19,6 +19,7 @@ use dynamo_protocols::types::{
     CreateCompletionResponse, Logprobs, Prompt, Stop,
 };
 use futures::StreamExt;
+use serde::Serialize;
 use tokio::sync::mpsc;
 
 use super::super::guard::AbortGuard;
@@ -58,6 +59,61 @@ pub(super) struct ChoiceExtensions {
     /// Dynamo's enum covers the standard values. Python additionally exposes
     /// `abort`, and native unknown finish types are preserved rather than lost.
     finish_reason_override: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum CompletionFinishReasonWire<'a> {
+    Standard(CompletionFinishReason),
+    Override(&'a str),
+}
+
+struct NegativeOneOffsets(usize);
+
+impl Serialize for NegativeOneOffsets {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq; // codespell:ignore ser
+
+        let mut seq = serializer.serialize_seq(Some(self.0))?;
+        for _ in 0..self.0 {
+            seq.serialize_element(&-1i8)?;
+        }
+        seq.end()
+    }
+}
+
+#[derive(Serialize)]
+struct CompletionLogprobsWire<'a> {
+    tokens: &'a [String],
+    token_logprobs: &'a [Option<f32>],
+    top_logprobs: &'a [serde_json::Value],
+    text_offset: NegativeOneOffsets,
+}
+
+#[derive(Serialize)]
+struct CompletionChoiceWire<'a> {
+    text: &'a str,
+    index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    logprobs: Option<CompletionLogprobsWire<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finish_reason: Option<CompletionFinishReasonWire<'a>>,
+    matched_stop: Option<&'a serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct CompletionResponseWire<'a> {
+    id: &'a str,
+    choices: Vec<CompletionChoiceWire<'a>>,
+    created: u32,
+    model: &'a str,
+    // Keep `usage` before `object`: removing `system_fingerprint` from the old
+    // Value representation swap-removed `object` to the final map position.
+    usage: Option<&'a CompletionUsage>,
+    object: &'a str,
 }
 
 async fn completions(
@@ -510,6 +566,56 @@ pub(super) fn completion_response_value(
     value
 }
 
+/// Serialize the streaming wire shape directly instead of allocating and
+/// traversing a complete intermediate `serde_json::Value` tree.
+fn completion_response_string(
+    response: CreateCompletionResponse,
+    extensions: &[ChoiceExtensions],
+) -> String {
+    // Preserve the old helper's permissive behavior for unexpected internal
+    // callers rather than dropping choices when the parallel slices diverge.
+    if response.choices.len() != extensions.len() {
+        return completion_response_value(response, extensions).to_string();
+    }
+
+    let choices = response
+        .choices
+        .iter()
+        .zip(extensions)
+        .map(|(choice, extension)| CompletionChoiceWire {
+            text: &choice.text,
+            index: choice.index,
+            logprobs: choice
+                .logprobs
+                .as_ref()
+                .map(|logprobs| CompletionLogprobsWire {
+                    tokens: &logprobs.tokens,
+                    token_logprobs: &logprobs.token_logprobs,
+                    top_logprobs: &logprobs.top_logprobs,
+                    text_offset: NegativeOneOffsets(logprobs.tokens.len()),
+                }),
+            finish_reason: extension.finish_reason_override.as_deref().map_or_else(
+                || {
+                    choice
+                        .finish_reason
+                        .map(CompletionFinishReasonWire::Standard)
+                },
+                |reason| Some(CompletionFinishReasonWire::Override(reason)),
+            ),
+            matched_stop: extension.matched_stop.as_ref(),
+        })
+        .collect();
+    serde_json::to_string(&CompletionResponseWire {
+        id: &response.id,
+        choices,
+        created: response.created,
+        model: &response.model,
+        usage: response.usage.as_ref(),
+        object: &response.object,
+    })
+    .expect("OpenAI response must serialize")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn completion_event_stream(
     submitted: Vec<SubmittedChoice>,
@@ -602,7 +708,7 @@ pub(super) fn completion_event_stream(
                 object: "text_completion".into(),
                 usage: chunk_usage,
             };
-            yield completion_response_value(chunk, &[extension]).to_string();
+            yield completion_response_string(chunk, &[extension]);
         }
 
         if include_usage {
@@ -625,7 +731,7 @@ pub(super) fn completion_event_stream(
                     u32::try_from(completion_tokens).unwrap_or(u32::MAX),
                 )),
             };
-            yield completion_response_value(final_chunk, &[]).to_string();
+            yield completion_response_string(final_chunk, &[]);
         }
         yield "[DONE]".to_string();
     }
@@ -735,13 +841,15 @@ mod tests {
     use super::super::test_utils::{chunk, senders, submitted};
     use super::{
         ChoiceExtensions, PromptSpec, completion_event_stream, completion_logprobs,
-        completion_prompt_specs, completion_response_value, unary_completion,
+        completion_prompt_specs, completion_response_string, completion_response_value,
+        unary_completion,
     };
     use crate::api_server::guard::AbortGuard;
     use crate::message::response::ChunkExtras;
     use axum::http::StatusCode;
     use dynamo_protocols::types::{
-        Choice, CreateCompletionRequest, CreateCompletionResponse, Prompt,
+        Choice, CompletionFinishReason, CompletionUsage, CreateCompletionRequest,
+        CreateCompletionResponse, Logprobs, Prompt,
     };
     use futures::StreamExt;
 
@@ -814,6 +922,119 @@ mod tests {
         assert_eq!(
             value["choices"][0]["logprobs"]["text_offset"],
             serde_json::json!([-1])
+        );
+    }
+
+    #[test]
+    fn direct_stream_serializer_matches_value_path() {
+        fn response(
+            choices: Vec<Choice>,
+            usage: Option<CompletionUsage>,
+        ) -> CreateCompletionResponse {
+            CreateCompletionResponse {
+                id: "cmpl-\"escaped\"".into(),
+                choices,
+                created: 7,
+                model: "模型\\name".into(),
+                system_fingerprint: Some("must-be-removed".into()),
+                object: "text_completion".into(),
+                usage,
+            }
+        }
+
+        fn assert_matches(response: CreateCompletionResponse, extensions: Vec<ChoiceExtensions>) {
+            let expected = completion_response_value(response.clone(), &extensions).to_string();
+            let actual = completion_response_string(response, &extensions);
+            assert_eq!(actual, expected);
+        }
+
+        assert_matches(
+            response(
+                vec![Choice {
+                    text: "plain\n\"文本\"".into(),
+                    index: 0,
+                    logprobs: None,
+                    finish_reason: None,
+                }],
+                None,
+            ),
+            vec![ChoiceExtensions::default()],
+        );
+        assert_matches(
+            response(
+                vec![Choice {
+                    text: "token".into(),
+                    index: 3,
+                    logprobs: Some(Logprobs {
+                        tokens: vec!["a".into(), "b\\c".into()],
+                        token_logprobs: vec![Some(-0.25), None],
+                        top_logprobs: vec![
+                            serde_json::json!({"a": -0.25, "á": -1.5}),
+                            serde_json::Value::Null,
+                        ],
+                        text_offset: vec![41, 42],
+                    }),
+                    finish_reason: Some(CompletionFinishReason::Stop),
+                }],
+                None,
+            ),
+            vec![ChoiceExtensions {
+                matched_stop: Some(serde_json::json!("</s>")),
+                finish_reason_override: None,
+            }],
+        );
+        assert_matches(
+            response(
+                vec![Choice {
+                    text: String::new(),
+                    index: 1,
+                    logprobs: None,
+                    finish_reason: Some(CompletionFinishReason::Length),
+                }],
+                None,
+            ),
+            vec![ChoiceExtensions {
+                matched_stop: Some(serde_json::json!([1, 2, 3])),
+                finish_reason_override: Some("abort".into()),
+            }],
+        );
+        assert_matches(
+            response(
+                vec![
+                    Choice {
+                        text: "first".into(),
+                        index: 0,
+                        logprobs: None,
+                        finish_reason: Some(CompletionFinishReason::ContentFilter),
+                    },
+                    Choice {
+                        text: "second".into(),
+                        index: 1,
+                        logprobs: None,
+                        finish_reason: None,
+                    },
+                ],
+                None,
+            ),
+            vec![
+                ChoiceExtensions {
+                    matched_stop: Some(serde_json::json!(17)),
+                    finish_reason_override: None,
+                },
+                ChoiceExtensions::default(),
+            ],
+        );
+        assert_matches(
+            response(
+                vec![],
+                Some(CompletionUsage {
+                    prompt_tokens: 11,
+                    completion_tokens: 13,
+                    total_tokens: 24,
+                    ..Default::default()
+                }),
+            ),
+            vec![],
         );
     }
 


### PR DESCRIPTION
## Motivation

The Rust `/v1/completions` streaming path currently constructs a complete `serde_json::Value`, mutates that tree to add SGLang fields, and serializes it again for every emitted chunk. That duplicates allocation and traversal work on a per-token response path.

## Modifications

- Serialize the text-completion streaming wire shape directly from borrowed response fields.
- Preserve the existing fallback `Value` path if internal choice/extension lengths diverge.
- Keep the non-streaming response path unchanged.
- Add an exact-byte parity test covering plain and escaped Unicode text, logprobs, standard and overridden finish reasons, string/integer/list `matched_stop`, multiple choices, and usage-only chunks.

## Accuracy Tests

- Exact baseline/candidate output parity in the production `completion_event_stream` harness: **45/45 paired cases** (identical frame count, byte count, and stream hash).
- `cargo test --locked -p sglang-server --lib`: **265 passed, 0 failed**.
- Focused `api_server::openai::completions::tests`: **7 passed, 0 failed**.

## Speed Tests and Profiling

I built separate release test binaries for the baseline and candidate and drove the real `completion_event_stream` path from a pre-filled channel. Each shape used 9 paired fresh-process runs on one pinned logical CPU, alternating arm order. Point estimates are geometric means of paired speedups; intervals are 95% percentile bootstrap intervals over paired log-speedups.

| shape | chunks/process | speedup | 95% CI |
|---|---:|---:|---:|
| plain ASCII | 50,000 | 3.47x | [3.41x, 3.53x] |
| escaped text | 20,000 | 2.24x | [2.17x, 2.30x] |
| long text | 2,000 | 1.40x | [1.34x, 1.45x] |
| top-5 logprobs (primary) | 10,000 | 2.61x | [2.56x, 2.66x] |
| continuous usage | 20,000 | 4.04x | [3.92x, 4.15x] |

The exact temporary benchmark harness is preserved in [eeb10201](https://github.com/adenzhou1350/sglang/commit/eeb10201fe30c0dbddcffa191f58ef63d81a4120). Apply that commit's diff to separate baseline and candidate worktrees, build `sglang-server` lib tests with `--release` in separate `CARGO_TARGET_DIR`s, then run the ignored `api_server::openai::completions::performance_tests::bench_completion_stream_production` test with `SG_COMPLETION_STREAM_PAYLOAD` and `SG_COMPLETION_STREAM_CHUNKS` set to the rows above. The measured region begins immediately before `completion_event_stream` construction and ends after collecting its output frames; input construction and correctness checks are outside the timed region.

Claim boundary: these measurements cover CPU-side Rust text-completion streaming response preparation and JSON serialization only. They do not claim model execution, scheduler, GPU, network, whole-server, or end-to-end request throughput gains.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked -p sglang-server --lib --tests -- -D warnings`
- [x] Added focused unit coverage and ran the full Rust library test suite
- [x] No documentation change is required for this internal response-serialization optimization
- [x] Included paired speed results and their scope/limitations

## Production HTTP-path attribution

I also measured this change through the in-process production Axum `POST /v1/completions` route: raw JSON extraction, request validation, the real submit/response-sink path, `completion_event_stream`, SSE framing, and response-body consumption. A deterministic task-local responder injected generated frames, so the timed path excludes tokenizer, scheduler, model, GPU, and external-network work.

Each result below is the geometric mean of 9 paired fresh-process runs on one pinned logical CPU, alternating arm order. Intervals are 95% percentile-bootstrap intervals over paired log-speedups. All 18 processes and 72 shape records passed; paired arms matched request bytes, response bytes, SSE frame count, and normalized semantic response hash.

| shape | requests/process | generated steps/request | speedup | 95% CI |
| --- | ---: | ---: | ---: | ---: |
| plain | 100 | 128 | 1.47x | [1.43x, 1.51x] |
| top-5 logprobs | 50 | 128 | 1.43x | [1.40x, 1.47x] |
| plain short boundary | 500 | 16 | 1.41x | [1.37x, 1.45x] |
| top-5 logprobs short boundary | 200 | 16 | 1.41x | [1.34x, 1.48x] |

The production target-file blob remains byte-identical to this PR's base at current `origin/main` `87db743`.

Claim boundary: these results establish CPU-side savings through the production request/response HTTP stack under deterministic generated-frame injection. They do not claim tokenizer, scheduler, model, GPU, external-network, whole-server throughput, TTFT, ITL, or end-to-end gains.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34636624476](https://github.com/sgl-project/sglang/actions/runs/34636624476)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34636623931](https://github.com/sgl-project/sglang/actions/runs/34636623931)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->