### PR TITLE
[PD] Allow decode radix caching with EAGLE/EAGLE3

### DIFF
--- a/python/sglang/srt/arg_groups/fields/disagg.py
+++ b/python/sglang/srt/arg_groups/fields/disagg.py
@@ -79,7 +79,7 @@ class Disagg(msgspec.Struct):
     ] = None
     disaggregation_decode_enable_radix_cache: A[
         bool,
-        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse, speculative decoding, and --disaggregation-transfer-backend fake.",
+        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Supports EAGLE/EAGLE3 speculative decoding. Incompatible with --enable-hisparse and --disaggregation-transfer-backend fake.",
     ] = False
     disaggregation_decode_enable_offload_kvcache: A[
         bool, "Enable async KV cache offloading on decode server (PD mode)."

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -86,11 +86,14 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
                     "--disaggregation-decode-enable-radix-cache is incompatible "
                     "with --disaggregation-transfer-backend fake"
                 )
-            if cfg.speculative_algorithm is not None:
+            if (
+                cfg.speculative_algorithm is not None
+                and cfg.speculative_algorithm.upper() not in ("EAGLE", "EAGLE3")
+            ):
                 raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache is incompatible "
-                    "with speculative decoding "
-                    f"(--speculative-algorithm {cfg.speculative_algorithm})"
+                    "--disaggregation-decode-enable-radix-cache with speculative "
+                    "decoding supports EAGLE/EAGLE3, but got "
+                    f"--speculative-algorithm {cfg.speculative_algorithm}"
                 )
 
             if resolved_view(server_args).enable_dp_attention:


### PR DESCRIPTION
## Why?

- P/D servers reject decode radix caching with every speculative algorithm, so EAGLE/EAGLE3 cannot reuse decode KV prefixes across turns.

## What?

- Allow EAGLE and EAGLE3 with decode radix caching and update the flag's help text.
- Keep validation for the other speculative algorithms, HiSparse, and the fake transfer backend.

## Verification?

- Observed on two H200 GPUs with Qwen3-1.7B, its AngelSlim EAGLE3 draft, Mooncake, and overlap enabled:

```text
EAGLE3 + --disaggregation-decode-enable-radix-cache

Before: start server -> ValueError: incompatible with speculative decoding
After:  start server -> generate 64 tokens from a 384-token prompt
                    -> next turn reuses 446 cached tokens

4 clients x 3 turns -> 5,360 cached tokens total
```

- EAGLE's paired-token cache keys leave two trailing tokens uncached in this case: the final output has no KV yet, and the preceding key needs its next token.

## Test?

- EAGLE and EAGLE3/Mooncake: greedy outputs matched cache-off results; each existing multi-turn cache-helper run passed 12 requests with `miss_tolerance=2`.
- Both P/D baselines and a standalone EAGLE3 comparison accepted zero draft tokens. Multi-token acceptance remains unvalidated, so this PR stays draft.
- Existing decode-cache unit suite passed. Server-args unit suite: 229 passed, 46 subtests passed.
- Before/after argument check: 21 algorithm/backend combinations.
- EAGLE3/NIXL: cold/hot greedy parity and 12 multi-turn requests passed.
- Lint passed. GPU CI remains pending while the PR is draft.
