### PR TITLE
fix(kda_prefill): fence shared writes before async proxy reads

### DIFF
--- a/python/sglang/kernels/jit/csrc/attention/kda_prefill.cu
+++ b/python/sglang/kernels/jit/csrc/attention/kda_prefill.cu
@@ -150,6 +150,9 @@ static __device__ __forceinline__ uint32_t ld_acq_b32(const uint32_t* ptr) {
 static __device__ __forceinline__ void fence_async_global() {
   asm volatile("fence.proxy.async.global;");
 }
+static __device__ __forceinline__ void fence_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
 
 // ---- tcgen05 (TMEM lifecycle, ld/st, MMA, fences) ----
 static __device__ __forceinline__ void tcgen05_alloc(uint32_t smem_addr_for_taddr, uint32_t n_cols) {
@@ -1524,6 +1527,7 @@ __device__ static void chain_body(
       // after the TMA through mb_pre)
       ptx::mbar_wait_parity(&S.mb_pre, q2 & 1);
       widen_map_tf32(bL, pL, vc, ch);
+      ptx::fence_async_shared();
       ptx::tcgen05_fence_before_thread_sync();
       __syncthreads();
       if (tid == 0) {


### PR DESCRIPTION
## Motivation

`chain_body` writes the widened L tile to shared memory through the generic proxy, then consumes it through the tcgen05 async machinery. `__syncthreads()` synchronizes participating threads, but it does not establish ordering between generic-proxy shared-memory writes and async-proxy reads. On affected SM103 KDA prefill runs, that missing proxy fence can race and cause incorrect results or device faults.

## Modifications

Add a small PTX helper for `fence.proxy.async.shared::cta` and issue it immediately after `widen_map_tf32`, before the existing tcgen05 thread fence and CTA synchronization.

## Accuracy Tests

- `clang-format` 20.1.7 passes.
- `git diff --check` passes.

An isolated A/B stress test on B300 (SM103) compiled two extensions from the
same source. The second variant removed exactly the three-line fence helper and
its one call. A CUDA profile confirmed all tested shapes selected
`kda_fused<0, true, true>`, which exercises the multi-piece prefix-composition
path containing this fence. Two fixed input sets were alternated between calls
to expose stale shared-memory data.

| Tokens | Heads | Fenced mismatch vs. its baseline | Unfenced mismatch vs. fenced baseline | Unfenced mismatch vs. its own first result |
| ---: | ---: | ---: | ---: | ---: |
| 8,192 | 12 | 0 / 100 | 86 / 100 | 100 / 100 |
| 16,384 | 12 | 0 / 100 | 82 / 100 | 89 / 100 |
| 8,192 | 16 | 0 / 100 | 75 / 100 | 100 / 100 |

The unfenced mismatches affected both BF16 output and FP32 final state. Sampled
mismatches were finite, and this run did not produce a device fault. The
fenced variant was bitwise stable across every repetition.

A CPU unit test would not exercise this hardware memory-ordering requirement. A regression test intended to provoke the race on SM103 would also be nondeterministic, so this PR does not add one.

## Speed Tests and Profiling

Not separately benchmarked. The change adds one CTA-scoped proxy fence only on the affected chain path; this PR makes no performance claim.

## Checklist

- [x] The code is formatted with the repository-pinned clang-format version.
- [x] The change is limited to the KDA prefill memory-ordering fix.
- [x] Accuracy evidence and its limitations are described above.
- [x] No documentation update is needed for this internal kernel synchronization change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35156460479](https://github.com/sgl-project/sglang/actions/runs/35156460479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35156460391](https://github.com/sgl-project/sglang/actions/runs/35156460391)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35156460597](https://github.com/sgl-project/sglang/actions/runs/35156460597)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
