### PR TITLE
Test CuTe DSL W4A16 raw weight reloads and CUDA graph scales

### DIFF
--- a/test/registered/unit/layers/quantization/test_nvfp4_moe_backends.py
+++ b/test/registered/unit/layers/quantization/test_nvfp4_moe_backends.py
@@ -3,12 +3,16 @@
 Real FusedMoE path (NVFP4 checkpoint shards through the real weight_loader
 -> weight processing -> forward) per backend vs a dequantized torch MoE
 reference. Single GPU, tp=ep=1.
+
+W4A16 raw weight reloads also reuse the original destination buffers and a
+captured CUDA graph, comparing each update with a freshly loaded layer.
 """
 
 import unittest
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
 from sglang.srt.runtime_context import get_context, get_flags, get_parallel
@@ -23,7 +27,7 @@ from sglang.test.quant_ref_utils import (
 )
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=14, stage="base-b", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=45, stage="base-b", runner_config="4-gpu-b200")
 
 E, H, I, TOPK, M = 8, 1024, 1024, 2, 32
 
@@ -151,6 +155,157 @@ class TestNvFp4MoeBackends(CustomTestCase):
 
     def test_flashinfer_cutedsl(self):
         self._run_backend("flashinfer_cutedsl")
+
+    def test_flashinfer_cutedsl_w4a16_weight_reload(self):
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+        from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+
+        def make_layer(device):
+            with torch.device(device):
+                return FusedMoE(
+                    num_experts=E,
+                    hidden_size=H,
+                    intermediate_size=I,
+                    layer_id=0,
+                    top_k=TOPK,
+                    params_dtype=torch.bfloat16,
+                    quant_config=ModelOptFp4Config(
+                        is_checkpoint_nvfp4_serialized=True, group_size=16
+                    ),
+                    gate_up_interleaved=False,
+                )
+
+        def checkpoint(seed):
+            torch.manual_seed(seed)
+            shards = []
+            for expert in range(E):
+                w13 = torch.randn(2, I, H, dtype=torch.bfloat16) / 10
+                gs13 = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / w13.abs().max().float()
+                for shard_id, weight in (
+                    ("w1", w13[0]),
+                    ("w3", w13[1]),
+                    ("w2", torch.randn(H, I, dtype=torch.bfloat16) / 10),
+                ):
+                    q, sf, gs, _ = quantize_nvfp4_shard(
+                        weight, gs=gs13 if shard_id != "w2" else None
+                    )
+                    prefix = "w2" if shard_id == "w2" else "w13"
+                    for suffix, value in (
+                        ("weight", q),
+                        ("weight_scale", sf),
+                        ("weight_scale_2", 1.0 / gs),
+                        ("input_scale", torch.tensor(1.0)),
+                    ):
+                        shards.append(
+                            (f"{prefix}_{suffix}", shard_id, expert, value.cpu())
+                        )
+            return shards
+
+        def load(layer, shards):
+            for name, shard_id, expert, value in shards:
+                param = getattr(layer, name)
+                layer.weight_loader(
+                    param, value.to(param.device), name, shard_id, expert
+                )
+
+        def forward(layer):
+            out = layer.forward(x, topk)
+            if isinstance(out, torch.Tensor):
+                return out
+            return out[0] if isinstance(out, tuple) else out.hidden_states
+
+        def pointers(layer):
+            tensors = [*layer.parameters(), *layer._cutedsl_scales]
+            tensors.append(layer._cutedsl_input_scale)
+            return [(t.data_ptr(), t.shape, t.dtype, t.device) for t in tensors]
+
+        with (
+            get_context().override_server_args(
+                model_path="dummy", chunked_prefill_size=M
+            ),
+            get_flags().moe.override(
+                runner_backend=MoeRunnerBackend.FLASHINFER_CUTEDSL
+            ),
+            get_parallel().override(
+                moe_ep_size=1,
+                moe_ep_rank=0,
+                moe_tp_size=1,
+                moe_tp_rank=0,
+                tp_size=1,
+                tp_rank=0,
+            ),
+            envs.SGLANG_FLASHINFER_CUTEDSL_NVFP4_W4A16.override(True),
+            envs.SGLANG_FLASHINFER_MOE_FUSED_FINALIZE.override(False),
+            torch.no_grad(),
+        ):
+            a, b = checkpoint(31), checkpoint(57)
+            cpu = make_layer("cpu")
+            # Match a dummy CPU replica followed by pinned staging allocation.
+            for param in cpu.parameters():
+                param.fill_(1)
+            cpu.quant_method.process_weights_after_loading(cpu)
+            for param in cpu.parameters():
+                param.data = param.data.pin_memory()
+            raw = {
+                name: param
+                for name, param in cpu.named_parameters()
+                if hasattr(param, "weight_loader")
+            }
+            gpu = make_layer("cuda")
+            load(gpu, a)
+            gpu.quant_method.process_weights_after_loading(gpu)
+            # Retain the initial registered buffers across every update.
+            registered = {name: getattr(gpu, name).detach() for name in raw}
+            x = torch.randn(M, H, dtype=torch.bfloat16) / 10
+            topk = select_experts(
+                hidden_states=x,
+                router_logits=torch.randn(M, E, dtype=torch.float32),
+                topk_config=TopKConfig(top_k=TOPK, renormalize=True),
+            )
+            baseline = forward(gpu).clone()
+            self.assertEqual(gpu._cutedsl_wrapper.quant_mode, "w4a16")
+            initial_pointers = pointers(gpu)
+            warmup = torch.cuda.Stream()
+            warmup.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(warmup):
+                for _ in range(3):
+                    forward(gpu)
+            torch.cuda.current_stream().wait_stream(warmup)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                graph_output = forward(gpu)
+
+            for state, shards in (("A1", a), ("B", b), ("A2", a)):
+                with self.subTest(state=state):
+                    load(cpu, shards)
+                    for name, source in raw.items():
+                        target = registered[name]
+                        self.assertEqual(
+                            (source.shape, source.dtype), (target.shape, target.dtype)
+                        )
+                        self.assertTrue(
+                            source.is_contiguous() and target.is_contiguous()
+                        )
+                        target.view(torch.uint8).view(-1).copy_(
+                            source.view(torch.uint8).view(-1)
+                        )
+                    gpu.quant_method.process_weights_after_loading(gpu)
+                    self.assertEqual(pointers(gpu), initial_pointers)
+                    graph_output.fill_(float("nan"))
+                    graph.replay()
+                    torch.cuda.synchronize()
+                    replay = graph_output.clone()
+                    eager = forward(gpu).clone()
+                    fresh = make_layer("cuda")
+                    load(fresh, shards)
+                    fresh.quant_method.process_weights_after_loading(fresh)
+                    expected = forward(fresh)
+                    torch.testing.assert_close(eager, expected, rtol=0, atol=0)
+                    torch.testing.assert_close(replay, expected, rtol=0, atol=0)
+                    if state == "B":
+                        self.assertFalse(torch.equal(eager, baseline))
+                    else:
+                        torch.testing.assert_close(eager, baseline, rtol=0, atol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

@humansand

Cover CuTe DSL NVFP4 W4A16 weight reloads used by disjoint Miles training/rollout workers. Raw transfers must update the buffers captured by CUDA graphs and refresh derived scale tensors.

## Modifications

- **Contract:** stage checkpoint-format expert tensors in a pinned CPU replica, copy bytes into the original GPU buffers, then finalize the packed weights.
- **Regression:** run A → B → A updates; require stable parameter/cached-scale addresses, bit-exact eager and graph outputs against independent fresh loads, changed B output, and exact recovery of A. Poison the captured output before each replay so an unwritten output cannot pass.
- **Reuse:** extend the existing real `FusedMoE` NVFP4 backend test and quantization helpers. Adjust its CI time estimate for the added test.
- **Scope:** this adds regression coverage; the current CuTe DSL reload implementation already passes. The test simulates raw transfer with byte copies; network transport and distributed expert sharding are exercised separately in [Miles #3216](https://github.com/radixark/miles/pull/3216), which completed two training/rollout rounds and three P2P syncs on four training plus four rollout B300 GPUs. That integration run had zero gradients; changed-weight semantics are checked here by A → B → A. The existing fused-indexer mapping fix in #35312 remains a separate `sglang-miles` dependency.

## Accuracy Tests

- **Environment:** one NVIDIA B300 SXM6 AC GPU from an eight-GPU C2 node, driver `590.48.01`; image `radixark/miles:dev-202609111228`, amd64 manifest `sha256:f774dee95a80a213c30489cf82b13295d8a50338ea39f5aaadb0377d3e4a9bba`.
- **Software:** PyTorch `2.13.0+cu130` / CUDA `13.0`, FlashInfer `0.6.18`, CuTe DSL `4.6.2`, TE `2.17.0`. SGLang source is this PR on upstream `main`, selected through `PYTHONPATH`, rather than the image's `sglang-miles` source.
- **Workload:** 8 local experts, hidden/intermediate dimensions 1024, top-k 2, 32 BF16 tokens; serialized NVFP4 weights, W4A16 activations, fused finalize disabled, TP=EP=1. No numerical tolerance was relaxed (`rtol=atol=0` against a fresh load of the same packed weights).
- **Tested commit:** `5c499272f91d08cc5837f770d1f8867b7661bce2`.

From this checkout in the image:

```bash
CUDA_VISIBLE_DEVICES=1 PYTHONPATH="$PWD/python" \
python test/registered/unit/layers/quantization/test_nvfp4_moe_backends.py \
  TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload
```

```text
[CI Test Method] TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload
/opt/sglang/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/_mlir_helpers/op.py:294: DeprecationWarning: make_trivial_tiled_mma with ab_dtype is deprecated, use the overload with separate a_dtype and b_dtype instead
  res_or_list = opFunc(*args, **kwargs, loc=loc)
/opt/sglang/lib/python3.12/site-packages/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py:2525: DeprecationWarning: Migrated to examples/CuTeDSL/helpers/static_persistent_tile_scheduler.py (BSD-3). The wheel copy will be removed in a future release.
  tile_sched_params = utils.PersistentTileSchedulerParams(
/opt/sglang/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/_mlir_helpers/op.py:294: DeprecationWarning: FastDivmodDivisor is deprecated in favor of cute.FastDivmodDivisorV2 / cute.fast_divmod_create_divisor_v2. V2 additionally carries the scalar divisor across kernel boundaries (2 MLIR values per object instead of 1), so '.divisor' is readable inside kernels; arithmetic (divmod, //, %) is unchanged.
  res_or_list = opFunc(*args, **kwargs, loc=loc)
/opt/sglang/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/utils/static_persistent_tile_scheduler.py:292: DeprecationWarning: Migrated to examples/CuTeDSL/helpers/static_persistent_tile_scheduler.py (BSD-3). The wheel copy will be removed in a future release.
  new_params = PersistentTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
/opt/sglang/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/utils/static_persistent_tile_scheduler.py:780: DeprecationWarning: Migrated to examples/CuTeDSL/helpers/static_persistent_tile_scheduler.py (BSD-3). The wheel copy will be removed in a future release.
  return StaticPersistentRuntimeTileScheduler(
/opt/sglang/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/utils/static_persistent_tile_scheduler.py:725: DeprecationWarning: Migrated to examples/CuTeDSL/helpers/static_persistent_tile_scheduler.py (BSD-3). The wheel copy will be removed in a future release.
  return StaticPersistentRuntimeTileScheduler(
.
----------------------------------------------------------------------
Ran 1 test in 5.169s

OK
```

**Negative control:** on the same test body, replace `refresh_cutedsl_standard_scales_for_weight_update` with a no-op using `unittest.mock.patch`. The B update must fail against its fresh-load control. Complete output:

```text
test_flashinfer_cutedsl_w4a16_weight_reload (test_nvfp4_moe_backends.TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload) ... [CI Test Method] TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload

  test_flashinfer_cutedsl_w4a16_weight_reload (test_nvfp4_moe_backends.TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload) (state='B') ... FAIL

======================================================================
FAIL: test_flashinfer_cutedsl_w4a16_weight_reload (test_nvfp4_moe_backends.TestNvFp4MoeBackends.test_flashinfer_cutedsl_w4a16_weight_reload) (state='B')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/hai-workspace/miles-cutedsl-w4a16-p2p/sglang-main/test/registered/unit/layers/quantization/test_nvfp4_moe_backends.py", line 303, in test_flashinfer_cutedsl_w4a16_weight_reload
    torch.testing.assert_close(eager, expected, rtol=0, atol=0)
  File "/opt/sglang/lib/python3.12/site-packages/torch/testing/_comparison.py", line 1631, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not equal!

Mismatched elements: 32206 / 32768 (98.3%)
Greatest absolute difference: 0.14453125 at index (15, 30)
Greatest relative difference: 800.0 at index (22, 512)

----------------------------------------------------------------------
Ran 1 test in 7.419s

FAILED (failures=1)
```

- **Validation boundary:** no full-model learning or BF16 parity claim; no RDMA performance claim. Other backend tests were not rerun for this test-only change.

## Speed Tests and Profiling

No inference implementation change or speedup claim. Only test execution time was measured.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable to this test-only change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Exact regression and negative control above; no inference speed change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Full GPU CI matrix remains for maintainer CI.

## Review and Merge Process

Normal SGLang review and CI; this PR does not merge or duplicate #35312.
