### PR TITLE
[AMD] Support compressed-tensors W4A16 linear layers on ROCm

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/README.md
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/README.md
@@ -4,3 +4,13 @@ To support compressed_tensors format quantization models, we adapted https://git
 
 
 For practical purposes, we have only applied the compressed_tensors format of `w8a8_fp8`. If you have requirements for other formats, you can submit an issue through this [link](https://github.com/sgl-project/sglang/issues).
+
+## ROCm W4A16 linear layers
+
+Symmetric 4-bit group/channel checkpoints can use the optional ROCm vLLM GPTQ
+operators (`gptq_gemm` with `use_v2_format`, and `gptq_shuffle`, as in vLLM 0.16).
+Supported group sizes are 32, 64, 128, or channelwise; activation ordering is
+unsupported, and each local weight partition must have K and N divisible by 128.
+The kernel uses FP16 arithmetic. BF16 activations and scales are converted to
+FP16, so models must stay within FP16's numerical range. Checkpoint scales that
+overflow FP16 are rejected during loading. CUDA continues to use Marlin.

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -39,9 +39,10 @@ from sglang.srt.layers.quantization.utils import (
     replace_parameter,
     unpack_cols,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_hip
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 
 if _is_cuda:
     from sglang.kernels.ops.quantization.gptq_marlin_repack import gptq_marlin_repack
@@ -69,6 +70,18 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
                  group_size: Optional[int] = None,
                  symmetric: Optional[bool] = True,
                  actorder: Optional[ActivationOrdering] = None):
+
+        if _is_hip and (
+            num_bits != 4
+            or not symmetric
+            or actorder is not None
+            or strategy not in ("group", "channel")
+            or group_size not in (None, -1, 32, 64, 128)
+        ):
+            raise NotImplementedError(
+                "ROCm WNA16 requires symmetric 4-bit group/channel quantization "
+                "without activation ordering (group_size: -1, 32, 64, 128)."
+            )
 
         self.pack_factor = 32 // num_bits
         self.strategy = strategy
@@ -115,6 +128,14 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
             zero_points=not self.symmetric,
             has_g_idx=self.has_g_idx
         )
+
+        if _is_hip:
+            if params_dtype not in (torch.float16, torch.bfloat16):
+                raise NotImplementedError("ROCm WNA16 requires float16 or bfloat16.")
+            if input_size_per_partition % 128 or output_size_per_partition % 128:
+                raise NotImplementedError(
+                    "ROCm WNA16 requires partition dimensions divisible by 128."
+                )
 
         # If group_size is -1, we are in channelwise case.
         group_size = self.group_size if self.group_size != -1 else input_size
@@ -205,9 +226,60 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
                                             weight_loader=weight_loader)
             layer.register_parameter("weight_g_idx", weight_g_idx)
 
+    def _process_weights_rocm(self, layer: torch.nn.Module) -> None:
+        # These optional ops are supplied by ROCm vLLM builds. Do not import
+        # vLLM at module scope: CUDA and other quantization schemes do not need it.
+        try:
+            from vllm._custom_ops import gptq_gemm, gptq_shuffle
+        except ImportError as exc:
+            raise ImportError(
+                "ROCm compressed-tensors W4A16 requires a ROCm vLLM build "
+                "providing gptq_gemm and gptq_shuffle."
+            ) from exc
+
+        self._rocm_gptq_gemm = gptq_gemm
+        k, n = self.kernel_config.partition_weight_shape
+        group_size = k if self.group_size == -1 else self.group_size
+        if k % group_size:
+            raise ValueError("ROCm WNA16 input partition must contain whole groups.")
+
+        # The checkpoint packs unsigned (signed + 8) nibbles along K, in
+        # [N, K/8] order. GPTQ wants [K/8, N]; scales follow the same transpose.
+        # Use the checkpoint layout, not a shape heuristic (square shapes
+        # cannot distinguish the two orientations).
+        if tuple(layer.weight_packed.shape) != (n, k // 8):
+            raise ValueError("Unexpected compressed-tensors packed weight shape.")
+        if tuple(layer.weight_scale.shape) != (n, k // group_size):
+            raise ValueError("Unexpected compressed-tensors scale shape.")
+        qweight = layer.weight_packed.t().contiguous()
+        scales = layer.weight_scale.t().contiguous().to(torch.float16)
+        if not torch.isfinite(scales).all():
+            raise ValueError("ROCm WNA16 scales must be finite in float16.")
+
+        # GPTQ v1 stores zero - 1: symmetric CT's zero=8 becomes eight 7s
+        # per int32. No unpack/repack or full dequantization is necessary.
+        qzeros = torch.full(
+            (k // group_size, n // 8),
+            0x77777777,
+            dtype=torch.int32,
+            device=qweight.device,
+        )
+        g_idx = torch.empty(0, dtype=torch.int32, device=qweight.device)
+        gptq_shuffle(qweight, g_idx, 4)
+
+        # Replace the checkpoint parameters rather than retaining duplicate
+        # packed weights/scales alongside the serving representation.
+        replace_parameter(layer, "weight_packed", qweight)
+        replace_parameter(layer, "weight_scale", scales)
+        layer.register_buffer("rocm_qzeros", qzeros)
+        layer.register_buffer("rocm_g_idx", g_idx)
+
     # Checkpoints are serialized in compressed-tensors format, which is
     # different from the format the kernel may want. Handle repacking here.
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if _is_hip:
+            self._process_weights_rocm(layer)
+            return
         # Default names since marlin requires empty parameters for these,
         # TODO: remove this requirement from marlin (allow optional tensors)
         self.w_q_name = "weight_packed"
@@ -303,6 +375,31 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
 
     def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
                       bias: Optional[torch.Tensor]) -> torch.Tensor:
+        if _is_hip:
+            if x.dtype not in (torch.float16, torch.bfloat16):
+                raise TypeError("ROCm WNA16 requires float16 or bfloat16 input.")
+            if x.shape[-1] != self.kernel_config.partition_weight_shape[0]:
+                raise ValueError("ROCm WNA16 input does not match the weight partition.")
+            output_shape = (
+                *x.shape[:-1], self.kernel_config.partition_weight_shape[1]
+            )
+            if x.numel() == 0:
+                return x.new_empty(output_shape)
+            # ExLlama's ROCm GPTQ kernel requires FP16 activations/scales.
+            # BF16 inputs therefore use FP16 arithmetic and must fit its range.
+            out = self._rocm_gptq_gemm(
+                x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous(),
+                layer.weight_packed,
+                layer.rocm_qzeros,
+                layer.weight_scale,
+                layer.rocm_g_idx,
+                True,  # use_exllama
+                False,  # use_v2_format (GPTQ v1 zero points)
+                4,
+            )
+            out = out.to(x.dtype).reshape(output_shape)
+            return out if bias is None else out + bias
+
         c = self.kernel_config
 
         def _get_weight_params(

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_wna16_rocm.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_wna16_rocm.py
@@ -1,0 +1,239 @@
+"""ROCm W4A16 format/dispatch regressions; no GPU or vLLM installation needed."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+import torch
+from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
+from compressed_tensors.quantization import ActivationOrdering
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_wNa16 as wna16,
+)
+
+
+def make_layer(
+    k=256, n=128, group_size=128, dtype=torch.float16, full_k=None, full_n=None
+):
+    scheme = wna16.CompressedTensorsWNA16(
+        strategy="channel" if group_size == -1 else "group",
+        num_bits=4,
+        group_size=group_size,
+    )
+    layer = torch.nn.Module()
+    scheme.create_weights(
+        layer,
+        output_size=full_n or n,
+        input_size=full_k or k,
+        output_partition_sizes=[n],
+        input_size_per_partition=k,
+        params_dtype=dtype,
+        weight_loader=lambda *args, **kwargs: None,
+    )
+    # Deterministic signed values exercise every nibble, including -8 and +7.
+    signed = (
+        (torch.arange(n * k).reshape(n, k) * 7 + torch.arange(n).unsqueeze(1)) % 16 - 8
+    ).to(torch.int8)
+    groups = 1 if group_size == -1 else k // group_size
+    scales = (torch.arange(n * groups).reshape(n, groups) % 17 + 1).to(dtype) / 128
+    layer.weight_packed.data.copy_(pack_to_int32(signed, 4))
+    layer.weight_scale.data.copy_(scales)
+    group_size = k if group_size == -1 else group_size
+    reference = signed.float() * scales.float().repeat_interleave(group_size, dim=1)
+    return scheme, layer, reference
+
+
+class TestRocmWNA16(unittest.TestCase):
+    def setUp(self):
+        self.platform = patch.object(wna16, "_is_hip", True)
+        self.platform.start()
+        self.addCleanup(self.platform.stop)
+        self.ops = types.ModuleType("vllm._custom_ops")
+        self.ops.gptq_shuffle = Mock()
+        self.ops.gptq_gemm = Mock(side_effect=self.reference_gemm)
+        modules = patch.dict(
+            sys.modules,
+            {
+                "vllm": types.ModuleType("vllm"),
+                "vllm._custom_ops": self.ops,
+            },
+        )
+        modules.start()
+        self.addCleanup(modules.stop)
+
+    @staticmethod
+    def reference_gemm(x, qw, qz, scales, g_idx, exllama, v2, bits):
+        # Independent GPTQ v1 decoder. Real packed CT data must survive the
+        # layout and zero-point conversion before a kernel sees it.
+        assert exllama and not v2 and bits == 4
+        assert x.dtype == scales.dtype == torch.float16
+        assert x.is_contiguous() and qw.is_contiguous() and scales.is_contiguous()
+        shifts = torch.arange(8, dtype=torch.int32) * 4
+        q = ((qw[:, None, :] >> shifts[None, :, None]) & 15).reshape(-1, qw.shape[1])
+        zeros = ((qz[:, :, None] >> shifts) & 15).reshape(qz.shape[0], -1) + 1
+        group_size = q.shape[0] // scales.shape[0]
+        weight = (
+            q.float() - zeros.repeat_interleave(group_size, 0)
+        ) * scales.repeat_interleave(group_size, 0)
+        return (x.float() @ weight).half()
+
+    def test_conversion_and_output(self):
+        for k, n, group in [
+            (256, 128, 32),
+            (256, 128, 64),
+            (256, 128, 128),
+            (256, 128, -1),
+            (1024, 128, 128),
+        ]:
+            for dtype in (torch.float16, torch.bfloat16):
+                with self.subTest(k=k, n=n, group=group, dtype=dtype):
+                    scheme, layer, weight = make_layer(k, n, group, dtype)
+                    scheme.process_weights_after_loading(layer)
+                    x = (torch.arange(2 * 3 * k).reshape(2, 3, k) % 19).to(dtype) / 32
+                    bias = torch.linspace(-0.1, 0.1, n).to(dtype)
+                    got = scheme.apply_weights(layer, x, bias)
+                    expected = (x.half().float() @ weight.t()).half().to(dtype) + bias
+                    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+                    self.assertEqual(layer.weight_packed.shape, (k // 8, n))
+                    self.assertIs(type(layer.weight_packed), torch.nn.Parameter)
+                    self.assertFalse(layer.weight_packed.requires_grad)
+                    self.assertFalse(hasattr(layer, "rocm_qweight"))
+                    self.assertEqual(got.dtype, dtype)
+                    self.assertEqual(got.shape, (2, 3, n))
+
+    def test_partitioned_weights(self):
+        for full_k, full_n, group in [(512, 128, 128), (256, 256, 128), (512, 128, -1)]:
+            with self.subTest(full_k=full_k, full_n=full_n, group=group):
+                scheme, layer, weight = make_layer(
+                    group_size=group, full_k=full_k, full_n=full_n
+                )
+                scheme.process_weights_after_loading(layer)
+                x = torch.ones(2, 256, dtype=torch.float16)
+                torch.testing.assert_close(
+                    scheme.apply_weights(layer, x, None),
+                    (x.float() @ weight.t()).half(),
+                )
+
+    def test_noncontiguous_and_empty_input(self):
+        scheme, layer, weight = make_layer()
+        scheme.process_weights_after_loading(layer)
+        x = torch.ones(256, 3, dtype=torch.float16).t()
+        torch.testing.assert_close(
+            scheme.apply_weights(layer, x, None), (x.float() @ weight.t()).half()
+        )
+        self.ops.gptq_gemm.reset_mock()
+        got = scheme.apply_weights(
+            layer, torch.empty(2, 0, 256, dtype=torch.float16), None
+        )
+        self.assertEqual(got.shape, (2, 0, 128))
+        self.ops.gptq_gemm.assert_not_called()
+
+    def test_reject_unsupported_formats(self):
+        for kwargs in [
+            {"num_bits": 8},
+            {"symmetric": False},
+            {"actorder": ActivationOrdering.GROUP},
+            {"group_size": 16},
+        ]:
+            args = dict(strategy="group", num_bits=4, group_size=128)
+            args.update(kwargs)
+            with self.subTest(kwargs=kwargs), self.assertRaises(NotImplementedError):
+                wna16.CompressedTensorsWNA16(**args)
+        self.ops.gptq_shuffle.assert_not_called()
+
+    def test_reject_invalid_shapes_and_dtypes(self):
+        for kwargs in [{"k": 192}, {"n": 136}, {"dtype": torch.float32}]:
+            with self.subTest(kwargs=kwargs), self.assertRaises(NotImplementedError):
+                make_layer(**kwargs)
+        scheme, layer, _ = make_layer()
+        layer.weight_scale.data = torch.ones(128, 3, dtype=torch.float16)
+        with self.assertRaisesRegex(ValueError, "scale shape"):
+            scheme.process_weights_after_loading(layer)
+        self.ops.gptq_shuffle.assert_not_called()
+
+    def test_reject_overflowing_scales(self):
+        scheme, layer, _ = make_layer(dtype=torch.bfloat16)
+        layer.weight_scale.data.fill_(1e10)
+        with self.assertRaisesRegex(ValueError, "finite in float16"):
+            scheme.process_weights_after_loading(layer)
+        self.ops.gptq_shuffle.assert_not_called()
+
+    def test_missing_optional_dependency(self):
+        scheme, layer, _ = make_layer()
+        with patch.dict(sys.modules, {"vllm._custom_ops": None}):
+            with self.assertRaisesRegex(ImportError, "ROCm vLLM build"):
+                scheme.process_weights_after_loading(layer)
+
+    def test_other_platform_does_not_use_rocm(self):
+        with patch.object(wna16, "_is_hip", False):
+            scheme = wna16.CompressedTensorsWNA16("group", 8, 128)
+            with patch.object(scheme, "_process_weights_rocm") as rocm:
+                # The original Marlin path still owns this call.
+                with self.assertRaises(AttributeError):
+                    scheme.process_weights_after_loading(torch.nn.Module())
+                rocm.assert_not_called()
+
+
+@unittest.skipUnless(torch.version.hip and torch.cuda.is_available(), "requires ROCm")
+class TestRocmWNA16GPU(unittest.TestCase):
+    """Also runnable on a ROCm host with vLLM GPTQ ops for numerical validation."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from vllm._custom_ops import gptq_gemm, gptq_shuffle  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("requires ROCm vLLM GPTQ ops")
+
+    def test_kernel_against_dequantized_reference(self):
+        for k, n, group in [
+            (256, 128, 32),
+            (256, 128, 64),
+            (256, 128, 128),
+            (256, 128, -1),
+            (1024, 128, 128),
+            (2048, 256, 128),
+        ]:
+            for dtype in (torch.float16, torch.bfloat16):
+                for batch in (1, 8, 64):
+                    with self.subTest(k=k, n=n, group=group, dtype=dtype, batch=batch):
+                        scheme, layer, weight = make_layer(k, n, group, dtype)
+                        layer = layer.to("cuda")
+                        scheme.process_weights_after_loading(layer)
+                        torch.manual_seed(42)
+                        x = (torch.randn(batch, k, device="cuda") * 0.125).to(dtype)
+                        bias = torch.linspace(-0.1, 0.1, n, device="cuda").to(dtype)
+                        got = scheme.apply_weights(layer, x, bias)
+                        ref = (x.half().float() @ weight.to("cuda").t()).half().to(
+                            dtype
+                        ) + bias
+                        # ExLlama accumulates in FP16; compare against independent
+                        # FP32 dequantization/matmul, not another GPTQ execution.
+                        torch.testing.assert_close(got, ref, atol=0.04, rtol=0.02)
+                        self.assertTrue(torch.isfinite(got).all())
+
+    def test_cuda_graph_replay(self):
+        scheme, layer, _ = make_layer()
+        layer = layer.to("cuda")
+        scheme.process_weights_after_loading(layer)
+        x = torch.ones(1, 256, device="cuda", dtype=torch.float16)
+        for _ in range(3):
+            expected = scheme.apply_weights(layer, x, None)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            got = scheme.apply_weights(layer, x, None)
+        x.mul_(0.5)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(got, expected * 0.5, rtol=0.001, atol=0.001)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Enable symmetric compressed-tensors W4A16 linear layers on ROCm using optional vLLM GPTQ operators, with format/shape guards and FP16 arithmetic.

Ported from patch 7 in my [strix-halo-sglang](https://github.com/JeremiahM37/strix-halo-sglang) repo.

Validation: 10 tests passed, including 36 gfx1151 numerical cases and CUDA-graph replay; pre-commit passed. GPU checks used isolated vLLM 0.16 kernels with ROCm compatibility adjustments. Full-server integration has not been rerun.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34652735364](https://github.com/sgl-project/sglang/actions/runs/34652735364)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34652735213](https://github.com/sgl-project/sglang/actions/runs/34652735213)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34652735457](https://github.com/sgl-project/sglang/actions/runs/34652735457)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->