### PR TITLE
[core] Make SWA sizing policy explicit and separate pool costs

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -545,9 +545,15 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--swa-sizing-policy`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>How to size the hybrid SWA pool. `auto` selects `ratio` when you explicitly set `--swa-full-tokens-ratio`; otherwise it selects a supported request-based budget or falls back to `ratio`. Generic paged request sizing requires full-attention layers, `--disable-radix-cache`, positive `--max-running-requests` per attention-DP worker, and positive `--chunked-prefill-size`. DSV4 paged SWA supports `ratio`; DSV4 unified ring supports `request`. An explicit unsupported policy raises an error.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>ratio</code>, <code>request</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--swa-full-tokens-ratio`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The ratio of SWA layer KV tokens / full layer KV tokens, regardless of the number of swa:full layers. It should be between 0 and 1. E.g. 0.5 means if each swa layer has 50 tokens, then each full layer has 100 tokens.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0.8`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>SWA tokens per full-attention token, independent of layer counts; valid range is (0, 1]. For example, 0.5 reserves 50 SWA tokens for every 100 full tokens. Explicitly setting this selects ratio sizing, including when you specify the default value. It cannot be combined with `--swa-sizing-policy=request` or the DSV4 unified ring layout. Leave it unset to allow automatic request sizing.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Model default, otherwise `0.8`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: float</td>
     </tr>
         <tr>

--- a/python/sglang/srt/arg_groups/fields/schedule.py
+++ b/python/sglang/srt/arg_groups/fields/schedule.py
@@ -146,6 +146,21 @@ class Schedule(msgspec.Struct):
         int,
         "The physical page size of the NPU DSV4 C128 KV cache. Must be a positive multiple of 16.",
     ] = 16
+    swa_sizing_policy: A[
+        str,
+        Arg(
+            help=(
+                "How to size the hybrid SWA pool. 'auto' uses ratio when "
+                "--swa-full-tokens-ratio is explicit, otherwise selects the "
+                "layout's supported request-based budget or falls back to ratio. "
+                "'ratio' scales SWA capacity with full-token capacity. 'request' "
+                "reserves SWA capacity from concurrency and requires a supported "
+                "layout and configuration."
+            ),
+            choices=["auto", "ratio", "request"],
+            resolvable=True,
+        ),
+    ] = "auto"
     swa_full_tokens_ratio: A[
         Optional[float],
         Arg(
@@ -153,7 +168,8 @@ class Schedule(msgspec.Struct):
                 "The ratio of SWA layer KV tokens / full layer KV tokens, regardless "
                 "of the number of swa:full layers. It should be between 0 and 1. "
                 "E.g. 0.5 means if each swa layer has 50 tokens, then each full "
-                "layer has 100 tokens."
+                "layer has 100 tokens. Setting this explicitly selects ratio "
+                "sizing and is incompatible with --swa-sizing-policy=request."
             ),
             resolvable=True,
             fallback=0.8,

--- a/python/sglang/srt/arg_groups/kv_cache_hook.py
+++ b/python/sglang/srt/arg_groups/kv_cache_hook.py
@@ -22,6 +22,26 @@ from sglang.srt.runtime_context import get_platform
 logger = logging.getLogger(__name__)
 
 
+def handle_swa_sizing_policy(server_args: Any) -> None:
+    """Resolve user intent before model defaults fill in the effective ratio."""
+    policy = server_args.swa_sizing_policy
+    ratio = server_args.swa_full_tokens_ratio
+    if policy not in ("auto", "ratio", "request"):
+        raise ValueError("--swa-sizing-policy must be auto, ratio, or request.")
+    if ratio is not None:
+        if not 0 < ratio <= 1:
+            raise ValueError("--swa-full-tokens-ratio must be in (0, 1].")
+        if policy == "request":
+            raise ValueError(
+                "--swa-full-tokens-ratio cannot be combined with "
+                "--swa-sizing-policy=request."
+            )
+        if policy == "auto":
+            declare_resolution(
+                server_args, "explicit_swa_ratio", swa_sizing_policy="ratio"
+            )
+
+
 def handle_mxfp8_kv_cache_compatibility(server_args: Any) -> None:
     """MXFP8 KV cache uses operands available only on SM100+ (Blackwell)."""
     cfg = resolving_view(server_args)

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -101,6 +101,10 @@ def run_resolution_pipeline(server_args: Any) -> None:
     validate_prefill_decode_interval(server_args)
     validate_sampling_mask_max_tokens(server_args)
 
+    from sglang.srt.arg_groups.kv_cache_hook import handle_swa_sizing_policy
+
+    handle_swa_sizing_policy(server_args)
+
     # Reject an explicitly enabled but incompatible hardware runtime before
     # model path resolution, downloads, or the dummy-model short circuit.
     from sglang.srt.arg_groups.parallel_hook import validate_prefill_cp_platform

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -842,6 +842,35 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         return self._solve_pool_sizes(max_total_num_tokens, page_size)
 
 
+@dataclass(frozen=True)
+class _SWARequestBudget:
+    working_set_tokens: int
+    execution_headroom_tokens: int
+    cache_headroom_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.working_set_tokens
+            + self.execution_headroom_tokens
+            + self.cache_headroom_tokens
+        )
+
+    def log(self, *, layout: str, reserved_tokens: int, capacity_tokens: int) -> None:
+        logger.info(
+            "SWA request budget (tokens): layout=%s, working_set=%d, "
+            "execution_headroom=%d, cache_headroom=%d, page_alignment=%d, "
+            "reservation=%d, capacity=%d",
+            layout,
+            self.working_set_tokens,
+            self.execution_headroom_tokens,
+            self.cache_headroom_tokens,
+            reserved_tokens - self.total_tokens,
+            reserved_tokens,
+            capacity_tokens,
+        )
+
+
 class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
     """Hybrid SWA configurator with a request-based SWA reservation.
 
@@ -861,11 +890,7 @@ class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
         draft_tokens = get_spec().speculative_num_draft_tokens or 1
         eviction_interval = max(1, envs.SGLANG_SWA_EVICTION_INTERVAL.get())
 
-        """
-        __________[padding][eviction_interval][window]
-        Padding to make sure eviction point is page-aligned.
-        """
-        trailing_tokens = window + eviction_interval * draft_tokens + page_size
+        eviction_headroom = eviction_interval * draft_tokens
         if get_spec().speculative_algorithm is None:
             decode_alloc = page_size
         elif get_schedule().disable_overlap_schedule:
@@ -880,21 +905,25 @@ class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
             # spec-v2: the overlap allocator keeps 2 * alloc_len outstanding
             # (eagle_utils.eagle_prepare_for_decode: kv_committed_len + 2 * alloc_len).
             decode_alloc = 2 * get_alloc_len_per_decode()
-        per_request = trailing_tokens + decode_alloc
+        per_request_headroom = eviction_headroom + page_size + decode_alloc
 
         num_reqs = get_schedule().max_running_requests // kvc.ps.attn_dp_size
         if get_disagg().disaggregation_mode == "decode":
-            self._swa_request_tokens = (
-                per_request * num_reqs
-                + (window + page_size) * get_disagg().disaggregation_decode_extra_slots
-            )
+            batch_headroom = (
+                window + page_size
+            ) * get_disagg().disaggregation_decode_extra_slots
         else:
             chunks_in_flight = 1 if get_schedule().disable_overlap_schedule else 2
-            self._swa_request_tokens = (
-                per_request * num_reqs
-                + chunks_in_flight * get_schedule().chunked_prefill_size
-                + page_size
+            batch_headroom = (
+                chunks_in_flight * get_schedule().chunked_prefill_size + page_size
             )
+
+        self._swa_request_budget = _SWARequestBudget(
+            working_set_tokens=num_reqs * window,
+            execution_headroom_tokens=num_reqs * per_request_headroom + batch_headroom,
+            # Paged request sizing currently requires radix cache to be disabled.
+            cache_headroom_tokens=0,
+        )
 
     @staticmethod
     def is_applicable(kvc: KVCacheConfigurator) -> bool:
@@ -912,10 +941,27 @@ class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
             return False
         return len(kvc.model_config.full_attention_layer_ids) > 0
 
+    def _resolve_swa_tokens(
+        self, page_size: int, token_limit: Optional[int] = None
+    ) -> int:
+        budget = self._swa_request_budget
+        reserved_tokens = ceil_align(budget.total_tokens, page_size)
+        capacity_tokens = (
+            reserved_tokens
+            if token_limit is None
+            else min(reserved_tokens, token_limit)
+        )
+        budget.log(
+            layout="paged",
+            reserved_tokens=reserved_tokens,
+            capacity_tokens=capacity_tokens,
+        )
+        return capacity_tokens
+
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
-        swa_tokens = ceil_align(self._swa_request_tokens, page_size)
+        swa_tokens = self._resolve_swa_tokens(page_size)
         fixed_swa_bytes = self._swa_pool_bytes(swa_tokens)
         if self._enable_unified_memory and self._draft_pool_bytes_per_token() > 0:
             full_tokens = self._max_unified_full_tokens(
@@ -944,12 +990,12 @@ class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
         self, max_total_num_tokens: int, page_size: int
     ) -> MemoryPoolConfig:
         # A global token limit also bounds the useful request reservation.
-        swa_tokens = ceil_align(self._swa_request_tokens, page_size)
+        swa_tokens = self._resolve_swa_tokens(page_size, max_total_num_tokens)
         full_tokens = (max_total_num_tokens // page_size) * page_size
         return MemoryPoolConfig(
             max_total_num_tokens=full_tokens,
             full_max_total_num_tokens=full_tokens,
-            swa_max_total_num_tokens=min(swa_tokens, max_total_num_tokens),
+            swa_max_total_num_tokens=swa_tokens,
         )
 
 
@@ -1227,13 +1273,24 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         estimated = max(min(estimated, 4096), 2048)
         return min(estimated, full_token // 2)
 
+    def _swa_ring_request_budget(self, max_running_requests: int) -> _SWARequestBudget:
+        num_req_slots = self._get_num_req_slots(max_running_requests)
+        extra_slots = num_req_slots - max_running_requests
+        return _SWARequestBudget(
+            working_set_tokens=max_running_requests * self.swa_page_size,
+            execution_headroom_tokens=(
+                max_running_requests * (self._swa_ring_size - self.swa_page_size)
+                + extra_slots * self._swa_ring_size
+            ),
+            cache_headroom_tokens=0,
+        )
+
     def _fixed_swa_bytes(self, max_running_requests: int) -> int:
         if not self._unified:
             return 0
-        num_req_slots = self._get_num_req_slots(max_running_requests)
+        budget = self._swa_ring_request_budget(max_running_requests)
         ring_bytes = (
-            num_req_slots
-            * self._swa_ring_size
+            budget.total_tokens
             * self.attn_head_dim
             * 2  # bf16
             * self.num_layers_total
@@ -1290,6 +1347,13 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             max_running_requests_per_worker
         )
         swa_ring_fixed_bytes = self._fixed_swa_bytes(max_running_requests_per_worker)
+        if self._unified:
+            budget = self._swa_ring_request_budget(max_running_requests_per_worker)
+            budget.log(
+                layout="ring",
+                reserved_tokens=budget.total_tokens,
+                capacity_tokens=budget.total_tokens,
+            )
         c4_state_fixed_bytes = self._fixed_c4_state_bytes(
             max_running_requests_per_worker
         )

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -101,6 +101,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_swa_sizing_policy(
+    *,
+    request_supported: bool,
+    ratio_supported: bool,
+    layout: str,
+    request_requirements: str = "This layout currently only supports ratio sizing.",
+) -> str:
+    """Select a sizing rule after the layout's capabilities are known."""
+    requested = get_schedule().swa_sizing_policy
+    policy = requested
+    if policy == "auto":
+        policy = "request" if request_supported else "ratio"
+    if policy == "request" and not request_supported:
+        raise ValueError(
+            f"--swa-sizing-policy=request is unavailable for {layout}. "
+            f"{request_requirements}"
+        )
+    if policy == "ratio" and not ratio_supported:
+        raise ValueError(
+            f"Ratio sizing is unavailable for {layout}. Remove "
+            "--swa-full-tokens-ratio and use --swa-sizing-policy=auto or request."
+        )
+    logger.info(
+        "SWA sizing policy: %s (requested=%s, layout=%s)", policy, requested, layout
+    )
+    return policy
+
+
 def _dflash_draft_cell_size(kvc: KVCacheConfigurator) -> int:
     """Bytes/token the DFLASH draft KV pool adds to the target's budget, 0 if none.
 
@@ -689,12 +717,8 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
             )
         else:
             self._cell_size = (
-                self._full_per_token
-                * (self._full_layers_num + self._draft_full_layers_num)
-                + self._swa_per_token * self._draft_swa_full_layers_num
-                + self._swa_full_tokens_ratio
-                * self._swa_per_token
-                * (self._swa_layers_num + self._draft_swa_layers_num)
+                self._full_pool_bytes_per_token()
+                + self._swa_pool_bytes(self._swa_full_tokens_ratio)
                 + self._draft_cell_size
             )
 
@@ -704,6 +728,20 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
             + self._swa_per_token
             * (self._draft_swa_layers_num + self._draft_swa_full_layers_num)
             + self._draft_cell_size
+        )
+
+    def _full_pool_bytes_per_token(self) -> int:
+        """Cost that grows with full capacity, independent of SWA sizing."""
+        return (
+            self._full_per_token * (self._full_layers_num + self._draft_full_layers_num)
+            + self._swa_per_token * self._draft_swa_full_layers_num
+        )
+
+    def _swa_pool_bytes(self, swa_tokens: float) -> float:
+        return (
+            swa_tokens
+            * self._swa_per_token
+            * (self._swa_layers_num + self._draft_swa_layers_num)
         )
 
     def _max_unified_full_tokens(
@@ -804,12 +842,12 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         return self._solve_pool_sizes(max_total_num_tokens, page_size)
 
 
-class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
-    """Hybrid SWA configurator with the SWA pool sized from a fixed token cap.
+class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
+    """Hybrid SWA configurator with a request-based SWA reservation.
 
     When max_running_requests is explicit, the SWA pool's worst-case
     footprint is bounded per request. The SWA pool is sized tightly from that
-    cap and the freed memory is redirected to the full pool, instead of sizing
+    reservation and the remaining memory goes to the full pool, instead of sizing
     both pools by swa_full_tokens_ratio.
     """
 
@@ -846,13 +884,13 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
 
         num_reqs = get_schedule().max_running_requests // kvc.ps.attn_dp_size
         if get_disagg().disaggregation_mode == "decode":
-            self._swa_cap = (
+            self._swa_request_tokens = (
                 per_request * num_reqs
                 + (window + page_size) * get_disagg().disaggregation_decode_extra_slots
             )
         else:
             chunks_in_flight = 1 if get_schedule().disable_overlap_schedule else 2
-            self._swa_cap = (
+            self._swa_request_tokens = (
                 per_request * num_reqs
                 + chunks_in_flight * get_schedule().chunked_prefill_size
                 + page_size
@@ -861,11 +899,14 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
     @staticmethod
     def is_applicable(kvc: KVCacheConfigurator) -> bool:
         """True when SWAChunkCache can be sized from explicit max requests."""
-        if get_schedule().max_running_requests is None:
+        if (
+            get_schedule().max_running_requests is None
+            or get_schedule().max_running_requests // kvc.ps.attn_dp_size <= 0
+        ):
             return False
         if not get_memory().disable_radix_cache:
             return False
-        if get_schedule().chunked_prefill_size is None:
+        if (get_schedule().chunked_prefill_size or 0) <= 0:
             return False
         if kvc.sliding_window_size is None:
             return False
@@ -874,29 +915,20 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
-        # SWA pool sized tightly from the cap; the rest of the budget goes to full.
-        swa_tokens = ceil_align(self._swa_cap, page_size)
-        fixed_swa_bytes = (
-            swa_tokens
-            * self._swa_per_token
-            * (self._swa_layers_num + self._draft_swa_layers_num)
-        )
+        swa_tokens = ceil_align(self._swa_request_tokens, page_size)
+        fixed_swa_bytes = self._swa_pool_bytes(swa_tokens)
         if self._enable_unified_memory and self._draft_pool_bytes_per_token() > 0:
             full_tokens = self._max_unified_full_tokens(
                 available_bytes, page_size, fixed_swa_tokens=swa_tokens
             )
         else:
-            full_cell_size = (
-                self._full_per_token
-                * (self._full_layers_num + self._draft_full_layers_num)
-                + self._swa_per_token * self._draft_swa_full_layers_num
-            )
+            full_cell_size = self._full_pool_bytes_per_token()
             full_tokens = (
                 int((available_bytes - fixed_swa_bytes) // full_cell_size) // page_size
             ) * page_size
         if full_tokens <= 0:
             raise RuntimeError(
-                f"SWA pool cap ({swa_tokens} tokens, "
+                f"SWA request reservation ({swa_tokens} tokens, "
                 f"{fixed_swa_bytes / (1 << 30):.2f} GiB) leaves no room for the full "
                 f"KV pool within the available {available_bytes / (1 << 30):.2f} GiB. "
                 f"Reduce --max-running-requests, lower SGLANG_SWA_EVICTION_INTERVAL, "
@@ -911,8 +943,8 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
     def calculate_pool_sizes_from_max_tokens(
         self, max_total_num_tokens: int, page_size: int
     ) -> MemoryPoolConfig:
-        # Constrained max_total goes to the full pool; SWA stays at its cap.
-        swa_tokens = ceil_align(self._swa_cap, page_size)
+        # A global token limit also bounds the useful request reservation.
+        swa_tokens = ceil_align(self._swa_request_tokens, page_size)
         full_tokens = (max_total_num_tokens // page_size) * page_size
         return MemoryPoolConfig(
             max_total_num_tokens=full_tokens,
@@ -999,6 +1031,11 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         )
 
         self._unified = is_unified_kv_triton()
+        self.swa_sizing_policy = _resolve_swa_sizing_policy(
+            request_supported=self._unified,
+            ratio_supported=not self._unified,
+            layout="DSV4 request-owned ring" if self._unified else "DSV4 paged SWA",
+        )
         self.attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
         # swa_page_size is the model's sliding window (cfg.window_size).
         self._swa_ring_size = get_swa_ring_size(self.swa_page_size, self.is_speculative)
@@ -1071,66 +1108,50 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"get_compress_state_ring_size()."
             )
 
-    def _get_bytes_per_full_token(self) -> float:
+    def _kv_bytes_per_token(self) -> int:
         if self._unified:
-            # Unified_kv stores the whole latent in bf16.
-            kv_bytes = self.attn_head_dim * 2
-        else:
-            kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
+            return self.attn_head_dim * 2  # bf16 latent
+        return self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
 
-        attn_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-        c4_state_dtype_size, c128_state_dtype_size = (
-            _get_dsv4_compress_state_dtype_sizes()
-        )
-        c4_state_bytes = 2 * 2 * attn_head_dim * c4_state_dtype_size
-        # Online c128 stores (max, sum, kv) per slot (3*head_dim) instead of
-        # raw (kv, score) (2*head_dim). Combined with ring_size=1 this still
-        # nets a large reduction (~3/256x) but the per-slot bytes go up.
-        c128_online = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
-        c128_state_bytes = (
-            (3 if c128_online else 2 * 1) * attn_head_dim * c128_state_dtype_size
-        )
-        c4_indexer_state_bytes = 2 * 2 * self.indexer_head_dim * c4_state_dtype_size
-
-        c4_state_ratio = self.c4_ring_size / self.swa_page_size
-        # C128 state is request-scoped and is finalized after
-        # max_running_requests is known, so it should not scale with
-        # full-token capacity here.
-        c128_state_ratio = 0
-
-        c4_frac = 1 / (4 * self.c4_shrink_factor)
+    def _compressed_costs_per_full_token(self) -> tuple[float, float, float]:
+        kv_bytes = self._kv_bytes_per_token()
+        c4_fraction = 1 / (4 * self.c4_shrink_factor)
         return (
-            # Ring mode: SWA is a fixed per-request pool (see _fixed_swa_bytes).
-            (
-                0.0
-                if self._unified
-                else self.swa_ratio * kv_bytes * self.num_layers_total
-            )
-            + c4_frac * kv_bytes * self.num_layers_ca4
-            + 1 / 128 * kv_bytes * self.num_layers_ca128
-            + 1 / 4 * self.indexer_bytes_per_token * self.num_layers_ca4
-            # Ring mode: C4 state is per-request too (see _fixed_c4_state_bytes).
-            + (
-                0.0
-                if self._unified
-                else self.swa_ratio
-                * c4_state_ratio
-                * c4_state_bytes
-                * self.num_layers_ca4
-            )
-            + c128_state_ratio * c128_state_bytes * self.num_layers_ca128
-            + (
-                0.0
-                if self._unified
-                else self.swa_ratio
-                * c4_state_ratio
-                * c4_indexer_state_bytes
-                * self.num_layers_ca4
-            )
+            c4_fraction * kv_bytes * self.num_layers_ca4,
+            1 / 128 * kv_bytes * self.num_layers_ca128,
+            1 / 4 * self.indexer_bytes_per_token * self.num_layers_ca4,
         )
+
+    def _paged_swa_costs(self, swa_tokens: float) -> tuple[float, float, float]:
+        """Price SWA KV, C4 attention state, and C4 indexer state separately.
+
+        For ratio sizing, swa_tokens is the SWA capacity per full token.
+        A fixed request reservation can be priced with its token count instead.
+        """
+        c4_state_dtype_size, _ = _get_dsv4_compress_state_dtype_sizes()
+        c4_state_bytes = 4 * self.attn_head_dim * c4_state_dtype_size
+        c4_indexer_state_bytes = 4 * self.indexer_head_dim * c4_state_dtype_size
+        c4_state_ratio = self.c4_ring_size / self.swa_page_size
+        return (
+            swa_tokens * self._kv_bytes_per_token() * self.num_layers_total,
+            swa_tokens * c4_state_ratio * c4_state_bytes * self.num_layers_ca4,
+            swa_tokens * c4_state_ratio * c4_indexer_state_bytes * self.num_layers_ca4,
+        )
+
+    def _get_bytes_per_full_token(self) -> float:
+        c4_kv, c128_kv, indexer = self._compressed_costs_per_full_token()
+        if self._unified:
+            # SWA and C4 state are request-owned; charged in the fixed budget.
+            swa_kv, c4_state, c4_indexer_state = 0.0, 0.0, 0.0
+        else:
+            swa_kv, c4_state, c4_indexer_state = self._paged_swa_costs(self.swa_ratio)
+        # Keep the accumulation order: rounding can change capacity by one page.
+        return swa_kv + c4_kv + c128_kv + indexer + c4_state + c4_indexer_state
 
     def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
+        # Ring mode retains this legacy nominal size until the allocator replaces
+        # it with size_swa. Physical ring capacity and cost are request-scoped.
         swa_tokens = int(full_token * self.swa_ratio) // page_size * page_size
         if not self._unified:
             # Ring mode: the paged SWA pool is vestigial, so its floor does not apply.
@@ -1313,8 +1334,20 @@ def create_memory_pool_configurator(
     if is_deepseek_v4(kvc.model_config.hf_config) and kvc.is_hybrid_swa:
         return DSV4PoolConfigurator(kvc)
     if kvc.is_hybrid_swa:
-        if SWAChunkCapPoolConfigurator.is_applicable(kvc):
-            return SWAChunkCapPoolConfigurator(kvc)
+        policy = _resolve_swa_sizing_policy(
+            request_supported=SWARequestPoolConfigurator.is_applicable(kvc),
+            ratio_supported=True,
+            layout="hybrid paged SWA",
+            request_requirements=(
+                "Paged request sizing requires full-attention layers, "
+                "--disable-radix-cache, positive --max-running-requests per worker, "
+                "and positive --chunked-prefill-size."
+            ),
+        )
+        if policy == "request":
+            return SWARequestPoolConfigurator(kvc)
         return HybridSWAPoolConfigurator(kvc)
+    if get_schedule().swa_sizing_policy == "request":
+        raise ValueError("--swa-sizing-policy=request requires a hybrid SWA pool.")
     # Future: MambaPoolConfigurator
     return DefaultPoolConfigurator(kvc)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -922,7 +922,7 @@ class SWARequestPoolConfigurator(HybridSWAPoolConfigurator):
                 available_bytes, page_size, fixed_swa_tokens=swa_tokens
             )
         else:
-            full_cell_size = self._full_pool_bytes_per_token()
+            full_cell_size = self._full_pool_bytes_per_token() + self._draft_cell_size
             full_tokens = (
                 int((available_bytes - fixed_swa_bytes) // full_cell_size) // page_size
             ) * page_size

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -978,6 +978,42 @@ class TestSWARequestSizing(CustomTestCase):
                 expected_full = (budget // 1024 - expected_swa) // 16 * 16
                 self.assertEqual(sizes.max_total_num_tokens, expected_full)
 
+    def test_request_headroom_covers_prefill_overlap_and_pd_transfer(self):
+        for fields, execution_headroom in (
+            ({}, 288),
+            ({"disable_overlap_schedule": True}, 224),
+            (
+                {
+                    "disaggregation_mode": "decode",
+                    "disaggregation_decode_extra_slots": 3,
+                },
+                576,
+            ),
+        ):
+            with self.subTest(fields=fields):
+                cfg = self._configurator(**fields)
+                budget = cfg._swa_request_budget
+                self.assertEqual(budget.working_set_tokens, 4 * 128)
+                self.assertEqual(budget.execution_headroom_tokens, execution_headroom)
+                self.assertEqual(budget.cache_headroom_tokens, 0)
+                sizes = cfg.calculate_pool_sizes(8 << 20, 16)
+                self.assertEqual(
+                    sizes.swa_max_total_num_tokens, 512 + execution_headroom
+                )
+
+    def test_budget_log_distinguishes_headroom_alignment_and_token_limit(self):
+        cfg = self._configurator(max_running_requests=3, sliding_window_size=127)
+        with self.assertLogs(
+            "sglang.srt.model_executor.pool_configurator", level="INFO"
+        ) as logs:
+            sizes = cfg.calculate_pool_sizes_from_max_tokens(512, 16)
+        self.assertEqual(sizes.swa_max_total_num_tokens, 512)
+        self.assertIn(
+            "working_set=381, execution_headroom=252, cache_headroom=0, "
+            "page_alignment=7, reservation=640, capacity=512",
+            logs.output[0],
+        )
+
     def test_request_rejects_unsupported_configurations(self):
         for fields in (
             {"max_running_requests": None},
@@ -1073,6 +1109,32 @@ class TestDSV4SizingPolicy(CustomTestCase):
             cfg.finalize_with_max_running_requests(config)
         self.assertEqual(first.c4_state_pool_size, second.c4_state_pool_size)
         self.assertEqual(first.c128_state_pool_size, second.c128_state_pool_size)
+
+    def test_ring_headroom_accounts_for_extra_slots_without_changing_bytes(self):
+        cfg = self._configurator(
+            unified=True,
+            swa_full_tokens_ratio=None,
+            disaggregation_mode="decode",
+            disaggregation_decode_extra_slots=3,
+        )
+        budget = cfg._swa_ring_request_budget(16)
+        self.assertEqual(budget.working_set_tokens, 16 * 128)
+        self.assertEqual(
+            budget.execution_headroom_tokens,
+            16 * (cfg._swa_ring_size - 128) + 4 * cfg._swa_ring_size,
+        )
+        self.assertEqual(budget.cache_headroom_tokens, 0)
+        self.assertEqual(
+            cfg._fixed_swa_bytes(16),
+            20 * cfg._swa_ring_size * 192 * 2 * 2,
+        )
+        with self.assertLogs(
+            "sglang.srt.model_executor.pool_configurator", level="INFO"
+        ) as logs:
+            cfg.calculate_pool_sizes(128 << 20, 128)
+        self.assertTrue(
+            any("layout=ring, working_set=2048" in line for line in logs.output)
+        )
 
     def test_paged_cost_matches_main_budget_equation(self):
         from sglang.srt.environ import envs

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -924,7 +924,7 @@ class TestFactory(CustomTestCase):
 
 
 class TestSWARequestSizing(CustomTestCase):
-    def _configurator(self, **overrides):
+    def _configurator(self, *, draft_cell_size=None, **overrides):
         fields = dict(
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
@@ -938,6 +938,9 @@ class TestSWARequestSizing(CustomTestCase):
         )
         fields.update(overrides)
         mr = _make_model_runner(self, **fields)
+        if draft_cell_size is not None:
+            mr.spec_algorithm.is_dflash_family.return_value = True
+            mr.spec_aux_config.dflash_draft_cell_size_per_token = draft_cell_size
         from sglang.srt.model_executor.pool_configurator import (
             create_memory_pool_configurator,
         )
@@ -988,6 +991,15 @@ class TestSWARequestSizing(CustomTestCase):
                 self.assertRaisesRegex(ValueError, "request is unavailable"),
             ):
                 self._configurator(swa_sizing_policy="request", **fields)
+
+    def test_request_reservation_accounts_for_dflash_draft(self):
+        cfg = self._configurator(draft_cell_size=256)
+        budget = 8 << 20
+        sizes = cfg.calculate_pool_sizes(budget, 16)
+        used = sizes.max_total_num_tokens * (1024 + 256)
+        used += sizes.swa_max_total_num_tokens * 1024
+        self.assertLessEqual(used, budget)
+        self.assertGreater(used + 16 * (1024 + 256), budget)
 
     def test_token_limit_cannot_increase_either_pool(self):
         cfg = self._configurator()

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -29,8 +29,8 @@ def mock_cpu_env(kv_size=2, tp_size=1, swa_eviction_interval=4):
     """Mock GPU-dependent functions for CPU-only testing.
 
     swa_eviction_interval pins SGLANG_SWA_EVICTION_INTERVAL (decode batches between
-    SWA evictions) to a small value so the chunk-cap formula stays hand-computable;
-    only SWAChunkCapPoolConfigurator reads it.
+    SWA evictions) to a small value so the request-budget formula stays hand-computable;
+    only SWARequestPoolConfigurator reads it.
     """
     from sglang.srt.environ import envs
 
@@ -49,10 +49,14 @@ def _publish_config(testcase, **fields):
     case cannot leave a partial publish for a later file in a monolithic run.
     """
     from sglang.srt.runtime_context import get_context
+    from sglang.srt.server_args import ServerArgs
 
-    override = get_context().override_server_args(**fields)
+    override = get_context().override_server_args()
     override.install()
     testcase.addCleanup(override.restore)
+    server_args = ServerArgs(model_path="dummy", **fields)
+    server_args.resolve_once()
+    get_context().set_server_args(server_args)
 
 
 def _make_model_runner(
@@ -70,6 +74,7 @@ def _make_model_runner(
     swa_head_dim=None,
     swa_v_head_dim=None,
     swa_full_tokens_ratio=0.5,
+    swa_sizing_policy="auto",
     page_size=1,
     mambaish_config=None,
     disable_radix_cache=False,
@@ -139,6 +144,7 @@ def _make_model_runner(
         testcase,
         max_total_tokens=None,
         swa_full_tokens_ratio=swa_full_tokens_ratio,
+        swa_sizing_policy=swa_sizing_policy,
         page_size=page_size,
         disable_radix_cache=disable_radix_cache,
         chunked_prefill_size=chunked_prefill_size,
@@ -439,7 +445,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             int(config.full_max_total_num_tokens * 0.5),
         )
 
-    def test_chunk_cache_cap_accounts_for_spec_topk_page_rounding(self):
+    def test_request_budget_accounts_for_spec_topk_page_rounding(self):
         available = 1_000_000
         mr = _make_model_runner(
             self,
@@ -447,7 +453,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
-            swa_full_tokens_ratio=0.5,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=4,
             sliding_window_size=8,
@@ -474,7 +480,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
         self.assertEqual(config.swa_max_total_num_tokens, 104)
         self.assertLessEqual(_actual_memory_used(mr, config), available)
 
-    def test_chunk_cache_cap_doubles_decode_alloc_for_spec_v2_overlap(self):
+    def test_request_budget_doubles_decode_alloc_for_spec_v2_overlap(self):
         # Overlap on -> spec-v2: decode_alloc = 2 * get_alloc_len_per_decode =
         # 2 * max(steps*topk, max_draft) = 2 * max(6, 5) = 12 (page=1, since the
         # v2 allocator does not support page>1 & topk>1). trailing = 8 + 20 +
@@ -487,7 +493,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
-            swa_full_tokens_ratio=0.5,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=4,
             sliding_window_size=8,
@@ -510,7 +516,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
         self.assertEqual(config.swa_max_total_num_tokens, 91)
         self.assertLessEqual(_actual_memory_used(mr, config), available)
 
-    def test_chunk_cache_cap_accounts_for_draft_swa_layers(self):
+    def test_request_budget_accounts_for_draft_swa_layers(self):
         """Draft SWA tensors consume the same fixed-capacity pool as target SWA."""
         available = 1_000_000
         mr = _make_model_runner(
@@ -519,6 +525,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=4,
             sliding_window_size=8,
@@ -544,7 +551,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
         self.assertLessEqual(used, available)
         self.assertGreater(used, available * 0.99)
 
-    def test_chunk_cache_cap_drops_prefill_for_disagg_decode(self):
+    def test_request_budget_drops_prefill_for_disagg_decode(self):
         available = 1_000_000
         mr = _make_model_runner(
             self,
@@ -552,7 +559,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
-            swa_full_tokens_ratio=0.5,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=1000,
             sliding_window_size=4,
@@ -572,7 +579,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
         self.assertEqual(config.swa_max_total_num_tokens, 100)
         self.assertLessEqual(_actual_memory_used(mr, config), available)
 
-    def test_chunk_cache_cap_prefill_holds_window_plus_chunk(self):
+    def test_request_budget_prefill_holds_window_plus_chunk(self):
         # Non-decode (prefill) engine: each request keeps its decode footprint, while
         # in-flight chunked-prefill tokens are a global batch budget -- two chunks
         # under overlap.
@@ -583,7 +590,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
-            swa_full_tokens_ratio=0.5,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=16,
             sliding_window_size=8,
@@ -606,7 +613,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
         self.assertEqual(config.swa_max_total_num_tokens, 76)
         self.assertLessEqual(_actual_memory_used(mr, config), available)
 
-    def test_chunk_cache_cap_disagg_decode_pre_alloc(self):
+    def test_request_budget_disagg_decode_pre_alloc(self):
         # decode adds disaggregation_decode_extra_slots in-transfer slots to the
         # request count (num_reserved_decode_tokens is a full-pool concern, not SWA).
         available = 2_000_000
@@ -616,7 +623,7 @@ class TestHybridSWAConfigurator(CustomTestCase):
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
             swa_num_kv_heads=4,
-            swa_full_tokens_ratio=0.5,
+            swa_full_tokens_ratio=None,
             disable_radix_cache=True,
             chunked_prefill_size=1000,
             sliding_window_size=4,
@@ -886,8 +893,8 @@ class TestFactory(CustomTestCase):
             cfg = create_memory_pool_configurator(mr)
         self.assertIsInstance(cfg, HybridSWAPoolConfigurator)
 
-    def test_chunk_cap_configurator_selection(self):
-        # SWAChunkCapPoolConfigurator is selected only when max_running_requests is set.
+    def test_request_configurator_selection(self):
+        # SWARequestPoolConfigurator is selected only when max_running_requests is set.
         def _cfg(max_running_requests):
             mr = _make_model_runner(
                 self,
@@ -899,6 +906,7 @@ class TestFactory(CustomTestCase):
                 chunked_prefill_size=4,
                 sliding_window_size=8,
                 max_running_requests=max_running_requests,
+                swa_full_tokens_ratio=None,
             )
             with mock_cpu_env():
                 from sglang.srt.model_executor.pool_configurator import (
@@ -908,11 +916,196 @@ class TestFactory(CustomTestCase):
                 return create_memory_pool_configurator(mr)
 
         from sglang.srt.model_executor.pool_configurator import (
-            SWAChunkCapPoolConfigurator,
+            SWARequestPoolConfigurator,
         )
 
-        self.assertIsInstance(_cfg(2), SWAChunkCapPoolConfigurator)
-        self.assertNotIsInstance(_cfg(None), SWAChunkCapPoolConfigurator)
+        self.assertIsInstance(_cfg(2), SWARequestPoolConfigurator)
+        self.assertNotIsInstance(_cfg(None), SWARequestPoolConfigurator)
+
+
+class TestSWARequestSizing(CustomTestCase):
+    def _configurator(self, **overrides):
+        fields = dict(
+            is_hybrid_swa=True,
+            full_attention_layer_ids=[0],
+            swa_attention_layer_ids=[1],
+            disable_radix_cache=True,
+            chunked_prefill_size=64,
+            sliding_window_size=128,
+            page_size=16,
+            max_running_requests=4,
+            swa_full_tokens_ratio=None,
+        )
+        fields.update(overrides)
+        mr = _make_model_runner(self, **fields)
+        from sglang.srt.model_executor.pool_configurator import (
+            create_memory_pool_configurator,
+        )
+
+        with mock_cpu_env():
+            return create_memory_pool_configurator(mr)
+
+    def test_explicit_ratio_overrides_automatic_request_selection(self):
+        from sglang.srt.model_executor.pool_configurator import (
+            HybridSWAPoolConfigurator,
+            SWARequestPoolConfigurator,
+        )
+
+        self.assertIsInstance(self._configurator(), SWARequestPoolConfigurator)
+        for fields in (
+            {"swa_full_tokens_ratio": 0.8},
+            {"swa_sizing_policy": "ratio"},
+        ):
+            with self.subTest(fields=fields):
+                cfg = self._configurator(**fields)
+                self.assertIs(type(cfg), HybridSWAPoolConfigurator)
+                sizes = cfg.calculate_pool_sizes_from_max_tokens(4096, 16)
+                self.assertEqual(sizes.swa_max_total_num_tokens, 3264)
+
+    def test_request_reservation_is_independent_of_available_memory(self):
+        cfg = self._configurator()
+        # 4 * (window + eviction lag + alignment + decode) + 2 chunks + padding.
+        expected_swa = 4 * (128 + 4 + 16 + 16) + 2 * 64 + 16
+        expected_swa = (expected_swa + 15) // 16 * 16
+        for budget in (8 << 20, 16 << 20):
+            with self.subTest(budget=budget):
+                sizes = cfg.calculate_pool_sizes(budget, 16)
+                self.assertEqual(sizes.swa_max_total_num_tokens, expected_swa)
+                # Each pool has one bf16 layer with 4 heads of 64+64 elements.
+                expected_full = (budget // 1024 - expected_swa) // 16 * 16
+                self.assertEqual(sizes.max_total_num_tokens, expected_full)
+
+    def test_request_rejects_unsupported_configurations(self):
+        for fields in (
+            {"max_running_requests": None},
+            {"max_running_requests": 0},
+            {"disable_radix_cache": False},
+            {"chunked_prefill_size": -1},
+            {"full_attention_layer_ids": []},
+        ):
+            with (
+                self.subTest(fields=fields),
+                self.assertRaisesRegex(ValueError, "request is unavailable"),
+            ):
+                self._configurator(swa_sizing_policy="request", **fields)
+
+    def test_token_limit_cannot_increase_either_pool(self):
+        cfg = self._configurator()
+        original = cfg.calculate_pool_sizes(8 << 20, 16)
+        for limit in (4096, 256, 128):
+            with self.subTest(limit=limit):
+                limited = cfg.calculate_pool_sizes_from_max_tokens(limit, 16)
+                self.assertLessEqual(
+                    limited.full_max_total_num_tokens,
+                    original.full_max_total_num_tokens,
+                )
+                self.assertLessEqual(
+                    limited.swa_max_total_num_tokens,
+                    original.swa_max_total_num_tokens,
+                )
+
+
+class TestDSV4SizingPolicy(CustomTestCase):
+    def _configurator(self, *, unified=False, **fields):
+        from sglang.srt.environ import envs
+        from sglang.srt.model_executor.pool_configurator import (
+            create_memory_pool_configurator,
+        )
+
+        mr = _make_model_runner(
+            self,
+            num_layers=2,
+            is_hybrid_swa=True,
+            sliding_window_size=128,
+            max_running_requests=16,
+            **fields,
+        )
+        mc = mr.model_config
+        mc.hf_config.architectures = ["DeepseekV4ForCausalLM"]
+        mc.compress_ratios = [4, 128]
+        mc.qk_nope_head_dim = 128
+        mc.qk_rope_head_dim = 64
+        mc.index_head_dim = 128
+        mc.window_size = 128
+        with (
+            mock_cpu_env(),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate.is_unified_kv_triton",
+                return_value=unified,
+            ),
+            envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(False),
+        ):
+            return create_memory_pool_configurator(mr)
+
+    def test_layout_dispatch_and_explicit_ratio_validation(self):
+        cfg = self._configurator(unified=True, swa_full_tokens_ratio=None)
+        self.assertEqual(cfg.swa_sizing_policy, "request")
+        cfg = self._configurator(unified=False, swa_full_tokens_ratio=None)
+        self.assertEqual(cfg.swa_sizing_policy, "ratio")
+        with self.assertRaisesRegex(ValueError, "Ratio sizing is unavailable"):
+            self._configurator(unified=True, swa_full_tokens_ratio=0.1)
+        with self.assertRaisesRegex(ValueError, "request is unavailable"):
+            self._configurator(
+                unified=False, swa_full_tokens_ratio=None, swa_sizing_policy="request"
+            )
+
+    def test_ring_budget_does_not_depend_on_model_default_ratio(self):
+        cfg = self._configurator(unified=True, swa_full_tokens_ratio=None)
+        first = cfg.calculate_pool_sizes(128 << 20, 128)
+        cfg.swa_ratio = 0.1
+        cfg.bytes_per_full_token = cfg._get_bytes_per_full_token()
+        second = cfg.calculate_pool_sizes(128 << 20, 128)
+        self.assertEqual(first.max_total_num_tokens, second.max_total_num_tokens)
+        for config in (first, second):
+            config.max_running_requests = 16
+            cfg.finalize_with_max_running_requests(config)
+        self.assertEqual(first.c4_state_pool_size, second.c4_state_pool_size)
+        self.assertEqual(first.c128_state_pool_size, second.c128_state_pool_size)
+
+    def test_paged_cost_matches_main_budget_equation(self):
+        from sglang.srt.environ import envs
+
+        for dtype, itemsize in (("float32", 4), ("bfloat16", 2)):
+            for ratio in (0.1, 0.5, 0.8, 1.0):
+                with (
+                    self.subTest(dtype=dtype, ratio=ratio),
+                    envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.override(dtype),
+                    envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(False),
+                ):
+                    cfg = self._configurator(swa_full_tokens_ratio=ratio)
+                    # Main's original per-full-token equation, with one C4
+                    # and one C128 layer, and FP8 KV with bf16 RoPE.
+                    kv_bytes = 128 + 64 * 2 + 8
+                    legacy = ratio * kv_bytes * 2
+                    legacy += kv_bytes / 4 + kv_bytes / 128
+                    legacy += cfg.indexer_bytes_per_token / 4
+                    legacy += ratio * cfg.c4_ring_size / 128 * 4 * 192 * itemsize
+                    legacy += ratio * cfg.c4_ring_size / 128 * 4 * 128 * itemsize
+                    self.assertAlmostEqual(cfg.bytes_per_full_token, legacy)
+                    budget = 128 << 20
+                    fixed = cfg._get_c128_state_fixed_bytes(16)
+                    expected = int((budget - fixed) / legacy) // 128 * 128
+                    actual = cfg.calculate_pool_sizes(budget, 128)
+                    self.assertEqual(actual.max_total_num_tokens, expected)
+
+    def test_ratio_rounding_preserves_capacity_at_a_page_boundary(self):
+        from sglang.srt.environ import envs
+
+        with (
+            envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.override("float32"),
+            envs.SGLANG_OPT_USE_ONLINE_COMPRESS.override(False),
+        ):
+            cfg = self._configurator(swa_full_tokens_ratio=0.1)
+            cfg.qk_nope_head_dim = 512
+            cfg.attn_head_dim = 576
+            cfg.c4_ring_size = 8
+            cfg.indexer_bytes_per_token = 132
+            cfg.bytes_per_full_token = cfg._get_bytes_per_full_token()
+            # Main's left-to-right sum is just above 400.0625 bytes/token.
+            # Re-associating that sum would grow this capacity by one page.
+            budget = 512080000 + cfg._get_c128_state_fixed_bytes(16)
+            config = cfg.calculate_pool_sizes(budget, 128)
+            self.assertEqual(config.max_total_num_tokens, 1279872)
 
 
 class TestDflashDraftKvBudget(CustomTestCase):

--- a/test/registered/unit/server_args/test_declared_fallbacks.py
+++ b/test/registered/unit/server_args/test_declared_fallbacks.py
@@ -28,6 +28,7 @@ would make `if cfg.swa_full_tokens_ratio is None` in `model_overrides/inkling.py
 never fire, and the family's 0.1 would be silently replaced by the generic 0.8.
 """
 
+import argparse
 import unittest
 
 from sglang.srt.arg_groups.overrides import (
@@ -108,6 +109,62 @@ class TestAPassDecidingStillSeesUnset(CustomTestCase):
         if cfg.swa_full_tokens_ratio is None:  # the family's exact shape
             declared["swa_full_tokens_ratio"] = 0.1
         self.assertEqual(declared, {"swa_full_tokens_ratio": 0.1})
+
+
+class TestSWASizingPolicy(CustomTestCase):
+    def test_cli_preserves_auto_and_explicit_ratio_intent(self):
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        for flags, expected in (
+            ([], "auto"),
+            (["--swa-sizing-policy", "request"], "request"),
+            (["--swa-sizing-policy", "ratio"], "ratio"),
+            (["--swa-full-tokens-ratio", "0.8"], "ratio"),
+        ):
+            with self.subTest(flags=flags):
+                parsed = parser.parse_args(["--model-path", "dummy", *flags])
+                server_args = ServerArgs.from_cli_args(parsed)
+                server_args.resolve_once()
+                self.assertEqual(
+                    resolution_result(server_args, "swa_sizing_policy"), expected
+                )
+
+    def test_model_ratio_default_does_not_select_ratio_policy(self):
+        server_args = _resolved()
+        declare_resolution(server_args, "a_model_family", swa_full_tokens_ratio=0.1)
+        self.assertEqual(resolution_result(server_args, "swa_sizing_policy"), "auto")
+        self.assertEqual(resolution_result(server_args, "swa_full_tokens_ratio"), 0.1)
+
+    def test_explicit_ratio_selects_ratio_even_when_equal_to_a_default(self):
+        for ratio in (0.1, 0.8, 0.5):
+            with self.subTest(ratio=ratio):
+                server_args = _resolved(swa_full_tokens_ratio=ratio)
+                self.assertEqual(server_args.swa_sizing_policy, "auto")
+                self.assertEqual(
+                    resolution_result(server_args, "swa_sizing_policy"), "ratio"
+                )
+
+    def test_explicit_policy_uses_default_ratio_without_losing_intent(self):
+        for policy in ("ratio", "request"):
+            with self.subTest(policy=policy):
+                server_args = _resolved(swa_sizing_policy=policy)
+                self.assertEqual(
+                    resolution_result(server_args, "swa_sizing_policy"), policy
+                )
+                self.assertIsNone(server_args.swa_full_tokens_ratio)
+
+    def test_conflicting_or_invalid_inputs_fail_before_dummy_short_circuit(self):
+        cases = (
+            {"swa_sizing_policy": "request", "swa_full_tokens_ratio": 0.8},
+            {"swa_sizing_policy": "cap"},
+            {"swa_full_tokens_ratio": 0},
+            {"swa_full_tokens_ratio": -0.1},
+            {"swa_full_tokens_ratio": 1.1},
+            {"swa_full_tokens_ratio": float("nan")},
+        )
+        for fields in cases:
+            with self.subTest(fields=fields), self.assertRaises(ValueError):
+                _resolved(**fields)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

- An explicit `--swa-full-tokens-ratio` could be silently bypassed when concurrency enabled request-based sizing. Make policy selection explicit before applying capacity and cost formulas.
- Prepare the existing SWA accounting for the additional sizing policies in #38798 without introducing its prefix-tail or encoder-replay features.

## Modifications

- Add `--swa-sizing-policy=auto|ratio|request`. In `auto`, an explicit ratio selects `ratio`; otherwise retain capability-based request sizing with a ratio fallback. Detect explicit input from pristine `ServerArgs`, independently of model defaults.
- Reject `request` combined with an explicit ratio, unsupported request configurations, and ratio sizing for DSV4 request-owned rings; log the selected policy and layout.
- Rename `SWAChunkCapPoolConfigurator` to `SWARequestPoolConfigurator` and separate full-token, paged-SWA, and request-scoped costs. Preserve existing ratio arithmetic order, including page-boundary rounding, and DSV4 ring/C4/C128 accounting.
- Break paged and ring request budgets into working set, execution headroom, and cache headroom (currently zero). Log each component, final page-alignment padding, reservation, and token-limited capacity without changing existing capacities.
- In a separate commit, include the previously omitted DFlash draft KV cost in request-based sizing.
- Update CLI documentation and add dispatch, budget, input-preservation, and rounding regression coverage.

## Accuracy Tests

- Re-ran all 53 pool-configuration tests for the headroom decomposition; compared 1,536 paged request budgets and 96 ring fixed-cost cases against the previous PR head with identical results.
- Passed 312 CPU unit tests across pool configuration, server arguments, declared fallbacks, runtime config bags, and pristine-input preservation.
- Compared 2,880 DSV4 capacity cases and 432 hybrid-SWA cost cases against main at `ad5af539cd`: no differences in the refactored arithmetic.
- Passed pre-commit, documentation build validation, and broken-link checks.
- GPU model accuracy tests were not run.

## Speed Tests and Profiling

- No inference benchmarks were run; changes affect startup policy selection and memory-pool sizing.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Update documentation.
- [ ] Provide GPU accuracy and speed benchmark results.
- [x] Follow SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34651776582](https://github.com/sgl-project/sglang/actions/runs/34651776582)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34651776361](https://github.com/sgl-project/sglang/actions/runs/34651776361)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34651776528](https://github.com/sgl-project/sglang/actions/runs/34651776528)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->