### PR TITLE
[sglang-miles] Remove obsolete PD retract guard after rebootstrap support (#25372); squash into 17c3be8e5d (#23672/#23887)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5134,19 +5134,6 @@ class Scheduler(
 
     def pause_generation(self, recv_req: PauseGenerationReqInput):
         assert recv_req.mode in ("in_place", "retract")
-        # PD disaggregation: `retract` has no decode-to-prefill rebootstrap path,
-        # so retracted decode-side requests cannot be re-prefilled under new
-        # weights. Fail fast before mutating any scheduler state to avoid
-        # leaving the engine in a half-paused / inconsistent state that later
-        # crashes inside radix-cache cleanup on flush_cache.
-        assert not (
-            recv_req.mode == "retract"
-            and self.disaggregation_mode != DisaggregationMode.NULL
-        ), (
-            "pause_generation(mode='retract') is not supported in PD "
-            "disaggregation mode yet. Decode-side retracted requests need "
-            "a rebootstrap path back to prefill."
-        )
 
         self._engine_paused = True
 


### PR DESCRIPTION
## Summary
Restore PD retract pause by removing an obsolete rejection on `sglang-miles`.

## Symptom & Reproduction
- **Symptom:** `pause_generation(mode="retract")` raises an assertion in both PD modes before pausing, blocking the supported retract/update/resume flow.
- **Reproduction:** At `32839114c4ada2ae237581405a8ff39dc0db9e25`, run `python -m pytest -q test/registered/unit/managers/test_scheduler_pause_generation.py`: 3 PD cases fail with `pause_generation(mode='retract') is not supported in PD disaggregation mode yet`; 17 pass. The existing tests expect PD retract to succeed.

## Root Cause
1. `Scheduler.pause_generation` received the old PD prohibition from #23672 when rebootstrap was unavailable.
2. `hold_rebootstrap` and resume-time enqueueing were implemented in #25372, already merged into `main`.
3. `17c3be8e5dc6579edce6715ba8e6ba05081170cd` replayed the obsolete guard onto `sglang-miles`, preventing entry into that implementation.

## Fix
Remove the 13-line guard and its outdated explanation. Keep mode validation, in-place pause handling, event-loop gates, and the existing retract/rebootstrap implementation unchanged.

**Patch-stack maintenance:** Squash this fix into [17c3be8e5dc6579edce6715ba8e6ba05081170cd](https://github.com/sgl-project/sglang/commit/17c3be8e5dc6579edce6715ba8e6ba05081170cd), titled `[8/35] [sglang-miles] Improve PD pause handling (#23672, #23887)`, when refreshing the `sglang-miles` patch stack. That is the branch commit that reintroduced the outdated restriction.

## Verification
- `test_scheduler_pause_generation.py`: all 20 unchanged tests pass after the fix.
- Existing PD GPU test bodies: 5/5 pass, covering prefill idle retract, running decode retract, paused decode weight reload/cache flush/rebootstrap, in-place pause/resume, and prefill request-leak checks.
- Runtime: Llama-3.1-8B-Instruct, Mooncake, both endpoints on one H200, CUDA graphs disabled. This does not establish multi-GPU coverage or prefill live-chunk weight consistency.
- `git diff --check`: passed. Test processes exited; GPU memory and test ports were released.

## Review Focus
- `Scheduler.pause_generation`: PD retract must reach the existing implementation while preserving unified and in-place behavior.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34635912091](https://github.com/sgl-project/sglang/actions/runs/34635912091)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34635911727](https://github.com/sgl-project/sglang/actions/runs/34635911727)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34635911773](https://github.com/sgl-project/sglang/actions/runs/34635911773)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->