### PR TITLE
[HiCache] Intersect file-backend hybrid prefix boundaries

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -187,8 +187,9 @@ class HiCacheStorage(ABC):
         ------------------------------------------------------
         Each ``PoolTransfer`` in ``pool_transfers`` describes a secondary
         cache pool (e.g. Mamba SSM states) that must be co-present with the
-        KV pages.  The final ``final_pages`` is the minimum across all pools,
-        so a missing auxiliary page shrinks the usable prefix.
+        KV pages. The usable prefix ends at the greatest stop point that all
+        pools can restore. Trailing-page pools may have gaps in their valid
+        stop points, so taking the minimum of their maxima is not sufficient.
 
         - ``"all_pages"`` (default):  every page in [0, kv_hit) must exist
           for this pool.  Used for pools that are required for every token
@@ -634,31 +635,39 @@ class HiCacheFile(HiCacheStorage):
         )
 
         hit_count: dict[str, int] = {PoolName.KV: kv_pages} if kv_pages else {}
-        final_pages = kv_pages
+        # Trailing pools can have holes in their valid stop points: a longer
+        # prefix being restorable does not imply that a shorter one is. Keep
+        # the common stop points instead of taking the minimum of maxima.
+        restorable = list(range(1, kv_pages + 1))
 
         for transfer in pool_transfers or []:
-            if final_pages == 0:
+            if not restorable:
                 break
             name = transfer.name
             if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
                 boundary = next(
                     (i for i in range(kv_pages) if not has_component(i, name)), kv_pages
                 )
+                pool_restorable = list(range(1, boundary + 1))
             else:  # trailing_pages
                 trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                boundary = 0
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        has_component(i, name)
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
+                pool_restorable = []
+                consecutive = 0
+                for prefix_len in range(1, kv_pages + 1):
+                    if has_component(prefix_len - 1, name):
+                        consecutive += 1
+                    else:
+                        consecutive = 0
+                    if consecutive >= min(trailing, prefix_len):
+                        pool_restorable.append(prefix_len)
+                boundary = pool_restorable[-1] if pool_restorable else 0
             if boundary:
                 hit_count[name] = boundary
-            final_pages = min(final_pages, boundary)
+            pool_restorable_set = set(pool_restorable)
+            restorable = [p for p in restorable if p in pool_restorable_set]
 
-        return PoolTransferResult(final_pages, hit_count)
+        final_pages = restorable[-1] if restorable else 0
+        return PoolTransferResult(final_pages, hit_count, restorable)
 
     def _log_key(self, pool_name: str, key: str) -> str:
         return key if pool_name == PoolName.KV else f"{key}.{pool_name}"

--- a/test/registered/unit/mem_cache/test_hicache_file_prefix.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_prefix.py
@@ -1,0 +1,137 @@
+"""CPU coverage for file-backend hybrid prefix intersection."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.srt.mem_cache.hicache_storage import (
+    HiCacheFile,
+    MetadataCache,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestHiCacheFilePrefix(CustomTestCase):
+    def check_prefix(self, kv_pages, pools, expected, num_pages=3):
+        # Exercise real file scans and metadata lookups without constructing
+        # the unrelated eviction/controller machinery.
+        for metadata_enabled in (False, True):
+            for reverse in (False, True):
+                with self.subTest(metadata=metadata_enabled, reverse=reverse):
+                    with tempfile.TemporaryDirectory() as directory:
+                        backend = HiCacheFile.__new__(HiCacheFile)
+                        backend.file_path = directory
+                        backend.config_suffix = "_prefix_test"
+                        backend.metadata_cache = (
+                            MetadataCache(-1.0) if metadata_enabled else None
+                        )
+                        keys = [f"page{i}" for i in range(1, num_pages + 1)]
+                        for name, pages in [(PoolName.KV, kv_pages)] + [
+                            (name, pages) for name, pages, _, _ in pools
+                        ]:
+                            for page in pages:
+                                Path(
+                                    backend._get_component_path(keys[page - 1], name)
+                                ).touch()
+                        transfers = [
+                            PoolTransfer(
+                                name=name, keys=keys[-window:], hit_policy=policy
+                            )
+                            for name, _, policy, window in pools
+                        ]
+                        if reverse:
+                            transfers.reverse()
+                        # Second query also exercises warm metadata-cache hits.
+                        for _ in range(2):
+                            result = backend.batch_exists_v2(keys, transfers)
+                            self.assertEqual(
+                                result.kv_hit_pages, max(expected, default=0)
+                            )
+                            self.assertEqual(result.restorable_prefix_pages, expected)
+
+    def test_aligned_checkpoints(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [3],
+        )
+
+    def test_disjoint_checkpoints(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {2}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [],
+        )
+
+    def test_preserves_non_contiguous_stop_points(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [(PoolName.MAMBA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1)],
+            [1, 3],
+        )
+
+    def test_earlier_common_checkpoint(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.SWA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1),
+                (PoolName.MAMBA, {1, 2}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [1],
+        )
+
+    def test_all_pages_truncates_trailing_pool(self):
+        self.check_prefix(
+            {1, 2, 3},
+            [
+                (PoolName.INDEXER, {1, 2}, PoolHitPolicy.ALL_PAGES, 3),
+                (PoolName.MAMBA, {1, 3}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [1],
+        )
+
+    def test_multi_page_window_with_holes(self):
+        self.check_prefix(
+            {1, 2, 3, 4, 5},
+            [
+                (PoolName.SWA, {1, 2, 4, 5}, PoolHitPolicy.TRAILING_PAGES, 2),
+                (PoolName.MAMBA, {2, 4}, PoolHitPolicy.TRAILING_PAGES, 1),
+            ],
+            [2],
+            num_pages=5,
+        )
+
+    def test_prefix_shorter_than_window(self):
+        self.check_prefix(
+            {1, 2},
+            [(PoolName.SWA, {1, 2}, PoolHitPolicy.TRAILING_PAGES, 3)],
+            [1, 2],
+        )
+
+    def test_kv_hole_limits_auxiliary_hits(self):
+        self.check_prefix(
+            {1, 3},
+            [(PoolName.MAMBA, {3}, PoolHitPolicy.TRAILING_PAGES, 1)],
+            [],
+        )
+
+    def test_kv_only_and_empty(self):
+        self.check_prefix({1, 3}, [], [1])
+        self.check_prefix(set(), [], [])
+        self.check_prefix(set(), [], [], num_pages=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Superseded by #39267. This closed PR contains the original local-pool-only patch; the successor adds cross-rank agreement and expanded local validation.

## Motivation

Fixes #39147.

The file backend can report a prefix whose required trailing state is absent. For example, pools restorable at `{1, 3}` and `{1, 2}` currently select endpoint 2, although only endpoint 1 is shared.

## Modifications

- Intersect each required pool's legal prefix endpoints and return the greatest common endpoint, matching the existing Mooncake query semantics.
- Scan trailing coverage once using consecutive present pages, avoiding repeated scans of overlapping windows.
- Return the complete `restorable_prefix_pages` set and clarify the storage-query contract.
- Add nine registered CPU regression tests using `CustomTestCase`: disjoint checkpoints, earlier common endpoints, mixed hit policies, multi-page windows, KV holes and empty input, with both pool orders and cold/warm metadata caches.

## Accuracy Tests

- Nine component tests pass locally using the checkout's actual storage module and real temporary files. The original three-case reproducer changes from `[3, 2, 2]` to `[3, 0, 1]`.
- The local runner bypasses GPU-heavy package initialization and compiles the original `CustomTestCase` and its direct helpers from source. This is isolated component validation, not normal full-package CI collection.
- Coverage from this isolated run covers all 16 changed executable storage lines (`diff-cover --compare-branch=origin/main`: 100%). This is line coverage, not a claim of complete behavioral coverage.
- The normal test/check-env import path is unavailable on this Apple Silicon environment because Triton is missing. The new test is registered in `base-a-test-cpu` for normal CI execution.
- No model weights, GPU E2E run or successful KV-payload restoration is claimed.

## Speed Tests and Profiling

The trailing endpoint scan is linear in the number of candidate KV pages for each pool. No model-serving throughput benchmark was run.

## Checklist

- [x] All applicable repository pre-commit hooks pass for both changed files.
- [x] Add focused regression tests and CPU CI registration.
- [x] Update the affected API docstring.
- [ ] Full CI and GPU E2E validation; local validation limits are listed above.

## Review and Merge Process

Please review the file-backend prefix semantics and help trigger the normal CPU CI. AI assistance was used for investigation and implementation.
