### PR TITLE
[Bugfix] Fix FlashInfer EAGLE verification with sliding-window attention

### DIFF
--- a/python/sglang/kernels/ops/speculative/eagle.py
+++ b/python/sglang/kernels/ops/speculative/eagle.py
@@ -11,6 +11,52 @@ if _is_cpu:
 
 
 @triton.jit
+def compact_eagle_swa_mask(
+    mask,
+    positions,
+    kv_indptr,
+    full_kv_indptr,
+    kv_start_idx,
+    output,
+    mask_numel,
+    positions_numel,
+    NUM_DRAFT: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Gather full-prefix tree masks into windowed rows using logical positions."""
+    req = tl.program_id(0)
+    query = tl.program_id(1)
+    dst_begin = tl.load(kv_indptr + req).to(tl.int64)
+    row_len = tl.load(kv_indptr + req + 1) - dst_begin
+    src_begin = tl.load(full_kv_indptr + req).to(tl.int64)
+    full_row_len = tl.load(full_kv_indptr + req + 1) - src_begin
+    start = tl.load(kv_start_idx + req)
+    query_pos = tl.load(
+        positions + req * NUM_DRAFT + query,
+        mask=req * NUM_DRAFT + query < positions_numel,
+        other=0,
+    )
+    for block in range(tl.cdiv(row_len, BLOCK_SIZE)):
+        col = block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        valid = col < row_len
+        src = src_begin * NUM_DRAFT + query * full_row_len + start + col
+        # Graph padding can add requests beyond the original tree-mask buffer.
+        visible = tl.load(mask + src, mask=valid & (src < mask_numel), other=1)
+        draft_idx = col - (row_len - NUM_DRAFT)
+        key_pos = tl.load(
+            positions + req * NUM_DRAFT + draft_idx,
+            mask=valid
+            & (draft_idx >= 0)
+            & (req * NUM_DRAFT + draft_idx < positions_numel),
+            other=0,
+        )
+        key_pos = tl.where(draft_idx >= 0, key_pos, start + col)
+        visible = visible & (key_pos >= query_pos - WINDOW_LEFT)
+        tl.store(output + dst_begin * NUM_DRAFT + query * row_len + col, visible, valid)
+
+
+@triton.jit
 def fill_bonus_tokens(
     accept_tokens,
     accept_lens,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1064,11 +1064,16 @@ class FlashInferAttnBackend(AttentionBackend):
                 self.cuda_graph_kv_indices[i][0] = 0
 
         if not self.skip_prefill:
-            self.cuda_graph_custom_mask = torch.zeros(
-                (max_num_tokens * self.max_context_len),
-                dtype=torch.uint8,
-                device="cuda",
-            )
+            # SWA and full-attention wrappers plan different packed masks.
+            # Each must keep its own buffer through capture and replay.
+            self.cuda_graph_custom_mask = [
+                torch.zeros(
+                    (max_num_tokens * self.max_context_len),
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                for _ in range(self.num_wrappers)
+            ]
             self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
             self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
 
@@ -1114,7 +1119,7 @@ class FlashInferAttnBackend(AttentionBackend):
         for i in range(self.num_wrappers):
             extra = (
                 {
-                    "custom_mask_buf": self.cuda_graph_custom_mask,
+                    "custom_mask_buf": self.cuda_graph_custom_mask[i],
                     "mask_indptr_buf": self.cuda_graph_qk_indptr[i][: bs + 1],
                 }
                 if use_custom_mask
@@ -2001,6 +2006,9 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
+                spec_sliding_window_size=(
+                    sliding_window_size if wrapper_id == 0 else -1
+                ),
                 # paged-only SWA path only; ragged keeps its custom prefix
                 # mask, spec-verify keeps its tree mask
                 window_left=(
@@ -2125,6 +2133,7 @@ class FlashInferIndicesUpdaterPrefill:
         seq_lens_cpu: Optional[torch.Tensor] = None,
         custom_kv_indices: Optional[torch.Tensor] = None,
         window_left: int = -1,
+        spec_sliding_window_size: int = -1,
     ):
         bs = len(seq_lens)
         # Unified SWA wrapper-0: gather from the swa canonical directly -- its
@@ -2180,6 +2189,20 @@ class FlashInferIndicesUpdaterPrefill:
                         paged_kernel_lens_sum,
                         self.req_to_token,
                         kv_start_idx=kv_start_idx,
+                    )
+                )
+            elif (
+                spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+                and spec_sliding_window_size >= 0
+            ):
+                kv_indices, kv_indptr, qo_indptr, custom_mask = (
+                    spec_info.generate_attn_arg_prefill(
+                        req_pool_indices,
+                        paged_kernel_lens,
+                        paged_kernel_lens_sum,
+                        self.req_to_token,
+                        kv_start_idx=kv_start_idx,
+                        sliding_window_size=spec_sliding_window_size,
                     )
                 )
             else:

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.kernels.ops.speculative.eagle import compact_eagle_swa_mask
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -85,6 +86,8 @@ class EagleVerifyInput(SpecInput):
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
         req_to_token: torch.Tensor,
+        kv_start_idx: Optional[torch.Tensor] = None,
+        sliding_window_size: int = -1,
     ):
         device = req_pool_indices.device
         batch_size = len(req_pool_indices)
@@ -112,7 +115,7 @@ class EagleVerifyInput(SpecInput):
             req_pool_indices,
             paged_kernel_lens,
             cum_kv_seq_len,
-            None,
+            kv_start_idx,
             kv_indices,
             req_to_token.size(1),
         )
@@ -120,6 +123,35 @@ class EagleVerifyInput(SpecInput):
             paged_kernel_lens_sum * self.draft_token_num
             + (self.draft_token_num**2) * batch_size
         )
+        if sliding_window_size >= 0:
+            assert kv_start_idx is not None
+            # Each original row includes the dropped prefix. Its batch offset
+            # also includes all prefix tokens dropped by preceding requests.
+            full_kv_indptr = cum_kv_seq_len.clone()
+            full_kv_indptr[1:] += torch.cumsum(kv_start_idx, dim=0)
+            custom_mask = torch.empty(mask_numel, dtype=torch.bool, device=device)
+            positions = self.positions
+            if positions is None:
+                # Capture uses a dummy verify input without positions. Its
+                # output is discarded; replay supplies the real tree positions.
+                positions = torch.zeros(
+                    batch_size * self.draft_token_num, dtype=torch.int64, device=device
+                )
+            compact_eagle_swa_mask[(batch_size, self.draft_token_num)](
+                self.custom_mask,
+                positions,
+                cum_kv_seq_len,
+                full_kv_indptr,
+                kv_start_idx,
+                custom_mask,
+                self.custom_mask.numel(),
+                positions.numel(),
+                self.draft_token_num,
+                sliding_window_size,
+                256,
+            )
+            return kv_indices, cum_kv_seq_len, qo_indptr, custom_mask
+
         if self.custom_mask.numel() < mask_numel:
             # FIXME(attn): temporary fix for custom mask padding with cuda graph
             self.custom_mask = torch.cat(

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -1231,13 +1231,20 @@ def prepare_dense_runner_inputs(
     *,
     max_context_len: int,
 ) -> None:
-    del batch
+    # The eager fixture can use shuffled pages, while capture/replay batches
+    # rebuild their mapping. Refill the cache at the current batch's locations.
+    req_to_token = (
+        fixture.runner.req_to_token_pool.req_to_token[batch.req_pool_indices]
+        .cpu()
+        .tolist()
+    )
     _populate_prefix_kv(
         fixture.actual_module,
         case,
         fixture.runner,
         inputs["prefix_hidden"],
         max_context_len=max_context_len,
+        loc_fn=lambda req_idx, pos: req_to_token[req_idx][pos],
     )
 
 

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_cuda_graph_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_cuda_graph_runner.py
@@ -42,6 +42,7 @@ class SpeculativeCudaGraphAdapter:
     prepare_inputs: Callable[..., None]
     run_forward: Callable[[Any, Any, dict[str, Any]], torch.Tensor]
     expected_output: Callable[[Any, Any, dict[str, Any], Any], torch.Tensor]
+    prepare_capture_batch: Callable[[Any, Any], None] | None = None
     max_num_tokens: Callable[[Any, int], int] | None = None
     clone_state: Callable[[Any], Any] = lambda _: None
     restore_state: Callable[[Any, Any], None] = lambda _fixture, _state: None
@@ -226,7 +227,9 @@ def run_speculative_cuda_graph_case(
         max_context_len=max_context_len,
         device=device,
     )
-    adapter.prepare_batch(capture_case, capture_batch)
+    (adapter.prepare_capture_batch or adapter.prepare_batch)(
+        capture_case, capture_batch
+    )
     adapter.prepare_inputs(
         graph_fixture,
         capture_case,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
@@ -301,7 +301,32 @@ def _expected_case_and_masks_for_spec_verify(
         )
 
     masks_by_req, _ = _make_custom_masks(case, topk=topk, device=device)
+    if _is_flashinfer_eagle_swa(case, spec_kind):
+        # A sibling's flattened index is not its logical token position.
+        # Define visibility from the tree and token positions, independently
+        # of the backend's windowed KV layout.
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=_check_target_verify_case(case),
+                topk=topk,
+                device=device,
+            ).sum(dim=1)
+            - 1
+        )
+        for prefix_len, mask in zip(case.prefix_lens, masks_by_req):
+            query_pos = prefix_len + depth
+            key_pos = torch.cat((torch.arange(prefix_len, device=device), query_pos))
+            mask &= key_pos[None, :] >= query_pos[:, None] - case.sliding_window_size
+        return replace(case, sliding_window_size=None), masks_by_req
     return case, masks_by_req
+
+
+def _is_flashinfer_eagle_swa(case, spec_kind: SpecVerifyKind) -> bool:
+    return (
+        spec_kind == "eagle"
+        and case.backend == "flashinfer"
+        and getattr(case, "sliding_window_size", None) is not None
+    )
 
 
 def _make_retrieve_tensors(
@@ -376,10 +401,19 @@ def _make_spec_verify_input(
         "eagle": EagleVerifyInput,
         "frozen_kv_mtp": FrozenKVMTPVerifyInput,
     }[spec_kind]
+    positions = batch.positions
+    if _is_flashinfer_eagle_swa(case, spec_kind):
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=draft_token_num, topk=topk, device=device
+            ).sum(dim=1)
+            - 1
+        )
+        positions = torch.cat([prefix_len + depth for prefix_len in case.prefix_lens])
     return verify_cls(
         draft_token=batch.input_ids,
         custom_mask=custom_mask,
-        positions=batch.positions,
+        positions=positions,
         retrieve_index=retrieve_index,
         retrieve_next_token=retrieve_next_token,
         retrieve_next_sibling=retrieve_next_sibling,
@@ -453,6 +487,7 @@ def _prepare_spec_verify_batch(
     topk: int,
     spec_kind: SpecVerifyKind,
     device: str,
+    capture: bool = False,
 ) -> None:
     _prepare_target_verify_batch(batch, case, device)
     batch.spec_info = _make_spec_verify_input(
@@ -462,6 +497,9 @@ def _prepare_spec_verify_batch(
         device=device,
         spec_kind=spec_kind,
     )
+    if capture and isinstance(batch.spec_info, EagleVerifyInput):
+        # Match DecodeCudaGraphRunner's dummy EAGLE capture input.
+        batch.spec_info.positions = None
 
 
 def _run_spec_verify_cuda_graph_case(
@@ -506,6 +544,14 @@ def _run_spec_verify_cuda_graph_case(
             topk=topk,
             spec_kind=spec_kind,
             device=device,
+        ),
+        prepare_capture_batch=lambda spec_case, batch: _prepare_spec_verify_batch(
+            spec_case,
+            batch,
+            topk=topk,
+            spec_kind=spec_kind,
+            device=device,
+            capture=True,
         ),
         prepare_inputs=prepare_inputs,
         run_forward=run_forward,

--- a/test/registered/attention/unittests/swa/test_flashinfer.py
+++ b/test/registered/attention/unittests/swa/test_flashinfer.py
@@ -155,6 +155,57 @@ class TestFlashInferSWAAttentionBackendCorrectness(CustomTestCase):
         ),
     )
 
+    EAGLE_VERIFY_CASES = tuple(
+        DenseAttentionCase(
+            name=f"eagle_swa_{prefix_lens}_{draft_tokens}_{window}",
+            backend="flashinfer",
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            num_heads=4,
+            num_kv_heads=2,
+            page_size=16,
+            prefix_lens=prefix_lens,
+            extend_lens=(draft_tokens,) * len(prefix_lens),
+            sliding_window_size=window,
+        )
+        for prefix_lens, draft_tokens, window in (
+            ((2,), 3, 4),
+            ((3, 4, 5), 3, 4),
+            ((9, 2), 3, 4),
+            ((2, 9), 3, 4),
+            ((12, 7), 3, 4),
+            ((0, 9), 3, 4),
+            ((9, 2), 7, 2),
+            ((1220, 325), 8, 1023),
+            ((325, 1220), 8, 1023),
+        )
+    )
+
+    def test_eagle_swa_verify(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
+    def test_eagle_swa_verify_cuda_graph(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_cuda_graph_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
     def test_projected_swa_attention_cases(self):
         for case in self.CASES:
             with self.subTest(case=case.name, backend=case.backend):


### PR DESCRIPTION
## Motivation

FlashInfer EAGLE verification clips sliding-window prefix lengths but still gathers KV from offset zero and returns a mask laid out for the full prefix. Once a request crosses the window, verification reads the wrong keys and mask columns. The changed row widths also misalign masks for later requests in the batch.

This completes the EAGLE side of the constraint discussed in [#27469](https://github.com/sgl-project/sglang/pull/27469#discussion_r3406047598), which passed `kv_start_idx` for DFlash only. EAGLE uses custom tree masks even with topk=1, so moving the KV start must also transform those masks.

## Modifications

- Pass the SWA start into EAGLE's FlashInfer metadata builder and compact each request's full-prefix mask into the retained KV layout.
- Apply the window using logical query/key positions while preserving tree ancestry, including siblings that share a position.
- Keep separate packed-mask buffers for SWA and full-attention CUDA graph wrappers, and handle the dummy capture input with no positions.
- Add EAGLE chain/tree, window-boundary, long/short batch-order, and graph replay coverage. Match production's dummy capture input and refill test KV using the batch's actual page mapping.

## Accuracy Tests

RTX PRO 6000 Blackwell 96GB (SM120), PyTorch 2.13.0+cu129, FlashInfer 0.6.18, Triton 3.7.1:

- The same new EAGLE regression fails 24 of 30 numerical subcases on upstream `e91c9480`; all 30 pass with the fix. Includes prefix lengths 1220/325 with a 1023-token left window, both batch orders, and padded CUDA graph replay.
- Complete FlashInfer SWA suite: 9 test methods pass, retaining prefill, decode, and DFlash controls.
- Complete FlashInfer dense-attention suite: 8 test methods pass.
- Triton SWA suite: 6 test methods pass.

Gemma3-27B AWQ (`gaunernst/gemma-3-27b-it-int4-awq`) / EAGLE3 (`witcheer/gemma-3-27b-eagle3-drafter`), topk=4, steps=3, draft_tokens=8: all six request-order controls complete. On the first 16 LiveCodeBench prompts with a 256-token diagnostic cap, upstream has 11 parseable outputs, 2 syntax errors and 3 empty extractions; the fix has 15 parseable outputs, no syntax errors and 1 empty extraction. These are diagnostic counts, not task accuracy. The short sentinel passes the official checker in all six placements in both arms. All model controls use the same paged prefill setting to isolate this verify fix from the separate ragged prefill issue discussed in #34093.

Run the primary regression with `python test/registered/attention/unittests/swa/test_flashinfer.py`. The reference uses full-coordinate tree ancestry and logical positions, independent of the compacted KV layout.

## Speed Tests and Profiling

Isolated `EagleVerifyInput.generate_attn_arg_prefill` timing on an otherwise idle GPU, before (`e91c9480`) / after (`eed3ed08`), draft_tokens=8, topk=4 tree, window_left=1023. `triton.testing.do_bench` uses 100 ms warmup and 500 ms measurement; values are medians.

| Batch size | Prefix lengths | Before (µs) | After (µs) |
| ---: | --- | ---: | ---: |
| 1 | 512 | 20.4 | 35.6 |
| 1 | 2048 | 20.4 | 35.5 |
| 1 | 16384 | 20.4 | 36.9 |
| 16 | alternating 512/325 | 20.4 | 35.5 |
| 16 | alternating 2048/325 | 20.4 | 35.5 |
| 16 | alternating 16384/325 | 20.4 | 34.8 |

This measures the metadata builder, including allocations, cumulative offsets, KV gathering, and the added mask compaction. It excludes FlashInfer planning, attention, and the model. The corrected builder adds roughly 14–17 µs in these cases; this is not an end-to-end throughput comparison, and the baseline metadata is incorrect once clipping occurs. The separate packed-mask buffers also add one preallocated mask buffer when both SWA and full-attention wrappers are present.

## Checklist

- [x] Code formatted and checked with the upstream pre-commit configuration.
- [x] Numerical regression tests added.
- [x] No user-facing API documentation change is needed.
- [x] Numerical/model checks and scoped metadata timing results provided.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34669329790](https://github.com/sgl-project/sglang/actions/runs/34669329790)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34669329599](https://github.com/sgl-project/sglang/actions/runs/34669329599)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34669329758](https://github.com/sgl-project/sglang/actions/runs/34669329758)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->