### PR TITLE
[Bugfix] Preserve complete Gemma speculative hidden-state captures

### DIFF
--- a/python/sglang/kernels/ops/speculative/eagle.py
+++ b/python/sglang/kernels/ops/speculative/eagle.py
@@ -11,6 +11,52 @@ if _is_cpu:
 
 
 @triton.jit
+def compact_eagle_swa_mask(
+    mask,
+    positions,
+    kv_indptr,
+    full_kv_indptr,
+    kv_start_idx,
+    output,
+    mask_numel,
+    positions_numel,
+    NUM_DRAFT: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Gather full-prefix tree masks into windowed rows using logical positions."""
+    req = tl.program_id(0)
+    query = tl.program_id(1)
+    dst_begin = tl.load(kv_indptr + req).to(tl.int64)
+    row_len = tl.load(kv_indptr + req + 1) - dst_begin
+    src_begin = tl.load(full_kv_indptr + req).to(tl.int64)
+    full_row_len = tl.load(full_kv_indptr + req + 1) - src_begin
+    start = tl.load(kv_start_idx + req)
+    query_pos = tl.load(
+        positions + req * NUM_DRAFT + query,
+        mask=req * NUM_DRAFT + query < positions_numel,
+        other=0,
+    )
+    for block in range(tl.cdiv(row_len, BLOCK_SIZE)):
+        col = block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        valid = col < row_len
+        src = src_begin * NUM_DRAFT + query * full_row_len + start + col
+        # Graph padding can add requests beyond the original tree-mask buffer.
+        visible = tl.load(mask + src, mask=valid & (src < mask_numel), other=1)
+        draft_idx = col - (row_len - NUM_DRAFT)
+        key_pos = tl.load(
+            positions + req * NUM_DRAFT + draft_idx,
+            mask=valid
+            & (draft_idx >= 0)
+            & (req * NUM_DRAFT + draft_idx < positions_numel),
+            other=0,
+        )
+        key_pos = tl.where(draft_idx >= 0, key_pos, start + col)
+        visible = visible & (key_pos >= query_pos - WINDOW_LEFT)
+        tl.store(output + dst_begin * NUM_DRAFT + query * row_len + col, visible, valid)
+
+
+@triton.jit
 def fill_bonus_tokens(
     accept_tokens,
     accept_lens,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1064,11 +1064,16 @@ class FlashInferAttnBackend(AttentionBackend):
                 self.cuda_graph_kv_indices[i][0] = 0
 
         if not self.skip_prefill:
-            self.cuda_graph_custom_mask = torch.zeros(
-                (max_num_tokens * self.max_context_len),
-                dtype=torch.uint8,
-                device="cuda",
-            )
+            # SWA and full-attention wrappers plan different packed masks.
+            # Each must keep its own buffer through capture and replay.
+            self.cuda_graph_custom_mask = [
+                torch.zeros(
+                    (max_num_tokens * self.max_context_len),
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                for _ in range(self.num_wrappers)
+            ]
             self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
             self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
 
@@ -1114,7 +1119,7 @@ class FlashInferAttnBackend(AttentionBackend):
         for i in range(self.num_wrappers):
             extra = (
                 {
-                    "custom_mask_buf": self.cuda_graph_custom_mask,
+                    "custom_mask_buf": self.cuda_graph_custom_mask[i],
                     "mask_indptr_buf": self.cuda_graph_qk_indptr[i][: bs + 1],
                 }
                 if use_custom_mask
@@ -2001,6 +2006,9 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
+                spec_sliding_window_size=(
+                    sliding_window_size if wrapper_id == 0 else -1
+                ),
                 # paged-only SWA path only; ragged keeps its custom prefix
                 # mask, spec-verify keeps its tree mask
                 window_left=(
@@ -2125,6 +2133,7 @@ class FlashInferIndicesUpdaterPrefill:
         seq_lens_cpu: Optional[torch.Tensor] = None,
         custom_kv_indices: Optional[torch.Tensor] = None,
         window_left: int = -1,
+        spec_sliding_window_size: int = -1,
     ):
         bs = len(seq_lens)
         # Unified SWA wrapper-0: gather from the swa canonical directly -- its
@@ -2180,6 +2189,20 @@ class FlashInferIndicesUpdaterPrefill:
                         paged_kernel_lens_sum,
                         self.req_to_token,
                         kv_start_idx=kv_start_idx,
+                    )
+                )
+            elif (
+                spec_info.spec_input_type == SpecInputType.EAGLE_VERIFY
+                and spec_sliding_window_size >= 0
+            ):
+                kv_indices, kv_indptr, qo_indptr, custom_mask = (
+                    spec_info.generate_attn_arg_prefill(
+                        req_pool_indices,
+                        paged_kernel_lens,
+                        paged_kernel_lens_sum,
+                        self.req_to_token,
+                        kv_start_idx=kv_start_idx,
+                        sliding_window_size=spec_sliding_window_size,
                     )
                 )
             else:

--- a/python/sglang/srt/models/gemma3_causal.py
+++ b/python/sglang/srt/models/gemma3_causal.py
@@ -640,7 +640,11 @@ class Gemma3TextModel(PreTrainedModel):
         if _is_cpu and _is_cpu_amx_available:
             for i, layer in enumerate(self.layers):
                 if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states)
+                    aux_hidden_states.append(
+                        hidden_states.clone()
+                        if residual is None
+                        else hidden_states + residual
+                    )
                 hidden_states, residual = layer(
                     positions=positions,
                     position_embeddings_global=None,
@@ -658,7 +662,11 @@ class Gemma3TextModel(PreTrainedModel):
             position_embeddings_local = self.rotary_emb_local(hidden_states, positions)
             for i, layer in enumerate(self.layers):
                 if i in self.layers_to_capture:
-                    aux_hidden_states.append(hidden_states)
+                    aux_hidden_states.append(
+                        hidden_states.clone()
+                        if residual is None
+                        else hidden_states + residual
+                    )
                 hidden_states, residual = layer(
                     positions=positions,
                     position_embeddings_global=position_embeddings_global,
@@ -673,7 +681,9 @@ class Gemma3TextModel(PreTrainedModel):
         # layers_to_capture uses +1 offset (captures input of layer i = output of i-1),
         # so index num_layers means the output of the final layer.
         if num_layers in self.layers_to_capture:
-            aux_hidden_states.append(hidden_states)
+            aux_hidden_states.append(
+                hidden_states.clone() if residual is None else hidden_states + residual
+            )
 
         hidden_states, _ = self.norm(hidden_states, residual)
 

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -994,7 +994,8 @@ class Gemma4TextModel(PreTrainedModel):
 
         for layer_idx in range(self.start_layer, self.end_layer):
             if layer_idx in self.layers_to_capture:
-                aux_hidden_states.append(hidden_states)
+                # The next layer's fused norm updates its input residual in place.
+                aux_hidden_states.append(hidden_states.clone())
 
             if per_layer_inputs is not None:
                 per_layer_input = per_layer_inputs[:, layer_idx, :]

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.kernels.ops.speculative.eagle import compact_eagle_swa_mask
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -85,6 +86,8 @@ class EagleVerifyInput(SpecInput):
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
         req_to_token: torch.Tensor,
+        kv_start_idx: Optional[torch.Tensor] = None,
+        sliding_window_size: int = -1,
     ):
         device = req_pool_indices.device
         batch_size = len(req_pool_indices)
@@ -112,7 +115,7 @@ class EagleVerifyInput(SpecInput):
             req_pool_indices,
             paged_kernel_lens,
             cum_kv_seq_len,
-            None,
+            kv_start_idx,
             kv_indices,
             req_to_token.size(1),
         )
@@ -120,6 +123,35 @@ class EagleVerifyInput(SpecInput):
             paged_kernel_lens_sum * self.draft_token_num
             + (self.draft_token_num**2) * batch_size
         )
+        if sliding_window_size >= 0:
+            assert kv_start_idx is not None
+            # Each original row includes the dropped prefix. Its batch offset
+            # also includes all prefix tokens dropped by preceding requests.
+            full_kv_indptr = cum_kv_seq_len.clone()
+            full_kv_indptr[1:] += torch.cumsum(kv_start_idx, dim=0)
+            custom_mask = torch.empty(mask_numel, dtype=torch.bool, device=device)
+            positions = self.positions
+            if positions is None:
+                # Capture uses a dummy verify input without positions. Its
+                # output is discarded; replay supplies the real tree positions.
+                positions = torch.zeros(
+                    batch_size * self.draft_token_num, dtype=torch.int64, device=device
+                )
+            compact_eagle_swa_mask[(batch_size, self.draft_token_num)](
+                self.custom_mask,
+                positions,
+                cum_kv_seq_len,
+                full_kv_indptr,
+                kv_start_idx,
+                custom_mask,
+                self.custom_mask.numel(),
+                positions.numel(),
+                self.draft_token_num,
+                sliding_window_size,
+                256,
+            )
+            return kv_indices, cum_kv_seq_len, qo_indptr, custom_mask
+
         if self.custom_mask.numel() < mask_numel:
             # FIXME(attn): temporary fix for custom mask padding with cuda graph
             self.custom_mask = torch.cat(

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -1231,13 +1231,20 @@ def prepare_dense_runner_inputs(
     *,
     max_context_len: int,
 ) -> None:
-    del batch
+    # The eager fixture can use shuffled pages, while capture/replay batches
+    # rebuild their mapping. Refill the cache at the current batch's locations.
+    req_to_token = (
+        fixture.runner.req_to_token_pool.req_to_token[batch.req_pool_indices]
+        .cpu()
+        .tolist()
+    )
     _populate_prefix_kv(
         fixture.actual_module,
         case,
         fixture.runner,
         inputs["prefix_hidden"],
         max_context_len=max_context_len,
+        loc_fn=lambda req_idx, pos: req_to_token[req_idx][pos],
     )
 
 

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_cuda_graph_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_cuda_graph_runner.py
@@ -42,6 +42,7 @@ class SpeculativeCudaGraphAdapter:
     prepare_inputs: Callable[..., None]
     run_forward: Callable[[Any, Any, dict[str, Any]], torch.Tensor]
     expected_output: Callable[[Any, Any, dict[str, Any], Any], torch.Tensor]
+    prepare_capture_batch: Callable[[Any, Any], None] | None = None
     max_num_tokens: Callable[[Any, int], int] | None = None
     clone_state: Callable[[Any], Any] = lambda _: None
     restore_state: Callable[[Any, Any], None] = lambda _fixture, _state: None
@@ -226,7 +227,9 @@ def run_speculative_cuda_graph_case(
         max_context_len=max_context_len,
         device=device,
     )
-    adapter.prepare_batch(capture_case, capture_batch)
+    (adapter.prepare_capture_batch or adapter.prepare_batch)(
+        capture_case, capture_batch
+    )
     adapter.prepare_inputs(
         graph_fixture,
         capture_case,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
@@ -301,7 +301,32 @@ def _expected_case_and_masks_for_spec_verify(
         )
 
     masks_by_req, _ = _make_custom_masks(case, topk=topk, device=device)
+    if _is_flashinfer_eagle_swa(case, spec_kind):
+        # A sibling's flattened index is not its logical token position.
+        # Define visibility from the tree and token positions, independently
+        # of the backend's windowed KV layout.
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=_check_target_verify_case(case),
+                topk=topk,
+                device=device,
+            ).sum(dim=1)
+            - 1
+        )
+        for prefix_len, mask in zip(case.prefix_lens, masks_by_req):
+            query_pos = prefix_len + depth
+            key_pos = torch.cat((torch.arange(prefix_len, device=device), query_pos))
+            mask &= key_pos[None, :] >= query_pos[:, None] - case.sliding_window_size
+        return replace(case, sliding_window_size=None), masks_by_req
     return case, masks_by_req
+
+
+def _is_flashinfer_eagle_swa(case, spec_kind: SpecVerifyKind) -> bool:
+    return (
+        spec_kind == "eagle"
+        and case.backend == "flashinfer"
+        and getattr(case, "sliding_window_size", None) is not None
+    )
 
 
 def _make_retrieve_tensors(
@@ -376,10 +401,19 @@ def _make_spec_verify_input(
         "eagle": EagleVerifyInput,
         "frozen_kv_mtp": FrozenKVMTPVerifyInput,
     }[spec_kind]
+    positions = batch.positions
+    if _is_flashinfer_eagle_swa(case, spec_kind):
+        depth = (
+            _draft_tree_mask(
+                draft_token_num=draft_token_num, topk=topk, device=device
+            ).sum(dim=1)
+            - 1
+        )
+        positions = torch.cat([prefix_len + depth for prefix_len in case.prefix_lens])
     return verify_cls(
         draft_token=batch.input_ids,
         custom_mask=custom_mask,
-        positions=batch.positions,
+        positions=positions,
         retrieve_index=retrieve_index,
         retrieve_next_token=retrieve_next_token,
         retrieve_next_sibling=retrieve_next_sibling,
@@ -453,6 +487,7 @@ def _prepare_spec_verify_batch(
     topk: int,
     spec_kind: SpecVerifyKind,
     device: str,
+    capture: bool = False,
 ) -> None:
     _prepare_target_verify_batch(batch, case, device)
     batch.spec_info = _make_spec_verify_input(
@@ -462,6 +497,9 @@ def _prepare_spec_verify_batch(
         device=device,
         spec_kind=spec_kind,
     )
+    if capture and isinstance(batch.spec_info, EagleVerifyInput):
+        # Match DecodeCudaGraphRunner's dummy EAGLE capture input.
+        batch.spec_info.positions = None
 
 
 def _run_spec_verify_cuda_graph_case(
@@ -506,6 +544,14 @@ def _run_spec_verify_cuda_graph_case(
             topk=topk,
             spec_kind=spec_kind,
             device=device,
+        ),
+        prepare_capture_batch=lambda spec_case, batch: _prepare_spec_verify_batch(
+            spec_case,
+            batch,
+            topk=topk,
+            spec_kind=spec_kind,
+            device=device,
+            capture=True,
         ),
         prepare_inputs=prepare_inputs,
         run_forward=run_forward,

--- a/test/registered/attention/unittests/swa/test_flashinfer.py
+++ b/test/registered/attention/unittests/swa/test_flashinfer.py
@@ -155,6 +155,57 @@ class TestFlashInferSWAAttentionBackendCorrectness(CustomTestCase):
         ),
     )
 
+    EAGLE_VERIFY_CASES = tuple(
+        DenseAttentionCase(
+            name=f"eagle_swa_{prefix_lens}_{draft_tokens}_{window}",
+            backend="flashinfer",
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            num_heads=4,
+            num_kv_heads=2,
+            page_size=16,
+            prefix_lens=prefix_lens,
+            extend_lens=(draft_tokens,) * len(prefix_lens),
+            sliding_window_size=window,
+        )
+        for prefix_lens, draft_tokens, window in (
+            ((2,), 3, 4),
+            ((3, 4, 5), 3, 4),
+            ((9, 2), 3, 4),
+            ((2, 9), 3, 4),
+            ((12, 7), 3, 4),
+            ((0, 9), 3, 4),
+            ((9, 2), 7, 2),
+            ((1220, 325), 8, 1023),
+            ((325, 1220), 8, 1023),
+        )
+    )
+
+    def test_eagle_swa_verify(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
+    def test_eagle_swa_verify_cuda_graph(self):
+        for case in self.EAGLE_VERIFY_CASES:
+            for topk in (1, 2) if case.extend_lens[0] == 3 else (1,):
+                with self.subTest(case=case.name, topk=topk):
+                    run_dense_spec_verify_cuda_graph_case(
+                        self,
+                        case,
+                        topk=topk,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                        max_context_len=2048,
+                    )
+
     def test_projected_swa_attention_cases(self):
         for case in self.CASES:
             with self.subTest(case=case.name, backend=case.backend):

--- a/test/registered/kernel/speculative/test_gemma_aux_hidden_states.py
+++ b/test/registered/kernel/speculative/test_gemma_aux_hidden_states.py
@@ -1,0 +1,153 @@
+"""Speculative captures must retain the eager decoder's complete layer outputs."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.layernorm import Gemma3RMSNorm, RMSNorm
+from sglang.srt.models.gemma3_causal import Gemma3DecoderLayer, Gemma3TextModel
+from sglang.srt.models.gemma4_causal import Gemma4DecoderLayer, Gemma4TextModel
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class ToyAttention(nn.Module):
+    is_sliding = False
+
+    def forward(self, hidden_states, **kwargs):
+        return hidden_states.roll(1, dims=-1) * 0.25
+
+
+def make_model(version, device, dtype):
+    """Use the real decoder and norm paths, with small deterministic sublayers."""
+    model_cls, layer_cls, norm_cls = (
+        (Gemma3TextModel, Gemma3DecoderLayer, Gemma3RMSNorm)
+        if version == 3
+        else (Gemma4TextModel, Gemma4DecoderLayer, RMSNorm)
+    )
+
+    def norm():
+        module = norm_cls(128, eps=1e-6).to(device=device, dtype=dtype)
+        offset = 0.0 if version == 3 else 1.0
+        module.weight.data.copy_(
+            torch.linspace(-0.2, 0.2, 128, device=device, dtype=dtype) + offset
+        )
+        if device == "cpu":
+            module._forward_method = module.forward_native
+        return module
+
+    model = model_cls.__new__(model_cls)
+    nn.Module.__init__(model)
+    layers = []
+    for _ in range(3):
+        layer = layer_cls.__new__(layer_cls)
+        nn.Module.__init__(layer)
+        layer.self_attn = ToyAttention()
+        layer.mlp = nn.Tanh()
+        layer.input_layernorm = norm()
+        layer.post_attention_layernorm = norm()
+        layer.pre_feedforward_layernorm = norm()
+        layer.post_feedforward_layernorm = norm()
+        if version == 4:
+            layer.enable_moe_block = False
+            layer.has_ple = False
+            layer.moe = None
+            layer.layer_scalar = torch.tensor([0.75], device=device, dtype=dtype)
+        layers.append(layer)
+    model.layers = nn.ModuleList(layers)
+    model.norm = norm()
+    model.layers_to_capture = [0, 1, 3]
+    if version == 3:
+        model.rotary_emb = lambda *args: None
+        model.rotary_emb_local = lambda *args: None
+    else:
+        model.config = SimpleNamespace(num_hidden_layers=3)
+        model.pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+        model.start_layer, model.end_layer = 0, 3
+        model.per_layer_model_projection = None
+    return model
+
+
+def eager_reference(model, inputs, version):
+    """Unfused residual additions, without a separately carried residual stream."""
+
+    def norm(x, module):
+        value = x.float()
+        value = value * torch.rsqrt(value.square().mean(-1, keepdim=True) + 1e-6)
+        weight = module.weight.float() + (1.0 if version == 3 else 0.0)
+        return (value * weight).to(x.dtype)
+
+    hidden = inputs.clone()
+    outputs = [hidden]
+    for layer in model.layers:
+        attn = layer.self_attn(hidden_states=norm(hidden, layer.input_layernorm))
+        hidden = hidden + norm(attn, layer.post_attention_layernorm)
+        mlp = layer.mlp(norm(hidden, layer.pre_feedforward_layernorm))
+        hidden = hidden + norm(mlp, layer.post_feedforward_layernorm)
+        if version == 4:
+            hidden = hidden * layer.layer_scalar
+        outputs.append(hidden)
+    return norm(hidden, model.norm), [outputs[i] for i in model.layers_to_capture]
+
+
+class TestGemmaAuxHiddenStates(CustomTestCase):
+    def check_captures(self, version, device, dtype, tokens, graph=False):
+        model = make_model(version, device, dtype)
+        generator = torch.Generator(device=device).manual_seed(42)
+        inputs = torch.randn(tokens, 128, generator=generator, device=device).to(dtype)
+        positions = torch.arange(tokens, device=device)
+
+        def forward():
+            return model(None, positions, None, input_embeds=inputs.clone())
+
+        expected_final, expected_captures = eager_reference(model, inputs, version)
+        final, captured = forward()
+        if graph:
+            for _ in range(3):
+                forward()
+            cuda_graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(cuda_graph):
+                final, captured = forward()
+            cuda_graph.replay()
+            cuda_graph.replay()
+            torch.cuda.synchronize()
+        atol, rtol = (0.08, 0.02) if dtype == torch.bfloat16 else (0.005, 0.005)
+        self.assertEqual(len(captured), len(expected_captures))
+        for actual, expected in zip(captured, expected_captures):
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        torch.testing.assert_close(final, expected_final, atol=atol, rtol=rtol)
+        model.layers_to_capture = []
+        torch.testing.assert_close(final, forward(), atol=0, rtol=0)
+
+    @torch.no_grad()
+    def test_native_captures_match_eager_residual_additions(self):
+        for version in (3, 4):
+            for cpu_amx in (False, True):
+                with (
+                    self.subTest(version=version, cpu_amx=cpu_amx),
+                    patch("sglang.srt.models.gemma3_causal._is_cpu", cpu_amx),
+                    patch(
+                        "sglang.srt.models.gemma3_causal._is_cpu_amx_available",
+                        cpu_amx,
+                        create=True,
+                    ),
+                ):
+                    self.check_captures(version, "cpu", torch.float32, 3)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    @torch.no_grad()
+    def test_fused_captures_survive_inplace_norms_and_graph_replay(self):
+        for version in (3, 4):
+            for dtype in (torch.float16, torch.bfloat16):
+                for tokens in (1, 8):
+                    with self.subTest(version=version, dtype=dtype, tokens=tokens):
+                        self.check_captures(version, "cuda", dtype, tokens, graph=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Gemma3's auxiliary captures still store `hidden_states` alone after #32383 separated the residual stream across decoder layers. The captures omit the residual and can be overwritten by subsequent fused normalization, reducing EAGLE3 acceptance.

Gemma4 returns complete layer outputs, but its captures share storage with the next layer's in-place residual update. The aliasing mechanism was discussed in #27540; this change preserves the actual auxiliary captures passed to the draft.

**Depends on #39160.** This branch contains that backend fix followed by one capture commit. Review the [capture-only diff](https://github.com/whzzt/sglang/compare/eed3ed08a0cb781bccf4e9d1b6929155292f1e3f...2c01dc2f1eb8173f26669926c9d92ec70966776a); it changes only the two Gemma model files and the capture regression test. Merge the backend PR first.

## Modifications

- Include Gemma3's residual at each requested capture boundary and snapshot Gemma4's intermediate captures.
- Add a regression test for complete capture values, snapshot preservation, unchanged target outputs, and CUDA graph replay.

## Accuracy Tests

The capture regression passes all 12 numerical subcases (2 test methods) on the stacked commit. Run `python test/registered/kernel/speculative/test_gemma_aux_hidden_states.py`.

One RTX PRO 6000 Blackwell 96GB, TP=1, temperature=0, max_new_tokens=8192, concurrency=16, native chat templates. MT-Bench reports supplemental Qwen3-30B-A3B-Instruct-2507 ratings (/10) over all 160 answers. Acceptance length includes target bonus tokens.

Fresh Gemma3 runs compare `eed3ed08a` (backend fix, original capture) with `2c01dc2f1` (backend fix plus this capture change). Both use target and draft FlashInfer, EAGLE3 topk=4 / steps=3 / draft_tokens=8, `SGLANG_FLASHINFER_USE_PAGED=1`, and `SGLANG_SWA_EVICTION_INTERVAL=1`. The paged prefill setting isolates this comparison from the separate ragged plan-time issue #34093. Runtime: PyTorch 2.13.0+cu129, FlashInfer 0.6.18, Triton 3.7.1.

| Model / dataset | Score Before | Score After | Acceptance Length Before | Acceptance Length After |
| --- | ---: | ---: | ---: | ---: |
| Gemma3-27B AWQ / EAGLE3 / GSM8K | 467/500 | 470/500 | 1.055 | 1.891 |
| Gemma3-27B AWQ / EAGLE3 / MT-Bench | 8.9375 | 8.8500 | 1.041 | 1.563 |
| Gemma3-27B AWQ / EAGLE3 / HumanEval | 139/164 | 138/164 | 1.084 | 1.742 |
| Gemma3-27B AWQ / EAGLE3 / LiveCodeBench v6 increment | 45/175 | 45/175 | 1.369 | 1.840 |
| Gemma4-31B-it / DFlash (prior run) / GSM8K | 486/500 | 487/500 | 6.646 | 6.425 |
| Gemma4-31B-it / DFlash (prior run) / MT-Bench | 9.5625 | 9.5312 | 3.563 | 3.449 |
| Gemma4-31B-it / DFlash (prior run) / HumanEval | 155/164 | 157/164 | 10.527 | 9.336 |
| Gemma4-31B-it / DFlash (prior run) / LiveCodeBench v6 increment | 123/175 | 126/175 | 5.409 | 5.119 |

Gemma3 has four length-capped LiveCodeBench answers in each arm and no truncation on GSM8K, HumanEval, or MT-Bench. Every answer remains in the reported score. Five unique judge explanations needed one rating-only follow-up (six expanded answer entries); all final ratings are valid, and original judgments are retained. The earlier 36/175 to 4/175 LiveCodeBench comparison used the broken verification backend and is superseded by this controlled run. These are single greedy task runs; they do not establish statistical quality equivalence.

Gemma4 rows are retained from the September 11 experiment on `a338a9a0` versus `786fbe21`, using a Triton target. The capture files are identical to this PR after rebasing, but those rows are not a rerun on the new backend commit.

## Speed Tests and Profiling

Fixed prompts, 256 output tokens per request (`ignore_eos`), concurrency 1 and 16. ABBA process order, three warmups and eight timed repeats per process; each number is output tokens divided by the median of 16 observations per variant/concurrency. Fresh Gemma3 speed runs use the same engine configuration as the new quality runs. Gemma4 timings are retained from the prior experiment; its base/EAGLE3 pairing uses the matching base checkpoint and raw completion prompts.

| Model / concurrent requests | Before tok/s | After tok/s |
| --- | ---: | ---: |
| Gemma3-27B AWQ / EAGLE3 / 1 | 47.0 | 62.8 |
| Gemma3-27B AWQ / EAGLE3 / 16 | 276.9 | 392.8 |
| Gemma4-31B-it / DFlash (prior run) / 1 | 85.9 | 83.0 |
| Gemma4-31B-it / DFlash (prior run) / 16 | 490.7 | 462.4 |
| Gemma4-31B / EAGLE3 (prior run) / 1 | 50.2 | 51.5 |
| Gemma4-31B / EAGLE3 (prior run) / 16 | 390.9 | 392.4 |

The capture correction does not improve throughput for every draft pairing; regressions are retained in the table.

## Checklist

- [x] Code formatted and checked with the upstream pre-commit configuration.
- [x] Unit tests added.
- [x] No documentation update is needed.
- [x] Accuracy and speed benchmark results provided.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34669531651](https://github.com/sgl-project/sglang/actions/runs/34669531651)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34669531443](https://github.com/sgl-project/sglang/actions/runs/34669531443)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34669531618](https://github.com/sgl-project/sglang/actions/runs/34669531618)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
