### PR TITLE
[Session + MM] Fix text positions in session continuations

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1330,7 +1330,21 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     :,
                     extend_prefix_len : extend_prefix_len + extend_seq_len,
                 ]
-                if mrope_positions.numel() == 0:
+                if (
+                    batch.reqs[batch_idx].session is not None
+                    and mrope_positions.shape[1] < extend_seq_len
+                ):
+                    # Session history includes generated and appended text that
+                    # is not covered by the saved prompt positions.
+                    tail_len = extend_seq_len - mrope_positions.shape[1]
+                    tail_start = extend_prefix_len + mrope_positions.shape[1]
+                    text_positions = self._expand_mrope_from_input(
+                        mm_input, tail_start + 1
+                    ) + torch.arange(tail_len)
+                    mrope_positions = torch.cat(
+                        [mrope_positions, text_positions], dim=1
+                    )
+                elif mrope_positions.numel() == 0:
                     mrope_positions = self._expand_mrope_from_input(
                         mm_input, seq_lens_cpu[batch_idx]
                     )


### PR DESCRIPTION
## Why?

- Text appended to a session after an image can receive too few position values and produce control tokens instead of an answer.

## What?

- Fill missing text positions using the saved position delta.
- Keep existing image positions and precomputed decode positions.

- Related: #35485 addresses the same issue. This patch keeps the change specific to session continuations and reuses the existing decode-position helper.

## Verification?

- Reproduce with Qwen2.5-VL-3B: open a regular or streaming session, send a 56x56 red image with turn 1, then append turn 2 using the previous request ID. Use `temperature=0`, `max_new_tokens=4`, and `ignore_eos=true` for both turns.
- mRoPE supplies three position values per token. The three rows are identical for the appended text, so one row is shown below. This image leaves a saved position offset of `-2`: text position = token index - 2.

```text
Turn 1: red image + "What color is this image?"
        -> "The image is red" (4 generated tokens)
Turn 2: "Name that color again." (15 tokens including chat markers)

Token indices:  0..19          20..23         24..38
Contents:       first prompt   first reply   appended text
Cached KV:      <------ 24 tokens -------->
Saved mRoPE:    <20 columns>
Needed now:                                  <15 columns>

Before:
  saved_positions[:, 24:39] -> empty (saved table has only 20 columns)
  Single-token fallback   -> [36]                 shape [3, 1]
  Result: only 1 position column for 15 input tokens.

After:
  Fill the missing text positions using token index + saved offset:
  [24, 25, ..., 38] - 2    -> [22, 23, ..., 36]     shape [3, 15]
  Full-history replay     -> [22, 23, ..., 36]     exact match

Observed model output:
  Before -> <|im_start|>\n<|im_start|><|im_end|>
  After  -> "The color is red" (same four token IDs as full replay)
```

- Model outputs were observed on one H200 for both session modes; full-history replay used a separate cache key. The position arrays above were reproduced separately on the box with the base and patched position helpers, using the same image, prompt, and recorded first reply.

## Test?

- Same external position checks: **12 failed / 8 passed before; 20 passed after**. Covers partial/empty saved positions, position deltas, and decode fallback.
- Model replay comparisons: **2 passed**; server health returned 200 after each session closed.
- Existing session, multimodal cleanup, and position encoder tests: **22 passed**.
- Ruff formatting/lint, Python compilation, and `git diff --check`: passed.
- Base: `5f3606c7b2`; CI: pending.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34658487169](https://github.com/sgl-project/sglang/actions/runs/34658487169)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34658486638](https://github.com/sgl-project/sglang/actions/runs/34658486638)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34658487453](https://github.com/sgl-project/sglang/actions/runs/34658487453)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->