### PR TITLE
[PD] Preserve replay outputs when generation finishes at prefill

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -123,6 +123,9 @@ class SchedulerBatchResultProcessor:
             req.update_finish_state()
             if req.finished():
                 req.time_stats.set_quick_finish_time()
+                # Capture before releasing the request's token-to-KV mapping.
+                self._maybe_collect_routed_experts(req)
+                self._maybe_collect_indexer_topk(req)
                 if get_memory().enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
                 release_kv_cache(req, self.tree_cache)


### PR DESCRIPTION
## Why?

- A P/D MoE request with `max_new_tokens=1` returns its generated token, but omits requested expert IDs.
- **Draft: the real GPU repro below shows this patch returns zeros instead of correct expert IDs.**

## What?

- The current three-line patch collects decode's local replay buffers before releasing the request mapping.
- A complete fix must return the prompt's actual prefill-produced expert IDs. The live prefill response also omits them, so this decode-only change is insufficient.

## Verification?

- **Observed** on dev box `3522195`, three H200 GPUs, Qwen/Qwen1.5-MoE-A2.7B at revision `1a758c50ecb6350748b9ce0a99d2352fd9fc11c9`.
- Compared base `5f3606c7b2` with PR head `69a737158e`. Real model inference and Mooncake P/D transfer; ordinary standalone inference supplied the reference expert IDs.

```text
Prompt: "The capital of France is"
Request: max_new_tokens=1, return_routed_experts=true
Expected shape: 5 prompt tokens x 24 layers x 4 experts = 480 IDs

                         Returned text   Expert IDs
Standalone reference     " ______"       480 IDs; 475 nonzero
P/D before this patch    " ______"       missing
P/D after this patch     " ______"       480 zeros (incorrect)

First prompt token, layer 0:
Reference: [33, 8, 44, 16]
Patched D: [ 0, 0,  0,  0]
```

- Prefill samples the first token and sends it to decode; decode returns that token without another model forward. The generated text was already correct.
- Repeating the one-token request after an eight-token generation still returned 480 zeros with the patch.

<details>
<summary>Runnable reproduction: three server commands and an HTTP client</summary>

Run from the base checkout, then repeat from the PR checkout. Use the same installed runtime and model for both. Start the three servers, wait for readiness, and run the client below. Stop those servers between versions.

```bash
export PYTHONPATH="$PWD/python"
COMMON=(
  --model-path Qwen/Qwen1.5-MoE-A2.7B
  --revision 1a758c50ecb6350748b9ce0a99d2352fd9fc11c9
  --host 127.0.0.1 --dtype bfloat16 --enable-return-routed-experts
  --attention-backend flashinfer --moe-runner-backend triton
  --context-length 2048 --max-total-tokens 4096
  --chunked-prefill-size 512 --max-running-requests 4
  --mem-fraction-static 0.5 --disable-cuda-graph --disable-overlap-schedule
)

CUDA_VISIBLE_DEVICES=0 python -m sglang.launch_server "${COMMON[@]}" \
  --port 32500 --nccl-port 32510 --disaggregation-mode prefill \
  --disaggregation-bootstrap-port 32502 \
  --disaggregation-transfer-backend mooncake >prefill.log 2>&1 &

CUDA_VISIBLE_DEVICES=1 python -m sglang.launch_server "${COMMON[@]}" \
  --port 32501 --nccl-port 32511 --disaggregation-mode decode \
  --disaggregation-bootstrap-port 32502 \
  --disaggregation-transfer-backend mooncake >decode.log 2>&1 &

CUDA_VISIBLE_DEVICES=2 python -m sglang.launch_server "${COMMON[@]}" \
  --port 32503 --nccl-port 32512 >reference.log 2>&1 &
```

```python
import base64
import time
from concurrent.futures import ThreadPoolExecutor

import numpy as np
import requests

request = {
    "text": "The capital of France is",
    "sampling_params": {
        "temperature": 0, "max_new_tokens": 1, "ignore_eos": True
    },
    "return_routed_experts": True,
}

def generate(port, payload):
    response = requests.post(
        f"http://127.0.0.1:{port}/generate", json=payload, timeout=180
    )
    response.raise_for_status()
    return response.json()

reference = generate(32503, request)
handoff = dict(
    request, bootstrap_host="127.0.0.1", bootstrap_port=32502,
    bootstrap_room=time.time_ns() % (1 << 62)
)
with ThreadPoolExecutor(2) as pool:
    p = pool.submit(generate, 32500, handoff)
    d = pool.submit(generate, 32501, handoff)
    prefill, decode = p.result(), d.result()

for name, response in [("reference", reference), ("prefill", prefill), ("decode", decode)]:
    encoded = response["meta_info"].get("routed_experts")
    ids = None if encoded is None else np.frombuffer(base64.b64decode(encoded), dtype=np.int32)
    print(name, repr(response["text"]), "missing" if ids is None else {
        "ids": ids.size, "nonzero": int(np.count_nonzero(ids)),
        "first_token_layer0": ids[:4].tolist(),
    })
```

</details>

## Test?

- Real GPU matrix: one-token, eight-token, one-token after reuse, and replay-disabled requests on base and patch. All eight decode responses matched standalone generated text. Requested replay values remain incorrect.
- The live prefill response omitted `routed_experts` in every replay-enabled case. The eight-token decode response also had zero prompt rows before and after this patch.
- Earlier seeded-buffer tests: 8 passed; existing hidden-state tests: 7 passed + 2 subtests. These verify collection order, not replay-value correctness.
- Runtime: Python 3.12.3, PyTorch 2.13.0+cu130, Transformers 5.12.1; TP1, BF16, FlashInfer attention, Triton MoE, CUDA graphs and overlap disabled.
- The reproduced metadata failure keeps this PR draft. Indexer replay and other model/backend combinations remain unvalidated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34659030906](https://github.com/sgl-project/sglang/actions/runs/34659030906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34659030610](https://github.com/sgl-project/sglang/actions/runs/34659030610)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34659030916](https://github.com/sgl-project/sglang/actions/runs/34659030916)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->