### PR TITLE
fix: restore DSA indexes with hybrid HiCache

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -769,6 +769,61 @@ def build_deepseek_v4_hicache_stack(
     return host_pool_group, cache_controller
 
 
+def _hybrid_dsa_index_buffers(kv_pool, draft_pools=()):
+    from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+    if not isinstance(kv_pool, DSATokenToKVPool):
+        return []
+    return [
+        buffer
+        for pool in (kv_pool, *draft_pools)
+        for buffer in pool.index_k_with_scale_buffer
+    ]
+
+
+def _build_hybrid_dsa_index_entry(
+    *,
+    kv_pool,
+    kv_host_pool,
+    layer_mapping,
+    transfer_layer_num,
+    draft_pools=(),
+    pool_name=PoolName.INDEXER,
+):
+    buffers = _hybrid_dsa_index_buffers(kv_pool, draft_pools)
+    live_layers = [i for i, buffer in enumerate(buffers) if buffer.numel()]
+    if not live_layers:
+        return None
+    compact_layers = {layer: i for i, layer in enumerate(live_layers)}
+    live_buffers = [buffers[i] for i in live_layers]
+    item_bytes = live_buffers[0].shape[1] * live_buffers[0].element_size()
+    if any(b.shape[1] * b.element_size() != item_bytes for b in live_buffers):
+        raise ValueError("Hybrid DSA index buffers must have the same page row width.")
+    # Empty shared-topk layers must not reach the transfer kernels.
+    host_pool = DeepSeekV4PagedHostPool(
+        pool_name=str(pool_name),
+        device_buffers=live_buffers,
+        item_bytes=item_bytes,
+        num_host_pages=kv_host_pool.page_num,
+        slot_page_size=kv_pool.page_size,
+        layout=get_memory().hicache_mem_layout,
+        allocator_type=_get_allocator_type(),
+        page_aligned_only=True,
+    )
+    return build_pool_entry(
+        name=pool_name,
+        host_pool=host_pool,
+        device_pool=kv_pool,
+        layer_mapping={
+            global_layer: compact_layers[local_layer]
+            for global_layer, local_layer in layer_mapping.items()
+            if local_layer in compact_layers
+        },
+        transfer_layer_num=transfer_layer_num,
+        packed_draft_device_pools=draft_pools,
+    )
+
+
 def build_hybrid_mamba_stack(
     *,
     params: CacheInitParams,
@@ -799,6 +854,20 @@ def build_hybrid_mamba_stack(
         kv_host_size, mamba_host_size = _split_hicache_size(
             get_memory().hicache_size, (kv_pool, mamba_pool)
         )
+        index_buffers = _hybrid_dsa_index_buffers(kv_pool, mtp_draft_device_pools)
+        if index_buffers:
+            kv_bytes_per_token = sum(
+                pool.kv_cache_dim * pool.store_dtype.itemsize * pool.layer_num
+                for pool in (kv_pool, *mtp_draft_device_pools)
+            )
+            index_bytes_per_token = sum(
+                b.shape[1] * b.element_size() / kv_pool.page_size
+                for b in index_buffers
+                if b.numel()
+            )
+            kv_host_size *= kv_bytes_per_token / (
+                kv_bytes_per_token + index_bytes_per_token
+            )
     kv_host_pool = build_kv_host_pool(
         kv_pool=kv_pool,
         page_size=params.page_size,
@@ -842,6 +911,15 @@ def build_hybrid_mamba_stack(
             device_free_fn=mamba_allocator.free,
         ),
     ]
+    index_entry = _build_hybrid_dsa_index_entry(
+        kv_pool=kv_pool,
+        kv_host_pool=kv_host_pool,
+        layer_mapping=full_layer_mapping,
+        transfer_layer_num=transfer_layer_num + len(mtp_draft_device_pools),
+        draft_pools=mtp_draft_device_pools,
+    )
+    if index_entry is not None:
+        entries.append(index_entry)
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
         params.token_to_kv_pool_allocator,
@@ -1410,6 +1488,7 @@ class _MambaStrategy(StackStrategy):
             storage_backend_extra_config=storage_backend_extra_config,
             enable_storage_metrics=enable_storage_metrics,
         )
+        has_indexer = PoolName.INDEXER in host_pool_group.entry_map
         return StackBuildResult(
             host_pool_group=host_pool_group,
             cache_controller=cache_controller,
@@ -1419,7 +1498,16 @@ class _MambaStrategy(StackStrategy):
             },
             register_req_to_token_counter=True,
             transfer_layer_num=len(full_layer_mapping | mamba_layer_mapping),
-            pools_desc="KV + MAMBA",
+            sidecars=(
+                [
+                    SidecarPoolSpec(
+                        pool_name=PoolName.INDEXER, indices_from_pool=PoolName.KV
+                    )
+                ]
+                if has_indexer
+                else []
+            ),
+            pools_desc="KV + MAMBA + INDEXER" if has_indexer else "KV + MAMBA",
         )
 
 

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -24,9 +24,7 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 if _is_cuda or _is_hip:
     from sgl_kernel.kvcacheio import (
-        transfer_kv_all_layer_direct_lf_pf,
         transfer_kv_direct,
-        transfer_kv_per_layer_direct_pf_lf,
         transfer_kv_per_layer_mla,
     )
 if _is_cuda or _is_hip:
@@ -353,13 +351,20 @@ class MambaPoolHost(HostKVCache):
                 src_layout_dim=item_size * num_layers,
             )
         elif io_backend == "direct":
-            transfer_kv_per_layer_direct_pf_lf(
-                src_ptrs=[src],
-                dst_ptrs=[dst],
+            # Use the Mamba state transfer kernel even with direct KV I/O.
+            if src_indices.device.type != "cuda":
+                src_indices = src_indices.to(dst.device, non_blocking=True)
+            if dst_indices.device.type != "cuda":
+                dst_indices = dst_indices.to(dst.device, non_blocking=True)
+            item_size = MambaPoolHost._item_size_per_index(dst)
+            transfer_kv_mamba_pf_lf(
+                src=src,
+                dst=dst,
                 src_indices=src_indices,
                 dst_indices=dst_indices,
                 layer_id=layer_id,
-                page_size=1,
+                item_size=item_size,
+                src_layout_dim=item_size * num_layers,
             )
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
@@ -396,13 +401,20 @@ class MambaPoolHost(HostKVCache):
                 num_layers=num_layers,
             )
         elif io_backend == "direct":
-            src_ptrs = [src_layers[i] for i in range(num_layers)]
-            transfer_kv_all_layer_direct_lf_pf(
+            # Use the Mamba state transfer kernel even with direct KV I/O.
+            if src_indices.device.type != "cuda":
+                src_indices = src_indices.to(src_layers.device, non_blocking=True)
+            if dst_indices.device.type != "cuda":
+                dst_indices = dst_indices.to(src_layers.device, non_blocking=True)
+            item_size = MambaPoolHost._item_size_per_index(src_layers[0])
+            transfer_kv_mamba_lf_pf(
                 src_ptrs=src_ptrs,
-                dst_ptrs=[dst],
+                dst=dst,
                 src_indices=src_indices,
                 dst_indices=dst_indices,
-                page_size=1,
+                item_size=item_size,
+                dst_layout_dim=item_size * num_layers,
+                num_layers=num_layers,
             )
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -351,7 +351,6 @@ class MambaPoolHost(HostKVCache):
                 src_layout_dim=item_size * num_layers,
             )
         elif io_backend == "direct":
-            # Use the Mamba state transfer kernel even with direct KV I/O.
             if src_indices.device.type != "cuda":
                 src_indices = src_indices.to(dst.device, non_blocking=True)
             if dst_indices.device.type != "cuda":
@@ -401,7 +400,6 @@ class MambaPoolHost(HostKVCache):
                 num_layers=num_layers,
             )
         elif io_backend == "direct":
-            # Use the Mamba state transfer kernel even with direct KV I/O.
             if src_indices.device.type != "cuda":
                 src_indices = src_indices.to(src_layers.device, non_blocking=True)
             if dst_indices.device.type != "cuda":

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -24,7 +24,9 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 if _is_cuda or _is_hip:
     from sgl_kernel.kvcacheio import (
+        transfer_kv_all_layer_direct_lf_pf,
         transfer_kv_direct,
+        transfer_kv_per_layer_direct_pf_lf,
         transfer_kv_per_layer_mla,
     )
 if _is_cuda or _is_hip:
@@ -351,19 +353,13 @@ class MambaPoolHost(HostKVCache):
                 src_layout_dim=item_size * num_layers,
             )
         elif io_backend == "direct":
-            if src_indices.device.type != "cuda":
-                src_indices = src_indices.to(dst.device, non_blocking=True)
-            if dst_indices.device.type != "cuda":
-                dst_indices = dst_indices.to(dst.device, non_blocking=True)
-            item_size = MambaPoolHost._item_size_per_index(dst)
-            transfer_kv_mamba_pf_lf(
-                src=src,
-                dst=dst,
+            transfer_kv_per_layer_direct_pf_lf(
+                src_ptrs=[src],
+                dst_ptrs=[dst],
                 src_indices=src_indices,
                 dst_indices=dst_indices,
                 layer_id=layer_id,
-                item_size=item_size,
-                src_layout_dim=item_size * num_layers,
+                page_size=1,
             )
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
@@ -400,19 +396,13 @@ class MambaPoolHost(HostKVCache):
                 num_layers=num_layers,
             )
         elif io_backend == "direct":
-            if src_indices.device.type != "cuda":
-                src_indices = src_indices.to(src_layers.device, non_blocking=True)
-            if dst_indices.device.type != "cuda":
-                dst_indices = dst_indices.to(src_layers.device, non_blocking=True)
-            item_size = MambaPoolHost._item_size_per_index(src_layers[0])
-            transfer_kv_mamba_lf_pf(
+            src_ptrs = [src_layers[i] for i in range(num_layers)]
+            transfer_kv_all_layer_direct_lf_pf(
                 src_ptrs=src_ptrs,
-                dst=dst,
+                dst_ptrs=[dst],
                 src_indices=src_indices,
                 dst_indices=dst_indices,
-                item_size=item_size,
-                dst_layout_dim=item_size * num_layers,
-                num_layers=num_layers,
+                page_size=1,
             )
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")

--- a/test/registered/kernels/ops/mamba/test_transfer_mamba.py
+++ b/test/registered/kernels/ops/mamba/test_transfer_mamba.py
@@ -1,7 +1,7 @@
 """Unit tests for the Mamba JIT transfer kernel.
 
 Verifies kernel backup (D2H) and load (H2D) correctness for
-``MambaPoolHost`` via the ``io_backend='kernel'`` path, across both
+``MambaPoolHost`` via the kernel and direct backends, across both
 supported layouts and multiple index scenarios.
 """
 
@@ -200,8 +200,9 @@ def assert_device_matches_host(host, device_pool, host_indices, device_indices):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("layout", LAYOUTS)
-def test_mamba_kernel_backup_load_roundtrip(dtype, layout):
-    """Test D2H backup + H2D load roundtrip with io_backend='kernel'."""
+@pytest.mark.parametrize("io_backend", ["kernel", "direct"])
+def test_mamba_kernel_backup_load_roundtrip(dtype, layout, io_backend):
+    """Test D2H backup + H2D load roundtrip with both backends."""
     host = make_host_pool(dtype, layout)
     assert_host_mock_complete(host)
     device_pool = host.device_pool
@@ -214,9 +215,9 @@ def test_mamba_kernel_backup_load_roundtrip(dtype, layout):
     host_indices = torch.tensor([0, 1, 2], dtype=torch.int64)
     load_indices = torch.tensor([3, 7, 12], dtype=torch.int64, device=DEVICE)
 
-    # --- Backup: device -> host (kernel) ---
+    # --- Backup: device -> host ---
     host.backup_from_device_all_layer(
-        device_pool, host_indices, device_indices, io_backend="kernel"
+        device_pool, host_indices, device_indices, io_backend=io_backend
     )
     torch.cuda.synchronize()
     assert_host_matches_device(host, device_pool, host_indices, device_indices)
@@ -227,14 +228,14 @@ def test_mamba_kernel_backup_load_roundtrip(dtype, layout):
         for conv_idx in range(len(device_pool.mamba_cache.conv)):
             device_pool.mamba_cache.conv[conv_idx][layer_id].zero_()
 
-    # --- Load: host -> device (kernel), per layer ---
+    # --- Load: host -> device, per layer ---
     for layer_id in range(NUM_LAYERS):
         host.load_to_device_per_layer(
             device_pool,
             host_indices,
             load_indices,
             layer_id,
-            io_backend="kernel",
+            io_backend=io_backend,
         )
     torch.cuda.synchronize()
     assert_device_matches_host(host, device_pool, host_indices, load_indices)

--- a/test/registered/kernels/ops/mamba/test_transfer_mamba.py
+++ b/test/registered/kernels/ops/mamba/test_transfer_mamba.py
@@ -1,7 +1,7 @@
 """Unit tests for the Mamba JIT transfer kernel.
 
 Verifies kernel backup (D2H) and load (H2D) correctness for
-``MambaPoolHost`` via the kernel and direct backends, across both
+``MambaPoolHost`` via the ``io_backend='kernel'`` path, across both
 supported layouts and multiple index scenarios.
 """
 
@@ -200,9 +200,8 @@ def assert_device_matches_host(host, device_pool, host_indices, device_indices):
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("layout", LAYOUTS)
-@pytest.mark.parametrize("io_backend", ["kernel", "direct"])
-def test_mamba_kernel_backup_load_roundtrip(dtype, layout, io_backend):
-    """Test D2H backup + H2D load roundtrip with both backends."""
+def test_mamba_kernel_backup_load_roundtrip(dtype, layout):
+    """Test D2H backup + H2D load roundtrip with io_backend='kernel'."""
     host = make_host_pool(dtype, layout)
     assert_host_mock_complete(host)
     device_pool = host.device_pool
@@ -215,9 +214,9 @@ def test_mamba_kernel_backup_load_roundtrip(dtype, layout, io_backend):
     host_indices = torch.tensor([0, 1, 2], dtype=torch.int64)
     load_indices = torch.tensor([3, 7, 12], dtype=torch.int64, device=DEVICE)
 
-    # --- Backup: device -> host ---
+    # --- Backup: device -> host (kernel) ---
     host.backup_from_device_all_layer(
-        device_pool, host_indices, device_indices, io_backend=io_backend
+        device_pool, host_indices, device_indices, io_backend="kernel"
     )
     torch.cuda.synchronize()
     assert_host_matches_device(host, device_pool, host_indices, device_indices)
@@ -228,14 +227,14 @@ def test_mamba_kernel_backup_load_roundtrip(dtype, layout, io_backend):
         for conv_idx in range(len(device_pool.mamba_cache.conv)):
             device_pool.mamba_cache.conv[conv_idx][layer_id].zero_()
 
-    # --- Load: host -> device, per layer ---
+    # --- Load: host -> device (kernel), per layer ---
     for layer_id in range(NUM_LAYERS):
         host.load_to_device_per_layer(
             device_pool,
             host_indices,
             load_indices,
             layer_id,
-            io_backend=io_backend,
+            io_backend="kernel",
         )
     torch.cuda.synchronize()
     assert_device_matches_host(host, device_pool, host_indices, load_indices)


### PR DESCRIPTION
## Motivation

Hybrid Mamba/DSA HiCache restores full KV and recurrent state without restoring `index_k_with_scale_buffer`. After GPU slot reuse, attention can select KV using stale index keys/scales. In a captured GLM-5.3-Flash host replay, the requested `echo hello-repro` became `echo "repro"` in the model's raw output and tool arguments.

Related to #38031. This is a narrow extraction of the index-assembly work from ormandj's #38212; it does not include that PR's separate compressed-prefix ownership, checkpoint, or draft-layout changes.

## Modifications

Register an INDEXER sidecar using the full-KV physical page indices and existing transfer implementation. Map nonempty target/draft index layers, skip empty shared-topk buffers, and account for index storage in the fixed host budget. Mamba transfer kernels are unchanged.

Add one standalone GLM-5.3-Flash NVFP4 host-restoration KL test, following the cache-hit controls in #38474. It requests full-vocabulary output logprobs at eight fixed continuation prefixes and requires substantial host restoration. Every comparison has the same eight conditioning prefixes, even when argmax tokens differ. Scoring must reuse the long prefix and may recompute at most 255 trailing input tokens. Five seeded rounds are mandatory; no implicit CI retry or median gate is used.

The test is registered for `extra-b / 4-gpu-b200` but disabled until the base supports `Glm5NextForConditionalGeneration` and the B200 configuration is calibrated. It can be run directly on a compatible GLM image. Unlike #38474, it computes exact full-vocabulary KL rather than selected-token k3 estimates and gates every per-sequence mean rather than a median. Compressed-prefix branching is outside this test's scope.

## Accuracy Tests

### New fixed-prefix KL regression

Completed original/fixed/original/fixed runs on the same 4 B300 GPUs, using the exact committed test bytes (SHA256 `e23f1394a20081a4aaa93efd3070e5866bf74aa00265a461e6e6e5ff7caa10ec`). The gate is **every per-sequence mean KL over eight fixed continuation prefixes `< 0.1`**, including device controls.

| Check | Original | Fixed | Original switchback | Fixed repeat |
|---|---:|---:|---:|---:|
| Maximum host mean KL | **0.150306** | **0.051590** | **0.195408** | **0.060670** |
| Host cases failing the gate | 3/5 | 0/5 | 2/5 | 0/5 |
| Maximum device-control mean KL | 0.041535 | 0.021682 | 0.034721 | 0.075492 |
| Test result | FAIL | PASS | FAIL | PASS |

All 20 device controls passed. All 20 first host scores restored **180032 host tokens plus 128 device tokens**. The following seven scores reuse the restored device-resident prefix. All 40 comparisons contain eight positions; their conditioning continuation prefixes match across all arms. All 420 test generation requests completed. Only the assembler Python file differs between runtime arms. No threshold increase, implicit retry, median gate, or missing-position padding was used.

This run used the pinned image below as a container, Python 3.12.3, PyTorch 2.13.0+cu130, glibc 2.39 and driver 590.48.01. All 49 model-file hashes match the earlier experiment. It is B300 calibration, not a B200 CI pass or universal numerical guarantee. The shared server teardown emits `CancelledError` after requests complete, including in passing runs; logs are not claimed to be pristine.

The registered test is `test/registered/e2e/radix_cache/test_glm53_flash_hicache_restore_kl.py`. To run it on a compatible model implementation:

```bash
SGLANG_TEST_GLM53_MODEL=/models/glm53-nvfp4 \
  python test/registered/e2e/radix_cache/test_glm53_flash_hicache_restore_kl.py
```

### Earlier full tool-call experiment (separate metric/runtime)

Completed a 105-request A/B/A experiment on 4 B300 GPUs with the same model files, inputs and serving configuration:

| Check | Original | Fixed | Original switchback |
|---|---:|---:|---:|
| Correct complete tool arguments | 34/35 | 35/35 | 35/35 |
| Correct host replays | 4/5 | 5/5 | 5/5 |
| Verified host replays | 5/5 | 5/5 | 5/5 |

Every host replay used 180032 host and 128 device tokens. All 90 non-host requests were correct. The error is intermittent; switchback did not reproduce wrong arguments in these five requests, so these samples do not establish a failure-rate reduction or universal correctness.

Asynchronous full-logit captures also show a reversible distribution change. At the same r4 generated prefix (sequence length 180177), full-vocabulary `KL(device-warm || host)` was **0.25731 → 0.00193 → 0.58711**. The host argmax changed from ` simple` to ` bash` in both original runs; the fixed run retained ` simple`. Comparisons use unit-temperature softmax and stop at the first divergent token. Raw argmax tokens match subsequent decode inputs. KL is diagnostic, not a standalone semantic pass/fail gate; clean paths have numerical variation too.

Configuration: ModelScope `RadixArk/GLM-5.3-Flash-NVFP4`, TP4/EP4, DSA/TRTLLM, FP8 KV, speculation off, direct/page_first_direct, write-through, 620000 KV tokens, Mamba cap 128, host size 20 GB, chunked prefill 8192, context 262144, greedy output. Five seeded rounds each flush, cold-replay, device-replay, send four pressure prompts, then host-replay the target. Target filler is 180000 tokens; target seeds start at 919433029 and increase by 100. The failing case is seed 919433429.

Model hashes matched all 38 shards and 11 configuration/tokenizer/template files. Serving configurations differed only in startup timings. Runtime source/packages came from `lmsysorg/sglang@sha256:a2c0f7d4d9ebce97a2707c5415081d284d741db1033a1008a955453b9b5255bf`, executed natively with CPython 3.12.11, PyTorch 2.13.0+cu130 and driver 580.159.03. Both arms use the same parser overlay. The old-image adapter omits its unavailable `page_aligned_only` constructor flag; all tested transfers are whole pages. This is image-overlay validation, not an upstream-main GLM serving claim.

Real index-byte roundtrips also passed all four direct/kernel and layer-first/page-first layout combinations, checking host contents, restored and untouched device bytes, shuffled pages and empty-layer compaction. Pre-commit and commit hooks passed.

## Speed Tests and Profiling

No controlled performance claim.
