### PR TITLE
[CI] Install elfutils headers for DeepGEMM wheel builds

### DIFF
--- a/docker/sgl-deep-gemm.Dockerfile
+++ b/docker/sgl-deep-gemm.Dockerfile
@@ -15,7 +15,9 @@ ARG PYTORCH_MIRROR=download.pytorch.org
 ENV PYTHON_ROOT_PATH=/opt/python/${PYTHON_TAG}
 ENV PATH=${PYTHON_ROOT_PATH}/bin:${PATH}
 
+# DeepJIT's exception handling requires elfutils/libdwfl.h and libelf headers.
 RUN yum install -y --nogpgcheck git wget tar gcc gcc-c++ make \
+    elfutils-devel elfutils-libelf-devel \
  && yum clean all && rm -rf /var/cache/yum
 
 RUN set -eux; \


### PR DESCRIPTION
## Motivation

The [DeepGEMM wheel release job](https://github.com/sgl-project/sglang/actions/runs/34660081250/job/103460583847) fails while compiling `_C.so` after updating DeepGEMM dev:

```text
fatal error: elfutils/libdwfl.h: No such file or directory
```

DeepJIT now includes this header for exception stack traces, but the SGLang release image does not install the elfutils development packages.

## Modifications

Install `elfutils-devel` and `elfutils-libelf-devel` in `docker/sgl-deep-gemm.Dockerfile`. The release workflow uses this Dockerfile for both x86_64 and aarch64 wheel builds.

## Accuracy Tests

- `pre-commit run --files docker/sgl-deep-gemm.Dockerfile` — passed.
- `git diff --check` — passed.
- `bash -n scripts/build_sgl_deep_gemm.sh` and syntax validation of the Dockerfile's updated `RUN yum ...` command — passed.
- Confirmed both packages are available in the official AlmaLinux 8 BaseOS repositories for x86_64 and aarch64.
- Full container/wheel builds have not been rerun; Docker/Podman are unavailable on the local host.

## Speed Tests and Profiling

Not applicable: build dependency installation only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34661243766](https://github.com/sgl-project/sglang/actions/runs/34661243766)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34661243647](https://github.com/sgl-project/sglang/actions/runs/34661243647)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->