### PR TITLE
[ROCm][DSpark] Make model loading barrier timeout configurable, raise…

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -48,7 +48,14 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 
-UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
+UNBALANCED_MODEL_LOADING_TIMEOUT_S = int(
+    os.environ.get("SGLANG_MODEL_LOADING_TIMEOUT_S", "1800")
+)
+# Default 1800s (30 min). The original 480s is too short for large checkpoints
+# where post-load weight processing (scale layout transforms, APE hotfix,
+# MHC norm caching) takes several minutes on certain TP ranks. Particularly
+# affected: DSpark checkpoints on ROCm where TP0/TP7 process heavier expert
+# shards. Override via SGLANG_MODEL_LOADING_TIMEOUT_S env var.
 
 
 def maybe_precompile_model_kernels_after_loading(model, device: str) -> None:


### PR DESCRIPTION
## Motivation

The `dist.monitored_barrier` in `dist_barrier_after_load` has a hardcoded 480-second timeout. This is insufficient for large checkpoints where `post_load_weights` (scale layout transforms, APE hotfix, MHC norm weight caching) takes significantly longer on specific TP ranks.

Observed failure case: `deepseek-ai/DeepSeek-V4-Pro-DSpark` on AMD MI355X with TP=8. The DSpark checkpoint (66 safetensors shards) assigns heavier expert weight shards to TP0 and TP7. Their `post_load_weights` takes 10–15 minutes (vs ~4 minutes for other ranks). The 480s barrier times out, causing a `RuntimeError: TP rank X could finish the model loading, but there are other ranks that didn't finish loading`, which kills all ranks.

## Modifications

- Raise the default timeout from 480s to 1800s (30 minutes).
- Make it configurable via `SGLANG_MODEL_LOADING_TIMEOUT_S` environment variable so operators can tune it without code changes.

## How to reproduce

```bash
# MI355X TP=8, DSpark checkpoint, sglang v0.5.18-rocm720
python3 -m sglang.launch_server \
  --model-path deepseek-ai/DeepSeek-V4-Pro-DSpark \
  --tp 8 --speculative-algorithm DSPARK \
  --speculative-dspark-block-size 5
```

With the old 480s timeout: server dies with `RuntimeError: TP rank 0 could finish the model loading, but there are other ranks that didn't finish`. With 1800s: all ranks complete and the server reaches READY.

## Notes

- The original 480s was already a "leave more time" value above the original limit. 1800s is safe — a rank that truly OOMs or crashes will cause a Python exception before the barrier is reached, which produces a clean error rather than a timeout.
- CUDA/non-ROCm paths are unaffected in practice (barrier completes in seconds on standard checkpoints).

## Checklist

- [x] Format checked
- [x] No functional change on CUDA paths (barrier still hit within seconds)
- [x] Configurable for operators needing different values

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34648957828](https://github.com/sgl-project/sglang/actions/runs/34648957828)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34648957822](https://github.com/sgl-project/sglang/actions/runs/34648957822)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34648957813](https://github.com/sgl-project/sglang/actions/runs/34648957813)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->