### PR TITLE
[Ollama] Map options.seed to the sampling_seed field

### DIFF
--- a/python/sglang/srt/entrypoints/ollama/serving.py
+++ b/python/sglang/srt/entrypoints/ollama/serving.py
@@ -52,7 +52,7 @@ class OllamaServing:
                 "stop": "stop",
                 "presence_penalty": "presence_penalty",
                 "frequency_penalty": "frequency_penalty",
-                "seed": "seed",
+                "seed": "sampling_seed",
             }
             for ollama_param, sglang_param in param_mapping.items():
                 if ollama_param in options:


### PR DESCRIPTION
## Motivation

`/api/generate` with `options.seed` set fails. `_convert_options_to_sampling_params` maps `"seed"` to a `SamplingParams` field named `seed`, and that field does not exist. The field is `sampling_seed` (`python/sglang/srt/sampling/sampling_params.py:153`).

`SamplingParams` is a `msgspec.Struct` with `kw_only=True`, so the unknown keyword raises `TypeError: Unexpected keyword argument 'seed'` at `tokenizer_manager.py:1381` while the request is being built. Because `stream` defaults to `True` and `StreamingResponse` is returned before the first chunk is awaited, the client sees HTTP 200 with a truncated body rather than an error.

The other seven entries in the same table already use the SGLang side name. `seed` is the only one that does not match a real field:

```
python3 -c "
from sglang.srt.sampling.sampling_params import SamplingParams
print([f for f in SamplingParams.__struct_fields__ if 'seed' in f])   # ['sampling_seed']
SamplingParams(seed=7)                                                # TypeError
"
```

The OpenAI layer already performs the same rename at `openai/protocol.py:1143` and `openai/serving_completions.py:171`.

## Modifications

One line in `python/sglang/srt/entrypoints/ollama/serving.py`. `"seed": "seed"` becomes `"seed": "sampling_seed"`.

## Accuracy Tests

Not applicable. This does not touch a kernel or model forward path.

Executed: `SamplingParams.__struct_fields__` contains `sampling_seed` and no `seed`, and constructing the struct with `seed=` raises `TypeError` under msgspec 0.21.1.

Not executed: an Ollama client against a running server. No test in the tree exercises `options`.

One thing a reviewer should know. After this change the seed reaches `sampling_seed`, but the seed tensor is only built when deterministic inference is enabled (`sampling_batch_info.py:117-132`). Without `--enable-deterministic-inference` the request now succeeds and the seed has no effect. If you would prefer the converter to validate its own table against `SamplingParams.__struct_fields__` so this class of typo cannot recur, I am happy to add that here.

## Speed Tests and Profiling

We did not measure this. The change is one dict value and cannot affect inference speed.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34650101336](https://github.com/sgl-project/sglang/actions/runs/34650101336)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34650101132](https://github.com/sgl-project/sglang/actions/runs/34650101132)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34650101255](https://github.com/sgl-project/sglang/actions/runs/34650101255)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->