### PR TITLE
[DeepSeek-V4.1] Commit the engram decode history inside the hash kernel

### DIFF
--- a/python/sglang/kernels/ops/embeddings/__init__.py
+++ b/python/sglang/kernels/ops/embeddings/__init__.py
@@ -30,4 +30,12 @@ register_kernel(
     )
 )
 
+register_kernel(
+    KernelSpec(
+        op="embeddings.engram_hash_ids_and_commit",
+        backend=KernelBackend.TRITON,
+        target="sglang.kernels.ops.embeddings.engram_hash:engram_hash_ids_and_commit",
+    )
+)
+
 __all__ = []

--- a/python/sglang/kernels/ops/embeddings/engram_hash.py
+++ b/python/sglang/kernels/ops/embeddings/engram_hash.py
@@ -106,6 +106,7 @@ def _engram_hash_kernel(
     HIST_VIA_SLOTS: tl.constexpr,
     HAS_IMAGE: tl.constexpr,
     COMMIT: tl.constexpr,
+    WRITE_TOKENS: tl.constexpr,
     N: tl.constexpr,
     L: tl.constexpr,
     H: tl.constexpr,
@@ -154,7 +155,8 @@ def _engram_hash_kernel(
         blk = blk | (tok == image_token_id)
     # Once a shift is blocked every older shift is too (cummax along s).
     blocked = tl.cumsum(blk.to(tl.int32), axis=1) > 0
-    tl.store(tokens_out_ptr + t2 * N + s, tok.to(tl.int32), mask=tmask2)
+    if WRITE_TOKENS:
+        tl.store(tokens_out_ptr + t2 * N + s, tok.to(tl.int32), mask=tmask2)
     if COMMIT:
         # Decode: the token and its n - 2 newest predecessors become the request's
         # history, oldest first. Graph-padded rows (out_cache_loc 0) write nothing.
@@ -184,6 +186,85 @@ def _engram_hash_kernel(
             )
 
 
+def _launch_hash_kernel(
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    mode: int,
+    history: torch.Tensor,
+    token_map: torch.Tensor,
+    multipliers: torch.Tensor,
+    primes: torch.Tensor,
+    offsets: torch.Tensor,
+    pad_id: int,
+    num_real: Optional[int],
+    req_slots: Optional[torch.Tensor],
+    block: int,
+    row: Optional[torch.Tensor],
+    starts: Optional[torch.Tensor],
+    image_token_id: Optional[int],
+    mm_pad_shift: int,
+    out_cache_loc: Optional[torch.Tensor],
+    write_tokens: bool,
+    block_t: int,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    num_tokens = input_ids.shape[0]
+    L, N = multipliers.shape
+    H = primes.shape[-1]
+    assert N & (N - 1) == 0 and H & (H - 1) == 0, (N, H)
+    assert primes.shape == (L, N - 1, H) and offsets.shape == (L, (N - 1) * H)
+    assert history.dim() == 2 and history.shape[1] == N - 1, history.shape
+    if mode == MODE_EXTEND:
+        assert row is not None and starts is not None
+    if out_cache_loc is not None:
+        assert mode == MODE_DECODE and req_slots is not None, "commit is decode-only"
+        assert out_cache_loc.shape[0] == num_tokens, out_cache_loc.shape
+    if num_real is None:
+        num_real = num_tokens
+    device = input_ids.device
+    out = torch.empty(num_tokens, L, (N - 1) * H, dtype=torch.int64, device=device)
+    tokens = (
+        torch.empty(num_tokens, N, dtype=torch.int32, device=device)
+        if write_tokens
+        else None
+    )
+    if num_tokens == 0:
+        return out, tokens
+    dummy = out  # unused pointer slots; never dereferenced under their constexprs
+    _engram_hash_kernel[(triton.cdiv(num_tokens, block_t),)](
+        input_ids,
+        positions,
+        row if row is not None else dummy,
+        starts if starts is not None else dummy,
+        req_slots if req_slots is not None else dummy,
+        history,
+        token_map,
+        multipliers,
+        primes,
+        offsets,
+        out_cache_loc if out_cache_loc is not None else dummy,
+        tokens if tokens is not None else dummy,
+        out,
+        num_tokens,
+        num_real,
+        pad_id,
+        image_token_id if image_token_id is not None else -1,
+        mm_pad_shift,
+        MODE=mode,
+        BLOCK=block,
+        HIST_VIA_SLOTS=req_slots is not None,
+        HAS_IMAGE=image_token_id is not None,
+        COMMIT=out_cache_loc is not None,
+        WRITE_TOKENS=write_tokens,
+        N=N,
+        L=L,
+        H=H,
+        BLOCK_T=block_t,
+        num_warps=4,
+    )
+    return out, tokens
+
+
 def engram_hash_ids(
     input_ids: torch.Tensor,
     positions: torch.Tensor,
@@ -202,66 +283,81 @@ def engram_hash_ids(
     starts: Optional[torch.Tensor] = None,
     image_token_id: Optional[int] = None,
     mm_pad_shift: int = 0,
-    commit_out_loc: Optional[torch.Tensor] = None,
     block_t: int = 32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Hash ids [T, L, (n - 1) * heads] int64 and the predecessor table [T, n] int32.
+    Reads ``history`` and never writes it.
 
     ``mode``: MODE_DECODE (row = t, offset 0), MODE_VERIFY (row = t // block),
     MODE_EXTEND (``row`` [num_real] and ``starts`` [bs] give each token's request and
     the run's first token). ``history`` is [rows, n - 1] oldest first; with
     ``req_slots`` given it is indexed by ``req_slots[row]``, else by ``row``.
     Tokens at or past ``num_real`` are padding: PAD ids, zero predecessors.
-    ``commit_out_loc`` (decode via ``req_slots`` only) makes the kernel also write each
-    live request's new history row; rows whose out_cache_loc is 0 are padding.
     """
-    num_tokens = input_ids.shape[0]
-    L, N = multipliers.shape
-    H = primes.shape[-1]
-    assert N & (N - 1) == 0 and H & (H - 1) == 0, (N, H)
-    assert primes.shape == (L, N - 1, H) and offsets.shape == (L, (N - 1) * H)
-    assert history.dim() == 2 and history.shape[1] == N - 1, history.shape
-    if mode == MODE_EXTEND:
-        assert row is not None and starts is not None
-    if commit_out_loc is not None:
-        assert mode == MODE_DECODE and req_slots is not None, "commit is decode-only"
-        assert commit_out_loc.shape[0] == num_tokens, commit_out_loc.shape
-    if num_real is None:
-        num_real = num_tokens
-    device = input_ids.device
-    out = torch.empty(num_tokens, L, (N - 1) * H, dtype=torch.int64, device=device)
-    tokens = torch.empty(num_tokens, N, dtype=torch.int32, device=device)
-    if num_tokens == 0:
-        return out, tokens
-    dummy = out  # unused pointer slots; never dereferenced under their constexprs
-    _engram_hash_kernel[(triton.cdiv(num_tokens, block_t),)](
+    out, tokens = _launch_hash_kernel(
         input_ids,
         positions,
-        row if row is not None else dummy,
-        starts if starts is not None else dummy,
-        req_slots if req_slots is not None else dummy,
-        history,
-        token_map,
-        multipliers,
-        primes,
-        offsets,
-        commit_out_loc if commit_out_loc is not None else dummy,
-        tokens,
-        out,
-        num_tokens,
-        num_real,
-        pad_id,
-        image_token_id if image_token_id is not None else -1,
-        mm_pad_shift,
-        MODE=mode,
-        BLOCK=block,
-        HIST_VIA_SLOTS=req_slots is not None,
-        HAS_IMAGE=image_token_id is not None,
-        COMMIT=commit_out_loc is not None,
-        N=N,
-        L=L,
-        H=H,
-        BLOCK_T=block_t,
-        num_warps=4,
+        mode=mode,
+        history=history,
+        token_map=token_map,
+        multipliers=multipliers,
+        primes=primes,
+        offsets=offsets,
+        pad_id=pad_id,
+        num_real=num_real,
+        req_slots=req_slots,
+        block=block,
+        row=row,
+        starts=starts,
+        image_token_id=image_token_id,
+        mm_pad_shift=mm_pad_shift,
+        out_cache_loc=None,
+        write_tokens=True,
+        block_t=block_t,
     )
     return out, tokens
+
+
+def engram_hash_ids_and_commit(
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    history: torch.Tensor,
+    req_slots: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    token_map: torch.Tensor,
+    multipliers: torch.Tensor,
+    primes: torch.Tensor,
+    offsets: torch.Tensor,
+    pad_id: int,
+    image_token_id: Optional[int] = None,
+    mm_pad_shift: int = 0,
+    block_t: int = 32,
+) -> torch.Tensor:
+    """One decode step: hash ids [T, L, (n - 1) * heads] for the T = bs tokens, and
+    ``history[req_slots[t]]`` advanced in place to the token and its n - 2 newest
+    predecessors (oldest first). Rows whose ``out_cache_loc`` is 0 are CUDA-graph
+    padding and leave the table untouched.
+    """
+    out, _ = _launch_hash_kernel(
+        input_ids,
+        positions,
+        mode=MODE_DECODE,
+        history=history,
+        token_map=token_map,
+        multipliers=multipliers,
+        primes=primes,
+        offsets=offsets,
+        pad_id=pad_id,
+        num_real=None,
+        req_slots=req_slots,
+        block=1,
+        row=None,
+        starts=None,
+        image_token_id=image_token_id,
+        mm_pad_shift=mm_pad_shift,
+        out_cache_loc=out_cache_loc,
+        write_tokens=False,
+        block_t=block_t,
+    )
+    return out

--- a/python/sglang/kernels/ops/embeddings/engram_hash.py
+++ b/python/sglang/kernels/ops/embeddings/engram_hash.py
@@ -93,6 +93,7 @@ def _engram_hash_kernel(
     mult_ptr,
     primes_ptr,
     offsets_ptr,
+    out_loc_ptr,
     tokens_out_ptr,
     out_ptr,
     num_tokens,
@@ -104,6 +105,7 @@ def _engram_hash_kernel(
     BLOCK: tl.constexpr,
     HIST_VIA_SLOTS: tl.constexpr,
     HAS_IMAGE: tl.constexpr,
+    COMMIT: tl.constexpr,
     N: tl.constexpr,
     L: tl.constexpr,
     H: tl.constexpr,
@@ -153,6 +155,16 @@ def _engram_hash_kernel(
     # Once a shift is blocked every older shift is too (cummax along s).
     blocked = tl.cumsum(blk.to(tl.int32), axis=1) > 0
     tl.store(tokens_out_ptr + t2 * N + s, tok.to(tl.int32), mask=tmask2)
+    if COMMIT:
+        # Decode: the token and its n - 2 newest predecessors become the request's
+        # history, oldest first. Graph-padded rows (out_cache_loc 0) write nothing.
+        live = tl.load(out_loc_ptr + t, mask=real, other=0) != 0
+        cmask = real2 & live[:, None] & (s <= N - 2)
+        tl.store(
+            hist_ptr + hrow[:, None] * (N - 1) + (N - 2 - s),
+            tok.to(tl.int32),
+            mask=cmask,
+        )
     mapped = tl.load(token_map_ptr + tok, mask=tmask2, other=0).to(tl.int64)
     comp = tl.where(blocked, pad_id, mapped)
 
@@ -190,6 +202,7 @@ def engram_hash_ids(
     starts: Optional[torch.Tensor] = None,
     image_token_id: Optional[int] = None,
     mm_pad_shift: int = 0,
+    commit_out_loc: Optional[torch.Tensor] = None,
     block_t: int = 32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Hash ids [T, L, (n - 1) * heads] int64 and the predecessor table [T, n] int32.
@@ -199,6 +212,8 @@ def engram_hash_ids(
     the run's first token). ``history`` is [rows, n - 1] oldest first; with
     ``req_slots`` given it is indexed by ``req_slots[row]``, else by ``row``.
     Tokens at or past ``num_real`` are padding: PAD ids, zero predecessors.
+    ``commit_out_loc`` (decode via ``req_slots`` only) makes the kernel also write each
+    live request's new history row; rows whose out_cache_loc is 0 are padding.
     """
     num_tokens = input_ids.shape[0]
     L, N = multipliers.shape
@@ -208,6 +223,9 @@ def engram_hash_ids(
     assert history.dim() == 2 and history.shape[1] == N - 1, history.shape
     if mode == MODE_EXTEND:
         assert row is not None and starts is not None
+    if commit_out_loc is not None:
+        assert mode == MODE_DECODE and req_slots is not None, "commit is decode-only"
+        assert commit_out_loc.shape[0] == num_tokens, commit_out_loc.shape
     if num_real is None:
         num_real = num_tokens
     device = input_ids.device
@@ -227,6 +245,7 @@ def engram_hash_ids(
         multipliers,
         primes,
         offsets,
+        commit_out_loc if commit_out_loc is not None else dummy,
         tokens,
         out,
         num_tokens,
@@ -238,6 +257,7 @@ def engram_hash_ids(
         BLOCK=block,
         HIST_VIA_SLOTS=req_slots is not None,
         HAS_IMAGE=image_token_id is not None,
+        COMMIT=commit_out_loc is not None,
         N=N,
         L=L,
         H=H,

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -316,8 +316,7 @@ class EngramHasher(nn.Module):
 
         if input_ids.is_cuda and torch.version.cuda is not None:
             if kmode == MODE_DECODE:
-                # Decode advances the history rows inside the kernel; out_cache_loc
-                # is what marks the CUDA-graph padded rows that must not write.
+                # out_cache_loc 0 marks the CUDA-graph padded rows that must not commit.
                 assert forward_batch.out_cache_loc is not None
                 return engram_hash_ids_and_commit(
                     input_ids,

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -315,8 +315,10 @@ class EngramHasher(nn.Module):
             commit_last = (starts + lens - 1).clamp(0, num_tokens - 1)
 
         if input_ids.is_cuda and torch.version.cuda is not None:
-            if kmode == MODE_DECODE and forward_batch.out_cache_loc is not None:
-                # Decode advances the history rows inside the kernel.
+            if kmode == MODE_DECODE:
+                # Decode advances the history rows inside the kernel; out_cache_loc
+                # is what marks the CUDA-graph padded rows that must not write.
+                assert forward_batch.out_cache_loc is not None
                 return engram_hash_ids_and_commit(
                     input_ids,
                     forward_batch.positions,

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -280,7 +280,7 @@ class EngramHasher(nn.Module):
                 device=input_ids.device,
             )
         mode = forward_batch.forward_mode
-        req_slots = forward_batch.req_pool_indices.to(torch.int64)
+        req_slots = forward_batch.req_pool_indices
         bs = req_slots.shape[0]
         device = input_ids.device
         # Which request each token belongs to and where its run starts; tokens at or
@@ -314,6 +314,10 @@ class EngramHasher(nn.Module):
             commit_last = (starts + lens - 1).clamp(0, num_tokens - 1)
 
         if input_ids.is_cuda and torch.version.cuda is not None:
+            # Decode commits its history rows inside the kernel; extend commits below.
+            commit_out_loc = (
+                forward_batch.out_cache_loc if kmode == MODE_DECODE else None
+            )
             hash_ids, tokens = engram_hash_ids(
                 input_ids,
                 forward_batch.positions,
@@ -331,7 +335,10 @@ class EngramHasher(nn.Module):
                 starts=starts,
                 image_token_id=self.image_token_id,
                 mm_pad_shift=MM_PAD_SHIFT_VALUE,
+                commit_out_loc=commit_out_loc,
             )
+            if commit_out_loc is not None:
+                commit_rows = None
         else:
             hash_ids, tokens = self._torch_hash_ids(
                 input_ids,

--- a/python/sglang/srt/layers/engram.py
+++ b/python/sglang/srt/layers/engram.py
@@ -29,6 +29,7 @@ from sglang.kernels.ops.embeddings.engram_hash import (
     MODE_VERIFY,
     engram_commit_history,
     engram_hash_ids,
+    engram_hash_ids_and_commit,
 )
 from sglang.srt.distributed import tensor_model_parallel_all_reduce
 from sglang.srt.distributed.parallel_state import get_tp_group
@@ -314,10 +315,22 @@ class EngramHasher(nn.Module):
             commit_last = (starts + lens - 1).clamp(0, num_tokens - 1)
 
         if input_ids.is_cuda and torch.version.cuda is not None:
-            # Decode commits its history rows inside the kernel; extend commits below.
-            commit_out_loc = (
-                forward_batch.out_cache_loc if kmode == MODE_DECODE else None
-            )
+            if kmode == MODE_DECODE and forward_batch.out_cache_loc is not None:
+                # Decode advances the history rows inside the kernel.
+                return engram_hash_ids_and_commit(
+                    input_ids,
+                    forward_batch.positions,
+                    history=self.history,
+                    req_slots=req_slots,
+                    out_cache_loc=forward_batch.out_cache_loc,
+                    token_map=self.token_map,
+                    multipliers=self.multipliers,
+                    primes=self.primes,
+                    offsets=self.offsets,
+                    pad_id=self.pad_id,
+                    image_token_id=self.image_token_id,
+                    mm_pad_shift=MM_PAD_SHIFT_VALUE,
+                )
             hash_ids, tokens = engram_hash_ids(
                 input_ids,
                 forward_batch.positions,
@@ -335,10 +348,7 @@ class EngramHasher(nn.Module):
                 starts=starts,
                 image_token_id=self.image_token_id,
                 mm_pad_shift=MM_PAD_SHIFT_VALUE,
-                commit_out_loc=commit_out_loc,
             )
-            if commit_out_loc is not None:
-                commit_rows = None
         else:
             hash_ids, tokens = self._torch_hash_ids(
                 input_ids,

--- a/test/registered/kernels/ops/embeddings/test_engram_hash.py
+++ b/test/registered/kernels/ops/embeddings/test_engram_hash.py
@@ -7,6 +7,7 @@ from sglang.kernels.ops.embeddings.engram_hash import (
     MODE_DECODE,
     MODE_EXTEND,
     engram_hash_ids,
+    engram_hash_ids_and_commit,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -201,8 +202,8 @@ def test_decode_reads_history_through_req_slots():
 
 
 def test_decode_commit_writes_live_rows_only():
-    # With commit_out_loc the kernel writes each live request's new history row
-    # (token plus its n - 2 newest predecessors, oldest first); a padded row
+    # The commit entry point writes each live request's new history row (token
+    # plus its n - 2 newest predecessors, oldest first); a padded row
     # (out_cache_loc 0) writes nothing. Hash ids still read the old history.
     g = torch.Generator().manual_seed(6)
     bs, slots_total = 5, 9
@@ -229,23 +230,16 @@ def test_decode_commit_writes_live_rows_only():
     )
     dev = {k: (v.cuda() if torch.is_tensor(v) else v) for k, v in kw.items()}
     hist_dev = history.cuda()
-    got_ids, got_toks = engram_hash_ids(
+    got_ids = engram_hash_ids_and_commit(
         ids.cuda(),
         pos.cuda(),
-        mode=MODE_DECODE,
         history=hist_dev,
-        num_real=bs,
         req_slots=req_slots.cuda(),
-        block=1,
-        row=None,
-        starts=None,
+        out_cache_loc=out_loc.cuda(),
         mm_pad_shift=MM_PAD_SHIFT,
-        commit_out_loc=out_loc.cuda(),
         **dev,
     )
-    assert torch.equal(got_ids.cpu(), want_ids) and torch.equal(
-        got_toks.cpu(), want_toks
-    )
+    assert torch.equal(got_ids.cpu(), want_ids)
     expect = before.clone()
     for t in range(bs - 1):  # row 4 is padding
         expect[req_slots[t]] = want_toks[t, : N - 1].flip(0)
@@ -271,18 +265,13 @@ def test_decode_commit_across_programs():
     before = history.clone()
     dev = {k: (v.cuda() if torch.is_tensor(v) else v) for k, v in kw.items()}
     hist_dev = history.cuda()
-    got_ids, got_toks = engram_hash_ids(
+    got_ids = engram_hash_ids_and_commit(
         ids.cuda(),
         pos.cuda(),
-        mode=MODE_DECODE,
         history=hist_dev,
-        num_real=bs,
         req_slots=req_slots.cuda(),
-        block=1,
-        row=None,
-        starts=None,
+        out_cache_loc=out_loc.cuda(),
         mm_pad_shift=MM_PAD_SHIFT,
-        commit_out_loc=out_loc.cuda(),
         **dev,
     )
     want_ids, want_toks = naive(
@@ -299,7 +288,6 @@ def test_decode_commit_across_programs():
     )
     # Live rows read the old history and hash identically to the oracle.
     assert torch.equal(got_ids[:live].cpu(), want_ids[:live])
-    assert torch.equal(got_toks[:live].cpu(), want_toks[:live])
     expect = before.clone()
     for t in range(live):
         expect[req_slots[t]] = want_toks[t, : N - 1].flip(0)

--- a/test/registered/kernels/ops/embeddings/test_engram_hash.py
+++ b/test/registered/kernels/ops/embeddings/test_engram_hash.py
@@ -202,9 +202,8 @@ def test_decode_reads_history_through_req_slots():
 
 
 def test_decode_commit_writes_live_rows_only():
-    # The commit entry point writes each live request's new history row (token
-    # plus its n - 2 newest predecessors, oldest first); a padded row
-    # (out_cache_loc 0) writes nothing. Hash ids still read the old history.
+    # Live rows commit (token + n - 2 newest predecessors, oldest first); the
+    # padded row (out_cache_loc 0) does not. Hash ids still read the old history.
     g = torch.Generator().manual_seed(6)
     bs, slots_total = 5, 9
     ids = torch.randint(0, VOCAB, (bs,), generator=g)

--- a/test/registered/kernels/ops/embeddings/test_engram_hash.py
+++ b/test/registered/kernels/ops/embeddings/test_engram_hash.py
@@ -200,6 +200,112 @@ def test_decode_reads_history_through_req_slots():
     )
 
 
+def test_decode_commit_writes_live_rows_only():
+    # With commit_out_loc the kernel writes each live request's new history row
+    # (token plus its n - 2 newest predecessors, oldest first); a padded row
+    # (out_cache_loc 0) writes nothing. Hash ids still read the old history.
+    g = torch.Generator().manual_seed(6)
+    bs, slots_total = 5, 9
+    ids = torch.randint(0, VOCAB, (bs,), generator=g)
+    pos = torch.randint(3, 50, (bs,), generator=g)
+    history = torch.randint(
+        0, VOCAB, (slots_total + 1, N - 1), generator=g, dtype=torch.int32
+    )
+    req_slots = torch.tensor([7, 2, 0, 5, 2])  # the padded row 4 aliases live row 1
+    out_loc = torch.tensor([11, 12, 13, 14, 0])
+    kw = _common()
+    before = history.clone()
+    want_ids, want_toks = naive(
+        ids,
+        pos,
+        mode=MODE_DECODE,
+        history=history,
+        num_real=bs,
+        req_slots=req_slots,
+        block=1,
+        row=None,
+        starts=None,
+        **kw,
+    )
+    dev = {k: (v.cuda() if torch.is_tensor(v) else v) for k, v in kw.items()}
+    hist_dev = history.cuda()
+    got_ids, got_toks = engram_hash_ids(
+        ids.cuda(),
+        pos.cuda(),
+        mode=MODE_DECODE,
+        history=hist_dev,
+        num_real=bs,
+        req_slots=req_slots.cuda(),
+        block=1,
+        row=None,
+        starts=None,
+        mm_pad_shift=MM_PAD_SHIFT,
+        commit_out_loc=out_loc.cuda(),
+        **dev,
+    )
+    assert torch.equal(got_ids.cpu(), want_ids) and torch.equal(
+        got_toks.cpu(), want_toks
+    )
+    expect = before.clone()
+    for t in range(bs - 1):  # row 4 is padding
+        expect[req_slots[t]] = want_toks[t, : N - 1].flip(0)
+    assert torch.equal(hist_dev.cpu(), expect)
+
+
+def test_decode_commit_across_programs():
+    # 100 rows span four 32-token programs; live rows hold distinct slots and the
+    # padded rows alias live slots, so cross-program read/write order matters.
+    g = torch.Generator().manual_seed(8)
+    bs, slots_total, live = 100, 160, 90
+    ids = torch.randint(0, VOCAB, (bs,), generator=g)
+    pos = torch.randint(3, 50, (bs,), generator=g)
+    history = torch.randint(
+        0, VOCAB, (slots_total + 1, N - 1), generator=g, dtype=torch.int32
+    )
+    live_slots = torch.randperm(slots_total, generator=g)[:live]
+    req_slots = torch.cat([live_slots, live_slots[: bs - live]])  # padded rows alias
+    out_loc = torch.cat(
+        [torch.arange(1, live + 1), torch.zeros(bs - live, dtype=torch.long)]
+    )
+    kw = _common()
+    before = history.clone()
+    dev = {k: (v.cuda() if torch.is_tensor(v) else v) for k, v in kw.items()}
+    hist_dev = history.cuda()
+    got_ids, got_toks = engram_hash_ids(
+        ids.cuda(),
+        pos.cuda(),
+        mode=MODE_DECODE,
+        history=hist_dev,
+        num_real=bs,
+        req_slots=req_slots.cuda(),
+        block=1,
+        row=None,
+        starts=None,
+        mm_pad_shift=MM_PAD_SHIFT,
+        commit_out_loc=out_loc.cuda(),
+        **dev,
+    )
+    want_ids, want_toks = naive(
+        ids,
+        pos,
+        mode=MODE_DECODE,
+        history=before,
+        num_real=bs,
+        req_slots=req_slots,
+        block=1,
+        row=None,
+        starts=None,
+        **kw,
+    )
+    # Live rows read the old history and hash identically to the oracle.
+    assert torch.equal(got_ids[:live].cpu(), want_ids[:live])
+    assert torch.equal(got_toks[:live].cpu(), want_toks[:live])
+    expect = before.clone()
+    for t in range(live):
+        expect[req_slots[t]] = want_toks[t, : N - 1].flip(0)
+    assert torch.equal(hist_dev.cpu(), expect)
+
+
 def _extend_batch(g, lens, padded_to):
     starts = torch.cumsum(torch.tensor([0] + lens[:-1]), 0)
     row = torch.repeat_interleave(torch.arange(len(lens)), torch.tensor(lens))


### PR DESCRIPTION
In decode every token is its request's newest token, so the engram hash kernel already holds the row that becomes the request's new n-gram history. This writes it from the kernel instead of the five torch ops that followed the kernel (`req_pool_indices` cast, `out_cache_loc == 0`, `where`, `flip`, `index_put`). The kernel keeps one pure entry point, `engram_hash_ids`, and gains a decode one, `engram_hash_ids_and_commit`, which advances `history` in place (rows whose out_cache_loc is 0 are graph padding and write nothing) and skips the predecessor table that only the extend commit reads. The hasher is one node in the decode CUDA graph; extend keeps the torch commit, and verify is unchanged.

Hash ids are integers, so the change is bitwise. `test_engram_hash.py` adds a 5-row decode case (a padded row aliasing a live slot) and a 100-row case over four programs, both checked against the naive oracle and the expected history table.

A/B against the `dsv4.1` base on DeepSeek-V4.1-Flash, TP4/EP4 on 4x GB300, one server at a time:

| | base | this PR |
|---|---:|---:|
| 28-prompt greedy, 64 tokens, first-token top-5 logprobs | | 28/28 identical, all deltas 0 |
| bs=1 decode, 1k in | 227.9 tok/s | 228.1 tok/s |
| bs=1 decode, 16k in | 196.8 tok/s | 197.5 tok/s |
| bs=64 decode, 1k in | 5225 tok/s | 5240 tok/s |
| 16k-prompt TTFT | 0.422 s | 0.424 s |
| gsm8k 5-shot 1319 | 0.895 | 0.902 |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34656639330](https://github.com/sgl-project/sglang/actions/runs/34656639330)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34656639236](https://github.com/sgl-project/sglang/actions/runs/34656639236)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34656639290](https://github.com/sgl-project/sglang/actions/runs/34656639290)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
